### PR TITLE
feat(install): add project-local agent setup

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "tokensave": {
-      "command": "/home/zack/projects/tokensave/.worktrees/holographic-memory/scripts/tokensave-dev-mcp.sh",
-      "env": {
-        "TOKENSAVE_DEV_PROJECT_ROOT": "/home/zack/projects/tokensave/.worktrees/holographic-memory"
-      }
+      "args": [
+        "serve"
+      ],
+      "command": "/home/zack/projects/tokensave/target/debug/tokensave"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For project-scoped setup, run from the repository root:
 tokensave install --local --agent cursor
 ```
 
-Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json`, `.codex/config.toml`, `.vscode/mcp.json`, or the equivalent project config for Claude, Codex, Gemini, Kiro, OpenCode, Copilot/VS Code, Zed, Cline, Roo Code, Kimi, Kilo, and Vibe. Generated MCP configs use the resolved absolute `tokensave` executable path. Local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook. Antigravity is global-only and returns a clear unsupported error for `--local`.
+Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json`, `.codex/config.toml`, `.vscode/mcp.json`, or the equivalent project config for Claude, Codex, Gemini, Kiro, OpenCode, Copilot/VS Code, Zed, Roo Code, Kimi, Kilo, and Vibe. Generated MCP configs use the resolved absolute `tokensave` executable path. Local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook. Antigravity and Cline are global-only and return clear unsupported errors for `--local`.
 
 ### 3. Index your project
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ Each agent gets its MCP server registered in the native config format. Claude Co
 
 All changes are idempotent -- safe to run again after upgrading. After agent setup, you'll be offered a global git post-commit hook.
 
+For project-scoped setup, run from the repository root:
+
+```bash
+tokensave install --local --agent cursor
+```
+
+Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json`, `.codex/config.toml`, `.vscode/mcp.json`, or the equivalent project config for Claude, Codex, Gemini, Kiro, OpenCode, Copilot/VS Code, Zed, Cline, Roo Code, Kimi, Kilo, and Vibe. Generated MCP configs use the resolved absolute `tokensave` executable path. Local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook. Antigravity is global-only and returns a clear unsupported error for `--local`.
+
 ### 3. Index your project
 
 ```bash

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -223,9 +223,9 @@ tokensave install --local --agent cursor
 tokensave install --local --agent copilot
 ```
 
-Local installs write workspace files instead of user-level agent config. Supported local targets are Claude Code, Codex, Gemini, Kiro, OpenCode, GitHub Copilot / VS Code, Cursor, Zed, Cline, Roo Code, Kimi, Kilo, and Mistral Vibe. Examples include `.mcp.json`, `.claude/settings.json`, `.cursor/mcp.json`, `.codex/config.toml`, `.vscode/mcp.json`, `.kiro/settings/mcp.json`, `opencode.json`, `.roo/mcp.json`, `.kimi-code/mcp.json`, `.kilocode/mcp.json`, and `.vibe/config.toml`.
+Local installs write workspace files instead of user-level agent config. Supported local targets are Claude Code, Codex, Gemini, Kiro, OpenCode, GitHub Copilot / VS Code, Cursor, Zed, Roo Code, Kimi, Kilo, and Mistral Vibe. Examples include `.mcp.json`, `.claude/settings.json`, `.cursor/mcp.json`, `.codex/config.toml`, `.vscode/mcp.json`, `.kiro/settings/mcp.json`, `opencode.json`, `.roo/mcp.json`, `.kimi-code/mcp.json`, `kilo.json`, and `.vibe/config.toml`.
 
-The generated MCP entries use the resolved absolute path to the current `tokensave` executable. A local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook prompt. Antigravity does not currently have a documented project-local config path, so `tokensave install --local --agent antigravity` is rejected with an unsupported-agent error.
+The generated MCP entries use the resolved absolute path to the current `tokensave` executable. A local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook prompt. Antigravity and Cline do not currently have documented project-local config paths, so `tokensave install --local --agent antigravity` and `tokensave install --local --agent cline` are rejected with unsupported-agent errors.
 
 #### Config backups
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -213,6 +213,20 @@ If you already have a different custom default agent or a user-managed
 
 The install is idempotent — safe to run again after upgrading tokensave. You'll also be offered the option to set up a global git post-commit hook (more on that below).
 
+### Project-local installs
+
+If you want an integration to apply only to the current repository, run install from the project root with `--local`:
+
+```bash
+tokensave install --local --agent claude
+tokensave install --local --agent cursor
+tokensave install --local --agent copilot
+```
+
+Local installs write workspace files instead of user-level agent config. Supported local targets are Claude Code, Codex, Gemini, Kiro, OpenCode, GitHub Copilot / VS Code, Cursor, Zed, Cline, Roo Code, Kimi, Kilo, and Mistral Vibe. Examples include `.mcp.json`, `.claude/settings.json`, `.cursor/mcp.json`, `.codex/config.toml`, `.vscode/mcp.json`, `.kiro/settings/mcp.json`, `opencode.json`, `.roo/mcp.json`, `.kimi-code/mcp.json`, `.kilocode/mcp.json`, and `.vibe/config.toml`.
+
+The generated MCP entries use the resolved absolute path to the current `tokensave` executable. A local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook prompt. Antigravity does not currently have a documented project-local config path, so `tokensave install --local --agent antigravity` is rejected with an unsupported-agent error.
+
 #### Config backups
 
 Whenever tokensave rewrites an agent config file — on `install`, on `uninstall`, or when the `doctor` auto-repairs hooks — it first copies the original to a sibling `.bak` file in the same directory. For example:

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -55,6 +55,26 @@ impl AgentIntegration for ClaudeIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        let claude_dir = project_path.join(".claude");
+        let settings_path = claude_dir.join("settings.json");
+        let claude_md_path = claude_dir.join("CLAUDE.md");
+
+        install_mcp_server(&project_path.join(".mcp.json"), &ctx.tokensave_bin)?;
+
+        std::fs::create_dir_all(&claude_dir).ok();
+        let mut settings = load_json_file_strict(&settings_path)?;
+        install_hook(&mut settings, &ctx.tokensave_bin);
+        install_permissions(&mut settings, &ctx.tool_permissions);
+        write_json_file(&settings_path, &settings)?;
+
+        install_claude_md_rules(&claude_md_path)
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let claude_dir = ctx.home.join(".claude");
         let settings_path = claude_dir.join("settings.json");

--- a/src/agents/cline.rs
+++ b/src/agents/cline.rs
@@ -33,38 +33,24 @@ impl AgentIntegration for ClineIntegration {
 
     fn install(&self, ctx: &InstallContext) -> Result<()> {
         let settings_path = cline_ext_dir(&ctx.home).join("settings/cline_mcp_settings.json");
-
-        if let Some(parent) = settings_path.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
-
-        let backup = backup_config_file(&settings_path)?;
-        let mut settings = match load_json_file_strict(&settings_path) {
-            Ok(v) => v,
-            Err(e) => {
-                if let Some(ref b) = backup {
-                    eprintln!("  Backup preserved at: {}", b.display());
-                }
-                return Err(e);
-            }
-        };
-        settings["mcpServers"]["tokensave"] = json!({
-            "command": ctx.tokensave_bin,
-            "args": ["serve"],
-            "disabled": false
-        });
-
-        safe_write_json_file(&settings_path, &settings, backup.as_deref())?;
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
-            settings_path.display()
-        );
+        install_mcp_server(&settings_path, &ctx.tokensave_bin)?;
 
         eprintln!();
         eprintln!("Setup complete. Next steps:");
         eprintln!("  1. cd into your project and run: tokensave init");
         eprintln!("  2. Restart VS Code — tokensave tools are now available in Cline");
         Ok(())
+    }
+
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_mcp_server(
+            &project_path.join(".cline_mcp_servers.json"),
+            &ctx.tokensave_bin,
+        )
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
@@ -105,6 +91,35 @@ impl AgentIntegration for ClineIntegration {
 // ---------------------------------------------------------------------------
 // Uninstall helpers
 // ---------------------------------------------------------------------------
+
+fn install_mcp_server(settings_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(settings_path)?;
+    let mut settings = match load_json_file_strict(settings_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+    settings["mcpServers"]["tokensave"] = json!({
+        "command": tokensave_bin,
+        "args": ["serve"],
+        "disabled": false
+    });
+
+    safe_write_json_file(settings_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        settings_path.display()
+    );
+    Ok(())
+}
 
 /// Remove MCP server entry from Cline's `cline_mcp_settings.json`.
 fn uninstall_mcp_server(settings_path: &Path) {

--- a/src/agents/cline.rs
+++ b/src/agents/cline.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::json;
 
-use crate::errors::Result;
+use crate::errors::{Result, TokenSaveError};
 
 use super::{
     backup_and_write_json, backup_config_file, load_json_file, load_json_file_strict,
@@ -43,14 +43,16 @@ impl AgentIntegration for ClineIntegration {
     }
 
     fn supports_local_install(&self) -> bool {
-        true
+        false
     }
 
-    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
-        install_mcp_server(
-            &project_path.join(".cline_mcp_servers.json"),
-            &ctx.tokensave_bin,
-        )
+    fn install_local(&self, _ctx: &InstallContext, _project_path: &Path) -> Result<()> {
+        Err(TokenSaveError::Config {
+            message: "Cline does not currently document or ship a project-local MCP config path. \
+                      `tokensave install --local --agent cline` is unsupported. \
+                      Run `tokensave install --agent cline` for a global install."
+                .to_string(),
+        })
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -44,6 +44,17 @@ impl AgentIntegration for CodexIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        let codex_dir = project_path.join(".codex");
+        std::fs::create_dir_all(&codex_dir).ok();
+        install_mcp_server(&codex_dir.join("config.toml"), &ctx.tokensave_bin)?;
+        install_prompt_rules(&project_path.join("AGENTS.md"))
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let codex_dir = ctx.home.join(".codex");
         let config_path = codex_dir.join("config.toml");

--- a/src/agents/copilot.rs
+++ b/src/agents/copilot.rs
@@ -66,6 +66,15 @@ impl AgentIntegration for CopilotIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_workspace_mcp_server(&project_path.join(".vscode/mcp.json"), &ctx.tokensave_bin)?;
+        install_prompt_rules(&project_path.join(".github/copilot-instructions.md"))
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let vscode_settings_path = super::vscode_data_dir(&ctx.home).join("User/settings.json");
         let cli_settings_path = super::copilot_cli_dir(&ctx.home).join("mcp-config.json");
@@ -199,6 +208,36 @@ fn install_cli_mcp_server(settings_path: &Path, tokensave_bin: &str) -> Result<(
         }
     };
     settings["mcpServers"]["tokensave"] = json!({
+        "type": "stdio",
+        "command": tokensave_bin,
+        "args": ["serve"]
+    });
+
+    safe_write_json_file(settings_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        settings_path.display()
+    );
+    Ok(())
+}
+
+/// Register MCP server in a project `.vscode/mcp.json` file.
+fn install_workspace_mcp_server(settings_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(settings_path)?;
+    let mut settings = match load_jsonc_file_strict(settings_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+    settings["servers"]["tokensave"] = json!({
         "type": "stdio",
         "command": tokensave_bin,
         "args": ["serve"]

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -27,38 +27,21 @@ impl AgentIntegration for CursorIntegration {
     }
 
     fn install(&self, ctx: &InstallContext) -> Result<()> {
-        let mcp_path = ctx.home.join(".cursor/mcp.json");
-
-        if let Some(parent) = mcp_path.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
-
-        let backup = backup_config_file(&mcp_path)?;
-        let mut settings = match load_json_file_strict(&mcp_path) {
-            Ok(v) => v,
-            Err(e) => {
-                if let Some(ref b) = backup {
-                    eprintln!("  Backup preserved at: {}", b.display());
-                }
-                return Err(e);
-            }
-        };
-        settings["mcpServers"]["tokensave"] = json!({
-            "command": ctx.tokensave_bin,
-            "args": ["serve"]
-        });
-
-        safe_write_json_file(&mcp_path, &settings, backup.as_deref())?;
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
-            mcp_path.display()
-        );
+        install_mcp_server(&ctx.home.join(".cursor/mcp.json"), &ctx.tokensave_bin)?;
 
         eprintln!();
         eprintln!("Setup complete. Next steps:");
         eprintln!("  1. cd into your project and run: tokensave init");
         eprintln!("  2. Restart Cursor — tokensave tools are now available");
         Ok(())
+    }
+
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_mcp_server(&project_path.join(".cursor/mcp.json"), &ctx.tokensave_bin)
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
@@ -99,6 +82,34 @@ impl AgentIntegration for CursorIntegration {
 // ---------------------------------------------------------------------------
 // Uninstall helpers
 // ---------------------------------------------------------------------------
+
+fn install_mcp_server(mcp_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = mcp_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(mcp_path)?;
+    let mut settings = match load_json_file_strict(mcp_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+    settings["mcpServers"]["tokensave"] = json!({
+        "command": tokensave_bin,
+        "args": ["serve"]
+    });
+
+    safe_write_json_file(mcp_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        mcp_path.display()
+    );
+    Ok(())
+}
 
 /// Remove MCP server entry from ~/.cursor/mcp.json.
 fn uninstall_mcp_server(mcp_path: &Path) {

--- a/src/agents/gemini.rs
+++ b/src/agents/gemini.rs
@@ -46,6 +46,17 @@ impl AgentIntegration for GeminiIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        let gemini_dir = project_path.join(".gemini");
+        std::fs::create_dir_all(&gemini_dir).ok();
+        install_mcp_server(&gemini_dir.join("settings.json"), &ctx.tokensave_bin)?;
+        install_prompt_rules(&project_path.join("GEMINI.md"))
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let gemini_dir = ctx.home.join(".gemini");
         let settings_path = gemini_dir.join("settings.json");

--- a/src/agents/kilo.rs
+++ b/src/agents/kilo.rs
@@ -1,9 +1,8 @@
 //! Kilo CLI agent integration.
 //!
-//! Handles registration of the tokensave MCP server in Kilo CLI's config
-//! file (`~/.config/kilo/kilo.jsonc`). Kilo uses the `mcp` key (not
-//! `mcpServers`) with entries having `type`, `command` (as array), and
-//! `enabled` fields.
+//! Handles registration of the tokensave MCP server in Kilo CLI config files.
+//! Kilo uses the `mcp` key (not `mcpServers`) with entries having `type`,
+//! `command` (as array), and `enabled` fields.
 
 use std::path::Path;
 
@@ -54,7 +53,7 @@ impl AgentIntegration for KiloIntegration {
     }
 
     fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
-        install_mcp_server(&project_path.join(".kilocode/mcp.json"), &ctx.tokensave_bin)
+        install_mcp_server(&project_path.join("kilo.json"), &ctx.tokensave_bin)
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {

--- a/src/agents/kilo.rs
+++ b/src/agents/kilo.rs
@@ -40,35 +40,21 @@ impl AgentIntegration for KiloIntegration {
         let config_dir = kilo_config_dir(&ctx.home);
         std::fs::create_dir_all(&config_dir).ok();
         let config_path = kilo_config_path(&ctx.home);
-
-        let backup = backup_config_file(&config_path)?;
-        let mut settings = match load_jsonc_file_strict(&config_path) {
-            Ok(v) => v,
-            Err(e) => {
-                if let Some(ref b) = backup {
-                    eprintln!("  Backup preserved at: {}", b.display());
-                }
-                return Err(e);
-            }
-        };
-
-        settings["mcp"]["tokensave"] = json!({
-            "type": "local",
-            "command": [ctx.tokensave_bin, "serve"],
-            "enabled": true
-        });
-
-        safe_write_json_file(&config_path, &settings, backup.as_deref())?;
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
-            config_path.display()
-        );
+        install_mcp_server(&config_path, &ctx.tokensave_bin)?;
 
         eprintln!();
         eprintln!("Setup complete. Next steps:");
         eprintln!("  1. cd into your project and run: tokensave init");
         eprintln!("  2. Start a new Kilo CLI session — tokensave tools are now available");
         Ok(())
+    }
+
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_mcp_server(&project_path.join(".kilocode/mcp.json"), &ctx.tokensave_bin)
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
@@ -107,6 +93,36 @@ impl AgentIntegration for KiloIntegration {
 // ---------------------------------------------------------------------------
 // Uninstall helpers
 // ---------------------------------------------------------------------------
+
+fn install_mcp_server(config_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(config_path)?;
+    let mut settings = match load_jsonc_file_strict(config_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+
+    settings["mcp"]["tokensave"] = json!({
+        "type": "local",
+        "command": [tokensave_bin, "serve"],
+        "enabled": true
+    });
+
+    safe_write_json_file(config_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        config_path.display()
+    );
+    Ok(())
+}
 
 fn uninstall_mcp_server(config_path: &Path) {
     if !config_path.exists() {

--- a/src/agents/kimi.rs
+++ b/src/agents/kimi.rs
@@ -48,6 +48,17 @@ impl AgentIntegration for KimiIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        let kimi_dir = project_path.join(".kimi-code");
+        std::fs::create_dir_all(&kimi_dir).ok();
+        install_mcp_server(&kimi_dir.join("mcp.json"), &ctx.tokensave_bin)?;
+        install_prompt_rules(&project_path.join("AGENTS.md"))
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let kimi_dir = ctx.home.join(".kimi");
         let mcp_path = kimi_dir.join("mcp.json");

--- a/src/agents/kiro.rs
+++ b/src/agents/kiro.rs
@@ -106,6 +106,23 @@ impl AgentIntegration for KiroIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        let mcp_path = workspace_mcp_config_path(project_path);
+        install_mcp_server(&mcp_path, &ctx.tokensave_bin)?;
+
+        let steering = project_path.join(".kiro/steering/tokensave.md");
+        install_steering_rules(&steering)?;
+
+        let agent_path = project_path.join(".kiro/agents/tokensave.json");
+        install_managed_agent(&agent_path, &ctx.tokensave_bin, &steering)?;
+
+        Ok(())
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         uninstall_mcp_server(&mcp_config_path(&ctx.home));
         remove_steering_rules(&steering_path(&ctx.home));

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -57,6 +57,24 @@ pub trait AgentIntegration {
     /// Register MCP server, permissions, hooks, and prompt rules.
     fn install(&self, ctx: &InstallContext) -> Result<()>;
 
+    /// Returns true when this agent supports project-local configuration.
+    fn supports_local_install(&self) -> bool {
+        false
+    }
+
+    /// Register MCP server, permissions, hooks, and prompt rules under a
+    /// project/workspace directory instead of the user's global config.
+    fn install_local(&self, _ctx: &InstallContext, _project_path: &Path) -> Result<()> {
+        Err(TokenSaveError::Config {
+            message: format!(
+                "{} does not support `tokensave install --local` yet. \
+                 Run `tokensave install --agent {}` for a global install.",
+                self.name(),
+                self.id()
+            ),
+        })
+    }
+
     /// Remove everything installed by [`AgentIntegration::install`].
     fn uninstall(&self, ctx: &InstallContext) -> Result<()>;
 

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -45,6 +45,15 @@ impl AgentIntegration for OpenCodeIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_mcp_server(&project_path.join("opencode.json"), &ctx.tokensave_bin)?;
+        install_prompt_rules(&project_path.join("AGENTS.md"))
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let config_path = opencode_config_path(&ctx.home);
         uninstall_mcp_server(&config_path);

--- a/src/agents/roo_code.rs
+++ b/src/agents/roo_code.rs
@@ -33,38 +33,21 @@ impl AgentIntegration for RooCodeIntegration {
 
     fn install(&self, ctx: &InstallContext) -> Result<()> {
         let settings_path = roo_ext_dir(&ctx.home).join("settings/cline_mcp_settings.json");
-
-        if let Some(parent) = settings_path.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
-
-        let backup = backup_config_file(&settings_path)?;
-        let mut settings = match load_json_file_strict(&settings_path) {
-            Ok(v) => v,
-            Err(e) => {
-                if let Some(ref b) = backup {
-                    eprintln!("  Backup preserved at: {}", b.display());
-                }
-                return Err(e);
-            }
-        };
-        settings["mcpServers"]["tokensave"] = json!({
-            "command": ctx.tokensave_bin,
-            "args": ["serve"],
-            "disabled": false
-        });
-
-        safe_write_json_file(&settings_path, &settings, backup.as_deref())?;
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
-            settings_path.display()
-        );
+        install_mcp_server(&settings_path, &ctx.tokensave_bin)?;
 
         eprintln!();
         eprintln!("Setup complete. Next steps:");
         eprintln!("  1. cd into your project and run: tokensave init");
         eprintln!("  2. Restart VS Code — tokensave tools are now available in Roo Code");
         Ok(())
+    }
+
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_mcp_server(&project_path.join(".roo/mcp.json"), &ctx.tokensave_bin)
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
@@ -105,6 +88,35 @@ impl AgentIntegration for RooCodeIntegration {
 // ---------------------------------------------------------------------------
 // Uninstall helpers
 // ---------------------------------------------------------------------------
+
+fn install_mcp_server(settings_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(settings_path)?;
+    let mut settings = match load_json_file_strict(settings_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+    settings["mcpServers"]["tokensave"] = json!({
+        "command": tokensave_bin,
+        "args": ["serve"],
+        "disabled": false
+    });
+
+    safe_write_json_file(settings_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave MCP server to {}",
+        settings_path.display()
+    );
+    Ok(())
+}
 
 /// Remove MCP server entry from Roo Code's `cline_mcp_settings.json`.
 fn uninstall_mcp_server(settings_path: &Path) {

--- a/src/agents/vibe.rs
+++ b/src/agents/vibe.rs
@@ -66,6 +66,19 @@ impl AgentIntegration for VibeIntegration {
         Ok(())
     }
 
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        let vibe_dir = project_path.join(".vibe");
+        std::fs::create_dir_all(&vibe_dir).ok();
+        std::fs::create_dir_all(vibe_dir.join("prompts")).ok();
+
+        install_mcp_server(&vibe_dir.join("config.toml"), &ctx.tokensave_bin)?;
+        install_prompt_rules(&vibe_dir.join("prompts/cli.md"))
+    }
+
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         let config_path = vibe_config_path(&ctx.home);
         uninstall_mcp_server(&config_path);

--- a/src/agents/zed.rs
+++ b/src/agents/zed.rs
@@ -41,39 +41,21 @@ impl AgentIntegration for ZedIntegration {
     fn install(&self, ctx: &InstallContext) -> Result<()> {
         let config_dir = zed_config_dir(&ctx.home);
         let settings_path = config_dir.join("settings.json");
-
-        if let Some(parent) = settings_path.parent() {
-            std::fs::create_dir_all(parent).ok();
-        }
-
-        let backup = backup_config_file(&settings_path)?;
-        let mut settings = match load_jsonc_file_strict(&settings_path) {
-            Ok(v) => v,
-            Err(e) => {
-                if let Some(ref b) = backup {
-                    eprintln!("  Backup preserved at: {}", b.display());
-                }
-                return Err(e);
-            }
-        };
-        settings["context_servers"]["tokensave"] = json!({
-            "command": {
-                "path": ctx.tokensave_bin,
-                "args": ["serve"]
-            }
-        });
-
-        safe_write_json_file(&settings_path, &settings, backup.as_deref())?;
-        eprintln!(
-            "\x1b[32m✔\x1b[0m Added tokensave context server to {}",
-            settings_path.display()
-        );
+        install_context_server(&settings_path, &ctx.tokensave_bin)?;
 
         eprintln!();
         eprintln!("Setup complete. Next steps:");
         eprintln!("  1. cd into your project and run: tokensave init");
         eprintln!("  2. Restart Zed — tokensave tools are now available");
         Ok(())
+    }
+
+    fn supports_local_install(&self) -> bool {
+        true
+    }
+
+    fn install_local(&self, ctx: &InstallContext, project_path: &Path) -> Result<()> {
+        install_context_server(&project_path.join(".zed/settings.json"), &ctx.tokensave_bin)
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
@@ -114,6 +96,36 @@ impl AgentIntegration for ZedIntegration {
 // ---------------------------------------------------------------------------
 // Uninstall helpers
 // ---------------------------------------------------------------------------
+
+fn install_context_server(settings_path: &Path, tokensave_bin: &str) -> Result<()> {
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+
+    let backup = backup_config_file(settings_path)?;
+    let mut settings = match load_jsonc_file_strict(settings_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+    settings["context_servers"]["tokensave"] = json!({
+        "command": {
+            "path": tokensave_bin,
+            "args": ["serve"]
+        }
+    });
+
+    safe_write_json_file(settings_path, &settings, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added tokensave context server to {}",
+        settings_path.display()
+    );
+    Ok(())
+}
 
 /// Remove context server entry from Zed settings.json.
 /// Does not delete settings.json even if object is otherwise empty.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,6 +85,9 @@ pub enum Commands {
         /// Agent to configure (auto-detects if omitted)
         #[arg(long, value_parser = agent_value_parser())]
         agent: Option<String>,
+        /// Write project-local configuration in the current directory
+        #[arg(long)]
+        local: bool,
     },
     /// Refresh settings for all already-installed agents
     Reinstall,

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,9 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
     if !skip_agent_install_maintenance {
         global::try_flush(&mut user_config, is_force_flush);
     }
-    user_config.save();
+    if !is_local_install_command(&command) {
+        user_config.save();
+    }
 
     if is_first_run && !skip_agent_install_maintenance {
         eprintln!(
@@ -538,7 +540,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
         Commands::Tool { name, args } => {
             tool_command::run(name, args).await?;
         }
-        Commands::Install { agent } => {
+        Commands::Install { agent, local } => {
             let home = tokensave::agents::home_dir().ok_or_else(|| {
                 tokensave::errors::TokenSaveError::Config {
                     message: "could not determine home directory".to_string(),
@@ -552,6 +554,51 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                         .to_string(),
                 }
             })?;
+            if local {
+                let project_path = std::env::current_dir().map_err(|e| {
+                    tokensave::errors::TokenSaveError::Config {
+                        message: format!("could not determine current project directory: {e}"),
+                    }
+                })?;
+                let ctx = tokensave::agents::InstallContext {
+                    home: home.clone(),
+                    tokensave_bin: tokensave_bin.clone(),
+                    tool_permissions: tokensave::agents::expected_tool_perms(),
+                };
+                let mut installed_names: Vec<String> = Vec::new();
+
+                if let Some(id) = agent {
+                    let ag = tokensave::agents::get_integration(&id)?;
+                    ag.install_local(&ctx, &project_path)?;
+                    installed_names.push(ag.name().to_string());
+                } else {
+                    let (to_install, _) =
+                        tokensave::agents::pick_integrations_interactive(&home, &[])?;
+                    for id in &to_install {
+                        let ag = tokensave::agents::get_integration(id)?;
+                        if ag.supports_local_install() {
+                            ag.install_local(&ctx, &project_path)?;
+                            installed_names.push(ag.name().to_string());
+                        } else {
+                            eprintln!(
+                                "Skipping {}: project-local install is not supported",
+                                ag.name()
+                            );
+                        }
+                    }
+                }
+
+                eprintln!();
+                if installed_names.is_empty() {
+                    eprintln!("No local changes.");
+                } else {
+                    for name in &installed_names {
+                        eprintln!("\x1b[32m+\x1b[0m {name} (local)");
+                    }
+                }
+                return Ok(());
+            }
+
             let mut user_cfg = tokensave::user_config::UserConfig::load();
             tokensave::agents::migrate_installed_agents(&home, &mut user_cfg);
 
@@ -1087,6 +1134,10 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
     )
 }
 
+fn is_local_install_command(command: &Commands) -> bool {
+    matches!(command, Commands::Install { local: true, .. })
+}
+
 #[cfg(test)]
 mod startup_tests {
     use super::{should_skip_agent_install_maintenance, Commands};
@@ -1103,6 +1154,7 @@ mod startup_tests {
     fn explicit_agent_config_commands_skip_agent_install_maintenance() {
         assert!(should_skip_agent_install_maintenance(&Commands::Install {
             agent: Some("kiro".to_string()),
+            local: false,
         }));
         assert!(should_skip_agent_install_maintenance(&Commands::Reinstall));
         assert!(should_skip_agent_install_maintenance(

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::process::Command;
 
 use tempfile::TempDir;
 use tokensave::agents::*;
@@ -110,6 +111,164 @@ fn make_install_ctx(home: &Path) -> InstallContext {
         tokensave_bin: "/usr/local/bin/tokensave".to_string(),
         tool_permissions: expected_tool_perms(),
     }
+}
+
+fn run_local_install(agent: &str, project: &Path, home: &Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_tokensave"))
+        .arg("install")
+        .arg("--local")
+        .arg("--agent")
+        .arg(agent)
+        .current_dir(project)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("KIRO_HOME", home.join(".kiro"))
+        .env("VIBE_HOME", home.join(".vibe"))
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run local install for {agent}: {e}"))
+}
+
+fn assert_local_install_success(agent: &str, project: &Path, home: &Path) {
+    let output = run_local_install(agent, project, home);
+    assert!(
+        output.status.success(),
+        "local install for {agent} should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_str(
+        &std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read JSON {}: {e}", path.display())),
+    )
+    .unwrap_or_else(|e| panic!("failed to parse JSON {}: {e}", path.display()))
+}
+
+fn assert_command_is_tokensave(json: &serde_json::Value, command_path: &[&str]) {
+    let mut node = json;
+    for key in command_path {
+        node = node
+            .get(*key)
+            .unwrap_or_else(|| panic!("missing key {key} in {json:?}"));
+    }
+    assert_eq!(
+        node.as_str(),
+        Some(env!("CARGO_BIN_EXE_tokensave")),
+        "local MCP config must use the resolved absolute tokensave executable"
+    );
+}
+
+#[test]
+fn test_local_install_cursor_writes_project_config_only() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    assert_local_install_success("cursor", project.path(), home.path());
+
+    let mcp_path = project.path().join(".cursor/mcp.json");
+    assert!(mcp_path.exists(), "Cursor local MCP config should exist");
+    let config = read_json(&mcp_path);
+    assert_command_is_tokensave(&config, &["mcpServers", "tokensave", "command"]);
+    assert_eq!(
+        config["mcpServers"]["tokensave"]["args"],
+        serde_json::json!(["serve"])
+    );
+
+    assert!(
+        !home.path().join(".cursor/mcp.json").exists(),
+        "local install must not write the global Cursor config"
+    );
+    assert!(
+        !home.path().join(".tokensave/config.toml").exists(),
+        "local install must not create or mutate user-level install tracking"
+    );
+}
+
+#[test]
+fn test_local_install_supported_agents_write_project_paths() {
+    let cases = [
+        (
+            "claude",
+            vec![".mcp.json", ".claude/settings.json", ".claude/CLAUDE.md"],
+        ),
+        ("codex", vec![".codex/config.toml", "AGENTS.md"]),
+        ("gemini", vec![".gemini/settings.json", "GEMINI.md"]),
+        (
+            "kiro",
+            vec![
+                ".kiro/settings/mcp.json",
+                ".kiro/steering/tokensave.md",
+                ".kiro/agents/tokensave.json",
+            ],
+        ),
+        ("opencode", vec!["opencode.json", "AGENTS.md"]),
+        ("copilot", vec![".vscode/mcp.json"]),
+        ("zed", vec![".zed/settings.json"]),
+        ("cline", vec![".cline_mcp_servers.json"]),
+        ("roo-code", vec![".roo/mcp.json"]),
+        ("kimi", vec![".kimi-code/mcp.json", "AGENTS.md"]),
+        ("kilo", vec![".kilocode/mcp.json"]),
+        ("vibe", vec![".vibe/config.toml", ".vibe/prompts/cli.md"]),
+    ];
+
+    for (agent, paths) in cases {
+        let home = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+
+        assert_local_install_success(agent, project.path(), home.path());
+
+        for relative in paths {
+            let path = project.path().join(relative);
+            assert!(
+                path.exists(),
+                "{agent} local install should create project path {}",
+                path.display()
+            );
+            let body = std::fs::read_to_string(&path).unwrap();
+            assert!(
+                body.contains("tokensave"),
+                "{agent} local file {} should mention tokensave",
+                path.display()
+            );
+            if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+                assert!(
+                    body.contains(env!("CARGO_BIN_EXE_tokensave")),
+                    "{agent} local config {} should use the resolved absolute tokensave executable",
+                    path.display()
+                );
+            }
+        }
+
+        assert!(
+            !home.path().join(".tokensave/config.toml").exists(),
+            "{agent} local install must not create or mutate user-level install tracking"
+        );
+    }
+}
+
+#[test]
+fn test_local_install_rejects_antigravity_without_project_mutation() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    let output = run_local_install("antigravity", project.path(), home.path());
+
+    assert!(
+        !output.status.success(),
+        "Antigravity local install should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Antigravity") && stderr.contains("--local"),
+        "unsupported-agent error should name Antigravity and --local, got:\n{stderr}"
+    );
+    assert!(
+        !home.path().join(".tokensave/config.toml").exists(),
+        "rejected local install must not mutate user-level install tracking"
+    );
 }
 
 #[test]

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -207,10 +207,9 @@ fn test_local_install_supported_agents_write_project_paths() {
         ("opencode", vec!["opencode.json", "AGENTS.md"]),
         ("copilot", vec![".vscode/mcp.json"]),
         ("zed", vec![".zed/settings.json"]),
-        ("cline", vec![".cline_mcp_servers.json"]),
         ("roo-code", vec![".roo/mcp.json"]),
         ("kimi", vec![".kimi-code/mcp.json", "AGENTS.md"]),
-        ("kilo", vec![".kilocode/mcp.json"]),
+        ("kilo", vec!["kilo.json"]),
         ("vibe", vec![".vibe/config.toml", ".vibe/prompts/cli.md"]),
     ];
 
@@ -264,6 +263,32 @@ fn test_local_install_rejects_antigravity_without_project_mutation() {
     assert!(
         stderr.contains("Antigravity") && stderr.contains("--local"),
         "unsupported-agent error should name Antigravity and --local, got:\n{stderr}"
+    );
+    assert!(
+        !home.path().join(".tokensave/config.toml").exists(),
+        "rejected local install must not mutate user-level install tracking"
+    );
+}
+
+#[test]
+fn test_local_install_rejects_cline_without_project_mutation() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    let output = run_local_install("cline", project.path(), home.path());
+
+    assert!(
+        !output.status.success(),
+        "Cline local install should be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Cline") && stderr.contains("--local"),
+        "unsupported-agent error should name Cline and --local, got:\n{stderr}"
+    );
+    assert!(
+        !project.path().join(".cline_mcp_servers.json").exists(),
+        "unsupported Cline local install must not write undocumented workspace config"
     );
     assert!(
         !home.path().join(".tokensave/config.toml").exists(),

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -147,6 +147,10 @@ fn read_json(path: &Path) -> serde_json::Value {
     .unwrap_or_else(|e| panic!("failed to parse JSON {}: {e}", path.display()))
 }
 
+fn expected_tokensave_bin() -> String {
+    env!("CARGO_BIN_EXE_tokensave").replace('\\', "/")
+}
+
 fn assert_command_is_tokensave(json: &serde_json::Value, command_path: &[&str]) {
     let mut node = json;
     for key in command_path {
@@ -154,9 +158,10 @@ fn assert_command_is_tokensave(json: &serde_json::Value, command_path: &[&str]) 
             .get(*key)
             .unwrap_or_else(|| panic!("missing key {key} in {json:?}"));
     }
+    let expected = expected_tokensave_bin();
     assert_eq!(
         node.as_str(),
-        Some(env!("CARGO_BIN_EXE_tokensave")),
+        Some(expected.as_str()),
         "local MCP config must use the resolved absolute tokensave executable"
     );
 }
@@ -233,8 +238,9 @@ fn test_local_install_supported_agents_write_project_paths() {
                 path.display()
             );
             if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+                let expected = expected_tokensave_bin();
                 assert!(
-                    body.contains(env!("CARGO_BIN_EXE_tokensave")),
+                    body.contains(&expected),
                     "{agent} local config {} should use the resolved absolute tokensave executable",
                     path.display()
                 );


### PR DESCRIPTION
## Summary
- Add `tokensave install --local` plumbing for project-scoped agent setup.
- Wire local config paths across supported integrations without updating user-level install tracking.
- Document project-local install behavior and unsupported Antigravity local setup.

## Test plan
- Covered by branch tests in the original green PR #3 run.
- This split PR is cherry-picked from the previously green feature branch.