### PR TITLE
feat(codex): add lifecycle hook integration

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,228 @@
+[mcp_servers.tokensave]
+args = ["serve"]
+command = "/home/zack/projects/tokensave/target/debug/tokensave"
+
+[mcp_servers.tokensave.tools.tokensave_affected]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_body]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_branch_diff]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_branch_list]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_branch_search]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_by_qualified_name]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_call_chain]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_callees]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_callers]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_callers_for]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_changelog]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_circular]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_commit_context]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_complexity]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_config]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_constructors]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_context]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_coupling]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_dead_code]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_dependency_depth]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_derives]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_diagnose]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_diagnostics]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_diff_context]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_distribution]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_doc_coverage]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_dsm]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_field_sites]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_file_dependents]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_files]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_find_exact_symbol]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_gini]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_god_class]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_health]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_hotspots]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_impact]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_implementations]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_impls]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_inheritance_depth]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_insert_at]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_insert_at_symbol]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_largest]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_module_api]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_multi_str_replace]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_node]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_outline]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_port_order]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_port_status]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_pr_context]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_rank]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_read]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_record_code_area]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_record_decision]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_recursion]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_redundancy]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_rename_preview]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_replace_symbol]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_run_affected_tests]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_runtime]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_search]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_session_end]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_session_recall]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_session_start]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_signature]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_signature_search]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_similar]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_simplify_scan]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_status]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_str_replace]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_test_map]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_test_risk]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_todos]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_type_hierarchy]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_unsafe_patterns]
+approval_mode = "auto"
+
+[mcp_servers.tokensave.tools.tokensave_unused_imports]
+approval_mode = "auto"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,49 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-codex-post-tool-use",
+            "timeout": 60,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|apply_patch"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-codex-session-start",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-codex-subagent-start",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-codex-user-prompt-submit",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ docs/superpowers
 /local-only
 .worktrees
 .agents/
-.codex/
 .rtk/
 .sentrux/
 cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+
+## Prefer tokensave MCP tools
+
+Before reading source files or scanning the codebase, use the tokensave MCP tools (`tokensave_context`, `tokensave_search`, `tokensave_callers`, `tokensave_callees`, `tokensave_impact`, `tokensave_node`, `tokensave_files`, `tokensave_affected`). They provide instant semantic results from a pre-built knowledge graph and are faster than file reads.
+
+If a code analysis question cannot be fully answered by tokensave MCP tools, try querying the SQLite database directly at `.tokensave/tokensave.db` (tables: `nodes`, `edges`, `files`). Use SQL to answer complex structural queries that go beyond what the built-in tools expose.
+
+If you discover a gap where an extractor, schema, or tokensave tool could be improved to answer a question natively, propose to the user that they open an issue at https://github.com/aovestdipaperino/tokensave describing the limitation. **Remind the user to strip any sensitive or proprietary code from the bug description before submitting.**

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ tokensave install --agent vibe            # Mistral Vibe
 tokensave install --agent zed             # Zed
 ```
 
-Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, `tokensave.md` steering loaded as a resource, and a tokensave-managed default agent with permissive built-in/tokensave tool approval, delegation guardrail hooks, and post-write sync; user-managed Kiro agents are preserved. Cursor global install currently registers the MCP server only; the richer Cursor integration is project-local so it can be checked into a repository.
+Each agent gets its MCP server registered in the native config format. Claude Code additionally gets a PreToolUse hook (blocks wasteful Explore agents), a UserPromptSubmit hook, a Stop hook, prompt rules in CLAUDE.md, and auto-allowed tool permissions. Kiro gets global MCP config, `tokensave.md` steering loaded as a resource, and a tokensave-managed default agent with permissive built-in/tokensave tool approval, delegation guardrail hooks, and post-write sync; user-managed Kiro agents are preserved. Codex gets MCP config + auto-approval in `~/.codex/config.toml`, prompt rules in `AGENTS.md`, and a Claude-style lifecycle hook set in `~/.codex/hooks.json` (see below). Cursor global install currently registers the MCP server only; the richer Cursor integration is project-local so it can be checked into a repository.
 
 All changes are idempotent -- safe to run again after upgrading. After agent setup, you'll be offered a global git post-commit hook.
 
@@ -155,6 +155,17 @@ Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json
 - `workspaceOpen` — ensures the current branch's DB exists (branch add if missing) and runs a catch-up incremental sync.
 
 All Cursor hooks are fail-open and only act when a `.tokensave/` index already exists. **Blind spot:** Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual/external-terminal `git checkout` and in-place branch switches are NOT seen by these hooks (`workspaceOpen` does not fire for an in-place checkout). For those, the git post-commit hook and the on-demand MCP staleness check remain the freshness mechanism. We intentionally do not add `beforeReadFile`/`preToolUse` blocking hooks here (too aggressive/noisy); they may become opt-in later.
+
+### Codex lifecycle hooks
+
+Codex now supports a Claude-style lifecycle hook system (verified against Codex 0.136.0 — the old "Codex has no hook system" note was wrong). Both global (`~/.codex/hooks.json`) and project-local (`<root>/.codex/hooks.json`) installs register tokensave hooks, written in Codex's nested `hooks[event] -> { matcher?, hooks: [ { type:"command", command, timeout } ] }` shape and reconciled idempotently (foreign hooks preserved). Each hook reads Codex's stdin JSON event and emits Codex-shaped stdout:
+
+- `SessionStart` — emits `hookSpecificOutput.additionalContext` steering the agent toward tokensave MCP tools and reporting index freshness (suggests `tokensave init` when uninitialized).
+- `UserPromptSubmit` — resets the per-project local counter and injects the same steering context for the new turn.
+- `SubagentStart` — redirects research/explore subagents toward tokensave MCP tools via `additionalContext`. (Per Codex docs, `SubagentStart` cannot hard-stop a subagent — `continue:false` is ignored — so this steers rather than denies.)
+- `PostToolUse` (matcher `Bash|apply_patch`) — for `apply_patch` edits, runs a **targeted single-file** sync of just the patched paths (parsed from the patch envelope); for `Bash` git commands, reuses the shared classifier to route branch switches → `branch add` and other state-changing commands → coalesced incremental sync.
+
+All Codex hooks are fail-open and only act when a `.tokensave/` index exists. **Trust gate:** Codex skips new or changed non-managed command hooks until you trust them — run `/hooks` inside Codex to review and trust the tokensave hooks (the installer prints this reminder; `--dangerously-bypass-hook-trust` exists for one-off non-interactive runs). **Blind spots:** `PostToolUse` only fires for `apply_patch` edits and "simple" Bash — raw-shell file edits, `unified_exec`, and `WebSearch` are not observed; there is no first-class branch-switch event, so branch switches are derived from Bash `git` commands. `PreToolUse` is intentionally not installed: Codex documents it as a partial guardrail (it can't intercept `unified_exec`/`WebSearch`/raw-shell edits), so a redundant-exploration blocker there would be unreliable and noisy.
 
 Local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook. Antigravity is global-only and returns a clear unsupported error for `--local`.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -202,6 +202,14 @@ tokensave install --agent vibe        # Mistral Vibe
 
 Each agent gets an appropriate configuration: MCP server registration, tool permissions (where the agent supports them), and prompt rules in the agent's instruction file. Cursor's global install currently registers the MCP server only; use project-local install for Cursor rules, permissions, and hooks that can live with the repository.
 
+Codex setup registers tokensave in `~/.codex/config.toml` (MCP server + per-tool
+auto-approval), writes prompt rules to `~/.codex/AGENTS.md`, and installs a
+Claude-style lifecycle hook set in `~/.codex/hooks.json` (SessionStart,
+UserPromptSubmit, SubagentStart, and PostToolUse). Codex requires you to **trust**
+new or changed command hooks before they run — run `/hooks` inside Codex to review
+and trust the tokensave hooks. See "Codex lifecycle hooks" below for what each one
+does and the known blind spots.
+
 Kiro setup registers tokensave in `~/.kiro/settings/mcp.json`, writes steering to
 `~/.kiro/steering/tokensave.md`, and writes a tokensave-managed agent that loads
 that steering as a resource while keeping Kiro's default prompt. The managed
@@ -239,6 +247,21 @@ Cursor local install creates a stronger project-local setup:
   - `workspaceOpen` ensures the current branch's DB exists (branch add if missing) and runs a catch-up incremental sync.
 
   Blind spot: Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual or external-terminal `git checkout` and in-place branch switches are not visible to these hooks (`workspaceOpen` does not fire for an in-place checkout). Use the git post-commit hook and the on-demand MCP staleness check to keep the index fresh for those cases. `beforeReadFile`/`preToolUse` blocking hooks are intentionally omitted for now to avoid noise; they may become opt-in later.
+
+Codex local install writes `<root>/.codex/config.toml` (MCP), `<root>/AGENTS.md` (prompt rules), and `<root>/.codex/hooks.json` (lifecycle hooks, using the resolved absolute `tokensave` path). The hooks are identical to the global Codex install described under "Codex lifecycle hooks" below.
+
+#### Codex lifecycle hooks
+
+Codex supports a Claude-style lifecycle hook system (enabled by default; verified against Codex 0.136.0). Both global (`~/.codex/hooks.json`) and project-local (`<root>/.codex/hooks.json`) installs register tokensave hooks using Codex's nested config shape — `hooks[event] -> [ { matcher?, hooks: [ { type: "command", command, timeout } ] } ]` — and reconcile them idempotently while preserving any foreign hooks. Each hook reads Codex's single stdin JSON event (`session_id`, `cwd`, `hook_event_name`, plus event-specific fields) and writes Codex-shaped stdout. The project root is resolved from the event `cwd`, and every hook is fail-open and only acts when a `.tokensave/` index exists.
+
+- `SessionStart` — emits `hookSpecificOutput.additionalContext` steering the agent toward tokensave MCP tools and reporting index freshness (suggests `tokensave init` when uninitialized).
+- `UserPromptSubmit` — resets the per-project local token counter for the new turn and injects the same steering context.
+- `SubagentStart` — redirects research/explore subagents toward tokensave MCP tools via `additionalContext`. Codex's `SubagentStart` cannot hard-stop a subagent (`continue: false` is ignored for this event), so this steers rather than denies.
+- `PostToolUse` (matcher `Bash|apply_patch`) — for `apply_patch` edits, runs a targeted single-file sync of just the patched files (parsed from the patch envelope); for `Bash` git commands, branch switches bootstrap/maintain branch tracking (`branch add`) and other state-changing git commands run a coalesced incremental sync.
+
+**Trust gate:** Codex records trust against each hook's hash and skips new or changed non-managed command hooks until trusted. After install, run `/hooks` inside Codex to review and trust the tokensave hooks (the installer prints this reminder). For one-off non-interactive runs you can pass `--dangerously-bypass-hook-trust`, but trusting via `/hooks` is recommended. `tokensave doctor --agent codex` reports whether the hooks are registered and repeats the trust reminder.
+
+**Blind spots:** `PostToolUse` only fires for `apply_patch` edits and "simple" Bash commands — file edits made through raw shell, the newer `unified_exec` mechanism, and `WebSearch` are not observed. There is no first-class branch-switch event, so branch switches are derived from Bash `git` commands. `PreToolUse` is intentionally not installed: Codex documents it as a partial guardrail (it can't intercept `unified_exec`/`WebSearch`/raw-shell edits), so installing a redundant-exploration blocker there would be unreliable.
 
 The generated MCP entries use the resolved absolute path to the current `tokensave` executable. A local install does not update `~/.tokensave/config.toml`, installed-agent tracking, the last installed version, or the global git post-commit hook prompt. Antigravity does not currently have a documented project-local config path, so `tokensave install --local --agent antigravity` is rejected with an unsupported-agent error.
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -2,17 +2,25 @@
 //! `OpenAI` Codex CLI agent integration.
 //!
 //! Handles registration of the tokensave MCP server in Codex's config
-//! file (`~/.codex/config.toml`), per-tool auto-approval settings,
-//! and prompt rules via `AGENTS.md`. Codex has no hook system.
+//! file (`~/.codex/config.toml`), per-tool auto-approval settings, prompt
+//! rules via `AGENTS.md`, and lifecycle hooks via `hooks.json`.
+//!
+//! Codex supports a Claude-style lifecycle hook system (`SessionStart`,
+//! `UserPromptSubmit`, `SubagentStart`, `PostToolUse`, …). Hooks are enabled by
+//! default, but non-managed command hooks must be reviewed and trusted with the
+//! `/hooks` CLI before they run — newly installed or changed hooks are skipped
+//! until trusted. The installer prints that guidance after writing `hooks.json`.
 
 use std::io::Write;
 use std::path::Path;
 
+use serde_json::json;
+
 use crate::errors::{Result, TokenSaveError};
 
 use super::{
-    load_toml_file, tool_names, write_toml_file, AgentIntegration, DoctorCounters,
-    HealthcheckContext, InstallContext,
+    backup_config_file, load_json_file_strict, load_toml_file, safe_write_json_file, tool_names,
+    write_toml_file, AgentIntegration, DoctorCounters, HealthcheckContext, InstallContext,
 };
 
 /// `OpenAI` Codex CLI agent.
@@ -37,10 +45,13 @@ impl AgentIntegration for CodexIntegration {
         let agents_md = codex_dir.join("AGENTS.md");
         install_prompt_rules(&agents_md)?;
 
+        install_hooks(&codex_dir.join("hooks.json"), &ctx.tokensave_bin)?;
+
         eprintln!();
         eprintln!("Setup complete. Next steps:");
         eprintln!("  1. cd into your project and run: tokensave init");
         eprintln!("  2. Start a new Codex session — tokensave tools are now available");
+        print_hook_trust_guidance();
         Ok(())
     }
 
@@ -52,7 +63,10 @@ impl AgentIntegration for CodexIntegration {
         let codex_dir = project_path.join(".codex");
         std::fs::create_dir_all(&codex_dir).ok();
         install_mcp_server(&codex_dir.join("config.toml"), &ctx.tokensave_bin)?;
-        install_prompt_rules(&project_path.join("AGENTS.md"))
+        install_prompt_rules(&project_path.join("AGENTS.md"))?;
+        install_hooks(&codex_dir.join("hooks.json"), &ctx.tokensave_bin)?;
+        print_hook_trust_guidance();
+        Ok(())
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
@@ -63,6 +77,8 @@ impl AgentIntegration for CodexIntegration {
 
         let agents_md = codex_dir.join("AGENTS.md");
         uninstall_prompt_rules(&agents_md);
+
+        uninstall_hooks(&codex_dir.join("hooks.json"));
 
         eprintln!();
         eprintln!("Uninstall complete. Tokensave has been removed from Codex CLI.");
@@ -76,6 +92,7 @@ impl AgentIntegration for CodexIntegration {
         let config_path = codex_dir.join("config.toml");
         doctor_check_config(dc, &config_path);
         doctor_check_prompt(dc, &codex_dir);
+        doctor_check_hooks(dc, &codex_dir.join("hooks.json"));
     }
 
     fn is_detected(&self, home: &Path) -> bool {
@@ -201,9 +218,180 @@ fn install_prompt_rules(agents_md: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Register tokensave lifecycle hooks in a Codex `hooks.json` (idempotent).
+///
+/// Codex organizes hooks as `hooks[event][] -> { matcher?, hooks: [handler] }`
+/// where only `type: "command"` handlers run today and `timeout` is in seconds.
+/// We register the tokensave-owned group for each event, preserving any foreign
+/// groups, so reinstalls reconcile in place. Backs up an existing file first.
+fn install_hooks(hooks_path: &Path, tokensave_bin: &str) -> Result<()> {
+    let backup = backup_config_file(hooks_path)?;
+    let mut hooks = match load_json_file_strict(hooks_path) {
+        Ok(v) => v,
+        Err(e) => {
+            if let Some(ref b) = backup {
+                eprintln!("  Backup preserved at: {}", b.display());
+            }
+            return Err(e);
+        }
+    };
+
+    // Steer the agent toward tokensave MCP tools + report index freshness.
+    install_codex_hook_event(
+        &mut hooks,
+        "SessionStart",
+        tokensave_bin,
+        "hook-codex-session-start",
+        5,
+        None,
+    );
+    install_codex_hook_event(
+        &mut hooks,
+        "UserPromptSubmit",
+        tokensave_bin,
+        "hook-codex-user-prompt-submit",
+        5,
+        None,
+    );
+    install_codex_hook_event(
+        &mut hooks,
+        "SubagentStart",
+        tokensave_bin,
+        "hook-codex-subagent-start",
+        5,
+        None,
+    );
+    // Keep the index fresh: apply_patch → targeted single-file sync; Bash →
+    // branch-aware / incremental sync. Matcher targets both tool names.
+    install_codex_hook_event(
+        &mut hooks,
+        "PostToolUse",
+        tokensave_bin,
+        "hook-codex-post-tool-use",
+        60,
+        Some("Bash|apply_patch"),
+    );
+
+    safe_write_json_file(hooks_path, &hooks, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Added Codex lifecycle hooks to {}",
+        hooks_path.display()
+    );
+    Ok(())
+}
+
+/// Insert (or reconcile) the tokensave-owned matcher group for `event`.
+///
+/// Drops any pre-existing group that already contains our `subcommand` handler
+/// (so refinements to matcher/timeout reach old configs) while preserving every
+/// foreign group. Idempotent: exactly one tokensave group per event.
+fn install_codex_hook_event(
+    hooks: &mut serde_json::Value,
+    event: &str,
+    tokensave_bin: &str,
+    subcommand: &str,
+    timeout: u64,
+    matcher: Option<&str>,
+) {
+    let existing = hooks["hooks"][event]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let mut groups: Vec<serde_json::Value> = existing
+        .into_iter()
+        .filter(|group| !group_has_subcommand(group, subcommand))
+        .collect();
+
+    let handler = json!({
+        "type": "command",
+        "command": format!("{} {subcommand}", shell_quote(tokensave_bin)),
+        "timeout": timeout,
+    });
+    let mut group = json!({ "hooks": [handler] });
+    if let Some(matcher) = matcher {
+        group["matcher"] = json!(matcher);
+    }
+    groups.push(group);
+
+    hooks["hooks"][event] = serde_json::Value::Array(groups);
+}
+
+/// True when any handler command in `group` contains `subcommand`.
+fn group_has_subcommand(group: &serde_json::Value, subcommand: &str) -> bool {
+    group["hooks"].as_array().is_some_and(|handlers| {
+        handlers.iter().any(|h| {
+            h.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|command| command.contains(subcommand))
+        })
+    })
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// Codex requires non-managed command hooks to be trusted via `/hooks` before
+/// they run; newly installed/changed hooks are skipped until trusted.
+fn print_hook_trust_guidance() {
+    eprintln!();
+    eprintln!(
+        "\x1b[1mAction required:\x1b[0m Codex skips new/changed command hooks until you trust them."
+    );
+    eprintln!("  Run \x1b[1m/hooks\x1b[0m inside Codex to review and trust the tokensave hooks.");
+    eprintln!(
+        "  (For one-off non-interactive runs you can pass --dangerously-bypass-hook-trust, \
+         but trusting via /hooks is recommended.)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Uninstall helpers
 // ---------------------------------------------------------------------------
+
+/// Remove tokensave-owned hook groups from a Codex `hooks.json`.
+fn uninstall_hooks(hooks_path: &Path) {
+    const SUBCOMMANDS: [&str; 4] = [
+        "hook-codex-session-start",
+        "hook-codex-user-prompt-submit",
+        "hook-codex-subagent-start",
+        "hook-codex-post-tool-use",
+    ];
+
+    if !hooks_path.exists() {
+        return;
+    }
+    let Ok(mut hooks) = load_json_file_strict(hooks_path) else {
+        return;
+    };
+
+    let Some(events) = hooks.get_mut("hooks").and_then(|h| h.as_object_mut()) else {
+        return;
+    };
+    for groups in events.values_mut() {
+        if let Some(arr) = groups.as_array_mut() {
+            arr.retain(|group| !SUBCOMMANDS.iter().any(|sc| group_has_subcommand(group, sc)));
+        }
+    }
+    events.retain(|_, groups| groups.as_array().is_some_and(|a| !a.is_empty()));
+
+    let is_empty = hooks
+        .get("hooks")
+        .and_then(|h| h.as_object())
+        .is_some_and(serde_json::Map::is_empty);
+    if is_empty {
+        std::fs::remove_file(hooks_path).ok();
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed {} (was empty)",
+            hooks_path.display()
+        );
+    } else if safe_write_json_file(hooks_path, &hooks, None).is_ok() {
+        eprintln!(
+            "\x1b[32m✔\x1b[0m Removed tokensave hooks from {}",
+            hooks_path.display()
+        );
+    }
+}
 
 /// Remove MCP server from ~/.codex/config.toml.
 fn uninstall_mcp_server(config_path: &Path) -> Result<()> {
@@ -365,5 +553,45 @@ fn doctor_check_prompt(dc: &mut DoctorCounters, codex_dir: &Path) {
         }
     } else {
         dc.warn("~/.codex/AGENTS.md does not exist");
+    }
+}
+
+/// Check hooks.json registers the tokensave lifecycle hooks, and remind the
+/// user that Codex requires trusting them via `/hooks` before they run.
+fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path) {
+    if !hooks_path.exists() {
+        dc.warn(&format!(
+            "{} not found — run `tokensave install --agent codex` to add lifecycle hooks",
+            hooks_path.display()
+        ));
+        return;
+    }
+    let hooks = super::load_json_file(hooks_path);
+    let has_session_start = hooks["hooks"]["SessionStart"]
+        .as_array()
+        .is_some_and(|groups| {
+            groups.iter().any(|group| {
+                group["hooks"].as_array().is_some_and(|handlers| {
+                    handlers.iter().any(|h| {
+                        h["command"]
+                            .as_str()
+                            .is_some_and(|c| c.contains("hook-codex-session-start"))
+                    })
+                })
+            })
+        });
+    if has_session_start {
+        dc.pass(&format!(
+            "Lifecycle hooks registered in {}",
+            hooks_path.display()
+        ));
+        dc.info(
+            "Codex skips new/changed command hooks until trusted — run `/hooks` in Codex to trust the tokensave hooks",
+        );
+    } else {
+        dc.warn(&format!(
+            "tokensave hooks NOT registered in {} — run `tokensave install --agent codex`",
+            hooks_path.display()
+        ));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,6 +137,18 @@ pub enum Commands {
     /// Cursor workspaceOpen hook handler (called by Cursor, not by users directly)
     #[command(name = "hook-cursor-workspace-open", hide = true)]
     HookCursorWorkspaceOpen,
+    /// Codex SessionStart hook handler (called by Codex, not by users directly)
+    #[command(name = "hook-codex-session-start", hide = true)]
+    HookCodexSessionStart,
+    /// Codex UserPromptSubmit hook handler (called by Codex, not by users directly)
+    #[command(name = "hook-codex-user-prompt-submit", hide = true)]
+    HookCodexUserPromptSubmit,
+    /// Codex SubagentStart hook handler (called by Codex, not by users directly)
+    #[command(name = "hook-codex-subagent-start", hide = true)]
+    HookCodexSubagentStart,
+    /// Codex PostToolUse hook handler for incremental sync (called by Codex)
+    #[command(name = "hook-codex-post-tool-use", hide = true)]
+    HookCodexPostToolUse,
     /// Start MCP server over stdio
     Serve {
         /// Project path

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,9 +1,10 @@
-//! Hook handlers for Claude Code and Kiro integrations.
+//! Hook handlers for Claude Code, Kiro, Cursor, and Codex integrations.
 //!
-//! These functions are invoked by Claude Code's hook system to intercept
-//! tool calls, redirect exploration work to tokensave MCP tools, and
-//! track per-session token savings. Kiro invokes its own handlers with hook
-//! events on stdin and expects blocking decisions through process exit codes.
+//! These functions are invoked by each agent's hook system to intercept tool
+//! calls, redirect exploration work to tokensave MCP tools, keep the index
+//! fresh after edits / git state changes, and track per-session token savings.
+//! Each agent sends its own event schema on stdin and expects its own output
+//! shape, so the handlers are kept agent-specific rather than shared blindly.
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -148,15 +149,22 @@ pub async fn hook_cursor_after_file_edit() -> i32 {
 pub async fn hook_cursor_session_start() -> i32 {
     let event = read_stdin_to_string();
     let root = cursor_project_root_from_event(&event);
-    let (initialized, staleness) = match &root {
+    let context = session_steering_context_for_root(root.as_deref()).await;
+    println!("{}", cursor_session_start_json(root.as_deref(), &context));
+    0
+}
+
+/// Builds the tokensave steering `additional_context` for a resolved project
+/// root: reports index freshness when initialized, otherwise suggests
+/// `tokensave init`. Shared by the Cursor and Codex session/prompt hooks.
+async fn session_steering_context_for_root(root: Option<&Path>) -> String {
+    let (initialized, staleness) = match root {
         Some(r) if crate::tokensave::TokenSave::is_initialized(r) => {
             (true, cursor_staleness_for_root(r).await)
         }
         _ => (false, None),
     };
-    let context = build_cursor_session_context(initialized, staleness.as_deref());
-    println!("{}", cursor_session_start_json(root.as_deref(), &context));
-    0
+    build_cursor_session_context(initialized, staleness.as_deref())
 }
 
 /// Cursor `afterShellExecution` hook handler.
@@ -547,21 +555,29 @@ async fn sync_after_cursor_shell_event(event_json: &str) {
             let _ = crate::branch::add_branch_tracking(&root, &branch).await;
         }
         CursorShellSyncPlan::IncrementalSync => {
-            let marker = cursor_shell_sync_marker_path(&root);
-            let now = now_unix_secs();
-            if !cursor_should_run_sync(now, read_marker_secs(&marker), 3) {
-                return;
-            }
-            write_marker_secs(&marker, now);
-
-            if let Ok(cg) = crate::tokensave::TokenSave::open(&root).await {
-                match cg.sync().await {
-                    Ok(_) | Err(crate::errors::TokenSaveError::SyncLock { .. }) => {}
-                    Err(e) => eprintln!("tokensave sync failed: {e}"),
-                }
-            }
+            run_coalesced_incremental_sync(&root, ".cursor_shell_sync_at").await;
         }
         CursorShellSyncPlan::Noop => {}
+    }
+}
+
+/// Runs a full incremental `sync()`, coalescing back-to-back invocations via a
+/// short marker-based debounce so a burst of git commands doesn't stack syncs.
+/// `marker_file` names the per-agent marker inside the `.tokensave/` dir. The
+/// sync lock additionally no-ops genuinely concurrent runs. Fail-open.
+async fn run_coalesced_incremental_sync(root: &Path, marker_file: &str) {
+    let marker = crate::config::get_tokensave_dir(root).join(marker_file);
+    let now = now_unix_secs();
+    if !cursor_should_run_sync(now, read_marker_secs(&marker), 3) {
+        return;
+    }
+    write_marker_secs(&marker, now);
+
+    if let Ok(cg) = crate::tokensave::TokenSave::open(root).await {
+        match cg.sync().await {
+            Ok(_) | Err(crate::errors::TokenSaveError::SyncLock { .. }) => {}
+            Err(e) => eprintln!("tokensave sync failed: {e}"),
+        }
     }
 }
 
@@ -591,10 +607,6 @@ async fn workspace_open_for_cursor_event(event_json: &str) {
     let _ = sync_for_cursor_event(event_json).await;
 }
 
-fn cursor_shell_sync_marker_path(root: &Path) -> PathBuf {
-    crate::config::get_tokensave_dir(root).join(".cursor_shell_sync_at")
-}
-
 fn read_marker_secs(path: &Path) -> Option<i64> {
     std::fs::read_to_string(path)
         .ok()?
@@ -612,6 +624,232 @@ fn now_unix_secs() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI hook handlers
+//
+// Codex sends ONE JSON object on stdin (shared fields: session_id,
+// transcript_path, cwd, hook_event_name, model, plus event-specific fields)
+// and reads a Codex-shaped JSON object from stdout. These handlers intentionally
+// emit Codex's documented output schema (`hookSpecificOutput.additionalContext`
+// for steering, `hookSpecificOutput.permissionDecision` for PreToolUse) rather
+// than reusing the Claude / Cursor / Kiro output shapes.
+// ---------------------------------------------------------------------------
+
+/// Codex `SessionStart` hook handler (fire-and-forget).
+///
+/// Emits `hookSpecificOutput.additionalContext` steering the agent toward
+/// tokensave MCP tools and reporting index freshness for the session `cwd`.
+pub async fn hook_codex_session_start() -> i32 {
+    let event = read_stdin_to_string();
+    let root = codex_project_root_from_event(&event);
+    let context = session_steering_context_for_root(root.as_deref()).await;
+    println!(
+        "{}",
+        codex_additional_context_json("SessionStart", &context)
+    );
+    0
+}
+
+/// Codex `UserPromptSubmit` hook handler.
+///
+/// Resets the per-project local counter for the new turn and injects the same
+/// tokensave steering context as `SessionStart`. Never blocks the prompt.
+pub async fn hook_codex_user_prompt_submit() -> i32 {
+    let event = read_stdin_to_string();
+    let root = codex_project_root_from_event(&event);
+    reset_counter_for_codex_event(&event).await;
+    let context = session_steering_context_for_root(root.as_deref()).await;
+    println!(
+        "{}",
+        codex_additional_context_json("UserPromptSubmit", &context)
+    );
+    0
+}
+
+/// Codex `SubagentStart` hook handler.
+///
+/// Steers research/explore subagents toward tokensave MCP tools. Codex cannot
+/// hard-stop a subagent at start (`continue: false` is ignored for this event),
+/// so this injects `additionalContext` instead of denying.
+pub fn hook_codex_subagent_start() -> i32 {
+    let event = read_stdin_to_string();
+    if let Some(output) = evaluate_codex_subagent_start(&event) {
+        println!("{output}");
+    }
+    0
+}
+
+/// Codex `PostToolUse` hook handler used to keep the graph fresh after writes.
+///
+/// For `apply_patch` edits this runs a **targeted** single-file sync using the
+/// paths parsed from the patch envelope (never a full-tree scan). For `Bash`
+/// commands it reuses the shared git-command classifier: branch switches
+/// bootstrap branch tracking, other state-changing commands run a coalesced
+/// incremental sync. Fail-open and silent.
+pub async fn hook_codex_post_tool_use() -> i32 {
+    let event = read_stdin_to_string();
+    codex_post_tool_use(&event).await;
+    0
+}
+
+/// Builds a Codex hook stdout payload that injects model-visible context via
+/// `hookSpecificOutput.additionalContext`. Used by `SessionStart`,
+/// `UserPromptSubmit`, and `SubagentStart`.
+pub fn codex_additional_context_json(event_name: &str, additional_context: &str) -> String {
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": additional_context,
+        }
+    })
+    .to_string()
+}
+
+/// Pure decision logic for Codex `SubagentStart` events.
+///
+/// Returns a Codex `additionalContext` payload steering research/explore
+/// subagents toward tokensave MCP tools, or `None` for execution-style
+/// subagents. Inspects `agent_type` (Codex's documented field) and any
+/// prompt/task/description text.
+pub fn evaluate_codex_subagent_start(event_json: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let agent_type = parsed
+        .get("agent_type")
+        .or_else(|| parsed.get("subagent_type"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let task = parsed
+        .get("prompt")
+        .or_else(|| parsed.get("task"))
+        .or_else(|| parsed.get("description"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let is_explore = agent_type.eq_ignore_ascii_case("explore");
+    if is_explore || is_code_research_prompt(task) {
+        return Some(codex_additional_context_json(
+            "SubagentStart",
+            TOKENSAVE_RESEARCH_BLOCK_REASON,
+        ));
+    }
+    None
+}
+
+/// Resolves the tokensave project root for a Codex event from its `cwd`.
+pub fn codex_project_root_from_event(event_json: &str) -> Option<PathBuf> {
+    let cwd = event_cwd(event_json)?;
+    crate::config::discover_project_root(&cwd)
+}
+
+/// Extracts the project-relative paths touched by a Codex `apply_patch` command.
+///
+/// Codex sends the patch text as `tool_input.command`. The `apply_patch` envelope
+/// names each file with `*** Add File:`, `*** Update File:`, `*** Delete File:`,
+/// or `*** Move to:` lines. Patch paths are relative to the session `cwd`
+/// (which may be a subdirectory of the discovered project root), so we resolve
+/// each against `cwd` and then make it relative to `project_root`. Absolute
+/// paths outside the root are skipped. The result feeds the targeted
+/// [`TokenSave::sync_if_stale_silent`] single-file sync.
+pub fn codex_apply_patch_rel_paths(command: &str, cwd: &Path, project_root: &Path) -> Vec<String> {
+    const PREFIXES: [&str; 4] = [
+        "*** Add File:",
+        "*** Update File:",
+        "*** Delete File:",
+        "*** Move to:",
+    ];
+    let mut rels: Vec<String> = Vec::new();
+    for line in command.lines() {
+        let line = line.trim();
+        for prefix in PREFIXES {
+            if let Some(rest) = line.strip_prefix(prefix) {
+                let raw = rest.trim();
+                if raw.is_empty() {
+                    continue;
+                }
+                let candidate = Path::new(raw);
+                let abs = if candidate.is_absolute() {
+                    candidate.to_path_buf()
+                } else {
+                    cwd.join(candidate)
+                };
+                if let Some(rel) = rel_under_root(project_root, &abs) {
+                    if !rels.contains(&rel) {
+                        rels.push(rel);
+                    }
+                }
+            }
+        }
+    }
+    rels
+}
+
+fn is_codex_edit_tool(tool_name: &str) -> bool {
+    matches!(
+        tool_name.to_ascii_lowercase().as_str(),
+        "apply_patch" | "edit" | "write"
+    )
+}
+
+fn is_codex_bash_tool(tool_name: &str) -> bool {
+    matches!(tool_name.to_ascii_lowercase().as_str(), "bash" | "shell")
+}
+
+async fn codex_post_tool_use(event_json: &str) {
+    let Ok(parsed) = serde_json::from_str::<Value>(event_json) else {
+        return;
+    };
+    let tool_name = parsed
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let command = parsed
+        .get("tool_input")
+        .and_then(|ti| ti.get("command"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let Some(cwd) = event_cwd(event_json) else {
+        return;
+    };
+    let Some(root) = crate::config::discover_project_root(&cwd) else {
+        return;
+    };
+    // Never bootstrap indexing in an unindexed repo.
+    if !crate::tokensave::TokenSave::is_initialized(&root) {
+        return;
+    }
+
+    if is_codex_edit_tool(tool_name) {
+        let rels = codex_apply_patch_rel_paths(command, &cwd, &root);
+        if rels.is_empty() {
+            return;
+        }
+        if let Ok(cg) = crate::tokensave::TokenSave::open(&root).await {
+            let _ = cg.sync_if_stale_silent(&rels).await;
+        }
+    } else if is_codex_bash_tool(tool_name) {
+        match cursor_shell_sync_plan(command) {
+            CursorShellSyncPlan::BranchAdd(branch) => {
+                // Idempotent + fail-open: already-tracked branches no-op.
+                let _ = crate::branch::add_branch_tracking(&root, &branch).await;
+            }
+            CursorShellSyncPlan::IncrementalSync => {
+                run_coalesced_incremental_sync(&root, ".codex_shell_sync_at").await;
+            }
+            CursorShellSyncPlan::Noop => {}
+        }
+    }
+}
+
+async fn reset_counter_for_codex_event(event_json: &str) {
+    let Some(project_root) = codex_project_root_from_event(event_json) else {
+        return;
+    };
+    if let Ok(cg) = crate::tokensave::TokenSave::open(&project_root).await {
+        let _ = cg.reset_local_counter().await;
+    }
 }
 
 /// Pure decision logic for Kiro `preToolUse` hook events.
@@ -771,11 +1009,13 @@ async fn sync_for_cursor_event(event_json: &str) -> crate::errors::Result<()> {
 }
 
 fn kiro_project_root(event_json: &str) -> Option<PathBuf> {
-    let cwd = kiro_event_cwd(event_json).or_else(|| std::env::current_dir().ok())?;
+    let cwd = event_cwd(event_json).or_else(|| std::env::current_dir().ok())?;
     crate::config::discover_project_root(&cwd)
 }
 
-fn kiro_event_cwd(event_json: &str) -> Option<PathBuf> {
+/// Reads the `cwd` string field from a hook event JSON payload. Shared by the
+/// Kiro and Codex handlers, both of which send the session working directory.
+fn event_cwd(event_json: &str) -> Option<PathBuf> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let cwd = parsed.get("cwd").and_then(Value::as_str)?;
     let path = Path::new(cwd);

--- a/src/main.rs
+++ b/src/main.rs
@@ -809,6 +809,30 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 process::exit(code);
             }
         }
+        Commands::HookCodexSessionStart => {
+            let code = tokensave::hooks::hook_codex_session_start().await;
+            if code != 0 {
+                process::exit(code);
+            }
+        }
+        Commands::HookCodexUserPromptSubmit => {
+            let code = tokensave::hooks::hook_codex_user_prompt_submit().await;
+            if code != 0 {
+                process::exit(code);
+            }
+        }
+        Commands::HookCodexSubagentStart => {
+            let code = tokensave::hooks::hook_codex_subagent_start();
+            if code != 0 {
+                process::exit(code);
+            }
+        }
+        Commands::HookCodexPostToolUse => {
+            let code = tokensave::hooks::hook_codex_post_tool_use().await;
+            if code != 0 {
+                process::exit(code);
+            }
+        }
         Commands::Serve { path, timings } => {
             if std::env::var("DISABLE_TOKENSAVE").as_deref() == Ok("true") {
                 // Allow users to opt out per-project by setting
@@ -1165,6 +1189,10 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
             | Commands::HookCursorSessionStart
             | Commands::HookCursorAfterShell
             | Commands::HookCursorWorkspaceOpen
+            | Commands::HookCodexSessionStart
+            | Commands::HookCodexUserPromptSubmit
+            | Commands::HookCodexSubagentStart
+            | Commands::HookCodexPostToolUse
             // `Serve` is the hot path used by MCP clients (Claude Code,
             // Codex, etc.). Clients impose a 30 s `initialize` timeout, so
             // every pre-serve startup task — `try_flush` network round-trip,

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -358,7 +358,10 @@ fn test_local_install_supported_agents_write_project_paths() {
             "claude",
             vec![".mcp.json", ".claude/settings.json", ".claude/CLAUDE.md"],
         ),
-        ("codex", vec![".codex/config.toml", "AGENTS.md"]),
+        (
+            "codex",
+            vec![".codex/config.toml", ".codex/hooks.json", "AGENTS.md"],
+        ),
         ("gemini", vec![".gemini/settings.json", "GEMINI.md"]),
         (
             "kiro",
@@ -571,6 +574,208 @@ fn test_codex_install_creates_config() {
     assert!(agents_md.exists(), "AGENTS.md should exist after install");
     let md_content = std::fs::read_to_string(&agents_md).unwrap();
     assert!(md_content.contains("tokensave"));
+}
+
+/// Returns true if any matcher group registered under `event` has a handler
+/// whose `command` contains `needle`. Mirrors Codex's nested hooks.json shape:
+/// `hooks[event][] -> { matcher?, hooks: [ { type, command, timeout } ] }`.
+fn codex_event_has_handler(hooks: &serde_json::Value, event: &str, needle: &str) -> bool {
+    hooks["hooks"][event].as_array().is_some_and(|groups| {
+        groups.iter().any(|group| {
+            group["hooks"].as_array().is_some_and(|handlers| {
+                handlers.iter().any(|h| {
+                    h["command"]
+                        .as_str()
+                        .is_some_and(|command| command.contains(needle))
+                })
+            })
+        })
+    })
+}
+
+/// Returns the matcher string for the group containing `needle` under `event`.
+fn codex_matcher_for_handler(
+    hooks: &serde_json::Value,
+    event: &str,
+    needle: &str,
+) -> Option<String> {
+    let groups = hooks["hooks"][event].as_array()?;
+    for group in groups {
+        let has = group["hooks"].as_array().is_some_and(|handlers| {
+            handlers.iter().any(|h| {
+                h["command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains(needle))
+            })
+        });
+        if has {
+            return Some(group["matcher"].as_str().unwrap_or_default().to_string());
+        }
+    }
+    None
+}
+
+fn assert_codex_hooks_registered(hooks: &serde_json::Value) {
+    assert!(
+        codex_event_has_handler(hooks, "SessionStart", "hook-codex-session-start"),
+        "Codex SessionStart hook should steer toward tokensave MCP tools: {hooks}"
+    );
+    assert!(
+        codex_event_has_handler(hooks, "UserPromptSubmit", "hook-codex-user-prompt-submit"),
+        "Codex UserPromptSubmit hook should reset the counter and steer the agent: {hooks}"
+    );
+    assert!(
+        codex_event_has_handler(hooks, "SubagentStart", "hook-codex-subagent-start"),
+        "Codex SubagentStart hook should redirect research subagents: {hooks}"
+    );
+    assert!(
+        codex_event_has_handler(hooks, "PostToolUse", "hook-codex-post-tool-use"),
+        "Codex PostToolUse hook should keep the index fresh: {hooks}"
+    );
+    let matcher = codex_matcher_for_handler(hooks, "PostToolUse", "hook-codex-post-tool-use")
+        .expect("PostToolUse handler should exist");
+    assert!(
+        matcher.contains("Bash") && matcher.contains("apply_patch"),
+        "PostToolUse matcher should target Bash and apply_patch, got {matcher:?}"
+    );
+}
+
+#[test]
+fn test_codex_global_install_writes_hooks() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_install_ctx(home);
+    CodexIntegration.install(&ctx).unwrap();
+
+    let hooks_path = home.join(".codex/hooks.json");
+    assert!(
+        hooks_path.exists(),
+        "global Codex install should write ~/.codex/hooks.json"
+    );
+    let hooks = read_json(&hooks_path);
+    assert_codex_hooks_registered(&hooks);
+}
+
+#[test]
+fn test_codex_local_install_writes_hooks() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    assert_local_install_success("codex", project.path(), home.path());
+
+    let hooks_path = project.path().join(".codex/hooks.json");
+    assert!(
+        hooks_path.exists(),
+        "local Codex install should write <project>/.codex/hooks.json"
+    );
+    let hooks = read_json(&hooks_path);
+    assert_codex_hooks_registered(&hooks);
+    // Local install must use the resolved absolute tokensave binary path.
+    assert_command_contains_bin(&hooks, "SessionStart", "hook-codex-session-start");
+
+    assert!(
+        !home.path().join(".codex/hooks.json").exists(),
+        "local install must not write the global Codex hooks config"
+    );
+}
+
+fn assert_command_contains_bin(hooks: &serde_json::Value, event: &str, needle: &str) {
+    let groups = hooks["hooks"][event].as_array().expect("event array");
+    let command = groups
+        .iter()
+        .find_map(|group| {
+            group["hooks"].as_array().and_then(|handlers| {
+                handlers.iter().find_map(|h| {
+                    h["command"]
+                        .as_str()
+                        .filter(|command| command.contains(needle))
+                })
+            })
+        })
+        .expect("handler command should exist");
+    assert!(
+        command.contains(env!("CARGO_BIN_EXE_tokensave")),
+        "Codex hook command must use the resolved absolute tokensave executable, got {command}"
+    );
+}
+
+#[test]
+fn test_codex_install_reconciles_hooks_idempotently() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+
+    // Pre-seed a hooks.json with a stale tokensave PostToolUse group plus a
+    // foreign hook that must be preserved across reinstall.
+    let codex_dir = home.join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        codex_dir.join("hooks.json"),
+        r#"{
+          "hooks": {
+            "PostToolUse": [
+              { "matcher": "Bash", "hooks": [ { "type": "command", "command": "/old/tokensave hook-codex-post-tool-use", "timeout": 60 } ] },
+              { "matcher": "Bash", "hooks": [ { "type": "command", "command": "/usr/bin/foreign-hook", "timeout": 10 } ] }
+            ]
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let ctx = make_install_ctx(home);
+    CodexIntegration.install(&ctx).unwrap();
+    CodexIntegration.install(&ctx).unwrap();
+
+    let hooks = read_json(&codex_dir.join("hooks.json"));
+    let groups = hooks["hooks"]["PostToolUse"].as_array().unwrap();
+
+    let tokensave_groups: Vec<_> = groups
+        .iter()
+        .filter(|group| {
+            group["hooks"].as_array().is_some_and(|handlers| {
+                handlers.iter().any(|h| {
+                    h["command"]
+                        .as_str()
+                        .is_some_and(|c| c.contains("hook-codex-post-tool-use"))
+                })
+            })
+        })
+        .collect();
+    assert_eq!(
+        tokensave_groups.len(),
+        1,
+        "reinstall must keep exactly one tokensave PostToolUse group, got {groups:?}"
+    );
+    assert!(
+        groups.iter().any(|group| {
+            group["hooks"].as_array().is_some_and(|handlers| {
+                handlers
+                    .iter()
+                    .any(|h| h["command"].as_str() == Some("/usr/bin/foreign-hook"))
+            })
+        }),
+        "reinstall must preserve foreign hooks, got {groups:?}"
+    );
+}
+
+#[test]
+fn test_codex_uninstall_removes_hooks() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_install_ctx(home);
+
+    CodexIntegration.install(&ctx).unwrap();
+    let hooks_path = home.join(".codex/hooks.json");
+    assert!(hooks_path.exists());
+
+    CodexIntegration.uninstall(&ctx).unwrap();
+
+    if hooks_path.exists() {
+        let hooks = read_json(&hooks_path);
+        assert!(
+            !codex_event_has_handler(&hooks, "SessionStart", "hook-codex-session-start"),
+            "uninstall should remove tokensave Codex hooks"
+        );
+    }
 }
 
 #[test]

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -724,8 +724,9 @@ fn assert_command_contains_bin(hooks: &serde_json::Value, event: &str, needle: &
             })
         })
         .expect("handler command should exist");
+    let expected = expected_tokensave_bin();
     assert!(
-        command.contains(env!("CARGO_BIN_EXE_tokensave")),
+        command.contains(&expected),
         "Codex hook command must use the resolved absolute tokensave executable, got {command}"
     );
 }

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -1,8 +1,10 @@
 use tokensave::hooks::{
-    build_cursor_session_context, cursor_branch_switch_target, cursor_project_root_from_event,
+    build_cursor_session_context, codex_additional_context_json, codex_apply_patch_rel_paths,
+    codex_project_root_from_event, cursor_branch_switch_target, cursor_project_root_from_event,
     cursor_session_start_json, cursor_shell_sync_plan, cursor_should_run_sync,
-    cursor_staleness_hint, evaluate_cursor_subagent_start, evaluate_hook_decision,
-    evaluate_kiro_pre_tool_use, is_git_state_changing_command, CursorShellSyncPlan,
+    cursor_staleness_hint, evaluate_codex_subagent_start, evaluate_cursor_subagent_start,
+    evaluate_hook_decision, evaluate_kiro_pre_tool_use, is_git_state_changing_command,
+    CursorShellSyncPlan,
 };
 
 fn is_blocked(json: &str) -> bool {
@@ -495,4 +497,137 @@ fn test_cursor_shell_sync_plan_noop_for_read_only_and_non_git() {
             "{command} should be a no-op"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Codex hook handlers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_codex_additional_context_json_uses_codex_schema() {
+    let json = codex_additional_context_json("SessionStart", "hello context");
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        v["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("SessionStart")
+    );
+    assert_eq!(
+        v["hookSpecificOutput"]["additionalContext"].as_str(),
+        Some("hello context")
+    );
+    // Codex must not reuse the Cursor/Claude permission output shapes.
+    assert!(v.get("permission").is_none());
+    assert!(v["hookSpecificOutput"].get("permissionDecision").is_none());
+}
+
+#[test]
+fn test_codex_subagent_start_redirects_explore_research_agent() {
+    // Codex SubagentStart cannot hard-stop a subagent (`continue: false` is
+    // ignored), so the handler steers it via hookSpecificOutput.additionalContext.
+    let input = r#"{
+        "hook_event_name": "SubagentStart",
+        "agent_type": "explore",
+        "cwd": "/tmp/x"
+    }"#;
+
+    let output = evaluate_codex_subagent_start(input).expect("should redirect research subagent");
+    let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(
+        v["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("SubagentStart")
+    );
+    assert!(v["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("tokensave MCP tools"));
+    // Must use the Codex output schema, not Cursor's `permission`/`user_message`.
+    assert!(
+        v.get("permission").is_none(),
+        "Codex hook output must not use Cursor's subagentStart fields"
+    );
+}
+
+#[test]
+fn test_codex_subagent_start_allows_execution_agent() {
+    let input = r#"{
+        "hook_event_name": "SubagentStart",
+        "agent_type": "generalPurpose",
+        "prompt": "Run the test suite and summarize failures"
+    }"#;
+    assert!(evaluate_codex_subagent_start(input).is_none());
+}
+
+#[test]
+fn test_codex_subagent_start_allows_invalid_json() {
+    assert!(evaluate_codex_subagent_start("not json").is_none());
+}
+
+#[test]
+fn test_codex_apply_patch_rel_paths_extracts_patched_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let command = "*** Begin Patch\n\
+        *** Update File: src/lib.rs\n\
+        @@\n-old\n+new\n\
+        *** Add File: src/new_mod.rs\n+contents\n\
+        *** Delete File: src/old_mod.rs\n\
+        *** End Patch\n";
+
+    let mut rels = codex_apply_patch_rel_paths(command, &root, &root);
+    rels.sort();
+    assert_eq!(
+        rels,
+        vec![
+            "src/lib.rs".to_string(),
+            "src/new_mod.rs".to_string(),
+            "src/old_mod.rs".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn test_codex_apply_patch_rel_paths_resolves_relative_to_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let cwd = root.join("crate_a");
+    std::fs::create_dir_all(&cwd).unwrap();
+    // apply_patch paths are relative to the session cwd, which may be a
+    // subdirectory of the discovered project root.
+    let command = "*** Begin Patch\n*** Update File: src/lib.rs\n*** End Patch\n";
+
+    let rels = codex_apply_patch_rel_paths(command, &cwd, &root);
+    assert_eq!(rels, vec!["crate_a/src/lib.rs".to_string()]);
+}
+
+#[test]
+fn test_codex_apply_patch_rel_paths_skips_paths_outside_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let command = "*** Begin Patch\n*** Update File: /etc/passwd\n*** End Patch\n";
+
+    let rels = codex_apply_patch_rel_paths(command, &root, &root);
+    assert!(
+        rels.is_empty(),
+        "absolute paths outside the project root must be ignored, got {rels:?}"
+    );
+}
+
+#[test]
+fn test_codex_project_root_uses_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".tokensave")).unwrap();
+    std::fs::write(dir.path().join(".tokensave/tokensave.db"), "").unwrap();
+    let input = format!(
+        r#"{{
+            "hook_event_name": "PostToolUse",
+            "cwd": {}
+        }}"#,
+        serde_json::to_string(dir.path().to_str().unwrap()).unwrap()
+    );
+
+    assert_eq!(
+        codex_project_root_from_event(&input),
+        Some(dir.path().to_path_buf())
+    );
 }


### PR DESCRIPTION
## Summary
- Add Codex lifecycle hook installation and hook commands for session context, prompt reset, subagent guidance, and post-tool freshness.
- Add Codex hook trust guidance and project-local `.codex` dogfood config.
- Preserve Codex auto-approval behavior for all tokensave tools, including mutating tools.

## Test plan
- Covered by branch tests in the original green PR #3 run.
- This split PR is cherry-picked from the previously green feature branch.