### PR TITLE
feat(sessions): add Cursor and Codex transcript ingestion

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -255,6 +255,11 @@ pub enum Commands {
     },
     /// Live token savings monitor (global, all projects)
     Monitor,
+    /// Ingest and search local agent session transcripts
+    Sessions {
+        #[command(subcommand)]
+        action: SessionsAction,
+    },
     /// Manage multi-branch indexing
     Branch {
         #[command(subcommand)]
@@ -271,6 +276,27 @@ pub enum Commands {
         /// List ALL tracked projects from the global DB
         #[arg(short, long)]
         all: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SessionsAction {
+    /// Ingest Cursor and/or Codex transcript JSONL files into the global DB
+    Ingest {
+        /// Provider to ingest: cursor, codex, or all
+        #[arg(long)]
+        provider: Option<String>,
+    },
+    /// Search previously ingested session messages
+    Search {
+        /// Full-text query to search for
+        query: String,
+        /// Provider to search: cursor, codex, or all
+        #[arg(long)]
+        provider: Option<String>,
+        /// Maximum number of matches per provider
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
     },
 }
 
@@ -310,4 +336,49 @@ pub enum BranchAction {
         #[arg(short, long)]
         path: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_sessions_ingest_and_search_commands() {
+        let ingest =
+            Cli::try_parse_from(["tokensave", "sessions", "ingest", "--provider", "cursor"])
+                .unwrap();
+        match ingest.command {
+            Some(Commands::Sessions {
+                action: SessionsAction::Ingest { provider },
+            }) => assert_eq!(provider.as_deref(), Some("cursor")),
+            _ => panic!("expected sessions ingest command"),
+        }
+
+        let search = Cli::try_parse_from([
+            "tokensave",
+            "sessions",
+            "search",
+            "needle",
+            "--provider",
+            "codex",
+            "--limit",
+            "5",
+        ])
+        .unwrap();
+        match search.command {
+            Some(Commands::Sessions {
+                action:
+                    SessionsAction::Search {
+                        query,
+                        provider,
+                        limit,
+                    },
+            }) => {
+                assert_eq!(query, "needle");
+                assert_eq!(provider.as_deref(), Some("codex"));
+                assert_eq!(limit, 5);
+            }
+            _ => panic!("expected sessions search command"),
+        }
+    }
 }

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -530,6 +530,11 @@ impl GlobalDb {
         if fts_query.is_empty() || limit == 0 {
             return Vec::new();
         }
+        let literal_terms: Vec<String> = query
+            .split_whitespace()
+            .filter(|term| term.contains('-'))
+            .map(str::to_lowercase)
+            .collect();
 
         let select = "SELECT
                 s.provider, s.session_id, s.project_key, s.project_path, s.title, s.started_at,
@@ -572,6 +577,12 @@ impl GlobalDb {
             let Some(message) = row_to_message(&row, 9) else {
                 continue;
             };
+            if !literal_terms.is_empty() {
+                let text = message.text.to_lowercase();
+                if !literal_terms.iter().all(|term| text.contains(term)) {
+                    continue;
+                }
+            }
             let score = row.get::<f64>(22).map_or(0.0, |rank| -rank);
             results.push(SessionMessageSearchResult {
                 session,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use clap::Parser;
 use std::io::{self, BufRead, Write};
 use std::process;
 
+use tokensave::errors::TokenSaveError;
+use tokensave::sessions::{ingest_sessions_from_roots, SessionIngestProvider, SessionIngestRoots};
 use tokensave::tokensave::TokenSave;
 
 mod cli;
@@ -1175,6 +1177,9 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 process::exit(1);
             }
         }
+        Commands::Sessions { action } => {
+            handle_sessions_action(action).await?;
+        }
         Commands::Branch { action } => {
             commands::handle_branch_action(action).await?;
         }
@@ -1186,6 +1191,104 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
         }
     }
     Ok(())
+}
+
+async fn handle_sessions_action(action: SessionsAction) -> tokensave::errors::Result<()> {
+    match action {
+        SessionsAction::Ingest { provider } => {
+            let db = tokensave::global_db::GlobalDb::open()
+                .await
+                .ok_or_else(|| TokenSaveError::Config {
+                    message: "could not open global database".to_string(),
+                })?;
+            let home = dirs::home_dir().ok_or_else(|| TokenSaveError::Config {
+                message: "could not determine home directory".to_string(),
+            })?;
+            let provider = parse_session_provider(provider.as_deref())?;
+            let roots = SessionIngestRoots {
+                cursor_home: home.clone(),
+                codex_home: home,
+            };
+            let stats = ingest_sessions_from_roots(&db, provider, &roots).await;
+            println!(
+                "ingested {} messages from {} files ({} malformed lines)",
+                stats.messages_inserted, stats.files_seen, stats.malformed_lines
+            );
+            if !stats.token_usages.is_empty() {
+                let input_tokens: u64 = stats
+                    .token_usages
+                    .iter()
+                    .map(|usage| usage.input_tokens)
+                    .sum();
+                let cache_read_tokens: u64 = stats
+                    .token_usages
+                    .iter()
+                    .map(|usage| usage.cache_read_tokens)
+                    .sum();
+                let output_tokens: u64 = stats
+                    .token_usages
+                    .iter()
+                    .map(|usage| usage.output_tokens)
+                    .sum();
+                println!(
+                    "observed token usage records: {} input, {} cache-read, {} output tokens",
+                    input_tokens, cache_read_tokens, output_tokens
+                );
+            }
+        }
+        SessionsAction::Search {
+            query,
+            provider,
+            limit,
+        } => {
+            let db = tokensave::global_db::GlobalDb::open()
+                .await
+                .ok_or_else(|| TokenSaveError::Config {
+                    message: "could not open global database".to_string(),
+                })?;
+            for provider in session_search_providers(provider.as_deref())? {
+                for result in db
+                    .search_session_messages(provider, None, &query, limit)
+                    .await
+                {
+                    println!(
+                        "[{}] {} {}: {}",
+                        result.session.provider,
+                        result.session.project_key,
+                        result.message.role,
+                        result.message.text.replace('\n', " ")
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_session_provider(
+    provider: Option<&str>,
+) -> tokensave::errors::Result<SessionIngestProvider> {
+    match provider.unwrap_or("all") {
+        "cursor" => Ok(SessionIngestProvider::Cursor),
+        "codex" => Ok(SessionIngestProvider::Codex),
+        "all" => Ok(SessionIngestProvider::All),
+        other => Err(TokenSaveError::Config {
+            message: format!("unknown session provider '{other}' (expected cursor, codex, or all)"),
+        }),
+    }
+}
+
+fn session_search_providers(
+    provider: Option<&str>,
+) -> tokensave::errors::Result<Vec<&'static str>> {
+    match provider.unwrap_or("all") {
+        "cursor" => Ok(vec!["cursor"]),
+        "codex" => Ok(vec!["codex"]),
+        "all" => Ok(vec!["cursor", "codex"]),
+        other => Err(TokenSaveError::Config {
+            message: format!("unknown session provider '{other}' (expected cursor, codex, or all)"),
+        }),
+    }
 }
 
 fn should_skip_agent_install_maintenance(command: &Commands) -> bool {

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -161,7 +161,7 @@ async fn read_jsonl_records(
     path: &Path,
     stats: &mut SessionIngestStats,
 ) -> Vec<(Value, u64)> {
-    let offset_key = format!("{provider}:{}", path.to_string_lossy());
+    let offset_key = format!("{provider}:{}", stable_path_string(path));
     let saved_offset = db
         .get_parse_offset(&offset_key)
         .await
@@ -386,7 +386,7 @@ async fn upsert_codex_session(db: &GlobalDb, context: &CodexFileContext) -> bool
 }
 
 fn cursor_context_for_path(path: &Path) -> CursorFileContext {
-    let transcript_path = path.to_string_lossy().to_string();
+    let transcript_path = stable_path_string(path);
     let session_id = path
         .file_stem()
         .and_then(|stem| stem.to_str())
@@ -404,7 +404,7 @@ fn cursor_context_for_path(path: &Path) -> CursorFileContext {
 }
 
 fn codex_context_for_path(path: &Path) -> CodexFileContext {
-    let transcript_path = path.to_string_lossy().to_string();
+    let transcript_path = stable_path_string(path);
     let session_id = path
         .file_stem()
         .and_then(|stem| stem.to_str())
@@ -519,4 +519,8 @@ fn file_mtime(path: &Path) -> u64 {
         .ok()
         .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
         .map_or(0, |duration| duration.as_secs())
+}
+
+fn stable_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -1,4 +1,13 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::global_db::GlobalDb;
 
 /// Provider-neutral metadata for an indexed agent session.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,4 +47,476 @@ pub struct SessionMessageSearchResult {
     pub session: SessionRecord,
     pub message: SessionMessageRecord,
     pub score: f64,
+}
+
+/// Transcript providers supported by the sample ingestion path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionIngestProvider {
+    Cursor,
+    Codex,
+    All,
+}
+
+/// Explicit roots used by tests and local callers instead of reading real homes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionIngestRoots {
+    pub cursor_home: PathBuf,
+    pub codex_home: PathBuf,
+}
+
+/// Minimal token usage summary reported by transcript ingestion.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionTokenUsage {
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub output_tokens: u64,
+}
+
+/// Best-effort counters for a transcript ingestion run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionIngestStats {
+    pub files_seen: usize,
+    pub messages_inserted: usize,
+    pub malformed_lines: usize,
+    pub token_usages: Vec<SessionTokenUsage>,
+}
+
+struct CursorFileContext {
+    session_id: String,
+    project_key: String,
+    project_path: String,
+    transcript_path: String,
+    ordinal: i64,
+}
+
+struct CodexFileContext {
+    session_id: String,
+    project_key: String,
+    project_path: String,
+    transcript_path: String,
+    ordinal: i64,
+    model: Option<String>,
+    started_at: Option<i64>,
+}
+
+/// Ingests the small Cursor/Codex fixture shapes currently covered by tests.
+pub async fn ingest_sessions_from_roots(
+    db: &GlobalDb,
+    provider: SessionIngestProvider,
+    roots: &SessionIngestRoots,
+) -> SessionIngestStats {
+    let mut stats = SessionIngestStats::default();
+
+    if matches!(
+        provider,
+        SessionIngestProvider::Cursor | SessionIngestProvider::All
+    ) {
+        ingest_cursor_sessions(db, &roots.cursor_home, &mut stats).await;
+    }
+
+    if matches!(
+        provider,
+        SessionIngestProvider::Codex | SessionIngestProvider::All
+    ) {
+        ingest_codex_sessions(db, &roots.codex_home, &mut stats).await;
+    }
+
+    stats
+}
+
+async fn ingest_cursor_sessions(db: &GlobalDb, cursor_home: &Path, stats: &mut SessionIngestStats) {
+    let mut files = Vec::new();
+    collect_jsonl_files(&cursor_home.join(".cursor").join("projects"), &mut files);
+
+    files.retain(|path| {
+        path.components()
+            .any(|component| component.as_os_str() == "agent-transcripts")
+    });
+
+    for path in files {
+        stats.files_seen += 1;
+        let mut context = cursor_context_for_path(&path);
+        for (value, line_offset) in read_jsonl_records(db, "cursor", &path, stats).await {
+            parse_cursor_record(db, value, line_offset, stats, &mut context).await;
+        }
+    }
+}
+
+async fn ingest_codex_sessions(db: &GlobalDb, codex_home: &Path, stats: &mut SessionIngestStats) {
+    let mut files = Vec::new();
+    collect_jsonl_files(&codex_home.join(".codex").join("sessions"), &mut files);
+
+    for path in files {
+        stats.files_seen += 1;
+        let mut context = codex_context_for_path(&path);
+        for (value, line_offset) in read_jsonl_records(db, "codex", &path, stats).await {
+            parse_codex_record(db, value, line_offset, stats, &mut context).await;
+        }
+    }
+}
+
+async fn read_jsonl_records(
+    db: &GlobalDb,
+    provider: &str,
+    path: &Path,
+    stats: &mut SessionIngestStats,
+) -> Vec<(Value, u64)> {
+    let offset_key = format!("{provider}:{}", path.to_string_lossy());
+    let saved_offset = db
+        .get_parse_offset(&offset_key)
+        .await
+        .map_or(0, |(offset, _)| offset);
+
+    let Ok(bytes) = fs::read(path) else {
+        return Vec::new();
+    };
+    let start = if saved_offset <= bytes.len() as u64 {
+        saved_offset as usize
+    } else {
+        0
+    };
+    let mut current_offset = start as u64;
+    let mut records = Vec::new();
+
+    for chunk in bytes[start..].split_inclusive(|byte| *byte == b'\n') {
+        let line_offset = current_offset;
+        current_offset = current_offset.saturating_add(chunk.len() as u64);
+        let line = trim_jsonl_line(chunk);
+        if line.is_empty() {
+            continue;
+        }
+
+        let Ok(line) = std::str::from_utf8(line) else {
+            stats.malformed_lines += 1;
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            stats.malformed_lines += 1;
+            continue;
+        };
+
+        records.push((value, line_offset));
+    }
+
+    db.set_parse_offset(&offset_key, bytes.len() as u64, file_mtime(path))
+        .await;
+    records
+}
+
+async fn parse_cursor_record(
+    db: &GlobalDb,
+    value: Value,
+    line_offset: u64,
+    stats: &mut SessionIngestStats,
+    context: &mut CursorFileContext,
+) {
+    let Some(role) = value.get("role").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(content) = value
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+
+    let (text, tool_names) = text_and_tools_from_content(content, &["text"]);
+    if text.is_empty() {
+        return;
+    }
+
+    let session = SessionRecord {
+        provider: "cursor".to_string(),
+        session_id: context.session_id.clone(),
+        project_key: context.project_key.clone(),
+        project_path: context.project_path.clone(),
+        title: None,
+        started_at: None,
+        ended_at: None,
+        transcript_path: Some(context.transcript_path.clone()),
+        metadata_json: None,
+    };
+    if !db.upsert_session(&session).await {
+        return;
+    }
+
+    let model = value
+        .get("model")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let message = SessionMessageRecord {
+        provider: "cursor".to_string(),
+        message_id: format!(
+            "{}:{}:{line_offset}",
+            context.session_id, context.transcript_path
+        ),
+        session_id: context.session_id.clone(),
+        role: role.to_string(),
+        timestamp: None,
+        ordinal: context.ordinal,
+        text,
+        kind: Some("message".to_string()),
+        model,
+        tool_names,
+        source_path: Some(context.transcript_path.clone()),
+        source_offset: Some(line_offset as i64),
+        metadata_json: None,
+    };
+    if db.upsert_session_message(&message).await {
+        context.ordinal += 1;
+        stats.messages_inserted += 1;
+    }
+}
+
+async fn parse_codex_record(
+    db: &GlobalDb,
+    value: Value,
+    line_offset: u64,
+    stats: &mut SessionIngestStats,
+    context: &mut CodexFileContext,
+) {
+    match value.get("type").and_then(Value::as_str) {
+        Some("session_meta") => {
+            if let Some(id) = value
+                .get("payload")
+                .and_then(|payload| payload.get("id"))
+                .and_then(Value::as_str)
+            {
+                context.session_id = id.to_string();
+            }
+            upsert_codex_session(db, context).await;
+        }
+        Some("turn_context") => {
+            let payload = value.get("payload");
+            if let Some(cwd) = payload
+                .and_then(|payload| payload.get("cwd"))
+                .and_then(Value::as_str)
+            {
+                context.project_key = cwd.to_string();
+                context.project_path = cwd.to_string();
+            }
+            context.model = payload
+                .and_then(|payload| payload.get("model"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            upsert_codex_session(db, context).await;
+        }
+        Some("response_item") => {
+            parse_codex_response_item(db, value, line_offset, stats, context).await;
+        }
+        Some("event_msg") => {
+            if let Some(token_usage) = codex_token_usage(&value) {
+                stats.token_usages.push(token_usage);
+            }
+        }
+        _ => {}
+    }
+}
+
+async fn parse_codex_response_item(
+    db: &GlobalDb,
+    value: Value,
+    line_offset: u64,
+    stats: &mut SessionIngestStats,
+    context: &mut CodexFileContext,
+) {
+    let Some(item) = value.get("payload").and_then(|payload| payload.get("item")) else {
+        return;
+    };
+    if item.get("type").and_then(Value::as_str) != Some("message") {
+        return;
+    }
+    let Some(role) = item.get("role").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(content) = item.get("content").and_then(Value::as_array) else {
+        return;
+    };
+
+    let (text, tool_names) = text_and_tools_from_content(content, &["output_text", "text"]);
+    if text.is_empty() {
+        return;
+    }
+    if !upsert_codex_session(db, context).await {
+        return;
+    }
+
+    let local_id = item
+        .get("id")
+        .and_then(Value::as_str)
+        .map_or_else(|| line_offset.to_string(), ToString::to_string);
+    let message = SessionMessageRecord {
+        provider: "codex".to_string(),
+        message_id: format!(
+            "{}:{local_id}:{}",
+            context.session_id, context.transcript_path
+        ),
+        session_id: context.session_id.clone(),
+        role: role.to_string(),
+        timestamp: None,
+        ordinal: context.ordinal,
+        text,
+        kind: Some("message".to_string()),
+        model: context.model.clone(),
+        tool_names,
+        source_path: Some(context.transcript_path.clone()),
+        source_offset: Some(line_offset as i64),
+        metadata_json: None,
+    };
+    if db.upsert_session_message(&message).await {
+        context.ordinal += 1;
+        stats.messages_inserted += 1;
+    }
+}
+
+async fn upsert_codex_session(db: &GlobalDb, context: &CodexFileContext) -> bool {
+    let session = SessionRecord {
+        provider: "codex".to_string(),
+        session_id: context.session_id.clone(),
+        project_key: context.project_key.clone(),
+        project_path: context.project_path.clone(),
+        title: None,
+        started_at: context.started_at,
+        ended_at: None,
+        transcript_path: Some(context.transcript_path.clone()),
+        metadata_json: None,
+    };
+    db.upsert_session(&session).await
+}
+
+fn cursor_context_for_path(path: &Path) -> CursorFileContext {
+    let transcript_path = path.to_string_lossy().to_string();
+    let session_id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("cursor-session")
+        .to_string();
+    let project_key = component_after(path, "projects").unwrap_or_else(|| "unknown".to_string());
+
+    CursorFileContext {
+        session_id,
+        project_path: project_key.clone(),
+        project_key,
+        transcript_path,
+        ordinal: 0,
+    }
+}
+
+fn codex_context_for_path(path: &Path) -> CodexFileContext {
+    let transcript_path = path.to_string_lossy().to_string();
+    let session_id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("codex-session")
+        .to_string();
+
+    CodexFileContext {
+        session_id,
+        project_key: String::new(),
+        project_path: String::new(),
+        transcript_path,
+        ordinal: 0,
+        model: None,
+        started_at: None,
+    }
+}
+
+fn text_and_tools_from_content(
+    content: &[Value],
+    text_block_types: &[&str],
+) -> (String, Option<String>) {
+    let mut text_parts = Vec::new();
+    let mut tool_names = Vec::new();
+
+    for block in content {
+        let block_type = block.get("type").and_then(Value::as_str);
+        if block_type.is_some_and(|kind| text_block_types.contains(&kind)) {
+            if let Some(text) = block.get("text").and_then(Value::as_str) {
+                text_parts.push(text.to_string());
+            }
+        } else if block_type == Some("tool_use") {
+            if let Some(name) = block.get("name").and_then(Value::as_str) {
+                tool_names.push(name.to_string());
+            }
+        }
+    }
+
+    let text = text_parts.join("\n");
+    let tool_names = if tool_names.is_empty() {
+        None
+    } else {
+        Some(tool_names.join(","))
+    };
+    (text, tool_names)
+}
+
+fn codex_token_usage(value: &Value) -> Option<SessionTokenUsage> {
+    let msg = value.get("msg")?;
+    if msg.get("type").and_then(Value::as_str) != Some("token_count") {
+        return None;
+    }
+    let usage = msg.get("info")?.get("last_token_usage")?;
+    Some(SessionTokenUsage {
+        input_tokens: usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        cache_read_tokens: usage
+            .get("cached_input_tokens")
+            .or_else(|| usage.get("cache_read_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        output_tokens: usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    })
+}
+
+fn collect_jsonl_files(root: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files);
+        } else if path
+            .extension()
+            .is_some_and(|extension| extension.to_string_lossy() == "jsonl")
+        {
+            files.push(path);
+        }
+    }
+    files.sort();
+}
+
+fn component_after(path: &Path, marker: &str) -> Option<String> {
+    let mut components = path.components();
+    while let Some(component) = components.next() {
+        if component.as_os_str() == marker {
+            return components
+                .next()
+                .and_then(|next| next.as_os_str().to_str())
+                .map(ToString::to_string);
+        }
+    }
+    None
+}
+
+fn trim_jsonl_line(mut line: &[u8]) -> &[u8] {
+    while matches!(line.last(), Some(b'\n' | b'\r')) {
+        line = &line[..line.len().saturating_sub(1)];
+    }
+    line
+}
+
+fn file_mtime(path: &Path) -> u64 {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map_or(0, |duration| duration.as_secs())
 }

--- a/tests/session_ingest_test.rs
+++ b/tests/session_ingest_test.rs
@@ -135,7 +135,7 @@ async fn offset_resume_only_ingests_appended_lines() {
         1
     );
 
-    let offset_key = format!("cursor:{}", transcript.to_string_lossy());
+    let offset_key = format!("cursor:{}", transcript.to_string_lossy().replace('\\', "/"));
     assert!(db.get_parse_offset(&offset_key).await.is_some());
 }
 

--- a/tests/session_ingest_test.rs
+++ b/tests/session_ingest_test.rs
@@ -1,0 +1,172 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+
+use tempfile::TempDir;
+use tokensave::global_db::GlobalDb;
+use tokensave::sessions::{ingest_sessions_from_roots, SessionIngestProvider, SessionIngestRoots};
+
+async fn open_isolated_db(tmp: &TempDir) -> GlobalDb {
+    let db_path = tmp.path().join(".tokensave").join("global.db");
+    GlobalDb::open_at(&db_path).await.expect("global db open")
+}
+
+fn write_jsonl(path: &std::path::Path, lines: &[&str]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create fixture parent");
+    }
+    fs::write(path, format!("{}\n", lines.join("\n"))).expect("write fixture");
+}
+
+#[tokio::test]
+async fn cursor_jsonl_ingests_messages_for_fts_search() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let cursor_home = tmp.path().join("cursor-home");
+    let transcript =
+        cursor_home.join(".cursor/projects/project-slug/agent-transcripts/convo-1/convo-1.jsonl");
+    write_jsonl(
+        &transcript,
+        &[
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"Please explain needle-indexing for local transcripts."}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"Needle indexing works by flattening message text."},{"type":"tool_use","name":"tokensave_search","input":{"query":"needle indexing"}}]},"model":"gpt-5.5"}"#,
+            r#"{"unknown":true}"#,
+        ],
+    );
+
+    let roots = SessionIngestRoots {
+        cursor_home,
+        codex_home: tmp.path().join("codex-home"),
+    };
+    let stats = ingest_sessions_from_roots(&db, SessionIngestProvider::Cursor, &roots).await;
+
+    assert_eq!(stats.files_seen, 1);
+    assert_eq!(stats.messages_inserted, 2);
+    assert_eq!(stats.malformed_lines, 0);
+
+    let results = db
+        .search_session_messages("cursor", Some("project-slug"), "needle-indexing", 10)
+        .await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].session.session_id, "convo-1");
+    assert_eq!(results[0].message.role, "user");
+}
+
+#[tokio::test]
+async fn codex_rollout_ingests_messages_and_reports_exact_token_usage() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let codex_home = tmp.path().join("codex-home");
+    let rollout = codex_home.join(".codex/sessions/2026/06/07/rollout-abc.jsonl");
+    write_jsonl(
+        &rollout,
+        &[
+            r#"{"type":"session_meta","payload":{"id":"codex-session-1","timestamp":"2026-06-07T08:00:00Z"}}"#,
+            r#"{"type":"turn_context","payload":{"cwd":"/work/project","model":"gpt-5.4-medium"}}"#,
+            r#"{"type":"response_item","payload":{"item":{"id":"item-1","type":"message","role":"assistant","content":[{"type":"output_text","text":"Codex found the rollout needle."}]}}}"#,
+            r#"{"type":"event_msg","msg":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1200,"cached_input_tokens":300,"output_tokens":80}}}}"#,
+        ],
+    );
+
+    let roots = SessionIngestRoots {
+        cursor_home: tmp.path().join("cursor-home"),
+        codex_home,
+    };
+    let stats = ingest_sessions_from_roots(&db, SessionIngestProvider::Codex, &roots).await;
+
+    assert_eq!(stats.files_seen, 1);
+    assert_eq!(stats.messages_inserted, 1);
+    assert_eq!(stats.token_usages.len(), 1);
+    assert_eq!(stats.token_usages[0].input_tokens, 1200);
+    assert_eq!(stats.token_usages[0].cache_read_tokens, 300);
+    assert_eq!(stats.token_usages[0].output_tokens, 80);
+
+    let results = db
+        .search_session_messages("codex", Some("/work/project"), "rollout needle", 10)
+        .await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].session.session_id, "codex-session-1");
+    assert_eq!(results[0].message.model.as_deref(), Some("gpt-5.4-medium"));
+}
+
+#[tokio::test]
+async fn offset_resume_only_ingests_appended_lines() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let cursor_home = tmp.path().join("cursor-home");
+    let transcript =
+        cursor_home.join(".cursor/projects/project-slug/agent-transcripts/convo-2/convo-2.jsonl");
+    write_jsonl(
+        &transcript,
+        &[
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"first searchable marker"}]}}"#,
+        ],
+    );
+
+    let roots = SessionIngestRoots {
+        cursor_home,
+        codex_home: tmp.path().join("codex-home"),
+    };
+    let first = ingest_sessions_from_roots(&db, SessionIngestProvider::Cursor, &roots).await;
+    assert_eq!(first.messages_inserted, 1);
+
+    let mut file = OpenOptions::new()
+        .append(true)
+        .open(&transcript)
+        .expect("open transcript for append");
+    writeln!(
+        file,
+        r#"{{"role":"assistant","message":{{"content":[{{"type":"text","text":"second appended marker"}}]}}}}"#
+    )
+    .expect("append line");
+
+    let second = ingest_sessions_from_roots(&db, SessionIngestProvider::Cursor, &roots).await;
+    assert_eq!(second.messages_inserted, 1);
+
+    assert_eq!(
+        db.search_session_messages("cursor", Some("project-slug"), "first searchable", 10)
+            .await
+            .len(),
+        1
+    );
+    assert_eq!(
+        db.search_session_messages("cursor", Some("project-slug"), "second appended", 10)
+            .await
+            .len(),
+        1
+    );
+
+    let offset_key = format!("cursor:{}", transcript.to_string_lossy());
+    assert!(db.get_parse_offset(&offset_key).await.is_some());
+}
+
+#[tokio::test]
+async fn malformed_and_unknown_records_fail_open() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let codex_home = tmp.path().join("codex-home");
+    let rollout = codex_home.join(".codex/sessions/2026/06/07/rollout-bad.jsonl");
+    write_jsonl(
+        &rollout,
+        &[
+            "not json at all",
+            r#"{"type":"unknown","payload":{"anything":true}}"#,
+            r#"{"type":"response_item","payload":{"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"still searchable after bad records"}]}}}"#,
+        ],
+    );
+
+    let roots = SessionIngestRoots {
+        cursor_home: tmp.path().join("cursor-home"),
+        codex_home,
+    };
+    let stats = ingest_sessions_from_roots(&db, SessionIngestProvider::Codex, &roots).await;
+
+    assert_eq!(stats.files_seen, 1);
+    assert_eq!(stats.messages_inserted, 1);
+    assert_eq!(stats.malformed_lines, 1);
+    assert_eq!(
+        db.search_session_messages("codex", None, "still searchable", 10)
+            .await
+            .len(),
+        1
+    );
+}


### PR DESCRIPTION
## Summary
- Add a minimal session ingestion path for Cursor agent transcripts and Codex rollout JSONL files.
- Store provider-neutral session/message rows in the global DB with resumable parse offsets and FTS search support.
- Expose coherent `tokensave sessions ingest/search` CLI commands without adding exact Cursor cost accounting.

## Test plan
- `bash -lc 'ulimit -Sv 41943040; timeout --kill-after=5s 120s cargo test --test session_ingest_test -- --nocapture'`
- `bash -lc 'ulimit -Sv 41943040; timeout --kill-after=5s 120s cargo test --bin tokensave parses_sessions_ingest_and_search_commands -- --nocapture'`
- `cargo fmt --check` (fails on pre-existing `src/hooks.rs` formatting from the base branch)