### PR TITLE
fix(cursor): hint before broad search tools

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -2,45 +2,45 @@
   "hooks": {
     "afterFileEdit": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-after-file-edit",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-after-file-edit",
         "matcher": "Write",
         "timeout": 30
       }
     ],
     "afterShellExecution": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-after-shell",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-after-shell",
         "timeout": 60
       }
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-before-submit-prompt",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-before-submit-prompt",
         "timeout": 5
       }
     ],
     "preToolUse": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-pre-tool-use",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-pre-tool-use",
         "matcher": "Shell|Bash|Grep|Glob|Search",
         "timeout": 5
       }
     ],
     "sessionStart": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-session-start",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-session-start",
         "timeout": 5
       }
     ],
     "subagentStart": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-subagent-start",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-subagent-start",
         "timeout": 5
       }
     ],
     "workspaceOpen": [
       {
-        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-workspace-open",
+        "command": "cargo run --quiet --manifest-path ./Cargo.toml -- hook-cursor-workspace-open",
         "timeout": 60
       }
     ]

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -19,6 +19,13 @@
         "timeout": 5
       }
     ],
+    "preToolUse": [
+      {
+        "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-pre-tool-use",
+        "matcher": "Shell|Bash|Grep|Glob|Search",
+        "timeout": 5
+      }
+    ],
     "sessionStart": [
       {
         "command": "'/home/zack/projects/tokensave/target/debug/tokensave' hook-cursor-session-start",

--- a/.cursor/rules/tokensave.mdc
+++ b/.cursor/rules/tokensave.mdc
@@ -5,6 +5,7 @@ alwaysApply: true
 
 # Prefer tokensave MCP tools
 
-- For codebase exploration, symbol lookup, call graphs, callers/callees, impact analysis, affected files, and architectural navigation, use the tokensave MCP tools first.
+- For codebase exploration, symbol lookup, call graphs, callers/callees, impact analysis, affected files, and architectural navigation, use the tokensave MCP tools first. Treat `tokensave_context` as the default starting point before Grep/Glob/search when `.tokensave/` exists.
 - Prefer tools such as `tokensave_context`, `tokensave_search`, `tokensave_callers`, `tokensave_callees`, `tokensave_impact`, `tokensave_files`, `tokensave_affected`, and related read-only tokensave tools before broad file reads or search.
+- For durable project/user facts, prefer `tokensave_fact_store`, `tokensave_fact_feedback`, and `tokensave_memory_status` over ad-hoc notes. Use `tokensave_message_search` for project-local Cursor transcript recall when prior conversation context matters.
 - Only fall back to regular file reads, search, or shell commands when tokensave cannot answer the question or after tokensave has identified the exact files or symbols to inspect.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json
 
 - `sessionStart` — fire-and-forget; injects context steering the Agent toward tokensave MCP tools and reports index freshness (suggests `tokensave init` when no `.tokensave/` exists).
 - `subagentStart` — blocks research/explore subagents until tokensave MCP tools have been tried.
-- `preToolUse` (matcher `Shell|Bash|Grep|Glob|Search`) — fail-open; injects a soft `additional_context` hint before broad search tools so Cursor can switch to `tokensave_context`, `tokensave_search`, or `tokensave_files` before spending a Grep/rg call.
+- `preToolUse` (matcher `Shell|Bash|Grep|Glob|Search`) — fail-open; injects a soft `hookSpecificOutput.additionalContext` hint before broad search tools so Cursor can switch to `tokensave_context`, `tokensave_search`, or `tokensave_files` before spending a Grep/rg call.
 - `beforeSubmitPrompt` — resets the local token counter for the new turn and ingests the current Cursor transcript into `.tokensave/sessions.db` when `transcript_path` is present.
 - `afterFileEdit` (matcher `Write`) — runs a **targeted single-file** sync of just the edited path(s) via `sync_if_stale_silent`, never a full-tree scan (which would scale with repo size, not edit size).
 - `afterShellExecution` — on Agent-run `git checkout`/`switch`/`worktree add`, bootstraps/maintains tokensave branch tracking (`branch add`); on other state-changing git commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop), runs a coalesced incremental sync.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json
 
 - `sessionStart` — fire-and-forget; injects context steering the Agent toward tokensave MCP tools and reports index freshness (suggests `tokensave init` when no `.tokensave/` exists).
 - `subagentStart` — blocks research/explore subagents until tokensave MCP tools have been tried.
-- `preToolUse` (matcher `Shell|Bash|Grep|Glob|Search`) — fail-open; injects a soft `hookSpecificOutput.additionalContext` hint before broad search tools so Cursor can switch to `tokensave_context`, `tokensave_search`, or `tokensave_files` before spending a Grep/rg call.
+- `preToolUse` (matcher `Shell|Bash|Grep|Glob|Search`) — fail-open; injects a soft `additional_context` hint before broad search tools so Cursor can switch to `tokensave_context`, `tokensave_search`, or `tokensave_files` before spending a Grep/rg call.
 - `beforeSubmitPrompt` — resets the local token counter for the new turn and ingests the current Cursor transcript into `.tokensave/sessions.db` when `transcript_path` is present.
 - `afterFileEdit` (matcher `Write`) — runs a **targeted single-file** sync of just the edited path(s) via `sync_if_stale_silent`, never a full-tree scan (which would scale with repo size, not edit size).
 - `afterShellExecution` — on Agent-run `git checkout`/`switch`/`worktree add`, bootstraps/maintains tokensave branch tracking (`branch add`); on other state-changing git commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop), runs a coalesced incremental sync.

--- a/README.md
+++ b/README.md
@@ -151,12 +151,13 @@ Local install writes only workspace files such as `.cursor/mcp.json`, `.mcp.json
 
 - `sessionStart` — fire-and-forget; injects context steering the Agent toward tokensave MCP tools and reports index freshness (suggests `tokensave init` when no `.tokensave/` exists).
 - `subagentStart` — blocks research/explore subagents until tokensave MCP tools have been tried.
+- `preToolUse` (matcher `Shell|Bash|Grep|Glob|Search`) — fail-open; injects a soft `additional_context` hint before broad search tools so Cursor can switch to `tokensave_context`, `tokensave_search`, or `tokensave_files` before spending a Grep/rg call.
 - `beforeSubmitPrompt` — resets the local token counter for the new turn and ingests the current Cursor transcript into `.tokensave/sessions.db` when `transcript_path` is present.
 - `afterFileEdit` (matcher `Write`) — runs a **targeted single-file** sync of just the edited path(s) via `sync_if_stale_silent`, never a full-tree scan (which would scale with repo size, not edit size).
 - `afterShellExecution` — on Agent-run `git checkout`/`switch`/`worktree add`, bootstraps/maintains tokensave branch tracking (`branch add`); on other state-changing git commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop), runs a coalesced incremental sync.
 - `workspaceOpen` — ensures the current branch's DB exists (branch add if missing) and runs a catch-up incremental sync.
 
-All Cursor hooks are fail-open and only act when a `.tokensave/` index already exists. **Blind spot:** Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual/external-terminal `git checkout` and in-place branch switches are NOT seen by these hooks (`workspaceOpen` does not fire for an in-place checkout). For those, the git post-commit hook and the on-demand MCP staleness check remain the freshness mechanism. We intentionally do not add `beforeReadFile`/`preToolUse` blocking hooks here (too aggressive/noisy); they may become opt-in later.
+All Cursor hooks are fail-open and only act when a `.tokensave/` index already exists. **Blind spot:** Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual/external-terminal `git checkout` and in-place branch switches are NOT seen by these hooks (`workspaceOpen` does not fire for an in-place checkout). For those, the git post-commit hook and the on-demand MCP staleness check remain the freshness mechanism. We intentionally keep Cursor `preToolUse` nonblocking: it nudges broad search toward tokensave but does not deny reads/search.
 
 ### Codex lifecycle hooks
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -269,12 +269,13 @@ Cursor local install creates a stronger project-local setup:
 - `.cursor/hooks.json` installs Cursor-specific, fail-open project hooks (each acts only when a `.tokensave/` index exists):
   - `sessionStart` injects context steering the Agent toward tokensave MCP tools and reports index freshness (suggests `tokensave init` when uninitialized).
   - `subagentStart` denies research/explore subagents with Cursor's documented hook response shape.
+  - `preToolUse` (matcher `Shell|Bash|Grep|Glob|Search`) injects a nonblocking `additional_context` hint before broad search tools so Cursor can switch to `tokensave_context`, `tokensave_search`, or `tokensave_files`.
   - `beforeSubmitPrompt` resets the local token counter and ingests the current Cursor transcript into `.tokensave/sessions.db` when `transcript_path` is present.
   - `afterFileEdit` (matcher `Write`) runs a **targeted single-file** sync of only the edited path(s) — not a full-tree scan — so it stays cheap on large codebases even when the Agent edits many files per turn.
   - `afterShellExecution` makes branch handling automatic: Agent-run `git checkout`/`switch`/`worktree add` bootstraps/maintains tokensave branch tracking (`branch add`), while other state-changing git commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop) trigger a coalesced incremental sync.
   - `workspaceOpen` ensures the current branch's DB exists (branch add if missing) and runs a catch-up incremental sync.
 
-  Blind spot: Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual or external-terminal `git checkout` and in-place branch switches are not visible to these hooks (`workspaceOpen` does not fire for an in-place checkout). Use the git post-commit hook and the on-demand MCP staleness check to keep the index fresh for those cases. `beforeReadFile`/`preToolUse` blocking hooks are intentionally omitted for now to avoid noise; they may become opt-in later.
+  Blind spot: Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual or external-terminal `git checkout` and in-place branch switches are not visible to these hooks (`workspaceOpen` does not fire for an in-place checkout). Use the git post-commit hook and the on-demand MCP staleness check to keep the index fresh for those cases. Cursor `preToolUse` remains nonblocking to avoid noisy denials.
 
 Codex local install writes `<root>/.codex/config.toml` (MCP), `<root>/AGENTS.md` (prompt rules), and `<root>/.codex/hooks.json` (lifecycle hooks, using the resolved absolute `tokensave` path). The hooks are identical to the global Codex install described under "Codex lifecycle hooks" below.
 

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -164,7 +164,7 @@ alwaysApply: true
 
 # Prefer tokensave MCP tools
 
-- For codebase exploration, symbol lookup, call graphs, callers/callees, impact analysis, affected files, and architectural navigation, use the tokensave MCP tools first.
+- For codebase exploration, symbol lookup, call graphs, callers/callees, impact analysis, affected files, and architectural navigation, use the tokensave MCP tools first. Treat `tokensave_context` as the default starting point before Grep/Glob/search when `.tokensave/` exists.
 - Prefer tools such as `tokensave_context`, `tokensave_search`, `tokensave_callers`, `tokensave_callees`, `tokensave_impact`, `tokensave_files`, `tokensave_affected`, and related read-only tokensave tools before broad file reads or search.
 - For durable project/user facts, prefer `tokensave_fact_store`, `tokensave_fact_feedback`, and `tokensave_memory_status` over ad-hoc notes. Use `tokensave_message_search` for project-local Cursor transcript recall when prior conversation context matters.
 - Only fall back to regular file reads, search, or shell commands when tokensave cannot answer the question or after tokensave has identified the exact files or symbols to inspect.
@@ -255,6 +255,14 @@ fn install_hooks(hooks_path: &Path, tokensave_bin: &str) -> Result<()> {
         "hook-cursor-subagent-start",
         5,
         None,
+    );
+    install_cursor_hook_entry(
+        &mut hooks,
+        "preToolUse",
+        tokensave_bin,
+        "hook-cursor-pre-tool-use",
+        5,
+        Some("Shell|Bash|Grep|Glob|Search"),
     );
     install_cursor_hook_entry(
         &mut hooks,
@@ -508,6 +516,7 @@ fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path) {
     let expected = [
         ("sessionStart", "hook-cursor-session-start"),
         ("subagentStart", "hook-cursor-subagent-start"),
+        ("preToolUse", "hook-cursor-pre-tool-use"),
         ("beforeSubmitPrompt", "hook-cursor-before-submit-prompt"),
         ("afterFileEdit", "hook-cursor-after-file-edit"),
         ("afterShellExecution", "hook-cursor-after-shell"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,6 +128,9 @@ pub enum Commands {
     /// Cursor subagentStart hook handler (called by Cursor, not by users directly)
     #[command(name = "hook-cursor-subagent-start", hide = true)]
     HookCursorSubagentStart,
+    /// Cursor preToolUse hook handler (called by Cursor, not by users directly)
+    #[command(name = "hook-cursor-pre-tool-use", hide = true)]
+    HookCursorPreToolUse,
     /// Cursor beforeSubmitPrompt hook handler (called by Cursor, not by users directly)
     #[command(name = "hook-cursor-before-submit-prompt", hide = true)]
     HookCursorBeforeSubmitPrompt,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -150,8 +150,8 @@ pub fn hook_cursor_subagent_start() -> i32 {
 
 /// Cursor `preToolUse` hook handler.
 ///
-/// Emits nonblocking Cursor-shaped `additional_context` for broad search tools
-/// such as Grep and shell `rg` before the model spends a tool call on them.
+/// Emits nonblocking Cursor-shaped hook-specific context for broad search
+/// tools such as Grep and shell `rg` before the model spends a tool call on them.
 pub fn hook_cursor_pre_tool_use() -> i32 {
     let event = read_stdin_to_string();
     if let Some(decision) = evaluate_cursor_pre_tool_use(&event) {
@@ -307,15 +307,19 @@ pub fn evaluate_cursor_subagent_start(event_json: &str) -> Option<String> {
 
 /// Pure decision logic for Cursor `preToolUse` hook events.
 ///
-/// Returns a soft `additional_context` hint only for high-confidence broad
-/// search tools. Invalid or unrelated tool events fail open with no output.
+/// Returns a soft `hookSpecificOutput.additionalContext` hint only for
+/// high-confidence broad search tools. Invalid or unrelated tool events fail
+/// open with no output.
 pub fn evaluate_cursor_pre_tool_use(event_json: &str) -> Option<String> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let hint = decide_hint(&cursor_pre_tool_hint_input(&parsed))?;
     Some(
         serde_json::json!({
             "continue": true,
-            "additional_context": format_tool_hint(&hint),
+            "hookSpecificOutput": {
+                "hookEventName": "preToolUse",
+                "additionalContext": format_tool_hint(&hint),
+            },
         })
         .to_string(),
     )

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -147,6 +147,18 @@ pub fn hook_cursor_subagent_start() -> i32 {
     0
 }
 
+/// Cursor `preToolUse` hook handler.
+///
+/// Emits nonblocking Cursor-shaped `additional_context` for broad search tools
+/// such as Grep and shell `rg` before the model spends a tool call on them.
+pub fn hook_cursor_pre_tool_use() -> i32 {
+    let event = read_stdin_to_string();
+    if let Some(decision) = evaluate_cursor_pre_tool_use(&event) {
+        println!("{decision}");
+    }
+    0
+}
+
 /// Cursor `beforeSubmitPrompt` hook handler.
 ///
 /// Resets the project-local counter for a new prompt turn. The output uses
@@ -266,6 +278,22 @@ pub fn evaluate_cursor_subagent_start(event_json: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Pure decision logic for Cursor `preToolUse` hook events.
+///
+/// Returns a soft `additional_context` hint only for high-confidence broad
+/// search tools. Invalid or unrelated tool events fail open with no output.
+pub fn evaluate_cursor_pre_tool_use(event_json: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let hint = decide_hint(&cursor_pre_tool_hint_input(&parsed))?;
+    Some(
+        serde_json::json!({
+            "continue": true,
+            "additional_context": format_tool_hint(&hint),
+        })
+        .to_string(),
+    )
 }
 
 pub fn cursor_project_root_from_event(event_json: &str) -> Option<PathBuf> {
@@ -1282,6 +1310,35 @@ fn cursor_prompt_hint(event_json: &str) -> Option<ToolHint> {
     })
 }
 
+fn cursor_pre_tool_hint_input(parsed: &Value) -> ToolHintInput {
+    let tool_input = parsed
+        .get("tool_input")
+        .or_else(|| parsed.get("toolInput"))
+        .or_else(|| parsed.get("input"))
+        .unwrap_or(&Value::Null);
+    ToolHintInput {
+        agent: HintAgent::Cursor,
+        session_id: event_session_id(parsed),
+        tool_name: text_field(parsed, &["tool_name", "toolName", "name"]),
+        command: text_field(tool_input, &["command", "cmd"])
+            .or_else(|| text_field(parsed, &["command", "cmd"])),
+        prompt: text_field(
+            tool_input,
+            &["prompt", "query", "pattern", "task", "description"],
+        )
+        .or_else(|| {
+            text_field(
+                parsed,
+                &["prompt", "query", "pattern", "task", "description"],
+            )
+        }),
+        subagent_type: text_field(parsed, &["subagent_type", "subagentType", "agent_type"]),
+        file_path: text_field(tool_input, &["file_path", "filePath", "path"])
+            .or_else(|| text_field(parsed, &["file_path", "filePath", "path"])),
+        hints_enabled: true,
+    }
+}
+
 fn codex_prompt_hint(event_json: &str) -> Option<ToolHint> {
     let parsed = serde_json::from_str::<Value>(event_json).ok()?;
     decide_hint(&ToolHintInput {
@@ -1294,6 +1351,13 @@ fn codex_prompt_hint(event_json: &str) -> Option<ToolHint> {
         file_path: None,
         hints_enabled: true,
     })
+}
+
+fn text_field(value: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_str))
+        .filter(|text| !text.is_empty())
+        .map(str::to_string)
 }
 
 fn prompt_like_text(parsed: &Value) -> Option<String> {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -307,19 +307,15 @@ pub fn evaluate_cursor_subagent_start(event_json: &str) -> Option<String> {
 
 /// Pure decision logic for Cursor `preToolUse` hook events.
 ///
-/// Returns a soft `hookSpecificOutput.additionalContext` hint only for
-/// high-confidence broad search tools. Invalid or unrelated tool events fail
-/// open with no output.
+/// Returns a soft native Cursor `additional_context` hint only for high-confidence
+/// broad search tools. Invalid or unrelated tool events fail open with no output.
 pub fn evaluate_cursor_pre_tool_use(event_json: &str) -> Option<String> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let hint = decide_hint(&cursor_pre_tool_hint_input(&parsed))?;
     Some(
         serde_json::json!({
             "continue": true,
-            "hookSpecificOutput": {
-                "hookEventName": "preToolUse",
-                "additionalContext": format_tool_hint(&hint),
-            },
+            "additional_context": format_tool_hint(&hint),
         })
         .to_string(),
     )

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -166,6 +166,32 @@ pub fn decide_hint(input: &ToolHintInput) -> Option<ToolHint> {
         ));
     }
 
+    if input
+        .tool_name
+        .as_deref()
+        .is_some_and(|name| matches_normalized(name, &["grep", "search"]))
+    {
+        return Some(hint(
+            HintCategory::Search,
+            "For codebase search, consider using tokensave_search or tokensave_context.",
+            "tokensave_search uses the existing index for code search; tokensave_context can gather focused surrounding context when a text search is only a starting point.",
+            false,
+        ));
+    }
+
+    if input
+        .tool_name
+        .as_deref()
+        .is_some_and(|name| matches_normalized(name, &["glob"]))
+    {
+        return Some(hint(
+            HintCategory::FileLookup,
+            "For finding files by role or path, consider using tokensave_files.",
+            "tokensave_files can list indexed files and narrow file lookup before opening individual files.",
+            false,
+        ));
+    }
+
     let text = combined_text(input);
     if text.is_empty() {
         return None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -802,6 +802,12 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 process::exit(code);
             }
         }
+        Commands::HookCursorPreToolUse => {
+            let code = tokensave::hooks::hook_cursor_pre_tool_use();
+            if code != 0 {
+                process::exit(code);
+            }
+        }
         Commands::HookCursorBeforeSubmitPrompt => {
             let code = tokensave::hooks::hook_cursor_before_submit_prompt().await;
             if code != 0 {
@@ -1207,6 +1213,7 @@ fn should_skip_startup_maintenance(command: &Commands) -> bool {
             | Commands::Uninstall { .. }
             | Commands::Doctor { .. }
             | Commands::HookCursorSubagentStart
+            | Commands::HookCursorPreToolUse
             | Commands::HookCursorBeforeSubmitPrompt
             | Commands::HookCursorAfterFileEdit
             | Commands::HookCursorSessionStart

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -861,6 +861,30 @@ fn test_local_install_cursor_reconciles_existing_hooks_idempotently() {
         tokensave_entries[0]["matcher"], "Write",
         "reinstall must reconcile the matcher onto a pre-existing entry"
     );
+
+    let pre = hooks["hooks"]["preToolUse"]
+        .as_array()
+        .expect("preToolUse should be an array");
+    let pre_tokensave_entries: Vec<_> = pre
+        .iter()
+        .filter(|hook| {
+            hook["command"]
+                .as_str()
+                .is_some_and(|command| command.contains("hook-cursor-pre-tool-use"))
+        })
+        .collect();
+    assert_eq!(
+        pre_tokensave_entries.len(),
+        1,
+        "install should add exactly one Cursor preToolUse hint hook"
+    );
+    assert!(
+        pre_tokensave_entries[0]["matcher"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Grep"),
+        "preToolUse hook should match Grep/search tools"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -2,9 +2,9 @@ use tokensave::hooks::{
     build_cursor_session_context, codex_additional_context_json, codex_apply_patch_rel_paths,
     codex_project_root_from_event, cursor_branch_switch_target, cursor_project_root_from_event,
     cursor_session_start_json, cursor_shell_sync_plan, cursor_should_run_sync,
-    cursor_staleness_hint, evaluate_codex_subagent_start, evaluate_cursor_subagent_start,
-    evaluate_hook_decision, evaluate_kiro_pre_tool_use, is_git_state_changing_command,
-    CursorShellSyncPlan,
+    cursor_staleness_hint, evaluate_codex_subagent_start, evaluate_cursor_pre_tool_use,
+    evaluate_cursor_subagent_start, evaluate_hook_decision, evaluate_kiro_pre_tool_use,
+    is_git_state_changing_command, CursorShellSyncPlan,
 };
 
 fn is_blocked(json: &str) -> bool {
@@ -247,6 +247,66 @@ fn test_cursor_subagent_start_allows_execution_task() {
     }"#;
 
     assert!(evaluate_cursor_subagent_start(input).is_none());
+}
+
+#[test]
+fn test_cursor_pre_tool_use_hints_for_grep_search() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "Grep",
+        "tool_input": {
+            "pattern": "cursor_prompt_hint",
+            "path": "src"
+        },
+        "session_id": "cursor-test"
+    }"#;
+
+    let output = evaluate_cursor_pre_tool_use(input).expect("Grep should get a tokensave hint");
+    let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(v["continue"].as_bool(), Some(true));
+    assert!(v["additional_context"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("tokensave hint:"));
+    assert!(v["additional_context"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("tokensave_search"));
+    assert!(v.get("permission").is_none());
+}
+
+#[test]
+fn test_cursor_pre_tool_use_hints_for_shell_rg() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "Shell",
+        "tool_input": {
+            "command": "rg cursor_prompt_hint src"
+        },
+        "session_id": "cursor-test"
+    }"#;
+
+    let output = evaluate_cursor_pre_tool_use(input).expect("rg shell command should get a hint");
+    let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(v["continue"].as_bool(), Some(true));
+    assert!(v["additional_context"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("tokensave hint:"));
+}
+
+#[test]
+fn test_cursor_pre_tool_use_allows_single_file_read() {
+    let input = r#"{
+        "hook_event_name": "preToolUse",
+        "tool_name": "Read",
+        "tool_input": {
+            "file_path": "src/hooks.rs"
+        },
+        "session_id": "cursor-test"
+    }"#;
+
+    assert!(evaluate_cursor_pre_tool_use(input).is_none());
 }
 
 #[test]

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -264,19 +264,15 @@ fn test_cursor_pre_tool_use_hints_for_grep_search() {
     let output = evaluate_cursor_pre_tool_use(input).expect("Grep should get a tokensave hint");
     let v: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(v["continue"].as_bool(), Some(true));
-    assert_eq!(
-        v["hookSpecificOutput"]["hookEventName"].as_str(),
-        Some("preToolUse")
-    );
-    assert!(v["hookSpecificOutput"]["additionalContext"]
+    assert!(v["additional_context"]
         .as_str()
         .unwrap_or_default()
         .contains("tokensave hint:"));
-    assert!(v["hookSpecificOutput"]["additionalContext"]
+    assert!(v["additional_context"]
         .as_str()
         .unwrap_or_default()
         .contains("tokensave_search"));
-    assert!(v.get("additional_context").is_none());
+    assert!(v.get("hookSpecificOutput").is_none());
     assert!(v.get("permission").is_none());
 }
 
@@ -294,7 +290,7 @@ fn test_cursor_pre_tool_use_hints_for_shell_rg() {
     let output = evaluate_cursor_pre_tool_use(input).expect("rg shell command should get a hint");
     let v: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(v["continue"].as_bool(), Some(true));
-    assert!(v["hookSpecificOutput"]["additionalContext"]
+    assert!(v["additional_context"]
         .as_str()
         .unwrap_or_default()
         .contains("tokensave hint:"));

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -264,14 +264,19 @@ fn test_cursor_pre_tool_use_hints_for_grep_search() {
     let output = evaluate_cursor_pre_tool_use(input).expect("Grep should get a tokensave hint");
     let v: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(v["continue"].as_bool(), Some(true));
-    assert!(v["additional_context"]
+    assert_eq!(
+        v["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("preToolUse")
+    );
+    assert!(v["hookSpecificOutput"]["additionalContext"]
         .as_str()
         .unwrap_or_default()
         .contains("tokensave hint:"));
-    assert!(v["additional_context"]
+    assert!(v["hookSpecificOutput"]["additionalContext"]
         .as_str()
         .unwrap_or_default()
         .contains("tokensave_search"));
+    assert!(v.get("additional_context").is_none());
     assert!(v.get("permission").is_none());
 }
 
@@ -289,7 +294,7 @@ fn test_cursor_pre_tool_use_hints_for_shell_rg() {
     let output = evaluate_cursor_pre_tool_use(input).expect("rg shell command should get a hint");
     let v: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(v["continue"].as_bool(), Some(true));
-    assert!(v["additional_context"]
+    assert!(v["hookSpecificOutput"]["additionalContext"]
         .as_str()
         .unwrap_or_default()
         .contains("tokensave hint:"));


### PR DESCRIPTION
## Summary
- Add a Cursor `preToolUse` hook that emits nonblocking `additional_context` before broad search tools like Grep and shell `rg`.
- Register the hook during Cursor local install and update doctor/docs/rules to describe the new soft search nudge.
- Extend hook and install tests to cover Grep, shell `rg`, single-file read pass-through, and preToolUse hook registration.

## Test plan
- `cargo fmt --check`
- `cargo test --test hooks_test`
- `cargo test --test agent_test test_local_install_cursor_reconciles_existing_hooks_idempotently`
- `cargo test --test agent_test test_local_install_cursor_writes_project_config_only`
- `cargo check`
- Manual smoke: `hook-cursor-pre-tool-use` emits `additional_context` with `tokensave hint:` for a Grep event.