### PR TITLE
fix(hooks): skip startup maintenance for Claude and Kiro hooks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1218,6 +1218,12 @@ fn should_skip_startup_maintenance(command: &Commands) -> bool {
             | Commands::Reinstall
             | Commands::Uninstall { .. }
             | Commands::Doctor { .. }
+            | Commands::HookPreToolUse
+            | Commands::HookPromptSubmit
+            | Commands::HookStop
+            | Commands::HookKiroPreToolUse
+            | Commands::HookKiroPromptSubmit
+            | Commands::HookKiroPostToolUse
             | Commands::HookCursorSubagentStart
             | Commands::HookCursorPreToolUse
             | Commands::HookCursorBeforeSubmitPrompt
@@ -1366,6 +1372,27 @@ mod startup_tests {
             path: None,
             timings: false,
         }));
+    }
+
+    #[test]
+    fn claude_and_kiro_hooks_skip_startup_maintenance() {
+        // Claude and Kiro lifecycle hooks are agent-invoked hot-path
+        // commands, exactly like the Cursor/Codex hooks already in the
+        // skip-list. They must skip the synchronous `try_flush` network
+        // round-trip (and the rest of the pre-command startup maintenance)
+        // so they stay fast on every tool-use/prompt/stop event (#84).
+        assert!(should_skip_startup_maintenance(&Commands::HookPreToolUse));
+        assert!(should_skip_startup_maintenance(&Commands::HookPromptSubmit));
+        assert!(should_skip_startup_maintenance(&Commands::HookStop));
+        assert!(should_skip_startup_maintenance(
+            &Commands::HookKiroPreToolUse
+        ));
+        assert!(should_skip_startup_maintenance(
+            &Commands::HookKiroPromptSubmit
+        ));
+        assert!(should_skip_startup_maintenance(
+            &Commands::HookKiroPostToolUse
+        ));
     }
 }
 


### PR DESCRIPTION
## Summary

`should_skip_startup_maintenance(command: &Commands)` in `src/main.rs` is a hand-maintained allow-list of commands that should NOT run the implicit pre-command startup maintenance — specifically the synchronous `global::try_flush()` worldwide-counter HTTP round-trip (and the first-run notice). The list exists to keep hot, agent-invoked paths fast (the same rationale as `Serve`, #84).

As each agent's hook integration landed, that agent's hook variants were appended:
- all **8 Cursor** `HookCursor*` variants ✅
- all **4 Codex** `HookCodex*` variants ✅

But the **older Claude and Kiro hook variants — which predate the Cursor/Codex hook work — were never added**:
- Claude: `HookPreToolUse`, `HookPromptSubmit`, `HookStop`
- Kiro: `HookKiroPreToolUse`, `HookKiroPromptSubmit`, `HookKiroPostToolUse`

These are agent-invoked lifecycle hooks (fired on every tool-use / prompt / stop event), structurally identical in role to the Cursor/Codex hooks. Because they fell through the list, every Claude/Kiro hook invocation ran a **blocking network flush on the hot path** that the Cursor/Codex hooks already skip — an accidental latency regression, not a deliberate design choice.

### Evidence it's an accidental omission (not intentional)
- `git blame` shows the skip-list grew incrementally per agent (`35d71cf1`, `a4d5ea3`, `19400576`, `9d0e90f`, `1a75e6e`); the Claude/Kiro hooks existed before any of those commits and were simply never back-filled.
- No comment, commit message, or test indicates Claude/Kiro hooks should run startup maintenance while Cursor/Codex hooks skip it.
- The `Serve` rationale comment (#84) describes exactly the cost being incurred here.

## Changes

- Add the 6 missing Claude/Kiro hook variants to `should_skip_startup_maintenance`, placed before the Cursor block to mirror the command-dispatch order (Claude → Kiro → Cursor → Codex).
- Add regression test `claude_and_kiro_hooks_skip_startup_maintenance` asserting all 6 variants skip.

This is intentionally minimal — it does **not** convert the list into a data-driven hook registry (deferred refactor), and does not touch `should_skip_agent_install_maintenance`.

## Test plan

- [x] New test fails before the fix (red): `claude_and_kiro_hooks_skip_startup_maintenance` panics on `HookPreToolUse`.
- [x] New test passes after the fix (green); all 6 startup unit tests pass.
- [x] `cargo fmt --check` clean
- [x] `cargo check --all-targets` clean
- [x] `cargo test --bin tokensave startup` → 6 passed
- [x] `cargo test --test hooks_test --test agent_test --test claude_agent_test --test kiro_agent_test --test hook_branch_routing_test` → all passed
- [x] `cargo build` succeeds