### PR TITLE
fix(indexing): refresh targeted sync deletes and edit refs

### DIFF
--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -939,7 +939,11 @@ impl TokenSave {
         // canonical form is forward-slash (#87).
         let file_paths = normalize_rel_paths(file_paths);
 
-        // Read and hash the files
+        // Read and hash files that still exist. Missing targeted paths are
+        // deletions, so clean their DB rows immediately instead of handing
+        // them to extraction where they would be silently skipped.
+        let mut existing_file_paths: Vec<String> = Vec::with_capacity(file_paths.len());
+        let mut removed_file_paths: Vec<String> = Vec::new();
         let mut hash_map: HashMap<String, String> = HashMap::new();
         let mut stat_map: HashMap<String, (i64, u64)> = HashMap::new();
 
@@ -947,6 +951,10 @@ impl TokenSave {
             let abs_path = project_root.join(path);
             if let Some((mtime, size)) = sync_mod::file_stat(&abs_path) {
                 stat_map.insert(path.clone(), (mtime, size));
+                existing_file_paths.push(path.clone());
+            } else {
+                removed_file_paths.push(path.clone());
+                continue;
             }
             if let Ok(source) = sync_mod::read_source_file(&abs_path) {
                 let hash = sync_mod::content_hash(&source);
@@ -954,10 +962,14 @@ impl TokenSave {
             }
         }
 
+        for path in &removed_file_paths {
+            self.db.delete_file(path).await?;
+        }
+
         // Extract graph data from the files in parallel (subprocess-isolated)
         let _ = stat_map; // worker re-stats internally; map kept for potential future use
         let (sync_extractions, _skipped_extractions) =
-            extract_files_isolated(project_root, registry, file_paths.clone());
+            extract_files_isolated(project_root, registry, existing_file_paths.clone());
 
         // Phase 1: insert all nodes (and metadata) so cross-file edges
         // can reference them. Edges are queued for phase 2 (#58).
@@ -991,18 +1003,9 @@ impl TokenSave {
             self.db.insert_edges(&owned).await?;
         }
 
-        // Resolve references for any new/changed unresolved refs
-        if !file_paths.is_empty() {
-            let all_nodes = self.db.get_all_nodes().await.unwrap_or_default();
-            let resolver = ReferenceResolver::from_nodes(&self.db, &all_nodes);
-            let unresolved = self.db.get_unresolved_refs().await?;
-            if !unresolved.is_empty() {
-                let resolution = resolver.resolve_all(&unresolved);
-                let edges = resolver.create_edges(&resolution.resolved);
-                if !edges.is_empty() {
-                    self.db.insert_edges(&edges).await?;
-                }
-            }
+        // Resolve references for any new/changed unresolved refs.
+        if !existing_file_paths.is_empty() {
+            self.resolve_unresolved_refs().await?;
         }
 
         self.db
@@ -1016,6 +1019,22 @@ impl TokenSave {
             .await?;
 
         clear_dirty_sentinel(&self.project_root);
+        Ok(())
+    }
+
+    async fn resolve_unresolved_refs(&self) -> Result<()> {
+        let all_nodes = self.db.get_all_nodes().await.unwrap_or_default();
+        let resolver = ReferenceResolver::from_nodes(&self.db, &all_nodes);
+        let unresolved = self.db.get_unresolved_refs().await?;
+        if unresolved.is_empty() {
+            return Ok(());
+        }
+
+        let resolution = resolver.resolve_all(&unresolved);
+        let edges = resolver.create_edges(&resolution.resolved);
+        if !edges.is_empty() {
+            self.db.insert_edges(&edges).await?;
+        }
         Ok(())
     }
 
@@ -1526,6 +1545,7 @@ impl TokenSave {
             node_count: result.nodes.len() as u32,
         };
         self.db.upsert_file(&file_record).await?;
+        self.resolve_unresolved_refs().await?;
 
         Ok(())
     }

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -1023,13 +1023,13 @@ impl TokenSave {
     }
 
     async fn resolve_unresolved_refs(&self) -> Result<()> {
-        let all_nodes = self.db.get_all_nodes().await.unwrap_or_default();
-        let resolver = ReferenceResolver::from_nodes(&self.db, &all_nodes);
         let unresolved = self.db.get_unresolved_refs().await?;
         if unresolved.is_empty() {
             return Ok(());
         }
 
+        let all_nodes = self.db.get_all_nodes().await.unwrap_or_default();
+        let resolver = ReferenceResolver::from_nodes(&self.db, &all_nodes);
         let resolution = resolver.resolve_all(&unresolved);
         let edges = resolver.create_edges(&resolution.resolved);
         if !edges.is_empty() {

--- a/tests/tokensave_test.rs
+++ b/tests/tokensave_test.rs
@@ -4,7 +4,7 @@
 use std::fs;
 use tempfile::TempDir;
 use tokensave::tokensave::{is_test_file, TokenSave};
-use tokensave::types::NodeKind;
+use tokensave::types::{EdgeKind, NodeKind};
 
 // ---------------------------------------------------------------------------
 // Shared setup
@@ -543,6 +543,85 @@ async fn test_get_stats() {
 // ---------------------------------------------------------------------------
 // sync_if_stale_silent
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sync_if_stale_removes_deleted_indexed_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/keep.rs"), "pub fn keep() {}\n").unwrap();
+    fs::write(
+        project.join("src/remove_me.rs"),
+        "pub fn deleted_symbol() {}\n",
+    )
+    .unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.sync().await.unwrap();
+    fs::remove_file(project.join("src/remove_me.rs")).unwrap();
+
+    let still_stale = cg
+        .sync_if_stale(&["src/remove_me.rs".to_string()])
+        .await
+        .unwrap();
+
+    assert!(
+        !still_stale,
+        "targeted sync should clear stale state for deleted indexed files"
+    );
+    let files = cg.get_all_files().await.unwrap();
+    assert!(
+        !files.iter().any(|file| file.path == "src/remove_me.rs"),
+        "deleted file row should be removed, got {files:?}"
+    );
+    let nodes = cg.get_all_nodes().await.unwrap();
+    assert!(
+        !nodes
+            .iter()
+            .any(|node| node.file_path == "src/remove_me.rs"),
+        "deleted file nodes should be removed"
+    );
+}
+
+#[tokio::test]
+async fn str_replace_reindex_resolves_new_cross_file_call() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/target.rs"), "pub fn target() {}\n").unwrap();
+    fs::write(project.join("src/caller.rs"), "pub fn caller() {}\n").unwrap();
+
+    let cg = TokenSave::init(project).await.unwrap();
+    cg.sync().await.unwrap();
+
+    let edit = cg
+        .str_replace(
+            "src/caller.rs",
+            "pub fn caller() {}\n",
+            "pub fn caller() { target(); }\n",
+        )
+        .await
+        .unwrap();
+    assert!(edit.success, "edit should succeed: {edit:?}");
+
+    let nodes = cg.get_all_nodes().await.unwrap();
+    let caller = nodes
+        .iter()
+        .find(|node| node.name == "caller" && node.file_path == "src/caller.rs")
+        .unwrap();
+    let target = nodes
+        .iter()
+        .find(|node| node.name == "target" && node.file_path == "src/target.rs")
+        .unwrap();
+    let edges = cg.get_all_edges().await.unwrap();
+
+    assert!(
+        edges.iter().any(|edge| {
+            edge.kind == EdgeKind::Calls && edge.source == caller.id && edge.target == target.id
+        }),
+        "direct edit reindex should resolve the new caller -> target edge; edges={edges:?}"
+    );
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sync_if_stale_silent_waits_for_peer_then_returns_ok() {


### PR DESCRIPTION
## Summary
- Clean up targeted `sync_if_stale[_silent]` paths that have been deleted on disk by removing their file rows and graph data instead of letting extraction skip them.
- Reuse the reference-resolution pass after direct edit reindexing so newly introduced cross-file calls are queryable immediately.
- Add regression coverage for deleted-file targeted sync and `str_replace` cross-file call resolution.

## Test plan
- RED: `cargo test --test tokensave_test sync_if_stale_removes_deleted_indexed_file -- --exact` failed with stale deleted file not cleared.
- RED: `cargo test --test tokensave_test str_replace_reindex_resolves_new_cross_file_call -- --exact` failed with no resolved call edges.
- GREEN: `cargo test --test tokensave_test sync_if_stale_removes_deleted_indexed_file -- --exact`
- GREEN: `cargo test --test tokensave_test str_replace_reindex_resolves_new_cross_file_call -- --exact`
- Validation: `cargo test --test tokensave_test --test sync_test --test resolution_test`
- Validation: `cargo build`