### PR TITLE
Prevent fallback branch sync writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fallback branch DBs are now read-only for sync/index writes.** `tokensave sync`, lazy single-file syncs, and full indexing now refuse to write when the active git branch is being served from an ancestor branch database, preventing branch-only files from being indexed into the fallback DB.
+
 ## [6.1.3] - 2026-06-04
 
 ### Fixed

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -928,6 +928,8 @@ impl TokenSave {
     async fn sync_single_files(&self, file_paths: &[String]) -> Result<()> {
         use crate::sync as sync_mod;
 
+        self.ensure_branch_writable("sync files")?;
+
         let start = Instant::now();
         let project_root = &self.project_root;
         let registry = &self.registry;
@@ -1044,6 +1046,7 @@ impl TokenSave {
             self.project_root.is_dir(),
             "sync: project root is not a directory"
         );
+        self.ensure_branch_writable("sync")?;
         let _lock = try_acquire_sync_lock(&self.project_root)?;
         write_dirty_sentinel(&self.project_root);
         let start = Instant::now();
@@ -2600,6 +2603,27 @@ impl TokenSave {
     /// Returns the project root path.
     pub fn project_root(&self) -> &Path {
         &self.project_root
+    }
+
+    fn ensure_branch_writable(&self, operation: &str) -> Result<()> {
+        if !self.is_fallback() {
+            return Ok(());
+        }
+
+        let active = self.active_branch.as_deref().unwrap_or("detached HEAD");
+        let serving = self.serving_branch.as_deref().unwrap_or("default branch");
+        let hint = self
+            .active_branch
+            .as_deref()
+            .map(|branch| format!(" Run `tokensave branch add {branch}` before writing."))
+            .unwrap_or_else(|| " Check out a tracked branch before writing.".to_string());
+
+        Err(TokenSaveError::Config {
+            message: format!(
+                "cannot {operation}: active branch '{active}' is served from fallback branch \
+                 '{serving}'.{hint}"
+            ),
+        })
     }
 
     /// Recompute the on-disk path to the `SQLite` DB this instance is

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -856,6 +856,8 @@ impl TokenSave {
             return Ok(false);
         }
 
+        self.ensure_branch_writable("sync files")?;
+
         let Ok(lock) = try_acquire_sync_lock(&self.project_root) else {
             return Ok(true);
         };
@@ -890,6 +892,8 @@ impl TokenSave {
         if still_stale_before.is_empty() {
             return Ok(());
         }
+
+        self.ensure_branch_writable("sync files")?;
 
         let lock = if let Ok(lock) = try_acquire_sync_lock(&self.project_root) {
             lock

--- a/src/tokensave.rs
+++ b/src/tokensave.rs
@@ -695,6 +695,7 @@ impl TokenSave {
             self.project_root.is_dir(),
             "project root is not a directory"
         );
+        self.ensure_branch_writable("full index")?;
         let _lock = try_acquire_sync_lock(&self.project_root)?;
         write_dirty_sentinel(&self.project_root);
         let start = Instant::now();

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use tempfile::TempDir;
@@ -35,91 +36,114 @@ fn commit_all(project: &Path, message: &str) {
     );
 }
 
-#[tokio::test]
-async fn sync_refuses_to_write_when_opened_on_fallback_branch() {
+async fn open_untracked_fallback_project() -> (TempDir, PathBuf, TokenSave) {
     let dir = TempDir::new().unwrap();
-    let project = dir.path();
+    let project = dir.path().to_path_buf();
 
-    git(project, &["init", "-b", "main"]);
+    git(&project, &["init", "-b", "main"]);
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub fn indexed_on_main() {}\n").unwrap();
-    commit_all(project, "initial commit");
+    commit_all(&project, "initial commit");
 
-    let main = TokenSave::init(project).await.unwrap();
+    let main = TokenSave::init(&project).await.unwrap();
     main.index_all().await.unwrap();
     drop(main);
 
-    git(project, &["checkout", "-b", "feature/untracked"]);
+    git(&project, &["checkout", "-b", "feature/untracked"]);
     fs::write(
         project.join("src/untracked_only.rs"),
         "pub fn untracked_only() {}\n",
     )
     .unwrap();
 
-    let fallback = TokenSave::open(project).await.unwrap();
+    let fallback = TokenSave::open(&project).await.unwrap();
     assert_eq!(fallback.active_branch(), Some("feature/untracked"));
     assert_eq!(fallback.serving_branch(), Some("main"));
     assert!(fallback.is_fallback());
 
-    let err = fallback.sync().await.unwrap_err();
+    (dir, project, fallback)
+}
+
+async fn assert_main_db_missing_untracked_only(project: &Path, message: &str) {
+    git(project, &["checkout", "main"]);
+    let main = TokenSave::open(project).await.unwrap();
+    let results = main.search("untracked_only", 10).await.unwrap();
+    assert!(results.is_empty(), "{message}");
+}
+
+fn assert_fallback_write_refused(err: impl std::fmt::Display) {
     let message = err.to_string();
     assert!(
         message.contains("fallback") && message.contains("tokensave branch add"),
         "unexpected error: {message}"
     );
+}
+
+#[tokio::test]
+async fn sync_refuses_to_write_when_opened_on_fallback_branch() {
+    let (_dir, project, fallback) = open_untracked_fallback_project().await;
+
+    let err = fallback.sync().await.unwrap_err();
+    assert_fallback_write_refused(err);
 
     drop(fallback);
-    git(project, &["checkout", "main"]);
-    let main = TokenSave::open(project).await.unwrap();
-    let results = main.search("untracked_only", 10).await.unwrap();
-    assert!(
-        results.is_empty(),
-        "fallback sync must not index untracked branch files into main DB"
-    );
+    assert_main_db_missing_untracked_only(
+        &project,
+        "fallback sync must not index untracked branch files into main DB",
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn full_index_refuses_to_write_when_opened_on_fallback_branch() {
-    let dir = TempDir::new().unwrap();
-    let project = dir.path();
-
-    git(project, &["init", "-b", "main"]);
-    fs::create_dir_all(project.join("src")).unwrap();
-    fs::write(project.join("src/lib.rs"), "pub fn indexed_on_main() {}\n").unwrap();
-    commit_all(project, "initial commit");
-
-    let main = TokenSave::init(project).await.unwrap();
-    main.index_all().await.unwrap();
-    drop(main);
-
-    git(project, &["checkout", "-b", "feature/untracked"]);
-    fs::write(
-        project.join("src/untracked_only.rs"),
-        "pub fn untracked_only() {}\n",
-    )
-    .unwrap();
-
-    let fallback = TokenSave::open(project).await.unwrap();
-    assert_eq!(fallback.active_branch(), Some("feature/untracked"));
-    assert_eq!(fallback.serving_branch(), Some("main"));
-    assert!(fallback.is_fallback());
+    let (_dir, project, fallback) = open_untracked_fallback_project().await;
 
     let err = match fallback.index_all().await {
         Ok(_) => panic!("full index should refuse fallback writes"),
         Err(err) => err,
     };
-    let message = err.to_string();
-    assert!(
-        message.contains("fallback") && message.contains("tokensave branch add"),
-        "unexpected error: {message}"
-    );
+    assert_fallback_write_refused(err);
 
     drop(fallback);
-    git(project, &["checkout", "main"]);
-    let main = TokenSave::open(project).await.unwrap();
-    let results = main.search("untracked_only", 10).await.unwrap();
-    assert!(
-        results.is_empty(),
-        "fallback full index must not index untracked branch files into main DB"
-    );
+    assert_main_db_missing_untracked_only(
+        &project,
+        "fallback full index must not index untracked branch files into main DB",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn stale_sync_refuses_to_write_when_opened_on_fallback_branch() {
+    let (_dir, project, fallback) = open_untracked_fallback_project().await;
+
+    let err = fallback
+        .sync_if_stale(&["src/untracked_only.rs".to_string()])
+        .await
+        .unwrap_err();
+    assert_fallback_write_refused(err);
+
+    drop(fallback);
+    assert_main_db_missing_untracked_only(
+        &project,
+        "fallback stale sync must not index untracked branch files into main DB",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn silent_stale_sync_refuses_to_write_when_opened_on_fallback_branch() {
+    let (_dir, project, fallback) = open_untracked_fallback_project().await;
+
+    let err = fallback
+        .sync_if_stale_silent(&["src/untracked_only.rs".to_string()])
+        .await
+        .unwrap_err();
+    assert_fallback_write_refused(err);
+
+    drop(fallback);
+    assert_main_db_missing_untracked_only(
+        &project,
+        "fallback silent stale sync must not index untracked branch files into main DB",
+    )
+    .await;
 }

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -1,0 +1,79 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use tokensave::tokensave::TokenSave;
+
+fn git(project: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(project)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_all(project: &Path, message: &str) {
+    git(project, &["add", "."]);
+    git(
+        project,
+        &[
+            "-c",
+            "user.name=TokenSave Test",
+            "-c",
+            "user.email=tokensave-test@example.com",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
+}
+
+#[tokio::test]
+async fn sync_refuses_to_write_when_opened_on_fallback_branch() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    git(project, &["init", "-b", "main"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn indexed_on_main() {}\n").unwrap();
+    commit_all(project, "initial commit");
+
+    let main = TokenSave::init(project).await.unwrap();
+    main.index_all().await.unwrap();
+    drop(main);
+
+    git(project, &["checkout", "-b", "feature/untracked"]);
+    fs::write(
+        project.join("src/untracked_only.rs"),
+        "pub fn untracked_only() {}\n",
+    )
+    .unwrap();
+
+    let fallback = TokenSave::open(project).await.unwrap();
+    assert_eq!(fallback.active_branch(), Some("feature/untracked"));
+    assert_eq!(fallback.serving_branch(), Some("main"));
+    assert!(fallback.is_fallback());
+
+    let err = fallback.sync().await.unwrap_err();
+    let message = err.to_string();
+    assert!(
+        message.contains("fallback") && message.contains("tokensave branch add"),
+        "unexpected error: {message}"
+    );
+
+    drop(fallback);
+    git(project, &["checkout", "main"]);
+    let main = TokenSave::open(project).await.unwrap();
+    let results = main.search("untracked_only", 10).await.unwrap();
+    assert!(
+        results.is_empty(),
+        "fallback sync must not index untracked branch files into main DB"
+    );
+}

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -77,3 +77,49 @@ async fn sync_refuses_to_write_when_opened_on_fallback_branch() {
         "fallback sync must not index untracked branch files into main DB"
     );
 }
+
+#[tokio::test]
+async fn full_index_refuses_to_write_when_opened_on_fallback_branch() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    git(project, &["init", "-b", "main"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn indexed_on_main() {}\n").unwrap();
+    commit_all(project, "initial commit");
+
+    let main = TokenSave::init(project).await.unwrap();
+    main.index_all().await.unwrap();
+    drop(main);
+
+    git(project, &["checkout", "-b", "feature/untracked"]);
+    fs::write(
+        project.join("src/untracked_only.rs"),
+        "pub fn untracked_only() {}\n",
+    )
+    .unwrap();
+
+    let fallback = TokenSave::open(project).await.unwrap();
+    assert_eq!(fallback.active_branch(), Some("feature/untracked"));
+    assert_eq!(fallback.serving_branch(), Some("main"));
+    assert!(fallback.is_fallback());
+
+    let err = match fallback.index_all().await {
+        Ok(_) => panic!("full index should refuse fallback writes"),
+        Err(err) => err,
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("fallback") && message.contains("tokensave branch add"),
+        "unexpected error: {message}"
+    );
+
+    drop(fallback);
+    git(project, &["checkout", "main"]);
+    let main = TokenSave::open(project).await.unwrap();
+    let results = main.search("untracked_only", 10).await.unwrap();
+    assert!(
+        results.is_empty(),
+        "fallback full index must not index untracked branch files into main DB"
+    );
+}


### PR DESCRIPTION
## Summary
- Prevent `TokenSave` instances opened on branch fallback DBs from running full syncs or focused lazy sync writes.
- Add a regression test proving an untracked branch can read from `main` fallback but cannot sync branch-only files into `main`'s DB.

## Test plan
- RED: `cargo test --test branch_db_safety_test sync_refuses_to_write_when_opened_on_fallback_branch` failed before the fix because `sync()` returned `Ok(SyncResult { files_added: 1, ... })` and indexed `src/untracked_only.rs` into the fallback DB.
- GREEN: `cargo test --test branch_db_safety_test sync_refuses_to_write_when_opened_on_fallback_branch`
- `cargo fmt --check`
- `cargo test --test branch_db_safety_test`
- `cargo test branch`

## Caveats
- This PR targets the highest-risk write-safety issue only.
- Deferred: branch DB filename collision handling, `branch add <name>` current-checkout mismatch, and improved warnings for missing tracked branch DB files.