### PR TITLE
fix(db): roll back failed batch transactions

### DIFF
--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -433,8 +433,7 @@ impl Database {
                 })?;
 
             for node in nodes {
-                if let Err(e) = stmt
-                    .execute(params![
+                let params = params![
                     node.id.as_str(),
                     node.kind.as_str(),
                     node.name.as_str(),
@@ -458,9 +457,9 @@ impl Database {
                     node.updated_at as i64,
                     i64::from(node.attrs_start_line),
                     opt_str(node.parent_id.as_deref()),
-                ])
-                    .await
-                {
+                ];
+                let insert_result = stmt.execute(params).await;
+                if let Err(e) = insert_result {
                     stmt.reset();
                     return Err(TokenSaveError::Database {
                         message: format!("failed to insert node: {e}"),

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -27,6 +27,12 @@ fn build_qmark_placeholders(n: usize) -> String {
     s
 }
 
+impl Database {
+    async fn rollback_batch_transaction(&self) {
+        let _ = self.conn().execute("ROLLBACK", ()).await;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helper: map a libsql row to domain types (by column index)
 // ---------------------------------------------------------------------------
@@ -409,64 +415,76 @@ impl Database {
                 operation: "insert_nodes".to_string(),
             })?;
 
-        let stmt = self.conn()
-            .prepare(
-                "INSERT OR REPLACE INTO nodes \
-                 (id,kind,name,qualified_name,file_path,\
-                 start_line,end_line,start_column,end_column,\
-                 docstring,signature,visibility,is_async,\
-                 branches,loops,returns,max_nesting,\
-                 unsafe_blocks,unchecked_calls,assertions,updated_at,attrs_start_line,parent_id) \
-                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23)"
-            )
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to prepare: {e}"),
-                operation: "insert_nodes".to_string(),
-            })?;
+        let result = async {
+            let stmt = self.conn()
+                .prepare(
+                    "INSERT OR REPLACE INTO nodes \
+                     (id,kind,name,qualified_name,file_path,\
+                     start_line,end_line,start_column,end_column,\
+                     docstring,signature,visibility,is_async,\
+                     branches,loops,returns,max_nesting,\
+                     unsafe_blocks,unchecked_calls,assertions,updated_at,attrs_start_line,parent_id) \
+                     VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23)"
+                )
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to prepare: {e}"),
+                    operation: "insert_nodes".to_string(),
+                })?;
 
-        for node in nodes {
-            stmt.execute(params![
-                node.id.as_str(),
-                node.kind.as_str(),
-                node.name.as_str(),
-                node.qualified_name.as_str(),
-                node.file_path.as_str(),
-                i64::from(node.start_line),
-                i64::from(node.end_line),
-                i64::from(node.start_column),
-                i64::from(node.end_column),
-                opt_str(node.docstring.as_deref()),
-                opt_str(node.signature.as_deref()),
-                node.visibility.as_str(),
-                i64::from(node.is_async),
-                i64::from(node.branches),
-                i64::from(node.loops),
-                i64::from(node.returns),
-                i64::from(node.max_nesting),
-                i64::from(node.unsafe_blocks),
-                i64::from(node.unchecked_calls),
-                i64::from(node.assertions),
-                node.updated_at as i64,
-                i64::from(node.attrs_start_line),
-                opt_str(node.parent_id.as_deref()),
-            ])
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to insert node: {e}"),
-                operation: "insert_nodes".to_string(),
-            })?;
-            stmt.reset();
+            for node in nodes {
+                if let Err(e) = stmt
+                    .execute(params![
+                    node.id.as_str(),
+                    node.kind.as_str(),
+                    node.name.as_str(),
+                    node.qualified_name.as_str(),
+                    node.file_path.as_str(),
+                    i64::from(node.start_line),
+                    i64::from(node.end_line),
+                    i64::from(node.start_column),
+                    i64::from(node.end_column),
+                    opt_str(node.docstring.as_deref()),
+                    opt_str(node.signature.as_deref()),
+                    node.visibility.as_str(),
+                    i64::from(node.is_async),
+                    i64::from(node.branches),
+                    i64::from(node.loops),
+                    i64::from(node.returns),
+                    i64::from(node.max_nesting),
+                    i64::from(node.unsafe_blocks),
+                    i64::from(node.unchecked_calls),
+                    i64::from(node.assertions),
+                    node.updated_at as i64,
+                    i64::from(node.attrs_start_line),
+                    opt_str(node.parent_id.as_deref()),
+                ])
+                    .await
+                {
+                    stmt.reset();
+                    return Err(TokenSaveError::Database {
+                        message: format!("failed to insert node: {e}"),
+                        operation: "insert_nodes".to_string(),
+                    });
+                }
+                stmt.reset();
+            }
+
+            self.conn()
+                .execute("COMMIT", ())
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to commit: {e}"),
+                    operation: "insert_nodes".to_string(),
+                })?;
+            Ok(())
         }
+        .await;
 
-        self.conn()
-            .execute("COMMIT", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to commit: {e}"),
-                operation: "insert_nodes".to_string(),
-            })?;
-        Ok(())
+        if result.is_err() {
+            self.rollback_batch_transaction().await;
+        }
+        result
     }
 
     /// Retrieves a node by its unique ID, returning `None` if not found.
@@ -775,66 +793,81 @@ impl Database {
                 operation: "insert_edges".to_string(),
             })?;
 
-        // Conditional INSERT: only insert when both endpoints exist in
-        // `nodes`. This avoids FK violations during incremental sync
-        // when an edge references a node from a not-yet-indexed file.
-        let stmt = self
-            .conn()
-            .prepare(
-                "INSERT OR IGNORE INTO edges (source, target, kind, line) \
-                 SELECT ?1, ?2, ?3, ?4 \
-                 WHERE EXISTS (SELECT 1 FROM nodes WHERE id = ?1) \
-                   AND EXISTS (SELECT 1 FROM nodes WHERE id = ?2)",
-            )
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to prepare: {e}"),
-                operation: "insert_edges".to_string(),
-            })?;
+        let result = async {
+            // Conditional INSERT: only insert when both endpoints exist in
+            // `nodes`. This avoids FK violations during incremental sync
+            // when an edge references a node from a not-yet-indexed file.
+            let stmt = self
+                .conn()
+                .prepare(
+                    "INSERT OR IGNORE INTO edges (source, target, kind, line) \
+                     SELECT ?1, ?2, ?3, ?4 \
+                     WHERE EXISTS (SELECT 1 FROM nodes WHERE id = ?1) \
+                       AND EXISTS (SELECT 1 FROM nodes WHERE id = ?2)",
+                )
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to prepare: {e}"),
+                    operation: "insert_edges".to_string(),
+                })?;
 
-        let parent_stmt = self
-            .conn()
-            .prepare("UPDATE nodes SET parent_id = ?1 WHERE id = ?2")
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to prepare parent update: {e}"),
-                operation: "insert_edges".to_string(),
-            })?;
+            let parent_stmt = self
+                .conn()
+                .prepare("UPDATE nodes SET parent_id = ?1 WHERE id = ?2")
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to prepare parent update: {e}"),
+                    operation: "insert_edges".to_string(),
+                })?;
 
-        for edge in edges {
-            if edge.kind == EdgeKind::Contains {
-                parent_stmt
-                    .execute(params![edge.source.as_str(), edge.target.as_str()])
+            for edge in edges {
+                if edge.kind == EdgeKind::Contains {
+                    if let Err(e) = parent_stmt
+                        .execute(params![edge.source.as_str(), edge.target.as_str()])
+                        .await
+                    {
+                        parent_stmt.reset();
+                        return Err(TokenSaveError::Database {
+                            message: format!("failed to set parent_id: {e}"),
+                            operation: "insert_edges".to_string(),
+                        });
+                    }
+                    parent_stmt.reset();
+                    continue;
+                }
+                if let Err(e) = stmt
+                    .execute(params![
+                        edge.source.as_str(),
+                        edge.target.as_str(),
+                        edge.kind.as_str(),
+                        edge.line.map(i64::from),
+                    ])
                     .await
-                    .map_err(|e| TokenSaveError::Database {
-                        message: format!("failed to set parent_id: {e}"),
+                {
+                    stmt.reset();
+                    return Err(TokenSaveError::Database {
+                        message: format!("failed to insert edge: {e}"),
                         operation: "insert_edges".to_string(),
-                    })?;
-                parent_stmt.reset();
-                continue;
+                    });
+                }
+                stmt.reset();
             }
-            stmt.execute(params![
-                edge.source.as_str(),
-                edge.target.as_str(),
-                edge.kind.as_str(),
-                edge.line.map(i64::from),
-            ])
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to insert edge: {e}"),
-                operation: "insert_edges".to_string(),
-            })?;
-            stmt.reset();
-        }
 
-        self.conn()
-            .execute("COMMIT", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to commit: {e}"),
-                operation: "insert_edges".to_string(),
-            })?;
-        Ok(())
+            self.conn()
+                .execute("COMMIT", ())
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to commit: {e}"),
+                    operation: "insert_edges".to_string(),
+                })?;
+            Ok(())
+        }
+        .await;
+
+        if result.is_err() {
+            self.rollback_batch_transaction().await;
+        }
+        result
     }
 
     /// Returns outgoing edges from a source node, optionally filtered by edge kinds.
@@ -1940,39 +1973,51 @@ impl Database {
                 operation: "upsert_files".to_string(),
             })?;
 
-        let stmt = self.conn()
-            .prepare("INSERT OR REPLACE INTO files (path,content_hash,size,modified_at,indexed_at,node_count) VALUES (?1,?2,?3,?4,?5,?6)")
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to prepare: {e}"),
-                operation: "upsert_files".to_string(),
-            })?;
+        let result = async {
+            let stmt = self.conn()
+                .prepare("INSERT OR REPLACE INTO files (path,content_hash,size,modified_at,indexed_at,node_count) VALUES (?1,?2,?3,?4,?5,?6)")
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to prepare: {e}"),
+                    operation: "upsert_files".to_string(),
+                })?;
 
-        for file in files {
-            stmt.execute(params![
-                file.path.as_str(),
-                file.content_hash.as_str(),
-                file.size as i64,
-                file.modified_at,
-                file.indexed_at,
-                i64::from(file.node_count),
-            ])
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to upsert file: {e}"),
-                operation: "upsert_files".to_string(),
-            })?;
-            stmt.reset();
+            for file in files {
+                if let Err(e) = stmt
+                    .execute(params![
+                        file.path.as_str(),
+                        file.content_hash.as_str(),
+                        file.size as i64,
+                        file.modified_at,
+                        file.indexed_at,
+                        i64::from(file.node_count),
+                    ])
+                    .await
+                {
+                    stmt.reset();
+                    return Err(TokenSaveError::Database {
+                        message: format!("failed to upsert file: {e}"),
+                        operation: "upsert_files".to_string(),
+                    });
+                }
+                stmt.reset();
+            }
+
+            self.conn()
+                .execute("COMMIT", ())
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to commit: {e}"),
+                    operation: "upsert_files".to_string(),
+                })?;
+            Ok(())
         }
+        .await;
 
-        self.conn()
-            .execute("COMMIT", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to commit: {e}"),
-                operation: "upsert_files".to_string(),
-            })?;
-        Ok(())
+        if result.is_err() {
+            self.rollback_batch_transaction().await;
+        }
+        result
     }
 
     pub async fn upsert_file(&self, file: &FileRecord) -> Result<()> {
@@ -2102,39 +2147,51 @@ impl Database {
                 operation: "insert_unresolved_refs".to_string(),
             })?;
 
-        let stmt = self.conn()
-            .prepare("INSERT INTO unresolved_refs (from_node_id,reference_name,reference_kind,line,col,file_path) VALUES (?1,?2,?3,?4,?5,?6)")
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to prepare: {e}"),
-                operation: "insert_unresolved_refs".to_string(),
-            })?;
+        let result = async {
+            let stmt = self.conn()
+                .prepare("INSERT INTO unresolved_refs (from_node_id,reference_name,reference_kind,line,col,file_path) VALUES (?1,?2,?3,?4,?5,?6)")
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to prepare: {e}"),
+                    operation: "insert_unresolved_refs".to_string(),
+                })?;
 
-        for uref in refs {
-            stmt.execute(params![
-                uref.from_node_id.as_str(),
-                uref.reference_name.as_str(),
-                uref.reference_kind.as_str(),
-                i64::from(uref.line),
-                i64::from(uref.column),
-                uref.file_path.as_str(),
-            ])
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to insert unresolved ref: {e}"),
-                operation: "insert_unresolved_refs".to_string(),
-            })?;
-            stmt.reset();
+            for uref in refs {
+                if let Err(e) = stmt
+                    .execute(params![
+                        uref.from_node_id.as_str(),
+                        uref.reference_name.as_str(),
+                        uref.reference_kind.as_str(),
+                        i64::from(uref.line),
+                        i64::from(uref.column),
+                        uref.file_path.as_str(),
+                    ])
+                    .await
+                {
+                    stmt.reset();
+                    return Err(TokenSaveError::Database {
+                        message: format!("failed to insert unresolved ref: {e}"),
+                        operation: "insert_unresolved_refs".to_string(),
+                    });
+                }
+                stmt.reset();
+            }
+
+            self.conn()
+                .execute("COMMIT", ())
+                .await
+                .map_err(|e| TokenSaveError::Database {
+                    message: format!("failed to commit: {e}"),
+                    operation: "insert_unresolved_refs".to_string(),
+                })?;
+            Ok(())
         }
+        .await;
 
-        self.conn()
-            .execute("COMMIT", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to commit: {e}"),
-                operation: "insert_unresolved_refs".to_string(),
-            })?;
-        Ok(())
+        if result.is_err() {
+            self.rollback_batch_transaction().await;
+        }
+        result
     }
 
     /// Returns all unresolved references.

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -28,8 +28,35 @@ fn build_qmark_placeholders(n: usize) -> String {
 }
 
 impl Database {
-    async fn rollback_batch_transaction(&self) {
-        let _ = self.conn().execute("ROLLBACK", ()).await;
+    async fn with_batch_transaction<T>(
+        &self,
+        operation: &str,
+        work: impl std::future::Future<Output = Result<T>>,
+    ) -> Result<T> {
+        self.conn()
+            .execute("BEGIN", ())
+            .await
+            .map_err(|e| TokenSaveError::Database {
+                message: format!("failed to begin: {e}"),
+                operation: operation.to_string(),
+            })?;
+
+        match work.await {
+            Ok(value) => {
+                if let Err(e) = self.conn().execute("COMMIT", ()).await {
+                    let _ = self.conn().execute("ROLLBACK", ()).await;
+                    return Err(TokenSaveError::Database {
+                        message: format!("failed to commit: {e}"),
+                        operation: operation.to_string(),
+                    });
+                }
+                Ok(value)
+            }
+            Err(e) => {
+                let _ = self.conn().execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
     }
 }
 
@@ -407,15 +434,7 @@ impl Database {
             return Ok(());
         }
 
-        self.conn()
-            .execute("BEGIN", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to begin: {e}"),
-                operation: "insert_nodes".to_string(),
-            })?;
-
-        let result = async {
+        self.with_batch_transaction("insert_nodes", async {
             let stmt = self.conn()
                 .prepare(
                     "INSERT OR REPLACE INTO nodes \
@@ -469,21 +488,9 @@ impl Database {
                 stmt.reset();
             }
 
-            self.conn()
-                .execute("COMMIT", ())
-                .await
-                .map_err(|e| TokenSaveError::Database {
-                    message: format!("failed to commit: {e}"),
-                    operation: "insert_nodes".to_string(),
-                })?;
             Ok(())
-        }
-        .await;
-
-        if result.is_err() {
-            self.rollback_batch_transaction().await;
-        }
-        result
+        })
+        .await
     }
 
     /// Retrieves a node by its unique ID, returning `None` if not found.
@@ -784,15 +791,7 @@ impl Database {
             return Ok(());
         }
 
-        self.conn()
-            .execute("BEGIN", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to begin: {e}"),
-                operation: "insert_edges".to_string(),
-            })?;
-
-        let result = async {
+        self.with_batch_transaction("insert_edges", async {
             // Conditional INSERT: only insert when both endpoints exist in
             // `nodes`. This avoids FK violations during incremental sync
             // when an edge references a node from a not-yet-indexed file.
@@ -852,21 +851,9 @@ impl Database {
                 stmt.reset();
             }
 
-            self.conn()
-                .execute("COMMIT", ())
-                .await
-                .map_err(|e| TokenSaveError::Database {
-                    message: format!("failed to commit: {e}"),
-                    operation: "insert_edges".to_string(),
-                })?;
             Ok(())
-        }
-        .await;
-
-        if result.is_err() {
-            self.rollback_batch_transaction().await;
-        }
-        result
+        })
+        .await
     }
 
     /// Returns outgoing edges from a source node, optionally filtered by edge kinds.
@@ -1964,15 +1951,7 @@ impl Database {
             return Ok(());
         }
 
-        self.conn()
-            .execute("BEGIN", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to begin: {e}"),
-                operation: "upsert_files".to_string(),
-            })?;
-
-        let result = async {
+        self.with_batch_transaction("upsert_files", async {
             let stmt = self.conn()
                 .prepare("INSERT OR REPLACE INTO files (path,content_hash,size,modified_at,indexed_at,node_count) VALUES (?1,?2,?3,?4,?5,?6)")
                 .await
@@ -2002,21 +1981,9 @@ impl Database {
                 stmt.reset();
             }
 
-            self.conn()
-                .execute("COMMIT", ())
-                .await
-                .map_err(|e| TokenSaveError::Database {
-                    message: format!("failed to commit: {e}"),
-                    operation: "upsert_files".to_string(),
-                })?;
             Ok(())
-        }
-        .await;
-
-        if result.is_err() {
-            self.rollback_batch_transaction().await;
-        }
-        result
+        })
+        .await
     }
 
     pub async fn upsert_file(&self, file: &FileRecord) -> Result<()> {
@@ -2138,15 +2105,7 @@ impl Database {
             return Ok(());
         }
 
-        self.conn()
-            .execute("BEGIN", ())
-            .await
-            .map_err(|e| TokenSaveError::Database {
-                message: format!("failed to begin: {e}"),
-                operation: "insert_unresolved_refs".to_string(),
-            })?;
-
-        let result = async {
+        self.with_batch_transaction("insert_unresolved_refs", async {
             let stmt = self.conn()
                 .prepare("INSERT INTO unresolved_refs (from_node_id,reference_name,reference_kind,line,col,file_path) VALUES (?1,?2,?3,?4,?5,?6)")
                 .await
@@ -2176,21 +2135,9 @@ impl Database {
                 stmt.reset();
             }
 
-            self.conn()
-                .execute("COMMIT", ())
-                .await
-                .map_err(|e| TokenSaveError::Database {
-                    message: format!("failed to commit: {e}"),
-                    operation: "insert_unresolved_refs".to_string(),
-                })?;
             Ok(())
-        }
-        .await;
-
-        if result.is_err() {
-            self.rollback_batch_transaction().await;
-        }
-        result
+        })
+        .await
     }
 
     /// Returns all unresolved references.

--- a/tests/db_query_test.rs
+++ b/tests/db_query_test.rs
@@ -62,6 +62,137 @@ fn sample_file(path: &str) -> FileRecord {
     }
 }
 
+fn sample_unresolved_ref(from_node_id: &str) -> UnresolvedRef {
+    UnresolvedRef {
+        from_node_id: from_node_id.to_string(),
+        reference_name: "MissingType".to_string(),
+        reference_kind: EdgeKind::Uses,
+        line: 7,
+        column: 12,
+        file_path: "src/lib.rs".to_string(),
+    }
+}
+
+async fn assert_can_start_new_transaction(db: &Database) {
+    db.conn()
+        .execute("BEGIN", ())
+        .await
+        .expect("connection should not be left inside a transaction");
+    db.conn()
+        .execute("ROLLBACK", ())
+        .await
+        .expect("test transaction rollback should succeed");
+}
+
+// -------------------------------------------------------------------------
+// batch rollback on failure
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_insert_nodes_rolls_back_after_execute_failure() {
+    let (db, _dir) = setup_db().await;
+    db.conn()
+        .execute_batch(
+            "CREATE TRIGGER fail_nodes_insert BEFORE INSERT ON nodes BEGIN
+                 SELECT RAISE(FAIL, 'forced node insert failure');
+             END;",
+        )
+        .await
+        .expect("failed to install node failure trigger");
+
+    let err = db
+        .insert_nodes(&[sample_node("rb-node", "failing_node", "src/lib.rs")])
+        .await
+        .expect_err("forced trigger should make insert_nodes fail");
+    assert!(
+        err.to_string().contains("forced node insert failure"),
+        "unexpected error: {err}"
+    );
+
+    assert_can_start_new_transaction(&db).await;
+}
+
+#[tokio::test]
+async fn test_insert_edges_rolls_back_after_execute_failure() {
+    let (db, _dir) = setup_db().await;
+    let nodes = vec![
+        sample_node("rb-edge-a", "edge_a", "src/lib.rs"),
+        sample_node("rb-edge-b", "edge_b", "src/lib.rs"),
+    ];
+    db.insert_nodes(&nodes).await.expect("insert_nodes failed");
+    db.conn()
+        .execute_batch(
+            "CREATE TRIGGER fail_edges_insert BEFORE INSERT ON edges BEGIN
+                 SELECT RAISE(FAIL, 'forced edge insert failure');
+             END;",
+        )
+        .await
+        .expect("failed to install edge failure trigger");
+
+    let err = db
+        .insert_edges(&[sample_edge("rb-edge-a", "rb-edge-b", EdgeKind::Calls)])
+        .await
+        .expect_err("forced trigger should make insert_edges fail");
+    assert!(
+        err.to_string().contains("forced edge insert failure"),
+        "unexpected error: {err}"
+    );
+
+    assert_can_start_new_transaction(&db).await;
+}
+
+#[tokio::test]
+async fn test_upsert_files_rolls_back_after_execute_failure() {
+    let (db, _dir) = setup_db().await;
+    db.conn()
+        .execute_batch(
+            "CREATE TRIGGER fail_files_insert BEFORE INSERT ON files BEGIN
+                 SELECT RAISE(FAIL, 'forced file insert failure');
+             END;",
+        )
+        .await
+        .expect("failed to install file failure trigger");
+
+    let err = db
+        .upsert_files(&[sample_file("src/lib.rs")])
+        .await
+        .expect_err("forced trigger should make upsert_files fail");
+    assert!(
+        err.to_string().contains("forced file insert failure"),
+        "unexpected error: {err}"
+    );
+
+    assert_can_start_new_transaction(&db).await;
+}
+
+#[tokio::test]
+async fn test_insert_unresolved_refs_rolls_back_after_execute_failure() {
+    let (db, _dir) = setup_db().await;
+    db.insert_nodes(&[sample_node("rb-ref", "ref_source", "src/lib.rs")])
+        .await
+        .expect("insert_nodes failed");
+    db.conn()
+        .execute_batch(
+            "CREATE TRIGGER fail_unresolved_refs_insert BEFORE INSERT ON unresolved_refs BEGIN
+                 SELECT RAISE(FAIL, 'forced unresolved ref insert failure');
+             END;",
+        )
+        .await
+        .expect("failed to install unresolved ref failure trigger");
+
+    let err = db
+        .insert_unresolved_refs(&[sample_unresolved_ref("rb-ref")])
+        .await
+        .expect_err("forced trigger should make insert_unresolved_refs fail");
+    assert!(
+        err.to_string()
+            .contains("forced unresolved ref insert failure"),
+        "unexpected error: {err}"
+    );
+
+    assert_can_start_new_transaction(&db).await;
+}
+
 // -------------------------------------------------------------------------
 // get_nodes_by_kind
 // -------------------------------------------------------------------------

--- a/tests/db_query_test.rs
+++ b/tests/db_query_test.rs
@@ -62,17 +62,6 @@ fn sample_file(path: &str) -> FileRecord {
     }
 }
 
-fn sample_unresolved_ref(from_node_id: &str) -> UnresolvedRef {
-    UnresolvedRef {
-        from_node_id: from_node_id.to_string(),
-        reference_name: "MissingType".to_string(),
-        reference_kind: EdgeKind::Uses,
-        line: 7,
-        column: 12,
-        file_path: "src/lib.rs".to_string(),
-    }
-}
-
 async fn assert_can_start_new_transaction(db: &Database) {
     db.conn()
         .execute("BEGIN", ())
@@ -181,7 +170,14 @@ async fn test_insert_unresolved_refs_rolls_back_after_execute_failure() {
         .expect("failed to install unresolved ref failure trigger");
 
     let err = db
-        .insert_unresolved_refs(&[sample_unresolved_ref("rb-ref")])
+        .insert_unresolved_refs(&[UnresolvedRef {
+            from_node_id: "rb-ref".to_string(),
+            reference_name: "MissingType".to_string(),
+            reference_kind: EdgeKind::Uses,
+            line: 7,
+            column: 12,
+            file_path: "src/lib.rs".to_string(),
+        }])
         .await
         .expect_err("forced trigger should make insert_unresolved_refs fail");
     assert!(


### PR DESCRIPTION
## Summary
- Add regression coverage for manual batch writers leaving the SQLite connection inside a transaction after mid-batch failures.
- Roll back failed `insert_nodes`, `insert_edges`, `upsert_files`, and `insert_unresolved_refs` transactions, resetting failed prepared statements before rollback so subsequent DB operations can recover cleanly.
- Keep the fix focused on transaction cleanup for the DB/index atomicity bug-hunt item; full re-index shadow-swap/sentinel recovery is left out of scope for this PR.

## Test plan
- RED: `cargo test --test db_query_test rolls_back_after_execute_failure` failed with 3 failures and 1 pass; failing tests showed `cannot start a transaction within a transaction` for `insert_edges`, `upsert_files`, and `insert_unresolved_refs`.
- GREEN: `cargo test --test db_query_test rolls_back_after_execute_failure` passed, 4 passed.
- Final: `cargo test --test db_query_test` passed, 75 passed.
- Final: `cargo build` passed.