### PR TITLE
Fix MCP protocol error semantics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1023,7 +1023,7 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
             let mut transport = tokensave::mcp::StdioTransport::new();
             // If we peeked at stdin to read `initialize` roots, replay that line.
             if let Some(line) = peeked_line {
-                server.handle_and_write(&line, &mut transport).await;
+                server.handle_and_write(&line, &mut transport).await?;
             }
             server.run(&mut transport).await?;
             server.shutdown().await;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -43,8 +43,7 @@ const VERSION_CHECK_INTERVAL: Duration = Duration::from_mins(15);
 
 fn global_db_enabled() -> bool {
     std::env::var("TOKENSAVE_ENABLE_GLOBAL_DB")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
-        .unwrap_or(false)
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
 }
 
 /// Hand-maintained schema documentation for the `tokensave://schema` resource.
@@ -239,11 +238,14 @@ fn tool_result_has_semantic_error(value: &Value) -> bool {
     value
         .get("content")
         .and_then(Value::as_array)
-        .map(|content| {
+        .is_some_and(|content| {
             content.iter().any(|item| {
                 let Some(text) = item.get("text").and_then(Value::as_str) else {
                     return false;
                 };
+                if plain_text_tool_failure(text) {
+                    return true;
+                }
                 let Ok(payload) = serde_json::from_str::<Value>(text) else {
                     return false;
                 };
@@ -258,7 +260,11 @@ fn tool_result_has_semantic_error(value: &Value) -> bool {
                         .is_some_and(|code| !code.is_null() && code.as_i64() != Some(0))
             })
         })
-        .unwrap_or(false)
+}
+
+fn plain_text_tool_failure(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("git error:") || trimmed.starts_with("git diff failed:")
 }
 
 fn mark_semantic_tool_error(value: &mut Value) {
@@ -921,9 +927,7 @@ impl McpServer {
             "handle_request called with empty method"
         );
         self.stats.total_requests.fetch_add(1, Ordering::Relaxed);
-        let Some(id) = request.id.clone() else {
-            return None;
-        };
+        let id = request.id.clone()?;
 
         let result = match request.method.as_str() {
             "initialize" => Some(Self::handle_initialize(id)),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -243,10 +243,14 @@ fn tool_result_has_semantic_error(value: &Value) -> bool {
                 let Some(text) = item.get("text").and_then(Value::as_str) else {
                     return false;
                 };
-                if plain_text_tool_failure(text) {
+                let trimmed = text.trim_start();
+                if plain_text_tool_failure(trimmed) {
                     return true;
                 }
-                let Ok(payload) = serde_json::from_str::<Value>(text) else {
+                if !trimmed.starts_with('{') {
+                    return false;
+                }
+                let Ok(payload) = serde_json::from_str::<Value>(trimmed) else {
                     return false;
                 };
                 payload.get("success").and_then(Value::as_bool) == Some(false)
@@ -263,8 +267,7 @@ fn tool_result_has_semantic_error(value: &Value) -> bool {
 }
 
 fn plain_text_tool_failure(text: &str) -> bool {
-    let trimmed = text.trim_start();
-    trimmed.starts_with("git error:") || trimmed.starts_with("git diff failed:")
+    text.starts_with("git error:") || text.starts_with("git diff failed:")
 }
 
 fn mark_semantic_tool_error(value: &mut Value) {
@@ -932,11 +935,11 @@ impl McpServer {
         let result = match request.method.as_str() {
             "initialize" => Some(Self::handle_initialize(id)),
             "initialized" => {
-                // Notification - no response required
+                // Some clients send this notification with an id; keep it a no-op.
                 None
             }
             "notifications/initialized" => {
-                // Alternative notification path - no response required
+                // Alternate initialized request path; also a compatibility no-op.
                 None
             }
             "tools/list" => Some(self.handle_tools_list(id).await),
@@ -1252,10 +1255,6 @@ impl McpServer {
 
     /// Handles the `tools/call` method, dispatching to the appropriate tool handler.
     async fn handle_tools_call(&self, id: Value, params: Option<&Value>) -> JsonRpcResponse {
-        debug_assert!(
-            !id.is_null(),
-            "handle_tools_call called with null request id"
-        );
         let Some(params) = params else {
             return JsonRpcResponse::error(
                 id,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -235,6 +235,41 @@ fn humanize_age(secs: i64) -> String {
     }
 }
 
+fn tool_result_has_semantic_error(value: &Value) -> bool {
+    value
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|content| {
+            content.iter().any(|item| {
+                let Some(text) = item.get("text").and_then(Value::as_str) else {
+                    return false;
+                };
+                let Ok(payload) = serde_json::from_str::<Value>(text) else {
+                    return false;
+                };
+                payload.get("success").and_then(Value::as_bool) == Some(false)
+                    || payload.get("error").is_some_and(|error| !error.is_null())
+                    || payload
+                        .get("failed")
+                        .and_then(Value::as_u64)
+                        .is_some_and(|failed| failed > 0)
+                    || payload
+                        .get("exit_code")
+                        .is_some_and(|code| !code.is_null() && code.as_i64() != Some(0))
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn mark_semantic_tool_error(value: &mut Value) {
+    if !tool_result_has_semantic_error(value) {
+        return;
+    }
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("isError".to_string(), json!(true));
+    }
+}
+
 /// Cached result of a latest-version check against GitHub releases.
 struct VersionCheckState {
     latest: Option<String>,
@@ -684,7 +719,7 @@ impl McpServer {
         &self,
         line: &str,
         transport: &mut impl super::transport::McpTransport,
-    ) {
+    ) -> Result<()> {
         let parsed: std::result::Result<super::transport::JsonRpcRequest, _> =
             serde_json::from_str(line);
         let response = match parsed {
@@ -697,9 +732,10 @@ impl McpServer {
         };
         if let Some(resp) = response {
             let json_str = serde_json::to_string(&resp).unwrap_or_default();
-            let _ = transport.write_line(&json_str).await;
-            let _ = transport.flush().await;
+            transport.write_line(&json_str).await?;
+            transport.flush().await?;
         }
+        Ok(())
     }
 
     /// Runs the server, reading JSON-RPC requests from stdin and writing
@@ -723,7 +759,11 @@ impl McpServer {
                         result = transport.read_line() => {
                             match result {
                                 Ok(Some(line)) => line,
-                                _ => break,
+                                Ok(None) => break,
+                                Err(e) => {
+                                    self.shutdown().await;
+                                    return Err(e.into());
+                                }
                             }
                         }
                         _ = tokio::signal::ctrl_c() => break,
@@ -736,7 +776,11 @@ impl McpServer {
                         result = transport.read_line() => {
                             match result {
                                 Ok(Some(line)) => line,
-                                _ => break,
+                                Ok(None) => break,
+                                Err(e) => {
+                                    self.shutdown().await;
+                                    return Err(e.into());
+                                }
                             }
                         }
                         _ = tokio::signal::ctrl_c() => break,
@@ -770,8 +814,14 @@ impl McpServer {
                     .unwrap_or_default();
                 for notification in notifications {
                     if let Ok(s) = serde_json::to_string(&notification) {
-                        let _ = transport.write_line(&format!("{s}\n")).await;
-                        let _ = transport.flush().await;
+                        if let Err(e) = transport.write_line(&format!("{s}\n")).await {
+                            self.shutdown().await;
+                            return Err(e.into());
+                        }
+                        if let Err(e) = transport.flush().await {
+                            self.shutdown().await;
+                            return Err(e.into());
+                        }
                     }
                 }
             }
@@ -788,11 +838,13 @@ impl McpServer {
                 let output = format!("{json_line}\n");
                 if let Err(e) = transport.write_line(&output).await {
                     eprintln!("failed to write response: {e}");
-                    break;
+                    self.shutdown().await;
+                    return Err(e.into());
                 }
                 if let Err(e) = transport.flush().await {
                     eprintln!("failed to flush stdout: {e}");
-                    break;
+                    self.shutdown().await;
+                    return Err(e.into());
                 }
             }
         }
@@ -869,7 +921,9 @@ impl McpServer {
             "handle_request called with empty method"
         );
         self.stats.total_requests.fetch_add(1, Ordering::Relaxed);
-        let id = request.id.clone();
+        let Some(id) = request.id.clone() else {
+            return None;
+        };
 
         let result = match request.method.as_str() {
             "initialize" => Some(Self::handle_initialize(id)),
@@ -1443,6 +1497,7 @@ impl McpServer {
                     }
                 }
 
+                mark_semantic_tool_error(&mut result.value);
                 JsonRpcResponse::success(id, result.value)
             }
             Err(e) => JsonRpcResponse::error(

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -21,7 +21,11 @@ pub struct JsonRpcRequest {
     pub jsonrpc: String,
     /// Request identifier. May be a number, string, or null.
     /// Absent for notifications.
-    #[serde(default, deserialize_with = "deserialize_request_id")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_request_id",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub id: Option<serde_json::Value>,
     /// The RPC method name.
     pub method: String,

--- a/src/mcp/transport.rs
+++ b/src/mcp/transport.rs
@@ -3,7 +3,16 @@
 //! Provides serialization and deserialization of JSON-RPC 2.0 messages
 //! used to communicate between the MCP client and server over stdio.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+fn deserialize_request_id<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    serde_json::Value::deserialize(deserializer).map(Some)
+}
 
 /// A JSON-RPC 2.0 request received from the client.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,8 +21,8 @@ pub struct JsonRpcRequest {
     pub jsonrpc: String,
     /// Request identifier. May be a number, string, or null.
     /// Absent for notifications.
-    #[serde(default)]
-    pub id: serde_json::Value,
+    #[serde(default, deserialize_with = "deserialize_request_id")]
+    pub id: Option<serde_json::Value>,
     /// The RPC method name.
     pub method: String,
     /// Optional parameters for the method.
@@ -227,7 +236,7 @@ mod tests {
 
         let request: JsonRpcRequest = serde_json::from_value(msg).unwrap();
         assert_eq!(request.method, "tools/list");
-        assert_eq!(request.id, serde_json::Value::Number(1.into()));
+        assert_eq!(request.id, Some(serde_json::Value::Number(1.into())));
     }
 
     #[test]
@@ -239,7 +248,7 @@ mod tests {
 
         let request: JsonRpcRequest = serde_json::from_value(msg).unwrap();
         assert_eq!(request.method, "initialized");
-        assert!(request.id.is_null());
+        assert!(request.id.is_none());
         assert!(request.params.is_none());
     }
 
@@ -286,6 +295,9 @@ mod tests {
         });
 
         let request: JsonRpcRequest = serde_json::from_value(msg).unwrap();
-        assert_eq!(request.id, serde_json::Value::String("abc-123".to_string()));
+        assert_eq!(
+            request.id,
+            Some(serde_json::Value::String("abc-123".to_string()))
+        );
     }
 }

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -373,6 +373,48 @@ async fn test_tools_call_semantic_failure_sets_is_error() {
     assert_eq!(payload["success"], false);
 }
 
+#[tokio::test]
+async fn test_tools_call_plain_text_failure_sets_is_error() {
+    let (server, _dir) = setup_server().await;
+    let responses = run_server_with_messages(
+        server,
+        vec![jsonrpc_request(
+            json!(34),
+            "tools/call",
+            json!({
+                "name": "tokensave_changelog",
+                "arguments": {
+                    "from_ref": "HEAD~1",
+                    "to_ref": "HEAD"
+                }
+            }),
+        )],
+    )
+    .await;
+
+    let resp = parse_response(
+        responses
+            .iter()
+            .find(|r| parse_response(r)["id"] == 34)
+            .expect("response with id 34"),
+    );
+    assert!(
+        resp["error"].is_null(),
+        "plain-text semantic failures should not become JSON-RPC errors"
+    );
+    assert_eq!(
+        resp["result"]["isError"], true,
+        "plain-text semantic failure should set MCP isError=true, got {resp}"
+    );
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("tool result text");
+    assert!(
+        text.contains("git diff failed"),
+        "expected changelog git failure text, got: {text}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 6b. test_tools_call_timings_flag
 // ---------------------------------------------------------------------------

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -83,6 +83,14 @@ fn parse_response(s: &str) -> Value {
     serde_json::from_str(s).unwrap()
 }
 
+fn response_with_id(responses: &[String], id: Value) -> Value {
+    responses
+        .iter()
+        .map(|r| parse_response(r))
+        .find(|resp| resp.get("id") == Some(&id))
+        .unwrap_or_else(|| panic!("response with id {id}"))
+}
+
 struct ReadErrorTransport;
 
 impl McpTransport for ReadErrorTransport {
@@ -186,13 +194,7 @@ async fn test_explicit_null_id_is_still_a_request() {
     let (server, _dir) = setup_server().await;
     let responses = run_server_with_messages(
         server,
-        vec![serde_json::to_string(&json!({
-            "jsonrpc": "2.0",
-            "id": null,
-            "method": "ping",
-            "params": {}
-        }))
-        .unwrap()],
+        vec![jsonrpc_request(json!(null), "ping", json!({}))],
     )
     .await;
 
@@ -204,6 +206,35 @@ async fn test_explicit_null_id_is_still_a_request() {
     let resp = parse_response(&responses[0]);
     assert!(resp["id"].is_null(), "response should preserve null id");
     assert!(resp["error"].is_null(), "ping request should succeed");
+}
+
+#[tokio::test]
+async fn test_tools_call_explicit_null_id_is_still_a_request() {
+    let (server, _dir) = setup_server().await;
+    let responses = run_server_with_messages(
+        server,
+        vec![jsonrpc_request(
+            json!(null),
+            "tools/call",
+            json!({
+                "name": "tokensave_status",
+                "arguments": {}
+            }),
+        )],
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "explicit id=null is a tools/call request id and should receive a response"
+    );
+    let resp = response_with_id(&responses, json!(null));
+    assert!(resp["error"].is_null(), "tools/call request should succeed");
+    assert!(
+        resp["result"].is_object(),
+        "tools/call should return a result"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -352,12 +383,7 @@ async fn test_tools_call_semantic_failure_sets_is_error() {
     )
     .await;
 
-    let resp = parse_response(
-        responses
-            .iter()
-            .find(|r| parse_response(r)["id"] == 33)
-            .expect("response with id 33"),
-    );
+    let resp = response_with_id(&responses, json!(33));
     assert!(
         resp["error"].is_null(),
         "semantic tool failures should not become JSON-RPC errors"
@@ -392,12 +418,7 @@ async fn test_tools_call_plain_text_failure_sets_is_error() {
     )
     .await;
 
-    let resp = parse_response(
-        responses
-            .iter()
-            .find(|r| parse_response(r)["id"] == 34)
-            .expect("response with id 34"),
-    );
+    let resp = response_with_id(&responses, json!(34));
     assert!(
         resp["error"].is_null(),
         "plain-text semantic failures should not become JSON-RPC errors"

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use std::fs;
 use std::sync::Arc;
 use tempfile::TempDir;
-use tokensave::mcp::transport::ChannelTransport;
+use tokensave::mcp::transport::{ChannelTransport, McpTransport};
 use tokensave::mcp::McpServer;
 use tokensave::tokensave::TokenSave;
 
@@ -83,6 +83,25 @@ fn parse_response(s: &str) -> Value {
     serde_json::from_str(s).unwrap()
 }
 
+struct ReadErrorTransport;
+
+impl McpTransport for ReadErrorTransport {
+    async fn read_line(&mut self) -> std::io::Result<Option<String>> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "synthetic read failure",
+        ))
+    }
+
+    async fn write_line(&mut self, _line: &str) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 1. test_initialize
 // ---------------------------------------------------------------------------
@@ -138,6 +157,53 @@ async fn test_initialized_notification() {
     );
     let resp = parse_response(ping_responses[0]);
     assert!(resp["error"].is_null(), "ping should succeed");
+}
+
+#[tokio::test]
+async fn test_any_notification_without_id_produces_no_response() {
+    let (server, _dir) = setup_server().await;
+    let responses = run_server_with_messages(
+        server,
+        vec![
+            jsonrpc_notification("ping"),
+            jsonrpc_request(json!(901), "ping", json!({})),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "only the request with id=901 should produce a response, got {responses:?}"
+    );
+    let resp = parse_response(&responses[0]);
+    assert_eq!(resp["id"], 901);
+    assert!(resp["error"].is_null(), "ping request should succeed");
+}
+
+#[tokio::test]
+async fn test_explicit_null_id_is_still_a_request() {
+    let (server, _dir) = setup_server().await;
+    let responses = run_server_with_messages(
+        server,
+        vec![serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": null,
+            "method": "ping",
+            "params": {}
+        }))
+        .unwrap()],
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "explicit id=null is a request id and should receive a response"
+    );
+    let resp = parse_response(&responses[0]);
+    assert!(resp["id"].is_null(), "response should preserve null id");
+    assert!(resp["error"].is_null(), "ping request should succeed");
 }
 
 // ---------------------------------------------------------------------------
@@ -264,6 +330,47 @@ async fn test_tools_call_search() {
             .unwrap_or(false)
     });
     assert!(has_helper, "search results should contain 'helper'");
+}
+
+#[tokio::test]
+async fn test_tools_call_semantic_failure_sets_is_error() {
+    let (server, _dir) = setup_server().await;
+    let responses = run_server_with_messages(
+        server,
+        vec![jsonrpc_request(
+            json!(33),
+            "tools/call",
+            json!({
+                "name": "tokensave_str_replace",
+                "arguments": {
+                    "path": "src/main.rs",
+                    "old_str": "fn missing() {}",
+                    "new_str": "fn replaced() {}"
+                }
+            }),
+        )],
+    )
+    .await;
+
+    let resp = parse_response(
+        responses
+            .iter()
+            .find(|r| parse_response(r)["id"] == 33)
+            .expect("response with id 33"),
+    );
+    assert!(
+        resp["error"].is_null(),
+        "semantic tool failures should not become JSON-RPC errors"
+    );
+    assert_eq!(
+        resp["result"]["isError"], true,
+        "semantic tool failure should set MCP isError=true, got {resp}"
+    );
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .expect("tool result text");
+    let payload: Value = serde_json::from_str(text).expect("tool result JSON");
+    assert_eq!(payload["success"], false);
 }
 
 // ---------------------------------------------------------------------------
@@ -1171,6 +1278,21 @@ async fn test_initialize_advertises_logging_capability() {
     assert!(
         resp["result"]["capabilities"]["logging"].is_object(),
         "initialize must advertise logging capability, got: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_run_returns_transport_read_errors() {
+    let (server, _dir) = setup_server().await;
+    let mut transport = ReadErrorTransport;
+
+    let err = server
+        .run(&mut transport)
+        .await
+        .expect_err("transport read failure should be returned");
+    assert!(
+        err.to_string().contains("synthetic read failure"),
+        "unexpected error: {err}"
     );
 }
 

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -179,6 +179,27 @@ fn test_notification_without_id() {
 }
 
 #[test]
+fn test_serialize_request_omits_absent_id_but_preserves_null_id() {
+    let notification = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "initialized".to_string(),
+        params: None,
+    };
+    let serialized = serde_json::to_value(&notification).unwrap();
+    assert!(serialized.get("id").is_none());
+
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(serde_json::Value::Null),
+        method: "ping".to_string(),
+        params: None,
+    };
+    let serialized = serde_json::to_value(&request).unwrap();
+    assert!(serialized["id"].is_null());
+}
+
+#[test]
 fn test_request_with_string_id() {
     let msg = json!({
         "jsonrpc": "2.0",

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -13,7 +13,7 @@ fn test_parse_jsonrpc_request() {
 
     let request: JsonRpcRequest = serde_json::from_value(msg).unwrap();
     assert_eq!(request.method, "tools/list");
-    assert_eq!(request.id, serde_json::Value::Number(1.into()));
+    assert_eq!(request.id, Some(serde_json::Value::Number(1.into())));
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn test_notification_without_id() {
 
     let request: JsonRpcRequest = serde_json::from_value(msg).unwrap();
     assert_eq!(request.method, "initialized");
-    assert!(request.id.is_null());
+    assert!(request.id.is_none());
     assert!(request.params.is_none());
 }
 
@@ -187,6 +187,9 @@ fn test_request_with_string_id() {
     });
 
     let request: JsonRpcRequest = serde_json::from_value(msg).unwrap();
-    assert_eq!(request.id, serde_json::Value::String("req-42".to_string()));
+    assert_eq!(
+        request.id,
+        Some(serde_json::Value::String("req-42".to_string()))
+    );
     assert_eq!(request.method, "ping");
 }


### PR DESCRIPTION
## Summary
- Treat JSON-RPC messages with no `id` as notifications for every method, while preserving explicit `id: null` requests.
- Mark MCP tool results with `isError: true` when structured tool payloads report semantic failure, without converting them into JSON-RPC errors.
- Propagate MCP transport read/write/flush failures instead of exiting `run()` as `Ok(())`.

## Test plan
- RED: `cargo test --features test-transport --test mcp_server_test` failed on `test_any_notification_without_id_produces_no_response`, `test_tools_call_semantic_failure_sets_is_error`, and `test_run_returns_transport_read_errors`; the pre-existing `search_call_writes_savings_ledger_row` also failed.
- RED: `cargo test --features test-transport --test mcp_server_test test_explicit_null_id_is_still_a_request` failed before the custom request-id deserializer.
- GREEN: `cargo test --features test-transport --test mcp_server_test test_explicit_null_id_is_still_a_request`
- GREEN: `cargo test --test mcp_test`
- GREEN: `cargo test --features test-transport --test mcp_server_test test_any_notification_without_id_produces_no_response`
- GREEN: `cargo test --features test-transport --test mcp_server_test test_tools_call_semantic_failure_sets_is_error`
- GREEN: `cargo test --features test-transport --test mcp_server_test test_run_returns_transport_read_errors`
- GREEN: `cargo test --features test-transport --test mcp_server_test -- --skip search_call_writes_savings_ledger_row`
- GREEN: `cargo check --features test-transport`

## Caveats
- Full `cargo test --features test-transport --test mcp_server_test` still fails on the unrelated pre-existing `search_call_writes_savings_ledger_row` ledger assertion.
- Structured JSON truncation is left as a follow-up; this PR stays focused on notification handling, MCP `isError`, and transport I/O error propagation.