### PR TITLE
Fix serve root URI fallbacks

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -37,8 +37,13 @@ pub struct GlobalDb {
     _db: LibsqlDatabase,
 }
 
+const GLOBAL_DB_PATH_ENV: &str = "TOKENSAVE_GLOBAL_DB";
+
 /// Returns the path to the global database: `~/.tokensave/global.db`.
 pub fn global_db_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(GLOBAL_DB_PATH_ENV).filter(|path| !path.is_empty()) {
+        return Some(PathBuf::from(path));
+    }
     dirs::home_dir().map(|h| h.join(".tokensave").join("global.db"))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -989,14 +989,25 @@ async fn run(cli: Cli) -> tokensave::errors::Result<()> {
                 Err(_) => {
                     // CWD-based discovery failed (e.g. VS Code launched us from ~).
                     // Fall back to the global DB's registered projects.
-                    match serve::resolve_serve_from_global_db().await {
-                        Some(p) => serve::ensure_initialized(&p).await?,
-                        None => {
+                    let global_fallback = serve::resolve_serve_from_global_db().await;
+                    match global_fallback {
+                        serve::ServeGlobalDbResolution::Found(p) => {
+                            serve::ensure_initialized(&p).await?
+                        }
+                        serve::ServeGlobalDbResolution::None
+                        | serve::ServeGlobalDbResolution::Ambiguous(_) => {
                             // Last resort: peek at the first stdin line for MCP
                             // `initialize` roots (e.g. VS Code multi-folder workspace).
                             match serve::resolve_serve_from_mcp_roots(&mut peeked_line).await {
                                 Some(p) => serve::ensure_initialized(&p).await?,
                                 None => {
+                                    if let serve::ServeGlobalDbResolution::Ambiguous(paths) =
+                                        global_fallback
+                                    {
+                                        return Err(tokensave::errors::TokenSaveError::Config {
+                                            message: serve::global_db_ambiguity_message(&paths),
+                                        });
+                                    }
                                     return Err(tokensave::errors::TokenSaveError::Config {
                                         message: format!(
                                             "no TokenSave index found at '{}' and no projects registered in the global database — run 'tokensave init' in your project first",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -696,8 +696,9 @@ impl McpServer {
             )),
         };
         if let Some(resp) = response {
-            let json_str = serde_json::to_string(&resp).unwrap_or_default();
-            let _ = transport.write_line(&format!("{json_str}\n")).await;
+            let mut json_str = serde_json::to_string(&resp).unwrap_or_default();
+            json_str.push('\n');
+            let _ = transport.write_line(&json_str).await;
             let _ = transport.flush().await;
         }
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -697,7 +697,7 @@ impl McpServer {
         };
         if let Some(resp) = response {
             let json_str = serde_json::to_string(&resp).unwrap_or_default();
-            let _ = transport.write_line(&json_str).await;
+            let _ = transport.write_line(&format!("{json_str}\n")).await;
             let _ = transport.flush().await;
         }
     }
@@ -706,11 +706,6 @@ impl McpServer {
     /// responses to stdout. Runs until stdin is closed or a shutdown signal
     /// (SIGINT/SIGTERM) is received, then performs graceful cleanup.
     pub async fn run(&self, transport: &mut impl super::transport::McpTransport) -> Result<()> {
-        debug_assert!(
-            self.stats.total_requests.load(Ordering::Relaxed) == 0,
-            "server run() called on an already-used server"
-        );
-
         loop {
             let line: String = {
                 #[cfg(unix)]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -31,6 +31,11 @@ pub async fn ensure_initialized(project_path: &Path) -> tokensave::errors::Resul
     })
 }
 
+fn initialized_project_paths(mut paths: Vec<String>) -> Vec<String> {
+    paths.retain(|path| TokenSave::is_initialized(Path::new(path)));
+    paths
+}
+
 /// Fallback for `serve`: when CWD-based discovery fails, check the global DB
 /// for registered projects. When multiple projects exist, pick the best match
 /// against cwd: prefer a project that is an ancestor of cwd (cwd is inside the
@@ -40,14 +45,8 @@ pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
     let Some(gdb) = tokensave::global_db::GlobalDb::open().await else {
         return ServeGlobalDbResolution::None;
     };
-    let mut paths: Vec<String> = gdb.list_project_paths().await;
+    let mut paths = initialized_project_paths(gdb.list_project_paths().await);
     paths.sort();
-    // Keep only projects whose .tokensave dir still exists on disk.
-    paths.retain(|p| {
-        std::path::Path::new(p)
-            .join(".tokensave/tokensave.db")
-            .exists()
-    });
     if paths.len() == 1 {
         return ServeGlobalDbResolution::Found(std::path::PathBuf::from(paths.remove(0)));
     }
@@ -117,12 +116,7 @@ pub async fn resolve_serve_from_mcp_roots(out: &mut Option<String>) -> Option<st
     let roots = parsed.pointer("/params/roots").and_then(|v| v.as_array())?;
 
     let gdb = tokensave::global_db::GlobalDb::open().await?;
-    let mut registered: Vec<String> = gdb.list_project_paths().await;
-    registered.retain(|p| {
-        std::path::Path::new(p)
-            .join(".tokensave/tokensave.db")
-            .exists()
-    });
+    let registered = initialized_project_paths(gdb.list_project_paths().await);
 
     // Try each root URI — first match wins.
     for root in roots {
@@ -151,6 +145,8 @@ async fn read_first_non_empty_stdin_line() -> Option<String> {
     let mut stdin = tokio::io::stdin();
     let mut line = Vec::new();
     let mut byte = [0_u8; 1];
+    // Avoid buffering past the first line; the normal stdio transport must still
+    // receive any later JSON-RPC messages from stdin.
     loop {
         match stdin.read(&mut byte).await {
             Ok(0) if line.is_empty() => return None,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,6 +1,23 @@
 use std::path::Path;
 use tokensave::tokensave::TokenSave;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServeGlobalDbResolution {
+    Found(std::path::PathBuf),
+    Ambiguous(Vec<String>),
+    None,
+}
+
+pub fn global_db_ambiguity_message(paths: &[String]) -> String {
+    let mut message =
+        "Multiple tokensave projects found — pass -p <path> to select one:".to_string();
+    for path in paths {
+        message.push_str("\n  ");
+        message.push_str(path);
+    }
+    message
+}
+
 /// Opens an existing project, or tells the user to run `tokensave init` first.
 pub async fn ensure_initialized(project_path: &Path) -> tokensave::errors::Result<TokenSave> {
     if TokenSave::is_initialized(project_path) {
@@ -18,10 +35,13 @@ pub async fn ensure_initialized(project_path: &Path) -> tokensave::errors::Resul
 /// for registered projects. When multiple projects exist, pick the best match
 /// against cwd: prefer a project that is an ancestor of cwd (cwd is inside the
 /// project), then a project that is a descendant of cwd (project is under cwd).
-/// Among multiple matches, the deepest (most specific) path wins.
-pub async fn resolve_serve_from_global_db() -> Option<std::path::PathBuf> {
-    let gdb = tokensave::global_db::GlobalDb::open().await?;
+/// Ties at the winning depth are ambiguous and require an explicit path.
+pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
+    let Some(gdb) = tokensave::global_db::GlobalDb::open().await else {
+        return ServeGlobalDbResolution::None;
+    };
     let mut paths: Vec<String> = gdb.list_project_paths().await;
+    paths.sort();
     // Keep only projects whose .tokensave dir still exists on disk.
     paths.retain(|p| {
         std::path::Path::new(p)
@@ -29,14 +49,16 @@ pub async fn resolve_serve_from_global_db() -> Option<std::path::PathBuf> {
             .exists()
     });
     if paths.len() == 1 {
-        return Some(std::path::PathBuf::from(paths.remove(0)));
+        return ServeGlobalDbResolution::Found(std::path::PathBuf::from(paths.remove(0)));
     }
     if paths.is_empty() {
-        return None;
+        return ServeGlobalDbResolution::None;
     }
 
     // Multiple projects — try to resolve using cwd.
-    let cwd = std::env::current_dir().ok()?;
+    let Ok(cwd) = std::env::current_dir() else {
+        return ServeGlobalDbResolution::Ambiguous(paths);
+    };
     let cwd = cwd.canonicalize().unwrap_or(cwd);
 
     // Priority 1: cwd is inside a project (project is ancestor of cwd).
@@ -49,9 +71,14 @@ pub async fn resolve_serve_from_global_db() -> Option<std::path::PathBuf> {
                 .then(|| (pp.components().count(), p.clone()))
         })
         .collect();
-    ancestors.sort_by_key(|a| std::cmp::Reverse(a.0)); // deepest first
-    if let Some((_, best)) = ancestors.into_iter().next() {
-        return Some(std::path::PathBuf::from(best));
+    ancestors.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    if let Some((depth, _)) = ancestors.first() {
+        if ancestors.get(1).is_some_and(|next| next.0 == *depth) {
+            return ServeGlobalDbResolution::Ambiguous(
+                ancestors.into_iter().map(|(_, p)| p).collect(),
+            );
+        }
+        return ServeGlobalDbResolution::Found(std::path::PathBuf::from(ancestors.remove(0).1));
     }
 
     // Priority 2: a project is under cwd (cwd is ancestor of project).
@@ -64,17 +91,18 @@ pub async fn resolve_serve_from_global_db() -> Option<std::path::PathBuf> {
                 .then(|| (pp.components().count(), p.clone()))
         })
         .collect();
-    descendants.sort_by_key(|a| a.0); // shallowest first
-    if let Some((_, best)) = descendants.into_iter().next() {
-        return Some(std::path::PathBuf::from(best));
+    descendants.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    if let Some((depth, _)) = descendants.first() {
+        if descendants.get(1).is_some_and(|next| next.0 == *depth) {
+            return ServeGlobalDbResolution::Ambiguous(
+                descendants.into_iter().map(|(_, p)| p).collect(),
+            );
+        }
+        return ServeGlobalDbResolution::Found(std::path::PathBuf::from(descendants.remove(0).1));
     }
 
-    // No cwd-based match — report the ambiguity.
-    eprintln!("Multiple tokensave projects found — pass -p <path> to select one:");
-    for p in &paths {
-        eprintln!("  {p}");
-    }
-    None
+    // No cwd-based match — the global DB alone cannot disambiguate.
+    ServeGlobalDbResolution::Ambiguous(paths)
 }
 
 /// Last-resort fallback for `serve`: peek at the first stdin line to read the
@@ -82,24 +110,7 @@ pub async fn resolve_serve_from_global_db() -> Option<std::path::PathBuf> {
 /// project, return its path.  The raw line is stored in `out` so the caller
 /// can replay it into the MCP transport (the server still needs to see it).
 pub async fn resolve_serve_from_mcp_roots(out: &mut Option<String>) -> Option<std::path::PathBuf> {
-    use tokio::io::AsyncBufReadExt;
-    let stdin = tokio::io::stdin();
-    let mut reader = tokio::io::BufReader::new(stdin);
-    let mut line = String::new();
-    // Read the first non-empty line (should be the `initialize` request).
-    loop {
-        line.clear();
-        match reader.read_line(&mut line).await {
-            Ok(0) => return None, // EOF
-            Ok(_) => {
-                let trimmed = line.trim();
-                if !trimmed.is_empty() {
-                    break;
-                }
-            }
-            Err(_) => return None,
-        }
-    }
+    let line = read_first_non_empty_stdin_line().await?;
     *out = Some(line.trim().to_string());
 
     let parsed: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
@@ -116,19 +127,91 @@ pub async fn resolve_serve_from_mcp_roots(out: &mut Option<String>) -> Option<st
     // Try each root URI — first match wins.
     for root in roots {
         let uri = root.get("uri").and_then(|v| v.as_str()).unwrap_or_default();
-        let root_path = uri.strip_prefix("file://").unwrap_or(uri);
-        let root_path = std::path::Path::new(root_path);
+        let Some(root_path) = local_path_from_mcp_root_uri(uri) else {
+            continue;
+        };
         // Exact match: the root IS a registered project.
         if let Some(hit) = registered
             .iter()
-            .find(|p| std::path::Path::new(p) == root_path)
+            .find(|p| std::path::Path::new(p) == root_path.as_path())
         {
             return Some(std::path::PathBuf::from(hit));
         }
         // Walk up from the root to find the nearest enclosing project.
-        if let Some(discovered) = tokensave::config::discover_project_root(root_path) {
+        if let Some(discovered) = tokensave::config::discover_project_root(&root_path) {
             return Some(discovered);
         }
     }
     None
+}
+
+async fn read_first_non_empty_stdin_line() -> Option<String> {
+    use tokio::io::AsyncReadExt;
+
+    let mut stdin = tokio::io::stdin();
+    let mut line = Vec::new();
+    let mut byte = [0_u8; 1];
+    loop {
+        match stdin.read(&mut byte).await {
+            Ok(0) if line.is_empty() => return None,
+            Ok(0) => {
+                let text = String::from_utf8(line).ok()?;
+                return (!text.trim().is_empty()).then_some(text);
+            }
+            Ok(_) => {
+                line.push(byte[0]);
+                if byte[0] == b'\n' {
+                    let text = String::from_utf8(std::mem::take(&mut line)).ok()?;
+                    if !text.trim().is_empty() {
+                        return Some(text);
+                    }
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+fn local_path_from_mcp_root_uri(uri: &str) -> Option<std::path::PathBuf> {
+    let path = if let Some(rest) = uri.strip_prefix("file://") {
+        if let Some(localhost_path) = rest.strip_prefix("localhost/") {
+            format!("/{localhost_path}")
+        } else if rest == "localhost" {
+            "/".to_string()
+        } else if rest.starts_with('/') {
+            rest.to_string()
+        } else {
+            return None;
+        }
+    } else {
+        uri.to_string()
+    };
+    percent_decode_path(&path).map(std::path::PathBuf::from)
+}
+
+fn percent_decode_path(path: &str) -> Option<String> {
+    let bytes = path.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hi = *bytes.get(i + 1)?;
+            let lo = *bytes.get(i + 2)?;
+            decoded.push((hex_value(hi)? << 4) | hex_value(lo)?);
+            i += 3;
+        } else {
+            decoded.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
 }

--- a/tests/mcp_cli_serve_test.rs
+++ b/tests/mcp_cli_serve_test.rs
@@ -42,7 +42,7 @@ async fn register_global_project(home: &Path, project: &Path) {
 
 fn tokensave_command_with_home(home: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_tokensave"));
-    command.env("HOME", home);
+    command.env("HOME", home).env("USERPROFILE", home);
     command
 }
 

--- a/tests/mcp_cli_serve_test.rs
+++ b/tests/mcp_cli_serve_test.rs
@@ -1,0 +1,190 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use tempfile::TempDir;
+use tokensave::global_db::GlobalDb;
+use tokensave::tokensave::TokenSave;
+
+struct ProjectFixture {
+    _tmp: TempDir,
+    path: PathBuf,
+}
+
+async fn init_project_named(name: &str, source: &str) -> ProjectFixture {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join(name);
+    fs::create_dir_all(path.join("src")).unwrap();
+    fs::write(path.join("src/lib.rs"), source).unwrap();
+
+    let cg = TokenSave::init(&path).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    ProjectFixture { _tmp: tmp, path }
+}
+
+async fn init_project_under(parent: &Path, name: &str, source: &str) -> PathBuf {
+    let path = parent.join(name);
+    fs::create_dir_all(path.join("src")).unwrap();
+    fs::write(path.join("src/lib.rs"), source).unwrap();
+
+    let cg = TokenSave::init(&path).await.unwrap();
+    cg.index_all().await.unwrap();
+    path
+}
+
+async fn register_global_project(home: &Path, project: &Path) {
+    let db_path = home.join(".tokensave").join("global.db");
+    let db = GlobalDb::open_at(&db_path).await.unwrap();
+    db.upsert(project, 0).await;
+}
+
+fn tokensave_command_with_home(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_tokensave"));
+    command.env("HOME", home);
+    command
+}
+
+fn serve_with_initialize_root(home: &Path, cwd: &Path, root_uri: String) -> Output {
+    let mut child = tokensave_command_with_home(home)
+        .arg("serve")
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("tokensave serve should start");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "roots": [{
+                        "uri": root_uri,
+                        "name": "active"
+                    }]
+                }
+            })
+        )
+        .unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "tokensave_runtime",
+                    "arguments": {}
+                }
+            })
+        )
+        .unwrap();
+    }
+
+    child
+        .wait_with_output()
+        .expect("tokensave serve should exit after stdin closes")
+}
+
+fn runtime_project_root(stdout: &[u8], response_id: i64) -> String {
+    let stdout = String::from_utf8_lossy(stdout);
+    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
+        let response: Value = serde_json::from_str(line).unwrap();
+        if response["id"].as_i64() != Some(response_id) {
+            continue;
+        }
+        let text = response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("tool response should include text content");
+        let runtime: Value = serde_json::from_str(text).unwrap();
+        let db_path = runtime["database"]["db_path"]
+            .as_str()
+            .expect("runtime snapshot should include database path");
+        return Path::new(db_path)
+            .parent()
+            .and_then(Path::parent)
+            .expect("database path should live under .tokensave")
+            .to_string_lossy()
+            .into_owned();
+    }
+    panic!("response id {response_id} not found in stdout:\n{stdout}");
+}
+
+#[cfg(unix)]
+fn file_uri_localhost_percent_encoded(path: &Path) -> String {
+    let encoded_path = path.to_string_lossy().replace(' ', "%20");
+    format!("file://localhost{encoded_path}")
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn initialize_roots_decode_file_uri_localhost_and_percent_escapes() {
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let stale = init_project_named("stale-project", "pub fn stale_project_marker() {}\n").await;
+    let active = init_project_named("active project", "pub fn active_project_marker() {}\n").await;
+    register_global_project(home.path(), &stale.path).await;
+    register_global_project(home.path(), &active.path).await;
+
+    let output = serve_with_initialize_root(
+        home.path(),
+        cwd.path(),
+        file_uri_localhost_percent_encoded(&active.path),
+    );
+
+    assert!(
+        output.status.success(),
+        "tokensave serve should accept encoded file://localhost MCP roots\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        runtime_project_root(&output.stdout, 2),
+        active.path.to_string_lossy(),
+        "serve should use the decoded MCP root project"
+    );
+}
+
+#[tokio::test]
+async fn same_depth_descendant_global_fallback_is_ambiguous() {
+    let home = TempDir::new().unwrap();
+    let cwd = TempDir::new().unwrap();
+    let alpha = init_project_under(cwd.path(), "alpha", "pub fn alpha_marker() {}\n").await;
+    let beta = init_project_under(cwd.path(), "beta", "pub fn beta_marker() {}\n").await;
+    register_global_project(home.path(), &alpha).await;
+    register_global_project(home.path(), &beta).await;
+
+    let output = tokensave_command_with_home(home.path())
+        .arg("serve")
+        .current_dir(cwd.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("tokensave serve should run");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "ambiguous same-depth descendants should not select an arbitrary project\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr
+    );
+    assert!(
+        stderr.contains("Multiple tokensave projects found"),
+        "stderr should explain the ambiguity:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("no projects registered in the global database"),
+        "stderr should not contradict the ambiguity with a no-projects error:\n{stderr}"
+    );
+}

--- a/tests/mcp_cli_serve_test.rs
+++ b/tests/mcp_cli_serve_test.rs
@@ -42,7 +42,10 @@ async fn register_global_project(home: &Path, project: &Path) {
 
 fn tokensave_command_with_home(home: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_tokensave"));
-    command.env("HOME", home).env("USERPROFILE", home);
+    command.env("HOME", home).env("USERPROFILE", home).env(
+        "TOKENSAVE_GLOBAL_DB",
+        home.join(".tokensave").join("global.db"),
+    );
     command
 }
 


### PR DESCRIPTION
## Summary
- Decode local MCP root file URIs, including `file://localhost/...` and percent-escaped paths, before resolving serve roots.
- Treat same-depth global DB fallback matches as ambiguous instead of selecting one arbitrarily.
- Preserve and replay the peeked `initialize` line without swallowing later MCP messages, and keep replayed responses newline-delimited.

## Tests
- RED: `cargo test --test mcp_cli_serve_test -- --nocapture` failed with encoded `file://localhost` roots unresolved and same-depth descendants selected arbitrarily.
- GREEN: `cargo test --test mcp_cli_serve_test -- --nocapture`
- GREEN: `cargo test --test mcp_test`
- GREEN: `cargo test --test mcp_handler_test test_runtime_snapshot_exposes_process_and_db_signals`
- GREEN: `cargo test --features test-transport --test mcp_server_test test_initialize`
- GREEN: `cargo fmt --check && cargo clippy --test mcp_cli_serve_test`

## Caveats
- `cargo clippy --test mcp_cli_serve_test` exits successfully but still reports existing pedantic warnings outside this change.
- This PR keeps the Cursor `${workspaceFolder}` placeholder behavior unchanged; the focused fix is URI decoding plus deterministic/explicit global fallback ambiguity.