### PR TITLE
fix(lcm): preserve Hermes compaction replay

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -247,6 +247,29 @@ provider config, and LCM session storage. If you pass
 targets the named profile instead of the project plugin directory; use this when
 you want to run the command from a project but update a Hermes profile.
 
+#### Verifying Hermes plugin and context-engine changes
+
+When changing generated Hermes plugin or context-engine behavior, start with
+TraceDecay's read-only analysis tools before rebuilding or reinstalling
+anything: use `tracedecay_diff_context` to inspect modified symbols,
+dependencies, and affected tests; `tracedecay_simplify_scan` for complexity,
+duplication, dead-code, and coupling regressions; `tracedecay_test_risk` for
+untested hot spots; `tracedecay_diagnostics` for structured compiler/type
+feedback; and `tracedecay_run_affected_tests` for the focused test set when test
+execution is appropriate.
+
+For LCM/session issues, pair `tracedecay_lcm_status` with the LCM doctor
+(`tracedecay_lcm_doctor`, or the native Hermes `lcm_doctor` wrapper). Prefer its
+dry-run or diagnose mode first, then inspect the reported store, config, and
+payload diagnostics before applying any repair.
+
+Known Hermes API caveats: native `lcm_*` tool dispatch receives
+`messages=messages`, but direct registered live-ingest tools should remain
+gated unless the host explicitly forwards messages. The
+`context_engine_tool_handlers_receive_messages` flag is a TraceDecay convention,
+not stock Hermes API. Treat `compression.*` as built-in compressor config; only
+`compression.enabled` gates auto-compaction globally.
+
 Kiro setup registers tracedecay in `~/.kiro/settings/mcp.json`, writes steering to
 `~/.kiro/steering/tracedecay.md`, and writes a tracedecay-managed agent that loads
 that steering as a resource while keeping Kiro's default prompt. The managed

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -2037,9 +2037,11 @@ def call_tracedecay_json(name: str, args: dict, **kwargs) -> dict:
         and payload.get("truncated") is True
         and payload.get("handle")
     ):
+        retrieve_kwargs = _copy_without_none({"project_root": kwargs.get("project_root")})
         retrieved_raw = tools.call_tracedecay_tool(
             "tracedecay_retrieve",
             {"handle": payload["handle"]},
+            **retrieve_kwargs,
         )
         return _parse_retrieved_tracedecay_content(retrieved_raw)
     return payload

--- a/src/agents/hermes.rs
+++ b/src/agents/hermes.rs
@@ -1958,9 +1958,14 @@ def _bridge_preview(value, limit: int = 2048) -> str:
         return preview[:limit] + "...[truncated]"
     return preview
 
+CONTRACT_CRITICAL_RETRIEVABLE_TOOLS = frozenset((
+    "tracedecay_lcm_compress",
+    "tracedecay_lcm_preflight",
+    "tracedecay_lcm_expand_query",
+    "tracedecay_lcm_status",
+))
 
-def call_tracedecay_json(name: str, args: dict, **kwargs) -> dict:
-    raw = tools.call_tracedecay_tool(name, args, **kwargs)
+def _parse_tracedecay_json_response(raw) -> dict:
     try:
         outer = json.loads(raw)
     except json.JSONDecodeError:
@@ -1994,6 +1999,50 @@ def call_tracedecay_json(name: str, args: dict, **kwargs) -> dict:
             "error": "tracedecay tool returned invalid nested JSON",
             "text_preview": _bridge_preview(text),
         }
+
+def _parse_retrieved_tracedecay_content(raw) -> dict:
+    payload = _parse_tracedecay_json_response(raw)
+    if not isinstance(payload, dict):
+        return {"error": "tracedecay retrieve returned invalid payload"}
+    if payload.get("expired"):
+        return {"error": "tracedecay retrieve handle expired", "handle": payload.get("handle")}
+    content = payload.get("content")
+    if isinstance(content, str):
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return {
+                "error": "tracedecay retrieve content was not JSON",
+                "text_preview": _bridge_preview(content),
+            }
+        if isinstance(parsed, dict):
+            return parsed
+        return {
+            "error": "tracedecay retrieve content was not an object",
+            "text_preview": _bridge_preview(content),
+        }
+    if isinstance(content, dict):
+        return content
+    return {
+        "error": "tracedecay retrieve response missing content",
+        "raw_preview": _bridge_preview(payload),
+    }
+
+def call_tracedecay_json(name: str, args: dict, **kwargs) -> dict:
+    raw = tools.call_tracedecay_tool(name, args, **kwargs)
+    payload = _parse_tracedecay_json_response(raw)
+    if (
+        name in CONTRACT_CRITICAL_RETRIEVABLE_TOOLS
+        and isinstance(payload, dict)
+        and payload.get("truncated") is True
+        and payload.get("handle")
+    ):
+        retrieved_raw = tools.call_tracedecay_tool(
+            "tracedecay_retrieve",
+            {"handle": payload["handle"]},
+        )
+        return _parse_retrieved_tracedecay_content(retrieved_raw)
+    return payload
 
 def _memory_schema(tracedecay_name: str, hermes_name: str, action: str = None) -> dict:
     for schema in schemas.TOOL_SCHEMAS:
@@ -3317,6 +3366,26 @@ def _translate_lcm_args(native_name: str, args: dict) -> dict:
 
 _ENGINE_DEFAULT_SESSION = "__default__"
 
+def _has_compressible_message_content(messages) -> bool:
+    if not isinstance(messages, list):
+        return False
+
+    def _content_has_text(content) -> bool:
+        if isinstance(content, str):
+            return bool(content.strip())
+        if isinstance(content, list):
+            return any(_content_has_text(item) for item in content)
+        if isinstance(content, dict):
+            for key in ("text", "content"):
+                if _content_has_text(content.get(key)):
+                    return True
+        return False
+
+    for message in messages:
+        if isinstance(message, dict) and _content_has_text(message.get("content")):
+            return True
+    return False
+
 class _EngineSessionState:
     """Mutable per-conversation engine state.
 
@@ -3332,6 +3401,7 @@ class _EngineSessionState:
         "last_prompt_tokens",
         "last_completion_tokens",
         "last_total_tokens",
+        "last_real_prompt_tokens",
         "context_length",
         "threshold_tokens",
         "compression_count",
@@ -3341,6 +3411,7 @@ class _EngineSessionState:
         "_runtime_context_length",
         "_session_start_context_length",
         "_last_preflight_signature",
+        "_awaiting_real_usage_after_compression",
     )
 
     def __init__(self):
@@ -3349,6 +3420,7 @@ class _EngineSessionState:
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
         self.last_total_tokens = 0
+        self.last_real_prompt_tokens = 0
         # Host-contract token state (run_agent.py reads these directly; the
         # minimum-context guard in agent/agent_init.py checks context_length).
         self.context_length = 0
@@ -3362,6 +3434,7 @@ class _EngineSessionState:
         self._runtime_context_length = None
         self._session_start_context_length = None
         self._last_preflight_signature = None
+        self._awaiting_real_usage_after_compression = False
 
     def adopt(self, other):
         """Carry conversation state across a compression-rotation rebind."""
@@ -3406,12 +3479,17 @@ class TraceDecayContextEngine(ContextEngine):
         # a broken summary model is broken for every session.
         self._route_failures = {}
         self._cooldown_until = {}
+        self._registered_tool_names = []
+        self._registered_context_tool_names = []
+        self._host_forwards_registered_tool_messages = None
+        self._live_ingest_gate_reason = "not_registered"
 
     agent = _engine_session_property("agent")
     model = _engine_session_property("model")
     last_prompt_tokens = _engine_session_property("last_prompt_tokens")
     last_completion_tokens = _engine_session_property("last_completion_tokens")
     last_total_tokens = _engine_session_property("last_total_tokens")
+    last_real_prompt_tokens = _engine_session_property("last_real_prompt_tokens")
     context_length = _engine_session_property("context_length")
     threshold_tokens = _engine_session_property("threshold_tokens")
     compression_count = _engine_session_property("compression_count")
@@ -3421,6 +3499,7 @@ class TraceDecayContextEngine(ContextEngine):
     _runtime_context_length = _engine_session_property("_runtime_context_length")
     _session_start_context_length = _engine_session_property("_session_start_context_length")
     _last_preflight_signature = _engine_session_property("_last_preflight_signature")
+    _awaiting_real_usage_after_compression = _engine_session_property("_awaiting_real_usage_after_compression")
 
     def _session_key(self, session_id=None):
         if session_id:
@@ -3500,6 +3579,24 @@ class TraceDecayContextEngine(ContextEngine):
         self._bind_session(session_id, hermes_home, project_root, **kwargs)
         self._report_compression_boundary(session_id, bound_session_id, kwargs)
 
+    def carry_over_new_session_context(self, old_session_id, new_session_id, **kwargs):
+        """Compatibility hook for Hermes compression session rotation."""
+        old_session_id = str(old_session_id or "")
+        new_session_id = str(new_session_id or "")
+        if not old_session_id or not new_session_id or old_session_id == new_session_id:
+            return False
+        bound_session_id = self.active_session_id or old_session_id
+        self._bind_session(new_session_id, old_session_id=old_session_id, **kwargs)
+        boundary_kwargs = dict(kwargs)
+        boundary_kwargs["old_session_id"] = old_session_id
+        boundary_kwargs["boundary_reason"] = "compression"
+        self._report_compression_boundary(
+            new_session_id,
+            bound_session_id,
+            boundary_kwargs,
+        )
+        return True
+
     def on_session_end(self, session_id=None, messages=None, **kwargs):
         # Real session boundary: drop the per-session record so long-lived
         # gateway processes do not accumulate dead conversation state.
@@ -3562,6 +3659,9 @@ class TraceDecayContextEngine(ContextEngine):
         self.last_total_tokens = _as_int(usage.get("total_tokens")) or (
             self.last_prompt_tokens + self.last_completion_tokens
         )
+        self.last_real_prompt_tokens = self.last_prompt_tokens
+        if self.last_prompt_tokens or self.last_completion_tokens or self.last_total_tokens:
+            self._awaiting_real_usage_after_compression = False
 
     def _effective_context_length(self):
         if self._runtime_context_length is not None:
@@ -3600,6 +3700,23 @@ class TraceDecayContextEngine(ContextEngine):
             tools.call_tracedecay_tool("tracedecay_lcm_session_boundary", args)
         except Exception as exc:
             logger.warning("LCM session boundary report failed: %s", exc)
+
+    def has_content_to_compress(self, messages, current_tokens=None, **kwargs):
+        """Optional Hermes hook: conservatively probe only eligible content."""
+        del current_tokens, kwargs
+        if not _has_compressible_message_content(messages):
+            return False
+        compressible = [
+            message
+            for message in messages
+            if isinstance(message, dict) and _has_compressible_message_content([message])
+        ]
+        return len(compressible) > 1
+
+    def should_defer_preflight_to_real_usage(self, rough_tokens=None, **kwargs):
+        """Suppress rough-token retry loops until post-compression usage arrives."""
+        del rough_tokens, kwargs
+        return bool(self._awaiting_real_usage_after_compression)
 
     def should_compress_preflight(self, messages, current_tokens=None, **kwargs):
         """ABC contract: quick pre-flight check returning a BOOL.
@@ -3670,11 +3787,50 @@ class TraceDecayContextEngine(ContextEngine):
     def get_tool_schemas(self):
         return _lcm_tool_schemas()
 
+    def _last_compress_result_summary(self):
+        result = self.last_compress_result
+        if result is None:
+            return {"status": "never_ran"}
+        if not isinstance(result, dict):
+            return {"status": "invalid", "type": type(result).__name__}
+        summary = {}
+        for key in (
+            "status",
+            "reason",
+            "error",
+            "summary_node_count",
+            "summary_nodes_created",
+            "raw_message_count",
+            "replay_token_estimate",
+            "replay_over_budget",
+            "auxiliary_attempts",
+            "auxiliary_retry_status",
+            "auxiliary_error_classification",
+            "fallback_used",
+        ):
+            if key in result:
+                summary[key] = result[key]
+        if "status" not in summary:
+            summary["status"] = "error" if result.get("error") else "ok"
+        return summary
+
     def get_status(self):
         storage = _storage_args(self.project_root, self.hermes_home)
+        now = time.time()
+        route_cooldowns = {
+            route: max(0, int(until - now))
+            for route, until in self._cooldown_until.items()
+        }
+        message_dependent_registered = bool(
+            set(self._registered_tool_names).intersection(MESSAGE_DEPENDENT_TOOLS)
+            or self._registered_context_tool_names
+        )
         return {
             "engine": self.name,
             "session_id": self.active_session_id,
+            "active_session_id": self.active_session_id,
+            "tracedecay_binary_path": tools.TRACEDECAY_BIN,
+            "tracedecay_binary_available": _tracedecay_binary_available(),
             "storage_scope": storage.get("storage_scope"),
             "hermes_home": self.hermes_home,
             "project_root": self.project_root,
@@ -3683,6 +3839,18 @@ class TraceDecayContextEngine(ContextEngine):
             ),
             "route_failures": dict(self._route_failures),
             "cooldown_routes": sorted(self._cooldown_until.keys()),
+            "route_cooldowns": route_cooldowns,
+            "last_compress_result": self._last_compress_result_summary(),
+            "awaiting_real_usage_after_compression": bool(
+                self._awaiting_real_usage_after_compression
+            ),
+            "live_ingest": {
+                "registered_tool_names": sorted(self._registered_tool_names),
+                "context_tool_names": sorted(self._registered_context_tool_names),
+                "host_forwards_messages": self._host_forwards_registered_tool_messages,
+                "message_dependent_tools_registered": message_dependent_registered,
+                "gate_reason": self._live_ingest_gate_reason,
+            },
         }
 
     def _current_turn_preflight(self, messages, **kwargs):
@@ -4110,6 +4278,7 @@ class TraceDecayContextEngine(ContextEngine):
             logger.warning("tracedecay compression failed: %s", exc)
             self._last_compress_aborted = True
             self._last_summary_error = str(exc)
+            self._awaiting_real_usage_after_compression = False
             return original
         self.last_compress_result = result if isinstance(result, dict) else {}
         if (
@@ -4124,14 +4293,19 @@ class TraceDecayContextEngine(ContextEngine):
                 )
             else:
                 self._last_summary_error = "invalid compression result"
+            self._awaiting_real_usage_after_compression = False
             return original
         replay = _replay_message_list(result.get("replay_messages"))
         if replay is None or (not replay and original):
             # No usable replay window — treat as a no-op; the host detects
             # ``compressed == messages`` and skips session rotation.
+            self._awaiting_real_usage_after_compression = False
             return original
         if replay != original:
             self.compression_count += 1
+            self._awaiting_real_usage_after_compression = True
+        else:
+            self._awaiting_real_usage_after_compression = False
         return replay
 
     def _compress_to_result(self, messages, current_tokens=None, focus_topic=None, **kwargs):
@@ -4608,6 +4782,11 @@ def register(ctx):
     register_tool = getattr(ctx, "register_tool", None)
     host_forwards_messages = _host_forwards_registered_tool_messages(ctx)
     tracedecay_is_memory_provider = _active_memory_provider(ctx) == "tracedecay"
+    context_engine._host_forwards_registered_tool_messages = (
+        host_forwards_messages if callable(register_tool) else None
+    )
+    registered_tool_names = []
+    registered_context_tool_names = []
     if callable(register_tool):
         for schema in schemas.TOOL_SCHEMAS:
             name = schema["name"]
@@ -4634,6 +4813,8 @@ def register(ctx):
                 )
             else:
                 _REGISTERED_TOOL_NAMES.add(name)
+                if name in MESSAGE_DEPENDENT_TOOLS:
+                    registered_tool_names.append(name)
         if host_forwards_messages:
             for schema in context_engine.get_tool_schemas():
                 name = schema["name"]
@@ -4651,14 +4832,21 @@ def register(ctx):
                         name,
                         exc,
                     )
+                else:
+                    registered_context_tool_names.append(name)
+            context_engine._live_ingest_gate_reason = "registered"
         else:
+            context_engine._live_ingest_gate_reason = "host_does_not_forward_messages"
             logger.info(
                 "tracedecay LCM live-ingest tools skipped: this Hermes host does not forward messages to registered tool handlers"
             )
     else:
+        context_engine._live_ingest_gate_reason = "register_tool_unavailable"
         logger.info(
             "tracedecay direct tool registration unavailable on this Hermes host; continuing with context-engine schemas"
         )
+    context_engine._registered_tool_names = registered_tool_names
+    context_engine._registered_context_tool_names = registered_context_tool_names
 
     skills_dir = Path(__file__).parent / "skills"
     skill_path = skills_dir / "tracedecay" / "SKILL.md"

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -42,6 +42,156 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     }
 }
 
+fn lcm_compress_tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
+    let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
+    let text = if formatted.len() <= MAX_RESPONSE_CHARS {
+        formatted
+    } else if value.get("status").and_then(Value::as_str) == Some("needs_summary") {
+        let compact = compact_lcm_compress_payload(value, formatted.len(), false);
+        let compact_text = serde_json::to_string_pretty(&compact).unwrap_or_default();
+        if compact_text.len() <= MAX_RESPONSE_CHARS {
+            compact_text
+        } else {
+            let minimal = compact_lcm_compress_payload(value, formatted.len(), true);
+            serde_json::to_string_pretty(&minimal).unwrap_or_default()
+        }
+    } else {
+        truncated_json_envelope_with_handle(project_root, &formatted)
+    };
+    ToolResult {
+        value: json!({ "content": [{ "type": "text", "text": text }] }),
+        touched_files: Vec::new(),
+    }
+}
+
+fn compact_lcm_compress_payload(value: &Value, original_chars: usize, minimal: bool) -> Value {
+    let mut object = Map::new();
+    let keys: &[&str] = if minimal {
+        &[
+            "status",
+            "provider",
+            "session_id",
+            "reason",
+            "summary_nodes_created",
+            "replay_token_estimate",
+            "replay_over_budget",
+            "compression_attempts",
+            "fallback_used",
+            "retry_status",
+        ]
+    } else {
+        &[
+            "status",
+            "provider",
+            "session_id",
+            "reason",
+            "summary_nodes_created",
+            "summary_nodes",
+            "replay_messages",
+            "replay_token_estimate",
+            "replay_over_budget",
+            "compression_attempts",
+            "fallback_used",
+            "retry_status",
+            "frontier",
+        ]
+    };
+    for key in keys {
+        if let Some(field) = value.get(key) {
+            object.insert((*key).to_string(), field.clone());
+        }
+    }
+    if minimal {
+        let (replay_messages, replay_truncated) =
+            compact_replay_messages(value.get("replay_messages"), 8, 512);
+        object.insert("replay_messages".to_string(), replay_messages);
+        object.insert(
+            "replay_messages_truncated_for_mcp".to_string(),
+            json!(replay_truncated),
+        );
+    }
+
+    if let Some(summary_request) = value.get("summary_request").and_then(Value::as_object) {
+        let mut compact_request = Map::new();
+        for key in [
+            "provider",
+            "session_id",
+            "focus_topic",
+            "source_range",
+            "token_budget",
+            "routes",
+        ] {
+            if let Some(field) = summary_request.get(key) {
+                compact_request.insert(key.to_string(), field.clone());
+            }
+        }
+        compact_request.insert("source_messages_omitted_for_mcp".to_string(), json!(true));
+        compact_request.insert("prompt_omitted_for_mcp".to_string(), json!(true));
+        compact_request.insert(
+            "extraction_request_omitted_for_mcp".to_string(),
+            json!(true),
+        );
+        object.insert(
+            "summary_request".to_string(),
+            Value::Object(compact_request),
+        );
+    } else if let Some(field) = value.get("summary_request") {
+        object.insert("summary_request".to_string(), field.clone());
+    }
+
+    object.insert("mcp_response_truncated".to_string(), json!(true));
+    object.insert("contract_truncated".to_string(), json!(true));
+    object.insert(
+        "mcp_original_response_chars".to_string(),
+        json!(original_chars),
+    );
+    object.insert(
+        "mcp_truncation_reason".to_string(),
+        json!("lcm-compress needs-summary response compacted to preserve Hermes bridge contract"),
+    );
+    Value::Object(object)
+}
+
+fn compact_replay_messages(
+    value: Option<&Value>,
+    limit: usize,
+    content_chars: usize,
+) -> (Value, bool) {
+    let Some(array) = value.and_then(Value::as_array) else {
+        return (json!([]), false);
+    };
+    let mut truncated = array.len() > limit;
+    let messages = array
+        .iter()
+        .take(limit)
+        .map(|item| {
+            let mut object = Map::new();
+            if let Some(map) = item.as_object() {
+                for (key, field) in map {
+                    if key == "content" {
+                        if let Some(content) = field.as_str() {
+                            let (content, content_truncated) =
+                                truncate_chars(content, content_chars);
+                            object.insert(key.clone(), json!(content));
+                            object.insert(
+                                "content_truncated_for_mcp".to_string(),
+                                json!(content_truncated),
+                            );
+                            truncated |= content_truncated;
+                        } else {
+                            object.insert(key.clone(), field.clone());
+                        }
+                    } else {
+                        object.insert(key.clone(), field.clone());
+                    }
+                }
+            }
+            Value::Object(object)
+        })
+        .collect::<Vec<_>>();
+    (Value::Array(messages), truncated)
+}
+
 fn lcm_expand_query_tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
     let needs_synthesis = value
@@ -1571,7 +1721,7 @@ pub(super) async fn handle_lcm_compress(
         })
         .await
         .map_err(lcm_error)?;
-    Ok(tool_json(
+    Ok(lcm_compress_tool_json(
         project_root,
         &json!({
             "status": response.status,

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -42,6 +42,67 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     }
 }
 
+fn lcm_preflight_tool_json(value: &Value) -> ToolResult {
+    let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
+    let text = if formatted.len() <= MAX_RESPONSE_CHARS {
+        formatted
+    } else {
+        let compact = compact_lcm_preflight_payload(value, formatted.len(), 8, 512);
+        let compact_text = serde_json::to_string_pretty(&compact).unwrap_or_default();
+        if compact_text.len() <= MAX_RESPONSE_CHARS {
+            compact_text
+        } else {
+            let minimal = compact_lcm_preflight_payload(value, formatted.len(), 4, 256);
+            serde_json::to_string_pretty(&minimal).unwrap_or_default()
+        }
+    };
+    ToolResult {
+        value: json!({ "content": [{ "type": "text", "text": text }] }),
+        touched_files: Vec::new(),
+    }
+}
+
+fn compact_lcm_preflight_payload(
+    value: &Value,
+    original_chars: usize,
+    replay_limit: usize,
+    replay_content_chars: usize,
+) -> Value {
+    let mut object = Map::new();
+    for key in [
+        "status",
+        "provider",
+        "session_id",
+        "should_compress",
+        "reason",
+    ] {
+        if let Some(field) = value.get(key) {
+            object.insert(key.to_string(), field.clone());
+        }
+    }
+    let (replay_messages, replay_truncated) = compact_replay_messages(
+        value.get("replay_messages"),
+        replay_limit,
+        replay_content_chars,
+    );
+    object.insert("replay_messages".to_string(), replay_messages);
+    object.insert(
+        "replay_messages_truncated_for_mcp".to_string(),
+        json!(replay_truncated),
+    );
+    object.insert("mcp_response_truncated".to_string(), json!(true));
+    object.insert("contract_truncated".to_string(), json!(true));
+    object.insert(
+        "mcp_original_response_chars".to_string(),
+        json!(original_chars),
+    );
+    object.insert(
+        "mcp_truncation_reason".to_string(),
+        json!("lcm-preflight response compacted to preserve Hermes bridge contract"),
+    );
+    Value::Object(object)
+}
+
 fn lcm_compress_tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
     let text = if formatted.len() <= MAX_RESPONSE_CHARS {
@@ -1671,17 +1732,14 @@ pub(super) async fn handle_lcm_preflight(
         })
         .await
         .map_err(lcm_error)?;
-    Ok(tool_json(
-        project_root,
-        &json!({
-            "status": response.status,
-            "provider": provider,
-            "session_id": session_id,
-            "should_compress": response.should_compress,
-            "reason": response.reason,
-            "replay_messages": response.replay_messages,
-        }),
-    ))
+    Ok(lcm_preflight_tool_json(&json!({
+        "status": response.status,
+        "provider": provider,
+        "session_id": session_id,
+        "should_compress": response.should_compress,
+        "reason": response.reason,
+        "replay_messages": response.replay_messages,
+    })))
 }
 
 pub(super) async fn handle_lcm_compress(

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -53,7 +53,13 @@ fn lcm_preflight_tool_json(value: &Value) -> ToolResult {
             compact_text
         } else {
             let minimal = compact_lcm_preflight_payload(value, formatted.len(), 4, 256);
-            serde_json::to_string_pretty(&minimal).unwrap_or_default()
+            let minimal_text = serde_json::to_string_pretty(&minimal).unwrap_or_default();
+            if minimal_text.len() <= MAX_RESPONSE_CHARS {
+                minimal_text
+            } else {
+                let floor = compact_lcm_preflight_payload(value, formatted.len(), 1, 64);
+                bounded_lcm_contract_text(&floor)
+            }
         }
     };
     ToolResult {
@@ -80,7 +86,7 @@ fn compact_lcm_preflight_payload(
             object.insert(key.to_string(), field.clone());
         }
     }
-    let (replay_messages, replay_truncated) = compact_replay_messages(
+    let (replay_messages, replay_truncated, replay_compacted) = compact_replay_messages(
         value.get("replay_messages"),
         replay_limit,
         replay_content_chars,
@@ -89,6 +95,10 @@ fn compact_lcm_preflight_payload(
     object.insert(
         "replay_messages_truncated_for_mcp".to_string(),
         json!(replay_truncated),
+    );
+    object.insert(
+        "replay_messages_compacted_for_mcp".to_string(),
+        json!(replay_compacted),
     );
     object.insert("mcp_response_truncated".to_string(), json!(true));
     object.insert("contract_truncated".to_string(), json!(true));
@@ -108,13 +118,19 @@ fn lcm_compress_tool_json(project_root: Option<&Path>, value: &Value) -> ToolRes
     let text = if formatted.len() <= MAX_RESPONSE_CHARS {
         formatted
     } else if value.get("status").and_then(Value::as_str) == Some("needs_summary") {
-        let compact = compact_lcm_compress_payload(value, formatted.len(), false);
+        let compact = compact_lcm_compress_payload(value, formatted.len(), false, 8, 512);
         let compact_text = serde_json::to_string_pretty(&compact).unwrap_or_default();
         if compact_text.len() <= MAX_RESPONSE_CHARS {
             compact_text
         } else {
-            let minimal = compact_lcm_compress_payload(value, formatted.len(), true);
-            serde_json::to_string_pretty(&minimal).unwrap_or_default()
+            let minimal = compact_lcm_compress_payload(value, formatted.len(), true, 8, 512);
+            let minimal_text = serde_json::to_string_pretty(&minimal).unwrap_or_default();
+            if minimal_text.len() <= MAX_RESPONSE_CHARS {
+                minimal_text
+            } else {
+                let floor = compact_lcm_compress_payload(value, formatted.len(), true, 1, 64);
+                bounded_lcm_contract_text(&floor)
+            }
         }
     } else {
         truncated_json_envelope_with_handle(project_root, &formatted)
@@ -125,7 +141,13 @@ fn lcm_compress_tool_json(project_root: Option<&Path>, value: &Value) -> ToolRes
     }
 }
 
-fn compact_lcm_compress_payload(value: &Value, original_chars: usize, minimal: bool) -> Value {
+fn compact_lcm_compress_payload(
+    value: &Value,
+    original_chars: usize,
+    minimal: bool,
+    replay_limit: usize,
+    replay_content_chars: usize,
+) -> Value {
     let mut object = Map::new();
     let keys: &[&str] = if minimal {
         &[
@@ -163,12 +185,19 @@ fn compact_lcm_compress_payload(value: &Value, original_chars: usize, minimal: b
         }
     }
     if minimal {
-        let (replay_messages, replay_truncated) =
-            compact_replay_messages(value.get("replay_messages"), 8, 512);
+        let (replay_messages, replay_truncated, replay_compacted) = compact_replay_messages(
+            value.get("replay_messages"),
+            replay_limit,
+            replay_content_chars,
+        );
         object.insert("replay_messages".to_string(), replay_messages);
         object.insert(
             "replay_messages_truncated_for_mcp".to_string(),
             json!(replay_truncated),
+        );
+        object.insert(
+            "replay_messages_compacted_for_mcp".to_string(),
+            json!(replay_compacted),
         );
     }
 
@@ -217,11 +246,12 @@ fn compact_replay_messages(
     value: Option<&Value>,
     limit: usize,
     content_chars: usize,
-) -> (Value, bool) {
+) -> (Value, bool, bool) {
     let Some(array) = value.and_then(Value::as_array) else {
-        return (json!([]), false);
+        return (json!([]), false, false);
     };
     let mut truncated = array.len() > limit;
+    let mut compacted = false;
     let messages = array
         .iter()
         .take(limit)
@@ -230,18 +260,22 @@ fn compact_replay_messages(
             if let Some(map) = item.as_object() {
                 for (key, field) in map {
                     if key == "content" {
-                        if let Some(content) = field.as_str() {
-                            let (content, content_truncated) =
-                                truncate_chars(content, content_chars);
-                            object.insert(key.clone(), json!(content));
-                            object.insert(
-                                "content_truncated_for_mcp".to_string(),
-                                json!(content_truncated),
-                            );
-                            truncated |= content_truncated;
-                        } else {
-                            object.insert(key.clone(), field.clone());
+                        let content_text = field
+                            .as_str()
+                            .map(str::to_string)
+                            .unwrap_or_else(|| serde_json::to_string(field).unwrap_or_default());
+                        let (content, content_truncated) =
+                            truncate_chars(&content_text, content_chars);
+                        object.insert(key.clone(), json!(content));
+                        object.insert(
+                            "content_truncated_for_mcp".to_string(),
+                            json!(content_truncated),
+                        );
+                        if !field.is_string() {
+                            object.insert("content_serialized_for_mcp".to_string(), json!(true));
+                            compacted = true;
                         }
+                        truncated |= content_truncated;
                     } else {
                         object.insert(key.clone(), field.clone());
                     }
@@ -250,7 +284,25 @@ fn compact_replay_messages(
             Value::Object(object)
         })
         .collect::<Vec<_>>();
-    (Value::Array(messages), truncated)
+    (Value::Array(messages), truncated, compacted || truncated)
+}
+
+fn bounded_lcm_contract_text(value: &Value) -> String {
+    let text = serde_json::to_string_pretty(value).unwrap_or_default();
+    if text.len() <= MAX_RESPONSE_CHARS {
+        return text;
+    }
+    serde_json::to_string_pretty(&json!({
+        "status": value.get("status").cloned().unwrap_or_else(|| json!("ok")),
+        "reason": value.get("reason").cloned().unwrap_or_else(|| json!("mcp_contract_floor_over_budget")),
+        "mcp_response_truncated": true,
+        "contract_truncated": true,
+        "mcp_truncation_reason": "lcm response exceeded minimum Hermes bridge contract budget",
+        "replay_messages": [],
+        "replay_messages_truncated_for_mcp": true,
+        "replay_messages_compacted_for_mcp": true,
+    }))
+    .unwrap_or_default()
 }
 
 fn lcm_expand_query_tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -262,8 +262,7 @@ fn compact_replay_messages(
                     if key == "content" {
                         let content_text = field
                             .as_str()
-                            .map(str::to_string)
-                            .unwrap_or_else(|| serde_json::to_string(field).unwrap_or_default());
+                            .map_or_else(|| serde_json::to_string(field).unwrap_or_default(), str::to_string);
                         let (content, content_truncated) =
                             truncate_chars(&content_text, content_chars);
                         object.insert(key.clone(), json!(content));

--- a/src/sessions/lcm/compression.rs
+++ b/src/sessions/lcm/compression.rs
@@ -341,6 +341,8 @@ pub(crate) async fn preflight(
         &raw_messages,
         existing_frontier.current_frontier_store_id,
         request.fresh_tail_count,
+        request.current_tokens,
+        request.threshold_tokens,
     );
     let (should_compress, reason) = preflight_decision(&request, &existing_frontier, &window);
     let should_compress = ingested.changed_replay || should_compress;
@@ -501,6 +503,8 @@ async fn compress_in_transaction(
                 &raw_messages,
                 existing_frontier.current_frontier_store_id,
                 request.fresh_tail_count,
+                request.current_tokens,
+                request.threshold_tokens,
             );
             let replay_messages =
                 replay_without_summary(&window.pinned_anchors, &window.fresh_tail);
@@ -522,6 +526,8 @@ async fn compress_in_transaction(
         &raw_messages,
         existing_frontier.current_frontier_store_id,
         request.fresh_tail_count,
+        request.current_tokens,
+        request.threshold_tokens,
     );
 
     if window.backlog.is_empty() {
@@ -948,6 +954,8 @@ fn compression_window(
     raw_messages: &[LcmRawMessage],
     current_frontier_store_id: Option<i64>,
     fresh_tail_count: Option<usize>,
+    current_tokens: Option<i64>,
+    threshold_tokens: Option<i64>,
 ) -> CompressionWindow {
     let frontier_store_id = current_frontier_store_id.unwrap_or(0);
     let unsummarized = raw_messages
@@ -955,9 +963,16 @@ fn compression_window(
         .filter(|message| message.store_id > frontier_store_id)
         .cloned()
         .collect::<Vec<_>>();
+    let configured_fresh_tail_count = fresh_tail_count.unwrap_or(LCM_DEFAULT_FRESH_TAIL_COUNT);
+    let effective_fresh_tail_count =
+        if unsummarized.len() > 1 && threshold_pressure(current_tokens, threshold_tokens) {
+            configured_fresh_tail_count.min(unsummarized.len() - 1)
+        } else {
+            configured_fresh_tail_count
+        };
     let backlog_len = unsummarized
         .len()
-        .saturating_sub(fresh_tail_count.unwrap_or(LCM_DEFAULT_FRESH_TAIL_COUNT));
+        .saturating_sub(effective_fresh_tail_count);
     let (older_unsummarized, fresh_tail) = unsummarized.split_at(backlog_len);
     let fresh_tail_start_store_id = fresh_tail
         .first()
@@ -1891,18 +1906,17 @@ fn summary_request_for_backlog(
          Preserve durable instructions, decisions, open tasks, and facts needed to continue."
     );
 
+    let extraction_request =
+        extraction::build_extraction_request(session_id, &source_range, &source_messages);
+
     LcmSummaryRequest {
         provider: provider.to_string(),
         session_id: session_id.to_string(),
         focus_topic,
         prompt,
         source_range: source_range.clone(),
-        source_messages: source_messages.clone(),
-        extraction_request: extraction::build_extraction_request(
-            session_id,
-            &source_range,
-            &source_messages,
-        ),
+        source_messages,
+        extraction_request,
     }
 }
 

--- a/tests/hermes_lcm_bridge_test.rs
+++ b/tests/hermes_lcm_bridge_test.rs
@@ -1330,9 +1330,16 @@ assert engine.last_compress_result == {"status": "not_implemented", "message": "
 assert len(calls) == 1
 argv = calls[0]
 assert argv[0] == plugin.tools.TRACEDECAY_BIN
-assert argv[1:4] == ["tool", "tracedecay_lcm_compress", "--json"]
-assert "--project" not in argv
-args = json.loads(argv[argv.index("--args") + 1])
+assert argv[1] == "tool"
+tool_idx = argv.index("tracedecay_lcm_compress")
+assert argv[tool_idx + 1] == "--json"
+assert argv[tool_idx + 2] == "--args"
+args_ref = argv[argv.index("--args") + 1]
+if args_ref.startswith("@"):
+    with open(args_ref[1:], encoding="utf-8") as args_file:
+        args = json.load(args_file)
+else:
+    args = json.loads(args_ref)
 # expanduser matches the plugin's fallback byte-for-byte on Windows too.
 assert args == {
     "storage_scope": "hermes_profile",

--- a/tests/hermes_lcm_bridge_test.rs
+++ b/tests/hermes_lcm_bridge_test.rs
@@ -3698,13 +3698,14 @@ def fake_retrieve_call(name, args, **kwargs):
         return envelope({"truncated": True, "handle": "payload-1"})
     if name == "tracedecay_retrieve":
         assert args == {"handle": "payload-1"}
+        assert kwargs == {"project_root": "/tmp/project"}
         return envelope({"content": json.dumps({"should_compress": True, "source": "retrieved"})})
     if name == "tracedecay_fact_store":
         return envelope({"truncated": True, "handle": "payload-ignored"})
     raise AssertionError(f"unexpected tool call: {name}")
 
 plugin.tools.call_tracedecay_tool = fake_retrieve_call
-retrieved = plugin.call_tracedecay_json("tracedecay_lcm_preflight", {})
+retrieved = plugin.call_tracedecay_json("tracedecay_lcm_preflight", {}, project_root="/tmp/project")
 assert retrieved == {"should_compress": True, "source": "retrieved"}
 assert [call[0] for call in calls] == ["tracedecay_lcm_preflight", "tracedecay_retrieve"]
 

--- a/tests/hermes_lcm_bridge_test.rs
+++ b/tests/hermes_lcm_bridge_test.rs
@@ -283,8 +283,22 @@ assert doctor_params["properties"] == {}
 status = engine.get_status()
 assert status["engine"] == "tracedecay"
 assert status["session_id"] == "session-1"
+assert status["active_session_id"] == "session-1"
 assert status["storage_scope"] == "hermes_profile"
+assert status["hermes_home"] == os.environ["HERMES_HOME"]
+assert status["project_root"] == "/tmp/project"
+assert status["tracedecay_binary_path"] == plugin.tools.TRACEDECAY_BIN
+assert isinstance(status["tracedecay_binary_available"], bool)
 assert status["context_engine_tool_names"] == sorted(schema_names)
+assert status["route_failures"] == {}
+assert status["cooldown_routes"] == []
+assert status["route_cooldowns"] == {}
+assert status["last_compress_result"] == {"status": "never_ran"}
+assert status["live_ingest"]["registered_tool_names"] == []
+assert status["live_ingest"]["context_tool_names"] == []
+assert status["live_ingest"]["host_forwards_messages"] is None
+assert status["live_ingest"]["message_dependent_tools_registered"] is False
+assert status["live_ingest"]["gate_reason"] == "not_registered"
 
 calls = []
 
@@ -389,6 +403,83 @@ assert calls[8][1]["hermes_home"] == os.environ["HERMES_HOME"]
 assert calls[8][1]["session_id"] == "session-1"
 "#,
         "generated context engine should expose Hermes-style native LCM surface",
+    );
+}
+
+#[test]
+fn generated_context_engine_exposes_optional_hermes_hooks() {
+    run_generated_plugin_script(
+        "check_context_engine_optional_hooks.py",
+        r#"
+import json
+
+engine = plugin.TraceDecayContextEngine()
+engine.initialize(session_id="old-session", project_root="/tmp/project")
+
+calls = []
+
+def envelope(payload):
+    return json.dumps({"content": [{"type": "text", "text": json.dumps(payload)}]})
+
+def fake_call_tracedecay_tool(name, args, **kwargs):
+    calls.append((name, args, kwargs))
+    if name == "tracedecay_lcm_preflight":
+        return envelope({"should_compress": True})
+    if name == "tracedecay_lcm_compress":
+        return envelope({
+            "status": "compressed",
+            "replay_messages": [{"role": "system", "content": "summary"}],
+            "summary_node_count": 1,
+            "raw_message_count": 2,
+        })
+    if name == "tracedecay_lcm_session_boundary":
+        return json.dumps({"ok": True})
+    raise AssertionError(f"unexpected tool call: {name}")
+
+plugin.tools.call_tracedecay_tool = fake_call_tracedecay_tool
+
+assert engine.has_content_to_compress([]) is False
+assert engine.has_content_to_compress([
+    {"role": "system", "content": ""},
+    {"role": "assistant", "content": "   "},
+]) is False
+assert calls == []
+assert engine.has_content_to_compress([
+    {"role": "user", "content": "single message stays protected"},
+]) is False
+
+eligible = [
+    {"role": "user", "content": "older content"},
+    {"role": "assistant", "content": "newer content"},
+]
+assert engine.has_content_to_compress(eligible, current_tokens=123) is True
+assert calls == []
+
+compressed = engine.compress(
+    [{"role": "user", "content": "one"}, {"role": "assistant", "content": "two"}],
+    current_tokens=999,
+)
+assert compressed == [{"role": "system", "content": "summary"}]
+assert engine.should_defer_preflight_to_real_usage(rough_tokens=1000) is True
+status = engine.get_status()
+assert status["awaiting_real_usage_after_compression"] is True
+assert status["last_compress_result"]["status"] == "compressed"
+assert status["last_compress_result"]["summary_node_count"] == 1
+assert status["last_compress_result"]["raw_message_count"] == 2
+
+engine.update_from_response({"prompt_tokens": 321, "completion_tokens": 7})
+assert engine.should_defer_preflight_to_real_usage(rough_tokens=1000) is False
+assert engine.last_real_prompt_tokens == 321
+
+engine.carry_over_new_session_context("old-session", "new-session")
+boundary_calls = [call for call in calls if call[0] == "tracedecay_lcm_session_boundary"]
+assert len(boundary_calls) == 1
+assert boundary_calls[0][1]["old_session_id"] == "old-session"
+assert boundary_calls[0][1]["session_id"] == "new-session"
+assert boundary_calls[0][1]["boundary_reason"] == "compression"
+assert engine.active_session_id == "new-session"
+"#,
+        "generated context engine should expose optional Hermes hook shims",
     );
 }
 
@@ -3595,6 +3686,35 @@ assert invalid_nested_json["error"] == "tracedecay tool returned invalid nested 
 
 outer_error = {"error": "tool failed", "code": "boom", "content": []}
 assert call_with_outer(outer_error) == outer_error
+
+calls = []
+
+def envelope(payload):
+    return json.dumps({"content": [{"type": "text", "text": json.dumps(payload)}]})
+
+def fake_retrieve_call(name, args, **kwargs):
+    calls.append((name, args, kwargs))
+    if name == "tracedecay_lcm_preflight":
+        return envelope({"truncated": True, "handle": "payload-1"})
+    if name == "tracedecay_retrieve":
+        assert args == {"handle": "payload-1"}
+        return envelope({"content": json.dumps({"should_compress": True, "source": "retrieved"})})
+    if name == "tracedecay_fact_store":
+        return envelope({"truncated": True, "handle": "payload-ignored"})
+    raise AssertionError(f"unexpected tool call: {name}")
+
+plugin.tools.call_tracedecay_tool = fake_retrieve_call
+retrieved = plugin.call_tracedecay_json("tracedecay_lcm_preflight", {})
+assert retrieved == {"should_compress": True, "source": "retrieved"}
+assert [call[0] for call in calls] == ["tracedecay_lcm_preflight", "tracedecay_retrieve"]
+
+not_contract_critical = plugin.call_tracedecay_json("tracedecay_fact_store", {})
+assert not_contract_critical == {"truncated": True, "handle": "payload-ignored"}
+assert [call[0] for call in calls] == [
+    "tracedecay_lcm_preflight",
+    "tracedecay_retrieve",
+    "tracedecay_fact_store",
+]
 "#,
     )
     .unwrap();

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5552,10 +5552,64 @@ async fn lcm_preflight_oversized_replay_preserves_bridge_contract() {
     assert_eq!(payload["contract_truncated"], true);
     assert!(payload.get("truncated").is_none());
     assert!(text.len() <= 15_000);
+    assert!(payload["replay_messages_compacted_for_mcp"]
+        .as_bool()
+        .unwrap_or(false));
     assert_eq!(
         payload["replay_messages"][0]["content_truncated_for_mcp"],
         true
     );
+}
+
+#[tokio::test]
+async fn lcm_preflight_structured_replay_content_is_bounded_for_mcp() {
+    let (cg, _dir) = setup_project().await;
+    let huge_source = "structured preflight payload ".repeat(8_000);
+
+    let preflight = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_preflight",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-structured-preflight",
+            "messages": [
+                {
+                    "id": "structured-preflight-1",
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": huge_source},
+                        {"type": "input_json", "value": {"nested": huge_source}}
+                    ]
+                },
+                {"id": "structured-preflight-2", "role": "assistant", "content": "acknowledged"}
+            ],
+            "current_tokens": 10,
+            "threshold_tokens": 1_000
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&preflight.value);
+    let payload: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(payload["status"], "ok");
+    assert!(payload.get("truncated").is_none());
+    assert!(text.len() <= 15_000);
+    let compacted_content = payload["replay_messages"][0]["content"]
+        .as_str()
+        .expect("structured replay content should be serialized to bounded text");
+    assert!(compacted_content.len() <= 512);
+    assert_eq!(
+        payload["replay_messages"][0]["content_serialized_for_mcp"],
+        true
+    );
+    assert_eq!(
+        payload["replay_messages"][0]["content_truncated_for_mcp"],
+        true
+    );
+    assert_eq!(payload["replay_messages_compacted_for_mcp"], true);
 }
 
 #[tokio::test]

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5520,6 +5520,45 @@ async fn lcm_compress_oversized_needs_summary_preserves_bridge_contract() {
 }
 
 #[tokio::test]
+async fn lcm_preflight_oversized_replay_preserves_bridge_contract() {
+    let (cg, _dir) = setup_project().await;
+    let huge_source = "preflight oversized active context ".repeat(8_000);
+
+    let preflight = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_preflight",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-oversized-preflight",
+            "messages": [
+                {"id": "preflight-1", "role": "user", "content": huge_source},
+                {"id": "preflight-2", "role": "assistant", "content": "acknowledged"}
+            ],
+            "current_tokens": 10,
+            "threshold_tokens": 1_000
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&preflight.value);
+    let payload: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["should_compress"], false);
+    assert_eq!(payload["reason"], "no_compression_needed");
+    assert_eq!(payload["mcp_response_truncated"], true);
+    assert_eq!(payload["contract_truncated"], true);
+    assert!(payload.get("truncated").is_none());
+    assert!(text.len() <= 15_000);
+    assert_eq!(
+        payload["replay_messages"][0]["content_truncated_for_mcp"],
+        true
+    );
+}
+
+#[tokio::test]
 async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() {
     let (cg, _dir) = setup_project().await;
     for (index, content) in ["old-1 token", "old-2 token", "fresh-1", "fresh-2"]

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5467,6 +5467,59 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
 }
 
 #[tokio::test]
+async fn lcm_compress_oversized_needs_summary_preserves_bridge_contract() {
+    let (cg, _dir) = setup_project().await;
+    let huge_source = "alpha oversized context ".repeat(8_000);
+
+    let compress = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_compress",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-oversized-needs-summary",
+            "messages": [
+                {"id": "oversized-1", "role": "user", "content": huge_source},
+                {"id": "oversized-2", "role": "assistant", "content": "acknowledged"},
+                {"id": "oversized-3", "role": "user", "content": "latest objective"}
+            ],
+            "current_tokens": 30_000,
+            "threshold_tokens": 1_000,
+            "fresh_tail_count": 64,
+            "leaf_chunk_tokens": 20_000,
+            "summarizer": {"mode": "hermes_auxiliary"}
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&compress.value);
+    let payload: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(payload["status"], "needs_summary");
+    assert_eq!(payload["reason"], "hermes_auxiliary_not_available");
+    assert!(
+        payload["replay_messages"]
+            .as_array()
+            .is_some_and(|messages| !messages.is_empty()),
+        "bridge must retain replay messages, got {payload:#}"
+    );
+    assert!(
+        payload["summary_request"].is_object(),
+        "bridge must retain summary request metadata, got {payload:#}"
+    );
+    assert_eq!(payload["mcp_response_truncated"], true);
+    assert_eq!(payload["contract_truncated"], true);
+    assert!(payload.get("truncated").is_none());
+    assert!(extract_text(&compress.value).len() <= 15_000);
+    assert!(payload["summary_request"].get("source_messages").is_none());
+    assert_eq!(
+        payload["summary_request"]["source_messages_omitted_for_mcp"],
+        true
+    );
+}
+
+#[tokio::test]
 async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() {
     let (cg, _dir) = setup_project().await;
     for (index, content) in ["old-1 token", "old-2 token", "fresh-1", "fresh-2"]

--- a/tests/session_lcm_compression_test.rs
+++ b/tests/session_lcm_compression_test.rs
@@ -381,6 +381,72 @@ async fn noop_summarizer_ingests_without_summary_nodes() {
 }
 
 #[tokio::test]
+async fn threshold_pressure_summarizes_short_huge_active_context() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    insert_session(&db, "cursor", "short-huge").await;
+
+    let messages = vec![
+        json!({
+            "id": "short-huge-1",
+            "role": "user",
+            "content": "first long user turn ".repeat(80),
+        }),
+        json!({
+            "id": "short-huge-2",
+            "role": "assistant",
+            "content": "assistant response ".repeat(80),
+        }),
+        json!({
+            "id": "short-huge-3",
+            "role": "user",
+            "content": "latest user objective ".repeat(80),
+        }),
+    ];
+
+    let response = db
+        .lcm_compress(LcmCompressionRequest {
+            provider: "cursor".into(),
+            session_id: "short-huge".into(),
+            messages,
+            current_tokens: Some(2_000),
+            focus_topic: None,
+            ignore_session_patterns: Vec::new(),
+            stateless_session_patterns: Vec::new(),
+            ignore_message_patterns: Vec::new(),
+            expected_current_frontier_store_id: None,
+            threshold_tokens: Some(1_000),
+            max_assembly_tokens: None,
+            leaf_chunk_tokens: Some(100),
+            max_source_messages: None,
+            summary_fan_in: None,
+            incremental_max_depth: None,
+            fresh_tail_count: Some(64),
+            dynamic_leaf_chunk_enabled: None,
+            dynamic_leaf_chunk_max: None,
+            context_length: None,
+            reserve_tokens_floor: None,
+            summarizer: LcmSummarizerMode::HermesAuxiliary,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status, "needs_summary",
+        "response reason: {}",
+        response.reason
+    );
+    assert_eq!(response.reason, "hermes_auxiliary_not_available");
+    let summary_request = response
+        .summary_request
+        .expect("threshold pressure should select source messages to summarize");
+    assert!(
+        !summary_request.source_messages.is_empty(),
+        "short high-token conversations must not be kept entirely as fresh tail"
+    );
+}
+
+#[tokio::test]
 async fn active_structured_content_survives_preflight_and_noop_compress_replay() {
     let tmp = TempDir::new().unwrap();
     let db = open_lcm_db(&tmp).await;


### PR DESCRIPTION
## Summary
- Ensure threshold-triggered LCM compaction can summarize short oversized conversations instead of preserving the entire fresh tail.
- Preserve the Hermes bridge contract for oversized `tracedecay_lcm_compress` responses by compacting payloads without losing replay/control fields.
- Add regression coverage for the short-huge compaction case, oversized MCP response contract, and generated Hermes args-file handling.

## Test plan
- `cargo test --test session_lcm_compression_test`
- `cargo test --test mcp_handler_test lcm -- --nocapture`
- `cargo test --test hermes_lcm_bridge_test`
- `cargo fmt --check`
- Disposable Hermes `compress_context(..., force=false)` harness verified `compressed_backlog`, session rotation, and no no-change warning.