### PR TITLE
fix(lcm): preserve compaction replay contracts

### DIFF
--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -215,7 +215,20 @@ fn compact_lcm_compress_payload(
                 compact_request.insert(key.to_string(), field.clone());
             }
         }
-        compact_request.insert("source_messages_omitted_for_mcp".to_string(), json!(true));
+        let (source_messages, source_truncated, source_compacted) = compact_replay_messages(
+            summary_request.get("source_messages"),
+            replay_limit,
+            replay_content_chars,
+        );
+        compact_request.insert("source_messages".to_string(), source_messages);
+        compact_request.insert(
+            "source_messages_truncated_for_mcp".to_string(),
+            json!(source_truncated),
+        );
+        compact_request.insert(
+            "source_messages_compacted_for_mcp".to_string(),
+            json!(source_compacted),
+        );
         compact_request.insert("prompt_omitted_for_mcp".to_string(), json!(true));
         compact_request.insert(
             "extraction_request_omitted_for_mcp".to_string(),

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -260,9 +260,10 @@ fn compact_replay_messages(
             if let Some(map) = item.as_object() {
                 for (key, field) in map {
                     if key == "content" {
-                        let content_text = field
-                            .as_str()
-                            .map_or_else(|| serde_json::to_string(field).unwrap_or_default(), str::to_string);
+                        let content_text = field.as_str().map_or_else(
+                            || serde_json::to_string(field).unwrap_or_default(),
+                            str::to_string,
+                        );
                         let (content, content_truncated) =
                             truncate_chars(&content_text, content_chars);
                         object.insert(key.clone(), json!(content));

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -42,6 +42,268 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     }
 }
 
+fn lcm_preflight_tool_json(value: &Value) -> ToolResult {
+    let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
+    let text = if formatted.len() <= MAX_RESPONSE_CHARS {
+        formatted
+    } else {
+        let compact = compact_lcm_preflight_payload(value, formatted.len(), 8, 512);
+        let compact_text = serde_json::to_string_pretty(&compact).unwrap_or_default();
+        if compact_text.len() <= MAX_RESPONSE_CHARS {
+            compact_text
+        } else {
+            let minimal = compact_lcm_preflight_payload(value, formatted.len(), 4, 256);
+            let minimal_text = serde_json::to_string_pretty(&minimal).unwrap_or_default();
+            if minimal_text.len() <= MAX_RESPONSE_CHARS {
+                minimal_text
+            } else {
+                let floor = compact_lcm_preflight_payload(value, formatted.len(), 1, 64);
+                bounded_lcm_contract_text(&floor)
+            }
+        }
+    };
+    ToolResult {
+        value: json!({ "content": [{ "type": "text", "text": text }] }),
+        touched_files: Vec::new(),
+    }
+}
+
+fn compact_lcm_preflight_payload(
+    value: &Value,
+    original_chars: usize,
+    replay_limit: usize,
+    replay_content_chars: usize,
+) -> Value {
+    let mut object = Map::new();
+    for key in [
+        "status",
+        "provider",
+        "session_id",
+        "should_compress",
+        "reason",
+    ] {
+        if let Some(field) = value.get(key) {
+            object.insert(key.to_string(), field.clone());
+        }
+    }
+    let (replay_messages, replay_truncated, replay_compacted) = compact_replay_messages(
+        value.get("replay_messages"),
+        replay_limit,
+        replay_content_chars,
+    );
+    object.insert("replay_messages".to_string(), replay_messages);
+    object.insert(
+        "replay_messages_truncated_for_mcp".to_string(),
+        json!(replay_truncated),
+    );
+    object.insert(
+        "replay_messages_compacted_for_mcp".to_string(),
+        json!(replay_compacted),
+    );
+    object.insert("mcp_response_truncated".to_string(), json!(true));
+    object.insert("contract_truncated".to_string(), json!(true));
+    object.insert(
+        "mcp_original_response_chars".to_string(),
+        json!(original_chars),
+    );
+    object.insert(
+        "mcp_truncation_reason".to_string(),
+        json!("lcm-preflight response compacted to preserve Hermes bridge contract"),
+    );
+    Value::Object(object)
+}
+
+fn lcm_compress_tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
+    let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
+    let text = if formatted.len() <= MAX_RESPONSE_CHARS {
+        formatted
+    } else if value.get("status").and_then(Value::as_str) == Some("needs_summary") {
+        let compact = compact_lcm_compress_payload(value, formatted.len(), false, 8, 512);
+        let compact_text = serde_json::to_string_pretty(&compact).unwrap_or_default();
+        if compact_text.len() <= MAX_RESPONSE_CHARS {
+            compact_text
+        } else {
+            let minimal = compact_lcm_compress_payload(value, formatted.len(), true, 8, 512);
+            let minimal_text = serde_json::to_string_pretty(&minimal).unwrap_or_default();
+            if minimal_text.len() <= MAX_RESPONSE_CHARS {
+                minimal_text
+            } else {
+                let floor = compact_lcm_compress_payload(value, formatted.len(), true, 1, 64);
+                bounded_lcm_contract_text(&floor)
+            }
+        }
+    } else {
+        truncated_json_envelope_with_handle(project_root, &formatted)
+    };
+    ToolResult {
+        value: json!({ "content": [{ "type": "text", "text": text }] }),
+        touched_files: Vec::new(),
+    }
+}
+
+fn compact_lcm_compress_payload(
+    value: &Value,
+    original_chars: usize,
+    minimal: bool,
+    replay_limit: usize,
+    replay_content_chars: usize,
+) -> Value {
+    let mut object = Map::new();
+    let keys: &[&str] = if minimal {
+        &[
+            "status",
+            "provider",
+            "session_id",
+            "reason",
+            "summary_nodes_created",
+            "replay_token_estimate",
+            "replay_over_budget",
+            "compression_attempts",
+            "fallback_used",
+            "retry_status",
+        ]
+    } else {
+        &[
+            "status",
+            "provider",
+            "session_id",
+            "reason",
+            "summary_nodes_created",
+            "summary_nodes",
+            "replay_messages",
+            "replay_token_estimate",
+            "replay_over_budget",
+            "compression_attempts",
+            "fallback_used",
+            "retry_status",
+            "frontier",
+        ]
+    };
+    for key in keys {
+        if let Some(field) = value.get(key) {
+            object.insert((*key).to_string(), field.clone());
+        }
+    }
+    if minimal {
+        let (replay_messages, replay_truncated, replay_compacted) = compact_replay_messages(
+            value.get("replay_messages"),
+            replay_limit,
+            replay_content_chars,
+        );
+        object.insert("replay_messages".to_string(), replay_messages);
+        object.insert(
+            "replay_messages_truncated_for_mcp".to_string(),
+            json!(replay_truncated),
+        );
+        object.insert(
+            "replay_messages_compacted_for_mcp".to_string(),
+            json!(replay_compacted),
+        );
+    }
+
+    if let Some(summary_request) = value.get("summary_request").and_then(Value::as_object) {
+        let mut compact_request = Map::new();
+        for key in [
+            "provider",
+            "session_id",
+            "focus_topic",
+            "source_range",
+            "token_budget",
+            "routes",
+        ] {
+            if let Some(field) = summary_request.get(key) {
+                compact_request.insert(key.to_string(), field.clone());
+            }
+        }
+        compact_request.insert("source_messages_omitted_for_mcp".to_string(), json!(true));
+        compact_request.insert("prompt_omitted_for_mcp".to_string(), json!(true));
+        compact_request.insert(
+            "extraction_request_omitted_for_mcp".to_string(),
+            json!(true),
+        );
+        object.insert(
+            "summary_request".to_string(),
+            Value::Object(compact_request),
+        );
+    } else if let Some(field) = value.get("summary_request") {
+        object.insert("summary_request".to_string(), field.clone());
+    }
+
+    object.insert("mcp_response_truncated".to_string(), json!(true));
+    object.insert("contract_truncated".to_string(), json!(true));
+    object.insert(
+        "mcp_original_response_chars".to_string(),
+        json!(original_chars),
+    );
+    object.insert(
+        "mcp_truncation_reason".to_string(),
+        json!("lcm-compress needs-summary response compacted to preserve Hermes bridge contract"),
+    );
+    Value::Object(object)
+}
+
+fn compact_replay_messages(
+    value: Option<&Value>,
+    limit: usize,
+    content_chars: usize,
+) -> (Value, bool, bool) {
+    let Some(array) = value.and_then(Value::as_array) else {
+        return (json!([]), false, false);
+    };
+    let mut truncated = array.len() > limit;
+    let mut compacted = false;
+    let messages = array
+        .iter()
+        .take(limit)
+        .map(|item| {
+            let mut object = Map::new();
+            if let Some(map) = item.as_object() {
+                for (key, field) in map {
+                    if key == "content" {
+                        let content_text = field
+                            .as_str()
+                            .map_or_else(|| serde_json::to_string(field).unwrap_or_default(), str::to_string);
+                        let (content, content_truncated) =
+                            truncate_chars(&content_text, content_chars);
+                        object.insert(key.clone(), json!(content));
+                        object.insert(
+                            "content_truncated_for_mcp".to_string(),
+                            json!(content_truncated),
+                        );
+                        if !field.is_string() {
+                            object.insert("content_serialized_for_mcp".to_string(), json!(true));
+                            compacted = true;
+                        }
+                        truncated |= content_truncated;
+                    } else {
+                        object.insert(key.clone(), field.clone());
+                    }
+                }
+            }
+            Value::Object(object)
+        })
+        .collect::<Vec<_>>();
+    (Value::Array(messages), truncated, compacted || truncated)
+}
+
+fn bounded_lcm_contract_text(value: &Value) -> String {
+    let text = serde_json::to_string_pretty(value).unwrap_or_default();
+    if text.len() <= MAX_RESPONSE_CHARS {
+        return text;
+    }
+    serde_json::to_string_pretty(&json!({
+        "status": value.get("status").cloned().unwrap_or_else(|| json!("ok")),
+        "reason": value.get("reason").cloned().unwrap_or_else(|| json!("mcp_contract_floor_over_budget")),
+        "mcp_response_truncated": true,
+        "contract_truncated": true,
+        "mcp_truncation_reason": "lcm response exceeded minimum Hermes bridge contract budget",
+        "replay_messages": [],
+        "replay_messages_truncated_for_mcp": true,
+        "replay_messages_compacted_for_mcp": true,
+    }))
+    .unwrap_or_default()
+}
+
 fn lcm_expand_query_tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     let formatted = serde_json::to_string_pretty(value).unwrap_or_default();
     let needs_synthesis = value
@@ -1521,17 +1783,14 @@ pub(super) async fn handle_lcm_preflight(
         })
         .await
         .map_err(lcm_error)?;
-    Ok(tool_json(
-        project_root,
-        &json!({
-            "status": response.status,
-            "provider": provider,
-            "session_id": session_id,
-            "should_compress": response.should_compress,
-            "reason": response.reason,
-            "replay_messages": response.replay_messages,
-        }),
-    ))
+    Ok(lcm_preflight_tool_json(&json!({
+        "status": response.status,
+        "provider": provider,
+        "session_id": session_id,
+        "should_compress": response.should_compress,
+        "reason": response.reason,
+        "replay_messages": response.replay_messages,
+    })))
 }
 
 pub(super) async fn handle_lcm_compress(
@@ -1571,7 +1830,7 @@ pub(super) async fn handle_lcm_compress(
         })
         .await
         .map_err(lcm_error)?;
-    Ok(tool_json(
+    Ok(lcm_compress_tool_json(
         project_root,
         &json!({
             "status": response.status,

--- a/src/sessions/lcm/compression.rs
+++ b/src/sessions/lcm/compression.rs
@@ -341,6 +341,8 @@ pub(crate) async fn preflight(
         &raw_messages,
         existing_frontier.current_frontier_store_id,
         request.fresh_tail_count,
+        request.current_tokens,
+        request.threshold_tokens,
     );
     let (should_compress, reason) = preflight_decision(&request, &existing_frontier, &window);
     let should_compress = ingested.changed_replay || should_compress;
@@ -501,6 +503,8 @@ async fn compress_in_transaction(
                 &raw_messages,
                 existing_frontier.current_frontier_store_id,
                 request.fresh_tail_count,
+                request.current_tokens,
+                request.threshold_tokens,
             );
             let replay_messages =
                 replay_without_summary(&window.pinned_anchors, &window.fresh_tail);
@@ -522,6 +526,8 @@ async fn compress_in_transaction(
         &raw_messages,
         existing_frontier.current_frontier_store_id,
         request.fresh_tail_count,
+        request.current_tokens,
+        request.threshold_tokens,
     );
 
     if window.backlog.is_empty() {
@@ -948,6 +954,8 @@ fn compression_window(
     raw_messages: &[LcmRawMessage],
     current_frontier_store_id: Option<i64>,
     fresh_tail_count: Option<usize>,
+    current_tokens: Option<i64>,
+    threshold_tokens: Option<i64>,
 ) -> CompressionWindow {
     let frontier_store_id = current_frontier_store_id.unwrap_or(0);
     let unsummarized = raw_messages
@@ -955,9 +963,16 @@ fn compression_window(
         .filter(|message| message.store_id > frontier_store_id)
         .cloned()
         .collect::<Vec<_>>();
+    let configured_fresh_tail_count = fresh_tail_count.unwrap_or(LCM_DEFAULT_FRESH_TAIL_COUNT);
+    let effective_fresh_tail_count =
+        if unsummarized.len() > 1 && threshold_pressure(current_tokens, threshold_tokens) {
+            configured_fresh_tail_count.min(unsummarized.len() - 1)
+        } else {
+            configured_fresh_tail_count
+        };
     let backlog_len = unsummarized
         .len()
-        .saturating_sub(fresh_tail_count.unwrap_or(LCM_DEFAULT_FRESH_TAIL_COUNT));
+        .saturating_sub(effective_fresh_tail_count);
     let (older_unsummarized, fresh_tail) = unsummarized.split_at(backlog_len);
     let fresh_tail_start_store_id = fresh_tail
         .first()
@@ -1891,18 +1906,17 @@ fn summary_request_for_backlog(
          Preserve durable instructions, decisions, open tasks, and facts needed to continue."
     );
 
+    let extraction_request =
+        extraction::build_extraction_request(session_id, &source_range, &source_messages);
+
     LcmSummaryRequest {
         provider: provider.to_string(),
         session_id: session_id.to_string(),
         focus_topic,
         prompt,
         source_range: source_range.clone(),
-        source_messages: source_messages.clone(),
-        extraction_request: extraction::build_extraction_request(
-            session_id,
-            &source_range,
-            &source_messages,
-        ),
+        source_messages,
+        extraction_request,
     }
 }
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5512,9 +5512,15 @@ async fn lcm_compress_oversized_needs_summary_preserves_bridge_contract() {
     assert_eq!(payload["contract_truncated"], true);
     assert!(payload.get("truncated").is_none());
     assert!(extract_text(&compress.value).len() <= 15_000);
-    assert!(payload["summary_request"].get("source_messages").is_none());
+    let source_messages = payload["summary_request"]["source_messages"]
+        .as_array()
+        .expect("compact needs-summary payload should retain bounded source messages");
+    assert!(!source_messages.is_empty());
+    assert!(source_messages[0]["content"]
+        .as_str()
+        .is_some_and(|content| content.len() <= 512));
     assert_eq!(
-        payload["summary_request"]["source_messages_omitted_for_mcp"],
+        payload["summary_request"]["source_messages_compacted_for_mcp"],
         true
     );
 }

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -5467,6 +5467,152 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
 }
 
 #[tokio::test]
+async fn lcm_compress_oversized_needs_summary_preserves_bridge_contract() {
+    let (cg, _dir) = setup_project().await;
+    let huge_source = "alpha oversized context ".repeat(8_000);
+
+    let compress = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_compress",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-oversized-needs-summary",
+            "messages": [
+                {"id": "oversized-1", "role": "user", "content": huge_source},
+                {"id": "oversized-2", "role": "assistant", "content": "acknowledged"},
+                {"id": "oversized-3", "role": "user", "content": "latest objective"}
+            ],
+            "current_tokens": 30_000,
+            "threshold_tokens": 1_000,
+            "fresh_tail_count": 64,
+            "leaf_chunk_tokens": 20_000,
+            "summarizer": {"mode": "hermes_auxiliary"}
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&compress.value);
+    let payload: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(payload["status"], "needs_summary");
+    assert_eq!(payload["reason"], "hermes_auxiliary_not_available");
+    assert!(
+        payload["replay_messages"]
+            .as_array()
+            .is_some_and(|messages| !messages.is_empty()),
+        "bridge must retain replay messages, got {payload:#}"
+    );
+    assert!(
+        payload["summary_request"].is_object(),
+        "bridge must retain summary request metadata, got {payload:#}"
+    );
+    assert_eq!(payload["mcp_response_truncated"], true);
+    assert_eq!(payload["contract_truncated"], true);
+    assert!(payload.get("truncated").is_none());
+    assert!(extract_text(&compress.value).len() <= 15_000);
+    assert!(payload["summary_request"].get("source_messages").is_none());
+    assert_eq!(
+        payload["summary_request"]["source_messages_omitted_for_mcp"],
+        true
+    );
+}
+
+#[tokio::test]
+async fn lcm_preflight_oversized_replay_preserves_bridge_contract() {
+    let (cg, _dir) = setup_project().await;
+    let huge_source = "preflight oversized active context ".repeat(8_000);
+
+    let preflight = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_preflight",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-oversized-preflight",
+            "messages": [
+                {"id": "preflight-1", "role": "user", "content": huge_source},
+                {"id": "preflight-2", "role": "assistant", "content": "acknowledged"}
+            ],
+            "current_tokens": 10,
+            "threshold_tokens": 1_000
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&preflight.value);
+    let payload: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["should_compress"], false);
+    assert_eq!(payload["reason"], "no_compression_needed");
+    assert_eq!(payload["mcp_response_truncated"], true);
+    assert_eq!(payload["contract_truncated"], true);
+    assert!(payload.get("truncated").is_none());
+    assert!(text.len() <= 15_000);
+    assert!(payload["replay_messages_compacted_for_mcp"]
+        .as_bool()
+        .unwrap_or(false));
+    assert_eq!(
+        payload["replay_messages"][0]["content_truncated_for_mcp"],
+        true
+    );
+}
+
+#[tokio::test]
+async fn lcm_preflight_structured_replay_content_is_bounded_for_mcp() {
+    let (cg, _dir) = setup_project().await;
+    let huge_source = "structured preflight payload ".repeat(8_000);
+
+    let preflight = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_preflight",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-structured-preflight",
+            "messages": [
+                {
+                    "id": "structured-preflight-1",
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": huge_source},
+                        {"type": "input_json", "value": {"nested": huge_source}}
+                    ]
+                },
+                {"id": "structured-preflight-2", "role": "assistant", "content": "acknowledged"}
+            ],
+            "current_tokens": 10,
+            "threshold_tokens": 1_000
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&preflight.value);
+    let payload: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(payload["status"], "ok");
+    assert!(payload.get("truncated").is_none());
+    assert!(text.len() <= 15_000);
+    let compacted_content = payload["replay_messages"][0]["content"]
+        .as_str()
+        .expect("structured replay content should be serialized to bounded text");
+    assert!(compacted_content.len() <= 512);
+    assert_eq!(
+        payload["replay_messages"][0]["content_serialized_for_mcp"],
+        true
+    );
+    assert_eq!(
+        payload["replay_messages"][0]["content_truncated_for_mcp"],
+        true
+    );
+    assert_eq!(payload["replay_messages_compacted_for_mcp"], true);
+}
+
+#[tokio::test]
 async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() {
     let (cg, _dir) = setup_project().await;
     for (index, content) in ["old-1 token", "old-2 token", "fresh-1", "fresh-2"]

--- a/tests/session_lcm_compression_test.rs
+++ b/tests/session_lcm_compression_test.rs
@@ -381,6 +381,72 @@ async fn noop_summarizer_ingests_without_summary_nodes() {
 }
 
 #[tokio::test]
+async fn threshold_pressure_summarizes_short_huge_active_context() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    insert_session(&db, "cursor", "short-huge").await;
+
+    let messages = vec![
+        json!({
+            "id": "short-huge-1",
+            "role": "user",
+            "content": "first long user turn ".repeat(80),
+        }),
+        json!({
+            "id": "short-huge-2",
+            "role": "assistant",
+            "content": "assistant response ".repeat(80),
+        }),
+        json!({
+            "id": "short-huge-3",
+            "role": "user",
+            "content": "latest user objective ".repeat(80),
+        }),
+    ];
+
+    let response = db
+        .lcm_compress(LcmCompressionRequest {
+            provider: "cursor".into(),
+            session_id: "short-huge".into(),
+            messages,
+            current_tokens: Some(2_000),
+            focus_topic: None,
+            ignore_session_patterns: Vec::new(),
+            stateless_session_patterns: Vec::new(),
+            ignore_message_patterns: Vec::new(),
+            expected_current_frontier_store_id: None,
+            threshold_tokens: Some(1_000),
+            max_assembly_tokens: None,
+            leaf_chunk_tokens: Some(100),
+            max_source_messages: None,
+            summary_fan_in: None,
+            incremental_max_depth: None,
+            fresh_tail_count: Some(64),
+            dynamic_leaf_chunk_enabled: None,
+            dynamic_leaf_chunk_max: None,
+            context_length: None,
+            reserve_tokens_floor: None,
+            summarizer: LcmSummarizerMode::HermesAuxiliary,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status, "needs_summary",
+        "response reason: {}",
+        response.reason
+    );
+    assert_eq!(response.reason, "hermes_auxiliary_not_available");
+    let summary_request = response
+        .summary_request
+        .expect("threshold pressure should select source messages to summarize");
+    assert!(
+        !summary_request.source_messages.is_empty(),
+        "short high-token conversations must not be kept entirely as fresh tail"
+    );
+}
+
+#[tokio::test]
 async fn active_structured_content_survives_preflight_and_noop_compress_replay() {
     let tmp = TempDir::new().unwrap();
     let db = open_lcm_db(&tmp).await;


### PR DESCRIPTION
## Summary
- Allow threshold-triggered LCM compaction to summarize short oversized contexts instead of preserving the entire fresh tail.
- Keep oversized LCM compress/preflight replay responses machine-readable for Hermes consumers.
- Bound structured replay content in compact MCP responses.

## Test plan
- `cargo test --test mcp_handler_test lcm -- --nocapture`
- `cargo fmt --check && git diff --check`