### PR TITLE
fix(lcm): strip replay sidecars from raw compression

### DIFF
--- a/src/sessions/lcm/compression.rs
+++ b/src/sessions/lcm/compression.rs
@@ -2063,7 +2063,10 @@ fn default_message_kind(role: &str) -> String {
 fn active_message_metadata(message: &Value, replay: &Value) -> String {
     let mut metadata = Map::new();
     metadata.insert(ACTIVE_REPLAY_METADATA_KEY.to_string(), Value::Bool(true));
-    metadata.insert(ACTIVE_REPLAY_MESSAGE_KEY.to_string(), replay.clone());
+    metadata.insert(
+        ACTIVE_REPLAY_MESSAGE_KEY.to_string(),
+        active_replay_for_metadata(replay),
+    );
     if let Some(lcm_ingest) = message.get("lcm_ingest") {
         metadata.insert("lcm_ingest".to_string(), lcm_ingest.clone());
     }
@@ -2090,8 +2093,19 @@ fn active_replay_metadata_json(existing_metadata_json: Option<&str>, replay: &Va
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
     metadata.insert(ACTIVE_REPLAY_METADATA_KEY.to_string(), Value::Bool(true));
-    metadata.insert(ACTIVE_REPLAY_MESSAGE_KEY.to_string(), replay.clone());
+    metadata.insert(
+        ACTIVE_REPLAY_MESSAGE_KEY.to_string(),
+        active_replay_for_metadata(replay),
+    );
     Value::Object(metadata).to_string()
+}
+
+fn active_replay_for_metadata(replay: &Value) -> Value {
+    let mut replay = replay.clone();
+    if let Some(object) = replay.as_object_mut() {
+        strip_disposable_assistant_replay_sidecars(object, "");
+    }
+    replay
 }
 
 async fn update_active_replay_metadata(
@@ -2273,7 +2287,34 @@ fn active_replay_message_from_metadata(message: &LcmRawMessage) -> Option<Value>
             Value::String(message.content.clone()),
         );
     }
+    strip_disposable_assistant_replay_sidecars(&mut replay, &message.role);
     Some(Value::Object(replay))
+}
+
+fn strip_disposable_assistant_replay_sidecars(
+    replay: &mut Map<String, Value>,
+    fallback_role: &str,
+) {
+    if !replay
+        .get("role")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback_role)
+        .eq_ignore_ascii_case("assistant")
+    {
+        return;
+    }
+
+    // Provider replay sidecars are useful before the next API call, but once
+    // LCM is rebuilding compressed history they become large derived state.
+    for key in [
+        "codex_message_items",
+        "codex_reasoning_items",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+    ] {
+        replay.remove(key);
+    }
 }
 
 fn legacy_active_replay_message_from_metadata(metadata: &Value) -> Option<Map<String, Value>> {

--- a/tests/session_lcm_compression_test.rs
+++ b/tests/session_lcm_compression_test.rs
@@ -561,6 +561,7 @@ async fn active_replay_preserves_top_level_fields_that_collide_with_storage_meta
         "sha256": "user-sha256",
         "external_payload": {"kind": "user-field"},
         "ingest_protection": {"kind": "user-metadata"},
+        "reasoning": {"kind": "user-authored-field"},
     });
 
     let preflight = db
@@ -624,6 +625,93 @@ async fn active_replay_preserves_top_level_fields_that_collide_with_storage_meta
     let mut expected = active_message;
     expected["store_id"] = Value::from(raw.store_id);
     assert_eq!(replay_from_raw.replay_messages, vec![expected]);
+}
+
+#[tokio::test]
+async fn raw_replay_strips_disposable_provider_reasoning_sidecars() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    insert_session(&db, "cursor", "session-sidecars").await;
+
+    db.lcm_preflight(LcmPreflightRequest {
+        provider: "cursor".into(),
+        session_id: "session-sidecars".into(),
+        messages: vec![json!({
+            "id": "assistant-sidecars",
+            "role": "assistant",
+            "content": "assistant visible content",
+            "reasoning": "private scratchpad",
+            "reasoning_content": "provider scratchpad",
+            "reasoning_details": [{"text": "derived reasoning"}],
+            "codex_reasoning_items": [{"encrypted_content": "large encrypted blob"}],
+            "codex_message_items": [{"type": "reasoning"}],
+        })],
+        current_tokens: Some(100),
+        threshold_tokens: None,
+        max_assembly_tokens: None,
+        leaf_chunk_tokens: None,
+        max_source_messages: None,
+        summary_fan_in: None,
+        incremental_max_depth: None,
+        fresh_tail_count: None,
+        dynamic_leaf_chunk_enabled: None,
+        dynamic_leaf_chunk_max: None,
+        context_length: None,
+        reserve_tokens_floor: None,
+        ignore_session_patterns: Vec::new(),
+        stateless_session_patterns: Vec::new(),
+        ignore_message_patterns: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let raw = db
+        .lcm_load_raw_message("cursor", "assistant-sidecars")
+        .await
+        .expect("raw sidecar message should exist");
+    let metadata: Value = serde_json::from_str(raw.metadata_json.as_deref().unwrap()).unwrap();
+    let stored_replay = metadata["active_replay"]
+        .as_object()
+        .expect("stored active replay should be an object");
+    for key in [
+        "codex_message_items",
+        "codex_reasoning_items",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+    ] {
+        assert!(
+            stored_replay.get(key).is_none(),
+            "persisted active replay should drop disposable provider sidecar {key}"
+        );
+    }
+
+    let replay_from_raw = db
+        .lcm_compress(compress_request(
+            "cursor",
+            "session-sidecars",
+            LcmSummarizerMode::Fake {
+                summary_text: "unused".into(),
+            },
+        ))
+        .await
+        .unwrap();
+
+    let replay = &replay_from_raw.replay_messages[0];
+    assert_eq!(replay["role"], "assistant");
+    assert_eq!(replay["content"], "assistant visible content");
+    for key in [
+        "codex_message_items",
+        "codex_reasoning_items",
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+    ] {
+        assert!(
+            replay.get(key).is_none(),
+            "compressed raw replay should drop disposable provider sidecar {key}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Strip disposable provider reasoning sidecars before persisting active replay metadata for assistant messages.
- Keep raw compression replay bounded while preserving visible content and user-authored fields.

## Test plan
- `cargo fmt --check`
- `cargo test --test session_lcm_compression_test -- --test-threads=1`