### PR TITLE
fix(hermes): prevent LCM compression no-ops

### DIFF
--- a/src/agents/hermes/templates.rs
+++ b/src/agents/hermes/templates.rs
@@ -2056,8 +2056,9 @@ def _synthesize_expand_query_payload(retrieval, agent=None, **kwargs):
     return payload
 
 def _handle_lcm_expand_query(args, **kwargs) -> str:
+    kwargs = dict(kwargs)
+    agent = kwargs.pop("agent", None)
     retrieval = call_tracedecay_json("tracedecay_lcm_expand_query", args or {}, **kwargs)
-    agent = kwargs.get("agent")
     payload = _synthesize_expand_query_payload(retrieval, agent=agent, **kwargs)
     return json.dumps(payload)
 
@@ -2539,6 +2540,7 @@ class TraceDecayContextEngine(ContextEngine):
 
     def get_status(self):
         storage = _storage_args(self.project_root, self.hermes_home)
+        hermes_home = storage.get("hermes_home")
         last_result = self.last_compress_result
         if not isinstance(last_result, dict):
             last_result = {"status": "never_ran"}
@@ -2554,6 +2556,12 @@ class TraceDecayContextEngine(ContextEngine):
             "active_session_id": self.active_session_id,
             "storage_scope": storage.get("storage_scope"),
             "hermes_home": self.hermes_home,
+            "lcm_session_db_path": (
+                str(Path(hermes_home) / ".tracedecay" / "sessions.db")
+                if hermes_home
+                else None
+            ),
+            "storage_note": "Hermes LCM conversation state is stored in the Hermes profile .tracedecay/sessions.db.",
             "project_root": self.project_root,
             "tracedecay_binary_path": tools.TRACEDECAY_BIN,
             "tracedecay_binary_available": _tracedecay_binary_available(),
@@ -2658,7 +2666,9 @@ class TraceDecayContextEngine(ContextEngine):
             tool_args.setdefault("session_id", self.active_session_id)
 
         if tracedecay_name == "tracedecay_lcm_expand_query":
-            return _handle_lcm_expand_query(tool_args, agent=self.agent, **preflight_kwargs)
+            expand_kwargs = dict(preflight_kwargs)
+            agent = expand_kwargs.pop("agent", None) or self.agent
+            return _handle_lcm_expand_query(tool_args, agent=agent, **expand_kwargs)
         return tools.call_tracedecay_tool(tracedecay_name, tool_args, **preflight_kwargs)
 
     def expand_query(self, prompt, query=None, node_ids=None, **kwargs):
@@ -2676,6 +2686,7 @@ class TraceDecayContextEngine(ContextEngine):
             args["context_max_tokens"] = _lcm_expansion_context_tokens(self.config)
         retrieval = call_tracedecay_json("tracedecay_lcm_expand_query", args, **kwargs)
         synthesis_kwargs = dict(kwargs)
+        synthesis_agent = synthesis_kwargs.pop("agent", None) or self.agent
         if synthesis_kwargs.get("model") is None:
             expansion_model = _lcm_expansion_model(self.config)
             if expansion_model:
@@ -2685,7 +2696,7 @@ class TraceDecayContextEngine(ContextEngine):
             and synthesis_kwargs.get("expansion_timeout") is None
         ):
             synthesis_kwargs["expansion_timeout"] = _lcm_expansion_timeout_ms(self.config) / 1000
-        return _synthesize_expand_query_payload(retrieval, agent=self.agent, **synthesis_kwargs)
+        return _synthesize_expand_query_payload(retrieval, agent=synthesis_agent, **synthesis_kwargs)
 
     def _auxiliary_routes(self, summary_request=None, **kwargs):
         routes = (
@@ -3034,7 +3045,12 @@ class TraceDecayContextEngine(ContextEngine):
         if replay is None or (not replay and original):
             # No usable replay window — treat as a no-op; the host detects
             # ``compressed == messages`` and skips session rotation.
+            self._last_compress_aborted = True
+            self._last_summary_error = str(result.get("reason") or "no usable replay")
             return original
+        if replay == original and original:
+            self._last_compress_aborted = True
+            self._last_summary_error = str(result.get("reason") or "unchanged replay")
         if replay != original:
             self.compression_count += 1
         return replay
@@ -3180,6 +3196,7 @@ class TracedecayMemoryProvider(MemoryProvider):
         self.agent_context = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_cache = {}
+        self._sync_turn_sequence = 0
 
     @property
     def name(self) -> str:
@@ -3334,6 +3351,24 @@ class TracedecayMemoryProvider(MemoryProvider):
                 turn_messages.append({"role": "assistant", "content": str(assistant_content)})
         if not turn_messages:
             return
+        self._sync_turn_sequence += 1
+        batch_id = self._sync_turn_sequence
+        timestamp_ns = time.time_ns()
+        normalized_messages = []
+        for idx, message in enumerate(turn_messages):
+            entry = dict(message) if isinstance(message, dict) else {
+                "role": "user",
+                "content": str(message),
+            }
+            if not entry.get("id") and not entry.get("message_id"):
+                role = str(entry.get("role") or "user")
+                content = _message_content(entry)
+                digest = hashlib.sha256(
+                    f"{sid}\0{batch_id}\0{timestamp_ns}\0{idx}\0{role}\0{content}".encode("utf-8")
+                ).hexdigest()[:16]
+                entry["id"] = f"tracedecay_sync_{batch_id}_{idx}_{digest}"
+            normalized_messages.append(entry)
+        turn_messages = normalized_messages
         args = _storage_args(None, self.hermes_home)
         args.update({"session_id": sid, "messages": turn_messages})
         try:
@@ -3573,11 +3608,11 @@ def register(ctx):
                         name,
                         exc,
                     )
-            else:
-                _CONTEXT_TOOL_NAMES.add(name)
+                else:
+                    _CONTEXT_TOOL_NAMES.add(name)
         else:
             logger.info(
-                "tracedecay LCM live-ingest tools skipped: this Hermes host does not forward messages to registered tool handlers"
+                "tracedecay LCM registered live-ingest tools skipped: this Hermes host does not forward messages to registered tool handlers; context-engine compression still receives host messages"
             )
     else:
         logger.info(

--- a/src/agents/hermes/templates.rs
+++ b/src/agents/hermes/templates.rs
@@ -850,6 +850,14 @@ def _storage_args(project_root=None, hermes_home=None):
     home = hermes_home or _resolve_hermes_home()
     return {"storage_scope": "hermes_profile", "hermes_home": str(home)}
 
+def _hermes_profile_session_db_path(hermes_home):
+    if not hermes_home:
+        return None
+    primary = Path(hermes_home) / ".tracedecay"
+    legacy = Path(hermes_home) / ".tokensave"
+    base = legacy if not primary.is_dir() and legacy.is_dir() else primary
+    return (base / "sessions.db").as_posix()
+
 # Conventional config home: a `plugins.tracedecay` block in the profile
 # config.yaml (the same `plugins.<name>` convention bundled Hermes plugins
 # use). Keys are flat and mirror the host-config attribute names the
@@ -2555,13 +2563,13 @@ class TraceDecayContextEngine(ContextEngine):
             "session_id": self.active_session_id,
             "active_session_id": self.active_session_id,
             "storage_scope": storage.get("storage_scope"),
-            "hermes_home": self.hermes_home,
-            "lcm_session_db_path": (
-                str(Path(hermes_home) / ".tracedecay" / "sessions.db")
-                if hermes_home
-                else None
+            "hermes_home": hermes_home,
+            "lcm_session_db_path": _hermes_profile_session_db_path(hermes_home),
+            "storage_note": (
+                "Hermes LCM conversation state is stored in the Hermes profile "
+                ".tracedecay/sessions.db, or legacy .tokensave/sessions.db when "
+                "that is the existing profile store."
             ),
-            "storage_note": "Hermes LCM conversation state is stored in the Hermes profile .tracedecay/sessions.db.",
             "project_root": self.project_root,
             "tracedecay_binary_path": tools.TRACEDECAY_BIN,
             "tracedecay_binary_available": _tracedecay_binary_available(),
@@ -3342,7 +3350,8 @@ class TracedecayMemoryProvider(MemoryProvider):
         sid = session_id or self.session_id
         if not sid:
             return
-        turn_messages = messages if isinstance(messages, list) else None
+        forwarded_messages = isinstance(messages, list) and bool(messages)
+        turn_messages = messages if forwarded_messages else None
         if not turn_messages:
             turn_messages = []
             if user_content:
@@ -3351,24 +3360,13 @@ class TracedecayMemoryProvider(MemoryProvider):
                 turn_messages.append({"role": "assistant", "content": str(assistant_content)})
         if not turn_messages:
             return
-        self._sync_turn_sequence += 1
-        batch_id = self._sync_turn_sequence
-        timestamp_ns = time.time_ns()
-        normalized_messages = []
-        for idx, message in enumerate(turn_messages):
-            entry = dict(message) if isinstance(message, dict) else {
-                "role": "user",
-                "content": str(message),
-            }
-            if not entry.get("id") and not entry.get("message_id"):
+        if not forwarded_messages:
+            self._sync_turn_sequence += 1
+            batch_id = self._sync_turn_sequence
+            timestamp_ns = time.time_ns()
+            for idx, entry in enumerate(turn_messages):
                 role = str(entry.get("role") or "user")
-                content = _message_content(entry)
-                digest = hashlib.sha256(
-                    f"{sid}\0{batch_id}\0{timestamp_ns}\0{idx}\0{role}\0{content}".encode("utf-8")
-                ).hexdigest()[:16]
-                entry["id"] = f"tracedecay_sync_{batch_id}_{idx}_{digest}"
-            normalized_messages.append(entry)
-        turn_messages = normalized_messages
+                entry["id"] = f"tracedecay_sync_{batch_id}_{timestamp_ns}_{idx}_{role}"
         args = _storage_args(None, self.hermes_home)
         args.update({"session_id": sid, "messages": turn_messages})
         try:

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -890,11 +890,53 @@ fn string_array_arg(args: &Value, name: &str) -> Result<Vec<String>> {
 }
 
 fn summarizer_arg(args: &Value) -> Result<LcmSummarizerMode> {
-    let Some(summarizer) = args.get("summarizer") else {
-        return Ok(LcmSummarizerMode::Noop);
+    let mode = match args.get("summarizer") {
+        Some(summarizer) => {
+            serde_json::from_value(summarizer.clone()).map_err(|err| TraceDecayError::Config {
+                message: format!("invalid summarizer: {err}"),
+            })?
+        }
+        None => LcmSummarizerMode::HermesAuxiliary,
     };
-    serde_json::from_value(summarizer.clone()).map_err(|err| TraceDecayError::Config {
-        message: format!("invalid summarizer: {err}"),
+    if matches!(mode, LcmSummarizerMode::Noop) && hard_compression_pressure(args) {
+        Ok(LcmSummarizerMode::HermesAuxiliary)
+    } else {
+        Ok(mode)
+    }
+}
+
+fn hard_compression_pressure(args: &Value) -> bool {
+    let Some(current_tokens) = i64_arg_value(args, "current_tokens") else {
+        return false;
+    };
+    if i64_arg_value(args, "threshold_tokens")
+        .is_some_and(|threshold| threshold > 0 && current_tokens >= threshold)
+    {
+        return true;
+    }
+    if i64_arg_value(args, "max_assembly_tokens")
+        .is_some_and(|max_tokens| max_tokens > 0 && current_tokens >= max_tokens)
+    {
+        return true;
+    }
+    match (
+        i64_arg_value(args, "context_length"),
+        i64_arg_value(args, "reserve_tokens_floor"),
+    ) {
+        (Some(context_length), Some(reserve)) if context_length > reserve && reserve > 0 => {
+            current_tokens >= context_length - reserve
+        }
+        _ => false,
+    }
+}
+
+fn i64_arg_value(args: &Value, name: &str) -> Option<i64> {
+    args.get(name).and_then(|value| {
+        value.as_i64().or_else(|| {
+            value
+                .as_str()
+                .and_then(|text| text.trim().parse::<i64>().ok())
+        })
     })
 }
 

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -9,6 +9,7 @@ use crate::errors::{Result, TraceDecayError};
 use crate::global_db::GlobalDb;
 use crate::mcp::tools::{ToolResult, MAX_RESPONSE_CHARS};
 use crate::sessions::cursor::HermesProfileDbReadOnly;
+use crate::sessions::lcm::compression_decision::{self, AssemblyCapInput};
 use crate::sessions::lcm::{
     LcmCleanConfig, LcmCompressionRequest, LcmContentSlice, LcmDescribeRequest, LcmDescribeTarget,
     LcmExpandQueryRequest, LcmExpandRequest, LcmExpandTarget, LcmGcConfig, LcmGrepRequest,
@@ -898,46 +899,28 @@ fn summarizer_arg(args: &Value) -> Result<LcmSummarizerMode> {
         }
         None => LcmSummarizerMode::HermesAuxiliary,
     };
-    if matches!(mode, LcmSummarizerMode::Noop) && hard_compression_pressure(args) {
+    if matches!(mode, LcmSummarizerMode::Noop) && hard_compression_pressure(args)? {
         Ok(LcmSummarizerMode::HermesAuxiliary)
     } else {
         Ok(mode)
     }
 }
 
-fn hard_compression_pressure(args: &Value) -> bool {
-    let Some(current_tokens) = i64_arg_value(args, "current_tokens") else {
-        return false;
+fn hard_compression_pressure(args: &Value) -> Result<bool> {
+    let Some(current_tokens) = non_negative_i64_arg(args, "current_tokens")? else {
+        return Ok(false);
     };
-    if i64_arg_value(args, "threshold_tokens")
+    if non_negative_i64_arg(args, "threshold_tokens")?
         .is_some_and(|threshold| threshold > 0 && current_tokens >= threshold)
     {
-        return true;
+        return Ok(true);
     }
-    if i64_arg_value(args, "max_assembly_tokens")
-        .is_some_and(|max_tokens| max_tokens > 0 && current_tokens >= max_tokens)
-    {
-        return true;
-    }
-    match (
-        i64_arg_value(args, "context_length"),
-        i64_arg_value(args, "reserve_tokens_floor"),
-    ) {
-        (Some(context_length), Some(reserve)) if context_length > reserve && reserve > 0 => {
-            current_tokens >= context_length - reserve
-        }
-        _ => false,
-    }
-}
-
-fn i64_arg_value(args: &Value, name: &str) -> Option<i64> {
-    args.get(name).and_then(|value| {
-        value.as_i64().or_else(|| {
-            value
-                .as_str()
-                .and_then(|text| text.trim().parse::<i64>().ok())
-        })
-    })
+    let assembly_cap = compression_decision::effective_assembly_token_cap(AssemblyCapInput {
+        max_assembly_tokens: non_negative_i64_arg(args, "max_assembly_tokens")?,
+        context_length: non_negative_i64_arg(args, "context_length")?,
+        reserve_tokens_floor: non_negative_i64_arg(args, "reserve_tokens_floor")?,
+    });
+    Ok(assembly_cap.is_some_and(|cap| current_tokens >= cap))
 }
 
 fn lcm_content_slice(args: &Value) -> Result<LcmContentSlice> {

--- a/tests/hermes_lcm_bridge_test.rs
+++ b/tests/hermes_lcm_bridge_test.rs
@@ -299,6 +299,12 @@ assert status["storage_scope"] == "hermes_profile"
 assert status["hermes_home"] == os.environ["HERMES_HOME"]
 assert status["lcm_session_db_path"].endswith("/.tracedecay/sessions.db")
 assert "Hermes profile" in status["storage_note"]
+legacy_home = pathlib.Path(os.environ["HERMES_HOME"]).parent / "legacy-hermes"
+(legacy_home / ".tokensave").mkdir(parents=True)
+legacy_engine = plugin.TraceDecayContextEngine(hermes_home=str(legacy_home))
+legacy_engine.initialize(session_id="legacy-session", hermes_home=str(legacy_home))
+legacy_status = legacy_engine.get_status()
+assert legacy_status["lcm_session_db_path"].endswith("/.tokensave/sessions.db")
 assert status["project_root"] == "/tmp/project"
 assert status["tracedecay_binary_path"] == plugin.tools.TRACEDECAY_BIN
 assert isinstance(status["tracedecay_binary_available"], bool)
@@ -2235,14 +2241,23 @@ provider = plugin.TracedecayMemoryProvider()
 provider.initialize(session_id="session-1", hermes_home="/tmp/hermes")
 provider.sync_turn("repeat", "same", session_id="session-1")
 provider.sync_turn("repeat", "same", session_id="session-1")
+provider.sync_turn("repeat", "same", session_id="session-1", messages=[])
+provider.sync_turn("repeat", "same", session_id="session-1", messages=[])
 
 first_messages = calls[0][1]["messages"]
 second_messages = calls[1][1]["messages"]
+empty_list_first_messages = calls[2][1]["messages"]
+empty_list_second_messages = calls[3][1]["messages"]
 assert [message["role"] for message in first_messages] == ["user", "assistant"]
 assert all(message.get("id") for message in first_messages)
 assert all(message.get("id") for message in second_messages)
 assert first_messages[0]["id"] != second_messages[0]["id"]
 assert first_messages[1]["id"] != second_messages[1]["id"]
+assert [message["role"] for message in empty_list_first_messages] == ["user", "assistant"]
+assert all(message.get("id") for message in empty_list_first_messages)
+assert all(message.get("id") for message in empty_list_second_messages)
+assert empty_list_first_messages[0]["id"] != empty_list_second_messages[0]["id"]
+assert empty_list_first_messages[1]["id"] != empty_list_second_messages[1]["id"]
 "#,
         "sync_turn fallback messages should not collapse repeated identical turns",
     );

--- a/tests/hermes_lcm_bridge_test.rs
+++ b/tests/hermes_lcm_bridge_test.rs
@@ -297,6 +297,8 @@ assert status["session_id"] == "session-1"
 assert status["active_session_id"] == "session-1"
 assert status["storage_scope"] == "hermes_profile"
 assert status["hermes_home"] == os.environ["HERMES_HOME"]
+assert status["lcm_session_db_path"].endswith("/.tracedecay/sessions.db")
+assert "Hermes profile" in status["storage_note"]
 assert status["project_root"] == "/tmp/project"
 assert status["tracedecay_binary_path"] == plugin.tools.TRACEDECAY_BIN
 assert isinstance(status["tracedecay_binary_available"], bool)
@@ -2126,6 +2128,199 @@ assert agent.auxiliary_client.calls[0]["max_tokens"] == 4000
         "generated context engine should provide auxiliary summaries back to Rust\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn context_engine_marks_no_usable_replay_as_aborted() {
+    run_generated_plugin_script(
+        "check_no_usable_replay_abort.py",
+        r#"
+import json
+
+class Result:
+    def __init__(self, returncode, stdout, stderr):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+def mcp_response(inner):
+    return Result(0, json.dumps({"content": [{"type": "text", "text": json.dumps(inner)}]}), "")
+
+def fake_run(argv, check, capture_output, text, timeout, shell):
+    return mcp_response({
+        "status": "ok",
+        "reason": "noop_summarizer",
+        "summary_nodes_created": 0,
+        "summary_nodes": [],
+        "replay_messages": [],
+        "replay_token_estimate": 0,
+        "replay_over_budget": False,
+    })
+
+plugin.tools.subprocess.run = fake_run
+
+engine = plugin.TraceDecayContextEngine()
+engine.initialize(session_id="session-1", project_root="/tmp/project")
+messages = [{"role": "user", "content": "oversized live transcript"}]
+compressed = engine.compress(messages, current_tokens=292666)
+
+assert compressed == messages
+assert engine._last_compress_aborted is True
+assert engine._last_summary_error == "noop_summarizer"
+assert engine.last_compress_result["reason"] == "noop_summarizer"
+"#,
+        "generated context engine should mark no usable replay as an aborted compression",
+    );
+}
+
+#[test]
+fn context_engine_marks_identical_replay_as_aborted() {
+    run_generated_plugin_script(
+        "check_identical_replay_abort.py",
+        r#"
+import json
+
+messages = [{"role": "user", "content": "same replay should not count as progress"}]
+
+class Result:
+    def __init__(self, returncode, stdout, stderr):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+def mcp_response(inner):
+    return Result(0, json.dumps({"content": [{"type": "text", "text": json.dumps(inner)}]}), "")
+
+def fake_run(argv, check, capture_output, text, timeout, shell):
+    return mcp_response({
+        "status": "ok",
+        "reason": "no_backlog_to_compress",
+        "summary_nodes_created": 0,
+        "summary_nodes": [],
+        "replay_messages": messages,
+        "replay_token_estimate": 10,
+        "replay_over_budget": False,
+    })
+
+plugin.tools.subprocess.run = fake_run
+
+engine = plugin.TraceDecayContextEngine()
+engine.initialize(session_id="session-1", project_root="/tmp/project")
+compressed = engine.compress(list(messages), current_tokens=292666)
+
+assert compressed == messages
+assert engine._last_compress_aborted is True
+assert engine._last_summary_error == "no_backlog_to_compress"
+assert engine.compression_count == 0
+"#,
+        "generated context engine should mark identical replay as aborted compression",
+    );
+}
+
+#[test]
+fn memory_provider_sync_turn_assigns_unique_fallback_message_ids() {
+    run_generated_plugin_script(
+        "check_sync_turn_unique_ids.py",
+        r#"
+calls = []
+
+def fake_call_tracedecay_tool(name, args, **kwargs):
+    calls.append((name, args, kwargs))
+    return '{"content":[{"type":"text","text":"{\\"status\\":\\"ok\\"}"}]}'
+
+plugin.tools.call_tracedecay_tool = fake_call_tracedecay_tool
+
+provider = plugin.TracedecayMemoryProvider()
+provider.initialize(session_id="session-1", hermes_home="/tmp/hermes")
+provider.sync_turn("repeat", "same", session_id="session-1")
+provider.sync_turn("repeat", "same", session_id="session-1")
+
+first_messages = calls[0][1]["messages"]
+second_messages = calls[1][1]["messages"]
+assert [message["role"] for message in first_messages] == ["user", "assistant"]
+assert all(message.get("id") for message in first_messages)
+assert all(message.get("id") for message in second_messages)
+assert first_messages[0]["id"] != second_messages[0]["id"]
+assert first_messages[1]["id"] != second_messages[1]["id"]
+"#,
+        "sync_turn fallback messages should not collapse repeated identical turns",
+    );
+}
+
+#[test]
+fn context_engine_records_all_forwarded_native_lcm_tools() {
+    run_generated_plugin_script(
+        "check_context_tool_names_bookkeeping.py",
+        r#"
+class Ctx:
+    context_engine_tool_handlers_receive_messages = True
+
+    def __init__(self):
+        self.registered = []
+
+    def register_hook(self, *args, **kwargs):
+        pass
+
+    def register_context_engine(self, engine):
+        self.engine = engine
+
+    def register_tool(self, **kwargs):
+        self.registered.append(kwargs["name"])
+
+    def register_memory_provider(self, provider):
+        self.memory_provider = provider
+
+    def register_command(self, *args, **kwargs):
+        pass
+
+ctx = Ctx()
+plugin.register(ctx)
+
+expected = sorted(schema["name"] for schema in plugin.LCM_NATIVE_SCHEMAS)
+assert sorted(plugin._CONTEXT_TOOL_NAMES) == expected
+assert set(expected).issubset(set(ctx.registered))
+"#,
+        "generated plugin should record every forwarded native LCM context tool",
+    );
+}
+
+#[test]
+fn context_engine_lcm_expand_query_tolerates_forwarded_agent_kwarg() {
+    run_generated_plugin_script(
+        "check_expand_query_forwarded_agent.py",
+        r#"
+import json
+
+def fake_call_tracedecay_json(name, args, **kwargs):
+    assert name == "tracedecay_lcm_expand_query"
+    return {
+        "status": "ok",
+        "prompt": args["prompt"],
+        "needs_synthesis": False,
+        "answer": "retrieval-only answer",
+    }
+
+plugin.call_tracedecay_json = fake_call_tracedecay_json
+
+class Aux:
+    def call_llm(self, **kwargs):
+        raise AssertionError("synthesis should not run")
+
+forwarded_agent = type("ForwardedAgent", (), {"auxiliary_client": Aux()})()
+engine = plugin.TraceDecayContextEngine()
+engine.initialize(session_id="session-1", project_root="/tmp/project", agent=forwarded_agent)
+
+raw = engine.handle_tool_call(
+    "lcm_expand_query",
+    {"prompt": "What changed?"},
+    agent=forwarded_agent,
+)
+payload = json.loads(raw)
+assert payload["status"] == "ok"
+assert payload["answer"] == "retrieval-only answer"
+"#,
+        "generated context engine should not pass duplicate agent kwargs through lcm_expand_query",
     );
 }
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -6220,6 +6220,37 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
         "hard-overflow explicit noop should be upgraded to auxiliary summary mode"
     );
 
+    let reserve_cap_noop_compress = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_compress",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-session",
+            "messages": [],
+            "current_tokens": 8_000,
+            "context_length": 10_000,
+            "reserve_tokens_floor": 2_000,
+            "fresh_tail_count": 1,
+            "leaf_chunk_tokens": 1,
+            "summarizer": {"mode": "noop"}
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let reserve_cap_noop_payload: Value =
+        serde_json::from_str(extract_text(&reserve_cap_noop_compress.value)).unwrap();
+    assert_eq!(reserve_cap_noop_payload["status"], "needs_summary");
+    assert_eq!(
+        reserve_cap_noop_payload["reason"],
+        "hermes_auxiliary_not_available"
+    );
+    assert!(
+        reserve_cap_noop_payload["summary_request"].is_object(),
+        "reserve-derived hard pressure should upgrade explicit noop to auxiliary summary mode"
+    );
+
     for (index, content) in [
         "old-1 token",
         "old-2 token",

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -6189,6 +6189,37 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
     );
     assert_eq!(compress_payload["retry_status"], Value::Null);
 
+    let unsafe_noop_compress = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_compress",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-session",
+            "messages": [],
+            "current_tokens": 50_000,
+            "threshold_tokens": 1_000,
+            "fresh_tail_count": 1,
+            "leaf_chunk_tokens": 1,
+            "summarizer": {"mode": "noop"}
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let unsafe_noop_payload: Value =
+        serde_json::from_str(extract_text(&unsafe_noop_compress.value)).unwrap();
+    assert_eq!(unsafe_noop_payload["status"], "needs_summary");
+    assert_eq!(
+        unsafe_noop_payload["reason"],
+        "hermes_auxiliary_not_available"
+    );
+    assert_eq!(unsafe_noop_payload["summary_nodes_created"], 0);
+    assert!(
+        unsafe_noop_payload["summary_request"].is_object(),
+        "hard-overflow explicit noop should be upgraded to auxiliary summary mode"
+    );
+
     for (index, content) in [
         "old-1 token",
         "old-2 token",
@@ -6240,6 +6271,76 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
     assert_eq!(
         critical_payload["retry_status"],
         "critical_pressure_catch_up"
+    );
+}
+
+#[tokio::test]
+async fn lcm_compress_without_summarizer_requests_auxiliary_summary() {
+    let (cg, _dir) = setup_project().await;
+    for (index, content) in [
+        "historical planning context alpha beta gamma",
+        "historical tool result delta epsilon zeta",
+        "fresh objective eta theta",
+    ]
+    .iter()
+    .enumerate()
+    {
+        seed_lcm_session_message(
+            &cg,
+            "lcm-default-summarizer-session",
+            &format!("lcm-default-summarizer-message-{}", index + 1),
+            *content,
+            (index + 1) as i64,
+        )
+        .await;
+    }
+
+    let compress = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_compress",
+        json!({
+            "provider": "cursor",
+            "session_id": "lcm-default-summarizer-session",
+            "messages": [],
+            "current_tokens": 10_000,
+            "threshold_tokens": 100,
+            "fresh_tail_count": 1,
+            "leaf_chunk_tokens": 1,
+            "max_assembly_tokens": 20
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&compress.value)).unwrap();
+
+    assert_eq!(payload["status"], "needs_summary");
+    assert_eq!(payload["reason"], "hermes_auxiliary_not_available");
+    assert_eq!(payload["summary_nodes_created"], 0);
+    assert_eq!(payload["compression_attempts"], 0);
+    assert_eq!(payload["fallback_used"], false);
+    assert_eq!(payload["retry_status"], Value::Null);
+    assert_eq!(
+        payload["summary_request"]["source_range"]["from_store_id"],
+        1
+    );
+    assert_eq!(payload["summary_request"]["source_range"]["to_store_id"], 1);
+    assert_eq!(
+        payload["summary_request"]["source_messages"]
+            .as_array()
+            .expect("source messages should be present")
+            .len(),
+        1
+    );
+    let replay = payload["replay_messages"]
+        .as_array()
+        .expect("bounded replay should be present");
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0]["content"], "fresh objective eta theta");
+    assert!(
+        payload["replay_token_estimate"].as_i64().unwrap() <= 20,
+        "default auxiliary mode must return a bounded replay"
     );
 }
 


### PR DESCRIPTION
## Summary
- Default Hermes LCM compression to auxiliary summarization instead of no-op, and upgrade explicit noop requests under hard compression pressure.
- Mark empty or unchanged replay as aborted with backend reason diagnostics, fix duplicate forwarded `agent` kwargs, and clarify Hermes profile LCM DB status.
- Add coverage for bounded replay requests, hard-overflow noop upgrades, unique `sync_turn` fallback IDs, and native LCM tool bookkeeping.

## Test plan
- `cargo fmt --check`
- `cargo test --test mcp_handler_test lcm_session_handlers_expose_bounded_read_apis_and_placeholders`
- `cargo test --test mcp_handler_test lcm_compress`
- `cargo test --test hermes_lcm_bridge_test context_engine_`
- `cargo test --test session_lcm_compression_test`

## Deployment notes
- Refreshed global binary with `cargo install --path . --force` from this branch.
- Ran `tracedecay update-plugins` to refresh Codex, Cursor, global Hermes, and Hermes profile plugins.
- Restarted Hermes gateway with `hermes --accept-hooks gateway restart`; `hermes gateway status` reports the service active.