### PR TITLE
feat(codex): ship full tracedecay skill suite for Cursor parity

### DIFF
--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -1,8 +1,27 @@
 # TraceDecay for Codex
 
-This plugin exposes the TraceDecay MCP server and Codex skills for code graph,
-impact, recall, and context-saving workflows.
+This plugin bundles the TraceDecay MCP server, a suite of workflow skills, and
+lifecycle hooks for code-graph, impact, recall, and context-saving workflows in
+Codex.
 
-Codex command hooks are installed separately through `~/.codex/hooks.json`
-because the current Codex plugin manifest schema supports MCP servers and
-skills, but not plugin-declared hooks.
+## What it ships
+
+- **MCP server** (`.mcp.json`): the `tracedecay` stdio server exposing the code
+  graph, search, call-graph, impact, memory, and session-recall tools.
+- **Skills** (`skills/`): one skill per common workflow — searching for code,
+  reading code cheaply, mapping architecture, impact analysis, reviewing diffs,
+  recalling project memory and session context, and more. Codex auto-discovers
+  each `SKILL.md` by its `name`/`description` frontmatter and loads the body
+  only when the workflow matches. These mirror the model-invocable Cursor skills
+  so both hosts steer agents toward the same tracedecay tools.
+- **Lifecycle hooks** (`hooks/hooks.json`, referenced from the manifest's
+  `hooks` field): `SessionStart`, `UserPromptSubmit`, `SubagentStart`, and
+  `PostToolUse` handlers that inject index status and tool-routing steering and
+  keep the graph and session store warm.
+
+Codex skips newly installed or changed command hooks until they are trusted —
+run `/hooks` in Codex to review and trust the tracedecay hooks.
+
+Codex has no always-applied rule surface (unlike Cursor's `rules/`), so the
+tool-routing steering Cursor places in a rule is injected through the
+`SessionStart`/`UserPromptSubmit` hooks instead.

--- a/codex-plugin/skills/architecture-overview/SKILL.md
+++ b/codex-plugin/skills/architecture-overview/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: architecture-overview
+description: Use when mapping repo or directory architecture, module structure, public APIs, dependency layers, circular dependencies, coupling hotspots, or onboarding; use tracedecay:code-health-report for quality scoring and tech-debt ranking.
+---
+
+# Architecture overview
+
+This skill **maps structure**. Its companion `tracedecay:code-health-report` **scores quality** and owns the `tracedecay_health` weak-dimension drill-down ladder — don't duplicate that ladder here.
+
+## Workflow
+
+1. **Shape & size:** `tracedecay_status` (node/edge/file counts), `tracedecay_files` + `tracedecay_distribution` (what lives where).
+2. **Public surface:** `tracedecay_module_api` per top-level directory.
+3. **Dependency structure:** `tracedecay_dsm` (`format`: `stats`|`clusters`|`matrix` — clusters and layering violations), `tracedecay_coupling` (`fan_in`/`fan_out` hubs), `tracedecay_circular` (cycles), `tracedecay_dependency_depth` (fragile long chains).
+4. **Quality triage (optional):** one `tracedecay_health` (`details: true`) call for the composite signal. To drill into weak dimensions (complexity, duplication, doc gaps, test risk, god files), hand off to `tracedecay:code-health-report` rather than re-running its ladder here.
+
+## Guardrails
+
+- All tools here are read-only and parallel-safe. This skill maps and explains; it does not edit and it does not rank tech debt.
+
+## Output
+
+- A layered module map, the dependency hotspots/violations, and a prioritized structural risk list.
+- Pairs with the `docs-canvas` plugin (if installed) for a rendered overview.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/assessing-test-coverage/SKILL.md
+++ b/codex-plugin/skills/assessing-test-coverage/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: assessing-test-coverage
+description: Use when answering which tests cover code, whether a function or file is tested, which tests are affected by changed files, or where the next test should go without running tests.
+---
+
+# Assessing test coverage
+
+Read-only coverage intelligence from the graph (structural test↔source edges, not line coverage). To actually run the selected tests, hand off to `tracedecay:running-impacted-tests`.
+
+## Workflow
+
+1. **Symbol/file → its tests → `tracedecay_test_map`** (`file` or `node_id`): the direct coverage edges; an empty result means no test reaches it through the indexed graph.
+2. **Changed files → affected tests → `tracedecay_affected`** (`files`): dependency-graph traversal to every test file that can see the change.
+3. **Where the next test goes → `tracedecay_test_risk`** (`path?`, `limit?`): risk = (complexity + 1) × (fan_in + 1) × untested-multiplier — the prioritized gap list.
+4. **Judging a diff's coverage → reuse `tracedecay_diff_context`** (`files`): it already bundles modified symbols + dependents + affected tests in one call — prefer it over separate lookups.
+
+## Guardrails
+
+- All read-only and parallel-safe; nothing here executes tests. Coverage is structural (call/use edges), so integration tests that reach code indirectly (through a binary, fixture, or IO boundary) can be missed — an empty `test_map` is strong but not absolute evidence of "untested".
+
+## Output
+
+- The tests covering the target, the affected-test set for a change, and the ranked coverage gaps with a recommendation for the next test.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/atomic-code-edits/SKILL.md
+++ b/codex-plugin/skills/atomic-code-edits/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: atomic-code-edits
+description: Use when editing source with safe anchored primitives: unique string replacement, atomic multi-replace, anchored insert, whole-symbol rewrite, structural ast-grep rewrite, or mechanical edits that should re-index the graph.
+---
+
+# Atomic code edits
+
+These tools mutate files; invoke them only when an edit is relevant to the task and respect Cursor approval/run-mode. Each writer targets a single file and triggers an in-place re-index, so the graph stays fresh.
+
+## Pick the primitive
+
+1. **Unique string swap → `tracedecay_str_replace`** (`path`, `old_str`, `new_str`): fails unless `old_str` matches exactly once — the safest default; use instead of sed/awk.
+2. **Several swaps, all-or-nothing → `tracedecay_multi_str_replace`** (`path`, `replacements` as `[[old, new], …]`): every pair must match exactly once or the whole edit aborts.
+3. **Insert at an anchor → `tracedecay_insert_at`** (`path`, `anchor` = unique string or 1-indexed line number, `content`, `before?`): add a line/block before or after a unique anchor.
+4. **Insert around a symbol → `tracedecay_insert_at_symbol`** (`symbol`, `content`, `position`: `before`|`after`): drop code adjacent to a named symbol's range (prefer a qualified name).
+5. **Rewrite a whole symbol → `tracedecay_replace_symbol`** (`symbol`, `new_source`): replace a function/method/struct/enum; `new_source` must include the declaration line. Refused on unresolved ambiguity.
+6. **Structural pattern rewrite → `tracedecay_ast_grep_rewrite`** (`path`, `pattern`, `rewrite`, ast-grep SGPattern syntax): rewrite every match of a syntactic pattern in one file — e.g. swap argument order or wrap calls (`foo($A)` → `bar(foo($A))`) — where string matching would over- or under-match. Repeat per file for multi-file rewrites.
+
+## Before & after
+
+- **Preview blast radius first → `tracedecay_rename_preview`** (`node_id`) for renames, or resolve the target with the `tracedecay:searching-for-code` ladder so you edit the right symbol. For multi-site mechanical refactors (rename everywhere, signature/field changes), run the `tracedecay:refactoring-safely` recon first and use its checklist as the edit plan.
+- **Verify after editing:** typecheck via `tracedecay:fixing-build-and-type-errors`, then `tracedecay:running-impacted-tests`.
+
+## Guardrails
+
+- `str_replace` / `multi_str_replace` / `insert_at` are single-file; `insert_at_symbol` / `replace_symbol` resolve by (qualified) name and refuse ambiguous matches — disambiguate rather than forcing.
+- `tracedecay_ast_grep_rewrite` shells out to the external `ast-grep` binary: it is only registered when `ast-grep` is on PATH and fails when it is not installed. If the tool is absent, tell the user to install ast-grep rather than approximating the rewrite with regex.
+
+## Output
+
+- The files/symbols changed and the verification result.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/auditing-code-safety/SKILL.md
+++ b/codex-plugin/skills/auditing-code-safety/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: auditing-code-safety
+description: Use when auditing ship-blocking code risk: panic/unwrap/expect/todo/unimplemented/unsafe sites, FIXME/HACK markers, dead code, unused imports, or high-risk untested symbols.
+---
+
+# Auditing code safety
+
+A focused ship-readiness sweep. For the full quality scorecard (complexity, duplication, docs) use `tracedecay:code-health-report`; for reviewing one diff use `tracedecay:reviewing-a-diff`.
+
+## Workflow
+
+1. **Panic & unsafe sites → `tracedecay_unsafe_patterns`** (`kinds?` to narrow e.g. to `unwrap`/`unsafe`, `exclude_tests: true` for production-only, `path?`): each hit carries file, line, kind, enclosing symbol, and an `in_test` flag.
+2. **Unfinished work → `tracedecay_todos`** (`kinds: ["FIXME","HACK","XXX","UNIMPLEMENTED"]` for the risk-relevant subset): markers with their enclosing symbol.
+3. **Unreachable code → `tracedecay_dead_code`** (`include_public: true` for workspace-internal audits) and **`tracedecay_unused_imports`**: dead paths hide stale assumptions and untested branches.
+4. **Risky and untested → `tracedecay_test_risk`** (`path?`, `limit?`): high-complexity, high-fan-in symbols with weak coverage — where a latent bug hurts most.
+5. **Rank the findings:** production panic/unsafe sites in hot paths first (cross-check fan-in with `tracedecay_callers` on the worst offenders), then UNIMPLEMENTED/HACK markers, then untested high-risk symbols, then dead code and imports.
+
+## Guardrails
+
+- Entirely read-only and parallel-safe; this skill reports, it does not fix. Hand fixes to `tracedecay:atomic-code-edits` / `tracedecay:cleaning-up-dead-code`, verification to `tracedecay:running-impacted-tests`.
+- `unwrap`/`panic!` inside tests is normal — respect `exclude_tests` / `in_test` before flagging. An `unsafe { }` block is not automatically a bug; report it as a review-attention site, not a finding to "fix".
+
+## Output
+
+- Findings grouped **Critical** (production panic/unsafe in hot paths) / **Warning** (risk markers, untested high-risk symbols) / **Note** (dead code, unused imports), each with file + enclosing symbol, plus a prioritized follow-up list.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/cleaning-up-dead-code/SKILL.md
+++ b/codex-plugin/skills/cleaning-up-dead-code/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: cleaning-up-dead-code
+description: Use when removing or consolidating dead code, unused imports, duplicate implementations, stale helpers, or cleanup findings after confirming callers and references.
+---
+
+# Cleaning up dead code
+
+## Workflow
+
+1. **Unreachable symbols → `tracedecay_dead_code`** (`include_public: true` for workspace-internal audits; `main`/`test*` are always excluded).
+2. **Dead imports → `tracedecay_unused_imports`.**
+3. **Duplication → `tracedecay_redundancy`** (`min_lines`, `similarity_threshold`; buckets: definite / likely / naming_only). For duplicate *discovery* and the pre-write "does a helper already exist" probe, use `tracedecay:finding-duplicate-logic`; this skill owns the removal.
+4. **Focused pass on a subset → `tracedecay_simplify_scan`** (`files`).
+5. **Before deleting anything → confirm zero real callers** with `tracedecay_callers` / `tracedecay_rename_preview`. Be conservative with `pub` items (they may be used outside the indexed scope).
+6. **Apply edits** with the `tracedecay:atomic-code-edits` primitives (`tracedecay_str_replace` / `tracedecay_replace_symbol` / `tracedecay_multi_str_replace`) or your normal edit tools.
+7. **Verify → `tracedecay_diagnostics`**, then the `tracedecay:running-impacted-tests` skill.
+
+## Measuring (optional)
+
+- Bracket the session via `tracedecay:tracking-session-health` to show the before/after health delta.
+
+## Guardrails
+
+- Discovery tools are read-only. The editing tools, `tracedecay_diagnostics`, and `session_start`/`session_end` mutate state or run checks; use them when cleanup/verification is relevant and respect Cursor approval/run-mode. Never delete a symbol whose callers/references are non-empty.
+
+## Output
+
+- Removed/consolidated items and the before/after health or test result.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/code-health-report/SKILL.md
+++ b/codex-plugin/skills/code-health-report/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: code-health-report
+description: Use when producing a code-health scorecard, tech-debt audit, worst-code ranking, complexity/duplication/doc-gap/test-risk report, or before/after health review; use architecture-overview for module maps.
+---
+
+# Code-health report
+
+Quality-scorecard companion to `tracedecay:architecture-overview` (which maps structure; for a module map or layering questions go there). This skill is the **canonical home of the `tracedecay_health` drill-down ladder**: lead with the one composite signal, then drill only into the weak dimensions and the specific scans the user asked for — don't run every tool by reflex.
+
+## Workflow
+
+1. **Composite signal → `tracedecay_health`** (`details: true`, optional `path`): the 0–10000 score plus the 5-dimension breakdown (acyclicity, depth, equality, redundancy, modularity) and the `coverage_discipline` penalty. The weak dimensions choose the drill-downs.
+2. **Inequality / god files → `tracedecay_gini`** (`metric`: `complexity`|`lines`|`fan_in`|`fan_out`|`members`, `scope`: `file`|`symbol`, `path?`, `limit?`).
+3. **Complexity & size offenders:** `tracedecay_complexity` (`limit?`, `node_kind?`, `path?`), `tracedecay_largest` (`node_kind?`, `path?`), `tracedecay_god_class` (`path?`), `tracedecay_hotspots` (`limit?`).
+4. **Structure drill-downs (match the weak `health` dimension):** acyclicity → `tracedecay_circular` (`max_depth?`) + `tracedecay_recursion`; modularity → `tracedecay_dsm` (`format`: `stats`|`clusters`|`matrix`) + `tracedecay_coupling` (`direction`: `fan_in`|`fan_out`); depth → `tracedecay_dependency_depth` + `tracedecay_inheritance_depth`; relationships → `tracedecay_rank` (`edge_kind` required); kind mix → `tracedecay_distribution`.
+5. **Duplication → `tracedecay_redundancy`** (`min_lines?`, `similarity_threshold?`, `include_naming_only?`, `max_pairs?`, `path?`); near-duplicate names → `tracedecay_similar` (`symbol`).
+6. **Documentation gaps → `tracedecay_doc_coverage`** (`path?`, `limit?`).
+7. **Safety / panic sites → `tracedecay_unsafe_patterns`** (`kinds?`, `exclude_tests?`, `path?`).
+8. **Risk-weighted test gaps → `tracedecay_test_risk`** (`path?`, `limit?`): where the next test should go.
+9. **Changed-files-only pass (optional) → `tracedecay_simplify_scan`** (`files`).
+10. **Track a session (optional):** bracket the work via `tracedecay:tracking-session-health` for the per-dimension before/after delta.
+
+## Guardrails
+
+- Discovery/analysis tools are read-only and parallel-safe. `tracedecay_session_start` / `tracedecay_session_end` write/remove `.tracedecay/session_baseline.json`; use them only when a before/after delta is relevant and respect Cursor approval/run-mode.
+- `tracedecay_redundancy` is computed lazily and cached; the first call on a fresh index can be slow on large repos — keep `path`/`max_pairs` tight.
+- This skill reports and prioritizes; it does not edit. To fix findings, hand off to `tracedecay:atomic-code-edits` / `tracedecay:cleaning-up-dead-code`; to verify, `tracedecay:running-impacted-tests`. For a focused ship-readiness sweep (panic sites, risk markers, dead code, untested high-risk symbols) use `tracedecay:auditing-code-safety` instead of the full scorecard.
+
+## Output
+
+- The composite score + weak dimensions, ranked worst offenders (complexity, duplication, god files, doc gaps, panic sites, test-risk), and a prioritized fix list. Pairs with the `docs-canvas` plugin (if installed) for a rendered scorecard.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/cross-branch-investigation/SKILL.md
+++ b/codex-plugin/skills/cross-branch-investigation/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: cross-branch-investigation
+description: Use when searching or comparing code across git branches without switching checkout, checking whether a symbol exists on another branch, or diffing branch graph changes.
+---
+
+# Cross-branch investigation
+
+TraceDecay can keep a separate code graph per git branch, so you can query another branch's graph directly. These tools are read-only and never change your checkout.
+
+## Workflow
+
+1. **See what's tracked first → `tracedecay_branch_list`** (no args): each tracked branch with DB size, parent, last-sync time, and which is current/default. If the list is empty or your target branch is missing, cross-branch data for that branch does not exist yet — see Enablement.
+2. **Search another branch → `tracedecay_branch_search`** (`branch` required, `query` required, `limit?`): find a symbol in that branch's graph (e.g. confirm `parse_config` exists on `main` before calling it).
+3. **Compare two branches → `tracedecay_branch_diff`** (`base?`, `head?`, `file?`, `kind?`): symbols `added` / `removed` / `changed` (signature differs). `base` defaults to the project default branch and `head` to the current branch, so a bare call compares current vs default. Narrow large diffs with `file` or `kind` (e.g. `kind: "function"`).
+
+## Enablement
+
+- Multi-branch tracking is **opt-in per branch** from the terminal: `tracedecay branch add <branch>` (no MCP tool does this). The plugin's Cursor hooks already auto-track the **current** branch on `git checkout`/`switch`/`worktree add` and on workspace open, so branches you visit get tracked over time.
+- To diff/search a branch you have **not** visited, ask the user to run `tracedecay branch add <branch>` (or `git checkout <branch>` once) in the terminal, then retry. There is no env var / `mcp.json` flag for this.
+- If a tool response is prefixed with a branch-fallback `WARNING`, the current branch isn't tracked and results came from the nearest ancestor — surface that to the user.
+
+## Guardrails
+
+- All three tools are read-only and parallel-safe; they open the target branch's DB without touching your working tree. Suggest `tracedecay branch add` as a terminal step — never try to enable tracking via edit tools.
+
+## Output
+
+- The cross-branch search hits or the added/removed/changed symbol lists, with the branches compared and any fallback warning surfaced.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/curating-project-memory/SKILL.md
+++ b/codex-plugin/skills/curating-project-memory/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: curating-project-memory
+description: Use when reviewing, updating, merging, deleting, pruning, or repairing tracedecay memory facts; handling stale, contradictory, duplicate, or secret-like facts; inspecting memory health; or opening the dashboard curation UI.
+---
+
+# Curating project memory
+
+This skill owns memory lifecycle changes. For read-only recall, start with `tracedecay:recalling-project-memory`; for adding a researched subject from scratch, use `tracedecay:memorizing-subject`.
+
+## Workflow
+
+1. **Start read-only:** `tracedecay_fact_store` with `action: "search"`, `"list"`, `"probe"`, `"related"`, `"reason"`, or `"contradict"`; use `tracedecay_memory_status` when the user asks for memory counts/health; use `tracedecay_dashboard` (`action: "start"`) when they want visual curation.
+2. **Classify the change:** update stale content/trust/tags, remove confirmed duplicates or wrong facts, or record `tracedecay_fact_feedback` only when the user rates a fact that was actually used.
+3. **Confirm destructive actions:** before `action: "remove"`, show the fact id, content/source, and reason, unless the user already named the exact fact to delete.
+4. **Apply narrowly:** `tracedecay_fact_store` `action: "update"` / `"remove"` / `"add"` only for the approved fact set. Re-run a read-only search/list to verify the final state.
+
+## Guardrails
+
+- Search/list/probe/related/reason/contradict are read-only. Add/update/remove, feedback, memory status repair, and dashboard start/stop mutate state or launch a local process; respect Cursor approval/run-mode.
+- Deletion is permanent: there is no archive, soft-delete, restore, or undo path. Prefer update/merge when useful provenance should survive; delete only confirmed stale, duplicate, wrong, secret-like, or user-requested facts.
+- Never store secrets, credentials, API keys, or PII. Do not lower trust merely because a fact is old; cite the newer evidence or contradiction.
+- Dashboard curation can apply hard deletes. Use preview/dry-run first when available and surface high-risk delete/merge operations before applying them.
+
+## Handoff
+
+- Need to remember a new subject with research fan-out → `tracedecay:memorizing-subject`.
+- Need raw session messages or summary-DAG replay → `tracedecay:recalling-session-context`.
+- Need only index/server status, not memory mutation → `tracedecay:project-status`.
+
+## Output
+
+- Facts searched/changed, confirmations requested, final verification result, and any skipped high-risk candidates.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/curating-project-memory/SKILL.md
+++ b/codex-plugin/skills/curating-project-memory/SKILL.md
@@ -5,7 +5,7 @@ description: Use when reviewing, updating, merging, deleting, pruning, or repair
 
 # Curating project memory
 
-This skill owns memory lifecycle changes. For read-only recall, start with `tracedecay:recalling-project-memory`; for adding a researched subject from scratch, use `tracedecay:memorizing-subject`.
+This skill owns memory lifecycle changes. For read-only recall, start with `tracedecay:recalling-project-memory`. To add a researched subject from scratch, use the research-then-`add` flow in the Handoff section.
 
 ## Workflow
 
@@ -23,7 +23,7 @@ This skill owns memory lifecycle changes. For read-only recall, start with `trac
 
 ## Handoff
 
-- Need to remember a new subject with research fan-out → `tracedecay:memorizing-subject`.
+- Need to remember a new subject with research fan-out → research read-only first, dedupe via `tracedecay_fact_store` `action: "search"`, then store durable, cited facts with `action: "add"`; reject secrets, credentials, and PII.
 - Need raw session messages or summary-DAG replay → `tracedecay:recalling-session-context`.
 - Need only index/server status, not memory mutation → `tracedecay:project-status`.
 

--- a/codex-plugin/skills/drafting-commit-and-pr/SKILL.md
+++ b/codex-plugin/skills/drafting-commit-and-pr/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: drafting-commit-and-pr
+description: Use when drafting a commit message, PR description, release notes, or changelog from semantic diff context; drafts text only and must not commit, push, or create PRs.
+---
+
+# Drafting commit & PR text
+
+## Workflow
+
+1. **Commit message → `tracedecay_commit_context`** (`staged_only`): changed symbols + file roles + recent commit style → draft a message that matches the repo's style.
+2. **PR description → `tracedecay_pr_context`** (`base_ref`, `head_ref`): semantic summary → draft body (Summary / Impact / Tests).
+3. **Release notes → `tracedecay_changelog`** (`from_ref`, `to_ref`): categorized added / removed / modified symbols.
+4. **Sanity-check what actually changed → `tracedecay_branch_diff`** (base vs head graph).
+
+## Guardrails
+
+- Read-only with respect to the working tree: this skill drafts text only. Leave `git commit` / `gh pr create` to the user or a dedicated git workflow.
+
+## Output
+
+- The drafted commit / PR / changelog text.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/exploring-types-and-traits/SKILL.md
+++ b/codex-plugin/skills/exploring-types-and-traits/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: exploring-types-and-traits
+description: Use when answering type-level questions: trait implementors, impl blocks, type hierarchies, struct construction sites, field read/write sites, derive-generated methods, or method bodies across implementors.
+---
+
+# Exploring types & traits
+
+Call-graph questions ("who calls X") belong in `tracedecay:tracing-functions`; this skill answers the type-level questions around them.
+
+## Workflow
+
+1. **Resolve the type/trait first** with `tracedecay_search` / `tracedecay_find_exact_symbol` (full resolver ladder: `tracedecay:searching-for-code`).
+2. **Who implements a trait / every body of a method → `tracedecay_implementations`** (`trait` form: each implementing type plus its impl-block methods; `method` form: every function named X across the project, grouped by enclosing type, with bodies).
+3. **Impl blocks by trait, type, or both → `tracedecay_impls`** (short or qualified names): which traits a type implements, which types satisfy a trait, dispatch targets. Avoid the no-filter form — it returns every impl in the graph.
+4. **Recursive hierarchy → `tracedecay_type_hierarchy`** (all implementors/extenders, transitively); deepest extends-chains → `tracedecay_inheritance_depth`.
+5. **"Where does this method come from?" → `tracedecay_derives`**: the `#[derive(...)]` macros on a type and the trait + method names each one synthesizes — check here before concluding `.clone()` / `.eq()` / `.hash()` has no definition.
+6. **Construction sites → `tracedecay_constructors`** (struct name): every struct-literal site with its present and missing fields — after adding a required field, the missing-fields list is the exact to-do list, before cargo even runs.
+7. **Field usage → `tracedecay_field_sites`** (`field` or `Struct::field`): every read site and write site with file, line, and enclosing symbol — the blast radius for renaming/removing a field or adding an invariant (write sites are what enforce it).
+
+## Guardrails
+
+- All read-only and parallel-safe. `tracedecay_constructors` is best-effort for Rust (ignores `match` arms and `if let` patterns); `tracedecay_field_sites` pattern-matches `.<field>` references, so same-named fields on other types can appear — prefer the `Struct::field` form to narrow. Unknown proc-macro derives surface with `well_known: false` (name only, no synthesized-method info).
+- This skill maps types; it does not edit. Hand renames/edits to `tracedecay:refactoring-safely` / `tracedecay:atomic-code-edits`.
+
+## Output
+
+- The implementor/hierarchy map or the site list (file, line, enclosing symbol) the question asked for.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/finding-duplicate-logic/SKILL.md
+++ b/codex-plugin/skills/finding-duplicate-logic/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: finding-duplicate-logic
+description: Use before writing a new helper or utility to check whether equivalent code already exists, or when finding duplicate logic, similar symbols, repeated implementations, and consolidation candidates.
+---
+
+# Finding duplicate logic
+
+Two uses: a 30-second pre-write probe before adding any new helper, and a deeper duplication audit.
+
+## Pre-write probe (always cheap)
+
+1. **By name/keyword → `tracedecay_search`** with the helper's likely names; **fuzzy twins → `tracedecay_similar`** (`parse_cfg` vs `config_parse`).
+2. **By shape → `tracedecay_signature_search`** (return type / param substring / async): "any fn taking `&Path` and returning `Result<Config>`?"
+3. **By concept → `tracedecay_context`** (one call, `task` = what the helper should do) when naming guesses fail.
+4. **Found one?** Inspect with `tracedecay_body` and reuse or extend it instead of writing a new copy.
+
+## Duplication audit
+
+5. **Functional duplicates → `tracedecay_redundancy`** (`min_lines?`, `similarity_threshold?`, `path?`, `max_pairs?`): AST-isomorphism / control-flow / call-sequence / token-shingle matching, bucketed `definite` / `likely` / `naming_only`. Trust `definite`; verify `likely` by reading both bodies; treat `naming_only` as a hint only.
+6. **Consolidating?** Keep the better-tested copy (check `tracedecay_test_map` on both), then hand removal to `tracedecay:cleaning-up-dead-code` and the edits to `tracedecay:atomic-code-edits`.
+
+## Guardrails
+
+- All discovery here is read-only and parallel-safe. `tracedecay_redundancy` is computed lazily and cached — the first call on a fresh index can be slow on large repos; keep `path` / `max_pairs` tight.
+- This skill finds and judges duplication; deleting or merging belongs to the cleanup and edit skills.
+
+## Output
+
+- The existing helper to reuse (or its confirmed absence), or the bucketed duplicate pairs with a consolidation recommendation.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/finding-impacted-areas/SKILL.md
+++ b/codex-plugin/skills/finding-impacted-areas/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: finding-impacted-areas
+description: Use when estimating blast radius: what depends on a symbol or file, affected tests, risk of a change, impacted areas for a refactor, or what could break if a target changes.
+---
+
+# Finding impacted areas
+
+## Workflow
+
+1. **Resolve the target → node ID** with `tracedecay_search` / `tracedecay_find_exact_symbol` / `tracedecay_by_qualified_name` (see `tracedecay:searching-for-code` for the full resolver ladder).
+2. **Symbol blast radius → `tracedecay_impact`** (`node_id`, small `max_depth` first, widen if needed): all direct + transitive dependents.
+3. **File-level fan-in → `tracedecay_file_dependents`** (every file that imports the changed file).
+4. **Already have changed paths → `tracedecay_diff_context`** (`files`): modified symbols + dependents + affected tests in one call.
+5. **Tests to run:**
+   - Reuse `tracedecay_diff_context` affected tests first.
+   - Need more detail? `tracedecay_affected` (`files`) finds affected tests; `tracedecay_test_map` (`file` / `node_id`) shows direct coverage.
+   - Use `tracedecay_test_risk` for high-risk, weakly-tested dependents.
+6. **Structural fragility (optional):** `tracedecay_coupling` / `tracedecay_dependency_depth` to see if the target is a high-fan-in hub.
+
+## Guardrails
+
+- Read-only analysis. This skill identifies impact and the test set; it does **not** run tests.
+- Start with a shallow `max_depth` and widen only when the picture is incomplete.
+
+## Handoff
+
+- To run the selected tests, use the `tracedecay:running-impacted-tests` skill.
+- For deeper read-only coverage questions, `tracedecay:assessing-test-coverage`; for a mechanical refactor (rename, signature/field change) where impact analysis becomes an edit checklist, `tracedecay:refactoring-safely`.
+
+## Output
+
+- (a) impacted symbols + files, (b) the test set to run, (c) any hub/coupling risk.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/fixing-build-and-type-errors/SKILL.md
+++ b/codex-plugin/skills/fixing-build-and-type-errors/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: fixing-build-and-type-errors
+description: Use when diagnosing or fixing compiler/type-checker errors, cargo/clippy output, tsc/pyright failures, mapped diagnostics, or build failures that need graph-anchored context.
+---
+
+# Fixing build & type errors
+
+Use this when build or type diagnostics are relevant to the task. Prefer pasted output when available; respect Cursor approval/run-mode before running fresh toolchain checks.
+
+## Workflow
+
+1. **Already have raw output? → `tracedecay_diagnose`** (`cargo_output` required, `severity?`: `error`|`warning`|`all`, `include_callers?`, `max_diagnostics?`): paste full `cargo check`/`clippy`/`rustc` stderr; each diagnostic maps to the smallest containing node with up to 5 callers pre-attached. No toolchain run — cheap and safe.
+2. **Need fresh diagnostics → `tracedecay_diagnostics`** (`scope`: `workspace` (default) | `package` (needs `name`) | `file` (needs `path`)): structured errors/warnings, each mapped to the enclosing graph node. Forces target dir `.tracedecay/target/`; the **first** run on a fresh tree can take minutes, later calls are sub-second.
+3. **Understand the failing code:** resolve/inspect with the `tracedecay:searching-for-code` ladder; widen blast radius with `tracedecay_impact` if a fix is risky.
+4. **Apply the fix → `tracedecay:atomic-code-edits`** (or your normal edit tools).
+5. **Re-check** with the cheapest applicable diagnostic path, then verify behavior via `tracedecay:running-impacted-tests`.
+
+## Guardrails
+
+- `tracedecay_diagnostics` runs `cargo`/`tsc`/`pyright` and is the only heavyweight call here; `tracedecay_diagnose` only parses text you provide — prefer it when you already captured the output.
+- `tracedecay_diagnostics` is multi-language (cargo/tsc/pyright); `tracedecay_diagnose` is Rust/cargo-specific.
+
+## Output
+
+- The grouped diagnostics with enclosing symbols + callers, the applied fix, and a clean re-check.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/porting-code/SKILL.md
+++ b/codex-plugin/skills/porting-code/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: porting-code
+description: Use when porting, migrating, or rewriting code between directories, crates, modules, branches, or languages while preserving dependency order and tracking port progress.
+---
+
+# Porting code
+
+## Workflow
+
+1. **Baseline → `tracedecay_port_status`** (`source_dir`, `target_dir`, `kinds`): what is already ported vs missing.
+2. **Order → `tracedecay_port_order`** (`source_dir`, `kinds`, `limit`): topological sort — **port leaves first**, dependents after.
+3. **Per symbol, in order:**
+   - Pull source with `tracedecay_body` / `tracedecay_node`.
+   - Map dependencies with `tracedecay_callees`; map incoming use with `tracedecay_callers`.
+   - Confirm the contract with `tracedecay_signature`.
+   - Apply the ported code with the `tracedecay:atomic-code-edits` primitives (`tracedecay_replace_symbol` / `tracedecay_str_replace` / `tracedecay_insert_at_symbol`) or your normal edit tools.
+4. **After each batch:** re-run `tracedecay_port_status` to update progress; run `tracedecay_diagnostics` to typecheck the target.
+5. **Cross-branch parity (if porting across refs):** `tracedecay_branch_diff` / `tracedecay_changelog`.
+
+## Guardrails
+
+- Never port a symbol before its dependencies (respect `tracedecay_port_order`).
+- `tracedecay_port_status` / `tracedecay_port_order` and the lookups are read-only; the editing tools and `tracedecay_diagnostics` mutate the working tree / run the toolchain. Use them when porting/verification is relevant and respect Cursor approval/run-mode.
+- `tracedecay_diagnostics` forces target dir `.tracedecay/target/`; the first run can take minutes.
+
+## Output
+
+- Updated port status (done / remaining) and the per-batch typecheck result.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/project-status/SKILL.md
+++ b/codex-plugin/skills/project-status/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: project-status
+description: Use when checking tracedecay index freshness, project file/config status, TODO/FIXME markers, MCP runtime CPU/RAM, dashboard URL, or memory subsystem counts.
+---
+
+# Project status & config
+
+Cheap, read-only surface for the index, project config, work markers, and server health.
+
+## Workflow
+
+1. **Index status → `tracedecay_status`** (no args): node/edge/file counts, DB size, active branch + any branch-fallback warning, tokens saved. Add `tracedecay_distribution` (`path?`, `summary?`) / `tracedecay_files` (`path?`, `pattern?`) for a kind/file breakdown.
+2. **Config lookups → `tracedecay_config`** (`key` required, plus `path` for one file **or** `glob` for many): query TOML/JSON by dotted key (e.g. `key: "package.version"` on `Cargo.toml`, or `glob: "crates/*/Cargo.toml"`). Pure filesystem parse — works even before `tracedecay init`.
+3. **Outstanding work → `tracedecay_todos`** (`kinds?`, `path?`, `limit?`): TODO/FIXME/XXX/HACK/WIP/NOTE/UNIMPLEMENTED markers with the enclosing symbol.
+4. **Server triage → `tracedecay_runtime`** (no args): PID, resident/virtual memory, CPU%, threads, DB/WAL/SHM sizes — use when TraceDecay seems to hog CPU or RAM.
+5. **User wants a visual → `tracedecay_dashboard`** (`action`: `start`|`stop`, optional `host`/`port`): starts the local dashboard server in the background and returns its URL (idempotent; `stop` shuts it down). Hand the URL to the user instead of describing charts.
+6. **Memory subsystem health (optional) → `tracedecay_memory_status`** (repairs derived vectors/banks; returns fact/entity counts + trust distribution).
+
+## Guardrails
+
+- `tracedecay_status`, `tracedecay_config`, `tracedecay_todos`, `tracedecay_runtime` are read-only. `tracedecay_dashboard` starts/stops a local server and `tracedecay_memory_status` repairs/normalizes memory state — use them only when the user wants the dashboard or memory counts.
+- For deeper structural/quality questions hand off to `tracedecay:architecture-overview` or `tracedecay:code-health-report`; for memory recall, `tracedecay:recalling-project-memory`; for memory curation/update/delete, `tracedecay:curating-project-memory`; for past-session recall, `tracedecay:recalling-session-context`.
+
+## Output
+
+- The status numbers, config values (with the file + line each was found at), marker list, or runtime snapshot the user asked for.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/reading-code-cheaply/SKILL.md
+++ b/codex-plugin/skills/reading-code-cheaply/SKILL.md
@@ -1,18 +1,32 @@
 ---
 name: reading-code-cheaply
-description: Inspect code at the cheapest sufficient depth using TraceDecay outlines, signatures, symbol bodies, line slices, and module API surfaces before reading whole files.
+description: Inspect code at the cheapest sufficient depth — file outlines, cached signatures, single-symbol bodies, line slices, and module API surfaces instead of full-file reads. Use when about to read or open a source file, when a file is large, for "what's in this file", "what's the signature of X", or "what does this module export".
 ---
 
-# Reading Code Cheaply
+# Reading code cheaply
 
-Climb this ladder and stop at the first rung that answers the question.
+Climb this ladder and stop at the first rung that answers the question. Most "read the file" impulses are satisfied by rungs 1–3.
 
-1. Orient in a file with `tracedecay_outline`.
-2. Read API surface with `tracedecay_signature` or `tracedecay_read` in `signatures` mode.
-3. Read one symbol with `tracedecay_body` or `tracedecay_node`.
-4. Read a specific region with `tracedecay_read` in `lines` mode.
-5. Read a whole file with `tracedecay_read` in `full` mode only when narrower calls are insufficient.
-6. Map a directory or module with `tracedecay_module_api` and `tracedecay_files`.
+## Ladder
 
-Check `tracedecay_status` before falling back to raw file reads when results
-look stale or empty.
+1. **Orient in a file → `tracedecay_outline`** (`path`, optional `kinds`): every top-level symbol with line numbers, no bodies — the table of contents.
+2. **API surface only → `tracedecay_signature`** (qualified name): visibility, generics, params, return type, docstring, async flag — no bodies, no file bytes. Bulk per-file variant: `tracedecay_read` with `mode: "signatures"`.
+3. **One symbol's source → `tracedecay_body`** (name → ranked full source in one call) or `tracedecay_node` (by node ID, with metadata) — instead of opening the whole file for one function.
+4. **A specific region → `tracedecay_read`** (`mode: "lines"`, e.g. `"120-180"`): slice the file instead of reading all of it.
+5. **Whole file (last resort) → `tracedecay_read`** (`mode: "full"`): cross-session cached — re-reading an unchanged file returns a tiny `unchanged: true` stub instead of repeat bytes, so prefer it over the plain Read tool.
+6. **Module/directory surface → `tracedecay_module_api`** (all `pub` symbols sorted by file and line); enumerate files with `tracedecay_files` (`path?`, `pattern?`).
+
+## Guardrails
+
+- All read-only and parallel-safe. Don't chain rungs you don't need — outline + one body beats a full read of a 2000-line file.
+- The graph covers symbols, not prose: comments, string literals, and config bodies need Grep/Read (or `tracedecay_config` for TOML/JSON keys). If results look empty or stale, check `tracedecay_status` (index freshness, branch-fallback warning) before falling back to raw reads.
+- If a tracedecay read response is truncated and includes a `handle`, prefer a narrower symbol/range request first; call `tracedecay_retrieve` with that `handle` when the omitted content is needed.
+
+## Handoff
+
+- Don't know where the code lives yet → `tracedecay:searching-for-code`. Type-level questions (implementors, construction sites, derives) → `tracedecay:exploring-types-and-traits`.
+
+## Output
+
+- The outline/signature/snippet that answers the question, and which rung produced it.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/recalling-project-memory/SKILL.md
+++ b/codex-plugin/skills/recalling-project-memory/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: recalling-project-memory
+description: Use when recalling prior decisions, durable facts, user/project preferences, or past project context before answering or planning; use curating-project-memory for updating or deleting stored facts.
+---
+
+# Recalling project memory
+
+Recall memory **before** reaching for external or web search — prior sessions often already answered the question, and a memory hit is cheaper and project-specific.
+
+## Workflow
+
+1. **Past conversations → `tracedecay_message_search`** (`query`, optional `provider`, `limit`) over ingested Cursor/Codex/agent transcripts (project-local FTS index).
+2. **Durable facts → `tracedecay_fact_store`** with `action: "search"` (or `"probe"` / `"reason"`), plus `query` and `min_trust`.
+3. **If the user asks to inspect or repair memory health → `tracedecay_memory_status`** (repairs derived vectors/banks; returns fact/entity counts + trust distribution).
+4. **If the user rates a recalled fact → `tracedecay_fact_feedback`** (`helpful` / `unhelpful`) to tune its trust score.
+5. **Persist a new durable decision → `tracedecay_fact_store`** `action: "add"` (`content`, `category`, `tags`, `trust`) only when the user asks to remember it.
+
+## Guardrails
+
+- `tracedecay_message_search` and `fact_store` searches are read-only. `fact_store` adds, `fact_feedback`, and `memory_status` mutate memory state; use them only for explicit user requests or ratings.
+
+## Handoff
+
+- For raw conversation recall beyond FTS — scoped/role/time-filtered grep, lossless session replay, or summary-DAG drill-down — use `tracedecay:recalling-session-context`.
+- For stale, contradictory, duplicate, or user-requested fact updates/deletes — use `tracedecay:curating-project-memory`.
+
+## Output
+
+- The relevant prior context/decisions found, with source.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/recalling-session-context/SKILL.md
+++ b/codex-plugin/skills/recalling-session-context/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: recalling-session-context
+description: Use when retrieving what happened in past agent sessions: full-text transcript recall, scoped/time-filtered grep, lossless session replay, summary-DAG drill-down, or compaction recovery.
+---
+
+# Recalling session context
+
+Climb this ladder cheapest-first; stop as soon as the question is answered. For durable *decisions and facts* (rather than raw conversation), start with `tracedecay:recalling-project-memory` instead.
+
+## Retrieval ladder
+
+1. **Fast full-text recall → `tracedecay_message_search`** (`query`, optional `provider`, `scope`: `all`|`parents_only`|`subagents_only`, `limit`): FTS over ingested transcripts; returns messages with their session ids — the entry point for everything below.
+2. **Scoped/filtered grep → `tracedecay_lcm_grep`** (`query`, `scope`: `current`|`session`|`all` — `current`/`session` require `session_id`; `role`, `source`, `start_time`/`end_time`, `sort`: `recency`|`relevance`|`hybrid`): bounded raw-message snippets plus summary text when FTS recall needs role/time/session precision.
+3. **Lossless replay → `tracedecay_lcm_load_session`** (`session_id`, `after_store_id` + `limit` for stable pagination, `roles`, `content_offset`/`content_limit`): ordered raw messages of one session; page with `next_cursor` instead of asking for everything at once.
+4. **Summary-DAG drill-down:** `tracedecay_lcm_describe` (`session_id`) for the session's raw/summary shape; `tracedecay_lcm_expand` (`target.kind`: `raw_message`|`summary_node`|`external_payload`) to open one node, paging sources via `source_offset`/`source_limit`; `tracedecay_lcm_expand_query` (`query`) to assemble bounded retrieval context for a prompt in one call.
+5. **Store inspection → `tracedecay_lcm_status`** (counts, token estimates, DAG depth/compression ratio) when you need to know what the store contains before searching it.
+
+## Guardrails
+
+- Steps 1–5 are read-only. `tracedecay_lcm_compress`, `tracedecay_lcm_preflight`, and `tracedecay_lcm_session_boundary` are **lifecycle-integration tools for host agents** — never invoke them casually during recall.
+- If the LCM store itself looks wrong (missing sessions, broken FTS, stale counts) → `tracedecay_lcm_doctor` (`mode: "diagnose"` first; `repair`/`clean` mutate and need explicit user intent).
+- All LCM tools default to `storage_scope: "project_local"`; only pass `hermes_profile` (with an absolute `hermes_home`) when the user asks about a Hermes profile store.
+
+## Handoff
+
+- Durable decisions/facts and persisting new ones → `tracedecay:recalling-project-memory`.
+
+## Output
+
+- The recalled messages/summaries with session ids and timestamps, and which rung answered the question.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/refactoring-safely/SKILL.md
+++ b/codex-plugin/skills/refactoring-safely/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: refactoring-safely
+description: Use when planning or executing mechanical refactors: renames, signature changes, field add/remove/rename, moving helpers, or any edit where missed call sites break the build.
+---
+
+# Refactoring safely
+
+Enumerate every affected site *before* the first edit; the recon output is the edit checklist.
+
+## Workflow
+
+1. **Resolve the target → node ID** with `tracedecay_search` / `tracedecay_find_exact_symbol` (resolver ladder: `tracedecay:searching-for-code`).
+2. **Recon, by refactor type (read-only):**
+   - Rename / move a symbol → `tracedecay_rename_preview` (`node_id`): every edge where it appears as source or target.
+   - Signature change → `tracedecay_callers` (every call site must adapt) plus `tracedecay_signature_search` for shape-twins that should change together (e.g. every `fn` returning `Result<_, OldError>`).
+   - Field rename/remove/new invariant → `tracedecay_field_sites` (`Struct::field`): write sites are the blast radius.
+   - Newly required field → `tracedecay_constructors`: every struct-literal site, with missing-field lists.
+   - Names that will collide or confuse after the rename → `tracedecay_similar`.
+3. **Risk check → `tracedecay_impact`** (`node_id`, shallow `max_depth` first) when the target is widely depended on; widen only if the picture is incomplete.
+4. **Apply via `tracedecay:atomic-code-edits`:** `tracedecay_multi_str_replace` for the per-file site checklist (all-or-nothing), `tracedecay_replace_symbol` for the definition itself, `tracedecay_ast_grep_rewrite` for structural call-shape changes (e.g. argument reorder).
+5. **Verify:** typecheck via `tracedecay:fixing-build-and-type-errors`, then `tracedecay:running-impacted-tests`.
+
+## Guardrails
+
+- Steps 1–3 are read-only; step 4 mutates files and step 5 runs toolchains — respect Cursor approval/run-mode. `tracedecay_rename_preview` only previews; nothing renames automatically.
+- Recon sees only the indexed scope: `pub` items may have external users, and macro-generated or string-keyed references won't appear in the graph — grep once for the bare name before declaring the checklist complete.
+
+## Output
+
+- The recon checklist (sites grouped by file), the edits applied, and the clean verify result.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/reviewing-a-diff/SKILL.md
+++ b/codex-plugin/skills/reviewing-a-diff/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: reviewing-a-diff
+description: Use when reviewing a PR, branch diff, or working-tree diff for impact, behavioral risk, quality issues, unsafe patterns, affected tests, or pre-merge readiness.
+---
+
+# Reviewing a diff
+
+## Workflow
+
+1. **Get changed files** — working tree, or `git diff --name-only <base>...HEAD` (default base `main`).
+2. **Semantic change summary:**
+   - Working tree / file list → `tracedecay_diff_context` (`files`): modified symbols + dependents + affected tests.
+   - Ref-to-ref PR → `tracedecay_pr_context` (`base_ref`, `head_ref`).
+3. **Go deeper only if needed:** `tracedecay_diff_context` already returns dependents + affected tests — reuse those first. Use **`tracedecay_impact`** (`node_id`) to widen the blast radius on a specific high-risk changed symbol, and **`tracedecay_affected`** (`files`) only when you need the full test set beyond what step 2 surfaced.
+4. **Quality scan of just the changed files → `tracedecay_simplify_scan`** (`files`): duplications, dead code, coupling, complexity hotspots.
+5. **Risk surfacing:** `tracedecay_test_risk` on changed paths; `tracedecay_unsafe_patterns` on changed files (unwrap/expect/panic/unsafe).
+
+## Guardrails
+
+- Read-only review. Do not edit or run tests from this skill; to verify behavior, hand off to the `tracedecay:running-impacted-tests` skill.
+- If diff context is truncated and includes a `handle`, narrow by file/symbol first when possible; call `tracedecay_retrieve` with that `handle` only when the omitted risk detail is needed.
+
+## Output
+
+- Findings grouped **Critical / Warning / Note**, the impacted areas, and the test set to run.
+- Pairs with the `pr-review-canvas` plugin if installed.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/running-impacted-tests/SKILL.md
+++ b/codex-plugin/skills/running-impacted-tests/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: running-impacted-tests
+description: Use when running only tests affected by changed Rust files, mapping failures back to source, verifying a change without a full suite, or handling cargo-backed impacted-test checks.
+paths:
+  - "**/*.rs"
+  - "**/Cargo.toml"
+---
+
+# Running impacted tests
+
+Use this when impacted-test verification is relevant to the task. Respect Cursor approval/run-mode before invoking cargo-backed tools.
+
+## Workflow
+
+1. **Changed paths** — working tree, or explicit `changed_paths`.
+2. **Preview coverage:** `tracedecay_affected` (`files`) and `tracedecay_test_map` (which tests cover the changes).
+3. **Run → `tracedecay_run_affected_tests`** (`changed_paths`, `max_tests`, `profile`, `timeout_secs`): pass/fail per test, with the source nodes each test covers.
+4. **On compile/type failure → `tracedecay_diagnose`** for captured cargo stderr, or `tracedecay_diagnostics` when fresh structured diagnostics are needed. For standalone compile/type errors, use `tracedecay:fixing-build-and-type-errors`.
+5. **Coverage gaps → `tracedecay_test_risk`** to recommend where the next test goes.
+
+## Guardrails
+
+- `tracedecay_run_affected_tests` and `tracedecay_diagnostics` run cargo-backed checks, and the first `diagnostics` build can take minutes (forced target dir `.tracedecay/target/`). Respect Cursor approval/run-mode and avoid duplicate runs.
+- `tracedecay_run_affected_tests` is cargo-only. For non-Rust repos use `tracedecay_diagnostics` (tsc/pyright) and the project's own test runner.
+- Steps 1–2 and 5 are read-only and safe to run first to preview scope before the user commits to a run.
+- Pure coverage questions ("which tests cover X", "is this tested", "where should the next test go") that don't need a run → `tracedecay:assessing-test-coverage`.
+
+## Output
+
+- Pass/fail summary + failing-symbol mapping + suggested missing tests.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/searching-for-code/SKILL.md
+++ b/codex-plugin/skills/searching-for-code/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: searching-for-code
+description: Find code by concept, symbol, signature, or qualified name in this repo using the TraceDecay code graph. Use when searching the codebase, locating a function/struct/trait/class/method, exploring how a feature works, or before grep/file-search when a .tracedecay index exists.
+---
+
+# Searching for code
+
+Use the TraceDecay code graph before Grep/Glob/file reads. Pick the cheapest tool that answers the question.
+
+## Workflow
+
+1. **Conceptual / "how does X work" / names unknown → `tracedecay_context`.**
+   - `task` = the question. Add `keywords` to expand synonyms (e.g. auth → `["login","session","token","credential"]`).
+   - Set `include_code: true` only when you need snippets; use `mode: "plan"` when scoping an implementation.
+   - **Respect the per-project call budget printed in the tool description** (it scales with graph size — stop at the stated max and synthesize from what you have). Pass prior `seen_node_ids` via `exclude_node_ids` to dedupe across calls.
+2. **Exact name known → `tracedecay_find_exact_symbol`** (cheapest index probe) or **`tracedecay_body`** (name → full source in one shot; ranks matches when ambiguous).
+3. **Relevance-ranked discovery by name/keyword → `tracedecay_search`.**
+4. **Half-remembered name → `tracedecay_similar`** (fuzzy / substring).
+5. **Stable cross-run identity → `tracedecay_by_qualified_name`** (when content-hash node IDs changed).
+6. **By shape, not name → `tracedecay_signature_search`** (return type / param substring / `async` / path), e.g. "every fn returning `Result<_, MyError>`".
+7. **Found it — inspect it cheaply:** follow the `tracedecay:reading-code-cheaply` ladder (`tracedecay_outline` → `tracedecay_signature` → `tracedecay_body` → `tracedecay_read` slices; `tracedecay_module_api` for a module's public surface) instead of full file reads.
+8. **Type-level questions** (trait implementors, impl blocks, construction sites, field usage, derive-generated methods) → `tracedecay:exploring-types-and-traits`.
+
+## Guardrails
+
+- All tools above are read-only and parallel-safe. Do not call mutating/editing tools from this skill.
+- Only fall back to Grep/Glob/Read for non-indexed content (string literals, comments, config the graph does not cover) or after TraceDecay pinpoints exact files.
+- Prefer one well-formed `tracedecay_context` call over many narrow searches.
+- If a response is truncated and includes a `handle`, narrow the query/result set first when possible; call `tracedecay_retrieve` with that `handle` only when the omitted details are needed.
+- About to write a new helper because the search came up empty? Run the `tracedecay:finding-duplicate-logic` pre-write probe first.
+
+## Output
+
+- The file + symbol the user needs (path, qualified name, signature), and how you found it.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/tracing-functions/SKILL.md
+++ b/codex-plugin/skills/tracing-functions/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: tracing-functions
+description: Use when tracing call relationships: who calls a function, what it calls, shortest call paths between symbols, references for rename prep, recursion, hubs, or dynamic dispatch.
+---
+
+# Tracing functions
+
+## Workflow
+
+1. **Resolve symbol(s) → node ID(s)** with `tracedecay_search` / `tracedecay_find_exact_symbol` / `tracedecay_by_qualified_name` (see `tracedecay:searching-for-code` for the full resolver ladder).
+2. **Upstream (callers) → `tracedecay_callers`** (`node_id`, `max_depth` 1–2 first). For many symbols at once → `tracedecay_callers_for` (`node_ids[]`, one round-trip).
+3. **Downstream (callees) → `tracedecay_callees`** (resolves trait dispatch; watch for `dispatch_via_trait: true` / `dispatch_from`). Pass `resolve_dispatch: false` for direct edges only.
+4. **Path between two symbols → `tracedecay_call_chain`** (`from_id`, `to_id`, `max_depth`).
+5. **Polymorphism → `tracedecay_implementations`** for a quick "every implementor / every body of this method"; the full type-level toolkit (impl blocks, hierarchies, derives, construction/field sites) is `tracedecay:exploring-types-and-traits`.
+6. **All references (rename prep) → `tracedecay_rename_preview`** (`node_id`): every edge where the node is source or target. For the full recon-then-edit rename workflow, use `tracedecay:refactoring-safely`.
+7. **Cycles / hubs:** `tracedecay_recursion`, `tracedecay_hotspots`, `tracedecay_rank`.
+
+## Guardrails
+
+- Read-only and parallel-safe. Keep `max_depth` small (1–2) first; widen only when the chain is not yet clear. `tracedecay_rename_preview` only previews references — it does not rename.
+- If a trace response is truncated and includes a `handle`, narrow depth or target set first when possible; call `tracedecay_retrieve` with that `handle` when the omitted chain details are needed.
+
+## Output
+
+- The caller/callee tree or the resolved path, with dispatch targets noted.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/tracking-session-health/SKILL.md
+++ b/codex-plugin/skills/tracking-session-health/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: tracking-session-health
+description: Use when bracketing refactor or cleanup work with a code-health baseline and final per-dimension delta to prove whether quality improved or degraded.
+---
+
+# Tracking session health
+
+## Workflow
+
+1. **Before the first edit → `tracedecay_session_start`** (no args): snapshots current health metrics as the baseline (`.tracedecay/session_baseline.json`).
+2. **Work normally** — edits via `tracedecay:atomic-code-edits` or regular tools; TraceDecay re-indexes as files change.
+3. **After the work → `tracedecay_session_end`**: re-scans and returns the per-dimension diff (acyclicity, depth, equality, redundancy, modularity) — what improved, what degraded — and clears the baseline.
+4. **Interpret the delta:** a dropped dimension names the follow-up — e.g. redundancy fell → `tracedecay_redundancy` to find what got duplicated; acyclicity fell → `tracedecay_circular`. The full dimension→drill-down table lives in `tracedecay:code-health-report`.
+
+## Guardrails
+
+- `tracedecay_session_start` / `tracedecay_session_end` write/remove `.tracedecay/session_baseline.json` — a second `session_start` silently overwrites the baseline, so bracket one session at a time; respect Cursor approval/run-mode.
+- `session_end` without a prior `session_start` has no baseline to compare against — start one first.
+- Bracket only work where a before/after delta is wanted (refactors, cleanups, health-focused sessions) — don't bracket trivial edits.
+
+## Output
+
+- The per-dimension health delta with a one-line interpretation (improved / degraded / unchanged) and any recommended follow-up.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -1195,9 +1195,16 @@ mod tests {
     /// (with a reason) in `CODEX_SKILL_DIVERGENCES`.
     #[test]
     fn codex_skills_match_the_cursor_source_for_parity() {
-        // Skills deliberately specialized for Codex. Empty today — every shared
-        // skill is a verbatim mirror of the Cursor source.
-        const CODEX_SKILL_DIVERGENCES: &[&str] = &[];
+        // Skills deliberately specialized for Codex (host-specific bodies that
+        // are not byte-compared against the Cursor source):
+        //
+        // - `curating-project-memory`: the Cursor source hands the "add a
+        //   researched subject from scratch" flow off to the `memorizing-subject`
+        //   skill, an explicit-invoke (`disable-model-invocation: true`) slash
+        //   workflow Codex intentionally does not ship. The Codex copy inlines
+        //   that flow's guardrails (read-only research, dedupe, cited facts,
+        //   secret/PII rejection) instead of pointing at a skill absent here.
+        const CODEX_SKILL_DIVERGENCES: &[&str] = &["curating-project-memory"];
         let root = repo_root();
         for &skill in crate::hooks::CURSOR_PLUGIN_SKILLS {
             let codex_path = root
@@ -1225,5 +1232,57 @@ mod tests {
                  CODEX_SKILL_DIVERGENCES if a host-specific version is intended)"
             );
         }
+    }
+
+    /// Extracts the `<name>` from every `tracedecay:<name>` skill handoff in a
+    /// body. MCP tool calls use `tracedecay_*` (underscore) and are ignored.
+    fn skill_handoff_references(body: &str) -> Vec<String> {
+        const MARKER: &str = "tracedecay:";
+        let mut refs = Vec::new();
+        let mut rest = body;
+        while let Some(pos) = rest.find(MARKER) {
+            rest = &rest[pos + MARKER.len()..];
+            let name: String = rest
+                .chars()
+                .take_while(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-')
+                .collect();
+            if !name.is_empty() {
+                refs.push(name);
+            }
+        }
+        refs
+    }
+
+    /// Every `tracedecay:<skill>` handoff inside the embedded Codex skill bodies
+    /// must resolve to a skill this bundle actually ships. A dangling reference
+    /// (e.g. to a Cursor-only explicit-invoke skill like `memorizing-subject`)
+    /// would point a Codex agent at a workflow that does not exist here.
+    #[test]
+    fn codex_skill_cross_references_resolve_to_shipped_skills() {
+        let shipped: std::collections::BTreeSet<String> = CODEX_EMBEDDED_PLUGIN_FILES
+            .iter()
+            .filter_map(|&(relative, _)| {
+                relative
+                    .strip_prefix("skills/")
+                    .and_then(|rest| rest.strip_suffix("/SKILL.md"))
+                    .map(str::to_string)
+            })
+            .collect();
+
+        let mut dangling: Vec<String> = Vec::new();
+        for &(relative, contents) in CODEX_EMBEDDED_PLUGIN_FILES {
+            if !relative.starts_with("skills/") {
+                continue;
+            }
+            for reference in skill_handoff_references(contents) {
+                if !shipped.contains(&reference) {
+                    dangling.push(format!("{relative} -> tracedecay:{reference}"));
+                }
+            }
+        }
+        assert!(
+            dangling.is_empty(),
+            "Codex skill bodies reference skills absent from the bundle: {dangling:?}"
+        );
     }
 }

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -166,12 +166,111 @@ const CODEX_EMBEDDED_PLUGIN_FILES: &[(&str, &str)] = &[
     (".mcp.json", include_str!("../../codex-plugin/.mcp.json")),
     ("README.md", include_str!("../../codex-plugin/README.md")),
     (
+        "hooks/hooks.json",
+        include_str!("../../codex-plugin/hooks/hooks.json"),
+    ),
+    // Codex auto-discovers every `SKILL.md` under the manifest `skills/` dir by
+    // its `name`/`description` frontmatter. The Codex bundle mirrors the
+    // model-invocable Cursor skills (`hooks::CURSOR_PLUGIN_SKILLS`) so both
+    // hosts steer agents toward the same tracedecay workflows; the parity is
+    // enforced by `codex_skills_match_the_cursor_source_for_parity`. The
+    // Cursor-only slash dispatchers (`tracedecay-*`) and explicit-invoke memory
+    // skills are intentionally omitted (Codex has no slash-command surface).
+    (
+        "skills/architecture-overview/SKILL.md",
+        include_str!("../../codex-plugin/skills/architecture-overview/SKILL.md"),
+    ),
+    (
+        "skills/assessing-test-coverage/SKILL.md",
+        include_str!("../../codex-plugin/skills/assessing-test-coverage/SKILL.md"),
+    ),
+    (
+        "skills/atomic-code-edits/SKILL.md",
+        include_str!("../../codex-plugin/skills/atomic-code-edits/SKILL.md"),
+    ),
+    (
+        "skills/auditing-code-safety/SKILL.md",
+        include_str!("../../codex-plugin/skills/auditing-code-safety/SKILL.md"),
+    ),
+    (
+        "skills/cleaning-up-dead-code/SKILL.md",
+        include_str!("../../codex-plugin/skills/cleaning-up-dead-code/SKILL.md"),
+    ),
+    (
+        "skills/code-health-report/SKILL.md",
+        include_str!("../../codex-plugin/skills/code-health-report/SKILL.md"),
+    ),
+    (
+        "skills/cross-branch-investigation/SKILL.md",
+        include_str!("../../codex-plugin/skills/cross-branch-investigation/SKILL.md"),
+    ),
+    (
+        "skills/curating-project-memory/SKILL.md",
+        include_str!("../../codex-plugin/skills/curating-project-memory/SKILL.md"),
+    ),
+    (
+        "skills/drafting-commit-and-pr/SKILL.md",
+        include_str!("../../codex-plugin/skills/drafting-commit-and-pr/SKILL.md"),
+    ),
+    (
+        "skills/exploring-types-and-traits/SKILL.md",
+        include_str!("../../codex-plugin/skills/exploring-types-and-traits/SKILL.md"),
+    ),
+    (
+        "skills/finding-duplicate-logic/SKILL.md",
+        include_str!("../../codex-plugin/skills/finding-duplicate-logic/SKILL.md"),
+    ),
+    (
+        "skills/finding-impacted-areas/SKILL.md",
+        include_str!("../../codex-plugin/skills/finding-impacted-areas/SKILL.md"),
+    ),
+    (
+        "skills/fixing-build-and-type-errors/SKILL.md",
+        include_str!("../../codex-plugin/skills/fixing-build-and-type-errors/SKILL.md"),
+    ),
+    (
+        "skills/porting-code/SKILL.md",
+        include_str!("../../codex-plugin/skills/porting-code/SKILL.md"),
+    ),
+    (
+        "skills/project-status/SKILL.md",
+        include_str!("../../codex-plugin/skills/project-status/SKILL.md"),
+    ),
+    (
         "skills/reading-code-cheaply/SKILL.md",
         include_str!("../../codex-plugin/skills/reading-code-cheaply/SKILL.md"),
     ),
     (
-        "hooks/hooks.json",
-        include_str!("../../codex-plugin/hooks/hooks.json"),
+        "skills/recalling-project-memory/SKILL.md",
+        include_str!("../../codex-plugin/skills/recalling-project-memory/SKILL.md"),
+    ),
+    (
+        "skills/recalling-session-context/SKILL.md",
+        include_str!("../../codex-plugin/skills/recalling-session-context/SKILL.md"),
+    ),
+    (
+        "skills/refactoring-safely/SKILL.md",
+        include_str!("../../codex-plugin/skills/refactoring-safely/SKILL.md"),
+    ),
+    (
+        "skills/reviewing-a-diff/SKILL.md",
+        include_str!("../../codex-plugin/skills/reviewing-a-diff/SKILL.md"),
+    ),
+    (
+        "skills/running-impacted-tests/SKILL.md",
+        include_str!("../../codex-plugin/skills/running-impacted-tests/SKILL.md"),
+    ),
+    (
+        "skills/searching-for-code/SKILL.md",
+        include_str!("../../codex-plugin/skills/searching-for-code/SKILL.md"),
+    ),
+    (
+        "skills/tracing-functions/SKILL.md",
+        include_str!("../../codex-plugin/skills/tracing-functions/SKILL.md"),
+    ),
+    (
+        "skills/tracking-session-health/SKILL.md",
+        include_str!("../../codex-plugin/skills/tracking-session-health/SKILL.md"),
     ),
 ];
 
@@ -1015,4 +1114,116 @@ fn codex_hook_present(hooks: &serde_json::Value, event: &str, command: &str) -> 
             })
         })
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn repo_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+    }
+
+    fn relative_paths_under(root: &Path) -> Vec<String> {
+        let mut paths: Vec<String> = collect_regular_files(root)
+            .expect("plugin source bundle should be readable")
+            .iter()
+            .map(|path| {
+                path.strip_prefix(root)
+                    .expect("collected paths live under root")
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        paths.sort();
+        paths
+    }
+
+    /// The embedded writer is the single source of truth for released installs
+    /// (the binary ships without the repo `codex-plugin/` tree), so the list
+    /// must cover every file actually present in the source bundle — otherwise
+    /// a freshly added skill file would silently never reach Codex users.
+    #[test]
+    fn codex_embedded_file_list_covers_the_whole_source_bundle() {
+        let on_disk = relative_paths_under(&repo_root().join("codex-plugin"));
+        let mut expected: Vec<String> = CODEX_EMBEDDED_PLUGIN_FILES
+            .iter()
+            .map(|&(relative, _)| relative.to_string())
+            .collect();
+        expected.sort();
+        assert_eq!(
+            on_disk, expected,
+            "CODEX_EMBEDDED_PLUGIN_FILES must cover every codex-plugin file"
+        );
+    }
+
+    /// Codex auto-discovers skills by description (it has no slash-command or
+    /// `disable-model-invocation` surface), so the Codex bundle ships exactly
+    /// the *model-invocable* Cursor skills — the same set the Cursor plugin
+    /// advertises via [`crate::hooks::CURSOR_PLUGIN_SKILLS`]. The Cursor-only
+    /// slash dispatchers (`tracedecay-*`) and explicit-invoke memory skills are
+    /// intentionally not mirrored: their workflows are covered by these skills.
+    #[test]
+    fn codex_bundle_ships_exactly_the_model_invocable_cursor_skills() {
+        let mut shipped: Vec<String> = CODEX_EMBEDDED_PLUGIN_FILES
+            .iter()
+            .filter_map(|&(relative, _)| {
+                relative
+                    .strip_prefix("skills/")
+                    .and_then(|rest| rest.strip_suffix("/SKILL.md"))
+                    .map(str::to_string)
+            })
+            .collect();
+        shipped.sort();
+        let mut expected: Vec<String> = crate::hooks::CURSOR_PLUGIN_SKILLS
+            .iter()
+            .map(|skill| (*skill).to_string())
+            .collect();
+        expected.sort();
+        assert_eq!(
+            shipped, expected,
+            "Codex must embed exactly the model-invocable Cursor skills for parity"
+        );
+    }
+
+    /// Each Codex skill is a byte-identical mirror of its Cursor source so the
+    /// two host plugins never drift. Codex reads only the `name`/`description`
+    /// frontmatter for invocation and ignores extra keys, and the skill bodies
+    /// reference host-neutral `tracedecay_*` MCP tools, so the same content is
+    /// correct in both hosts. Intentional per-skill divergences must be listed
+    /// (with a reason) in `CODEX_SKILL_DIVERGENCES`.
+    #[test]
+    fn codex_skills_match_the_cursor_source_for_parity() {
+        // Skills deliberately specialized for Codex. Empty today — every shared
+        // skill is a verbatim mirror of the Cursor source.
+        const CODEX_SKILL_DIVERGENCES: &[&str] = &[];
+        let root = repo_root();
+        for &skill in crate::hooks::CURSOR_PLUGIN_SKILLS {
+            let codex_path = root
+                .join("codex-plugin/skills")
+                .join(skill)
+                .join("SKILL.md");
+            assert!(
+                codex_path.exists(),
+                "Codex plugin must ship the `{skill}` skill for parity with Cursor"
+            );
+            if CODEX_SKILL_DIVERGENCES.contains(&skill) {
+                continue;
+            }
+            let cursor_body = std::fs::read_to_string(
+                root.join("cursor-plugin/skills")
+                    .join(skill)
+                    .join("SKILL.md"),
+            )
+            .expect("cursor skill source should be readable");
+            let codex_body = std::fs::read_to_string(&codex_path)
+                .expect("codex skill source should be readable");
+            assert_eq!(
+                codex_body, cursor_body,
+                "Codex `{skill}` skill must mirror the Cursor source (add it to \
+                 CODEX_SKILL_DIVERGENCES if a host-specific version is intended)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Brings the Codex plugin to parity with the Cursor plugin for model-invocable tracedecay skills.

- **Codex now ships every model-invocable Cursor tracedecay skill** (24 total), byte-identical to the Cursor source, so both hosts steer agents toward the same `tracedecay_*` workflows (searching, reading-code-cheaply, architecture, impact, diff review, memory/session recall, etc.).
- **`src/agents/codex.rs`** embeds the new `SKILL.md` files in the binary — the release ships without the repo `codex-plugin/` tree, so the embedded list is the source of truth for installs.
- **`codex-plugin/README.md`** updated to document the bundled skills + lifecycle hooks and the `/hooks` trust step.
- **New coverage/parity tests** assert: the embedded file list covers the whole `codex-plugin/` source bundle; the bundle ships exactly the model-invocable Cursor skill set; and each Codex skill is byte-identical to its Cursor source (guarded by an explicit `CODEX_SKILL_DIVERGENCES` allowlist, empty today).

### Intentionally out of scope (Cursor-only surfaces)

- **Cursor `rules/`** has no Codex equivalent — that always-applied tool-routing steering is injected via the Codex `SessionStart`/`UserPromptSubmit` hooks instead.
- **Cursor slash dispatchers (`tracedecay-*`)** and explicit-invoke memory skills are not mirrored — Codex has no slash-command surface, and their workflows are covered by the shipped skills.

## Test plan

All run with an isolated `CARGO_TARGET_DIR` (per the repo cargo-contention policy), not the shared repo `target/`:

- [x] `cargo fmt --check` — clean
- [x] `cargo test --lib agents::codex::tests` — 3 passed (parity + bundle-coverage)
- [x] `cargo test --test agent_test codex` — 16 passed
- [x] `cargo test --test update_plugin_test codex` — 3 passed

## Operational notes

- Because skills are embedded in the binary, deployed installs need a **rebuilt/reinstalled binary** to pick up the new skills: `cargo install --path . --force` (refresh the on-PATH binary), then `tracedecay update-plugins` to refresh installed Codex plugin bundles. After that the installed Codex plugin advertises all 24 skills.
- Codex skips newly added/changed hooks until trusted — run `/hooks` in Codex to review and trust the tracedecay hooks.