### PR TITLE
chore(release): prepare v0.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
@@ -90,7 +89,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
@@ -167,7 +165,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-dashboard-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-dashboard-
@@ -257,7 +254,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-hermes-integration-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-hermes-integration-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,18 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo
+        uses: actions/cache@v4
         with:
-          prefix-key: v1-rust-test
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
 
       - name: Run tests
         run: cargo test --workspace
@@ -74,7 +83,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-
       - name: Run blocking Clippy policy
         run: cargo clippy --workspace --all-targets
 
@@ -133,15 +153,25 @@ jobs:
               exit 1
             fi
           done
+          # shellcheck disable=SC2086
           sha256sum $DASHBOARD_DIST_FILES > /tmp/dashboard-dist.sha
           npm run build
           sha256sum -c /tmp/dashboard-dist.sha
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo
+        uses: actions/cache@v4
         with:
-          prefix-key: v1-rust-dashboard
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-dashboard-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-dashboard-
+            ${{ runner.os }}-cargo-
 
       - name: Run dashboard integration tests
         run: cargo test --test dashboard_api_test
@@ -220,9 +250,18 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Cargo
+        uses: actions/cache@v4
         with:
-          prefix-key: v1-rust-hermes-integration
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-hermes-integration-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-hermes-integration-
+            ${{ runner.os }}-cargo-
 
       - name: Build tracedecay binary
         run: cargo build --bin tracedecay

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -69,6 +69,19 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-beta-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-beta-
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -8,8 +8,9 @@ name: Release (Beta)
 #      trigger.
 #   2. Removing the `BETA_CHANNEL_ENABLED` guard from every job (`if:`).
 #
-# While the guard is `false`, the workflow can still be exercised
-# manually via `workflow_dispatch` for debugging — the jobs simply skip.
+# While the repository variable is unset or not `true`, the workflow can still
+# be exercised manually via `workflow_dispatch` for debugging — the jobs simply
+# skip.
 on:
   workflow_dispatch:
 
@@ -20,14 +21,11 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Single toggle that gates every job in this workflow. Flip to `true`
-  # (or remove the guard from each `if:` line below) to re-enable.
-  BETA_CHANNEL_ENABLED: 'false'
 
 jobs:
   build:
     name: Build ${{ matrix.name }}
-    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease
+    if: vars.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -123,7 +121,7 @@ jobs:
 
   update-homebrew:
     name: Update Homebrew tap (beta)
-    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease && !cancelled()
+    if: vars.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease && !cancelled()
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -151,7 +149,6 @@ jobs:
 
       - name: Download source tarball
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           curl -sL "https://github.com/${{ github.repository }}/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz" -o "source.tar.gz"
 
       - name: Compute SHA256 hashes
@@ -197,7 +194,7 @@ jobs:
 
             depends_on "rust" => :build
 
-            conflicts_with "tracedecay", because: "both install a `tracedecay` binary"
+            conflicts_with "tracedecay", because: "both install a 'tracedecay' binary"
 
             def install
               system "cargo", "install", *std_cargo_args
@@ -218,7 +215,7 @@ jobs:
 
   update-scoop:
     name: Update Scoop bucket (beta)
-    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease && !cancelled()
+    if: vars.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease && !cancelled()
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -76,7 +76,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-beta-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-beta-

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -50,7 +50,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-release-plz-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-release-plz-release-
@@ -90,7 +89,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-cargo-release-plz-pr-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-release-plz-pr-

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -43,6 +43,19 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-plz-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-plz-release-
+            ${{ runner.os }}-cargo-
+
       - name: Run release-plz release
         uses: release-plz/action@v0.5
         with:
@@ -69,6 +82,19 @@ jobs:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-plz-pr-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-plz-pr-
+            ${{ runner.os }}-cargo-
 
       - name: Run release-plz release-pr
         uses: release-plz/action@v0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-release-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,19 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-release-
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.0.2] - 2026-06-18
+
 ### Changed
 - **Project renamed: TokenSave → TraceDecay.** The crate, binary, CLI command, and MCP server are now `tracedecay`, and the MCP tools are prefixed `tracedecay_*`. The data directory is now `.tracedecay/` (an existing `.tokensave/` directory is still honored as a fallback), and environment variables use the `TRACEDECAY_*` prefix (legacy `TOKENSAVE_*` variables are still honored as a fallback). All entries below predate the rename and intentionally retain the historical `tokensave`/`TokenSave` names.
 - **Version reset for the rebranded crate.** `tracedecay` now restarts at `0.0.2` as a fresh crate line; `0.0.1` is already occupied on crates.io by the name-reservation placeholder, so `0.0.2` is the first publishable release number.
@@ -1402,3 +1405,4 @@ tokensave sync --force           # re-index to pick up new language extractors
 - Core types and error handling scaffold
 [6.1.1]: https://github.com/ScriptedAlchemy/tokensave/releases/tag/v6.1.1
 [--help]: https://github.com/ScriptedAlchemy/tokensave/releases/tag/v--help
+[0.0.2]: https://github.com/ScriptedAlchemy/tracedecay/releases/tag/v0.0.2


### PR DESCRIPTION
## Summary

Prepares the first real TraceDecay crate release, `v0.0.2`.

## Notes

- Promotes the existing `[Unreleased]` changelog section to `[0.0.2] - 2026-06-18`.
- Uses the `release-plz-` branch prefix so the merged PR is recognized by release-plz's `release_always = false` release gate.
- `Cargo.toml` is already at `0.0.2`; local `cargo publish --dry-run --allow-dirty` already packaged `tracedecay v0.0.2` successfully.

## Expected after merge

Release-plz should publish `tracedecay v0.0.2` to crates.io via Trusted Publishing and create the `v0.0.2` GitHub Release, which then triggers binary/Homebrew/Scoop/server manifest release automation.