### PR TITLE
[codex] fix disabled beta release workflow

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -20,14 +20,14 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Single toggle that gates every job in this workflow. Flip to `true`
-  # (or remove the guard from each `if:` line below) to re-enable.
-  BETA_CHANNEL_ENABLED: 'false'
+  # Beta is also gated by the BETA_CHANNEL_ENABLED repository variable in
+  # every job below. Set that variable to `true` when restoring the release
+  # trigger, or remove the guards entirely.
 
 jobs:
   build:
     name: Build ${{ matrix.name }}
-    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease
+    if: vars.BETA_CHANNEL_ENABLED == 'true' && github.event_name == 'release' && github.event.release.prerelease
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -123,7 +123,7 @@ jobs:
 
   update-homebrew:
     name: Update Homebrew tap (beta)
-    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease && !cancelled()
+    if: vars.BETA_CHANNEL_ENABLED == 'true' && github.event_name == 'release' && github.event.release.prerelease && !cancelled()
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -218,7 +218,7 @@ jobs:
 
   update-scoop:
     name: Update Scoop bucket (beta)
-    if: env.BETA_CHANNEL_ENABLED == 'true' && github.event.release.prerelease && !cancelled()
+    if: vars.BETA_CHANNEL_ENABLED == 'true' && github.event_name == 'release' && github.event.release.prerelease && !cancelled()
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Fixes the disabled beta release workflow so pushes to `master` no longer produce an invalid zero-job workflow failure.

## Root Cause

`release-beta.yml` used the top-level `env` context inside job-level `if` expressions. GitHub does not allow `env` in job-level conditions, so the workflow failed before creating any jobs.

## Changes

- Replace the invalid `env.BETA_CHANNEL_ENABLED` job guards with a repository-variable guard using `vars.BETA_CHANNEL_ENABLED`.
- Keep beta disabled unless the repository variable is set to `true` and the release trigger is restored.
- Update the workflow comment so the re-enable path is clear.

## Validation

- Ran `actionlint .github/workflows/*.yml`.
- Parsed all workflow YAML files with PyYAML.
- Parsed `release-plz.toml` with `tomllib`.
- Ran `git diff --check`.