### PR TITLE
[codex] serialize release-plz jobs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -65,6 +65,7 @@ jobs:
   release-plz-pr:
     name: Open or update release PR
     if: github.repository == 'ScriptedAlchemy/tracedecay'
+    needs: release-plz-release
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Serializes the release-plz workflow so the release PR updater waits for the publish/release job.

## Root Cause

When PR #48 merged, `release-plz release` and `release-plz release-pr` ran concurrently. The release-pr job opened a duplicate `v0.0.2` PR (#51) before the publish/release path finished; that PR tried to delete old planning/spec docs and has been closed.

## Change

- Add `needs: release-plz-release` to the `release-plz-pr` job.

This preserves the normal flow on feature merges: the release job quickly skips non-release commits, then the release-pr job opens/updates the next release PR. On release-PR merges, it waits for publishing to complete first.

## Validation

- `actionlint .github/workflows/*.yml`
- parsed all workflow YAML files with PyYAML
- parsed `release-plz.toml` with `tomllib`
- `git diff --check`