### PR TITLE
ci: cancel superseded CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/src/sessions/lcm/gc.rs
+++ b/src/sessions/lcm/gc.rs
@@ -1678,9 +1678,13 @@ mod tests {
             "payload_2222222222222222222222222222222222222222222222222222222222222222.payload";
         fs::write(payload_path(&store, orphan_a), b"orphan-a").map_err(|err| err.to_string())?;
         fs::write(payload_path(&store, orphan_b), b"orphan-b").map_err(|err| err.to_string())?;
-        let oldest_mtime = file_mtime_seconds(
+        let orphan_a_mtime = file_mtime_seconds(
             &fs::symlink_metadata(payload_path(&store, orphan_a)).map_err(|err| err.to_string())?,
         );
+        let orphan_b_mtime = file_mtime_seconds(
+            &fs::symlink_metadata(payload_path(&store, orphan_b)).map_err(|err| err.to_string())?,
+        );
+        let newest_orphan_mtime = orphan_a_mtime.max(orphan_b_mtime);
         let cfg = LcmGcConfig {
             grace_seconds: LcmGcConfig::MIN_GRACE_SECONDS,
             backup_before_reap: false,
@@ -1694,7 +1698,7 @@ mod tests {
             None,
             &cfg,
             true,
-            oldest_mtime + LcmGcConfig::MIN_GRACE_SECONDS as i64,
+            newest_orphan_mtime + LcmGcConfig::MIN_GRACE_SECONDS as i64,
         )
         .await
         .map_err(|err| err.to_string())?;


### PR DESCRIPTION
## Summary
- add workflow-level concurrency to CI so stale runs for the same PR/branch are cancelled automatically
- stabilize the Windows GC test by advancing synthetic time from the newest orphan payload mtime
- leave release workflows untouched so publish jobs cannot be interrupted

## Root cause fixed
The latest master CI failed on Windows in `sessions::lcm::gc::tests::run_payload_gc_isolates_corrupted_ref_errors_while_reaping_orphans`: the test wrote two orphan files, then used only the first file mtime when advancing past the GC grace period. On Windows the second file can have a later timestamp tick, so only one orphan was old enough to reap.

## Validation
- `/tmp/tracedecay-tools/actionlint .github/workflows/*.yml`
- `python3` YAML parse for `.github/workflows/*.yml`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=.tracedecay/target/ci-concurrency cargo test sessions::lcm::gc::tests::run_payload_gc_isolates_corrupted_ref_errors_while_reaping_orphans`
- `gitleaks protect --source . --staged --redact --exit-code 2`

## Secret scan notes
- GitHub secret-scanning API reports 0 open alerts.
- Full gitleaks history scan reports 11 pre-existing fixture hits in redaction/hygiene tests/docs, not introduced by this PR.