### PR TITLE
fix(storage): stabilize profile storage workflows

### DIFF
--- a/src/dashboard/assets.rs
+++ b/src/dashboard/assets.rs
@@ -25,7 +25,7 @@ const INDEX_HTML: &str = r#"<!doctype html>
 
 const SHELL_JS: &[u8] = include_bytes!("../../dashboard/shell/dist/shell.js");
 const SHELL_CSS: &[u8] = include_bytes!("../../dashboard/shell/dist/shell.css");
-// Plugin bundles are embedded as &str (they are UTF-8 esbuild output) so the
+// Plugin bundles are embedded as &str (they are UTF-8 JavaScript output) so the
 // Hermes installer (src/agents/hermes/dashboard_wrapper.rs) can reuse the exact same
 // embedded data when writing the wrapper plugin's dist files to disk.
 pub(crate) const HOLOGRAPHIC_JS: &str = include_str!("../../dashboard/holographic/dist/index.js");

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -483,10 +483,7 @@ mod tests {
         let shard_root = profile_root.join(&shard_relpath);
         std::fs::create_dir_all(&project_root)?;
         std::fs::create_dir_all(&shard_root)?;
-        let profile_root = canonical_temp_path(&profile_root);
         let project_root = canonical_temp_path(&project_root);
-        let shard_root = crate::storage::profile_sharded_data_root(&profile_root, "proj_doctor");
-        std::fs::create_dir_all(&shard_root)?;
         std::fs::write(shard_root.join("tracedecay.db"), b"graph")?;
         let db = crate::global_db::GlobalDb::open_at(&dir.path().join("global.db"))
             .await

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -452,6 +452,17 @@ mod tests {
         }
     }
 
+    fn canonical_temp_path(path: &Path) -> PathBuf {
+        #[cfg(windows)]
+        {
+            path.to_path_buf()
+        }
+        #[cfg(not(windows))]
+        {
+            path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+        }
+    }
+
     #[test]
     fn format_bytes_boundaries() {
         assert_eq!(format_bytes(0), "0 B");

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -452,17 +452,6 @@ mod tests {
         }
     }
 
-    fn canonical_temp_path(path: &Path) -> PathBuf {
-        #[cfg(windows)]
-        {
-            path.to_path_buf()
-        }
-        #[cfg(not(windows))]
-        {
-            path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
-        }
-    }
-
     #[test]
     fn format_bytes_boundaries() {
         assert_eq!(format_bytes(0), "0 B");

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::{json, Value};
 
@@ -1594,6 +1594,93 @@ pub(super) async fn handle_todos(
     })
 }
 
+fn relative_source_key(path: &Path) -> Result<Option<String>> {
+    if path.is_absolute() {
+        return Ok(None);
+    }
+
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            _ => {
+                return Err(TraceDecayError::Config {
+                    message: format!("path '{}' contains unsafe components", path.display()),
+                });
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        return Err(TraceDecayError::Config {
+            message: "path must name a project file".to_string(),
+        });
+    }
+
+    Ok(Some(parts.join("/")))
+}
+
+fn absolute_source_key(project_root: &Path, path: &Path) -> Result<Option<String>> {
+    if !path.is_absolute() {
+        return Ok(None);
+    }
+    let Ok(relative) = path.strip_prefix(project_root) else {
+        return Ok(None);
+    };
+    relative_source_key(relative)
+}
+
+async fn resolve_indexed_source_file(cg: &TraceDecay, file: &str) -> Result<(PathBuf, String)> {
+    if file.contains('\0') {
+        return Err(TraceDecayError::Config {
+            message: "path contains NUL byte".to_string(),
+        });
+    }
+
+    let project_root = cg.project_root().to_path_buf();
+    let input = Path::new(file);
+
+    if let Ok(project_path) = ProjectPath::resolve(&project_root, input) {
+        let display_file = match relative_source_key(input)? {
+            Some(relative) => relative,
+            None => project_path.relative_path_string(),
+        };
+        return Ok((project_path.absolute_path(), display_file));
+    }
+
+    let display_file = if let Some(relative) = relative_source_key(input)? {
+        relative
+    } else if let Some(relative) = absolute_source_key(&project_root, input)? {
+        relative
+    } else {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "path '{}' escapes project root '{}'",
+                input.display(),
+                project_root.display()
+            ),
+        });
+    };
+
+    let nodes = cg.get_nodes_by_file(&display_file).await?;
+    if nodes.is_empty() {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "path '{}' escapes project root '{}' and is not indexed",
+                input.display(),
+                project_root.display()
+            ),
+        });
+    }
+
+    let abs_path = if input.is_absolute() {
+        input.to_path_buf()
+    } else {
+        project_root.join(input)
+    };
+    Ok((abs_path, display_file))
+}
+
 /// Handles `tracedecay_read` — mode-aware file read with cross-session cache.
 pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     use crate::context::read_cache::{self, GLOBAL_SESSION};
@@ -1630,11 +1717,9 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
         None
     };
 
+    let (abs_path, display_file) = resolve_indexed_source_file(cg, file).await?;
     let project_root = cg.project_root().to_path_buf();
     let project_id = project_root.to_string_lossy().to_string();
-    let project_path = ProjectPath::resolve(&project_root, std::path::Path::new(file))?;
-    let abs_path = project_path.absolute_path();
-    let display_file = project_path.relative_path_string();
 
     let mtime_ns = read_cache::file_mtime_ns(&abs_path).map_err(|e| TraceDecayError::Config {
         message: format!("cannot read file metadata for '{file}': {e}"),
@@ -1762,9 +1847,7 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
             .collect()
     });
 
-    let project_root = cg.project_root();
-    let project_path = ProjectPath::resolve(project_root, Path::new(file))?;
-    let display_file = project_path.relative_path_string();
+    let (_abs_path, display_file) = resolve_indexed_source_file(cg, file).await?;
 
     let kinds_slice: Option<&[String]> = kinds.as_deref();
     let value = render_map(cg.db(), &display_file, kinds_slice).await?;

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -1379,14 +1379,19 @@ pub(super) async fn handle_body(
 
     for result in &chosen {
         let n = &result.node;
-        let abs_path = project_root.join(&n.file_path);
-        let body = match crate::sync::read_source_file(&abs_path) {
-            Ok(source) => extract_lines(&source, n.start_line, n.end_line),
-            Err(_) => String::from("<file unreadable>"),
+        let project_path = ProjectPath::resolve(project_root, Path::new(&n.file_path));
+        let body = match project_path {
+            Ok(ref path) => match crate::sync::read_source_file(&path.absolute_path()) {
+                Ok(source) => {
+                    if !touched.contains(&n.file_path) {
+                        touched.push(n.file_path.clone());
+                    }
+                    extract_lines(&source, n.start_line, n.end_line)
+                }
+                Err(_) => String::from("<file unreadable>"),
+            },
+            Err(_) => String::from("<file path outside project>"),
         };
-        if !touched.contains(&n.file_path) {
-            touched.push(n.file_path.clone());
-        }
         matches.push(json!({
             "id": n.id,
             "name": n.name,
@@ -1533,8 +1538,10 @@ pub(super) async fn handle_todos(
                 continue;
             }
         }
-        let abs_path = project_root.join(&file.path);
-        let Ok(source) = crate::sync::read_source_file(&abs_path) else {
+        let Ok(project_path) = ProjectPath::resolve(project_root, Path::new(&file.path)) else {
+            continue;
+        };
+        let Ok(source) = crate::sync::read_source_file(&project_path.absolute_path()) else {
             continue;
         };
         // Cache nodes per file so enclosing-symbol lookup is one DB call per

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -2092,8 +2092,10 @@ impl TraceDecay {
     /// the wrong site.
     pub async fn replace_symbol(&self, symbol: &str, new_source: &str) -> Result<EditResult> {
         let target = resolve_symbol_for_edit(self, symbol).await?;
-        let rel_path = target.file_path.clone();
-        let abs_path = self.absolute_path(&rel_path);
+        let project_path =
+            crate::storage::ProjectPath::resolve(&self.project_root, Path::new(&target.file_path))?;
+        let rel_path = project_path.relative_path_string();
+        let abs_path = project_path.absolute_path();
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TraceDecayError::Config {
             message: format!("failed to read {rel_path}: {e}"),
         })?;
@@ -2162,8 +2164,10 @@ impl TraceDecay {
             }
         };
         let target = resolve_symbol_for_edit(self, symbol).await?;
-        let rel_path = target.file_path.clone();
-        let abs_path = self.absolute_path(&rel_path);
+        let project_path =
+            crate::storage::ProjectPath::resolve(&self.project_root, Path::new(&target.file_path))?;
+        let rel_path = project_path.relative_path_string();
+        let abs_path = project_path.absolute_path();
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TraceDecayError::Config {
             message: format!("failed to read {rel_path}: {e}"),
         })?;

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -2094,7 +2094,7 @@ impl TraceDecay {
         let target = resolve_symbol_for_edit(self, symbol).await?;
         let project_path =
             crate::storage::ProjectPath::resolve(&self.project_root, Path::new(&target.file_path))?;
-        let rel_path = project_path.relative_path_string();
+        let rel_path = target.file_path.clone();
         let abs_path = project_path.absolute_path();
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TraceDecayError::Config {
             message: format!("failed to read {rel_path}: {e}"),
@@ -2166,7 +2166,7 @@ impl TraceDecay {
         let target = resolve_symbol_for_edit(self, symbol).await?;
         let project_path =
             crate::storage::ProjectPath::resolve(&self.project_root, Path::new(&target.file_path))?;
-        let rel_path = project_path.relative_path_string();
+        let rel_path = target.file_path.clone();
         let abs_path = project_path.absolute_path();
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TraceDecayError::Config {
             message: format!("failed to read {rel_path}: {e}"),

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -10,7 +10,7 @@ use tracedecay::tracedecay::TraceDecay;
 
 fn git(project: &Path, args: &[&str]) {
     let output = Command::new("git")
-        .args(["-c", "core.hooksPath=/dev/null"])
+        .args(["-c", "core.hooksPath=.git/no-hooks"])
         .args(args)
         .current_dir(project)
         .output()

--- a/tests/branch_drift_test.rs
+++ b/tests/branch_drift_test.rs
@@ -12,7 +12,7 @@ use tracedecay::tracedecay::TraceDecay;
 
 fn git(project: &std::path::Path, args: &[&str]) {
     let status = Command::new("git")
-        .args(["-c", "core.hooksPath=/dev/null"])
+        .args(["-c", "core.hooksPath=.git/no-hooks"])
         .args(args)
         .current_dir(project)
         .output()

--- a/tests/global_registry_test.rs
+++ b/tests/global_registry_test.rs
@@ -1,7 +1,10 @@
 use std::path::Path;
 
 use tempfile::TempDir;
+use tokio::sync::Mutex;
 use tracedecay::global_db::{GlobalDb, GraphScopeUpsert, StoreArtifactUpsert, StoreInstanceUpsert};
+
+static GLOBAL_REGISTRY_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
 async fn table_exists(db_path: &Path, table: &str) -> bool {
     let db = libsql::Builder::new_local(db_path).build().await.unwrap();
@@ -31,6 +34,7 @@ async fn project_column_exists(db_path: &Path, column: &str) -> bool {
 
 #[tokio::test]
 async fn open_at_migrates_existing_project_rows_to_canonical_keys() {
+    let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("global.db");
     let project_root = dir.path().join("repo");
@@ -69,6 +73,7 @@ async fn open_at_migrates_existing_project_rows_to_canonical_keys() {
 
 #[tokio::test]
 async fn delete_project_paths_use_same_canonical_key_as_upsert() {
+    let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("global.db");
     let project_one = dir.path().join("repo-one");
@@ -92,6 +97,7 @@ async fn delete_project_paths_use_same_canonical_key_as_upsert() {
 
 #[tokio::test]
 async fn open_at_creates_registry_tables_and_round_trips_registry_records() {
+    let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("global.db");
     let project_root = dir.path().join("repo");
@@ -185,6 +191,7 @@ async fn open_at_creates_registry_tables_and_round_trips_registry_records() {
 
 #[tokio::test]
 async fn legacy_projects_tokens_saved_schema_and_queries_still_work() {
+    let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let db_path = dir.path().join("global.db");
     let project_one = dir.path().join("repo-one");

--- a/tests/hermes_dashboard_test.rs
+++ b/tests/hermes_dashboard_test.rs
@@ -202,7 +202,8 @@ fn deployed_bundles_match_embedded_standalone_assets() {
     let entry = read(&dist.join("index.js"));
     let css = read(&dist.join("style.css"));
 
-    assert!(holographic.contains("tracedecay holographic-memory dashboard plugin"));
+    assert!(holographic.contains(r#"register("holographic""#));
+    assert!(holographic.contains("/api/plugins/holographic"));
     assert!(entry.contains("\"tracedecay\""));
     // Wrapper chrome first, then the child stylesheets concatenated.
     assert!(css.starts_with("/* Wrapper chrome"));

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -2947,6 +2947,62 @@ async fn path_containment_read_rejects_parent_traversal_before_serving_file() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn read_and_outline_preserve_symlink_indexed_file_key() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let external = dir.path().join("external-src");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&external).unwrap();
+    fs::write(external.join("lib.rs"), "pub fn through_symlink() {}\n").unwrap();
+    unix_fs::symlink(&external, project.join("src")).unwrap();
+
+    let cg = TraceDecay::init(&project).await.unwrap();
+    cg.index_all().await.unwrap();
+
+    let read = handle_tool_call(
+        &cg,
+        "tracedecay_read",
+        json!({"file": "src/lib.rs", "mode": "full"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let read_text = extract_text(&read.value);
+    let read_payload: serde_json::Value = serde_json::from_str(read_text).unwrap();
+    assert_eq!(read_payload["file"], "src/lib.rs");
+    assert!(
+        read_payload["body"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("through_symlink"),
+        "read should serve indexed source behind symlink: {read_payload:?}"
+    );
+
+    let outline = handle_tool_call(
+        &cg,
+        "tracedecay_outline",
+        json!({"file": "src/lib.rs"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let outline_text = extract_text(&outline.value);
+    let outline_payload: serde_json::Value = serde_json::from_str(outline_text).unwrap();
+    assert_eq!(outline_payload["file"], "src/lib.rs");
+    assert!(
+        outline_payload["symbols"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|symbol| symbol["name"] == "through_symlink"),
+        "outline should query graph by indexed symlink path: {outline_payload:?}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn path_containment_config_rejects_symlink_escape_before_serving_config() {
     let dir = TempDir::new().unwrap();
     let project = dir.path().join("repo");

--- a/tests/migrate_inventory_test.rs
+++ b/tests/migrate_inventory_test.rs
@@ -61,6 +61,14 @@ fn same_path(left: &Path, right: &Path) -> bool {
     inventory_path(left) == inventory_path(right)
 }
 
+fn inventory_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn same_path(left: &Path, right: &Path) -> bool {
+    inventory_path(left) == inventory_path(right)
+}
+
 fn block_on_inventory(
     options: MigrationInventoryOptions,
 ) -> tracedecay::errors::Result<tracedecay::migrate::inventory::MigrationInventory> {

--- a/tests/migrate_inventory_test.rs
+++ b/tests/migrate_inventory_test.rs
@@ -61,14 +61,6 @@ fn same_path(left: &Path, right: &Path) -> bool {
     inventory_path(left) == inventory_path(right)
 }
 
-fn inventory_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
-}
-
-fn same_path(left: &Path, right: &Path) -> bool {
-    inventory_path(left) == inventory_path(right)
-}
-
 fn block_on_inventory(
     options: MigrationInventoryOptions,
 ) -> tracedecay::errors::Result<tracedecay::migrate::inventory::MigrationInventory> {


### PR DESCRIPTION
## Summary
- Complete profile storage migration, doctor, and MCP routing edge cases on top of the storage foundation.
- Add cross-platform fixture canonicalization and CI cache adjustments for reliable PR checks.
- Sync plugin project-status guidance with the new active-project and storage-status tools.

## Test plan
- cargo test --test cli_non_interactive_test --test storage_resolver_test --test profile_storage_migration_test --test migrate_inventory_test --test migration_manifest_test --test global_registry_test
- Included in the final focused storage stack verification.