### PR TITLE
fix(migrate): verify sqlite artifacts logically

### DIFF
--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -98,7 +98,7 @@ impl Database {
     /// Opens an existing database in read-only mode.
     ///
     /// This intentionally skips write-oriented PRAGMAs and migrations so
-    /// status/verification paths can inspect read-only SQLite files without
+    /// status/verification paths can inspect read-only `SQLite` files without
     /// creating WAL files or attempting schema updates.
     pub async fn open_read_only(db_path: &Path) -> Result<(Self, bool)> {
         let db = Builder::new_local(db_path)

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -1,7 +1,7 @@
 // Rust guideline compliant 2025-10-17
 use std::path::Path;
 
-use libsql::{Builder, Connection, Database as LibsqlDatabase};
+use libsql::{Builder, Connection, Database as LibsqlDatabase, OpenFlags};
 
 use crate::errors::{Result, TraceDecayError};
 
@@ -93,6 +93,32 @@ impl Database {
         let migrated = migrations::migrate(&conn).await?;
 
         Ok((Self { conn, _db: db }, migrated))
+    }
+
+    /// Opens an existing database in read-only mode.
+    ///
+    /// This intentionally skips write-oriented PRAGMAs and migrations so
+    /// status/verification paths can inspect read-only SQLite files without
+    /// creating WAL files or attempting schema updates.
+    pub async fn open_read_only(db_path: &Path) -> Result<(Self, bool)> {
+        let db = Builder::new_local(db_path)
+            .flags(OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .build()
+            .await
+            .map_err(|e| TraceDecayError::Database {
+                message: format!("failed to open database read-only: {e}"),
+                operation: "open_read_only".to_string(),
+            })?;
+
+        let conn = db.connect().map_err(|e| TraceDecayError::Database {
+            message: format!("failed to connect to database read-only: {e}"),
+            operation: "open_read_only".to_string(),
+        })?;
+
+        let file_size = std::fs::metadata(db_path).map_or(0, |m| m.len());
+        Self::apply_read_only_pragmas(&conn, file_size).await?;
+
+        Ok((Self { conn, _db: db }, false))
     }
 
     /// Returns a reference to the underlying libsql connection.
@@ -226,6 +252,23 @@ impl Database {
         .map_err(|e| TraceDecayError::Database {
             message: format!("failed to apply pragmas: {e}"),
             operation: "apply_pragmas".to_string(),
+        })?;
+        Ok(())
+    }
+
+    async fn apply_read_only_pragmas(conn: &Connection, db_file_size: u64) -> Result<()> {
+        let (cache_kb, mmap) = adaptive_cache_sizes(db_file_size);
+        conn.execute_batch(&format!(
+            "PRAGMA foreign_keys = ON;
+             PRAGMA busy_timeout = 120000;
+             PRAGMA cache_size = -{cache_kb};
+             PRAGMA temp_store = MEMORY;
+             PRAGMA mmap_size = {mmap};",
+        ))
+        .await
+        .map_err(|e| TraceDecayError::Database {
+            message: format!("failed to apply read-only pragmas: {e}"),
+            operation: "apply_read_only_pragmas".to_string(),
         })?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,7 +458,7 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
         } => {
             let project_path = tracedecay::config::resolve_path_with_discovery(path);
             let cg = if TraceDecay::is_initialized(&project_path) {
-                TraceDecay::open(&project_path).await?
+                TraceDecay::open_read_only(&project_path).await?
             } else if !io::stdin().is_terminal() {
                 eprintln!(
                     "No TraceDecay index found at '{}'. Non-interactive: skipping index creation (run `tracedecay init`).",

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,7 +458,10 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
         } => {
             let project_path = tracedecay::config::resolve_path_with_discovery(path);
             let cg = if TraceDecay::is_initialized(&project_path) {
-                TraceDecay::open_read_only(&project_path).await?
+                match TraceDecay::open(&project_path).await {
+                    Ok(cg) => cg,
+                    Err(_) => TraceDecay::open_read_only(&project_path).await?,
+                }
             } else if !io::stdin().is_terminal() {
                 eprintln!(
                     "No TraceDecay index found at '{}'. Non-interactive: skipping index creation (run `tracedecay init`).",

--- a/src/migrate/manifest.rs
+++ b/src/migrate/manifest.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 use std::fs;
-use std::io;
+use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 
+use libsql::{Builder, Connection, OpenFlags, Value};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::migrate::inventory::{MigrationInventory, StoreStatus};
 use crate::migrate::registry::{
@@ -143,6 +145,21 @@ pub struct MigrationExportReport {
 pub struct MigrationCleanupSourcesReport {
     pub migration_id: String,
     pub removed_artifacts: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SqliteLogicalSummary {
+    user_version: i64,
+    schema: Vec<String>,
+    tables: Vec<SqliteTableSummary>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SqliteTableSummary {
+    name: String,
+    columns: Vec<String>,
+    row_count: u64,
+    checksum: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -969,6 +986,9 @@ fn verify_artifact_contents(source: &Path, target: &Path) -> io::Result<()> {
     if !source_meta.is_file() || !target_meta.is_file() {
         return Err(invalid_manifest("migration artifact is not a regular file"));
     }
+    if is_sqlite_database_file(source)? && is_sqlite_database_file(target)? {
+        return verify_sqlite_artifact_contents(source, target);
+    }
     if fs::read(source)? != fs::read(target)? {
         return Err(invalid_manifest(&format!(
             "migration target '{}' differs from source '{}'",
@@ -977,6 +997,347 @@ fn verify_artifact_contents(source: &Path, target: &Path) -> io::Result<()> {
         )));
     }
     Ok(())
+}
+
+fn is_sqlite_database_file(path: &Path) -> io::Result<bool> {
+    let mut file = fs::File::open(path)?;
+    let mut header = [0_u8; 16];
+    match file.read_exact(&mut header) {
+        Ok(()) => Ok(header == *b"SQLite format 3\0"),
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn verify_sqlite_artifact_contents(source: &Path, target: &Path) -> io::Result<()> {
+    let source = source.to_path_buf();
+    let target = target.to_path_buf();
+    let worker = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(io::Error::other)?;
+        runtime.block_on(async {
+            let source_summary = summarize_sqlite_database(&source).await?;
+            let target_summary = summarize_sqlite_database(&target).await?;
+            Ok::<_, io::Error>((source, target, source_summary, target_summary))
+        })
+    });
+    let (source, target, source_summary, target_summary) = worker
+        .join()
+        .map_err(|_| invalid_manifest("SQLite logical verification thread panicked"))??;
+    if source_summary != target_summary {
+        return Err(invalid_manifest(&format!(
+            "SQLite logical verification failed for target '{}' against source '{}'",
+            target.display(),
+            source.display()
+        )));
+    }
+    Ok(())
+}
+
+async fn summarize_sqlite_database(path: &Path) -> io::Result<SqliteLogicalSummary> {
+    let db = Builder::new_local(path)
+        .flags(OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .build()
+        .await
+        .map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to open SQLite DB '{}': {e}",
+                path.display()
+            ))
+        })?;
+    let conn = db.connect().map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to connect to SQLite DB '{}': {e}",
+            path.display()
+        ))
+    })?;
+    if !sqlite_quick_check(&conn, path).await? {
+        return Err(invalid_manifest(&format!(
+            "SQLite quick_check failed for '{}'",
+            path.display()
+        )));
+    }
+    let user_version = sqlite_i64(&conn, "PRAGMA user_version", path).await?;
+    let schema = sqlite_schema_summary(&conn, path).await?;
+    let tables = sqlite_table_summaries(&conn, path).await?;
+    Ok(SqliteLogicalSummary {
+        user_version,
+        schema,
+        tables,
+    })
+}
+
+async fn sqlite_quick_check(conn: &Connection, path: &Path) -> io::Result<bool> {
+    let mut rows = conn.query("PRAGMA quick_check", ()).await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to run quick_check on '{}': {e}",
+            path.display()
+        ))
+    })?;
+    let Some(row) = rows.next().await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to read quick_check result for '{}': {e}",
+            path.display()
+        ))
+    })?
+    else {
+        return Ok(false);
+    };
+    let result = row.get::<String>(0).map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to decode quick_check result for '{}': {e}",
+            path.display()
+        ))
+    })?;
+    Ok(result == "ok")
+}
+
+async fn sqlite_i64(conn: &Connection, sql: &str, path: &Path) -> io::Result<i64> {
+    let mut rows = conn.query(sql, ()).await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to query SQLite metadata for '{}': {e}",
+            path.display()
+        ))
+    })?;
+    let Some(row) = rows.next().await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to read SQLite metadata for '{}': {e}",
+            path.display()
+        ))
+    })?
+    else {
+        return Err(invalid_manifest(&format!(
+            "SQLite metadata query returned no rows for '{}'",
+            path.display()
+        )));
+    };
+    row.get::<i64>(0).map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to decode SQLite metadata for '{}': {e}",
+            path.display()
+        ))
+    })
+}
+
+async fn sqlite_schema_summary(conn: &Connection, path: &Path) -> io::Result<Vec<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT type, name, tbl_name, COALESCE(sql, '')
+             FROM sqlite_schema
+             WHERE name NOT LIKE 'sqlite_%'
+             ORDER BY type, name, tbl_name, sql",
+            (),
+        )
+        .await
+        .map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to read SQLite schema for '{}': {e}",
+                path.display()
+            ))
+        })?;
+    let mut schema = Vec::new();
+    while let Some(row) = rows.next().await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to read SQLite schema row for '{}': {e}",
+            path.display()
+        ))
+    })? {
+        let name = row.get::<String>(1).map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to decode SQLite schema name for '{}': {e}",
+                path.display()
+            ))
+        })?;
+        if is_fts_shadow_table(&name) {
+            continue;
+        }
+        let entry = format!(
+            "{}\x1f{}\x1f{}\x1f{}",
+            row.get::<String>(0).map_err(|e| invalid_manifest(&format!(
+                "failed to decode SQLite schema type for '{}': {e}",
+                path.display()
+            )))?,
+            name,
+            row.get::<String>(2).map_err(|e| invalid_manifest(&format!(
+                "failed to decode SQLite schema table for '{}': {e}",
+                path.display()
+            )))?,
+            row.get::<String>(3).map_err(|e| invalid_manifest(&format!(
+                "failed to decode SQLite schema SQL for '{}': {e}",
+                path.display()
+            )))?
+        );
+        schema.push(entry);
+    }
+    Ok(schema)
+}
+
+async fn sqlite_table_summaries(
+    conn: &Connection,
+    path: &Path,
+) -> io::Result<Vec<SqliteTableSummary>> {
+    let mut rows = conn
+        .query(
+            "SELECT name, COALESCE(sql, '')
+             FROM sqlite_schema
+             WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+             ORDER BY name",
+            (),
+        )
+        .await
+        .map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to list SQLite tables for '{}': {e}",
+                path.display()
+            ))
+        })?;
+    let mut tables = Vec::new();
+    while let Some(row) = rows.next().await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to read SQLite table row for '{}': {e}",
+            path.display()
+        ))
+    })? {
+        let name = row.get::<String>(0).map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to decode SQLite table name for '{}': {e}",
+                path.display()
+            ))
+        })?;
+        let sql = row.get::<String>(1).map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to decode SQLite table SQL for '{}': {e}",
+                path.display()
+            ))
+        })?;
+        if is_fts_shadow_table(&name) || is_virtual_table_sql(&sql) {
+            continue;
+        }
+        tables.push(sqlite_table_summary(conn, path, &name).await?);
+    }
+    Ok(tables)
+}
+
+async fn sqlite_table_summary(
+    conn: &Connection,
+    path: &Path,
+    table: &str,
+) -> io::Result<SqliteTableSummary> {
+    let columns = sqlite_table_columns(conn, path, table).await?;
+    let mut checksum = Sha256::new();
+    checksum.update(table.as_bytes());
+    for column in &columns {
+        checksum.update(b"\x1f");
+        checksum.update(column.as_bytes());
+    }
+    let mut row_count = 0_u64;
+    if !columns.is_empty() {
+        let column_list = columns
+            .iter()
+            .map(|column| quote_sqlite_identifier(column))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT {column_list} FROM {} ORDER BY {column_list}",
+            quote_sqlite_identifier(table)
+        );
+        let mut rows = conn.query(&sql, ()).await.map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to read SQLite table '{}' from '{}': {e}",
+                table,
+                path.display()
+            ))
+        })?;
+        while let Some(row) = rows.next().await.map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to read SQLite row from table '{}' in '{}': {e}",
+                table,
+                path.display()
+            ))
+        })? {
+            row_count = row_count.saturating_add(1);
+            for index in 0..columns.len() {
+                let index = i32::try_from(index).map_err(|e| {
+                    invalid_manifest(&format!(
+                        "too many SQLite columns in table '{}' in '{}': {e}",
+                        table,
+                        path.display()
+                    ))
+                })?;
+                let value = row.get::<Value>(index).map_err(|e| {
+                    invalid_manifest(&format!(
+                        "failed to decode SQLite row from table '{}' in '{}': {e}",
+                        table,
+                        path.display()
+                    ))
+                })?;
+                checksum.update(sqlite_value_fingerprint(value).as_bytes());
+                checksum.update(b"\x1e");
+            }
+        }
+    }
+    Ok(SqliteTableSummary {
+        name: table.to_string(),
+        columns,
+        row_count,
+        checksum: hex::encode(checksum.finalize()),
+    })
+}
+
+async fn sqlite_table_columns(
+    conn: &Connection,
+    path: &Path,
+    table: &str,
+) -> io::Result<Vec<String>> {
+    let sql = format!("PRAGMA table_info({})", quote_sqlite_identifier(table));
+    let mut rows = conn.query(&sql, ()).await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to inspect SQLite table '{}' in '{}': {e}",
+            table,
+            path.display()
+        ))
+    })?;
+    let mut columns = Vec::new();
+    while let Some(row) = rows.next().await.map_err(|e| {
+        invalid_manifest(&format!(
+            "failed to read SQLite table info for '{}' in '{}': {e}",
+            table,
+            path.display()
+        ))
+    })? {
+        columns.push(row.get::<String>(1).map_err(|e| {
+            invalid_manifest(&format!(
+                "failed to decode SQLite column name for '{}' in '{}': {e}",
+                table,
+                path.display()
+            ))
+        })?);
+    }
+    Ok(columns)
+}
+
+fn is_fts_shadow_table(name: &str) -> bool {
+    name.contains("_fts_")
+}
+
+fn is_virtual_table_sql(sql: &str) -> bool {
+    sql.to_ascii_uppercase().contains("VIRTUAL TABLE")
+}
+
+fn quote_sqlite_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn sqlite_value_fingerprint(value: Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Integer(value) => format!("integer:{value}"),
+        Value::Real(value) => format!("real:{:016x}", value.to_bits()),
+        Value::Text(value) => format!("text:{}:{value}", value.len()),
+        Value::Blob(value) => format!("blob:{}:{}", value.len(), hex::encode(value)),
+    }
 }
 
 fn verify_directory_contents(source: &Path, target: &Path) -> io::Result<()> {

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -481,6 +481,45 @@ impl TraceDecay {
         Ok(ts)
     }
 
+    /// Opens an existing project for read-only inspection.
+    ///
+    /// Unlike [`Self::open`], this does not run migrations, repair dirty
+    /// sentinels, clear markers, or rewrite corrupted DBs. It is intended for
+    /// status/verification commands that must be able to inspect read-only
+    /// stores without mutating them.
+    pub async fn open_read_only(project_root: &Path) -> Result<Self> {
+        let store_layout = storage::resolve_layout_for_current_profile(project_root)?;
+        let config = load_config_from_path(project_root, &store_layout.config_path)?;
+        let active_branch = branch::current_branch(project_root);
+
+        let (db_path, serving_branch, fallback_warning) = Self::resolve_db_for_branch(
+            project_root,
+            &store_layout.data_root,
+            active_branch.as_deref(),
+        );
+
+        if !db_path.exists() {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "no TraceDecay database found at '{}'; run 'tracedecay init' first",
+                    db_path.display()
+                ),
+            });
+        }
+
+        let (db, _) = Database::open_read_only(&db_path).await?;
+        Ok(Self {
+            db,
+            config,
+            project_root: project_root.to_path_buf(),
+            store_layout,
+            registry: LanguageRegistry::new(),
+            active_branch,
+            serving_branch,
+            fallback_warning,
+        })
+    }
+
     /// Resolves which DB file to open for a given branch.
     ///
     /// Returns `(db_path, serving_branch, fallback_warning)`.

--- a/tests/cli_non_interactive_test.rs
+++ b/tests/cli_non_interactive_test.rs
@@ -2,8 +2,11 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
 use tracedecay::branch_meta::BranchMeta;
+use tracedecay::db::Database;
 use tracedecay::global_db::{GlobalDb, StoreInstanceUpsert};
 use tracedecay::migrate::inventory::MigrationInventory;
 use tracedecay::migrate::manifest::{
@@ -14,6 +17,7 @@ use tracedecay::storage::{
     read_enrollment_marker, write_enrollment_marker, EnrollmentMarker, StorageMode, StoreKind,
     StoreManifest, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
 };
+use tracedecay::types::{Node, NodeKind, Visibility};
 
 fn canonical_temp_path(path: &Path) -> PathBuf {
     #[cfg(windows)]
@@ -105,6 +109,34 @@ fn write_sqlite_placeholder(path: &Path) {
             .await
             .unwrap();
     });
+}
+
+fn sample_node(id: &str, name: &str) -> Node {
+    Node {
+        id: id.to_string(),
+        kind: NodeKind::Function,
+        name: name.to_string(),
+        qualified_name: format!("crate::{name}"),
+        file_path: "src/lib.rs".to_string(),
+        start_line: 1,
+        attrs_start_line: 1,
+        end_line: 3,
+        start_column: 0,
+        end_column: 1,
+        signature: Some(format!("fn {name}()")),
+        docstring: None,
+        visibility: Visibility::Pub,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 1_800_000_000,
+        parent_id: None,
+    }
 }
 
 async fn register_profile_sharded_store(
@@ -286,6 +318,36 @@ fn status_skips_create_prompt_when_stdin_not_a_terminal() {
         stderr.contains("Non-interactive: skipping index creation"),
         "stderr should explain the non-interactive default\nstderr:\n{stderr}"
     );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn status_json_reads_readonly_project_database() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let db_path = project.path().join(".tracedecay/tracedecay.db");
+    let (db, _) = Database::initialize(&db_path).await.unwrap();
+    db.insert_node(&sample_node("node-1", "process_data"))
+        .await
+        .unwrap();
+    db.checkpoint().await.unwrap();
+    db.close();
+    let mut permissions = std::fs::metadata(&db_path).unwrap().permissions();
+    permissions.set_mode(0o444);
+    std::fs::set_permissions(&db_path, permissions).unwrap();
+
+    let mut command = tracedecay_command(home.path(), project.path());
+    command.args(["status", "--json"]);
+    let output = run_with_timeout(command, Duration::from_secs(30));
+
+    assert!(
+        output.status.success(),
+        "status --json should read readonly DB\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["node_count"], 1);
 }
 
 #[tokio::test]

--- a/tests/cli_non_interactive_test.rs
+++ b/tests/cli_non_interactive_test.rs
@@ -2,6 +2,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+mod common;
+
+use common::sample_node;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
@@ -17,7 +20,6 @@ use tracedecay::storage::{
     read_enrollment_marker, write_enrollment_marker, EnrollmentMarker, StorageMode, StoreKind,
     StoreManifest, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
 };
-use tracedecay::types::{Node, NodeKind, Visibility};
 
 fn canonical_temp_path(path: &Path) -> PathBuf {
     #[cfg(windows)]
@@ -109,34 +111,6 @@ fn write_sqlite_placeholder(path: &Path) {
             .await
             .unwrap();
     });
-}
-
-fn sample_node(id: &str, name: &str) -> Node {
-    Node {
-        id: id.to_string(),
-        kind: NodeKind::Function,
-        name: name.to_string(),
-        qualified_name: format!("crate::{name}"),
-        file_path: "src/lib.rs".to_string(),
-        start_line: 1,
-        attrs_start_line: 1,
-        end_line: 3,
-        start_column: 0,
-        end_column: 1,
-        signature: Some(format!("fn {name}()")),
-        docstring: None,
-        visibility: Visibility::Pub,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 1_800_000_000,
-        parent_id: None,
-    }
 }
 
 async fn register_profile_sharded_store(
@@ -327,7 +301,7 @@ async fn status_json_reads_readonly_project_database() {
     let project = TempDir::new().unwrap();
     let db_path = project.path().join(".tracedecay/tracedecay.db");
     let (db, _) = Database::initialize(&db_path).await.unwrap();
-    db.insert_node(&sample_node("node-1", "process_data"))
+    db.insert_node(&sample_node("node-1", "process_data", "src/lib.rs"))
         .await
         .unwrap();
     db.checkpoint().await.unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use tempfile::TempDir;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
+use tracedecay::types::{Node, NodeKind, Visibility};
 
 /// Sets (or removes) an environment variable for its lifetime, restoring the
 /// previous value on drop.
@@ -53,6 +54,34 @@ pub fn tempdir_or_panic() -> TempDir {
     match TempDir::new() {
         Ok(dir) => dir,
         Err(err) => panic!("failed to create temp dir: {err}"),
+    }
+}
+
+pub fn sample_node(id: &str, name: &str, file_path: &str) -> Node {
+    Node {
+        id: id.to_string(),
+        kind: NodeKind::Function,
+        name: name.to_string(),
+        qualified_name: format!("crate::{name}"),
+        file_path: file_path.to_string(),
+        start_line: 1,
+        attrs_start_line: 1,
+        end_line: 3,
+        start_column: 0,
+        end_column: 1,
+        signature: Some(format!("fn {name}()")),
+        docstring: None,
+        visibility: Visibility::Pub,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 1_800_000_000,
+        parent_id: None,
     }
 }
 

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
 use tracedecay::db::Database;
 use tracedecay::types::*;
@@ -53,6 +55,39 @@ async fn test_initialize_creates_database() {
         db_path.exists(),
         "database file should exist after initialize"
     );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_open_read_only_reads_existing_database_without_write_pragmas() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let db_path = dir.path().join("code_graph.db");
+    let (db, _) = Database::initialize(&db_path)
+        .await
+        .expect("failed to initialize database");
+    db.insert_node(&sample_node("node-1", "process_data", "src/main.rs"))
+        .await
+        .expect("failed to insert node");
+    db.checkpoint()
+        .await
+        .expect("failed to checkpoint database");
+    db.close();
+    let mut permissions = std::fs::metadata(&db_path)
+        .expect("failed to stat database")
+        .permissions();
+    permissions.set_mode(0o444);
+    std::fs::set_permissions(&db_path, permissions).expect("failed to mark database readonly");
+
+    let (db, migrated) = Database::open_read_only(&db_path)
+        .await
+        .expect("readonly database should open");
+    let stats = db
+        .get_stats()
+        .await
+        .expect("readonly stats should be available");
+
+    assert!(!migrated);
+    assert_eq!(stats.node_count, 1);
 }
 
 #[tokio::test]

--- a/tests/migration_manifest_test.rs
+++ b/tests/migration_manifest_test.rs
@@ -2,6 +2,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+mod common;
+
+use common::sample_node;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
 use tempfile::TempDir;
@@ -21,7 +24,6 @@ use tracedecay::storage::{
     read_enrollment_marker, read_store_manifest, write_enrollment_marker, EnrollmentMarker,
     StorageMode, StoreKind, StoreManifest, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
 };
-use tracedecay::types::{Node, NodeKind, Visibility};
 
 fn empty_inventory() -> MigrationInventory {
     MigrationInventory {
@@ -50,34 +52,6 @@ fn canonical_temp_path(path: &Path) -> PathBuf {
     #[cfg(not(windows))]
     {
         path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
-    }
-}
-
-fn sample_node(id: &str, name: &str) -> Node {
-    Node {
-        id: id.to_string(),
-        kind: NodeKind::Function,
-        name: name.to_string(),
-        qualified_name: format!("crate::{name}"),
-        file_path: "src/lib.rs".to_string(),
-        start_line: 1,
-        attrs_start_line: 1,
-        end_line: 3,
-        start_column: 0,
-        end_column: 1,
-        signature: Some(format!("fn {name}()")),
-        docstring: None,
-        visibility: Visibility::Pub,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 1_800_000_000,
-        parent_id: None,
     }
 }
 
@@ -494,7 +468,7 @@ async fn verify_manifest_accepts_logically_equal_sqlite_artifacts_with_different
         .await
         .unwrap();
     source
-        .insert_node(&sample_node("node-1", "process_data"))
+        .insert_node(&sample_node("node-1", "process_data", "src/lib.rs"))
         .await
         .unwrap();
     source.checkpoint().await.unwrap();
@@ -504,7 +478,7 @@ async fn verify_manifest_accepts_logically_equal_sqlite_artifacts_with_different
         .await
         .unwrap();
     target
-        .insert_node(&sample_node("node-extra", "deleted_later"))
+        .insert_node(&sample_node("node-extra", "deleted_later", "src/lib.rs"))
         .await
         .unwrap();
     target
@@ -516,7 +490,7 @@ async fn verify_manifest_accepts_logically_equal_sqlite_artifacts_with_different
         .await
         .unwrap();
     target
-        .insert_node(&sample_node("node-1", "process_data"))
+        .insert_node(&sample_node("node-1", "process_data", "src/lib.rs"))
         .await
         .unwrap();
     target.checkpoint().await.unwrap();

--- a/tests/migration_manifest_test.rs
+++ b/tests/migration_manifest_test.rs
@@ -18,9 +18,10 @@ use tracedecay::migrate::manifest::{
     MigrationRollbackState, MIGRATION_MANIFEST_SCHEMA_VERSION,
 };
 use tracedecay::storage::{
-    read_enrollment_marker, read_store_manifest, StorageMode, StoreKind, StoreManifest,
-    STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
+    read_enrollment_marker, read_store_manifest, write_enrollment_marker, EnrollmentMarker,
+    StorageMode, StoreKind, StoreManifest, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
 };
+use tracedecay::types::{Node, NodeKind, Visibility};
 
 fn empty_inventory() -> MigrationInventory {
     MigrationInventory {
@@ -49,6 +50,34 @@ fn canonical_temp_path(path: &Path) -> PathBuf {
     #[cfg(not(windows))]
     {
         path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+fn sample_node(id: &str, name: &str) -> Node {
+    Node {
+        id: id.to_string(),
+        kind: NodeKind::Function,
+        name: name.to_string(),
+        qualified_name: format!("crate::{name}"),
+        file_path: "src/lib.rs".to_string(),
+        start_line: 1,
+        attrs_start_line: 1,
+        end_line: 3,
+        start_column: 0,
+        end_column: 1,
+        signature: Some(format!("fn {name}()")),
+        docstring: None,
+        visibility: Visibility::Pub,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 1_800_000_000,
+        parent_id: None,
     }
 }
 
@@ -445,6 +474,124 @@ fn verify_manifest_validates_profile_store_manifest_registry_records() {
     assert_eq!(report.store_manifest_count, 1);
     assert_eq!(report.registry_plan_count, 1);
     assert!(!report.apply_supported);
+    assert!(report.issues.is_empty(), "{:?}", report.issues);
+}
+
+#[tokio::test]
+async fn verify_manifest_accepts_logically_equal_sqlite_artifacts_with_different_bytes() {
+    let dir = TempDir::new().unwrap();
+    let root = canonical_temp_path(dir.path());
+    let project = root.join("repo");
+    let data_dir = project.join(".tracedecay");
+    let source_db = data_dir.join("tracedecay.db");
+    let profile_root = root.join("profile");
+    let data_root = profile_root.join("projects/proj_123");
+    let target_db = data_root.join("tracedecay.db");
+    fs::create_dir_all(&data_dir).unwrap();
+    fs::create_dir_all(&data_root).unwrap();
+
+    let (source, _) = tracedecay::db::Database::initialize(&source_db)
+        .await
+        .unwrap();
+    source
+        .insert_node(&sample_node("node-1", "process_data"))
+        .await
+        .unwrap();
+    source.checkpoint().await.unwrap();
+    source.close();
+
+    let (target, _) = tracedecay::db::Database::initialize(&target_db)
+        .await
+        .unwrap();
+    target
+        .insert_node(&sample_node("node-extra", "deleted_later"))
+        .await
+        .unwrap();
+    target
+        .conn()
+        .execute(
+            "DELETE FROM nodes WHERE id = ?1",
+            libsql::params!["node-extra"],
+        )
+        .await
+        .unwrap();
+    target
+        .insert_node(&sample_node("node-1", "process_data"))
+        .await
+        .unwrap();
+    target.checkpoint().await.unwrap();
+    target.close();
+    assert_ne!(fs::read(&source_db).unwrap(), fs::read(&target_db).unwrap());
+
+    fs::write(
+        data_root.join("branch-meta.json"),
+        r#"{"default_branch":"main","branches":{}}"#,
+    )
+    .unwrap();
+    fs::write(data_root.join("sessions.db"), b"sessions").unwrap();
+    let store_manifest = StoreManifest {
+        schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+        project_id: Some("proj_123".to_string()),
+        store_kind: StoreKind::CodeProject,
+        storage_mode: StorageMode::ProfileSharded,
+        project_root: project.clone(),
+        data_root: data_root.clone(),
+        graph_db_relpath: "tracedecay.db".into(),
+        sessions_db_relpath: "sessions.db".into(),
+        branch_meta_relpath: "branch-meta.json".into(),
+    };
+    let store_manifest_path = data_root.join(STORE_MANIFEST_FILENAME);
+    fs::write(
+        &store_manifest_path,
+        serde_json::to_string_pretty(&store_manifest).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        data_dir.join(STORE_MANIFEST_FILENAME),
+        serde_json::to_string_pretty(&store_manifest).unwrap(),
+    )
+    .unwrap();
+    write_enrollment_marker(
+        &project,
+        &EnrollmentMarker {
+            project_id: "proj_123".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let protocol = MigrationProtocol::for_manifest(root.join("manifest.json"), "mig_123");
+    let mut manifest = MigrationManifest::new(
+        "mig_123",
+        "0.0.2",
+        1_800_000_000,
+        "confirm-mig_123",
+        protocol,
+        MigrationInventory {
+            stores: Vec::new(),
+            skipped: Vec::new(),
+            global_db: None,
+        },
+    );
+    manifest.source.project_root = Some(project);
+    manifest.source.data_dir = Some(data_dir.clone());
+    manifest.destination.profile_root = Some(profile_root);
+    manifest.destination.project_id = Some("proj_123".to_string());
+    manifest.artifacts.push(MigrationArtifact {
+        kind: "graph_db".to_string(),
+        source_path: source_db,
+        target_path: Some(target_db),
+        state: ArtifactState::Applied,
+    });
+    manifest.artifacts.push(MigrationArtifact {
+        kind: "store_manifest".to_string(),
+        source_path: data_dir.join("store_manifest.json"),
+        target_path: Some(store_manifest_path),
+        state: ArtifactState::Applied,
+    });
+
+    let report = verify_migration_manifest(&manifest);
+
+    assert!(report.apply_supported, "{:?}", report.issues);
     assert!(report.issues.is_empty(), "{:?}", report.issues);
 }
 

--- a/tests/session_global_db_test.rs
+++ b/tests/session_global_db_test.rs
@@ -28,7 +28,11 @@ async fn raw_message_count(db_path: &std::path::Path, provider: &str, message_id
         )
         .await
         .unwrap();
-    rows.next().await.unwrap().unwrap().get(0).unwrap()
+    let count = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    drop(rows);
+    drop(conn);
+    drop(db);
+    count
 }
 
 async fn raw_snippet_and_index(
@@ -48,7 +52,11 @@ async fn raw_snippet_and_index(
         .await
         .unwrap();
     let row = rows.next().await.unwrap().unwrap();
-    (row.get(0).unwrap(), row.get(1).unwrap())
+    let snippet_and_index = (row.get(0).unwrap(), row.get(1).unwrap());
+    drop(rows);
+    drop(conn);
+    drop(db);
+    snippet_and_index
 }
 
 async fn lcm_fts_count(db_path: &std::path::Path, query: &str) -> i64 {
@@ -63,7 +71,11 @@ async fn lcm_fts_count(db_path: &std::path::Path, query: &str) -> i64 {
         )
         .await
         .unwrap();
-    rows.next().await.unwrap().unwrap().get(0).unwrap()
+    let count = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    drop(rows);
+    drop(conn);
+    drop(db);
+    count
 }
 
 #[tokio::test]
@@ -199,6 +211,8 @@ async fn upsert_session_message_rolls_back_raw_when_projection_fails() {
         )
         .await
         .unwrap();
+    drop(trigger_conn);
+    drop(trigger_db);
 
     let message = sample_message(
         "cursor",


### PR DESCRIPTION
## Summary
- Open status databases read-only so status checks work against immutable/read-only stores.
- Verify migrated SQLite artifacts by quick_check, schema, row counts, and deterministic checksums instead of byte-for-byte file layout.
- Add regressions for read-only status and logical SQLite migration verification.

## Test plan
- cargo test --test db_test --test migration_manifest_test --test cli_non_interactive_test --test storage_resolver_test --test profile_storage_migration_test --test migrate_inventory_test --test global_registry_test