### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.4...v0.0.5) - 2026-06-20
+
+### Fixed
+
+- *(dashboard)* refresh shell source stamp
+- *(branch)* harden auto tracking under contention
+- *(branch)* auto-track active tracedecay branches
+- *(dashboard)* tighten dist freshness checks
+- *(build)* refresh dashboard deps during auto rebuilds
+
+### Other
+
+- *(dashboard)* trim primitive comments
+- *(dashboard)* real React imports, stale-dist build guard
+
 ## [0.0.4](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.3...v0.0.4) - 2026-06-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,7 +4499,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"

--- a/cursor-plugin/.cursor-plugin/plugin.json
+++ b/cursor-plugin/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tracedecay",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Cursor integration for the TraceDecay semantic code intelligence MCP server.",
   "author": {
     "name": "ScriptedAlchemy",


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.4 -> 0.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.5](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.4...v0.0.5) - 2026-06-20

### Fixed

- *(dashboard)* refresh shell source stamp
- *(branch)* harden auto tracking under contention
- *(branch)* auto-track active tracedecay branches
- *(dashboard)* tighten dist freshness checks
- *(build)* refresh dashboard deps during auto rebuilds

### Other

- *(dashboard)* trim primitive comments
- *(dashboard)* real React imports, stale-dist build guard
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).