### PR TITLE
ci: avoid redundant dashboard builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
   test:
@@ -35,18 +37,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: dashboard/package-lock.json
-
-      - name: Build dashboard assets
-        working-directory: dashboard
-        run: |
-          npm ci
-          npm run build
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -71,18 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: dashboard/package-lock.json
-
-      - name: Build dashboard assets
-        working-directory: dashboard
-        run: |
-          npm ci
-          npm run build
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -241,18 +219,6 @@ jobs:
       HERMES_UPSTREAM_REF: 9dd9ef0ec99a87f078f7272b4323df5440b4b3f9
     steps:
       - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: dashboard/package-lock.json
-
-      - name: Build dashboard assets
-        working-directory: dashboard
-        run: |
-          npm ci
-          npm run build
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Summary
- remove duplicate dashboard Node setup/build steps from Rust test, Clippy, and Hermes integration jobs
- keep dashboard asset build, dist verification, unit tests, integration tests, and smoke tests in the dedicated Dashboard job
- disable debug info for CI dev/test profiles to reduce compile/link work, especially on Windows

## Validation
- python3 YAML parse for .github/workflows/ci.yml
- git diff --check