### PR TITLE
Harden Dockerfile and TypeScript extractors

### DIFF
--- a/src/extraction/bash_extractor.rs
+++ b/src/extraction/bash_extractor.rs
@@ -125,7 +125,7 @@ impl BashExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("bash");
+        let language = crate::extraction::ts_provider::try_language("bash")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Bash grammar: {e}"))?;

--- a/src/extraction/batch_extractor.rs
+++ b/src/extraction/batch_extractor.rs
@@ -144,7 +144,7 @@ impl BatchExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("batch");
+        let language = crate::extraction::ts_provider::try_language("batch")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Batch grammar: {e}"))?;

--- a/src/extraction/c_extractor.rs
+++ b/src/extraction/c_extractor.rs
@@ -129,7 +129,7 @@ impl CExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("c");
+        let language = crate::extraction::ts_provider::try_language("c")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load C grammar: {e}"))?;

--- a/src/extraction/clojure_extractor.rs
+++ b/src/extraction/clojure_extractor.rs
@@ -107,7 +107,7 @@ impl ClojureExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("clojure");
+        let language = crate::extraction::ts_provider::try_language("clojure")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Clojure grammar: {e}"))?;

--- a/src/extraction/cobol_extractor.rs
+++ b/src/extraction/cobol_extractor.rs
@@ -143,7 +143,7 @@ impl CobolExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("cobol");
+        let language = crate::extraction::ts_provider::try_language("cobol")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load COBOL grammar: {e}"))?;

--- a/src/extraction/cpp_extractor.rs
+++ b/src/extraction/cpp_extractor.rs
@@ -136,7 +136,7 @@ impl CppExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("cpp");
+        let language = crate::extraction::ts_provider::try_language("cpp")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load C++ grammar: {e}"))?;

--- a/src/extraction/csharp_extractor.rs
+++ b/src/extraction/csharp_extractor.rs
@@ -128,7 +128,7 @@ impl CSharpExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("c_sharp");
+        let language = crate::extraction::ts_provider::try_language("c_sharp")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load C# grammar: {e}"))?;

--- a/src/extraction/dart_extractor.rs
+++ b/src/extraction/dart_extractor.rs
@@ -128,7 +128,7 @@ impl DartExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("dart");
+        let language = crate::extraction::ts_provider::try_language("dart")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Dart grammar: {e}"))?;

--- a/src/extraction/dockerfile_extractor.rs
+++ b/src/extraction/dockerfile_extractor.rs
@@ -19,6 +19,9 @@ struct ExtractionState {
     errors: Vec<String>,
     /// Stack of (name, `node_id`) for building qualified names and parent edges.
     node_stack: Vec<(String, String)>,
+    /// COPY --from targets keyed by stage alias or zero-based stage index.
+    stage_targets: Vec<(String, String)>,
+    stage_count: usize,
     file_path: String,
     source: Vec<u8>,
     timestamp: u64,
@@ -35,6 +38,8 @@ impl ExtractionState {
             edges: Vec::new(),
             errors: Vec::new(),
             node_stack: Vec::new(),
+            stage_targets: Vec::new(),
+            stage_count: 0,
             file_path: file_path.to_string(),
             source: source.as_bytes().to_vec(),
             timestamp,
@@ -53,6 +58,18 @@ impl ExtractionState {
     /// Returns the current parent node ID, or None if at file root level.
     fn parent_node_id(&self) -> Option<&str> {
         self.node_stack.last().map(|(_, id)| id.as_str())
+    }
+
+    fn register_stage_target(&mut self, name: impl Into<String>, id: &str) {
+        self.stage_targets.push((name.into(), id.to_string()));
+    }
+
+    fn stage_target(&self, name: &str) -> Option<String> {
+        self.stage_targets
+            .iter()
+            .rev()
+            .find(|(candidate, _)| candidate == name)
+            .map(|(_, id)| id.clone())
     }
 
     /// Gets the text of a tree-sitter node from the source.
@@ -122,7 +139,7 @@ impl DockerfileExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("dockerfile");
+        let language = crate::extraction::ts_provider::try_language("dockerfile")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Dockerfile grammar: {e}"))?;
@@ -160,8 +177,8 @@ impl DockerfileExtractor {
 
     /// Extract a FROM instruction.
     ///
-    /// `FROM image AS alias` creates a Module node for the stage.
-    /// `FROM image` (no alias) creates a Use node for the base image.
+    /// `FROM image AS alias` creates a Module node for the named stage.
+    /// `FROM image` (no alias) creates a Module node named by stage index.
     ///
     /// When a named stage is created, subsequent instructions until the next
     /// FROM are considered children of that stage.
@@ -170,6 +187,8 @@ impl DockerfileExtractor {
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
         let end_column = node.end_position().column as u32;
+        let stage_index = state.stage_count;
+        state.stage_count += 1;
 
         // If there's a previous stage on the stack (not the file root), pop it
         // so the new FROM starts a new scope. The file root is always at index 0.
@@ -179,11 +198,6 @@ impl DockerfileExtractor {
 
         // Check for AS alias (named stage).
         let alias = node.child_by_field_name("as").map(|n| state.node_text(n));
-
-        // Get the image spec text.
-        let image_spec = Self::find_child_by_kind(node, "image_spec")
-            .map(|n| state.node_text(n))
-            .unwrap_or_default();
 
         let text = state.node_text(node);
 
@@ -219,6 +233,8 @@ impl DockerfileExtractor {
                 parent_id: None,
             };
             state.nodes.push(graph_node);
+            state.register_stage_target(stage_index.to_string(), &id);
+            state.register_stage_target(alias_name.clone(), &id);
 
             // Contains edge from parent.
             if let Some(parent_id) = state.parent_node_id() {
@@ -233,15 +249,16 @@ impl DockerfileExtractor {
             // Push stage onto the stack so subsequent instructions belong to it.
             state.node_stack.push((alias_name, id));
         } else {
-            // Unnamed FROM -> Use node for the base image.
-            let kind = NodeKind::Use;
-            let qualified_name = format!("{}::{}", state.qualified_prefix(), image_spec);
-            let id = generate_node_id(&state.file_path, &kind, &image_spec, start_line);
+            // Unnamed stage -> synthetic Module node keyed by stage index.
+            let stage_name = format!("stage{stage_index}");
+            let kind = NodeKind::Module;
+            let qualified_name = format!("{}::{}", state.qualified_prefix(), stage_name);
+            let id = generate_node_id(&state.file_path, &kind, &stage_name, start_line);
 
             let graph_node = Node {
                 id: id.clone(),
                 kind,
-                name: image_spec,
+                name: stage_name.clone(),
                 qualified_name,
                 file_path: state.file_path.clone(),
                 start_line,
@@ -264,16 +281,20 @@ impl DockerfileExtractor {
                 parent_id: None,
             };
             state.nodes.push(graph_node);
+            state.register_stage_target(stage_index.to_string(), &id);
 
             // Contains edge from parent.
             if let Some(parent_id) = state.parent_node_id() {
                 state.edges.push(Edge {
                     source: parent_id.to_string(),
-                    target: id,
+                    target: id.clone(),
                     kind: EdgeKind::Contains,
                     line: Some(start_line),
                 });
             }
+
+            // Push stage onto the stack so subsequent instructions belong to it.
+            state.node_stack.push((stage_name, id));
         }
     }
 
@@ -550,24 +571,47 @@ impl DockerfileExtractor {
                 if child.kind() == "param" {
                     let param_text = state.node_text(child);
                     if let Some(stage_name) = param_text.strip_prefix("--from=") {
-                        // Create a Uses edge from the current parent to the
-                        // referenced stage. We generate the target ID using the
-                        // same convention as visit_from for Module nodes.
-                        let target_id = generate_node_id(
-                            &state.file_path,
-                            &NodeKind::Module,
-                            stage_name,
-                            0, // We don't know the exact line; use 0 as placeholder
-                        );
-
-                        // Find the actual target node ID by searching existing nodes.
-                        let resolved_target = state
-                            .nodes
-                            .iter()
-                            .find(|n| n.kind == NodeKind::Module && n.name == stage_name)
-                            .map(|n| n.id.clone());
-
-                        let target = resolved_target.unwrap_or(target_id);
+                        let target = if let Some(target) = state.stage_target(stage_name) {
+                            target
+                        } else {
+                            let id = generate_node_id(
+                                &state.file_path,
+                                &NodeKind::Use,
+                                stage_name,
+                                start_line,
+                            );
+                            let text = state.node_text(node);
+                            state.nodes.push(Node {
+                                id: id.clone(),
+                                kind: NodeKind::Use,
+                                name: stage_name.to_string(),
+                                qualified_name: format!(
+                                    "{}::{}",
+                                    state.qualified_prefix(),
+                                    stage_name
+                                ),
+                                file_path: state.file_path.clone(),
+                                start_line,
+                                attrs_start_line: start_line,
+                                end_line: node.end_position().row as u32,
+                                start_column: node.start_position().column as u32,
+                                end_column: node.end_position().column as u32,
+                                signature: Some(text.trim().to_string()),
+                                docstring: None,
+                                visibility: Visibility::Pub,
+                                is_async: false,
+                                branches: 0,
+                                loops: 0,
+                                returns: 0,
+                                max_nesting: 0,
+                                unsafe_blocks: 0,
+                                unchecked_calls: 0,
+                                assertions: 0,
+                                updated_at: state.timestamp,
+                                parent_id: None,
+                            });
+                            id
+                        };
 
                         if let Some(parent_id) = state.parent_node_id() {
                             state.edges.push(Edge {
@@ -584,27 +628,6 @@ impl DockerfileExtractor {
                 }
             }
         }
-    }
-
-    // ----------------------------
-    // Helper methods
-    // ----------------------------
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/elixir_extractor.rs
+++ b/src/extraction/elixir_extractor.rs
@@ -107,7 +107,7 @@ impl ElixirExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("elixir");
+        let language = crate::extraction::ts_provider::try_language("elixir")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Elixir grammar: {e}"))?;

--- a/src/extraction/erlang_extractor.rs
+++ b/src/extraction/erlang_extractor.rs
@@ -93,7 +93,7 @@ impl ErlangExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("erlang");
+        let language = crate::extraction::ts_provider::try_language("erlang")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Erlang grammar: {e}"))?;

--- a/src/extraction/fortran_extractor.rs
+++ b/src/extraction/fortran_extractor.rs
@@ -122,7 +122,7 @@ impl FortranExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("fortran");
+        let language = crate::extraction::ts_provider::try_language("fortran")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Fortran grammar: {e}"))?;

--- a/src/extraction/fsharp_extractor.rs
+++ b/src/extraction/fsharp_extractor.rs
@@ -108,7 +108,7 @@ impl FSharpExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("fsharp");
+        let language = crate::extraction::ts_provider::try_language("fsharp")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load F# grammar: {e}"))?;

--- a/src/extraction/glsl_extractor.rs
+++ b/src/extraction/glsl_extractor.rs
@@ -117,7 +117,7 @@ impl GlslExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("glsl");
+        let language = crate::extraction::ts_provider::try_language("glsl")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load GLSL grammar: {e}"))?;

--- a/src/extraction/go_extractor.rs
+++ b/src/extraction/go_extractor.rs
@@ -125,7 +125,7 @@ impl GoExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("go");
+        let language = crate::extraction::ts_provider::try_language("go")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Go grammar: {e}"))?;

--- a/src/extraction/gwbasic_extractor.rs
+++ b/src/extraction/gwbasic_extractor.rs
@@ -152,7 +152,7 @@ impl GwBasicExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("gwbasic");
+        let language = crate::extraction::ts_provider::try_language("gwbasic")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load GW-BASIC grammar: {e}"))?;

--- a/src/extraction/haskell_extractor.rs
+++ b/src/extraction/haskell_extractor.rs
@@ -93,7 +93,7 @@ impl HaskellExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("haskell");
+        let language = crate::extraction::ts_provider::try_language("haskell")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Haskell grammar: {e}"))?;

--- a/src/extraction/hlsl_extractor.rs
+++ b/src/extraction/hlsl_extractor.rs
@@ -113,7 +113,7 @@ impl HlslExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("hlsl");
+        let language = crate::extraction::ts_provider::try_language("hlsl")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load HLSL grammar: {e}"))?;

--- a/src/extraction/java_extractor.rs
+++ b/src/extraction/java_extractor.rs
@@ -170,7 +170,7 @@ impl JavaExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("java");
+        let language = crate::extraction::ts_provider::try_language("java")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Java grammar: {e}"))?;

--- a/src/extraction/julia_extractor.rs
+++ b/src/extraction/julia_extractor.rs
@@ -108,7 +108,7 @@ impl JuliaExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("julia");
+        let language = crate::extraction::ts_provider::try_language("julia")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Julia grammar: {e}"))?;

--- a/src/extraction/kotlin_extractor.rs
+++ b/src/extraction/kotlin_extractor.rs
@@ -172,7 +172,7 @@ impl KotlinExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("kotlin");
+        let language = crate::extraction::ts_provider::try_language("kotlin")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Kotlin grammar: {e}"))?;

--- a/src/extraction/lean_extractor.rs
+++ b/src/extraction/lean_extractor.rs
@@ -106,7 +106,7 @@ impl LeanExtractor {
 
     fn parse(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("lean");
+        let language = crate::extraction::ts_provider::try_language("lean")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Lean grammar: {e}"))?;

--- a/src/extraction/lua_extractor.rs
+++ b/src/extraction/lua_extractor.rs
@@ -125,7 +125,7 @@ impl LuaExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("lua");
+        let language = crate::extraction::ts_provider::try_language("lua")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Lua grammar: {e}"))?;

--- a/src/extraction/msbasic2_extractor.rs
+++ b/src/extraction/msbasic2_extractor.rs
@@ -150,7 +150,7 @@ impl MsBasic2Extractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("msbasic2");
+        let language = crate::extraction::ts_provider::try_language("msbasic2")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load MS BASIC 2.0 grammar: {e}"))?;

--- a/src/extraction/nix_extractor.rs
+++ b/src/extraction/nix_extractor.rs
@@ -125,7 +125,7 @@ impl NixExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("nix");
+        let language = crate::extraction::ts_provider::try_language("nix")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Nix grammar: {e}"))?;

--- a/src/extraction/objc_extractor.rs
+++ b/src/extraction/objc_extractor.rs
@@ -129,7 +129,7 @@ impl ObjcExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("objc");
+        let language = crate::extraction::ts_provider::try_language("objc")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Objective-C grammar: {e}"))?;

--- a/src/extraction/ocaml_extractor.rs
+++ b/src/extraction/ocaml_extractor.rs
@@ -108,7 +108,7 @@ impl OcamlExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("ocaml");
+        let language = crate::extraction::ts_provider::try_language("ocaml")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load OCaml grammar: {e}"))?;

--- a/src/extraction/pascal_extractor.rs
+++ b/src/extraction/pascal_extractor.rs
@@ -137,7 +137,7 @@ impl PascalExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("pascal");
+        let language = crate::extraction::ts_provider::try_language("pascal")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Pascal grammar: {e}"))?;

--- a/src/extraction/perl_extractor.rs
+++ b/src/extraction/perl_extractor.rs
@@ -128,7 +128,7 @@ impl PerlExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("perl");
+        let language = crate::extraction::ts_provider::try_language("perl")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Perl grammar: {e}"))?;

--- a/src/extraction/php_extractor.rs
+++ b/src/extraction/php_extractor.rs
@@ -128,7 +128,7 @@ impl PhpExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("php");
+        let language = crate::extraction::ts_provider::try_language("php")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load PHP grammar: {e}"))?;

--- a/src/extraction/powershell_extractor.rs
+++ b/src/extraction/powershell_extractor.rs
@@ -125,7 +125,7 @@ impl PowerShellExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("powershell");
+        let language = crate::extraction::ts_provider::try_language("powershell")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load PowerShell grammar: {e}"))?;

--- a/src/extraction/proto_extractor.rs
+++ b/src/extraction/proto_extractor.rs
@@ -119,7 +119,7 @@ impl ProtoExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("protobuf");
+        let language = crate::extraction::ts_provider::try_language("protobuf")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Protobuf grammar: {e}"))?;

--- a/src/extraction/python_extractor.rs
+++ b/src/extraction/python_extractor.rs
@@ -128,7 +128,7 @@ impl PythonExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("python");
+        let language = crate::extraction::ts_provider::try_language("python")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Python grammar: {e}"))?;

--- a/src/extraction/qbasic_extractor.rs
+++ b/src/extraction/qbasic_extractor.rs
@@ -173,7 +173,7 @@ impl QBasicExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("qbasic");
+        let language = crate::extraction::ts_provider::try_language("qbasic")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load QBasic grammar: {e}"))?;

--- a/src/extraction/quint_extractor.rs
+++ b/src/extraction/quint_extractor.rs
@@ -132,7 +132,7 @@ impl QuintExtractor {
 
     fn parse(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("quint");
+        let language = crate::extraction::ts_provider::try_language("quint")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Quint grammar: {e}"))?;

--- a/src/extraction/r_extractor.rs
+++ b/src/extraction/r_extractor.rs
@@ -108,7 +108,7 @@ impl RExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("r");
+        let language = crate::extraction::ts_provider::try_language("r")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load R grammar: {e}"))?;

--- a/src/extraction/ruby_extractor.rs
+++ b/src/extraction/ruby_extractor.rs
@@ -128,7 +128,7 @@ impl RubyExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("ruby");
+        let language = crate::extraction::ts_provider::try_language("ruby")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Ruby grammar: {e}"))?;

--- a/src/extraction/rust_extractor.rs
+++ b/src/extraction/rust_extractor.rs
@@ -130,7 +130,7 @@ impl RustExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("rust");
+        let language = crate::extraction::ts_provider::try_language("rust")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Rust grammar: {e}"))?;

--- a/src/extraction/scala_extractor.rs
+++ b/src/extraction/scala_extractor.rs
@@ -134,7 +134,7 @@ impl ScalaExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("scala");
+        let language = crate::extraction::ts_provider::try_language("scala")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Scala grammar: {e}"))?;

--- a/src/extraction/sql_extractor.rs
+++ b/src/extraction/sql_extractor.rs
@@ -93,7 +93,7 @@ impl SqlExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("sql");
+        let language = crate::extraction::ts_provider::try_language("sql")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load SQL grammar: {e}"))?;

--- a/src/extraction/swift_extractor.rs
+++ b/src/extraction/swift_extractor.rs
@@ -128,7 +128,7 @@ impl SwiftExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("swift");
+        let language = crate::extraction::ts_provider::try_language("swift")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Swift grammar: {e}"))?;

--- a/src/extraction/toml_extractor.rs
+++ b/src/extraction/toml_extractor.rs
@@ -94,7 +94,7 @@ impl TomlExtractor {
 
     fn parse(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("toml");
+        let language = crate::extraction::ts_provider::try_language("toml")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load TOML grammar: {e}"))?;

--- a/src/extraction/traversal.rs
+++ b/src/extraction/traversal.rs
@@ -77,7 +77,7 @@ mod tests {
     fn parse_c_function(source: &str) -> TsNode<'_> {
         let mut parser = Parser::new();
         parser
-            .set_language(&ts_provider::language("c"))
+            .set_language(&ts_provider::try_language("c").expect("c grammar should load"))
             .expect("c grammar should load");
         let tree = parser.parse(source, None).expect("c source should parse");
         let leaked = Box::leak(Box::new(tree));

--- a/src/extraction/ts_provider.rs
+++ b/src/extraction/ts_provider.rs
@@ -40,20 +40,21 @@ static LANGUAGES: LazyLock<HashMap<&'static str, Language>> = LazyLock::new(|| {
 });
 
 /// Returns the `tree_sitter::Language` for the given extractor language key.
-///
-/// # Panics
-///
-/// Panics if `key` is not recognised.
-pub fn language(key: &str) -> Language {
+pub fn try_language(key: &str) -> Result<Language, String> {
     LANGUAGES
         .get(key)
         .cloned()
-        .unwrap_or_else(|| panic!("ts_provider: unknown language key '{key}'"))
+        .ok_or_else(|| format!("ts_provider: unknown language key '{key}'"))
+}
+
+/// Backward-compatible fallible alias for extractor parser call sites.
+pub fn language(key: &str) -> Result<Language, String> {
+    try_language(key)
 }
 
 #[cfg(test)]
 mod tests {
-    /// Every key that an extractor passes to `language()` must be present in the
+    /// Every key that an extractor passes to `try_language()` must be present in the
     /// grammar table. Add new entries here whenever a new extractor is added.
     #[test]
     fn all_extractor_keys_are_registered() {
@@ -87,5 +88,23 @@ mod tests {
             missing.is_empty(),
             "grammar keys missing from LANGUAGES: {missing:?}"
         );
+    }
+
+    #[test]
+    fn language_reports_unknown_key() -> Result<(), String> {
+        let Err(err) = super::language("definitely-not-registered") else {
+            return Err("unknown key should return an error".to_string());
+        };
+        assert!(err.contains("unknown language key"));
+        Ok(())
+    }
+
+    #[test]
+    fn try_language_reports_unknown_key() -> Result<(), String> {
+        let Err(err) = super::try_language("definitely-not-registered") else {
+            return Err("unknown key should return an error".to_string());
+        };
+        assert!(err.contains("unknown language key"));
+        Ok(())
     }
 }

--- a/src/extraction/typescript_extractor.rs
+++ b/src/extraction/typescript_extractor.rs
@@ -129,15 +129,38 @@ impl TypeScriptExtractor {
         Self::build_result(state, start)
     }
 
+    fn node_name(state: &ExtractionState, node: TsNode<'_>) -> String {
+        Self::clean_name(&state.node_text(node))
+    }
+
+    fn child_name(state: &ExtractionState, node: Option<TsNode<'_>>) -> String {
+        node.map_or_else(Self::anonymous_name, |n| Self::node_name(state, n))
+    }
+
+    fn clean_name(name: &str) -> String {
+        let name = name.trim();
+        if name.is_empty() {
+            Self::anonymous_name()
+        } else {
+            name.to_string()
+        }
+    }
+
+    fn anonymous_name() -> String {
+        "<anonymous>".to_string()
+    }
+
     /// Parse source code into a tree-sitter AST, selecting grammar by file extension.
     fn parse_source(source: &str, extension: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
         let (key, label) = match extension {
+            "ts" | "astro" | "svelte" => ("typescript", "TypeScript"),
             "tsx" => ("tsx", "TSX"),
             "js" | "jsx" => ("javascript", "JavaScript"),
-            _ => ("typescript", "TypeScript"),
+            other => (other, other),
         };
-        let language = crate::extraction::ts_provider::language(key);
+        let language = crate::extraction::ts_provider::try_language(key)
+            .map_err(|e| format!("failed to load {label} grammar: {e}"))?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load {label} grammar: {e}"))?;
@@ -264,8 +287,7 @@ impl TypeScriptExtractor {
 
     /// Extract a function declaration node.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -359,8 +381,7 @@ impl TypeScriptExtractor {
         declarator: TsNode<'_>,
         arrow_node: TsNode<'_>,
     ) {
-        let name = Self::find_child_by_kind(declarator, "identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(declarator, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -437,8 +458,7 @@ impl TypeScriptExtractor {
 
     /// Extract a const variable declaration (not an arrow function).
     fn visit_const_variable(state: &mut ExtractionState, declarator: TsNode<'_>) {
-        let name = Self::find_child_by_kind(declarator, "identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(declarator, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -493,9 +513,11 @@ impl TypeScriptExtractor {
     /// Extract a class declaration node.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
         // TS uses type_identifier, JS uses identifier for class names.
-        let name = Self::find_child_by_kind(node, "type_identifier")
-            .or_else(|| Self::find_child_by_kind(node, "identifier"))
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(
+            state,
+            Self::find_child_by_kind(node, "type_identifier")
+                .or_else(|| Self::find_child_by_kind(node, "identifier")),
+        );
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -581,8 +603,7 @@ impl TypeScriptExtractor {
 
     /// Extract a `method_definition` from a class body.
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "property_identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "property_identifier"));
 
         let kind = if name == "constructor" {
             NodeKind::Constructor
@@ -651,8 +672,7 @@ impl TypeScriptExtractor {
 
     /// Extract a field from a class body (`public_field_definition`).
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "property_identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "property_identifier"));
         let visibility = Self::extract_ts_accessibility(state, node);
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -702,8 +722,7 @@ impl TypeScriptExtractor {
 
     /// Extract an interface declaration node.
     fn visit_interface(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "type_identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "type_identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -781,8 +800,7 @@ impl TypeScriptExtractor {
 
     /// Extract a `method_signature` from an interface body.
     fn visit_interface_method(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "property_identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "property_identifier"));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -831,8 +849,7 @@ impl TypeScriptExtractor {
 
     /// Extract an enum declaration node.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -911,7 +928,7 @@ impl TypeScriptExtractor {
 
     /// Extract an enum member (variant).
     fn visit_enum_member(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = state.node_text(node);
+        let name = Self::node_name(state, node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
         let start_column = node.start_position().column as u32;
@@ -959,8 +976,7 @@ impl TypeScriptExtractor {
 
     /// Extract a type alias declaration.
     fn visit_type_alias(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "type_identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "type_identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -1075,8 +1091,7 @@ impl TypeScriptExtractor {
 
     /// Extract a namespace (`internal_module`) declaration.
     fn visit_namespace(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
-            .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
+        let name = Self::child_name(state, Self::find_child_by_kind(node, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -1150,13 +1165,12 @@ impl TypeScriptExtractor {
                 if child.kind() == "decorator" {
                     let text = state.node_text(child);
                     // Get the decorator name (strip @ and potential arguments).
-                    let name = text
-                        .trim_start_matches('@')
-                        .split('(')
-                        .next()
-                        .unwrap_or(&text)
-                        .trim()
-                        .to_string();
+                    let name = Self::clean_name(
+                        text.trim_start_matches('@')
+                            .split('(')
+                            .next()
+                            .unwrap_or(&text),
+                    );
                     let start_line = child.start_position().row as u32;
                     let end_line = child.end_position().row as u32;
                     let start_column = child.start_position().column as u32;
@@ -1439,6 +1453,9 @@ impl TypeScriptExtractor {
     fn clean_jsdoc(comment: &str) -> String {
         let trimmed = comment.trim();
         if trimmed.starts_with("/**") && trimmed.ends_with("*/") {
+            if trimmed.len() <= 5 {
+                return String::new();
+            }
             let inner = &trimmed[3..trimmed.len() - 2];
             inner
                 .lines()

--- a/src/extraction/vbnet_extractor.rs
+++ b/src/extraction/vbnet_extractor.rs
@@ -155,7 +155,7 @@ impl VbNetExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("vbnet");
+        let language = crate::extraction::ts_provider::try_language("vbnet")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load VB.NET grammar: {e}"))?;

--- a/src/extraction/wgsl_extractor.rs
+++ b/src/extraction/wgsl_extractor.rs
@@ -113,7 +113,7 @@ impl WgslExtractor {
 
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("wgsl");
+        let language = crate::extraction::ts_provider::try_language("wgsl")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load WGSL grammar: {e}"))?;

--- a/src/extraction/zig_extractor.rs
+++ b/src/extraction/zig_extractor.rs
@@ -128,7 +128,7 @@ impl ZigExtractor {
     /// Parse source code into a tree-sitter AST.
     fn parse_source(source: &str) -> Result<Tree, String> {
         let mut parser = Parser::new();
-        let language = crate::extraction::ts_provider::language("zig");
+        let language = crate::extraction::ts_provider::try_language("zig")?;
         parser
             .set_language(&language)
             .map_err(|e| format!("failed to load Zig grammar: {e}"))?;

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -193,7 +193,9 @@ async fn ensure_fingerprints(
 
         // At least one node in this file needs a fresh fingerprint —
         // parse once and compute for every miss.
-        let language = crate::extraction::ts_provider::language(lang_key);
+        let Ok(language) = crate::extraction::ts_provider::language(lang_key) else {
+            continue;
+        };
         let Some(tree) = parse_file(&source, &language) else {
             continue;
         };

--- a/src/redundancy.rs
+++ b/src/redundancy.rs
@@ -478,7 +478,7 @@ mod tests {
 
     /// Helper that parses a Rust snippet and returns the first function body.
     fn fingerprint_for_rust_fn(snippet: &str) -> Fingerprint {
-        let lang = crate::extraction::ts_provider::language("rust");
+        let lang = crate::extraction::ts_provider::language("rust").expect("rust grammar");
         let tree = parse_file(snippet, &lang).expect("parse failed");
         let root = tree.root_node();
         let fn_node = find_first_kind(root, "function_item").expect("no function in snippet");

--- a/tests/annotation_helpers_test.rs
+++ b/tests/annotation_helpers_test.rs
@@ -102,7 +102,7 @@ fn find_descendant_by_kind<'tree>(node: TsNode<'tree>, kind: &str) -> Option<TsN
 fn parse_java_method(source: &str) -> TsNode<'_> {
     let mut parser = Parser::new();
     parser
-        .set_language(&ts_provider::language("java"))
+        .set_language(&ts_provider::language("java").expect("java grammar should load"))
         .expect("java grammar should load");
     let tree = parser
         .parse(source, None)
@@ -115,7 +115,7 @@ fn parse_java_method(source: &str) -> TsNode<'_> {
 fn parse_kotlin_function(source: &str) -> TsNode<'_> {
     let mut parser = Parser::new();
     parser
-        .set_language(&ts_provider::language("kotlin"))
+        .set_language(&ts_provider::language("kotlin").expect("kotlin grammar should load"))
         .expect("kotlin grammar should load");
     let tree = parser
         .parse(source, None)

--- a/tests/complexity_test.rs
+++ b/tests/complexity_test.rs
@@ -4,7 +4,10 @@ use tracedecay::extraction::complexity::{count_complexity, RUST_COMPLEXITY};
 fn rust_fn_complexity(source: &str) -> tracedecay::extraction::complexity::ComplexityMetrics {
     let mut parser = tree_sitter::Parser::new();
     parser
-        .set_language(&tracedecay::extraction::ts_provider::language("rust"))
+        .set_language(
+            &tracedecay::extraction::ts_provider::language("rust")
+                .expect("failed to load Rust grammar"),
+        )
         .expect("failed to load Rust grammar");
     let tree = parser.parse(source, None).expect("parse failed");
     let root = tree.root_node();

--- a/tests/dockerfile_extraction_test.rs
+++ b/tests/dockerfile_extraction_test.rs
@@ -130,15 +130,84 @@ fn test_dockerfile_copy_from_creates_uses_edge() {
     let source = std::fs::read_to_string("tests/fixtures/sample.dockerfile").unwrap();
     let result = DockerfileExtractor.extract("sample.dockerfile", &source);
     assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
-    // COPY --from=builder creates a Uses edge referencing the builder stage
+    let builder = result
+        .nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Module && n.name == "builder")
+        .unwrap_or_else(|| panic!("expected builder stage module"));
+    // COPY --from=builder creates a Uses edge referencing the actual builder stage node.
     let uses_edges: Vec<_> = result
         .edges
         .iter()
-        .filter(|e| e.kind == EdgeKind::Uses)
+        .filter(|e| e.kind == EdgeKind::Uses && e.target == builder.id)
         .collect();
     assert!(
         !uses_edges.is_empty(),
-        "COPY --from=builder should create a Uses edge"
+        "COPY --from=builder should create a Uses edge to the builder stage node"
+    );
+}
+
+#[test]
+fn test_dockerfile_copy_from_numeric_stage_uses_unnamed_stage_node() {
+    let source = r#"
+FROM alpine
+RUN apk add --no-cache curl
+FROM scratch
+COPY --from=0 /bin/curl /bin/curl
+"#;
+    let result = DockerfileExtractor.extract("Dockerfile", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let first_stage = result
+        .nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Module && n.name == "stage0")
+        .unwrap_or_else(|| panic!("expected unnamed stage representation"));
+    assert_eq!(
+        first_stage.signature.as_deref(),
+        Some("FROM alpine"),
+        "numeric COPY --from should target the stage, not the base image"
+    );
+    assert!(
+        result
+            .edges
+            .iter()
+            .any(|e| e.kind == EdgeKind::Uses && e.target == first_stage.id),
+        "COPY --from=0 should create a Uses edge to the unnamed stage node"
+    );
+    assert!(
+        !result.edges.iter().any(|e| e.kind == EdgeKind::Uses
+            && result
+                .nodes
+                .iter()
+                .any(|n| n.id == e.target && n.kind == NodeKind::Use && n.name == "alpine")),
+        "COPY --from=0 should not use the base image node directly"
+    );
+}
+
+#[test]
+fn test_dockerfile_copy_from_external_image_creates_backed_use_node() {
+    let source = r#"
+FROM alpine AS runtime
+COPY --from=nginx:alpine /etc/nginx/nginx.conf /tmp/nginx.conf
+"#;
+    let result = DockerfileExtractor.extract("Dockerfile", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let external = result
+        .nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Use && n.name == "nginx:alpine")
+        .unwrap_or_else(|| panic!("expected external COPY --from image use node"));
+    assert_eq!(
+        external.start_line, 2,
+        "external COPY --from image should be located on the COPY line"
+    );
+    assert!(
+        result
+            .edges
+            .iter()
+            .any(|e| e.kind == EdgeKind::Uses && e.target == external.id),
+        "COPY --from external image should use the explicit external node"
     );
 }
 

--- a/tests/typescript_extraction_test.rs
+++ b/tests/typescript_extraction_test.rs
@@ -67,6 +67,54 @@ function internal(): void {}
 }
 
 #[test]
+fn test_ts_empty_jsdoc_comment_does_not_panic() {
+    let source = r#"
+/**/
+export function documented(): void {}
+"#;
+    let extractor = TypeScriptExtractor;
+    let result = extractor.extract("empty-jsdoc.ts", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let function = result
+        .nodes
+        .iter()
+        .find(|n| n.kind == NodeKind::Function && n.name == "documented")
+        .expect("function should be extracted");
+    assert_eq!(function.docstring.as_deref(), Some(""));
+}
+
+#[test]
+fn test_ts_anonymous_generator_method_does_not_panic() {
+    let source = r#"
+class C {
+    *() {}
+}
+"#;
+    let extractor = TypeScriptExtractor;
+    let result = extractor.extract("anonymous-generator-method.ts", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert!(result
+        .nodes
+        .iter()
+        .any(|n| n.kind == NodeKind::Method && n.name == "<anonymous>"));
+}
+
+#[test]
+fn test_ts_empty_decorator_name_does_not_panic() {
+    let source = r#"
+@(() => {})
+class C {}
+"#;
+    let extractor = TypeScriptExtractor;
+    let result = extractor.extract("empty-decorator.ts", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert!(result
+        .nodes
+        .iter()
+        .any(|n| n.kind == NodeKind::Class && n.name == "C"));
+}
+
+#[test]
 fn test_ts_arrow_function() {
     let source = r#"
 const add = (a: number, b: number): number => a + b;
@@ -569,6 +617,25 @@ export default class Foo {
         .collect();
     assert_eq!(methods.len(), 1);
     assert_eq!(methods[0].name, "bar");
+}
+
+#[test]
+fn test_ts_unknown_language_key_surfaces_parse_error() {
+    let extractor = TypeScriptExtractor;
+    let result = extractor.extract("test.definitely-not-registered", "const value = 1;");
+
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|err| err.contains("unknown language key 'definitely-not-registered'")),
+        "unknown TypeScript provider keys should be returned as parse errors: {:?}",
+        result.errors
+    );
+    assert!(
+        result.nodes.is_empty(),
+        "parse errors should stop extraction before creating graph nodes"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Resolve Dockerfile COPY --from edges to actual stage nodes and model external image sources as use nodes
- Make TypeScript language lookup recoverable for unknown keys
- Avoid panics for empty/anonymous TypeScript names and short JSDoc comments

## Verification
- cargo test --test dockerfile_extraction_test --test typescript_extraction_test
