### PR TITLE
Isolate real-model eval and benchmark state

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -27,6 +27,7 @@ import resource
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import tracemalloc
 from pathlib import Path
@@ -61,6 +62,8 @@ def clone_repo(name: str, url: str, skip_clone: bool) -> Path:
     if dest.exists():
         log(f"{name}: reusing existing clone at {dest}")
         return dest
+    if skip_clone:
+        raise FileNotFoundError(f"{name}: --skip-clone requested but {dest} does not exist")
     CLONE_DIR.mkdir(parents=True, exist_ok=True)
     log(f"{name}: cloning {url} (shallow, depth=1) ...")
     subprocess.run(
@@ -167,10 +170,14 @@ def ru_maxrss_bytes() -> int:
     return r if sys.platform == "darwin" else r * 1024
 
 
-def run_timed(cmd: list[str], cwd: str | None = None) -> tuple[float, int, subprocess.CompletedProcess]:
+def run_timed(
+    cmd: list[str],
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[float, int, subprocess.CompletedProcess]:
     before = ru_maxrss_bytes()
     t0 = time.perf_counter()
-    cp = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    cp = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
     dt = time.perf_counter() - t0
     after = ru_maxrss_bytes()
     return dt, max(0, after - before), cp
@@ -184,8 +191,9 @@ class TraceDecayMcp:
     Length framing — see src/mcp/transport.rs.
     """
 
-    def __init__(self, root: Path):
+    def __init__(self, root: Path, env: dict[str, str] | None = None):
         self.root = root
+        self.env = env
         self.proc: subprocess.Popen | None = None
         self._next_id = 1
 
@@ -195,6 +203,7 @@ class TraceDecayMcp:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
+            env=self.env,
             text=True,
             bufsize=1,
         )
@@ -269,85 +278,94 @@ def benchmark_tracedecay(name: str, root: Path, sample_symbols: list[str]) -> di
     if ts_dir.exists():
         shutil.rmtree(ts_dir)
 
-    log(f"[tk] {name}: init (cold) ...")
-    dt, mem, cp = run_timed([TRACEDECAY_BIN, "init"], cwd=str(root))
-    if cp.returncode != 0:
-        log(f"[tk] init failed: {cp.stderr[-400:]}")
-        out["error"] = cp.stderr[-2000:]
-        return out
-    out["cold_index_seconds"] = round(dt, 3)
-    out["cold_index_peak_memory_bytes"] = mem
+    with tempfile.TemporaryDirectory(prefix=f"tracedecay-bench-{name}-") as tmp:
+        data_dir = Path(tmp) / ".tracedecay"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ)
+        env["TRACEDECAY_DATA_DIR"] = str(data_dir)
+        env["TRACEDECAY_GLOBAL_DB"] = str(data_dir / "global.db")
 
-    log(f"[tk] {name}: sync (warm) ...")
-    dt, _, cp = run_timed([TRACEDECAY_BIN, "sync"], cwd=str(root))
-    out["warm_index_seconds"] = round(dt, 3) if cp.returncode == 0 else None
+        log(f"[tk] {name}: init (cold) ...")
+        dt, mem, cp = run_timed([TRACEDECAY_BIN, "init"], cwd=str(root), env=env)
+        if cp.returncode != 0:
+            log(f"[tk] init failed: {cp.stderr[-400:]}")
+            out["error"] = cp.stderr[-2000:]
+            return out
+        out["cold_index_seconds"] = round(dt, 3)
+        out["cold_index_peak_memory_bytes"] = mem
 
-    _, _, cp = run_timed([TRACEDECAY_BIN, "status", "--json"], cwd=str(root))
-    if cp.returncode == 0:
-        try:
-            status = json.loads(cp.stdout)
-            out["node_count"] = status.get("node_count")
-            out["edge_count"] = status.get("edge_count")
-            out["file_count"] = status.get("file_count")
-            out["files_by_language"] = status.get("files_by_language")
-        except json.JSONDecodeError:
-            pass
+        log(f"[tk] {name}: sync (warm) ...")
+        dt, _, cp = run_timed([TRACEDECAY_BIN, "sync"], cwd=str(root), env=env)
+        out["warm_index_seconds"] = round(dt, 3) if cp.returncode == 0 else None
 
-    log(f"[tk] {name}: query benchmarks via MCP ({len(sample_symbols)} symbols) ...")
-    queries = [sym.split(".")[-1] for sym in sample_symbols]
+        status: dict = {}
+        _, _, cp = run_timed([TRACEDECAY_BIN, "status", "--json"], cwd=str(root), env=env)
+        if cp.returncode == 0:
+            try:
+                status = json.loads(cp.stdout)
+                out["node_count"] = status.get("node_count")
+                out["edge_count"] = status.get("edge_count")
+                out["file_count"] = status.get("file_count")
+                out["files_by_language"] = status.get("files_by_language")
+            except json.JSONDecodeError:
+                pass
 
-    def handler_us(resp: dict) -> int | None:
-        meta = resp.get("result", {}).get("_meta", {})
-        v = meta.get("duration_us")
-        return int(v) if isinstance(v, (int, float)) else None
+        log(f"[tk] {name}: query benchmarks via MCP ({len(sample_symbols)} symbols) ...")
+        queries = [sym.split(".")[-1] for sym in sample_symbols]
 
-    def avg_ms(samples: list[int]) -> float | None:
-        return round(sum(samples) / len(samples) / 1000.0, 3) if samples else None
+        def handler_us(resp: dict) -> int | None:
+            meta = resp.get("result", {}).get("_meta", {})
+            v = meta.get("duration_us")
+            return int(v) if isinstance(v, (int, float)) else None
 
-    with TraceDecayMcp(root) as mcp:
-        # Warm-up so first-query DB/cache fill doesn't skew the averages.
-        # `_meta.duration_us` already excludes transport overhead, but the
-        # first call also pays one-time index warmup we want to drop.
-        if queries:
-            mcp.call_tool("tracedecay_search", {"query": queries[0], "limit": 5})
+        def avg_ms(samples: list[int]) -> float | None:
+            return round(sum(samples) / len(samples) / 1000.0, 3) if samples else None
 
-        # Apples-to-apples vs token-savior's find_symbol: bare-name index
-        # probe via `tracedecay_find_exact_symbol`, not BM25-ranked `search`.
-        find_us = [
-            d
-            for q in queries
-            if (
-                d := handler_us(
-                    mcp.call_tool("tracedecay_find_exact_symbol", {"name": q})
+        with TraceDecayMcp(root, env=env) as mcp:
+            # Warm-up so first-query DB/cache fill doesn't skew the averages.
+            # `_meta.duration_us` already excludes transport overhead, but the
+            # first call also pays one-time index warmup we want to drop.
+            if queries:
+                mcp.call_tool("tracedecay_search", {"query": queries[0], "limit": 5})
+
+            # Apples-to-apples vs token-savior's find_symbol: bare-name index
+            # probe via `tracedecay_find_exact_symbol`, not BM25-ranked `search`.
+            find_us = [
+                d
+                for q in queries
+                if (
+                    d := handler_us(
+                        mcp.call_tool("tracedecay_find_exact_symbol", {"name": q})
+                    )
                 )
-            )
-            is not None
-        ]
-        out["find_symbol_avg_ms"] = avg_ms(find_us)
+                is not None
+            ]
+            out["find_symbol_avg_ms"] = avg_ms(find_us)
 
-        body_us = [
-            d
-            for q in queries
-            if (d := handler_us(mcp.call_tool("tracedecay_body", {"symbol": q, "limit": 1})))
-            is not None
-        ]
-        out["get_function_source_avg_ms"] = avg_ms(body_us)
+            body_us = [
+                d
+                for q in queries
+                if (
+                    d := handler_us(mcp.call_tool("tracedecay_body", {"symbol": q, "limit": 1}))
+                )
+                is not None
+            ]
+            out["get_function_source_avg_ms"] = avg_ms(body_us)
 
-        impact_us: list[int] = []
-        for q in queries:
-            sresp = mcp.call_tool("tracedecay_search", {"query": q, "limit": 1})
-            search_us = handler_us(sresp) or 0
-            node_id = TraceDecayMcp.first_node_id(sresp)
-            if node_id is None:
-                continue
-            iresp = mcp.call_tool("tracedecay_impact", {"node_id": node_id, "max_depth": 3})
-            ius = handler_us(iresp)
-            if ius is not None:
-                impact_us.append(search_us + ius)
-        out["get_change_impact_avg_ms"] = avg_ms(impact_us)
+            impact_us: list[int] = []
+            for q in queries:
+                sresp = mcp.call_tool("tracedecay_search", {"query": q, "limit": 1})
+                search_us = handler_us(sresp) or 0
+                node_id = TraceDecayMcp.first_node_id(sresp)
+                if node_id is None:
+                    continue
+                iresp = mcp.call_tool("tracedecay_impact", {"node_id": node_id, "max_depth": 3})
+                ius = handler_us(iresp)
+                if ius is not None:
+                    impact_us.append(search_us + ius)
+            out["get_change_impact_avg_ms"] = avg_ms(impact_us)
 
-    db = ts_dir / "tracedecay.db"
-    out["cache_size_bytes"] = os.path.getsize(db) if db.exists() else 0
+        out["cache_size_bytes"] = status.get("db_size_bytes", 0)
 
     return out
 
@@ -486,8 +504,9 @@ def main() -> None:
     for name in args.repos:
         try:
             root = clone_repo(name, REPOS[name], skip_clone=args.skip_clone)
-        except subprocess.CalledProcessError as exc:
-            log(f"SKIP {name}: clone failed -- {exc.stderr.strip()[:200]}")
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            detail = getattr(exc, "stderr", None) or str(exc)
+            log(f"SKIP {name}: clone failed -- {detail.strip()[:200]}")
             continue
 
         naive_sizes[name] = naive_source_size(str(root))

--- a/eval/run_real_model.py
+++ b/eval/run_real_model.py
@@ -4,7 +4,7 @@
 Seeds a throwaway fixture project, points a REAL agent (Hermes by default,
 optionally `cursor-agent`) at it through the generated tracedecay plugin /
 MCP server, sends the scenario prompts, then asserts on end-state with plain
-SQL against the fixture's `.tracedecay/tracedecay.db`.
+SQL against the TraceDecay store resolved by the CLI.
 
 Real model turns consume credits/quota, so the run is gated behind BOTH
 `--agent-turn` and `--i-understand-model-cost` (pattern adopted from the
@@ -143,6 +143,52 @@ class HermesProfileSelection:
             self._temp_dir = None
 
 
+@dataclass
+class EvalEnvironment:
+    root: Path
+    home: Path
+    data_dir: Path
+    global_db: Path
+    env: dict[str, str]
+    _temp_dir: tempfile.TemporaryDirectory
+
+    def cleanup(self):
+        self._temp_dir.cleanup()
+
+
+def cleanup_eval_artifacts(args, fixture, eval_env):
+    if fixture is not None and not args.keep_fixture:
+        shutil.rmtree(fixture, ignore_errors=True)
+    if not args.keep_fixture:
+        eval_env.cleanup()
+
+
+def create_eval_environment(scenario_id):
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", scenario_id)
+    temp_dir = tempfile.TemporaryDirectory(prefix=f"tracedecay-eval-env-{safe_id}-")
+    root = Path(temp_dir.name)
+    home = root / "home"
+    data_dir = root / ".tracedecay"
+    global_db = data_dir / "global.db"
+    home.mkdir(parents=True, exist_ok=True)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["XDG_CONFIG_HOME"] = str(home / ".config")
+    env["TRACEDECAY_DATA_DIR"] = str(data_dir)
+    env["TRACEDECAY_GLOBAL_DB"] = str(global_db)
+    return EvalEnvironment(
+        root=root,
+        home=home,
+        data_dir=data_dir,
+        global_db=global_db,
+        env=env,
+        _temp_dir=temp_dir,
+    )
+
+
 def resolve_hermes_profile(args):
     profile = args.profile or DEFAULT_PROFILE
     if args.hermes_home is not None:
@@ -213,19 +259,49 @@ def run(cmd, cwd=None, env=None, timeout=None, check=True):
     return result
 
 
-def build_fixture(scenario, tracedecay_bin):
+def resolve_store_db_path(tracedecay_bin, fixture, env):
+    result = run(
+        [tracedecay_bin, "status", "--runtime", "--json"],
+        cwd=fixture,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit(
+            "failed to resolve TraceDecay store path with status --runtime --json\n"
+            f"{result.stdout}"
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"invalid status --runtime --json output while resolving store path: {exc}")
+
+    db_path = payload.get("database", {}).get("db_path") or payload.get("db_path")
+    if not db_path:
+        sys.exit("status --runtime --json did not report database.db_path")
+    return Path(db_path)
+
+
+def build_fixture(scenario, tracedecay_bin, env):
     fixture = Path(tempfile.mkdtemp(prefix=f"tracedecay-eval-{scenario['id']}-"))
     (fixture / "src").mkdir()
     (fixture / "src/lib.rs").write_text("pub fn eval_fixture_marker() {}\n")
     for name, contents in scenario["setup"].get("files", {}).items():
         (fixture / name).write_text(contents)
-    run([tracedecay_bin, "init"], cwd=fixture, timeout=300)
+    run([tracedecay_bin, "init"], cwd=fixture, env=env, timeout=300)
     for fact in scenario["setup"].get("facts", []):
         args = json.dumps(
             {"action": "add", "content": fact["content"], "category": fact["category"]}
         )
-        run([tracedecay_bin, "tool", "fact_store", "--args", args], cwd=fixture, timeout=120)
-    db = sqlite3.connect(fixture / ".tracedecay/tracedecay.db")
+        run(
+            [tracedecay_bin, "tool", "fact_store", "--args", args],
+            cwd=fixture,
+            env=env,
+            timeout=120,
+        )
+    db_path = resolve_store_db_path(tracedecay_bin, fixture, env)
+    db = sqlite3.connect(db_path)
     with db:
         for fact in scenario["setup"].get("facts", []):
             db.execute(
@@ -234,7 +310,7 @@ def build_fixture(scenario, tracedecay_bin):
                 (fact["trust"], fact["retrieval_count"], fact["source"], fact["content"]),
             )
     db.close()
-    return fixture
+    return fixture, db_path
 
 
 def provider_env_passthrough(env):
@@ -252,7 +328,7 @@ def provider_env_passthrough(env):
             env[key] = value.strip().strip('"').strip("'")
 
 
-def ensure_hermes_profile(selection, model, provider, tracedecay_bin, fixture):
+def ensure_hermes_profile(selection, model, provider, tracedecay_bin, fixture, eval_env):
     profile = selection.profile
     profile_dir = selection.profile_dir
     profile_dir.mkdir(parents=True, exist_ok=True)
@@ -265,8 +341,9 @@ def ensure_hermes_profile(selection, model, provider, tracedecay_bin, fixture):
         "  max_turns: 16\n"
     )
     if selection.install_home is not None:
-        install_env = dict(os.environ)
+        install_env = dict(eval_env)
         install_env["HOME"] = str(selection.install_home)
+        install_env["USERPROFILE"] = str(selection.install_home)
         run(
             [
                 tracedecay_bin,
@@ -291,12 +368,12 @@ def ensure_hermes_profile(selection, model, provider, tracedecay_bin, fixture):
     return profile_dir
 
 
-def drive_hermes(args, scenario, fixture, log_dir):
+def drive_hermes(args, scenario, fixture, log_dir, eval_env):
     profile_dir = ensure_hermes_profile(
-        args.hermes_profile, args.model, args.provider, args.tracedecay_bin, fixture
+        args.hermes_profile, args.model, args.provider, args.tracedecay_bin, fixture, eval_env
     )
     max_turns = args.max_turns or scenario["real_model"].get("max_turns", 8)
-    env = dict(os.environ)
+    env = dict(eval_env)
     env["HERMES_HOME"] = str(profile_dir)
     provider_env_passthrough(env)
     transcripts = []
@@ -366,18 +443,19 @@ def read_hermes_usage(profile_dir, started_after):
     }
 
 
-def drive_cursor_agent(args, scenario, fixture, log_dir):
+def drive_cursor_agent(args, scenario, fixture, log_dir, eval_env):
     """Experimental: drives `cursor-agent -p` against the fixture's local MCP setup."""
     run(
         [args.tracedecay_bin, "install", "--agent", "cursor", "--local"],
         cwd=fixture,
+        env=eval_env,
         timeout=120,
     )
     transcripts = []
     for index, prompt in enumerate(scenario["real_model"]["prompts"], start=1):
         cmd = ["cursor-agent", "-p", "--output-format", "text", "--model", args.model, prompt]
         started = datetime.datetime.now(datetime.timezone.utc)
-        result = run(cmd, cwd=fixture, timeout=900, check=False)
+        result = run(cmd, cwd=fixture, env=eval_env, timeout=900, check=False)
         elapsed = (datetime.datetime.now(datetime.timezone.utc) - started).total_seconds()
         log_path = log_dir / f"{scenario['id']}-prompt{index}.log"
         log_path.write_text(result.stdout)
@@ -421,28 +499,119 @@ def extract_token_hints(output):
     return unique[:10]
 
 
-def evaluate_assertions(scenario, fixture):
-    db = sqlite3.connect(fixture / ".tracedecay/tracedecay.db")
+def assertion_applies_to_real_model(assertion):
+    if assertion.get("deterministic_only"):
+        return False
+    phase = assertion.get("phase", "both")
+    return phase in ("both", "well-behaved-only", "real-model", "real-model-only")
+
+
+def failed_assertion(assertion, error, error_type="assertion", **extra):
+    outcome = {
+        "name": assertion.get("name", "(unnamed assertion)"),
+        "kind": assertion.get("kind"),
+        "passed": False,
+        "error": error,
+        "error_type": error_type,
+    }
+    outcome.update(extra)
+    return outcome
+
+
+def compare_assertion_value(actual, expected, op):
+    if op == "eq":
+        return actual == expected
+    if op == "ne":
+        return actual != expected
+    if op == "gt":
+        return actual > expected
+    if op == "gte":
+        return actual >= expected
+    if op == "lt":
+        return actual < expected
+    if op == "lte":
+        return actual <= expected
+    return None
+
+
+def evaluate_assertions(scenario, db_path):
     outcomes = []
+    assertions = [
+        assertion
+        for assertion in scenario["assertions"]
+        if assertion_applies_to_real_model(assertion)
+    ]
+    if not assertions:
+        return outcomes
+
+    try:
+        db = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        return [
+            failed_assertion(
+                assertion,
+                f"failed to open TraceDecay store: {exc}",
+                error_type="sqlite",
+            )
+            for assertion in assertions
+        ]
+
     for assertion in scenario["assertions"]:
-        if assertion["kind"] != "sql":
-            continue  # curate-report assertions are deterministic-layer-only
-        if assertion.get("deterministic_only"):
+        if not assertion_applies_to_real_model(assertion):
             continue
-        actual = db.execute(assertion["sql"]).fetchone()[0]
+        if assertion["kind"] != "sql":
+            outcomes.append(
+                failed_assertion(
+                    assertion,
+                    f"unsupported assertion kind for real-model eval: {assertion['kind']}",
+                )
+            )
+            continue
         expected = assertion["value"]
         op = assertion["op"]
-        passed = {
-            "eq": actual == expected,
-            "ne": actual != expected,
-            "gt": actual > expected,
-            "gte": actual >= expected,
-            "lt": actual < expected,
-            "lte": actual <= expected,
-        }[op]
+        try:
+            row = db.execute(assertion["sql"]).fetchone()
+            actual = row[0] if row is not None else None
+        except sqlite3.Error as exc:
+            outcomes.append(
+                failed_assertion(
+                    assertion,
+                    str(exc),
+                    error_type="sqlite",
+                    actual=None,
+                    op=op,
+                    expected=expected,
+                )
+            )
+            continue
+        try:
+            passed = compare_assertion_value(actual, expected, op)
+        except TypeError as exc:
+            outcomes.append(
+                failed_assertion(
+                    assertion,
+                    f"could not compare assertion values: {exc}",
+                    actual=actual,
+                    op=op,
+                    expected=expected,
+                )
+            )
+            continue
+        if passed is None:
+            outcomes.append(
+                failed_assertion(
+                    assertion,
+                    f"unsupported assertion op: {op}",
+                    actual=actual,
+                    op=op,
+                    expected=expected,
+                )
+            )
+            continue
         outcomes.append(
             {
                 "name": assertion["name"],
+                "kind": assertion["kind"],
                 "passed": passed,
                 "actual": actual,
                 "op": op,
@@ -485,47 +654,50 @@ def main(argv):
         print(f"\nblocked report written to {report_path}", file=sys.stderr)
         return 2
 
-    args.hermes_profile = resolve_hermes_profile(args)
     overall_ok = True
-    try:
-        for scenario in scenarios:
-            fixture = build_fixture(scenario, args.tracedecay_bin)
-            try:
-                if args.driver == "hermes":
-                    transcripts = drive_hermes(args, scenario, fixture, run_dir)
+    for scenario in scenarios:
+        eval_env = create_eval_environment(scenario["id"])
+        args.hermes_profile = resolve_hermes_profile(args)
+        fixture = None
+        try:
+            fixture, db_path = build_fixture(scenario, args.tracedecay_bin, eval_env.env)
+            if args.driver == "hermes":
+                transcripts = drive_hermes(args, scenario, fixture, run_dir, eval_env.env)
+            else:
+                transcripts = drive_cursor_agent(args, scenario, fixture, run_dir, eval_env.env)
+            outcomes = evaluate_assertions(scenario, db_path)
+            failed = [o for o in outcomes if not o["passed"]]
+            status = "pass" if not failed else "fail"
+            if failed and scenario.get("contract") == "pending-sibling":
+                status = "fail (note: scenario contract is pending-sibling — see contract_notes)"
+            if not all(t["turn_valid"] for t in transcripts):
+                status = "error (agent turn invalid — see transcript logs)"
+                failed = failed or [{"name": "agent-turn", "passed": False}]
+            report["scenarios"].append(
+                {
+                    "id": scenario["id"],
+                    "contract": scenario.get("contract", "stable"),
+                    "status": status,
+                    "assertions": outcomes,
+                    "transcripts": transcripts,
+                    "fixture": str(fixture) if args.keep_fixture else "(removed)",
+                    "store": str(eval_env.data_dir) if args.keep_fixture else "(removed)",
+                }
+            )
+            overall_ok &= not failed
+            print(f"[{scenario['id']}] {status}")
+            for outcome in outcomes:
+                marker = "pass" if outcome["passed"] else "FAIL"
+                if outcome.get("error"):
+                    print(f"  [{marker}] {outcome['name']} — {outcome['error']}")
                 else:
-                    transcripts = drive_cursor_agent(args, scenario, fixture, run_dir)
-                outcomes = evaluate_assertions(scenario, fixture)
-                failed = [o for o in outcomes if not o["passed"]]
-                status = "pass" if not failed else "fail"
-                if failed and scenario.get("contract") == "pending-sibling":
-                    status = "fail (note: scenario contract is pending-sibling — see contract_notes)"
-                if not all(t["turn_valid"] for t in transcripts):
-                    status = "error (agent turn invalid — see transcript logs)"
-                    failed = failed or [{"name": "agent-turn", "passed": False}]
-                report["scenarios"].append(
-                    {
-                        "id": scenario["id"],
-                        "contract": scenario.get("contract", "stable"),
-                        "status": status,
-                        "assertions": outcomes,
-                        "transcripts": transcripts,
-                        "fixture": str(fixture) if args.keep_fixture else "(removed)",
-                    }
-                )
-                overall_ok &= not failed
-                print(f"[{scenario['id']}] {status}")
-                for outcome in outcomes:
-                    marker = "pass" if outcome["passed"] else "FAIL"
                     print(
                         f"  [{marker}] {outcome['name']} — actual {outcome['actual']} "
                         f"{outcome['op']} expected {outcome['expected']}"
                     )
-            finally:
-                if not args.keep_fixture:
-                    shutil.rmtree(fixture, ignore_errors=True)
-    finally:
-        args.hermes_profile.cleanup()
+        finally:
+            args.hermes_profile.cleanup()
+            cleanup_eval_artifacts(args, fixture, eval_env)
 
     report["status"] = "pass" if overall_ok else "fail"
     report_path = run_dir / "report.json"

--- a/eval/test_run_real_model.py
+++ b/eval/test_run_real_model.py
@@ -1,6 +1,11 @@
+import argparse
 import importlib.util
+import json
+import sqlite3
+import subprocess
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -8,6 +13,11 @@ MODULE_PATH = Path(__file__).with_name("run_real_model.py")
 SPEC = importlib.util.spec_from_file_location("run_real_model", MODULE_PATH)
 run_real_model = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(run_real_model)
+
+BENCHMARK_PATH = MODULE_PATH.parent.parent / "benchmarks" / "run_benchmarks.py"
+BENCHMARK_SPEC = importlib.util.spec_from_file_location("run_benchmarks", BENCHMARK_PATH)
+run_benchmarks = importlib.util.module_from_spec(BENCHMARK_SPEC)
+BENCHMARK_SPEC.loader.exec_module(run_benchmarks)
 
 
 class HermesHomeSelectionTest(unittest.TestCase):
@@ -45,6 +55,205 @@ class HermesHomeSelectionTest(unittest.TestCase):
 
             self.assertEqual(selected.profile, run_real_model.DEFAULT_PROFILE)
             self.assertEqual(selected.profile_dir, home)
+
+
+class EvalStorageIsolationTest(unittest.TestCase):
+    def test_eval_environment_pins_home_and_profile_storage_to_tempdir(self):
+        env = run_real_model.create_eval_environment("memory-no-pollution")
+        self.addCleanup(env.cleanup)
+
+        self.assertNotEqual(Path(env.env["HOME"]), Path.home())
+        self.assertEqual(env.env["USERPROFILE"], env.env["HOME"])
+        self.assertEqual(Path(env.env["TRACEDECAY_DATA_DIR"]), env.data_dir)
+        self.assertEqual(Path(env.env["TRACEDECAY_GLOBAL_DB"]), env.global_db)
+        self.assertTrue(env.data_dir.is_relative_to(env.root))
+        self.assertNotEqual(env.global_db, Path.home() / ".tracedecay/global.db")
+
+    def test_store_path_is_resolved_from_runtime_status_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = Path(tmp) / "fixture"
+            fixture.mkdir()
+            db_path = Path(tmp) / "profile" / "projects" / "eval" / "tracedecay.db"
+            db_path.parent.mkdir(parents=True)
+            db_path.write_text("")
+            env = {"TRACEDECAY_DATA_DIR": str(Path(tmp) / "profile")}
+            completed = subprocess.CompletedProcess(
+                ["tracedecay", "status", "--runtime", "--json"],
+                0,
+                stdout=json.dumps({"database": {"db_path": str(db_path)}}),
+                stderr="",
+            )
+
+            with mock.patch.object(run_real_model, "run", return_value=completed) as run_mock:
+                resolved = run_real_model.resolve_store_db_path("tracedecay", fixture, env)
+
+            self.assertEqual(resolved, db_path)
+            run_mock.assert_called_once()
+            cmd = run_mock.call_args.args[0]
+            self.assertEqual(cmd, ["tracedecay", "status", "--runtime", "--json"])
+            self.assertEqual(run_mock.call_args.kwargs["cwd"], fixture)
+            self.assertEqual(run_mock.call_args.kwargs["env"], env)
+
+    def test_keep_fixture_preserves_isolated_eval_store(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = Path(tmp) / "fixture"
+            fixture.mkdir()
+            eval_env = run_real_model.create_eval_environment("keep-store")
+            self.addCleanup(eval_env.cleanup)
+
+            args = argparse.Namespace(keep_fixture=True)
+            run_real_model.cleanup_eval_artifacts(args, fixture, eval_env)
+
+            self.assertTrue(fixture.exists())
+            self.assertTrue(eval_env.data_dir.exists())
+
+    def test_cleanup_removes_fixture_and_isolated_eval_store_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = Path(tmp) / "fixture"
+            fixture.mkdir()
+            eval_env = run_real_model.create_eval_environment("cleanup-store")
+
+            args = argparse.Namespace(keep_fixture=False)
+            run_real_model.cleanup_eval_artifacts(args, fixture, eval_env)
+
+            self.assertFalse(fixture.exists())
+            self.assertFalse(eval_env.root.exists())
+
+
+class AssertionEvaluationTest(unittest.TestCase):
+    def make_db(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        db_path = Path(tmp.name) / "tracedecay.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE memory_facts (content TEXT)")
+        conn.execute("INSERT INTO memory_facts VALUES ('kept')")
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_unsupported_assertion_kind_is_structured_failure(self):
+        db_path = self.make_db()
+        scenario = {
+            "assertions": [
+                {
+                    "kind": "search-rank",
+                    "name": "unsupported_search_rank",
+                    "phase": "both",
+                }
+            ]
+        }
+
+        outcomes = run_real_model.evaluate_assertions(scenario, db_path)
+
+        self.assertEqual(len(outcomes), 1)
+        self.assertFalse(outcomes[0]["passed"])
+        self.assertEqual(outcomes[0]["kind"], "search-rank")
+        self.assertIn("unsupported assertion kind", outcomes[0]["error"])
+
+    def test_assertions_for_other_phases_are_skipped(self):
+        db_path = self.make_db()
+        scenario = {
+            "assertions": [
+                {
+                    "kind": "search-rank",
+                    "name": "violation_only_rank",
+                    "phase": "violation-only",
+                },
+                {
+                    "kind": "sql",
+                    "name": "deterministic_sql",
+                    "sql": "SELECT 1",
+                    "op": "eq",
+                    "value": 1,
+                    "deterministic_only": True,
+                },
+            ]
+        }
+
+        self.assertEqual(run_real_model.evaluate_assertions(scenario, db_path), [])
+
+    def test_sql_errors_are_reported_as_assertion_failures(self):
+        db_path = self.make_db()
+        scenario = {
+            "assertions": [
+                {
+                    "kind": "sql",
+                    "name": "missing_table",
+                    "sql": "SELECT COUNT(*) FROM missing_table",
+                    "op": "eq",
+                    "value": 0,
+                }
+            ]
+        }
+
+        outcomes = run_real_model.evaluate_assertions(scenario, db_path)
+
+        self.assertEqual(len(outcomes), 1)
+        self.assertFalse(outcomes[0]["passed"])
+        self.assertEqual(outcomes[0]["name"], "missing_table")
+        self.assertEqual(outcomes[0]["error_type"], "sqlite")
+        self.assertIn("missing_table", outcomes[0]["error"])
+
+
+class BenchmarkRunnerTest(unittest.TestCase):
+    def test_tracedecay_benchmark_uses_temp_profile_and_status_db_size(self):
+        calls = []
+
+        def fake_run_timed(cmd, cwd=None, env=None):
+            calls.append((cmd, cwd, env))
+            stdout = ""
+            if cmd == ["tracedecay", "status", "--json"]:
+                stdout = json.dumps(
+                    {
+                        "db_size_bytes": 12345,
+                        "node_count": 7,
+                        "edge_count": 8,
+                        "file_count": 9,
+                    }
+                )
+            return 0.01, 0, subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        class DummyMcp:
+            def __init__(self, root, env=None):
+                self.root = root
+                self.env = env
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return None
+
+            def call_tool(self, *_args, **_kwargs):
+                return {"result": {"_meta": {"duration_us": 1}, "content": [{"text": "[]"}]}}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with (
+                mock.patch.object(run_benchmarks, "run_timed", side_effect=fake_run_timed),
+                mock.patch.object(run_benchmarks, "TraceDecayMcp", DummyMcp),
+            ):
+                out = run_benchmarks.benchmark_tracedecay("fixture", root, [])
+
+        self.assertEqual(out["cache_size_bytes"], 12345)
+        tracedecay_envs = [env for _cmd, _cwd, env in calls if env is not None]
+        self.assertTrue(tracedecay_envs)
+        for env in tracedecay_envs:
+            self.assertIn("TRACEDECAY_DATA_DIR", env)
+            self.assertIn("TRACEDECAY_GLOBAL_DB", env)
+            self.assertTrue(Path(env["TRACEDECAY_GLOBAL_DB"]).is_relative_to(Path(env["TRACEDECAY_DATA_DIR"])))
+
+    def test_skip_clone_requires_existing_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                mock.patch.object(run_benchmarks, "CLONE_DIR", Path(tmp)),
+                mock.patch.object(run_benchmarks.subprocess, "run") as run_mock,
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    run_benchmarks.clone_repo("missing", "https://example.invalid/repo.git", skip_clone=True)
+
+        run_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Run real-model eval fixtures with isolated HOME/data/global DB state
- Resolve TraceDecay store paths through the CLI before SQL assertions
- Run benchmark indexing in temporary profile-scoped storage and report DB size from status

## Verification
- python -m unittest eval/test_run_real_model.py
