### PR TITLE
Harden transcript ingestion edge cases

### DIFF
--- a/src/sessions/cline_like.rs
+++ b/src/sessions/cline_like.rs
@@ -111,15 +111,32 @@ impl TranscriptSource for ClineLikeSource {
         _max_new_bytes: Option<u64>,
     ) -> Option<ParsedTranscript> {
         let task_dir = path.parent()?;
+        let ui_path = task_dir.join("ui_messages.json");
+        let changed = read_changed_with_companion(path, &ui_path, prev)?;
         let metadata = read_task_metadata(task_dir)?;
         if !metadata_belongs_to_project(&metadata, project_root) {
             return None;
         }
 
-        let ui_path = task_dir.join("ui_messages.json");
-        let changed = read_changed_with_companion(path, &ui_path, prev)?;
-        let document: Value = serde_json::from_str(&changed.contents).ok()?;
-        let entries = document.as_array()?;
+        let document: Value = match serde_json::from_str(&changed.contents) {
+            Ok(document) => document,
+            Err(_) => {
+                return Some(empty_changed_transcript(
+                    self.provider,
+                    path,
+                    project_root,
+                    changed.new_cursor,
+                ));
+            }
+        };
+        let Some(entries) = document.as_array() else {
+            return Some(empty_changed_transcript(
+                self.provider,
+                path,
+                project_root,
+                changed.new_cursor,
+            ));
+        };
         let task_id = task_dir
             .file_name()
             .and_then(|name| name.to_str())
@@ -129,18 +146,19 @@ impl TranscriptSource for ClineLikeSource {
         let mut messages = Vec::new();
         let mut assistant_index = 0_usize;
         for (index, entry) in entries.iter().enumerate() {
-            let usage = if entry.get("role").and_then(Value::as_str) == Some("assistant")
-                || entry.get("role").and_then(Value::as_str) == Some("model")
-            {
-                let usage = usage_by_assistant.get(assistant_index).cloned();
-                assistant_index += 1;
-                usage
+            let is_assistant = entry.get("role").and_then(Value::as_str) == Some("assistant")
+                || entry.get("role").and_then(Value::as_str) == Some("model");
+            let usage = if is_assistant {
+                usage_by_assistant.get(assistant_index).cloned()
             } else {
                 None
             };
             if let Some(message) =
                 message_from_entry(self.provider, entry, task_id, path, index, usage.as_ref())
             {
+                if message.role == "assistant" {
+                    assistant_index += 1;
+                }
                 messages.push(message);
             }
         }
@@ -167,6 +185,38 @@ impl TranscriptSource for ClineLikeSource {
             messages,
             new_cursor: changed.new_cursor,
         })
+    }
+}
+
+fn empty_changed_transcript(
+    provider: &str,
+    path: &Path,
+    project_root: &Path,
+    new_cursor: StoredCursor,
+) -> ParsedTranscript {
+    let project = project_root.to_string_lossy().to_string();
+    ParsedTranscript {
+        draft: SessionDraft {
+            session_id: path
+                .parent()
+                .and_then(|dir| dir.file_name())
+                .and_then(|name| name.to_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            project_key: project.clone(),
+            project_path: project,
+            title: None,
+            metadata_json: serde_json::to_string(&serde_json::json!({
+                "source": format!("{provider}_task_history"),
+            }))
+            .ok(),
+            parent_session_id: None,
+            is_subagent: false,
+            agent_id: None,
+            parent_tool_use_id: None,
+        },
+        messages: Vec::new(),
+        new_cursor,
     }
 }
 

--- a/src/sessions/hermes.rs
+++ b/src/sessions/hermes.rs
@@ -380,6 +380,12 @@ fn session_from_row(
         metadata.insert("usage".to_string(), usage);
     }
     let project = project_root.to_string_lossy().to_string();
+    let parent_session_id = row
+        .parent_session_id
+        .as_deref()
+        .filter(|parent| !parent.is_empty())
+        .map(str::to_string);
+    let is_subagent = parent_session_id.is_some();
     SessionRecord {
         provider: PROVIDER.to_string(),
         session_id: row.session_id.clone(),
@@ -394,12 +400,8 @@ fn session_from_row(
         ended_at: row.session_ended_at.map(|secs| secs as i64),
         transcript_path: Some(state_db_path.to_string()),
         metadata_json: Some(Value::Object(metadata).to_string()),
-        parent_session_id: row
-            .parent_session_id
-            .as_deref()
-            .filter(|parent| !parent.is_empty())
-            .map(str::to_string),
-        is_subagent: false,
+        parent_session_id,
+        is_subagent,
         agent_id: None,
         parent_tool_use_id: None,
     }

--- a/src/sessions/kiro.rs
+++ b/src/sessions/kiro.rs
@@ -14,6 +14,10 @@
 //! `workspace-sessions`, by base64-decoding the directory name. The source uses
 //! the shared **`ContentHash`** reader because Kiro writes full snapshot files.
 
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -89,16 +93,33 @@ impl TranscriptSource for KiroSource {
         }
 
         let changed = read_changed_file(path, prev)?;
-        let value: Value = serde_json::from_str(&changed.contents).ok()?;
+        let value: Value = match serde_json::from_str(&changed.contents) {
+            Ok(value) => value,
+            Err(_) => {
+                return Some(empty_changed_transcript(
+                    path,
+                    project_root,
+                    changed.new_cursor,
+                ));
+            }
+        };
         if value.get("executions").and_then(Value::as_array).is_some() {
-            return None;
+            return Some(empty_changed_transcript(
+                path,
+                project_root,
+                changed.new_cursor,
+            ));
         }
 
         let session_id = session_id_from_transcript(path, &value);
         let model = model_from_transcript(&value);
         let messages = messages_from_transcript(&value, &session_id, path, model.as_deref());
         if messages.is_empty() {
-            return None;
+            return Some(empty_changed_transcript(
+                path,
+                project_root,
+                changed.new_cursor,
+            ));
         }
 
         let project = project_root.to_string_lossy().to_string();
@@ -135,6 +156,36 @@ pub async fn ingest_kiro_for_project(
         return TranscriptIngestStats::default();
     };
     crate::sessions::source::ingest_source(db, &source, project_root, max_new_bytes).await
+}
+
+fn empty_changed_transcript(
+    path: &Path,
+    project_root: &Path,
+    new_cursor: StoredCursor,
+) -> ParsedTranscript {
+    let project = project_root.to_string_lossy().to_string();
+    ParsedTranscript {
+        draft: SessionDraft {
+            session_id: path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            project_key: project.clone(),
+            project_path: project,
+            title: None,
+            metadata_json: serde_json::to_string(&serde_json::json!({
+                "source": "kiro_transcript",
+            }))
+            .ok(),
+            parent_session_id: None,
+            is_subagent: false,
+            agent_id: None,
+            parent_tool_use_id: None,
+        },
+        messages: Vec::new(),
+        new_cursor,
+    }
 }
 
 fn collect_workspace_session_files(sessions_root: &Path, project_root: &Path) -> Vec<PathBuf> {
@@ -294,7 +345,7 @@ fn folder_field_to_path(folder: &str) -> Option<PathBuf> {
 }
 
 fn percent_decode_path(value: &str) -> PathBuf {
-    let mut out = String::new();
+    let mut out = Vec::new();
     let bytes = value.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -303,15 +354,25 @@ fn percent_decode_path(value: &str) -> PathBuf {
                 std::str::from_utf8(&bytes[index + 1..index + 3]).unwrap_or(""),
                 16,
             ) {
-                out.push(byte as char);
+                out.push(byte);
                 index += 3;
                 continue;
             }
         }
-        out.push(bytes[index] as char);
+        out.push(bytes[index]);
         index += 1;
     }
-    PathBuf::from(out)
+    pathbuf_from_decoded_bytes(out)
+}
+
+#[cfg(unix)]
+fn pathbuf_from_decoded_bytes(bytes: Vec<u8>) -> PathBuf {
+    PathBuf::from(OsString::from_vec(bytes))
+}
+
+#[cfg(not(unix))]
+fn pathbuf_from_decoded_bytes(bytes: Vec<u8>) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 fn decode_workspace_sessions_dir(name: &str) -> Option<PathBuf> {

--- a/tests/cline_like_transcript_ingest_test.rs
+++ b/tests/cline_like_transcript_ingest_test.rs
@@ -1,6 +1,7 @@
 use tempfile::TempDir;
+use tracedecay::global_db::{GlobalDb, ParseOffset};
 use tracedecay::sessions::cline_like::ClineLikeSource;
-use tracedecay::sessions::cursor::open_project_session_db;
+use tracedecay::sessions::cursor::{open_project_session_db, project_session_db_path};
 use tracedecay::sessions::source::ingest_source;
 
 fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
@@ -17,6 +18,68 @@ fn vscode_storage_root(home: &std::path::Path, extension_id: &str) -> std::path:
         .join("User/globalStorage")
         .join(extension_id)
         .join("tasks")
+}
+
+async fn parse_offset_for_path(db: &GlobalDb, path: &std::path::Path) -> Option<ParseOffset> {
+    let path = path.to_string_lossy();
+    if let Some(offset) = db.get_parse_offset(path.as_ref()).await {
+        return Some(offset);
+    }
+
+    #[cfg(windows)]
+    {
+        let alternate = if path.contains('/') {
+            path.replace('/', "\\")
+        } else {
+            path.replace('\\', "/")
+        };
+        if alternate != path {
+            return db.get_parse_offset(&alternate).await;
+        }
+    }
+
+    None
+}
+
+async fn parse_offset_for_task_history(
+    db: &GlobalDb,
+    project: &std::path::Path,
+    path: &std::path::Path,
+) -> Option<ParseOffset> {
+    if let Some(offset) = parse_offset_for_path(db, path).await {
+        return Some(offset);
+    }
+
+    let task_dir = path.parent()?.file_name()?.to_string_lossy();
+    let file_name = path.file_name()?.to_string_lossy();
+    let expected_suffix = format!("{task_dir}/{file_name}");
+    let raw_db = libsql::Builder::new_local(project_session_db_path(project))
+        .build()
+        .await
+        .ok()?;
+    let conn = raw_db.connect().ok()?;
+    let mut rows = conn
+        .query(
+            "SELECT file_path, byte_offset, mtime, file_id FROM parse_offsets",
+            (),
+        )
+        .await
+        .ok()?;
+    while let Some(row) = rows.next().await.ok()? {
+        let file_path: String = row.get(0).ok()?;
+        let normalized = file_path.replace('\\', "/");
+        if normalized.ends_with(&expected_suffix) {
+            let offset: i64 = row.get(1).ok()?;
+            let mtime: i64 = row.get(2).ok()?;
+            let file_id: i64 = row.get(3).ok()?;
+            return Some(ParseOffset {
+                byte_offset: offset as u64,
+                mtime: mtime as u64,
+                file_id: file_id as u64,
+            });
+        }
+    }
+    None
 }
 
 fn write_task(
@@ -265,6 +328,135 @@ async fn cline_ui_messages_only_change_triggers_usage_refresh() {
     let metadata: serde_json::Value =
         serde_json::from_str(assistant.message.metadata_json.as_deref().unwrap()).unwrap();
     assert_eq!(metadata["usage"]["input_tokens"], 2200);
+}
+
+#[tokio::test]
+async fn cline_usage_index_skips_unemitted_assistant_entries() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    let root = vscode_storage_root(&home, "saoudrizwan.claude-dev");
+    let dir = root.join("cline-skipped-assistant");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("task_metadata.json"),
+        serde_json::json!({
+            "task": "Usage indexing",
+            "workspacePath": project
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("api_conversation_history.json"),
+        serde_json::json!([
+            {"role": "assistant", "content": ""},
+            {"role": "assistant", "content": "Emitted assistant usage target"}
+        ])
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("ui_messages.json"),
+        serde_json::json!([
+            {
+                "type": "say",
+                "say": "api_req_started",
+                "text": serde_json::json!({"tokensIn": 777}).to_string()
+            }
+        ])
+        .to_string(),
+    )
+    .unwrap();
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClineLikeSource::cline_with_home(&home);
+    assert_eq!(
+        ingest_source(&db, &source, &project, None)
+            .await
+            .messages_upserted,
+        1
+    );
+    let hits = db
+        .search_session_messages("cline", None, "usage target", 10)
+        .await;
+    assert_eq!(hits.len(), 1);
+    let metadata: serde_json::Value =
+        serde_json::from_str(hits[0].message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["usage"]["input_tokens"], 777);
+}
+
+#[tokio::test]
+async fn cline_parse_failures_advance_content_hash_cursor() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    let root = vscode_storage_root(&home, "saoudrizwan.claude-dev");
+    let dir = root.join("cline-invalid-json");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("task_metadata.json"),
+        serde_json::json!({"workspacePath": project}).to_string(),
+    )
+    .unwrap();
+    let api = dir.join("api_conversation_history.json");
+    std::fs::write(&api, "{not json").unwrap();
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClineLikeSource::cline_with_home(&home);
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 0);
+
+    let offset = parse_offset_for_task_history(&db, &project, &api)
+        .await
+        .expect("invalid changed task history should still advance its cursor");
+    assert_ne!(offset.byte_offset, 0);
+}
+
+#[tokio::test]
+async fn cline_missing_metadata_waits_for_later_metadata_before_advancing_cursor() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    let root = vscode_storage_root(&home, "saoudrizwan.claude-dev");
+    let dir = root.join("cline-missing-metadata");
+    std::fs::create_dir_all(&dir).unwrap();
+    let api = dir.join("api_conversation_history.json");
+    std::fs::write(
+        &api,
+        serde_json::json!([
+            {"role": "user", "content": "Metadata missing prompt"}
+        ])
+        .to_string(),
+    )
+    .unwrap();
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClineLikeSource::cline_with_home(&home);
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 0);
+
+    assert!(
+        parse_offset_for_task_history(&db, &project, &api)
+            .await
+            .is_none(),
+        "metadata-less task should not advance its cursor"
+    );
+
+    std::fs::write(
+        dir.join("task_metadata.json"),
+        serde_json::json!({
+            "task": "Metadata arrived later",
+            "workspacePath": project
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 1);
+
+    let offset = parse_offset_for_task_history(&db, &project, &api)
+        .await
+        .expect("task should advance once metadata is available");
+    assert_ne!(offset.byte_offset, 0);
 }
 
 #[tokio::test]

--- a/tests/hermes_transcript_ingest_test.rs
+++ b/tests/hermes_transcript_ingest_test.rs
@@ -260,6 +260,34 @@ async fn hermes_state_db_populates_projection_for_pinned_project() {
 }
 
 #[tokio::test]
+async fn hermes_parent_session_id_marks_subagent_session() {
+    let tmp = TempDir::new().unwrap();
+    let (hermes_home, project) = setup(&tmp);
+    let state_db = write_hermes_profile(&hermes_home, "test", Some(&project)).await;
+    let conn = open_state_db(&state_db).await;
+    conn.execute(
+        "UPDATE sessions SET parent_session_id = 'parent-hermes-session' WHERE id = ?1",
+        libsql::params![SESSION_ID],
+    )
+    .await
+    .unwrap();
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let stats = ingest_homes(&db, std::slice::from_ref(&hermes_home), &project).await;
+    assert_eq!(stats.messages_upserted, 4);
+
+    let session = db
+        .get_session("hermes", SESSION_ID)
+        .await
+        .expect("hermes child session should be stored");
+    assert_eq!(
+        session.parent_session_id.as_deref(),
+        Some("parent-hermes-session")
+    );
+    assert!(session.is_subagent);
+}
+
+#[tokio::test]
 async fn hermes_projection_sweep_does_not_mutate_runtime_owned_raw_messages() {
     let tmp = TempDir::new().unwrap();
     let (hermes_home, project) = setup(&tmp);


### PR DESCRIPTION
## Summary
- Advance Cline/Kiro content cursors on malformed or metadata-less changed transcripts without ingesting bogus messages
- Keep Cline assistant usage aligned with emitted assistant messages
- Mark Hermes sessions with parent_session_id as subagent sessions

## Verification
- cargo test --test cline_like_transcript_ingest_test --test hermes_transcript_ingest_test
- cargo test --test kiro_agent_test --test kiro_transcript_ingest_test
