### PR TITLE
Harden LCM compression and payload lifecycle

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -882,7 +882,9 @@ impl GlobalDb {
         .ok()?;
         ensure_session_parent_columns(&db.conn).await?;
         ensure_parse_offset_columns(&db.conn).await?;
-        crate::sessions::lcm::schema::ensure_lcm_schema(&db.conn).await?;
+        crate::sessions::lcm::schema::ensure_lcm_schema(&db.conn)
+            .await
+            .ok()?;
         // One-off self-heal: re-derive timestamps and token-usage counters
         // for legacy messages ingested before extraction existed.
         // Marker-guarded (runs once per store) and fail-open, like the LCM

--- a/src/sessions/lcm/compression.rs
+++ b/src/sessions/lcm/compression.rs
@@ -893,7 +893,7 @@ async fn persist_compression_transaction_writes(
             write.request.dynamic_leaf_chunk_max,
             source_token_count(&remaining_backlog),
         );
-        let selected_len = compression_decision::bounded_leaf_chunk_len(
+        let selected_len = compression_decision::progress_leaf_chunk_len(
             &remaining_backlog,
             leaf_chunk_tokens,
             write.request.max_source_messages,

--- a/src/sessions/lcm/compression_decision.rs
+++ b/src/sessions/lcm/compression_decision.rs
@@ -247,7 +247,7 @@ pub fn compression_plan(input: CompressionPlanInput<'_>) -> CompressionPlan {
         input.request.dynamic_leaf_chunk_max,
         source_token_count(input.backlog),
     );
-    let selected_len = bounded_leaf_chunk_len(
+    let selected_len = progress_leaf_chunk_len(
         input.backlog,
         leaf_chunk_tokens,
         input.request.max_source_messages,
@@ -316,17 +316,28 @@ pub fn bounded_leaf_chunk_len(
     let mut selected_tokens = 0;
     for message in backlog.iter().take(max_messages) {
         let message_tokens = estimate_tokens(&message.content);
-        if selected_len > 0 {
-            if let Some(token_limit) = token_limit {
-                if selected_tokens + message_tokens > token_limit {
-                    break;
-                }
+        if let Some(token_limit) = token_limit {
+            if selected_tokens + message_tokens > token_limit {
+                break;
             }
         }
         selected_tokens += message_tokens;
         selected_len += 1;
     }
-    selected_len.max(1)
+    selected_len
+}
+
+pub fn progress_leaf_chunk_len(
+    backlog: &[LcmRawMessage],
+    leaf_chunk_tokens: Option<i64>,
+    max_source_messages: Option<usize>,
+) -> usize {
+    let selected_len = bounded_leaf_chunk_len(backlog, leaf_chunk_tokens, max_source_messages);
+    if selected_len == 0 && !backlog.is_empty() {
+        1
+    } else {
+        selected_len
+    }
 }
 
 fn should_force_overflow_recovery(request: &LcmCompressionRequest) -> bool {

--- a/src/sessions/lcm/dag.rs
+++ b/src/sessions/lcm/dag.rs
@@ -130,15 +130,34 @@ pub(crate) async fn load_uncondensed_summary_nodes(
                      AND s.source_id = n.node_id
                  )
              ),
-             lineage(root_id, source_kind, source_id) AS (
-               SELECT s.node_id, s.source_kind, s.source_id
+             lineage(root_id, source_kind, source_id, path, depth) AS (
+               SELECT s.node_id,
+                      s.source_kind,
+                      s.source_id,
+                      '|' || s.node_id || CASE
+                          WHEN s.source_kind = 'summary_node' THEN '|' || s.source_id || '|'
+                          ELSE '|'
+                      END,
+                      0
                FROM lcm_summary_sources s
                JOIN unparented u ON u.node_id = s.node_id
                UNION ALL
-               SELECT l.root_id, s.source_kind, s.source_id
+               SELECT l.root_id,
+                      s.source_kind,
+                      s.source_id,
+                      l.path || CASE
+                          WHEN s.source_kind = 'summary_node' THEN s.source_id || '|'
+                          ELSE ''
+                      END,
+                      l.depth + 1
                FROM lineage l
                JOIN lcm_summary_sources s
                  ON l.source_kind = 'summary_node' AND s.node_id = l.source_id
+               WHERE l.depth < 128
+                 AND (
+                   s.source_kind != 'summary_node'
+                   OR instr(l.path, '|' || s.source_id || '|') = 0
+                 )
              ),
              first_raw AS (
                SELECT root_id, MIN(CAST(source_id AS INTEGER)) AS first_source_store_id
@@ -305,10 +324,14 @@ async fn validate_summary_sources(
 
     let child_owners = load_summary_node_owners_by_ids(conn, &child_node_ids).await?;
     for child_node_id in child_node_ids {
-        let Some((provider, session_id)) = child_owners.get(child_node_id.as_str()) else {
+        let Some((provider, session_id, child_depth)) = child_owners.get(child_node_id.as_str())
+        else {
             return Err(LcmError::SummaryNodeNotFound);
         };
         if provider != &draft.provider || session_id != &draft.session_id {
+            return Err(LcmError::SummarySourceNotOwnedBySession);
+        }
+        if *child_depth >= draft.depth {
             return Err(LcmError::SummarySourceNotOwnedBySession);
         }
     }
@@ -574,7 +597,7 @@ async fn load_raw_message_owners_by_store_ids(
 async fn load_summary_node_owners_by_ids(
     conn: &Connection,
     node_ids: &[String],
-) -> Result<BTreeMap<String, (String, String)>, LcmError> {
+) -> Result<BTreeMap<String, (String, String, i64)>, LcmError> {
     let unique_node_ids = node_ids
         .iter()
         .cloned()
@@ -588,7 +611,7 @@ async fn load_summary_node_owners_by_ids(
         .collect::<Vec<_>>()
         .join(", ");
     let sql = format!(
-        "SELECT node_id, provider, session_id
+        "SELECT node_id, provider, session_id, depth
          FROM lcm_summary_nodes
          WHERE node_id IN ({placeholders})"
     );
@@ -606,7 +629,8 @@ async fn load_summary_node_owners_by_ids(
         let node_id: String = row.get(0)?;
         let provider: String = row.get(1)?;
         let session_id: String = row.get(2)?;
-        out.insert(node_id, (provider, session_id));
+        let depth: i64 = row.get(3)?;
+        out.insert(node_id, (provider, session_id, depth));
     }
     Ok(out)
 }

--- a/src/sessions/lcm/doctor.rs
+++ b/src/sessions/lcm/doctor.rs
@@ -10,8 +10,7 @@ use serde_json::{json, Value};
 use crate::tracedecay::current_timestamp;
 
 use super::{
-    gc, payload, query, schema, security, util, LcmCleanConfig, LcmError, LcmGcConfig,
-    LCM_SCHEMA_VERSION,
+    gc, query, schema, security, util, LcmCleanConfig, LcmError, LcmGcConfig, LCM_SCHEMA_VERSION,
 };
 
 const MAX_SAMPLES: usize = 20;
@@ -392,85 +391,6 @@ async fn payload_diagnostics(
         "reclaimable_bytes_after_grace": detail.payload.reclaimable_bytes_after_grace,
         "integrity_mismatch_count": detail.payload.integrity_mismatch_count,
         "integrity_mismatch_refs": detail.integrity_mismatch_refs,
-    }))
-}
-
-#[allow(dead_code)]
-async fn placeholder_ref_diagnostics(
-    conn: &Connection,
-    payload_dir: &Path,
-    provider: &str,
-    session_id: Option<&str>,
-    metadata_refs: &BTreeSet<String>,
-) -> Result<Value, LcmError> {
-    let mut refs = BTreeSet::new();
-    let mut first_locations = serde_json::Map::new();
-    let mut rows = conn
-        .query(
-            "SELECT store_id, message_id, content, snippet_text, index_text, metadata_json
-             FROM lcm_raw_messages
-             WHERE provider = ?1 AND (?2 IS NULL OR session_id = ?2)",
-            params![provider, util::opt_text(session_id)],
-        )
-        .await?;
-    while let Some(row) = rows.next().await? {
-        let store_id: i64 = row.get(0)?;
-        let message_id: String = row.get(1)?;
-        for index in 2..6 {
-            let value: Option<String> = row.get(index).unwrap_or(None);
-            let field = match index {
-                2 => "content",
-                3 => "snippet_text",
-                4 => "index_text",
-                _ => "metadata_json",
-            };
-            for payload_ref in value
-                .as_deref()
-                .map(payload::extract_payload_refs_from_text)
-                .unwrap_or_default()
-            {
-                if refs.insert(payload_ref.clone()) {
-                    first_locations.insert(
-                        payload_ref.clone(),
-                        json!({
-                            "payload_ref": payload_ref,
-                            "store_id": store_id,
-                            "message_id": message_id,
-                            "field": field,
-                        }),
-                    );
-                }
-            }
-        }
-    }
-
-    let missing_metadata = refs
-        .iter()
-        .filter(|payload_ref| !metadata_refs.contains(*payload_ref))
-        .count();
-    let missing_files = refs
-        .iter()
-        .filter(|payload_ref| {
-            payload::validate_payload_ref(payload_ref).is_err()
-                || !payload_dir.join(payload_ref).is_file()
-        })
-        .count();
-    let missing_refs = refs
-        .iter()
-        .filter(|payload_ref| {
-            !metadata_refs.contains(*payload_ref)
-                || payload::validate_payload_ref(payload_ref).is_err()
-                || !payload_dir.join(payload_ref).is_file()
-        })
-        .filter_map(|payload_ref| first_locations.get(payload_ref).cloned())
-        .take(MAX_SAMPLES)
-        .collect::<Vec<_>>();
-
-    Ok(json!({
-        "placeholder_refs_total": refs.len(),
-        "missing_placeholder_metadata": missing_metadata,
-        "missing_placeholder_files": missing_files,
-        "missing_placeholder_refs": missing_refs,
     }))
 }
 

--- a/src/sessions/lcm/gc.rs
+++ b/src/sessions/lcm/gc.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use libsql::{params, Connection};
 use serde::{Deserialize, Serialize};
@@ -327,6 +328,7 @@ pub async fn run_payload_gc_with_apply(
     apply: bool,
     now: i64,
 ) -> Result<LcmGcReport, LcmError> {
+    let started = Instant::now();
     let cfg = cfg.clone().normalized();
     let mut report = LcmGcReport::new(provider, session_id, &cfg, apply, now);
     report.last_gc_at = schema::get_gc_meta(conn, "last_gc_at")
@@ -399,7 +401,15 @@ pub async fn run_payload_gc_with_apply(
 
     report.ended_at = now;
     if apply {
+        let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let status = if report.errors.is_empty() {
+            "ok"
+        } else {
+            "partial"
+        };
         schema::set_gc_meta(conn, "last_gc_at", &now.to_string()).await?;
+        schema::set_gc_meta(conn, "last_gc_duration_ms", &duration_ms.to_string()).await?;
+        schema::set_gc_meta(conn, "last_gc_status", status).await?;
         schema::set_gc_meta(conn, "last_reaped_refs", &report.totals.files.to_string()).await?;
         schema::set_gc_meta(conn, "last_reaped_bytes", &report.totals.bytes.to_string()).await?;
         if report.errors.is_empty() {
@@ -899,7 +909,7 @@ mod tests {
             .map_err(|err| format!("set test busy timeout: {err}"))?;
         schema::ensure_lcm_schema(&conn)
             .await
-            .ok_or_else(|| "ensure lcm schema".to_string())?;
+            .map_err(|err| format!("ensure lcm schema: {err}"))?;
         Ok(TestStore {
             _temp: temp,
             storage_root,
@@ -1707,6 +1717,13 @@ mod tests {
         assert_eq!(report.errors.len(), 1);
         assert_eq!(report.errors[0].payload_ref, corrupted_ref);
         assert_eq!(report.errors[0].kind, "integrity_mismatch");
+        assert_eq!(
+            schema::get_gc_meta(&store.conn, "last_gc_status")
+                .await
+                .map_err(|err| err.to_string())?
+                .as_deref(),
+            Some("partial")
+        );
         assert!(payload::load_payload_metadata(&store.conn, &corrupted_ref)
             .await
             .is_ok());

--- a/src/sessions/lcm/payload.rs
+++ b/src/sessions/lcm/payload.rs
@@ -349,14 +349,15 @@ pub async fn delete_external_payload(
 
     conn.execute("BEGIN IMMEDIATE", ()).await?;
     let tx_result: Result<(), LcmError> = async {
-        if opts.verify_hash {
-            if let Some(metadata) = metadata.as_ref() {
-                if gc::referenced_payload_refs(conn, &metadata.provider, None)
-                    .await?
-                    .contains(payload_ref)
-                {
-                    return Err(LcmError::StillReferenced);
-                }
+        let tombstone_missing_payload =
+            opts.rewrite_placeholders && !opts.remove_file && !opts.verify_hash;
+        if let Some(metadata) = metadata.as_ref() {
+            if gc::referenced_payload_refs(conn, &metadata.provider, None)
+                .await?
+                .contains(payload_ref)
+                && !tombstone_missing_payload
+            {
+                return Err(LcmError::StillReferenced);
             }
         }
         conn.execute(

--- a/src/sessions/lcm/query.rs
+++ b/src/sessions/lcm/query.rs
@@ -1616,17 +1616,22 @@ pub(crate) async fn payload_health_detail(
         i64::try_from(gc_config.reap_missing_after).unwrap_or(i64::MAX);
 
     let last_gc_at = gc_meta_i64(conn, "last_gc_at").await?;
+    let last_gc_duration_ms = gc_meta_i64(conn, "last_gc_duration_ms")
+        .await?
+        .map(|value| value.max(0) as u64);
     let last_gc_error = schema::get_gc_meta(conn, "last_error").await?;
     let last_reaped_refs = gc_meta_i64(conn, "last_reaped_refs").await?;
     let last_reaped_bytes = gc_meta_i64(conn, "last_reaped_bytes")
         .await?
         .map(|value| value.max(0) as u64);
-    let last_gc_status = match (last_gc_at, last_gc_error.as_deref()) {
-        (None, _) => None,
-        (Some(_), None | Some("")) => Some("ok".to_string()),
-        (Some(_), Some("partial")) => Some("partial".to_string()),
-        (Some(_), Some(_)) => Some("failed".to_string()),
-    };
+    let last_gc_status = schema::get_gc_meta(conn, "last_gc_status")
+        .await?
+        .or_else(|| match (last_gc_at, last_gc_error.as_deref()) {
+            (None, _) => None,
+            (Some(_), None | Some("")) => Some("ok".to_string()),
+            (Some(_), Some("partial")) => Some("partial".to_string()),
+            (Some(_), Some(_)) => Some("failed".to_string()),
+        });
 
     let mut missing_count = 0_i64;
     let mut missing_payload_refs = Vec::new();
@@ -1778,7 +1783,7 @@ pub(crate) async fn payload_health_detail(
         },
         payload_gc: LcmPayloadGcStatus {
             last_gc_at,
-            last_gc_duration_ms: None,
+            last_gc_duration_ms,
             last_gc_status,
             last_gc_error,
             last_reaped_refs,

--- a/src/sessions/lcm/schema.rs
+++ b/src/sessions/lcm/schema.rs
@@ -83,7 +83,7 @@ pub(crate) async fn rebuild_raw_fts(conn: &Connection) -> Option<()> {
     Some(())
 }
 
-pub(crate) async fn ensure_lcm_schema(conn: &Connection) -> Option<()> {
+pub(crate) async fn ensure_lcm_schema(conn: &Connection) -> Result<(), LcmError> {
     // Mirrors hermes-lcm `run_versioned_migrations`: version steps are
     // monotonic, so a database written by a newer release is left untouched
     // (no marker downgrade, no carry-forward re-run against newer data).
@@ -91,7 +91,7 @@ pub(crate) async fn ensure_lcm_schema(conn: &Connection) -> Option<()> {
         .await
         .is_some_and(|version| version >= LCM_SCHEMA_VERSION)
     {
-        return Some(());
+        return Ok(());
     }
 
     conn.execute_batch(
@@ -244,8 +244,7 @@ pub(crate) async fn ensure_lcm_schema(conn: &Connection) -> Option<()> {
                 VALUES (NEW.rowid, NEW.summary_text, NEW.expand_hint, NEW.metadata_json);
             END;",
     )
-    .await
-    .ok()?;
+    .await?;
 
     // Schema v3: the raw-message FTS index dropped the role and
     // metadata_json columns (see RAW_FTS_DDL). The rebuild is gated on the
@@ -262,10 +261,16 @@ pub(crate) async fn ensure_lcm_schema(conn: &Connection) -> Option<()> {
         (),
         "raw FTS presence query returned no rows",
     )
-    .await
-    .is_ok_and(|count| count > 0);
-    if !fts_exists || !raw_fts_structure_is_current(conn).await.unwrap_or(false) {
-        rebuild_raw_fts(conn).await?;
+    .await?
+        > 0;
+    if !fts_exists
+        || !raw_fts_structure_is_current(conn)
+            .await
+            .ok_or_else(|| LcmError::Db("raw FTS structure check failed".to_string()))?
+    {
+        rebuild_raw_fts(conn)
+            .await
+            .ok_or_else(|| LcmError::Db("raw FTS rebuild failed".to_string()))?;
     }
 
     // Schema v2: lifecycle rows gained the compression-boundary cooldown
@@ -287,9 +292,8 @@ pub(crate) async fn ensure_lcm_schema(conn: &Connection) -> Option<()> {
             applied_at = unixepoch()",
         params![MIGRATION_NAME, LCM_SCHEMA_VERSION],
     )
-    .await
-    .ok()?;
-    Some(())
+    .await?;
+    Ok(())
 }
 
 pub(crate) async fn schema_version(conn: &Connection) -> Option<i64> {
@@ -368,23 +372,26 @@ pub(crate) async fn load_raw_message(
     })
 }
 
-async fn carry_forward_legacy_messages(conn: &Connection) -> Option<()> {
-    conn.execute("BEGIN IMMEDIATE", ()).await.ok()?;
+async fn carry_forward_legacy_messages(conn: &Connection) -> Result<(), LcmError> {
+    conn.execute("BEGIN IMMEDIATE", ()).await?;
     let carry_forward = carry_forward_legacy_messages_in_transaction(conn).await;
-    if let Some(()) = carry_forward {
-        if conn.execute("COMMIT", ()).await.is_ok() {
-            Some(())
-        } else {
-            let _ = conn.execute("ROLLBACK", ()).await;
-            None
+    match carry_forward {
+        Ok(()) => {
+            if let Err(err) = conn.execute("COMMIT", ()).await {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(err.into())
+            } else {
+                Ok(())
+            }
         }
-    } else {
-        let _ = conn.execute("ROLLBACK", ()).await;
-        None
+        Err(err) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(err)
+        }
     }
 }
 
-async fn carry_forward_legacy_messages_in_transaction(conn: &Connection) -> Option<()> {
+async fn carry_forward_legacy_messages_in_transaction(conn: &Connection) -> Result<(), LcmError> {
     let mut rows = conn
         .query(
             "SELECT provider, message_id, session_id, role, timestamp, ordinal,
@@ -393,17 +400,16 @@ async fn carry_forward_legacy_messages_in_transaction(conn: &Connection) -> Opti
              ORDER BY provider, session_id, ordinal, message_id",
             (),
         )
-        .await
-        .ok()?;
-    while let Some(row) = rows.next().await.ok()? {
-        let provider: String = row.get(0).ok()?;
-        let message_id: String = row.get(1).ok()?;
-        let session_id: String = row.get(2).ok()?;
-        let role: String = row.get(3).ok()?;
-        let timestamp: Option<i64> = row.get(4).ok()?;
-        let ordinal: i64 = row.get(5).ok()?;
-        let content: String = row.get(6).ok()?;
-        let metadata_json: Option<String> = row.get(7).ok()?;
+        .await?;
+    while let Some(row) = rows.next().await? {
+        let provider: String = row.get(0)?;
+        let message_id: String = row.get(1)?;
+        let session_id: String = row.get(2)?;
+        let role: String = row.get(3)?;
+        let timestamp: Option<i64> = row.get(4)?;
+        let ordinal: i64 = row.get(5)?;
+        let content: String = row.get(6)?;
+        let metadata_json: Option<String> = row.get(7)?;
         let legacy_truncated = content.contains(TRUNCATION_MARKER);
         let content_hash = raw::sha256_hex(&content);
         let snippet_text = raw::derived_text_for_snippet(&content);
@@ -432,8 +438,118 @@ async fn carry_forward_legacy_messages_in_transaction(conn: &Connection) -> Opti
                 util::opt_text(metadata_json.as_deref()),
             ],
         )
-        .await
-        .ok()?;
+        .await?;
     }
-    Some(())
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use libsql::Builder;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn ensure_lcm_schema_errors_and_rolls_back_failed_legacy_carry_forward(
+    ) -> Result<(), String> {
+        let tmp = TempDir::new().map_err(|err| err.to_string())?;
+        let db_path = tmp.path().join("sessions.db");
+        let db = Builder::new_local(&db_path)
+            .build()
+            .await
+            .map_err(|err| err.to_string())?;
+        let conn = db.connect().map_err(|err| err.to_string())?;
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                provider TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                project_key TEXT NOT NULL,
+                project_path TEXT NOT NULL,
+                title TEXT,
+                started_at INTEGER,
+                ended_at INTEGER,
+                transcript_path TEXT,
+                metadata_json TEXT,
+                PRIMARY KEY(provider, session_id)
+            );
+            CREATE TABLE session_messages (
+                provider TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                timestamp INTEGER,
+                ordinal INTEGER NOT NULL,
+                text TEXT NOT NULL,
+                kind TEXT,
+                model TEXT,
+                tool_names TEXT,
+                source_path TEXT,
+                source_offset INTEGER,
+                metadata_json TEXT,
+                PRIMARY KEY(provider, message_id)
+            );
+            CREATE TABLE lcm_raw_messages (
+                provider TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                store_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                role TEXT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                timestamp INTEGER,
+                content TEXT,
+                content_hash TEXT NOT NULL,
+                storage_kind TEXT NOT NULL CHECK(storage_kind IN ('inline', 'external')),
+                payload_ref TEXT,
+                snippet_text TEXT NOT NULL,
+                index_text TEXT NOT NULL,
+                legacy_source INTEGER NOT NULL DEFAULT 0,
+                legacy_truncated INTEGER NOT NULL DEFAULT 0,
+                metadata_json TEXT,
+                UNIQUE(provider, message_id)
+            );
+            CREATE TRIGGER lcm_raw_messages_fail_second
+            BEFORE INSERT ON lcm_raw_messages
+            WHEN NEW.message_id = 'legacy-message-2'
+            BEGIN
+                SELECT RAISE(ABORT, 'legacy carry-forward insert failed');
+            END;
+            INSERT INTO sessions(provider, session_id, project_key, project_path)
+            VALUES ('cursor', 'legacy-session', '/tmp/project', '/tmp/project');
+            INSERT INTO session_messages(provider, message_id, session_id, role, ordinal, text)
+            VALUES
+              ('cursor', 'legacy-message-1', 'legacy-session', 'assistant', 1, 'legacy one'),
+              ('cursor', 'legacy-message-2', 'legacy-session', 'assistant', 2, 'legacy two');",
+        )
+        .await
+        .map_err(|err| err.to_string())?;
+
+        let Err(err) = ensure_lcm_schema(&conn).await else {
+            return Err("failed carry-forward insert should propagate".to_string());
+        };
+        assert!(matches!(err, LcmError::Db(_)));
+        assert_eq!(
+            util::fetch_i64(
+                &conn,
+                "SELECT COUNT(*) FROM lcm_raw_messages",
+                (),
+                "raw count",
+            )
+            .await
+            .map_err(|err| err.to_string())?,
+            0
+        );
+        assert_eq!(
+            util::fetch_i64(
+                &conn,
+                "SELECT COUNT(*) FROM session_schema_migrations WHERE name = 'lcm'",
+                (),
+                "migration marker count",
+            )
+            .await
+            .map_err(|err| err.to_string())?,
+            0
+        );
+        Ok(())
+    }
 }

--- a/tests/session_lcm_compression_test.rs
+++ b/tests/session_lcm_compression_test.rs
@@ -1,10 +1,12 @@
+use std::time::Duration;
+
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::lcm::compression_decision::{
-    compression_plan, effective_assembly_token_cap, overflow_recovery_assembly_cap,
-    preflight_decision, AssemblyCapInput, CompressionPlanInput, OverflowRecoveryCapInput,
-    PreflightDecisionInput,
+    bounded_leaf_chunk_len, compression_plan, effective_assembly_token_cap,
+    overflow_recovery_assembly_cap, preflight_decision, AssemblyCapInput, CompressionPlanInput,
+    OverflowRecoveryCapInput, PreflightDecisionInput,
 };
 use tracedecay::sessions::lcm::{
     LcmCompressionRequest, LcmGrepRequest, LcmGrepSort, LcmLifecycleState, LcmLifecycleUpdate,
@@ -808,6 +810,16 @@ fn compression_decision_seam_preserves_token_budget_contract() {
     );
 }
 
+#[test]
+fn bounded_leaf_chunk_len_returns_zero_when_first_message_exceeds_token_cap() {
+    let backlog = vec![
+        lcm_raw_message(1, "assistant", "one two three"),
+        lcm_raw_message(2, "assistant", "four"),
+    ];
+
+    assert_eq!(bounded_leaf_chunk_len(&backlog, Some(2), None), 0);
+}
+
 #[tokio::test]
 async fn lifecycle_frontier_survives_reopen() {
     let tmp = TempDir::new().unwrap();
@@ -916,6 +928,101 @@ async fn noop_summarizer_ingests_without_summary_nodes() {
 
     let status = db.lcm_status("cursor", Some("session-1")).await.unwrap();
     assert_eq!(status.summary_node_count, 0);
+}
+
+#[tokio::test]
+async fn replay_assembly_terminates_when_existing_summary_sources_contain_cycle() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    let store_ids = insert_raw_messages(&db, "cursor", "cycle-session", &["alpha"]).await;
+    let leaf = db
+        .lcm_insert_summary_node(summary_draft(
+            "cursor",
+            "cycle-session",
+            0,
+            "leaf summary",
+            vec![LcmSourceRef::RawMessage {
+                store_id: store_ids[0],
+            }],
+        ))
+        .await
+        .expect("leaf summary insert should succeed");
+    let middle = db
+        .lcm_insert_summary_node(summary_draft(
+            "cursor",
+            "cycle-session",
+            1,
+            "middle summary",
+            vec![LcmSourceRef::SummaryNode {
+                node_id: leaf.node_id.clone(),
+            }],
+        ))
+        .await
+        .expect("middle summary insert should succeed");
+    let _root = db
+        .lcm_insert_summary_node(summary_draft(
+            "cursor",
+            "cycle-session",
+            2,
+            "root summary",
+            vec![LcmSourceRef::SummaryNode {
+                node_id: middle.node_id.clone(),
+            }],
+        ))
+        .await
+        .expect("root summary insert should succeed");
+
+    let conn = open_lcm_conn(&tmp).await;
+    conn.execute(
+        "DELETE FROM lcm_summary_sources WHERE node_id = ?1",
+        libsql::params![leaf.node_id.as_str()],
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO lcm_summary_sources (node_id, source_kind, source_id, ordinal)
+         VALUES (?1, 'summary_node', ?2, 0)",
+        libsql::params![leaf.node_id.as_str(), middle.node_id.as_str()],
+    )
+    .await
+    .unwrap();
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(2),
+        db.lcm_compress(LcmCompressionRequest {
+            provider: "cursor".into(),
+            session_id: "cycle-session".into(),
+            messages: vec![json!({
+                "id": "active-after-cycle",
+                "role": "user",
+                "content": "active after corrupt summary cycle"
+            })],
+            current_tokens: Some(100),
+            focus_topic: None,
+            ignore_session_patterns: Vec::new(),
+            stateless_session_patterns: Vec::new(),
+            ignore_message_patterns: Vec::new(),
+            expected_current_frontier_store_id: None,
+            threshold_tokens: None,
+            max_assembly_tokens: None,
+            leaf_chunk_tokens: None,
+            max_source_messages: None,
+            summary_fan_in: None,
+            incremental_max_depth: None,
+            fresh_tail_count: None,
+            dynamic_leaf_chunk_enabled: None,
+            dynamic_leaf_chunk_max: None,
+            context_length: None,
+            reserve_tokens_floor: None,
+            summarizer: LcmSummarizerMode::Noop,
+        }),
+    )
+    .await
+    .expect("replay assembly should terminate despite corrupt summary cycle")
+    .expect("compression should succeed");
+
+    assert_eq!(response.status, "ok");
+    assert!(!response.replay_messages.is_empty());
 }
 
 #[tokio::test]

--- a/tests/session_lcm_dag_test.rs
+++ b/tests/session_lcm_dag_test.rs
@@ -382,6 +382,45 @@ async fn nested_summary_expansion_is_direct_only() {
 }
 
 #[tokio::test]
+async fn summary_insert_rejects_non_decreasing_child_depth_without_persisting_rows() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = isolated_db_path(&tmp);
+    let db = open_lcm_db(&tmp).await;
+    let store_ids = insert_raw_messages(&db, "cursor", "session-1", &["alpha"]).await;
+    let child = db
+        .lcm_insert_summary_node(summary_draft(
+            "cursor",
+            "session-1",
+            1,
+            "child summary",
+            vec![LcmSourceRef::RawMessage {
+                store_id: store_ids[0],
+            }],
+        ))
+        .await
+        .expect("child summary insert should succeed");
+    let before = summary_table_counts(&db_path).await;
+
+    let result = db
+        .lcm_insert_summary_node(summary_draft(
+            "cursor",
+            "session-1",
+            1,
+            "parent summary at invalid depth",
+            vec![LcmSourceRef::SummaryNode {
+                node_id: child.node_id,
+            }],
+        ))
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(LcmError::SummarySourceNotOwnedBySession)
+    ));
+    assert_eq!(summary_table_counts(&db_path).await, before);
+}
+
+#[tokio::test]
 async fn summary_fts_matches_inserted_summary_text() {
     let tmp = TempDir::new().unwrap();
     let db_path = isolated_db_path(&tmp);

--- a/tests/session_lcm_payload_test.rs
+++ b/tests/session_lcm_payload_test.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
+use tracedecay::sessions::lcm::payload::{delete_external_payload, DeleteOpts};
 use tracedecay::sessions::lcm::{LcmError, LcmStorageKind, LCM_SCHEMA_VERSION};
 
 mod common;
@@ -956,6 +957,74 @@ async fn denies_cross_session_payload_expansion() {
         .lcm_expand_payload("cursor", "session-b", &payload_ref, 0, 100)
         .await;
     assert!(matches!(denied, Err(LcmError::PayloadNotOwnedBySession)));
+}
+
+#[tokio::test]
+async fn delete_external_payload_rejects_referenced_payload_without_hash_verification() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = isolated_db_path(&tmp);
+    let storage_root = tmp.path().join(".tracedecay");
+    let db = open_lcm_db(&tmp).await;
+    assert!(
+        db.upsert_session(&sample_session("cursor", "session-1"))
+            .await
+    );
+
+    let payload = format!("active referenced payload\n{}", "R".repeat(300_000));
+    let message = raw_message(
+        "cursor",
+        "referenced-payload",
+        "session-1",
+        "tool",
+        &payload,
+    );
+    let store = db.lcm_store(&storage_root);
+    store
+        .ingest_raw_message(&message)
+        .await
+        .expect("payload should ingest");
+    let payload_ref = db
+        .lcm_load_raw_message("cursor", "referenced-payload")
+        .await
+        .unwrap()
+        .payload_ref
+        .expect("payload ref");
+    let payload_path =
+        tracedecay::sessions::lcm::payload::payload_dir(&storage_root).join(&payload_ref);
+    assert!(payload_path.exists());
+
+    let direct_db = libsql::Builder::new_local(&db_path).build().await.unwrap();
+    let conn = direct_db.connect().unwrap();
+    let result = delete_external_payload(
+        &conn,
+        &storage_root,
+        &payload_ref,
+        &DeleteOpts {
+            rewrite_placeholders: true,
+            remove_file: true,
+            verify_hash: false,
+        },
+    )
+    .await;
+
+    assert!(matches!(result, Err(LcmError::StillReferenced)));
+    assert!(payload_path.exists());
+    let raw = db
+        .lcm_load_raw_message("cursor", "referenced-payload")
+        .await
+        .expect("referenced raw message should remain");
+    assert_eq!(raw.payload_ref.as_deref(), Some(payload_ref.as_str()));
+    let expanded = store
+        .lcm_expand_payload(
+            "cursor",
+            "session-1",
+            &payload_ref,
+            0,
+            payload.chars().count(),
+        )
+        .await
+        .expect("referenced payload should still expand");
+    assert_eq!(expanded.content, payload);
 }
 
 #[tokio::test]

--- a/tests/session_lcm_query_test.rs
+++ b/tests/session_lcm_query_test.rs
@@ -2,9 +2,9 @@ use tempfile::TempDir;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::lcm::{
     LcmContentSlice, LcmDescribeRequest, LcmDescribeTarget, LcmError, LcmExpandQueryRequest,
-    LcmExpandRequest, LcmExpandTarget, LcmGrepRequest, LcmGrepSort, LcmLifecycleUpdate,
-    LcmLoadSessionRequest, LcmMaintenanceDebt, LcmScope, LcmSourceRef, LcmStorageKind,
-    LcmSummaryNodeDraft, LCM_SCHEMA_VERSION, MAX_DERIVED_SNIPPET_CHARS,
+    LcmExpandRequest, LcmExpandTarget, LcmGcConfig, LcmGrepRequest, LcmGrepSort,
+    LcmLifecycleUpdate, LcmLoadSessionRequest, LcmMaintenanceDebt, LcmScope, LcmSourceRef,
+    LcmStorageKind, LcmSummaryNodeDraft, LCM_SCHEMA_VERSION, MAX_DERIVED_SNIPPET_CHARS,
 };
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 
@@ -792,6 +792,72 @@ async fn status_reports_schema_frontier_payload_and_debt_counts() {
 
     let rendered = serde_json::to_string(&status).unwrap();
     assert!(!rendered.contains("private payload marker"));
+}
+
+#[tokio::test]
+async fn status_reports_payload_gc_run_metadata_after_apply() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = isolated_db_path(&tmp);
+    let storage_root = tmp.path().join(".tracedecay");
+    let db = GlobalDb::open_at(&db_path).await.expect("session db open");
+    insert_session(&db, "cursor", "session-gc").await;
+
+    let payload = format!("gc metadata payload\n{}", "G".repeat(300_000));
+    let mut external = raw_message("cursor", "tool-gc", "session-gc", 1, &payload);
+    external.role = "tool".to_string();
+    external.kind = Some("tool_result".to_string());
+    db.lcm_store(&storage_root)
+        .ingest_raw_message(&external)
+        .await
+        .expect("external payload should ingest");
+
+    let raw_db = libsql::Builder::new_local(&db_path).build().await.unwrap();
+    let conn = raw_db.connect().unwrap();
+    let cfg = LcmGcConfig {
+        backup_before_reap: false,
+        ..LcmGcConfig::default()
+    };
+    let report = tracedecay::sessions::lcm::gc::run_payload_gc_with_apply(
+        &conn,
+        &storage_root,
+        "cursor",
+        Some("session-gc"),
+        &cfg,
+        true,
+        1_715_123_456,
+    )
+    .await
+    .expect("payload gc should run");
+    assert_eq!(report.status, "applied");
+
+    let mut rows = conn
+        .query(
+            "SELECT value FROM lcm_gc_meta WHERE key = 'last_gc_status'",
+            (),
+        )
+        .await
+        .expect("last GC status query should run");
+    let row = rows
+        .next()
+        .await
+        .expect("last GC status row should load")
+        .expect("last GC status should be stored");
+    let stored_status: String = row.get(0).expect("last GC status should be text");
+    assert_eq!(stored_status, "ok");
+
+    let status = db
+        .lcm_status("cursor", Some("session-gc"))
+        .await
+        .expect("status should load");
+    assert_eq!(status.payload_gc.last_gc_at, Some(1_715_123_456));
+    assert!(
+        status.payload_gc.last_gc_duration_ms.is_some(),
+        "status should expose the last GC duration"
+    );
+    assert_eq!(status.payload_gc.last_gc_status.as_deref(), Some("ok"));
+    assert_eq!(status.payload_gc.last_gc_error, None);
+    assert_eq!(status.payload_gc.last_reaped_refs, Some(0));
+    assert_eq!(status.payload_gc.last_reaped_bytes, Some(0));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Prevent corrupt summary cycles and invalid summary depth writes from hanging or persisting partial DAG rows
- Preserve compression progress when token caps reject the first backlog message
- Add payload delete safety and expose payload GC run metadata in status

## Verification
- cargo test --test session_lcm_compression_test --test session_lcm_dag_test --test session_lcm_payload_test --test session_lcm_query_test
