### PR TITLE
Record hook hints and steer new subagents

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -6,15 +6,16 @@
 //! Each agent sends its own event schema on stdin and expects its own output
 //! shape, so the handlers are kept agent-specific rather than shared blindly.
 
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
 pub mod tool_hints;
 
-use tool_hints::{decide_hint, HintAgent, ToolHint, ToolHintInput};
+use tool_hints::{decide_hint, HintAgent, HintCategory, ToolHint, ToolHintInput};
 
 macro_rules! read_hook_event {
     () => {{
@@ -35,6 +36,17 @@ code research. TraceDecay is faster and more precise for symbol relationships, \
 call paths, and code structure. Only use agents for code exploration if you \
 have already tried tracedecay and it cannot answer the question.";
 
+const CODEX_SUBAGENT_START_CONTEXT: &str = "tracedecay subagent context: this looks like a \
+new/no-history subagent or code-research subagent. Use tracedecay MCP tools and the relevant TraceDecay skill/tool \
+workflow before broad file reads: `tracedecay:searching-for-code` with `tracedecay_context` \
+for code exploration, `tracedecay:reading-code-cheaply` with `tracedecay_outline` or \
+`tracedecay_body` before whole-file reads, `tracedecay:recalling-project-memory` when \
+project decisions/preferences matter, and `tracedecay:recalling-session-context` with \
+`tracedecay_message_search`, `tracedecay_lcm_expand_query`, and `tracedecay_lcm_describe` \
+when prior conversation context may be missing.";
+
+const HOOK_ANALYTICS_FILENAME: &str = "hook_analytics.jsonl";
+
 fn research_block_reason(hint: Option<ToolHint>) -> String {
     let base = crate::config::brand_env("RESEARCH_BLOCK_REASON")
         .unwrap_or_else(|| TRACEDECAY_RESEARCH_BLOCK_REASON.to_string());
@@ -42,6 +54,98 @@ fn research_block_reason(hint: Option<ToolHint>) -> String {
         || base.clone(),
         |hint| format!("{}\n\n{}", base, format_tool_hint(&hint)),
     )
+}
+
+fn record_hook_analytics(root: Option<&Path>, event: &str, mut fields: serde_json::Value) {
+    let Some(path) = hook_analytics_path(root) else {
+        return;
+    };
+    let Some(fields) = fields.as_object_mut() else {
+        return;
+    };
+    fields.insert(
+        "event".to_string(),
+        serde_json::Value::String(event.to_string()),
+    );
+    fields.insert(
+        "ts_unix_ms".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(now_unix_millis())),
+    );
+    let Ok(line) = serde_json::to_string(&fields) else {
+        return;
+    };
+    append_private_jsonl(&path, &line);
+}
+
+fn hook_analytics_path(root: Option<&Path>) -> Option<PathBuf> {
+    match root {
+        Some(root) => crate::storage::resolve_layout_for_current_profile(root)
+            .ok()
+            .map(|layout| layout.data_root.join(HOOK_ANALYTICS_FILENAME)),
+        None => crate::storage::default_profile_root()
+            .ok()
+            .map(|root| root.join(HOOK_ANALYTICS_FILENAME)),
+    }
+}
+
+fn append_private_jsonl(path: &Path, line: &str) {
+    let mut content = std::fs::read_to_string(path).unwrap_or_default();
+    content.push_str(line);
+    content.push('\n');
+    let _ = crate::storage::PrivateStoreIo::write_file(path, content.as_bytes());
+}
+
+fn now_unix_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or_default()
+}
+
+fn record_hint_analytics(
+    root: Option<&Path>,
+    event: &str,
+    agent: HintAgent,
+    session_id: Option<&str>,
+    hint: &ToolHint,
+) {
+    record_hook_analytics(
+        root,
+        event,
+        serde_json::json!({
+            "agent": agent.as_key(),
+            "session_id": session_id,
+            "category": hint.category.as_key(),
+        }),
+    );
+}
+
+fn record_workspace_status_analytics(
+    root: Option<&Path>,
+    status: HookWorkspaceStatus,
+    session_id: Option<&str>,
+) {
+    record_hook_analytics(
+        root,
+        "workspace_status",
+        serde_json::json!({
+            "agent": HintAgent::Codex.as_key(),
+            "session_id": session_id,
+            "workspace_status": status.as_key(),
+        }),
+    );
+}
+
+fn record_hint_emitted(
+    root: Option<&Path>,
+    agent: HintAgent,
+    session_id: Option<&str>,
+    hint: &ToolHint,
+) {
+    if session_id.is_none() {
+        record_hint_analytics(root, "missing_session", agent, None, hint);
+    }
+    record_hint_analytics(root, "hint_emitted", agent, session_id, hint);
 }
 
 /// `PreToolUse` hook handler for Claude Code's Agent tool matcher.
@@ -461,15 +565,24 @@ async fn cursor_session_context_for_root(root: Option<&Path>) -> String {
 /// Builds the tracedecay steering `additional_context` for Codex session/prompt
 /// hooks. Unlike Cursor, Codex has no always-applied tracedecay rule, so this
 /// context carries the full tool-routing steering plus index freshness.
-async fn codex_session_context_for_root(root: Option<&Path>) -> String {
-    let (initialized, staleness) = match root {
-        Some(r) if crate::tracedecay::TraceDecay::is_initialized(r) => {
+async fn codex_session_context_for_event(event_json: &str) -> (String, HookWorkspaceStatus) {
+    let parsed = serde_json::from_str::<Value>(event_json).unwrap_or(Value::Null);
+    let root = codex_project_root_from_parsed_event(&parsed);
+    let cwd = event_cwd_from_parsed(&parsed);
+    let session_id = event_session_id(&parsed);
+    let status = codex_workspace_status(root.as_deref(), cwd.as_deref());
+    record_workspace_status_analytics(root.as_deref(), status, session_id.as_deref());
+    let staleness = match (status, root.as_deref()) {
+        (HookWorkspaceStatus::Initialized, Some(r)) => {
             let (staleness, _) = cursor_index_signals_for_root(r).await;
-            (true, staleness)
+            staleness
         }
-        _ => (false, None),
+        _ => None,
     };
-    build_codex_session_context(initialized, staleness.as_deref())
+    (
+        build_codex_session_context_for_workspace(status, staleness.as_deref()),
+        status,
+    )
 }
 
 /// Cursor `afterShellExecution` hook handler.
@@ -600,6 +713,14 @@ pub fn evaluate_cursor_post_tool_use(event_json: &str) -> Option<String> {
 pub fn cursor_post_tool_use_decision(event_json: &str) -> Option<String> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let hint = decide_hint(&cursor_tool_hint_input(&parsed))?;
+    let root = cursor_project_root_candidate_from_parsed_event(&parsed);
+    record_hint_analytics(
+        root.as_deref(),
+        "hint_candidate",
+        HintAgent::Cursor,
+        event_session_id(&parsed).as_deref(),
+        &hint,
+    );
     let hint = deduped_cursor_hint(event_json, hint)?;
     Some(
         serde_json::json!({
@@ -619,17 +740,30 @@ pub fn cursor_post_tool_use_decision(event_json: &str) -> Option<String> {
 /// the hint is emitted as-is — dedupe is impossible but the hint is still
 /// useful (fail-open).
 fn deduped_cursor_hint(event_json: &str, hint: ToolHint) -> Option<ToolHint> {
-    let root = cursor_project_root_from_event(event_json)?;
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let root = cursor_project_root_candidate_from_parsed_event(&parsed)?;
     if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+        record_hint_analytics(
+            Some(&root),
+            "suppressed_uninitialized",
+            HintAgent::Cursor,
+            event_session_id(&parsed).as_deref(),
+            &hint,
+        );
         return None;
     }
-    let parsed: Value = serde_json::from_str(event_json).ok()?;
-    deduped_project_hint(Some(root), event_session_id(&parsed), hint)
+    deduped_project_hint(
+        Some(root),
+        HintAgent::Cursor,
+        event_session_id(&parsed),
+        hint,
+    )
 }
 
 fn deduped_codex_hint(event_json: &str, parsed: &Value, hint: ToolHint) -> Option<ToolHint> {
     deduped_project_hint(
         codex_project_root_from_event(event_json),
+        HintAgent::Codex,
         event_session_id(parsed),
         hint,
     )
@@ -637,33 +771,54 @@ fn deduped_codex_hint(event_json: &str, parsed: &Value, hint: ToolHint) -> Optio
 
 fn deduped_project_hint(
     root: Option<PathBuf>,
+    agent: HintAgent,
     session_id: Option<String>,
     hint: ToolHint,
 ) -> Option<ToolHint> {
     let Some(root) = root else {
+        record_hint_emitted(None, agent, session_id.as_deref(), &hint);
         return Some(hint);
     };
     let Ok(layout) = crate::storage::resolve_layout_for_current_profile(&root) else {
+        record_hint_emitted(Some(&root), agent, session_id.as_deref(), &hint);
         return Some(hint);
     };
     if !layout.data_root.is_dir() {
+        record_hint_emitted(Some(&root), agent, session_id.as_deref(), &hint);
         return Some(hint);
     }
     let Some(session_id) = session_id else {
+        record_hint_emitted(Some(&root), agent, None, &hint);
         return Some(hint);
     };
     let path = layout.data_root.join("tool_hints_seen.json");
     let mut dedupe = tool_hints::ToolHintDedupe::load_or_default(&path);
-    if !dedupe.should_emit(session_id, hint.category) {
+    if !dedupe.should_emit(&session_id, hint.category) {
+        record_hint_analytics(
+            Some(&root),
+            "suppressed_duplicate",
+            agent,
+            Some(&session_id),
+            &hint,
+        );
         return None;
     }
     let _ = dedupe.save(&path);
+    record_hint_analytics(Some(&root), "hint_emitted", agent, Some(&session_id), &hint);
     Some(hint)
 }
 
 pub fn cursor_project_root_from_event(event_json: &str) -> Option<PathBuf> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     cursor_project_root_from_parsed_event(&parsed)
+}
+
+fn cursor_project_root_candidate_from_parsed_event(parsed: &Value) -> Option<PathBuf> {
+    cursor_project_root_from_parsed_event(parsed).or_else(|| {
+        cursor_event_candidates(parsed)
+            .into_iter()
+            .find_map(|candidate| nearest_project_like_root(&candidate))
+    })
 }
 
 fn cursor_project_root_from_parsed_event(parsed: &Value) -> Option<PathBuf> {
@@ -679,6 +834,21 @@ fn cursor_project_root_from_parsed_event(parsed: &Value) -> Option<PathBuf> {
         (Some(cwd_root), Some(resolved)) if !paths_same(&cwd_root, &resolved) => Some(cwd_root),
         (Some(cwd_root), None) => Some(cwd_root),
         (_, other) => other,
+    }
+}
+
+fn nearest_project_like_root(start: &Path) -> Option<PathBuf> {
+    if let Some(root) = crate::worktree::git_worktree_root(start) {
+        return Some(root);
+    }
+    let mut dir = start.to_path_buf();
+    loop {
+        if project_marker_exists(&dir) {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
     }
 }
 
@@ -901,6 +1071,10 @@ fn is_obvious_checkout_pathspec(token: &str) -> bool {
 /// backslash escapes. Shared with `tool_hints` so search-command
 /// classification sees the same tokens as the checkout/sync parsing here.
 pub(crate) fn shell_words(command: &str) -> Vec<String> {
+    shell_words_for_platform(command, cfg!(windows))
+}
+
+fn shell_words_for_platform(command: &str, windows: bool) -> Vec<String> {
     let mut words = Vec::new();
     let mut current = String::new();
     let mut quote: Option<char> = None;
@@ -928,6 +1102,7 @@ pub(crate) fn shell_words(command: &str) -> Vec<String> {
             },
             _ => match c {
                 '\'' | '"' => quote = Some(c),
+                '\\' if windows => current.push(c),
                 '\\' => escaped = true,
                 c if c.is_whitespace() => {
                     if !current.is_empty() {
@@ -1175,28 +1350,71 @@ pub fn build_cursor_session_context(
 /// always-applied tracedecay rule, so the full tool-routing steering lives
 /// here.
 pub fn build_codex_session_context(initialized: bool, staleness_hint: Option<&str>) -> String {
-    let mut s = String::new();
-    s.push_str(
-        "tracedecay is available via MCP. Prefer tracedecay MCP tools \
-         (tracedecay_context, tracedecay_search, tracedecay_callers, tracedecay_callees, \
-         tracedecay_impact, tracedecay_files, tracedecay_affected) over broad file reads \
-         or shell search for codebase exploration, symbol lookup, call graphs, and \
-         impact analysis. Fall back to file reads only when tracedecay cannot answer.\n",
-    );
-    if initialized {
-        match staleness_hint {
-            Some(hint) => {
-                s.push_str("Index status: ");
-                s.push_str(hint);
-                s.push_str(".\n");
-            }
-            None => s.push_str("Index status: initialized.\n"),
-        }
+    let status = if initialized {
+        HookWorkspaceStatus::Initialized
     } else {
-        s.push_str(
-            "Index status: no project index found in this workspace — \
-             run `tracedecay init` to enable tracedecay tools.\n",
-        );
+        HookWorkspaceStatus::UnindexedProject
+    };
+    build_codex_session_context_for_workspace(status, staleness_hint)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookWorkspaceStatus {
+    Initialized,
+    UnindexedProject,
+    Generic,
+}
+
+impl HookWorkspaceStatus {
+    fn as_key(self) -> &'static str {
+        match self {
+            HookWorkspaceStatus::Initialized => "initialized",
+            HookWorkspaceStatus::UnindexedProject => "unindexed_project",
+            HookWorkspaceStatus::Generic => "generic",
+        }
+    }
+}
+
+/// Builds the Codex session/prompt context for the detected workspace kind.
+pub fn build_codex_session_context_for_workspace(
+    status: HookWorkspaceStatus,
+    staleness_hint: Option<&str>,
+) -> String {
+    let mut s = String::new();
+    match status {
+        HookWorkspaceStatus::Initialized | HookWorkspaceStatus::UnindexedProject => {
+            s.push_str(
+                "tracedecay is available via MCP. Prefer tracedecay MCP tools \
+                 (tracedecay_context, tracedecay_search, tracedecay_callers, tracedecay_callees, \
+                 tracedecay_impact, tracedecay_files, tracedecay_affected) over broad file reads \
+                 or shell search for codebase exploration, symbol lookup, call graphs, and \
+                 impact analysis. Fall back to file reads only when tracedecay cannot answer.\n",
+            );
+            match status {
+                HookWorkspaceStatus::Initialized => match staleness_hint {
+                    Some(hint) => {
+                        s.push_str("Index status: ");
+                        s.push_str(hint);
+                        s.push_str(".\n");
+                    }
+                    None => s.push_str("Index status: initialized.\n"),
+                },
+                HookWorkspaceStatus::UnindexedProject => s.push_str(
+                    "Index status: no project index found in this code workspace — \
+                     run `tracedecay init` to enable tracedecay code-graph tools.\n",
+                ),
+                HookWorkspaceStatus::Generic => {}
+            }
+        }
+        HookWorkspaceStatus::Generic => {
+            s.push_str(
+                "TraceDecay session context is available via MCP. For prior conversation \
+                 recovery, use tracedecay_lcm_expand_query, tracedecay_message_search, and \
+                 tracedecay_lcm_describe; use project memory tools only when durable \
+                 preferences or decisions matter.\n",
+            );
+            s.push_str("Workspace status: no active project workspace; no setup guidance needed for this prompt.\n");
+        }
     }
     s
 }
@@ -1312,15 +1530,20 @@ async fn sync_after_cursor_shell_event(event_json: &str) {
         .get("command")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let plan = cursor_shell_sync_plan(command);
-    if matches!(plan, CursorShellSyncPlan::Noop) {
-        return;
-    }
     let Some(root) = cursor_project_root_from_event(event_json) else {
         return;
     };
     // Never bootstrap indexing in an unindexed repo.
     if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+        return;
+    }
+    let cwd = cursor_event_cwd(&parsed).unwrap_or_else(|| root.clone());
+    if !cursor_shell_command_targets_project(command, &cwd, &root) {
+        return;
+    }
+    let current_branch = crate::branch::current_branch(&root);
+    let plan = cursor_shell_sync_plan_with_current_branch(command, current_branch.as_deref());
+    if matches!(plan, CursorShellSyncPlan::Noop) {
         return;
     }
 
@@ -1425,8 +1648,7 @@ fn now_unix_secs() -> i64 {
 /// tracedecay MCP tools and reporting index freshness for the session `cwd`.
 pub async fn hook_codex_session_start() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
-    let mut context = codex_session_context_for_root(root.as_deref()).await;
+    let (mut context, _) = codex_session_context_for_event(&event).await;
     if session_start_from_compaction(&event) {
         append_context_recovery_hint(&mut context);
     }
@@ -1443,17 +1665,23 @@ pub async fn hook_codex_session_start() -> i32 {
 /// tracedecay steering context as `SessionStart`. Never blocks the prompt.
 pub async fn hook_codex_user_prompt_submit() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
     reset_counter_for_codex_event(&event).await;
-    let mut context = codex_session_context_for_root(root.as_deref()).await;
-    if let Some(hint) = codex_prompt_hint(&event) {
-        append_tool_hint(&mut context, &hint);
-    }
+    let context = codex_user_prompt_submit_context_for_event(&event).await;
     println!(
         "{}",
         codex_additional_context_json("UserPromptSubmit", &context)
     );
     0
+}
+
+pub async fn codex_user_prompt_submit_context_for_event(event: &str) -> String {
+    let (mut context, status) = codex_session_context_for_event(event).await;
+    if !matches!(status, HookWorkspaceStatus::Generic) {
+        if let Some(hint) = codex_prompt_hint(event) {
+            append_tool_hint(&mut context, &hint);
+        }
+    }
+    context
 }
 
 /// Codex `SubagentStart` hook handler.
@@ -1463,7 +1691,13 @@ pub async fn hook_codex_user_prompt_submit() -> i32 {
 /// so this injects `additionalContext` instead of denying.
 pub fn hook_codex_subagent_start() -> i32 {
     let event = read_hook_event!();
-    if let Some(output) = evaluate_codex_subagent_start(&event) {
+    let count = record_codex_subagent_start(&event);
+    let output = evaluate_codex_subagent_start(&event);
+    eprintln!(
+        "{}",
+        codex_subagent_start_log_line(&event, count, output.is_some())
+    );
+    if let Some(output) = output {
         println!("{output}");
     }
     0
@@ -1513,9 +1747,10 @@ pub fn codex_additional_context_json(event_name: &str, additional_context: &str)
 /// Pure decision logic for Codex `SubagentStart` events.
 ///
 /// Returns a Codex `additionalContext` payload steering research/explore
-/// subagents toward tracedecay MCP tools, or `None` for execution-style
-/// subagents. Inspects `agent_type` (Codex's documented field) and any
-/// prompt/task/description text.
+/// or new/no-history subagents toward tracedecay MCP tools and compact memory
+/// recall, or `None` for execution-style subagents that already have history.
+/// Inspects `agent_type` (Codex's documented field), any prompt/task/description
+/// text, and conservative history/newness fields when present.
 pub fn evaluate_codex_subagent_start(event_json: &str) -> Option<String> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let agent_type = parsed
@@ -1541,17 +1776,220 @@ pub fn evaluate_codex_subagent_start(event_json: &str) -> Option<String> {
         hints_enabled: true,
     });
     let is_explore = agent_type.eq_ignore_ascii_case("explore");
-    if is_explore || is_code_research_prompt(task) {
-        let context = research_block_reason(hint);
+    let is_research = is_explore || is_code_research_prompt(task);
+    let needs_context = codex_subagent_needs_context(&parsed);
+    if is_research || needs_context {
+        let dedupe_hint = ToolHint {
+            category: if is_research {
+                HintCategory::ExploreSubagent
+            } else {
+                HintCategory::SubagentStartContext
+            },
+            message: "For Codex subagents, add compact TraceDecay context before isolated work."
+                .to_string(),
+            context: CODEX_SUBAGENT_START_CONTEXT.to_string(),
+            nonblocking: true,
+        };
+        let root = codex_project_root_from_event(event_json);
+        record_hint_analytics(
+            root.as_deref(),
+            "hint_candidate",
+            HintAgent::Codex,
+            event_session_id(&parsed).as_deref(),
+            &dedupe_hint,
+        );
+        let _ = deduped_codex_hint(event_json, &parsed, dedupe_hint)?;
+        let context = codex_subagent_start_context(hint, needs_context);
         return Some(codex_additional_context_json("SubagentStart", &context));
     }
     None
 }
 
+/// Records a Codex `SubagentStart` in the current project's profile-sharded
+/// hook state and returns the session-local count. Fail-open: malformed events,
+/// missing roots, and storage errors only disable counting.
+pub fn record_codex_subagent_start(event_json: &str) -> Option<u64> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let root = codex_project_root_from_parsed_event(&parsed)?;
+    let layout = crate::storage::resolve_layout_for_current_profile(&root).ok()?;
+    let path = layout.data_root.join("codex_subagent_starts.json");
+    let analytics_session_id = event_session_id(&parsed);
+    let session_id = analytics_session_id
+        .clone()
+        .unwrap_or_else(|| "unknown-codex-session".to_string());
+    let mut counts = read_codex_subagent_start_counts(&path);
+    let count = counts.entry(session_id).or_insert(0);
+    *count = count.saturating_add(1);
+    let next = *count;
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(&counts) {
+        let _ = std::fs::write(path, format!("{json}\n"));
+    }
+    let agent_type = parsed
+        .get("agent_type")
+        .or_else(|| parsed.get("subagent_type"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown");
+    record_hook_analytics(
+        Some(&root),
+        "codex_subagent_start",
+        serde_json::json!({
+            "agent": HintAgent::Codex.as_key(),
+            "session_id": analytics_session_id.as_deref(),
+            "agent_type": agent_type,
+            "count": next,
+        }),
+    );
+    Some(next)
+}
+
+pub fn codex_subagent_start_log_line(
+    event_json: &str,
+    count: Option<u64>,
+    emitted_context: bool,
+) -> String {
+    let parsed = serde_json::from_str::<Value>(event_json).unwrap_or(Value::Null);
+    let agent_type = parsed
+        .get("agent_type")
+        .or_else(|| parsed.get("subagent_type"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown");
+    let session_id = event_session_id(&parsed).unwrap_or_else(|| "unknown".to_string());
+    let count = count
+        .map(|value| format!("#{value}"))
+        .unwrap_or_else(|| "#?".to_string());
+    format!(
+        "tracedecay Codex SubagentStart {count}: session_id={session_id} agent_type={agent_type} additional_context={emitted_context}"
+    )
+}
+
+fn read_codex_subagent_start_counts(path: &Path) -> BTreeMap<String, u64> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+        .unwrap_or_default()
+}
+
+fn codex_subagent_start_context(hint: Option<ToolHint>, no_history: bool) -> String {
+    let mut context = String::new();
+    if no_history {
+        context.push_str("new/no-history subagent: recover only relevant project memory or prior-session context before assuming missing decisions.\n");
+    }
+    context.push_str(CODEX_SUBAGENT_START_CONTEXT);
+    context.push('\n');
+    if let Some(hint) = hint {
+        context.push('\n');
+        context.push_str(&format_tool_hint(&hint));
+        context.push('\n');
+    }
+    context
+}
+
+fn codex_subagent_needs_context(parsed: &Value) -> bool {
+    bool_field(
+        parsed,
+        &["is_new", "new_subagent", "fresh_subagent", "no_history"],
+    ) == Some(true)
+        || bool_field(
+            parsed,
+            &[
+                "has_history",
+                "history_included",
+                "receives_history",
+                "conversation_history_included",
+            ],
+        ) == Some(false)
+        || text_field(
+            parsed,
+            &[
+                "history_mode",
+                "context_mode",
+                "conversation_history",
+                "source",
+                "reason",
+            ],
+        )
+        .is_some_and(|value| matches_no_history_marker(&value))
+        || empty_array_field(parsed, &["history", "messages", "conversation"])
+}
+
+fn bool_field(value: &Value, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| value.get(*key).and_then(Value::as_bool))
+}
+
+fn empty_array_field(value: &Value, keys: &[&str]) -> bool {
+    keys.iter().any(|key| {
+        value
+            .get(*key)
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+    })
+}
+
+fn matches_no_history_marker(value: &str) -> bool {
+    let normalized = value
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "new" | "fresh" | "none" | "empty" | "nohistory" | "withoutconversationhistory"
+    )
+}
+
 /// Resolves the tracedecay project root for a Codex event from its `cwd`.
 pub fn codex_project_root_from_event(event_json: &str) -> Option<PathBuf> {
-    let cwd = event_cwd(event_json)?;
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    codex_project_root_from_parsed_event(&parsed)
+}
+
+fn codex_project_root_from_parsed_event(parsed: &Value) -> Option<PathBuf> {
+    let cwd = event_cwd_from_parsed(parsed)?;
     crate::config::discover_project_root(&cwd)
+}
+
+fn codex_workspace_status(root: Option<&Path>, cwd: Option<&Path>) -> HookWorkspaceStatus {
+    if root.is_some() {
+        return HookWorkspaceStatus::Initialized;
+    }
+    if cwd.is_some_and(is_project_like_workspace) {
+        HookWorkspaceStatus::UnindexedProject
+    } else {
+        HookWorkspaceStatus::Generic
+    }
+}
+
+pub fn codex_workspace_status_from_event(event_json: &str) -> HookWorkspaceStatus {
+    let parsed = serde_json::from_str::<Value>(event_json).unwrap_or(Value::Null);
+    let root = codex_project_root_from_parsed_event(&parsed);
+    let cwd = event_cwd_from_parsed(&parsed);
+    codex_workspace_status(root.as_deref(), cwd.as_deref())
+}
+
+fn is_project_like_workspace(cwd: &Path) -> bool {
+    nearest_project_like_root(cwd).is_some()
+}
+
+fn project_marker_exists(dir: &Path) -> bool {
+    const MARKERS: &[&str] = &[
+        ".git",
+        "Cargo.toml",
+        "package.json",
+        "pyproject.toml",
+        "go.mod",
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "deno.json",
+        "tsconfig.json",
+    ];
+    MARKERS.iter().any(|marker| dir.join(marker).exists())
 }
 
 /// Extracts the project-relative paths touched by a Codex `apply_patch` command.
@@ -1641,7 +2079,11 @@ async fn codex_post_tool_use(event_json: &str) {
             let _ = cg.sync_if_stale_silent(&rels).await;
         }
     } else if is_codex_bash_tool(tool_name) {
-        match cursor_shell_sync_plan(command) {
+        if !cursor_shell_command_targets_project(command, &cwd, &root) {
+            return;
+        }
+        let current_branch = crate::branch::current_branch(&root);
+        match cursor_shell_sync_plan_with_current_branch(command, current_branch.as_deref()) {
             CursorShellSyncPlan::BranchAdd(branch) => {
                 // Idempotent + fail-open: already-tracked branches no-op.
                 let _ = crate::branch::add_branch_tracking(&root, &branch).await;
@@ -2034,6 +2476,9 @@ async fn sync_for_kiro_event(event_json: &str) -> crate::errors::Result<()> {
     let Some(project_root) = kiro_project_root(event_json) else {
         return Ok(());
     };
+    if !crate::tracedecay::TraceDecay::is_initialized(&project_root) {
+        return Ok(());
+    }
     let cg = crate::tracedecay::TraceDecay::open(&project_root).await?;
     match cg.sync().await {
         Ok(_) | Err(crate::errors::TraceDecayError::SyncLock { .. }) => Ok(()),
@@ -2096,6 +2541,14 @@ fn codex_prompt_hint(event_json: &str) -> Option<ToolHint> {
         file_path: None,
         hints_enabled: true,
     })?;
+    let root = codex_project_root_from_event(event_json);
+    record_hint_analytics(
+        root.as_deref(),
+        "hint_candidate",
+        HintAgent::Codex,
+        event_session_id(&parsed).as_deref(),
+        &hint,
+    );
     deduped_codex_hint(event_json, &parsed, hint)
 }
 
@@ -2150,6 +2603,10 @@ fn kiro_project_root(event_json: &str) -> Option<PathBuf> {
 /// Kiro and Codex handlers, both of which send the session working directory.
 fn event_cwd(event_json: &str) -> Option<PathBuf> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
+    event_cwd_from_parsed(&parsed)
+}
+
+fn event_cwd_from_parsed(parsed: &Value) -> Option<PathBuf> {
     let cwd = parsed.get("cwd").and_then(Value::as_str)?;
     let path = Path::new(cwd);
     if path.as_os_str().is_empty() {
@@ -2242,6 +2699,18 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         ENV_LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn shell_words_preserves_unquoted_windows_paths() {
+        assert_eq!(
+            shell_words_for_platform(r"git --work-tree=C:\Users\me\repo pull", true),
+            vec!["git", r"--work-tree=C:\Users\me\repo", "pull"]
+        );
+        assert_eq!(
+            shell_words_for_platform(r"git --work-tree=C:\Users\me\repo pull", false),
+            vec!["git", r"--work-tree=C:Usersmerepo", "pull"]
+        );
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -780,14 +780,6 @@ fn deduped_project_hint(
         record_hint_emitted(None, agent, session_id.as_deref(), &hint);
         return Some(hint);
     };
-    let Ok(layout) = crate::storage::resolve_layout_for_current_profile(&root) else {
-        record_hint_emitted(Some(&root), agent, session_id.as_deref(), &hint);
-        return Some(hint);
-    };
-    if !layout.data_root.is_dir() {
-        record_hint_emitted(Some(&root), agent, session_id.as_deref(), &hint);
-        return Some(hint);
-    }
     let Some(session_id) = session_id else {
         record_hint_emitted(Some(&root), agent, None, &hint);
         return Some(hint);
@@ -801,6 +793,14 @@ fn deduped_project_hint(
             &hint,
         );
         return None;
+    }
+    let Ok(layout) = crate::storage::resolve_layout_for_current_profile(&root) else {
+        record_hint_emitted(Some(&root), agent, Some(&session_id), &hint);
+        return Some(hint);
+    };
+    if !layout.data_root.is_dir() {
+        record_hint_emitted(Some(&root), agent, Some(&session_id), &hint);
+        return Some(hint);
     }
     let path = layout.data_root.join("tool_hints_seen.json");
     let mut dedupe = tool_hints::ToolHintDedupe::load_or_default(&path);

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1175,17 +1175,20 @@ pub fn cursor_shell_command_targets_project(
 
 fn git_explicit_work_dir(tokens: &[String], cwd: &Path) -> Option<PathBuf> {
     let mut i = 1;
+    let mut explicit_work_dir = None;
     while i < tokens.len() {
         let token = &tokens[i];
         match token.as_str() {
             "-C" | "--work-tree" => {
                 let value = tokens.get(i + 1)?;
-                return Some(resolve_shell_path(cwd, value));
+                explicit_work_dir = Some(resolve_shell_path(cwd, value));
+                i += 2;
             }
             "-c" | "--git-dir" | "--namespace" | "--config-env" => i += 2,
             _ if token.starts_with("--work-tree=") => {
                 let value = token.trim_start_matches("--work-tree=");
-                return Some(resolve_shell_path(cwd, value));
+                explicit_work_dir = Some(resolve_shell_path(cwd, value));
+                i += 1;
             }
             _ if token.starts_with("--git-dir=")
                 || token.starts_with("--namespace=")
@@ -1197,7 +1200,7 @@ fn git_explicit_work_dir(tokens: &[String], cwd: &Path) -> Option<PathBuf> {
             _ => break,
         }
     }
-    None
+    explicit_work_dir
 }
 
 fn resolve_shell_path(cwd: &Path, value: &str) -> PathBuf {
@@ -2711,6 +2714,26 @@ mod tests {
             shell_words_for_platform(r"git --work-tree=C:\Users\me\repo pull", false),
             vec!["git", r"--work-tree=C:Usersmerepo", "pull"]
         );
+    }
+
+    #[test]
+    fn git_work_tree_overrides_prior_c_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("repo");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(project.join(".git")).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let command = format!(
+            "git -C {} --git-dir={}/.git --work-tree={} pull",
+            outside.display(),
+            project.display(),
+            project.display()
+        );
+
+        assert!(cursor_shell_command_targets_project(
+            &command, &outside, &project
+        ));
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -6,9 +6,10 @@
 //! Each agent sends its own event schema on stdin and expects its own output
 //! shape, so the handlers are kept agent-specific rather than shared blindly.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
@@ -791,6 +792,16 @@ fn deduped_project_hint(
         record_hint_emitted(Some(&root), agent, None, &hint);
         return Some(hint);
     };
+    if !remember_hint_in_process(&root, agent, &session_id, hint.category) {
+        record_hint_analytics(
+            Some(&root),
+            "suppressed_duplicate",
+            agent,
+            Some(&session_id),
+            &hint,
+        );
+        return None;
+    }
     let path = layout.data_root.join("tool_hints_seen.json");
     let mut dedupe = tool_hints::ToolHintDedupe::load_or_default(&path);
     if !dedupe.should_emit(&session_id, hint.category) {
@@ -806,6 +817,26 @@ fn deduped_project_hint(
     let _ = dedupe.save(&path);
     record_hint_analytics(Some(&root), "hint_emitted", agent, Some(&session_id), &hint);
     Some(hint)
+}
+
+fn remember_hint_in_process(
+    root: &Path,
+    agent: HintAgent,
+    session_id: &str,
+    category: HintCategory,
+) -> bool {
+    static MEMORY: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let key = format!(
+        "{}\0{}\0{}\0{}",
+        root.display(),
+        agent.as_key(),
+        session_id,
+        category.as_key()
+    );
+    let Ok(mut memory) = MEMORY.get_or_init(|| Mutex::new(HashSet::new())).lock() else {
+        return true;
+    };
+    memory.insert(key)
 }
 
 pub fn cursor_project_root_from_event(event_json: &str) -> Option<PathBuf> {

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -15,6 +15,17 @@ pub enum HintAgent {
     Kiro,
 }
 
+impl HintAgent {
+    pub(crate) fn as_key(self) -> &'static str {
+        match self {
+            HintAgent::Claude => "claude",
+            HintAgent::Cursor => "cursor",
+            HintAgent::Codex => "codex",
+            HintAgent::Kiro => "kiro",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum HintCategory {
     Search,
@@ -26,10 +37,11 @@ pub enum HintCategory {
     SymbolLookup,
     FileLookup,
     ExploreSubagent,
+    SubagentStartContext,
 }
 
 impl HintCategory {
-    fn as_key(self) -> &'static str {
+    pub(crate) fn as_key(self) -> &'static str {
         match self {
             HintCategory::Search => "search",
             HintCategory::SemanticSearch => "semantic_search",
@@ -40,6 +52,7 @@ impl HintCategory {
             HintCategory::SymbolLookup => "symbol_lookup",
             HintCategory::FileLookup => "file_lookup",
             HintCategory::ExploreSubagent => "explore_subagent",
+            HintCategory::SubagentStartContext => "subagent_start_context",
         }
     }
 
@@ -54,6 +67,7 @@ impl HintCategory {
             "symbol_lookup" => Some(HintCategory::SymbolLookup),
             "file_lookup" => Some(HintCategory::FileLookup),
             "explore_subagent" => Some(HintCategory::ExploreSubagent),
+            "subagent_start_context" => Some(HintCategory::SubagentStartContext),
             _ => None,
         }
     }

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -1,13 +1,18 @@
 mod common;
 
 use common::{EnvVarGuard, GLOBAL_DB_ENV, GLOBAL_DB_ENV_LOCK};
+use std::path::Path;
+use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::hooks::{
     build_cursor_session_context, codex_additional_context_json, codex_apply_patch_rel_paths,
-    codex_project_root_from_event, cursor_branch_switch_target, cursor_project_root_from_event,
-    cursor_session_start_json, cursor_shell_sync_plan, cursor_should_run_sync,
-    cursor_staleness_hint, evaluate_codex_subagent_start, evaluate_cursor_post_tool_use,
-    evaluate_cursor_subagent_start, evaluate_hook_decision, evaluate_kiro_pre_tool_use,
-    is_git_state_changing_command, CursorShellSyncPlan,
+    codex_project_root_from_event, codex_subagent_start_log_line,
+    codex_user_prompt_submit_context_for_event, codex_workspace_status_from_event,
+    cursor_branch_switch_target, cursor_project_root_from_event, cursor_session_start_json,
+    cursor_shell_command_targets_project, cursor_shell_sync_plan,
+    cursor_shell_sync_plan_with_current_branch, cursor_should_run_sync, cursor_staleness_hint,
+    evaluate_codex_subagent_start, evaluate_cursor_post_tool_use, evaluate_cursor_subagent_start,
+    evaluate_hook_decision, evaluate_kiro_pre_tool_use, is_git_state_changing_command,
+    record_codex_subagent_start, CursorShellSyncPlan, HookWorkspaceStatus,
 };
 use tracedecay::storage::{
     resolve_layout_for_current_profile, write_enrollment_marker, EnrollmentMarker, StorageMode,
@@ -24,6 +29,44 @@ fn get_block_reason(json: &str) -> String {
         .as_str()
         .unwrap_or("")
         .to_string()
+}
+
+fn read_hook_analytics_events(root: &Path) -> Vec<serde_json::Value> {
+    let path = root.join("hook_analytics.jsonl");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    content
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn analytics_contains(events: &[serde_json::Value], event: &str, category: Option<&str>) -> bool {
+    events.iter().any(|item| {
+        item["event"].as_str() == Some(event)
+            && category.is_none_or(|category| item["category"].as_str() == Some(category))
+    })
+}
+
+fn enroll_profile_project(project_root: &Path, project_id: &str) {
+    write_enrollment_marker(
+        project_root,
+        &EnrollmentMarker {
+            project_id: project_id.to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+}
+
+fn hook_profile_env(project_root: &Path, profile_root: &Path) -> [EnvVarGuard; 4] {
+    let home = project_root.join("home");
+    [
+        EnvVarGuard::set(USER_DATA_DIR_ENV, profile_root),
+        EnvVarGuard::set(GLOBAL_DB_ENV, profile_root.join("global.db")),
+        EnvVarGuard::set("HOME", &home),
+        EnvVarGuard::set("USERPROFILE", &home),
+    ]
 }
 
 #[test]
@@ -370,20 +413,8 @@ fn test_cursor_post_tool_use_dedupes_hints_per_session() {
         .unwrap_or_else(|err| err.into_inner());
     let project_root = dir.path().canonicalize().unwrap();
     let profile_root = project_root.join("profile");
-    let _env_guards = [
-        EnvVarGuard::set("TRACEDECAY_DATA_DIR", &profile_root),
-        EnvVarGuard::set(GLOBAL_DB_ENV, profile_root.join("global.db")),
-        EnvVarGuard::set("HOME", project_root.join("home")),
-        EnvVarGuard::set("USERPROFILE", project_root.join("home")),
-    ];
-    write_enrollment_marker(
-        &project_root,
-        &EnrollmentMarker {
-            project_id: "proj_hooks_dedupe".to_string(),
-            storage_mode: StorageMode::ProfileSharded,
-        },
-    )
-    .unwrap();
+    let _env_guards = hook_profile_env(&project_root, &profile_root);
+    enroll_profile_project(&project_root, "proj_hooks_dedupe");
     let layout = resolve_layout_for_current_profile(&project_root).unwrap();
     std::fs::create_dir_all(&layout.data_root).unwrap();
     std::fs::write(&layout.graph_db_path, "").unwrap();
@@ -434,6 +465,75 @@ fn test_cursor_post_tool_use_dedupes_hints_per_session() {
 }
 
 #[test]
+fn test_cursor_post_tool_use_records_hint_analytics_for_emitted_duplicate_and_missing_session() {
+    let dir = tempfile::tempdir().unwrap();
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    let project_root = dir.path().canonicalize().unwrap();
+    let profile_root = project_root.join("profile");
+    let _env_guards = hook_profile_env(&project_root, &profile_root);
+    enroll_profile_project(&project_root, "proj_hooks_analytics");
+    let layout = resolve_layout_for_current_profile(&project_root).unwrap();
+    std::fs::create_dir_all(&layout.data_root).unwrap();
+    std::fs::write(&layout.graph_db_path, "").unwrap();
+    let root = serde_json::to_string(project_root.to_str().unwrap()).unwrap();
+    let grep_event = format!(
+        r#"{{
+            "hook_event_name": "postToolUse",
+            "tool_name": "Grep",
+            "tool_input": {{ "pattern": "foo" }},
+            "session_id": "session-a",
+            "workspace_roots": [{root}]
+        }}"#
+    );
+
+    assert!(tracedecay::hooks::cursor_post_tool_use_decision(&grep_event).is_some());
+    assert!(tracedecay::hooks::cursor_post_tool_use_decision(&grep_event).is_none());
+
+    let missing_session_event = format!(
+        r#"{{
+            "hook_event_name": "postToolUse",
+            "tool_name": "Read",
+            "tool_input": {{ "file_path": "src/lib.rs" }},
+            "workspace_roots": [{root}]
+        }}"#
+    );
+    let output = tracedecay::hooks::cursor_post_tool_use_decision(&missing_session_event)
+        .expect("missing session id should still emit a useful hint");
+    let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert!(v["additional_context"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("tracedecay hint:"));
+    assert!(v.get("hookSpecificOutput").is_none());
+    assert!(v.get("permission").is_none());
+
+    let events = read_hook_analytics_events(&layout.data_root);
+    assert!(analytics_contains(
+        &events,
+        "hint_candidate",
+        Some("search")
+    ));
+    assert!(analytics_contains(&events, "hint_emitted", Some("search")));
+    assert!(analytics_contains(
+        &events,
+        "suppressed_duplicate",
+        Some("search")
+    ));
+    assert!(analytics_contains(
+        &events,
+        "missing_session",
+        Some("file_read")
+    ));
+    assert!(analytics_contains(
+        &events,
+        "hint_emitted",
+        Some("file_read")
+    ));
+}
+
+#[test]
 fn test_cursor_post_tool_use_decision_silent_without_index() {
     let dir = tempfile::tempdir().unwrap();
     let root = serde_json::to_string(dir.path().to_str().unwrap()).unwrap();
@@ -450,6 +550,48 @@ fn test_cursor_post_tool_use_decision_silent_without_index() {
         tracedecay::hooks::cursor_post_tool_use_decision(&event).is_none(),
         "hints must not fire in workspaces without a tracedecay index"
     );
+}
+
+#[test]
+fn test_cursor_post_tool_use_records_uninitialized_suppression() {
+    let dir = tempfile::tempdir().unwrap();
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    let project_root = dir.path().canonicalize().unwrap();
+    let profile_root = project_root.join("profile");
+    let _env_guards = hook_profile_env(&project_root, &profile_root);
+    std::fs::write(
+        project_root.join("Cargo.toml"),
+        "[package]\nname = \"uninitialized\"\n",
+    )
+    .unwrap();
+    let layout = resolve_layout_for_current_profile(&project_root).unwrap();
+    std::fs::create_dir_all(&layout.data_root).unwrap();
+    let root = serde_json::to_string(project_root.to_str().unwrap()).unwrap();
+    let event = format!(
+        r#"{{
+            "hook_event_name": "postToolUse",
+            "tool_name": "Grep",
+            "tool_input": {{ "pattern": "foo" }},
+            "session_id": "session-a",
+            "workspace_roots": [{root}]
+        }}"#
+    );
+
+    assert!(tracedecay::hooks::cursor_post_tool_use_decision(&event).is_none());
+
+    let events = read_hook_analytics_events(&layout.data_root);
+    assert!(analytics_contains(
+        &events,
+        "hint_candidate",
+        Some("search")
+    ));
+    assert!(analytics_contains(
+        &events,
+        "suppressed_uninitialized",
+        Some("search")
+    ));
 }
 
 #[test]
@@ -659,6 +801,178 @@ fn test_build_codex_session_context_carries_full_steering() {
 }
 
 #[test]
+fn test_build_codex_session_context_for_unindexed_project_suggests_init() {
+    let context = tracedecay::hooks::build_codex_session_context_for_workspace(
+        HookWorkspaceStatus::UnindexedProject,
+        None,
+    );
+
+    assert!(context.contains("tracedecay_context"));
+    assert!(context.contains("tracedecay init"));
+}
+
+#[test]
+fn test_build_codex_session_context_for_generic_workspace_uses_session_guidance() {
+    let context = tracedecay::hooks::build_codex_session_context_for_workspace(
+        HookWorkspaceStatus::Generic,
+        None,
+    );
+
+    assert!(context.contains("TraceDecay session context"));
+    assert!(context.contains("tracedecay_lcm_expand_query"));
+    assert!(context.contains("tracedecay_message_search"));
+    assert!(
+        !context.contains("tracedecay init"),
+        "non-project chats should not be told to initialize a code graph: {context}"
+    );
+    assert!(
+        !context.contains("tracedecay_context"),
+        "non-project chats should not get code graph steering: {context}"
+    );
+    assert!(
+        !context.contains("code-graph"),
+        "non-project chats should not mention code graph setup: {context}"
+    );
+    assert!(
+        !context.contains("repository"),
+        "non-project chats should not mention repositories: {context}"
+    );
+}
+
+#[tokio::test]
+async fn test_codex_user_prompt_submit_generic_workspace_suppresses_code_hints() {
+    let generic = tempfile::tempdir().unwrap();
+    let event = serde_json::json!({
+        "cwd": generic.path(),
+        "session_id": "codex-generic-prompt-1",
+        "prompt": "Who calls build_codex_session_context?"
+    })
+    .to_string();
+
+    let context = codex_user_prompt_submit_context_for_event(&event).await;
+
+    assert!(context.contains("TraceDecay session context"));
+    assert!(context.contains("tracedecay_lcm_expand_query"));
+    assert!(
+        !context.contains("tracedecay hint:"),
+        "generic workspaces should suppress prompt-derived code hints: {context}"
+    );
+    assert!(
+        !context.contains("tracedecay_context"),
+        "generic workspaces should not include code graph tools: {context}"
+    );
+    assert!(
+        !context.contains("tracedecay init"),
+        "generic workspaces should not suggest code graph initialization: {context}"
+    );
+}
+
+#[tokio::test]
+async fn test_codex_user_prompt_submit_records_workspace_status_and_missing_session_hint() {
+    let _lock = GLOBAL_DB_ENV_LOCK.lock().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let generic = tempfile::tempdir().unwrap();
+    let profile = tempfile::tempdir().unwrap();
+    let project_root = project.path().canonicalize().unwrap();
+    let profile_root = profile.path().canonicalize().unwrap();
+    let _profile_env = EnvVarGuard::set(USER_DATA_DIR_ENV, profile_root.to_str().unwrap());
+    enroll_profile_project(&project_root, "codex_prompt_analytics");
+    let layout = resolve_layout_for_current_profile(&project_root).unwrap();
+    std::fs::create_dir_all(&layout.data_root).unwrap();
+
+    let generic_event = serde_json::json!({
+        "cwd": generic.path(),
+        "session_id": "codex-generic-analytics",
+        "prompt": "Who calls build_codex_session_context?"
+    })
+    .to_string();
+    let generic_context = codex_user_prompt_submit_context_for_event(&generic_event).await;
+    assert!(generic_context.contains("TraceDecay session context"));
+    assert!(!generic_context.contains("tracedecay hint:"));
+
+    let prompt_event = serde_json::json!({
+        "cwd": project_root,
+        "prompt": "Please explain the impact of changing parse_user"
+    })
+    .to_string();
+    let prompt_context = codex_user_prompt_submit_context_for_event(&prompt_event).await;
+    assert!(prompt_context.contains("tracedecay hint:"));
+
+    let profile_events = read_hook_analytics_events(&profile_root);
+    assert!(profile_events.iter().any(|item| {
+        item["event"].as_str() == Some("workspace_status")
+            && item["workspace_status"].as_str() == Some("generic")
+    }));
+
+    let project_events = read_hook_analytics_events(&layout.data_root);
+    assert!(project_events.iter().any(|item| {
+        item["event"].as_str() == Some("workspace_status")
+            && item["workspace_status"].as_str() == Some("initialized")
+    }));
+    assert!(analytics_contains(
+        &project_events,
+        "missing_session",
+        Some("impact")
+    ));
+    assert!(analytics_contains(
+        &project_events,
+        "hint_emitted",
+        Some("impact")
+    ));
+}
+
+#[test]
+fn test_codex_workspace_status_distinguishes_generic_and_project_like_dirs() {
+    let generic = tempfile::tempdir().unwrap();
+    let generic_event = serde_json::json!({ "cwd": generic.path() }).to_string();
+    assert_eq!(
+        codex_workspace_status_from_event(&generic_event),
+        HookWorkspaceStatus::Generic
+    );
+
+    let project_like = tempfile::tempdir().unwrap();
+    std::fs::write(
+        project_like.path().join("Cargo.toml"),
+        "[package]\nname = \"x\"\n",
+    )
+    .unwrap();
+    let project_event = serde_json::json!({ "cwd": project_like.path() }).to_string();
+    assert_eq!(
+        codex_workspace_status_from_event(&project_event),
+        HookWorkspaceStatus::UnindexedProject
+    );
+
+    let git_like = tempfile::tempdir().unwrap();
+    std::fs::create_dir(git_like.path().join(".git")).unwrap();
+    let nested = git_like.path().join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    let git_event = serde_json::json!({ "cwd": nested }).to_string();
+    assert_eq!(
+        codex_workspace_status_from_event(&git_event),
+        HookWorkspaceStatus::UnindexedProject
+    );
+}
+
+#[test]
+fn test_codex_workspace_status_detects_initialized_trace_decay_project() {
+    let _lock = GLOBAL_DB_ENV_LOCK.lock().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let profile = tempfile::tempdir().unwrap();
+    let project_root = project.path().canonicalize().unwrap();
+    let profile_root = profile.path().canonicalize().unwrap();
+    let _profile_env = EnvVarGuard::set(USER_DATA_DIR_ENV, profile_root.to_str().unwrap());
+    enroll_profile_project(&project_root, "codex_workspace_status_initialized");
+
+    let nested = project_root.join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    let event = serde_json::json!({ "cwd": nested }).to_string();
+    assert_eq!(
+        codex_workspace_status_from_event(&event),
+        HookWorkspaceStatus::Initialized
+    );
+}
+
+#[test]
 fn test_build_cursor_session_context_lists_skills_and_tokens_saved() {
     let context = build_cursor_session_context(true, None, Some(12_345));
     assert!(context.contains("Workflow skills: tracedecay:"));
@@ -790,6 +1104,18 @@ fn test_cursor_shell_sync_plan_routes_same_branch_changes_to_incremental_sync() 
 }
 
 #[test]
+fn test_cursor_shell_sync_plan_uses_current_branch_for_implicit_git_changes() {
+    assert_eq!(
+        cursor_shell_sync_plan_with_current_branch("git pull --rebase", Some("feature/x")),
+        CursorShellSyncPlan::CurrentBranchSync("feature/x".to_string())
+    );
+    assert_eq!(
+        cursor_shell_sync_plan_with_current_branch("git pull --rebase", None),
+        CursorShellSyncPlan::IncrementalSync
+    );
+}
+
+#[test]
 fn test_cursor_shell_sync_plan_noop_for_read_only_and_non_git() {
     for command in ["git status", "git log", "ls -la", "cargo build"] {
         assert_eq!(
@@ -798,6 +1124,26 @@ fn test_cursor_shell_sync_plan_noop_for_read_only_and_non_git() {
             "{command} should be a no-op"
         );
     }
+}
+
+#[test]
+fn test_cursor_shell_command_targets_project_respects_explicit_git_workdir() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project = workspace.path().join("project");
+    let other = workspace.path().join("other");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(&other).unwrap();
+
+    assert!(!cursor_shell_command_targets_project(
+        &format!("git -C {} pull", other.display()),
+        &project,
+        &project,
+    ));
+    assert!(cursor_shell_command_targets_project(
+        &format!("git --work-tree={} pull", project.display()),
+        &project,
+        &project,
+    ));
 }
 
 // ---------------------------------------------------------------------------
@@ -866,6 +1212,147 @@ fn test_codex_subagent_start_allows_execution_agent() {
 #[test]
 fn test_codex_subagent_start_allows_invalid_json() {
     assert!(evaluate_codex_subagent_start("not json").is_none());
+}
+
+#[test]
+fn test_codex_subagent_start_injects_context_for_new_no_history_agent() {
+    let input = r#"{
+        "hook_event_name": "SubagentStart",
+        "agent_type": "generalPurpose",
+        "session_id": "codex-subagent-session-1",
+        "is_new": true,
+        "has_history": false,
+        "prompt": "Implement the fix in the relevant files"
+    }"#;
+
+    let output = evaluate_codex_subagent_start(input).expect("new subagent should get context");
+    let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let context = v["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .unwrap_or_default();
+
+    assert_eq!(
+        v["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("SubagentStart")
+    );
+    assert!(context.contains("new/no-history subagent"));
+    assert!(context.contains("tracedecay_context"));
+    assert!(context.contains("tracedecay:searching-for-code"));
+    assert!(context.contains("tracedecay_lcm_expand_query"));
+    assert!(context.contains("tracedecay_message_search"));
+    assert!(
+        v.get("continue").is_none(),
+        "Codex SubagentStart must stay fail-open"
+    );
+}
+
+#[test]
+fn test_codex_subagent_start_dedupes_context_per_session() {
+    let _lock = GLOBAL_DB_ENV_LOCK.lock().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let profile = tempfile::tempdir().unwrap();
+    let project_root = project.path().canonicalize().unwrap();
+    let profile_root = profile.path().canonicalize().unwrap();
+    let _profile_env = EnvVarGuard::set(USER_DATA_DIR_ENV, profile_root.to_str().unwrap());
+    enroll_profile_project(&project_root, "codex_subagent_dedupe");
+    let layout = resolve_layout_for_current_profile(&project_root).unwrap();
+    std::fs::create_dir_all(&layout.data_root).unwrap();
+    let input = serde_json::json!({
+        "hook_event_name": "SubagentStart",
+        "agent_type": "generalPurpose",
+        "session_id": "codex-subagent-session-2",
+        "cwd": project_root,
+        "is_new": true,
+        "has_history": false
+    })
+    .to_string();
+
+    assert!(evaluate_codex_subagent_start(&input).is_some());
+    assert!(
+        evaluate_codex_subagent_start(&input).is_none(),
+        "repeated SubagentStart context should be suppressed per session"
+    );
+}
+
+#[test]
+fn test_codex_subagent_start_no_history_does_not_suppress_later_research_context() {
+    let _lock = GLOBAL_DB_ENV_LOCK.lock().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let profile = tempfile::tempdir().unwrap();
+    let project_root = project.path().canonicalize().unwrap();
+    let profile_root = profile.path().canonicalize().unwrap();
+    let _profile_env = EnvVarGuard::set(USER_DATA_DIR_ENV, profile_root.to_str().unwrap());
+    enroll_profile_project(&project_root, "codex_subagent_research_after_no_history");
+    let layout = resolve_layout_for_current_profile(&project_root).unwrap();
+    std::fs::create_dir_all(&layout.data_root).unwrap();
+    let no_history_input = serde_json::json!({
+        "hook_event_name": "SubagentStart",
+        "agent_type": "generalPurpose",
+        "session_id": "codex-subagent-session-research-after-no-history",
+        "cwd": project_root,
+        "is_new": true,
+        "has_history": false,
+        "prompt": "Implement the requested fix"
+    })
+    .to_string();
+    let research_input = serde_json::json!({
+        "hook_event_name": "SubagentStart",
+        "agent_type": "explore",
+        "session_id": "codex-subagent-session-research-after-no-history",
+        "cwd": project_root,
+        "prompt": "Explore the codebase architecture before changing files"
+    })
+    .to_string();
+
+    assert!(evaluate_codex_subagent_start(&no_history_input).is_some());
+
+    let output = evaluate_codex_subagent_start(&research_input)
+        .expect("later research/explore subagent should still get context");
+    let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let context = v["hookSpecificOutput"]["additionalContext"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(context.contains("tracedecay MCP tools"));
+    assert!(context.contains("tracedecay hint:"));
+}
+
+#[test]
+fn test_codex_subagent_start_counts_and_formats_log_line() {
+    let _lock = GLOBAL_DB_ENV_LOCK.lock().unwrap();
+    let project = tempfile::tempdir().unwrap();
+    let profile = tempfile::tempdir().unwrap();
+    let project_root = project.path().canonicalize().unwrap();
+    let profile_root = profile.path().canonicalize().unwrap();
+    let _profile_env = EnvVarGuard::set(USER_DATA_DIR_ENV, profile_root.to_str().unwrap());
+    enroll_profile_project(&project_root, "codex_subagent_count");
+    let input = serde_json::json!({
+        "hook_event_name": "SubagentStart",
+        "agent_type": "generalPurpose",
+        "session_id": "codex-subagent-session-3",
+        "cwd": project_root
+    })
+    .to_string();
+
+    assert_eq!(record_codex_subagent_start(&input), Some(1));
+    assert_eq!(record_codex_subagent_start(&input), Some(2));
+
+    let line = codex_subagent_start_log_line(&input, Some(2), true);
+    assert!(line.contains("Codex SubagentStart #2"));
+    assert!(line.contains("agent_type=generalPurpose"));
+    assert!(line.contains("additional_context=true"));
+
+    let layout = resolve_layout_for_current_profile(&project_root).unwrap();
+    let events = read_hook_analytics_events(&layout.data_root);
+    assert!(events.iter().any(|item| {
+        item["event"].as_str() == Some("codex_subagent_start")
+            && item["count"].as_u64() == Some(1)
+            && item["agent_type"].as_str() == Some("generalPurpose")
+    }));
+    assert!(events.iter().any(|item| {
+        item["event"].as_str() == Some("codex_subagent_start")
+            && item["count"].as_u64() == Some(2)
+            && item["agent_type"].as_str() == Some("generalPurpose")
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Record hook hint/workspace/subagent telemetry in profile-scoped JSONL state
- Distinguish initialized, unindexed project-like, and generic Codex workspaces
- Add compact TraceDecay context for new/no-history Codex subagents and count starts per session
- Tighten Cursor git sync routing to commands that target the active project

## Verification
- cargo test --test hooks_test
