### PR TITLE
Refresh Codex plugin source and cache flow

### DIFF
--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -11,6 +11,7 @@
 //! `/hooks` CLI before they run — newly installed or changed hooks are skipped
 //! until trusted. The installer prints that guidance after writing `hooks.json`.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
@@ -89,10 +90,14 @@ impl AgentIntegration for CodexIntegration {
     fn update_plugin(&self, ctx: &InstallContext) -> Result<UpdatePluginOutcome> {
         let cached_dirs = codex_plugin_cached_install_dirs(&ctx.home);
         let plugin_dir = codex_plugin_install_dir(&ctx.home);
+        let mut refreshed = Vec::new();
         if !cached_dirs.is_empty() {
             let target = install_codex_cached_plugin(&ctx.home, &ctx.tracedecay_bin)?;
-            cleanup_codex_plugin_bootstrap(&ctx.home)?;
-            return Ok(UpdatePluginOutcome::Refreshed(vec![target]));
+            refreshed.push(target);
+            refreshed.push(install_codex_personal_bootstrap(
+                &ctx.home,
+                &ctx.tracedecay_bin,
+            )?);
         }
 
         if let Some(project_path) = codex_update_project_path(ctx) {
@@ -105,8 +110,18 @@ impl AgentIntegration for CodexIntegration {
                     &ctx.tracedecay_bin,
                     InstallScope::ProjectLocal,
                 )?;
-                return Ok(UpdatePluginOutcome::Refreshed(vec![repo_dir]));
+                install_codex_marketplace_entry(
+                    &codex_repo_marketplace_path(&project_path),
+                    "local-repo",
+                    "Local Repo",
+                    "./plugins/tracedecay",
+                )?;
+                refreshed.push(repo_dir);
             }
+        }
+
+        if !refreshed.is_empty() {
+            return Ok(UpdatePluginOutcome::Refreshed(refreshed));
         }
 
         let target = if codex_plugin_manifest_path(&ctx.home).exists() {
@@ -120,7 +135,7 @@ impl AgentIntegration for CodexIntegration {
         let Some(target) = target else {
             return Ok(UpdatePluginOutcome::NotInstalled);
         };
-        write_codex_plugin_files(&target, &ctx.tracedecay_bin, InstallScope::Global)?;
+        install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
         Ok(UpdatePluginOutcome::Refreshed(vec![target]))
     }
 
@@ -130,6 +145,13 @@ impl AgentIntegration for CodexIntegration {
         let local_plugin_dir = codex_repo_plugin_install_dir(&ctx.project_path);
         if local_plugin_dir.join(".codex-plugin/plugin.json").exists() {
             doctor_check_plugin_dir(dc, &local_plugin_dir);
+            doctor_check_marketplace_entry(
+                dc,
+                &codex_repo_marketplace_path(&ctx.project_path),
+                "repo marketplace",
+                "./plugins/tracedecay",
+                "tracedecay install --local --agent codex",
+            );
         } else if local_codex_dir.join("config.toml").exists()
             || local_codex_dir.join("hooks.json").exists()
         {
@@ -350,7 +372,7 @@ fn install_codex_plugin(home: &Path, tracedecay_bin: &str) -> Result<()> {
     let cached_dirs = codex_plugin_cached_install_dirs(home);
     if !cached_dirs.is_empty() {
         let install_dir = install_codex_cached_plugin(home, tracedecay_bin)?;
-        cleanup_codex_plugin_bootstrap(home)?;
+        install_codex_personal_bootstrap(home, tracedecay_bin)?;
         eprintln!(
             "\x1b[32m✔\x1b[0m Refreshed installed Codex plugin bundle at {}",
             install_dir.display()
@@ -358,6 +380,15 @@ fn install_codex_plugin(home: &Path, tracedecay_bin: &str) -> Result<()> {
         return Ok(());
     }
 
+    let install_dir = install_codex_personal_bootstrap(home, tracedecay_bin)?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Installed Codex plugin source at {}",
+        install_dir.display()
+    );
+    Ok(())
+}
+
+fn install_codex_personal_bootstrap(home: &Path, tracedecay_bin: &str) -> Result<PathBuf> {
     let install_dir = codex_plugin_install_dir(home);
     install_codex_plugin_bundle(&install_dir, tracedecay_bin, InstallScope::Global)?;
     install_codex_marketplace_entry(
@@ -366,11 +397,7 @@ fn install_codex_plugin(home: &Path, tracedecay_bin: &str) -> Result<()> {
         "Personal",
         "./plugins/tracedecay",
     )?;
-    eprintln!(
-        "\x1b[32m✔\x1b[0m Installed Codex plugin source at {}",
-        install_dir.display()
-    );
-    Ok(())
+    Ok(install_dir)
 }
 
 fn install_codex_cached_plugin(home: &Path, tracedecay_bin: &str) -> Result<PathBuf> {
@@ -589,7 +616,7 @@ fn install_codex_marketplace_entry(
     }));
     safe_write_json_file(marketplace_path, &marketplace, None)?;
     eprintln!(
-        "\x1b[32m✔\x1b[0m Added tracedecay to Codex personal marketplace at {}",
+        "\x1b[32m✔\x1b[0m Added tracedecay to Codex {marketplace_name} marketplace at {}",
         marketplace_path.display()
     );
     Ok(())
@@ -618,12 +645,6 @@ fn uninstall_codex_repo_plugin_if_present(ctx: &InstallContext) -> Result<()> {
     Ok(())
 }
 
-fn cleanup_codex_plugin_bootstrap(home: &Path) -> Result<()> {
-    remove_codex_plugin_bootstrap_source(&codex_plugin_install_dir(home))?;
-    remove_codex_marketplace_entry(home)?;
-    Ok(())
-}
-
 fn remove_codex_plugin_bootstrap_source(install_dir: &Path) -> Result<()> {
     if install_dir.exists() && codex_plugin_dir_is_tracedecay(install_dir) {
         remove_codex_plugin_skills_dir(install_dir)?;
@@ -641,9 +662,52 @@ fn remove_codex_plugin_skills_dir(install_dir: &Path) -> Result<()> {
             message: format!("failed to remove {}: {e}", skills_dir.display()),
         })?;
     } else if metadata.is_dir() {
-        std::fs::remove_dir_all(&skills_dir).map_err(|e| TraceDecayError::Config {
-            message: format!("failed to remove {}: {e}", skills_dir.display()),
-        })?;
+        remove_codex_plugin_managed_skills(install_dir, &skills_dir)?;
+    }
+    Ok(())
+}
+
+fn remove_codex_plugin_managed_skills(install_dir: &Path, skills_dir: &Path) -> Result<()> {
+    let managed: HashSet<PathBuf> = codex_plugin_managed_paths(install_dir)
+        .into_iter()
+        .filter(|path| path.starts_with(skills_dir))
+        .collect();
+    let mut files = collect_regular_files(skills_dir).map_err(|e| TraceDecayError::Config {
+        message: format!("failed to list {}: {e}", skills_dir.display()),
+    })?;
+    files.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    for file in files {
+        if managed.contains(&file) || codex_skill_file_is_legacy_tracedecay_managed(&file) {
+            std::fs::remove_file(&file).map_err(|e| TraceDecayError::Config {
+                message: format!("failed to remove {}: {e}", file.display()),
+            })?;
+        }
+    }
+    prune_empty_dirs(skills_dir).map_err(|e| TraceDecayError::Config {
+        message: format!("failed to prune empty Codex skill directories: {e}"),
+    })
+}
+
+fn codex_skill_file_is_legacy_tracedecay_managed(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "SKILL.md")
+        && std::fs::read_to_string(path).is_ok_and(|contents| {
+            contents
+                .lines()
+                .any(|line| line.starts_with("name: tracedecay:"))
+        })
+}
+
+fn prune_empty_dirs(root: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            prune_empty_dirs(&entry.path())?;
+        }
+    }
+    if std::fs::read_dir(root)?.next().is_none() {
+        std::fs::remove_dir(root)?;
     }
     Ok(())
 }
@@ -674,6 +738,7 @@ fn remove_codex_plugin_install(install_dir: &Path) -> Result<()> {
             ),
         });
     }
+    remove_codex_plugin_skills_dir(install_dir)?;
     if codex_plugin_dir_has_only_managed_files(install_dir) {
         std::fs::remove_dir_all(install_dir).map_err(|e| TraceDecayError::Config {
             message: format!("failed to remove {}: {e}", install_dir.display()),
@@ -1002,7 +1067,7 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
     match manifest.get("version").and_then(|value| value.as_str()) {
         Some(env!("CARGO_PKG_VERSION")) => dc.pass("Codex plugin version matches tracedecay"),
         Some(version) => dc.warn(&format!(
-            "Codex plugin version {version} does not match tracedecay {} — run `tracedecay update-plugin --agent codex`",
+            "Codex plugin version {version} does not match tracedecay {} — run `tracedecay update-plugin`",
             env!("CARGO_PKG_VERSION")
         )),
         None => dc.warn("Codex plugin manifest does not contain a version"),
@@ -1027,24 +1092,49 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
     }
     doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"));
 
-    let marketplace_path = codex_personal_marketplace_path(home);
-    let marketplace = load_json_file(&marketplace_path);
+    doctor_check_marketplace_entry(
+        dc,
+        &codex_personal_marketplace_path(home),
+        "personal marketplace",
+        "./plugins/tracedecay",
+        "tracedecay install --agent codex",
+    );
+}
+
+fn doctor_check_marketplace_entry(
+    dc: &mut DoctorCounters,
+    marketplace_path: &Path,
+    label: &str,
+    expected_source_path: &str,
+    install_command: &str,
+) {
+    let marketplace = load_json_file(marketplace_path);
     let has_entry = marketplace
         .get("plugins")
         .and_then(|value| value.as_array())
         .is_some_and(|plugins| {
             plugins.iter().any(|entry| {
                 entry.get("name").and_then(|value| value.as_str()) == Some("tracedecay")
+                    && entry
+                        .get("source")
+                        .and_then(|source| source.get("source"))
+                        .and_then(|value| value.as_str())
+                        == Some("local")
+                    && entry
+                        .get("source")
+                        .and_then(|source| source.get("path"))
+                        .and_then(|value| value.as_str())
+                        == Some(expected_source_path)
             })
         });
     if has_entry {
         dc.pass(&format!(
-            "Codex personal marketplace contains tracedecay in {}",
+            "Codex {label} contains tracedecay in {}",
             marketplace_path.display()
         ));
     } else {
         dc.warn(&format!(
-            "Codex personal marketplace missing tracedecay in {} — run `tracedecay install --agent codex`",
+            "Codex {label} missing tracedecay in {} — run `{install_command}`",
             marketplace_path.display()
         ));
     }
@@ -1067,7 +1157,7 @@ fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path) {
     match manifest.get("version").and_then(|value| value.as_str()) {
         Some(env!("CARGO_PKG_VERSION")) => dc.pass("Codex plugin version matches tracedecay"),
         Some(version) => dc.warn(&format!(
-            "Codex plugin version {version} does not match tracedecay {} — run `tracedecay update-plugin --agent codex`",
+            "Codex plugin version {version} does not match tracedecay {} — run `tracedecay update-plugin`",
             env!("CARGO_PKG_VERSION")
         )),
         None => dc.warn("Codex plugin manifest does not contain a version"),

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -425,7 +425,7 @@ fn cursor_plugin_hooks(raw: &str, tracedecay_bin: &str) -> Result<String> {
                         continue;
                     };
                     if let Some(suffix) = command.strip_prefix("tracedecay ") {
-                        *command_value = json!(format!("{tracedecay_bin} {suffix}"));
+                        *command_value = json!(super::hook_command(tracedecay_bin, suffix));
                     }
                 }
             }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -585,30 +585,57 @@ pub fn backup_and_write_json(path: &Path, value: &serde_json::Value) -> bool {
 /// On Windows the returned path uses forward slashes so it can be safely
 /// embedded in JSON hook commands without backslash-escaping issues.
 pub fn which_tracedecay() -> Option<String> {
-    // Check the current executable first
-    if let Ok(exe) = std::env::current_exe() {
-        if exe
-            .file_name()
-            .and_then(|n| n.to_str())
-            .is_some_and(|n| n.starts_with("tracedecay"))
-        {
-            return Some(normalize_path_separators(&exe.to_string_lossy()));
+    let current_exe = std::env::current_exe().ok();
+    let path_var = std::env::var_os("PATH");
+    which_tracedecay_from(current_exe.as_deref(), path_var.as_deref())
+}
+
+fn which_tracedecay_from(
+    current_exe: Option<&Path>,
+    path_var: Option<&std::ffi::OsStr>,
+) -> Option<String> {
+    if let Some(exe) =
+        current_exe.filter(|exe| is_tracedecay_exe(exe) && !is_cargo_target_binary(exe))
+    {
+        return Some(normalize_path_separators(&exe.to_string_lossy()));
+    }
+
+    let path_match = path_var.and_then(|path_var| {
+        std::env::split_paths(path_var).find_map(|dir| {
+            let candidate = dir.join(tracedecay_bin_name());
+            (candidate.exists() && !is_cargo_target_binary(&candidate))
+                .then(|| normalize_path_separators(&candidate.to_string_lossy()))
+        })
+    });
+    path_match.or_else(|| {
+        current_exe
+            .filter(|exe| is_tracedecay_exe(exe))
+            .map(|exe| normalize_path_separators(&exe.to_string_lossy()))
+    })
+}
+
+fn tracedecay_bin_name() -> String {
+    format!("tracedecay{}", std::env::consts::EXE_SUFFIX)
+}
+
+fn is_tracedecay_exe(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "tracedecay")
+}
+
+fn is_cargo_target_binary(path: &Path) -> bool {
+    let mut saw_target = false;
+    for component in path.components() {
+        let value = component.as_os_str();
+        if saw_target && (value == "debug" || value == "release") {
+            return true;
+        }
+        if value == "target" {
+            saw_target = true;
         }
     }
-    // Fall back to PATH lookup
-    let path_var = std::env::var("PATH").ok()?;
-    let separator = if cfg!(windows) { ';' } else { ':' };
-    let bin_name = if cfg!(windows) {
-        "tracedecay.exe"
-    } else {
-        "tracedecay"
-    };
-    path_var.split(separator).find_map(|dir| {
-        let candidate = PathBuf::from(dir).join(bin_name);
-        candidate
-            .exists()
-            .then(|| normalize_path_separators(&candidate.to_string_lossy()))
-    })
+    false
 }
 
 /// Replace backslashes with forward slashes so paths work in JSON/shell
@@ -1229,7 +1256,7 @@ const HOOK_MARKER: &str = "# tracedecay: auto-sync";
 
 /// The hook snippet appended to (or written as) the post-commit script.
 fn post_commit_snippet(tracedecay_bin: &str) -> String {
-    let bin = tracedecay_bin.replace('\\', "/");
+    let bin = quote_posix_command_arg(&tracedecay_bin.replace('\\', "/"));
     format!(
         "{HOOK_MARKER}\n\
          {bin} sync >/dev/null 2>&1 &\n"
@@ -2130,6 +2157,70 @@ mod path_normalize_tests {
             "/usr/local/bin/tracedecay"
         );
     }
+
+    #[test]
+    fn which_tracedecay_prefers_path_when_current_exe_is_cargo_target_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_bin = dir.path().join("bin").join(tracedecay_bin_name());
+        std::fs::create_dir_all(path_bin.parent().unwrap()).unwrap();
+        std::fs::write(&path_bin, "").unwrap();
+        let current_exe = dir
+            .path()
+            .join("checkout/target/debug")
+            .join(tracedecay_bin_name());
+        let path_var = std::env::join_paths([dir.path().join("bin")]).unwrap();
+
+        let found = which_tracedecay_from(Some(&current_exe), Some(path_var.as_os_str()))
+            .expect("PATH binary should be preferred over cargo target binary");
+
+        assert_eq!(
+            found,
+            normalize_path_separators(&path_bin.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn which_tracedecay_skips_cargo_target_binary_on_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_bin = dir
+            .path()
+            .join("checkout/target/debug")
+            .join(tracedecay_bin_name());
+        let stable_bin = dir.path().join(".cargo/bin").join(tracedecay_bin_name());
+        std::fs::create_dir_all(target_bin.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(stable_bin.parent().unwrap()).unwrap();
+        std::fs::write(&target_bin, "").unwrap();
+        std::fs::write(&stable_bin, "").unwrap();
+        let path_var =
+            std::env::join_paths([target_bin.parent().unwrap(), stable_bin.parent().unwrap()])
+                .unwrap();
+
+        let found = which_tracedecay_from(None, Some(path_var.as_os_str()))
+            .expect("stable PATH binary should be found after skipping cargo target binary");
+
+        assert_eq!(
+            found,
+            normalize_path_separators(&stable_bin.to_string_lossy())
+        );
+    }
+
+    #[test]
+    fn which_tracedecay_keeps_non_target_current_exe() {
+        let dir = tempfile::tempdir().unwrap();
+        let path_bin = dir.path().join("bin").join(tracedecay_bin_name());
+        std::fs::create_dir_all(path_bin.parent().unwrap()).unwrap();
+        std::fs::write(&path_bin, "").unwrap();
+        let current_exe = dir.path().join(".cargo/bin").join(tracedecay_bin_name());
+        let path_var = std::env::join_paths([dir.path().join("bin")]).unwrap();
+
+        let found = which_tracedecay_from(Some(&current_exe), Some(path_var.as_os_str()))
+            .expect("non-target current exe should be accepted");
+
+        assert_eq!(
+            found,
+            normalize_path_separators(&current_exe.to_string_lossy())
+        );
+    }
 }
 
 #[cfg(test)]
@@ -2156,6 +2247,13 @@ mod local_install_safety_tests {
         let command = hook_command_for_platform("/tmp/tracedecay's/bin", "hook-test", false);
 
         assert_eq!(command, "'/tmp/tracedecay'\\''s/bin' hook-test");
+    }
+
+    #[test]
+    fn post_commit_snippet_quotes_posix_binary_paths_with_spaces() {
+        let snippet = post_commit_snippet("/tmp/bin with spaces/tracedecay");
+
+        assert!(snippet.contains("'/tmp/bin with spaces/tracedecay' sync"));
     }
 
     #[cfg(unix)]

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -181,7 +181,15 @@ fn read_json(path: &Path) -> serde_json::Value {
 }
 
 fn expected_tracedecay_bin() -> String {
-    env!("CARGO_BIN_EXE_tracedecay").replace('\\', "/")
+    let path_match = std::env::var_os("PATH").and_then(|path| {
+        std::env::split_paths(&path).find_map(|dir| {
+            let candidate = dir.join("tracedecay");
+            candidate
+                .exists()
+                .then(|| candidate.to_string_lossy().replace('\\', "/"))
+        })
+    });
+    path_match.unwrap_or_else(|| env!("CARGO_BIN_EXE_tracedecay").replace('\\', "/"))
 }
 
 fn assert_python_compiles(paths: &[&Path]) {
@@ -226,6 +234,24 @@ fn codex_repo_marketplace_path(project: &Path) -> std::path::PathBuf {
 
 fn codex_project_plugin_install_dir(project: &Path) -> std::path::PathBuf {
     project.join("plugins/tracedecay")
+}
+
+fn write_codex_plugin_manifest(plugin_dir: &Path, version: &str) {
+    std::fs::create_dir_all(plugin_dir.join(".codex-plugin")).unwrap();
+    std::fs::write(
+        plugin_dir.join(".codex-plugin/plugin.json"),
+        format!(r#"{{"name":"tracedecay","version":"{version}"}}"#),
+    )
+    .unwrap();
+}
+
+fn write_stale_codex_skill(plugin_dir: &Path) {
+    std::fs::create_dir_all(plugin_dir.join("skills/stale-skill")).unwrap();
+    std::fs::write(
+        plugin_dir.join("skills/stale-skill/SKILL.md"),
+        "---\nname: tracedecay:stale-skill\n---\n",
+    )
+    .unwrap();
 }
 
 fn assert_codex_plugin_bundle(
@@ -296,16 +322,21 @@ fn assert_codex_marketplace_entry(
     assert_eq!(entry["category"], "Productivity");
 }
 
-fn assert_codex_marketplace_has_no_tracedecay(marketplace_path: &Path) {
-    if !marketplace_path.exists() {
-        return;
-    }
-    let marketplace = read_json(marketplace_path);
-    assert!(
-        marketplace["plugins"]
-            .as_array()
-            .is_none_or(|plugins| plugins.iter().all(|entry| entry["name"] != "tracedecay")),
-        "Codex marketplace should not keep a tracedecay source entry after cache install"
+fn assert_codex_personal_marketplace_entry(home: &Path) {
+    assert_codex_marketplace_entry(
+        &codex_personal_marketplace_path(home),
+        "personal",
+        "Personal",
+        "./plugins/tracedecay",
+    );
+}
+
+fn assert_codex_repo_marketplace_entry(project: &Path) {
+    assert_codex_marketplace_entry(
+        &codex_repo_marketplace_path(project),
+        "local-repo",
+        "Local Repo",
+        "./plugins/tracedecay",
     );
 }
 
@@ -386,7 +417,7 @@ fn assert_cursor_plugin_bundle(plugin_dir: &Path, expected_command: &str, expect
         assert!(
             hook["command"]
                 .as_str()
-                .is_some_and(|command| command.starts_with(&format!("{expected_command} "))),
+                .is_some_and(|command| command.contains(expected_command)),
             "plugin hook commands should use the installed tracedecay binary"
         );
         assert!(
@@ -603,6 +634,37 @@ fn test_cursor_install_installs_local_plugin_without_global_mcp() {
         !home.path().join(".cursor/mcp.json").exists(),
         "Cursor plugin install should not write legacy ~/.cursor/mcp.json"
     );
+}
+
+#[test]
+fn test_cursor_plugin_hooks_quote_binary_paths_with_spaces() {
+    let home = TempDir::new().unwrap();
+    let tracedecay_bin = home.path().join("bin with spaces/tracedecay");
+    let ctx = InstallContext {
+        home: home.path().to_path_buf(),
+        tracedecay_bin: tracedecay_bin.to_string_lossy().to_string(),
+        tool_permissions: expected_tool_perms(),
+        profile: None,
+        project_root: None,
+        dashboard: true,
+    };
+
+    CursorIntegration.install(&ctx).unwrap();
+
+    let hooks = read_json(&cursor_plugin_install_dir(home.path()).join("hooks/hooks.json"));
+    let command = hooks["hooks"]["sessionStart"][0]["command"]
+        .as_str()
+        .expect("sessionStart command should be a string");
+    let expected_bin = tracedecay_bin.to_string_lossy();
+    let expected = if cfg!(windows) {
+        format!(
+            "\"{}\" hook-cursor-session-start",
+            expected_bin.replace('\\', "/")
+        )
+    } else {
+        format!("'{}' hook-cursor-session-start", expected_bin)
+    };
+    assert_eq!(command, expected);
 }
 
 #[test]
@@ -2873,12 +2935,7 @@ fn test_codex_install_creates_plugin_bundle_and_marketplace() {
         serde_json::json!(["serve"]),
         true,
     );
-    assert_codex_marketplace_entry(
-        &codex_personal_marketplace_path(home),
-        "personal",
-        "Personal",
-        "./plugins/tracedecay",
-    );
+    assert_codex_personal_marketplace_entry(home);
 
     assert!(
         !home.join(".codex/config.toml").exists(),
@@ -2895,31 +2952,16 @@ fn test_codex_install_creates_plugin_bundle_and_marketplace() {
 }
 
 #[test]
-fn test_codex_install_refreshes_existing_cache_and_removes_bootstrap_source() {
+fn test_codex_install_refreshes_existing_cache_and_keeps_bootstrap_source_listable() {
     let dir = TempDir::new().unwrap();
     let home = dir.path();
     let ctx = make_install_ctx(home);
     let stale_plugin_dir = codex_stale_cached_plugin_install_dir(home);
-    std::fs::create_dir_all(stale_plugin_dir.join(".codex-plugin")).unwrap();
-    std::fs::write(
-        stale_plugin_dir.join(".codex-plugin/plugin.json"),
-        r#"{"name":"tracedecay","version":"0.0.0"}"#,
-    )
-    .unwrap();
+    write_codex_plugin_manifest(&stale_plugin_dir, "0.0.0");
 
     let bootstrap_dir = codex_plugin_install_dir(home);
-    std::fs::create_dir_all(bootstrap_dir.join(".codex-plugin")).unwrap();
-    std::fs::write(
-        bootstrap_dir.join(".codex-plugin/plugin.json"),
-        r#"{"name":"tracedecay","version":"0.0.0"}"#,
-    )
-    .unwrap();
-    std::fs::create_dir_all(bootstrap_dir.join("skills/stale-skill")).unwrap();
-    std::fs::write(
-        bootstrap_dir.join("skills/stale-skill/SKILL.md"),
-        "---\nname: tracedecay:stale-skill\n---\n",
-    )
-    .unwrap();
+    write_codex_plugin_manifest(&bootstrap_dir, "0.0.0");
+    write_stale_codex_skill(&bootstrap_dir);
     std::fs::create_dir_all(home.join(".agents/plugins")).unwrap();
     std::fs::write(
         codex_personal_marketplace_path(home),
@@ -2936,15 +2978,60 @@ fn test_codex_install_refreshes_existing_cache_and_removes_bootstrap_source() {
         serde_json::json!(["serve"]),
         true,
     );
+    assert_codex_plugin_bundle(
+        &bootstrap_dir,
+        &ctx.tracedecay_bin,
+        serde_json::json!(["serve"]),
+        true,
+    );
     assert!(
-        !bootstrap_dir.exists(),
-        "global Codex install should remove the loose marketplace source once a cache install exists"
+        !bootstrap_dir.join("skills/stale-skill/SKILL.md").exists(),
+        "global Codex install should refresh the bootstrap source so plugin list/add sees current skills"
     );
     assert!(
         !stale_plugin_dir.exists(),
         "global Codex install should migrate managed cache installs to the current plugin version"
     );
-    assert_codex_marketplace_has_no_tracedecay(&codex_personal_marketplace_path(home));
+    assert_codex_personal_marketplace_entry(home);
+}
+
+#[test]
+fn test_codex_install_refreshes_existing_cache_and_prunes_stale_skills() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_install_ctx(home);
+    let cached_plugin_dir = codex_cached_plugin_install_dir(home);
+    let bootstrap_dir = codex_plugin_install_dir(home);
+    write_codex_plugin_manifest(&cached_plugin_dir, "0.0.0");
+    write_stale_codex_skill(&cached_plugin_dir);
+    std::fs::write(cached_plugin_dir.join("user-note.txt"), "mine\n").unwrap();
+
+    CodexIntegration.install(&ctx).unwrap();
+
+    assert_codex_plugin_bundle(
+        &cached_plugin_dir,
+        &ctx.tracedecay_bin,
+        serde_json::json!(["serve"]),
+        true,
+    );
+    assert_codex_plugin_bundle(
+        &bootstrap_dir,
+        &ctx.tracedecay_bin,
+        serde_json::json!(["serve"]),
+        true,
+    );
+    assert!(
+        !cached_plugin_dir
+            .join("skills/stale-skill/SKILL.md")
+            .exists(),
+        "refreshing an installed Codex plugin cache must prune obsolete managed skills"
+    );
+    assert_eq!(
+        std::fs::read_to_string(cached_plugin_dir.join("user-note.txt")).unwrap(),
+        "mine\n",
+        "refresh should preserve unmanaged root-level user files"
+    );
+    assert_codex_personal_marketplace_entry(home);
 }
 
 #[test]
@@ -3006,12 +3093,7 @@ fn test_codex_local_install_creates_repo_plugin_bundle_and_marketplace() {
         serde_json::json!(["serve", "--path", "."]),
         false,
     );
-    assert_codex_marketplace_entry(
-        &codex_repo_marketplace_path(project.path()),
-        "local-repo",
-        "Local Repo",
-        "./plugins/tracedecay",
-    );
+    assert_codex_repo_marketplace_entry(project.path());
     assert!(
         !project.path().join(".codex/config.toml").exists(),
         "local Codex install should use the repo plugin marketplace, not write .codex/config.toml"
@@ -3607,12 +3689,7 @@ fn test_codex_install_then_uninstall() {
     CodexIntegration.install(&ctx).unwrap();
     let plugin_dir = codex_plugin_install_dir(home);
     assert!(plugin_dir.exists());
-    assert_codex_marketplace_entry(
-        &codex_personal_marketplace_path(home),
-        "personal",
-        "Personal",
-        "./plugins/tracedecay",
-    );
+    assert_codex_personal_marketplace_entry(home);
 
     CodexIntegration.uninstall(&ctx).unwrap();
 
@@ -4218,6 +4295,25 @@ fn test_healthcheck_codex_local_install_checks_project_config() {
     assert_eq!(
         dc.issues, 0,
         "local Codex healthcheck should pass without global ~/.codex config"
+    );
+}
+
+#[test]
+fn test_healthcheck_codex_local_install_warns_when_repo_marketplace_missing() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    assert_local_install_success("codex", project.path(), home.path());
+    std::fs::remove_file(codex_repo_marketplace_path(project.path())).unwrap();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.path().to_path_buf(),
+        project_path: project.path().to_path_buf(),
+    };
+    CodexIntegration.healthcheck(&mut dc, &hctx);
+    assert!(
+        dc.issues > 0 || dc.warnings > 0,
+        "local Codex healthcheck should flag a missing repo plugin marketplace"
     );
 }
 

--- a/tests/update_plugin_test.rs
+++ b/tests/update_plugin_test.rs
@@ -55,6 +55,60 @@ fn text(path: &Path) -> String {
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
 }
 
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&text(path))
+        .unwrap_or_else(|e| panic!("failed to parse JSON {}: {e}", path.display()))
+}
+
+fn assert_codex_marketplace_entry(marketplace_path: &Path, source_path: &str) {
+    let marketplace = read_json(marketplace_path);
+    let plugins = marketplace["plugins"]
+        .as_array()
+        .expect("marketplace plugins should be an array");
+    let entry = plugins
+        .iter()
+        .find(|entry| entry["name"] == "tracedecay")
+        .expect("marketplace should contain tracedecay");
+    assert_eq!(entry["source"]["source"], "local");
+    assert_eq!(entry["source"]["path"], source_path);
+}
+
+fn assert_codex_bundle_contains_bin(plugin_dir: &Path, tracedecay_bin: &str) {
+    assert!(text(&plugin_dir.join(".mcp.json")).contains(tracedecay_bin));
+    assert!(text(&plugin_dir.join("hooks/hooks.json")).contains(tracedecay_bin));
+}
+
+fn codex_bootstrap_dir(home: &Path) -> PathBuf {
+    home.join("plugins/tracedecay")
+}
+
+fn codex_cached_plugin_dir(home: &Path) -> PathBuf {
+    home.join(".codex/plugins/cache/personal/tracedecay")
+        .join(env!("CARGO_PKG_VERSION"))
+}
+
+fn codex_marketplace_path(home: &Path) -> PathBuf {
+    home.join(".agents/plugins/marketplace.json")
+}
+
+fn write_codex_plugin_manifest(plugin_dir: &Path, version: &str) {
+    std::fs::create_dir_all(plugin_dir.join(".codex-plugin")).unwrap();
+    std::fs::write(
+        plugin_dir.join(".codex-plugin/plugin.json"),
+        format!(r#"{{"name":"tracedecay","version":"{version}"}}"#),
+    )
+    .unwrap();
+}
+
+fn write_stale_codex_skill(plugin_dir: &Path) {
+    std::fs::create_dir_all(plugin_dir.join("skills/stale-skill")).unwrap();
+    std::fs::write(
+        plugin_dir.join("skills/stale-skill/SKILL.md"),
+        "---\nname: tracedecay:stale-skill\n---\n",
+    )
+    .unwrap();
+}
+
 /// Every regular file under `root`, relative to it, sorted.
 fn file_listing(root: &Path) -> Vec<PathBuf> {
     fn walk(dir: &Path, root: &Path, out: &mut Vec<PathBuf>) {
@@ -250,11 +304,17 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
     let codex = get_integration("codex").unwrap();
     codex.install(&ctx(home.path(), OLD_BIN)).unwrap();
 
-    let plugin_dir = home.path().join("plugins/tracedecay");
+    let plugin_dir = codex_bootstrap_dir(home.path());
     let codex_config = home.path().join(".codex/config.toml");
     std::fs::create_dir_all(codex_config.parent().unwrap()).unwrap();
     std::fs::write(&codex_config, "model = \"gpt-5\"\n").unwrap();
     std::fs::write(plugin_dir.join("user-note.txt"), "mine\n").unwrap();
+    std::fs::create_dir_all(plugin_dir.join("skills/private-skill")).unwrap();
+    std::fs::write(
+        plugin_dir.join("skills/private-skill/SKILL.md"),
+        "---\nname: private-skill\n---\n",
+    )
+    .unwrap();
     let config_before = bytes(&codex_config);
 
     let outcome = codex
@@ -267,45 +327,30 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
 
     assert_eq!(bytes(&codex_config), config_before);
     assert_eq!(text(&plugin_dir.join("user-note.txt")), "mine\n");
-    assert!(text(&plugin_dir.join(".mcp.json")).contains(NEW_BIN));
-    assert!(text(&plugin_dir.join("hooks/hooks.json")).contains(NEW_BIN));
+    assert_eq!(
+        text(&plugin_dir.join("skills/private-skill/SKILL.md")),
+        "---\nname: private-skill\n---\n"
+    );
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
     assert!(text(&plugin_dir.join(".codex-plugin/plugin.json")).contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]
-fn codex_update_plugin_refreshes_cache_and_removes_bootstrap_source() {
+fn codex_update_plugin_refreshes_cache_and_keeps_bootstrap_source_listable() {
     let home = TempDir::new().unwrap();
     let project_root = home.path().join("workspace");
     let stale_plugin_dir = home
         .path()
         .join(".codex/plugins/cache/personal/tracedecay/0.0.4");
-    let cached_plugin_dir = home
-        .path()
-        .join(".codex/plugins/cache/personal/tracedecay")
-        .join(env!("CARGO_PKG_VERSION"));
-    std::fs::create_dir_all(stale_plugin_dir.join(".codex-plugin")).unwrap();
-    std::fs::write(
-        stale_plugin_dir.join(".codex-plugin/plugin.json"),
-        r#"{"name":"tracedecay","version":"0.0.0"}"#,
-    )
-    .unwrap();
+    let cached_plugin_dir = codex_cached_plugin_dir(home.path());
+    write_codex_plugin_manifest(&stale_plugin_dir, "0.0.0");
 
-    let bootstrap_dir = home.path().join("plugins/tracedecay");
-    std::fs::create_dir_all(bootstrap_dir.join(".codex-plugin")).unwrap();
-    std::fs::write(
-        bootstrap_dir.join(".codex-plugin/plugin.json"),
-        r#"{"name":"tracedecay","version":"0.0.0"}"#,
-    )
-    .unwrap();
-    std::fs::create_dir_all(bootstrap_dir.join("skills/stale-skill")).unwrap();
-    std::fs::write(
-        bootstrap_dir.join("skills/stale-skill/SKILL.md"),
-        "---\nname: tracedecay:stale-skill\n---\n",
-    )
-    .unwrap();
+    let bootstrap_dir = codex_bootstrap_dir(home.path());
+    write_codex_plugin_manifest(&bootstrap_dir, "0.0.0");
+    write_stale_codex_skill(&bootstrap_dir);
     std::fs::create_dir_all(home.path().join(".agents/plugins")).unwrap();
     std::fs::write(
-        home.path().join(".agents/plugins/marketplace.json"),
+        codex_marketplace_path(home.path()),
         r#"{"interface":{"displayName":"Personal"},"name":"personal","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
     )
     .unwrap();
@@ -317,19 +362,113 @@ fn codex_update_plugin_refreshes_cache_and_removes_bootstrap_source() {
     let UpdatePluginOutcome::Refreshed(paths) = outcome else {
         panic!("expected codex update_plugin to refresh the installed cache");
     };
-    assert_eq!(paths, vec![cached_plugin_dir.clone()]);
+    assert_eq!(
+        paths,
+        vec![cached_plugin_dir.clone(), bootstrap_dir.clone()]
+    );
 
-    assert!(text(&cached_plugin_dir.join(".mcp.json")).contains(NEW_BIN));
-    assert!(text(&cached_plugin_dir.join("hooks/hooks.json")).contains(NEW_BIN));
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN);
     assert!(
         !stale_plugin_dir.exists(),
         "update-plugin should migrate managed Codex cache installs to the current plugin version"
     );
-    assert!(!bootstrap_dir.exists());
+    assert!(
+        !bootstrap_dir.join("skills/stale-skill/SKILL.md").exists(),
+        "update-plugin should refresh the bootstrap source so plugin list/add sees current skills"
+    );
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
+}
 
-    let marketplace = text(&home.path().join(".agents/plugins/marketplace.json"));
-    assert!(!marketplace.contains(r#""name": "tracedecay""#));
-    assert!(!marketplace.contains(r#""name":"tracedecay""#));
+#[test]
+fn codex_update_plugin_recreates_bootstrap_source_from_cache_only_state() {
+    let home = TempDir::new().unwrap();
+    let project_root = home.path().join("workspace");
+    let cached_plugin_dir = codex_cached_plugin_dir(home.path());
+    let bootstrap_dir = codex_bootstrap_dir(home.path());
+    write_codex_plugin_manifest(&cached_plugin_dir, "0.0.0");
+    write_stale_codex_skill(&cached_plugin_dir);
+    std::fs::write(cached_plugin_dir.join("user-note.txt"), "mine\n").unwrap();
+
+    let codex = get_integration("codex").unwrap();
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh the installed cache");
+    };
+    assert_eq!(
+        paths,
+        vec![cached_plugin_dir.clone(), bootstrap_dir.clone()]
+    );
+
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN);
+    assert!(
+        !cached_plugin_dir
+            .join("skills/stale-skill/SKILL.md")
+            .exists(),
+        "update-plugin must prune obsolete skills from installed Codex plugin caches"
+    );
+    assert_eq!(text(&cached_plugin_dir.join("user-note.txt")), "mine\n");
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
+}
+
+#[test]
+fn codex_update_plugin_refreshes_global_cache_and_repo_local_bundle() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let cached_plugin_dir = codex_cached_plugin_dir(home.path());
+    write_codex_plugin_manifest(&cached_plugin_dir, "0.0.0");
+
+    let repo_plugin_dir = codex_bootstrap_dir(project.path());
+    write_codex_plugin_manifest(&repo_plugin_dir, "0.0.0");
+
+    let codex = get_integration("codex").unwrap();
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, project.path()))
+        .unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh both detected bundles");
+    };
+    let bootstrap_dir = codex_bootstrap_dir(home.path());
+    assert_eq!(
+        paths,
+        vec![
+            cached_plugin_dir.clone(),
+            bootstrap_dir.clone(),
+            repo_plugin_dir.clone()
+        ]
+    );
+
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&repo_plugin_dir, NEW_BIN);
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
+    assert_codex_marketplace_entry(
+        &codex_marketplace_path(project.path()),
+        "./plugins/tracedecay",
+    );
+}
+
+#[test]
+fn codex_update_plugin_repairs_personal_marketplace_for_bootstrap_bundle() {
+    let home = TempDir::new().unwrap();
+    let project_root = home.path().join("workspace");
+    let plugin_dir = codex_bootstrap_dir(home.path());
+    write_codex_plugin_manifest(&plugin_dir, "0.0.0");
+
+    let codex = get_integration("codex").unwrap();
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh the bootstrap bundle");
+    };
+    assert_eq!(paths, vec![plugin_dir.clone()]);
+
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
 }
 
 #[test]
@@ -340,7 +479,7 @@ fn codex_update_plugin_refreshes_repo_local_bundle_from_project_root() {
     codex
         .install_local(&ctx(home.path(), OLD_BIN), project.path())
         .unwrap();
-    let plugin_dir = project.path().join("plugins/tracedecay");
+    let plugin_dir = codex_bootstrap_dir(project.path());
     std::fs::write(plugin_dir.join("user-note.txt"), "mine\n").unwrap();
 
     let outcome = codex
@@ -352,8 +491,7 @@ fn codex_update_plugin_refreshes_repo_local_bundle_from_project_root() {
 
     assert_eq!(paths, vec![plugin_dir.clone()]);
     assert_eq!(text(&plugin_dir.join("user-note.txt")), "mine\n");
-    assert!(text(&plugin_dir.join(".mcp.json")).contains(NEW_BIN));
-    assert!(text(&plugin_dir.join("hooks/hooks.json")).contains(NEW_BIN));
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
     assert!(text(&plugin_dir.join(".codex-plugin/plugin.json")).contains(env!("CARGO_PKG_VERSION")));
 }
 
@@ -364,8 +502,8 @@ fn codex_uninstall_removes_repo_local_bundle_from_project_root() {
     let codex = get_integration("codex").unwrap();
     let install_ctx = ctx_with_project(home.path(), OLD_BIN, project.path());
     codex.install_local(&install_ctx, project.path()).unwrap();
-    let plugin_dir = project.path().join("plugins/tracedecay");
-    let marketplace = project.path().join(".agents/plugins/marketplace.json");
+    let plugin_dir = codex_bootstrap_dir(project.path());
+    let marketplace = codex_marketplace_path(project.path());
     assert!(plugin_dir.exists());
 
     codex.uninstall(&install_ctx).unwrap();


### PR DESCRIPTION
## Summary
- Keep Codex marketplace source bundles listable and refreshed alongside installed caches
- Recreate bootstrap source from cache-only installs and prune stale managed skills
- Prefer stable installed binaries over checkout target/debug binaries for generated hooks

## Verification
- cargo test --test agent_test --test update_plugin_test

## Note
- Related README/User Guide wording is split into a separate docs PR to avoid mixing unrelated documentation hunks.
