### PR TITLE
Preserve corrupt branch metadata on branch add

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -346,10 +346,22 @@ pub async fn add_branch_tracking(
         }
     };
 
-    let mut meta = branch_meta::load_branch_meta(&tracedecay_dir).unwrap_or_else(|| {
-        let default = detect_default_branch(project_root).unwrap_or_else(|| "main".to_string());
-        branch_meta::BranchMeta::new_for_dir(&tracedecay_dir, &default)
-    });
+    let meta_path = tracedecay_dir.join("branch-meta.json");
+    let mut meta = match branch_meta::load_branch_meta(&tracedecay_dir) {
+        Some(meta) => meta,
+        None if meta_path.exists() => {
+            return Err(crate::errors::TraceDecayError::Config {
+                message: format!(
+                    "corrupt branch metadata at '{}'; repair or remove it before adding branch tracking",
+                    meta_path.display()
+                ),
+            });
+        }
+        None => {
+            let default = detect_default_branch(project_root).unwrap_or_else(|| "main".to_string());
+            branch_meta::BranchMeta::new_for_dir(&tracedecay_dir, &default)
+        }
+    };
     prune_missing_branch_dbs(&tracedecay_dir, &mut meta);
 
     if meta.is_tracked(branch_name) {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -479,8 +479,6 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
         }
         BranchAction::Add { name, path } => {
             let project_path = tracedecay::config::resolve_path(path);
-            let tracedecay_dir = resolve_branch_data_root(&project_path);
-
             let branch_name = match name {
                 Some(n) => n,
                 None => branch::current_branch(&project_path).ok_or_else(|| {
@@ -492,72 +490,22 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
                 })?,
             };
 
-            // Load or bootstrap metadata
-            let mut meta = branch_meta::load_branch_meta(&tracedecay_dir).unwrap_or_else(|| {
-                let default = branch::detect_default_branch(&project_path)
-                    .unwrap_or_else(|| "main".to_string());
-                branch_meta::BranchMeta::new_for_dir(&tracedecay_dir, &default)
-            });
-
-            if meta.is_tracked(&branch_name) {
-                eprintln!("Branch '{branch_name}' is already tracked.");
-                return Ok(());
-            }
-
-            // Find parent DB to copy from
-            let parent = branch::find_nearest_tracked_ancestor(&project_path, &branch_name, &meta)
-                .unwrap_or_else(|| meta.default_branch.clone());
-            let parent_db = branch::resolve_branch_db_path(&tracedecay_dir, &parent, &meta)
-                .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
-                    message: format!("parent branch '{parent}' has no DB"),
-                })?;
-            if !parent_db.exists() {
-                return Err(tracedecay::errors::TraceDecayError::Config {
-                    message: format!("parent DB not found at '{}'", parent_db.display()),
-                });
-            }
-
-            // Copy DB
-            let sanitized = branch::sanitize_branch_name(&branch_name);
-            let branches_dir = branch_meta::ensure_branches_dir(&tracedecay_dir)?;
-            let new_db_path = branches_dir.join(format!("{sanitized}.db"));
             let spinner = Spinner::new();
-            spinner.set_message(&format!("copying DB from '{parent}'"));
-            std::fs::copy(&parent_db, &new_db_path)?;
-
-            // Save metadata BEFORE open() so it resolves the new branch to its DB
-            let db_file = format!("branches/{sanitized}.db");
-            meta.add_branch(&branch_name, &db_file, &parent);
-            branch_meta::save_branch_meta(&tracedecay_dir, &meta)?;
-
-            // Run incremental sync (hash-based delta) against the new branch DB
             spinner.set_message("syncing changes");
-            let cg = TraceDecay::open(&project_path).await?;
-            let result = cg.sync().await?;
-
-            // Update sync timestamp after successful sync
-            if let Some(mut meta) = branch_meta::load_branch_meta(&tracedecay_dir) {
-                meta.touch_synced(&branch_name);
-                let _ = branch_meta::save_branch_meta(&tracedecay_dir, &meta);
-            }
-
-            let skipped_msg = if result.skipped_paths.is_empty() {
-                String::new()
-            } else {
-                format!(", {} skipped", result.skipped_paths.len())
-            };
-            spinner.done(&format!(
-                "branch '{branch_name}' tracked — {} added, {} modified, {} removed{skipped_msg}",
-                result.files_added, result.files_modified, result.files_removed
-            ));
-            if !result.skipped_paths.is_empty() {
-                eprintln!();
-                eprintln!(
-                    "\x1b[33mSkipped ({}) — files found but not readable:\x1b[0m",
-                    result.skipped_paths.len()
-                );
-                for (path, reason) in &result.skipped_paths {
-                    eprintln!("  ! {path}: {reason}");
+            match branch::add_branch_tracking(&project_path, &branch_name).await? {
+                branch::BranchAddOutcome::NotIndexed => {
+                    spinner.done("no TraceDecay index found; run `tracedecay init` first");
+                }
+                branch::BranchAddOutcome::AlreadyTracked => {
+                    spinner.done(&format!("Branch '{branch_name}' is already tracked."));
+                }
+                branch::BranchAddOutcome::Added => {
+                    spinner.done(&format!("branch '{branch_name}' tracked"));
+                }
+                branch::BranchAddOutcome::Deferred => {
+                    spinner.done(&format!(
+                        "branch '{branch_name}' tracked; sync deferred because another process is active"
+                    ));
                 }
             }
         }

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -306,3 +306,102 @@ async fn add_branch_tracking_copies_from_nearest_tracked_ancestor() {
         "new branch tracking should still sync the current branch's own files"
     );
 }
+
+#[tokio::test]
+async fn add_branch_tracking_refuses_corrupt_metadata_without_overwriting() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    git(project, &["init", "-b", "main"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    commit_all(project, "initial commit");
+
+    let main = TraceDecay::init(project).await.unwrap();
+    main.index_all().await.unwrap();
+    drop(main);
+
+    let tracedecay_dir = project_data_dir(project);
+    let meta_path = tracedecay_dir.join("branch-meta.json");
+    fs::write(&meta_path, b"{not valid json").unwrap();
+
+    git(project, &["checkout", "-b", "feature/corrupt-meta"]);
+    fs::write(
+        project.join("src/feature_only.rs"),
+        "pub fn feature_only() {}\n",
+    )
+    .unwrap();
+    commit_all(project, "feature commit");
+
+    let err = branch::add_branch_tracking(project, "feature/corrupt-meta")
+        .await
+        .expect_err("corrupt metadata must stop branch tracking instead of being replaced");
+
+    assert!(
+        err.to_string().contains("corrupt branch metadata"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        fs::read(&meta_path).unwrap(),
+        b"{not valid json",
+        "failed branch add must preserve the original corrupt metadata for repair"
+    );
+}
+
+#[test]
+fn cli_branch_add_refuses_corrupt_metadata_without_overwriting() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    git(project, &["init", "-b", "main"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    commit_all(project, "initial commit");
+
+    let init = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+        .arg("init")
+        .arg(project)
+        .output()
+        .expect("tracedecay init");
+    assert!(
+        init.status.success(),
+        "tracedecay init failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let tracedecay_dir = project_data_dir(project);
+    let meta_path = tracedecay_dir.join("branch-meta.json");
+    fs::write(&meta_path, b"{not valid json").unwrap();
+
+    git(project, &["checkout", "-b", "feature/corrupt-meta"]);
+    fs::write(
+        project.join("src/feature_only.rs"),
+        "pub fn feature_only() {}\n",
+    )
+    .unwrap();
+    commit_all(project, "feature commit");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+        .args(["branch", "add", "feature/corrupt-meta", "--path"])
+        .arg(project)
+        .output()
+        .expect("tracedecay branch add");
+
+    assert!(
+        !output.status.success(),
+        "corrupt metadata must fail CLI branch add\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("corrupt branch metadata"),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(&meta_path).unwrap(),
+        b"{not valid json",
+        "failed CLI branch add must preserve corrupt metadata for repair"
+    );
+}

--- a/tests/cli_non_interactive_test.rs
+++ b/tests/cli_non_interactive_test.rs
@@ -63,6 +63,37 @@ fn tracedecay_command_with_stdin(home: &std::path::Path, project: &std::path::Pa
     command
 }
 
+fn git(project: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(["-c", "core.hooksPath=.git/no-hooks"])
+        .args(args)
+        .current_dir(project)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_all(project: &Path, message: &str) {
+    git(project, &["add", "."]);
+    git(
+        project,
+        &[
+            "-c",
+            "user.name=TraceDecay Test",
+            "-c",
+            "user.email=tracedecay-test@example.com",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
+}
+
 #[test]
 fn init_accepts_relative_current_directory() {
     let home = TempDir::new().unwrap();
@@ -121,6 +152,23 @@ fn write_profile_sharded_fixture(home: &std::path::Path, project: &std::path::Pa
         serde_json::to_string_pretty(&manifest).unwrap(),
     )
     .unwrap();
+}
+
+fn write_profile_sharded_branch_fixture(home: &std::path::Path, project: &std::path::Path) {
+    write_profile_sharded_fixture(home, project);
+    let project = canonical_temp_path(project);
+    let shard_root = profile_shard_root(home);
+    git(&project, &["init", "-b", "main"]);
+    std::fs::write(project.join("lib.rs"), "pub fn indexed() {}\n").unwrap();
+    commit_all(&project, "initial commit");
+    git(&project, &["checkout", "-b", "feature/new"]);
+    std::fs::remove_file(shard_root.join("tracedecay.db")).unwrap();
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(Database::initialize(&shard_root.join("tracedecay.db")))
+        .unwrap();
 }
 
 fn write_sqlite_placeholder(path: &Path) {
@@ -550,7 +598,7 @@ fn branch_list_reads_profile_sharded_branch_meta() {
 fn branch_add_writes_new_branch_db_into_profile_shard() {
     let home = TempDir::new().unwrap();
     let project = TempDir::new().unwrap();
-    write_profile_sharded_fixture(home.path(), project.path());
+    write_profile_sharded_branch_fixture(home.path(), project.path());
     let shard_root = profile_shard_root(home.path());
     write_branch_meta(&shard_root, &[], false);
 


### PR DESCRIPTION
## Summary
- Refuse to overwrite corrupt branch metadata when adding branch tracking
- Preserve the original corrupt metadata file for operator repair

## Verification
- cargo test --test branch_db_safety_test
