### PR TITLE
Use holographic similarity for memory diffing

### DIFF
--- a/src/memory/diff.rs
+++ b/src/memory/diff.rs
@@ -2,13 +2,15 @@
 //!
 //! `MemoryStore::add_fact` runs every new fact through this module after the
 //! exact-duplicate check: FTS candidates are scored with lexical overlap plus
-//! phase-cosine similarity, and the strongest match is classified as
-//! `near_duplicate` or `possible_conflict`. The result is a REPORT returned to
-//! the writer — nothing here auto-deletes or auto-merges, and nothing here
-//! calls an LLM; review stays with the caller (agent, human, or the Hermes
+//! real cosine similarity for stored holographic vectors, and the strongest
+//! match is classified as `near_duplicate` or `possible_conflict`. The result
+//! is a REPORT returned to the writer — nothing here auto-deletes or
+//! auto-merges, and nothing here calls an LLM; review stays with the caller
+//! (agent, human, or the Hermes
 //! LLM curation layer).
 
-use super::similarity::{lexical_overlap, phase_cosine_similarity};
+use super::encoding::HolographicEncoder;
+use super::similarity::lexical_overlap;
 use super::types::AddFactDiffKind;
 
 /// A new fact whose strongest candidate scores above this is a near-duplicate.
@@ -17,7 +19,7 @@ pub const NEAR_DUPLICATE_THRESHOLD: f64 = 0.9;
 /// similarity; below it, texts can share domain vocabulary without being
 /// about the same subject.
 pub const CONFLICT_THRESHOLD: f64 = 0.7;
-/// Phase-cosine similarity only contributes to the combined score above this
+/// Vector cosine similarity only contributes to the combined score above this
 /// floor: same-domain content clusters in the 0.70–0.85 band and would
 /// otherwise produce false near-duplicate matches.
 const COSINE_CONTRIBUTION_FLOOR: f64 = 0.85;
@@ -63,9 +65,9 @@ pub fn normalized_equivalent(a: &str, b: &str) -> bool {
 }
 
 /// Combined lexical + holographic similarity between a new fact and one
-/// existing candidate. Token overlap is the baseline; the phase-cosine score
+/// existing candidate. Token overlap is the baseline; real vector cosine
 /// contributes only when it is high enough to be trustworthy (mnemon's
-/// combination rule, adapted to phase vectors).
+/// combination rule, adapted to stored holographic vectors).
 pub fn combined_similarity(new_content: &str, existing_content: &str, cosine: Option<f64>) -> f64 {
     let (_, token_overlap, _) = lexical_overlap(new_content, existing_content);
     let mut similarity = token_overlap;
@@ -77,9 +79,9 @@ pub fn combined_similarity(new_content: &str, existing_content: &str, cosine: Op
     similarity
 }
 
-/// Convenience wrapper for callers holding both phase vectors.
+/// Convenience wrapper for callers holding both stored holographic vectors.
 pub fn vector_similarity(a: &[f64], b: &[f64]) -> f64 {
-    phase_cosine_similarity(a, b)
+    HolographicEncoder::new().similarity(a, b)
 }
 
 /// Classifies how a new fact relates to its strongest existing candidate.
@@ -161,5 +163,20 @@ mod tests {
         // High cosine lifts the score.
         let sim = combined_similarity("alpha beta", "delta epsilon", Some(0.95));
         assert!((sim - 0.95).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn vector_similarity_uses_real_cosine_for_normalized_vectors() {
+        let mut left = vec![0.0; 2048];
+        let mut right = vec![0.0; 2048];
+        left[0] = 1.0;
+        right[1] = 1.0;
+
+        let sim = vector_similarity(&left, &right);
+
+        assert!(
+            sim.abs() < f64::EPSILON,
+            "expected orthogonal vectors to score near 0, got {sim}"
+        );
     }
 }

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -6,7 +6,8 @@ use std::fmt;
 use libsql::{params, Connection};
 
 use super::diff::{
-    classify_add_diff, combined_similarity, normalized_equivalent, NEAR_DUPLICATE_THRESHOLD,
+    classify_add_diff, combined_similarity, normalized_equivalent, vector_similarity,
+    NEAR_DUPLICATE_THRESHOLD,
 };
 use super::encoding::HolographicEncoder;
 use super::entities::{extract_entities, normalize_entity};
@@ -324,7 +325,7 @@ impl<'a> MemoryStore<'a> {
                 .flatten();
             let cosine = stored_vector
                 .as_deref()
-                .map(|vector| super::similarity::phase_cosine_similarity(phase_vector, vector));
+                .map(|vector| vector_similarity(phase_vector, vector));
             let similarity = combined_similarity(content, &candidate_content, cosine);
             if best
                 .as_ref()

--- a/tests/memory_test.rs
+++ b/tests/memory_test.rs
@@ -1,5 +1,6 @@
 use tempfile::TempDir;
 use tracedecay::db::Database;
+use tracedecay::memory::diff::vector_similarity;
 use tracedecay::memory::encoding::HolographicEncoder;
 use tracedecay::memory::entities::{extract_entities, normalize_entity};
 use tracedecay::memory::retrieval::FactRetriever;
@@ -411,9 +412,24 @@ fn holographic_encoding_is_deterministic_and_round_trips() {
     );
     assert!(
         encoder.similarity(&decoded, &first) > 0.999_999_999,
-        "phase-cosine similarity should be preserved across f32 serialization"
+        "holographic similarity should be preserved across f32 serialization"
     );
     assert!(HolographicEncoder::deserialize(b"not bincode").is_err());
+}
+
+#[test]
+fn write_time_vector_similarity_uses_real_cosine_for_normalized_vectors() {
+    let mut left = vec![0.0; HolographicEncoder::DIMENSIONS];
+    let mut right = vec![0.0; HolographicEncoder::DIMENSIONS];
+    left[0] = 1.0;
+    right[1] = 1.0;
+
+    let sim = vector_similarity(&left, &right);
+
+    assert!(
+        sim.abs() < f64::EPSILON,
+        "expected orthogonal vectors to score near 0, got {sim}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- switch write-time memory diff similarity to the holographic encoder similarity metric
- keep the diff/store comparison path aligned with persisted compact vectors
- add coverage for normalized-vector cosine behavior

## Verification
- cargo test --test memory_test