### PR TITLE
Inventory branch graph database artifacts

### DIFF
--- a/src/migrate/inventory.rs
+++ b/src/migrate/inventory.rs
@@ -280,7 +280,16 @@ async fn inspect_data_dir_candidate(
     }
     let brand = StoreBrand::TraceDecay;
     let db_path = data_dir.join(db_filename(&data_dir));
-    let store = inspect_project_store(project_root, &data_dir, db_path, brand, role).await?;
+    let store = inspect_project_store(
+        project_root,
+        &data_dir,
+        db_path,
+        brand,
+        role,
+        follow_symlinks,
+        skipped,
+    )
+    .await?;
     stores.push(store);
     Ok(())
 }
@@ -291,6 +300,8 @@ async fn inspect_project_store(
     db_path: PathBuf,
     brand: StoreBrand,
     role: StoreRole,
+    follow_symlinks: bool,
+    skipped: &mut Vec<SkippedPath>,
 ) -> Result<StoreInventory> {
     let mut statuses = Vec::new();
     let mut artifacts = Vec::new();
@@ -320,6 +331,14 @@ async fn inspect_project_store(
         BRANCH_META_FILENAME,
         &mut artifacts,
     );
+    record_branch_db_artifacts(
+        data_dir,
+        follow_symlinks,
+        skipped,
+        &mut statuses,
+        &mut artifacts,
+    )
+    .await;
     record_optional_artifact(data_dir, "config", "config.json", &mut artifacts);
     record_optional_artifact(
         data_dir,
@@ -676,6 +695,81 @@ fn record_optional_artifact(
         artifacts.push(StoreArtifact {
             kind: kind.to_string(),
             size_bytes,
+            path,
+        });
+    }
+}
+
+async fn record_branch_db_artifacts(
+    data_dir: &Path,
+    follow_symlinks: bool,
+    skipped: &mut Vec<SkippedPath>,
+    statuses: &mut Vec<StoreStatus>,
+    artifacts: &mut Vec<StoreArtifact>,
+) {
+    let mut branches_dir = data_dir.join("branches");
+    let Ok(meta) = std::fs::symlink_metadata(&branches_dir) else {
+        return;
+    };
+    if meta.file_type().is_symlink() {
+        if !follow_symlinks {
+            skipped.push(SkippedPath {
+                path: branches_dir,
+                reason: "symlink".to_string(),
+            });
+            return;
+        }
+        if !branches_dir.is_dir() {
+            return;
+        }
+        branches_dir = branches_dir.canonicalize().unwrap_or(branches_dir);
+    } else if !meta.is_dir() {
+        return;
+    }
+
+    let Ok(entries) = std::fs::read_dir(branches_dir) else {
+        return;
+    };
+    let mut db_paths = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            entry
+                .file_type()
+                .is_ok_and(|file_type| file_type.is_file())
+                .then_some(path)
+        })
+        .filter(|path| path.extension().is_some_and(|extension| extension == "db"))
+        .collect::<Vec<_>>();
+    db_paths.sort();
+
+    for path in db_paths {
+        artifacts.push(StoreArtifact {
+            kind: "branch_graph_db".to_string(),
+            size_bytes: file_size(&path),
+            path: path.clone(),
+        });
+        record_sqlite_sidecar_artifact(&path, "-wal", "branch_graph_db_wal", artifacts);
+        record_sqlite_sidecar_artifact(&path, "-shm", "branch_graph_db_shm", artifacts);
+        if !sqlite_quick_check(&path).await && !statuses.contains(&StoreStatus::Corrupt) {
+            statuses.push(StoreStatus::Corrupt);
+        }
+    }
+}
+
+fn record_sqlite_sidecar_artifact(
+    db_path: &Path,
+    suffix: &str,
+    kind: &str,
+    artifacts: &mut Vec<StoreArtifact>,
+) {
+    let mut path = db_path.as_os_str().to_os_string();
+    path.push(suffix);
+    let path = PathBuf::from(path);
+    if path.is_file() {
+        artifacts.push(StoreArtifact {
+            kind: kind.to_string(),
+            size_bytes: file_size(&path),
             path,
         });
     }

--- a/tests/migrate_inventory_test.rs
+++ b/tests/migrate_inventory_test.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+use libsql::Builder;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
 use tempfile::TempDir;
@@ -73,6 +74,19 @@ fn make_project_store(root: &Path) {
     let data_dir = root.join(".tracedecay");
     fs::create_dir_all(&data_dir).unwrap();
     fs::write(data_dir.join("tracedecay.db"), b"not sqlite").unwrap();
+}
+
+async fn make_healthy_project_store(root: &Path) {
+    let data_dir = root.join(".tracedecay");
+    fs::create_dir_all(&data_dir).unwrap();
+    let db = Builder::new_local(data_dir.join("tracedecay.db"))
+        .build()
+        .await
+        .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE health_check (id INTEGER PRIMARY KEY)", ())
+        .await
+        .unwrap();
 }
 
 fn single_ok_inventory(project: &Path, data_dir: &Path, graph_db: &Path) -> MigrationInventory {
@@ -285,6 +299,89 @@ async fn inventory_records_project_store_sidecar_artifacts() {
     ] {
         assert!(kinds.contains(&kind), "{kind} missing from {kinds:?}");
     }
+}
+
+#[tokio::test]
+async fn inventory_records_branch_graph_db_and_marks_corrupt_when_quick_check_fails() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("repo");
+    let branches_dir = root.join(".tracedecay/branches");
+    let branch_db = branches_dir.join("feature.db");
+    fs::create_dir_all(&root).unwrap();
+    make_healthy_project_store(&root).await;
+    fs::create_dir_all(&branches_dir).unwrap();
+    fs::write(&branch_db, b"not sqlite").unwrap();
+    fs::write(branches_dir.join("feature.db-wal"), b"wal").unwrap();
+    fs::write(branches_dir.join("feature.db-shm"), b"shm").unwrap();
+
+    let report = build_inventory(MigrationInventoryOptions {
+        roots: vec![dir.path().to_path_buf()],
+        ..MigrationInventoryOptions::default()
+    })
+    .await
+    .unwrap();
+
+    let store = report
+        .stores
+        .iter()
+        .find(|store| store.project_root == root)
+        .expect("project store should be inventoried");
+    let artifact = store
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.kind == "branch_graph_db")
+        .expect("branch DB artifact should be recorded");
+
+    assert!(same_path(&artifact.path, &branch_db));
+    assert_eq!(artifact.size_bytes, fs::metadata(&branch_db).unwrap().len());
+    assert!(store.artifacts.iter().any(|artifact| {
+        artifact.kind == "branch_graph_db_wal"
+            && same_path(&artifact.path, &branches_dir.join("feature.db-wal"))
+            && artifact.size_bytes == 3
+    }));
+    assert!(store.artifacts.iter().any(|artifact| {
+        artifact.kind == "branch_graph_db_shm"
+            && same_path(&artifact.path, &branches_dir.join("feature.db-shm"))
+            && artifact.size_bytes == 3
+    }));
+    assert_eq!(store.statuses, vec![StoreStatus::Corrupt]);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn inventory_skips_symlinked_branches_dir_by_default() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().join("repo");
+    let real_branches = dir.path().join("outside_branches");
+    let branch_db = real_branches.join("feature.db");
+    fs::create_dir_all(&root).unwrap();
+    make_healthy_project_store(&root).await;
+    fs::create_dir_all(&real_branches).unwrap();
+    fs::write(&branch_db, b"not sqlite").unwrap();
+    symlink(&real_branches, root.join(".tracedecay/branches")).unwrap();
+
+    let report = build_inventory(MigrationInventoryOptions {
+        roots: vec![dir.path().to_path_buf()],
+        follow_symlinks: false,
+        ..MigrationInventoryOptions::default()
+    })
+    .await
+    .unwrap();
+
+    let store = report
+        .stores
+        .iter()
+        .find(|store| store.project_root == root)
+        .expect("project store should be inventoried");
+
+    assert_eq!(store.statuses, vec![StoreStatus::Ok]);
+    assert!(!store
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.kind == "branch_graph_db"));
+    assert!(report.skipped.iter().any(|skipped| {
+        skipped.path == root.join(".tracedecay/branches") && skipped.reason == "symlink"
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- include per-branch graph databases in migration inventory artifacts
- mark a store corrupt when a branch database fails SQLite quick-check
- keep inventory scans tolerant of missing branch directories

## Verification
- cargo test --test migrate_inventory_test