### PR TITLE
Record dashboard curation activity

### DIFF
--- a/dashboard/holographic/src/types.ts
+++ b/dashboard/holographic/src/types.ts
@@ -408,8 +408,13 @@ export interface MemoryCuratorStatusResponse {
     max_entities_per_run?: number | string | null;
   };
   snapshots: Array<{
+    id?: string;
     name: string;
     path: string;
+    ts?: string | null;
+    summary?: string | null;
+    provider?: string;
+    mode?: string;
   }>;
 }
 

--- a/src/dashboard/memory_api.rs
+++ b/src/dashboard/memory_api.rs
@@ -254,7 +254,7 @@ pub(crate) async fn overview(
     let holographic = Value::Object(obj);
 
     Json(json!({
-        "providers": memory_service::providers_stub(),
+        "providers": memory_service::providers_payload(),
         "query": params.q,
         "limit": limit,
         "holographic": holographic,
@@ -349,10 +349,13 @@ pub(crate) async fn curation_status(State(state): State<DashboardState>) -> Json
     Json(memory_service::curation_status_payload(&state).await)
 }
 
-/// `GET /api/plugins/holographic/curation/activity` — no live event stream.
-pub(crate) async fn curation_activity(JsonQuery(params): JsonQuery<LimitParams>) -> Json<Value> {
+/// `GET /api/plugins/holographic/curation/activity` — recent deterministic curator events.
+pub(crate) async fn curation_activity(
+    State(state): State<DashboardState>,
+    JsonQuery(params): JsonQuery<LimitParams>,
+) -> Json<Value> {
     let limit = coerce_limit(params.limit, 100, 300);
-    Json(memory_service::curation_activity_payload(limit))
+    Json(memory_service::curation_activity_payload(&state, limit).await)
 }
 
 /// `GET /api/plugins/holographic/curation/preview` — returns the last saved

--- a/src/dashboard/memory_curate.rs
+++ b/src/dashboard/memory_curate.rs
@@ -130,6 +130,7 @@ async fn cli_state(cg: &TraceDecay) -> DashboardState {
         store_root: store_layout.data_root.clone(),
         dashboard_root: store_layout.dashboard_root.clone(),
         curate_preview: Arc::new(RwLock::new(None)),
+        curation_activity: Arc::new(RwLock::new(Vec::new())),
         token_counts: Arc::new(token_count::TokenCountCache::new()),
     }
 }

--- a/src/dashboard/memory_service.rs
+++ b/src/dashboard/memory_service.rs
@@ -18,7 +18,7 @@ pub(crate) fn projection_point_cap() -> i64 {
     PROJECTION_POINT_CAP
 }
 
-pub(crate) fn providers_stub() -> Value {
+pub(crate) fn providers_payload() -> Value {
     json!({
         "memory_provider": "tracedecay",
         "memory_options": [
@@ -557,6 +557,19 @@ pub(crate) async fn similarity_payload(
     Value::Object(obj)
 }
 
+fn curation_apply_snapshot(index: usize, event: &Value) -> Value {
+    let id = format!("curate-apply-{}", index + 1);
+    json!({
+        "id": id,
+        "name": id,
+        "path": format!("curation://{id}"),
+        "ts": event.get("ts").cloned().unwrap_or(Value::Null),
+        "summary": event.get("message").cloned().unwrap_or(Value::Null),
+        "provider": "tracedecay",
+        "mode": "similarity_dedup",
+    })
+}
+
 pub(crate) async fn curation_status_payload(state: &DashboardState) -> Value {
     let preview = state.curate_preview.read().await;
     let (last_preview_at, last_preview_summary) = match preview.as_ref() {
@@ -574,14 +587,45 @@ pub(crate) async fn curation_status_payload(state: &DashboardState) -> Value {
         ),
         None => (Value::Null, Value::Null),
     };
+    let activity = state.curation_activity.read().await;
+    let apply_finishes: Vec<&Value> = activity
+        .iter()
+        .filter(|event| {
+            event.get("phase").and_then(Value::as_str) == Some("finish")
+                && event.get("dry_run").and_then(Value::as_bool) == Some(false)
+        })
+        .collect();
+    let run_count = apply_finishes.len() as i64;
+    let latest_run = apply_finishes.last().copied();
+    let last_run_at = latest_run
+        .and_then(|event| event.get("ts"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let last_run_summary = latest_run
+        .and_then(|event| event.get("message"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    let last_run_id = if run_count > 0 {
+        json!(format!("curate-apply-{run_count}"))
+    } else {
+        Value::Null
+    };
+    let snapshots: Vec<Value> = apply_finishes
+        .iter()
+        .rev()
+        .take(10)
+        .rev()
+        .enumerate()
+        .map(|(index, event)| curation_apply_snapshot(index, event))
+        .collect();
     json!({
         "provider": "tracedecay",
         "state": {
             "paused": false,
-            "last_run_at": null,
-            "run_count": 0,
-            "last_run_summary": null,
-            "last_run_id": null,
+            "last_run_at": last_run_at,
+            "run_count": run_count,
+            "last_run_summary": last_run_summary,
+            "last_run_id": last_run_id,
             "last_preview_at": last_preview_at,
             "last_preview_summary": last_preview_summary,
             "last_preview_run_id": null,
@@ -593,12 +637,37 @@ pub(crate) async fn curation_status_payload(state: &DashboardState) -> Value {
             "mode": "similarity_dedup",
             "dry_run_first": true,
         },
-        "snapshots": [],
+        "snapshots": snapshots,
     })
 }
 
-pub(crate) fn curation_activity_payload(limit: i64) -> Value {
-    json!({ "events": [], "count": 0, "limit": limit, "error": "" })
+async fn push_curation_activity(
+    state: &DashboardState,
+    phase: &str,
+    message: impl Into<String>,
+    dry_run: bool,
+) {
+    let mut events = state.curation_activity.write().await;
+    events.push(json!({
+        "ts": crate::timeutil::now_iso_utc(),
+        "phase": phase,
+        "message": message.into(),
+        "level": "info",
+        "dry_run": dry_run,
+    }));
+    if events.len() > 300 {
+        let overflow = events.len() - 300;
+        events.drain(0..overflow);
+    }
+}
+
+pub(crate) async fn curation_activity_payload(state: &DashboardState, limit: i64) -> Value {
+    let events = state.curation_activity.read().await;
+    let limit = limit.max(0) as usize;
+    let start = events.len().saturating_sub(limit);
+    let visible: Vec<Value> = events[start..].to_vec();
+    let count = visible.len();
+    json!({ "events": visible, "count": count, "limit": limit, "error": "" })
 }
 
 pub(crate) async fn curation_preview_payload(state: &DashboardState) -> Value {
@@ -679,6 +748,17 @@ pub(crate) async fn delete_fact(state: &DashboardState, fact_id: i64) -> Result<
 }
 
 pub(crate) async fn curate_payload(state: &DashboardState, dry_run: bool) -> Result<Value, String> {
+    push_curation_activity(
+        state,
+        "start",
+        if dry_run {
+            "Starting similarity-dedup curation preview"
+        } else {
+            "Starting similarity-dedup curation apply"
+        },
+        dry_run,
+    )
+    .await;
     let (actions, hygiene_candidates, counts, total) = build_delete_plan(state).await?;
 
     let report = json!({
@@ -711,6 +791,17 @@ pub(crate) async fn curate_payload(state: &DashboardState, dry_run: bool) -> Res
         };
         super::curate_preview_store::save(&state.dashboard_root, &entry).await;
         *state.curate_preview.write().await = Some(entry);
+        push_curation_activity(
+            state,
+            "finish",
+            format!(
+                "Preview completed: {} delete action(s), {} active fact(s) scanned",
+                actions.len(),
+                total
+            ),
+            true,
+        )
+        .await;
         return Ok(report);
     }
 
@@ -744,6 +835,13 @@ pub(crate) async fn curate_payload(state: &DashboardState, dry_run: bool) -> Res
     if applied > 0 {
         applied_counts.insert("delete".to_string(), json!(applied));
     }
+    push_curation_activity(
+        state,
+        "finish",
+        format!("Apply completed: {applied} fact(s) deleted, {skipped} action(s) skipped"),
+        false,
+    )
+    .await;
     Ok(json!({
         "ran": true,
         "dry_run": false,
@@ -906,6 +1004,15 @@ pub(crate) async fn curate_apply_payload(state: &DashboardState, ops: &[Value]) 
                 &json!({ "mode": "ops", "deleted": deleted, "merged": merged, "errors": errors }),
             )
             .await;
+        push_curation_activity(
+            state,
+            "finish",
+            format!(
+                "Explicit apply completed: {deleted} delete op(s), {merged} merge op(s), {errors} op(s) errored"
+            ),
+            false,
+        )
+        .await;
     }
 
     json!({
@@ -938,5 +1045,34 @@ pub(crate) async fn oplog_payload(state: &DashboardState, limit: i64) -> Value {
             json!({ "events": events, "count": count, "limit": limit, "error": "" })
         }
         Err(e) => json!({ "events": [], "count": 0, "limit": limit, "error": e }),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn curation_apply_snapshot_keeps_dashboard_history_contract() {
+        let event = json!({
+            "ts": "2026-06-23T00:00:00Z",
+            "phase": "finish",
+            "message": "Apply completed: 2 fact(s) deleted, 0 action(s) skipped",
+            "dry_run": false,
+        });
+
+        let snapshot = curation_apply_snapshot(0, &event);
+
+        assert_eq!(snapshot["id"], "curate-apply-1");
+        assert_eq!(snapshot["name"], "curate-apply-1");
+        assert_eq!(snapshot["path"], "curation://curate-apply-1");
+        assert_eq!(snapshot["ts"], "2026-06-23T00:00:00Z");
+        assert_eq!(
+            snapshot["summary"],
+            "Apply completed: 2 fact(s) deleted, 0 action(s) skipped"
+        );
+        assert_eq!(snapshot["provider"], "tracedecay");
+        assert_eq!(snapshot["mode"], "similarity_dedup");
     }
 }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -104,6 +104,8 @@ pub(crate) struct DashboardState {
     pub(crate) dashboard_root: PathBuf,
     /// Last saved dry-run curation preview (shared across all clones of the state).
     pub(crate) curate_preview: Arc<RwLock<Option<CuratePreviewEntry>>>,
+    /// Recent deterministic curation activity emitted by the standalone dashboard.
+    pub(crate) curation_activity: Arc<RwLock<Vec<Value>>>,
     /// In-process BPE token-count cache for the Savings & Cost tab (backed
     /// by the `dashboard_token_counts` sidecar in the global accounting DB).
     pub(crate) token_counts: Arc<token_count::TokenCountCache>,
@@ -232,6 +234,7 @@ pub(crate) async fn build_state(cg: &TraceDecay) -> DashboardState {
         store_root,
         dashboard_root,
         curate_preview: Arc::new(RwLock::new(persisted_preview)),
+        curation_activity: Arc::new(RwLock::new(Vec::new())),
         token_counts: Arc::new(token_count::TokenCountCache::new()),
     };
     if let Err(err) = memory_api::repair_derived_memory(&state).await {

--- a/tests/dashboard_api_test.rs
+++ b/tests/dashboard_api_test.rs
@@ -1524,6 +1524,39 @@ fn curation_delete_lifecycle() {
             "last_preview_at should be set after dry-run"
         );
 
+        let (status, dry_activity) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/holographic/curation/activity?limit=75",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(dry_activity["error"], "");
+        assert_eq!(dry_activity["limit"], 75);
+        let dry_events = dry_activity["events"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected dry-run activity events array"));
+        assert_eq!(
+            dry_activity["count"].as_u64(),
+            Some(dry_events.len() as u64)
+        );
+        assert!(
+            !dry_events.is_empty(),
+            "dry-run curation should emit activity events"
+        );
+        assert!(
+            dry_events.iter().any(|event| {
+                event["phase"] == "finish"
+                    && event["dry_run"] == true
+                    && event["message"]
+                        .as_str()
+                        .is_some_and(|message| !message.is_empty())
+                    && event["ts"].as_str().is_some_and(|ts| !ts.is_empty())
+            }),
+            "dry-run curation should emit a finish activity event"
+        );
+
         // --- Apply curation: hard-delete the duplicate ---
         let (status, applied) = post_json_body(
             &agent,
@@ -1536,6 +1569,61 @@ fn curation_delete_lifecycle() {
         assert!(
             applied["applied_counts"]["delete"].as_i64().unwrap_or(0) > 0,
             "apply should report at least one deleted fact"
+        );
+
+        let (status, apply_activity) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/holographic/curation/activity?limit=75",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 200);
+        let apply_events = apply_activity["events"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected apply activity events array"));
+        assert_eq!(
+            apply_activity["count"].as_u64(),
+            Some(apply_events.len() as u64)
+        );
+        assert!(
+            apply_events.len() > dry_events.len(),
+            "apply should append activity events after dry-run events"
+        );
+        assert!(
+            apply_events
+                .iter()
+                .rev()
+                .any(|event| event["phase"] == "finish" && event["dry_run"] == false),
+            "apply curation should emit a finish activity event"
+        );
+
+        let (status, status_after_apply) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/holographic/curation/status",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(status_after_apply["state"]["run_count"], 1);
+        assert!(
+            status_after_apply["state"]["last_run_at"]
+                .as_str()
+                .is_some_and(|ts| !ts.is_empty()),
+            "last_run_at should be set after apply"
+        );
+        assert!(
+            status_after_apply["state"]["last_run_summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("deleted")),
+            "last_run_summary should describe the apply result"
+        );
+        assert!(
+            status_after_apply["snapshots"]
+                .as_array()
+                .is_some_and(|snapshots| !snapshots.is_empty()),
+            "status snapshots should include recent apply history"
         );
 
         // --- Overview should show fewer facts and not contain the deleted one ---
@@ -1785,6 +1873,70 @@ fn curate_apply_ops_contract() {
         assert_eq!(response["counts"]["deleted"], 1);
         assert_eq!(response["counts"]["merged"], 1);
         assert_eq!(response["counts"]["errors"], 2);
+
+        let (status, apply_activity) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/holographic/curation/activity?limit=25",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 200);
+        let apply_events = apply_activity["events"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected generic apply activity events array"));
+        assert!(
+            apply_events.iter().any(|event| {
+                event["phase"] == "finish"
+                    && event["dry_run"] == false
+                    && event["message"].as_str().is_some_and(|message| {
+                        message.contains("Explicit apply completed")
+                            && message.contains("1 delete")
+                            && message.contains("1 merge")
+                            && message.contains("2 op(s) errored")
+                    })
+                    && event["ts"].as_str().is_some_and(|ts| !ts.is_empty())
+            }),
+            "/curate/apply should emit a finish activity event: {apply_activity}"
+        );
+
+        let (status, apply_status) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/holographic/curation/status",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(apply_status["state"]["run_count"], 1);
+        assert!(
+            apply_status["state"]["last_run_at"]
+                .as_str()
+                .is_some_and(|ts| !ts.is_empty()),
+            "last_run_at should be set after /curate/apply"
+        );
+        let summary = apply_status["state"]["last_run_summary"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            summary.contains("Explicit apply completed")
+                && summary.contains("1 delete")
+                && summary.contains("1 merge")
+                && summary.contains("2 op(s) errored"),
+            "/curate/apply should drive the status summary: {apply_status}"
+        );
+        assert!(
+            apply_status["snapshots"]
+                .as_array()
+                .is_some_and(|snapshots| {
+                    snapshots.iter().any(|snapshot| {
+                        snapshot["summary"]
+                            .as_str()
+                            .is_some_and(|summary| summary.contains("Explicit apply completed"))
+                    })
+                }),
+            "/curate/apply should appear in status snapshots: {apply_status}"
+        );
 
         // Hard deletes: rows + entity links gone from the project DB.
         for gone_id in [102_i64, 103] {


### PR DESCRIPTION
## Summary
- track recent deterministic curation activity in dashboard state
- expose dry-run/apply activity and status snapshots through holographic dashboard APIs
- cover dry-run and apply lifecycle activity in the dashboard API test

## Verification
- cargo test --test dashboard_api_test curation_delete_lifecycle