### PR TITLE
Fall back to read-only project open

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod monitor;
 pub mod redundancy;
 pub mod resolution;
 pub mod runtime_telemetry;
+pub mod serve;
 pub mod sessions;
 pub mod storage;
 pub mod sync;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ use tracedecay::tracedecay::TraceDecay;
 mod cli;
 mod commands;
 mod global;
-mod serve;
 mod tool_command;
+
+pub use tracedecay::serve;
 
 use cli::*;
 

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -236,7 +236,8 @@ pub(super) async fn handle_storage_status(
     let graph_db_size_bytes = graph_db_path
         .metadata()
         .map_or(0, |metadata| metadata.len());
-    let writable = branch.serving_db_exists && !branch.is_fallback;
+    let read_only = cg.is_read_only();
+    let writable = branch.serving_db_exists && !branch.is_fallback && !read_only;
     let mut warnings = branch.warnings.clone();
     if let Some(warning) = branch.fallback_warning.as_ref() {
         warnings.push(warning.clone());
@@ -273,6 +274,7 @@ pub(super) async fn handle_storage_status(
             "graph_db_size_limit_bytes": Value::Null,
         },
         "writable": writable,
+        "read_only": read_only,
         "warnings": warnings,
         "stats": stats,
     });

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -252,11 +252,6 @@ impl MmapReader {
         })
     }
 
-    /// The ring buffer capacity.
-    pub fn capacity(&self) -> usize {
-        RING_CAPACITY
-    }
-
     /// Re-read the mmap to pick up new writes.
     pub fn refresh(&mut self) -> std::io::Result<()> {
         let mmap_path = self.dir.join(MMAP_FILENAME);

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,5 +1,8 @@
 use std::path::Path;
-use tracedecay::tracedecay::TraceDecay;
+
+use crate::errors::{Result, TraceDecayError};
+use crate::global_db::GlobalDb;
+use crate::tracedecay::TraceDecay;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ServeGlobalDbResolution {
@@ -19,11 +22,20 @@ pub fn global_db_ambiguity_message(paths: &[String]) -> String {
 }
 
 /// Opens an existing project, or tells the user to run `tracedecay init` first.
-pub async fn ensure_initialized(project_path: &Path) -> tracedecay::errors::Result<TraceDecay> {
+pub async fn ensure_initialized(project_path: &Path) -> Result<TraceDecay> {
     if TraceDecay::is_initialized(project_path) {
-        return TraceDecay::open(project_path).await;
+        return match TraceDecay::open(project_path).await {
+            Ok(cg) => Ok(cg),
+            Err(open_err) => match TraceDecay::open_read_only(project_path).await {
+                Ok(cg) => {
+                    cg.ensure_schema_current().await?;
+                    Ok(cg)
+                }
+                Err(_) => Err(open_err),
+            },
+        };
     }
-    Err(tracedecay::errors::TraceDecayError::Config {
+    Err(TraceDecayError::Config {
         message: format!(
             "no TraceDecay index found at '{}' — run 'tracedecay init' first",
             project_path.display()
@@ -42,7 +54,7 @@ fn initialized_project_paths(mut paths: Vec<String>) -> Vec<String> {
 /// project), then a project that is a descendant of cwd (project is under cwd).
 /// Ties at the winning depth are ambiguous and require an explicit path.
 pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
-    let Some(gdb) = tracedecay::global_db::GlobalDb::open().await else {
+    let Some(gdb) = GlobalDb::open().await else {
         return ServeGlobalDbResolution::None;
     };
     let mut paths = initialized_project_paths(gdb.list_project_paths().await);
@@ -115,7 +127,7 @@ pub async fn resolve_serve_from_mcp_roots(out: &mut Option<String>) -> Option<st
     let parsed: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
     let roots = parsed.pointer("/params/roots").and_then(|v| v.as_array())?;
 
-    let registered = match tracedecay::global_db::GlobalDb::open().await {
+    let registered = match GlobalDb::open().await {
         Some(gdb) => initialized_project_paths(gdb.list_project_paths().await),
         None => Vec::new(),
     };
@@ -134,7 +146,7 @@ pub async fn resolve_serve_from_mcp_roots(out: &mut Option<String>) -> Option<st
             return Some(std::path::PathBuf::from(hit));
         }
         // Walk up from the root to find the nearest enclosing project.
-        if let Some(discovered) = tracedecay::config::discover_project_root(&root_path) {
+        if let Some(discovered) = crate::config::discover_project_root(&root_path) {
             return Some(discovered);
         }
     }

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -1,7 +1,7 @@
 // Rust guideline compliant 2025-10-17
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rayon::prelude::*;
 use serde::Serialize;
@@ -227,6 +227,7 @@ pub struct TraceDecay {
     serving_branch: Option<String>,
     /// Set when serving from a fallback (ancestor) DB instead of the exact branch.
     fallback_warning: Option<String>,
+    read_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -354,6 +355,7 @@ impl TraceDecay {
             active_branch,
             serving_branch: None,
             fallback_warning: None,
+            read_only: false,
         };
         ts.register_project_store_in_global_registry().await;
         Ok(ts)
@@ -362,6 +364,70 @@ impl TraceDecay {
     /// Returns a reference to the underlying database.
     pub fn db(&self) -> &Database {
         &self.db
+    }
+
+    async fn schema_version(db: &Database, operation: &str) -> Result<u32> {
+        let mut rows = db
+            .conn()
+            .query("PRAGMA user_version", ())
+            .await
+            .map_err(|e| TraceDecayError::Database {
+                message: format!("{operation}: failed to read user_version: {e}"),
+                operation: operation.to_string(),
+            })?;
+        let row = rows.next().await.map_err(|e| TraceDecayError::Database {
+            message: format!("{operation}: failed to read user_version row: {e}"),
+            operation: operation.to_string(),
+        })?;
+        match row {
+            Some(row) => {
+                let version: i64 = row.get(0).map_err(|e| TraceDecayError::Database {
+                    message: format!("{operation}: failed to read user_version value: {e}"),
+                    operation: operation.to_string(),
+                })?;
+                Ok(version as u32)
+            }
+            None => Ok(0),
+        }
+    }
+
+    async fn latest_schema_version() -> Result<u32> {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let db_path = std::env::temp_dir().join(format!(
+            "tracedecay-current-schema-{}-{stamp}.db",
+            std::process::id()
+        ));
+        let (db, _) = Database::initialize(&db_path).await?;
+        let version = Self::schema_version(&db, "latest_schema_version").await;
+        db.close();
+        delete_db_files(&db_path);
+        version
+    }
+
+    pub async fn ensure_schema_current(&self) -> Result<()> {
+        let current = Self::schema_version(&self.db, "ensure_schema_current").await?;
+        let latest = Self::latest_schema_version().await?;
+        if current < latest {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "read-only TraceDecay database schema is v{current}, but this binary requires \
+                     v{latest}; open the project with write access to run migrations before serving \
+                     it read-only"
+                ),
+            });
+        }
+        if current > latest {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "TraceDecay database schema v{current} is newer than this binary supports \
+                     (v{latest}); upgrade tracedecay before serving this store"
+                ),
+            });
+        }
+        Ok(())
     }
 
     async fn resolve_store_layout_for_project(project_root: &Path) -> Result<StoreLayout> {
@@ -460,6 +526,7 @@ impl TraceDecay {
                     active_branch: active_branch.clone(),
                     serving_branch: serving_branch.clone(),
                     fallback_warning: fallback_warning.clone(),
+                    read_only: false,
                 };
                 ts.index_all_with_progress(|c, t, f| {
                     eprintln!("[tracedecay] re-indexing [{c}/{t}] {f}");
@@ -491,6 +558,7 @@ impl TraceDecay {
                     active_branch: active_branch.clone(),
                     serving_branch: serving_branch.clone(),
                     fallback_warning: fallback_warning.clone(),
+                    read_only: false,
                 };
                 ts.index_all_with_progress(|c, t, f| {
                     eprintln!("[tracedecay] re-indexing [{c}/{t}] {f}");
@@ -513,6 +581,7 @@ impl TraceDecay {
             active_branch,
             serving_branch,
             fallback_warning,
+            read_only: false,
         };
 
         if migrated {
@@ -564,6 +633,7 @@ impl TraceDecay {
             active_branch,
             serving_branch,
             fallback_warning,
+            read_only: true,
         })
     }
 
@@ -678,6 +748,7 @@ impl TraceDecay {
             active_branch: Some(branch_name.to_string()),
             serving_branch: Some(branch_name.to_string()),
             fallback_warning: None,
+            read_only: false,
         })
     }
 
@@ -3263,6 +3334,12 @@ impl TraceDecay {
     }
 
     fn ensure_branch_writable(&self, operation: &str) -> Result<()> {
+        if self.read_only {
+            return Err(TraceDecayError::Config {
+                message: format!("cannot {operation}: active TraceDecay store is open read-only"),
+            });
+        }
+
         if self.is_fallback() {
             let active = self.active_branch.as_deref().unwrap_or("detached HEAD");
             let serving = self.serving_branch.as_deref().unwrap_or("default branch");
@@ -3346,6 +3423,12 @@ impl TraceDecay {
     }
 
     pub async fn open_project_store_db(&self) -> Result<Database> {
+        if self.read_only {
+            return Err(TraceDecayError::Config {
+                message: "cannot open project store for writing: active TraceDecay store is open read-only"
+                    .to_string(),
+            });
+        }
         let (db, _) = Database::open(&self.store_layout.graph_db_path).await?;
         Ok(db)
     }
@@ -3604,6 +3687,10 @@ impl TraceDecay {
     /// Returns true if serving from a fallback (ancestor) DB.
     pub fn is_fallback(&self) -> bool {
         self.fallback_warning.is_some()
+    }
+
+    pub fn is_read_only(&self) -> bool {
+        self.read_only
     }
 }
 

--- a/tests/mcp_cli_serve_test.rs
+++ b/tests/mcp_cli_serve_test.rs
@@ -3,9 +3,22 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use libsql::Builder;
 use serde_json::{json, Value};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
+#[cfg(unix)]
+use tokio::sync::Mutex;
+use tracedecay::db::Database;
 use tracedecay::global_db::GlobalDb;
+use tracedecay::mcp::handle_tool_call;
+use tracedecay::serve;
+use tracedecay::storage::{write_enrollment_marker, EnrollmentMarker, StorageMode};
+use tracedecay::tracedecay::TraceDecay;
+
+#[cfg(unix)]
+static READ_ONLY_SERVE_ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
 async fn init_project_with_file(home: &Path, contents: &str) -> TempDir {
     let dir = TempDir::new().unwrap();
@@ -88,6 +101,81 @@ fn canonical_path_string(path: &Path) -> String {
         .into_owned()
 }
 
+fn profile_root(home: &Path) -> PathBuf {
+    canonical_existing_path(home).join(".tracedecay")
+}
+
+async fn set_user_version(db_path: &Path, version: u32) {
+    let db = Builder::new_local(db_path).build().await.unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute(&format!("PRAGMA user_version = {version}"), ())
+        .await
+        .unwrap();
+}
+
+#[cfg(unix)]
+async fn drop_memory_facts(db_path: &Path) {
+    let mut permissions = fs::metadata(db_path).unwrap().permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(db_path, permissions).unwrap();
+
+    let db = Builder::new_local(db_path).build().await.unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("DROP TABLE memory_facts", ()).await.unwrap();
+
+    let mut permissions = fs::metadata(db_path).unwrap().permissions();
+    permissions.set_mode(0o444);
+    fs::set_permissions(db_path, permissions).unwrap();
+}
+
+fn extract_tool_text(value: &Value) -> &str {
+    value["content"][0]["text"]
+        .as_str()
+        .expect("tool result should include text content")
+}
+
+#[cfg(unix)]
+async fn create_read_only_project_db(
+    home: &Path,
+    project: &Path,
+    project_id: &str,
+    user_version: Option<u32>,
+) -> (PathBuf, PathBuf) {
+    let project_root = canonical_existing_path(project);
+    let profile_root = profile_root(home);
+    let data_root = profile_root.join(format!("projects/{project_id}"));
+    let db_path = data_root.join("tracedecay.db");
+
+    unsafe {
+        std::env::set_var("HOME", canonical_existing_path(home));
+        std::env::set_var("USERPROFILE", canonical_existing_path(home));
+        std::env::set_var("XDG_CONFIG_HOME", home.join(".config"));
+        std::env::set_var("TRACEDECAY_DATA_DIR", &profile_root);
+        std::env::set_var("TRACEDECAY_GLOBAL_DB", profile_root.join("global.db"));
+    }
+
+    write_enrollment_marker(
+        &project_root,
+        &EnrollmentMarker {
+            project_id: project_id.to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let (db, _) = Database::initialize(&db_path).await.unwrap();
+    db.checkpoint().await.unwrap();
+    db.close();
+    if let Some(version) = user_version {
+        set_user_version(&db_path, version).await;
+    }
+
+    let mut permissions = fs::metadata(&db_path).unwrap().permissions();
+    permissions.set_mode(0o444);
+    fs::set_permissions(&db_path, permissions).unwrap();
+
+    (project_root, db_path)
+}
+
 #[cfg(unix)]
 fn file_uri_localhost_percent_encoded(path: &Path) -> String {
     let encoded = path.to_string_lossy().replace(' ', "%20");
@@ -132,6 +220,80 @@ async fn explicit_uninitialized_path_reports_error_instead_of_global_fallback() 
     assert!(
         stderr.contains(&explicit.path().display().to_string()),
         "error should name the explicit project path\nstderr:\n{stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn ensure_initialized_rejects_read_only_db_with_pending_migrations() {
+    let _env_guard = READ_ONLY_SERVE_ENV_LOCK.lock().await;
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let (project_root, db_path) = create_read_only_project_db(
+        home.path(),
+        project.path(),
+        "proj_serve_readonly_old_schema",
+        Some(14),
+    )
+    .await;
+    drop_memory_facts(&db_path).await;
+
+    assert!(
+        TraceDecay::open(&project_root).await.is_err(),
+        "normal TraceDecay::open should fail against the read-only DB fixture"
+    );
+
+    let error = match serve::ensure_initialized(&project_root).await {
+        Ok(_) => panic!("read-only fallback must reject old schemas instead of serving them"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("schema") && message.contains("migrat"),
+        "error should explain that the read-only DB needs migration, got: {message}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn ensure_initialized_read_only_fallback_reports_and_guards_read_only_store() {
+    let _env_guard = READ_ONLY_SERVE_ENV_LOCK.lock().await;
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    fs::create_dir_all(project.path().join("src")).unwrap();
+    fs::write(
+        project.path().join("src/lib.rs"),
+        "pub fn readonly_marker() {}\n",
+    )
+    .unwrap();
+    let (project_root, _db_path) = create_read_only_project_db(
+        home.path(),
+        project.path(),
+        "proj_serve_readonly_current_schema",
+        None,
+    )
+    .await;
+
+    let cg = TraceDecay::open_read_only(&project_root)
+        .await
+        .expect("current-schema read-only DB should open for read-only serving");
+
+    let status = handle_tool_call(&cg, "tracedecay_storage_status", json!({}), None, None)
+        .await
+        .unwrap();
+    let payload: Value = serde_json::from_str(extract_tool_text(&status.value)).unwrap();
+    assert_eq!(payload["status"].as_str(), Some("ok"));
+    assert_eq!(payload["writable"].as_bool(), Some(false));
+    assert_eq!(payload["read_only"].as_bool(), Some(true));
+
+    let error = match cg.index_all().await {
+        Ok(_) => panic!("mutating operations should be guarded before SQLite rejects writes"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("read-only"),
+        "write guard should report read-only state, got: {message}"
     );
 }
 


### PR DESCRIPTION
## Summary
- allow serve initialization to fall back to a read-only project open when writable open fails
- remove the unused mmap reader capacity accessor

## Verification
- cargo test --test monitor_test
- cargo test --test db_test test_open_read_only_reads_existing_database_without_write_pragmas