### PR TITLE
Add global analytics and registry cleanup foundation

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -45,6 +45,50 @@ pub struct TokenCountUpsert {
     pub token_count: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyticsEventInsert {
+    pub provider: String,
+    pub project_id: String,
+    pub session_id: Option<String>,
+    pub timestamp: i64,
+    pub event_kind: String,
+    pub hook_name: Option<String>,
+    pub tool_name: Option<String>,
+    pub tool_category: Option<String>,
+    pub skill_name: Option<String>,
+    pub hint_category: Option<String>,
+    pub hint_id: Option<String>,
+    pub outcome: Option<String>,
+    pub metadata_json: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyticsEventRecord {
+    pub id: i64,
+    pub provider: String,
+    pub project_id: String,
+    pub session_id: Option<String>,
+    pub timestamp: i64,
+    pub event_kind: String,
+    pub hook_name: Option<String>,
+    pub tool_name: Option<String>,
+    pub tool_category: Option<String>,
+    pub skill_name: Option<String>,
+    pub hint_category: Option<String>,
+    pub hint_id: Option<String>,
+    pub outcome: Option<String>,
+    pub metadata_json: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AnalyticsEventQuery {
+    pub provider: Option<String>,
+    pub project_id: Option<String>,
+    pub session_id: Option<String>,
+    pub event_kind: Option<String>,
+    pub limit: usize,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PendingCodexCompactionSummary {
     pub node_id: String,
@@ -446,6 +490,37 @@ fn row_to_message(row: &libsql::Row, offset: i32) -> Option<SessionMessageRecord
     })
 }
 
+fn row_to_analytics_event(row: &libsql::Row) -> Option<AnalyticsEventRecord> {
+    Some(AnalyticsEventRecord {
+        id: row.get(0).ok()?,
+        provider: row.get(1).ok()?,
+        project_id: row.get(2).ok()?,
+        session_id: row.get(3).ok()?,
+        timestamp: row.get(4).ok()?,
+        event_kind: row.get(5).ok()?,
+        hook_name: row.get(6).ok()?,
+        tool_name: row.get(7).ok()?,
+        tool_category: row.get(8).ok()?,
+        skill_name: row.get(9).ok()?,
+        hint_category: row.get(10).ok()?,
+        hint_id: row.get(11).ok()?,
+        outcome: row.get(12).ok()?,
+        metadata_json: row.get(13).ok()?,
+    })
+}
+
+fn push_optional_analytics_filter(
+    clauses: &mut Vec<String>,
+    values: &mut Vec<Value>,
+    column: &str,
+    value: Option<&str>,
+) {
+    if let Some(value) = value {
+        values.push(Value::Text(value.to_string()));
+        clauses.push(format!("{column} = ?{}", values.len()));
+    }
+}
+
 fn row_to_code_project(row: &libsql::Row, offset: i32) -> Option<CodeProjectRecord> {
     Some(CodeProjectRecord {
         project_id: row.get(offset).ok()?,
@@ -812,6 +887,26 @@ impl GlobalDb {
             );
             CREATE INDEX IF NOT EXISTS idx_savings_ledger_ts ON savings_ledger(ts);
             CREATE INDEX IF NOT EXISTS idx_savings_ledger_project ON savings_ledger(project_path);
+            CREATE TABLE IF NOT EXISTS analytics_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                session_id TEXT,
+                timestamp INTEGER NOT NULL,
+                event_kind TEXT NOT NULL,
+                hook_name TEXT,
+                tool_name TEXT,
+                tool_category TEXT,
+                skill_name TEXT,
+                hint_category TEXT,
+                hint_id TEXT,
+                outcome TEXT,
+                metadata_json TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_analytics_events_provider_project_session
+                ON analytics_events(provider, project_id, session_id, timestamp);
+            CREATE INDEX IF NOT EXISTS idx_analytics_events_kind
+                ON analytics_events(event_kind, timestamp);
             CREATE TABLE IF NOT EXISTS sessions (
                 provider TEXT NOT NULL,
                 session_id TEXT NOT NULL,
@@ -1370,6 +1465,32 @@ impl GlobalDb {
         projects
     }
 
+    /// Removes registered code-project rows by exact project id.
+    ///
+    /// Dependent registry rows in `project_aliases`, `store_instances`,
+    /// `graph_scopes`, and `store_artifacts` cascade through foreign keys.
+    /// This only removes registry metadata; it never deletes project files or
+    /// profile-sharded store files on disk.
+    pub async fn delete_code_projects(&self, project_ids: &[String]) -> usize {
+        const CHUNK: usize = 256;
+        let mut total: usize = 0;
+        for chunk in project_ids.chunks(CHUNK) {
+            let placeholders = vec!["?"; chunk.len()];
+            let sql = format!(
+                "DELETE FROM code_projects WHERE project_id IN ({})",
+                placeholders.join(",")
+            );
+            let values: Vec<libsql::Value> = chunk
+                .iter()
+                .map(|project_id| libsql::Value::Text(project_id.clone()))
+                .collect();
+            if let Ok(n) = self.conn.execute(&sql, values).await {
+                total = total.saturating_add(n as usize);
+            }
+        }
+        total
+    }
+
     pub async fn search_code_projects(&self, query: &str, limit: usize) -> Vec<CodeProjectRecord> {
         let limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let pattern = like_pattern(query);
@@ -1627,12 +1748,19 @@ impl GlobalDb {
         after_tokens: u64,
         ts: i64,
     ) {
+        let project_path = Self::canonical_project_key(Path::new(project_path));
         let result = self
             .conn
             .execute(
                 "INSERT INTO savings_ledger (ts, project_path, tool_name, before_tokens, after_tokens) \
                  VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![ts, project_path, tool_name, before_tokens as i64, after_tokens as i64],
+                params![
+                    ts,
+                    project_path,
+                    tool_name,
+                    before_tokens as i64,
+                    after_tokens as i64
+                ],
             )
             .await;
         if let Err(e) = result {
@@ -1641,8 +1769,9 @@ impl GlobalDb {
     }
 
     /// Sum (before-after) across the ledger entries, with `ts >= since`. Optionally
-    /// filter by exact project path. Returns zeros on any DB error.
+    /// filter by canonical project path. Returns zeros on any DB error.
     pub async fn sum_savings(&self, project: Option<&str>, since: i64) -> SavingsTotal {
+        let project = project.map(|p| Self::canonical_project_key(Path::new(p)));
         let sql_with_project =
             "SELECT COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), COUNT(*) \
              FROM savings_ledger WHERE project_path = ?1 AND ts >= ?2";
@@ -1650,7 +1779,7 @@ impl GlobalDb {
             "SELECT COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), COUNT(*) \
              FROM savings_ledger WHERE ts >= ?1";
 
-        let rows = match project {
+        let rows = match project.as_deref() {
             Some(p) => self.conn.query(sql_with_project, params![p, since]).await,
             None => self.conn.query(sql_all, params![since]).await,
         };
@@ -1674,6 +1803,7 @@ impl GlobalDb {
 
     /// Group ledger entries by UTC calendar day. Newest-first.
     pub async fn savings_history(&self, project: Option<&str>, since: i64) -> Vec<SavingsDay> {
+        let project = project.map(|p| Self::canonical_project_key(Path::new(p)));
         let sql_with_project =
             "SELECT (ts/86400)*86400 AS day, \
                     COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), \
@@ -1687,7 +1817,7 @@ impl GlobalDb {
              FROM savings_ledger WHERE ts >= ?1 \
              GROUP BY day ORDER BY day DESC";
 
-        let rows = match project {
+        let rows = match project.as_deref() {
             Some(p) => self.conn.query(sql_with_project, params![p, since]).await,
             None => self.conn.query(sql_all, params![since]).await,
         };
@@ -1890,6 +2020,98 @@ impl GlobalDb {
             .await
             .ok()?;
         row_to_session(&rows.next().await.ok()??)
+    }
+
+    pub async fn append_analytics_event(
+        &self,
+        event: &AnalyticsEventInsert,
+    ) -> Result<i64, String> {
+        let mut rows = self
+            .conn
+            .query(
+                "INSERT INTO analytics_events
+                 (provider, project_id, session_id, timestamp, event_kind, hook_name,
+                  tool_name, tool_category, skill_name, hint_category, hint_id, outcome,
+                  metadata_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                 RETURNING id",
+                params![
+                    event.provider.as_str(),
+                    event.project_id.as_str(),
+                    opt_text(event.session_id.as_deref()),
+                    event.timestamp,
+                    event.event_kind.as_str(),
+                    opt_text(event.hook_name.as_deref()),
+                    opt_text(event.tool_name.as_deref()),
+                    opt_text(event.tool_category.as_deref()),
+                    opt_text(event.skill_name.as_deref()),
+                    opt_text(event.hint_category.as_deref()),
+                    opt_text(event.hint_id.as_deref()),
+                    opt_text(event.outcome.as_deref()),
+                    opt_text(event.metadata_json.as_deref()),
+                ],
+            )
+            .await
+            .map_err(|e| format!("failed to append analytics event: {e}"))?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read appended analytics event id: {e}"))?
+            .ok_or_else(|| "append analytics event returned no id".to_string())?;
+        row.get::<i64>(0)
+            .map_err(|e| format!("failed to decode appended analytics event id: {e}"))
+    }
+
+    pub async fn query_analytics_events(
+        &self,
+        query: &AnalyticsEventQuery,
+    ) -> Result<Vec<AnalyticsEventRecord>, String> {
+        if query.limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut sql = String::from(
+            "SELECT id, provider, project_id, session_id, timestamp, event_kind,
+                    hook_name, tool_name, tool_category, skill_name, hint_category,
+                    hint_id, outcome, metadata_json
+             FROM analytics_events",
+        );
+        let mut clauses = Vec::new();
+        let mut values = Vec::new();
+        for (column, value) in [
+            ("provider", query.provider.as_deref()),
+            ("project_id", query.project_id.as_deref()),
+            ("session_id", query.session_id.as_deref()),
+            ("event_kind", query.event_kind.as_deref()),
+        ] {
+            push_optional_analytics_filter(&mut clauses, &mut values, column, value);
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        values.push(Value::Integer(
+            i64::try_from(query.limit).unwrap_or(i64::MAX),
+        ));
+        let limit_param = values.len();
+        let _ = write!(sql, " ORDER BY timestamp, id LIMIT ?{limit_param}");
+
+        let mut rows = self
+            .conn
+            .query(&sql, libsql::params_from_iter(values))
+            .await
+            .map_err(|e| format!("failed to query analytics events: {e}"))?;
+        let mut events = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read analytics events: {e}"))?
+        {
+            let event = row_to_analytics_event(&row)
+                .ok_or_else(|| "failed to decode analytics event row".to_string())?;
+            events.push(event);
+        }
+        Ok(events)
     }
 
     /// Inserts or replaces a provider message. Returns `false` on any DB error.

--- a/tests/gain_test.rs
+++ b/tests/gain_test.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use tempfile::TempDir;
 use tracedecay::global_db::GlobalDb;
 
@@ -53,4 +55,50 @@ async fn savings_history_buckets_by_day() {
     // Newest first
     assert_eq!(history[0].saved_tokens, 720); // day2: 800 - 80
     assert_eq!(history[1].saved_tokens, 1350); // day1: (1000-100) + (500-50)
+}
+
+#[tokio::test]
+async fn savings_project_filters_canonicalize_read_side() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let project_dir = tmp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    let canonical_project = GlobalDb::canonical_project_key(&project_dir);
+    let project_with_trailing_slash = format!("{}/", project_dir.display());
+
+    db.record_savings(&canonical_project, "tracedecay_context", 2000, 250, 86_400)
+        .await;
+
+    let total = db.sum_savings(Some(&project_with_trailing_slash), 0).await;
+    assert_eq!(total.saved_tokens, 1750);
+    assert_eq!(total.calls, 1);
+
+    let history = db
+        .savings_history(Some(&project_with_trailing_slash), 0)
+        .await;
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].saved_tokens, 1750);
+    assert_eq!(history[0].calls, 1);
+}
+
+#[tokio::test]
+async fn record_savings_canonicalizes_project_path_on_write() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let project_dir = tmp.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    let raw_project = format!("{}/", project_dir.display());
+    let canonical_project = GlobalDb::canonical_project_key(&project_dir);
+
+    db.record_savings(&raw_project, "tracedecay_context", 3000, 400, 86_400)
+        .await;
+
+    let total = db.sum_savings(Some(&canonical_project), 0).await;
+    assert_eq!(total.saved_tokens, 2600);
+    assert_eq!(total.calls, 1);
+
+    let history = db.savings_history(Some(&canonical_project), 0).await;
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].saved_tokens, 2600);
+    assert_eq!(history[0].calls, 1);
 }

--- a/tests/global_registry_test.rs
+++ b/tests/global_registry_test.rs
@@ -21,6 +21,57 @@ async fn upsert_test_store(db: &GlobalDb, project_id: &str, store_id: &str) {
     .unwrap();
 }
 
+async fn upsert_registry_fixture(db: &GlobalDb, project_root: &Path) {
+    let project = db
+        .upsert_code_project(
+            "proj_registry",
+            project_root,
+            Some(&project_root.join(".git")),
+            Some("https://example.test/repo.git"),
+            Some("main"),
+        )
+        .await
+        .unwrap();
+    db.upsert_project_alias(&project_root.join("."), &project.project_id)
+        .await
+        .unwrap();
+    let store = db
+        .upsert_store_instance(StoreInstanceUpsert {
+            store_id: "store_registry".to_string(),
+            project_id: project.project_id.clone(),
+            store_kind: "code_project".to_string(),
+            storage_mode: "profile_sharded".to_string(),
+            store_relpath: "projects/proj_registry".to_string(),
+            manifest_relpath: Some("projects/proj_registry/store_manifest.json".to_string()),
+            last_verified_at: Some(100),
+            last_write_at: Some(101),
+        })
+        .await
+        .unwrap();
+    db.upsert_graph_scope(GraphScopeUpsert {
+        graph_scope_id: "scope_registry_main".to_string(),
+        project_id: project.project_id,
+        store_id: store.store_id.clone(),
+        branch_name: "main".to_string(),
+        db_relpath: "projects/proj_registry/tracedecay.db".to_string(),
+        parent_scope_id: None,
+        last_synced_at: Some(102),
+        writable: true,
+    })
+    .await
+    .unwrap();
+    db.upsert_store_artifact(StoreArtifactUpsert {
+        store_id: store.store_id,
+        artifact_kind: "store_manifest".to_string(),
+        relpath: "projects/proj_registry/store_manifest.json".to_string(),
+        size_bytes: Some(2048),
+        schema_version: Some("1".to_string()),
+        updated_at: Some(103),
+    })
+    .await
+    .unwrap();
+}
+
 async fn table_exists(db_path: &Path, table: &str) -> bool {
     let db = libsql::Builder::new_local(db_path).build().await.unwrap();
     let conn = db.connect().unwrap();
@@ -146,54 +197,7 @@ async fn open_at_creates_registry_tables_and_round_trips_registry_records() {
         assert!(table_exists(&db_path, table).await, "{table} missing");
     }
 
-    let project = db
-        .upsert_code_project(
-            "proj_registry",
-            &project_root,
-            Some(&project_root.join(".git")),
-            Some("https://example.test/repo.git"),
-            Some("main"),
-        )
-        .await
-        .unwrap();
-    db.upsert_project_alias(&project_root.join("."), &project.project_id)
-        .await
-        .unwrap();
-    let store = db
-        .upsert_store_instance(StoreInstanceUpsert {
-            store_id: "store_registry".to_string(),
-            project_id: project.project_id.clone(),
-            store_kind: "code_project".to_string(),
-            storage_mode: "profile_sharded".to_string(),
-            store_relpath: "projects/proj_registry".to_string(),
-            manifest_relpath: Some("projects/proj_registry/store_manifest.json".to_string()),
-            last_verified_at: Some(100),
-            last_write_at: Some(101),
-        })
-        .await
-        .unwrap();
-    db.upsert_graph_scope(GraphScopeUpsert {
-        graph_scope_id: "scope_registry_main".to_string(),
-        project_id: project.project_id.clone(),
-        store_id: store.store_id.clone(),
-        branch_name: "main".to_string(),
-        db_relpath: "projects/proj_registry/tracedecay.db".to_string(),
-        parent_scope_id: None,
-        last_synced_at: Some(102),
-        writable: true,
-    })
-    .await
-    .unwrap();
-    db.upsert_store_artifact(StoreArtifactUpsert {
-        store_id: store.store_id.clone(),
-        artifact_kind: "store_manifest".to_string(),
-        relpath: "projects/proj_registry/store_manifest.json".to_string(),
-        size_bytes: Some(2048),
-        schema_version: Some("1".to_string()),
-        updated_at: Some(103),
-    })
-    .await
-    .unwrap();
+    upsert_registry_fixture(&db, &project_root).await;
 
     let projects = db.list_code_projects(10).await;
     assert_eq!(projects.len(), 1);
@@ -232,6 +236,33 @@ async fn open_at_creates_registry_tables_and_round_trips_registry_records() {
         context.stores[0].artifacts[0].artifact_kind,
         "store_manifest"
     );
+}
+
+#[tokio::test]
+async fn delete_code_projects_cascades_registry_rows_without_touching_legacy_projects() {
+    let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("global.db");
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let db = GlobalDb::open_at(&db_path).await.unwrap();
+
+    db.upsert(&project_root, 42).await;
+    upsert_registry_fixture(&db, &project_root).await;
+
+    let deleted = db
+        .delete_code_projects(&["proj_registry".to_string()])
+        .await;
+
+    assert_eq!(deleted, 1);
+    assert!(db.get_code_project("proj_registry").await.is_none());
+    assert!(db
+        .project_registry_context_by_id("proj_registry")
+        .await
+        .is_none());
+    assert!(db.list_code_projects(10).await.is_empty());
+    assert_eq!(db.get_project_tokens(&project_root).await, 42);
+    assert_eq!(db.global_tokens_saved().await, Some(42));
 }
 
 #[tokio::test]

--- a/tests/session_global_db_test.rs
+++ b/tests/session_global_db_test.rs
@@ -1,6 +1,6 @@
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
-use tracedecay::global_db::GlobalDb;
+use tracedecay::global_db::{AnalyticsEventInsert, AnalyticsEventQuery, GlobalDb};
 use tracedecay::sessions::lcm::LcmStorageKind;
 use tracedecay::sessions::{SessionRecord, SessionSearchScope};
 
@@ -78,6 +78,70 @@ async fn lcm_fts_count(db_path: &std::path::Path, query: &str) -> i64 {
     count
 }
 
+async fn raw_analytics_event_count(
+    db_path: &std::path::Path,
+    provider: &str,
+    session_id: &str,
+    event_kind: &str,
+) -> i64 {
+    let db = libsql::Builder::new_local(db_path).build().await.unwrap();
+    let conn = db.connect().unwrap();
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*)
+             FROM analytics_events
+             WHERE provider = ?1 AND session_id = ?2 AND event_kind = ?3",
+            libsql::params![provider, session_id, event_kind],
+        )
+        .await
+        .unwrap();
+    let count = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    drop(rows);
+    drop(conn);
+    drop(db);
+    count
+}
+
+fn analytics_event(
+    session_id: Option<&str>,
+    timestamp: i64,
+    event_kind: &str,
+) -> AnalyticsEventInsert {
+    AnalyticsEventInsert {
+        provider: "codex".to_string(),
+        project_id: "project-a".to_string(),
+        session_id: session_id.map(ToOwned::to_owned),
+        timestamp,
+        event_kind: event_kind.to_string(),
+        hook_name: None,
+        tool_name: None,
+        tool_category: None,
+        skill_name: None,
+        hint_category: None,
+        hint_id: None,
+        outcome: None,
+        metadata_json: None,
+    }
+}
+
+fn analytics_query(
+    session_id: Option<&str>,
+    event_kind: Option<&str>,
+    limit: usize,
+) -> AnalyticsEventQuery {
+    AnalyticsEventQuery {
+        provider: Some("codex".to_string()),
+        project_id: Some("project-a".to_string()),
+        session_id: session_id.map(ToOwned::to_owned),
+        event_kind: event_kind.map(ToOwned::to_owned),
+        limit,
+    }
+}
+
+async fn append_analytics_event(db: &GlobalDb, event: &AnalyticsEventInsert, label: &str) -> i64 {
+    db.append_analytics_event(event).await.expect(label)
+}
+
 #[tokio::test]
 async fn global_db_opens_with_session_schema() {
     let tmp = TempDir::new().unwrap();
@@ -88,6 +152,256 @@ async fn global_db_opens_with_session_schema() {
         .search_session_messages("cursor", None, "not-present", 10)
         .await
         .is_empty());
+}
+
+#[tokio::test]
+async fn project_registry_path_aliases_resolve_exactly_without_active_fallback() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let active_root = tmp.path().join("active");
+    let target_root = tmp.path().join("target");
+    let nested_target_alias = target_root.join("nested/worktree");
+    let missing_root = tmp.path().join("missing");
+    std::fs::create_dir_all(&active_root).unwrap();
+    std::fs::create_dir_all(&target_root).unwrap();
+    std::fs::create_dir_all(&nested_target_alias).unwrap();
+
+    db.upsert_code_project("proj_active", &active_root, None, None, Some("main"))
+        .await
+        .expect("active project should upsert");
+    let target = db
+        .upsert_code_project("proj_target", &target_root, None, None, Some("main"))
+        .await
+        .expect("target project should upsert");
+    db.upsert_project_alias(&nested_target_alias, &target.project_id)
+        .await
+        .expect("nested target alias should upsert");
+
+    let by_root = db
+        .project_registry_context_by_alias(&target_root)
+        .await
+        .expect("target root alias should resolve");
+    assert_eq!(by_root.project.project_id, "proj_target");
+
+    let by_nested_alias = db
+        .project_registry_context_by_alias(&nested_target_alias)
+        .await
+        .expect("nested target alias should resolve");
+    assert_eq!(by_nested_alias.project.project_id, "proj_target");
+
+    assert!(
+        db.project_registry_context_by_id("proj_missing")
+            .await
+            .is_none(),
+        "unresolved project_id selectors must not synthesize an active-project context"
+    );
+    assert!(
+        db.project_registry_context_by_alias(&missing_root)
+            .await
+            .is_none(),
+        "unresolved path selectors must not fall back to the active registered project"
+    );
+}
+
+#[tokio::test]
+async fn analytics_events_append_and_query_by_provider_project_session_and_kind() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+
+    let tool_event = AnalyticsEventInsert {
+        tool_name: Some("tracedecay_context".to_string()),
+        tool_category: Some("mcp".to_string()),
+        hint_category: Some("search".to_string()),
+        hint_id: Some("hint-1".to_string()),
+        outcome: Some("success".to_string()),
+        metadata_json: Some(r#"{"tokens_saved":42}"#.to_string()),
+        ..analytics_event(Some("session-a"), 1_715_000_123, "tool")
+    };
+    let first_id = append_analytics_event(&db, &tool_event, "append analytics event").await;
+    let second_id =
+        append_analytics_event(&db, &tool_event, "append identical analytics event").await;
+    assert_ne!(first_id, second_id, "analytics storage must be append-only");
+
+    append_analytics_event(
+        &db,
+        &AnalyticsEventInsert {
+            hook_name: Some("pre-tool-use".to_string()),
+            skill_name: Some("tracedecay:searching-for-code".to_string()),
+            outcome: Some("shown".to_string()),
+            metadata_json: Some(r#"{"source":"test"}"#.to_string()),
+            ..analytics_event(Some("session-a"), 1_715_000_124, "skill")
+        },
+        "append skill analytics event",
+    )
+    .await;
+    append_analytics_event(
+        &db,
+        &AnalyticsEventInsert {
+            provider: "cursor".to_string(),
+            project_id: "project-b".to_string(),
+            tool_name: Some("other_tool".to_string()),
+            tool_category: Some("local".to_string()),
+            outcome: Some("success".to_string()),
+            ..analytics_event(Some("session-b"), 1_715_000_125, "tool")
+        },
+        "append filtered analytics event",
+    )
+    .await;
+
+    let events = db
+        .query_analytics_events(&analytics_query(Some("session-a"), Some("tool"), 10))
+        .await
+        .expect("query analytics events");
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].id, first_id);
+    assert_eq!(events[1].id, second_id);
+    assert_eq!(events[0].provider, "codex");
+    assert_eq!(events[0].project_id, "project-a");
+    assert_eq!(events[0].session_id.as_deref(), Some("session-a"));
+    assert_eq!(events[0].timestamp, 1_715_000_123);
+    assert_eq!(events[0].event_kind, "tool");
+    assert_eq!(events[0].tool_name.as_deref(), Some("tracedecay_context"));
+    assert_eq!(events[0].tool_category.as_deref(), Some("mcp"));
+    assert_eq!(events[0].hint_category.as_deref(), Some("search"));
+    assert_eq!(events[0].hint_id.as_deref(), Some("hint-1"));
+    assert_eq!(events[0].outcome.as_deref(), Some("success"));
+    assert_eq!(
+        events[0].metadata_json.as_deref(),
+        Some(r#"{"tokens_saved":42}"#)
+    );
+}
+
+#[tokio::test]
+async fn open_at_upgrades_existing_global_db_with_analytics_events_table() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join(".tracedecay").join("global.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+
+    let old_db = libsql::Builder::new_local(&db_path).build().await.unwrap();
+    let conn = old_db.connect().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE sessions (
+            provider TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            project_key TEXT NOT NULL,
+            project_path TEXT NOT NULL,
+            title TEXT,
+            started_at INTEGER,
+            ended_at INTEGER,
+            transcript_path TEXT,
+            metadata_json TEXT,
+            PRIMARY KEY(provider, session_id)
+        );",
+    )
+    .await
+    .unwrap();
+    drop(conn);
+    drop(old_db);
+
+    let db = GlobalDb::open_at(&db_path).await.expect("global db open");
+    let event = AnalyticsEventInsert {
+        hook_name: Some("post-tool-use".to_string()),
+        tool_name: Some("shell".to_string()),
+        tool_category: Some("local".to_string()),
+        outcome: Some("recorded".to_string()),
+        metadata_json: Some(r#"{"upgraded":true}"#.to_string()),
+        ..analytics_event(None, 1_715_000_126, "hook")
+    };
+    let id = append_analytics_event(&db, &event, "append analytics event after upgrade").await;
+
+    let events = db
+        .query_analytics_events(&analytics_query(None, Some("hook"), 5))
+        .await
+        .expect("query analytics events after upgrade");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].id, id);
+    assert_eq!(events[0].hook_name.as_deref(), Some("post-tool-use"));
+}
+
+#[tokio::test]
+async fn analytics_events_preserve_assistant_hook_tool_and_skill_fields() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = isolated_db_path(&tmp);
+    let db = open_isolated_db(&tmp).await;
+
+    let assistant_id = append_analytics_event(
+        &db,
+        &AnalyticsEventInsert {
+            hint_category: Some("workflow".to_string()),
+            hint_id: Some("hint-assistant".to_string()),
+            outcome: Some("shown".to_string()),
+            metadata_json: Some(r#"{"model":"gpt-5-codex","turn":1}"#.to_string()),
+            ..analytics_event(Some("session-required-fields"), 1_715_000_200, "assistant")
+        },
+        "append assistant analytics event",
+    )
+    .await;
+    append_analytics_event(
+        &db,
+        &AnalyticsEventInsert {
+            hook_name: Some("post-tool-use".to_string()),
+            outcome: Some("ok".to_string()),
+            metadata_json: Some(r#"{"exit_code":0}"#.to_string()),
+            ..analytics_event(Some("session-required-fields"), 1_715_000_201, "hook")
+        },
+        "append hook analytics event",
+    )
+    .await;
+    append_analytics_event(
+        &db,
+        &AnalyticsEventInsert {
+            tool_name: Some("tracedecay_context".to_string()),
+            tool_category: Some("mcp".to_string()),
+            outcome: Some("accepted".to_string()),
+            metadata_json: Some(r#"{"tokens_saved":42}"#.to_string()),
+            ..analytics_event(Some("session-required-fields"), 1_715_000_202, "tool")
+        },
+        "append tool analytics event",
+    )
+    .await;
+    append_analytics_event(
+        &db,
+        &AnalyticsEventInsert {
+            skill_name: Some("superpowers:test-driven-development".to_string()),
+            outcome: Some("used".to_string()),
+            metadata_json: Some(r#"{"stage":"red"}"#.to_string()),
+            ..analytics_event(Some("session-required-fields"), 1_715_000_203, "skill")
+        },
+        "append skill analytics event",
+    )
+    .await;
+
+    let events = db
+        .query_analytics_events(&analytics_query(Some("session-required-fields"), None, 10))
+        .await
+        .expect("query analytics events");
+
+    assert_eq!(events.len(), 4);
+    assert_eq!(events[0].id, assistant_id);
+    assert_eq!(events[0].event_kind, "assistant");
+    assert_eq!(events[0].hint_category.as_deref(), Some("workflow"));
+    assert_eq!(events[0].hint_id.as_deref(), Some("hint-assistant"));
+    assert_eq!(events[0].outcome.as_deref(), Some("shown"));
+    assert_eq!(
+        events[0].metadata_json.as_deref(),
+        Some(r#"{"model":"gpt-5-codex","turn":1}"#)
+    );
+    assert_eq!(events[1].event_kind, "hook");
+    assert_eq!(events[1].hook_name.as_deref(), Some("post-tool-use"));
+    assert_eq!(events[2].event_kind, "tool");
+    assert_eq!(events[2].tool_name.as_deref(), Some("tracedecay_context"));
+    assert_eq!(events[2].tool_category.as_deref(), Some("mcp"));
+    assert_eq!(events[3].event_kind, "skill");
+    assert_eq!(
+        events[3].skill_name.as_deref(),
+        Some("superpowers:test-driven-development")
+    );
+    assert_eq!(
+        raw_analytics_event_count(&db_path, "codex", "session-required-fields", "assistant").await,
+        1
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add durable analytics event storage/query helpers to the global DB
- add registry metadata deletion for stale code-project rows
- canonicalize savings project filters on read and tighten registry selector behavior tests

## Verification
- cargo test --test session_global_db_test --test global_registry_test --test gain_test