### PR TITLE
Expose runtime analytics dashboard APIs

### DIFF
--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,0 +1,688 @@
+//! Provider-neutral assistant usage taxonomy.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UsageKind {
+    Tool,
+    Skill,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum UsageCategory {
+    TraceDecayGraph,
+    LcmSession,
+    Memory,
+    BroadFileSearch,
+    Edit,
+    Shell,
+    WorkflowSkill,
+    TraceDecayWorkflowSkill,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UsageEvent {
+    pub kind: UsageKind,
+    pub name: String,
+    pub category: UsageCategory,
+}
+
+impl UsageCategory {
+    pub fn dashboard_label(self) -> &'static str {
+        match self {
+            Self::TraceDecayGraph => "tracedecay_mcp",
+            Self::LcmSession => "lcm_session",
+            Self::Memory => "memory",
+            Self::BroadFileSearch => "broad_code_context",
+            Self::Edit => "code_edit",
+            Self::Shell => "shell",
+            Self::WorkflowSkill => "workflow_skill",
+            Self::TraceDecayWorkflowSkill => "tracedecay_workflow_skill",
+            Self::Other => "other_tool",
+        }
+    }
+}
+
+pub fn normalize_tool_name(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let without_mcp = trimmed
+        .strip_prefix("mcp__tracedecay__")
+        .or_else(|| trimmed.strip_prefix("mcp_tracedecay_"))
+        .unwrap_or(trimmed);
+    without_mcp.to_ascii_lowercase().replace('-', "_")
+}
+
+fn categorize_normalized_tool(normalized: &str, command_hint: Option<&str>) -> UsageCategory {
+    if normalized.starts_with("tracedecay_memory")
+        || normalized == "tracedecay_fact_store"
+        || normalized == "tracedecay_memory_status"
+    {
+        return UsageCategory::Memory;
+    }
+    if normalized.starts_with("tracedecay_lcm")
+        || normalized.contains("session")
+        || normalized.contains("transcript")
+    {
+        return UsageCategory::LcmSession;
+    }
+    if normalized.starts_with("tracedecay_") {
+        return UsageCategory::TraceDecayGraph;
+    }
+    if matches!(
+        normalized,
+        "read" | "readfile" | "cat" | "sed" | "grep" | "rg" | "glob" | "search" | "find"
+    ) {
+        return UsageCategory::BroadFileSearch;
+    }
+    if matches!(normalized, "apply_patch" | "edit" | "write") {
+        return UsageCategory::Edit;
+    }
+    if matches!(
+        normalized,
+        "bash" | "shell" | "exec_command" | "functions.exec_command"
+    ) {
+        return command_hint.map_or(UsageCategory::Shell, command_category);
+    }
+    UsageCategory::Other
+}
+
+pub fn categorize_skill(raw: &str) -> UsageCategory {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.starts_with("tracedecay:") {
+        UsageCategory::TraceDecayWorkflowSkill
+    } else if normalized.is_empty() {
+        UsageCategory::Other
+    } else {
+        UsageCategory::WorkflowSkill
+    }
+}
+
+pub fn infer_usage_events(
+    tool_names: Option<&str>,
+    metadata_json: Option<&str>,
+    text: Option<&str>,
+) -> Vec<UsageEvent> {
+    let metadata = metadata_json.and_then(|raw| serde_json::from_str::<Value>(raw).ok());
+    let command_hint = metadata.as_ref().and_then(command_from_metadata);
+
+    let mut events = BTreeSet::new();
+    let tools = tool_names
+        .into_iter()
+        .flat_map(split_tool_names)
+        .collect::<Vec<_>>();
+    for tool in &tools {
+        insert_tool_event(&mut events, tool, command_hint.as_deref());
+    }
+
+    if let Some(value) = metadata.as_ref() {
+        let mut skills = explicit_skills_from_metadata(value);
+        if tools
+            .iter()
+            .any(|tool| normalize_tool_name(tool) == "skill_view")
+        {
+            collect_skill_view_metadata(value, &mut skills);
+        }
+        for skill in skills {
+            insert_skill_event(&mut events, &skill);
+        }
+    }
+
+    for skill in skills_from_text(text.unwrap_or_default()) {
+        insert_skill_event(&mut events, &skill);
+    }
+
+    events.into_iter().collect()
+}
+
+fn insert_tool_event(events: &mut BTreeSet<UsageEvent>, raw: &str, command_hint: Option<&str>) {
+    let name = normalize_tool_name(raw);
+    if name.is_empty() {
+        return;
+    }
+    events.insert(UsageEvent {
+        kind: UsageKind::Tool,
+        category: categorize_normalized_tool(&name, command_hint),
+        name,
+    });
+}
+
+fn insert_skill_event(events: &mut BTreeSet<UsageEvent>, raw: &str) {
+    let name = raw.trim();
+    if name.is_empty() {
+        return;
+    }
+    events.insert(UsageEvent {
+        kind: UsageKind::Skill,
+        category: categorize_skill(name),
+        name: name.to_string(),
+    });
+}
+
+pub fn split_tool_names(raw: &str) -> impl Iterator<Item = String> + '_ {
+    raw.split([',', '\n'])
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn command_category(command: &str) -> UsageCategory {
+    let normalized = command.to_ascii_lowercase();
+    let first_word = normalized.split_whitespace().next().unwrap_or_default();
+    if matches!(first_word, "rg" | "grep" | "find" | "fd" | "cat" | "sed") {
+        UsageCategory::BroadFileSearch
+    } else if normalized.contains("apply_patch") {
+        UsageCategory::Edit
+    } else {
+        UsageCategory::Shell
+    }
+}
+
+fn command_from_metadata(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for key in ["cmd", "command", "shell_command"] {
+                if let Some(command) = map.get(key).and_then(Value::as_str) {
+                    return Some(command.to_string());
+                }
+            }
+            map.values().find_map(command_from_metadata)
+        }
+        Value::Array(items) => items.iter().find_map(command_from_metadata),
+        _ => None,
+    }
+}
+
+fn explicit_skills_from_metadata(value: &Value) -> Vec<String> {
+    let mut skills = Vec::new();
+    collect_explicit_skills(value, &mut skills);
+    skills
+}
+
+fn collect_explicit_skills(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_explicit_skills(item, out);
+            }
+        }
+        Value::Object(map) => {
+            for (key, value) in map {
+                if matches!(
+                    key.as_str(),
+                    "skill" | "skills" | "skill_name" | "skill_names"
+                ) {
+                    collect_skill_values(value, out);
+                } else {
+                    collect_explicit_skills(value, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_skill_values(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(skill) => {
+            if let Some(skill) = normalize_skill_name(skill) {
+                out.push(skill);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_skill_values(item, out);
+            }
+        }
+        Value::Object(map) => {
+            for value in map.values() {
+                collect_skill_values(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn skills_from_text(text: &str) -> Vec<String> {
+    let mut skills = Vec::new();
+    if let Ok(value) = serde_json::from_str::<Value>(text) {
+        collect_skills_from_text_json(&value, &mut skills);
+    }
+    collect_using_skill_mentions(text, &mut skills);
+    skills
+}
+
+fn collect_skill_view_metadata(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_skill_view_metadata(item, out);
+            }
+        }
+        Value::Object(map) => {
+            if let Some(function) = map.get("function").and_then(Value::as_object) {
+                if function.get("name").and_then(Value::as_str) == Some("skill_view") {
+                    if let Some(arguments) = function.get("arguments") {
+                        collect_skill_view_arguments(arguments, out);
+                    }
+                }
+            }
+            for value in map.values() {
+                collect_skill_view_metadata(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_skill_view_arguments(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(name) = map.get("name").and_then(Value::as_str) {
+                if let Some(skill) = normalize_skill_name(name) {
+                    out.push(skill);
+                }
+            }
+        }
+        Value::String(raw) => {
+            if let Ok(parsed) = serde_json::from_str::<Value>(raw) {
+                collect_skill_view_arguments(&parsed, out);
+            } else if let Some(skill) = normalize_skill_name(raw) {
+                out.push(skill);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_skills_from_text_json(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_skills_from_text_json(item, out);
+            }
+        }
+        Value::Object(map) => {
+            let tool_name = map
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::to_ascii_lowercase);
+            let path = map
+                .get("input")
+                .and_then(|input| input.get("path"))
+                .or_else(|| map.get("path"))
+                .and_then(Value::as_str);
+
+            if matches!(tool_name.as_deref(), Some("read" | "readfile")) {
+                if let Some(skill) = path.and_then(skill_from_path) {
+                    out.push(skill);
+                }
+            } else if path.is_some_and(is_skill_file_path) {
+                if let Some(name) = map.get("name").and_then(Value::as_str) {
+                    if let Some(skill) = normalize_skill_name(name) {
+                        out.push(skill);
+                    } else if let Some(skill) = path.and_then(skill_from_path) {
+                        out.push(skill);
+                    }
+                } else if let Some(skill) = path.and_then(skill_from_path) {
+                    out.push(skill);
+                }
+            }
+
+            for value in map.values() {
+                collect_skills_from_text_json(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_using_skill_mentions(text: &str, out: &mut Vec<String>) {
+    for line in text.lines() {
+        if !line.to_ascii_lowercase().contains("using ") {
+            continue;
+        }
+
+        let mut rest = line;
+        while let Some(start) = rest.find('`') {
+            let after_start = &rest[start + 1..];
+            let Some(end) = after_start.find('`') else {
+                break;
+            };
+            if let Some(skill) = skill_from_token(&after_start[..end]) {
+                out.push(skill);
+            }
+            rest = &after_start[end + 1..];
+        }
+    }
+}
+
+fn skill_from_path(path: &str) -> Option<String> {
+    if !is_skill_file_path(path) {
+        return None;
+    }
+
+    let parts = path.split('/').collect::<Vec<_>>();
+    let Some(skills_index) = parts.iter().rposition(|part| *part == "skills") else {
+        return skill_from_relative_result_path(&parts);
+    };
+    let skill = if parts.get(skills_index + 3) == Some(&"SKILL.md") {
+        parts.get(skills_index + 2).copied()
+    } else {
+        parts.get(skills_index + 1).copied()
+    }?;
+
+    if !is_skill_ident(skill) {
+        return None;
+    }
+
+    let namespace = skill_path_namespace(&parts, skills_index);
+    Some(match namespace {
+        Some(namespace) => format!("{namespace}:{skill}"),
+        None => format!("skill:{skill}"),
+    })
+}
+
+fn skill_path_namespace(parts: &[&str], skills_index: usize) -> Option<String> {
+    if parts.get(skills_index + 3) == Some(&"SKILL.md") {
+        return parts
+            .get(skills_index + 1)
+            .copied()
+            .filter(|namespace| is_skill_ident(namespace))
+            .map(ToOwned::to_owned);
+    }
+
+    let previous = parts.get(skills_index.checked_sub(1)?)?.trim();
+    if is_cache_version(previous) {
+        return parts
+            .get(skills_index.checked_sub(2)?)
+            .copied()
+            .filter(|namespace| is_skill_ident(namespace))
+            .map(ToOwned::to_owned);
+    }
+    if is_skill_ident(previous) && !matches!(previous, ".codex" | ".cursor" | "package" | "skills")
+    {
+        return Some(previous.to_string());
+    }
+
+    None
+}
+
+fn is_skill_file_path(path: &str) -> bool {
+    path.ends_with("/SKILL.md") || path.ends_with("\\SKILL.md")
+}
+
+fn normalize_skill_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.contains(':') {
+        skill_from_token(trimmed)
+    } else {
+        is_skill_ident(trimmed).then(|| trimmed.to_string())
+    }
+}
+
+fn skill_from_relative_result_path(parts: &[&str]) -> Option<String> {
+    if parts.len() != 3 || parts.get(2) != Some(&"SKILL.md") {
+        return None;
+    }
+
+    let namespace = *parts.first()?;
+    let skill = *parts.get(1)?;
+    if is_skill_ident(namespace) && is_skill_ident(skill) {
+        Some(format!("{namespace}:{skill}"))
+    } else {
+        None
+    }
+}
+
+fn skill_from_token(token: &str) -> Option<String> {
+    let cleaned = token.trim_matches(|ch: char| {
+        matches!(
+            ch,
+            '`' | '\'' | '"' | ',' | '.' | ':' | ';' | '(' | ')' | '[' | ']'
+        )
+    });
+    let (namespace, name) = cleaned.split_once(':')?;
+    if cleaned.contains("://") || !is_skill_ident(namespace) || !is_skill_ident(name) {
+        return None;
+    }
+    Some(cleaned.to_string())
+}
+
+fn is_skill_ident(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_lowercase())
+        && value.chars().all(|ch| {
+            ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '-' | '_' | '.')
+        })
+}
+
+fn is_cache_version(value: &str) -> bool {
+    let has_digit = value.chars().any(|ch| ch.is_ascii_digit());
+    has_digit
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_hexdigit() || matches!(ch, '.' | '-' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{infer_usage_events, UsageCategory, UsageEvent, UsageKind};
+
+    fn assert_usage_event(
+        events: &[UsageEvent],
+        kind: UsageKind,
+        name: &str,
+        category: UsageCategory,
+    ) {
+        assert!(
+            events.iter().any(|event| {
+                event.kind == kind && event.name == name && event.category == category
+            }),
+            "missing {kind:?} event {name:?} in {events:#?}"
+        );
+    }
+
+    #[test]
+    fn normalizes_mcp_tracedecay_tool_names() {
+        let events =
+            infer_usage_events(Some("mcp__tracedecay__tracedecay_context,Read"), None, None);
+        assert_usage_event(
+            &events,
+            UsageKind::Tool,
+            "tracedecay_context",
+            UsageCategory::TraceDecayGraph,
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Tool,
+            "read",
+            UsageCategory::BroadFileSearch,
+        );
+    }
+
+    #[test]
+    fn ignores_tool_names_buried_in_metadata() {
+        let events = infer_usage_events(
+            None,
+            Some(
+                r#"{
+                    "tool_calls": [{"function": {"name": "tracedecay_search"}}],
+                    "tools": [{"tool_name": "apply_patch"}]
+                }"#,
+            ),
+            None,
+        );
+        assert!(
+            events.is_empty(),
+            "tool usage should come from explicit tool fields, got {events:#?}"
+        );
+    }
+
+    #[test]
+    fn shell_command_metadata_refines_category() {
+        let events = infer_usage_events(
+            Some("functions.exec_command"),
+            Some(r#"{"cmd":"rg -n \"analytics\" src tests"}"#),
+            None,
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Tool,
+            "functions.exec_command",
+            UsageCategory::BroadFileSearch,
+        );
+    }
+
+    #[test]
+    fn infers_skills_from_metadata_and_text() {
+        let events = infer_usage_events(
+            None,
+            Some(r#"{"context":{"skills":["tracedecay:searching-for-code"]}}"#),
+            Some("Using `build-web-apps:react-best-practices`."),
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "tracedecay:searching-for-code",
+            UsageCategory::TraceDecayWorkflowSkill,
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "build-web-apps:react-best-practices",
+            UsageCategory::WorkflowSkill,
+        );
+    }
+
+    #[test]
+    fn ignores_url_and_path_like_colon_tokens() {
+        let events = infer_usage_events(
+            None,
+            Some(r#"{"url":"https://example.com/a:b","path":"C:\\tmp\\SKILL.md"}"#),
+            Some("Also ignore file:///tmp/tracedecay:searching-for-code"),
+        );
+        assert!(
+            events.is_empty(),
+            "url and path strings should not become skills, got {events:#?}"
+        );
+    }
+
+    #[test]
+    fn normalizes_punctuation_wrapped_skill_mentions() {
+        let events = infer_usage_events(
+            None,
+            None,
+            Some("Using `tracedecay:reading-code-cheaply`, then continue."),
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "tracedecay:reading-code-cheaply",
+            UsageCategory::TraceDecayWorkflowSkill,
+        );
+    }
+
+    #[test]
+    fn infers_codex_skill_usage_from_real_prose_shape() {
+        let events = infer_usage_events(
+            None,
+            Some(r#"{"source":"codex_rollout"}"#),
+            Some(include_str!(
+                "../tests/fixtures/analytics/codex_skill_prose.txt"
+            )),
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "superpowers:using-superpowers",
+            UsageCategory::WorkflowSkill,
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "tracedecay:reading-code-cheaply",
+            UsageCategory::TraceDecayWorkflowSkill,
+        );
+    }
+
+    #[test]
+    fn infers_cursor_skill_reads_from_real_tool_use_shape() {
+        let events = infer_usage_events(
+            Some("ReadFile"),
+            Some(r#"{"raw_type":null,"source":"cursor_transcript"}"#),
+            Some(include_str!(
+                "../tests/fixtures/analytics/cursor_skill_read_text.json"
+            )),
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Tool,
+            "readfile",
+            UsageCategory::BroadFileSearch,
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "tracedecay:curating-project-memory",
+            UsageCategory::TraceDecayWorkflowSkill,
+        );
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "superpowers:using-superpowers",
+            UsageCategory::WorkflowSkill,
+        );
+    }
+
+    #[test]
+    fn infers_hermes_skill_view_from_real_metadata_and_result_shapes() {
+        let events = infer_usage_events(
+            Some("skill_view"),
+            Some(include_str!(
+                "../tests/fixtures/analytics/hermes_skill_view_metadata.json"
+            )),
+            Some(include_str!(
+                "../tests/fixtures/analytics/hermes_skill_view_text.json"
+            )),
+        );
+        assert_usage_event(&events, UsageKind::Tool, "skill_view", UsageCategory::Other);
+        assert_usage_event(
+            &events,
+            UsageKind::Skill,
+            "github-pr-workflow",
+            UsageCategory::WorkflowSkill,
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == UsageKind::Skill)
+                .count(),
+            1,
+            "skill_view should count one canonical skill event, got {events:#?}",
+        );
+    }
+
+    #[test]
+    fn ignores_colon_tokens_without_skill_context() {
+        let events = infer_usage_events(
+            None,
+            Some(
+                r#"{
+                    "scripts": {"test:ui": "vitest"},
+                    "query": "is:pr filetype:pdf",
+                    "time": "07:49"
+                }"#,
+            ),
+            Some("Aspect ratio 16:9, script bench:full, and tool MCP:browser_navigate."),
+        );
+        assert!(
+            events.is_empty(),
+            "unanchored colon tokens should not become skills, got {events:#?}"
+        );
+    }
+}

--- a/src/dashboard/analytics_api.rs
+++ b/src/dashboard/analytics_api.rs
@@ -1,0 +1,519 @@
+//! Read-only durable analytics API for dashboard-level agent behavior.
+//!
+//! Durable `analytics_events` rows are preferred when available. Older session
+//! stores still get session-message usage rollups, and hint lifecycle telemetry
+//! falls back to the legacy `dashboard_hint_events` table when present.
+
+use std::collections::BTreeMap;
+
+use axum::extract::State;
+use axum::response::Json;
+use serde_json::{json, Value};
+
+use crate::analytics::{categorize_skill, infer_usage_events, UsageKind};
+use crate::global_db::{AnalyticsEventQuery, AnalyticsEventRecord, GlobalDb};
+
+use super::util::{i64_field, query_i64, query_rows, str_field};
+use super::DashboardState;
+
+const HINT_CATEGORIES: &[&str] = &[
+    "search",
+    "semantic_search",
+    "file_read",
+    "broad_read",
+    "call_graph",
+    "impact",
+    "symbol_lookup",
+    "file_lookup",
+    "explore_subagent",
+    "subagent_start_context",
+];
+const ANALYTICS_EVENT_LIMIT: usize = 10_000;
+
+#[derive(Default)]
+struct FamilyCounts {
+    relevant_events: i64,
+    usage_events: i64,
+}
+
+#[derive(Default)]
+struct HintCounts {
+    emitted: i64,
+    followed: i64,
+    ignored: i64,
+    suppressed: i64,
+}
+
+/// `GET /api/plugins/analytics/overview`
+pub(crate) async fn overview(State(state): State<DashboardState>) -> Json<Value> {
+    let durable_events = durable_analytics_rows_for_state(&state).await;
+    let hints = hint_summary(state.lcm_conn.as_ref(), durable_events.as_deref()).await;
+    let usage = usage_summary(state.lcm_conn.as_ref(), durable_events.as_deref()).await;
+    let underused = underused_tool_families(state.lcm_conn.as_ref()).await;
+
+    Json(json!({
+        "available": state.lcm_conn.is_some() || durable_events.is_some(),
+        "db": state.lcm_db_path,
+        "scope": state.lcm_scope,
+        "hints": hints,
+        "usage": usage,
+        "underused_tool_families": underused,
+    }))
+}
+
+/// `GET /api/plugins/analytics/hints`
+pub(crate) async fn hints(State(state): State<DashboardState>) -> Json<Value> {
+    let durable_events = durable_analytics_rows_for_state(&state).await;
+    Json(hint_summary(state.lcm_conn.as_ref(), durable_events.as_deref()).await)
+}
+
+/// `GET /api/plugins/analytics/usage`
+pub(crate) async fn usage(State(state): State<DashboardState>) -> Json<Value> {
+    let durable_events = durable_analytics_rows_for_state(&state).await;
+    Json(usage_summary(state.lcm_conn.as_ref(), durable_events.as_deref()).await)
+}
+
+/// `GET /api/plugins/analytics/underused`
+pub(crate) async fn underused(State(state): State<DashboardState>) -> Json<Value> {
+    Json(json!({
+        "available": state.lcm_conn.is_some(),
+        "db": state.lcm_db_path,
+        "families": underused_tool_families(state.lcm_conn.as_ref()).await,
+    }))
+}
+
+fn empty_hint_rows() -> Vec<Value> {
+    HINT_CATEGORIES
+        .iter()
+        .map(|category| {
+            json!({
+                "category": category,
+                "emitted": 0,
+                "followed": 0,
+                "ignored": 0,
+                "suppressed": 0,
+            })
+        })
+        .collect()
+}
+
+async fn durable_analytics_rows_for_state(state: &DashboardState) -> Option<Vec<Value>> {
+    durable_analytics_rows(
+        state.savings_db.as_deref(),
+        state.lcm_conn.as_ref(),
+        &GlobalDb::canonical_project_key(&state.project_root),
+    )
+    .await
+}
+
+async fn durable_analytics_rows(
+    global_db: Option<&GlobalDb>,
+    lcm_conn: Option<&libsql::Connection>,
+    project_id: &str,
+) -> Option<Vec<Value>> {
+    if let Some(db) = global_db {
+        if let Ok(events) = db
+            .query_analytics_events(&AnalyticsEventQuery {
+                provider: None,
+                project_id: Some(project_id.to_string()),
+                session_id: None,
+                event_kind: None,
+                limit: ANALYTICS_EVENT_LIMIT,
+            })
+            .await
+        {
+            if !events.is_empty() {
+                return Some(events.iter().map(durable_analytics_event_row).collect());
+            }
+        }
+    }
+
+    let rows = query_rows(
+        lcm_conn?,
+        "SELECT event_kind, tool_name, tool_category, skill_name,
+                hint_category, outcome, metadata_json
+         FROM (
+             SELECT event_kind, tool_name, tool_category, skill_name,
+                    hint_category, outcome, metadata_json, timestamp, id
+             FROM analytics_events
+             WHERE project_id = ?1
+             ORDER BY timestamp DESC, id DESC
+             LIMIT 10000
+         )
+         ORDER BY timestamp, id",
+        libsql::params![project_id],
+    )
+    .await
+    .ok()?;
+    if rows.is_empty() {
+        None
+    } else {
+        Some(rows)
+    }
+}
+
+fn durable_analytics_event_row(event: &AnalyticsEventRecord) -> Value {
+    json!({
+        "event_kind": &event.event_kind,
+        "tool_name": &event.tool_name,
+        "tool_category": &event.tool_category,
+        "skill_name": &event.skill_name,
+        "hint_category": &event.hint_category,
+        "outcome": &event.outcome,
+        "metadata_json": &event.metadata_json,
+    })
+}
+
+fn hint_summary_from_events(events: &[Value]) -> Value {
+    let mut by_category: BTreeMap<String, HintCounts> = HINT_CATEGORIES
+        .iter()
+        .map(|category| ((*category).to_string(), HintCounts::default()))
+        .collect();
+
+    for event in events {
+        let category = str_field(event, "hint_category");
+        if category.is_empty() {
+            continue;
+        }
+        let counts = by_category.entry(category.to_string()).or_default();
+        match normalize(str_field(event, "outcome")).as_str() {
+            "emitted" | "shown" => counts.emitted += 1,
+            "followed" => counts.followed += 1,
+            "ignored" => counts.ignored += 1,
+            "suppressed" => counts.suppressed += 1,
+            _ => {}
+        }
+    }
+
+    json!({
+        "available": true,
+        "source": "analytics_events",
+        "by_category": by_category.into_iter().map(|(category, counts)| {
+            json!({
+                "category": category,
+                "emitted": counts.emitted,
+                "followed": counts.followed,
+                "ignored": counts.ignored,
+                "suppressed": counts.suppressed,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+async fn hint_summary(
+    conn: Option<&libsql::Connection>,
+    durable_events: Option<&[Value]>,
+) -> Value {
+    if let Some(events) = durable_events {
+        return hint_summary_from_events(events);
+    }
+
+    let Some(conn) = conn else {
+        return json!({
+            "available": false,
+            "source": "session_store_unavailable",
+            "by_category": empty_hint_rows(),
+        });
+    };
+
+    let has_table = query_i64(
+        conn,
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type IN ('table', 'view') AND name = 'dashboard_hint_events'",
+        (),
+    )
+    .await
+        > 0;
+    if !has_table {
+        return json!({
+            "available": false,
+            "source": "dashboard_hint_events_missing",
+            "by_category": empty_hint_rows(),
+        });
+    }
+
+    let rows = match query_rows(
+        conn,
+        "SELECT category,
+                SUM(CASE WHEN event_type = 'emitted' THEN 1 ELSE 0 END) AS emitted,
+                SUM(CASE WHEN event_type = 'followed' THEN 1 ELSE 0 END) AS followed,
+                SUM(CASE WHEN event_type = 'ignored' THEN 1 ELSE 0 END) AS ignored,
+                SUM(CASE WHEN event_type = 'suppressed' THEN 1 ELSE 0 END) AS suppressed
+         FROM dashboard_hint_events
+         GROUP BY category
+         ORDER BY category",
+        (),
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(err) => {
+            return json!({
+                "available": false,
+                "source": "dashboard_hint_events_error",
+                "error": err,
+                "by_category": empty_hint_rows(),
+            });
+        }
+    };
+
+    let mut by_category: BTreeMap<String, Value> = empty_hint_rows()
+        .into_iter()
+        .map(|row| (str_field(&row, "category").to_string(), row))
+        .collect();
+    for row in rows {
+        let category = str_field(&row, "category");
+        by_category.insert(
+            category.to_string(),
+            json!({
+                "category": category,
+                "emitted": i64_field(&row, "emitted"),
+                "followed": i64_field(&row, "followed"),
+                "ignored": i64_field(&row, "ignored"),
+                "suppressed": i64_field(&row, "suppressed"),
+            }),
+        );
+    }
+
+    json!({
+        "available": true,
+        "source": "dashboard_hint_events",
+        "by_category": by_category.into_values().collect::<Vec<_>>(),
+    })
+}
+
+async fn session_message_rows(conn: Option<&libsql::Connection>) -> Option<Vec<Value>> {
+    let conn = conn?;
+    query_rows(
+        conn,
+        "SELECT COALESCE(tool_names, '') AS tool_names,
+                COALESCE(text, '') AS text,
+                COALESCE(metadata_json, '') AS metadata_json
+         FROM session_messages
+         ORDER BY timestamp, ordinal
+         LIMIT 10000",
+        (),
+    )
+    .await
+    .ok()
+}
+
+fn usage_summary_from_events(events: &[Value]) -> Value {
+    let mut counts: BTreeMap<(String, String), i64> = BTreeMap::new();
+    for event in events {
+        let event_kind = str_field(event, "event_kind");
+        let tool_name = str_field(event, "tool_name");
+        let skill_name = str_field(event, "skill_name");
+        let metadata_json = str_field(event, "metadata_json");
+        record_event_usage(
+            &mut counts,
+            event_kind,
+            tool_name,
+            skill_name,
+            metadata_json,
+        );
+    }
+
+    json!({
+        "available": true,
+        "source": "analytics_events",
+        "message_count": events.len() as i64,
+        "event_count": events.len() as i64,
+        "by_category": usage_count_rows(counts),
+    })
+}
+
+fn record_event_usage(
+    counts: &mut BTreeMap<(String, String), i64>,
+    event_kind: &str,
+    tool_name: &str,
+    skill_name: &str,
+    metadata_json: &str,
+) {
+    let inferred = match event_kind {
+        "tool" | "mcp_tool_call" => infer_usage_events(Some(tool_name), Some(metadata_json), None),
+        "skill" => infer_usage_events(None, Some(metadata_json), Some(skill_name)),
+        _ => Vec::new(),
+    };
+
+    if inferred.is_empty() {
+        record_fallback_usage(counts, event_kind, skill_name);
+        return;
+    }
+
+    for event in inferred {
+        record_usage_count(counts, event.kind, event.category.dashboard_label());
+    }
+}
+
+fn record_fallback_usage(
+    counts: &mut BTreeMap<(String, String), i64>,
+    event_kind: &str,
+    skill_name: &str,
+) {
+    match event_kind {
+        "tool" | "mcp_tool_call" => increment_usage_count(counts, "tool", "other_tool"),
+        "skill" if !skill_name.is_empty() => {
+            increment_usage_count(
+                counts,
+                "skill",
+                categorize_skill(skill_name).dashboard_label(),
+            );
+        }
+        _ => {}
+    }
+}
+
+fn record_usage_count(
+    counts: &mut BTreeMap<(String, String), i64>,
+    kind: UsageKind,
+    category: &str,
+) {
+    let kind = match kind {
+        UsageKind::Tool => "tool",
+        UsageKind::Skill => "skill",
+    };
+    increment_usage_count(counts, kind, category);
+}
+
+fn increment_usage_count(counts: &mut BTreeMap<(String, String), i64>, kind: &str, category: &str) {
+    *counts
+        .entry((kind.to_string(), category.to_string()))
+        .or_default() += 1;
+}
+
+async fn usage_summary(
+    conn: Option<&libsql::Connection>,
+    durable_events: Option<&[Value]>,
+) -> Value {
+    if let Some(events) = durable_events {
+        return usage_summary_from_events(events);
+    }
+
+    let Some(rows) = session_message_rows(conn).await else {
+        return json!({
+            "available": false,
+            "message_count": 0,
+            "by_category": [],
+        });
+    };
+
+    let mut counts: BTreeMap<(String, String), i64> = BTreeMap::new();
+    for row in &rows {
+        for event in infer_usage_events(
+            Some(str_field(row, "tool_names")),
+            Some(str_field(row, "metadata_json")),
+            Some(str_field(row, "text")),
+        ) {
+            record_usage_count(&mut counts, event.kind, event.category.dashboard_label());
+        }
+    }
+
+    json!({
+        "available": true,
+        "message_count": rows.len() as i64,
+        "by_category": usage_count_rows(counts),
+    })
+}
+
+fn usage_count_rows(counts: BTreeMap<(String, String), i64>) -> Vec<Value> {
+    counts
+        .into_iter()
+        .map(|((kind, category), events)| {
+            json!({
+                "kind": kind,
+                "category": category,
+                "events": events,
+            })
+        })
+        .collect()
+}
+
+async fn underused_tool_families(conn: Option<&libsql::Connection>) -> Value {
+    let Some(rows) = session_message_rows(conn).await else {
+        return Value::Array(Vec::new());
+    };
+
+    let mut families: BTreeMap<String, FamilyCounts> = [
+        ("code_context".to_string(), FamilyCounts::default()),
+        ("code_search".to_string(), FamilyCounts::default()),
+        ("call_graph".to_string(), FamilyCounts::default()),
+        ("impact_analysis".to_string(), FamilyCounts::default()),
+    ]
+    .into_iter()
+    .collect();
+
+    for row in &rows {
+        let text = str_field(row, "text");
+        for event in infer_usage_events(
+            Some(str_field(row, "tool_names")),
+            Some(str_field(row, "metadata_json")),
+            Some(text),
+        ) {
+            if event.kind == UsageKind::Tool {
+                record_tool_family(&mut families, &event.name, text);
+            }
+        }
+    }
+
+    Value::Array(
+        families
+            .into_iter()
+            .map(|(family, counts)| {
+                let missed = counts.relevant_events.saturating_sub(counts.usage_events);
+                json!({
+                    "family": family,
+                    "relevant_events": counts.relevant_events,
+                    "usage_events": counts.usage_events,
+                    "missed_events": missed,
+                    "underused": missed > 0,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn record_tool_family(families: &mut BTreeMap<String, FamilyCounts>, tool: &str, text: &str) {
+    let normalized = normalize(tool);
+    let text = text.to_ascii_lowercase();
+    if normalized.contains("tracedecay_context")
+        || normalized.contains("tracedecay_node")
+        || normalized.contains("tracedecay_files")
+    {
+        increment_family_usage(families, "code_context");
+    }
+    if normalized.contains("tracedecay_search") || normalized.contains("find_exact_symbol") {
+        increment_family_usage(families, "code_search");
+    }
+    if normalized.contains("tracedecay_call") || normalized.contains("tracedecay_graph") {
+        increment_family_usage(families, "call_graph");
+    }
+    if normalized.contains("tracedecay_impact") || normalized.contains("tracedecay_affected") {
+        increment_family_usage(families, "impact_analysis");
+    }
+
+    if normalized == "read" || normalized == "cat" || normalized == "sed" {
+        increment_family_relevance(families, "code_context");
+    }
+    if matches!(normalized.as_str(), "grep" | "rg" | "glob" | "search")
+        || (matches!(normalized.as_str(), "bash" | "shell" | "exec_command")
+            && (text.contains(" rg ") || text.contains("grep") || text.contains("find ")))
+    {
+        increment_family_relevance(families, "code_search");
+    }
+}
+
+fn increment_family_usage(families: &mut BTreeMap<String, FamilyCounts>, family: &str) {
+    families.entry(family.to_string()).or_default().usage_events += 1;
+}
+
+fn increment_family_relevance(families: &mut BTreeMap<String, FamilyCounts>, family: &str) {
+    families
+        .entry(family.to_string())
+        .or_default()
+        .relevant_events += 1;
+}
+
+fn normalize(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace('-', "_")
+}

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -21,6 +21,7 @@
 //! `/api/capabilities` advertises which features are live so hosts (or a
 //! richer Hermes wrapper) can extend the surface without forking the UI.
 
+mod analytics_api;
 pub(crate) mod assets;
 mod curate_preview_store;
 mod graph_api;
@@ -413,6 +414,17 @@ pub(crate) fn router(state: DashboardState) -> Router {
         )
         .route("/api/plugins/graph/subgraph", get(graph_api::subgraph))
         .route("/api/plugins/graph/path", get(graph_api::path))
+        // Durable analytics API (hint lifecycle scaffolds + session usage rollups)
+        .route(
+            "/api/plugins/analytics/overview",
+            get(analytics_api::overview),
+        )
+        .route("/api/plugins/analytics/hints", get(analytics_api::hints))
+        .route("/api/plugins/analytics/usage", get(analytics_api::usage))
+        .route(
+            "/api/plugins/analytics/underused",
+            get(analytics_api::underused),
+        )
         // Savings & Cost API (savings ledger + session cost accounting)
         .route("/api/plugins/savings/overview", get(savings_api::overview))
         .route("/api/plugins/savings/ledger", get(savings_api::ledger))
@@ -444,6 +456,7 @@ async fn capabilities(State(state): State<DashboardState>) -> Json<Value> {
             "lcm_gc": has_lcm,
             "lcm_payload_health": has_lcm,
             "graph": true,
+            "analytics": true,
             // Similarity-based dedup curation (delete/merge ops via /curate
             // and /curate/apply). LLM-proposed curation is a host-side
             // extension (the Hermes wrapper flips llm_curation when it adds

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -2094,7 +2094,10 @@ impl GlobalDb {
             i64::try_from(query.limit).unwrap_or(i64::MAX),
         ));
         let limit_param = values.len();
-        let _ = write!(sql, " ORDER BY timestamp, id LIMIT ?{limit_param}");
+        let _ = write!(
+            sql,
+            " ORDER BY timestamp DESC, id DESC LIMIT ?{limit_param}"
+        );
 
         let mut rows = self
             .conn
@@ -2111,6 +2114,7 @@ impl GlobalDb {
                 .ok_or_else(|| "failed to decode analytics event row".to_string())?;
             events.push(event);
         }
+        events.reverse();
         Ok(events)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod accounting;
 pub mod agents;
+mod analytics;
 pub mod bench;
 pub mod branch;
 pub mod branch_meta;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use serde_json::{json, Value};
 
 use crate::errors::{Result, TraceDecayError};
-use crate::global_db::GlobalDb;
+use crate::global_db::{AnalyticsEventInsert, GlobalDb};
 use crate::mcp::response_handles::{
     cleanup_expired_response_handles, response_handle_stats_json, RESPONSE_RETRIEVE_TOOL,
 };
@@ -356,6 +356,36 @@ fn tool_error_response(id: Value, tool_name: &str, error: &TraceDecayError) -> J
         ErrorCode::InternalError,
         format!("tool execution failed: {error}"),
     )
+}
+
+fn hardcoded_internal_error_response(id: &Value, detail: &str) -> String {
+    let id_json = serde_json::to_string(id).unwrap_or_else(|_| "null".to_string());
+    let detail_json = serde_json::to_string(detail)
+        .unwrap_or_else(|_| "\"response serialization failed\"".to_string());
+    format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":{id_json},\"error\":{{\"code\":-32603,\"message\":\"failed to serialize JSON-RPC response\",\"data\":{{\"reason_code\":\"response_serialization_failed\",\"detail\":{detail_json}}}}}}}"
+    )
+}
+
+fn serialize_response_line(resp: &JsonRpcResponse) -> String {
+    match serde_json::to_string(resp) {
+        Ok(line) => line,
+        Err(e) => {
+            eprintln!("failed to serialize response: {e}");
+            let fallback = JsonRpcResponse::error_with_data(
+                resp.id.clone(),
+                ErrorCode::InternalError,
+                "failed to serialize JSON-RPC response".to_string(),
+                Some(json!({
+                    "reason_code": "response_serialization_failed",
+                    "detail": e.to_string(),
+                })),
+            );
+            serde_json::to_string(&fallback).unwrap_or_else(|fallback_err| {
+                hardcoded_internal_error_response(&resp.id, &fallback_err.to_string())
+            })
+        }
+    }
 }
 
 /// Cached result of a latest-version check against GitHub releases.
@@ -956,7 +986,7 @@ impl McpServer {
             )),
         };
         if let Some(resp) = response {
-            let mut json_str = serde_json::to_string(&resp).unwrap_or_default();
+            let mut json_str = serialize_response_line(&resp);
             json_str.push('\n');
             transport.write_line(&json_str).await?;
             transport.flush().await?;
@@ -1054,13 +1084,7 @@ impl McpServer {
 
             // Write response (if any) as a single line to stdout
             if let Some(resp) = response {
-                let json_line = match serde_json::to_string(&resp) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        eprintln!("failed to serialize response: {e}");
-                        continue;
-                    }
-                };
+                let json_line = serialize_response_line(&resp);
                 let output = format!("{json_line}\n");
                 if let Err(e) = transport.write_line(&output).await {
                     eprintln!("failed to write response: {e}");
@@ -1501,6 +1525,7 @@ impl McpServer {
         };
 
         let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
+        let analytics_session_id = mcp_analytics_session_id(&arguments);
 
         // Branch-drift hot-swap: if the working tree switched branches since
         // the served instance opened, reopen onto the live branch's DB so
@@ -1533,6 +1558,7 @@ impl McpServer {
         let dispatch_outcome =
             handle_tool_call(&cg, tool_name, arguments, server_stats, self.scope_prefix()).await;
         let handler_elapsed_us = handler_start.map(|t| t.elapsed().as_micros() as u64);
+        let request_id = id.clone();
         match dispatch_outcome {
             Ok(mut result) => {
                 if let Some(us) = handler_elapsed_us {
@@ -1586,6 +1612,11 @@ impl McpServer {
                         )}));
                     }
                 }
+                let analytics_outcome = if tool_result_has_semantic_error(&result.value) {
+                    "error"
+                } else {
+                    "success"
+                };
 
                 // Persist to the cross-project savings ledger (best-effort, non-blocking).
                 // Clone the Arc — no new connection is opened. The counters
@@ -1593,13 +1624,21 @@ impl McpServer {
                 // [`Self::ledger_writes_settled`] without making it awaited
                 // anywhere on the request path.
                 if let Some(gdb) = self.global_db.clone() {
-                    let project_path_str = cg.project_root().to_string_lossy().to_string();
+                    let project_path_str = GlobalDb::canonical_project_key(cg.project_root());
                     let tool_name_owned = tool_name.to_string();
                     let ts = crate::tracedecay::current_timestamp();
-                    self.ledger_writes_started.fetch_add(1, Ordering::SeqCst);
-                    let finished = self.ledger_writes_finished.clone();
-                    let notify = self.ledger_write_notify.clone();
-                    tokio::spawn(async move {
+                    let analytics_event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
+                        project_root: cg.project_root(),
+                        session_id: analytics_session_id.clone(),
+                        tool_name,
+                        outcome: analytics_outcome,
+                        raw_file_tokens,
+                        response_tokens,
+                        net_saved_tokens,
+                        timestamp: ts,
+                        request_id: &request_id,
+                    });
+                    self.spawn_observed_ledger_write(async move {
                         gdb.record_savings(
                             &project_path_str,
                             &tool_name_owned,
@@ -1608,8 +1647,9 @@ impl McpServer {
                             ts,
                         )
                         .await;
-                        finished.fetch_add(1, Ordering::SeqCst);
-                        notify.notify_waiters();
+                        if let Err(e) = gdb.append_analytics_event(&analytics_event).await {
+                            eprintln!("[tracedecay] analytics_events insert failed: {e}");
+                        }
                     });
                 }
 
@@ -1743,8 +1783,58 @@ impl McpServer {
                 mark_semantic_tool_error(&mut result.value);
                 JsonRpcResponse::success(id, result.value)
             }
-            Err(e) => tool_error_response(id, tool_name, &e),
+            Err(e) => {
+                self.record_mcp_tool_error_analytics(
+                    cg.project_root(),
+                    analytics_session_id,
+                    tool_name,
+                    &request_id,
+                );
+                tool_error_response(id, tool_name, &e)
+            }
         }
+    }
+
+    fn record_mcp_tool_error_analytics(
+        &self,
+        project_root: &std::path::Path,
+        session_id: Option<String>,
+        tool_name: &str,
+        request_id: &Value,
+    ) {
+        let Some(gdb) = self.global_db.clone() else {
+            return;
+        };
+        let event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
+            project_root,
+            session_id,
+            tool_name,
+            outcome: "error",
+            raw_file_tokens: 0,
+            response_tokens: 0,
+            net_saved_tokens: 0,
+            timestamp: crate::tracedecay::current_timestamp(),
+            request_id,
+        });
+        self.spawn_observed_ledger_write(async move {
+            if let Err(e) = gdb.append_analytics_event(&event).await {
+                eprintln!("[tracedecay] analytics_events insert failed: {e}");
+            }
+        });
+    }
+
+    fn spawn_observed_ledger_write<F>(&self, future: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        self.ledger_writes_started.fetch_add(1, Ordering::SeqCst);
+        let finished = self.ledger_writes_finished.clone();
+        let notify = self.ledger_write_notify.clone();
+        tokio::spawn(async move {
+            future.await;
+            finished.fetch_add(1, Ordering::SeqCst);
+            notify.notify_waiters();
+        });
     }
 
     /// Returns the current server runtime statistics as a JSON value.
@@ -1787,6 +1877,63 @@ impl McpServer {
         }
 
         stats
+    }
+}
+
+fn mcp_analytics_session_id(arguments: &Value) -> Option<String> {
+    fn string_field(value: &Value, key: &str) -> Option<String> {
+        value
+            .get(key)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
+    [Some(arguments), arguments.get("_meta")]
+        .into_iter()
+        .flatten()
+        .find_map(|value| {
+            string_field(value, "session_id").or_else(|| string_field(value, "sessionId"))
+        })
+}
+
+struct McpToolAnalyticsEvent<'a> {
+    project_root: &'a std::path::Path,
+    session_id: Option<String>,
+    tool_name: &'a str,
+    outcome: &'a str,
+    raw_file_tokens: u64,
+    response_tokens: u64,
+    net_saved_tokens: u64,
+    timestamp: i64,
+    request_id: &'a Value,
+}
+
+fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventInsert {
+    let category = crate::accounting::classifier::classify(&[input.tool_name], &[]);
+    AnalyticsEventInsert {
+        provider: "mcp".to_string(),
+        project_id: GlobalDb::canonical_project_key(input.project_root),
+        session_id: input.session_id,
+        timestamp: input.timestamp,
+        event_kind: "mcp_tool_call".to_string(),
+        hook_name: None,
+        tool_name: Some(input.tool_name.to_string()),
+        tool_category: Some(category.as_str().to_string()),
+        skill_name: None,
+        hint_category: None,
+        hint_id: None,
+        outcome: Some(input.outcome.to_string()),
+        metadata_json: Some(
+            json!({
+                "request_id": input.request_id,
+                "before_tokens": input.raw_file_tokens,
+                "after_tokens": input.response_tokens,
+                "tokens_saved": input.net_saved_tokens,
+            })
+            .to_string(),
+        ),
     }
 }
 

--- a/tests/dashboard_analytics_api_test.rs
+++ b/tests/dashboard_analytics_api_test.rs
@@ -1,0 +1,427 @@
+//! Integration tests for dashboard durable analytics endpoints.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use common::{
+    create_runtime, get_json, http_agent, message_record_at, pick_free_port, wait_for_dashboard,
+    EnvVarGuard,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+use tracedecay::dashboard;
+use tracedecay::global_db::{AnalyticsEventInsert, GlobalDb};
+use tracedecay::sessions::cursor::project_session_db_path;
+use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
+use tracedecay::tracedecay::TraceDecay;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct Fixture {
+    _tmp: TempDir,
+    _env_guard: EnvVarGuard,
+    base_url: String,
+    server: tokio::task::JoinHandle<()>,
+    project_root: PathBuf,
+    global_db_path: PathBuf,
+    session_db_path: PathBuf,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+fn session(project: &Path) -> SessionRecord {
+    SessionRecord {
+        provider: "codex".to_string(),
+        session_id: "analytics-session".to_string(),
+        project_key: "analytics-fixture".to_string(),
+        project_path: project.display().to_string(),
+        title: Some("Analytics fixture".to_string()),
+        started_at: Some(1_760_000_000),
+        ended_at: None,
+        transcript_path: None,
+        metadata_json: None,
+        parent_session_id: None,
+        is_subagent: false,
+        agent_id: None,
+        parent_tool_use_id: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn message(
+    id: &str,
+    role: &str,
+    ordinal: i64,
+    text: &str,
+    kind: &str,
+    tool_names: Option<&str>,
+    metadata_json: Option<&str>,
+) -> SessionMessageRecord {
+    message_record_at(
+        "codex",
+        id,
+        "analytics-session",
+        role,
+        ordinal,
+        Some(1_760_000_000 + ordinal),
+        text,
+        kind,
+        Some("gpt-5.5"),
+        tool_names,
+        None,
+        None,
+        metadata_json,
+    )
+}
+
+async fn seed_session_store(db_path: &Path, project: &Path) {
+    let gdb = GlobalDb::open_at(db_path).await.expect("open session db");
+    assert!(gdb.upsert_session(&session(project)).await);
+
+    let rows = [
+        message(
+            "msg-1",
+            "assistant",
+            1,
+            "Using tracedecay:searching-for-code before shell search.",
+            "message",
+            Some("mcp__tracedecay__tracedecay_context,mcp__tracedecay__tracedecay_search"),
+            Some(r#"{"skills":["tracedecay:searching-for-code"]}"#),
+        ),
+        message(
+            "msg-2",
+            "assistant",
+            2,
+            "Falling back to rg for a literal route path.",
+            "tool_use",
+            Some("Bash,rg"),
+            None,
+        ),
+        message(
+            "msg-3",
+            "assistant",
+            3,
+            "Reading one file after indexed context.",
+            "tool_use",
+            Some("Read"),
+            None,
+        ),
+        message(
+            "msg-4",
+            "assistant",
+            4,
+            "Applying focused route edits.",
+            "tool_use",
+            Some("apply_patch"),
+            None,
+        ),
+    ];
+
+    for row in rows {
+        assert!(gdb.upsert_session_message(&row).await);
+    }
+}
+
+fn analytics_event(project_id: &str, timestamp: i64, event_kind: &str) -> AnalyticsEventInsert {
+    AnalyticsEventInsert {
+        provider: "codex".to_string(),
+        project_id: project_id.to_string(),
+        session_id: Some("analytics-session".to_string()),
+        timestamp,
+        event_kind: event_kind.to_string(),
+        hook_name: None,
+        tool_name: None,
+        tool_category: None,
+        skill_name: None,
+        hint_category: None,
+        hint_id: None,
+        outcome: None,
+        metadata_json: None,
+    }
+}
+
+async fn seed_durable_analytics(db_path: &Path, project_root: &Path) {
+    let gdb = GlobalDb::open_at(db_path).await.expect("open global db");
+    let project_id = GlobalDb::canonical_project_key(project_root);
+    let rows = [
+        AnalyticsEventInsert {
+            hint_category: Some("search".to_string()),
+            hint_id: Some("hint-search".to_string()),
+            outcome: Some("shown".to_string()),
+            ..analytics_event(&project_id, 1_760_000_100, "hint")
+        },
+        AnalyticsEventInsert {
+            tool_name: Some("mcp__tracedecay__tracedecay_context".to_string()),
+            tool_category: Some("mcp".to_string()),
+            outcome: Some("success".to_string()),
+            ..analytics_event(&project_id, 1_760_000_101, "mcp_tool_call")
+        },
+        AnalyticsEventInsert {
+            skill_name: Some("superpowers:test-driven-development".to_string()),
+            outcome: Some("used".to_string()),
+            ..analytics_event(&project_id, 1_760_000_102, "skill")
+        },
+        AnalyticsEventInsert {
+            tool_name: Some("mcp__tracedecay__tracedecay_context".to_string()),
+            tool_category: Some("mcp".to_string()),
+            outcome: Some("success".to_string()),
+            ..analytics_event("other-project", 1_760_000_103, "mcp_tool_call")
+        },
+    ];
+    for row in rows {
+        gdb.append_analytics_event(&row)
+            .await
+            .expect("append durable analytics event");
+    }
+}
+
+async fn seed_durable_recent_window(db_path: &Path, project_root: &Path) {
+    let gdb = GlobalDb::open_at(db_path).await.expect("open global db");
+    let project_id = GlobalDb::canonical_project_key(project_root);
+    for offset in 0..10_000 {
+        gdb.append_analytics_event(&analytics_event(
+            &project_id,
+            1_760_000_000 + offset,
+            "older_noise",
+        ))
+        .await
+        .expect("append older durable analytics event");
+    }
+    gdb.append_analytics_event(&AnalyticsEventInsert {
+        skill_name: Some("superpowers:test-driven-development".to_string()),
+        outcome: Some("used".to_string()),
+        ..analytics_event(&project_id, 1_760_020_000, "skill")
+    })
+    .await
+    .expect("append recent durable analytics event");
+}
+
+async fn seed_fallback_analytics(db_path: &Path, project_root: &Path) {
+    let gdb = GlobalDb::open_at(db_path).await.expect("open session db");
+    let project_id = GlobalDb::canonical_project_key(project_root);
+    let rows = [
+        AnalyticsEventInsert {
+            hint_category: Some("search".to_string()),
+            hint_id: Some("hint-search".to_string()),
+            outcome: Some("shown".to_string()),
+            ..analytics_event(&project_id, 1_760_000_200, "hint")
+        },
+        AnalyticsEventInsert {
+            skill_name: Some("superpowers:test-driven-development".to_string()),
+            outcome: Some("used".to_string()),
+            ..analytics_event(&project_id, 1_760_000_201, "skill")
+        },
+        AnalyticsEventInsert {
+            tool_name: Some("mcp__tracedecay__tracedecay_context".to_string()),
+            tool_category: Some("mcp".to_string()),
+            outcome: Some("success".to_string()),
+            ..analytics_event("other-project", 1_760_000_202, "mcp_tool_call")
+        },
+    ];
+    for row in rows {
+        gdb.append_analytics_event(&row)
+            .await
+            .expect("append fallback analytics event");
+    }
+}
+
+async fn start_fixture(seed_durable_events: bool) -> Fixture {
+    let tmp = TempDir::new().expect("temp dir");
+    let project_root = tmp.path().join("project");
+    std::fs::create_dir_all(&project_root).expect("project dir");
+    std::fs::write(
+        project_root.join("lib.rs"),
+        "pub fn analytics_fixture() {}\n",
+    )
+    .expect("seed source file");
+
+    let global_db_path = tmp.path().join("global").join("global.db");
+    let env_guard = EnvVarGuard::set("TRACEDECAY_GLOBAL_DB", &global_db_path);
+    let cg = TraceDecay::init(&project_root)
+        .await
+        .expect("tracedecay init");
+    let session_db_path = project_session_db_path(&project_root);
+    seed_session_store(&session_db_path, &project_root).await;
+    if seed_durable_events {
+        seed_durable_analytics(&global_db_path, &project_root).await;
+    }
+
+    let port = pick_free_port();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let server = tokio::spawn(async move {
+        let _ = dashboard::run(&cg, "127.0.0.1", port, false).await;
+    });
+    wait_for_dashboard(&http_agent(), &base_url).await;
+
+    Fixture {
+        _tmp: tmp,
+        _env_guard: env_guard,
+        base_url,
+        server,
+        project_root,
+        global_db_path,
+        session_db_path,
+    }
+}
+
+fn find_row<'a>(rows: &'a Value, key: &str, value: &str) -> &'a Value {
+    rows.as_array()
+        .and_then(|items| items.iter().find(|row| row[key] == value))
+        .unwrap_or_else(|| panic!("missing row where {key}={value}: {rows:#}"))
+}
+
+fn assert_usage_row(usage: &Value, category: &str, events: i64, kind: &str) {
+    let row = find_row(usage, "category", category);
+    assert_eq!(row["events"], events);
+    assert_eq!(row["kind"], kind);
+}
+
+fn has_row(rows: &Value, key: &str, value: &str) -> bool {
+    rows.as_array()
+        .is_some_and(|items| items.iter().any(|row| row[key] == value))
+}
+
+#[test]
+fn analytics_api_advertises_and_aggregates_session_usage() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(false).await;
+        let agent = http_agent();
+
+        let (status, caps) = get_json(&agent, &format!("{}/api/capabilities", fixture.base_url));
+        assert_eq!(status, 200);
+        assert_eq!(caps["features"]["analytics"], true);
+        assert!(
+            caps["dashboards"]
+                .as_array()
+                .is_some_and(|dashboards| dashboards.iter().all(|name| name != "analytics")),
+            "capabilities should not advertise an analytics dashboard until a bundle exists"
+        );
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!("{}/api/plugins/analytics/overview", fixture.base_url),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(
+            overview["db"],
+            fixture.session_db_path.display().to_string()
+        );
+        assert_eq!(overview["hints"]["available"], false);
+        assert_eq!(overview["hints"]["by_category"][0]["emitted"], 0);
+
+        let usage = &overview["usage"]["by_category"];
+        assert_usage_row(usage, "tracedecay_mcp", 2, "tool");
+        assert_eq!(
+            find_row(usage, "category", "broad_code_context")["events"],
+            2
+        );
+        assert_usage_row(usage, "tracedecay_workflow_skill", 1, "skill");
+
+        let code_context = find_row(
+            &overview["underused_tool_families"],
+            "family",
+            "code_context",
+        );
+        assert_eq!(code_context["relevant_events"], 1);
+        assert_eq!(code_context["usage_events"], 1);
+        assert_eq!(code_context["underused"], false);
+    });
+}
+
+#[test]
+fn analytics_api_prefers_durable_events_when_available() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(true).await;
+        let agent = http_agent();
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!("{}/api/plugins/analytics/overview", fixture.base_url),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(overview["hints"]["source"], "analytics_events");
+        assert_eq!(overview["usage"]["source"], "analytics_events");
+
+        let search = find_row(&overview["hints"]["by_category"], "category", "search");
+        assert_eq!(search["emitted"], 1);
+
+        let usage = &overview["usage"]["by_category"];
+        assert_usage_row(usage, "tracedecay_mcp", 1, "tool");
+        assert_usage_row(usage, "workflow_skill", 1, "skill");
+    });
+}
+
+#[test]
+fn analytics_api_filters_fallback_events_to_current_project() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(false).await;
+        seed_fallback_analytics(&fixture.session_db_path, &fixture.project_root).await;
+        let agent = http_agent();
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!("{}/api/plugins/analytics/overview", fixture.base_url),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(overview["hints"]["source"], "analytics_events");
+        assert_eq!(overview["usage"]["source"], "analytics_events");
+
+        let search = find_row(&overview["hints"]["by_category"], "category", "search");
+        assert_eq!(search["emitted"], 1);
+
+        let usage = &overview["usage"]["by_category"];
+        assert_usage_row(usage, "workflow_skill", 1, "skill");
+        assert!(
+            !has_row(usage, "category", "tracedecay_mcp"),
+            "other-project fallback events must not leak into current project usage: {usage:#}"
+        );
+    });
+}
+
+#[test]
+fn analytics_api_uses_recent_durable_events_when_window_is_capped() {
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(false).await;
+        seed_durable_recent_window(&fixture.global_db_path, &fixture.project_root).await;
+        let agent = http_agent();
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!("{}/api/plugins/analytics/overview", fixture.base_url),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(overview["usage"]["source"], "analytics_events");
+        assert_eq!(overview["usage"]["event_count"], 10_000);
+
+        assert_usage_row(
+            &overview["usage"]["by_category"],
+            "workflow_skill",
+            1,
+            "skill",
+        );
+    });
+}

--- a/tests/fixtures/analytics/codex_skill_prose.txt
+++ b/tests/fixtures/analytics/codex_skill_prose.txt
@@ -1,0 +1,1 @@
+Using `superpowers:using-superpowers` before the repo scan. Also using `tracedecay:reading-code-cheaply` for cheap code context.

--- a/tests/fixtures/analytics/cursor_skill_read_text.json
+++ b/tests/fixtures/analytics/cursor_skill_read_text.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "tool_use",
+    "name": "ReadFile",
+    "input": {
+      "path": "/home/zack/.cursor/plugins/local/tracedecay/skills/curating-project-memory/SKILL.md"
+    }
+  },
+  {
+    "type": "tool_use",
+    "name": "ReadFile",
+    "input": {
+      "path": "/home/zack/.codex/plugins/cache/openai-curated/superpowers/c6ea566d/skills/using-superpowers/SKILL.md"
+    }
+  }
+]

--- a/tests/fixtures/analytics/hermes_skill_view_metadata.json
+++ b/tests/fixtures/analytics/hermes_skill_view_metadata.json
@@ -1,0 +1,12 @@
+{
+  "tool_calls": [
+    {
+      "function": {
+        "name": "skill_view",
+        "arguments": {
+          "name": "github-pr-workflow"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/analytics/hermes_skill_view_text.json
+++ b/tests/fixtures/analytics/hermes_skill_view_text.json
@@ -1,0 +1,6 @@
+{
+  "success": true,
+  "name": "github-pr-workflow",
+  "path": "github/github-pr-workflow/SKILL.md",
+  "skill_dir": "/home/zack/.hermes/profiles/tracedecay/skills/github/github-pr-workflow"
+}

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -21,6 +21,7 @@ use tracedecay::mcp::response_handles::{
 };
 use tracedecay::mcp::transport::{ChannelTransport, McpTransport};
 use tracedecay::mcp::McpServer;
+use tracedecay::storage::{resolve_layout_for_current_profile, resolve_response_handle_root};
 use tracedecay::tracedecay::{current_timestamp, TraceDecay};
 
 // ---------------------------------------------------------------------------
@@ -77,6 +78,11 @@ fn jsonrpc_request(id: Value, method: &str, params: Value) -> String {
         "params": params
     }))
     .unwrap()
+}
+
+fn response_handle_dir(cg: &TraceDecay) -> PathBuf {
+    resolve_response_handle_root(cg.project_root())
+        .unwrap_or_else(|err| panic!("failed to resolve test response handle root: {err}"))
 }
 
 /// Helper to build a JSON-RPC notification string (no id).
@@ -691,9 +697,7 @@ async fn test_tracedecay_retrieve_corrupt_handle_record_returns_actionable_inter
     let stored =
         store_response_handle(cg.project_root(), "{\"items\":[1]}", current_timestamp()).unwrap();
     fs::write(
-        cg.project_root()
-            .join(".tracedecay/response-handles")
-            .join(format!("{}.json", stored.handle)),
+        response_handle_dir(&cg).join(format!("{}.json", stored.handle)),
         "{not-json",
     )
     .unwrap();
@@ -730,10 +734,7 @@ async fn test_tracedecay_retrieve_handle_read_failure_returns_actionable_interna
     let cg = server.cg().await;
     let stored =
         store_response_handle(cg.project_root(), "{\"items\":[2]}", current_timestamp()).unwrap();
-    let handle_path = cg
-        .project_root()
-        .join(".tracedecay/response-handles")
-        .join(format!("{}.json", stored.handle));
+    let handle_path = response_handle_dir(&cg).join(format!("{}.json", stored.handle));
     fs::remove_file(&handle_path).unwrap();
     fs::create_dir(&handle_path).unwrap();
 
@@ -1031,10 +1032,7 @@ async fn test_server_stats_include_response_handle_metrics() {
 
     let broken =
         store_response_handle(cg.project_root(), "{\"broken\":true}", current_timestamp()).unwrap();
-    let broken_path = cg
-        .project_root()
-        .join(".tracedecay/response-handles")
-        .join(format!("{}.json", broken.handle));
+    let broken_path = response_handle_dir(&cg).join(format!("{}.json", broken.handle));
     fs::remove_file(&broken_path).unwrap();
     fs::create_dir(&broken_path).unwrap();
     assert!(
@@ -1065,7 +1063,9 @@ async fn test_server_stats_include_response_handle_metrics() {
     );
 
     let failure_root = TempDir::new().unwrap();
-    fs::write(failure_root.path().join(".tracedecay"), "not-a-directory").unwrap();
+    let failure_handle_root = resolve_response_handle_root(failure_root.path()).unwrap();
+    fs::create_dir_all(failure_handle_root.parent().unwrap()).unwrap();
+    fs::write(&failure_handle_root, "not-a-directory").unwrap();
     assert!(
         store_response_handle(
             failure_root.path(),
@@ -1823,20 +1823,29 @@ async fn repeated_serve_lcm_calls_do_not_rerun_migrations() {
     );
 }
 
-/// Serializes the savings-accounting tests below: they all mutate
-/// process-wide env vars (`HOME`, `TRACEDECAY_GLOBAL_DB`,
-/// `TRACEDECAY_ENABLE_GLOBAL_DB`). `#[tokio::test]` defaults to a
-/// current-thread runtime, so holding the guard across `.await` is fine.
+/// Serializes the savings-accounting tests below: they mutate process-wide
+/// global-accounting env vars. `#[tokio::test]` defaults to a current-thread
+/// runtime, so holding the guard across `.await` is fine.
 static SAVINGS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+static BRANCH_DRIFT_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// Redirects HOME at an isolated temp dir (so `~/.tracedecay/global.db`
-/// lands there) and enables the global DB. Deliberately does NOT set
-/// `TRACEDECAY_GLOBAL_DB`: that override also wins over project-local
-/// LCM store discovery and would leak into concurrently running tests.
-fn isolated_savings_env(tmp: &TempDir) -> Vec<EnvVarGuard> {
-    let mut guards = vec![EnvVarGuard::set("HOME", tmp.path().as_os_str())];
-    #[cfg(target_os = "windows")]
-    guards.push(EnvVarGuard::set("USERPROFILE", tmp.path().as_os_str()));
+fn persistent_temp_dir() -> std::path::PathBuf {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().to_path_buf();
+    // Other tests can construct servers while global-accounting env is
+    // temporarily redirected here. Keep the directory alive for the process so
+    // those captured paths do not dangle after this test restores the env.
+    std::mem::forget(dir);
+    path
+}
+
+/// Redirects only the global accounting DB, without changing HOME/profile
+/// storage resolution for concurrently running TraceDecay fixtures.
+fn isolated_savings_env(global_db_path: &std::path::Path) -> Vec<EnvVarGuard> {
+    let mut guards = vec![EnvVarGuard::set(
+        "TRACEDECAY_GLOBAL_DB",
+        global_db_path.as_os_str(),
+    )];
     // `.cargo/config.toml` sets TRACEDECAY_DISABLE_GLOBAL_DB=1 to keep
     // cargo-launched processes hermetic; the explicit enable wins.
     guards.push(EnvVarGuard::set(
@@ -1917,6 +1926,81 @@ fn parse_metrics_line(resp: &Value) -> Option<(u64, u64)> {
     Some((before.trim().parse().ok()?, after.trim().parse().ok()?))
 }
 
+async fn mcp_runtime_events(
+    global_db_path: &std::path::Path,
+    session_id: &str,
+) -> Vec<tracedecay::global_db::AnalyticsEventRecord> {
+    let db = tracedecay::global_db::GlobalDb::open_at(global_db_path)
+        .await
+        .expect("global db opens at isolated path");
+    db.query_analytics_events(&tracedecay::global_db::AnalyticsEventQuery {
+        provider: Some("mcp".to_string()),
+        project_id: None,
+        session_id: Some(session_id.to_string()),
+        event_kind: Some("mcp_tool_call".to_string()),
+        limit: 100,
+    })
+    .await
+    .expect("query runtime analytics events")
+}
+
+async fn mcp_runtime_event(
+    global_db_path: &std::path::Path,
+    tool_name: &str,
+    session_id: &str,
+) -> Option<tracedecay::global_db::AnalyticsEventRecord> {
+    mcp_runtime_events(global_db_path, session_id)
+        .await
+        .into_iter()
+        .find(|event| event.tool_name.as_deref() == Some(tool_name))
+}
+
+async fn expect_mcp_runtime_event(
+    global_db_path: &std::path::Path,
+    tool_name: &str,
+    session_id: &str,
+    label: &str,
+) -> tracedecay::global_db::AnalyticsEventRecord {
+    mcp_runtime_event(global_db_path, tool_name, session_id)
+        .await
+        .unwrap_or_else(|| panic!("{label}"))
+}
+
+async fn mcp_runtime_event_count(global_db_path: &std::path::Path, session_id: &str) -> u64 {
+    mcp_runtime_events(global_db_path, session_id).await.len() as u64
+}
+
+fn response_for_id(responses: &[String], id: i64) -> Value {
+    let response = responses
+        .iter()
+        .find(|r| parse_response(r)["id"] == id)
+        .unwrap_or_else(|| panic!("should have a response for id={id}"));
+    parse_response(response)
+}
+
+async fn call_tool(server: Arc<McpServer>, id: i64, tool_name: &str, arguments: Value) -> Value {
+    let responses = run_server_with_messages(
+        server,
+        vec![jsonrpc_request(
+            json!(id),
+            "tools/call",
+            json!({ "name": tool_name, "arguments": arguments }),
+        )],
+    )
+    .await;
+    response_for_id(&responses, id)
+}
+
+fn analytics_metadata(event: &tracedecay::global_db::AnalyticsEventRecord) -> Value {
+    serde_json::from_str(
+        event
+            .metadata_json
+            .as_deref()
+            .expect("analytics event metadata"),
+    )
+    .expect("analytics event metadata is JSON")
+}
+
 #[tokio::test]
 // Intentional: serializes env-mutating savings tests; #[tokio::test]
 // defaults to a current-thread runtime, so no executor thread blocks.
@@ -1925,8 +2009,8 @@ async fn search_call_writes_savings_ledger_row() {
     let _env_guard = SAVINGS_ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let tmp_home = tempfile::tempdir().unwrap();
-    let _env = isolated_savings_env(&tmp_home);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
 
     let (server, proj_tmp) = setup_server().await;
     let server_handle = server.clone();
@@ -1956,6 +2040,156 @@ async fn search_call_writes_savings_ledger_row() {
     settled_ledger_total(&server_handle, &db_path, proj_tmp.path(), 1).await;
 }
 
+#[tokio::test]
+// Intentional: serializes env-mutating savings tests; #[tokio::test]
+// defaults to a current-thread runtime, so no executor thread blocks.
+#[allow(clippy::await_holding_lock)]
+async fn search_call_writes_mcp_runtime_analytics_event() {
+    let _env_guard = SAVINGS_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
+
+    let (server, proj_tmp) = setup_savings_project().await;
+    let server_handle = server.clone();
+    let db_path = locked_global_db_path();
+    let project_path = proj_tmp.path().to_string_lossy().to_string();
+
+    let resp = call_tool(
+        server,
+        9002,
+        "tracedecay_search",
+        json!({
+            "query": "helper",
+            "session_id": "mcp-session-9002"
+        }),
+    )
+    .await;
+
+    assert!(resp["error"].is_null(), "search should not error");
+    let (before, after) = parse_metrics_line(&resp).expect("metrics line present");
+
+    settled_ledger_total(&server_handle, &db_path, proj_tmp.path(), 1).await;
+    assert_eq!(
+        mcp_runtime_event_count(&db_path, "mcp-session-9002").await,
+        1,
+        "one MCP runtime analytics event should be recorded per tool call"
+    );
+    let event = expect_mcp_runtime_event(
+        &db_path,
+        "tracedecay_search",
+        "mcp-session-9002",
+        "durable MCP runtime analytics event",
+    )
+    .await;
+    let metadata = analytics_metadata(&event);
+
+    assert_eq!(event.session_id.as_deref(), Some("mcp-session-9002"));
+    assert_eq!(event.project_id, project_path);
+    assert!(
+        event
+            .tool_category
+            .as_deref()
+            .is_some_and(|category| !category.is_empty()),
+        "category should be taxonomy-backed"
+    );
+    assert_eq!(event.outcome.as_deref(), Some("success"));
+    assert_eq!(metadata["before_tokens"], before);
+    assert_eq!(metadata["after_tokens"], after);
+    assert_eq!(metadata["tokens_saved"], before - after);
+}
+
+#[tokio::test]
+// Intentional: serializes env-mutating savings tests; #[tokio::test]
+// defaults to a current-thread runtime, so no executor thread blocks.
+#[allow(clippy::await_holding_lock)]
+async fn failed_tool_call_writes_mcp_runtime_analytics_event() {
+    let _env_guard = SAVINGS_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
+
+    let (server, _proj_tmp) = setup_server().await;
+    let server_handle = server.clone();
+    let db_path = locked_global_db_path();
+
+    let resp = call_tool(
+        server,
+        9003,
+        "tracedecay_not_a_real_tool",
+        json!({ "session_id": "mcp-session-9003" }),
+    )
+    .await;
+
+    assert!(resp["error"].is_object(), "unknown tool should error");
+
+    server_handle.ledger_writes_settled().await;
+    assert_eq!(
+        mcp_runtime_event_count(&db_path, "mcp-session-9003").await,
+        1,
+        "failed MCP tool calls should still record analytics"
+    );
+    let event = expect_mcp_runtime_event(
+        &db_path,
+        "tracedecay_not_a_real_tool",
+        "mcp-session-9003",
+        "durable failed MCP runtime analytics event",
+    )
+    .await;
+    let metadata = analytics_metadata(&event);
+
+    assert_eq!(event.session_id.as_deref(), Some("mcp-session-9003"));
+    assert_eq!(event.outcome.as_deref(), Some("error"));
+    assert_eq!(metadata["before_tokens"], 0);
+    assert_eq!(metadata["after_tokens"], 0);
+    assert_eq!(metadata["tokens_saved"], 0);
+}
+
+#[tokio::test]
+// Intentional: serializes env-mutating savings tests; #[tokio::test]
+// defaults to a current-thread runtime, so no executor thread blocks.
+#[allow(clippy::await_holding_lock)]
+async fn semantic_tool_failure_writes_error_mcp_runtime_analytics_event() {
+    let _env_guard = SAVINGS_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
+
+    let (server, _proj_tmp) = setup_server().await;
+    let server_handle = server.clone();
+    let db_path = locked_global_db_path();
+
+    let resp = call_tool(
+        server,
+        9004,
+        "tracedecay_changelog",
+        json!({
+            "from_ref": "definitely-not-a-ref",
+            "to_ref": "also-not-a-ref",
+            "_meta": { "sessionId": "mcp-session-9004" }
+        }),
+    )
+    .await;
+
+    assert!(resp["error"].is_null(), "semantic failures are MCP results");
+    assert_eq!(resp["result"]["isError"], true);
+
+    server_handle.ledger_writes_settled().await;
+    let event = expect_mcp_runtime_event(
+        &db_path,
+        "tracedecay_changelog",
+        "mcp-session-9004",
+        "durable semantic-failure MCP runtime analytics event",
+    )
+    .await;
+
+    assert_eq!(event.session_id.as_deref(), Some("mcp-session-9004"));
+    assert_eq!(event.outcome.as_deref(), Some("error"));
+}
+
 /// Regression test for the empty-ledger bug: the savings ledger must record
 /// **by default**, with no env opt-in. The holographic-fact-store commit
 /// made the global DB opt-in via `TRACEDECAY_ENABLE_GLOBAL_DB`, which
@@ -1970,10 +2204,11 @@ async fn ledger_records_by_default_without_env_opt_in() {
     let _env_guard = SAVINGS_ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let tmp_home = tempfile::tempdir().unwrap();
-    let mut env = vec![EnvVarGuard::set("HOME", tmp_home.path().as_os_str())];
-    #[cfg(target_os = "windows")]
-    env.push(EnvVarGuard::set("USERPROFILE", tmp_home.path().as_os_str()));
+    let tmp_global = persistent_temp_dir();
+    let mut env = vec![EnvVarGuard::set(
+        "TRACEDECAY_GLOBAL_DB",
+        tmp_global.join("global.db").as_os_str(),
+    )];
     // Simulate a real (non-cargo) launch: neither the opt-in nor the
     // cargo-test opt-out is present, so the default-on path is exercised.
     env.push(EnvVarGuard::unset("TRACEDECAY_ENABLE_GLOBAL_DB"));
@@ -2047,8 +2282,8 @@ async fn full_file_read_credits_zero_net_savings() {
     let _env_guard = SAVINGS_ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let tmp_home = tempfile::tempdir().unwrap();
-    let _env = isolated_savings_env(&tmp_home);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
 
     let (server, proj_tmp) = setup_savings_project().await;
     let server_handle = server.clone();
@@ -2110,8 +2345,8 @@ async fn lifetime_counter_matches_ledger_net_savings() {
     let _env_guard = SAVINGS_ENV_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let tmp_home = tempfile::tempdir().unwrap();
-    let _env = isolated_savings_env(&tmp_home);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
 
     let (server, proj_tmp) = setup_savings_project().await;
     let server_handle = server.clone();
@@ -2234,14 +2469,14 @@ async fn setup_branch_drift_fixture() -> (TempDir, PathBuf, Arc<McpServer>) {
     }
 
     // Track main + feature, seeding feature's DB from main's.
-    let tracedecay_dir = project.join(".tracedecay");
+    let layout = resolve_layout_for_current_profile(&project).unwrap();
     let mut meta = BranchMeta::new("main");
     meta.add_branch("feature", "branches/feature.db", "main");
-    save_branch_meta(&tracedecay_dir, &meta).unwrap();
-    fs::create_dir_all(tracedecay_dir.join("branches")).unwrap();
+    save_branch_meta(&layout.data_root, &meta).unwrap();
+    fs::create_dir_all(layout.data_root.join("branches")).unwrap();
     fs::copy(
-        tracedecay_dir.join("tracedecay.db"),
-        tracedecay_dir.join("branches/feature.db"),
+        &layout.graph_db_path,
+        layout.data_root.join("branches/feature.db"),
     )
     .unwrap();
 
@@ -2278,6 +2513,7 @@ async fn setup_branch_drift_fixture() -> (TempDir, PathBuf, Arc<McpServer>) {
 
 #[tokio::test]
 async fn tool_calls_reopen_branch_db_after_mid_session_checkout() {
+    let _branch_lock = BRANCH_DRIFT_TEST_LOCK.lock().await;
     let (_dir, project, server) = setup_branch_drift_fixture().await;
 
     // While on main, the feature-only symbol must be invisible.
@@ -2319,6 +2555,7 @@ async fn tool_calls_reopen_branch_db_after_mid_session_checkout() {
 
 #[tokio::test]
 async fn cross_branch_tools_keep_using_explicit_branch_dbs_after_drift_reopen() {
+    let _branch_lock = BRANCH_DRIFT_TEST_LOCK.lock().await;
     let (_dir, project, server) = setup_branch_drift_fixture().await;
 
     git(&project, &["checkout", "feature"]);


### PR DESCRIPTION
## Summary
- add runtime analytics aggregation helpers and dashboard API endpoints
- advertise analytics dashboard capability and fixture-backed API coverage
- record MCP tool-call analytics events into the durable analytics ledger

## Verification
- cargo test --test dashboard_analytics_api_test
- cargo test --test mcp_server_test -- --list (compiles target, but this target currently lists 0 tests in this checkout)