### PR TITLE
Harden selectors, indexing, and MCP responses

### DIFF
--- a/scripts/hermes_stock_check.py
+++ b/scripts/hermes_stock_check.py
@@ -116,8 +116,12 @@ def main():
     ok("should_compress_preflight honors the bool ABC contract")
 
     status = unwrap_tool_json(engine.handle_tool_call("lcm_status", {}))
-    assert status.get("session_id") == "stock-check-session", status
-    ok("lcm_status dispatch round-trips")
+    if status.get("status") == "not_ingested":
+        assert status.get("store_exists") is False, status
+        ok("lcm_status dispatch round-trips", "not_ingested before compress")
+    else:
+        assert status.get("session_id") == "stock-check-session", status
+        ok("lcm_status dispatch round-trips")
 
     messages = [
         {"role": "user", "content": "hello"},

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,9 @@ pub enum Commands {
         /// Folders to skip during indexing (can be repeated)
         #[arg(long = "skip-folder", num_args = 1..)]
         skip_folders: Vec<String>,
+        /// Folders to include even when ignored by default skips or .gitignore (can be repeated)
+        #[arg(long = "include-folder", num_args = 1..)]
+        include_folders: Vec<String>,
     },
     /// Incremental sync (project must already be initialized with `tracedecay init`)
     Sync {
@@ -36,6 +39,9 @@ pub enum Commands {
         /// Folders to skip during indexing (can be repeated)
         #[arg(long = "skip-folder", num_args = 1..)]
         skip_folders: Vec<String>,
+        /// Folders to include even when ignored by default skips or .gitignore (can be repeated)
+        #[arg(long = "include-folder", num_args = 1..)]
+        include_folders: Vec<String>,
         /// List added, modified, and removed files after sync
         #[arg(long)]
         doctor: bool,
@@ -47,6 +53,12 @@ pub enum Commands {
     Status {
         /// Project path (default: current directory)
         path: Option<String>,
+        /// Registered project id to inspect instead of discovering from cwd
+        #[arg(long, conflicts_with = "path")]
+        project_id: Option<String>,
+        /// Registered project root path or alias to inspect instead of discovering from cwd
+        #[arg(long, conflicts_with_all = ["path", "project_id"])]
+        project_path: Option<String>,
         /// Output as JSON
         #[arg(short, long)]
         json: bool,
@@ -116,10 +128,11 @@ pub enum Commands {
     ///
     /// Rewrites only tracedecay-generated artifacts — the Hermes plugin
     /// (.py files, schemas.json, dashboard page) for every detected profile,
-    /// the Cursor plugin bundle, and the Kiro managed agent — re-baking the
-    /// current binary path and version. Config files (Hermes config.yaml and
-    /// its project_root pin, mcp.json, settings, prompt rules) are left
-    /// byte-for-byte intact; use `tracedecay reinstall` to refresh those.
+    /// the Cursor plugin bundle, the Codex plugin bundle/cache, and the Kiro
+    /// managed agent — re-baking the current binary path and version. Config
+    /// files (Hermes config.yaml and its project_root pin, mcp.json, settings,
+    /// prompt rules) are left byte-for-byte intact; use `tracedecay reinstall`
+    /// to refresh those.
     #[command(name = "update-plugin", visible_alias = "update-plugins")]
     UpdatePlugin,
     /// Remove agent integration (MCP server, permissions, hooks, prompt rules)
@@ -357,6 +370,12 @@ pub enum SessionsAction {
         /// Provider to ingest: cursor, codex, or all
         #[arg(long)]
         provider: Option<String>,
+        /// Registered project id whose session store should receive ingested messages
+        #[arg(long)]
+        project_id: Option<String>,
+        /// Registered project root path or alias whose session store should receive ingested messages
+        #[arg(long, conflicts_with = "project_id")]
+        project_path: Option<String>,
     },
     /// Search previously ingested session messages
     Search {
@@ -368,6 +387,12 @@ pub enum SessionsAction {
         /// Maximum number of matches per provider
         #[arg(long, default_value_t = 10)]
         limit: usize,
+        /// Registered project id whose session store should be searched
+        #[arg(long)]
+        project_id: Option<String>,
+        /// Registered project root path or alias whose session store should be searched
+        #[arg(long, conflicts_with = "project_id")]
+        project_path: Option<String>,
     },
 }
 
@@ -381,6 +406,12 @@ pub enum MemoryAction {
         /// Project path (default: current directory, with discovery)
         #[arg(short, long)]
         path: Option<String>,
+        /// Registered project id to inspect instead of discovering from cwd
+        #[arg(long, conflicts_with = "path")]
+        project_id: Option<String>,
+        /// Registered project root path or alias to inspect instead of discovering from cwd
+        #[arg(long, conflicts_with_all = ["path", "project_id"])]
+        project_path: Option<String>,
     },
     /// Similarity-dedup curation (and the LLM-review plan/apply halves),
     /// suitable for a cron job — no dashboard server required.
@@ -444,7 +475,7 @@ pub enum MigrateAction {
     /// Export a profile-sharded project store to a standalone directory.
     Export {
         /// Export from the current profile-sharded store layout.
-        #[arg(long = "from-profile")]
+        #[arg(long = "from-profile", required = true)]
         from_profile: bool,
         /// Project path whose enrollment marker identifies the profile shard.
         #[arg(long, conflicts_with = "project_id")]
@@ -480,6 +511,19 @@ pub enum MigrateAction {
         #[arg(long = "profile-root")]
         profile_root: String,
         /// Apply registry reconstruction plans after scanning manifests.
+        #[arg(long)]
+        apply: bool,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove stale registry rows for projects whose canonical roots no longer exist.
+    #[command(name = "registry-gc")]
+    RegistryGc {
+        /// Only consider registered projects whose canonical root starts with this prefix.
+        #[arg(long)]
+        prefix: Option<String>,
+        /// Apply deletions. Omit for a dry-run preview.
         #[arg(long)]
         apply: bool,
         /// Output as JSON.
@@ -548,6 +592,10 @@ pub enum BranchAction {
 mod cli_parse_tests {
     use super::{BranchAction, Cli, Commands, MemoryAction, MigrateAction, SessionsAction};
     use clap::{error::ErrorKind, Parser};
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
 
     #[test]
     fn tool_command_preserves_trailing_help_and_reserved_args() {
@@ -638,11 +686,15 @@ mod cli_parse_tests {
             status.command,
             Some(Commands::Status {
                 path,
+                project_id,
+                project_path,
                 json,
                 short,
                 details,
                 runtime,
             }) if path.as_deref() == Some("/tmp/project")
+                && project_id.is_none()
+                && project_path.is_none()
                 && json
                 && short
                 && details
@@ -668,6 +720,98 @@ mod cli_parse_tests {
     }
 
     #[test]
+    fn init_and_sync_parse_runtime_skip_and_include_folders() {
+        let init = Cli::try_parse_from([
+            "tracedecay",
+            "init",
+            "/tmp/project",
+            "--skip-folder",
+            "vendor",
+            "dist",
+            "--include-folder",
+            "dist/generated",
+        ])
+        .expect("init skip/include folders should parse");
+        assert!(matches!(
+            init.command,
+            Some(Commands::Init {
+                path,
+                skip_folders,
+                include_folders,
+            }) if path.as_deref() == Some("/tmp/project")
+                && skip_folders == strings(&["vendor", "dist"])
+                && include_folders == strings(&["dist/generated"])
+        ));
+
+        let sync = Cli::try_parse_from([
+            "tracedecay",
+            "sync",
+            "/tmp/project",
+            "--force",
+            "--include-folder",
+            "dist",
+            "vendor/generated",
+        ])
+        .expect("sync include folders should parse");
+        assert!(matches!(
+            sync.command,
+            Some(Commands::Sync {
+                path,
+                force,
+                skip_folders,
+                include_folders,
+                ..
+            }) if path.as_deref() == Some("/tmp/project")
+                && force
+                && skip_folders.is_empty()
+                && include_folders == strings(&["dist", "vendor/generated"])
+        ));
+    }
+
+    #[test]
+    fn init_and_sync_parse_repeated_include_folder_flags() {
+        let init = Cli::try_parse_from([
+            "tracedecay",
+            "init",
+            "/tmp/project",
+            "--include-folder",
+            "dist",
+            "--include-folder",
+            "vendor/generated",
+        ])
+        .expect("repeated init include folders should parse");
+        assert!(matches!(
+            init.command,
+            Some(Commands::Init {
+                path,
+                include_folders,
+                ..
+            }) if path.as_deref() == Some("/tmp/project")
+                && include_folders == strings(&["dist", "vendor/generated"])
+        ));
+
+        let sync = Cli::try_parse_from([
+            "tracedecay",
+            "sync",
+            "/tmp/project",
+            "--include-folder",
+            "dist",
+            "--include-folder",
+            "vendor/generated",
+        ])
+        .expect("repeated sync include folders should parse");
+        assert!(matches!(
+            sync.command,
+            Some(Commands::Sync {
+                path,
+                include_folders,
+                ..
+            }) if path.as_deref() == Some("/tmp/project")
+                && include_folders == strings(&["dist", "vendor/generated"])
+        ));
+    }
+
+    #[test]
     fn memory_status_command_dispatches_to_expected_variant() {
         let cli = Cli::try_parse_from([
             "tracedecay",
@@ -682,8 +826,80 @@ mod cli_parse_tests {
         assert!(matches!(
             cli.command,
             Some(Commands::Memory {
-                action: MemoryAction::Status { json, path }
-            }) if json && path.as_deref() == Some("/tmp/project")
+                action: MemoryAction::Status {
+                    json,
+                    path,
+                    project_id,
+                    project_path,
+                }
+            }) if json
+                && path.as_deref() == Some("/tmp/project")
+                && project_id.is_none()
+                && project_path.is_none()
+        ));
+    }
+
+    #[test]
+    fn project_selector_flags_parse_for_cli_read_surfaces() {
+        let status =
+            Cli::try_parse_from(["tracedecay", "status", "--project-id", "proj_123", "--json"])
+                .expect("status project selector should parse");
+        assert!(matches!(
+            status.command,
+            Some(Commands::Status {
+                path,
+                project_id,
+                project_path,
+                json,
+                ..
+            }) if path.is_none()
+                && project_id.as_deref() == Some("proj_123")
+                && project_path.is_none()
+                && json
+        ));
+
+        let memory = Cli::try_parse_from([
+            "tracedecay",
+            "memory",
+            "status",
+            "--project-path",
+            "/tmp/project",
+        ])
+        .expect("memory status project selector should parse");
+        assert!(matches!(
+            memory.command,
+            Some(Commands::Memory {
+                action:
+                    MemoryAction::Status {
+                        path,
+                        project_id,
+                        project_path,
+                        ..
+                    }
+            }) if path.is_none()
+                && project_id.is_none()
+                && project_path.as_deref() == Some("/tmp/project")
+        ));
+
+        let sessions = Cli::try_parse_from([
+            "tracedecay",
+            "sessions",
+            "search",
+            "needle",
+            "--project-id",
+            "proj_123",
+        ])
+        .expect("sessions search project selector should parse");
+        assert!(matches!(
+            sessions.command,
+            Some(Commands::Sessions {
+                action:
+                    SessionsAction::Search {
+                        project_id,
+                        project_path,
+                        ..
+                    }
+            }) if project_id.as_deref() == Some("proj_123") && project_path.is_none()
         ));
     }
 
@@ -806,6 +1022,50 @@ mod cli_parse_tests {
     }
 
     #[test]
+    fn migrate_export_requires_from_profile_flag() {
+        let err = match Cli::try_parse_from([
+            "tracedecay",
+            "migrate",
+            "export",
+            "--project-id",
+            "proj_123",
+            "--to",
+            "/tmp/exported",
+        ]) {
+            Ok(_) => panic!("migrate export should require --from-profile"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn migrate_registry_gc_parses() {
+        let cli = Cli::try_parse_from([
+            "tracedecay",
+            "migrate",
+            "registry-gc",
+            "--prefix",
+            "/tmp",
+            "--apply",
+            "--json",
+        ])
+        .expect("migrate registry-gc should parse");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Migrate {
+                action:
+                    MigrateAction::RegistryGc {
+                        prefix,
+                        apply,
+                        json,
+                    }
+            }) if prefix.as_deref() == Some("/tmp") && apply && json
+        ));
+    }
+
+    #[test]
     fn branch_remove_requires_a_branch_name() {
         let err = match Cli::try_parse_from(["tracedecay", "branch", "remove"]) {
             Ok(_) => panic!("branch remove should require a name"),
@@ -822,8 +1082,17 @@ mod cli_parse_tests {
                 .unwrap();
         match ingest.command {
             Some(Commands::Sessions {
-                action: SessionsAction::Ingest { provider },
-            }) => assert_eq!(provider.as_deref(), Some("cursor")),
+                action:
+                    SessionsAction::Ingest {
+                        provider,
+                        project_id,
+                        project_path,
+                    },
+            }) => {
+                assert_eq!(provider.as_deref(), Some("cursor"));
+                assert!(project_id.is_none());
+                assert!(project_path.is_none());
+            }
             _ => panic!("expected sessions ingest command"),
         }
 
@@ -845,11 +1114,15 @@ mod cli_parse_tests {
                         query,
                         provider,
                         limit,
+                        project_id,
+                        project_path,
                     },
             }) => {
                 assert_eq!(query, "needle");
                 assert_eq!(provider.as_deref(), Some("codex"));
                 assert_eq!(limit, 5);
+                assert!(project_id.is_none());
+                assert!(project_path.is_none());
             }
             _ => panic!("expected sessions search command"),
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -153,16 +153,11 @@ pub(crate) async fn handle_migrate_action(action: MigrateAction) -> tracedecay::
             }
         }
         MigrateAction::Export {
-            from_profile,
+            from_profile: _,
             project,
             project_id,
             to,
         } => {
-            if !from_profile {
-                return Err(tracedecay::errors::TraceDecayError::Config {
-                    message: "migrate export currently supports only --from-profile".to_string(),
-                });
-            }
             let project_id = match project_id {
                 Some(project_id) => project_id,
                 None => {
@@ -344,6 +339,66 @@ pub(crate) async fn handle_migrate_action(action: MigrateAction) -> tracedecay::
                     report.issues.len()
                 );
                 println!("apply supported: yes (re-run with --apply after review)");
+            }
+        }
+        MigrateAction::RegistryGc {
+            prefix,
+            apply,
+            json,
+        } => {
+            let global_db = tracedecay::global_db::GlobalDb::open()
+                .await
+                .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+                    message: "could not open global DB for registry cleanup".to_string(),
+                })?;
+            let projects = global_db.list_code_projects(usize::MAX).await;
+            let prefix_path = prefix.as_deref().map(PathBuf::from);
+            let stale: Vec<_> = projects
+                .into_iter()
+                .filter(|project| {
+                    prefix_path.as_ref().is_none_or(|prefix| {
+                        PathBuf::from(&project.canonical_root).starts_with(prefix)
+                    })
+                })
+                .filter(|project| !PathBuf::from(&project.canonical_root).exists())
+                .collect();
+            let deleted = if apply {
+                let project_ids: Vec<String> = stale
+                    .iter()
+                    .map(|project| project.project_id.clone())
+                    .collect();
+                global_db.delete_code_projects(&project_ids).await
+            } else {
+                0
+            };
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "apply": apply,
+                        "prefix": prefix,
+                        "candidate_count": stale.len(),
+                        "deleted_count": deleted,
+                        "candidates": stale,
+                    }))?
+                );
+            } else {
+                println!(
+                    "registry-gc: {} stale project(s){}",
+                    stale.len(),
+                    if apply { " selected" } else { " found" }
+                );
+                if apply {
+                    println!("deleted: {deleted}");
+                } else {
+                    println!("dry run: re-run with --apply to delete registry metadata");
+                }
+                for project in stale.iter().take(20) {
+                    println!("{} {}", project.project_id, project.canonical_root);
+                }
+                if stale.len() > 20 {
+                    println!("... {} more", stale.len() - 20);
+                }
             }
         }
         MigrateAction::Rollback {
@@ -971,7 +1026,7 @@ pub(crate) async fn handle_no_command() -> tracedecay::errors::Result<()> {
     })?;
     let answer = answer.trim();
     if answer.is_empty() || answer.eq_ignore_ascii_case("y") {
-        init_and_index(&project_path, &[], false).await?;
+        init_and_index(&project_path, &[], &[], false).await?;
     }
     Ok(())
 }
@@ -979,6 +1034,7 @@ pub(crate) async fn handle_no_command() -> tracedecay::errors::Result<()> {
 pub(crate) async fn handle_init(
     path: Option<String>,
     skip_folders: Vec<String>,
+    include_folders: Vec<String>,
 ) -> tracedecay::errors::Result<()> {
     let project_path = tracedecay::config::resolve_path(path);
     if TraceDecay::is_initialized(&project_path) {
@@ -992,7 +1048,7 @@ pub(crate) async fn handle_init(
     }
 
     let version_handle = std::thread::spawn(tracedecay::cloud::fetch_latest_version);
-    init_and_index(&project_path, &skip_folders, false).await?;
+    init_and_index(&project_path, &skip_folders, &include_folders, false).await?;
     maybe_print_parallel_update_notice(version_handle);
     Ok(())
 }
@@ -1001,6 +1057,7 @@ pub(crate) async fn handle_sync(
     path: Option<String>,
     force: bool,
     skip_folders: Vec<String>,
+    include_folders: Vec<String>,
     doctor: bool,
     verbose: bool,
 ) -> tracedecay::errors::Result<()> {
@@ -1024,10 +1081,11 @@ pub(crate) async fn handle_sync(
     let version_handle = std::thread::spawn(tracedecay::cloud::fetch_latest_version);
 
     if force {
-        init_and_index(&project_path, &skip_folders, verbose).await?;
+        init_and_index(&project_path, &skip_folders, &include_folders, verbose).await?;
     } else {
         let mut cg = TraceDecay::open(&project_path).await?;
         cg.add_skip_folders(&skip_folders);
+        cg.add_include_folders(&include_folders);
         let spinner = Spinner::new();
         let sync_start = std::time::Instant::now();
         let result = cg
@@ -1195,6 +1253,7 @@ fn maybe_print_parallel_update_notice(version_handle: std::thread::JoinHandle<Op
 pub(crate) async fn init_and_index(
     project_path: &Path,
     skip_folders: &[String],
+    include_folders: &[String],
     verbose: bool,
 ) -> tracedecay::errors::Result<TraceDecay> {
     if !project_path.is_dir() {
@@ -1242,6 +1301,7 @@ pub(crate) async fn init_and_index(
         cg
     };
     cg.add_skip_folders(skip_folders);
+    cg.add_include_folders(include_folders);
     let spinner = Spinner::new();
     let index_start = std::time::Instant::now();
     let result = cg

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,38 @@ pub const USER_DATA_DIR_ENV: &str = "TRACEDECAY_DATA_DIR";
 /// Project graph database filename inside a `.tracedecay/` data dir.
 pub const DB_FILENAME: &str = "tracedecay.db";
 
+const DEFAULT_EXCLUDE_PATTERNS: &[&str] = &[
+    "target/**",
+    ".git/**",
+    ".tracedecay/**",
+    "**/node_modules/**",
+    "vendor/**",
+    "**/vendor/**",
+    "**/*.min.*",
+    "bin/**",
+    "build/**",
+    "**/build/**",
+    "dist/**",
+    "**/dist/**",
+    "out/**",
+    "**/out/**",
+    "coverage/**",
+    "**/coverage/**",
+    ".cache/**",
+    "**/.cache/**",
+    ".next/**",
+    "**/.next/**",
+    ".turbo/**",
+    "**/.turbo/**",
+    ".gradle/**",
+    "**/.gradle/**",
+    ".venv/**",
+    "**/.venv/**",
+    "venv/**",
+    "**/venv/**",
+    "**/__pycache__/**",
+];
+
 /// Configuration for a `TraceDecay` project.
 ///
 /// Controls which files are indexed, size limits, and feature toggles.
@@ -32,9 +64,10 @@ pub struct TraceDecayConfig {
     pub root_dir: String,
     /// Glob patterns for files to exclude during indexing.
     pub exclude: Vec<String>,
-    /// Glob patterns for hidden (dot-prefixed) paths to include despite the
-    /// default hidden-directory filter.  For example, `[".github/**"]` indexes
-    /// files under `.github/` that would otherwise be skipped.
+    /// Glob patterns for paths to include despite the default hidden-directory,
+    /// generated-directory, and gitignore filters. For example,
+    /// `[".github/**"]` indexes files under `.github/` that would otherwise be
+    /// skipped.
     #[serde(default)]
     pub include: Vec<String>,
     /// Maximum file size in bytes; files larger than this are skipped.
@@ -44,8 +77,12 @@ pub struct TraceDecayConfig {
     /// Whether to track call-site locations for edges.
     pub track_call_sites: bool,
     /// Whether to respect `.gitignore` rules when scanning files.
-    #[serde(default)]
+    #[serde(default = "default_git_ignore")]
     pub git_ignore: bool,
+}
+
+fn default_git_ignore() -> bool {
+    true
 }
 
 impl Default for TraceDecayConfig {
@@ -53,23 +90,15 @@ impl Default for TraceDecayConfig {
         Self {
             version: 1,
             root_dir: String::new(),
-            exclude: vec![
-                "target/**".to_string(),
-                ".git/**".to_string(),
-                ".tracedecay/**".to_string(),
-                "**/node_modules/**".to_string(),
-                "vendor/**".to_string(),
-                "**/*.min.*".to_string(),
-                "bin/**".to_string(),
-                "build/**".to_string(),
-                "out/**".to_string(),
-                ".gradle/**".to_string(),
-            ],
+            exclude: DEFAULT_EXCLUDE_PATTERNS
+                .iter()
+                .map(|pattern| (*pattern).to_string())
+                .collect(),
             include: Vec::new(),
             max_file_size: 1_048_576,
             extract_docstrings: true,
             track_call_sites: true,
-            git_ignore: false,
+            git_ignore: default_git_ignore(),
         }
     }
 }
@@ -395,6 +424,28 @@ pub fn is_included(path: &str, config: &TraceDecayConfig) -> bool {
     false
 }
 
+/// Returns `true` if a directory should be entered because it or one of its
+/// descendants matches an explicit include glob.
+pub fn is_included_dir(dir_path: &str, config: &TraceDecayConfig) -> bool {
+    let match_opts = glob::MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: false,
+        require_literal_leading_dot: false,
+    };
+
+    for pattern_str in &config.include {
+        if let Ok(pattern) = Pattern::new(pattern_str) {
+            if pattern.matches_with(dir_path, match_opts)
+                || pattern.matches_with(&format!("{dir_path}/_"), match_opts)
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
 /// Returns `true` if a directory should be pruned during scanning.
 ///
 /// Matches `dir/_` against exclude patterns (for `dir/**`-style globs) and
@@ -503,16 +554,20 @@ mod tests {
     }
 
     #[test]
-    fn test_include_does_not_override_exclude() {
+    fn test_include_records_explicit_override_even_when_excluded() {
         let config = TraceDecayConfig {
             include: vec![".config/**".to_string()],
             exclude: vec![".config/secret/**".to_string()],
             ..TraceDecayConfig::default()
         };
-        // Included by include glob
         assert!(is_included(".config/secret/key.rs", &config));
-        // But also matched by exclude glob
         assert!(is_excluded(".config/secret/key.rs", &config));
+    }
+
+    #[test]
+    fn test_default_gitignore_is_enabled() {
+        let config = TraceDecayConfig::default();
+        assert!(config.git_ignore);
     }
 
     #[test]
@@ -529,6 +584,10 @@ mod tests {
             "packages/web/node_modules/react/index.js",
             &config
         ));
+        assert!(is_excluded("dist/main.js", &config));
+        assert!(is_excluded("packages/web/dist/main.js", &config));
+        assert!(is_excluded("coverage/lcov.js", &config));
+        assert!(is_excluded("packages/web/.next/server/app.js", &config));
     }
 
     #[test]

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -115,7 +115,7 @@ impl<'a> ContextBuilder<'a> {
             "get_code called with empty file_path"
         );
         debug_assert!(!node.id.is_empty(), "get_code called with empty node id");
-        if node.start_line == 0 || node.end_line == 0 {
+        if node.start_line == 0 || node.end_line == 0 || node.start_line > node.end_line {
             return None;
         }
 
@@ -124,12 +124,14 @@ impl<'a> ContextBuilder<'a> {
         } else {
             let file_path = self.project_root.join(&node.file_path);
             // Prevent path traversal: ensure the resolved path stays within
-            // the project root. If either side fails to canonicalize (e.g.
-            // file missing on disk) fall through to the read attempt so the
-            // pre-existing missing-file path still returns `None` naturally.
-            let allowed = match (file_path.canonicalize(), self.project_root.canonicalize()) {
-                (Ok(canonical), Ok(root)) => canonical.starts_with(&root),
-                _ => true,
+            // the canonical project root. If the target itself is missing,
+            // allow the read attempt to fail naturally as `None`.
+            let allowed = match self.project_root.canonicalize() {
+                Ok(root) => match file_path.canonicalize() {
+                    Ok(canonical) => canonical.starts_with(&root),
+                    Err(_) => file_path.starts_with(&root),
+                },
+                Err(_) => false,
             };
             let loaded = if allowed {
                 fs::read_to_string(&file_path).ok()

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -177,6 +177,7 @@ async fn check_stale_stores(dc: &mut DoctorCounters) {
     }
 
     check_orphan_store_manifests(dc, &project_paths);
+    check_stale_code_projects(dc, &gdb).await;
     if stale.is_empty() {
         dc.pass("No stale projects in global DB");
         return;
@@ -219,6 +220,70 @@ async fn check_stale_stores(dc: &mut DoctorCounters) {
 
     let purged = gdb.delete_projects(&stale).await;
     dc.pass(&format!("Purged {purged} stale project(s)"));
+}
+
+async fn check_stale_code_projects(dc: &mut DoctorCounters, gdb: &crate::global_db::GlobalDb) {
+    use std::io::{IsTerminal, Write};
+
+    let stale: Vec<_> = gdb
+        .list_code_projects(usize::MAX)
+        .await
+        .into_iter()
+        .filter(|project| !code_project_root_exists(project))
+        .collect();
+
+    if stale.is_empty() {
+        dc.pass("No stale code project registry rows");
+        return;
+    }
+
+    dc.warn(&format!(
+        "{} stale code project registry row(s) (registered but project root is gone):",
+        stale.len()
+    ));
+    let preview = stale.len().min(10);
+    for project in &stale[..preview] {
+        dc.info(&format!(
+            "  • {} ({})",
+            project.project_id, project.display_root
+        ));
+    }
+    if stale.len() > preview {
+        dc.info(&format!("  … and {} more", stale.len() - preview));
+    }
+
+    if !std::io::stdin().is_terminal() {
+        dc.info("    Re-run `tracedecay doctor` interactively to purge registry rows.");
+        return;
+    }
+
+    eprint!(
+        "  Purge {} stale code project registry row(s)? [Y/n] ",
+        stale.len()
+    );
+    std::io::stderr().flush().ok();
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return;
+    }
+    let answer = answer.trim();
+    if !answer.is_empty() && !answer.eq_ignore_ascii_case("y") {
+        dc.info("Skipped code project registry purge.");
+        return;
+    }
+
+    let project_ids: Vec<String> = stale
+        .into_iter()
+        .map(|project| project.project_id)
+        .collect();
+    let purged = gdb.delete_code_projects(&project_ids).await;
+    dc.pass(&format!(
+        "Purged {purged} stale code project registry row(s)"
+    ));
+}
+
+fn code_project_root_exists(project: &crate::global_db::CodeProjectRecord) -> bool {
+    Path::new(&project.canonical_root).exists() || Path::new(&project.display_root).exists()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // Updated 2026-03-23: compact bordered table for status output
 use clap::Parser;
 use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::{Path, PathBuf};
 use std::process;
 
 use tracedecay::tracedecay::TraceDecay;
@@ -372,8 +373,8 @@ fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::UserCon
     }
 }
 
-async fn largest_memory_bank_fact_count(cg: &TraceDecay) -> tracedecay::errors::Result<usize> {
-    let db = libsql::Builder::new_local(cg.db_path()).build().await?;
+async fn largest_memory_bank_fact_count_at(db_path: &Path) -> tracedecay::errors::Result<usize> {
+    let db = libsql::Builder::new_local(db_path).build().await?;
     let conn = db.connect()?;
     let mut rows = conn
         .query("SELECT COALESCE(MAX(fact_count), 0) FROM memory_banks", ())
@@ -382,6 +383,44 @@ async fn largest_memory_bank_fact_count(cg: &TraceDecay) -> tracedecay::errors::
         return Ok(0);
     };
     Ok(row.get::<i64>(0).unwrap_or(0).max(0) as usize)
+}
+
+async fn resolve_registered_project_root(
+    project_id: Option<String>,
+    project_path: Option<String>,
+) -> tracedecay::errors::Result<Option<PathBuf>> {
+    let db = tracedecay::global_db::GlobalDb::open()
+        .await
+        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+            message: "could not open tracedecay project registry; run tracedecay init first"
+                .to_string(),
+        })?;
+    let context = if let Some(project_id) = project_id.as_deref() {
+        db.project_registry_context_by_id(project_id).await
+    } else if let Some(project_path) = project_path.as_deref() {
+        db.project_registry_context_by_alias(Path::new(project_path))
+            .await
+    } else {
+        return Ok(None);
+    };
+
+    context
+        .map(|context| PathBuf::from(context.project.display_root))
+        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+            message: "registered project not found for selector".to_string(),
+        })
+        .map(Some)
+}
+
+async fn resolve_cli_project_root(
+    path: Option<String>,
+    project_id: Option<String>,
+    project_path: Option<String>,
+) -> tracedecay::errors::Result<PathBuf> {
+    if let Some(root) = resolve_registered_project_root(project_id, project_path).await? {
+        return Ok(root);
+    }
+    Ok(tracedecay::config::resolve_path_with_discovery(path))
 }
 
 fn format_memory_status_report(
@@ -437,26 +476,34 @@ fn format_memory_status_report(
 
 async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
     match command {
-        Commands::Init { path, skip_folders } => {
-            commands::handle_init(path, skip_folders).await?;
+        Commands::Init {
+            path,
+            skip_folders,
+            include_folders,
+        } => {
+            commands::handle_init(path, skip_folders, include_folders).await?;
         }
         Commands::Sync {
             path,
             force,
             skip_folders,
+            include_folders,
             doctor,
             verbose,
         } => {
-            commands::handle_sync(path, force, skip_folders, doctor, verbose).await?;
+            commands::handle_sync(path, force, skip_folders, include_folders, doctor, verbose)
+                .await?;
         }
         Commands::Status {
             path,
+            project_id,
+            project_path,
             json,
             short,
             details,
             runtime,
         } => {
-            let project_path = tracedecay::config::resolve_path_with_discovery(path);
+            let project_path = resolve_cli_project_root(path, project_id, project_path).await?;
             let cg = if TraceDecay::is_initialized(&project_path) {
                 match TraceDecay::open(&project_path).await {
                     Ok(cg) => cg,
@@ -482,7 +529,7 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
                 })?;
                 let answer = answer.trim();
                 if answer.is_empty() || answer.eq_ignore_ascii_case("y") {
-                    commands::init_and_index(&project_path, &[], false).await?
+                    commands::init_and_index(&project_path, &[], &[], false).await?
                 } else {
                     return Ok(());
                 }
@@ -1380,11 +1427,17 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             commands::handle_branch_action(action).await?;
         }
         Commands::Memory { action } => match action {
-            MemoryAction::Status { json, path } => {
-                let project_path = tracedecay::config::resolve_path_with_discovery(path);
+            MemoryAction::Status {
+                json,
+                path,
+                project_id,
+                project_path,
+            } => {
+                let project_path = resolve_cli_project_root(path, project_id, project_path).await?;
                 let cg = crate::serve::ensure_initialized(&project_path).await?;
-                let status = cg.memory_status().await?;
-                let largest_bank_fact_count = largest_memory_bank_fact_count(&cg).await?;
+                let status = cg.project_memory_status().await?;
+                let largest_bank_fact_count =
+                    largest_memory_bank_fact_count_at(&cg.store_layout().graph_db_path).await?;
                 let largest_bank_utilization_pct = if status.estimated_capacity > 0 {
                     largest_bank_fact_count as f64 / status.estimated_capacity as f64 * 100.0
                 } else {
@@ -1433,8 +1486,12 @@ enum SessionProvider {
 
 async fn handle_sessions_action(action: SessionsAction) -> tracedecay::errors::Result<()> {
     match action {
-        SessionsAction::Ingest { provider } => {
-            let project_path = tracedecay::config::resolve_path_with_discovery(None);
+        SessionsAction::Ingest {
+            provider,
+            project_id,
+            project_path,
+        } => {
+            let project_path = resolve_cli_project_root(None, project_id, project_path).await?;
             let db = tracedecay::sessions::cursor::open_project_session_db(&project_path)
                 .await
                 .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
@@ -1454,8 +1511,10 @@ async fn handle_sessions_action(action: SessionsAction) -> tracedecay::errors::R
             query,
             provider,
             limit,
+            project_id,
+            project_path,
         } => {
-            let project_path = tracedecay::config::resolve_path_with_discovery(None);
+            let project_path = resolve_cli_project_root(None, project_id, project_path).await?;
             let db = tracedecay::sessions::cursor::open_project_session_db(&project_path)
                 .await
                 .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
@@ -1643,6 +1702,8 @@ mod startup_tests {
     fn normal_commands_keep_startup_maintenance() {
         assert!(!should_skip_startup_maintenance(&Commands::Status {
             path: None,
+            project_id: None,
+            project_path: None,
             json: false,
             short: false,
             details: false,
@@ -1697,9 +1758,12 @@ mod startup_tests {
         assert!(!should_skip_agent_install_maintenance(&Commands::Init {
             path: None,
             skip_folders: Vec::new(),
+            include_folders: Vec::new(),
         }));
         assert!(!should_skip_agent_install_maintenance(&Commands::Status {
             path: None,
+            project_id: None,
+            project_path: None,
             json: false,
             short: false,
             details: false,

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -200,6 +200,7 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
         def_insert_at_symbol(),
         def_find_exact_symbol(),
     ];
+    add_registered_project_selector_properties(&mut definitions);
     if !ast_grep_available() {
         definitions.retain(|d| d.name != "tracedecay_ast_grep_rewrite");
     }
@@ -214,6 +215,44 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
         "all tool definitions must have 'tracedecay_' prefix"
     );
     definitions
+}
+
+fn registered_project_selector_tool_names() -> &'static [&'static str] {
+    &[
+        "tracedecay_search",
+        "tracedecay_context",
+        "tracedecay_retrieve",
+        "tracedecay_callers",
+        "tracedecay_callees",
+        "tracedecay_impact",
+        "tracedecay_node",
+        "tracedecay_files",
+        "tracedecay_body",
+        "tracedecay_read",
+        "tracedecay_outline",
+        "tracedecay_signature_search",
+        "tracedecay_implementations",
+        "tracedecay_callers_for",
+        "tracedecay_call_chain",
+        "tracedecay_file_dependents",
+        "tracedecay_find_exact_symbol",
+        "tracedecay_by_qualified_name",
+        "tracedecay_signature",
+        "tracedecay_impls",
+        "tracedecay_derives",
+    ]
+}
+
+fn add_registered_project_selector_properties(definitions: &mut [ToolDefinition]) {
+    for definition in definitions {
+        if !registered_project_selector_tool_names().contains(&definition.name.as_str()) {
+            continue;
+        }
+        let Some(properties) = definition.input_schema.get_mut("properties") else {
+            continue;
+        };
+        *properties = with_project_selector_properties(std::mem::take(properties));
+    }
 }
 
 /// Returns true when the external `ast-grep` binary is on PATH. Result is
@@ -236,10 +275,10 @@ fn def_search() -> ToolDefinition {
     def_always_load(
         "tracedecay_search",
         "Search Symbols",
-        "Search for symbols (functions, structs, traits, etc.) in the code graph by name or keyword.",
+        "Search for symbols (functions, structs, traits, etc.) in the code graph by name or keyword. Defaults to the active project; pass project_id/project_path only when intentionally searching another registered project.",
         json!({
             "type": "object",
-            "properties": {
+            "properties": with_project_selector_properties(json!({
                 "query": {
                     "type": "string",
                     "description": "Search query string to match against symbol names"
@@ -248,7 +287,7 @@ fn def_search() -> ToolDefinition {
                     "type": "number",
                     "description": "Maximum number of results to return (default: 10)"
                 }
-            },
+            })),
             "required": ["query"]
         }),
     )
@@ -258,15 +297,15 @@ fn def_retrieve() -> ToolDefinition {
     def(
         "tracedecay_retrieve",
         "Retrieve Truncated Response",
-        "Use `tracedecay_retrieve` with required argument `handle` to retrieve the exact cached original text for a local response handle emitted by a truncated MCP response. This does not re-run the source tool or read a file/session/node again; handles are scoped to the active project store, expire automatically, and never reference remote storage. Only call it when the missing details are needed to answer the user's request.",
+        "Use `tracedecay_retrieve` with required argument `handle` to retrieve the exact cached original text for a local response handle emitted by a truncated MCP response. This does not re-run the source tool or read a file/session/node again; handles are scoped to the active project store, expire automatically, and never reference remote storage. If the original truncated response used project_id/project_path, pass the same selector here. Only call it when the missing details are needed to answer the user's request.",
         json!({
             "type": "object",
-            "properties": {
+            "properties": with_project_selector_properties(json!({
                 "handle": {
                     "type": "string",
                     "description": "The required `handle` argument copied exactly from a truncated MCP response envelope."
                 }
-            },
+            })),
             "required": ["handle"]
         }),
     )
@@ -279,7 +318,7 @@ fn def_context() -> ToolDefinition {
         &context_description(0, 3),
         json!({
             "type": "object",
-            "properties": {
+            "properties": with_project_selector_properties(json!({
                 "task": {
                     "type": "string",
                     "description": "Natural language description of the task or question"
@@ -319,7 +358,7 @@ fn def_context() -> ToolDefinition {
                     "type": "number",
                     "description": "Maximum symbols from a single file in results. Prevents one large file from dominating (default: max_nodes/3, minimum 3)"
                 }
-            },
+            })),
             "required": ["task"]
         }),
     )
@@ -419,6 +458,56 @@ fn def_project_context() -> ToolDefinition {
             }
         }),
     )
+}
+
+fn project_selector_properties() -> Value {
+    json!({
+        "project_selector": project_selector_object(
+            "Optional registered project selector. Omit to use the active project.",
+            "query",
+        ),
+        "project_id": {
+            "type": "string",
+            "description": "Convenience selector: registered project id to query instead of the active project."
+        },
+        "project_path": {
+            "type": "string",
+            "description": "Convenience selector: registered project root path or alias to query instead of the active project."
+        }
+    })
+}
+
+fn with_project_selector_properties(mut properties: Value) -> Value {
+    let Some(target) = properties.as_object_mut() else {
+        return properties;
+    };
+    if let Some(selector_props) = project_selector_properties().as_object() {
+        for (key, value) in selector_props {
+            target.insert(key.clone(), value.clone());
+        }
+    }
+    properties
+}
+
+fn project_selector_object(description: &str, verb: &str) -> Value {
+    json!({
+        "type": "object",
+        "description": description,
+        "properties": {
+            "project_id": {
+                "type": "string",
+                "description": format!("Registered project id to {verb}.")
+            },
+            "path": {
+                "type": "string",
+                "description": format!("Registered project root path or alias to {verb}.")
+            },
+            "project_path": {
+                "type": "string",
+                "description": "Alias for path."
+            }
+        }
+    })
 }
 
 fn def_callers_for() -> ToolDefinition {
@@ -1748,6 +1837,18 @@ fn memory_fact_properties() -> Value {
         "note": {
             "type": "string",
             "description": "Human-readable feedback note or action context."
+        },
+        "project_selector": project_selector_object(
+            "Advanced optional registered project selector. Omit to use the active project.",
+            "query",
+        ),
+        "project_id": {
+            "type": "string",
+            "description": "Optional registered project id to query instead of the active project."
+        },
+        "project_path": {
+            "type": "string",
+            "description": "Optional registered project root path or alias to query instead of the active project."
         }
     })
 }
@@ -1811,6 +1912,7 @@ fn def_fact_store() -> ToolDefinition {
         "tracedecay_fact_store",
         "Fact Store",
         "Add, search, probe, relate, reason over, get, update, remove, or list holographic memory facts. The action field selects the operation. \
+         Defaults to the active project; project_id/project_path selectors are supported for read-only retrieval actions only (search/probe/related/reason/contradict/get/list). \
          The add result carries a write-time diff report (diff/closest_fact_id/similarity/reason): near_duplicate = a very similar fact exists \
          (prefer updating it), possible_conflict = a negation/state-change cue suggests supersession (confirm which fact is current), \
          rejected_secret_like = credential-like content was NOT stored. The get action returns the full fact plus trust_history so operators can answer \
@@ -1829,7 +1931,7 @@ fn def_fact_feedback() -> ToolDefinition {
     def_rw(
         "tracedecay_fact_feedback",
         "Fact Feedback",
-        "Record helpful/unhelpful feedback for a memory fact and adjust its trust score.",
+        "Record helpful/unhelpful feedback for an active-project memory fact and adjust its trust score.",
         json!({
             "type": "object",
             "properties": {
@@ -1887,10 +1989,10 @@ fn def_memory_status() -> ToolDefinition {
     def_rw(
         "tracedecay_memory_status",
         "Memory Status",
-        "Repair derived holographic memory vectors and banks, then return fact/entity counts, trust distribution, below-threshold and missing-vector signals, capacity-per-bank, and repair stats. Human/operator equivalents: `tracedecay memory status` and `GET /api/plugins/holographic/status`.",
+        "Repair derived holographic memory vectors and banks, then return fact/entity counts, trust distribution, below-threshold and missing-vector signals, capacity-per-bank, and repair stats. Defaults to the active project; pass project_id or project_path only when intentionally checking another registered project. Human/operator equivalents: `tracedecay memory status` and `GET /api/plugins/holographic/status`.",
         json!({
             "type": "object",
-            "properties": {}
+            "properties": project_selector_properties()
         }),
     )
 }
@@ -1899,7 +2001,7 @@ fn def_message_search() -> ToolDefinition {
     def(
         "tracedecay_message_search",
         "Message Search",
-        "Search ingested Cursor/Codex/agent transcript messages stored in tracedecay's active project session-message FTS index.",
+        "Search ingested Cursor/Codex/agent transcript messages. Defaults to the active project's session-message FTS index; pass project_id or project_path only when intentionally searching another registered project.",
         json!({
             "type": "object",
             "properties": {
@@ -1914,7 +2016,7 @@ fn def_message_search() -> ToolDefinition {
                 },
                 "project_key": {
                     "type": "string",
-                    "description": "Optional project key/path filter. For Cursor transcripts this is the project root path."
+                    "description": "Optional provider-level project key/path filter within the selected session-message store. This is not a registered-project selector; use project_id or project_path to search another registered project's store."
                 },
                 "include_subagents": {
                     "type": "boolean",
@@ -1932,6 +2034,18 @@ fn def_message_search() -> ToolDefinition {
                 "limit": {
                     "type": "number",
                     "description": "Maximum number of messages to return (default: 10, max: 50)."
+                },
+                "project_selector": project_selector_object(
+                    "Advanced optional registered project selector. Omit to use the active project.",
+                    "search",
+                ),
+                "project_id": {
+                    "type": "string",
+                    "description": "Optional registered project id to search instead of the active project."
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Optional registered project root path or alias to search instead of the active project."
                 }
             },
             "required": ["query"]
@@ -2557,11 +2671,11 @@ fn def_lcm_compress() -> ToolDefinition {
                 },
                 "summarizer": {
                     "type": "object",
-                    "description": "Deterministic summarizer mode: noop, fake, provided, or hermes_auxiliary.",
+                    "description": "Runtime summarizer mode: provided or hermes_auxiliary.",
                     "properties": {
                         "mode": {
                             "type": "string",
-                            "enum": ["noop", "fake", "provided", "hermes_auxiliary"]
+                            "enum": ["provided", "hermes_auxiliary"]
                         },
                         "summary_text": {"type": "string"},
                         "route": {"type": "string"}

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -11,7 +11,13 @@ use crate::tracedecay::TraceDecay;
 use crate::types::{NodeKind, Visibility};
 
 use super::super::ToolResult;
-use super::{effective_path, filter_by_scope, truncate_response, unique_file_paths};
+use super::{
+    effective_path, filter_by_scope, truncated_json_envelope_with_handle, unique_file_paths,
+};
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
 
 /// True if `line` contains `identifier` as a whole token (boundaries are
 /// any non-`[A-Za-z0-9_]` char or string ends). Avoids false positives
@@ -195,7 +201,7 @@ pub(super) async fn handle_dead_code(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -259,7 +265,7 @@ pub(super) async fn handle_module_api(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -279,7 +285,7 @@ pub(super) async fn handle_circular(cg: &TraceDecay, _args: Value) -> Result<Too
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -357,7 +363,7 @@ pub(super) async fn handle_hotspots(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -471,7 +477,7 @@ pub(super) async fn handle_unused_imports(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -559,7 +565,7 @@ pub(super) async fn handle_rank(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -613,7 +619,7 @@ pub(super) async fn handle_largest(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -668,7 +674,7 @@ pub(super) async fn handle_coupling(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -713,7 +719,7 @@ pub(super) async fn handle_inheritance_depth(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -787,7 +793,7 @@ pub(super) async fn handle_distribution(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -886,7 +892,7 @@ pub(super) async fn handle_recursion(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1163,7 +1169,7 @@ pub(super) async fn handle_complexity(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1225,7 +1231,7 @@ pub(super) async fn handle_doc_coverage(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1272,7 +1278,7 @@ pub(super) async fn handle_god_class(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1460,7 +1466,7 @@ pub(super) async fn handle_unsafe_patterns(
     let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -1532,9 +1538,10 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
             let fetched = cg.get_nodes_by_file(&diag.file).await?;
             nodes_by_file.entry(diag.file.clone()).or_insert(fetched)
         };
+        let node_line = diag.line_start.saturating_sub(1);
         let enclosing = nodes
             .iter()
-            .filter(|n| n.start_line <= diag.line_start && diag.line_start <= n.end_line)
+            .filter(|n| n.start_line <= node_line && node_line <= n.end_line)
             .min_by_key(|n| n.end_line.saturating_sub(n.start_line))
             .map(|n| n.qualified_name.clone());
         if !touched.contains(&diag.file) {
@@ -1562,7 +1569,7 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
     let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -1680,7 +1687,7 @@ pub(super) async fn handle_constructors(
     let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -2064,7 +2071,7 @@ pub(super) async fn handle_field_sites(
     let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })

--- a/src/mcp/tools/handlers/git.rs
+++ b/src/mcp/tools/handlers/git.rs
@@ -7,9 +7,36 @@ use std::collections::{HashMap, HashSet};
 use serde_json::{json, Value};
 
 use super::super::ToolResult;
-use super::{truncate_response, unique_file_paths};
+use super::{truncated_json_envelope_with_handle, unique_file_paths};
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitFileChange {
+    path: String,
+    status: &'static str,
+}
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
+
+fn git_error_result(cg: &TraceDecay, operation: &str, message: String) -> ToolResult {
+    let output = json!({
+        "error": {
+            "kind": "git",
+            "operation": operation,
+            "message": message,
+        }
+    });
+    let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
+    ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
+        }),
+        touched_files: vec![],
+    }
+}
 
 /// Handles `tracedecay_affected` tool calls.
 pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
@@ -86,7 +113,7 @@ pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<Tool
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -238,18 +265,18 @@ pub(super) async fn handle_diff_context(cg: &TraceDecay, args: Value) -> Result<
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
 }
 
-/// Diff two git refs and return the list of changed file paths.
-fn git_diff_files(
+/// Diff two git refs and return changed file paths with coarse status.
+fn git_diff_file_changes(
     project_root: &std::path::Path,
     from_ref: &str,
     to_ref: &str,
-) -> std::result::Result<Vec<String>, String> {
+) -> std::result::Result<Vec<GitFileChange>, String> {
     let repo = gix::open(project_root).map_err(|e| format!("failed to open git repo: {e}"))?;
 
     let from_tree = repo
@@ -285,19 +312,36 @@ fn git_diff_files(
                     location,
                     entry_mode,
                     ..
+                } => {
+                    if !entry_mode.is_tree() {
+                        changed.push(GitFileChange {
+                            path: location.to_string(),
+                            status: "added",
+                        });
+                    }
                 }
-                | Change::Modification {
-                    location,
-                    entry_mode,
-                    ..
-                }
-                | Change::Deletion {
+                Change::Modification {
                     location,
                     entry_mode,
                     ..
                 } => {
                     if !entry_mode.is_tree() {
-                        changed.push(location.to_string());
+                        changed.push(GitFileChange {
+                            path: location.to_string(),
+                            status: "modified",
+                        });
+                    }
+                }
+                Change::Deletion {
+                    location,
+                    entry_mode,
+                    ..
+                } => {
+                    if !entry_mode.is_tree() {
+                        changed.push(GitFileChange {
+                            path: location.to_string(),
+                            status: "deleted",
+                        });
                     }
                 }
                 Change::Rewrite {
@@ -308,10 +352,16 @@ fn git_diff_files(
                     ..
                 } => {
                     if !source_entry_mode.is_tree() {
-                        changed.push(source_location.to_string());
+                        changed.push(GitFileChange {
+                            path: source_location.to_string(),
+                            status: "deleted",
+                        });
                     }
                     if !entry_mode.is_tree() {
-                        changed.push(location.to_string());
+                        changed.push(GitFileChange {
+                            path: location.to_string(),
+                            status: "added",
+                        });
                     }
                 }
             }
@@ -323,7 +373,7 @@ fn git_diff_files(
     // path that resolves to a directory on disk for additions/modifications.
     // Pure deletions can't be checked this way (the path is gone), which is
     // exactly why entry_mode.is_tree() above is the load-bearing filter.
-    changed.retain(|p| !project_root.join(p).is_dir());
+    changed.retain(|change| !project_root.join(&change.path).is_dir());
     Ok(changed)
 }
 
@@ -557,24 +607,22 @@ pub(super) async fn handle_changelog(cg: &TraceDecay, args: Value) -> Result<Too
             })?;
 
     // Use gix to diff the two trees
-    let changed_files: Vec<String> = match git_diff_files(cg.project_root(), from_ref, to_ref) {
+    let changes = match git_diff_file_changes(cg.project_root(), from_ref, to_ref) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(ToolResult {
-                value: json!({
-                    "content": [{ "type": "text", "text": format!("git diff failed: {}", e) }]
-                }),
-                touched_files: vec![],
-            });
+            return Ok(git_error_result(cg, "diff", e));
         }
     };
+    let changed_files: Vec<String> = changes.iter().map(|change| change.path.clone()).collect();
 
     // For each changed file, get current symbols from the graph
-    let mut added: Vec<Value> = Vec::new();
+    let mut symbols_added: Vec<Value> = Vec::new();
+    let mut symbols_modified: Vec<Value> = Vec::new();
     let mut modified: Vec<Value> = Vec::new();
     let mut file_symbols: HashMap<String, Vec<Value>> = HashMap::new();
 
-    for file in &changed_files {
+    for change in &changes {
+        let file = &change.path;
         let nodes = cg.get_nodes_by_file(file).await?;
         let symbols: Vec<Value> = nodes
             .iter()
@@ -594,12 +642,12 @@ pub(super) async fn handle_changelog(cg: &TraceDecay, args: Value) -> Result<Too
             // File was likely removed or not indexed
             modified.push(json!({
                 "file": file,
-                "status": "removed_or_not_indexed",
+                "status": change.status,
             }));
+        } else if change.status == "added" {
+            symbols_added.extend(symbols.iter().cloned());
         } else {
-            for sym in &symbols {
-                added.push(sym.clone());
-            }
+            symbols_modified.extend(symbols.iter().cloned());
         }
         file_symbols.insert(file.clone(), symbols);
     }
@@ -611,14 +659,20 @@ pub(super) async fn handle_changelog(cg: &TraceDecay, args: Value) -> Result<Too
         "to_ref": to_ref,
         "changed_file_count": changed_files.len(),
         "changed_files": changed_files,
-        "symbols_in_changed_files": added,
+        "symbols_added": symbols_added,
+        "symbols_modified": symbols_modified,
+        "symbols_in_changed_files": file_symbols
+            .values()
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>(),
         "files_not_indexed": modified,
     });
 
     let formatted = serde_json::to_string_pretty(&result).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -634,10 +688,7 @@ pub(super) async fn handle_commit_context(cg: &TraceDecay, args: Value) -> Resul
     let changed_files = match git_changed_files(cg.project_root(), staged_only) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(ToolResult {
-                value: json!({"content": [{"type": "text", "text": format!("git error: {}", e)}]}),
-                touched_files: vec![],
-            });
+            return Ok(git_error_result(cg, "status", e));
         }
     };
 
@@ -703,7 +754,7 @@ pub(super) async fn handle_commit_context(cg: &TraceDecay, args: Value) -> Resul
 
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
-        value: json!({"content": [{"type": "text", "text": truncate_response(&formatted)}]}),
+        value: json!({"content": [{"type": "text", "text": project_response_text(cg, &formatted)}]}),
         touched_files: changed_files,
     })
 }
@@ -719,15 +770,13 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
         .and_then(|v| v.as_str())
         .unwrap_or("HEAD");
 
-    let changed_files = match git_diff_files(cg.project_root(), base, head) {
+    let changes = match git_diff_file_changes(cg.project_root(), base, head) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(ToolResult {
-                value: json!({"content": [{"type": "text", "text": format!("git error: {}", e)}]}),
-                touched_files: vec![],
-            });
+            return Ok(git_error_result(cg, "diff", e));
         }
     };
+    let changed_files: Vec<String> = changes.iter().map(|change| change.path.clone()).collect();
 
     let commits = git_commit_log(cg.project_root(), base, head).unwrap_or_default();
 
@@ -742,7 +791,8 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
         crate::tracedecay::is_test_file(path) || files_with_inline_tests.contains(path)
     };
 
-    for file in &changed_files {
+    for change in &changes {
+        let file = &change.path;
         if has_tests(file) {
             test_files_changed.push(file.clone());
         }
@@ -770,15 +820,21 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
                 "line": node.start_line,
             });
 
-            // Check if this symbol has callers outside changed files — if so, it's
-            // a modification to an existing API. Otherwise it's likely new.
+            // Only brand symbols as added when the file itself is added. For
+            // modified files the graph only has the post-change symbol set, so
+            // per-symbol added/modified inference would overstate additions.
             let callers = cg.get_callers(&node.id, 1).await?;
             let has_external_callers = callers
                 .iter()
                 .any(|(c, _)| !changed_files.contains(&c.file_path));
 
-            if has_external_callers {
+            if change.status == "added" {
+                symbols_added.push(sym);
+            } else {
                 symbols_modified.push(sym);
+            }
+
+            if has_external_callers {
                 // Track impacted modules
                 for (caller, _) in &callers {
                     if !changed_files.contains(&caller.file_path) {
@@ -791,8 +847,6 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
                         impacted_modules.insert(dir.to_string());
                     }
                 }
-            } else {
-                symbols_added.push(sym);
             }
         }
     }
@@ -835,7 +889,7 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
 
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
-        value: json!({"content": [{"type": "text", "text": truncate_response(&formatted)}]}),
+        value: json!({"content": [{"type": "text", "text": project_response_text(cg, &formatted)}]}),
         touched_files: changed_files,
     })
 }
@@ -856,7 +910,7 @@ pub(super) fn handle_branch_list(cg: &TraceDecay) -> ToolResult {
     let output = serde_json::to_string_pretty(&result).unwrap_or_default();
     ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files: vec![],
     }
@@ -903,7 +957,7 @@ pub(super) async fn handle_branch_search(cg: &TraceDecay, args: Value) -> Result
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files: vec![],
     })
@@ -953,7 +1007,7 @@ pub(super) async fn handle_branch_diff(cg: &TraceDecay, args: Value) -> Result<T
         let output = serde_json::to_string_pretty(&result).unwrap_or_default();
         return Ok(ToolResult {
             value: json!({
-                "content": [{ "type": "text", "text": truncate_response(&output) }]
+                "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
             }),
             touched_files: vec![],
         });
@@ -1085,7 +1139,7 @@ pub(super) async fn handle_branch_diff(cg: &TraceDecay, args: Value) -> Result<T
     let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -14,8 +14,17 @@ use crate::types::{BuildContextOptions, EdgeKind, NodeKind, Visibility};
 
 use super::super::ToolResult;
 use super::{
-    effective_path, filter_by_scope, require_node_id, truncate_response, unique_file_paths,
+    effective_path, filter_by_scope, require_node_id, truncated_json_envelope_with_handle,
+    unique_file_paths,
 };
+
+fn user_line(line: u32) -> u32 {
+    line.saturating_add(1)
+}
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
 
 /// Handles `tracedecay_search` tool calls.
 pub(super) async fn handle_search(
@@ -37,6 +46,7 @@ pub(super) async fn handle_search(
 
     let results = cg.search(query, limit).await?;
     let results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
+    let coverage_hint = cg.index_coverage_hint(results.len());
 
     let touched_files = unique_file_paths(results.iter().map(|r| r.node.file_path.as_str()));
 
@@ -48,17 +58,25 @@ pub(super) async fn handle_search(
                 "name": r.node.name,
                 "kind": r.node.kind.as_str(),
                 "file": r.node.file_path,
-                "line": r.node.start_line,
+                "line": user_line(r.node.start_line),
                 "signature": r.node.signature,
                 "score": r.score,
             })
         })
         .collect();
 
-    let output = serde_json::to_string_pretty(&items).unwrap_or_default();
+    let output_value = if let Some(hint) = coverage_hint {
+        json!({
+            "results": items,
+            "index_coverage_hint": hint,
+        })
+    } else {
+        json!(items)
+    };
+    let output = serde_json::to_string_pretty(&output_value).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -157,6 +175,15 @@ pub(super) async fn handle_context(
             ),
     );
     let mut output = format_context_as_markdown(&context);
+    if let Some(hint) = cg.index_coverage_hint(context.subgraph.nodes.len()) {
+        let _ = writeln!(
+            output,
+            "\n### Index Coverage Hint\n{}\nSkipped trees seen: {}\nTo opt in, run: `{}`\n",
+            hint.message,
+            hint.skipped_dirs.join(", "),
+            hint.suggested_command,
+        );
+    }
 
     // Plan mode: append extension points, test coverage, and dependency info
     if mode == "plan" {
@@ -177,7 +204,7 @@ pub(super) async fn handle_context(
                     node.name,
                     node.kind.as_str(),
                     node.file_path,
-                    node.start_line,
+                    user_line(node.start_line),
                     impl_count,
                 );
                 found_extension = true;
@@ -237,7 +264,7 @@ pub(super) async fn handle_context(
 
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -264,7 +291,7 @@ pub(super) async fn handle_callers(cg: &TraceDecay, args: Value) -> Result<ToolR
                 "name": node.name,
                 "kind": node.kind.as_str(),
                 "file": node.file_path,
-                "line": node.start_line,
+                "line": user_line(node.start_line),
                 "edge_kind": edge.kind.as_str(),
             })
         })
@@ -273,7 +300,7 @@ pub(super) async fn handle_callers(cg: &TraceDecay, args: Value) -> Result<ToolR
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -313,7 +340,7 @@ pub(super) async fn handle_callees(cg: &TraceDecay, args: Value) -> Result<ToolR
                 "name": node.name,
                 "kind": node.kind.as_str(),
                 "file": node.file_path,
-                "line": node.start_line,
+                "line": user_line(node.start_line),
                 "edge_kind": edge.kind.as_str(),
                 "dispatch_via_trait": false,
             })
@@ -332,7 +359,7 @@ pub(super) async fn handle_callees(cg: &TraceDecay, args: Value) -> Result<ToolR
                     "name": impl_method.name,
                     "kind": impl_method.kind.as_str(),
                     "file": impl_method.file_path,
-                    "line": impl_method.start_line,
+                    "line": user_line(impl_method.start_line),
                     "edge_kind": "calls",
                     "dispatch_via_trait": true,
                     "dispatch_from": callee.id.clone(),
@@ -350,7 +377,7 @@ pub(super) async fn handle_callees(cg: &TraceDecay, args: Value) -> Result<ToolR
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -394,7 +421,7 @@ pub(super) async fn handle_find_exact_symbol(
                 "qualified_name": n.qualified_name,
                 "kind": n.kind.as_str(),
                 "file": n.file_path,
-                "line": n.start_line,
+                "line": user_line(n.start_line),
                 "signature": n.signature,
             })
         })
@@ -408,7 +435,7 @@ pub(super) async fn handle_find_exact_symbol(
     let formatted = serde_json::to_string_pretty(&body).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -445,7 +472,7 @@ pub(super) async fn handle_call_chain(cg: &TraceDecay, args: Value) -> Result<To
                     "name": n.name,
                     "kind": n.kind.as_str(),
                     "file": n.file_path,
-                    "line": n.start_line,
+                    "line": user_line(n.start_line),
                     "edge_kind": edge.as_ref().map(|e| e.kind.as_str()),
                 })
             })
@@ -473,7 +500,7 @@ pub(super) async fn handle_call_chain(cg: &TraceDecay, args: Value) -> Result<To
     let formatted = serde_json::to_string_pretty(&body).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -498,7 +525,7 @@ pub(super) async fn handle_file_dependents(cg: &TraceDecay, args: Value) -> Resu
     let formatted = serde_json::to_string_pretty(&body).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -526,7 +553,7 @@ pub(super) async fn handle_impact(cg: &TraceDecay, args: Value) -> Result<ToolRe
                 "name": n.name,
                 "kind": n.kind.as_str(),
                 "file": n.file_path,
-                "line": n.start_line,
+                "line": user_line(n.start_line),
             })
         })
         .collect();
@@ -540,7 +567,7 @@ pub(super) async fn handle_impact(cg: &TraceDecay, args: Value) -> Result<ToolRe
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -591,8 +618,8 @@ pub(super) async fn handle_node(cg: &TraceDecay, args: Value) -> Result<ToolResu
                 "kind": n.kind.as_str(),
                 "qualified_name": n.qualified_name,
                 "file": n.file_path,
-                "start_line": n.start_line,
-                "end_line": n.end_line,
+                "start_line": user_line(n.start_line),
+                "end_line": user_line(n.end_line),
                 "signature": n.signature,
                 "docstring": n.docstring,
                 "visibility": n.visibility.as_str(),
@@ -611,7 +638,7 @@ pub(super) async fn handle_node(cg: &TraceDecay, args: Value) -> Result<ToolResu
             let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
             Ok(ToolResult {
                 value: json!({
-                    "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+                    "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
                 }),
                 touched_files,
             })
@@ -681,7 +708,7 @@ pub(super) async fn handle_similar(cg: &TraceDecay, args: Value) -> Result<ToolR
                 "name": r.node.name,
                 "kind": r.node.kind.as_str(),
                 "file": r.node.file_path,
-                "line": r.node.start_line,
+                "line": user_line(r.node.start_line),
                 "signature": r.node.signature,
                 "score": r.score,
             })
@@ -691,7 +718,7 @@ pub(super) async fn handle_similar(cg: &TraceDecay, args: Value) -> Result<ToolR
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -709,7 +736,7 @@ pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Resul
             "name": n.name,
             "kind": n.kind.as_str(),
             "file": n.file_path,
-            "line": n.start_line,
+            "line": user_line(n.start_line),
         }),
         None => {
             return Ok(ToolResult {
@@ -742,7 +769,7 @@ pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Resul
                 "name": source_node.name,
                 "kind": source_node.kind.as_str(),
                 "file": source_node.file_path,
-                "line": source_node.start_line,
+                "line": user_line(source_node.start_line),
                 "edge_kind": edge.kind.as_str(),
                 "edge_line": edge.line,
             }));
@@ -759,7 +786,7 @@ pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Resul
                 "name": target_node.name,
                 "kind": target_node.kind.as_str(),
                 "file": target_node.file_path,
-                "line": target_node.start_line,
+                "line": user_line(target_node.start_line),
                 "edge_kind": edge.kind.as_str(),
                 "edge_line": edge.line,
             }));
@@ -777,7 +804,7 @@ pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Resul
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -849,7 +876,7 @@ pub(super) async fn handle_callers_for(cg: &TraceDecay, args: Value) -> Result<T
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -876,9 +903,9 @@ pub(super) async fn handle_by_qualified_name(cg: &TraceDecay, args: Value) -> Re
                 "qualified_name": n.qualified_name,
                 "kind": n.kind.as_str(),
                 "file": n.file_path,
-                "start_line": n.start_line,
-                "attrs_start_line": n.attrs_start_line,
-                "end_line": n.end_line,
+                "start_line": user_line(n.start_line),
+                "attrs_start_line": user_line(n.attrs_start_line),
+                "end_line": user_line(n.end_line),
             })
         })
         .collect();
@@ -886,7 +913,7 @@ pub(super) async fn handle_by_qualified_name(cg: &TraceDecay, args: Value) -> Re
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -934,9 +961,9 @@ pub(super) async fn handle_signature(cg: &TraceDecay, args: Value) -> Result<Too
             "signature": n.signature,
             "docstring": n.docstring,
             "file": n.file_path,
-            "start_line": n.start_line,
-            "attrs_start_line": n.attrs_start_line,
-            "end_line": n.end_line,
+            "start_line": user_line(n.start_line),
+            "attrs_start_line": user_line(n.attrs_start_line),
+            "end_line": user_line(n.end_line),
             "cost_to_expand": cost_to_expand(n, file_size_bytes),
         }));
     }
@@ -944,7 +971,7 @@ pub(super) async fn handle_signature(cg: &TraceDecay, args: Value) -> Result<Too
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -984,8 +1011,8 @@ pub(super) async fn handle_impls(cg: &TraceDecay, args: Value) -> Result<ToolRes
                 "trait_qualified_name": trait_node.as_ref().map(|t| t.qualified_name.clone()),
                 "trait_id": trait_node.as_ref().map(|t| t.id.clone()),
                 "file": impl_node.file_path,
-                "start_line": impl_node.start_line,
-                "end_line": impl_node.end_line,
+                "start_line": user_line(impl_node.start_line),
+                "end_line": user_line(impl_node.end_line),
                 "signature": impl_node.signature,
             })
         })
@@ -999,7 +1026,7 @@ pub(super) async fn handle_impls(cg: &TraceDecay, args: Value) -> Result<ToolRes
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1055,7 +1082,7 @@ pub(super) async fn handle_derives(cg: &TraceDecay, args: Value) -> Result<ToolR
             "kind": n.kind.as_str(),
             "qualified_name": n.qualified_name,
             "file": n.file_path,
-            "start_line": n.start_line,
+            "start_line": user_line(n.start_line),
             "derives": derives,
         }));
     }
@@ -1063,7 +1090,7 @@ pub(super) async fn handle_derives(cg: &TraceDecay, args: Value) -> Result<ToolR
     let output = serde_json::to_string_pretty(&items).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&output) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files,
     })
@@ -1164,7 +1191,7 @@ pub(super) async fn handle_implementations(
                     "qualified_name": impl_node.qualified_name,
                     "kind": impl_node.kind.as_str(),
                     "file": impl_node.file_path,
-                    "line": impl_node.start_line,
+                    "line": user_line(impl_node.start_line),
                     "trait": trait_node.qualified_name,
                     "methods": methods,
                 }));
@@ -1209,8 +1236,8 @@ pub(super) async fn handle_implementations(
                 "qualified_name": n.qualified_name,
                 "kind": n.kind.as_str(),
                 "file": n.file_path,
-                "line": n.start_line,
-                "end_line": n.end_line,
+                "line": user_line(n.start_line),
+                "end_line": user_line(n.end_line),
                 "signature": n.signature,
                 "body": body,
             }));
@@ -1225,7 +1252,7 @@ pub(super) async fn handle_implementations(
 
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -1250,7 +1277,7 @@ async fn collect_method_bodies(
         out.push(json!({
             "name": child.name,
             "kind": child.kind.as_str(),
-            "line": child.start_line,
+            "line": user_line(child.start_line),
             "signature": child.signature,
             "body": body,
         }));

--- a/src/mcp/tools/handlers/health.rs
+++ b/src/mcp/tools/handlers/health.rs
@@ -26,7 +26,11 @@ use crate::tracedecay::TraceDecay;
 use crate::types::{EdgeKind, NodeKind};
 
 use super::super::ToolResult;
-use super::{effective_path, truncate_response, unique_file_paths};
+use super::{effective_path, truncated_json_envelope_with_handle, unique_file_paths};
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
 
 // ---------------------------------------------------------------------------
 // Shared health computation helper
@@ -347,7 +351,7 @@ pub(super) async fn handle_gini(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -394,7 +398,7 @@ pub(super) async fn handle_dependency_depth(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -470,7 +474,7 @@ pub(super) async fn handle_health(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -486,7 +490,7 @@ pub(super) async fn handle_runtime(cg: &TraceDecay, _args: Value) -> Result<Tool
     let formatted = crate::runtime_telemetry::to_pretty_json(&snap);
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -628,7 +632,7 @@ pub(super) async fn handle_dsm(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -989,7 +993,7 @@ pub(super) async fn handle_test_risk(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -1075,7 +1079,7 @@ pub(super) async fn handle_test_map(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     let touched_files = unique_file_paths(source_nodes.iter().map(|n| n.file_path.as_str()));
     Ok(ToolResult {
-        value: json!({"content": [{"type": "text", "text": truncate_response(&formatted)}]}),
+        value: json!({"content": [{"type": "text", "text": project_response_text(cg, &formatted)}]}),
         touched_files,
     })
 }
@@ -1131,7 +1135,7 @@ pub(super) async fn handle_session_start(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -1155,7 +1159,7 @@ pub(super) async fn handle_session_end(
         let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
         return Ok(ToolResult {
             value: json!({
-                "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+                "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
             }),
             touched_files: vec![],
         });
@@ -1242,7 +1246,7 @@ pub(super) async fn handle_session_end(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -14,7 +14,14 @@ use crate::tracedecay::{BranchDiagnostics, TraceDecay};
 use crate::types::{NodeKind, Visibility};
 
 use super::super::ToolResult;
-use super::{effective_path, require_node_id, truncate_response, unique_file_paths};
+use super::{
+    effective_path, require_node_id, truncate_response, truncated_json_envelope_with_handle,
+    unique_file_paths,
+};
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
 
 /// Handles `tracedecay_status` tool calls.
 pub(super) async fn handle_status(
@@ -135,7 +142,7 @@ pub(super) async fn handle_status(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -218,7 +225,7 @@ pub(super) fn handle_active_project(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     }
@@ -279,7 +286,7 @@ pub(super) async fn handle_storage_status(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -308,6 +315,16 @@ async fn open_project_registry_read_only() -> Result<Option<(PathBuf, GlobalDb)>
             ),
         })?;
     Ok(Some((path, db)))
+}
+
+fn project_registry_result(cg: &TraceDecay, payload: &Value) -> ToolResult {
+    let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
+    ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
+        }),
+        touched_files: vec![],
+    }
 }
 
 fn registry_result(payload: &Value) -> ToolResult {
@@ -403,7 +420,7 @@ fn project_context_alias_path<'a>(cg: &'a TraceDecay, args: &'a Value) -> PathBu
 /// Handles `tracedecay_project_context` tool calls.
 pub(super) async fn handle_project_context(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let Some((registry_path, db)) = open_project_registry_read_only().await? else {
-        return Ok(registry_result(&registry_missing_payload()));
+        return Ok(project_registry_result(cg, &registry_missing_payload()));
     };
     let context = if let Some(project_id) = args.get("project_id").and_then(Value::as_str) {
         db.project_registry_context_by_id(project_id).await
@@ -412,21 +429,27 @@ pub(super) async fn handle_project_context(cg: &TraceDecay, args: Value) -> Resu
         db.project_registry_context_by_alias(&alias_path).await
     };
     let Some(context) = context else {
-        return Ok(registry_result(&json!({
-            "status": "not_found",
-            "registry_path": display_path(&registry_path),
-            "project": null,
-            "aliases": [],
-            "stores": [],
-        })));
+        return Ok(project_registry_result(
+            cg,
+            &json!({
+                "status": "not_found",
+                "registry_path": display_path(&registry_path),
+                "project": null,
+                "aliases": [],
+                "stores": [],
+            }),
+        ));
     };
-    Ok(registry_result(&json!({
-        "status": "ok",
-        "registry_path": display_path(&registry_path),
-        "project": registry_project_value(&context.project),
-        "aliases": context.aliases,
-        "stores": context.stores,
-    })))
+    Ok(project_registry_result(
+        cg,
+        &json!({
+            "status": "ok",
+            "registry_path": display_path(&registry_path),
+            "project": registry_project_value(&context.project),
+            "aliases": context.aliases,
+            "stores": context.stores,
+        }),
+    ))
 }
 
 /// Handles `tracedecay_files` tool calls.
@@ -729,7 +752,7 @@ pub(super) async fn handle_port_status(cg: &TraceDecay, args: Value) -> Result<T
     let formatted = serde_json::to_string_pretty(&result).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1101,7 +1124,7 @@ pub(super) async fn handle_port_order(cg: &TraceDecay, args: Value) -> Result<To
     let formatted = serde_json::to_string_pretty(&result).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -1223,7 +1246,7 @@ pub(super) async fn handle_simplify_scan(
 
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
-        value: json!({"content": [{"type": "text", "text": truncate_response(&formatted)}]}),
+        value: json!({"content": [{"type": "text", "text": project_response_text(cg, &formatted)}]}),
         touched_files: files,
     })
 }
@@ -1412,7 +1435,7 @@ pub(super) async fn handle_body(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -1588,7 +1611,7 @@ pub(super) async fn handle_todos(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -1823,7 +1846,7 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
 
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![display_file],
     })
@@ -1855,7 +1878,7 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
 
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![display_file],
     })
@@ -1969,7 +1992,7 @@ pub(super) fn handle_config(cg: &TraceDecay, args: &Value) -> Result<ToolResult>
     let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })
@@ -2145,7 +2168,7 @@ pub(super) async fn handle_signature_search(
     let formatted = serde_json::to_string_pretty(&payload).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched,
     })

--- a/src/mcp/tools/handlers/memory.rs
+++ b/src/mcp/tools/handlers/memory.rs
@@ -1,21 +1,25 @@
 //! Cross-session and holographic memory handlers.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
+use crate::db::Database;
 use crate::errors::{Result, TraceDecayError};
 use crate::memory::retrieval::FactRetriever;
 use crate::memory::store::MemoryStore;
 use crate::memory::trust::DEFAULT_TRUST;
 use crate::memory::types::{
-    AddFactRequest, FeedbackAction, FeedbackRequest, MemoryCategory, SearchFactsRequest,
-    UpdateFactRequest,
+    AddFactRequest, FactRecord, FactSearchResult, FeedbackAction, FeedbackRequest, MemoryCategory,
+    SearchFactsRequest, UpdateFactRequest,
 };
 use crate::tracedecay::TraceDecay;
 
 use super::super::ToolResult;
-use super::truncated_json_envelope_with_handle;
+use super::{
+    global_db_profile_root, project_registry_context, project_selector_present,
+    safe_profile_relpath, truncated_json_envelope_with_handle,
+};
 
 const DEFAULT_FACT_LIMIT: usize = 20;
 const MAX_FACT_LIMIT: usize = 200;
@@ -26,6 +30,37 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
         value: json!({ "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(project_root, &formatted) }] }),
         touched_files: vec![],
     }
+}
+
+async fn open_target_memory_db(cg: &TraceDecay, args: &Value) -> Result<(Database, PathBuf)> {
+    let Some(context) = project_registry_context(args, &["project_path"]).await? else {
+        return Ok((
+            cg.open_project_store_db().await?,
+            cg.project_root().to_path_buf(),
+        ));
+    };
+    let profile_root = global_db_profile_root()?;
+    let graph_relpath = context
+        .stores
+        .iter()
+        .flat_map(|store| store.artifacts.iter())
+        .find(|artifact| artifact.artifact_kind == "graph_db")
+        .map(|artifact| artifact.relpath.as_str())
+        .ok_or_else(|| {
+            config_error(format!(
+                "project {} has no registered graph_db artifact",
+                context.project.project_id
+            ))
+        })?;
+    let db_path = profile_root.join(safe_profile_relpath(graph_relpath)?);
+    if !db_path.is_file() {
+        return Err(config_error(format!(
+            "registered graph_db artifact does not exist: {}",
+            db_path.display()
+        )));
+    }
+    let (db, _) = Database::open(&db_path).await?;
+    Ok((db, PathBuf::from(context.project.display_root)))
 }
 
 fn config_error(message: impl Into<String>) -> TraceDecayError {
@@ -142,11 +177,11 @@ fn results_envelope(action: &str, results: &Value, count: usize) -> Value {
     })
 }
 
-fn fact_result_ids(results: &[crate::memory::types::FactSearchResult]) -> Vec<i64> {
+fn fact_result_ids(results: &[FactSearchResult]) -> Vec<i64> {
     results.iter().map(|result| result.fact.fact_id).collect()
 }
 
-fn fact_ids(facts: &[crate::memory::types::FactRecord]) -> Vec<i64> {
+fn fact_ids(facts: &[FactRecord]) -> Vec<i64> {
     facts.iter().map(|fact| fact.fact_id).collect()
 }
 
@@ -159,6 +194,45 @@ fn update_rejected_secret_like(err: &TraceDecayError) -> Option<String> {
         }
         _ => None,
     }
+}
+
+fn action_mutates_memory(action: &str) -> bool {
+    matches!(action, "add" | "update" | "remove")
+}
+
+async fn record_retrieval_counts(
+    store: &MemoryStore<'_>,
+    cross_project_selector: bool,
+    ids: &[i64],
+) -> Result<()> {
+    if !cross_project_selector {
+        store.increment_retrieval_counts(ids).await?;
+    }
+    Ok(())
+}
+
+async fn search_results_envelope(
+    store: &MemoryStore<'_>,
+    cross_project_selector: bool,
+    action: &str,
+    facts: Vec<FactSearchResult>,
+) -> Result<Value> {
+    let ids = fact_result_ids(&facts);
+    record_retrieval_counts(store, cross_project_selector, &ids).await?;
+    let count = facts.len();
+    Ok(results_envelope(action, &json!(facts), count))
+}
+
+async fn fact_records_envelope(
+    store: &MemoryStore<'_>,
+    cross_project_selector: bool,
+    action: &str,
+    facts: Vec<FactRecord>,
+) -> Result<Value> {
+    let ids = fact_ids(&facts);
+    record_retrieval_counts(store, cross_project_selector, &ids).await?;
+    let count = facts.len();
+    Ok(results_envelope(action, &json!(facts), count))
 }
 
 async fn update_trust(args: &Value, store: &MemoryStore<'_>, fact_id: i64) -> Result<Option<f64>> {
@@ -177,7 +251,13 @@ async fn update_trust(args: &Value, store: &MemoryStore<'_>, fact_id: i64) -> Re
 
 pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let action = required_str(&args, "action")?;
-    let db = cg.open_project_store_db().await?;
+    let cross_project_selector = project_selector_present(&args, &["project_path"]);
+    if action_mutates_memory(action) && cross_project_selector {
+        return Err(config_error(
+            "cross-project fact_store writes are not supported; omit project_selector to write the active project",
+        ));
+    }
+    let (db, target_root) = open_target_memory_db(cg, &args).await?;
     let conn = db.conn();
     let store = MemoryStore::new(conn);
     let out = match action {
@@ -228,10 +308,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                     request.limit.unwrap_or(DEFAULT_FACT_LIMIT),
                 )
                 .await?;
-            let ids = fact_result_ids(&facts);
-            store.increment_retrieval_counts(&ids).await?;
-            let count = facts.len();
-            results_envelope(action, &json!(facts), count)
+            search_results_envelope(&store, cross_project_selector, action, facts).await?
         }
         "probe" => {
             let facts = FactRetriever::new(conn)
@@ -242,10 +319,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                     limit(&args),
                 )
                 .await?;
-            let ids = fact_result_ids(&facts);
-            store.increment_retrieval_counts(&ids).await?;
-            let count = facts.len();
-            results_envelope(action, &json!(facts), count)
+            search_results_envelope(&store, cross_project_selector, action, facts).await?
         }
         "related" => {
             let limit = limit(&args);
@@ -276,10 +350,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                     break;
                 }
             }
-            let ids = fact_result_ids(&facts);
-            store.increment_retrieval_counts(&ids).await?;
-            let count = facts.len();
-            results_envelope(action, &json!(facts), count)
+            search_results_envelope(&store, cross_project_selector, action, facts).await?
         }
         "reason" => {
             let entities = request_entities(&args);
@@ -291,10 +362,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                     limit(&args),
                 )
                 .await?;
-            let ids = fact_result_ids(&facts);
-            store.increment_retrieval_counts(&ids).await?;
-            let count = facts.len();
-            results_envelope(action, &json!(facts), count)
+            search_results_envelope(&store, cross_project_selector, action, facts).await?
         }
         "contradict" => {
             let threshold = optional_f64(&args, "threshold").unwrap_or(0.3);
@@ -385,14 +453,11 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                     limit(&args),
                 )
                 .await?;
-            let ids = fact_ids(&facts);
-            store.increment_retrieval_counts(&ids).await?;
-            let count = facts.len();
-            results_envelope(action, &json!(facts), count)
+            fact_records_envelope(&store, cross_project_selector, action, facts).await?
         }
         other => return Err(config_error(format!("unknown fact_store action: {other}"))),
     };
-    Ok(tool_json(Some(cg.project_root()), &out))
+    Ok(tool_json(Some(&target_root), &out))
 }
 
 pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
@@ -419,10 +484,11 @@ pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result
     ))
 }
 
-pub(super) async fn handle_memory_status(cg: &TraceDecay) -> Result<ToolResult> {
-    let status = cg.project_memory_status().await?;
+pub(super) async fn handle_memory_status(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+    let (db, target_root) = open_target_memory_db(cg, &args).await?;
+    let status = TraceDecay::memory_status_for_conn(db.conn()).await?;
     Ok(tool_json(
-        Some(cg.project_root()),
+        Some(&target_root),
         &json!({ "status": "ok", "memory": status }),
     ))
 }

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -17,11 +17,12 @@ pub mod session;
 pub mod workflow;
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::{json, Value};
 
 use crate::errors::{Result, TraceDecayError};
+use crate::global_db::{global_db_path, GlobalDb, ProjectRegistryContext};
 use crate::mcp::response_handles::{
     note_response_handle_store_skipped_no_project_root, observe_response_truncation,
     retrieve_response_handle, store_response_handle, ResponseHandleLookup,
@@ -93,6 +94,180 @@ pub(crate) fn unique_file_paths<'a>(paths: impl Iterator<Item = &'a str>) -> Vec
         }
     }
     result
+}
+
+pub(crate) fn safe_profile_relpath(value: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(value);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(TraceDecayError::Config {
+            message: format!("registry artifact path is not a safe profile-relative path: {value}"),
+        });
+    }
+    Ok(path)
+}
+
+pub(crate) fn global_db_profile_root() -> Result<PathBuf> {
+    global_db_path()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "could not resolve tracedecay profile root".to_string(),
+        })
+}
+
+pub(crate) fn project_selector_present(args: &Value, top_level_path_keys: &[&str]) -> bool {
+    args.get("project_selector").is_some()
+        || args.get("project_id").is_some()
+        || top_level_path_keys
+            .iter()
+            .any(|key| args.get(*key).is_some())
+}
+
+fn rejected_tool_project_selector_present(tool_name: &str, args: &Value) -> bool {
+    let top_level_path_keys = if tool_name.starts_with("tracedecay_lcm_") {
+        &["project_path"][..]
+    } else {
+        &["project_path", "project_root"][..]
+    };
+    project_selector_present(args, top_level_path_keys)
+}
+
+pub(crate) async fn project_registry_context(
+    args: &Value,
+    top_level_path_keys: &[&str],
+) -> Result<Option<ProjectRegistryContext>> {
+    let selector_present = project_selector_present(args, top_level_path_keys);
+    let selector = args
+        .get("project_selector")
+        .map(|value| {
+            value.as_object().ok_or_else(|| TraceDecayError::Config {
+                message: "project_selector must be an object".to_string(),
+            })
+        })
+        .transpose()?;
+    let project_id = selector
+        .and_then(|selector| selector.get("project_id"))
+        .or_else(|| args.get("project_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let project_path = selector
+        .and_then(|selector| {
+            selector
+                .get("path")
+                .or_else(|| selector.get("project_path"))
+        })
+        .or_else(|| top_level_path_keys.iter().find_map(|key| args.get(*key)))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if project_id.is_none() && project_path.is_none() {
+        if selector_present {
+            return Err(TraceDecayError::Config {
+                message: "project selector must include project_id or project_path".to_string(),
+            });
+        }
+        return Ok(None);
+    }
+
+    let db = GlobalDb::open()
+        .await
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "could not open tracedecay project registry; run tracedecay init first"
+                .to_string(),
+        })?;
+    let context = if let Some(project_id) = project_id {
+        db.project_registry_context_by_id(project_id).await
+    } else if let Some(project_path) = project_path {
+        db.project_registry_context_by_alias(Path::new(project_path))
+            .await
+    } else {
+        return Ok(None);
+    };
+
+    context
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "registered project not found for selector".to_string(),
+        })
+        .map(Some)
+}
+
+fn tool_accepts_registered_project_selector(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "tracedecay_search"
+            | "tracedecay_context"
+            | "tracedecay_retrieve"
+            | "tracedecay_callers"
+            | "tracedecay_callees"
+            | "tracedecay_impact"
+            | "tracedecay_node"
+            | "tracedecay_files"
+            | "tracedecay_body"
+            | "tracedecay_read"
+            | "tracedecay_outline"
+            | "tracedecay_signature_search"
+            | "tracedecay_implementations"
+            | "tracedecay_callers_for"
+            | "tracedecay_call_chain"
+            | "tracedecay_file_dependents"
+            | "tracedecay_find_exact_symbol"
+            | "tracedecay_by_qualified_name"
+            | "tracedecay_signature"
+            | "tracedecay_impls"
+            | "tracedecay_derives"
+            | "tracedecay_project_context"
+            | "tracedecay_fact_store"
+            | "tracedecay_memory_status"
+            | "tracedecay_message_search"
+    )
+}
+
+fn tool_dispatches_registered_project_reader(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "tracedecay_search"
+            | "tracedecay_context"
+            | "tracedecay_retrieve"
+            | "tracedecay_callers"
+            | "tracedecay_callees"
+            | "tracedecay_impact"
+            | "tracedecay_node"
+            | "tracedecay_files"
+            | "tracedecay_body"
+            | "tracedecay_read"
+            | "tracedecay_outline"
+            | "tracedecay_signature_search"
+            | "tracedecay_implementations"
+            | "tracedecay_callers_for"
+            | "tracedecay_call_chain"
+            | "tracedecay_file_dependents"
+            | "tracedecay_find_exact_symbol"
+            | "tracedecay_by_qualified_name"
+            | "tracedecay_signature"
+            | "tracedecay_impls"
+            | "tracedecay_derives"
+    )
+}
+
+async fn selected_registered_project_reader(
+    tool_name: &str,
+    args: &Value,
+) -> Result<Option<TraceDecay>> {
+    if !tool_dispatches_registered_project_reader(tool_name) {
+        return Ok(None);
+    }
+    let Some(context) = project_registry_context(args, &["project_path", "project_root"]).await?
+    else {
+        return Ok(None);
+    };
+
+    TraceDecay::open_read_only(Path::new(&context.project.canonical_root))
+        .await
+        .map(Some)
 }
 
 /// Truncates a string to the maximum response character limit, appending
@@ -195,7 +370,7 @@ pub(crate) fn truncated_json_envelope_with_handle(
                 object.insert(
                     "retrieve_instruction".to_string(),
                     json!(format!(
-                        "This response was truncated: `preview` contains only the first {} of {} characters. The full original response is stored locally in this project and expires at {} (TTL {} seconds). To recover it, call `{RESPONSE_RETRIEVE_TOOL}` with required argument `handle` set to `{}`. Only call it if the missing details are needed to answer the user's request.",
+                        "This response was truncated: `preview` contains only the first {} of {} characters. The full original response is stored locally in this project and expires at {} (TTL {} seconds). To recover it, call `{RESPONSE_RETRIEVE_TOOL}` with required argument `handle` set to `{}`. If the original tool call used a project selector (`project_id`, `project_path`, or `project_selector`), pass the same selector to `{RESPONSE_RETRIEVE_TOOL}` so the handle is looked up in the same project cache. Only call it if the missing details are needed to answer the user's request.",
                         preview.len(),
                         formatted.len(),
                         record.expires_at,
@@ -302,17 +477,26 @@ pub async fn handle_tool_call(
         tool_name.starts_with("tracedecay_"),
         "tool_name must start with 'tracedecay_' prefix"
     );
-    if args.get("project_selector").is_some() && tool_rejects_project_selector(tool_name) {
+    if !tool_accepts_registered_project_selector(tool_name)
+        && rejected_tool_project_selector_present(tool_name, &args)
+    {
         return Err(TraceDecayError::Config {
             message: format!(
-                "{tool_name} is scoped to the active project and does not accept project_selector"
+                "{tool_name} is scoped to the active project and does not accept project selectors"
             ),
         });
     }
+    let selected_cg = selected_registered_project_reader(tool_name, &args).await?;
+    let selected_scope_prefix = if selected_cg.is_some() {
+        None
+    } else {
+        scope_prefix
+    };
+    let cg = selected_cg.as_ref().unwrap_or(cg);
     match tool_name {
-        "tracedecay_search" => graph::handle_search(cg, args, scope_prefix).await,
+        "tracedecay_search" => graph::handle_search(cg, args, selected_scope_prefix).await,
         "tracedecay_retrieve" => handle_retrieve(cg, &args),
-        "tracedecay_context" => graph::handle_context(cg, args, scope_prefix).await,
+        "tracedecay_context" => graph::handle_context(cg, args, selected_scope_prefix).await,
         "tracedecay_callers" => graph::handle_callers(cg, args).await,
         "tracedecay_callees" => graph::handle_callees(cg, args).await,
         "tracedecay_impact" => graph::handle_impact(cg, args).await,
@@ -325,7 +509,7 @@ pub async fn handle_tool_call(
         "tracedecay_project_list" => info::handle_project_list(args).await,
         "tracedecay_project_search" => info::handle_project_search(args).await,
         "tracedecay_project_context" => info::handle_project_context(cg, args).await,
-        "tracedecay_files" => info::handle_files(cg, args, scope_prefix).await,
+        "tracedecay_files" => info::handle_files(cg, args, selected_scope_prefix).await,
         "tracedecay_affected" => git::handle_affected(cg, args).await,
         "tracedecay_dead_code" => analysis::handle_dead_code(cg, args, scope_prefix).await,
         "tracedecay_diff_context" => git::handle_diff_context(cg, args).await,
@@ -374,15 +558,17 @@ pub async fn handle_tool_call(
         "tracedecay_test_risk" => health::handle_test_risk(cg, args, scope_prefix).await,
         "tracedecay_session_start" => health::handle_session_start(cg, args, scope_prefix).await,
         "tracedecay_session_end" => health::handle_session_end(cg, args, scope_prefix).await,
-        "tracedecay_body" => info::handle_body(cg, args, scope_prefix).await,
+        "tracedecay_body" => info::handle_body(cg, args, selected_scope_prefix).await,
         "tracedecay_todos" => info::handle_todos(cg, args, scope_prefix).await,
         "tracedecay_read" => info::handle_read(cg, args).await,
         "tracedecay_outline" => info::handle_outline(cg, args).await,
         "tracedecay_config" => info::handle_config(cg, &args),
         "tracedecay_signature_search" => {
-            info::handle_signature_search(cg, args, scope_prefix).await
+            info::handle_signature_search(cg, args, selected_scope_prefix).await
         }
-        "tracedecay_implementations" => graph::handle_implementations(cg, args, scope_prefix).await,
+        "tracedecay_implementations" => {
+            graph::handle_implementations(cg, args, selected_scope_prefix).await
+        }
         "tracedecay_unsafe_patterns" => {
             analysis::handle_unsafe_patterns(cg, args, scope_prefix).await
         }
@@ -395,7 +581,7 @@ pub async fn handle_tool_call(
         "tracedecay_replace_symbol" => edit::handle_replace_symbol(cg, args).await,
         "tracedecay_insert_at_symbol" => edit::handle_insert_at_symbol(cg, args).await,
         "tracedecay_find_exact_symbol" => {
-            graph::handle_find_exact_symbol(cg, args, scope_prefix).await
+            graph::handle_find_exact_symbol(cg, args, selected_scope_prefix).await
         }
         "tracedecay_by_qualified_name" => graph::handle_by_qualified_name(cg, args).await,
         "tracedecay_signature" => graph::handle_signature(cg, args).await,
@@ -405,7 +591,7 @@ pub async fn handle_tool_call(
         "tracedecay_derives" => graph::handle_derives(cg, args).await,
         "tracedecay_fact_store" => memory::handle_fact_store(cg, args).await,
         "tracedecay_fact_feedback" => memory::handle_fact_feedback(cg, args).await,
-        "tracedecay_memory_status" => memory::handle_memory_status(cg).await,
+        "tracedecay_memory_status" => memory::handle_memory_status(cg, args).await,
         "tracedecay_dashboard" => dashboard::handle_dashboard(cg, args).await,
         "tracedecay_message_search" => session::handle_message_search(cg, args).await,
         "tracedecay_lcm_status" => session::handle_lcm_status(Some(cg.project_root()), args).await,
@@ -434,28 +620,6 @@ pub async fn handle_tool_call(
             message: format!("unknown tool: {tool_name}"),
         }),
     }
-}
-
-fn tool_rejects_project_selector(tool_name: &str) -> bool {
-    matches!(
-        tool_name,
-        "tracedecay_str_replace"
-            | "tracedecay_multi_str_replace"
-            | "tracedecay_insert_at"
-            | "tracedecay_replace_symbol"
-            | "tracedecay_insert_at_symbol"
-            | "tracedecay_ast_grep_rewrite"
-            | "tracedecay_run_affected_tests"
-            | "tracedecay_session_start"
-            | "tracedecay_session_end"
-            | "tracedecay_fact_store"
-            | "tracedecay_fact_feedback"
-            | "tracedecay_memory_status"
-            | "tracedecay_lcm_doctor"
-            | "tracedecay_lcm_preflight"
-            | "tracedecay_lcm_compress"
-            | "tracedecay_lcm_session_boundary"
-    )
 }
 
 /// Dispatches only the storage-scoped LCM tools that can run without an
@@ -490,11 +654,68 @@ pub async fn handle_profile_scoped_lcm_tool_call(
 )]
 mod tests {
     use std::collections::BTreeSet;
+    use std::ffi::{OsStr, OsString};
+    use std::fs;
+    use std::path::Path;
 
     use serde_json::json;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex;
 
     use super::super::get_tool_definitions;
     use super::*;
+    use crate::config::USER_DATA_DIR_ENV;
+
+    static SELECTOR_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    struct SelectorEnv {
+        _home: EnvVarGuard,
+        _userprofile: EnvVarGuard,
+        _data_dir: EnvVarGuard,
+        _global_db: EnvVarGuard,
+    }
+
+    impl SelectorEnv {
+        fn new(root: &Path) -> Self {
+            let home = root.join("home");
+            let profile_root = home.join(".tracedecay");
+            fs::create_dir_all(&profile_root).unwrap();
+            let home = home.canonicalize().unwrap();
+            let profile_root = home.join(".tracedecay");
+            Self {
+                _home: EnvVarGuard::set("HOME", &home),
+                _userprofile: EnvVarGuard::set("USERPROFILE", &home),
+                _data_dir: EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root),
+                _global_db: EnvVarGuard::set(
+                    "TRACEDECAY_GLOBAL_DB",
+                    profile_root.join("global.db"),
+                ),
+            }
+        }
+    }
 
     fn dispatch_tool_names_from_source(function_name: &str) -> BTreeSet<String> {
         let source = include_str!("mod.rs");
@@ -603,6 +824,250 @@ mod tests {
                 .cloned()
                 .collect(),
             "profile-scoped handler dispatches missing MCP tool definitions",
+        );
+    }
+
+    #[test]
+    fn graph_reader_selector_dispatch_policy_is_allowlisted() {
+        let allowlisted_tool_names = [
+            "tracedecay_search",
+            "tracedecay_context",
+            "tracedecay_callers",
+            "tracedecay_callees",
+            "tracedecay_impact",
+            "tracedecay_node",
+            "tracedecay_files",
+            "tracedecay_retrieve",
+            "tracedecay_body",
+            "tracedecay_read",
+            "tracedecay_outline",
+            "tracedecay_signature_search",
+            "tracedecay_implementations",
+            "tracedecay_callers_for",
+            "tracedecay_call_chain",
+            "tracedecay_file_dependents",
+            "tracedecay_find_exact_symbol",
+            "tracedecay_by_qualified_name",
+            "tracedecay_signature",
+            "tracedecay_impls",
+            "tracedecay_derives",
+            "tracedecay_project_context",
+            "tracedecay_fact_store",
+            "tracedecay_memory_status",
+            "tracedecay_message_search",
+        ];
+
+        for tool_name in allowlisted_tool_names {
+            assert!(
+                tool_accepts_registered_project_selector(tool_name),
+                "{tool_name} should dispatch through a selected registered project"
+            );
+        }
+
+        let definitions = get_tool_definitions()
+            .into_iter()
+            .map(|tool| (tool.name, tool.input_schema))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        for tool_name in allowlisted_tool_names {
+            let properties = &definitions[tool_name]["properties"];
+            assert!(
+                ["project_selector", "project_id", "project_path", "path"]
+                    .iter()
+                    .any(|selector_key| properties.get(*selector_key).is_some()),
+                "{tool_name} should advertise at least one registered project selector because its dispatcher accepts registered project selectors"
+            );
+        }
+
+        for tool_name in [
+            "tracedecay_str_replace",
+            "tracedecay_run_affected_tests",
+            "tracedecay_status",
+            "tracedecay_health",
+            "tracedecay_dead_code",
+        ] {
+            assert!(
+                !tool_accepts_registered_project_selector(tool_name),
+                "{tool_name} should not be routed by the pure graph-reader selector policy"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn graph_reader_selector_dispatch_targets_registered_project() {
+        let _env_lock = SELECTOR_ENV_LOCK.lock().await;
+        let dir = TempDir::new().unwrap();
+        let _env = SelectorEnv::new(dir.path());
+        let active_project = dir.path().join("active");
+        let target_project = dir.path().join("target");
+        fs::create_dir_all(active_project.join("src")).unwrap();
+        fs::create_dir_all(target_project.join("src")).unwrap();
+        fs::write(
+            active_project.join("src/lib.rs"),
+            "pub fn active_only_symbol() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            target_project.join("src/lib.rs"),
+            "pub fn target_only_symbol() {}\n",
+        )
+        .unwrap();
+
+        let active = TraceDecay::init(&active_project).await.unwrap();
+        let target = TraceDecay::init(&target_project).await.unwrap();
+        active.index_all().await.unwrap();
+        target.index_all().await.unwrap();
+        let target_project_id = target
+            .store_layout()
+            .identity
+            .project_id
+            .as_deref()
+            .expect("target project should be registered");
+
+        let result = handle_tool_call(
+            &active,
+            "tracedecay_search",
+            json!({
+                "query": "target_only_symbol",
+                "project_id": target_project_id,
+                "limit": 5
+            }),
+            None,
+            Some("tests"),
+        )
+        .await
+        .unwrap();
+        let text = result.value["content"][0]["text"].as_str().unwrap();
+
+        assert!(
+            text.contains("target_only_symbol"),
+            "selected registered project search should return target graph results: {text}"
+        );
+        assert!(
+            !text.contains("active_only_symbol"),
+            "selected registered project search should not query the active graph: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_selector_tool_rejects_explicit_project_selector() {
+        let _env_lock = SELECTOR_ENV_LOCK.lock().await;
+        let dir = TempDir::new().unwrap();
+        let _env = SelectorEnv::new(dir.path());
+        let project = dir.path().join("active");
+        fs::create_dir_all(project.join("src")).unwrap();
+        fs::write(project.join("src/lib.rs"), "pub fn active_symbol() {}\n").unwrap();
+        let cg = TraceDecay::init(&project).await.unwrap();
+        cg.index_all().await.unwrap();
+
+        let err = handle_tool_call(
+            &cg,
+            "tracedecay_status",
+            json!({
+                "project_id": "explicit-selector-should-not-fall-open",
+            }),
+            None,
+            None,
+        )
+        .await
+        .expect_err("unsupported selector tools must reject explicit selectors");
+
+        assert!(
+            format!("{err}").contains("does not accept project selectors"),
+            "unexpected selector rejection error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn selected_project_retrieve_finds_selected_project_response_handle() {
+        let _env_lock = SELECTOR_ENV_LOCK.lock().await;
+        let dir = TempDir::new().unwrap();
+        let _env = SelectorEnv::new(dir.path());
+        let active_project = dir.path().join("active");
+        let target_project = dir.path().join("target");
+        fs::create_dir_all(active_project.join("src")).unwrap();
+        fs::create_dir_all(target_project.join("src")).unwrap();
+        fs::write(
+            active_project.join("src/lib.rs"),
+            "pub fn active_only_symbol() {}\n",
+        )
+        .unwrap();
+
+        let mut target_source = String::new();
+        for i in 0..420 {
+            target_source.push_str(&format!(
+                "pub fn selected_project_handle_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}\n"
+            ));
+        }
+        fs::write(target_project.join("src/lib.rs"), target_source).unwrap();
+
+        let active = TraceDecay::init(&active_project).await.unwrap();
+        let target = TraceDecay::init(&target_project).await.unwrap();
+        active.index_all().await.unwrap();
+        target.index_all().await.unwrap();
+        let target_project_id = target
+            .store_layout()
+            .identity
+            .project_id
+            .as_deref()
+            .expect("target project should be registered")
+            .to_string();
+
+        let result = handle_tool_call(
+            &active,
+            "tracedecay_search",
+            json!({
+                "query": "selected_project_handle_marker",
+                "project_id": target_project_id,
+                "limit": 420
+            }),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let envelope: Value = serde_json::from_str(
+            result.value["content"][0]["text"]
+                .as_str()
+                .expect("search result text"),
+        )
+        .expect("truncated search envelope");
+        assert_eq!(envelope["truncated"], true);
+        let handle = envelope["handle"]
+            .as_str()
+            .expect("large selected-project search should return a handle");
+        let retrieve_instruction = envelope["retrieve_instruction"]
+            .as_str()
+            .expect("truncated envelope should include retrieve guidance");
+        assert!(
+            retrieve_instruction.contains("pass the same selector"),
+            "selected-project envelopes should tell clients to retrieve from the same project: {retrieve_instruction}"
+        );
+
+        let retrieved = handle_tool_call(
+            &active,
+            "tracedecay_retrieve",
+            json!({
+                "handle": handle,
+                "project_id": target.store_layout().identity.project_id.as_deref().unwrap()
+            }),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let payload: Value = serde_json::from_str(
+            retrieved.value["content"][0]["text"]
+                .as_str()
+                .expect("retrieve result text"),
+        )
+        .expect("retrieve payload");
+
+        assert_eq!(payload["expired"], false);
+        assert!(
+            payload["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("selected_project_handle_marker_419")),
+            "selected project retrieve should return the full selected-project response: {payload}"
         );
     }
 

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -27,7 +27,11 @@ use crate::tracedecay::TraceDecay;
 use crate::types::{Node, NodeKind};
 
 use super::super::ToolResult;
-use super::{effective_path, truncate_response};
+use super::{effective_path, truncated_json_envelope_with_handle};
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
 
 /// `tracedecay_redundancy` handler.
 pub(super) async fn handle_redundancy(
@@ -83,7 +87,7 @@ pub(super) async fn handle_redundancy(
     let formatted = serde_json::to_string_pretty(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
     })

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -4,9 +4,12 @@ use std::sync::{LazyLock, Mutex};
 
 use serde_json::{json, Map, Value};
 
-use super::truncated_json_envelope_with_handle;
+use super::{
+    global_db_profile_root, project_registry_context, safe_profile_relpath,
+    truncated_json_envelope_with_handle,
+};
 use crate::errors::{Result, TraceDecayError};
-use crate::global_db::GlobalDb;
+use crate::global_db::{GlobalDb, ProjectRegistryContext};
 use crate::mcp::tools::{ToolResult, MAX_RESPONSE_CHARS};
 use crate::sessions::cursor::HermesProfileDbReadOnly;
 use crate::sessions::lcm::compression_decision::{self, AssemblyCapInput};
@@ -41,6 +44,56 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
         value: json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files: Vec::new(),
     }
+}
+
+async fn selected_project_session_db_path(
+    project_root: &Path,
+    args: &Value,
+) -> Result<Option<(PathBuf, PathBuf)>> {
+    let Some(context) = project_registry_context(args, &["project_path", "project_root"]).await?
+    else {
+        return Ok(
+            crate::sessions::cursor::resolved_project_session_db_path(project_root)
+                .await
+                .map(|db_path| (db_path, project_root.to_path_buf())),
+        );
+    };
+    let profile_root = global_db_profile_root()?;
+    let candidates = registry_session_db_candidates(&context, &profile_root)?;
+    let target_root = PathBuf::from(context.project.display_root);
+    for db_path in candidates {
+        if db_path.is_file() {
+            return Ok(Some((db_path, target_root)));
+        }
+    }
+    Ok(None)
+}
+
+fn registry_session_db_candidates(
+    context: &ProjectRegistryContext,
+    profile_root: &Path,
+) -> Result<Vec<PathBuf>> {
+    let mut candidates = Vec::new();
+    if let Some(artifact) = context
+        .stores
+        .iter()
+        .flat_map(|store| store.artifacts.iter())
+        .find(|artifact| artifact.artifact_kind == "sessions_db")
+    {
+        candidates.push(profile_root.join(safe_profile_relpath(&artifact.relpath)?));
+    }
+    if let Some(store) = context
+        .stores
+        .iter()
+        .find(|store| store.store.storage_mode == "profile_sharded")
+    {
+        candidates.push(
+            profile_root
+                .join(safe_profile_relpath(&store.store.store_relpath)?)
+                .join(crate::storage::SESSIONS_DB_FILENAME),
+        );
+    }
+    Ok(candidates)
 }
 
 fn lcm_preflight_tool_json(value: &Value) -> ToolResult {
@@ -1319,14 +1372,14 @@ pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Resul
         .unwrap_or(10)
         .clamp(1, 50) as usize;
 
-    let Some(db_path) =
-        crate::sessions::cursor::resolved_project_session_db_path(cg.project_root()).await
+    let Some((db_path, target_root)) =
+        selected_project_session_db_path(cg.project_root(), &args).await?
     else {
         return Ok(tool_json(
             Some(cg.project_root()),
             &json!({
                 "status": "unavailable",
-                "message": "could not resolve active project tracedecay session database",
+                "message": "could not resolve selected project tracedecay session database",
                 "results": [],
                 "count": 0
             }),
@@ -1337,7 +1390,7 @@ pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Resul
             Some(cg.project_root()),
             &json!({
                 "status": "unavailable",
-                "message": "could not open active project tracedecay session database",
+                "message": "could not open selected project tracedecay session database",
                 "results": [],
                 "count": 0
             }),
@@ -1348,7 +1401,7 @@ pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Resul
         // by the serve/dashboard startup catch-ups; an incremental
         // search-time catch-up makes the `tracedecay tool` / generated-plugin
         // path self-sufficient (cursor-based, so it is cheap when fresh).
-        let _ = crate::sessions::hermes::ingest_for_project(&db, cg.project_root()).await;
+        let _ = crate::sessions::hermes::ingest_for_project(&db, &target_root).await;
     }
     let results = db
         .search_session_messages_filtered(
@@ -1362,10 +1415,11 @@ pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Resul
         .await;
 
     Ok(tool_json(
-        Some(cg.project_root()),
+        Some(&target_root),
         &json!({
             "status": "ok",
             "provider": provider,
+            "selected_project_root": target_root,
             "project_key": project_key,
             "parent_session_id": parent_session_id,
             "include_subagents": include_subagents,

--- a/src/mcp/tools/handlers/workflow.rs
+++ b/src/mcp/tools/handlers/workflow.rs
@@ -17,12 +17,56 @@ use crate::tracedecay::{is_test_file, TraceDecay};
 use crate::types::NodeKind;
 
 use super::super::ToolResult;
-use super::{truncate_response, unique_file_paths};
+use super::{truncated_json_envelope_with_handle, unique_file_paths};
+
+fn project_response_text(cg: &TraceDecay, text: &str) -> String {
+    truncated_json_envelope_with_handle(Some(cg.project_root()), text)
+}
 
 /// Maximum tests we'll allow `cargo test` to receive in one call. A loose
 /// cap — libtest filters are passed as positional args so very long lists
 /// can blow past OS argv limits on some platforms.
 const MAX_TESTS_HARD_CAP: usize = 500;
+
+#[derive(Debug, Clone)]
+struct TestTarget {
+    filter: String,
+    qualified_name: String,
+    node_id: String,
+    covers_source_ids: Vec<String>,
+}
+
+impl TestTarget {
+    fn new(node: &crate::types::Node) -> Self {
+        Self {
+            filter: node.name.clone(),
+            qualified_name: node.qualified_name.clone(),
+            node_id: node.id.clone(),
+            covers_source_ids: Vec::new(),
+        }
+    }
+
+    fn add_source(&mut self, source_id: &str) {
+        if !self.covers_source_ids.iter().any(|id| id == source_id) {
+            self.covers_source_ids.push(source_id.to_string());
+        }
+    }
+
+    fn matches_libtest_name(&self, name: &str) -> bool {
+        name == self.filter
+            || name.rsplit("::").next() == Some(self.filter.as_str())
+            || (!self.qualified_name.is_empty() && name == self.qualified_name)
+            || name == self.node_id
+    }
+}
+
+fn test_target_key(node: &crate::types::Node) -> String {
+    if node.qualified_name.is_empty() {
+        node.id.clone()
+    } else {
+        node.qualified_name.clone()
+    }
+}
 
 /// Handles `tracedecay_diagnose`.
 pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
@@ -121,7 +165,7 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
     let formatted = serde_json::to_string_pretty(&body).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: touched.into_iter().collect(),
     })
@@ -164,7 +208,12 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
     // 1) Resolve changed paths — explicit list, or fall back to `git diff`.
     let changed_paths = match explicit_paths {
         Some(p) => p,
-        None => git_changed_paths(&project_root).await,
+        None => match git_changed_paths(&project_root).await {
+            Ok(paths) => paths,
+            Err(message) => {
+                return Ok(error_result("git", "diff", &message));
+            }
+        },
     };
     if changed_paths.is_empty() {
         return Ok(empty_result("no changed files detected"));
@@ -182,8 +231,7 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
     //       directly. `#[test]` fns are leaves with no callers, so the
     //       indirect-coverage walk above always misses them and the tool
     //       used to silently skip PRs that only edit `tests/foo.rs`.
-    let mut test_targets: HashMap<String, Vec<String>> = HashMap::new();
-    let mut covered_sources: HashSet<String> = HashSet::new();
+    let mut test_targets: HashMap<String, TestTarget> = HashMap::new();
     for path in &changed_paths {
         let nodes = cg.get_nodes_by_file(path).await?;
 
@@ -209,10 +257,9 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
                 // source so the per-test `covers_source_ids` field
                 // remains useful.
                 test_targets
-                    .entry(node.name.clone())
-                    .or_default()
-                    .push(node.id.clone());
-                covered_sources.insert(node.id.clone());
+                    .entry(test_target_key(node))
+                    .or_insert_with(|| TestTarget::new(node))
+                    .add_source(&node.id);
             }
         }
 
@@ -232,10 +279,9 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
                     continue;
                 }
                 test_targets
-                    .entry(caller.name.clone())
-                    .or_default()
-                    .push(node.id.clone());
-                covered_sources.insert(node.id.clone());
+                    .entry(test_target_key(&caller))
+                    .or_insert_with(|| TestTarget::new(&caller))
+                    .add_source(&node.id);
             }
         }
     }
@@ -247,10 +293,21 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
         )));
     }
 
-    let mut test_names: Vec<String> = test_targets.keys().cloned().collect();
+    let mut selected_targets: Vec<TestTarget> = test_targets.into_values().collect();
+    selected_targets.sort_by(|a, b| {
+        a.qualified_name
+            .cmp(&b.qualified_name)
+            .then(a.node_id.cmp(&b.node_id))
+    });
+    let total_tests = selected_targets.len();
+    selected_targets.truncate(max_tests);
+    let truncated = total_tests > selected_targets.len();
+    let mut test_names: Vec<String> = selected_targets
+        .iter()
+        .map(|target| target.filter.clone())
+        .collect();
     test_names.sort();
-    let total_tests = test_names.len();
-    test_names.truncate(max_tests);
+    test_names.dedup();
 
     // 3) Run cargo test --no-fail-fast with each test name as a libtest
     // filter. We use `--` to pass them through.
@@ -271,12 +328,18 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
     let output = match timeout(Duration::from_secs(timeout_secs), run).await {
         Ok(Ok(o)) => o,
         Ok(Err(e)) => {
-            return Ok(error_result(&format!("failed to spawn cargo test: {e}")));
+            return Ok(error_result(
+                "cargo",
+                "test",
+                &format!("failed to spawn cargo test: {e}"),
+            ));
         }
         Err(_) => {
-            return Ok(error_result(&format!(
-                "cargo test timed out after {timeout_secs}s"
-            )));
+            return Ok(error_result(
+                "cargo",
+                "test",
+                &format!("cargo test timed out after {timeout_secs}s"),
+            ));
         }
     };
 
@@ -294,19 +357,20 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
         "failed": failed,
         "total_observed": results.len(),
         "dispatched_tests": test_names,
-        "truncated": total_tests > test_names.len(),
+        "truncated": truncated,
         "results": results
             .iter()
             .map(|(name, ok)| {
-                // libtest emits `module::path::test_fn` while the graph keys
-                // by the short fn name. Look up by both so we resolve either
-                // shape.
-                let short = name.rsplit("::").next().unwrap_or(name);
-                let covers = test_targets
-                    .get(name)
-                    .or_else(|| test_targets.get(short))
-                    .cloned()
-                    .unwrap_or_default();
+                let mut covers = Vec::new();
+                for target in &selected_targets {
+                    if target.matches_libtest_name(name) {
+                        for source_id in &target.covers_source_ids {
+                            if !covers.contains(source_id) {
+                                covers.push(source_id.clone());
+                            }
+                        }
+                    }
+                }
                 json!({
                     "test": name,
                     "passed": ok,
@@ -321,7 +385,7 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
     let formatted = serde_json::to_string_pretty(&body).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": truncate_response(&formatted) }]
+            "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files,
     })
@@ -339,11 +403,18 @@ fn empty_result(message: &str) -> ToolResult {
     }
 }
 
-fn error_result(message: &str) -> ToolResult {
+fn error_result(kind: &str, operation: &str, message: &str) -> ToolResult {
     ToolResult {
         value: json!({
             "content": [{ "type": "text", "text": serde_json::to_string_pretty(&json!({
-                "passed": 0, "failed": 0, "results": [], "error": message
+                "passed": 0,
+                "failed": 0,
+                "results": [],
+                "error": {
+                    "kind": kind,
+                    "operation": operation,
+                    "message": message,
+                }
             })).unwrap_or_default() }]
         }),
         touched_files: vec![],
@@ -363,25 +434,25 @@ fn tail(s: &str, n: usize) -> String {
 }
 
 /// Returns files changed in the working tree relative to HEAD (`git diff
-/// --name-only HEAD`). Empty on git failure — `cargo test` against zero
-/// affected tests is reported as a no-op above.
-async fn git_changed_paths(project_root: &std::path::Path) -> Vec<String> {
-    let Ok(output) = Command::new("git")
+/// --name-only HEAD`).
+async fn git_changed_paths(
+    project_root: &std::path::Path,
+) -> std::result::Result<Vec<String>, String> {
+    let output = Command::new("git")
         .args(["diff", "--name-only", "HEAD"])
         .current_dir(project_root)
         .output()
         .await
-    else {
-        return Vec::new();
-    };
+        .map_err(|e| format!("failed to spawn git diff: {e}"))?;
     if !output.status.success() {
-        return Vec::new();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git diff failed: {}", stderr.trim()));
     }
-    String::from_utf8_lossy(&output.stdout)
+    Ok(String::from_utf8_lossy(&output.stdout)
         .lines()
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
-        .collect()
+        .collect())
 }
 
 /// Parses libtest stdout for `test <name> ... ok` / `... FAILED` lines.

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -1,6 +1,6 @@
 // Rust guideline compliant 2025-10-17
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use rayon::prelude::*;
@@ -10,8 +10,8 @@ use walkdir::WalkDir;
 use crate::branch;
 use crate::branch_meta::{self, BranchMeta};
 use crate::config::{
-    brand_env, db_filename, is_excluded, is_excluded_dir, is_included, load_config_from_path,
-    save_config, TraceDecayConfig,
+    brand_env, db_filename, is_excluded, is_excluded_dir, is_included, is_included_dir,
+    load_config_from_path, save_config, TraceDecayConfig,
 };
 use crate::context::ContextBuilder;
 use crate::db::Database;
@@ -54,6 +54,60 @@ fn normalize_rel_path(path: &str) -> String {
 /// the caller's existing `Vec`.
 fn normalize_rel_paths(paths: &[String]) -> Vec<String> {
     paths.iter().map(|p| normalize_rel_path(p)).collect()
+}
+
+fn normalize_include_folder(project_root: &Path, folder: &str) -> String {
+    let trimmed = folder.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let raw_path = Path::new(trimmed);
+    let project_relative = if raw_path.is_absolute() {
+        raw_path.strip_prefix(project_root).unwrap_or(raw_path)
+    } else {
+        raw_path
+    };
+
+    let mut parts = Vec::new();
+    for component in project_relative.components() {
+        match component {
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+            Component::Normal(part) => parts.push(part.to_string_lossy().replace('\\', "/")),
+            Component::ParentDir => parts.push("..".to_string()),
+        }
+    }
+
+    parts.join("/").trim_matches('/').to_string()
+}
+
+fn include_may_match_descendant(dir_path: &str, config: &TraceDecayConfig) -> bool {
+    if is_included_dir(dir_path, config) || is_included(dir_path, config) {
+        return true;
+    }
+
+    let dir_prefix = format!("{}/", dir_path.trim_end_matches('/'));
+    for pattern in &config.include {
+        let normalized = pattern.trim_start_matches('/').replace('\\', "/");
+        if normalized.starts_with("**/") {
+            return true;
+        }
+        if normalized.starts_with(&dir_prefix) {
+            return true;
+        }
+        let literal_prefix = normalized
+            .split(['*', '?', '['])
+            .next()
+            .unwrap_or("")
+            .trim_end_matches('/');
+        if !literal_prefix.is_empty()
+            && (literal_prefix == dir_path || literal_prefix.starts_with(&dir_prefix))
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Metadata flag recording that the *complete* extracted reference set has
@@ -1133,6 +1187,19 @@ impl TraceDecay {
         }
     }
 
+    /// Appends runtime include-folder patterns to the include list.
+    ///
+    /// Includes are explicit user intent and override the built-in generated
+    /// folder/gitignore filters for the requested subtree.
+    pub fn add_include_folders(&mut self, folders: &[String]) {
+        for folder in folders {
+            let normalized = normalize_include_folder(&self.project_root, folder);
+            if !normalized.is_empty() {
+                self.config.include.push(format!("{normalized}/**"));
+            }
+        }
+    }
+
     /// Performs a full index: clears existing data, scans all Rust files,
     /// extracts nodes and edges, resolves references, and stores everything
     /// in the database.
@@ -2006,7 +2073,7 @@ impl TraceDecay {
                     // Allow if the relative path matches an include glob.
                     if let Ok(rel) = e.path().strip_prefix(root) {
                         let rel_str = rel.to_string_lossy().replace('\\', "/");
-                        return is_included(&rel_str, config);
+                        return is_included_dir(&rel_str, config) || is_included(&rel_str, config);
                     }
                     return false;
                 }
@@ -2016,7 +2083,10 @@ impl TraceDecay {
                 if e.file_type().is_dir() {
                     if let Ok(rel) = e.path().strip_prefix(root) {
                         let rel_str = rel.to_string_lossy().replace('\\', "/");
-                        if is_excluded_dir(&rel_str, config) {
+                        if is_excluded_dir(&rel_str, config)
+                            && !is_included_dir(&rel_str, config)
+                            && !is_included(&rel_str, config)
+                        {
                             return false;
                         }
                     }
@@ -2072,7 +2142,9 @@ impl TraceDecay {
                 if name.starts_with('.') {
                     if let Ok(rel) = entry.path().strip_prefix(&self.project_root) {
                         let rel_str = rel.to_string_lossy().replace('\\', "/");
-                        if !is_included(&rel_str, &self.config) {
+                        if !is_included(&rel_str, &self.config)
+                            && !is_included_dir(&rel_str, &self.config)
+                        {
                             continue;
                         }
                     } else {
@@ -2086,6 +2158,50 @@ impl TraceDecay {
             }
             if let Some(rel_str) = self.accept_file(entry.path(), supported_exts) {
                 files.push(rel_str);
+            }
+        }
+        if has_includes {
+            let mut seen: HashSet<String> = files.iter().cloned().collect();
+            for rel_str in self.scan_included_files(supported_exts) {
+                if seen.insert(rel_str.clone()) {
+                    files.push(rel_str);
+                }
+            }
+        }
+        files
+    }
+
+    /// Walk all files and add only explicit include matches. This lets
+    /// `include` pierce gitignore/default excludes without turning the whole
+    /// ignore-aware walker into an include-only walk.
+    fn scan_included_files(&self, supported_exts: &[&str]) -> Vec<String> {
+        let mut files = Vec::new();
+        if self.config.include.is_empty() {
+            return files;
+        }
+
+        for entry in WalkDir::new(&self.project_root)
+            .follow_links(true)
+            .into_iter()
+            .filter_entry(|entry| {
+                if entry.depth() == 0 || !entry.file_type().is_dir() {
+                    return true;
+                }
+                let Ok(rel) = entry.path().strip_prefix(&self.project_root) else {
+                    return true;
+                };
+                let rel_str = rel.to_string_lossy().replace('\\', "/");
+                include_may_match_descendant(&rel_str, &self.config)
+            })
+        {
+            let Ok(entry) = entry else { continue };
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            if let Some(rel_str) = self.accept_file(entry.path(), supported_exts) {
+                if is_included(&rel_str, &self.config) {
+                    files.push(rel_str);
+                }
             }
         }
         files
@@ -2102,7 +2218,7 @@ impl TraceDecay {
         // Normalize to forward slashes so paths are consistent across
         // platforms and between different directory walkers on Windows.
         let rel_str = relative.to_string_lossy().replace('\\', "/");
-        if is_excluded(&rel_str, &self.config) {
+        if is_excluded(&rel_str, &self.config) && !is_included(&rel_str, &self.config) {
             return None;
         }
         let metadata = std::fs::metadata(path).ok()?;
@@ -2110,6 +2226,86 @@ impl TraceDecay {
             return None;
         }
         Some(rel_str)
+    }
+
+    /// Returns a low-noise hint when a graph lookup may be incomplete because
+    /// generated/vendor/cache folders are intentionally excluded from the index.
+    pub fn index_coverage_hint(&self, result_count: usize) -> Option<IndexCoverageHint> {
+        if result_count > 0 {
+            return None;
+        }
+
+        let skipped_dirs = self.existing_skipped_dirs(5);
+        if skipped_dirs.is_empty() {
+            return None;
+        }
+
+        let first = skipped_dirs[0].clone();
+        let message = if self.config.git_ignore {
+            "No indexed symbols matched. This project respects .gitignore and default generated/vendor folder skips; the target may be under a skipped tree."
+        } else {
+            "No indexed symbols matched. This project uses default generated/vendor folder skips; the target may be under a skipped tree."
+        };
+
+        Some(IndexCoverageHint {
+            message: message.to_string(),
+            skipped_dirs,
+            suggested_command: format!("tracedecay sync --include-folder {first}"),
+        })
+    }
+
+    fn existing_skipped_dirs(&self, limit: usize) -> Vec<String> {
+        let mut dirs = Vec::new();
+        let mut seen = HashSet::new();
+        let root = &self.project_root;
+
+        for entry in WalkDir::new(root).follow_links(false).max_depth(5) {
+            if dirs.len() >= limit {
+                break;
+            }
+            let Ok(entry) = entry else {
+                continue;
+            };
+            if entry.depth() == 0 || !entry.file_type().is_dir() {
+                continue;
+            }
+            let Ok(rel) = entry.path().strip_prefix(root) else {
+                continue;
+            };
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let name = entry.file_name().to_string_lossy();
+            if Self::is_skipped_dir_hint(&rel_str, &name, &self.config)
+                && seen.insert(rel_str.clone())
+            {
+                dirs.push(rel_str);
+            }
+        }
+
+        dirs
+    }
+
+    fn is_skipped_dir_hint(rel_str: &str, name: &str, config: &TraceDecayConfig) -> bool {
+        if is_included_dir(rel_str, config) || is_included(rel_str, config) {
+            return false;
+        }
+
+        const HINTABLE_DIRS: &[&str] = &[
+            "node_modules",
+            "vendor",
+            "build",
+            "dist",
+            "out",
+            "coverage",
+            ".cache",
+            ".next",
+            ".turbo",
+            ".gradle",
+            ".venv",
+            "venv",
+            "__pycache__",
+        ];
+
+        HINTABLE_DIRS.contains(&name) && is_excluded_dir(rel_str, config)
     }
 
     /// Resolves a path to a relative path string.
@@ -4006,7 +4202,7 @@ impl TraceDecay {
         })
     }
 
-    async fn memory_status_for_conn(conn: &libsql::Connection) -> Result<MemoryStatus> {
+    pub(crate) async fn memory_status_for_conn(conn: &libsql::Connection) -> Result<MemoryStatus> {
         let operation = "memory_status";
         let repair = Self::repair_derived_memory_for_conn(conn).await?;
         let hrr_dim = HolographicEncoder::DIMENSIONS;

--- a/src/types.rs
+++ b/src/types.rs
@@ -446,6 +446,13 @@ pub struct SearchResult {
     pub score: f64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexCoverageHint {
+    pub message: String,
+    pub skipped_dirs: Vec<String>,
+    pub suggested_command: String,
+}
+
 /// Direction for graph traversal.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TraversalDirection {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,11 +1,14 @@
 #![allow(dead_code)]
 
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::net::TcpListener;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde_json::Value;
 use tempfile::TempDir;
+use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::types::{Node, NodeKind, Visibility};
@@ -49,6 +52,97 @@ pub const GLOBAL_DB_ENV: &str = "TRACEDECAY_GLOBAL_DB";
 
 /// Serializes tests within one binary that mutate process-wide env vars.
 pub static GLOBAL_DB_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Sets [`GLOBAL_DB_ENV`] to a test DB path for the guard's lifetime.
+pub struct GlobalDbEnvGuard {
+    _env_guard: EnvVarGuard,
+}
+
+impl GlobalDbEnvGuard {
+    pub fn set(db_path: impl AsRef<Path>) -> Self {
+        let db_path = canonicalize_test_db_path(db_path.as_ref());
+        Self {
+            _env_guard: EnvVarGuard::set(GLOBAL_DB_ENV, db_path),
+        }
+    }
+}
+
+/// Isolates TraceDecay user/profile storage and the global DB under one test home.
+///
+/// Callers that may run concurrently with other env-mutating tests should hold
+/// [`GLOBAL_DB_ENV_LOCK`] while this guard is alive.
+pub struct TraceDecayStorageEnvGuard {
+    home: PathBuf,
+    profile_root: PathBuf,
+    global_db_path: PathBuf,
+    _home_guard: EnvVarGuard,
+    _userprofile_guard: EnvVarGuard,
+    _data_dir_guard: EnvVarGuard,
+    _global_db_guard: GlobalDbEnvGuard,
+}
+
+impl TraceDecayStorageEnvGuard {
+    pub fn set(home: impl AsRef<Path>) -> Self {
+        let home = canonicalize_test_dir(home.as_ref());
+        let profile_root = canonicalize_test_dir(&home.join(".tracedecay"));
+        let global_db_path = canonicalize_test_db_path(&profile_root.join("global.db"));
+
+        Self {
+            home: home.clone(),
+            profile_root: profile_root.clone(),
+            global_db_path: global_db_path.clone(),
+            _home_guard: EnvVarGuard::set("HOME", &home),
+            _userprofile_guard: EnvVarGuard::set("USERPROFILE", &home),
+            _data_dir_guard: EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root),
+            _global_db_guard: GlobalDbEnvGuard::set(&global_db_path),
+        }
+    }
+
+    pub fn for_tempdir(tmp: &TempDir) -> Self {
+        Self::set(tmp.path().join("home"))
+    }
+
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    pub fn profile_root(&self) -> &Path {
+        &self.profile_root
+    }
+
+    pub fn global_db_path(&self) -> &Path {
+        &self.global_db_path
+    }
+}
+
+pub fn isolated_tracedecay_storage(tmp: &TempDir) -> TraceDecayStorageEnvGuard {
+    TraceDecayStorageEnvGuard::for_tempdir(tmp)
+}
+
+fn canonicalize_test_dir(path: &Path) -> PathBuf {
+    fs::create_dir_all(path).unwrap_or_else(|err| {
+        panic!(
+            "failed to create test directory '{}': {err}",
+            path.display()
+        )
+    });
+    path.canonicalize().unwrap_or_else(|err| {
+        panic!(
+            "failed to canonicalize test directory '{}': {err}",
+            path.display()
+        )
+    })
+}
+
+fn canonicalize_test_db_path(path: &Path) -> PathBuf {
+    let parent = path
+        .parent()
+        .unwrap_or_else(|| panic!("test DB path '{}' has no parent", path.display()));
+    canonicalize_test_dir(parent).join(
+        path.file_name()
+            .unwrap_or_else(|| panic!("test DB path '{}' has no file name", path.display())),
+    )
+}
 
 pub fn tempdir_or_panic() -> TempDir {
     match TempDir::new() {

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -2,10 +2,44 @@ use tempfile::TempDir;
 use tracedecay::config::*;
 
 #[test]
-fn test_default_config_has_exclude_patterns() {
+fn default_config_excludes_generated_vendor_cache_trees_and_gitignore_on() {
     let config = TraceDecayConfig::default();
-    assert!(config.exclude.iter().any(|p| p == "target/**"));
-    assert!(config.exclude.iter().any(|p| p == ".git/**"));
+    assert!(config.git_ignore);
+    assert!(config.include.is_empty());
+    for pattern in [
+        "target/**",
+        ".git/**",
+        ".tracedecay/**",
+        "**/node_modules/**",
+        "vendor/**",
+        "**/vendor/**",
+        "build/**",
+        "**/build/**",
+        "dist/**",
+        "**/dist/**",
+        "out/**",
+        "**/out/**",
+        "coverage/**",
+        "**/coverage/**",
+        ".cache/**",
+        "**/.cache/**",
+        ".next/**",
+        "**/.next/**",
+        ".turbo/**",
+        "**/.turbo/**",
+        ".gradle/**",
+        "**/.gradle/**",
+        ".venv/**",
+        "**/.venv/**",
+        "venv/**",
+        "**/venv/**",
+        "**/__pycache__/**",
+    ] {
+        assert!(
+            config.exclude.iter().any(|p| p == pattern),
+            "missing default exclude pattern {pattern}"
+        );
+    }
 }
 
 #[test]
@@ -25,6 +59,29 @@ fn test_is_excluded() {
     assert!(is_excluded("target/debug/foo", &config));
     assert!(is_excluded("node_modules/foo.rs", &config));
     assert!(is_excluded("build/classes/App.class", &config));
+    assert!(is_excluded("packages/web/dist/main.js", &config));
+    assert!(is_excluded("packages/web/coverage/lcov.js", &config));
+    assert!(is_excluded("packages/web/.next/server/app.js", &config));
+    assert!(is_excluded("tools/.cache/generated.py", &config));
+}
+
+#[test]
+fn default_generated_excludes_prune_nested_dirs() {
+    let config = TraceDecayConfig::default();
+    for path in [
+        "packages/web/dist",
+        "packages/web/coverage",
+        "packages/web/.next",
+        "packages/web/.turbo",
+        "tools/.cache",
+        "backend/.venv",
+        "backend/__pycache__",
+    ] {
+        assert!(
+            is_excluded_dir(path, &config),
+            "expected default excludes to prune {path}"
+        );
+    }
 }
 
 #[test]
@@ -63,6 +120,7 @@ fn test_legacy_config_with_include_field_still_loads() {
     let loaded = load_config(dir.path()).unwrap();
     assert_eq!(loaded.version, 1);
     assert!(loaded.exclude.contains(&"target/**".to_string()));
+    assert!(loaded.git_ignore);
 }
 
 // ── is_in_gitignore ─────────────────────────────────────────────────────────

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -299,6 +299,51 @@ async fn test_get_code_returns_none_for_missing_file() {
 }
 
 #[tokio::test]
+async fn test_get_code_returns_none_for_reversed_line_range() {
+    use std::fs;
+    use tempfile::TempDir;
+    use tracedecay::context::ContextBuilder;
+    use tracedecay::db::Database;
+
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "line 1\nline 2\nline 3\n").unwrap();
+
+    let (db, _) = Database::initialize(&project.join(".tracedecay/tracedecay.db"))
+        .await
+        .unwrap();
+
+    let node = context_test_node("src/lib.rs", 3, 1);
+    let builder = ContextBuilder::new(&db, project);
+    let code = builder.get_code(&node).unwrap();
+    assert!(code.is_none());
+}
+
+#[tokio::test]
+async fn test_get_code_rejects_absolute_path_when_root_is_not_canonical() {
+    use std::fs;
+    use tempfile::TempDir;
+    use tracedecay::context::ContextBuilder;
+    use tracedecay::db::Database;
+
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    let outside = project.join("outside.rs");
+    fs::write(&outside, "fn secret() {}\n").unwrap();
+
+    let (db, _) = Database::initialize(&project.join(".tracedecay/tracedecay.db"))
+        .await
+        .unwrap();
+
+    let missing_root = project.join("missing-root");
+    let node = context_test_node(outside.to_string_lossy().as_ref(), 1, 1);
+    let builder = ContextBuilder::new(&db, &missing_root);
+    let code = builder.get_code(&node).unwrap();
+    assert!(code.is_none());
+}
+
+#[tokio::test]
 async fn test_find_relevant_context() {
     use tempfile::TempDir;
     use tracedecay::context::ContextBuilder;
@@ -507,4 +552,32 @@ async fn test_merge_adjacent_code_blocks() {
     );
     assert!(ctx.code_blocks[0].content.contains("alpha"));
     assert!(ctx.code_blocks[0].content.contains("beta"));
+}
+
+fn context_test_node(file_path: &str, start_line: u32, end_line: u32) -> Node {
+    Node {
+        id: format!("function:{file_path}:{start_line}:{end_line}"),
+        kind: NodeKind::Function,
+        name: "test_node".to_string(),
+        qualified_name: format!("{file_path}::test_node"),
+        file_path: file_path.to_string(),
+        start_line,
+        attrs_start_line: start_line,
+        end_line,
+        start_column: 0,
+        end_column: 1,
+        signature: Some("fn test_node()".to_string()),
+        docstring: None,
+        visibility: Visibility::Private,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 0,
+        parent_id: None,
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
-use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
+use std::{fs, path::Path};
 use tempfile::TempDir;
 use tracedecay::config::{load_config, save_config};
 use tracedecay::storage::resolve_layout_for_current_profile;
@@ -452,12 +452,148 @@ async fn test_index_follows_symlinked_directories() {
 // ---------------------------------------------------------------------------
 
 /// Helper: init a project with git_ignore enabled and return the TraceDecay.
-async fn setup_gitignore_project(project: &std::path::Path) -> TraceDecay {
+async fn setup_gitignore_project(project: &Path) -> TraceDecay {
     TraceDecay::init(project).await.unwrap();
     let mut config = load_config(project).unwrap();
     config.git_ignore = true;
     save_config(project, &config).unwrap();
     TraceDecay::open(project).await.unwrap()
+}
+
+async fn indexed_project_paths(cg: &TraceDecay) -> Vec<String> {
+    cg.index_all().await.unwrap();
+    cg.get_all_files()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|file| file.path)
+        .collect()
+}
+
+async fn indexed_paths_for_project(project: &Path) -> Vec<String> {
+    let cg = TraceDecay::init(project).await.unwrap();
+    indexed_project_paths(&cg).await
+}
+
+#[tokio::test]
+async fn test_default_scan_excludes_generated_directories() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(project.join("packages/web/dist")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn kept() {}\n").unwrap();
+    fs::write(
+        project.join("packages/web/dist/generated.js"),
+        "export function generated() {}\n",
+    )
+    .unwrap();
+
+    let paths = indexed_paths_for_project(project).await;
+    assert!(
+        paths.iter().any(|p| p == "src/lib.rs"),
+        "src/lib.rs must be indexed"
+    );
+    assert!(
+        !paths.iter().any(|p| p.contains("/dist/")),
+        "generated dist files must be skipped by default: {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_default_scan_respects_gitignore() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    fs::create_dir_all(project.join("src/ignored")).unwrap();
+    fs::write(project.join(".gitignore"), "src/ignored/\n").unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn kept() {}\n").unwrap();
+    fs::write(
+        project.join("src/ignored/secret.rs"),
+        "pub fn ignored() {}\n",
+    )
+    .unwrap();
+
+    let paths = indexed_paths_for_project(project).await;
+    assert!(
+        paths.iter().any(|p| p == "src/lib.rs"),
+        "src/lib.rs must be indexed"
+    );
+    assert!(
+        !paths.iter().any(|p| p.contains("ignored")),
+        ".gitignore rules must be respected by default: {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_include_folder_indexes_default_excluded_directory() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    fs::create_dir_all(project.join("dist")).unwrap();
+    fs::write(
+        project.join("dist/generated.js"),
+        "export function generatedApi() {}\n",
+    )
+    .unwrap();
+
+    let mut cg = TraceDecay::init(project).await.unwrap();
+    cg.add_include_folders(&["dist".to_string()]);
+    cg.index_all().await.unwrap();
+
+    let results = cg.search("generatedApi", 10).await.unwrap();
+    assert!(
+        !results.is_empty(),
+        "explicit include folder should index skipped generated output"
+    );
+    assert!(
+        results
+            .iter()
+            .any(|r| r.node.file_path == "dist/generated.js"),
+        "result should point at included dist file: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_include_folder_normalizes_relative_and_project_absolute_prefixes() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+
+    fs::create_dir_all(project.join("dist")).unwrap();
+    fs::create_dir_all(project.join("generated")).unwrap();
+    fs::write(
+        project.join("dist/generated.js"),
+        "export function distGeneratedApi() {}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("generated/client.js"),
+        "export function absoluteGeneratedApi() {}\n",
+    )
+    .unwrap();
+
+    let mut cg = TraceDecay::init(project).await.unwrap();
+    cg.add_include_folders(&[
+        "./dist".to_string(),
+        project.join("generated").to_string_lossy().to_string(),
+    ]);
+    cg.index_all().await.unwrap();
+
+    let dist_results = cg.search("distGeneratedApi", 10).await.unwrap();
+    assert!(
+        dist_results
+            .iter()
+            .any(|r| r.node.file_path == "dist/generated.js"),
+        "dot-prefixed include folder should match project-relative scanner paths: {dist_results:?}"
+    );
+
+    let absolute_results = cg.search("absoluteGeneratedApi", 10).await.unwrap();
+    assert!(
+        absolute_results
+            .iter()
+            .any(|r| r.node.file_path == "generated/client.js"),
+        "absolute include folder under project root should match project-relative scanner paths: {absolute_results:?}"
+    );
 }
 
 /// A nested `.gitignore` in a subdirectory must exclude files inside that

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -3,6 +3,8 @@
 //! Each test exercises a real `TraceDecay` instance with indexed test data,
 //! ensuring that the MCP dispatch layer formats results correctly.
 
+mod common;
+
 use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
@@ -159,6 +161,12 @@ struct TestEnv {
     _global_db_guard: GlobalDbEnvGuard,
 }
 
+struct CrossProjectMemoryEnv {
+    _dir: TempDir,
+    _env_lock: MutexGuard<'static, ()>,
+    _storage_guard: common::TraceDecayStorageEnvGuard,
+}
+
 /// Creates a temporary Rust project with cross-file calls, structs, impls,
 /// test files, and doc comments, then initialises and indexes a `TraceDecay`.
 async fn setup_project() -> (TraceDecay, TestProject) {
@@ -237,6 +245,52 @@ async fn init_test_project(project: &Path) -> (TraceDecay, TestEnv) {
             _env_lock: env_lock,
             _home_guard: home_guard,
             _global_db_guard: global_db_guard,
+        },
+    )
+}
+
+async fn setup_generated_dir_project(include_dist: bool) -> (TraceDecay, TestEnv, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(project.join("dist")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn kept() {}\n").unwrap();
+    fs::write(
+        project.join("dist/generated.js"),
+        "export function generatedOnly() {}\n",
+    )
+    .unwrap();
+
+    let (mut cg, env) = init_test_project(project).await;
+    if include_dist {
+        cg.add_include_folders(&["dist".to_string()]);
+    }
+    cg.index_all().await.unwrap();
+    (cg, env, dir)
+}
+
+async fn setup_cross_project_memory_projects() -> (TraceDecay, TraceDecay, CrossProjectMemoryEnv) {
+    let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let storage_guard = common::isolated_tracedecay_storage(&dir);
+
+    let active_project = dir.path().join("active");
+    let target_project = dir.path().join("target");
+    fs::create_dir_all(active_project.join("src")).unwrap();
+    fs::create_dir_all(target_project.join("src")).unwrap();
+    fs::write(active_project.join("src/lib.rs"), "pub fn active() {}\n").unwrap();
+    fs::write(target_project.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
+
+    let active = TraceDecay::init(&active_project).await.unwrap();
+    let target = TraceDecay::init(&target_project).await.unwrap();
+
+    (
+        active,
+        target,
+        CrossProjectMemoryEnv {
+            _dir: dir,
+            _env_lock: env_lock,
+            _storage_guard: storage_guard,
         },
     )
 }
@@ -441,8 +495,25 @@ fn extract_text(value: &Value) -> &str {
         .unwrap_or("<missing text>")
 }
 
+fn extract_json(value: &Value) -> Value {
+    serde_json::from_str(extract_text(value)).unwrap()
+}
+
+fn assert_fact_results(payload: &Value, included: &str, excluded: &str, context: &str) {
+    assert_eq!(payload["count"].as_u64(), Some(1), "{context}: {payload}");
+    let results = payload["results"].to_string();
+    assert!(
+        results.contains(included),
+        "{context} should include {included:?}: {payload}"
+    );
+    assert!(
+        !results.contains(excluded),
+        "{context} should not include {excluded:?}: {payload}"
+    );
+}
+
 async fn extract_lcm_json_following_handle(cg: &TraceDecay, value: &Value) -> Value {
-    let payload: Value = serde_json::from_str(extract_text(value)).unwrap();
+    let payload = extract_json(value);
     if payload.get("truncated").and_then(Value::as_bool) != Some(true) {
         return payload;
     }
@@ -458,7 +529,7 @@ async fn extract_lcm_json_following_handle(cg: &TraceDecay, value: &Value) -> Va
     )
     .await
     .unwrap();
-    let retrieved_payload: Value = serde_json::from_str(extract_text(&retrieved.value)).unwrap();
+    let retrieved_payload = extract_json(&retrieved.value);
     serde_json::from_str(
         retrieved_payload["content"]
             .as_str()
@@ -1124,25 +1195,39 @@ async fn find_node_id(cg: &TraceDecay, name: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+fn tool_properties<'a>(
+    tools: &'a [tracedecay::mcp::ToolDefinition],
+    name: &str,
+) -> &'a serde_json::Map<String, Value> {
+    tools
+        .iter()
+        .find(|tool| tool.name == name)
+        .unwrap_or_else(|| panic!("{name} definition"))
+        .input_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("{name} properties"))
+}
+
 #[test]
-fn retrieve_tool_schema_uses_handle_only() {
+fn retrieve_tool_schema_requires_handle_and_accepts_project_selector() {
     let tools = get_tool_definitions();
     let retrieve = tools
         .iter()
         .find(|tool| tool.name == "tracedecay_retrieve")
         .expect("tracedecay_retrieve definition");
-    let properties = retrieve
-        .input_schema
-        .get("properties")
-        .and_then(Value::as_object)
-        .expect("retrieve properties");
+    let properties = tool_properties(&tools, "tracedecay_retrieve");
 
     assert!(properties.contains_key("handle"));
+    assert!(properties.contains_key("project_selector"));
+    assert!(properties.contains_key("project_id"));
+    assert!(properties.contains_key("project_path"));
     assert!(!properties.contains_key("retrieve_handle"));
     assert_eq!(retrieve.input_schema["required"], json!(["handle"]));
 
     assert!(retrieve.description.contains("tracedecay_retrieve"));
     assert!(retrieve.description.contains("required argument `handle`"));
+    assert!(retrieve.description.contains("pass the same selector"));
     assert!(retrieve
         .description
         .contains("Only call it when the missing details are needed"));
@@ -1150,6 +1235,45 @@ fn retrieve_tool_schema_uses_handle_only() {
         .as_str()
         .unwrap_or_default()
         .contains("required `handle` argument"));
+}
+
+#[test]
+fn always_loaded_graph_tool_schemas_advertise_project_selectors() {
+    let tools = get_tool_definitions();
+    for name in ["tracedecay_search", "tracedecay_context"] {
+        let properties = tool_properties(&tools, name);
+        assert!(
+            properties.contains_key("project_selector"),
+            "{name} should advertise nested project_selector"
+        );
+        assert!(
+            properties.contains_key("project_id"),
+            "{name} should advertise project_id"
+        );
+        assert!(
+            properties.contains_key("project_path"),
+            "{name} should advertise project_path"
+        );
+    }
+}
+
+#[test]
+fn lcm_compress_public_schema_excludes_test_summarizer_modes() {
+    let tools = get_tool_definitions();
+    let compress = tools
+        .iter()
+        .find(|tool| tool.name == "tracedecay_lcm_compress")
+        .expect("tracedecay_lcm_compress definition");
+    let modes = compress.input_schema["properties"]["summarizer"]["properties"]["mode"]["enum"]
+        .as_array()
+        .expect("summarizer mode enum");
+
+    assert!(modes.iter().any(|mode| mode == "provided"));
+    assert!(modes.iter().any(|mode| mode == "hermes_auxiliary"));
+    assert!(
+        modes.iter().all(|mode| mode != "noop" && mode != "fake"),
+        "public MCP schema should not advertise test/control summarizers: {modes:?}"
+    );
 }
 
 // 1. tracedecay_search
@@ -1172,6 +1296,77 @@ async fn test_search() {
     assert!(
         text.contains("helper"),
         "search results should contain 'helper'"
+    );
+}
+
+#[tokio::test]
+async fn test_search_returns_index_coverage_hint_for_skipped_generated_dirs() {
+    let (cg, _env, _dir) = setup_generated_dir_project(false).await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_search",
+        json!({"query": "generatedOnly", "limit": 5}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["results"].as_array().map(Vec::len), Some(0));
+    assert_eq!(
+        parsed["index_coverage_hint"]["suggested_command"].as_str(),
+        Some("tracedecay sync --include-folder dist")
+    );
+    assert_eq!(
+        parsed["index_coverage_hint"]["skipped_dirs"][0].as_str(),
+        Some("dist")
+    );
+}
+
+#[tokio::test]
+async fn test_context_appends_index_coverage_hint_for_skipped_generated_dirs() {
+    let (cg, _env, _dir) = setup_generated_dir_project(false).await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_context",
+        json!({"task": "generatedOnly", "max_nodes": 5}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    assert!(
+        text.contains("### Index Coverage Hint"),
+        "context miss should include coverage hint, got: {text}"
+    );
+    assert!(
+        text.contains("tracedecay sync --include-folder dist"),
+        "hint should include opt-in command, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn test_search_omits_index_coverage_hint_when_generated_dir_is_included() {
+    let (cg, _env, _dir) = setup_generated_dir_project(true).await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_search",
+        json!({"query": "missingAfterInclude", "limit": 5}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert!(
+        parsed.as_array().is_some(),
+        "search should keep array shape when there is no coverage hint, got: {text}"
     );
 }
 
@@ -1436,6 +1631,55 @@ async fn fact_store_large_list_response_reports_store_failure_actionably() {
         .as_str()
         .unwrap_or_default()
         .contains("re-run the original MCP tool"));
+}
+
+#[tokio::test]
+async fn search_large_response_uses_retrievable_truncation_handle() {
+    let (cg, project) = setup_project().await;
+    let mut source = String::new();
+    for i in 0..420 {
+        source.push_str(&format!(
+            "pub fn reversible_search_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}\n"
+        ));
+    }
+    fs::write(project.path().join("src/large_search.rs"), source).unwrap();
+    index_all_retrying_sync_lock(&cg).await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_search",
+        json!({"query": "reversible_search_marker", "limit": 420}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let envelope: Value =
+        serde_json::from_str(extract_text(&result.value)).expect("large search response envelope");
+    assert_eq!(envelope["truncated"], true);
+    assert_eq!(envelope["retrieve_tool"], "tracedecay_retrieve");
+    let handle = envelope["handle"]
+        .as_str()
+        .expect("large search response should include a handle");
+
+    let retrieved = handle_tool_call(
+        &cg,
+        "tracedecay_retrieve",
+        json!({ "handle": handle }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let retrieved_payload: Value = serde_json::from_str(extract_text(&retrieved.value)).unwrap();
+    assert_eq!(retrieved_payload["expired"], false);
+    let full_json = retrieved_payload["content"]
+        .as_str()
+        .expect("retrieve response should contain full search JSON");
+    assert!(
+        full_json.contains("reversible_search_marker_419"),
+        "retrieved search response should include the tail result"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1815,6 +2059,55 @@ async fn test_diff_context() {
     );
 }
 
+#[tokio::test]
+async fn diff_context_large_response_uses_retrievable_truncation_handle() {
+    let (cg, project) = setup_project().await;
+    let mut source = String::new();
+    for i in 0..420 {
+        source.push_str(&format!(
+            "pub fn reversible_diff_context_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}\n"
+        ));
+    }
+    fs::write(project.path().join("src/large_diff.rs"), source).unwrap();
+    index_all_retrying_sync_lock(&cg).await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_diff_context",
+        json!({"files": ["src/large_diff.rs"], "depth": 1}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let envelope: Value =
+        serde_json::from_str(extract_text(&result.value)).expect("large diff_context envelope");
+    assert_eq!(envelope["truncated"], true);
+    assert_eq!(envelope["retrieve_tool"], "tracedecay_retrieve");
+    let handle = envelope["handle"]
+        .as_str()
+        .expect("large diff_context response should include a handle");
+
+    let retrieved = handle_tool_call(
+        &cg,
+        "tracedecay_retrieve",
+        json!({ "handle": handle }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let retrieved_payload: Value = serde_json::from_str(extract_text(&retrieved.value)).unwrap();
+    assert_eq!(retrieved_payload["expired"], false);
+    let full_json = retrieved_payload["content"]
+        .as_str()
+        .expect("retrieve response should contain full diff_context JSON");
+    assert!(
+        full_json.contains("reversible_diff_context_marker_419"),
+        "retrieved diff_context response should include the tail result"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 16. tracedecay_module_api
 // ---------------------------------------------------------------------------
@@ -2160,8 +2453,8 @@ async fn test_god_class() {
 #[tokio::test]
 async fn test_changelog_no_git() {
     let (cg, _dir) = setup_project().await;
-    // The temp dir is not a git repo, so this should return a "git diff failed"
-    // message rather than a hard error.
+    // The temp dir is not a git repo, so this should return a structured git
+    // error in the tool payload rather than success-looking prose.
     let result = handle_tool_call(
         &cg,
         "tracedecay_changelog",
@@ -2172,11 +2465,53 @@ async fn test_changelog_no_git() {
     .await
     .unwrap();
     let text = extract_text(&result.value);
+    let output: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(output["error"]["kind"].as_str(), Some("git"));
+    assert_eq!(output["error"]["operation"].as_str(), Some("diff"));
+    assert!(output["error"]["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("failed to open git repo"));
+}
+
+#[tokio::test]
+async fn run_affected_tests_reports_git_failure_without_changed_paths() {
+    let (cg, _dir) = setup_project().await;
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_run_affected_tests",
+        json!({"timeout_secs": 1}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let output: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(output["error"]["kind"].as_str(), Some("git"));
+    assert_eq!(output["error"]["operation"].as_str(), Some("diff"));
     assert!(
-        text.contains("git diff failed"),
-        "changelog on non-git dir should report git diff failure, got: {}",
-        text,
+        output["note"].is_null(),
+        "git failure must not be reported as a no-change note: {output}"
     );
+}
+
+#[tokio::test]
+async fn pr_context_no_git_returns_structured_git_error() {
+    let (cg, _dir) = setup_project().await;
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_pr_context",
+        json!({"base_ref": "HEAD~1", "head_ref": "HEAD"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let output: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(output["error"]["kind"].as_str(), Some("git"));
+    assert_eq!(output["error"]["operation"].as_str(), Some("diff"));
 }
 
 // ---------------------------------------------------------------------------
@@ -3180,8 +3515,65 @@ async fn project_selector_is_rejected_before_write_tool_parsing() {
     let message = expect_tool_error(result);
 
     assert!(
-        message.contains("does not accept project_selector"),
+        message.contains("does not accept project selectors"),
         "write tool should reject project_selector before parser errors, got {message}"
+    );
+}
+
+#[tokio::test]
+async fn lcm_project_root_storage_arg_is_not_rejected_as_selector() {
+    let (cg, _dir) = setup_project().await;
+    let project_root = cg.project_root().to_string_lossy().to_string();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_preflight",
+        json!({
+            "session_id": "stock-check-session",
+            "project_root": project_root,
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"}
+            ],
+            "current_tokens": 50
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload = extract_json(&result.value);
+
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["session_id"], "stock-check-session");
+}
+
+#[tokio::test]
+async fn lcm_project_path_selector_is_rejected_before_dispatch() {
+    let (cg, _dir) = setup_project().await;
+    let project_path = cg.project_root().to_string_lossy().to_string();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_preflight",
+        json!({
+            "session_id": "stock-check-session",
+            "project_path": project_path,
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi there"}
+            ],
+            "current_tokens": 50
+        }),
+        None,
+        None,
+    )
+    .await;
+    let message = expect_tool_error(result);
+
+    assert!(
+        message.contains("does not accept project selectors"),
+        "LCM preflight should reject project_path selectors before dispatch, got {message}"
     );
 }
 
@@ -3429,8 +3821,7 @@ async fn ast_grep_rewrite_has_literal_fallback_when_binary_missing() {
     .await
     .unwrap();
 
-    let text = extract_text(&result.value);
-    let output: Value = serde_json::from_str(text).unwrap();
+    let output = extract_json(&result.value);
     assert_eq!(output["success"].as_bool(), Some(true), "{output}");
     assert!(
         fs::read_to_string(project.join("src/lib.rs"))
@@ -4922,6 +5313,293 @@ async fn memory_fact_store_add_search_update_remove_and_wrappers() {
 }
 
 #[tokio::test]
+async fn memory_fact_store_project_selector_targets_registered_project() {
+    let (active, target, _env) = setup_cross_project_memory_projects().await;
+    let target_project_id = target
+        .store_layout()
+        .identity
+        .project_id
+        .as_deref()
+        .expect("target project should have a profile project_id");
+    let target_project_path = target.project_root().to_string_lossy().to_string();
+
+    handle_tool_call(
+        &target,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": "Target selector fact stays with the registered target project",
+            "category": "project",
+            "entity": "Target selector"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": "Active selector fact stays with the active project",
+            "category": "project",
+            "entity": "Active selector"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let target_list = handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({
+            "action": "list",
+            "project_path": target_project_path,
+            "category": "project",
+            "min_trust": 0.0
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_list = extract_json(&target_list.value);
+    assert_fact_results(
+        &target_list,
+        "Target selector fact",
+        "Active selector fact",
+        "project_path selector should read target-project facts",
+    );
+
+    let target_list_by_nested_project_path = handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({
+            "action": "list",
+            "project_selector": {"project_path": target_project_path},
+            "category": "project",
+            "min_trust": 0.0
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_list_by_nested_project_path =
+        extract_json(&target_list_by_nested_project_path.value);
+    assert_fact_results(
+        &target_list_by_nested_project_path,
+        "Target selector fact",
+        "Active selector fact",
+        "nested project_path selector should read target-project facts",
+    );
+
+    let active_list = handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({"action": "list", "category": "project", "min_trust": 0.0}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let active_list = extract_json(&active_list.value);
+    assert_fact_results(
+        &active_list,
+        "Active selector fact",
+        "Target selector fact",
+        "default fact_store scope should remain the active project",
+    );
+
+    let cross_project_write = handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "project_selector": {"project_id": target_project_id},
+            "content": "Cross-project writes should be rejected",
+            "category": "project"
+        }),
+        None,
+        None,
+    )
+    .await;
+    let Err(err) = cross_project_write else {
+        panic!("expected cross-project fact_store add to be rejected");
+    };
+    assert!(
+        format!("{err}").contains("cross-project fact_store writes are not supported"),
+        "unexpected cross-project write error: {err}"
+    );
+
+    let cross_project_feedback = handle_tool_call(
+        &active,
+        "tracedecay_fact_feedback",
+        json!({
+            "fact_id": 1,
+            "action": "helpful",
+            "project_selector": {"project_id": target_project_id}
+        }),
+        None,
+        None,
+    )
+    .await;
+    let Err(err) = cross_project_feedback else {
+        panic!("expected cross-project fact feedback to be rejected");
+    };
+    assert!(
+        format!("{err}").contains("does not accept project selectors"),
+        "unexpected cross-project feedback error: {err}"
+    );
+
+    let typo_selector = handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({
+            "action": "list",
+            "project_id": "proj_does_not_exist",
+            "category": "project",
+            "min_trust": 0.0
+        }),
+        None,
+        None,
+    )
+    .await;
+    let Err(err) = typo_selector else {
+        panic!("expected unresolved explicit selector to fail");
+    };
+    assert!(
+        format!("{err}").contains("registered project not found for selector"),
+        "unresolved selector must not fall back to active project: {err}"
+    );
+
+    let hidden_top_level_path = handle_tool_call(
+        &active,
+        "tracedecay_fact_store",
+        json!({
+            "action": "list",
+            "path": target_project_path,
+            "category": "project",
+            "min_trust": 0.0
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let hidden_top_level_path = extract_json(&hidden_top_level_path.value);
+    assert_fact_results(
+        &hidden_top_level_path,
+        "Active selector fact",
+        "Target selector fact",
+        "top-level path should not act as an undocumented project selector",
+    );
+}
+
+#[tokio::test]
+async fn memory_status_project_selector_reports_registered_project_memory() {
+    let (active, target, _env) = setup_cross_project_memory_projects().await;
+    let target_project_id = target
+        .store_layout()
+        .identity
+        .project_id
+        .as_deref()
+        .expect("target project should have a profile project_id");
+    let target_project_path = target.project_root().to_string_lossy().to_string();
+
+    for content in ["Active status fact one", "Active status fact two"] {
+        handle_tool_call(
+            &active,
+            "tracedecay_fact_store",
+            json!({
+                "action": "add",
+                "content": content,
+                "category": "project"
+            }),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    handle_tool_call(
+        &target,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": "Target status fact",
+            "category": "project"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let active_status =
+        handle_tool_call(&active, "tracedecay_memory_status", json!({}), None, None)
+            .await
+            .unwrap();
+    let active_status = extract_json(&active_status.value);
+    assert_eq!(active_status["status"], "ok");
+    assert_eq!(active_status["memory"]["fact_count"].as_u64(), Some(2));
+
+    let target_status_by_id = handle_tool_call(
+        &active,
+        "tracedecay_memory_status",
+        json!({"project_id": target_project_id}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_status_by_id = extract_json(&target_status_by_id.value);
+    assert_eq!(target_status_by_id["status"], "ok");
+    assert_eq!(
+        target_status_by_id["memory"]["fact_count"].as_u64(),
+        Some(1),
+        "project_id selector should report the target project's memory: {target_status_by_id}"
+    );
+
+    let target_status_by_path = handle_tool_call(
+        &active,
+        "tracedecay_memory_status",
+        json!({"project_selector": {"path": target_project_path}}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_status_by_path = extract_json(&target_status_by_path.value);
+    assert_eq!(
+        target_status_by_path["memory"]["fact_count"].as_u64(),
+        Some(1),
+        "nested path selector should report the target project's memory: {target_status_by_path}"
+    );
+
+    let missing_status = handle_tool_call(
+        &active,
+        "tracedecay_memory_status",
+        json!({"project_id": "proj_does_not_exist"}),
+        None,
+        None,
+    )
+    .await;
+    let Err(err) = missing_status else {
+        panic!("expected unresolved memory_status selector to fail");
+    };
+    assert!(
+        format!("{err}").contains("registered project not found for selector"),
+        "unresolved memory_status selector must not fall back to active project: {err}"
+    );
+}
+
+#[tokio::test]
 async fn memory_fact_store_update_rejects_secret_like_content_with_diff_report() {
     let (cg, _dir) = setup_project().await;
     let added = handle_tool_call(
@@ -5382,7 +6060,7 @@ async fn message_search_reads_project_local_session_db() {
     )
     .await
     .unwrap();
-    let parsed: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
+    let parsed = extract_json(&result.value);
     assert_eq!(parsed["status"], "ok");
     assert_eq!(parsed["count"], 1);
     assert_eq!(
@@ -5408,8 +6086,7 @@ async fn message_search_reads_project_local_session_db() {
     )
     .await
     .unwrap();
-    let subagent_parsed: Value =
-        serde_json::from_str(extract_text(&subagent_result.value)).unwrap();
+    let subagent_parsed = extract_json(&subagent_result.value);
     assert_eq!(subagent_parsed["status"], "ok");
     assert_eq!(subagent_parsed["scope"], "subagents_only");
     assert_eq!(subagent_parsed["parent_session_id"], "cursor-session");
@@ -5503,7 +6180,7 @@ async fn message_search_reads_profile_sharded_session_db() {
     )
     .await
     .unwrap();
-    let parsed: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
+    let parsed = extract_json(&result.value);
 
     assert_eq!(parsed["status"], "ok");
     assert_eq!(parsed["count"], 1);
@@ -10942,4 +11619,223 @@ async fn type_hierarchy_surfaces_store_failure_instead_of_empty_tree() {
         result.is_err(),
         "a failing store query must produce a tool error, not an empty hierarchy"
     );
+}
+
+#[tokio::test]
+async fn message_search_selects_registered_project_session_db_by_project_id() {
+    let (cg, _dir) = setup_project().await;
+    let profile_root = cg.project_root().join("home/.tracedecay");
+    let target_project = cg.project_root().join("registered-target");
+    let target_project_path = target_project.to_string_lossy().to_string();
+    let target_store_relpath = "projects/proj_cross_messages";
+    let target_store_root = profile_root.join(target_store_relpath);
+    let target_session_db = target_store_root.join("sessions.db");
+    fs::create_dir_all(&target_project).unwrap();
+    fs::create_dir_all(&target_store_root).unwrap();
+
+    let active_db = open_project_session_db(cg.project_root())
+        .await
+        .expect("active project session db should open");
+    assert!(
+        active_db
+            .upsert_session(&SessionRecord {
+                provider: "cursor".to_string(),
+                session_id: "active-session".to_string(),
+                project_key: cg.project_root().to_string_lossy().to_string(),
+                project_path: cg.project_root().to_string_lossy().to_string(),
+                title: Some("Active project".to_string()),
+                started_at: Some(1),
+                ended_at: None,
+                transcript_path: Some("active-session.jsonl".to_string()),
+                metadata_json: None,
+                parent_session_id: None,
+                is_subagent: false,
+                agent_id: None,
+                parent_tool_use_id: None,
+            })
+            .await
+    );
+    assert!(
+        active_db
+            .upsert_session_message(&SessionMessageRecord {
+                provider: "cursor".to_string(),
+                message_id: "active-message".to_string(),
+                session_id: "active-session".to_string(),
+                role: "user".to_string(),
+                timestamp: Some(2),
+                ordinal: 1,
+                text: "Cross project dragonfruit belongs to the active database.".to_string(),
+                kind: Some("message".to_string()),
+                model: Some("test-model".to_string()),
+                tool_names: None,
+                source_path: Some("active-session.jsonl".to_string()),
+                source_offset: Some(0),
+                metadata_json: None,
+            })
+            .await
+    );
+
+    let registry = GlobalDb::open().await.expect("global registry should open");
+    let project = registry
+        .upsert_code_project(
+            "proj_cross_messages",
+            &target_project,
+            None,
+            None,
+            Some("main"),
+        )
+        .await
+        .expect("registered project should upsert");
+    let store = registry
+        .upsert_store_instance(tracedecay::global_db::StoreInstanceUpsert {
+            store_id: "store_cross_messages".to_string(),
+            project_id: project.project_id,
+            store_kind: "code_project".to_string(),
+            storage_mode: "profile_sharded".to_string(),
+            store_relpath: target_store_relpath.to_string(),
+            manifest_relpath: Some(format!("{target_store_relpath}/store_manifest.json")),
+            last_verified_at: Some(1_800_000_010),
+            last_write_at: Some(1_800_000_011),
+        })
+        .await
+        .expect("registered store should upsert");
+    registry
+        .upsert_store_artifact(tracedecay::global_db::StoreArtifactUpsert {
+            store_id: store.store_id,
+            artifact_kind: "sessions_db".to_string(),
+            relpath: format!("{target_store_relpath}/sessions.db"),
+            size_bytes: None,
+            schema_version: Some("1".to_string()),
+            updated_at: Some(1_800_000_012),
+        })
+        .await
+        .expect("session artifact should upsert");
+
+    let target_db = GlobalDb::open_at(&target_session_db)
+        .await
+        .expect("registered project session db should open");
+    assert!(
+        target_db
+            .upsert_session(&SessionRecord {
+                provider: "cursor".to_string(),
+                session_id: "target-session".to_string(),
+                project_key: target_project_path.clone(),
+                project_path: target_project_path.clone(),
+                title: Some("Registered project".to_string()),
+                started_at: Some(10),
+                ended_at: None,
+                transcript_path: Some("target-session.jsonl".to_string()),
+                metadata_json: None,
+                parent_session_id: None,
+                is_subagent: false,
+                agent_id: None,
+                parent_tool_use_id: None,
+            })
+            .await
+    );
+    assert!(
+        target_db
+            .upsert_session_message(&SessionMessageRecord {
+                provider: "cursor".to_string(),
+                message_id: "target-message".to_string(),
+                session_id: "target-session".to_string(),
+                role: "assistant".to_string(),
+                timestamp: Some(11),
+                ordinal: 1,
+                text: "Cross project dragonfruit belongs to the registered database.".to_string(),
+                kind: Some("message".to_string()),
+                model: Some("test-model".to_string()),
+                tool_names: None,
+                source_path: Some("target-session.jsonl".to_string()),
+                source_offset: Some(0),
+                metadata_json: None,
+            })
+            .await
+    );
+
+    fn message_search_args(selector: Value) -> Value {
+        let mut args = json!({
+            "query": "dragonfruit",
+            "provider": "cursor",
+            "limit": 5
+        });
+        args.as_object_mut()
+            .unwrap()
+            .extend(selector.as_object().unwrap().clone());
+        args
+    }
+
+    for (label, selector) in [
+        ("project_id", json!({"project_id": "proj_cross_messages"})),
+        (
+            "project_path",
+            json!({"project_path": target_project_path.clone()}),
+        ),
+        (
+            "project_root",
+            json!({"project_root": target_project_path.clone()}),
+        ),
+        (
+            "nested path",
+            json!({"project_selector": {"path": target_project_path.clone()}}),
+        ),
+        (
+            "nested project_path",
+            json!({"project_selector": {"project_path": target_project_path.clone()}}),
+        ),
+    ] {
+        let result = handle_tool_call(
+            &cg,
+            "tracedecay_message_search",
+            message_search_args(selector),
+            None,
+            None,
+        )
+        .await
+        .unwrap_or_else(|err| panic!("{label} selector should resolve target project: {err}"));
+        let parsed = extract_json(&result.value);
+
+        assert_eq!(parsed["status"], "ok", "{label}: {parsed}");
+        assert_eq!(
+            parsed["selected_project_root"],
+            target_project_path.as_str(),
+            "{label}: {parsed}"
+        );
+        assert_eq!(parsed["count"], 1, "{label}: {parsed}");
+        assert_eq!(
+            parsed["results"][0]["message"]["message_id"], "target-message",
+            "{label}: {parsed}"
+        );
+        assert_eq!(
+            parsed["results"][0]["session"]["project_key"],
+            target_project_path.as_str(),
+            "{label}: {parsed}"
+        );
+    }
+
+    for (label, selector) in [
+        (
+            "missing project_id",
+            json!({"project_id": "proj_missing_messages"}),
+        ),
+        (
+            "missing nested path",
+            json!({"project_selector": {"path": cg.project_root().join("missing-project").to_string_lossy().to_string()}}),
+        ),
+    ] {
+        let err = expect_tool_error(
+            handle_tool_call(
+                &cg,
+                "tracedecay_message_search",
+                message_search_args(selector),
+                None,
+                None,
+            )
+            .await,
+        );
+        assert!(
+            err.contains("registered project not found for selector"),
+            "{label} must fail closed instead of searching the active session DB: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- enable default generated/gitignore skips with runtime include-folder overrides and index coverage hints
- add fail-closed registered-project selectors for CLI/MCP read surfaces and session/memory reads
- harden MCP response truncation, structured git errors, and registry cleanup flows

## Verification
- cargo test cli_parse_tests
- cargo test --test config_test --test context_test
- cargo test --test integration_test test_default_scan
- cargo test --test integration_test test_include_folder_indexes_default_excluded_directory
- cargo test --test mcp_handler_test project_selector
- cargo test --test mcp_handler_test index_coverage
- cargo test --test mcp_handler_test large_response
- cargo test --test mcp_handler_test git_failure
- cargo test --test mcp_handler_test test_changelog_no_git
- cargo test --test mcp_handler_test pr_context_no_git_returns_structured_git_error
- cargo test --test mcp_handler_test message_search_selects_registered_project_session_db_by_project_id
- cargo test --test mcp_handler_test lcm_compress_public_schema_excludes_test_summarizer_modes