### PR TITLE
[codex] Shard Windows CI tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,18 @@
+[profile.ci]
+fail-fast = false
+retries = 0
+flaky-result = "fail"
+slow-timeout = { period = "90s", terminate-after = 4 }
+
+[test-groups]
+windows-global-state = { max-threads = 1 }
+
+[[profile.ci.overrides]]
+filter = 'binary_id(tracedecay::mcp_handler_test)'
+platform = { host = 'cfg(windows)' }
+test-group = 'windows-global-state'
+
+[[profile.ci.overrides]]
+filter = 'test(/^doctor::tests::/)'
+platform = { host = 'cfg(windows)' }
+test-group = 'windows-global-state'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
             runner: '"ubuntu-latest"'
           - name: macOS
             runner: '"macos-14"'
-          - name: Windows
-            runner: '"windows-latest"'
 
     steps:
       - uses: actions/checkout@v7
@@ -56,7 +54,87 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run tests
-        run: cargo nextest run --workspace --no-fail-fast
+        run: cargo nextest run --workspace --profile ci
+
+  windows-test-shards:
+    name: Test Windows ${{ matrix.partition }}/4
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3, 4]
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
+
+      - name: Run Windows test shard
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $partition = [int]"${{ matrix.partition }}"
+          $partitions = 4
+          $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
+          $package = $metadata.packages | Where-Object { $_.name -eq "tracedecay" } | Select-Object -First 1
+          $targets = @($package.targets | Where-Object { $_.kind -contains "test" } | Sort-Object name)
+          $selected = New-Object System.Collections.Generic.List[string]
+          for ($i = 0; $i -lt $targets.Count; $i++) {
+            if (($i % $partitions) -eq ($partition - 1)) {
+              $selected.Add($targets[$i].name)
+            }
+          }
+          if ($selected.Count -eq 0) {
+            throw "No integration test targets selected for Windows shard $partition/$partitions"
+          }
+          Write-Host "Windows shard $partition/$partitions running $($selected.Count) integration test targets"
+          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci")
+          if ($partition -eq 1) {
+            $nextestArgs += @("--lib", "--bin", "tracedecay")
+          }
+          foreach ($target in $selected) {
+            $nextestArgs += @("--test", $target)
+          }
+          cargo @nextestArgs
+
+      - name: Show sccache stats
+        if: always()
+        shell: pwsh
+        run: '& $env:SCCACHE_PATH --show-stats'
+
+  windows-test:
+    name: Test Windows
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref)) }}
+    needs: [windows-test-shards]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Windows shards
+        run: |
+          if [ "${{ needs.windows-test-shards.result }}" != "success" ]; then
+            echo "Windows test shards finished with: ${{ needs.windows-test-shards.result }}" >&2
+            exit 1
+          fi
 
   clippy:
     name: Clippy

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1417,6 +1417,7 @@ async fn test_search_omits_index_coverage_hint_when_generated_dir_is_included() 
         parsed.as_array().is_some(),
         "search should keep array shape when there is no coverage hint, got: {text}"
     );
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -1647,7 +1648,8 @@ async fn fact_store_large_list_response_reports_store_failure_actionably() {
         .unwrap();
     }
 
-    fs::write(response_handle_dir(&cg), "not-a-directory").unwrap();
+    let handle_dir = response_handle_dir(&cg);
+    fs::write(&handle_dir, "not-a-directory").unwrap();
 
     let listed = handle_tool_call(
         &cg,
@@ -1680,6 +1682,9 @@ async fn fact_store_large_list_response_reports_store_failure_actionably() {
         .as_str()
         .unwrap_or_default()
         .contains("re-run the original MCP tool"));
+    fs::remove_file(&handle_dir).unwrap();
+    fs::create_dir_all(&handle_dir).unwrap();
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -2584,6 +2589,7 @@ async fn test_port_status() {
         text.contains("coverage_percent"),
         "should have coverage_percent key"
     );
+    close_test_graph(cg).await;
 }
 
 /// Regression: port_status used to match symbols purely on (name,
@@ -2888,6 +2894,7 @@ async fn test_rank_outgoing() {
         text.contains("outgoing"),
         "should reflect outgoing direction"
     );
+    close_test_graph(cg).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -3343,6 +3350,7 @@ async fn test_status_reports_scope_prefix() {
         text.contains("src/mcp"),
         "status should show the actual prefix value"
     );
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -3431,6 +3439,7 @@ async fn path_containment_config_rejects_parent_traversal_before_serving_config(
         result.is_err(),
         "config read should reject parent traversal, got {result:?}"
     );
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -4772,6 +4781,7 @@ async fn test_test_risk_distinguishes_direct_and_closure_attribution() {
         "confidence note should explain the conservative closure signal, got: {}",
         text
     );
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -7099,6 +7109,7 @@ async fn lcm_doctor_counts_nested_externalized_payload_refs_as_referenced() {
         payload["diagnostics"]["payloads"]["missing_placeholder_files"],
         0
     );
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -7427,6 +7438,7 @@ async fn lcm_doctor_repair_dry_run_reports_fts_rebuild_without_mutating() {
         .iter()
         .any(|action| action["kind"] == "rebuild_raw_fts"));
     assert_eq!(lcm_fts_match_count(&cg, "needle").await, 0);
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -8012,6 +8024,7 @@ async fn lcm_compress_oversized_needs_summary_uses_retrievable_full_payload() {
     assert!(full_payload["summary_request"]
         .get("source_messages_truncated_for_mcp")
         .is_none());
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -2481,6 +2481,7 @@ async fn test_doc_coverage() {
         text.contains("total_undocumented"),
         "should have total_undocumented key"
     );
+    close_test_graph(cg).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -3963,6 +3964,7 @@ async fn branch_diff_returns_empty_when_base_equals_head() {
     assert_eq!(output["added"].as_array().map(Vec::len), Some(0));
     assert_eq!(output["removed"].as_array().map(Vec::len), Some(0));
     assert_eq!(output["changed"].as_array().map(Vec::len), Some(0));
+    close_test_graph(cg).await;
 }
 
 /// Regression: when ast-grep exits non-zero with empty stderr (no language


### PR DESCRIPTION
## Summary
- keep Linux/macOS on cargo-nextest with a shared CI profile
- replace the serialized Windows archive fanout with four immediate Windows shards
- split Windows by integration-test target list so each shard builds a smaller test-target set
- keep the stable aggregate `Test Windows` check for branch protection
- add sccache to Windows shard jobs and print stats for follow-up tuning
- close two MCP handler test graphs explicitly to avoid Windows teardown aborts under the split run

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo nextest show-config --profile ci version`
- `cargo nextest list -p tracedecay --profile ci --lib --bin tracedecay --test agent_test --test cli_non_interactive_test`
- `cargo nextest list -p tracedecay --profile ci --test mcp_handler_test`
- `cargo nextest run -p tracedecay --profile ci --test mcp_handler_test path_containment_config_rejects_parent_traversal_before_serving_config test_test_risk_distinguishes_direct_and_closure_attribution`
- confirmed 114 integration test targets split as 29/29/28/28

## Timing Notes
The archive-based attempt was slower than baseline: `Test Windows archive` alone took about 16m21s, with the archive build step about 15m28s, before shards could start.

The target-split Windows run started all four shards immediately and completed the Windows lane in about 8m42s. Three shards passed; the only failing shard had two Windows teardown aborts in MCP handler tests, now fixed by explicit graph cleanup.
