### PR TITLE
Centralize profile-scoped branch tracking

### DIFF
--- a/.github/conventional-commit-baseline.txt
+++ b/.github/conventional-commit-baseline.txt
@@ -1,0 +1,6 @@
+# Grandfathered stack commits that were already published before CI commit
+# linting was introduced. Keep this list fixed; new commits should use
+# conventional commit subjects instead of adding entries here.
+035bb71cd9059b571e18bbd69059e6dbd80f2b80 # PR #100 split/profile-branch-foundation
+c4d4ce4c427988701cde38915f4f3a5b5fa7d52d # PR #101 split/mcp-tool-surface
+5b4eeb1b9d279bfe64f289a80292bfd83fd852a1 # PR #102 split/daemon-transport

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,39 @@ env:
   CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
+  commit-messages:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate PR commit messages
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/check-conventional-commits.sh "$BASE_SHA..$HEAD_SHA"
+
+      - name: Validate pushed commit messages
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            if git rev-parse "${HEAD_SHA}^" >/dev/null 2>&1; then
+              RANGE="${HEAD_SHA}^..${HEAD_SHA}"
+            else
+              RANGE="$HEAD_SHA"
+            fi
+          else
+            RANGE="${BEFORE_SHA}..${HEAD_SHA}"
+          fi
+          scripts/check-conventional-commits.sh "$RANGE"
+
   test:
     name: Test ${{ matrix.name }}
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             throw "No integration test targets selected for Windows shard $partition/$partitions"
           }
           Write-Host "Windows shard $partition/$partitions running $($selected.Count) integration test targets"
-          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci")
+          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci", "--retries", "2")
           if ($partition -eq 1) {
             $nextestArgs += @("--lib", "--bin", "tracedecay")
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,5 +399,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add server.json
-          git diff --cached --quiet || git commit -m "server.json: tracedecay ${VERSION}"
+          git diff --cached --quiet || git commit -m "chore(release): update server.json for ${VERSION}"
           git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,12 @@ refactor: simplify reference resolver lookup
 
 Keep the first line under 72 characters. Add a body explaining *why* if the change isn't obvious.
 
+CI validates commit subjects with:
+
+```bash
+scripts/check-conventional-commits.sh origin/master..HEAD
+```
+
 ## Pull Requests
 
 - Target `master` for bug fixes and stable features.

--- a/docs/MULTI-BRANCH-INVARIANTS.md
+++ b/docs/MULTI-BRANCH-INVARIANTS.md
@@ -35,31 +35,18 @@ No branch data is stored in git. Branch DBs are plain files on disk keyed by
 and that mapping must be stable (the same branch always re-resolves to the same
 file).
 
-Two code paths compute the stem, and **they disagree**:
+The branch-tracking path is centralized through
+`TraceDecay::add_branch_tracking`, which keeps sync orchestration in the engine
+and branch metadata/copy work in `branch.rs`.
 
-- **Library path** (`branch::add_branch_tracking`, `branch.rs:251`): uses
-  `unique_branch_db_stem` (`branch.rs:118`), which returns the bare sanitized
-  stem only when it is free, otherwise appends a short content hash of the
-  *unsanitized* name. Guards against `sanitize_branch_name` being many-to-one
-  (`feature/foo` ≡ `feature_foo`) and against re-`fs::copy`-overwriting an
-  existing branch index. Used by the Cursor/Codex hooks (`hooks.rs:1077,1129`)
-  and `agents/cursor.rs:149`.
-- **CLI path** (`commands.rs` `BranchAction::Add`, `commands.rs:192-202`):
-  computes `sanitized = branch::sanitize_branch_name(&branch_name)` directly and
-  uses `branches/{sanitized}.db` for both the `fs::copy` target and the meta
-  `db_file`. It does **not** call `add_branch_tracking` or
-  `unique_branch_db_stem` (`commands.rs` has zero references to either).
-
-> ⚠️ **Risk A — CLI `branch add` DB-stem collision (data loss + aliasing).**
-> Adding a branch whose sanitized name collides with an existing tracked branch
-> (e.g. `feature/foo` then `feature_foo`; `fix/1` then `fix_1`) overwrites the
-> first branch's `.db` via `fs::copy`, and both meta entries then point at the
-> same file. Subsequent syncs to either branch write into the shared DB
-> (cross-contamination). The library path was hardened (issue #3 /
-> `unique_branch_db_stem`) but the CLI path was never updated. The doc comment
-> on `add_branch_tracking` claiming it is "shared with the `tracedecay branch
-> add` CLI command" is **inaccurate** — the CLI reimplements inline.
-> **No test exercises the CLI `branch add` path at all** (see §6).
+- **Branch metadata path** (`branch::prepare_branch_tracking_in_layout`): uses
+  `unique_branch_db_stem`, which returns the bare sanitized stem only when it is
+  free, otherwise appends a short content hash of the *unsanitized* name. This
+  guards against `sanitize_branch_name` being many-to-one (`feature/foo` ≡
+  `feature_foo`) and against re-`fs::copy`-overwriting an existing branch index.
+- **CLI/hook path** (`TraceDecay::add_branch_tracking`): calls the
+  same preparation path, so CLI `branch add`, Cursor/Codex hooks, and Cursor
+  install branch tracking share DB-stem collision behavior.
 
 **Empty-name guard:** both paths reject a name that sanitizes to empty
 (library: `branch.rs:274,298`; would otherwise produce a hidden
@@ -114,9 +101,9 @@ Iterates tracked branches, computes `git merge-base` with the target, picks the
 
 > ⚠️ **Risk B — silent default-seed when the branch ref is unresolvable.**
 > `find_nearest_tracked_ancestor` requires the *target* branch ref to peel to a
-> commit via gix (`branch.rs:184-188`); if gix can't see it (just-created ref,
+> commit via gix; if gix can't see it (just-created ref,
 > worktree-local ref, gix ref-store not refreshed), it returns `None` and both
-> `add_branch_tracking` (`branch.rs:282`) and the CLI (`commands.rs:132`) fall
+> branch tracking entry points fall
 > back to seeding from `default_branch`. Result: a branch whose files are
 > closest to a non-default ancestor gets seeded from `main`/`master` instead —
 > a larger initial sync and a worse first-query experience, not data loss.
@@ -196,7 +183,7 @@ variants: `List | Add | Remove | Removeall | Gc`.
 | Op | Behavior | Meta write |
 |---|---|---|
 | `list` (`:73`) | Print default + tracked branches; `*` marks current; shows size/parent/synced. | read-only |
-| `add` (`:152`) | Detect-or-arg branch; bootstrap meta if absent; seed from nearest ancestor (or default); `fs::copy` parent DB → `branches/<sanitized>.db`; save meta; `open`+`sync`; `touch_synced`. | write (**unsafe stem** — Risk A) |
+| `add` | Detect-or-arg branch; delegate through `TraceDecay::add_branch_tracking`; bootstrap meta if absent; seed from nearest ancestor (or default); `fs::copy` parent DB → collision-safe `branches/<stem>.db`; save meta; open+sync; `touch_synced`. | write |
 | `remove` (`:236`) | Refuse on default branch; else `meta.remove_branch`, `remove_file` (+WAL/SHM), save. | write |
 | `removeall` (`:262`) | Remove every non-default branch + its DB sidecars; save. | write |
 | `gc` (`:290`) | Detect branches in meta whose ref no longer exists in git; remove them + DBs; save. | write |
@@ -271,8 +258,7 @@ open below are intentional documented gaps rather than silent omissions.
 
 | # | Risk | Severity | Where | Suggested test |
 |---|---|---|---|---|
-| A | CLI `branch add` DB-stem collision overwrites/aliases branch DBs | **High** (data loss) | `commands.rs:192-202` | Integration test: `tracedecay branch add feature/foo` then `feature_foo` via the CLI binary; assert two distinct `.db` files and two distinct meta entries; assert a sync to one doesn't appear in the other. (Mirror the `unique_branch_db_stem` unit tests in `branch.rs:362`.) |
-| B | Fresh branch ref invisible to gix silently seeds from default | Med | `branch.rs:282`, `commands.rs:180` | Unit/integration: create branch, force gix ref-store lag (or mock), assert seeding source and that the warning/retry path is correct. |
+| B | Fresh branch ref invisible to gix silently seeds from default | Med | `branch.rs` ancestor lookup, `TraceDecay::add_branch_tracking` callers | Unit/integration: create branch, force gix ref-store lag (or mock), assert seeding source and that the warning/retry path is correct. |
 | C | `branch gc` filesystem-heuristic ref detection mis-handles worktrees/bare | Med (destructive) | `commands.rs:303-312` | Integration test in a linked worktree and a bare repo: assert `gc` does not delete a still-existing branch. Consider reimplementing on gix. |
 | D | Corrupt `branch-meta.json` → silent single-DB mode leaves orphaned `branches/*.db` | Low | `branch_meta.rs:130`, `resolve_db_for_branch` | `gc`/a new `doctor` check should detect `branches/*.db` not referenced by any meta entry. |
 | E | Path-traversal guard skipped when target doesn't exist | Low | `branch.rs:162-168` | Unit test with a crafted meta `db_file` containing `..` pointing at a missing path; assert it's rejected, not returned unchecked. |

--- a/docs/MULTI-BRANCH-RECOVERY.md
+++ b/docs/MULTI-BRANCH-RECOVERY.md
@@ -192,7 +192,7 @@ Match what §2 showed to the right recovery. **Always diagnose (§2) and capture
 | Added a branch you're on, but server still serves ancestor | `fallback_*` with `live_branch_tracked:true` | restart MCP server | §6 |
 | `tracking_enabled:false` unexpectedly (meta corrupt/missing) | `single_db` + orphaned `branches/*.db` | restore meta or re-add branches | §5 |
 | Merged/deleted branches still tracked | (meta lists gone refs) | `tracedecay branch gc` | §4c |
-| Wrong branch wrote into a DB (collision/aliasing) | two branches share one `db_file` | split DBs + re-index | §7 + INVARIANTS Risk A |
+| Wrong branch wrote into a DB (legacy collision/aliasing) | two branches share one `db_file` | split DBs + re-index | §7 |
 
 ---
 
@@ -209,16 +209,9 @@ tracedecay branch add                # [mutating] tracks the current branch
 tracedecay branch add feature/parser # [mutating] track by name without checkout
 ```
 
-> ⚠️ **CLI `branch add` collision caveat (INVARIANTS Risk A).** The CLI path
-> (`commands.rs:192-202`) computes the DB stem with bare `sanitize_branch_name`,
-> **not** the collision-safe `unique_branch_db_stem` the library/hooks use
-> (`branch.rs:118`). If you add two branches whose sanitized names collide
-> (e.g. `feature/foo` then `feature_foo`), the second `fs::copy` **overwrites**
-> the first branch's DB and both meta entries alias the same file. Workarounds:
-> - Prefer the agent/hooks auto-track path (Cursor `workspaceOpen`, Codex) which
->   uses the safe library path.
-> - If you must use the CLI, check `tracedecay branch list` first and avoid names
->   that sanitize to an existing stem (slashes and most punctuation → `_`).
+The CLI, hooks, and install-time branch tracking now share the collision-safe
+branch-tracking path. If an older store already has two branch names pointing at
+one `db_file`, use the legacy collision repair steps in §7.
 
 ### 4b. A tracked branch lost its DB (`[missing-db]`)
 
@@ -264,8 +257,9 @@ branch DB. Both only touch branches listed in `branch-meta.json`.
 
 When the CLI re-seed (§4b) isn't usable (e.g. the ancestor DB itself is corrupt,
 or you need to seed from a specific branch), you can perform the same DB-copy
-operation the code does and include the SQLite sidecars for safety. The CLI's
-core copy/meta-write path is in `commands.rs:192-203`:
+operation the code does and include the SQLite sidecars for safety. The normal
+code path enters through `TraceDecay::add_branch_tracking` and performs
+copy/meta-write work in `branch::prepare_branch_tracking_in_layout`:
 
 1. **Stop the MCP server** so no instance holds the DB/WAL open (see §1).
 2. Pick a healthy source DB — usually the default-branch DB or the nearest
@@ -441,9 +435,6 @@ and fallback, so a refused write is the signal that recovery isn't complete).
 - **Don't** run `branch gc` on linked worktrees / bare repos without
   cross-checking `git for-each-ref refs/heads` — the ref heuristic can delete a
   live branch's DB (INVARIANTS Risk C).
-- **Don't** add two CLI branches whose sanitized names collide (`feature/foo`
-  vs `feature_foo`) via `tracedecay branch add` — the CLI stem is collision-unsafe
-  and will overwrite/alias (INVARIANTS Risk A).
 - **Don't** delete `branches/*.db` files by hand to "clean up" — that creates
   `[missing-db]` entries. Use `branch remove` / `branch gc` so metadata stays
   consistent.

--- a/scripts/check-conventional-commits.sh
+++ b/scripts/check-conventional-commits.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly DEFAULT_BASELINE=".github/conventional-commit-baseline.txt"
+readonly CONVENTIONAL_SUBJECT_RE='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([A-Za-z0-9._/-]+\))?!?: [^[:space:]].*$'
+
+usage() {
+    echo "usage: $0 <commit-range-or-sha>" >&2
+    echo "example: $0 origin/master..HEAD" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+    exit 2
+fi
+
+range="$1"
+baseline_file="${CONVENTIONAL_COMMIT_BASELINE:-$DEFAULT_BASELINE}"
+baseline_commits=()
+
+if [ -f "$baseline_file" ]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line//[[:space:]]/}"
+        if [ -n "$line" ]; then
+            baseline_commits+=("$line")
+        fi
+    done < "$baseline_file"
+fi
+
+is_baselined_commit() {
+    local commit="$1"
+    local baseline
+
+    for baseline in "${baseline_commits[@]}"; do
+        if [[ "$commit" == "$baseline"* ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+rev_args=()
+if [[ "$range" == *".."* ]]; then
+    rev_args=("$range")
+else
+    rev_args=("-n" "1" "$range")
+fi
+
+if ! commits_output=$(git rev-list --reverse --no-merges "${rev_args[@]}"); then
+    echo "Failed to resolve commit range: $range" >&2
+    exit 2
+fi
+
+if [ -z "$commits_output" ]; then
+    echo "No non-merge commits to validate in $range"
+    exit 0
+fi
+
+mapfile -t commits <<< "$commits_output"
+failed=0
+
+for commit in "${commits[@]}"; do
+    short_sha=$(git rev-parse --short=7 "$commit")
+    subject=$(git log -1 --format=%s "$commit")
+    commit_failed=0
+
+    if is_baselined_commit "$commit"; then
+        echo "Skipping grandfathered commit $short_sha: $subject"
+        continue
+    fi
+
+    if ! [[ "$subject" =~ $CONVENTIONAL_SUBJECT_RE ]]; then
+        echo "::error::Commit $short_sha does not use conventional commit style: $subject" >&2
+        commit_failed=1
+    fi
+
+    if [ "${#subject}" -gt 72 ]; then
+        echo "::error::Commit $short_sha subject exceeds 72 characters (${#subject}): $subject" >&2
+        commit_failed=1
+    fi
+
+    if [ "$commit_failed" -ne 0 ]; then
+        failed=1
+    else
+        echo "OK $short_sha: $subject"
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    echo "Commit subjects must look like 'fix: handle UTF-16 files' and stay under 72 characters." >&2
+    exit 1
+fi

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -143,7 +143,7 @@ async fn track_branch_after_install(project_path: Option<&Path>) {
     let Some(branch_name) = crate::branch::current_branch(project_path) else {
         return;
     };
-    match crate::branch::add_branch_tracking(project_path, &branch_name).await {
+    match crate::tracedecay::TraceDecay::add_branch_tracking(project_path, &branch_name).await {
         Ok(crate::branch::BranchAddOutcome::Added) => {
             eprintln!(
                 "\x1b[32m✔\x1b[0m Tracked Cursor branch '{branch_name}' for tracedecay indexing"

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,6 +1,6 @@
 //! Git branch resolution utilities for multi-branch indexing.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::branch_meta::BranchMeta;
 
@@ -288,7 +288,7 @@ pub fn find_nearest_tracked_ancestor(
         .or_else(|| best_merge_base.map(|(name, _)| name))
 }
 
-/// Outcome of [`add_branch_tracking`].
+/// Outcome of `TraceDecay` branch tracking.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BranchAddOutcome {
     /// The project has no `.tracedecay/` index; nothing was done.
@@ -302,44 +302,41 @@ pub enum BranchAddOutcome {
     Deferred,
 }
 
-/// Silently bootstraps/maintains tracedecay branch tracking for `branch_name`.
+pub enum BranchTrackingPreparation {
+    AlreadyTracked,
+    Deferred,
+    Added(PreparedBranchTracking),
+}
+
+pub struct PreparedBranchTracking {
+    branch_name: String,
+    db_file: String,
+    new_db_path: PathBuf,
+    _branch_lock: std::fs::File,
+}
+
+/// Copies the nearest tracked ancestor DB and writes branch metadata.
 ///
-/// This is the library-level core shared with the `tracedecay branch add` CLI
-/// command, callable from hooks without shelling out to a second process. It:
-/// loads or bootstraps [`BranchMeta`] (via [`detect_default_branch`]), no-ops
-/// when the branch is already tracked, otherwise copies the nearest tracked
-/// ancestor's DB and runs an incremental sync against the new branch DB.
-///
-/// No-ops (returns [`BranchAddOutcome::NotIndexed`]) when the project has no
-/// `.tracedecay/` index, so it never bootstraps indexing in an unindexed repo.
-/// Idempotent: a re-add of a tracked branch returns
-/// [`BranchAddOutcome::AlreadyTracked`] without re-copying.
-pub async fn add_branch_tracking(
+/// The returned [`PreparedBranchTracking`] owns the branch-add lock and must be
+/// kept alive until the caller either finalizes or rolls back the new branch.
+pub async fn prepare_branch_tracking_in_layout(
     project_root: &Path,
     branch_name: &str,
-) -> crate::errors::Result<BranchAddOutcome> {
+    tracedecay_dir: &Path,
+) -> crate::errors::Result<BranchTrackingPreparation> {
     use crate::branch_meta;
 
-    if !crate::tracedecay::TraceDecay::is_initialized(project_root) {
-        return Ok(BranchAddOutcome::NotIndexed);
-    }
-    let tracedecay_dir = crate::storage::resolve_layout_for_current_profile(project_root)
-        .map_or_else(
-            |_| crate::config::get_tracedecay_dir(project_root),
-            |layout| layout.data_root,
-        );
-
-    let _branch_lock = {
+    let branch_lock = {
         let mut attempts = 0;
         loop {
-            match try_acquire_branch_add_lock(&tracedecay_dir) {
+            match try_acquire_branch_add_lock(tracedecay_dir) {
                 Ok(lock) => break lock,
                 Err(crate::errors::TraceDecayError::SyncLock { .. }) if attempts < 20 => {
                     attempts += 1;
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
                 Err(crate::errors::TraceDecayError::SyncLock { .. }) => {
-                    return Ok(BranchAddOutcome::Deferred);
+                    return Ok(BranchTrackingPreparation::Deferred);
                 }
                 Err(e) => return Err(e),
             }
@@ -347,7 +344,7 @@ pub async fn add_branch_tracking(
     };
 
     let meta_path = tracedecay_dir.join("branch-meta.json");
-    let mut meta = match branch_meta::load_branch_meta(&tracedecay_dir) {
+    let mut meta = match branch_meta::load_branch_meta(tracedecay_dir) {
         Some(meta) => meta,
         None if meta_path.exists() => {
             return Err(crate::errors::TraceDecayError::Config {
@@ -359,13 +356,13 @@ pub async fn add_branch_tracking(
         }
         None => {
             let default = detect_default_branch(project_root).unwrap_or_else(|| "main".to_string());
-            branch_meta::BranchMeta::new_for_dir(&tracedecay_dir, &default)
+            branch_meta::BranchMeta::new_for_dir(tracedecay_dir, &default)
         }
     };
-    prune_missing_branch_dbs(&tracedecay_dir, &mut meta);
+    prune_missing_branch_dbs(tracedecay_dir, &mut meta);
 
     if meta.is_tracked(branch_name) {
-        return Ok(BranchAddOutcome::AlreadyTracked);
+        return Ok(BranchTrackingPreparation::AlreadyTracked);
     }
 
     // Fail fast (before parent resolution) when the name sanitizes to empty —
@@ -380,7 +377,7 @@ pub async fn add_branch_tracking(
 
     let parent = find_nearest_tracked_ancestor(project_root, branch_name, &meta)
         .unwrap_or_else(|| meta.default_branch.clone());
-    let parent_db = resolve_branch_db_path(&tracedecay_dir, &parent, &meta).ok_or_else(|| {
+    let parent_db = resolve_branch_db_path(tracedecay_dir, &parent, &meta).ok_or_else(|| {
         crate::errors::TraceDecayError::Config {
             message: format!("parent branch '{parent}' has no DB"),
         }
@@ -391,7 +388,7 @@ pub async fn add_branch_tracking(
         });
     }
 
-    let branches_dir = branch_meta::ensure_branches_dir(&tracedecay_dir)?;
+    let branches_dir = branch_meta::ensure_branches_dir(tracedecay_dir)?;
     // Pick a collision-free stem so a branch whose sanitized name matches an
     // already-tracked branch gets its own DB instead of overwriting it (#3).
     let stem = unique_branch_db_stem(&meta, &branches_dir, branch_name).ok_or_else(|| {
@@ -407,46 +404,36 @@ pub async fn add_branch_tracking(
         return Err(e.into());
     }
 
-    // Save metadata BEFORE open_branch() so it resolves the new branch DB.
+    // Save metadata before the caller opens the new branch DB for sync.
     let db_file = format!("branches/{stem}.db");
     meta.add_branch(branch_name, &db_file, &parent);
-    if let Err(e) = branch_meta::save_branch_meta(&tracedecay_dir, &meta) {
+    if let Err(e) = branch_meta::save_branch_meta(tracedecay_dir, &meta) {
         remove_branch_db_files(&new_db_path);
         return Err(e.into());
     }
 
-    let sync_result = sync_new_branch_with_retries(project_root, branch_name).await;
-    if let Err(crate::errors::TraceDecayError::SyncLock { .. }) = sync_result {
-        return Ok(BranchAddOutcome::Deferred);
-    } else if let Err(e) = sync_result {
-        rollback_branch_tracking(&tracedecay_dir, branch_name, &db_file, &new_db_path);
-        return Err(e);
-    }
-
-    if let Some(mut meta) = branch_meta::load_branch_meta(&tracedecay_dir) {
-        meta.touch_synced(branch_name);
-        let _ = branch_meta::save_branch_meta(&tracedecay_dir, &meta);
-    }
-
-    Ok(BranchAddOutcome::Added)
+    Ok(BranchTrackingPreparation::Added(PreparedBranchTracking {
+        branch_name: branch_name.to_string(),
+        db_file,
+        new_db_path,
+        _branch_lock: branch_lock,
+    }))
 }
 
-async fn sync_new_branch_with_retries(
-    project_root: &Path,
-    branch_name: &str,
-) -> crate::errors::Result<()> {
-    let mut attempts = 0;
-    loop {
-        let cg = crate::tracedecay::TraceDecay::open_branch(project_root, branch_name).await?;
-        match cg.sync().await {
-            Ok(_) => return Ok(()),
-            Err(crate::errors::TraceDecayError::SyncLock { .. }) if attempts < 20 => {
-                attempts += 1;
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            }
-            Err(e) => return Err(e),
-        }
+pub fn finalize_prepared_branch_tracking(tracedecay_dir: &Path, prepared: &PreparedBranchTracking) {
+    if let Some(mut meta) = crate::branch_meta::load_branch_meta(tracedecay_dir) {
+        meta.touch_synced(&prepared.branch_name);
+        let _ = crate::branch_meta::save_branch_meta(tracedecay_dir, &meta);
     }
+}
+
+pub fn rollback_prepared_branch_tracking(tracedecay_dir: &Path, prepared: &PreparedBranchTracking) {
+    rollback_branch_tracking(
+        tracedecay_dir,
+        &prepared.branch_name,
+        &prepared.db_file,
+        &prepared.new_db_path,
+    );
 }
 
 fn rollback_branch_tracking(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -547,7 +547,7 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
 
             let spinner = Spinner::new();
             spinner.set_message("syncing changes");
-            match branch::add_branch_tracking(&project_path, &branch_name).await? {
+            match TraceDecay::add_branch_tracking(&project_path, &branch_name).await? {
                 branch::BranchAddOutcome::NotIndexed => {
                     spinner.done("no TraceDecay index found; run `tracedecay init` first");
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,10 @@ pub fn load_config_from_path(project_root: &Path, config_path: &Path) -> Result<
 /// ensuring that a partial write never corrupts the configuration.
 pub fn save_config(project_root: &Path, config: &TraceDecayConfig) -> Result<()> {
     let config_path = get_config_path(project_root);
+    save_config_to_path(&config_path, config)
+}
+
+pub fn save_config_to_path(config_path: &Path, config: &TraceDecayConfig) -> Result<()> {
     let data_dir = config_path
         .parent()
         .ok_or_else(|| TraceDecayError::Config {
@@ -236,7 +240,7 @@ pub fn save_config(project_root: &Path, config: &TraceDecayConfig) -> Result<()>
         ),
     })?;
 
-    fs::rename(&tmp_path, &config_path).map_err(|e| TraceDecayError::Config {
+    fs::rename(&tmp_path, config_path).map_err(|e| TraceDecayError::Config {
         message: format!(
             "failed to rename temporary config file '{}' to '{}': {}",
             tmp_path.display(),

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1408,7 +1408,7 @@ fn session_start_from_compaction(event_json: &str) -> bool {
 fn matches_compaction_source(value: &str) -> bool {
     let normalized = value
         .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
+        .filter(char::is_ascii_alphanumeric)
         .collect::<String>()
         .to_ascii_lowercase();
     matches!(
@@ -1485,7 +1485,7 @@ async fn targeted_sync_for_cursor_after_file_edit(event_json: &str) {
 /// Branch-aware, fail-open handler for git state-changing shell commands.
 ///
 /// Branch switches (`checkout`/`switch`/`worktree add`) bootstrap/maintain
-/// tracedecay branch tracking via [`crate::branch::add_branch_tracking`] —
+/// tracedecay branch tracking via [`crate::tracedecay::TraceDecay::add_branch_tracking`] —
 /// which is idempotent and supersedes a plain sync. Other state-changing
 /// commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop) run a full
 /// incremental `sync()`, coalesced by a short marker-based guard so back-to-back
@@ -1518,14 +1518,14 @@ async fn sync_after_cursor_shell_event(event_json: &str) {
     match plan {
         CursorShellSyncPlan::BranchAdd(branch) => {
             // Idempotent + fail-open: already-tracked branches no-op.
-            let _ = crate::branch::add_branch_tracking(&root, &branch).await;
+            let _ = crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await;
         }
         CursorShellSyncPlan::IncrementalSync => {
             run_coalesced_incremental_sync(&root, ".cursor_shell_sync_at").await;
         }
         CursorShellSyncPlan::CurrentBranchSync(branch) => {
             if !matches!(
-                crate::branch::add_branch_tracking(&root, &branch).await,
+                crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await,
                 Ok(crate::branch::BranchAddOutcome::Added)
             ) {
                 run_coalesced_incremental_sync(&root, ".cursor_shell_sync_at").await;
@@ -1572,7 +1572,7 @@ async fn workspace_open_for_cursor_event(event_json: &str) {
     // `add_branch_tracking` already runs a sync, so we can skip the catch-up.
     if let Some(branch) = crate::branch::current_branch(&root) {
         if let Ok(crate::branch::BranchAddOutcome::Added) =
-            crate::branch::add_branch_tracking(&root, &branch).await
+            crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await
         {
             return;
         }
@@ -1827,9 +1827,7 @@ pub fn codex_subagent_start_log_line(
         .filter(|value| !value.is_empty())
         .unwrap_or("unknown");
     let session_id = event_session_id(&parsed).unwrap_or_else(|| "unknown".to_string());
-    let count = count
-        .map(|value| format!("#{value}"))
-        .unwrap_or_else(|| "#?".to_string());
+    let count = count.map_or_else(|| "#?".to_string(), |value| format!("#{value}"));
     format!(
         "tracedecay Codex SubagentStart {count}: session_id={session_id} agent_type={agent_type} additional_context={emitted_context}"
     )
@@ -1902,7 +1900,7 @@ fn empty_array_field(value: &Value, keys: &[&str]) -> bool {
 fn matches_no_history_marker(value: &str) -> bool {
     let normalized = value
         .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
+        .filter(char::is_ascii_alphanumeric)
         .collect::<String>()
         .to_ascii_lowercase();
     matches!(
@@ -2054,14 +2052,14 @@ async fn codex_post_tool_use(event_json: &str) {
         match cursor_shell_sync_plan_with_current_branch(command, current_branch.as_deref()) {
             CursorShellSyncPlan::BranchAdd(branch) => {
                 // Idempotent + fail-open: already-tracked branches no-op.
-                let _ = crate::branch::add_branch_tracking(&root, &branch).await;
+                let _ = crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await;
             }
             CursorShellSyncPlan::IncrementalSync => {
                 run_coalesced_incremental_sync(&root, ".codex_shell_sync_at").await;
             }
             CursorShellSyncPlan::CurrentBranchSync(branch) => {
                 if !matches!(
-                    crate::branch::add_branch_tracking(&root, &branch).await,
+                    crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await,
                     Ok(crate::branch::BranchAddOutcome::Added)
                 ) {
                     run_coalesced_incremental_sync(&root, ".codex_shell_sync_at").await;

--- a/src/mcp/tools/handlers/git.rs
+++ b/src/mcp/tools/handlers/git.rs
@@ -22,7 +22,7 @@ fn project_response_text(cg: &TraceDecay, text: &str) -> String {
     truncated_json_envelope_with_handle(Some(cg.project_root()), text)
 }
 
-fn git_error_result(cg: &TraceDecay, operation: &str, message: String) -> ToolResult {
+fn git_error_result(cg: &TraceDecay, operation: &str, message: &str) -> ToolResult {
     let output = json!({
         "error": {
             "kind": "git",
@@ -615,7 +615,7 @@ pub(super) async fn handle_changelog(cg: &TraceDecay, args: Value) -> Result<Too
     let changes = match git_diff_file_changes(cg.project_root(), from_ref, to_ref) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(git_error_result(cg, "diff", e));
+            return Ok(git_error_result(cg, "diff", &e));
         }
     };
     let changed_files: Vec<String> = changes.iter().map(|change| change.path.clone()).collect();
@@ -695,7 +695,7 @@ pub(super) async fn handle_commit_context(cg: &TraceDecay, args: Value) -> Resul
     let changed_files = match git_changed_files(cg.project_root(), staged_only) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(git_error_result(cg, "status", e));
+            return Ok(git_error_result(cg, "status", &e));
         }
     };
 
@@ -792,7 +792,7 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
     let changes = match git_diff_file_changes(cg.project_root(), base, head) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(git_error_result(cg, "diff", e));
+            return Ok(git_error_result(cg, "diff", &e));
         }
     };
     let changed_files: Vec<String> = changes.iter().map(|change| change.path.clone()).collect();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -56,7 +56,7 @@ pub async fn ensure_initialized_with_options(
     project_path: &Path,
     open_options: TraceDecayOpenOptions,
 ) -> Result<TraceDecay> {
-    if TraceDecay::is_initialized_with_options(project_path, &open_options) {
+    if TraceDecay::has_initialized_store_with_options(project_path, &open_options).await {
         return match TraceDecay::open_with_options(project_path, open_options.clone()).await {
             Ok(cg) => Ok(cg),
             Err(open_err) => {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,14 +1,40 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::errors::{Result, TraceDecayError};
 use crate::global_db::GlobalDb;
-use crate::tracedecay::TraceDecay;
+use crate::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ServeGlobalDbResolution {
-    Found(std::path::PathBuf),
+    Found(PathBuf),
     Ambiguous(Vec<String>),
     None,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CwdProjectMatch {
+    ProjectContainsCwd,
+    ProjectUnderCwd,
+}
+
+impl CwdProjectMatch {
+    fn matches(self, project_path: &Path, cwd: &Path) -> bool {
+        match self {
+            Self::ProjectContainsCwd => cwd.starts_with(project_path),
+            Self::ProjectUnderCwd => project_path.starts_with(cwd),
+        }
+    }
+
+    fn sort_matches(self, matches: &mut [(usize, String)]) {
+        match self {
+            Self::ProjectContainsCwd => {
+                matches.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+            }
+            Self::ProjectUnderCwd => {
+                matches.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+            }
+        }
+    }
 }
 
 pub fn global_db_ambiguity_message(paths: &[String]) -> String {
@@ -23,16 +49,25 @@ pub fn global_db_ambiguity_message(paths: &[String]) -> String {
 
 /// Opens an existing project, or tells the user to run `tracedecay init` first.
 pub async fn ensure_initialized(project_path: &Path) -> Result<TraceDecay> {
-    if TraceDecay::is_initialized(project_path) {
-        return match TraceDecay::open(project_path).await {
+    ensure_initialized_with_options(project_path, TraceDecayOpenOptions::default()).await
+}
+
+pub async fn ensure_initialized_with_options(
+    project_path: &Path,
+    open_options: TraceDecayOpenOptions,
+) -> Result<TraceDecay> {
+    if TraceDecay::is_initialized_with_options(project_path, &open_options) {
+        return match TraceDecay::open_with_options(project_path, open_options.clone()).await {
             Ok(cg) => Ok(cg),
-            Err(open_err) => match TraceDecay::open_read_only(project_path).await {
-                Ok(cg) => {
-                    cg.ensure_schema_current().await?;
-                    Ok(cg)
+            Err(open_err) => {
+                match TraceDecay::open_read_only_with_options(project_path, open_options).await {
+                    Ok(cg) => {
+                        cg.ensure_schema_current().await?;
+                        Ok(cg)
+                    }
+                    Err(_) => Err(open_err),
                 }
-                Err(_) => Err(open_err),
-            },
+            }
         };
     }
     Err(TraceDecayError::Config {
@@ -48,6 +83,33 @@ fn initialized_project_paths(mut paths: Vec<String>) -> Vec<String> {
     paths
 }
 
+fn cwd_match_resolution(
+    paths: &[String],
+    cwd: &Path,
+    match_kind: CwdProjectMatch,
+) -> Option<ServeGlobalDbResolution> {
+    let mut matches: Vec<_> = paths
+        .iter()
+        .filter_map(|p| {
+            let project_path = Path::new(p).canonicalize().ok()?;
+            match_kind
+                .matches(&project_path, cwd)
+                .then(|| (project_path.components().count(), p.clone()))
+        })
+        .collect();
+    match_kind.sort_matches(&mut matches);
+
+    let (depth, _) = matches.first()?;
+    if matches.get(1).is_some_and(|next| next.0 == *depth) {
+        return Some(ServeGlobalDbResolution::Ambiguous(
+            matches.into_iter().map(|(_, p)| p).collect(),
+        ));
+    }
+    Some(ServeGlobalDbResolution::Found(PathBuf::from(
+        matches.remove(0).1,
+    )))
+}
+
 /// Fallback for `serve`: when CWD-based discovery fails, check the global DB
 /// for registered projects. When multiple projects exist, pick the best match
 /// against cwd: prefer a project that is an ancestor of cwd (cwd is inside the
@@ -60,7 +122,7 @@ pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
     let mut paths = initialized_project_paths(gdb.list_project_paths().await);
     paths.sort();
     if paths.len() == 1 {
-        return ServeGlobalDbResolution::Found(std::path::PathBuf::from(paths.remove(0)));
+        return ServeGlobalDbResolution::Found(PathBuf::from(paths.remove(0)));
     }
     if paths.is_empty() {
         return ServeGlobalDbResolution::None;
@@ -74,42 +136,16 @@ pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
 
     // Priority 1: cwd is inside a project (project is ancestor of cwd).
     // Pick the deepest ancestor (most specific match).
-    let mut ancestors: Vec<_> = paths
-        .iter()
-        .filter_map(|p| {
-            let pp = std::path::Path::new(p).canonicalize().ok()?;
-            cwd.starts_with(&pp)
-                .then(|| (pp.components().count(), p.clone()))
-        })
-        .collect();
-    ancestors.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
-    if let Some((depth, _)) = ancestors.first() {
-        if ancestors.get(1).is_some_and(|next| next.0 == *depth) {
-            return ServeGlobalDbResolution::Ambiguous(
-                ancestors.into_iter().map(|(_, p)| p).collect(),
-            );
-        }
-        return ServeGlobalDbResolution::Found(std::path::PathBuf::from(ancestors.remove(0).1));
+    if let Some(resolution) =
+        cwd_match_resolution(&paths, &cwd, CwdProjectMatch::ProjectContainsCwd)
+    {
+        return resolution;
     }
 
     // Priority 2: a project is under cwd (cwd is ancestor of project).
     // Pick the shallowest descendant (closest child).
-    let mut descendants: Vec<_> = paths
-        .iter()
-        .filter_map(|p| {
-            let pp = std::path::Path::new(p).canonicalize().ok()?;
-            pp.starts_with(&cwd)
-                .then(|| (pp.components().count(), p.clone()))
-        })
-        .collect();
-    descendants.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-    if let Some((depth, _)) = descendants.first() {
-        if descendants.get(1).is_some_and(|next| next.0 == *depth) {
-            return ServeGlobalDbResolution::Ambiguous(
-                descendants.into_iter().map(|(_, p)| p).collect(),
-            );
-        }
-        return ServeGlobalDbResolution::Found(std::path::PathBuf::from(descendants.remove(0).1));
+    if let Some(resolution) = cwd_match_resolution(&paths, &cwd, CwdProjectMatch::ProjectUnderCwd) {
+        return resolution;
     }
 
     // No cwd-based match — the global DB alone cannot disambiguate.

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -270,10 +270,11 @@ fn string_field(payload: &Value, key: &str) -> Option<String> {
 }
 
 fn prior_compaction_depth(path: &Path, before_offset: u64) -> i64 {
+    use std::io::BufRead;
+
     if before_offset == 0 {
         return 0;
     }
-    use std::io::BufRead;
     let Ok(file) = std::fs::File::open(path) else {
         return 0;
     };

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -998,8 +998,9 @@ impl TraceDecay {
         Some(meta.branches.keys().cloned().collect())
     }
 
-    #[allow(clippy::items_after_statements)]
     async fn register_project_store_in_global_registry(&self) {
+        static REGISTRY_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
         if self.store_layout.storage_mode != storage::StorageMode::ProfileSharded {
             return;
         }
@@ -1015,7 +1016,6 @@ impl TraceDecay {
             return;
         };
 
-        static REGISTRY_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
         let _registry_write = REGISTRY_WRITE_LOCK.lock().await;
 
         let Some(global_db) = self.open_options.open_global_db().await else {
@@ -2561,12 +2561,7 @@ impl TraceDecay {
         dirs
     }
 
-    #[allow(clippy::items_after_statements)]
     fn is_skipped_dir_hint(rel_str: &str, name: &str, config: &TraceDecayConfig) -> bool {
-        if is_included_dir(rel_str, config) || is_included(rel_str, config) {
-            return false;
-        }
-
         const HINTABLE_DIRS: &[&str] = &[
             "node_modules",
             "vendor",
@@ -2582,6 +2577,10 @@ impl TraceDecay {
             "venv",
             "__pycache__",
         ];
+
+        if is_included_dir(rel_str, config) || is_included(rel_str, config) {
+            return false;
+        }
 
         HINTABLE_DIRS.contains(&name) && is_excluded_dir(rel_str, config)
     }

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -11,7 +11,7 @@ use crate::branch;
 use crate::branch_meta::{self, BranchMeta};
 use crate::config::{
     brand_env, db_filename, is_excluded, is_excluded_dir, is_included, is_included_dir,
-    load_config_from_path, save_config, TraceDecayConfig,
+    load_config_from_path, save_config_to_path, TraceDecayConfig,
 };
 use crate::context::ContextBuilder;
 use crate::db::Database;
@@ -274,6 +274,7 @@ pub struct TraceDecay {
     config: TraceDecayConfig,
     project_root: PathBuf,
     store_layout: StoreLayout,
+    open_options: TraceDecayOpenOptions,
     registry: LanguageRegistry,
     /// The active git branch (None if detached HEAD or not a git repo).
     active_branch: Option<String>,
@@ -282,6 +283,35 @@ pub struct TraceDecay {
     /// Set when serving from a fallback (ancestor) DB instead of the exact branch.
     fallback_warning: Option<String>,
     read_only: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TraceDecayOpenOptions {
+    pub profile_root: Option<PathBuf>,
+    pub global_db_path: Option<PathBuf>,
+}
+
+impl TraceDecayOpenOptions {
+    fn resolved_profile_root(&self) -> Result<PathBuf> {
+        if let Some(profile_root) = &self.profile_root {
+            return Ok(profile_root.clone());
+        }
+        if let Some(parent) = self
+            .global_db_path
+            .as_deref()
+            .and_then(std::path::Path::parent)
+        {
+            return Ok(parent.to_path_buf());
+        }
+        storage::default_profile_root()
+    }
+
+    async fn open_global_db(&self) -> Option<GlobalDb> {
+        match self.global_db_path.as_deref() {
+            Some(path) => GlobalDb::open_at(path).await,
+            None => GlobalDb::open().await,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -379,12 +409,20 @@ impl TraceDecay {
     /// Writes a default configuration to the resolved project store and
     /// initializes a fresh `SQLite` database.
     pub async fn init(project_root: &Path) -> Result<Self> {
-        let store_layout = Self::resolve_store_layout_for_project(project_root).await?;
+        Self::init_with_options(project_root, TraceDecayOpenOptions::default()).await
+    }
+
+    pub async fn init_with_options(
+        project_root: &Path,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<Self> {
+        let store_layout =
+            Self::resolve_store_layout_for_project(project_root, &open_options).await?;
         let config = TraceDecayConfig {
             root_dir: project_root.to_string_lossy().to_string(),
             ..TraceDecayConfig::default()
         };
-        save_config(project_root, &config)?;
+        save_config_to_path(&store_layout.config_path, &config)?;
 
         let (db, _migrated) = Database::initialize(&store_layout.graph_db_path).await?;
         if store_layout.storage_mode == storage::StorageMode::ProfileSharded {
@@ -405,6 +443,7 @@ impl TraceDecay {
             config,
             project_root: project_root.to_path_buf(),
             store_layout,
+            open_options,
             registry: LanguageRegistry::new(),
             active_branch,
             serving_branch: None,
@@ -484,15 +523,18 @@ impl TraceDecay {
         Ok(())
     }
 
-    async fn resolve_store_layout_for_project(project_root: &Path) -> Result<StoreLayout> {
+    async fn resolve_store_layout_for_project(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> Result<StoreLayout> {
+        let profile_root = open_options.resolved_profile_root()?;
         if storage::read_enrollment_marker(project_root)?.is_some() {
-            return storage::resolve_layout_for_current_profile(project_root);
+            return storage::resolve_layout(project_root, &profile_root);
         }
 
-        let profile_root = storage::default_profile_root()?;
         let git_common_dir = git_common_dir(project_root);
         let git_remote_url = git_remote_url(project_root);
-        if let Some(global_db) = GlobalDb::open().await {
+        if let Some(global_db) = open_options.open_global_db().await {
             let resolution = match global_db
                 .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
                 .await
@@ -532,10 +574,24 @@ impl TraceDecay {
     /// If the previous operation was interrupted (dirty sentinel exists),
     /// the database is integrity-checked and rebuilt if corrupted.
     pub async fn open(project_root: &Path) -> Result<Self> {
-        let store_layout = Self::resolve_store_layout_for_project(project_root).await?;
+        Self::open_with_options(project_root, TraceDecayOpenOptions::default()).await
+    }
+
+    pub async fn open_with_options(
+        project_root: &Path,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<Self> {
+        let store_layout =
+            Self::resolve_store_layout_for_project(project_root, &open_options).await?;
         let config = load_config_from_path(project_root, &store_layout.config_path)?;
         let active_branch = branch::current_branch(project_root);
-        Self::auto_track_active_branch(project_root, active_branch.as_deref()).await?;
+        Self::auto_track_active_branch(
+            project_root,
+            &store_layout.data_root,
+            active_branch.as_deref(),
+            open_options.clone(),
+        )
+        .await?;
 
         let (db_path, serving_branch, fallback_warning) = Self::resolve_db_for_branch(
             project_root,
@@ -576,6 +632,7 @@ impl TraceDecay {
                     config,
                     project_root: project_root.to_path_buf(),
                     store_layout: store_layout.clone(),
+                    open_options: open_options.clone(),
                     registry: LanguageRegistry::new(),
                     active_branch: active_branch.clone(),
                     serving_branch: serving_branch.clone(),
@@ -608,6 +665,7 @@ impl TraceDecay {
                     config,
                     project_root: project_root.to_path_buf(),
                     store_layout: store_layout.clone(),
+                    open_options: open_options.clone(),
                     registry: LanguageRegistry::new(),
                     active_branch: active_branch.clone(),
                     serving_branch: serving_branch.clone(),
@@ -631,6 +689,7 @@ impl TraceDecay {
             config,
             project_root: project_root.to_path_buf(),
             store_layout,
+            open_options,
             registry: LanguageRegistry::new(),
             active_branch,
             serving_branch,
@@ -658,7 +717,15 @@ impl TraceDecay {
     /// status/verification commands that must be able to inspect read-only
     /// stores without mutating them.
     pub async fn open_read_only(project_root: &Path) -> Result<Self> {
-        let store_layout = Self::resolve_store_layout_for_project(project_root).await?;
+        Self::open_read_only_with_options(project_root, TraceDecayOpenOptions::default()).await
+    }
+
+    pub async fn open_read_only_with_options(
+        project_root: &Path,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<Self> {
+        let store_layout =
+            Self::resolve_store_layout_for_project(project_root, &open_options).await?;
         let config = load_config_from_path(project_root, &store_layout.config_path)?;
         let active_branch = branch::current_branch(project_root);
 
@@ -683,6 +750,7 @@ impl TraceDecay {
             config,
             project_root: project_root.to_path_buf(),
             store_layout,
+            open_options,
             registry: LanguageRegistry::new(),
             active_branch,
             serving_branch,
@@ -693,13 +761,115 @@ impl TraceDecay {
 
     async fn auto_track_active_branch(
         project_root: &Path,
+        tracedecay_dir: &Path,
         active_branch: Option<&str>,
+        open_options: TraceDecayOpenOptions,
     ) -> Result<()> {
         let Some(branch_name) = active_branch else {
             return Ok(());
         };
-        let _ = branch::add_branch_tracking(project_root, branch_name).await?;
+        let _ = Self::add_branch_tracking_in_layout(
+            project_root,
+            branch_name,
+            tracedecay_dir,
+            open_options,
+        )
+        .await?;
         Ok(())
+    }
+
+    /// Silently bootstraps/maintains tracedecay branch tracking for `branch_name`.
+    ///
+    /// This is the library-level core shared with the `tracedecay branch add`
+    /// CLI command and hook integrations. It loads or bootstraps branch
+    /// metadata, no-ops when the branch is already tracked, otherwise copies
+    /// the nearest tracked ancestor's DB and runs an incremental sync against
+    /// the new branch DB.
+    pub async fn add_branch_tracking(
+        project_root: &Path,
+        branch_name: &str,
+    ) -> Result<branch::BranchAddOutcome> {
+        Self::add_branch_tracking_with_options(
+            project_root,
+            branch_name,
+            TraceDecayOpenOptions::default(),
+        )
+        .await
+    }
+
+    pub async fn add_branch_tracking_with_options(
+        project_root: &Path,
+        branch_name: &str,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<branch::BranchAddOutcome> {
+        let store_layout = match Self::resolve_store_layout_for_project(project_root, &open_options)
+            .await
+        {
+            Ok(layout) => layout,
+            Err(TraceDecayError::Config { .. }) => return Ok(branch::BranchAddOutcome::NotIndexed),
+            Err(err) => return Err(err),
+        };
+
+        Self::add_branch_tracking_in_layout(
+            project_root,
+            branch_name,
+            &store_layout.data_root,
+            open_options,
+        )
+        .await
+    }
+
+    async fn add_branch_tracking_in_layout(
+        project_root: &Path,
+        branch_name: &str,
+        tracedecay_dir: &Path,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<branch::BranchAddOutcome> {
+        let prepared =
+            branch::prepare_branch_tracking_in_layout(project_root, branch_name, tracedecay_dir)
+                .await?;
+        let branch::BranchTrackingPreparation::Added(prepared) = prepared else {
+            return Ok(match prepared {
+                branch::BranchTrackingPreparation::AlreadyTracked => {
+                    branch::BranchAddOutcome::AlreadyTracked
+                }
+                branch::BranchTrackingPreparation::Deferred => branch::BranchAddOutcome::Deferred,
+                branch::BranchTrackingPreparation::Added(_) => unreachable!(),
+            });
+        };
+
+        let sync_result =
+            Self::sync_new_branch_with_retries(project_root, branch_name, open_options).await;
+        if let Err(TraceDecayError::SyncLock { .. }) = sync_result {
+            return Ok(branch::BranchAddOutcome::Deferred);
+        } else if let Err(e) = sync_result {
+            branch::rollback_prepared_branch_tracking(tracedecay_dir, &prepared);
+            return Err(e);
+        }
+
+        branch::finalize_prepared_branch_tracking(tracedecay_dir, &prepared);
+        Ok(branch::BranchAddOutcome::Added)
+    }
+
+    async fn sync_new_branch_with_retries(
+        project_root: &Path,
+        branch_name: &str,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<()> {
+        let mut attempts = 0;
+        loop {
+            let cg =
+                Self::open_branch_with_options(project_root, branch_name, open_options.clone())
+                    .await?;
+            match cg.sync().await {
+                Ok(_) => return Ok(()),
+                Err(TraceDecayError::SyncLock { .. }) if attempts < 20 => {
+                    attempts += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     /// Resolves which DB file to open for a given branch.
@@ -768,7 +938,17 @@ impl TraceDecay {
     ///
     /// Returns an error if the branch is not tracked or the DB doesn't exist.
     pub async fn open_branch(project_root: &Path, branch_name: &str) -> Result<Self> {
-        let store_layout = Self::resolve_store_layout_for_project(project_root).await?;
+        Self::open_branch_with_options(project_root, branch_name, TraceDecayOpenOptions::default())
+            .await
+    }
+
+    pub async fn open_branch_with_options(
+        project_root: &Path,
+        branch_name: &str,
+        open_options: TraceDecayOpenOptions,
+    ) -> Result<Self> {
+        let store_layout =
+            Self::resolve_store_layout_for_project(project_root, &open_options).await?;
         let config = load_config_from_path(project_root, &store_layout.config_path)?;
 
         let meta = branch_meta::load_branch_meta(&store_layout.data_root).ok_or_else(|| {
@@ -798,6 +978,7 @@ impl TraceDecay {
             config,
             project_root: project_root.to_path_buf(),
             store_layout,
+            open_options,
             registry: LanguageRegistry::new(),
             active_branch: Some(branch_name.to_string()),
             serving_branch: Some(branch_name.to_string()),
@@ -813,6 +994,7 @@ impl TraceDecay {
         Some(meta.branches.keys().cloned().collect())
     }
 
+    #[allow(clippy::items_after_statements)]
     async fn register_project_store_in_global_registry(&self) {
         if self.store_layout.storage_mode != storage::StorageMode::ProfileSharded {
             return;
@@ -832,7 +1014,7 @@ impl TraceDecay {
         static REGISTRY_WRITE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
         let _registry_write = REGISTRY_WRITE_LOCK.lock().await;
 
-        let Some(global_db) = GlobalDb::open().await else {
+        let Some(global_db) = self.open_options.open_global_db().await else {
             return;
         };
 
@@ -946,14 +1128,26 @@ impl TraceDecay {
 
     /// Returns `true` if a `TraceDecay` project has been initialized at the given root.
     pub fn is_initialized(project_root: &Path) -> bool {
-        crate::config::has_project_database(project_root)
+        Self::is_initialized_with_options(project_root, &TraceDecayOpenOptions::default())
+    }
+
+    pub fn is_initialized_with_options(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> bool {
+        let option_resolved_store_exists = open_options
+            .resolved_profile_root()
+            .and_then(|profile_root| crate::storage::resolve_layout(project_root, &profile_root))
+            .is_ok_and(|layout| {
+                layout.storage_mode == crate::storage::StorageMode::ProfileSharded
+                    && layout.graph_db_path.exists()
+            });
+        if open_options.profile_root.is_some() || open_options.global_db_path.is_some() {
+            return option_resolved_store_exists;
+        }
+        option_resolved_store_exists
+            || crate::config::has_project_database(project_root)
             || crate::storage::has_enrollment_marker(project_root)
-            || crate::storage::resolve_layout_for_current_profile(project_root).is_ok_and(
-                |layout| {
-                    layout.storage_mode == crate::storage::StorageMode::ProfileSharded
-                        && layout.graph_db_path.exists()
-                },
-            )
     }
 }
 
@@ -2354,6 +2548,7 @@ impl TraceDecay {
         dirs
     }
 
+    #[allow(clippy::items_after_statements)]
     fn is_skipped_dir_hint(rel_str: &str, name: &str, config: &TraceDecayConfig) -> bool {
         if is_included_dir(rel_str, config) || is_included(rel_str, config) {
             return false;
@@ -3603,7 +3798,7 @@ impl TraceDecay {
     /// bound to the correct branch DB. Use after [`branch_drifted`](Self::branch_drifted)
     /// reports drift so subsequent reads and writes target the right DB.
     pub async fn reopen_for_current_branch(&self) -> Result<Self> {
-        Self::open(&self.project_root).await
+        Self::open_with_options(&self.project_root, self.open_options.clone()).await
     }
 
     /// Recompute the on-disk path to the `SQLite` DB this instance is

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -810,6 +810,10 @@ impl TraceDecay {
             Err(err) => return Err(err),
         };
 
+        if !store_layout.graph_db_path.is_file() {
+            return Ok(branch::BranchAddOutcome::NotIndexed);
+        }
+
         Self::add_branch_tracking_in_layout(
             project_root,
             branch_name,
@@ -1148,6 +1152,15 @@ impl TraceDecay {
         option_resolved_store_exists
             || crate::config::has_project_database(project_root)
             || crate::storage::has_enrollment_marker(project_root)
+    }
+
+    pub(crate) async fn has_initialized_store_with_options(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> bool {
+        Self::resolve_store_layout_for_project(project_root, open_options)
+            .await
+            .is_ok_and(|layout| layout.graph_db_path.is_file())
     }
 }
 

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use tempfile::TempDir;
-use tracedecay::branch::{self, BranchAddOutcome};
+use tracedecay::branch::BranchAddOutcome;
 use tracedecay::branch_meta::load_branch_meta;
 use tracedecay::storage::resolve_layout_for_current_profile;
 use tracedecay::tracedecay::TraceDecay;
@@ -253,7 +253,7 @@ async fn add_branch_tracking_copies_from_nearest_tracked_ancestor() {
     .unwrap();
     commit_all(project, "feature commit");
 
-    let feature_outcome = branch::add_branch_tracking(project, "feature/parent")
+    let feature_outcome = TraceDecay::add_branch_tracking(project, "feature/parent")
         .await
         .unwrap();
     assert_eq!(feature_outcome, BranchAddOutcome::Added);
@@ -273,7 +273,7 @@ async fn add_branch_tracking_copies_from_nearest_tracked_ancestor() {
     .unwrap();
     commit_all(project, "topic commit");
 
-    let topic_outcome = branch::add_branch_tracking(project, "topic/child")
+    let topic_outcome = TraceDecay::add_branch_tracking(project, "topic/child")
         .await
         .unwrap();
     assert_eq!(topic_outcome, BranchAddOutcome::Added);
@@ -333,7 +333,7 @@ async fn add_branch_tracking_refuses_corrupt_metadata_without_overwriting() {
     .unwrap();
     commit_all(project, "feature commit");
 
-    let err = branch::add_branch_tracking(project, "feature/corrupt-meta")
+    let err = TraceDecay::add_branch_tracking(project, "feature/corrupt-meta")
         .await
         .expect_err("corrupt metadata must stop branch tracking instead of being replaced");
 

--- a/tests/branch_drift_test.rs
+++ b/tests/branch_drift_test.rs
@@ -305,7 +305,7 @@ async fn open_repairs_missing_tracked_branch_db_before_diagnostics() {
     git(project, &["add", "."]);
     git(project, &["commit", "-m", "feature"]);
 
-    tracedecay::branch::add_branch_tracking(project, "feature/tracked")
+    TraceDecay::add_branch_tracking(project, "feature/tracked")
         .await
         .unwrap();
 

--- a/tests/dashboard_api_test.rs
+++ b/tests/dashboard_api_test.rs
@@ -11,7 +11,6 @@ use common::{
 };
 use serde_json::Value;
 use tempfile::TempDir;
-use tracedecay::branch;
 use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::dashboard;
 use tracedecay::errors::TraceDecayError;
@@ -753,7 +752,8 @@ fn dashboard_reports_resolved_branch_db_path() {
             "pub fn feature_branch_symbol() {}\n",
         )
         .unwrap_or_else(|err| panic!("failed to write feature fixture: {err}"));
-        if let Err(err) = branch::add_branch_tracking(&project_root, "feature/dashboard-path").await
+        if let Err(err) =
+            TraceDecay::add_branch_tracking(&project_root, "feature/dashboard-path").await
         {
             panic!("failed to track feature branch: {err}");
         }
@@ -815,7 +815,8 @@ fn dashboard_uses_project_memory_db_and_branch_graph_db() {
             "pub fn feature_branch_symbol() {}\n",
         )
         .unwrap_or_else(|err| panic!("failed to write feature fixture: {err}"));
-        if let Err(err) = branch::add_branch_tracking(&project_root, "feature/dashboard-storage").await
+        if let Err(err) =
+            TraceDecay::add_branch_tracking(&project_root, "feature/dashboard-storage").await
         {
             panic!("failed to track feature branch: {err}");
         }

--- a/tests/hook_branch_routing_test.rs
+++ b/tests/hook_branch_routing_test.rs
@@ -11,6 +11,7 @@ use tracedecay::hooks::{
     cursor_shell_sync_plan_with_current_branch, CursorShellSyncPlan,
 };
 use tracedecay::storage::{write_enrollment_marker, EnrollmentMarker, StorageMode};
+use tracedecay::tracedecay::TraceDecay;
 
 static HOME_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
@@ -199,7 +200,7 @@ async fn hook_branch_tracking_writes_profile_sharded_branch_db() {
     git(&project, &["init", "-b", "main"]);
     git(&project, &["checkout", "-b", "feature/hook"]);
 
-    let outcome = tracedecay::branch::add_branch_tracking(&project, "feature/hook")
+    let outcome = TraceDecay::add_branch_tracking(&project, "feature/hook")
         .await
         .unwrap();
 

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -853,6 +853,9 @@ async fn test_codex_user_prompt_submit_generic_workspace_suppresses_code_hints()
 }
 
 #[tokio::test]
+// Intentional: this test pins process-wide TraceDecay profile env while awaited
+// hook context generation resolves profile storage and records analytics.
+#[allow(clippy::await_holding_lock)]
 async fn test_codex_user_prompt_submit_records_workspace_status_and_missing_session_hint() {
     let _lock = GLOBAL_DB_ENV_LOCK.lock().unwrap();
     let project = tempfile::tempdir().unwrap();

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -4902,6 +4902,7 @@ async fn test_test_risk_excludes_non_src_functions_from_denominator_and_risks() 
         "build script helper should not be ranked as source risk, got: {}",
         text
     );
+    close_test_graph(cg).await;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/profile_storage_migration_test.rs
+++ b/tests/profile_storage_migration_test.rs
@@ -24,7 +24,7 @@ use tracedecay::storage::{
     read_enrollment_marker, write_enrollment_marker, EnrollmentMarker, StorageMode, StoreKind,
     StoreManifest, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
 };
-use tracedecay::tracedecay::TraceDecay;
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 static HOME_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
@@ -497,6 +497,97 @@ async fn trace_decay_init_uses_profile_shard_when_enrolled() {
 }
 
 #[tokio::test]
+async fn trace_decay_init_with_options_uses_explicit_profile_identity() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let root = canonical_temp_path(dir.path());
+    let daemon_home = root.join("daemon-home");
+    let client_profile = root.join("client-profile");
+    let project = root.join("repo");
+    fs::create_dir_all(&project).unwrap();
+    let _home_guard = HomeEnvGuard::set(&daemon_home);
+    write_enrollment_marker(
+        &project,
+        &EnrollmentMarker {
+            project_id: "proj_explicit".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(client_profile.clone()),
+        global_db_path: Some(client_profile.join("global.db")),
+    };
+
+    assert!(
+        !TraceDecay::is_initialized_with_options(&project, &open_options),
+        "a marker alone must not initialize an explicit client profile"
+    );
+
+    let cg = TraceDecay::init_with_options(&project, open_options.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        cg.store_layout().data_root,
+        client_profile.join("projects/proj_explicit")
+    );
+    assert!(cg.store_layout().config_path.is_file());
+    assert!(cg.db_path().is_file());
+    assert!(TraceDecay::is_initialized_with_options(
+        &project,
+        &open_options
+    ));
+    assert!(
+        !daemon_home.join(".tracedecay").exists(),
+        "explicit client profile init must not create a store in the daemon/default profile"
+    );
+}
+
+#[tokio::test]
+async fn trace_decay_options_global_db_path_implies_profile_root() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let root = canonical_temp_path(dir.path());
+    let daemon_home = root.join("daemon-home");
+    let client_profile = root.join("client-profile");
+    let project = root.join("repo");
+    fs::create_dir_all(&project).unwrap();
+    let _home_guard = HomeEnvGuard::set(&daemon_home);
+    write_enrollment_marker(
+        &project,
+        &EnrollmentMarker {
+            project_id: "proj_db_only".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let open_options = TraceDecayOpenOptions {
+        profile_root: None,
+        global_db_path: Some(client_profile.join("global.db")),
+    };
+
+    let cg = TraceDecay::init_with_options(&project, open_options.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        cg.store_layout().data_root,
+        client_profile.join("projects/proj_db_only")
+    );
+    assert!(cg.store_layout().config_path.is_file());
+    assert!(cg.db_path().is_file());
+    assert!(TraceDecay::is_initialized_with_options(
+        &project,
+        &open_options
+    ));
+    assert!(
+        !daemon_home.join(".tracedecay").exists(),
+        "global_db_path-only options must not fall back to the daemon/default profile"
+    );
+}
+
+#[tokio::test]
 async fn trace_decay_open_matches_renamed_git_checkout_by_registered_remote() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
@@ -590,4 +681,65 @@ async fn trace_decay_open_branch_uses_profile_shard_branch_db() {
     assert_eq!(cg.store_layout().data_root, shard_root);
     assert_eq!(cg.db_path(), branch_db);
     assert_eq!(cg.serving_branch(), Some("feature/profile"));
+}
+
+#[tokio::test]
+async fn trace_decay_open_with_options_auto_tracks_branch_in_explicit_profile() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let root = canonical_temp_path(dir.path());
+    let daemon_home = root.join("daemon-home");
+    let client_profile = root.join("client-profile");
+    let project = root.join("repo");
+    fs::create_dir_all(&project).unwrap();
+    run_git(&project, &["init"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "TraceDecay Test"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/main.rs"), "fn main() {}\n").unwrap();
+    run_git(&project, &["add", "."]);
+    run_git(&project, &["commit", "-m", "initial"]);
+    run_git(&project, &["checkout", "-b", "feature/client-profile"]);
+    fs::write(
+        project.join("src/main.rs"),
+        "fn main() { println!(\"feature\"); }\n",
+    )
+    .unwrap();
+    run_git(&project, &["add", "."]);
+    run_git(&project, &["commit", "-m", "feature"]);
+    run_git(&project, &["checkout", "-"]);
+
+    let _home_guard = HomeEnvGuard::set(&daemon_home);
+    write_enrollment_marker(
+        &project,
+        &EnrollmentMarker {
+            project_id: "proj_auto_branch".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(client_profile.clone()),
+        global_db_path: Some(client_profile.join("global.db")),
+    };
+    let main = TraceDecay::init_with_options(&project, open_options.clone())
+        .await
+        .unwrap();
+    let shard_root = main.store_layout().data_root.clone();
+    assert_eq!(shard_root, client_profile.join("projects/proj_auto_branch"));
+    drop(main);
+
+    run_git(&project, &["checkout", "feature/client-profile"]);
+    let cg = TraceDecay::open_with_options(&project, open_options)
+        .await
+        .unwrap();
+
+    assert_eq!(cg.store_layout().data_root, shard_root);
+    assert_eq!(cg.serving_branch(), Some("feature/client-profile"));
+    assert!(cg.db_path().starts_with(shard_root.join("branches")));
+    assert!(cg.db_path().is_file());
+    assert!(
+        !daemon_home.join(".tracedecay").exists(),
+        "auto-tracking with explicit options must not create branch storage in the daemon/default profile"
+    );
 }

--- a/tests/profile_storage_migration_test.rs
+++ b/tests/profile_storage_migration_test.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
+use tracedecay::branch::BranchAddOutcome;
 use tracedecay::branch_meta::{self, BranchMeta};
 use tracedecay::config::{TraceDecayConfig, USER_DATA_DIR_ENV};
 use tracedecay::db::Database;
@@ -19,6 +20,7 @@ use tracedecay::migrate::registry::{
     apply_registry_reconstruction_report, reconstruct_registry_from_store_manifest,
     scan_profile_store_manifests,
 };
+use tracedecay::serve;
 use tracedecay::sessions::cursor::open_project_session_db;
 use tracedecay::storage::{
     read_enrollment_marker, write_enrollment_marker, EnrollmentMarker, StorageMode, StoreKind,
@@ -588,6 +590,30 @@ async fn trace_decay_options_global_db_path_implies_profile_root() {
 }
 
 #[tokio::test]
+async fn trace_decay_add_branch_tracking_returns_not_indexed_for_uninitialized_profile_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let root = canonical_temp_path(dir.path());
+    let home = root.join("home");
+    let project = root.join("repo");
+    fs::create_dir_all(&project).unwrap();
+    let _home_guard = HomeEnvGuard::set(&home);
+
+    let outcome = TraceDecay::add_branch_tracking(&project, "feature/unindexed")
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, BranchAddOutcome::NotIndexed);
+    assert!(
+        !home
+            .join(".tracedecay/projects")
+            .join(tracedecay::storage::default_profile_project_id(&project))
+            .exists(),
+        "branch add must not create project profile storage before tracedecay init"
+    );
+}
+
+#[tokio::test]
 async fn trace_decay_open_matches_renamed_git_checkout_by_registered_remote() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
@@ -633,6 +659,58 @@ async fn trace_decay_open_matches_renamed_git_checkout_by_registered_remote() {
             .join("tracedecay.db")
             .exists(),
         "renamed checkout must not create a second path-hash profile shard"
+    );
+}
+
+#[tokio::test]
+async fn ensure_initialized_with_options_uses_registered_remote_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let root = canonical_temp_path(dir.path());
+    let daemon_home = root.join("daemon-home");
+    let client_profile = root.join("client-profile");
+    let project = root.join("repo-before-rename");
+    let renamed = root.join("repo-after-rename");
+    fs::create_dir_all(&project).unwrap();
+    run_git(&project, &["init"]);
+    run_git(
+        &project,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:ScriptedAlchemy/tracedecay.git",
+        ],
+    );
+    let _home_guard = HomeEnvGuard::set(&daemon_home);
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(client_profile.clone()),
+        global_db_path: Some(client_profile.join("global.db")),
+    };
+
+    let initialized = TraceDecay::init_with_options(&project, open_options.clone())
+        .await
+        .unwrap();
+    let original_data_root = initialized.store_layout().data_root.clone();
+    drop(initialized);
+    fs::rename(&project, &renamed).unwrap();
+
+    assert!(
+        !TraceDecay::is_initialized_with_options(&renamed, &open_options),
+        "the synchronous marker check cannot see renamed registered stores"
+    );
+    let reopened = serve::ensure_initialized_with_options(&renamed, open_options)
+        .await
+        .unwrap();
+
+    assert_eq!(reopened.store_layout().data_root, original_data_root);
+    assert!(
+        !client_profile
+            .join("projects")
+            .join(tracedecay::storage::default_profile_project_id(&renamed))
+            .join("tracedecay.db")
+            .exists(),
+        "serve must not create or require a second path-hash profile shard"
     );
 }
 

--- a/tests/regression_core_engine_test.rs
+++ b/tests/regression_core_engine_test.rs
@@ -306,7 +306,7 @@ async fn add_branch_tracking_refuses_empty_sanitized_name() {
     cg.index_all().await.unwrap();
 
     // ".." sanitizes to "" — must be refused, never mapped to branches/.db.
-    let result = tracedecay::branch::add_branch_tracking(project, "..").await;
+    let result = TraceDecay::add_branch_tracking(project, "..").await;
     assert!(
         result.is_err(),
         "a branch name that sanitizes to empty must be refused, got: {result:?}"


### PR DESCRIPTION
## Summary
- Route branch tracking through `TraceDecay` so CLI, hooks, and profile-sharded clients share collision-safe branch DB setup.
- Add explicit profile/global DB open options used by profile-scoped clients.
- Update branch recovery/invariant docs for the centralized path.

## Test plan
- `cargo check`
- `cargo test --test tool_daemon_test -- --test-threads=1` (run on full stack)