### PR TITLE
Refactor MCP tool dispatch and outline support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
+  AST_GREP_VERSION: "0.44.0"
 
 jobs:
   commit-messages:
@@ -71,6 +72,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install ast-grep
+        run: |
+          npm install --global "@ast-grep/cli@${AST_GREP_VERSION}"
+          ast-grep --version
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
@@ -104,6 +110,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ast-grep
+        shell: pwsh
+        run: |
+          npm install --global "@ast-grep/cli@$env:AST_GREP_VERSION"
+          ast-grep --version
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -259,6 +271,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install ast-grep
+        run: |
+          npm install --global "@ast-grep/cli@${AST_GREP_VERSION}"
+          ast-grep --version
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
@@ -338,6 +355,11 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ast-grep
+        run: |
+          npm install --global "@ast-grep/cli@${AST_GREP_VERSION}"
+          ast-grep --version
 
       - name: Cache Cargo
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             throw "No integration test targets selected for Windows shard $partition/$partitions"
           }
           Write-Host "Windows shard $partition/$partitions running $($selected.Count) integration test targets"
-          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci", "--retries", "2")
+          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci", "--retries", "2", "--flaky-result", "pass")
           if ($partition -eq 1) {
             $nextestArgs += @("--lib", "--bin", "tracedecay")
           }

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ The default query set targets patterns present in most application codebases (CL
 
 Each repo is shallow-cloned (`git init` + `git fetch --progress --depth 1 origin <ref>` + `checkout FETCH_HEAD`) on first use and cached locally; subsequent runs reuse the checkout. Git output is streamed to the terminal so the multi-GB fetch shows real-time progress.
 
-**Tools covered (5 queries each).** Read tools — `search`, `context`, `callers`, `callees`, `node`, `by_qualified_name`, `signature`, `impact`, `body`, `files`, `complexity`, `doc_coverage`, `largest`, `hotspots`, `god_class`, `module_api`, `derives`, `dead_code`, `rank`, `coupling`, `circular`. Write tools — `str_replace`, `multi_str_replace`, `insert_at`, and (if `ast-grep` is on `PATH`) `ast_grep_rewrite`.
+**Tools covered (5 queries each).** Read tools — `search`, `context`, `callers`, `callees`, `node`, `by_qualified_name`, `signature`, `impact`, `body`, `files`, `complexity`, `doc_coverage`, `largest`, `hotspots`, `god_class`, `module_api`, `derives`, `dead_code`, `rank`, `coupling`, `circular`, and `outline` when `ast-grep` >= 0.44 is on `PATH`. Write tools — `str_replace`, `multi_str_replace`, `insert_at`, and (when the user-installed `ast-grep` CLI is available) `ast_grep_rewrite`.
 
 **Force-sync on every run.** Before any benchmark fires, the harness runs the equivalent of `tracedecay sync --force` on each repo (`index_all()` regardless of `.tracedecay/` freshness) so timings always reflect the pinned source.
 
@@ -492,7 +492,7 @@ Different from the criterion bench above: criterion measures per-iteration laten
 
 ## 70+ MCP Tools
 
-The server exposes more than 70 tools (one fewer when the optional `ast-grep` binary is not on `PATH`); the tables below group the most commonly used ones by category. Most are read-only, safe to call in parallel, and annotated with `readOnlyHint`. The edit primitives are scoped to single files and re-index in place; session baseline and memory tools also mutate the active local TraceDecay store and are annotated as non-read-only. The three core tools (`tracedecay_context`, `tracedecay_search`, `tracedecay_status`) are marked `anthropic/alwaysLoad` so they bypass the client's tool-search round-trip.
+The server exposes more than 70 tools; the tables below group the most commonly used ones by category. `ast-grep` is an optional external CLI capability used by structural refactor tools and `tracedecay_outline`; outline requires `ast-grep` >= 0.44 on `PATH` for the CLI's `outline` command. These tools have no backend-selection argument. Most tools are read-only, safe to call in parallel, and annotated with `readOnlyHint`. The edit primitives are scoped to single files and re-index in place; session baseline and memory tools also mutate the active local TraceDecay store and are annotated as non-read-only. The three core tools (`tracedecay_context`, `tracedecay_search`, `tracedecay_status`) are marked `anthropic/alwaysLoad` so they bypass the client's tool-search round-trip.
 
 ### Recovering Truncated Responses
 
@@ -513,6 +513,7 @@ produced the truncated response.
 | `tracedecay_context` | Get relevant code context for a task -- entry points, related symbols, code snippets |
 | `tracedecay_search` | Find symbols by name (functions, classes, types) |
 | `tracedecay_node` | Get details + source code for a specific symbol |
+| `tracedecay_outline` | Lightweight `ast-grep` CLI outline of top-level file symbols, with DB-backed TraceDecay symbols preserved for follow-up graph calls; requires `ast-grep` >= 0.44 |
 | `tracedecay_files` | List indexed project files with filtering |
 | `tracedecay_module_api` | Public API surface of a file or directory |
 | `tracedecay_similar` | Find symbols with similar names |
@@ -751,7 +752,7 @@ Run a comprehensive health check of your tracedecay installation:
 tracedecay doctor
 ```
 
-Checks: binary location, project index, global DB, user config, agent integration (MCP server or plugin, hooks, permissions, prompt rules where applicable), and network connectivity. If any tool permissions are missing after an upgrade, it tells you to run `tracedecay install`. Use `--agent` to check a specific agent only.
+Checks: binary location, project index, global DB, user config, optional external capabilities such as `ast-grep` for `tracedecay_outline` and structural refactor tools, agent integration (MCP server or plugin, hooks, permissions, prompt rules where applicable), and network connectivity. If `ast-grep` is missing or older than 0.44, install or update it, make sure it is on `PATH`, then rerun `tracedecay install` or `tracedecay update-plugin` as appropriate to refresh generated agent integrations. If any tool permissions are missing after an upgrade, doctor tells you to run `tracedecay install`. Use `--agent` to check a specific agent only.
 
 Doctor also validates that each installed hook uses the correct tracedecay subcommand and auto-repairs broken hooks.
 

--- a/TEST-QUERIES.md
+++ b/TEST-QUERIES.md
@@ -837,25 +837,28 @@ Expected: The second call returns `{"unchanged": true, "digest": ..., "mtime_ns"
 
 ## tracedecay_outline
 
-> Flat list of every top-level symbol in a file, with optional kind filter.
+> Optional `ast-grep` CLI outline of every top-level symbol in a file, with optional kind
+> filter. Requires `ast-grep` >= 0.44 on `PATH`. The response preserves DB-backed
+> TraceDecay symbols in the same payload for follow-up graph calls and has no
+> backend-selection argument.
 
 Test default (all kinds):
 ```
 tracedecay_outline(file="src/mcp/tools/handlers/info.rs")
 ```
-Expected: Returns `{file, symbol_count, symbols: [{kind, name, line, end_line, visibility}]}` sorted by line.
+Expected: Returns `{file, symbol_count, symbols: [{kind, name, line, end_line, visibility}], ast_grep_outline: [...]}` sorted by line. `symbols` keeps the DB-backed TraceDecay symbol map; `ast_grep_outline` carries the optional CLI outline payload.
 
 Test kinds filter:
 ```
 tracedecay_outline(file="src/mcp/tools/handlers/info.rs", kinds=["function"])
 ```
-Expected: Only function-kind entries. Filter is case-insensitive (`["FUNCTION"]` works the same).
+Expected: Only function-kind DB-backed `symbols`, with `ast_grep_outline` still present in the same payload. Filter is case-insensitive (`["FUNCTION"]` works the same).
 
 Unknown kind returns empty:
 ```
 tracedecay_outline(file="src/mcp/tools/handlers/info.rs", kinds=["banana"])
 ```
-Expected: `symbol_count: 0`.
+Expected: `symbol_count: 0` for DB-backed `symbols`; `ast_grep_outline` still carries the CLI outline payload when the host supports it.
 
 ---
 

--- a/docs/MCP-extensions.md
+++ b/docs/MCP-extensions.md
@@ -114,9 +114,22 @@ grep category — confirming it as a recurring opening move on essentially any l
 { "file": "src/tracedecay.rs", "kinds": ["function", "struct", "impl"] }
 ```
 
+**Backend:** The outline uses the optional external `ast-grep` CLI capability,
+the same dependency family as structural refactor tools such as
+`tracedecay_ast_grep_rewrite`. It requires `ast-grep` >= 0.44 on `PATH` because
+outline support depends on the CLI's `outline` command. There is no
+backend-selection argument.
+
 **Returns:** A flat list of `{kind, name, line, visibility}` for every top-level symbol in the
-file, sorted by line. No code bodies — just the map. Response should be cheap (graph lookup,
-no snippet extraction).
+file, sorted by line. No code bodies — just the map. The response should also preserve the
+DB-backed TraceDecay symbols for the same file in the same payload, so callers get the fresh
+CLI outline without losing indexed graph symbols, ids, or qualified names needed for
+follow-up graph calls.
+
+**Install guidance:** `tracedecay doctor` should report when `ast-grep` is
+missing or older than 0.44. After installing or updating `ast-grep`, rerun
+`tracedecay install` or `tracedecay update-plugin` as appropriate so agent
+integrations refresh their generated tool surfaces and guidance.
 
 **Value:** Turns "where is X defined in this file?" from a Read + manual scan into a single
 call. Also useful as a pre-flight before `tracedecay_context` — orient first, then zoom.
@@ -418,7 +431,7 @@ scan, where measurable.
 | `tracedecay_body` | ✅ shipped | 1571 targeted Reads + 52 sed -n | Low | **High** |
 | `tracedecay_todos` | ✅ shipped | scattered across projects | Low | Medium |
 | `tracedecay_diagnostics` | proposed | 777 cargo invocations | High (compiler integration) | **Very high** |
-| `tracedecay_outline` | proposed | 618 symbol-skeleton greps | Very low (file → node list) | **High** |
+| `tracedecay_outline` | proposed | 618 symbol-skeleton greps | Low (optional ast-grep CLI outline + DB symbols) | **High** |
 | `tracedecay_unsafe_patterns` | proposed | recurring in review/audit | Low (AST predicates) | High |
 | `tracedecay_implementations` | proposed | tracedecay 22ff55cd, 67f09223 | Low (method edges) | High |
 | `tracedecay_signature_search` | proposed | smaller volume, high token cost | Medium (AST matcher) | High |
@@ -432,8 +445,9 @@ scan, where measurable.
 
 **Build order recommendation (revised after telemetry scan):**
 
-1. `tracedecay_outline` — trivial query, addresses the single largest grep category (618 hits).
-   One afternoon.
+1. `tracedecay_outline` — optional `ast-grep` CLI outline with DB-backed TraceDecay symbols
+   preserved in the same payload; requires `ast-grep` >= 0.44 and addresses the single
+   largest grep category (618 hits). One afternoon.
 2. `tracedecay_unsafe_patterns` — AST predicates on top of the existing matcher. Replaces a
    recurring review-time grep family. Half-day.
 3. `tracedecay_diagnostics` — biggest single Bash : tracedecay gap. Highest impact even though

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,7 @@
 # Prerequisites:
 #   - tracedecay binary on PATH (cargo install or brew install)
 #   - jq installed (brew install jq)
+#   - cargo installed if ast-grep needs to be installed or upgraded
 #   - Claude Code installed
 
 set -euo pipefail
@@ -36,6 +37,56 @@ if ! command -v jq &>/dev/null; then
 fi
 
 TRACEDECAY_BIN="$(command -v tracedecay)"
+
+AST_GREP_MIN_VERSION="0.44.0"
+
+version_at_least() {
+    local current="$1"
+    local required="$2"
+    awk -v current="$current" -v required="$required" '
+      BEGIN {
+        split(current, c, ".")
+        split(required, r, ".")
+        for (i = 1; i <= 3; i++) {
+          cv = c[i] + 0
+          rv = r[i] + 0
+          if (cv > rv) exit 0
+          if (cv < rv) exit 1
+        }
+        exit 0
+      }
+    '
+}
+
+ast_grep_version() {
+    ast-grep --version 2>/dev/null | awk '{print $2}'
+}
+
+ensure_ast_grep() {
+    local current=""
+    if command -v ast-grep &>/dev/null; then
+        current="$(ast_grep_version)"
+        if [ -n "$current" ] && version_at_least "$current" "$AST_GREP_MIN_VERSION"; then
+            echo "ast-grep $current already installed"
+            return
+        fi
+        echo "ast-grep ${current:-unknown} is older than required $AST_GREP_MIN_VERSION; upgrading"
+    else
+        echo "ast-grep not found; installing $AST_GREP_MIN_VERSION"
+    fi
+
+    if ! command -v cargo &>/dev/null; then
+        echo "Error: cargo is required to install ast-grep $AST_GREP_MIN_VERSION" >&2
+        echo "Install ast-grep manually with one of:" >&2
+        echo "  cargo install ast-grep --locked --version $AST_GREP_MIN_VERSION" >&2
+        echo "  npm install --global @ast-grep/cli@$AST_GREP_MIN_VERSION" >&2
+        exit 1
+    fi
+
+    cargo install ast-grep --locked --version "$AST_GREP_MIN_VERSION"
+}
+
+ensure_ast_grep
 
 # 1. Install hook script
 mkdir -p "$HOOKS_DIR"

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -1701,7 +1701,7 @@ mod tests {
 
         let created_at = parsed
             .get("created_at")
-            .and_then(|value| value.as_integer())
+            .and_then(toml::Value::as_integer)
             .expect("created_at");
         install_codex_native_automation(home.path(), project).expect("automation reinstall");
         let reparsed = std::fs::read_to_string(&path)
@@ -1709,9 +1709,7 @@ mod tests {
             .parse::<toml::Table>()
             .expect("valid toml");
         assert_eq!(
-            reparsed
-                .get("created_at")
-                .and_then(|value| value.as_integer()),
+            reparsed.get("created_at").and_then(toml::Value::as_integer),
             Some(created_at),
             "reinstall should preserve created_at for the existing Codex automation"
         );

--- a/src/context/read_modes.rs
+++ b/src/context/read_modes.rs
@@ -113,25 +113,10 @@ pub fn render_lines(source: &str, range: LineRange) -> String {
 /// is included.
 pub async fn render_map(db: &Database, file_path: &str, kinds: Option<&[String]>) -> Result<Value> {
     let nodes = fetch_nodes(db, file_path).await?;
-    let active_filter: Option<&[String]> = kinds.filter(|k| !k.is_empty());
     let entries: Vec<Value> = nodes
         .iter()
-        .filter(|n| match active_filter {
-            None => true,
-            Some(filter) => {
-                let lhs = n.kind.as_str();
-                filter.iter().any(|want| want.eq_ignore_ascii_case(lhs))
-            }
-        })
-        .map(|n| {
-            json!({
-                "kind": n.kind.as_str(),
-                "name": n.name,
-                "line": n.start_line,
-                "end_line": n.end_line,
-                "visibility": n.visibility.as_str(),
-            })
-        })
+        .filter(|n| kind_matches_filter(&n.kind, kinds))
+        .map(map_symbol_entry)
         .collect();
     Ok(json!({
         "file": file_path,
@@ -148,19 +133,7 @@ pub async fn render_signatures(db: &Database, file_path: &str) -> Result<Value> 
     let entries: Vec<Value> = nodes
         .iter()
         .filter(|n| is_signature_kind(&n.kind))
-        .filter_map(|n| {
-            let sig = n.signature.as_deref()?;
-            Some(json!({
-                "kind": n.kind.as_str(),
-                "name": n.name,
-                "qualified_name": n.qualified_name,
-                "line": n.start_line,
-                "end_line": n.end_line,
-                "visibility": n.visibility.as_str(),
-                "signature": sig,
-                "is_async": n.is_async,
-            }))
-        })
+        .filter_map(signature_symbol_entry)
         .collect();
     Ok(json!({
         "file": file_path,
@@ -176,6 +149,38 @@ async fn fetch_nodes(db: &Database, file_path: &str) -> Result<Vec<Node>> {
             message: format!("read_modes: failed to load nodes for {file_path}: {e}"),
             operation: "read_modes::fetch_nodes".to_string(),
         })
+}
+
+fn kind_matches_filter(kind: &NodeKind, kinds: Option<&[String]>) -> bool {
+    let Some(filter) = kinds.filter(|k| !k.is_empty()) else {
+        return true;
+    };
+    let kind = kind.as_str();
+    filter.iter().any(|want| want.eq_ignore_ascii_case(kind))
+}
+
+fn map_symbol_entry(node: &Node) -> Value {
+    json!({
+        "kind": node.kind.as_str(),
+        "name": node.name,
+        "line": node.start_line,
+        "end_line": node.end_line,
+        "visibility": node.visibility.as_str(),
+    })
+}
+
+fn signature_symbol_entry(node: &Node) -> Option<Value> {
+    let signature = node.signature.as_deref()?;
+    Some(json!({
+        "kind": node.kind.as_str(),
+        "name": node.name,
+        "qualified_name": node.qualified_name,
+        "line": node.start_line,
+        "end_line": node.end_line,
+        "visibility": node.visibility.as_str(),
+        "signature": signature,
+        "is_async": node.is_async,
+    }))
 }
 
 /// Kinds whose `signature` column carries useful information for the
@@ -201,6 +206,35 @@ fn is_signature_kind(kind: &NodeKind) -> bool {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::types::Visibility;
+
+    fn node_fixture(kind: NodeKind, signature: Option<&str>) -> Node {
+        Node {
+            id: "node-1".to_string(),
+            kind,
+            name: "sample".to_string(),
+            qualified_name: "crate::sample".to_string(),
+            file_path: "src/sample.rs".to_string(),
+            start_line: 12,
+            attrs_start_line: 10,
+            end_line: 18,
+            start_column: 4,
+            end_column: 1,
+            signature: signature.map(str::to_string),
+            docstring: Some("sample docs".to_string()),
+            visibility: Visibility::Pub,
+            is_async: true,
+            branches: 1,
+            loops: 2,
+            returns: 3,
+            max_nesting: 4,
+            unsafe_blocks: 5,
+            unchecked_calls: 6,
+            assertions: 7,
+            updated_at: 8,
+            parent_id: Some("parent-1".to_string()),
+        }
+    }
 
     #[test]
     fn parse_mode_known_values() {
@@ -257,5 +291,61 @@ mod tests {
     fn render_full_returns_input() {
         let src = "hello\nworld\n";
         assert_eq!(render_full(src), src);
+    }
+
+    #[test]
+    fn kind_filter_is_empty_or_case_insensitive() {
+        assert!(kind_matches_filter(&NodeKind::Function, None));
+        assert!(kind_matches_filter(&NodeKind::Function, Some(&[])));
+        assert!(kind_matches_filter(
+            &NodeKind::Function,
+            Some(&["FUNCTION".to_string()])
+        ));
+        assert!(!kind_matches_filter(
+            &NodeKind::Function,
+            Some(&["struct".to_string()])
+        ));
+    }
+
+    #[test]
+    fn map_symbol_entry_preserves_outline_schema() {
+        let node = node_fixture(NodeKind::Function, Some("pub async fn sample()"));
+
+        assert_eq!(
+            map_symbol_entry(&node),
+            json!({
+                "kind": "function",
+                "name": "sample",
+                "line": 12,
+                "end_line": 18,
+                "visibility": "public",
+            })
+        );
+    }
+
+    #[test]
+    fn signature_symbol_entry_preserves_signature_schema() {
+        let node = node_fixture(NodeKind::Function, Some("pub async fn sample()"));
+
+        assert_eq!(
+            signature_symbol_entry(&node),
+            Some(json!({
+                "kind": "function",
+                "name": "sample",
+                "qualified_name": "crate::sample",
+                "line": 12,
+                "end_line": 18,
+                "visibility": "public",
+                "signature": "pub async fn sample()",
+                "is_async": true,
+            }))
+        );
+    }
+
+    #[test]
+    fn signature_symbol_entry_skips_missing_signature() {
+        let node = node_fixture(NodeKind::Function, None);
+
+        assert_eq!(signature_symbol_entry(&node), None);
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -40,6 +40,7 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
     check_global_db(&mut dc);
     check_stale_stores(&mut dc).await;
     check_user_config(&mut dc);
+    check_external_tools(&mut dc);
 
     // Agent-specific health checks
     if let Some(ref home) = agents::home_dir() {
@@ -462,6 +463,51 @@ fn check_user_config(dc: &mut DoctorCounters) {
     } else {
         dc.fail("Could not determine home directory for config");
     }
+}
+
+/// Check optional external tools that gate optional MCP capabilities.
+fn check_external_tools(dc: &mut DoctorCounters) {
+    eprintln!("\n\x1b[1mExternal tools\x1b[0m");
+    let diagnostics = crate::mcp::tools::ast_grep_diagnostics_json();
+    let installed = json_bool(&diagnostics, "installed");
+    let rewrite_available = json_bool(&diagnostics, "rewrite_available");
+    let outline_available = json_bool(&diagnostics, "outline_available");
+    let version = diagnostics
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let message = diagnostics
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("ast-grep status unavailable");
+
+    if outline_available {
+        dc.pass(&format!(
+            "ast-grep {version}: rewrite and outline support available"
+        ));
+        return;
+    }
+
+    if rewrite_available {
+        dc.warn(&format!(
+            "ast-grep {version}: rewrite support available, but outline support is missing"
+        ));
+    } else if installed {
+        dc.warn(&format!(
+            "ast-grep {version}: optional ast-grep-backed tools are unavailable"
+        ));
+    } else {
+        dc.warn("ast-grep not found on PATH; optional ast-grep-backed tools are hidden");
+    }
+    dc.info(message);
+    dc.info("Install or update ast-grep to >= 0.44, then rerun `tracedecay install` or `tracedecay update-plugin` if your agent integration caches tool metadata.");
+}
+
+fn json_bool(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 /// Check network connectivity.

--- a/src/extraction/traversal.rs
+++ b/src/extraction/traversal.rs
@@ -11,6 +11,18 @@ pub(crate) fn has_direct_child_kind(node: TsNode<'_>, kind: &str) -> bool {
     find_direct_child_by_kind(node, kind).is_some()
 }
 
+/// Visits each direct child in source order.
+///
+/// This keeps the raw tree-sitter cursor loop in one place so extractors that
+/// only need to recurse into direct children can share the traversal behavior.
+#[allow(dead_code)]
+pub(crate) fn visit_children<'tree>(node: TsNode<'tree>, mut visit: impl FnMut(TsNode<'tree>)) {
+    visit_children_while(node, |child| {
+        visit(child);
+        true
+    });
+}
+
 /// Returns the first direct child whose tree-sitter kind exactly matches
 /// `kind`.
 ///
@@ -22,20 +34,16 @@ pub(crate) fn find_direct_child_by_kind<'tree>(
     node: TsNode<'tree>,
     kind: &str,
 ) -> Option<TsNode<'tree>> {
-    let mut cursor = node.walk();
-    if cursor.goto_first_child() {
-        loop {
-            let child = cursor.node();
-            if child.kind() == kind {
-                return Some(child);
-            }
-            if !cursor.goto_next_sibling() {
-                break;
-            }
+    let mut found = None;
+    visit_children_while(node, |child| {
+        if child.kind() == kind {
+            found = Some(child);
+            return false;
         }
-    }
+        true
+    });
 
-    None
+    found
 }
 
 /// Returns the first descendant whose tree-sitter kind exactly matches `kind`.
@@ -48,29 +56,43 @@ pub(crate) fn find_descendant_by_kind<'tree>(
     node: TsNode<'tree>,
     kind: &str,
 ) -> Option<TsNode<'tree>> {
+    let mut found = None;
+    visit_children_while(node, |child| {
+        if child.kind() == kind {
+            found = Some(child);
+            return false;
+        }
+        if let Some(descendant) = find_descendant_by_kind(child, kind) {
+            found = Some(descendant);
+            return false;
+        }
+        true
+    });
+
+    found
+}
+
+fn visit_children_while<'tree>(node: TsNode<'tree>, mut visit: impl FnMut(TsNode<'tree>) -> bool) {
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
             let child = cursor.node();
-            if child.kind() == kind {
-                return Some(child);
-            }
-            if let Some(found) = find_descendant_by_kind(child, kind) {
-                return Some(found);
+            if !visit(child) {
+                break;
             }
             if !cursor.goto_next_sibling() {
                 break;
             }
         }
     }
-
-    None
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
-    use super::{find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind};
+    use super::{
+        find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind, visit_children,
+    };
     use crate::extraction::ts_provider;
     use tree_sitter::{Node as TsNode, Parser};
 
@@ -111,5 +133,24 @@ mod tests {
 
         assert!(has_direct_child_kind(function, "function_declarator"));
         assert!(!has_direct_child_kind(function, "identifier"));
+    }
+
+    #[test]
+    fn visits_direct_children_in_source_order() {
+        let function = parse_c_function("int answer(void) { return 42; }");
+        let mut child_kinds = Vec::new();
+
+        visit_children(function, |child| {
+            child_kinds.push(child.kind().to_owned());
+        });
+
+        assert_eq!(
+            child_kinds,
+            [
+                "primitive_type",
+                "function_declarator",
+                "compound_statement"
+            ]
+        );
     }
 }

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -723,6 +723,10 @@ async fn add_session_parent_column_after_missing_check(
 }
 
 impl GlobalDb {
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
     async fn open_local(db_path: &Path, read_only: bool) -> Option<Self> {
         let storage_root = db_path
             .parent()

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -6,6 +6,7 @@
 
 use serde_json::{json, Value};
 
+use super::dispatch_policy::REGISTERED_PROJECT_READER_TOOL_NAMES;
 use super::ToolDefinition;
 
 /// Read-only annotations shared by every tool.
@@ -63,6 +64,126 @@ fn def_always_load(
     }
 }
 
+fn object_schema(properties: Value) -> Value {
+    let mut schema = json!({ "type": "object" });
+    schema["properties"] = properties;
+    schema
+}
+
+fn required_object_schema(properties: Value, required: &[&str]) -> Value {
+    let mut schema = object_schema(properties);
+    schema["required"] = json!(required);
+    schema
+}
+
+fn def_object(name: &str, title: &str, description: &str, properties: Value) -> ToolDefinition {
+    def(name, title, description, object_schema(properties))
+}
+
+fn def_required_object(
+    name: &str,
+    title: &str,
+    description: &str,
+    properties: Value,
+    required: &[&str],
+) -> ToolDefinition {
+    def(
+        name,
+        title,
+        description,
+        required_object_schema(properties, required),
+    )
+}
+
+fn string_property(description: &str) -> Value {
+    json!({
+        "type": "string",
+        "description": description
+    })
+}
+
+fn number_property(description: &str) -> Value {
+    json!({
+        "type": "number",
+        "description": description
+    })
+}
+
+fn boolean_property(description: &str) -> Value {
+    json!({
+        "type": "boolean",
+        "description": description
+    })
+}
+
+fn def_path_limit_tool(
+    name: &str,
+    title: &str,
+    description: &str,
+    path_description: &str,
+    limit_description: &str,
+) -> ToolDefinition {
+    def_object(
+        name,
+        title,
+        description,
+        json!({
+            "path": string_property(path_description),
+            "limit": number_property(limit_description)
+        }),
+    )
+}
+
+fn def_limit_path_tool(
+    name: &str,
+    title: &str,
+    description: &str,
+    limit_description: &str,
+    path_description: &str,
+) -> ToolDefinition {
+    def_object(
+        name,
+        title,
+        description,
+        json!({
+            "limit": number_property(limit_description),
+            "path": string_property(path_description)
+        }),
+    )
+}
+
+fn def_path_flag_tool(
+    name: &str,
+    title: &str,
+    description: &str,
+    path_description: &str,
+    flag_name: &str,
+    flag_description: &str,
+) -> ToolDefinition {
+    let mut properties = serde_json::Map::new();
+    properties.insert("path".to_string(), string_property(path_description));
+    properties.insert(flag_name.to_string(), boolean_property(flag_description));
+    def_object(name, title, description, Value::Object(properties))
+}
+
+fn def_node_depth_tool(
+    name: &str,
+    title: &str,
+    description: &str,
+    node_id_description: &str,
+) -> ToolDefinition {
+    def_required_object(
+        name,
+        title,
+        description,
+        json!({
+            "node_id": string_property(node_id_description),
+            "max_depth": number_property("Maximum traversal depth (default: 3)")
+        }),
+        &["node_id"],
+    )
+}
+
 /// Computes the call budget based on project size.
 pub fn explore_call_budget(total_nodes: u64) -> u8 {
     match total_nodes {
@@ -101,8 +222,8 @@ pub fn get_tool_definitions_with_budget(node_count: u64, budget: u8) -> Vec<Tool
 ///
 /// Tools whose backing dependency is missing on the current host are
 /// filtered out so the model never sees a tool that will immediately
-/// fail when called. Currently this only affects `tracedecay_ast_grep_rewrite`,
-/// which shells out to the `ast-grep` binary.
+/// fail when called. The host `ast-grep` CLI gates rewrite support, and
+/// `ast-grep outline` support gates `tracedecay_outline`.
 pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     let mut definitions = vec![
         def_search(),
@@ -205,6 +326,9 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     if !ast_grep_available() {
         definitions.retain(|d| d.name != "tracedecay_ast_grep_rewrite");
     }
+    if !ast_grep_outline_available() {
+        definitions.retain(|d| d.name != "tracedecay_outline");
+    }
     debug_assert!(
         !definitions.is_empty(),
         "get_tool_definitions returned empty list"
@@ -218,37 +342,19 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     definitions
 }
 
-fn registered_project_selector_tool_names() -> &'static [&'static str] {
-    &[
-        "tracedecay_search",
-        "tracedecay_context",
-        "tracedecay_retrieve",
-        "tracedecay_callers",
-        "tracedecay_callees",
-        "tracedecay_impact",
-        "tracedecay_node",
-        "tracedecay_files",
-        "tracedecay_body",
-        "tracedecay_read",
-        "tracedecay_outline",
-        "tracedecay_signature_search",
-        "tracedecay_implementations",
-        "tracedecay_callers_for",
-        "tracedecay_call_chain",
-        "tracedecay_file_dependents",
-        "tracedecay_find_exact_symbol",
-        "tracedecay_by_qualified_name",
-        "tracedecay_signature",
-        "tracedecay_impls",
-        "tracedecay_derives",
-    ]
+fn matching_tool_definitions_mut<'a>(
+    definitions: &'a mut [ToolDefinition],
+    tool_names: &'a [&'static str],
+) -> impl Iterator<Item = &'a mut ToolDefinition> + 'a {
+    definitions
+        .iter_mut()
+        .filter(move |definition| tool_names.contains(&definition.name.as_str()))
 }
 
 fn add_registered_project_selector_properties(definitions: &mut [ToolDefinition]) {
-    for definition in definitions {
-        if !registered_project_selector_tool_names().contains(&definition.name.as_str()) {
-            continue;
-        }
+    for definition in
+        matching_tool_definitions_mut(definitions, REGISTERED_PROJECT_READER_TOOL_NAMES)
+    {
         let Some(properties) = definition.input_schema.get_mut("properties") else {
             continue;
         };
@@ -256,91 +362,90 @@ fn add_registered_project_selector_properties(definitions: &mut [ToolDefinition]
     }
 }
 
+const FORMAT_CAPABLE_TOOL_NAMES: &[&str] = &[
+    // graph
+    "tracedecay_search",
+    "tracedecay_context",
+    "tracedecay_callers",
+    "tracedecay_callees",
+    "tracedecay_impact",
+    "tracedecay_node",
+    "tracedecay_similar",
+    "tracedecay_rename_preview",
+    "tracedecay_implementations",
+    "tracedecay_callers_for",
+    "tracedecay_call_chain",
+    "tracedecay_file_dependents",
+    "tracedecay_find_exact_symbol",
+    "tracedecay_by_qualified_name",
+    "tracedecay_signature",
+    "tracedecay_impls",
+    "tracedecay_derives",
+    // info
+    "tracedecay_status",
+    "tracedecay_project_list",
+    "tracedecay_project_search",
+    "tracedecay_project_context",
+    "tracedecay_body",
+    "tracedecay_todos",
+    "tracedecay_read",
+    "tracedecay_outline",
+    "tracedecay_config",
+    "tracedecay_signature_search",
+    "tracedecay_port_status",
+    "tracedecay_port_order",
+    "tracedecay_simplify_scan",
+    // git
+    "tracedecay_affected",
+    "tracedecay_diff_context",
+    "tracedecay_changelog",
+    "tracedecay_commit_context",
+    "tracedecay_pr_context",
+    "tracedecay_branch_search",
+    "tracedecay_branch_diff",
+    // analysis
+    "tracedecay_dead_code",
+    "tracedecay_module_api",
+    "tracedecay_circular",
+    "tracedecay_hotspots",
+    "tracedecay_unused_imports",
+    "tracedecay_rank",
+    "tracedecay_largest",
+    "tracedecay_coupling",
+    "tracedecay_inheritance_depth",
+    "tracedecay_distribution",
+    "tracedecay_recursion",
+    "tracedecay_complexity",
+    "tracedecay_doc_coverage",
+    "tracedecay_god_class",
+    "tracedecay_unsafe_patterns",
+    "tracedecay_diagnostics",
+    "tracedecay_constructors",
+    "tracedecay_field_sites",
+    // health
+    "tracedecay_test_map",
+    "tracedecay_gini",
+    "tracedecay_dependency_depth",
+    "tracedecay_health",
+    "tracedecay_runtime",
+    "tracedecay_test_risk",
+    "tracedecay_session_start",
+    "tracedecay_session_end",
+    // redundancy
+    "tracedecay_redundancy",
+    // memory
+    "tracedecay_memory_status",
+    // workflow
+    "tracedecay_diagnose",
+    "tracedecay_run_affected_tests",
+];
+
 pub fn format_capable_tool_names() -> &'static [&'static str] {
-    &[
-        // graph
-        "tracedecay_search",
-        "tracedecay_context",
-        "tracedecay_callers",
-        "tracedecay_callees",
-        "tracedecay_impact",
-        "tracedecay_node",
-        "tracedecay_similar",
-        "tracedecay_rename_preview",
-        "tracedecay_implementations",
-        "tracedecay_callers_for",
-        "tracedecay_call_chain",
-        "tracedecay_file_dependents",
-        "tracedecay_find_exact_symbol",
-        "tracedecay_by_qualified_name",
-        "tracedecay_signature",
-        "tracedecay_impls",
-        "tracedecay_derives",
-        // info
-        "tracedecay_status",
-        "tracedecay_project_list",
-        "tracedecay_project_search",
-        "tracedecay_project_context",
-        "tracedecay_body",
-        "tracedecay_todos",
-        "tracedecay_read",
-        "tracedecay_outline",
-        "tracedecay_config",
-        "tracedecay_signature_search",
-        "tracedecay_port_status",
-        "tracedecay_port_order",
-        "tracedecay_simplify_scan",
-        // git
-        "tracedecay_affected",
-        "tracedecay_diff_context",
-        "tracedecay_changelog",
-        "tracedecay_commit_context",
-        "tracedecay_pr_context",
-        "tracedecay_branch_search",
-        "tracedecay_branch_diff",
-        // analysis
-        "tracedecay_dead_code",
-        "tracedecay_module_api",
-        "tracedecay_circular",
-        "tracedecay_hotspots",
-        "tracedecay_unused_imports",
-        "tracedecay_rank",
-        "tracedecay_largest",
-        "tracedecay_coupling",
-        "tracedecay_inheritance_depth",
-        "tracedecay_distribution",
-        "tracedecay_recursion",
-        "tracedecay_complexity",
-        "tracedecay_doc_coverage",
-        "tracedecay_god_class",
-        "tracedecay_unsafe_patterns",
-        "tracedecay_diagnostics",
-        "tracedecay_constructors",
-        "tracedecay_field_sites",
-        // health
-        "tracedecay_test_map",
-        "tracedecay_gini",
-        "tracedecay_dependency_depth",
-        "tracedecay_health",
-        "tracedecay_runtime",
-        "tracedecay_test_risk",
-        "tracedecay_session_start",
-        "tracedecay_session_end",
-        // redundancy
-        "tracedecay_redundancy",
-        // memory
-        "tracedecay_memory_status",
-        // workflow
-        "tracedecay_diagnose",
-        "tracedecay_run_affected_tests",
-    ]
+    FORMAT_CAPABLE_TOOL_NAMES
 }
 
 fn add_format_property(definitions: &mut [ToolDefinition]) {
-    for definition in definitions {
-        if !format_capable_tool_names().contains(&definition.name.as_str()) {
-            continue;
-        }
+    for definition in matching_tool_definitions_mut(definitions, FORMAT_CAPABLE_TOOL_NAMES) {
         let properties = definition
             .input_schema
             .get_mut("properties")
@@ -357,18 +462,166 @@ fn add_format_property(definitions: &mut [ToolDefinition]) {
     }
 }
 
-/// Returns true when the external `ast-grep` binary is on PATH. Result is
-/// cached after the first check so we don't fork a subprocess on every
-/// `tools/list` request.
-pub fn ast_grep_available() -> bool {
+const MIN_AST_GREP_OUTLINE_VERSION: (u64, u64, u64) = (0, 44, 0);
+
+#[derive(Debug, Clone)]
+pub struct AstGrepDiagnostics {
+    pub installed: bool,
+    pub version: Option<String>,
+    pub rewrite_available: bool,
+    pub outline_available: bool,
+    pub outline_version_ok: bool,
+    pub outline_flags_ok: bool,
+    pub message: String,
+}
+
+fn ast_grep_output_text(output: &std::process::Output) -> String {
+    let mut text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        if !text.is_empty() {
+            text.push('\n');
+        }
+        text.push_str(stderr);
+    }
+    text
+}
+
+fn parse_version_component(component: &str) -> Option<u64> {
+    let digits = component
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>();
+    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+}
+
+fn parse_ast_grep_version(text: &str) -> Option<(String, (u64, u64, u64))> {
+    for token in text.split_whitespace() {
+        let token = token
+            .trim_start_matches('v')
+            .trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '.');
+        let mut parts = token.split('.');
+        let Some(major) = parts.next().and_then(parse_version_component) else {
+            continue;
+        };
+        let Some(minor) = parts.next().and_then(parse_version_component) else {
+            continue;
+        };
+        let patch = parts.next().and_then(parse_version_component).unwrap_or(0);
+        return Some((format!("{major}.{minor}.{patch}"), (major, minor, patch)));
+    }
+    None
+}
+
+fn ast_grep_diagnostics_uncached() -> AstGrepDiagnostics {
+    let version_output = match std::process::Command::new("ast-grep")
+        .arg("--version")
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) => {
+            return AstGrepDiagnostics {
+                installed: false,
+                version: None,
+                rewrite_available: false,
+                outline_available: false,
+                outline_version_ok: false,
+                outline_flags_ok: false,
+                message: format!(
+                    "ast-grep is not installed or is not on PATH: {err}. Install ast-grep >= 0.44 for tracedecay_outline and rewrite support."
+                ),
+            };
+        }
+    };
+
+    let version_text = ast_grep_output_text(&version_output);
+    if !version_output.status.success() {
+        return AstGrepDiagnostics {
+            installed: true,
+            version: parse_ast_grep_version(&version_text).map(|(version, _)| version),
+            rewrite_available: false,
+            outline_available: false,
+            outline_version_ok: false,
+            outline_flags_ok: false,
+            message: format!(
+                "ast-grep --version failed. Install or repair ast-grep >= 0.44. Output: {version_text}"
+            ),
+        };
+    }
+
+    let (version, version_tuple) =
+        parse_ast_grep_version(&version_text).unwrap_or_else(|| (version_text.clone(), (0, 0, 0)));
+    let outline_version_ok = version_tuple >= MIN_AST_GREP_OUTLINE_VERSION;
+    let help_output = std::process::Command::new("ast-grep")
+        .args(["outline", "--help"])
+        .output();
+    let (outline_flags_ok, help_detail) = match help_output {
+        Ok(output) => {
+            let help_text = ast_grep_output_text(&output);
+            (
+                output.status.success()
+                    && help_text.contains("--json")
+                    && help_text.contains("--items")
+                    && help_text.contains("--view"),
+                help_text,
+            )
+        }
+        Err(err) => (false, err.to_string()),
+    };
+    let outline_available = outline_version_ok && outline_flags_ok;
+    let message = if outline_available {
+        format!("ast-grep {version} is available with outline JSON support")
+    } else if !outline_version_ok {
+        format!("ast-grep {version} is installed, but tracedecay_outline requires ast-grep >= 0.44")
+    } else {
+        format!(
+            "ast-grep {version} is installed, but `ast-grep outline --help` does not advertise the required --json, --items, and --view flags. Output: {help_detail}"
+        )
+    };
+
+    AstGrepDiagnostics {
+        installed: true,
+        version: Some(version),
+        rewrite_available: true,
+        outline_available,
+        outline_version_ok,
+        outline_flags_ok,
+        message,
+    }
+}
+
+pub fn ast_grep_diagnostics() -> &'static AstGrepDiagnostics {
     use std::sync::OnceLock;
-    static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    *AVAILABLE.get_or_init(|| {
-        std::process::Command::new("ast-grep")
-            .arg("--version")
-            .output()
-            .is_ok_and(|out| out.status.success())
+    static DIAGNOSTICS: OnceLock<AstGrepDiagnostics> = OnceLock::new();
+    DIAGNOSTICS.get_or_init(ast_grep_diagnostics_uncached)
+}
+
+pub fn ast_grep_diagnostics_json() -> Value {
+    let diagnostics = ast_grep_diagnostics();
+    json!({
+        "installed": diagnostics.installed,
+        "version": diagnostics.version.clone(),
+        "rewrite_available": diagnostics.rewrite_available,
+        "outline_available": diagnostics.outline_available,
+        "outline_min_version": "0.44.0",
+        "outline_version_ok": diagnostics.outline_version_ok,
+        "outline_flags_ok": diagnostics.outline_flags_ok,
+        "message": diagnostics.message.clone(),
     })
+}
+
+/// Returns true when the external `ast-grep` binary is on PATH and responds to
+/// `--version`. Result is cached after the first check so we don't fork a
+/// subprocess on every `tools/list` request.
+pub fn ast_grep_available() -> bool {
+    ast_grep_diagnostics().rewrite_available
+}
+
+/// Returns true when the external `ast-grep` CLI supports `outline` JSON output
+/// with the flags introduced in ast-grep 0.44.
+pub fn ast_grep_outline_available() -> bool {
+    ast_grep_diagnostics().outline_available
 }
 
 // ── alwaysLoad tools (loaded into the model prompt immediately) ─────────
@@ -643,27 +896,21 @@ fn def_callers_for() -> ToolDefinition {
 }
 
 fn def_by_qualified_name() -> ToolDefinition {
-    def(
+    def_required_object(
         "tracedecay_by_qualified_name",
         "Lookup by qualified name",
         "Look up nodes by their qualified name. Multiple rows can share a \
          qualified name (overloads, generics, separate impl blocks). Useful \
          for cross-run lookups where the content-hash node ID has changed.",
         json!({
-            "type": "object",
-            "properties": {
-                "qualified_name": {
-                    "type": "string",
-                    "description": "The exact qualified name to look up."
-                }
-            },
-            "required": ["qualified_name"]
+            "qualified_name": string_property("The exact qualified name to look up.")
         }),
+        &["qualified_name"],
     )
 }
 
 fn def_impls() -> ToolDefinition {
-    def(
+    def_object(
         "tracedecay_impls",
         "Trait Implementations",
         "List `impl` blocks matching a trait, a type, or both. With no filter \
@@ -673,27 +920,15 @@ fn def_impls() -> ToolDefinition {
          targets, which types satisfy a given trait, and which traits a type \
          implements.",
         json!({
-            "type": "object",
-            "properties": {
-                "trait": {
-                    "type": "string",
-                    "description": "Trait name to filter by (short or qualified). Omit to include all traits."
-                },
-                "type": {
-                    "type": "string",
-                    "description": "Implementing type to filter by (short or qualified). Omit to include all types."
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of results to return (default: 100)."
-                }
-            }
+            "trait": string_property("Trait name to filter by (short or qualified). Omit to include all traits."),
+            "type": string_property("Implementing type to filter by (short or qualified). Omit to include all types."),
+            "limit": number_property("Maximum number of results to return (default: 100).")
         }),
     )
 }
 
 fn def_signature() -> ToolDefinition {
-    def(
+    def_object(
         "tracedecay_signature",
         "Signature",
         "Return the signature-level metadata for symbols matching a qualified \
@@ -703,17 +938,8 @@ fn def_signature() -> ToolDefinition {
          surface of a function, method, or type. Multiple rows can be \
          returned (overloads, separate impls).",
         json!({
-            "type": "object",
-            "properties": {
-                "qualified_name": {
-                    "type": "string",
-                    "description": "The exact qualified name to look up."
-                },
-                "node_id": {
-                    "type": "string",
-                    "description": "Optional: look up a single node by its ID instead of qualified_name."
-                }
-            }
+            "qualified_name": string_property("The exact qualified name to look up."),
+            "node_id": string_property("Optional: look up a single node by its ID instead of qualified_name.")
         }),
     )
 }
@@ -721,29 +947,16 @@ fn def_signature() -> ToolDefinition {
 // ── Deferred tools (discovered via ToolSearch on demand) ────────────────
 
 fn def_callers() -> ToolDefinition {
-    def(
+    def_node_depth_tool(
         "tracedecay_callers",
         "Callers",
         "Find all callers of a given node (function, method, etc.) up to a specified depth.",
-        json!({
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "The unique node ID to find callers for"
-                },
-                "max_depth": {
-                    "type": "number",
-                    "description": "Maximum traversal depth (default: 3)"
-                }
-            },
-            "required": ["node_id"]
-        }),
+        "The unique node ID to find callers for",
     )
 }
 
 fn def_callees() -> ToolDefinition {
-    def(
+    def_required_object(
         "tracedecay_callees",
         "Callees",
         "Find all callees of a given node (function, method, etc.) up to a \
@@ -753,63 +966,32 @@ fn def_callees() -> ToolDefinition {
          pointing at the trait method. Pass `resolve_dispatch: false` to \
          disable this behaviour and get only direct call edges.",
         json!({
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "The unique node ID to find callees for"
-                },
-                "max_depth": {
-                    "type": "number",
-                    "description": "Maximum traversal depth (default: 3)"
-                },
-                "resolve_dispatch": {
-                    "type": "boolean",
-                    "description": "If true (default), append concrete impl methods for any trait-method callee."
-                }
-            },
-            "required": ["node_id"]
+            "node_id": string_property("The unique node ID to find callees for"),
+            "max_depth": number_property("Maximum traversal depth (default: 3)"),
+            "resolve_dispatch": boolean_property("If true (default), append concrete impl methods for any trait-method callee.")
         }),
+        &["node_id"],
     )
 }
 
 fn def_impact() -> ToolDefinition {
-    def(
+    def_node_depth_tool(
         "tracedecay_impact",
         "Impact Radius",
         "Compute the impact radius of a node: all symbols that directly or indirectly depend on it.",
-        json!({
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "The unique node ID to compute impact for"
-                },
-                "max_depth": {
-                    "type": "number",
-                    "description": "Maximum traversal depth (default: 3)"
-                }
-            },
-            "required": ["node_id"]
-        }),
+        "The unique node ID to compute impact for",
     )
 }
 
 fn def_node() -> ToolDefinition {
-    def(
+    def_required_object(
         "tracedecay_node",
         "Node Details",
         "Retrieve detailed information about a single node by its ID.",
         json!({
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "The unique node ID to retrieve"
-                }
-            },
-            "required": ["node_id"]
+            "node_id": string_property("The unique node ID to retrieve")
         }),
+        &["node_id"],
     )
 }
 
@@ -1056,26 +1238,14 @@ fn def_rank() -> ToolDefinition {
 }
 
 fn def_largest() -> ToolDefinition {
-    def(
+    def_object(
         "tracedecay_largest",
         "Largest Symbols",
         "Rank nodes by size (line count). Find the largest classes, longest methods, biggest enums, etc.",
         json!({
-            "type": "object",
-            "properties": {
-                "node_kind": {
-                    "type": "string",
-                    "description": "Filter by node kind (e.g. 'class', 'method', 'function', 'interface', 'enum', 'struct')"
-                },
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of results to return (default: 10)"
-                }
-            }
+            "node_kind": string_property("Filter by node kind (e.g. 'class', 'method', 'function', 'interface', 'enum', 'struct')"),
+            "path": string_property("Filter to files under this directory path (e.g. 'src/main/java')"),
+            "limit": number_property("Maximum number of results to return (default: 10)")
         }),
     )
 }
@@ -1107,132 +1277,66 @@ fn def_coupling() -> ToolDefinition {
 }
 
 fn def_inheritance_depth() -> ToolDefinition {
-    def(
+    def_path_limit_tool(
         "tracedecay_inheritance_depth",
         "Inheritance Depth",
         "Find the deepest class/interface inheritance hierarchies by walking extends chains.",
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of results to return (default: 10)"
-                }
-            }
-        }),
+        "Filter to files under this directory path (e.g. 'src/main/java')",
+        "Maximum number of results to return (default: 10)",
     )
 }
 
 fn def_distribution() -> ToolDefinition {
-    def(
+    def_path_flag_tool(
         "tracedecay_distribution",
         "Distribution",
         "Show node kind distribution (classes, methods, fields, etc.) per file or directory.",
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Directory or file path prefix to filter (e.g. 'src/main/java/com/example'). Omit for entire codebase."
-                },
-                "summary": {
-                    "type": "boolean",
-                    "description": "If true, aggregate counts across all matching files instead of per-file breakdown (default: false)"
-                }
-            }
-        }),
+        "Directory or file path prefix to filter (e.g. 'src/main/java/com/example'). Omit for entire codebase.",
+        "summary",
+        "If true, aggregate counts across all matching files instead of per-file breakdown (default: false)",
     )
 }
 
 fn def_recursion() -> ToolDefinition {
-    def(
+    def_path_limit_tool(
         "tracedecay_recursion",
         "Recursion",
         "Detect recursive and mutually-recursive call cycles in the call graph.",
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of cycles to return (default: 10)"
-                }
-            }
-        }),
+        "Filter to files under this directory path (e.g. 'src/main/java')",
+        "Maximum number of cycles to return (default: 10)",
     )
 }
 
 fn def_complexity() -> ToolDefinition {
-    def(
+    def_object(
         "tracedecay_complexity",
         "Complexity",
         "Rank functions/methods by composite complexity score (lines + fan-out + fan-in).",
         json!({
-            "type": "object",
-            "properties": {
-                "node_kind": {
-                    "type": "string",
-                    "description": "Filter by node kind (default: function and method)"
-                },
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of results to return (default: 10)"
-                }
-            }
+            "node_kind": string_property("Filter by node kind (default: function and method)"),
+            "path": string_property("Filter to files under this directory path (e.g. 'src/main/java')"),
+            "limit": number_property("Maximum number of results to return (default: 10)")
         }),
     )
 }
 
 fn def_doc_coverage() -> ToolDefinition {
-    def(
+    def_path_limit_tool(
         "tracedecay_doc_coverage",
         "Doc Coverage",
         "Find public symbols missing documentation (docstrings).",
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Directory or file path prefix to filter (e.g. 'src/main'). Omit for entire codebase."
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of results to return (default: 50)"
-                }
-            }
-        }),
+        "Directory or file path prefix to filter (e.g. 'src/main'). Omit for entire codebase.",
+        "Maximum number of results to return (default: 50)",
     )
 }
 
 fn def_god_class() -> ToolDefinition {
-    def(
+    def_path_limit_tool(
         "tracedecay_god_class",
         "God Classes",
         "Find classes with the most members (methods + fields).",
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path (e.g. 'src/main/java')"
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of results to return (default: 10)"
-                }
-            }
-        }),
+        "Filter to files under this directory path (e.g. 'src/main/java')",
+        "Maximum number of results to return (default: 10)",
     )
 }
 
@@ -1576,75 +1680,45 @@ fn def_insert_at() -> ToolDefinition {
 }
 
 fn def_gini() -> ToolDefinition {
-    def(
+    def_object(
         "tracedecay_gini",
         "Gini Inequality",
         "Compute inequality (Gini coefficient) for any metric across files or symbols. Detects god files and uneven complexity distribution.",
         json!({
-            "type": "object",
-            "properties": {
-                "metric": {
-                    "type": "string",
-                    "enum": ["complexity", "lines", "fan_in", "fan_out", "members"],
-                    "description": "Metric to measure inequality for (default: complexity)"
-                },
-                "scope": {
-                    "type": "string",
-                    "enum": ["file", "symbol"],
-                    "description": "Aggregate per file or per symbol (default: file)"
-                },
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path"
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Number of top outliers to return (default: 10)"
-                }
-            }
+            "metric": {
+                "type": "string",
+                "enum": ["complexity", "lines", "fan_in", "fan_out", "members"],
+                "description": "Metric to measure inequality for (default: complexity)"
+            },
+            "scope": {
+                "type": "string",
+                "enum": ["file", "symbol"],
+                "description": "Aggregate per file or per symbol (default: file)"
+            },
+            "path": string_property("Filter to files under this directory path"),
+            "limit": number_property("Number of top outliers to return (default: 10)")
         }),
     )
 }
 
 fn def_dependency_depth() -> ToolDefinition {
-    def(
+    def_limit_path_tool(
         "tracedecay_dependency_depth",
         "Dependency Depth",
         "Show the longest file-level dependency chains. Files at the end of long chains are fragile to upstream changes.",
-        json!({
-            "type": "object",
-            "properties": {
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of chains to return (default: 10)"
-                },
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path"
-                }
-            }
-        }),
+        "Maximum number of chains to return (default: 10)",
+        "Filter to files under this directory path",
     )
 }
 
 fn def_health() -> ToolDefinition {
-    def(
+    def_path_flag_tool(
         "tracedecay_health",
         "Health Score",
         "Get quality signal (0-10000) with root cause breakdown (acyclicity, depth, equality, redundancy, modularity). Quality signal = geometric mean of 5 dimensions — maximize this ONE number.",
-        json!({
-            "type": "object",
-            "properties": {
-                "path": {
-                    "type": "string",
-                    "description": "Filter to files under this directory path"
-                },
-                "details": {
-                    "type": "boolean",
-                    "description": "If true, include full dimension breakdown (default: false)"
-                }
-            }
-        }),
+        "Filter to files under this directory path",
+        "details",
+        "If true, include full dimension breakdown (default: false)",
     )
 }
 
@@ -2833,7 +2907,7 @@ fn def_lcm_session_boundary() -> ToolDefinition {
 fn def_ast_grep_rewrite() -> ToolDefinition {
     ToolDefinition {
         name: "tracedecay_ast_grep_rewrite".to_string(),
-        description: "Perform structural code rewrite using ast-grep. The pattern and rewrite use ast-grep's SGPattern syntax. Fails if ast-grep is not installed.".to_string(),
+        description: "Perform structural code rewrite using the host ast-grep CLI. The pattern and rewrite use ast-grep's SGPattern syntax. This tool is advertised only when that CLI is available.".to_string(),
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -3186,8 +3260,10 @@ fn def_outline() -> ToolDefinition {
         "File Outline",
         "Flat list of every top-level symbol defined in a file (functions, structs, \
          enums, traits, classes, impls, etc.) — like a table of contents. Sorted by \
-         line number; no code bodies. Optional 'kinds' filter narrows to specific \
-         node kinds. Use this as the cheapest way to orient before zooming into a \
+         line number; no code bodies. Includes ast-grep outline JSON when the host \
+         ast-grep CLI supports outline flags from ast-grep 0.44 or newer. Optional \
+         'kinds' filter narrows to specific node kinds. Use this as the cheapest way \
+         to orient before zooming into a \
          large file with tracedecay_node, tracedecay_body, or tracedecay_read.",
         json!({
             "type": "object",

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -222,8 +222,10 @@ pub fn get_tool_definitions_with_budget(node_count: u64, budget: u8) -> Vec<Tool
 ///
 /// Tools whose backing dependency is missing on the current host are
 /// filtered out so the model never sees a tool that will immediately
-/// fail when called. The host `ast-grep` CLI gates rewrite support, and
-/// `ast-grep outline` support gates `tracedecay_outline`.
+/// fail when called. The host `ast-grep` CLI gates rewrite support.
+/// `tracedecay_outline` remains advertised and reports its runtime
+/// `ast-grep outline` requirement from the handler, because the Cursor
+/// plugin docs/rules intentionally teach agents to start there.
 pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     let mut definitions = vec![
         def_search(),
@@ -325,9 +327,6 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     add_format_property(&mut definitions);
     if !ast_grep_available() {
         definitions.retain(|d| d.name != "tracedecay_ast_grep_rewrite");
-    }
-    if !ast_grep_outline_available() {
-        definitions.retain(|d| d.name != "tracedecay_outline");
     }
     debug_assert!(
         !definitions.is_empty(),

--- a/src/mcp/tools/dispatch_policy.rs
+++ b/src/mcp/tools/dispatch_policy.rs
@@ -1,0 +1,41 @@
+//! MCP tool dispatch policy shared by schema generation and handlers.
+
+pub(super) const REGISTERED_PROJECT_READER_TOOL_NAMES: &[&str] = &[
+    "tracedecay_search",
+    "tracedecay_context",
+    "tracedecay_retrieve",
+    "tracedecay_callers",
+    "tracedecay_callees",
+    "tracedecay_impact",
+    "tracedecay_node",
+    "tracedecay_files",
+    "tracedecay_body",
+    "tracedecay_read",
+    "tracedecay_outline",
+    "tracedecay_signature_search",
+    "tracedecay_implementations",
+    "tracedecay_callers_for",
+    "tracedecay_call_chain",
+    "tracedecay_file_dependents",
+    "tracedecay_find_exact_symbol",
+    "tracedecay_by_qualified_name",
+    "tracedecay_signature",
+    "tracedecay_impls",
+    "tracedecay_derives",
+];
+
+const REGISTERED_PROJECT_SELECTOR_ONLY_TOOL_NAMES: &[&str] = &[
+    "tracedecay_project_context",
+    "tracedecay_fact_store",
+    "tracedecay_memory_status",
+    "tracedecay_message_search",
+];
+
+pub(super) fn tool_accepts_registered_project_selector(tool_name: &str) -> bool {
+    tool_dispatches_registered_project_reader(tool_name)
+        || REGISTERED_PROJECT_SELECTOR_ONLY_TOOL_NAMES.contains(&tool_name)
+}
+
+pub(super) fn tool_dispatches_registered_project_reader(tool_name: &str) -> bool {
+    REGISTERED_PROJECT_READER_TOOL_NAMES.contains(&tool_name)
+}

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -12,7 +12,7 @@ use crate::types::{NodeKind, Visibility};
 
 use super::super::render;
 use super::super::ToolResult;
-use super::{effective_path, filter_by_scope, unique_file_paths};
+use super::support::{effective_path, filter_by_scope, unique_file_paths};
 
 /// True if `line` contains `identifier` as a whole token (boundaries are
 /// any non-`[A-Za-z0-9_]` char or string ends). Avoids false positives
@@ -148,6 +148,21 @@ fn identifier_from_segment(seg: &str) -> String {
         .unwrap_or(seg)
         .trim()
         .to_string()
+}
+
+fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    if path == prefix {
+        true
+    } else if prefix.ends_with('/') {
+        path.starts_with(prefix)
+    } else {
+        path.strip_prefix(prefix)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    }
+}
+
+fn path_matches_optional_scope(path: &str, scope_prefix: Option<&str>) -> bool {
+    scope_prefix.is_none_or(|prefix| path_matches_prefix(path, prefix))
 }
 
 /// Handles `tracedecay_dead_code` tool calls.
@@ -341,17 +356,12 @@ pub(super) async fn handle_hotspots(
     }
 
     if let Some(prefix) = scope_prefix {
-        let with_slash = if prefix.ends_with('/') {
-            prefix.to_string()
-        } else {
-            format!("{prefix}/")
-        };
         items.retain(|item| {
             item["file"]
                 .as_str()
-                .is_some_and(|f| f.starts_with(&with_slash) || f == prefix)
+                .is_some_and(|f| path_matches_prefix(f, prefix))
         });
-        touched.retain(|f| f.starts_with(&with_slash) || f == prefix);
+        touched.retain(|f| path_matches_prefix(f, prefix));
     }
 
     let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
@@ -385,16 +395,7 @@ pub(super) async fn handle_unused_imports(
     let use_nodes: Vec<&crate::types::Node> = all_nodes
         .iter()
         .filter(|n| n.kind == NodeKind::Use)
-        .filter(|n| {
-            scope_prefix.is_none_or(|prefix| {
-                let with_slash = if prefix.ends_with('/') {
-                    prefix.to_string()
-                } else {
-                    format!("{prefix}/")
-                };
-                n.file_path.starts_with(&with_slash) || n.file_path == prefix
-            })
-        })
+        .filter(|n| path_matches_optional_scope(&n.file_path, scope_prefix))
         .collect();
 
     let mut unused: Vec<Value> = Vec::new();
@@ -1431,15 +1432,8 @@ pub(super) async fn handle_unsafe_patterns(
     let mut touched: Vec<String> = Vec::new();
 
     'outer: for file in &files {
-        if let Some(prefix) = path {
-            let with_slash = if prefix.ends_with('/') {
-                prefix.to_string()
-            } else {
-                format!("{prefix}/")
-            };
-            if !file.path.starts_with(&with_slash) && file.path != prefix {
-                continue;
-            }
+        if !path_matches_optional_scope(&file.path, path) {
+            continue;
         }
         let in_test = path_looks_like_test(&file.path);
         if exclude_tests && in_test {
@@ -1501,8 +1495,8 @@ pub(super) async fn handle_unsafe_patterns(
 // tracedecay_diagnostics
 // ---------------------------------------------------------------------------
 
-pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    use crate::diagnostics::{run_all, Scope};
+fn diagnostics_scope_arg(args: &Value) -> Result<(&str, crate::diagnostics::Scope)> {
+    use crate::diagnostics::Scope;
 
     let scope_str = args
         .get("scope")
@@ -1511,26 +1505,12 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
 
     let scope = match scope_str {
         "workspace" => Scope::Workspace,
-        "package" => {
-            let name = args
-                .get("name")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| TraceDecayError::Config {
-                    message: "scope='package' requires a 'name' argument".to_string(),
-                })?
-                .to_string();
-            Scope::Package { name }
-        }
-        "file" => {
-            let path = args
-                .get("path")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| TraceDecayError::Config {
-                    message: "scope='file' requires a 'path' argument".to_string(),
-                })?
-                .to_string();
-            Scope::File { path }
-        }
+        "package" => Scope::Package {
+            name: required_diagnostics_scope_value(args, "package", "name")?,
+        },
+        "file" => Scope::File {
+            path: required_diagnostics_scope_value(args, "file", "path")?,
+        },
         other => {
             return Err(TraceDecayError::Config {
                 message: format!("unknown scope '{other}'; expected workspace, package, or file"),
@@ -1538,15 +1518,51 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
         }
     };
 
+    Ok((scope_str, scope))
+}
+
+fn required_diagnostics_scope_value(args: &Value, scope: &str, name: &str) -> Result<String> {
+    args.get(name)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("scope='{scope}' requires a '{name}' argument"),
+        })
+        .map(str::to_string)
+}
+
+async fn enclosing_diagnostic_node(
+    cg: &TraceDecay,
+    nodes_by_file: &mut HashMap<String, Vec<crate::types::Node>>,
+    file: &str,
+    line_start: u32,
+) -> Result<Option<String>> {
+    if !nodes_by_file.contains_key(file) {
+        let fetched = cg.get_nodes_by_file(file).await?;
+        nodes_by_file.insert(file.to_string(), fetched);
+    }
+
+    let node_line = line_start.saturating_sub(1);
+    Ok(nodes_by_file.get(file).and_then(|nodes| {
+        nodes
+            .iter()
+            .filter(|n| n.start_line <= node_line && node_line <= n.end_line)
+            .min_by_key(|n| n.end_line.saturating_sub(n.start_line))
+            .map(|n| n.qualified_name.clone())
+    }))
+}
+
+pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+    use crate::diagnostics::run_all;
+
+    let (scope_str, scope) = diagnostics_scope_arg(&args)?;
     let project_root = cg.project_root().to_path_buf();
     let mut diagnostics = run_all(&project_root, &scope).await?;
 
-    if let Scope::File { path } = &scope {
+    if let crate::diagnostics::Scope::File { path } = &scope {
         diagnostics.retain(|d| d.file == *path);
     }
 
     let mut entries: Vec<Value> = Vec::with_capacity(diagnostics.len());
-    let mut touched: Vec<String> = Vec::new();
     let mut error_count = 0u64;
     let mut warning_count = 0u64;
     let mut nodes_by_file: HashMap<String, Vec<crate::types::Node>> = HashMap::new();
@@ -1557,21 +1573,10 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
             "warning" => warning_count += 1,
             _ => {}
         }
-        let nodes = if let Some(n) = nodes_by_file.get(&diag.file) {
-            n
-        } else {
-            let fetched = cg.get_nodes_by_file(&diag.file).await?;
-            nodes_by_file.entry(diag.file.clone()).or_insert(fetched)
-        };
-        let node_line = diag.line_start.saturating_sub(1);
-        let enclosing = nodes
-            .iter()
-            .filter(|n| n.start_line <= node_line && node_line <= n.end_line)
-            .min_by_key(|n| n.end_line.saturating_sub(n.start_line))
-            .map(|n| n.qualified_name.clone());
-        if !touched.contains(&diag.file) {
-            touched.push(diag.file.clone());
-        }
+
+        let enclosing =
+            enclosing_diagnostic_node(cg, &mut nodes_by_file, &diag.file, diag.line_start).await?;
+
         entries.push(json!({
             "file": diag.file,
             "line_start": diag.line_start,
@@ -1598,7 +1603,7 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
         value: json!({
             "content": [{ "type": "text", "text": text }]
         }),
-        touched_files: touched,
+        touched_files: unique_file_paths(diagnostics.iter().map(|d| d.file.as_str())),
     })
 }
 
@@ -1664,15 +1669,8 @@ pub(super) async fn handle_constructors(
     let mut touched: Vec<String> = Vec::new();
 
     'outer: for file in &files {
-        if let Some(prefix) = scope_prefix {
-            let with_slash = if prefix.ends_with('/') {
-                prefix.to_string()
-            } else {
-                format!("{prefix}/")
-            };
-            if !file.path.starts_with(&with_slash) && file.path != prefix {
-                continue;
-            }
+        if !path_matches_optional_scope(&file.path, scope_prefix) {
+            continue;
         }
         let abs = project_root.join(&file.path);
         let Ok(source) = crate::sync::read_source_file(&abs) else {
@@ -2025,15 +2023,8 @@ pub(super) async fn handle_field_sites(
     let mut touched: Vec<String> = Vec::new();
 
     'outer: for file in &files {
-        if let Some(prefix) = scope_prefix {
-            let with_slash = if prefix.ends_with('/') {
-                prefix.to_string()
-            } else {
-                format!("{prefix}/")
-            };
-            if !file.path.starts_with(&with_slash) && file.path != prefix {
-                continue;
-            }
+        if !path_matches_optional_scope(&file.path, scope_prefix) {
+            continue;
         }
         let abs = project_root.join(&file.path);
         let Ok(source) = crate::sync::read_source_file(&abs) else {

--- a/src/mcp/tools/handlers/dashboard.rs
+++ b/src/mcp/tools/handlers/dashboard.rs
@@ -10,8 +10,8 @@ use serde_json::{json, Value};
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
 
+use super::super::render::truncated_json_envelope_with_handle;
 use super::super::ToolResult;
-use super::truncated_json_envelope_with_handle;
 
 use crate::dashboard::{bind_dashboard, build_state, router, DEFAULT_PORT};
 
@@ -43,6 +43,16 @@ fn validate_mcp_dashboard_host(host: &str) -> Result<&str> {
     })
 }
 
+fn dashboard_tool_result(cg: &TraceDecay, payload: &Value) -> ToolResult {
+    let formatted = serde_json::to_string(payload).unwrap_or_default();
+    ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
+        }),
+        touched_files: vec![],
+    }
+}
+
 /// Handles `tracedecay_dashboard` tool calls.
 pub(super) async fn handle_dashboard(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let action = args
@@ -60,13 +70,7 @@ pub(super) async fn handle_dashboard(cg: &TraceDecay, args: Value) -> Result<Too
             } else {
                 json!({ "status": "not_running" })
             };
-            let formatted = serde_json::to_string(&payload).unwrap_or_default();
-            Ok(ToolResult {
-                value: json!({
-                    "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
-                }),
-                touched_files: vec![],
-            })
+            Ok(dashboard_tool_result(cg, &payload))
         }
         "start" | "" => {
             let host = args
@@ -87,17 +91,13 @@ pub(super) async fn handle_dashboard(cg: &TraceDecay, args: Value) -> Result<Too
 
             if let Some(handle) = guard.as_ref() {
                 // already running — idempotent return
-                let formatted = serde_json::to_string(&json!({
-                    "status": "already_running",
-                    "url": handle.url
-                }))
-                .unwrap_or_default();
-                return Ok(ToolResult {
-                    value: json!({
-                        "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
+                return Ok(dashboard_tool_result(
+                    cg,
+                    &json!({
+                        "status": "already_running",
+                        "url": handle.url
                     }),
-                    touched_files: vec![],
-                });
+                ));
             }
 
             // Shared construction with the CLI path: resolved LCM/session store
@@ -125,20 +125,15 @@ pub(super) async fn handle_dashboard(cg: &TraceDecay, args: Value) -> Result<Too
                 shutdown: shutdown_tx,
             });
 
-            let formatted = serde_json::to_string(&json!({
-                "status": "started",
-                "url": url,
-                "host": host,
-                "port": addr.port()
-            }))
-            .unwrap_or_default();
-
-            Ok(ToolResult {
-                value: json!({
-                        "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
+            Ok(dashboard_tool_result(
+                cg,
+                &json!({
+                    "status": "started",
+                    "url": url,
+                    "host": host,
+                    "port": addr.port()
                 }),
-                touched_files: vec![],
-            })
+            ))
         }
         other => Err(TraceDecayError::Config {
             message: format!(

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -21,9 +21,10 @@ fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str> {
         .ok_or_else(|| missing_required_param(name))
 }
 
-fn required_array<'a>(args: &'a Value, name: &str) -> Result<&'a Vec<Value>> {
+fn required_array<'a>(args: &'a Value, name: &str) -> Result<&'a [Value]> {
     args.get(name)
         .and_then(Value::as_array)
+        .map(Vec::as_slice)
         .ok_or_else(|| missing_required_param(name))
 }
 
@@ -79,10 +80,7 @@ pub(super) async fn handle_insert_at(cg: &TraceDecay, args: Value) -> Result<Too
     let anchor = required_str(&args, "anchor")?;
     let content = required_str(&args, "content")?;
 
-    let before = args
-        .get("before")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
+    let before = args.get("before").and_then(Value::as_bool).unwrap_or(false);
 
     let result = cg.insert_at(path, anchor, content, before).await?;
     let touched_files = vec![result.file_path.clone()];

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -1,6 +1,7 @@
 //! File editing tool handlers: `str_replace`, `multi_str_replace`, `insert_at`,
 //! `ast_grep_rewrite`.
 
+use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::errors::{Result, TraceDecayError};
@@ -8,52 +9,46 @@ use crate::tracedecay::TraceDecay;
 
 use super::super::ToolResult;
 
+fn missing_required_param(name: &str) -> TraceDecayError {
+    TraceDecayError::Config {
+        message: format!("missing required parameter: {name}"),
+    }
+}
+
+fn required_str<'a>(args: &'a Value, name: &str) -> Result<&'a str> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| missing_required_param(name))
+}
+
+fn required_array<'a>(args: &'a Value, name: &str) -> Result<&'a Vec<Value>> {
+    args.get(name)
+        .and_then(Value::as_array)
+        .ok_or_else(|| missing_required_param(name))
+}
+
+fn text_tool_result<T: Serialize>(result: &T, touched_files: Vec<String>) -> ToolResult {
+    ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": serde_json::to_string(result).unwrap_or_default() }]
+        }),
+        touched_files,
+    }
+}
+
 pub(super) async fn handle_str_replace(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let path =
-        args.get("path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: path".to_string(),
-            })?;
-
-    let old_str = args
-        .get("old_str")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: old_str".to_string(),
-        })?;
-
-    let new_str = args
-        .get("new_str")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: new_str".to_string(),
-        })?;
+    let path = required_str(&args, "path")?;
+    let old_str = required_str(&args, "old_str")?;
+    let new_str = required_str(&args, "new_str")?;
 
     let result = cg.str_replace(path, old_str, new_str).await?;
     let touched_files = vec![result.file_path.clone()];
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap_or_default() }]
-        }),
-        touched_files,
-    })
+    Ok(text_tool_result(&result, touched_files))
 }
 
 pub(super) async fn handle_multi_str_replace(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let path =
-        args.get("path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: path".to_string(),
-            })?;
-
-    let replacements = args
-        .get("replacements")
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: replacements".to_string(),
-        })?;
+    let path = required_str(&args, "path")?;
+    let replacements = required_array(&args, "replacements")?;
 
     let parsed_replacements: Vec<(&str, &str)> = replacements
         .iter()
@@ -76,35 +71,13 @@ pub(super) async fn handle_multi_str_replace(cg: &TraceDecay, args: Value) -> Re
 
     let result = cg.multi_str_replace(path, &parsed_replacements).await?;
     let touched_files = vec![result.file_path.clone()];
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap_or_default() }]
-        }),
-        touched_files,
-    })
+    Ok(text_tool_result(&result, touched_files))
 }
 
 pub(super) async fn handle_insert_at(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let path =
-        args.get("path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: path".to_string(),
-            })?;
-
-    let anchor =
-        args.get("anchor")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: anchor".to_string(),
-            })?;
-
-    let content = args
-        .get("content")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: content".to_string(),
-        })?;
+    let path = required_str(&args, "path")?;
+    let anchor = required_str(&args, "anchor")?;
+    let content = required_str(&args, "content")?;
 
     let before = args
         .get("before")
@@ -113,27 +86,12 @@ pub(super) async fn handle_insert_at(cg: &TraceDecay, args: Value) -> Result<Too
 
     let result = cg.insert_at(path, anchor, content, before).await?;
     let touched_files = vec![result.file_path.clone()];
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap_or_default() }]
-        }),
-        touched_files,
-    })
+    Ok(text_tool_result(&result, touched_files))
 }
 
 pub(super) async fn handle_replace_symbol(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let symbol =
-        args.get("symbol")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: symbol".to_string(),
-            })?;
-    let new_source = args
-        .get("new_source")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: new_source".to_string(),
-        })?;
+    let symbol = required_str(&args, "symbol")?;
+    let new_source = required_str(&args, "new_source")?;
 
     let result = cg.replace_symbol(symbol, new_source).await?;
     let touched_files = if result.success {
@@ -141,27 +99,12 @@ pub(super) async fn handle_replace_symbol(cg: &TraceDecay, args: Value) -> Resul
     } else {
         vec![]
     };
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap_or_default() }]
-        }),
-        touched_files,
-    })
+    Ok(text_tool_result(&result, touched_files))
 }
 
 pub(super) async fn handle_insert_at_symbol(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let symbol =
-        args.get("symbol")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: symbol".to_string(),
-            })?;
-    let content = args
-        .get("content")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: content".to_string(),
-        })?;
+    let symbol = required_str(&args, "symbol")?;
+    let content = required_str(&args, "content")?;
     let position = args
         .get("position")
         .and_then(|v| v.as_str())
@@ -173,35 +116,13 @@ pub(super) async fn handle_insert_at_symbol(cg: &TraceDecay, args: Value) -> Res
     } else {
         vec![]
     };
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap_or_default() }]
-        }),
-        touched_files,
-    })
+    Ok(text_tool_result(&result, touched_files))
 }
 
 pub(super) async fn handle_ast_grep_rewrite(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let path =
-        args.get("path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "missing required parameter: path".to_string(),
-            })?;
-
-    let pattern = args
-        .get("pattern")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: pattern".to_string(),
-        })?;
-
-    let rewrite = args
-        .get("rewrite")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: rewrite".to_string(),
-        })?;
+    let path = required_str(&args, "path")?;
+    let pattern = required_str(&args, "pattern")?;
+    let rewrite = required_str(&args, "rewrite")?;
 
     let result = cg.ast_grep_rewrite(path, pattern, rewrite).await?;
     let touched_files = if result.success {
@@ -209,10 +130,5 @@ pub(super) async fn handle_ast_grep_rewrite(cg: &TraceDecay, args: Value) -> Res
     } else {
         vec![]
     };
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap_or_default() }]
-        }),
-        touched_files,
-    })
+    Ok(text_tool_result(&result, touched_files))
 }

--- a/src/mcp/tools/handlers/git.rs
+++ b/src/mcp/tools/handlers/git.rs
@@ -2,13 +2,13 @@
 //! `changelog`, `branch_list`, `branch_search`, `branch_diff`, `affected`, and
 //! git helper functions.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use serde_json::{json, Value};
 
-use super::super::render;
+use super::super::render::{self, truncated_json_envelope_with_handle};
 use super::super::ToolResult;
-use super::{truncated_json_envelope_with_handle, unique_file_paths};
+use super::support::unique_file_paths;
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
 
@@ -22,7 +22,7 @@ fn project_response_text(cg: &TraceDecay, text: &str) -> String {
     truncated_json_envelope_with_handle(Some(cg.project_root()), text)
 }
 
-fn git_error_result(cg: &TraceDecay, operation: &str, message: String) -> ToolResult {
+fn git_error_result(cg: &TraceDecay, operation: &str, message: &str) -> ToolResult {
     let output = json!({
         "error": {
             "kind": "git",
@@ -39,10 +39,8 @@ fn git_error_result(cg: &TraceDecay, operation: &str, message: String) -> ToolRe
     }
 }
 
-/// Handles `tracedecay_affected` tool calls.
-pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let files: Vec<String> = args
-        .get("files")
+fn require_string_array_arg(args: &Value, name: &str) -> Result<Vec<String>> {
+    args.get(name)
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
@@ -50,33 +48,41 @@ pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<Tool
                 .collect()
         })
         .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: files (array of strings)".to_string(),
-        })?;
+            message: format!("missing required parameter: {name} (array of strings)"),
+        })
+}
 
-    let max_depth = args
-        .get("depth")
+fn clamped_depth_arg(args: &Value, name: &str, default: usize, max: usize) -> usize {
+    args.get(name)
         .and_then(serde_json::Value::as_u64)
-        .map_or(5, |v| v.min(10) as usize);
+        .map_or(default, |v| v.min(max as u64) as usize)
+}
 
-    let custom_filter = args.get("filter").and_then(|v| v.as_str());
-    let custom_glob = custom_filter.and_then(|p| glob::Pattern::new(p).ok());
+fn matches_test_file(
+    path: &str,
+    custom_glob: Option<&glob::Pattern>,
+    files_with_inline_tests: &HashSet<String>,
+) -> bool {
+    if let Some(glob) = custom_glob {
+        glob.matches(path)
+    } else {
+        crate::tracedecay::is_test_file(path) || files_with_inline_tests.contains(path)
+    }
+}
 
-    // Pre-compute files with inline test modules for test detection.
-    let files_with_inline_tests = cg.get_files_with_test_annotations().await?;
-    let matches_test = |path: &str| -> bool {
-        if let Some(ref g) = custom_glob {
-            g.matches(path)
-        } else {
-            crate::tracedecay::is_test_file(path) || files_with_inline_tests.contains(path)
-        }
-    };
-
+async fn collect_affected_test_files(
+    cg: &TraceDecay,
+    files: &[String],
+    max_depth: usize,
+    custom_glob: Option<&glob::Pattern>,
+    files_with_inline_tests: &HashSet<String>,
+) -> Result<HashSet<String>> {
     let mut affected: HashSet<String> = HashSet::new();
     let mut visited: HashSet<String> = HashSet::new();
-    let mut queue: std::collections::VecDeque<(String, usize)> = std::collections::VecDeque::new();
+    let mut queue: VecDeque<(String, usize)> = VecDeque::new();
 
-    for file in &files {
-        if matches_test(file) {
+    for file in files {
+        if matches_test_file(file, custom_glob, files_with_inline_tests) {
             affected.insert(file.clone());
         }
         if visited.insert(file.clone()) {
@@ -93,7 +99,7 @@ pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<Tool
             if !visited.insert(dep.clone()) {
                 continue;
             }
-            if matches_test(&dep) {
+            if matches_test_file(&dep, custom_glob, files_with_inline_tests) {
                 affected.insert(dep.clone());
             } else {
                 queue.push_back((dep, depth + 1));
@@ -101,10 +107,31 @@ pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<Tool
         }
     }
 
+    Ok(affected)
+}
+
+/// Handles `tracedecay_affected` tool calls.
+pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+    let files = require_string_array_arg(&args, "files")?;
+    let max_depth = clamped_depth_arg(&args, "depth", 5, 10);
+
+    let custom_filter = args.get("filter").and_then(|v| v.as_str());
+    let custom_glob = custom_filter.and_then(|p| glob::Pattern::new(p).ok());
+
+    let files_with_inline_tests = cg.get_files_with_test_annotations().await?;
+    let affected = collect_affected_test_files(
+        cg,
+        &files,
+        max_depth,
+        custom_glob.as_ref(),
+        &files_with_inline_tests,
+    )
+    .await?;
+
     let mut result: Vec<String> = affected.into_iter().collect();
     result.sort();
 
-    let touched_files = result.clone();
+    let touched_files = unique_file_paths(result.iter().map(std::string::String::as_str));
     let output = json!({
         "changed_files": files,
         "affected_tests": result,
@@ -128,22 +155,8 @@ pub(super) async fn handle_diff_context(cg: &TraceDecay, args: Value) -> Result<
         args.is_object(),
         "handle_diff_context expects an object argument"
     );
-    let files: Vec<String> = args
-        .get("files")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(std::string::ToString::to_string))
-                .collect()
-        })
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: files (array of strings)".to_string(),
-        })?;
-
-    let depth = args
-        .get("depth")
-        .and_then(serde_json::Value::as_u64)
-        .map_or(2, |v| v.min(10) as usize);
+    let files = require_string_array_arg(&args, "files")?;
+    let depth = clamped_depth_arg(&args, "depth", 2, 10);
 
     let mut modified_symbols: Vec<Value> = Vec::new();
     let mut modified_seen: HashSet<String> = HashSet::new();
@@ -155,13 +168,7 @@ pub(super) async fn handle_diff_context(cg: &TraceDecay, args: Value) -> Result<
     // synthesising the list from a directory walk that double-counts symlinked
     // or canonicalised entries. Dedup early so downstream loops don't emit
     // the same node N times for the same path.
-    let files: Vec<String> = {
-        let mut seen: HashSet<String> = HashSet::new();
-        files
-            .into_iter()
-            .filter(|f| seen.insert(f.clone()))
-            .collect()
-    };
+    let files = unique_file_paths(files.iter().map(std::string::String::as_str));
 
     // Pre-compute files containing inline test modules.
     let files_with_inline_tests = cg.get_files_with_test_annotations().await?;
@@ -219,33 +226,9 @@ pub(super) async fn handle_diff_context(cg: &TraceDecay, args: Value) -> Result<
         }
     }
 
-    // Also run affected-tests BFS at file level
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut queue: std::collections::VecDeque<(String, usize)> = std::collections::VecDeque::new();
-    for file in &files {
-        if has_tests(file) {
-            affected_tests.insert(file.clone());
-        }
-        if visited.insert(file.clone()) {
-            queue.push_back((file.clone(), 0));
-        }
-    }
-    while let Some((file, d)) = queue.pop_front() {
-        if d >= depth {
-            continue;
-        }
-        let dependents = cg.get_file_dependents(&file).await?;
-        for dep in dependents {
-            if !visited.insert(dep.clone()) {
-                continue;
-            }
-            if has_tests(&dep) {
-                affected_tests.insert(dep.clone());
-            } else {
-                queue.push_back((dep, d + 1));
-            }
-        }
-    }
+    affected_tests.extend(
+        collect_affected_test_files(cg, &files, depth, None, &files_with_inline_tests).await?,
+    );
 
     let mut tests_sorted: Vec<String> = affected_tests.into_iter().collect();
     tests_sorted.sort();
@@ -615,7 +598,7 @@ pub(super) async fn handle_changelog(cg: &TraceDecay, args: Value) -> Result<Too
     let changes = match git_diff_file_changes(cg.project_root(), from_ref, to_ref) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(git_error_result(cg, "diff", e));
+            return Ok(git_error_result(cg, "diff", &e));
         }
     };
     let changed_files: Vec<String> = changes.iter().map(|change| change.path.clone()).collect();
@@ -695,7 +678,7 @@ pub(super) async fn handle_commit_context(cg: &TraceDecay, args: Value) -> Resul
     let changed_files = match git_changed_files(cg.project_root(), staged_only) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(git_error_result(cg, "status", e));
+            return Ok(git_error_result(cg, "status", &e));
         }
     };
 
@@ -792,7 +775,7 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
     let changes = match git_diff_file_changes(cg.project_root(), base, head) {
         Ok(files) => files,
         Err(e) => {
-            return Ok(git_error_result(cg, "diff", e));
+            return Ok(git_error_result(cg, "diff", &e));
         }
     };
     let changed_files: Vec<String> = changes.iter().map(|change| change.path.clone()).collect();

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -10,14 +10,39 @@ use serde_json::{json, Value};
 use crate::context::format_context_as_markdown;
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
-use crate::types::{BuildContextOptions, EdgeKind, NodeKind, Visibility};
+use crate::types::{BuildContextOptions, EdgeKind, Node, NodeKind, TaskContext, Visibility};
 
 use super::super::render::{self, Md};
 use super::super::ToolResult;
-use super::{effective_path, filter_by_scope, require_node_id, unique_file_paths};
+use super::support::{
+    effective_path, filter_by_scope, require_node_id, string_array_values, unique_file_paths,
+};
 
 fn user_line(line: u32) -> u32 {
     line.saturating_add(1)
+}
+
+fn rendered_tool_result<F>(
+    cg: &TraceDecay,
+    args: &Value,
+    value: &Value,
+    touched_files: Vec<String>,
+    md: F,
+) -> ToolResult
+where
+    F: FnOnce() -> String,
+{
+    let text = render::finalize(Some(cg.project_root()), args, value, md);
+    text_tool_result(&text, touched_files)
+}
+
+fn text_tool_result(text: &str, touched_files: Vec<String>) -> ToolResult {
+    ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": text }]
+        }),
+        touched_files,
+    }
 }
 
 /// Handles `tracedecay_search` tool calls.
@@ -67,15 +92,13 @@ pub(super) async fn handle_search(
     } else {
         json!(items)
     };
-    let text = render::finalize(Some(cg.project_root()), &args, &output_value, || {
-        render_search_md(&output_value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &output_value,
         touched_files,
-    })
+        || render_search_md(&output_value),
+    ))
 }
 
 fn render_search_md(value: &Value) -> String {
@@ -133,70 +156,11 @@ pub(super) async fn handle_context(
                 message: "missing required parameter: task".to_string(),
             })?;
 
-    let max_nodes = args
-        .get("max_nodes")
-        .and_then(serde_json::Value::as_u64)
-        .map_or(20, |v| v.min(100) as usize);
-
-    let include_code = args
-        .get("include_code")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-
-    let max_code_blocks = args
-        .get("max_code_blocks")
-        .and_then(serde_json::Value::as_u64)
-        .map_or(5, |v| v.min(20) as usize);
-
     let mode = args
         .get("mode")
         .and_then(|v| v.as_str())
         .unwrap_or("explore");
-
-    let extra_keywords: Vec<String> = args
-        .get("keywords")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let exclude_node_ids: std::collections::HashSet<String> = args
-        .get("exclude_node_ids")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let merge_adjacent = args
-        .get("merge_adjacent")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-
-    let max_per_file: Option<usize> = args
-        .get("max_per_file")
-        .and_then(serde_json::Value::as_u64)
-        .map(|v| v as usize)
-        .or(Some((max_nodes / 3).max(3)));
-
-    let path_prefix = effective_path(&args, scope_prefix).map(String::from);
-
-    let options = BuildContextOptions {
-        max_nodes,
-        max_code_blocks,
-        include_code,
-        extra_keywords,
-        exclude_node_ids,
-        merge_adjacent,
-        max_per_file,
-        path_prefix,
-        ..Default::default()
-    };
+    let options = build_context_options(&args, scope_prefix);
 
     let context = cg.build_context(task, &options).await?;
     let touched_files = unique_file_paths(
@@ -225,71 +189,7 @@ pub(super) async fn handle_context(
 
     // Plan mode: append extension points, test coverage, and dependency info
     if mode == "plan" {
-        output.push_str("\n### Extension Points\n");
-        let mut found_extension = false;
-        for node in &context.subgraph.nodes {
-            if matches!(node.kind, NodeKind::Trait | NodeKind::Interface)
-                && node.visibility == Visibility::Pub
-            {
-                let implementors = cg.get_callers(&node.id, 1).await?;
-                let impl_count = implementors
-                    .iter()
-                    .filter(|(_, e)| matches!(e.kind, crate::types::EdgeKind::Implements))
-                    .count();
-                let _ = writeln!(
-                    output,
-                    "- **{}** ({}) - {}:{} ({} implementors)",
-                    node.name,
-                    node.kind.as_str(),
-                    node.file_path,
-                    user_line(node.start_line),
-                    impl_count,
-                );
-                found_extension = true;
-            }
-        }
-        if !found_extension {
-            output.push_str("_No public traits/interfaces found in context._\n");
-        }
-
-        // Test coverage for related files
-        let file_paths: Vec<String> = context
-            .subgraph
-            .nodes
-            .iter()
-            .map(|n| n.file_path.clone())
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
-        if !file_paths.is_empty() {
-            output.push_str("\n### Test Coverage\n");
-            let mut test_files: HashSet<String> = HashSet::new();
-            for file in &file_paths {
-                let nodes = cg.get_nodes_by_file(file).await?;
-                for node in &nodes {
-                    let callers = cg.get_callers(&node.id, 2).await?;
-                    let caller_ids: Vec<String> =
-                        callers.iter().map(|(n, _)| n.id.clone()).collect();
-                    let test_annotated = cg.get_test_annotated_node_ids(&caller_ids).await?;
-                    for (caller, _) in &callers {
-                        if crate::tracedecay::is_test_file(&caller.file_path)
-                            || test_annotated.contains(&caller.id)
-                        {
-                            test_files.insert(caller.file_path.clone());
-                        }
-                    }
-                }
-            }
-            if test_files.is_empty() {
-                output.push_str("_No test files found covering these modules._\n");
-            } else {
-                let mut sorted: Vec<_> = test_files.into_iter().collect();
-                sorted.sort();
-                for tf in &sorted {
-                    let _ = writeln!(output, "- {tf}");
-                }
-            }
-        }
+        append_plan_context(cg, &context, &mut output).await?;
     }
 
     if !context.seen_node_ids.is_empty() {
@@ -301,13 +201,131 @@ pub(super) async fn handle_context(
     }
 
     let value = serde_json::to_value(&context).unwrap_or_else(|_| json!({}));
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || output);
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || output,
+    ))
+}
+
+fn build_context_options(args: &Value, scope_prefix: Option<&str>) -> BuildContextOptions {
+    let max_nodes = args
+        .get("max_nodes")
+        .and_then(serde_json::Value::as_u64)
+        .map_or(20, |v| v.min(100) as usize);
+
+    let max_per_file = args
+        .get("max_per_file")
+        .and_then(serde_json::Value::as_u64)
+        .map(|v| v as usize)
+        .or(Some((max_nodes / 3).max(3)));
+
+    BuildContextOptions {
+        max_nodes,
+        max_code_blocks: args
+            .get("max_code_blocks")
+            .and_then(serde_json::Value::as_u64)
+            .map_or(5, |v| v.min(20) as usize),
+        include_code: args
+            .get("include_code")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        extra_keywords: string_array_values(args, "keywords"),
+        exclude_node_ids: string_array_values(args, "exclude_node_ids")
+            .into_iter()
+            .collect(),
+        merge_adjacent: args
+            .get("merge_adjacent")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        max_per_file,
+        path_prefix: effective_path(args, scope_prefix).map(String::from),
+        ..Default::default()
+    }
+}
+
+async fn append_plan_context(
+    cg: &TraceDecay,
+    context: &TaskContext,
+    output: &mut String,
+) -> Result<()> {
+    output.push_str("\n### Extension Points\n");
+    let mut found_extension = false;
+    for node in &context.subgraph.nodes {
+        if matches!(node.kind, NodeKind::Trait | NodeKind::Interface)
+            && node.visibility == Visibility::Pub
+        {
+            let implementors = cg.get_callers(&node.id, 1).await?;
+            let impl_count = implementors
+                .iter()
+                .filter(|(_, e)| matches!(e.kind, EdgeKind::Implements))
+                .count();
+            let _ = writeln!(
+                output,
+                "- **{}** ({}) - {}:{} ({} implementors)",
+                node.name,
+                node.kind.as_str(),
+                node.file_path,
+                user_line(node.start_line),
+                impl_count,
+            );
+            found_extension = true;
+        }
+    }
+    if !found_extension {
+        output.push_str("_No public traits/interfaces found in context._\n");
+    }
+
+    append_plan_test_coverage(cg, context, output).await
+}
+
+async fn append_plan_test_coverage(
+    cg: &TraceDecay,
+    context: &TaskContext,
+    output: &mut String,
+) -> Result<()> {
+    let file_paths: Vec<String> = context
+        .subgraph
+        .nodes
+        .iter()
+        .map(|n| n.file_path.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    if file_paths.is_empty() {
+        return Ok(());
+    }
+
+    output.push_str("\n### Test Coverage\n");
+    let mut test_files: HashSet<String> = HashSet::new();
+    for file in &file_paths {
+        let nodes = cg.get_nodes_by_file(file).await?;
+        for node in &nodes {
+            let callers = cg.get_callers(&node.id, 2).await?;
+            let caller_ids: Vec<String> = callers.iter().map(|(n, _)| n.id.clone()).collect();
+            let test_annotated = cg.get_test_annotated_node_ids(&caller_ids).await?;
+            for (caller, _) in &callers {
+                if crate::tracedecay::is_test_file(&caller.file_path)
+                    || test_annotated.contains(&caller.id)
+                {
+                    test_files.insert(caller.file_path.clone());
+                }
+            }
+        }
+    }
+    if test_files.is_empty() {
+        output.push_str("_No test files found covering these modules._\n");
+    } else {
+        let mut sorted: Vec<_> = test_files.into_iter().collect();
+        sorted.sort();
+        for tf in &sorted {
+            let _ = writeln!(output, "- {tf}");
+        }
+    }
+
+    Ok(())
 }
 
 /// Handles `tracedecay_callers` tool calls.
@@ -338,15 +356,13 @@ pub(super) async fn handle_callers(cg: &TraceDecay, args: Value) -> Result<ToolR
         .collect();
 
     let value = json!(items);
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || render::generic_md(&value),
+    ))
 }
 
 /// Handles `tracedecay_callees` tool calls.
@@ -418,15 +434,13 @@ pub(super) async fn handle_callees(cg: &TraceDecay, args: Value) -> Result<ToolR
     );
 
     let value = json!(items);
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || render::generic_md(&value),
+    ))
 }
 
 /// Handles `tracedecay_find_exact_symbol` tool calls. Bare-name lookup against
@@ -478,15 +492,13 @@ pub(super) async fn handle_find_exact_symbol(
         "count": items.len(),
         "matches": items,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &body, || {
-        render::generic_md(&body)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &body,
         touched_files,
-    })
+        || render::generic_md(&body),
+    ))
 }
 
 /// Handles `tracedecay_call_chain` tool calls. Finds the shortest directed
@@ -545,15 +557,13 @@ pub(super) async fn handle_call_chain(cg: &TraceDecay, args: Value) -> Result<To
         )
     };
 
-    let text = render::finalize(Some(cg.project_root()), &args, &body, || {
-        render::generic_md(&body)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &body,
         touched_files,
-    })
+        || render::generic_md(&body),
+    ))
 }
 
 /// Handles `tracedecay_file_dependents` tool calls.
@@ -572,15 +582,13 @@ pub(super) async fn handle_file_dependents(cg: &TraceDecay, args: Value) -> Resu
         "count": dependents.len(),
         "dependents": dependents,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &body, || {
-        render::generic_md(&body)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &body,
         touched_files,
-    })
+        || render::generic_md(&body),
+    ))
 }
 
 /// Handles `tracedecay_impact` tool calls.
@@ -616,15 +624,13 @@ pub(super) async fn handle_impact(cg: &TraceDecay, args: Value) -> Result<ToolRe
         "nodes": nodes,
     });
 
-    let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &output,
         touched_files,
-    })
+        || render::generic_md(&output),
+    ))
 }
 
 /// Handles `tracedecay_node` tool calls.
@@ -689,22 +695,18 @@ pub(super) async fn handle_node(cg: &TraceDecay, args: Value) -> Result<ToolResu
                 "cost_to_expand": cost_to_expand(&n, file_size_bytes),
                 "derives": derives,
             });
-            let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-                render::generic_md(&output)
-            });
-            Ok(ToolResult {
-                value: json!({
-                    "content": [{ "type": "text", "text": text }]
-                }),
+            Ok(rendered_tool_result(
+                cg,
+                &args,
+                &output,
                 touched_files,
-            })
+                || render::generic_md(&output),
+            ))
         }
-        None => Ok(ToolResult {
-            value: json!({
-                "content": [{ "type": "text", "text": format!("Node not found: {}", node_id) }]
-            }),
-            touched_files: vec![],
-        }),
+        None => Ok(text_tool_result(
+            &format!("Node not found: {node_id}"),
+            vec![],
+        )),
     }
 }
 
@@ -772,15 +774,13 @@ pub(super) async fn handle_similar(cg: &TraceDecay, args: Value) -> Result<ToolR
         .collect();
 
     let value = json!(items);
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || render::generic_md(&value),
+    ))
 }
 
 /// Handles `tracedecay_rename_preview` tool calls.
@@ -798,12 +798,10 @@ pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Resul
             "line": user_line(n.start_line),
         }),
         None => {
-            return Ok(ToolResult {
-                value: json!({
-                    "content": [{ "type": "text", "text": format!("Node not found: {}", node_id) }]
-                }),
-                touched_files: vec![],
-            });
+            return Ok(text_tool_result(
+                &format!("Node not found: {node_id}"),
+                vec![],
+            ));
         }
     };
 
@@ -860,15 +858,13 @@ pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Resul
         "references": references,
     });
 
-    let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &output,
         touched_files,
-    })
+        || render::generic_md(&output),
+    ))
 }
 
 /// Handles `tracedecay_callers_for` tool calls — bulk caller lookup over many IDs.
@@ -934,15 +930,9 @@ pub(super) async fn handle_callers_for(cg: &TraceDecay, args: Value) -> Result<T
         "truncated": truncated,
         "max_per_item": max_per_item,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &output, || {
+    Ok(rendered_tool_result(cg, &args, &output, vec![], || {
         render::generic_md(&output)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
-        touched_files: vec![],
-    })
+    }))
 }
 
 /// Handles `tracedecay_by_qualified_name` — cross-run node lookup by name.
@@ -974,15 +964,13 @@ pub(super) async fn handle_by_qualified_name(cg: &TraceDecay, args: Value) -> Re
         .collect();
 
     let value = json!(items);
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || render::generic_md(&value),
+    ))
 }
 
 /// Handles `tracedecay_signature` — signature-only lookup (no body) by
@@ -1035,15 +1023,13 @@ pub(super) async fn handle_signature(cg: &TraceDecay, args: Value) -> Result<Too
     }
 
     let value = json!(items);
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || render::generic_md(&value),
+    ))
 }
 
 /// Handles `tracedecay_impls` — index of `impl Trait for Type` blocks.
@@ -1092,15 +1078,13 @@ pub(super) async fn handle_impls(cg: &TraceDecay, args: Value) -> Result<ToolRes
         "truncated": truncated,
         "impls": items,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &output,
         touched_files,
-    })
+        || render::generic_md(&output),
+    ))
 }
 
 /// Handles `tracedecay_derives` — lists `#[derive(...)]` macros on a type
@@ -1159,15 +1143,13 @@ pub(super) async fn handle_derives(cg: &TraceDecay, args: Value) -> Result<ToolR
     }
 
     let value = json!(items);
-    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
+    Ok(rendered_tool_result(
+        cg,
+        &args,
+        &value,
         touched_files,
-    })
+        || render::generic_md(&value),
+    ))
 }
 
 /// Approximate token cost of expanding a node's body and its full file.
@@ -1178,7 +1160,7 @@ pub(super) async fn handle_derives(cg: &TraceDecay, args: Value) -> Result<ToolR
 /// resolve to the single-line floor of 20 tokens. Good enough to decide whether
 /// to set `include_code=true`; not a reliable absolute count.
 /// `full_file` uses `size_bytes / 4` from the indexed `files.size`.
-pub(super) fn cost_to_expand(node: &crate::types::Node, file_size_bytes: u64) -> Value {
+fn cost_to_expand(node: &Node, file_size_bytes: u64) -> Value {
     let line_count = node
         .end_line
         .saturating_sub(node.start_line)
@@ -1236,12 +1218,10 @@ pub(super) async fn handle_implementations(
             })
             .collect();
         if trait_nodes.is_empty() {
-            return Ok(ToolResult {
-                value: json!({
-                    "content": [{ "type": "text", "text": format!("No trait or interface named '{name}' found.") }]
-                }),
-                touched_files: vec![],
-            });
+            return Ok(text_tool_result(
+                &format!("No trait or interface named '{name}' found."),
+                vec![],
+            ));
         }
 
         for trait_node in trait_nodes {
@@ -1289,12 +1269,10 @@ pub(super) async fn handle_implementations(
             .take(limit)
             .collect();
         if method_nodes.is_empty() {
-            return Ok(ToolResult {
-                value: json!({
-                    "content": [{ "type": "text", "text": format!("No function or method named '{name}' found.") }]
-                }),
-                touched_files: vec![],
-            });
+            return Ok(text_tool_result(
+                &format!("No function or method named '{name}' found."),
+                vec![],
+            ));
         }
         for n in method_nodes {
             let abs_path = project_root.join(&n.file_path);
@@ -1322,15 +1300,9 @@ pub(super) async fn handle_implementations(
         "match_count": entries.len(),
         "implementations": entries,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &payload, || {
+    Ok(rendered_tool_result(cg, &args, &payload, touched, || {
         render::generic_md(&payload)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
-        touched_files: touched,
-    })
+    }))
 }
 
 async fn collect_method_bodies(

--- a/src/mcp/tools/handlers/health.rs
+++ b/src/mcp/tools/handlers/health.rs
@@ -25,36 +25,47 @@ use crate::graph::queries::GraphQueryManager;
 use crate::tracedecay::TraceDecay;
 use crate::types::{EdgeKind, NodeKind};
 
-use super::super::render;
+use super::super::render::{self, truncated_json_envelope_with_handle};
 use super::super::ToolResult;
-use super::{effective_path, unique_file_paths};
+use super::support::{effective_path, unique_file_paths};
 
 // ---------------------------------------------------------------------------
 // Shared health computation helper
 // ---------------------------------------------------------------------------
 
-pub(super) struct HealthSnapshot {
-    pub(super) quality_signal: u32,
-    pub(super) files_analyzed: usize,
-    pub(super) acyclicity: f64,
-    pub(super) depth: f64,
-    pub(super) equality: f64,
-    pub(super) redundancy: f64,
-    pub(super) modularity: f64,
-    pub(super) coverage_discipline: f64,
+struct HealthSnapshot {
+    quality_signal: u32,
+    files_analyzed: usize,
+    acyclicity: f64,
+    depth: f64,
+    equality: f64,
+    redundancy: f64,
+    modularity: f64,
+    coverage_discipline: f64,
     /// Raw signals retained for `details=true` (#82).
-    pub(super) gini: f64,
-    pub(super) edges_in_cycles: usize,
-    pub(super) max_chain: usize,
-    pub(super) ideal_chain: usize,
-    pub(super) modularity_components: usize,
-    pub(super) dead_count: usize,
-    pub(super) total_fns: usize,
-    pub(super) skip_coverage_count: usize,
+    gini: f64,
+    edges_in_cycles: usize,
+    max_chain: usize,
+    ideal_chain: usize,
+    modularity_components: usize,
+    dead_count: usize,
+    total_fns: usize,
+    skip_coverage_count: usize,
+}
+
+fn file_matches_scope(file_path: &str, path_prefix: Option<&str>) -> bool {
+    path_prefix.is_none_or(|pfx| {
+        let with_slash = if pfx.ends_with('/') {
+            pfx.to_string()
+        } else {
+            format!("{pfx}/")
+        };
+        file_path.starts_with(&with_slash) || file_path == pfx
+    })
 }
 
 /// Computes all 5 health dimensions and the composite signal for a given scope.
-pub(super) async fn compute_health_snapshot(
+async fn compute_health_snapshot(
     cg: &TraceDecay,
     path_prefix: Option<&str>,
 ) -> Result<HealthSnapshot> {
@@ -70,16 +81,7 @@ pub(super) async fn compute_health_snapshot(
     let all_nodes = cg.get_all_nodes().await?;
     let nodes: Vec<_> = all_nodes
         .iter()
-        .filter(|n| {
-            path_prefix.is_none_or(|pfx| {
-                let with_slash = if pfx.ends_with('/') {
-                    pfx.to_string()
-                } else {
-                    format!("{pfx}/")
-                };
-                n.file_path.starts_with(&with_slash) || n.file_path == pfx
-            })
-        })
+        .filter(|n| file_matches_scope(&n.file_path, path_prefix))
         .collect();
 
     let mut per_file_complexity: HashMap<String, f64> = HashMap::new();
@@ -99,16 +101,9 @@ pub(super) async fn compute_health_snapshot(
     let dead = cg
         .find_dead_code(&[NodeKind::Function, NodeKind::Method], false)
         .await?;
-    let dead_in_scope = dead.iter().filter(|n| {
-        path_prefix.is_none_or(|pfx| {
-            let with_slash = if pfx.ends_with('/') {
-                pfx.to_string()
-            } else {
-                format!("{pfx}/")
-            };
-            n.file_path.starts_with(&with_slash) || n.file_path == pfx
-        })
-    });
+    let dead_in_scope = dead
+        .iter()
+        .filter(|n| file_matches_scope(&n.file_path, path_prefix));
     let dead_count = dead_in_scope.count();
     let total_fns = nodes
         .iter()
@@ -193,16 +188,7 @@ pub(super) async fn handle_gini(
     // Apply path filter
     let nodes: Vec<_> = all_nodes
         .into_iter()
-        .filter(|n| {
-            path_prefix.is_none_or(|pfx| {
-                let with_slash = if pfx.ends_with('/') {
-                    pfx.to_string()
-                } else {
-                    format!("{pfx}/")
-                };
-                n.file_path.starts_with(&with_slash) || n.file_path == pfx
-            })
-        })
+        .filter(|n| file_matches_scope(&n.file_path, path_prefix))
         .collect();
 
     // Build named_values per metric+scope
@@ -641,7 +627,7 @@ pub(super) async fn handle_dsm(
     let formatted = serde_json::to_string(&output).unwrap_or_default();
     Ok(ToolResult {
         value: json!({
-            "content": [{ "type": "text", "text": super::truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
+            "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
         }),
         touched_files: vec![],
     })
@@ -806,16 +792,7 @@ pub(super) async fn handle_test_risk(
                 && !skip_coverage.contains(&n.id)
                 && !n.qualified_name.contains("::tests::")
         })
-        .filter(|n| {
-            path_prefix.is_none_or(|pfx| {
-                let with_slash = if pfx.ends_with('/') {
-                    pfx.to_string()
-                } else {
-                    format!("{pfx}/")
-                };
-                n.file_path.starts_with(&with_slash) || n.file_path == pfx
-            })
-        })
+        .filter(|n| file_matches_scope(&n.file_path, path_prefix))
         .collect();
 
     // Phase-1 honest bucketing: non-`src/` code (dashboard Python, scripts,
@@ -1101,16 +1078,19 @@ pub(super) async fn handle_test_map(
 // Session start / end handlers
 // ---------------------------------------------------------------------------
 
-/// Handles `tracedecay_session_start` tool calls.
-pub(super) async fn handle_session_start(
-    cg: &TraceDecay,
-    args: Value,
-    scope_prefix: Option<&str>,
-) -> Result<ToolResult> {
-    let path_prefix = effective_path(&args, scope_prefix);
-    let snap = compute_health_snapshot(cg, path_prefix).await?;
+fn session_dimension_values(snap: &HealthSnapshot) -> [(&'static str, f64); 6] {
+    [
+        ("acyclicity", snap.acyclicity),
+        ("depth", snap.depth),
+        ("equality", snap.equality),
+        ("redundancy", snap.redundancy),
+        ("modularity", snap.modularity),
+        ("coverage_discipline", snap.coverage_discipline),
+    ]
+}
 
-    let baseline = json!({
+fn session_baseline_snapshot(snap: &HealthSnapshot) -> Value {
+    json!({
         "quality_signal": snap.quality_signal,
         "files_analyzed": snap.files_analyzed,
         "dimensions": {
@@ -1122,7 +1102,63 @@ pub(super) async fn handle_session_start(
             "coverage_discipline": snap.coverage_discipline,
         },
         "timestamp": crate::tracedecay::current_timestamp(),
+    })
+}
+
+fn session_dimension_deltas(
+    dims_before: &Value,
+    snap: &HealthSnapshot,
+) -> (serde_json::Map<String, Value>, Vec<String>) {
+    let mut dimensions = serde_json::Map::new();
+    let mut degraded_dimensions: Vec<String> = vec![];
+
+    for (name, after_val) in session_dimension_values(snap) {
+        let before_val = dims_before[name].as_f64().unwrap_or(0.0);
+        let dim_delta = after_val - before_val;
+        let status = if dim_delta > 0.001 {
+            "improved"
+        } else if dim_delta < -0.001 {
+            degraded_dimensions.push(name.to_string());
+            "degraded"
+        } else {
+            "unchanged"
+        };
+        dimensions.insert(
+            name.to_string(),
+            json!({
+                "before": (before_val * 10000.0).round() / 10000.0,
+                "after": (after_val * 10000.0).round() / 10000.0,
+                "delta": (dim_delta * 10000.0).round() / 10000.0,
+                "status": status,
+            }),
+        );
+    }
+
+    (dimensions, degraded_dimensions)
+}
+
+fn session_tool_result(cg: &TraceDecay, args: &Value, output: &Value) -> ToolResult {
+    let text = render::finalize(Some(cg.project_root()), args, output, || {
+        render::generic_md(output)
     });
+    ToolResult {
+        value: json!({
+            "content": [{ "type": "text", "text": text }]
+        }),
+        touched_files: vec![],
+    }
+}
+
+/// Handles `tracedecay_session_start` tool calls.
+pub(super) async fn handle_session_start(
+    cg: &TraceDecay,
+    args: Value,
+    scope_prefix: Option<&str>,
+) -> Result<ToolResult> {
+    let path_prefix = effective_path(&args, scope_prefix);
+    let snap = compute_health_snapshot(cg, path_prefix).await?;
+
+    let baseline = session_baseline_snapshot(&snap);
 
     // Write baseline to the active project store.
     let tracedecay_dir = &cg.store_layout().data_root;
@@ -1145,15 +1181,7 @@ pub(super) async fn handle_session_start(
         "quality_signal": snap.quality_signal,
         "files_analyzed": snap.files_analyzed,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
-        touched_files: vec![],
-    })
+    Ok(session_tool_result(cg, &args, &output))
 }
 
 /// Handles `tracedecay_session_end` tool calls.
@@ -1171,15 +1199,7 @@ pub(super) async fn handle_session_end(
             "status": "no_baseline",
             "message": "No session baseline found. Call tracedecay_session_start first.",
         });
-        let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-            render::generic_md(&output)
-        });
-        return Ok(ToolResult {
-            value: json!({
-                "content": [{ "type": "text", "text": text }]
-            }),
-            touched_files: vec![],
-        });
+        return Ok(session_tool_result(cg, &args, &output));
     }
 
     // Read baseline
@@ -1209,47 +1229,7 @@ pub(super) async fn handle_session_end(
     let pass = signal_after >= signal_before;
 
     // Compute per-dimension deltas
-    let dim_names = [
-        "acyclicity",
-        "depth",
-        "equality",
-        "redundancy",
-        "modularity",
-        "coverage_discipline",
-    ];
-    let after_vals = [
-        snap.acyclicity,
-        snap.depth,
-        snap.equality,
-        snap.redundancy,
-        snap.modularity,
-        snap.coverage_discipline,
-    ];
-
-    let mut dimensions = serde_json::Map::new();
-    let mut degraded_dimensions: Vec<String> = vec![];
-
-    for (name, after_val) in dim_names.iter().zip(after_vals.iter()) {
-        let before_val = dims_before[name].as_f64().unwrap_or(0.0);
-        let dim_delta = after_val - before_val;
-        let status = if dim_delta > 0.001 {
-            "improved"
-        } else if dim_delta < -0.001 {
-            degraded_dimensions.push((*name).to_string());
-            "degraded"
-        } else {
-            "unchanged"
-        };
-        dimensions.insert(
-            (*name).to_string(),
-            json!({
-                "before": (before_val * 10000.0).round() / 10000.0,
-                "after": (after_val * 10000.0).round() / 10000.0,
-                "delta": (dim_delta * 10000.0).round() / 10000.0,
-                "status": status,
-            }),
-        );
-    }
+    let (dimensions, degraded_dimensions) = session_dimension_deltas(dims_before, &snap);
 
     let output = json!({
         "pass": pass,
@@ -1260,13 +1240,5 @@ pub(super) async fn handle_session_end(
         "degraded_dimensions": degraded_dimensions,
         "dimensions": dimensions,
     });
-    let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
-    });
-    Ok(ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
-        touched_files: vec![],
-    })
+    Ok(session_tool_result(cg, &args, &output))
 }

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -13,12 +13,9 @@ use crate::storage::{ProjectPath, StorageMode, StoreKind};
 use crate::tracedecay::{BranchDiagnostics, TraceDecay};
 use crate::types::{NodeKind, Visibility};
 
-use super::super::render::{self, Md};
+use super::super::render::{self, truncate_response, truncated_json_envelope_with_handle, Md};
 use super::super::ToolResult;
-use super::{
-    effective_path, require_node_id, truncate_response, truncated_json_envelope_with_handle,
-    unique_file_paths,
-};
+use super::support::{effective_path, filter_by_scope, require_node_id, unique_file_paths};
 
 fn project_response_text(cg: &TraceDecay, text: &str) -> String {
     truncated_json_envelope_with_handle(Some(cg.project_root()), text)
@@ -85,9 +82,9 @@ pub(super) async fn handle_status(
 
     // Session-transcript ingest health (recall trust): last ingest time and
     // any un-ingested transcript backlog from the project sessions.db.
-    let session_db_path = crate::sessions::cursor::project_session_db_path(cg.project_root());
+    let session_db_path = cg.store_layout().sessions_db_path.clone();
     if session_db_path.exists() {
-        match crate::sessions::cursor::open_project_session_db(cg.project_root()).await {
+        match GlobalDb::open_at(&session_db_path).await {
             None => {
                 // The store exists but won't open — say so instead of
                 // silently dropping the section (which reads as "healthy").
@@ -344,7 +341,35 @@ fn bounded_limit(args: &Value, default: usize, max: usize) -> usize {
         .map_or(default, |value| value.clamp(1, max))
 }
 
-async fn open_project_registry_read_only() -> Result<Option<(PathBuf, GlobalDb)>> {
+enum ProjectRegistryDb<'a> {
+    Borrowed(&'a GlobalDb),
+    Owned(Box<GlobalDb>),
+}
+
+impl ProjectRegistryDb<'_> {
+    fn db(&self) -> &GlobalDb {
+        match self {
+            Self::Borrowed(db) => db,
+            Self::Owned(db) => db,
+        }
+    }
+}
+
+async fn open_project_registry_read_only(
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<Option<(PathBuf, ProjectRegistryDb<'_>)>> {
+    if let Some(db) = global_db {
+        return Ok(Some((
+            db.db_path().to_path_buf(),
+            ProjectRegistryDb::Borrowed(db),
+        )));
+    }
+    if !allow_default_registry_fallback {
+        return Err(TraceDecayError::Config {
+            message: "client project registry is unavailable for selector resolution".to_string(),
+        });
+    }
     let Some(path) = global_db_path() else {
         return Ok(None);
     };
@@ -359,23 +384,19 @@ async fn open_project_registry_read_only() -> Result<Option<(PathBuf, GlobalDb)>
                 path.display()
             ),
         })?;
-    Ok(Some((path, db)))
+    Ok(Some((path, ProjectRegistryDb::Owned(Box::new(db)))))
 }
 
 fn project_registry_result(cg: &TraceDecay, args: &Value, payload: &Value) -> ToolResult {
-    let text = render::finalize(Some(cg.project_root()), args, payload, || {
-        render::generic_md(payload)
-    });
-    ToolResult {
-        value: json!({
-            "content": [{ "type": "text", "text": text }]
-        }),
-        touched_files: vec![],
-    }
+    render_registry_result(Some(cg.project_root()), args, payload)
 }
 
 fn registry_result(args: &Value, payload: &Value) -> ToolResult {
-    let text = render::finalize(None, args, payload, || render::generic_md(payload));
+    render_registry_result(None, args, payload)
+}
+
+fn render_registry_result(root: Option<&Path>, args: &Value, payload: &Value) -> ToolResult {
+    let text = render::finalize(root, args, payload, || render::generic_md(payload));
     ToolResult {
         value: json!({
             "content": [{ "type": "text", "text": text }]
@@ -401,15 +422,21 @@ fn registry_project_value(project: &crate::global_db::CodeProjectRecord) -> Valu
 }
 
 /// Handles `tracedecay_project_list` tool calls.
-pub(super) async fn handle_project_list(args: Value) -> Result<ToolResult> {
+pub(super) async fn handle_project_list(
+    args: Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
     let limit = bounded_limit(&args, 25, 100);
-    let Some((registry_path, db)) = open_project_registry_read_only().await? else {
+    let Some((registry_path, db)) =
+        open_project_registry_read_only(global_db, allow_default_registry_fallback).await?
+    else {
         let mut payload = registry_missing_payload();
         payload["limit"] = json!(limit);
         payload["truncated"] = json!(false);
         return Ok(registry_result(&args, &payload));
     };
-    let mut projects = db.list_code_projects(limit + 1).await;
+    let mut projects = db.db().list_code_projects(limit + 1).await;
     let truncated = projects.len() > limit;
     projects.truncate(limit);
     let projects: Vec<Value> = projects.iter().map(registry_project_value).collect();
@@ -426,7 +453,11 @@ pub(super) async fn handle_project_list(args: Value) -> Result<ToolResult> {
 }
 
 /// Handles `tracedecay_project_search` tool calls.
-pub(super) async fn handle_project_search(args: Value) -> Result<ToolResult> {
+pub(super) async fn handle_project_search(
+    args: Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
     let query =
         args.get("query")
             .and_then(Value::as_str)
@@ -434,14 +465,16 @@ pub(super) async fn handle_project_search(args: Value) -> Result<ToolResult> {
                 message: "missing required parameter: query".to_string(),
             })?;
     let limit = bounded_limit(&args, 10, 50);
-    let Some((registry_path, db)) = open_project_registry_read_only().await? else {
+    let Some((registry_path, db)) =
+        open_project_registry_read_only(global_db, allow_default_registry_fallback).await?
+    else {
         let mut payload = registry_missing_payload();
         payload["query"] = json!(query);
         payload["limit"] = json!(limit);
         payload["truncated"] = json!(false);
         return Ok(registry_result(&args, &payload));
     };
-    let mut projects = db.search_code_projects(query, limit + 1).await;
+    let mut projects = db.db().search_code_projects(query, limit + 1).await;
     let truncated = projects.len() > limit;
     projects.truncate(limit);
     let projects: Vec<Value> = projects.iter().map(registry_project_value).collect();
@@ -471,8 +504,15 @@ fn project_context_alias_path<'a>(cg: &'a TraceDecay, args: &'a Value) -> PathBu
 }
 
 /// Handles `tracedecay_project_context` tool calls.
-pub(super) async fn handle_project_context(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let Some((registry_path, db)) = open_project_registry_read_only().await? else {
+pub(super) async fn handle_project_context(
+    cg: &TraceDecay,
+    args: Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
+    let Some((registry_path, db)) =
+        open_project_registry_read_only(global_db, allow_default_registry_fallback).await?
+    else {
         return Ok(project_registry_result(
             cg,
             &args,
@@ -480,10 +520,10 @@ pub(super) async fn handle_project_context(cg: &TraceDecay, args: Value) -> Resu
         ));
     };
     let context = if let Some(project_id) = args.get("project_id").and_then(Value::as_str) {
-        db.project_registry_context_by_id(project_id).await
+        db.db().project_registry_context_by_id(project_id).await
     } else {
         let alias_path = project_context_alias_path(cg, &args);
-        db.project_registry_context_by_alias(&alias_path).await
+        db.db().project_registry_context_by_alias(&alias_path).await
     };
     let Some(context) = context else {
         return Ok(project_registry_result(
@@ -1310,12 +1350,150 @@ pub(super) async fn handle_simplify_scan(
     });
 
     let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
+        render_simplify_scan_markdown(&output)
     });
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": text}]}),
         touched_files: files,
     })
+}
+
+fn render_simplify_scan_markdown(output: &Value) -> String {
+    let mut md = Md::new();
+    md.heading(1, "Simplify Scan");
+
+    let duplications = output
+        .get("duplications")
+        .and_then(Value::as_array)
+        .map_or(&[][..], Vec::as_slice);
+    let dead = output
+        .get("dead_introductions")
+        .and_then(Value::as_array)
+        .map_or(&[][..], Vec::as_slice);
+    let complexity = output
+        .get("complexity_warnings")
+        .and_then(Value::as_array)
+        .map_or(&[][..], Vec::as_slice);
+    let coupling = output
+        .get("coupling_warnings")
+        .and_then(Value::as_array)
+        .map_or(&[][..], Vec::as_slice);
+    let total = duplications.len() + dead.len() + complexity.len() + coupling.len();
+
+    if total == 0 {
+        md.empty_note("No simplification findings for the scanned files.");
+        return md.render();
+    }
+
+    md.field("Findings", &total.to_string()).blank();
+    render_simplify_duplications(&mut md, duplications);
+    render_simplify_dead_code(&mut md, dead);
+    render_simplify_complexity(&mut md, complexity);
+    render_simplify_coupling(&mut md, coupling);
+    md.render()
+}
+
+fn render_simplify_duplications(md: &mut Md, items: &[Value]) {
+    if items.is_empty() {
+        return;
+    }
+    md.heading(2, "Possible Duplications");
+    let rows = items
+        .iter()
+        .map(|item| {
+            vec![
+                render::field_str(item, "symbol").to_string(),
+                finding_location(item),
+                summarize_similar_symbols(item),
+            ]
+        })
+        .collect::<Vec<_>>();
+    md.table(&["Symbol", "Location", "Similar Symbols"], &rows)
+        .blank();
+}
+
+fn render_simplify_dead_code(md: &mut Md, items: &[Value]) {
+    if items.is_empty() {
+        return;
+    }
+    md.heading(2, "Potential Dead Code");
+    let rows = items
+        .iter()
+        .map(|item| {
+            vec![
+                render::field_str(item, "symbol").to_string(),
+                finding_location(item),
+                render::field_str(item, "reason").to_string(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    md.table(&["Symbol", "Location", "Reason"], &rows).blank();
+}
+
+fn render_simplify_complexity(md: &mut Md, items: &[Value]) {
+    if items.is_empty() {
+        return;
+    }
+    md.heading(2, "Complexity Warnings");
+    let rows = items
+        .iter()
+        .map(|item| {
+            vec![
+                render::field_str(item, "symbol").to_string(),
+                finding_location(item),
+                render::field_i64(item, "lines").to_string(),
+                render::field_i64(item, "fan_out").to_string(),
+                render::field_i64(item, "score").to_string(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    md.table(&["Symbol", "Location", "Lines", "Fan-out", "Score"], &rows)
+        .blank();
+}
+
+fn render_simplify_coupling(md: &mut Md, items: &[Value]) {
+    if items.is_empty() {
+        return;
+    }
+    md.heading(2, "Coupling Warnings");
+    let rows = items
+        .iter()
+        .map(|item| {
+            vec![
+                render::field_str(item, "file").to_string(),
+                render::field_i64(item, "fan_in").to_string(),
+                render::field_str(item, "warning").to_string(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    md.table(&["File", "Fan-in", "Warning"], &rows).blank();
+}
+
+fn finding_location(item: &Value) -> String {
+    format!(
+        "{}:{}",
+        render::field_str(item, "file"),
+        render::field_i64(item, "line")
+    )
+}
+
+fn summarize_similar_symbols(item: &Value) -> String {
+    let Some(similar) = item.get("similar_to").and_then(Value::as_array) else {
+        return String::new();
+    };
+    let Some(first) = similar.first() else {
+        return String::new();
+    };
+    let mut summary = format!(
+        "{} at {}:{}",
+        render::field_str(first, "name"),
+        render::field_str(first, "file"),
+        render::field_i64(first, "line")
+    );
+    if similar.len() > 1 {
+        let _ = write!(summary, " (+{} more)", similar.len() - 1);
+    }
+    summary
 }
 
 /// Handles `tracedecay_type_hierarchy` tool calls.
@@ -1427,32 +1605,7 @@ pub(super) async fn handle_body(
         .and_then(serde_json::Value::as_u64)
         .map_or(3, |v| v.clamp(1, 20) as usize);
 
-    // First try an exact-name lookup against the DB — this avoids the BM25
-    // ranker's tendency to bury a definition under unrelated noise when the
-    // bare name is common (e.g. `gmres` exists as both a `pub fn` and a
-    // struct field). Falls back to suffix / name match inside
-    // `get_nodes_by_qualified_name`.
-    let exact_nodes = cg.get_nodes_by_qualified_name(symbol).await?;
-    let exact_nodes = super::filter_by_scope(exact_nodes, scope_prefix, |n| &n.file_path);
-
-    // Wrap as SearchResult so the existing scoring/rendering path works.
-    let mut candidates: Vec<crate::types::SearchResult> = exact_nodes
-        .into_iter()
-        .map(|node| crate::types::SearchResult { node, score: 0.0 })
-        .collect();
-
-    // If exact lookup returned nothing, fall back to BM25 search.
-    if candidates.is_empty() {
-        let raw = cg.search(symbol, (limit * 4).max(20)).await?;
-        candidates = super::filter_by_scope(raw, scope_prefix, |r| &r.node.file_path);
-    }
-
-    // Whether the matches came from the exact lookup or the search fallback,
-    // sort by `body_kind_preference` so callable / type definitions surface
-    // above fields, variants, uses, etc. This is the bug-#1 fix: when both a
-    // function and a same-named field exist, the function wins.
-    candidates.sort_by_key(|r| body_kind_preference(&r.node.kind));
-    let chosen: Vec<_> = candidates.iter().take(limit).collect();
+    let chosen = body_candidates(cg, symbol, limit, scope_prefix).await?;
 
     if chosen.is_empty() {
         return Ok(ToolResult {
@@ -1469,19 +1622,13 @@ pub(super) async fn handle_body(
 
     for result in &chosen {
         let n = &result.node;
-        let project_path = ProjectPath::resolve(project_root, Path::new(&n.file_path));
-        let body = match project_path {
-            Ok(ref path) => match crate::sync::read_source_file(&path.absolute_path()) {
-                Ok(source) => {
-                    if !touched.contains(&n.file_path) {
-                        touched.push(n.file_path.clone());
-                    }
-                    extract_lines(&source, n.start_line, n.end_line)
-                }
-                Err(_) => String::from("<file unreadable>"),
-            },
-            Err(_) => String::from("<file path outside project>"),
-        };
+        let body = source_body_for_node(
+            project_root,
+            &n.file_path,
+            n.start_line,
+            n.end_line,
+            &mut touched,
+        );
         matches.push(json!({
             "id": n.id,
             "name": n.name,
@@ -1508,6 +1655,63 @@ pub(super) async fn handle_body(
         }),
         touched_files: touched,
     })
+}
+
+async fn body_candidates(
+    cg: &TraceDecay,
+    symbol: &str,
+    limit: usize,
+    scope_prefix: Option<&str>,
+) -> Result<Vec<crate::types::SearchResult>> {
+    // First try an exact-name lookup against the DB — this avoids the BM25
+    // ranker's tendency to bury a definition under unrelated noise when the
+    // bare name is common (e.g. `gmres` exists as both a `pub fn` and a
+    // struct field). Falls back to suffix / name match inside
+    // `get_nodes_by_qualified_name`.
+    let exact_nodes = cg.get_nodes_by_qualified_name(symbol).await?;
+    let exact_nodes = filter_by_scope(exact_nodes, scope_prefix, |n| &n.file_path);
+
+    // Wrap as SearchResult so the existing scoring/rendering path works.
+    let mut candidates: Vec<crate::types::SearchResult> = exact_nodes
+        .into_iter()
+        .map(|node| crate::types::SearchResult { node, score: 0.0 })
+        .collect();
+
+    // If exact lookup returned nothing, fall back to BM25 search.
+    if candidates.is_empty() {
+        let raw = cg.search(symbol, (limit * 4).max(20)).await?;
+        candidates = filter_by_scope(raw, scope_prefix, |r| &r.node.file_path);
+    }
+
+    // Whether the matches came from the exact lookup or the search fallback,
+    // sort by `body_kind_preference` so callable / type definitions surface
+    // above fields, variants, uses, etc. This is the bug-#1 fix: when both a
+    // function and a same-named field exist, the function wins.
+    candidates.sort_by_key(|r| body_kind_preference(&r.node.kind));
+    candidates.truncate(limit);
+    Ok(candidates)
+}
+
+fn source_body_for_node(
+    project_root: &Path,
+    file_path: &str,
+    start_line: u32,
+    end_line: u32,
+    touched: &mut Vec<String>,
+) -> String {
+    let project_path = ProjectPath::resolve(project_root, Path::new(file_path));
+    match project_path {
+        Ok(ref path) => match crate::sync::read_source_file(&path.absolute_path()) {
+            Ok(source) => {
+                if !touched.iter().any(|path| path == file_path) {
+                    touched.push(file_path.to_string());
+                }
+                extract_lines(&source, start_line, end_line)
+            }
+            Err(_) => String::from("<file unreadable>"),
+        },
+        Err(_) => String::from("<file path outside project>"),
+    }
 }
 
 /// Ordering key used by `handle_body` to choose between same-named symbols.
@@ -1959,10 +2163,11 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
             .collect()
     });
 
-    let (_abs_path, display_file) = resolve_indexed_source_file(cg, file).await?;
+    let (abs_path, display_file) = resolve_indexed_source_file(cg, file).await?;
 
     let kinds_slice: Option<&[String]> = kinds.as_deref();
-    let value = render_map(cg.db(), &display_file, kinds_slice).await?;
+    let mut value = render_map(cg.db(), &display_file, kinds_slice).await?;
+    value["ast_grep_outline"] = ast_grep_outline(&abs_path)?;
     let text = render::finalize(Some(cg.project_root()), &args, &value, || {
         render_outline_md(&value)
     });
@@ -1973,6 +2178,58 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
         }),
         touched_files: vec![display_file],
     })
+}
+
+fn ast_grep_outline(abs_path: &Path) -> Result<Value> {
+    ensure_ast_grep_outline_available()?;
+
+    let output = std::process::Command::new("ast-grep")
+        .args([
+            "outline",
+            "--json=compact",
+            "--items",
+            "structure",
+            "--view",
+            "expanded",
+        ])
+        .arg(abs_path)
+        .output()
+        .map_err(|err| TraceDecayError::Config {
+            message: format!("failed to run ast-grep outline: {err}"),
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let detail = if !stderr.trim().is_empty() {
+            stderr.trim()
+        } else if !stdout.trim().is_empty() {
+            stdout.trim()
+        } else {
+            "no output"
+        };
+        return Err(TraceDecayError::Config {
+            message: format!("ast-grep outline failed: {detail}"),
+        });
+    }
+
+    serde_json::from_slice::<Value>(&output.stdout).map_err(|err| TraceDecayError::Config {
+        message: format!("failed to parse ast-grep outline JSON: {err}"),
+    })
+}
+
+fn ensure_ast_grep_outline_available() -> Result<()> {
+    let diagnostics = super::super::definitions::ast_grep_diagnostics();
+    if diagnostics.outline_available {
+        Ok(())
+    } else {
+        Err(TraceDecayError::Config {
+            message: format!(
+                "tracedecay_outline requires ast-grep outline >= 0.44: {}",
+                diagnostics.message
+            ),
+        })
+    }
 }
 
 fn render_outline_md(value: &Value) -> String {
@@ -2062,54 +2319,24 @@ pub(super) fn handle_config(cg: &TraceDecay, args: &Value) -> Result<ToolResult>
         let Ok(contents) = std::fs::read_to_string(&abs) else {
             continue;
         };
-        let parsed = match config_format(&rel) {
-            Some(ConfigFormat::Toml) => match toml::from_str::<toml::Value>(&contents) {
-                Ok(v) => toml_to_json(&v),
-                Err(e) => {
-                    matches.push(json!({
-                        "file": rel,
-                        "error": format!("toml parse error: {e}"),
-                    }));
-                    continue;
-                }
-            },
-            Some(ConfigFormat::Json) => match serde_json::from_str::<Value>(&contents) {
-                Ok(v) => v,
-                Err(e) => {
-                    matches.push(json!({
-                        "file": rel,
-                        "error": format!("json parse error: {e}"),
-                    }));
-                    continue;
-                }
-            },
-            None => continue,
+        let Some(parsed) = parse_config_value(&rel, &contents) else {
+            continue;
         };
-
-        let value = lookup_dotted(&parsed, key);
-        let line = match &value {
-            Some(_) => find_key_line(&contents, key),
-            None => None,
+        let parsed = match parsed {
+            Ok(value) => value,
+            Err(error) => {
+                matches.push(json!({
+                    "file": rel,
+                    "error": error,
+                }));
+                continue;
+            }
         };
 
         if !touched.contains(&rel) {
             touched.push(rel.clone());
         }
-
-        matches.push(match value {
-            Some(v) => json!({
-                "file": rel,
-                "key": key,
-                "value": v,
-                "line": line,
-            }),
-            None => json!({
-                "file": rel,
-                "key": key,
-                "value": Value::Null,
-                "found": false,
-            }),
-        });
+        matches.push(config_match_value(&rel, key, &contents, &parsed));
     }
 
     let payload = json!({
@@ -2134,19 +2361,25 @@ enum ConfigFormat {
 }
 
 fn config_format(path: &str) -> Option<ConfigFormat> {
-    if std::path::Path::new(path)
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
-    {
+    let extension = Path::new(path).extension()?;
+    if extension.eq_ignore_ascii_case("toml") {
         Some(ConfigFormat::Toml)
-    } else if std::path::Path::new(path)
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
-    {
+    } else if extension.eq_ignore_ascii_case("json") {
         Some(ConfigFormat::Json)
     } else {
         None
     }
+}
+
+fn parse_config_value(path: &str, contents: &str) -> Option<std::result::Result<Value, String>> {
+    let parsed = match config_format(path)? {
+        ConfigFormat::Toml => toml::from_str::<toml::Value>(contents)
+            .map(|value| toml_to_json(&value))
+            .map_err(|err| format!("toml parse error: {err}")),
+        ConfigFormat::Json => serde_json::from_str::<Value>(contents)
+            .map_err(|err| format!("json parse error: {err}")),
+    };
+    Some(parsed)
 }
 
 fn lookup_dotted(value: &Value, key: &str) -> Option<Value> {
@@ -2184,21 +2417,41 @@ fn toml_to_json(v: &toml::Value) -> Value {
     }
 }
 
+fn config_match_value(file: &str, key: &str, contents: &str, parsed: &Value) -> Value {
+    match lookup_dotted(parsed, key) {
+        Some(value) => json!({
+            "file": file,
+            "key": key,
+            "value": value,
+            "line": find_key_line(contents, key),
+        }),
+        None => json!({
+            "file": file,
+            "key": key,
+            "value": Value::Null,
+            "found": false,
+        }),
+    }
+}
+
 fn find_key_line(contents: &str, key: &str) -> Option<u32> {
     let last = key.rsplit('.').next()?;
-    let toml_form_eq = format!("{last} =");
-    let toml_form_quoted = format!("\"{last}\" =");
-    let json_form = format!("\"{last}\":");
+    let prefixes = config_key_line_prefixes(last);
     for (idx, line) in contents.lines().enumerate() {
         let trimmed = line.trim_start();
-        if trimmed.starts_with(&toml_form_eq)
-            || trimmed.starts_with(&toml_form_quoted)
-            || trimmed.starts_with(&json_form)
-        {
+        if prefixes.iter().any(|prefix| trimmed.starts_with(prefix)) {
             return Some((idx as u32) + 1);
         }
     }
     None
+}
+
+fn config_key_line_prefixes(key: &str) -> [String; 3] {
+    [
+        format!("{key} ="),
+        format!("\"{key}\" ="),
+        format!("\"{key}\":"),
+    ]
 }
 
 /// Handles `tracedecay_signature_search` — substring search across the

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -2167,7 +2167,15 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
 
     let kinds_slice: Option<&[String]> = kinds.as_deref();
     let mut value = render_map(cg.db(), &display_file, kinds_slice).await?;
-    value["ast_grep_outline"] = ast_grep_outline(&abs_path)?;
+    match ast_grep_outline(&abs_path) {
+        Ok(outline) => {
+            value["ast_grep_outline"] = outline;
+        }
+        Err(err) => {
+            value["ast_grep_outline"] = Value::Null;
+            value["ast_grep_outline_error"] = json!(err.to_string());
+        }
+    }
     let text = render::finalize(Some(cg.project_root()), &args, &value, || {
         render_outline_md(&value)
     });

--- a/src/mcp/tools/handlers/memory.rs
+++ b/src/mcp/tools/handlers/memory.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 
 use crate::db::Database;
 use crate::errors::{Result, TraceDecayError};
+use crate::global_db::GlobalDb;
 use crate::memory::retrieval::FactRetriever;
 use crate::memory::store::MemoryStore;
 use crate::memory::trust::DEFAULT_TRUST;
@@ -15,32 +16,59 @@ use crate::memory::types::{
 };
 use crate::tracedecay::TraceDecay;
 
-use super::super::render;
+use super::super::render::{self, truncated_json_envelope_with_handle};
 use super::super::ToolResult;
-use super::{
-    global_db_profile_root, project_registry_context, project_selector_present,
-    safe_profile_relpath, truncated_json_envelope_with_handle,
+use super::support::{
+    profile_root_for_global_db, project_registry_context, project_selector_present,
+    safe_profile_relpath, string_array_values,
 };
 
 const DEFAULT_FACT_LIMIT: usize = 20;
 const MAX_FACT_LIMIT: usize = 200;
 
-fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
-    let formatted = serde_json::to_string(value).unwrap_or_default();
+struct TargetMemoryDb {
+    db: Database,
+    project_root: PathBuf,
+}
+
+fn text_tool_result(text: &str) -> ToolResult {
     ToolResult {
-        value: json!({ "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(project_root, &formatted) }] }),
+        value: json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files: vec![],
     }
 }
 
-async fn open_target_memory_db(cg: &TraceDecay, args: &Value) -> Result<(Database, PathBuf)> {
-    let Some(context) = project_registry_context(args, &["project_path"]).await? else {
-        return Ok((
-            cg.open_project_store_db().await?,
-            cg.project_root().to_path_buf(),
-        ));
+fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
+    let formatted = serde_json::to_string(value).unwrap_or_default();
+    let text = truncated_json_envelope_with_handle(project_root, &formatted);
+    text_tool_result(&text)
+}
+
+fn rendered_tool_json(project_root: Option<&Path>, args: &Value, value: &Value) -> ToolResult {
+    let text = render::finalize(project_root, args, value, || render::generic_md(value));
+    text_tool_result(&text)
+}
+
+async fn open_target_memory_db(
+    cg: &TraceDecay,
+    args: &Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<TargetMemoryDb> {
+    let Some(context) = project_registry_context(
+        args,
+        &["project_path"],
+        global_db,
+        allow_default_registry_fallback,
+    )
+    .await?
+    else {
+        return Ok(TargetMemoryDb {
+            db: cg.open_project_store_db().await?,
+            project_root: cg.project_root().to_path_buf(),
+        });
     };
-    let profile_root = global_db_profile_root()?;
+    let profile_root = profile_root_for_global_db(global_db, allow_default_registry_fallback)?;
     let graph_relpath = context
         .stores
         .iter()
@@ -61,7 +89,10 @@ async fn open_target_memory_db(cg: &TraceDecay, args: &Value) -> Result<(Databas
         )));
     }
     let (db, _) = Database::open(&db_path).await?;
-    Ok((db, PathBuf::from(context.project.display_root)))
+    Ok(TargetMemoryDb {
+        db,
+        project_root: PathBuf::from(context.project.display_root),
+    })
 }
 
 fn config_error(message: impl Into<String>) -> TraceDecayError {
@@ -96,18 +127,6 @@ fn optional_f64(args: &Value, key: &str) -> Option<f64> {
     args.get(key).and_then(Value::as_f64)
 }
 
-fn string_array(args: &Value, key: &str) -> Vec<String> {
-    args.get(key)
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| item.as_str().map(ToOwned::to_owned))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 fn fact_id(args: &Value) -> Result<i64> {
     let value = args
         .get("fact_id")
@@ -128,7 +147,7 @@ fn metadata_with_tags(args: &Value) -> Value {
         .cloned()
         .filter(Value::is_object)
         .unwrap_or_else(|| json!({}));
-    let tags = string_array(args, "tags");
+    let tags = string_array_values(args, "tags");
     if !tags.is_empty() {
         if let Some(map) = metadata.as_object_mut() {
             map.insert("tags".to_string(), json!(tags));
@@ -138,7 +157,7 @@ fn metadata_with_tags(args: &Value) -> Value {
 }
 
 fn request_entities(args: &Value) -> Vec<String> {
-    let mut entities = string_array(args, "entities");
+    let mut entities = string_array_values(args, "entities");
     if let Some(entity) = args.get("entity").and_then(Value::as_str) {
         entities.push(entity.to_string());
     }
@@ -250,7 +269,12 @@ async fn update_trust(args: &Value, store: &MemoryStore<'_>, fact_id: i64) -> Re
     Ok(Some((existing.trust_score + delta).clamp(0.0, 1.0)))
 }
 
-pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+pub(super) async fn handle_fact_store(
+    cg: &TraceDecay,
+    args: Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
     let action = required_str(&args, "action")?;
     let cross_project_selector = project_selector_present(&args, &["project_path"]);
     if action_mutates_memory(action) && cross_project_selector {
@@ -258,8 +282,9 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
             "cross-project fact_store writes are not supported; omit project_selector to write the active project",
         ));
     }
-    let (db, target_root) = open_target_memory_db(cg, &args).await?;
-    let conn = db.conn();
+    let target_memory =
+        open_target_memory_db(cg, &args, global_db, allow_default_registry_fallback).await?;
+    let conn = target_memory.db.conn();
     let store = MemoryStore::new(conn);
     let out = match action {
         "add" => {
@@ -272,7 +297,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                             .get("source")
                             .and_then(Value::as_str)
                             .map(ToOwned::to_owned),
-                        tags: string_array(&args, "tags"),
+                        tags: string_array_values(&args, "tags"),
                         entities: request_entities(&args),
                         trust: optional_f64(&args, "trust"),
                         metadata: metadata_with_tags(&args),
@@ -415,7 +440,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
                     .and_then(Value::as_str)
                     .map(ToOwned::to_owned),
                 category: optional_category(&args)?,
-                tags: args.get("tags").map(|_| string_array(&args, "tags")),
+                tags: args.get("tags").map(|_| string_array_values(&args, "tags")),
                 entities: args.get("entities").map(|_| request_entities(&args)),
                 trust: update_trust(&args, &store, id).await?,
                 source: args
@@ -458,7 +483,7 @@ pub(super) async fn handle_fact_store(cg: &TraceDecay, args: Value) -> Result<To
         }
         other => return Err(config_error(format!("unknown fact_store action: {other}"))),
     };
-    Ok(tool_json(Some(&target_root), &out))
+    Ok(tool_json(Some(&target_memory.project_root), &out))
 }
 
 pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
@@ -485,15 +510,19 @@ pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result
     ))
 }
 
-pub(super) async fn handle_memory_status(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let (db, target_root) = open_target_memory_db(cg, &args).await?;
-    let status = TraceDecay::memory_status_for_conn(db.conn()).await?;
+pub(super) async fn handle_memory_status(
+    cg: &TraceDecay,
+    args: Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
+    let target_memory =
+        open_target_memory_db(cg, &args, global_db, allow_default_registry_fallback).await?;
+    let status = TraceDecay::memory_status_for_conn(target_memory.db.conn()).await?;
     let value = json!({ "status": "ok", "memory": status });
-    let text = render::finalize(Some(&target_root), &args, &value, || {
-        render::generic_md(&value)
-    });
-    Ok(ToolResult {
-        value: json!({ "content": [{ "type": "text", "text": text }] }),
-        touched_files: vec![],
-    })
+    Ok(rendered_tool_json(
+        Some(&target_memory.project_root),
+        &args,
+        &value,
+    ))
 }

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -62,16 +62,40 @@ async fn selected_registered_project_reader(
         return Ok(None);
     };
 
-    let profile_root = profile_root_for_global_db(global_db, allow_default_registry_fallback)?;
-    TraceDecay::open_read_only_with_options(
-        Path::new(&context.project.canonical_root),
-        crate::tracedecay::TraceDecayOpenOptions {
-            profile_root: Some(profile_root.clone()),
-            global_db_path: global_db.map(|db| db.db_path().to_path_buf()),
-        },
-    )
-    .await
-    .map(Some)
+    let global_db_path = global_db
+        .map(|db| db.db_path().to_path_buf())
+        .or_else(crate::global_db::global_db_path);
+    let mut profile_roots = vec![profile_root_for_global_db(
+        global_db,
+        allow_default_registry_fallback,
+    )?];
+    if let Ok(default_profile_root) = crate::storage::default_profile_root() {
+        if !profile_roots
+            .iter()
+            .any(|root| root == &default_profile_root)
+        {
+            profile_roots.push(default_profile_root);
+        }
+    }
+
+    let mut last_error = None;
+    for profile_root in profile_roots {
+        match TraceDecay::open_read_only_with_options(
+            Path::new(&context.project.canonical_root),
+            crate::tracedecay::TraceDecayOpenOptions {
+                profile_root: Some(profile_root),
+                global_db_path: global_db_path.clone(),
+            },
+        )
+        .await
+        {
+            Ok(cg) => return Ok(Some(cg)),
+            Err(err) => last_error = Some(err),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| TraceDecayError::Config {
+        message: "registered project could not be opened".to_string(),
+    }))
 }
 
 fn handle_retrieve(cg: &TraceDecay, args: &Value) -> Result<ToolResult> {
@@ -782,9 +806,7 @@ mod tests {
         // host CLI capabilities they need; agents should never see a tool that
         // will instantly fail. The count and per-tool checks below adapt to
         // the host's capability set.
-        let expected_total = 92
-            + usize::from(super::super::definitions::ast_grep_available())
-            + usize::from(super::super::definitions::ast_grep_outline_available());
+        let expected_total = 93 + usize::from(super::super::definitions::ast_grep_available());
         assert_eq!(tools.len(), expected_total);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -14,117 +14,24 @@ pub mod info;
 pub mod memory;
 pub mod redundancy;
 pub mod session;
+mod support;
 pub mod workflow;
 
-use std::collections::HashSet;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use serde_json::{json, Value};
 
 use crate::errors::{Result, TraceDecayError};
-use crate::global_db::{global_db_path, GlobalDb, ProjectRegistryContext};
-use crate::mcp::response_handles::{
-    note_response_handle_store_skipped_no_project_root, observe_response_truncation,
-    retrieve_response_handle, store_response_handle, ResponseHandleLookup,
-    RESPONSE_HANDLE_TTL_SECS, RESPONSE_RETRIEVE_TOOL,
-};
+use crate::global_db::GlobalDb;
+use crate::mcp::response_handles::{retrieve_response_handle, ResponseHandleLookup};
 use crate::tracedecay::current_timestamp;
 use crate::tracedecay::TraceDecay;
 
-use super::{ToolResult, MAX_RESPONSE_CHARS};
-
-/// Extracts the `node_id` parameter from tool arguments, accepting `id` as a
-/// fallback alias. LLMs occasionally shorten `node_id` to `id`; this avoids a
-/// confusing error when that happens.
-pub(crate) fn require_node_id(args: &Value) -> Result<&str> {
-    args.get("node_id")
-        .or_else(|| args.get("id"))
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: node_id".to_string(),
-        })
-}
-
-/// Returns the user-provided `path` argument, falling back to the scope
-/// prefix when the argument is absent. This makes listing tools
-/// automatically scoped to the subdirectory the server was launched from.
-pub(crate) fn effective_path<'a>(
-    args: &'a Value,
-    scope_prefix: Option<&'a str>,
-) -> Option<&'a str> {
-    args.get("path").and_then(|v| v.as_str()).or(scope_prefix)
-}
-
-/// Filters a Vec of items by file path prefix when a scope is active.
-/// Returns the vec unchanged when `scope_prefix` is `None`.
-pub(crate) fn filter_by_scope<T, F>(
-    items: Vec<T>,
-    scope_prefix: Option<&str>,
-    get_path: F,
-) -> Vec<T>
-where
-    F: Fn(&T) -> &str,
-{
-    match scope_prefix {
-        Some(prefix) => {
-            let with_slash = if prefix.ends_with('/') {
-                prefix.to_string()
-            } else {
-                format!("{prefix}/")
-            };
-            items
-                .into_iter()
-                .filter(|item| {
-                    let p = get_path(item);
-                    p.starts_with(&with_slash) || p == prefix
-                })
-                .collect()
-        }
-        None => items,
-    }
-}
-
-/// Deduplicates an iterator of file path strings into a `Vec<String>`.
-pub(crate) fn unique_file_paths<'a>(paths: impl Iterator<Item = &'a str>) -> Vec<String> {
-    let mut seen = HashSet::new();
-    let mut result = Vec::new();
-    for p in paths {
-        if seen.insert(p) {
-            result.push(p.to_string());
-        }
-    }
-    result
-}
-
-pub(crate) fn safe_profile_relpath(value: &str) -> Result<PathBuf> {
-    let path = PathBuf::from(value);
-    if path.is_absolute()
-        || path
-            .components()
-            .any(|component| matches!(component, Component::ParentDir))
-    {
-        return Err(TraceDecayError::Config {
-            message: format!("registry artifact path is not a safe profile-relative path: {value}"),
-        });
-    }
-    Ok(path)
-}
-
-pub(crate) fn global_db_profile_root() -> Result<PathBuf> {
-    global_db_path()
-        .and_then(|path| path.parent().map(Path::to_path_buf))
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "could not resolve tracedecay profile root".to_string(),
-        })
-}
-
-pub(crate) fn project_selector_present(args: &Value, top_level_path_keys: &[&str]) -> bool {
-    args.get("project_selector").is_some()
-        || args.get("project_id").is_some()
-        || top_level_path_keys
-            .iter()
-            .any(|key| args.get(*key).is_some())
-}
+use super::dispatch_policy::{
+    tool_accepts_registered_project_selector, tool_dispatches_registered_project_reader,
+};
+use super::ToolResult;
+use support::{profile_root_for_global_db, project_registry_context, project_selector_present};
 
 fn rejected_tool_project_selector_present(tool_name: &str, args: &Value) -> bool {
     let top_level_path_keys = if tool_name.starts_with("tracedecay_lcm_") {
@@ -135,275 +42,36 @@ fn rejected_tool_project_selector_present(tool_name: &str, args: &Value) -> bool
     project_selector_present(args, top_level_path_keys)
 }
 
-pub(crate) async fn project_registry_context(
-    args: &Value,
-    top_level_path_keys: &[&str],
-) -> Result<Option<ProjectRegistryContext>> {
-    let selector_present = project_selector_present(args, top_level_path_keys);
-    let selector = args
-        .get("project_selector")
-        .map(|value| {
-            value.as_object().ok_or_else(|| TraceDecayError::Config {
-                message: "project_selector must be an object".to_string(),
-            })
-        })
-        .transpose()?;
-    let project_id = selector
-        .and_then(|selector| selector.get("project_id"))
-        .or_else(|| args.get("project_id"))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-    let project_path = selector
-        .and_then(|selector| {
-            selector
-                .get("path")
-                .or_else(|| selector.get("project_path"))
-        })
-        .or_else(|| top_level_path_keys.iter().find_map(|key| args.get(*key)))
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-    if project_id.is_none() && project_path.is_none() {
-        if selector_present {
-            return Err(TraceDecayError::Config {
-                message: "project selector must include project_id or project_path".to_string(),
-            });
-        }
-        return Ok(None);
-    }
-
-    let db = GlobalDb::open()
-        .await
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "could not open tracedecay project registry; run tracedecay init first"
-                .to_string(),
-        })?;
-    let context = if let Some(project_id) = project_id {
-        db.project_registry_context_by_id(project_id).await
-    } else if let Some(project_path) = project_path {
-        db.project_registry_context_by_alias(Path::new(project_path))
-            .await
-    } else {
-        return Ok(None);
-    };
-
-    context
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "registered project not found for selector".to_string(),
-        })
-        .map(Some)
-}
-
-fn tool_accepts_registered_project_selector(tool_name: &str) -> bool {
-    matches!(
-        tool_name,
-        "tracedecay_search"
-            | "tracedecay_context"
-            | "tracedecay_retrieve"
-            | "tracedecay_callers"
-            | "tracedecay_callees"
-            | "tracedecay_impact"
-            | "tracedecay_node"
-            | "tracedecay_files"
-            | "tracedecay_body"
-            | "tracedecay_read"
-            | "tracedecay_outline"
-            | "tracedecay_signature_search"
-            | "tracedecay_implementations"
-            | "tracedecay_callers_for"
-            | "tracedecay_call_chain"
-            | "tracedecay_file_dependents"
-            | "tracedecay_find_exact_symbol"
-            | "tracedecay_by_qualified_name"
-            | "tracedecay_signature"
-            | "tracedecay_impls"
-            | "tracedecay_derives"
-            | "tracedecay_project_context"
-            | "tracedecay_fact_store"
-            | "tracedecay_memory_status"
-            | "tracedecay_message_search"
-    )
-}
-
-fn tool_dispatches_registered_project_reader(tool_name: &str) -> bool {
-    matches!(
-        tool_name,
-        "tracedecay_search"
-            | "tracedecay_context"
-            | "tracedecay_retrieve"
-            | "tracedecay_callers"
-            | "tracedecay_callees"
-            | "tracedecay_impact"
-            | "tracedecay_node"
-            | "tracedecay_files"
-            | "tracedecay_body"
-            | "tracedecay_read"
-            | "tracedecay_outline"
-            | "tracedecay_signature_search"
-            | "tracedecay_implementations"
-            | "tracedecay_callers_for"
-            | "tracedecay_call_chain"
-            | "tracedecay_file_dependents"
-            | "tracedecay_find_exact_symbol"
-            | "tracedecay_by_qualified_name"
-            | "tracedecay_signature"
-            | "tracedecay_impls"
-            | "tracedecay_derives"
-    )
-}
-
 async fn selected_registered_project_reader(
     tool_name: &str,
     args: &Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
 ) -> Result<Option<TraceDecay>> {
     if !tool_dispatches_registered_project_reader(tool_name) {
         return Ok(None);
     }
-    let Some(context) = project_registry_context(args, &["project_path", "project_root"]).await?
+    let Some(context) = project_registry_context(
+        args,
+        &["project_path", "project_root"],
+        global_db,
+        allow_default_registry_fallback,
+    )
+    .await?
     else {
         return Ok(None);
     };
 
-    TraceDecay::open_read_only(Path::new(&context.project.canonical_root))
-        .await
-        .map(Some)
-}
-
-/// Truncates a string to the maximum response character limit, appending
-/// a truncation notice if necessary.
-pub(crate) fn truncate_response(s: &str) -> String {
-    debug_assert!(!s.is_empty(), "truncate_response called with empty string");
-    if s.len() <= MAX_RESPONSE_CHARS {
-        s.to_string()
-    } else {
-        let started = std::time::Instant::now();
-        let now = current_timestamp();
-        // Find a valid UTF-8 character boundary at or before MAX_RESPONSE_CHARS
-        let mut end = MAX_RESPONSE_CHARS;
-        while !s.is_char_boundary(end) && end > 0 {
-            end -= 1;
-        }
-        let truncated = format!("{}\n\n[... truncated at {} chars]", &s[..end], end);
-        observe_response_truncation(
-            s.len(),
-            truncated.len(),
-            false,
-            now,
-            "not_available",
-            started.elapsed(),
-        );
-        truncated
-    }
-}
-
-/// Wraps a JSON string that exceeds `MAX_RESPONSE_CHARS` in a
-/// `{"truncated": true, "preview": "..."}` envelope so the result is
-/// always valid JSON, never a mid-structure cut.
-///
-/// Prefer this over [`truncate_response`] for handlers whose payload is
-/// always JSON (e.g. the dashboard handler) to avoid breaking consumers
-/// that parse the entire response text.
-/// Wraps oversized JSON text in a valid preview envelope. When a project root
-/// is available, stores the full original locally and includes a retrieval
-/// handle.
-///
-/// If local handle storage is unavailable or fails, the envelope still carries
-/// a preview but also includes explicit recovery metadata so clients can tell
-/// why no handle was emitted and what to retry.
-pub(crate) fn truncated_json_envelope_with_handle(
-    project_root: Option<&Path>,
-    formatted: &str,
-) -> String {
-    if formatted.len() <= MAX_RESPONSE_CHARS {
-        return formatted.to_string();
-    }
-    let started = std::time::Instant::now();
-    let now = current_timestamp();
-    let mut handle_unavailable = None;
-    let stored = if let Some(root) = project_root {
-        match store_response_handle(root, formatted, current_timestamp()) {
-            Ok(record) => Some(record),
-            Err(err) => {
-                handle_unavailable = Some(json!({
-                    "reason_code": "handle_store_failed",
-                    "message": format!(
-                        "The full response could not be cached locally, so no retrieval handle is available: {err}"
-                    ),
-                    "retryable": true,
-                    "retry_instruction": "Fix the local project cache path or filesystem error, then re-run the original MCP tool to regenerate the full response and a fresh handle."
-                }));
-                None
-            }
-        }
-    } else {
-        note_response_handle_store_skipped_no_project_root();
-        handle_unavailable = Some(json!({
-            "reason_code": "handle_storage_unavailable",
-            "message": "This response was truncated in a context without a project-local cache path, so no retrieval handle could be created.",
-            "retryable": true,
-            "retry_instruction": "Re-run the original MCP tool from a project-scoped tracedecay session if you need a retrievable full response."
-        }));
-        None
-    };
-    let mut end = formatted.len().min(MAX_RESPONSE_CHARS.saturating_sub(1024));
-    loop {
-        while end > 0 && !formatted.is_char_boundary(end) {
-            end -= 1;
-        }
-        let preview = &formatted[..end];
-        let mut envelope = json!({
-            "truncated": true,
-            "original_chars": formatted.len(),
-            "preview_chars": preview.len(),
-            "preview": preview,
-        });
-        if let Some(object) = envelope.as_object_mut() {
-            if let Some(record) = &stored {
-                object.insert("handle".to_string(), json!(record.handle));
-                object.insert("retrieve_tool".to_string(), json!(RESPONSE_RETRIEVE_TOOL));
-                object.insert(
-                    "retrieve_ttl_seconds".to_string(),
-                    json!(RESPONSE_HANDLE_TTL_SECS),
-                );
-                object.insert("retrieve_expires_at".to_string(), json!(record.expires_at));
-                object.insert(
-                    "retrieve_instruction".to_string(),
-                    json!(format!(
-                        "This response was truncated: `preview` contains only the first {} of {} characters. The full original response is stored locally in this project and expires at {} (TTL {} seconds). To recover it, call `{RESPONSE_RETRIEVE_TOOL}` with required argument `handle` set to `{}`. If the original tool call used a project selector (`project_id`, `project_path`, or `project_selector`), pass the same selector to `{RESPONSE_RETRIEVE_TOOL}` so the handle is looked up in the same project cache. Only call it if the missing details are needed to answer the user's request.",
-                        preview.len(),
-                        formatted.len(),
-                        record.expires_at,
-                        RESPONSE_HANDLE_TTL_SECS,
-                        record.handle
-                    )),
-                );
-            } else if let Some(status) = &handle_unavailable {
-                object.insert("handle_available".to_string(), json!(false));
-                object.insert("handle_status".to_string(), status.clone());
-            }
-        }
-        let text = serde_json::to_string_pretty(&envelope).unwrap_or_default();
-        if text.len() <= MAX_RESPONSE_CHARS || end == 0 {
-            let handle_status = if stored.is_some() {
-                "stored"
-            } else if project_root.is_none() {
-                "no_project_root"
-            } else {
-                "store_failed"
-            };
-            observe_response_truncation(
-                formatted.len(),
-                text.len(),
-                true,
-                now,
-                handle_status,
-                started.elapsed(),
-            );
-            return text;
-        }
-        end = end.saturating_sub(1024);
-    }
+    let profile_root = profile_root_for_global_db(global_db, allow_default_registry_fallback)?;
+    TraceDecay::open_read_only_with_options(
+        Path::new(&context.project.canonical_root),
+        crate::tracedecay::TraceDecayOpenOptions {
+            profile_root: Some(profile_root.clone()),
+            global_db_path: global_db.map(|db| db.db_path().to_path_buf()),
+        },
+    )
+    .await
+    .map(Some)
 }
 
 fn handle_retrieve(cg: &TraceDecay, args: &Value) -> Result<ToolResult> {
@@ -469,6 +137,19 @@ pub async fn handle_tool_call(
     server_stats: Option<Value>,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
+    handle_tool_call_with_registry(cg, tool_name, args, server_stats, scope_prefix, None, true)
+        .await
+}
+
+pub async fn handle_tool_call_with_registry(
+    cg: &TraceDecay,
+    tool_name: &str,
+    args: Value,
+    server_stats: Option<Value>,
+    scope_prefix: Option<&str>,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
     debug_assert!(
         !tool_name.is_empty(),
         "handle_tool_call called with empty tool_name"
@@ -486,7 +167,13 @@ pub async fn handle_tool_call(
             ),
         });
     }
-    let selected_cg = selected_registered_project_reader(tool_name, &args).await?;
+    let selected_cg = selected_registered_project_reader(
+        tool_name,
+        &args,
+        global_db,
+        allow_default_registry_fallback,
+    )
+    .await?;
     let selected_scope_prefix = if selected_cg.is_some() {
         None
     } else {
@@ -506,9 +193,15 @@ pub async fn handle_tool_call(
             Ok(info::handle_active_project(cg, server_stats, scope_prefix))
         }
         "tracedecay_storage_status" => info::handle_storage_status(cg, args, scope_prefix).await,
-        "tracedecay_project_list" => info::handle_project_list(args).await,
-        "tracedecay_project_search" => info::handle_project_search(args).await,
-        "tracedecay_project_context" => info::handle_project_context(cg, args).await,
+        "tracedecay_project_list" => {
+            info::handle_project_list(args, global_db, allow_default_registry_fallback).await
+        }
+        "tracedecay_project_search" => {
+            info::handle_project_search(args, global_db, allow_default_registry_fallback).await
+        }
+        "tracedecay_project_context" => {
+            info::handle_project_context(cg, args, global_db, allow_default_registry_fallback).await
+        }
         "tracedecay_files" => info::handle_files(cg, args, selected_scope_prefix).await,
         "tracedecay_affected" => git::handle_affected(cg, args).await,
         "tracedecay_dead_code" => analysis::handle_dead_code(cg, args, scope_prefix).await,
@@ -589,32 +282,47 @@ pub async fn handle_tool_call(
         "tracedecay_diagnose" => workflow::handle_diagnose(cg, args).await,
         "tracedecay_run_affected_tests" => workflow::handle_run_affected_tests(cg, args).await,
         "tracedecay_derives" => graph::handle_derives(cg, args).await,
-        "tracedecay_fact_store" => memory::handle_fact_store(cg, args).await,
+        "tracedecay_fact_store" => {
+            memory::handle_fact_store(cg, args, global_db, allow_default_registry_fallback).await
+        }
         "tracedecay_fact_feedback" => memory::handle_fact_feedback(cg, args).await,
-        "tracedecay_memory_status" => memory::handle_memory_status(cg, args).await,
+        "tracedecay_memory_status" => {
+            memory::handle_memory_status(cg, args, global_db, allow_default_registry_fallback).await
+        }
         "tracedecay_dashboard" => dashboard::handle_dashboard(cg, args).await,
-        "tracedecay_message_search" => session::handle_message_search(cg, args).await,
-        "tracedecay_lcm_status" => session::handle_lcm_status(Some(cg.project_root()), args).await,
-        "tracedecay_lcm_doctor" => session::handle_lcm_doctor(Some(cg.project_root()), args).await,
+        "tracedecay_message_search" => {
+            session::handle_message_search(cg, args, global_db, allow_default_registry_fallback)
+                .await
+        }
+        "tracedecay_lcm_status" => {
+            session::handle_lcm_status(session::LcmHandlerContext::active(cg), args).await
+        }
+        "tracedecay_lcm_doctor" => {
+            session::handle_lcm_doctor(session::LcmHandlerContext::active(cg), args).await
+        }
         "tracedecay_lcm_load_session" => {
-            session::handle_lcm_load_session(Some(cg.project_root()), args).await
+            session::handle_lcm_load_session(session::LcmHandlerContext::active(cg), args).await
         }
-        "tracedecay_lcm_grep" => session::handle_lcm_grep(Some(cg.project_root()), args).await,
+        "tracedecay_lcm_grep" => {
+            session::handle_lcm_grep(session::LcmHandlerContext::active(cg), args).await
+        }
         "tracedecay_lcm_describe" => {
-            session::handle_lcm_describe(Some(cg.project_root()), args).await
+            session::handle_lcm_describe(session::LcmHandlerContext::active(cg), args).await
         }
-        "tracedecay_lcm_expand" => session::handle_lcm_expand(Some(cg.project_root()), args).await,
+        "tracedecay_lcm_expand" => {
+            session::handle_lcm_expand(session::LcmHandlerContext::active(cg), args).await
+        }
         "tracedecay_lcm_expand_query" => {
-            session::handle_lcm_expand_query(Some(cg.project_root()), args).await
+            session::handle_lcm_expand_query(session::LcmHandlerContext::active(cg), args).await
         }
         "tracedecay_lcm_preflight" => {
-            session::handle_lcm_preflight(Some(cg.project_root()), args).await
+            session::handle_lcm_preflight(session::LcmHandlerContext::active(cg), args).await
         }
         "tracedecay_lcm_compress" => {
-            session::handle_lcm_compress(Some(cg.project_root()), args).await
+            session::handle_lcm_compress(session::LcmHandlerContext::active(cg), args).await
         }
         "tracedecay_lcm_session_boundary" => {
-            session::handle_lcm_session_boundary(Some(cg.project_root()), args).await
+            session::handle_lcm_session_boundary(session::LcmHandlerContext::active(cg), args).await
         }
         _ => Err(TraceDecayError::Config {
             message: format!("unknown tool: {tool_name}"),
@@ -629,16 +337,37 @@ pub async fn handle_profile_scoped_lcm_tool_call(
     args: Value,
 ) -> Result<ToolResult> {
     match tool_name {
-        "tracedecay_lcm_status" => session::handle_lcm_status(None, args).await,
-        "tracedecay_lcm_doctor" => session::handle_lcm_doctor(None, args).await,
-        "tracedecay_lcm_load_session" => session::handle_lcm_load_session(None, args).await,
-        "tracedecay_lcm_grep" => session::handle_lcm_grep(None, args).await,
-        "tracedecay_lcm_describe" => session::handle_lcm_describe(None, args).await,
-        "tracedecay_lcm_expand" => session::handle_lcm_expand(None, args).await,
-        "tracedecay_lcm_expand_query" => session::handle_lcm_expand_query(None, args).await,
-        "tracedecay_lcm_preflight" => session::handle_lcm_preflight(None, args).await,
-        "tracedecay_lcm_compress" => session::handle_lcm_compress(None, args).await,
-        "tracedecay_lcm_session_boundary" => session::handle_lcm_session_boundary(None, args).await,
+        "tracedecay_lcm_status" => {
+            session::handle_lcm_status(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_doctor" => {
+            session::handle_lcm_doctor(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_load_session" => {
+            session::handle_lcm_load_session(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_grep" => {
+            session::handle_lcm_grep(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_describe" => {
+            session::handle_lcm_describe(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_expand" => {
+            session::handle_lcm_expand(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_expand_query" => {
+            session::handle_lcm_expand_query(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_preflight" => {
+            session::handle_lcm_preflight(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_compress" => {
+            session::handle_lcm_compress(session::LcmHandlerContext::projectless(), args).await
+        }
+        "tracedecay_lcm_session_boundary" => {
+            session::handle_lcm_session_boundary(session::LcmHandlerContext::projectless(), args)
+                .await
+        }
         _ => Err(TraceDecayError::Config {
             message: format!("tool `{tool_name}` does not support profile-scoped dispatch"),
         }),
@@ -655,6 +384,7 @@ pub async fn handle_profile_scoped_lcm_tool_call(
 mod tests {
     use std::collections::BTreeSet;
     use std::ffi::{OsStr, OsString};
+    use std::fmt::Write as _;
     use std::fs;
     use std::path::Path;
 
@@ -775,11 +505,15 @@ mod tests {
             .collect::<BTreeSet<_>>();
         let mut handler_names = dispatch_tool_names_from_source("handle_tool_call");
 
-        // This tool is intentionally hidden from the advertised surface when
-        // the host is missing ast-grep; mirror that runtime filter so the
-        // integrity check covers the actual MCP tools/list surface.
+        // These tools are intentionally hidden from the advertised surface when
+        // the host ast-grep CLI capability they need is unavailable; mirror the
+        // runtime filters so the integrity check covers the actual tools/list
+        // surface.
         if !super::super::definitions::ast_grep_available() {
             handler_names.remove("tracedecay_ast_grep_rewrite");
+        }
+        if !super::super::definitions::ast_grep_outline_available() {
+            handler_names.remove("tracedecay_outline");
         }
 
         assert_set_empty(
@@ -829,52 +563,17 @@ mod tests {
 
     #[test]
     fn graph_reader_selector_dispatch_policy_is_allowlisted() {
-        let allowlisted_tool_names = [
-            "tracedecay_search",
-            "tracedecay_context",
-            "tracedecay_callers",
-            "tracedecay_callees",
-            "tracedecay_impact",
-            "tracedecay_node",
-            "tracedecay_files",
-            "tracedecay_retrieve",
-            "tracedecay_body",
-            "tracedecay_read",
-            "tracedecay_outline",
-            "tracedecay_signature_search",
-            "tracedecay_implementations",
-            "tracedecay_callers_for",
-            "tracedecay_call_chain",
-            "tracedecay_file_dependents",
-            "tracedecay_find_exact_symbol",
-            "tracedecay_by_qualified_name",
-            "tracedecay_signature",
-            "tracedecay_impls",
-            "tracedecay_derives",
-            "tracedecay_project_context",
-            "tracedecay_fact_store",
-            "tracedecay_memory_status",
-            "tracedecay_message_search",
-        ];
-
-        for tool_name in allowlisted_tool_names {
-            assert!(
-                tool_accepts_registered_project_selector(tool_name),
-                "{tool_name} should dispatch through a selected registered project"
-            );
-        }
-
-        let definitions = get_tool_definitions()
-            .into_iter()
-            .map(|tool| (tool.name, tool.input_schema))
-            .collect::<std::collections::BTreeMap<_, _>>();
-        for tool_name in allowlisted_tool_names {
-            let properties = &definitions[tool_name]["properties"];
-            assert!(
-                ["project_selector", "project_id", "project_path", "path"]
+        for tool in get_tool_definitions() {
+            let properties = &tool.input_schema["properties"];
+            let schema_has_registered_project_selector =
+                ["project_selector", "project_id", "project_path"]
                     .iter()
-                    .any(|selector_key| properties.get(*selector_key).is_some()),
-                "{tool_name} should advertise at least one registered project selector because its dispatcher accepts registered project selectors"
+                    .any(|selector_key| properties.get(*selector_key).is_some());
+            assert_eq!(
+                tool_accepts_registered_project_selector(&tool.name),
+                schema_has_registered_project_selector,
+                "{} registered-project selector schema and dispatch policy should stay in lockstep",
+                tool.name
             );
         }
 
@@ -1000,9 +699,10 @@ mod tests {
 
         let mut target_source = String::new();
         for i in 0..420 {
-            target_source.push_str(&format!(
-                "pub fn selected_project_handle_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}\n"
-            ));
+            let _ = writeln!(
+                target_source,
+                "pub fn selected_project_handle_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}"
+            );
         }
         fs::write(target_project.join("src/lib.rs"), target_source).unwrap();
 
@@ -1081,15 +781,13 @@ mod tests {
     #[test]
     fn test_tool_definitions_complete() {
         let tools = get_tool_definitions();
-        // ast_grep_rewrite is conditionally registered based on whether the
-        // external `ast-grep` binary is on PATH — agents should never see a
-        // tool that will instantly fail. The count and the per-tool checks
-        // below adapt to the host's capability set.
-        let expected_total = if super::super::definitions::ast_grep_available() {
-            94
-        } else {
-            93
-        };
+        // ast-grep-backed tools are conditionally registered based on the
+        // host CLI capabilities they need; agents should never see a tool that
+        // will instantly fail. The count and per-tool checks below adapt to
+        // the host's capability set.
+        let expected_total = 92
+            + usize::from(super::super::definitions::ast_grep_available())
+            + usize::from(super::super::definitions::ast_grep_outline_available());
         assert_eq!(tools.len(), expected_total);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
@@ -1182,7 +880,11 @@ mod tests {
         assert!(tool_names.contains(&"tracedecay_lcm_compress"));
         assert!(tool_names.contains(&"tracedecay_lcm_session_boundary"));
         assert!(tool_names.contains(&"tracedecay_read"));
-        assert!(tool_names.contains(&"tracedecay_outline"));
+        if super::super::definitions::ast_grep_outline_available() {
+            assert!(tool_names.contains(&"tracedecay_outline"));
+        } else {
+            assert!(!tool_names.contains(&"tracedecay_outline"));
+        }
         assert!(tool_names.contains(&"tracedecay_implementations"));
         assert!(tool_names.contains(&"tracedecay_unsafe_patterns"));
         assert!(tool_names.contains(&"tracedecay_diagnostics"));
@@ -1298,113 +1000,10 @@ mod tests {
     }
 
     #[test]
-    fn test_truncate_short_response() {
-        let short = "hello world";
-        assert_eq!(truncate_response(short), short);
-    }
-
-    #[test]
-    fn test_truncate_long_response() {
-        let long = "x".repeat(20_000);
-        let result = truncate_response(&long);
-        assert!(result.len() < 20_000);
-        assert!(result.contains("[... truncated at 15000 chars]"));
-    }
-
-    #[test]
-    fn test_truncated_json_envelope_includes_handle() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let long = format!(
-            "{{\"items\":[{}]}}",
-            (0..3_000)
-                .map(|i| format!("{{\"id\":{i},\"name\":\"item-{i}\"}}"))
-                .collect::<Vec<_>>()
-                .join(",")
-        );
-
-        let result = truncated_json_envelope_with_handle(Some(dir.path()), &long);
-        let parsed: Value = serde_json::from_str(&result).unwrap();
-
-        assert_eq!(parsed["truncated"], true);
-        assert_eq!(parsed["retrieve_tool"], "tracedecay_retrieve");
-        assert!(parsed.get("retrieve_handle").is_none());
-        let handle = parsed["handle"].as_str().unwrap();
-        assert!(handle.starts_with("rh_"));
-
-        let stored = crate::mcp::response_handles::retrieve_response_handle(
-            dir.path(),
-            handle,
-            crate::tracedecay::current_timestamp(),
-        )
-        .unwrap();
-        match stored {
-            ResponseHandleLookup::Found(record) => assert_eq!(record.content, long),
-            other => panic!("stored response should be retrievable, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_truncated_json_envelope_reports_store_failure() {
-        let dir = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(dir.path().join(".tracedecay")).unwrap();
-        std::fs::write(
-            dir.path().join(".tracedecay/enrollment.json"),
-            r#"{"project_id":"../invalid","storage_mode":"profile_sharded"}"#,
-        )
-        .unwrap();
-        let long = format!(
-            "{{\"items\":[{}]}}",
-            (0..3_000)
-                .map(|i| format!("{{\"id\":{i},\"name\":\"item-{i}\"}}"))
-                .collect::<Vec<_>>()
-                .join(",")
-        );
-
-        let result = truncated_json_envelope_with_handle(Some(dir.path()), &long);
-        let parsed: Value = serde_json::from_str(&result).unwrap();
-
-        assert_eq!(parsed["truncated"], true);
-        assert_eq!(parsed["handle_available"], false);
-        assert!(parsed.get("handle").is_none());
-        assert_eq!(
-            parsed["handle_status"]["reason_code"],
-            "handle_store_failed"
-        );
-        assert!(parsed["handle_status"]["message"]
-            .as_str()
-            .unwrap_or_default()
-            .contains("could not be cached locally"));
-    }
-
-    #[test]
     fn test_tool_definitions_serializable() {
         let tools = get_tool_definitions();
         let json = serde_json::to_string(&tools).unwrap();
         assert!(json.contains("tracedecay_search"));
         assert!(json.contains("tracedecay_status"));
-    }
-
-    #[test]
-    fn test_require_node_id_canonical() {
-        let args = json!({"node_id": "fn:abc123"});
-        assert_eq!(require_node_id(&args).unwrap(), "fn:abc123");
-    }
-
-    #[test]
-    fn test_require_node_id_alias() {
-        let args = json!({"id": "trait:def456"});
-        assert_eq!(require_node_id(&args).unwrap(), "trait:def456");
-    }
-
-    #[test]
-    fn test_require_node_id_prefers_canonical() {
-        let args = json!({"node_id": "fn:canonical", "id": "fn:alias"});
-        assert_eq!(require_node_id(&args).unwrap(), "fn:canonical");
-    }
-
-    #[test]
-    fn test_require_node_id_missing() {
-        let args = json!({"query": "something"});
-        assert!(require_node_id(&args).is_err());
     }
 }

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -512,9 +512,6 @@ mod tests {
         if !super::super::definitions::ast_grep_available() {
             handler_names.remove("tracedecay_ast_grep_rewrite");
         }
-        if !super::super::definitions::ast_grep_outline_available() {
-            handler_names.remove("tracedecay_outline");
-        }
 
         assert_set_empty(
             definition_names
@@ -880,11 +877,7 @@ mod tests {
         assert!(tool_names.contains(&"tracedecay_lcm_compress"));
         assert!(tool_names.contains(&"tracedecay_lcm_session_boundary"));
         assert!(tool_names.contains(&"tracedecay_read"));
-        if super::super::definitions::ast_grep_outline_available() {
-            assert!(tool_names.contains(&"tracedecay_outline"));
-        } else {
-            assert!(!tool_names.contains(&"tracedecay_outline"));
-        }
+        assert!(tool_names.contains(&"tracedecay_outline"));
         assert!(tool_names.contains(&"tracedecay_implementations"));
         assert!(tool_names.contains(&"tracedecay_unsafe_patterns"));
         assert!(tool_names.contains(&"tracedecay_diagnostics"));

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -28,7 +28,7 @@ use crate::types::{Node, NodeKind};
 
 use super::super::render;
 use super::super::ToolResult;
-use super::effective_path;
+use super::support::effective_path;
 
 /// `tracedecay_redundancy` handler.
 pub(super) async fn handle_redundancy(
@@ -36,27 +36,10 @@ pub(super) async fn handle_redundancy(
     args: Value,
     scope_prefix: Option<&str>,
 ) -> Result<ToolResult> {
-    let path_prefix = effective_path(&args, scope_prefix);
-    let min_lines = args
-        .get("min_lines")
-        .and_then(Value::as_u64)
-        .map_or(8u32, |v| u32::try_from(v).unwrap_or(8));
-    let max_pairs = args
-        .get("max_pairs")
-        .and_then(Value::as_u64)
-        .map_or(20usize, |v| usize::try_from(v.min(500)).unwrap_or(20));
-    let threshold = args
-        .get("similarity_threshold")
-        .and_then(Value::as_f64)
-        .unwrap_or(0.6)
-        .clamp(0.0, 1.0);
-    let include_naming = args
-        .get("include_naming_only")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
+    let options = redundancy_options(&args, scope_prefix);
 
     // 1. Collect candidate function nodes.
-    let nodes = collect_candidates(cg, path_prefix, min_lines).await?;
+    let nodes = collect_candidates(cg, options.path_prefix, options.min_lines).await?;
     let total_candidates = nodes.len();
 
     // 2. Ensure each has a fresh fingerprint (cache by source hash).
@@ -64,23 +47,15 @@ pub(super) async fn handle_redundancy(
     let scanned = fingerprints.len();
 
     // 3. Bucket by token count to keep pairwise comparison sub-quadratic.
-    let pairs = find_redundant_pairs(&nodes, &fingerprints, threshold, include_naming, max_pairs);
+    let pairs = find_redundant_pairs(
+        &nodes,
+        &fingerprints,
+        options.threshold,
+        options.include_naming,
+        options.max_pairs,
+    );
 
-    let pair_count = pairs.len();
-    let output = json!({
-        "candidates": total_candidates,
-        "scanned": scanned,
-        "skipped_for_size": total_candidates.saturating_sub(scanned),
-        "pair_count": pair_count,
-        "pairs": pairs,
-        "ranked_by": "similarity desc",
-        "scope": path_prefix.unwrap_or("(whole project)"),
-        "thresholds": {
-            "min_lines": min_lines,
-            "similarity_threshold": threshold,
-            "include_naming_only": include_naming,
-        },
-    });
+    let output = redundancy_output(&options, total_candidates, scanned, &pairs);
     let text = render::finalize(Some(cg.project_root()), &args, &output, || {
         render::generic_md(&output)
     });
@@ -89,6 +64,60 @@ pub(super) async fn handle_redundancy(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+    })
+}
+
+struct RedundancyOptions<'a> {
+    path_prefix: Option<&'a str>,
+    min_lines: u32,
+    max_pairs: usize,
+    threshold: f64,
+    include_naming: bool,
+}
+
+fn redundancy_options<'a>(args: &'a Value, scope_prefix: Option<&'a str>) -> RedundancyOptions<'a> {
+    RedundancyOptions {
+        path_prefix: effective_path(args, scope_prefix),
+        min_lines: args
+            .get("min_lines")
+            .and_then(Value::as_u64)
+            .map_or(8u32, |v| u32::try_from(v).unwrap_or(8)),
+        max_pairs: args
+            .get("max_pairs")
+            .and_then(Value::as_u64)
+            .map_or(20usize, |v| usize::try_from(v.min(500)).unwrap_or(20)),
+        threshold: args
+            .get("similarity_threshold")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.6)
+            .clamp(0.0, 1.0),
+        include_naming: args
+            .get("include_naming_only")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    }
+}
+
+fn redundancy_output(
+    options: &RedundancyOptions<'_>,
+    total_candidates: usize,
+    scanned: usize,
+    pairs: &[Value],
+) -> Value {
+    let pair_count = pairs.len();
+    json!({
+        "candidates": total_candidates,
+        "scanned": scanned,
+        "skipped_for_size": total_candidates.saturating_sub(scanned),
+        "pair_count": pair_count,
+        "pairs": pairs,
+        "ranked_by": "similarity desc",
+        "scope": options.path_prefix.unwrap_or("(whole project)"),
+        "thresholds": {
+            "min_lines": options.min_lines,
+            "similarity_threshold": options.threshold,
+            "include_naming_only": options.include_naming,
+        },
     })
 }
 
@@ -268,6 +297,10 @@ fn extractor_to_language_key(name: &str) -> Option<&'static str> {
 /// slice. Node `start_line` / `end_line` are stored as raw tree-sitter
 /// row indices (see `info::extract_lines`).
 fn body_slice(source: &str, start_line: u32, end_line: u32) -> &str {
+    line_byte_range(source, start_line, end_line).map_or("", |range| &source[range])
+}
+
+fn line_byte_range(source: &str, start_line: u32, end_line: u32) -> Option<std::ops::Range<usize>> {
     let start = start_line as usize;
     let end = (end_line as usize).saturating_add(1);
     let mut offset = 0usize;
@@ -283,11 +316,11 @@ fn body_slice(source: &str, start_line: u32, end_line: u32) -> &str {
         }
         offset += line.len();
     }
-    let Some(s) = start_byte else { return "" };
+    let s = start_byte?;
     if end_byte <= s || end_byte > source.len() {
-        return "";
+        return None;
     }
-    &source[s..end_byte]
+    Some(s..end_byte)
 }
 
 /// Cheap body hash used for cache invalidation. Matches the format used
@@ -309,6 +342,17 @@ fn quick_body_hash(body: &str) -> String {
 // 3. Pairwise comparison + ranking
 // ---------------------------------------------------------------------------
 
+type ScopedFingerprint<'a> = (&'a Node, &'a Fingerprint);
+
+struct RedundantPair<'a> {
+    score: f64,
+    kind: &'static str,
+    node_a: &'a Node,
+    node_b: &'a Node,
+    fp_a: &'a Fingerprint,
+    fp_b: &'a Fingerprint,
+}
+
 fn find_redundant_pairs(
     nodes: &[Node],
     fingerprints: &HashMap<String, Fingerprint>,
@@ -316,21 +360,13 @@ fn find_redundant_pairs(
     include_naming: bool,
     max_pairs: usize,
 ) -> Vec<Value> {
-    // Pair each node with its fingerprint (skip nodes that failed to
-    // produce one).
-    let scope: Vec<(&Node, &Fingerprint)> = nodes
-        .iter()
-        .filter_map(|n| fingerprints.get(&n.id).map(|fp| (n, fp)))
-        .collect();
-
     // Sort by body_tokens so the size-window check is a linear scan.
-    let mut sorted = scope;
+    let mut sorted = scoped_fingerprints(nodes, fingerprints);
     sorted.sort_by_key(|(_, fp)| fp.body_tokens);
 
-    let mut found: Vec<(f64, &str, &Node, &Node, &Fingerprint, &Fingerprint)> = Vec::new();
+    let mut found = Vec::new();
     for (i, (node_a, fp_a)) in sorted.iter().enumerate() {
-        let lo = (fp_a.body_tokens as f64 * 0.75).floor() as usize;
-        let hi = (fp_a.body_tokens as f64 * 1.25).ceil() as usize;
+        let (lo, hi) = body_token_window(fp_a.body_tokens);
         for (node_b, fp_b) in sorted.iter().skip(i + 1) {
             if fp_b.body_tokens > hi {
                 break; // sorted, no need to scan further
@@ -338,52 +374,94 @@ fn find_redundant_pairs(
             if fp_b.body_tokens < lo {
                 continue;
             }
-            let score = composite_similarity(fp_a, fp_b);
-            if score < threshold {
-                continue;
+            if let Some(pair) =
+                redundant_pair(node_a, fp_a, node_b, fp_b, threshold, include_naming)
+            {
+                found.push(pair);
             }
-            let kind = overlap_kind(fp_a, fp_b);
-            if !include_naming && kind == "naming" {
-                continue;
-            }
-            found.push((score, kind, node_a, node_b, fp_a, fp_b));
         }
     }
 
-    found.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    found.sort_by(|a: &RedundantPair<'_>, b: &RedundantPair<'_>| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     found.truncate(max_pairs);
 
-    found
-        .into_iter()
-        .map(|(score, kind, na, nb, fp_a, fp_b)| {
-            let shingle_jaccard = jaccard_similarity(&fp_a.shingles, &fp_b.shingles);
-            let severity = severity_bucket(score, kind);
-            json!({
-                "similarity": (score * 10000.0).round() / 10000.0,
-                "severity": severity,
-                "overlap_kind": kind,
-                "a": {
-                    "file": na.file_path,
-                    "line": na.start_line,
-                    "name": na.name,
-                    "id": na.id,
-                },
-                "b": {
-                    "file": nb.file_path,
-                    "line": nb.start_line,
-                    "name": nb.name,
-                    "id": nb.id,
-                },
-                "signals": {
-                    "ast_match": fp_a.ast_hash == fp_b.ast_hash,
-                    "cfg_match": fp_a.cfg_hash == fp_b.cfg_hash,
-                    "call_seq_match": fp_a.call_seq_hash == fp_b.call_seq_hash,
-                    "shingle_jaccard": (shingle_jaccard * 10000.0).round() / 10000.0,
-                    "body_tokens": [fp_a.body_tokens, fp_b.body_tokens],
-                },
-            })
-        })
+    found.iter().map(redundant_pair_json).collect()
+}
+
+fn scoped_fingerprints<'a>(
+    nodes: &'a [Node],
+    fingerprints: &'a HashMap<String, Fingerprint>,
+) -> Vec<ScopedFingerprint<'a>> {
+    nodes
+        .iter()
+        .filter_map(|n| fingerprints.get(&n.id).map(|fp| (n, fp)))
         .collect()
+}
+
+fn body_token_window(body_tokens: usize) -> (usize, usize) {
+    (
+        (body_tokens as f64 * 0.75).floor() as usize,
+        (body_tokens as f64 * 1.25).ceil() as usize,
+    )
+}
+
+fn redundant_pair<'a>(
+    node_a: &'a Node,
+    fp_a: &'a Fingerprint,
+    node_b: &'a Node,
+    fp_b: &'a Fingerprint,
+    threshold: f64,
+    include_naming: bool,
+) -> Option<RedundantPair<'a>> {
+    let score = composite_similarity(fp_a, fp_b);
+    if score < threshold {
+        return None;
+    }
+    let kind = overlap_kind(fp_a, fp_b);
+    if !include_naming && kind == "naming" {
+        return None;
+    }
+    Some(RedundantPair {
+        score,
+        kind,
+        node_a,
+        node_b,
+        fp_a,
+        fp_b,
+    })
+}
+
+fn redundant_pair_json(pair: &RedundantPair<'_>) -> Value {
+    let shingle_jaccard = jaccard_similarity(&pair.fp_a.shingles, &pair.fp_b.shingles);
+    let severity = severity_bucket(pair.score, pair.kind);
+    json!({
+        "similarity": (pair.score * 10000.0).round() / 10000.0,
+        "severity": severity,
+        "overlap_kind": pair.kind,
+        "a": {
+            "file": pair.node_a.file_path,
+            "line": pair.node_a.start_line,
+            "name": pair.node_a.name,
+            "id": pair.node_a.id,
+        },
+        "b": {
+            "file": pair.node_b.file_path,
+            "line": pair.node_b.start_line,
+            "name": pair.node_b.name,
+            "id": pair.node_b.id,
+        },
+        "signals": {
+            "ast_match": pair.fp_a.ast_hash == pair.fp_b.ast_hash,
+            "cfg_match": pair.fp_a.cfg_hash == pair.fp_b.cfg_hash,
+            "call_seq_match": pair.fp_a.call_seq_hash == pair.fp_b.call_seq_hash,
+            "shingle_jaccard": (shingle_jaccard * 10000.0).round() / 10000.0,
+            "body_tokens": [pair.fp_a.body_tokens, pair.fp_b.body_tokens],
+        },
+    })
 }
 
 #[cfg(test)]

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -4,10 +4,8 @@ use std::sync::{LazyLock, Mutex};
 
 use serde_json::{json, Map, Value};
 
-use super::{
-    global_db_profile_root, project_registry_context, safe_profile_relpath,
-    truncated_json_envelope_with_handle,
-};
+use super::super::render::truncated_json_envelope_with_handle;
+use super::support::{profile_root_for_global_db, project_registry_context, safe_profile_relpath};
 use crate::errors::{Result, TraceDecayError};
 use crate::global_db::{GlobalDb, ProjectRegistryContext};
 use crate::mcp::tools::{ToolResult, MAX_RESPONSE_CHARS};
@@ -46,19 +44,49 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     }
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct LcmHandlerContext<'a> {
+    project_root: Option<&'a Path>,
+    project_session_db_path: Option<&'a Path>,
+}
+
+impl<'a> LcmHandlerContext<'a> {
+    pub(super) fn active(cg: &'a TraceDecay) -> Self {
+        Self {
+            project_root: Some(cg.project_root()),
+            project_session_db_path: Some(cg.store_layout().sessions_db_path.as_path()),
+        }
+    }
+
+    pub(super) const fn projectless() -> Self {
+        Self {
+            project_root: None,
+            project_session_db_path: None,
+        }
+    }
+}
+
 async fn selected_project_session_db_path(
     project_root: &Path,
+    project_session_db_path: &Path,
     args: &Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
 ) -> Result<Option<(PathBuf, PathBuf)>> {
-    let Some(context) = project_registry_context(args, &["project_path", "project_root"]).await?
+    let Some(context) = project_registry_context(
+        args,
+        &["project_path", "project_root"],
+        global_db,
+        allow_default_registry_fallback,
+    )
+    .await?
     else {
-        return Ok(
-            crate::sessions::cursor::resolved_project_session_db_path(project_root)
-                .await
-                .map(|db_path| (db_path, project_root.to_path_buf())),
-        );
+        return Ok(Some((
+            project_session_db_path.to_path_buf(),
+            project_root.to_path_buf(),
+        )));
     };
-    let profile_root = global_db_profile_root()?;
+    let profile_root = profile_root_for_global_db(global_db, allow_default_registry_fallback)?;
     let candidates = registry_session_db_candidates(&context, &profile_root)?;
     let target_root = PathBuf::from(context.project.display_root);
     for db_path in candidates {
@@ -1004,6 +1032,10 @@ struct LcmStorage {
     scope: &'static str,
 }
 
+fn available_lcm_storage(db: GlobalDb, scope: &'static str) -> LcmStorageResolution {
+    LcmStorageResolution::Available(Box::new(LcmStorage { db, scope }))
+}
+
 /// Database paths whose schema (sessions DDL + LCM migrations) has already
 /// been ensured by this process. In `tracedecay serve`, every LCM tool call
 /// re-opens the project session DB; once `GlobalDb::open_at` has ensured the
@@ -1108,9 +1140,18 @@ enum LcmOpenMode {
     ReadOnlyOrMissing,
 }
 
+async fn open_lcm_db_at(db_path: &Path, mode: LcmOpenMode) -> Option<GlobalDb> {
+    match mode {
+        LcmOpenMode::Writable => open_session_db_with_cached_ensure(db_path).await,
+        LcmOpenMode::ReadOnlyExisting | LcmOpenMode::ReadOnlyOrMissing => {
+            GlobalDb::open_read_only_at(db_path).await
+        }
+    }
+}
+
 macro_rules! lcm_open_storage {
-    ($project_root:expr, $args:expr) => {
-        match open_lcm_storage($project_root, $args, LcmOpenMode::Writable).await {
+    ($context:expr, $args:expr) => {
+        match open_lcm_storage($context, $args, LcmOpenMode::Writable).await {
             LcmStorageResolution::Available(storage) => storage,
             LcmStorageResolution::Unavailable(result) => return Ok(result),
         }
@@ -1120,8 +1161,8 @@ macro_rules! lcm_open_storage {
 /// Like `lcm_open_storage!` but with [`LcmOpenMode::ReadOnlyOrMissing`]
 /// semantics for `readOnlyHint` handlers.
 macro_rules! lcm_open_storage_ro {
-    ($project_root:expr, $args:expr) => {
-        match open_lcm_storage($project_root, $args, LcmOpenMode::ReadOnlyOrMissing).await {
+    ($context:expr, $args:expr) => {
+        match open_lcm_storage($context, $args, LcmOpenMode::ReadOnlyOrMissing).await {
             LcmStorageResolution::Available(storage) => storage,
             LcmStorageResolution::Unavailable(result) => return Ok(result),
         }
@@ -1129,40 +1170,27 @@ macro_rules! lcm_open_storage_ro {
 }
 
 async fn open_lcm_storage(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: &Value,
     mode: LcmOpenMode,
 ) -> LcmStorageResolution {
     let storage_scope = string_arg(args, "storage_scope").unwrap_or("project_local");
     match storage_scope {
         "project_local" => {
-            let Some(project_root) = project_root else {
+            if context.project_root.is_none() {
+                return LcmStorageResolution::Unavailable(project_local_storage_without_project());
+            }
+            let Some(db_path) = context.project_session_db_path else {
                 return LcmStorageResolution::Unavailable(project_local_storage_without_project());
             };
-            let Some(db_path) =
-                crate::sessions::cursor::resolved_project_session_db_path(project_root).await
-            else {
-                return LcmStorageResolution::Unavailable(project_local_storage_without_project());
-            };
-            let db = match mode {
-                LcmOpenMode::Writable => open_session_db_with_cached_ensure(&db_path).await,
-                LcmOpenMode::ReadOnlyExisting => GlobalDb::open_read_only_at(&db_path).await,
-                LcmOpenMode::ReadOnlyOrMissing => {
-                    if !db_path.is_file() {
-                        return LcmStorageResolution::Unavailable(lcm_not_yet_ingested(
-                            "project_local",
-                        ));
-                    }
-                    GlobalDb::open_read_only_at(&db_path).await
-                }
-            };
-            let Some(db) = db else {
+            let db_path = db_path.to_path_buf();
+            if mode == LcmOpenMode::ReadOnlyOrMissing && !db_path.is_file() {
+                return LcmStorageResolution::Unavailable(lcm_not_yet_ingested("project_local"));
+            }
+            let Some(db) = open_lcm_db_at(&db_path, mode).await else {
                 return LcmStorageResolution::Unavailable(lcm_unavailable());
             };
-            LcmStorageResolution::Available(Box::new(LcmStorage {
-                db,
-                scope: "project_local",
-            }))
+            available_lcm_storage(db, "project_local")
         }
         "hermes_profile" => {
             let hermes_home = match hermes_profile_home(args) {
@@ -1206,21 +1234,12 @@ async fn open_lcm_storage(
                     }
                 }
             };
-            let db = match mode {
-                LcmOpenMode::Writable => open_session_db_with_cached_ensure(&db_path).await,
-                LcmOpenMode::ReadOnlyExisting | LcmOpenMode::ReadOnlyOrMissing => {
-                    GlobalDb::open_read_only_at(&db_path).await
-                }
-            };
-            let Some(db) = db else {
+            let Some(db) = open_lcm_db_at(&db_path, mode).await else {
                 return LcmStorageResolution::Unavailable(invalid_hermes_profile_home(
                     "could not open hermes_profile tracedecay session database",
                 ));
             };
-            LcmStorageResolution::Available(Box::new(LcmStorage {
-                db,
-                scope: "hermes_profile",
-            }))
+            available_lcm_storage(db, "hermes_profile")
         }
         other => LcmStorageResolution::Unavailable(lcm_storage_scope_unavailable(other)),
     }
@@ -1333,7 +1352,12 @@ fn parse_message_search_scope(args: &Value) -> Result<SessionSearchScope> {
     }
 }
 
-pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+pub(super) async fn handle_message_search(
+    cg: &TraceDecay,
+    args: Value,
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<ToolResult> {
     let query = args
         .get("query")
         .and_then(Value::as_str)
@@ -1372,8 +1396,14 @@ pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Resul
         .unwrap_or(10)
         .clamp(1, 50) as usize;
 
-    let Some((db_path, target_root)) =
-        selected_project_session_db_path(cg.project_root(), &args).await?
+    let Some((db_path, target_root)) = selected_project_session_db_path(
+        cg.project_root(),
+        &cg.store_layout().sessions_db_path,
+        &args,
+        global_db,
+        allow_default_registry_fallback,
+    )
+    .await?
     else {
         return Ok(tool_json(
             Some(cg.project_root()),
@@ -1436,14 +1466,14 @@ pub(super) async fn handle_message_search(cg: &TraceDecay, args: Value) -> Resul
 }
 
 pub(super) async fn handle_lcm_status(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
     let session_id = string_arg(&args, "session_id");
     let deep = bool_arg(&args, "deep")?.unwrap_or(false);
     let gc_config = lcm_gc_config(&args)?;
-    let storage = lcm_open_storage_ro!(project_root, &args);
+    let storage = lcm_open_storage_ro!(context, &args);
     let mut status = storage
         .db
         .lcm_status_with_options(provider, session_id, deep, &gc_config)
@@ -1451,7 +1481,7 @@ pub(super) async fn handle_lcm_status(
         .map_err(lcm_error)?;
     status.storage_scope = Some(storage.scope.to_string());
     Ok(tool_json(
-        project_root,
+        context.project_root,
         &json!({
             "status": "ok",
             "provider": provider,
@@ -1463,7 +1493,7 @@ pub(super) async fn handle_lcm_status(
 }
 
 pub(super) async fn handle_lcm_doctor(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
@@ -1474,7 +1504,7 @@ pub(super) async fn handle_lcm_doctor(
     let gc_apply_enabled = lcm_gc_apply_enabled(&args)?;
     if mode == "clean" && apply && !clean_apply_enabled {
         return Ok(tool_json(
-            project_root,
+            context.project_root,
             &json!({
                 "status": "denied",
                 "provider": provider,
@@ -1501,7 +1531,7 @@ pub(super) async fn handle_lcm_doctor(
     }
     if mode == "gc" && apply && !gc_apply_enabled {
         return Ok(tool_json(
-            project_root,
+            context.project_root,
             &json!({
                 "status": "denied",
                 "provider": provider,
@@ -1533,7 +1563,7 @@ pub(super) async fn handle_lcm_doctor(
     } else {
         LcmOpenMode::ReadOnlyExisting
     };
-    let storage = match open_lcm_storage(project_root, &args, open_mode).await {
+    let storage = match open_lcm_storage(context, &args, open_mode).await {
         LcmStorageResolution::Available(storage) => storage,
         LcmStorageResolution::Unavailable(result) => return Ok(result),
     };
@@ -1544,18 +1574,27 @@ pub(super) async fn handle_lcm_doctor(
         .map_err(lcm_error)?;
     if let Some(object) = payload.as_object_mut() {
         object.insert("storage_scope".to_string(), json!(storage.scope));
+        if let Some(diagnostics) = object
+            .get_mut("diagnostics")
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            diagnostics.insert(
+                "ast_grep".to_string(),
+                super::super::definitions::ast_grep_diagnostics_json(),
+            );
+        }
     }
-    Ok(tool_json(project_root, &payload))
+    Ok(tool_json(context.project_root, &payload))
 }
 
 pub(super) async fn handle_lcm_load_session(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
     let session_id = required_string_arg(&args, "session_id")?;
     let (content_slice, content_limit_clamped_from) = lcm_load_content_slice(&args)?;
-    let storage = lcm_open_storage_ro!(project_root, &args);
+    let storage = lcm_open_storage_ro!(context, &args);
     let page = storage
         .db
         .lcm_load_session(LcmLoadSessionRequest {
@@ -1594,11 +1633,11 @@ pub(super) async fn handle_lcm_load_session(
             );
         }
     }
-    Ok(tool_json(project_root, &payload))
+    Ok(tool_json(context.project_root, &payload))
 }
 
 pub(super) async fn handle_lcm_grep(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
@@ -1606,7 +1645,7 @@ pub(super) async fn handle_lcm_grep(
     // Validate scope before opening storage so argument errors are reported
     // even when the sessions DB does not exist yet.
     let scope = parse_lcm_scope(&args)?;
-    let storage = lcm_open_storage_ro!(project_root, &args);
+    let storage = lcm_open_storage_ro!(context, &args);
     let hits = storage
         .db
         .lcm_grep(LcmGrepRequest {
@@ -1628,7 +1667,7 @@ pub(super) async fn handle_lcm_grep(
         .await
         .map_err(lcm_error)?;
     Ok(tool_json(
-        project_root,
+        context.project_root,
         &json!({
             "status": "ok",
             "provider": provider,
@@ -1641,7 +1680,7 @@ pub(super) async fn handle_lcm_grep(
 }
 
 pub(super) async fn handle_lcm_describe(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
@@ -1649,7 +1688,7 @@ pub(super) async fn handle_lcm_describe(
     // Validate target before opening storage so argument errors are reported
     // even when the sessions DB does not exist yet.
     let target = parse_lcm_describe_target(&args)?;
-    let storage = lcm_open_storage_ro!(project_root, &args);
+    let storage = lcm_open_storage_ro!(context, &args);
     let description = storage
         .db
         .lcm_describe(LcmDescribeRequest {
@@ -1660,7 +1699,7 @@ pub(super) async fn handle_lcm_describe(
         .await
         .map_err(lcm_error)?;
     Ok(tool_json(
-        project_root,
+        context.project_root,
         &json!({
             "status": "ok",
             "provider": provider,
@@ -1671,13 +1710,13 @@ pub(super) async fn handle_lcm_describe(
 }
 
 pub(super) async fn handle_lcm_expand(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
     let session_id = required_string_arg(&args, "session_id")?;
     let target = parse_lcm_expand_target(&args)?;
-    let storage = lcm_open_storage_ro!(project_root, &args);
+    let storage = lcm_open_storage_ro!(context, &args);
     let expansion = storage
         .db
         .lcm_expand(LcmExpandRequest {
@@ -1691,7 +1730,7 @@ pub(super) async fn handle_lcm_expand(
         .await
         .map_err(lcm_error)?;
     Ok(tool_json(
-        project_root,
+        context.project_root,
         &json!({
             "status": "ok",
             "provider": provider,
@@ -1702,7 +1741,7 @@ pub(super) async fn handle_lcm_expand(
 }
 
 pub(super) async fn handle_lcm_expand_query(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
@@ -1727,7 +1766,7 @@ pub(super) async fn handle_lcm_expand_query(
         MAX_LCM_EXPAND_QUERY_CONTEXT_LIMIT,
     )?
     .unwrap_or(DEFAULT_LCM_EXPAND_QUERY_CONTEXT_LIMIT);
-    let storage = lcm_open_storage_ro!(project_root, &args);
+    let storage = lcm_open_storage_ro!(context, &args);
     let response = storage
         .db
         .lcm_expand_query(LcmExpandQueryRequest {
@@ -1751,16 +1790,16 @@ pub(super) async fn handle_lcm_expand_query(
         object.insert("session_id".to_string(), json!(session_id));
         object.insert("storage_scope".to_string(), json!(storage.scope));
     }
-    Ok(lcm_expand_query_tool_json(project_root, &payload))
+    Ok(lcm_expand_query_tool_json(context.project_root, &payload))
 }
 
 pub(super) async fn handle_lcm_session_boundary(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
     let session_id = required_string_arg(&args, "session_id")?;
-    let storage = lcm_open_storage!(project_root, &args);
+    let storage = lcm_open_storage!(context, &args);
     let response = storage
         .db
         .lcm_session_boundary(LcmSessionBoundaryRequest {
@@ -1774,7 +1813,7 @@ pub(super) async fn handle_lcm_session_boundary(
         .await
         .map_err(lcm_error)?;
     Ok(tool_json(
-        project_root,
+        context.project_root,
         &json!({
             "status": response.status,
             "provider": provider,
@@ -1786,12 +1825,12 @@ pub(super) async fn handle_lcm_session_boundary(
 }
 
 pub(super) async fn handle_lcm_preflight(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
     let session_id = required_string_arg(&args, "session_id")?;
-    let storage = lcm_open_storage!(project_root, &args);
+    let storage = lcm_open_storage!(context, &args);
     let response = storage
         .db
         .lcm_preflight(LcmPreflightRequest {
@@ -1827,13 +1866,13 @@ pub(super) async fn handle_lcm_preflight(
 }
 
 pub(super) async fn handle_lcm_compress(
-    project_root: Option<&Path>,
+    context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
     let provider = provider_arg(&args);
     let session_id = required_string_arg(&args, "session_id")?;
-    let response_handle_root = lcm_response_handle_root(project_root, &args);
-    let storage = lcm_open_storage!(project_root, &args);
+    let response_handle_root = lcm_response_handle_root(context.project_root, &args);
+    let storage = lcm_open_storage!(context, &args);
     let response = storage
         .db
         .lcm_compress(LcmCompressionRequest {

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -179,22 +179,24 @@ pub(super) async fn project_registry_context(
     }
 
     let owned_db;
-    let db = if let Some(db) = global_db {
-        db
-    } else {
-        if !allow_default_registry_fallback {
+    let db = match global_db {
+        Some(db) => db,
+        None if allow_default_registry_fallback => {
+            owned_db = GlobalDb::open()
+                .await
+                .ok_or_else(|| TraceDecayError::Config {
+                    message:
+                        "could not open tracedecay project registry; run tracedecay init first"
+                            .to_string(),
+                })?;
+            &owned_db
+        }
+        None => {
             return Err(TraceDecayError::Config {
                 message: "client project registry is unavailable for selector resolution"
                     .to_string(),
             });
         }
-        owned_db = GlobalDb::open()
-            .await
-            .ok_or_else(|| TraceDecayError::Config {
-                message: "could not open tracedecay project registry; run tracedecay init first"
-                    .to_string(),
-            })?;
-        &owned_db
     };
     let context = if let Some(project_id) = project_id {
         db.project_registry_context_by_id(project_id).await

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -1,0 +1,259 @@
+//! Shared helpers for MCP tool handlers.
+//!
+//! Keep this module free of tool dispatch logic. Handler modules use it for
+//! argument normalization, scope filtering, and registered-project selection.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::errors::{Result, TraceDecayError};
+use crate::global_db::{global_db_path, GlobalDb, ProjectRegistryContext};
+
+/// Extracts the `node_id` parameter from tool arguments, accepting `id` as a
+/// fallback alias. LLMs occasionally shorten `node_id` to `id`; this avoids a
+/// confusing error when that happens.
+pub(super) fn require_node_id(args: &Value) -> Result<&str> {
+    args.get("node_id")
+        .or_else(|| args.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "missing required parameter: node_id".to_string(),
+        })
+}
+
+/// Returns the user-provided `path` argument, falling back to the scope
+/// prefix when the argument is absent. This makes listing tools
+/// automatically scoped to the subdirectory the server was launched from.
+pub(super) fn effective_path<'a>(
+    args: &'a Value,
+    scope_prefix: Option<&'a str>,
+) -> Option<&'a str> {
+    args.get("path").and_then(|v| v.as_str()).or(scope_prefix)
+}
+
+/// Returns string elements from an optional JSON array argument.
+pub(super) fn string_array_values(args: &Value, key: &str) -> Vec<String> {
+    args.get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Filters a Vec of items by file path prefix when a scope is active.
+/// Returns the vec unchanged when `scope_prefix` is `None`.
+pub(super) fn filter_by_scope<T, F>(
+    items: Vec<T>,
+    scope_prefix: Option<&str>,
+    get_path: F,
+) -> Vec<T>
+where
+    F: Fn(&T) -> &str,
+{
+    match scope_prefix {
+        Some(prefix) => {
+            let with_slash = if prefix.ends_with('/') {
+                prefix.to_string()
+            } else {
+                format!("{prefix}/")
+            };
+            items
+                .into_iter()
+                .filter(|item| {
+                    let p = get_path(item);
+                    p.starts_with(&with_slash) || p == prefix
+                })
+                .collect()
+        }
+        None => items,
+    }
+}
+
+/// Deduplicates an iterator of file path strings into a `Vec<String>`.
+pub(super) fn unique_file_paths<'a>(paths: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for p in paths {
+        if seen.insert(p) {
+            result.push(p.to_string());
+        }
+    }
+    result
+}
+
+pub(super) fn safe_profile_relpath(value: &str) -> Result<PathBuf> {
+    let path = PathBuf::from(value);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(TraceDecayError::Config {
+            message: format!("registry artifact path is not a safe profile-relative path: {value}"),
+        });
+    }
+    Ok(path)
+}
+
+fn global_db_profile_root() -> Result<PathBuf> {
+    global_db_path()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "could not resolve tracedecay profile root".to_string(),
+        })
+}
+
+pub(super) fn profile_root_for_global_db(
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<PathBuf> {
+    if let Some(global_db) = global_db {
+        return global_db
+            .db_path()
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| TraceDecayError::Config {
+                message: "could not resolve tracedecay profile root".to_string(),
+            });
+    }
+    if !allow_default_registry_fallback {
+        return Err(TraceDecayError::Config {
+            message: "client project registry is unavailable for selector resolution".to_string(),
+        });
+    }
+    global_db_profile_root()
+}
+
+pub(super) fn project_selector_present(args: &Value, top_level_path_keys: &[&str]) -> bool {
+    args.get("project_selector").is_some()
+        || args.get("project_id").is_some()
+        || top_level_path_keys
+            .iter()
+            .any(|key| args.get(*key).is_some())
+}
+
+pub(super) async fn project_registry_context(
+    args: &Value,
+    top_level_path_keys: &[&str],
+    global_db: Option<&GlobalDb>,
+    allow_default_registry_fallback: bool,
+) -> Result<Option<ProjectRegistryContext>> {
+    let selector_present = project_selector_present(args, top_level_path_keys);
+    let selector = args
+        .get("project_selector")
+        .map(|value| {
+            value.as_object().ok_or_else(|| TraceDecayError::Config {
+                message: "project_selector must be an object".to_string(),
+            })
+        })
+        .transpose()?;
+    let project_id = selector
+        .and_then(|selector| selector.get("project_id"))
+        .or_else(|| args.get("project_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let project_path = selector
+        .and_then(|selector| {
+            selector
+                .get("path")
+                .or_else(|| selector.get("project_path"))
+        })
+        .or_else(|| top_level_path_keys.iter().find_map(|key| args.get(*key)))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if project_id.is_none() && project_path.is_none() {
+        if selector_present {
+            return Err(TraceDecayError::Config {
+                message: "project selector must include project_id or project_path".to_string(),
+            });
+        }
+        return Ok(None);
+    }
+
+    let owned_db;
+    let db = if let Some(db) = global_db {
+        db
+    } else {
+        if !allow_default_registry_fallback {
+            return Err(TraceDecayError::Config {
+                message: "client project registry is unavailable for selector resolution"
+                    .to_string(),
+            });
+        }
+        owned_db = GlobalDb::open()
+            .await
+            .ok_or_else(|| TraceDecayError::Config {
+                message: "could not open tracedecay project registry; run tracedecay init first"
+                    .to_string(),
+            })?;
+        &owned_db
+    };
+    let context = if let Some(project_id) = project_id {
+        db.project_registry_context_by_id(project_id).await
+    } else if let Some(project_path) = project_path {
+        db.project_registry_context_by_alias(Path::new(project_path))
+            .await
+    } else {
+        return Ok(None);
+    };
+
+    context
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "registered project not found for selector".to_string(),
+        })
+        .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{require_node_id, string_array_values};
+
+    #[test]
+    fn test_require_node_id_canonical() {
+        let args = json!({"node_id": "fn:abc123"});
+        assert!(matches!(require_node_id(&args), Ok("fn:abc123")));
+    }
+
+    #[test]
+    fn test_require_node_id_alias() {
+        let args = json!({"id": "trait:def456"});
+        assert!(matches!(require_node_id(&args), Ok("trait:def456")));
+    }
+
+    #[test]
+    fn test_require_node_id_prefers_canonical() {
+        let args = json!({"node_id": "fn:canonical", "id": "fn:alias"});
+        assert!(matches!(require_node_id(&args), Ok("fn:canonical")));
+    }
+
+    #[test]
+    fn test_require_node_id_missing() {
+        let args = json!({"query": "something"});
+        assert!(require_node_id(&args).is_err());
+    }
+
+    #[test]
+    fn test_string_array_values_keeps_only_string_items() {
+        let args = json!({
+            "values": ["alpha", 7, null, "beta"],
+            "not_array": "alpha"
+        });
+
+        assert_eq!(
+            string_array_values(&args, "values"),
+            vec!["alpha".to_string(), "beta".to_string()]
+        );
+        assert!(string_array_values(&args, "missing").is_empty());
+        assert!(string_array_values(&args, "not_array").is_empty());
+    }
+}

--- a/src/mcp/tools/handlers/workflow.rs
+++ b/src/mcp/tools/handlers/workflow.rs
@@ -5,6 +5,8 @@
 //! already attached to the symbols they affect.
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::process::Output;
 use std::time::Duration;
 
 use serde_json::{json, Value};
@@ -14,11 +16,11 @@ use tokio::time::timeout;
 use crate::diagnose::{parse_cargo_output, Severity};
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::{is_test_file, TraceDecay};
-use crate::types::NodeKind;
+use crate::types::{Node, NodeKind};
 
 use super::super::render;
 use super::super::ToolResult;
-use super::unique_file_paths;
+use super::support::unique_file_paths;
 
 /// Maximum tests we'll allow `cargo test` to receive in one call. A loose
 /// cap — libtest filters are passed as positional args so very long lists
@@ -34,7 +36,7 @@ struct TestTarget {
 }
 
 impl TestTarget {
-    fn new(node: &crate::types::Node) -> Self {
+    fn new(node: &Node) -> Self {
         Self {
             filter: node.name.clone(),
             qualified_name: node.qualified_name.clone(),
@@ -57,11 +59,51 @@ impl TestTarget {
     }
 }
 
-fn test_target_key(node: &crate::types::Node) -> String {
+fn test_target_key(node: &Node) -> String {
     if node.qualified_name.is_empty() {
         node.id.clone()
     } else {
         node.qualified_name.clone()
+    }
+}
+
+#[derive(Debug)]
+struct RunAffectedArgs {
+    explicit_paths: Option<Vec<String>>,
+    profile: String,
+    timeout_secs: u64,
+    max_tests: usize,
+}
+
+impl RunAffectedArgs {
+    fn parse(args: &Value) -> Self {
+        let explicit_paths = args.get("changed_paths").and_then(|v| {
+            v.as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(|x| x.as_str().map(String::from))
+                    .collect()
+            })
+        });
+        let profile = args
+            .get("profile")
+            .and_then(|v| v.as_str())
+            .unwrap_or("debug")
+            .to_string();
+        let timeout_secs = args
+            .get("timeout_secs")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(300);
+        let max_tests = args
+            .get("max_tests")
+            .and_then(serde_json::Value::as_u64)
+            .map_or(100_usize, |v| (v as usize).min(MAX_TESTS_HARD_CAP));
+
+        Self {
+            explicit_paths,
+            profile,
+            timeout_secs,
+            max_tests,
+        }
     }
 }
 
@@ -181,109 +223,19 @@ fn severity_string(s: Severity) -> &'static str {
 
 /// Handles `tracedecay_run_affected_tests`.
 pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
-    let explicit_paths: Option<Vec<String>> = args.get("changed_paths").and_then(|v| {
-        v.as_array().map(|arr| {
-            arr.iter()
-                .filter_map(|x| x.as_str().map(String::from))
-                .collect()
-        })
-    });
-    let profile = args
-        .get("profile")
-        .and_then(|v| v.as_str())
-        .unwrap_or("debug")
-        .to_string();
-    let timeout_secs = args
-        .get("timeout_secs")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(300);
-    let max_tests = args
-        .get("max_tests")
-        .and_then(serde_json::Value::as_u64)
-        .map_or(100_usize, |v| (v as usize).min(MAX_TESTS_HARD_CAP));
-
+    let run_args = RunAffectedArgs::parse(&args);
     let project_root = cg.project_root().to_path_buf();
 
     // 1) Resolve changed paths — explicit list, or fall back to `git diff`.
-    let changed_paths = match explicit_paths {
-        Some(p) => p,
-        None => match git_changed_paths(&project_root).await {
-            Ok(paths) => paths,
-            Err(message) => {
-                return Ok(error_result("git", "diff", &message));
-            }
-        },
+    let changed_paths = match resolve_changed_paths(&project_root, run_args.explicit_paths).await {
+        Ok(paths) => paths,
+        Err(result) => return Ok(result),
     };
     if changed_paths.is_empty() {
         return Ok(empty_result("no changed files detected"));
     }
 
-    // 2) Find tests that cover the changed paths.
-    //
-    //    Two paths feed into the test set:
-    //    a) Indirect coverage — for every callable in a changed file, walk
-    //       callers and keep test-shaped ones (test file or `#[test]`
-    //       annotated). This is the common case when source changes are
-    //       what's being tested.
-    //    b) Direct change — when a changed path itself is a test file (or
-    //       holds `#[test]` annotations), dispatch its test functions
-    //       directly. `#[test]` fns are leaves with no callers, so the
-    //       indirect-coverage walk above always misses them and the tool
-    //       used to silently skip PRs that only edit `tests/foo.rs`.
-    let mut test_targets: HashMap<String, TestTarget> = HashMap::new();
-    for path in &changed_paths {
-        let nodes = cg.get_nodes_by_file(path).await?;
-
-        // (b) Direct dispatch from changed test files.
-        let path_is_test_file = is_test_file(path);
-        if path_is_test_file || !nodes.is_empty() {
-            let candidate_ids: Vec<String> = nodes
-                .iter()
-                .filter(|n| matches!(n.kind, NodeKind::Function | NodeKind::Method))
-                .map(|n| n.id.clone())
-                .collect();
-            let test_annotated_in_file = cg.get_test_annotated_node_ids(&candidate_ids).await?;
-            for node in &nodes {
-                if !matches!(node.kind, NodeKind::Function | NodeKind::Method) {
-                    continue;
-                }
-                let looks_like_test =
-                    path_is_test_file || test_annotated_in_file.contains(&node.id);
-                if !looks_like_test {
-                    continue;
-                }
-                // The test "covers itself" — record the node id as the
-                // source so the per-test `covers_source_ids` field
-                // remains useful.
-                test_targets
-                    .entry(test_target_key(node))
-                    .or_insert_with(|| TestTarget::new(node))
-                    .add_source(&node.id);
-            }
-        }
-
-        // (a) Indirect coverage — walk callers of every callable in the file.
-        for node in &nodes {
-            if !matches!(node.kind, NodeKind::Function | NodeKind::Method) {
-                continue;
-            }
-            let callers = cg.get_callers(&node.id, 3).await?;
-            let caller_ids: Vec<String> = callers.iter().map(|(n, _)| n.id.clone()).collect();
-            let test_annotated = cg.get_test_annotated_node_ids(&caller_ids).await?;
-            for (caller, _) in callers {
-                if !is_test_file(&caller.file_path) && !test_annotated.contains(&caller.id) {
-                    continue;
-                }
-                if !matches!(caller.kind, NodeKind::Function | NodeKind::Method) {
-                    continue;
-                }
-                test_targets
-                    .entry(test_target_key(&caller))
-                    .or_insert_with(|| TestTarget::new(&caller))
-                    .add_source(&node.id);
-            }
-        }
-    }
+    let test_targets = collect_affected_test_targets(cg, &changed_paths).await?;
 
     if test_targets.is_empty() {
         return Ok(empty_result(&format!(
@@ -292,39 +244,14 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
         )));
     }
 
-    let mut selected_targets: Vec<TestTarget> = test_targets.into_values().collect();
-    selected_targets.sort_by(|a, b| {
-        a.qualified_name
-            .cmp(&b.qualified_name)
-            .then(a.node_id.cmp(&b.node_id))
-    });
-    let total_tests = selected_targets.len();
-    selected_targets.truncate(max_tests);
-    let truncated = total_tests > selected_targets.len();
-    let mut test_names: Vec<String> = selected_targets
-        .iter()
-        .map(|target| target.filter.clone())
-        .collect();
-    test_names.sort();
-    test_names.dedup();
+    let (selected_targets, test_names, truncated) =
+        select_test_targets(test_targets, run_args.max_tests);
 
     // 3) Run cargo test --no-fail-fast with each test name as a libtest
     // filter. We use `--` to pass them through.
-    let mut cmd = Command::new("cargo");
-    cmd.current_dir(&project_root)
-        .arg("test")
-        .arg("--no-fail-fast");
-    if profile == "release" {
-        cmd.arg("--release");
-    }
-    cmd.arg("--");
-    for name in &test_names {
-        cmd.arg(name);
-    }
-    cmd.kill_on_drop(true);
-
+    let mut cmd = cargo_test_command(&project_root, &run_args.profile, &test_names);
     let run = cmd.output();
-    let output = match timeout(Duration::from_secs(timeout_secs), run).await {
+    let output = match timeout(Duration::from_secs(run_args.timeout_secs), run).await {
         Ok(Ok(o)) => o,
         Ok(Err(e)) => {
             return Ok(error_result(
@@ -337,7 +264,7 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
             return Ok(error_result(
                 "cargo",
                 "test",
-                &format!("cargo test timed out after {timeout_secs}s"),
+                &format!("cargo test timed out after {}s", run_args.timeout_secs),
             ));
         }
     };
@@ -346,40 +273,16 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let results = parse_libtest_output(&stdout);
 
-    let passed = results.iter().filter(|(_, ok)| *ok).count();
-    let failed = results.iter().filter(|(_, ok)| !*ok).count();
     let touched_files: Vec<String> = unique_file_paths(changed_paths.iter().map(String::as_str));
-
-    let body = json!({
-        "exit_code": output.status.code(),
-        "passed": passed,
-        "failed": failed,
-        "total_observed": results.len(),
-        "dispatched_tests": test_names,
-        "truncated": truncated,
-        "results": results
-            .iter()
-            .map(|(name, ok)| {
-                let mut covers = Vec::new();
-                for target in &selected_targets {
-                    if target.matches_libtest_name(name) {
-                        for source_id in &target.covers_source_ids {
-                            if !covers.contains(source_id) {
-                                covers.push(source_id.clone());
-                            }
-                        }
-                    }
-                }
-                json!({
-                    "test": name,
-                    "passed": ok,
-                    "covers_source_ids": covers,
-                })
-            })
-            .collect::<Vec<_>>(),
-        "stderr_tail": tail(&stderr, 2000),
-        "stdout_tail": tail(&stdout, 2000),
-    });
+    let body = run_affected_tests_body(
+        &output,
+        &results,
+        &test_names,
+        truncated,
+        &selected_targets,
+        &stderr,
+        &stdout,
+    );
 
     let text = render::finalize(Some(cg.project_root()), &args, &body, || {
         render::generic_md(&body)
@@ -390,6 +293,195 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
         }),
         touched_files,
     })
+}
+
+async fn resolve_changed_paths(
+    project_root: &Path,
+    explicit_paths: Option<Vec<String>>,
+) -> std::result::Result<Vec<String>, ToolResult> {
+    match explicit_paths {
+        Some(paths) => Ok(paths),
+        None => git_changed_paths(project_root)
+            .await
+            .map_err(|message| error_result("git", "diff", &message)),
+    }
+}
+
+async fn collect_affected_test_targets(
+    cg: &TraceDecay,
+    changed_paths: &[String],
+) -> Result<HashMap<String, TestTarget>> {
+    // Two paths feed into the test set:
+    // a) Indirect coverage: for each changed callable, walk callers and keep
+    //    test-shaped ones.
+    // b) Direct changes: when a changed path is itself a test file or contains
+    //    `#[test]` functions, dispatch those tests directly.
+    let mut test_targets = HashMap::new();
+    for path in changed_paths {
+        let nodes = cg.get_nodes_by_file(path).await?;
+        add_direct_test_targets(cg, path, &nodes, &mut test_targets).await?;
+        add_indirect_test_targets(cg, &nodes, &mut test_targets).await?;
+    }
+    Ok(test_targets)
+}
+
+async fn add_direct_test_targets(
+    cg: &TraceDecay,
+    path: &str,
+    nodes: &[Node],
+    test_targets: &mut HashMap<String, TestTarget>,
+) -> Result<()> {
+    let path_is_test_file = is_test_file(path);
+    if !path_is_test_file && nodes.is_empty() {
+        return Ok(());
+    }
+
+    let candidate_ids: Vec<String> = nodes
+        .iter()
+        .filter(|n| is_callable(n))
+        .map(|n| n.id.clone())
+        .collect();
+    let test_annotated_in_file = cg.get_test_annotated_node_ids(&candidate_ids).await?;
+
+    for node in nodes {
+        if !is_callable(node) {
+            continue;
+        }
+        if !path_is_test_file && !test_annotated_in_file.contains(&node.id) {
+            continue;
+        }
+        // The test "covers itself" so the per-test `covers_source_ids` field
+        // remains useful.
+        test_targets
+            .entry(test_target_key(node))
+            .or_insert_with(|| TestTarget::new(node))
+            .add_source(&node.id);
+    }
+
+    Ok(())
+}
+
+async fn add_indirect_test_targets(
+    cg: &TraceDecay,
+    nodes: &[Node],
+    test_targets: &mut HashMap<String, TestTarget>,
+) -> Result<()> {
+    for node in nodes {
+        if !is_callable(node) {
+            continue;
+        }
+
+        let callers = cg.get_callers(&node.id, 3).await?;
+        let caller_ids: Vec<String> = callers.iter().map(|(n, _)| n.id.clone()).collect();
+        let test_annotated = cg.get_test_annotated_node_ids(&caller_ids).await?;
+
+        for (caller, _) in callers {
+            if !is_test_file(&caller.file_path) && !test_annotated.contains(&caller.id) {
+                continue;
+            }
+            if !is_callable(&caller) {
+                continue;
+            }
+            test_targets
+                .entry(test_target_key(&caller))
+                .or_insert_with(|| TestTarget::new(&caller))
+                .add_source(&node.id);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_callable(node: &Node) -> bool {
+    matches!(node.kind, NodeKind::Function | NodeKind::Method)
+}
+
+fn select_test_targets(
+    test_targets: HashMap<String, TestTarget>,
+    max_tests: usize,
+) -> (Vec<TestTarget>, Vec<String>, bool) {
+    let mut selected_targets: Vec<TestTarget> = test_targets.into_values().collect();
+    selected_targets.sort_by(|a, b| {
+        a.qualified_name
+            .cmp(&b.qualified_name)
+            .then(a.node_id.cmp(&b.node_id))
+    });
+    let total_tests = selected_targets.len();
+    selected_targets.truncate(max_tests);
+    let truncated = total_tests > selected_targets.len();
+
+    let mut test_names: Vec<String> = selected_targets
+        .iter()
+        .map(|target| target.filter.clone())
+        .collect();
+    test_names.sort();
+    test_names.dedup();
+
+    (selected_targets, test_names, truncated)
+}
+
+fn cargo_test_command(project_root: &Path, profile: &str, test_names: &[String]) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(project_root)
+        .arg("test")
+        .arg("--no-fail-fast");
+    if profile == "release" {
+        cmd.arg("--release");
+    }
+    cmd.arg("--");
+    for name in test_names {
+        cmd.arg(name);
+    }
+    cmd.kill_on_drop(true);
+    cmd
+}
+
+fn run_affected_tests_body(
+    output: &Output,
+    results: &[(String, bool)],
+    test_names: &[String],
+    truncated: bool,
+    selected_targets: &[TestTarget],
+    stderr: &str,
+    stdout: &str,
+) -> Value {
+    let passed = results.iter().filter(|(_, ok)| *ok).count();
+    let failed = results.iter().filter(|(_, ok)| !*ok).count();
+
+    json!({
+        "exit_code": output.status.code(),
+        "passed": passed,
+        "failed": failed,
+        "total_observed": results.len(),
+        "dispatched_tests": test_names,
+        "truncated": truncated,
+        "results": results
+            .iter()
+            .map(|(name, ok)| {
+                json!({
+                    "test": name,
+                    "passed": ok,
+                    "covers_source_ids": covered_source_ids(name, selected_targets),
+                })
+            })
+            .collect::<Vec<_>>(),
+        "stderr_tail": tail(stderr, 2000),
+        "stdout_tail": tail(stdout, 2000),
+    })
+}
+
+fn covered_source_ids(name: &str, selected_targets: &[TestTarget]) -> Vec<String> {
+    let mut covers = Vec::new();
+    for target in selected_targets {
+        if target.matches_libtest_name(name) {
+            for source_id in &target.covers_source_ids {
+                if !covers.contains(source_id) {
+                    covers.push(source_id.clone());
+                }
+            }
+        }
+    }
+    covers
 }
 
 /// Wraps a short status message in a normal `ToolResult`.

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -5,6 +5,7 @@
 //! - `handlers`: tool call implementations (`handle_*` functions)
 
 mod definitions;
+mod dispatch_policy;
 mod handlers;
 pub(crate) mod render;
 
@@ -12,10 +13,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub use definitions::{
-    ast_grep_available, context_description, explore_call_budget, format_capable_tool_names,
-    get_tool_definitions, get_tool_definitions_with_budget,
+    ast_grep_available, ast_grep_diagnostics_json, ast_grep_outline_available, context_description,
+    explore_call_budget, format_capable_tool_names, get_tool_definitions,
+    get_tool_definitions_with_budget,
 };
-pub use handlers::{handle_profile_scoped_lcm_tool_call, handle_tool_call};
+pub use handlers::{
+    handle_profile_scoped_lcm_tool_call, handle_tool_call, handle_tool_call_with_registry,
+};
 
 /// Maximum character length for a tool response before truncation.
 const MAX_RESPONSE_CHARS: usize = 15_000;

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -134,19 +134,12 @@ pub(super) fn truncated_json_envelope_with_handle(
         }
         let text = serde_json::to_string_pretty(&envelope).unwrap_or_default();
         if text.len() <= MAX_RESPONSE_CHARS || end == 0 {
-            let handle_status = if handle.record.is_some() {
-                "stored"
-            } else if project_root.is_none() {
-                "no_project_root"
-            } else {
-                "store_failed"
-            };
             observe_response_truncation(
                 formatted.len(),
                 text.len(),
                 true,
                 now,
-                handle_status,
+                truncation_handle_status(project_root, &handle),
                 started.elapsed(),
             );
             return text;
@@ -170,19 +163,12 @@ fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> St
         let preview = &text[..end];
         let rendered = render_markdown_truncation(preview, text.len(), &handle);
         if rendered.len() <= MAX_RESPONSE_CHARS || end == 0 {
-            let handle_status = if handle.record.is_some() {
-                "stored"
-            } else if project_root.is_none() {
-                "no_project_root"
-            } else {
-                "store_failed"
-            };
             observe_response_truncation(
                 text.len(),
                 rendered.len(),
                 handle.record.is_some(),
                 now,
-                handle_status,
+                truncation_handle_status(project_root, &handle),
                 started.elapsed(),
             );
             return rendered;
@@ -194,6 +180,19 @@ fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> St
 struct TruncatedResponseHandle {
     record: Option<ResponseHandleRecord>,
     unavailable: Option<Value>,
+}
+
+fn truncation_handle_status(
+    project_root: Option<&Path>,
+    handle: &TruncatedResponseHandle,
+) -> &'static str {
+    if handle.record.is_some() {
+        "stored"
+    } else if project_root.is_none() {
+        "no_project_root"
+    } else {
+        "store_failed"
+    }
 }
 
 fn prepare_truncated_response_handle(

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -5,22 +5,28 @@ use std::path::Path;
 
 use serde_json::Value;
 
-use super::handlers::{truncate_response, truncated_json_envelope_with_handle};
+use crate::mcp::response_handles::{
+    note_response_handle_store_skipped_no_project_root, observe_response_truncation,
+    store_response_handle, ResponseHandleRecord, RESPONSE_HANDLE_TTL_SECS, RESPONSE_RETRIEVE_TOOL,
+};
+use crate::tracedecay::current_timestamp;
+
+use super::MAX_RESPONSE_CHARS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutputFormat {
+enum OutputFormat {
     Markdown,
     Json,
 }
 
-pub fn parse_format(args: &Value) -> OutputFormat {
+fn parse_format(args: &Value) -> OutputFormat {
     match args.get("format").and_then(Value::as_str) {
         Some(v) if v.eq_ignore_ascii_case("json") => OutputFormat::Json,
         _ => OutputFormat::Markdown,
     }
 }
 
-pub fn finalize<F>(project_root: Option<&Path>, args: &Value, value: &Value, md: F) -> String
+pub(super) fn finalize<F>(project_root: Option<&Path>, args: &Value, value: &Value, md: F) -> String
 where
     F: FnOnce() -> String,
 {
@@ -34,65 +40,286 @@ where
             if text.is_empty() {
                 return text;
             }
-            truncate_response(&text)
+            truncated_markdown_with_handle(project_root, &text)
         }
     }
 }
 
-pub fn esc_cell(s: &str) -> String {
+/// Truncates a string to the maximum response character limit, appending
+/// a truncation notice if necessary.
+pub(super) fn truncate_response(s: &str) -> String {
+    debug_assert!(!s.is_empty(), "truncate_response called with empty string");
+    if s.len() <= MAX_RESPONSE_CHARS {
+        s.to_string()
+    } else {
+        let started = std::time::Instant::now();
+        let now = current_timestamp();
+        // Find a valid UTF-8 character boundary at or before MAX_RESPONSE_CHARS.
+        let mut end = MAX_RESPONSE_CHARS;
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        let truncated = format!("{}\n\n[... truncated at {} chars]", &s[..end], end);
+        observe_response_truncation(
+            s.len(),
+            truncated.len(),
+            false,
+            now,
+            "not_available",
+            started.elapsed(),
+        );
+        truncated
+    }
+}
+
+/// Wraps oversized JSON text in a valid preview envelope. When a project root
+/// is available, stores the full original locally and includes a retrieval
+/// handle.
+///
+/// If local handle storage is unavailable or fails, the envelope still carries
+/// a preview but also includes explicit recovery metadata so clients can tell
+/// why no handle was emitted and what to retry.
+pub(super) fn truncated_json_envelope_with_handle(
+    project_root: Option<&Path>,
+    formatted: &str,
+) -> String {
+    if formatted.len() <= MAX_RESPONSE_CHARS {
+        return formatted.to_string();
+    }
+    let started = std::time::Instant::now();
+    let now = current_timestamp();
+    let handle = prepare_truncated_response_handle(project_root, formatted);
+    let mut end = formatted.len().min(MAX_RESPONSE_CHARS.saturating_sub(1024));
+    loop {
+        while end > 0 && !formatted.is_char_boundary(end) {
+            end -= 1;
+        }
+        let preview = &formatted[..end];
+        let mut envelope = serde_json::json!({
+            "truncated": true,
+            "original_chars": formatted.len(),
+            "preview_chars": preview.len(),
+            "preview": preview,
+        });
+        if let Some(object) = envelope.as_object_mut() {
+            if let Some(record) = &handle.record {
+                object.insert("handle".to_string(), serde_json::json!(record.handle));
+                object.insert(
+                    "retrieve_tool".to_string(),
+                    serde_json::json!(RESPONSE_RETRIEVE_TOOL),
+                );
+                object.insert(
+                    "retrieve_ttl_seconds".to_string(),
+                    serde_json::json!(RESPONSE_HANDLE_TTL_SECS),
+                );
+                object.insert(
+                    "retrieve_expires_at".to_string(),
+                    serde_json::json!(record.expires_at),
+                );
+                object.insert(
+                    "retrieve_instruction".to_string(),
+                    serde_json::json!(format!(
+                        "This response was truncated: `preview` contains only the first {} of {} characters. The full original response is stored locally in this project and expires at {} (TTL {} seconds). To recover it, call `{RESPONSE_RETRIEVE_TOOL}` with required argument `handle` set to `{}`. If the original tool call used a project selector (`project_id`, `project_path`, or `project_selector`), pass the same selector to `{RESPONSE_RETRIEVE_TOOL}` so the handle is looked up in the same project cache. Only call it if the missing details are needed to answer the user's request.",
+                        preview.len(),
+                        formatted.len(),
+                        record.expires_at,
+                        RESPONSE_HANDLE_TTL_SECS,
+                        record.handle
+                    )),
+                );
+            } else if let Some(status) = &handle.unavailable {
+                object.insert("handle_available".to_string(), serde_json::json!(false));
+                object.insert("handle_status".to_string(), status.clone());
+            }
+        }
+        let text = serde_json::to_string_pretty(&envelope).unwrap_or_default();
+        if text.len() <= MAX_RESPONSE_CHARS || end == 0 {
+            let handle_status = if handle.record.is_some() {
+                "stored"
+            } else if project_root.is_none() {
+                "no_project_root"
+            } else {
+                "store_failed"
+            };
+            observe_response_truncation(
+                formatted.len(),
+                text.len(),
+                true,
+                now,
+                handle_status,
+                started.elapsed(),
+            );
+            return text;
+        }
+        end = end.saturating_sub(1024);
+    }
+}
+
+fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> String {
+    if text.len() <= MAX_RESPONSE_CHARS {
+        return text.to_string();
+    }
+    let started = std::time::Instant::now();
+    let now = current_timestamp();
+    let handle = prepare_truncated_response_handle(project_root, text);
+    let mut end = text.len().min(MAX_RESPONSE_CHARS.saturating_sub(2048));
+    loop {
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        let preview = &text[..end];
+        let rendered = render_markdown_truncation(preview, text.len(), &handle);
+        if rendered.len() <= MAX_RESPONSE_CHARS || end == 0 {
+            let handle_status = if handle.record.is_some() {
+                "stored"
+            } else if project_root.is_none() {
+                "no_project_root"
+            } else {
+                "store_failed"
+            };
+            observe_response_truncation(
+                text.len(),
+                rendered.len(),
+                handle.record.is_some(),
+                now,
+                handle_status,
+                started.elapsed(),
+            );
+            return rendered;
+        }
+        end = end.saturating_sub(1024);
+    }
+}
+
+struct TruncatedResponseHandle {
+    record: Option<ResponseHandleRecord>,
+    unavailable: Option<Value>,
+}
+
+fn prepare_truncated_response_handle(
+    project_root: Option<&Path>,
+    text: &str,
+) -> TruncatedResponseHandle {
+    if let Some(root) = project_root {
+        match store_response_handle(root, text, current_timestamp()) {
+            Ok(record) => TruncatedResponseHandle {
+                record: Some(record),
+                unavailable: None,
+            },
+            Err(err) => TruncatedResponseHandle {
+                record: None,
+                unavailable: Some(serde_json::json!({
+                    "reason_code": "handle_store_failed",
+                    "message": format!(
+                        "The full response could not be cached locally, so no retrieval handle is available: {err}"
+                    ),
+                    "retryable": true,
+                    "retry_instruction": "Fix the local project cache path or filesystem error, then re-run the original MCP tool to regenerate the full response and a fresh handle."
+                })),
+            },
+        }
+    } else {
+        note_response_handle_store_skipped_no_project_root();
+        TruncatedResponseHandle {
+            record: None,
+            unavailable: Some(serde_json::json!({
+                "reason_code": "handle_storage_unavailable",
+                "message": "This response was truncated in a context without a project-local cache path, so no retrieval handle could be created.",
+                "retryable": true,
+                "retry_instruction": "Re-run the original MCP tool from a project-scoped tracedecay session if you need a retrievable full response."
+            })),
+        }
+    }
+}
+
+fn render_markdown_truncation(
+    preview: &str,
+    original_chars: usize,
+    handle: &TruncatedResponseHandle,
+) -> String {
+    let mut rendered = String::new();
+    rendered.push_str("# Truncated Response\n\n");
+    let _ = writeln!(
+        rendered,
+        "Showing the first {} of {original_chars} characters.",
+        preview.len()
+    );
+    if let Some(record) = &handle.record {
+        let _ = writeln!(
+            rendered,
+            "Full response stored locally. Retrieve it with `{RESPONSE_RETRIEVE_TOOL}` using handle `{}` before {}.",
+            record.handle,
+            record.expires_at
+        );
+    } else if let Some(status) = &handle.unavailable {
+        let message = status
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("No retrieval handle is available.");
+        let _ = writeln!(rendered, "{message}");
+    }
+    rendered.push_str("\n## Preview\n\n");
+    rendered.push_str(preview);
+    if !preview.ends_with('\n') {
+        rendered.push('\n');
+    }
+    rendered
+}
+
+fn esc_cell(s: &str) -> String {
     s.replace('|', "\\|").replace(['\n', '\r'], " ")
 }
 
-pub fn field_str<'a>(v: &'a Value, key: &str) -> &'a str {
+pub(super) fn field_str<'a>(v: &'a Value, key: &str) -> &'a str {
     v.get(key).and_then(Value::as_str).unwrap_or("")
 }
 
-pub fn field_i64(v: &Value, key: &str) -> i64 {
+pub(super) fn field_i64(v: &Value, key: &str) -> i64 {
     v.get(key).and_then(Value::as_i64).unwrap_or(0)
 }
 
 #[derive(Default)]
-pub struct Md {
+pub(super) struct Md {
     buf: String,
 }
 
 impl Md {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self::default()
     }
 
-    pub fn heading(&mut self, level: u8, text: &str) -> &mut Self {
+    pub(super) fn heading(&mut self, level: u8, text: &str) -> &mut Self {
         let hashes = "#".repeat(level.clamp(1, 6) as usize);
         let _ = writeln!(self.buf, "{hashes} {text}");
         self
     }
 
-    pub fn field(&mut self, key: &str, value: &str) -> &mut Self {
+    pub(super) fn field(&mut self, key: &str, value: &str) -> &mut Self {
         let _ = writeln!(self.buf, "**{key}:** {value}");
         self
     }
 
-    pub fn line(&mut self, text: &str) -> &mut Self {
+    pub(super) fn line(&mut self, text: &str) -> &mut Self {
         let _ = writeln!(self.buf, "{text}");
         self
     }
 
-    pub fn bullet(&mut self, text: &str) -> &mut Self {
+    pub(super) fn bullet(&mut self, text: &str) -> &mut Self {
         let _ = writeln!(self.buf, "- {text}");
         self
     }
 
-    pub fn empty_note(&mut self, text: &str) -> &mut Self {
+    pub(super) fn empty_note(&mut self, text: &str) -> &mut Self {
         let _ = writeln!(self.buf, "_{text}_");
         self
     }
 
-    pub fn blank(&mut self) -> &mut Self {
+    pub(super) fn blank(&mut self) -> &mut Self {
         self.buf.push('\n');
         self
     }
 
-    pub fn table(&mut self, headers: &[&str], rows: &[Vec<String>]) -> &mut Self {
+    pub(super) fn table(&mut self, headers: &[&str], rows: &[Vec<String>]) -> &mut Self {
         if headers.is_empty() {
             return self;
         }
@@ -106,7 +333,7 @@ impl Md {
         self
     }
 
-    pub fn code(&mut self, lang: &str, body: &str) -> &mut Self {
+    pub(super) fn code(&mut self, lang: &str, body: &str) -> &mut Self {
         let _ = writeln!(self.buf, "```{lang}");
         self.buf.push_str(body);
         if !body.ends_with('\n') {
@@ -116,14 +343,14 @@ impl Md {
         self
     }
 
-    pub fn render(self) -> String {
+    pub(super) fn render(self) -> String {
         self.buf
     }
 }
 
 const GENERIC_MAX_DEPTH: u8 = 4;
 
-pub fn generic_md(value: &Value) -> String {
+pub(super) fn generic_md(value: &Value) -> String {
     let mut md = Md::new();
     render_value(&mut md, value, 2);
     let out = md.render();
@@ -239,6 +466,8 @@ fn render_object(md: &mut Md, map: &serde_json::Map<String, Value>, depth: u8) {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::mcp::response_handles::{retrieve_response_handle, ResponseHandleLookup};
+    use crate::tracedecay::current_timestamp;
     use serde_json::json;
 
     #[test]
@@ -278,6 +507,111 @@ mod tests {
         let value = json!({"a": 1});
         let out = finalize(None, &json!({}), &value, || "## Hi\n".to_string());
         assert_eq!(out, "## Hi\n");
+    }
+
+    #[test]
+    fn truncate_short_response() {
+        let short = "hello world";
+        assert_eq!(truncate_response(short), short);
+    }
+
+    #[test]
+    fn truncate_long_response() {
+        let long = "x".repeat(20_000);
+        let result = truncate_response(&long);
+        assert!(result.len() < 20_000);
+        assert!(result.contains("[... truncated at 15000 chars]"));
+    }
+
+    #[test]
+    fn truncated_json_envelope_includes_handle() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let long = format!(
+            "{{\"items\":[{}]}}",
+            (0..3_000)
+                .map(|i| format!("{{\"id\":{i},\"name\":\"item-{i}\"}}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        let result = truncated_json_envelope_with_handle(Some(dir.path()), &long);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["truncated"], true);
+        assert_eq!(parsed["retrieve_tool"], "tracedecay_retrieve");
+        assert!(parsed.get("retrieve_handle").is_none());
+        let handle = parsed["handle"].as_str().unwrap();
+        assert!(handle.starts_with("rh_"));
+
+        let stored = retrieve_response_handle(dir.path(), handle, current_timestamp()).unwrap();
+        match stored {
+            ResponseHandleLookup::Found(record) => assert_eq!(record.content, long),
+            other => panic!("stored response should be retrievable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncated_markdown_includes_readable_handle_guidance() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let long = format!("# Scan\n\n{}", "- repeated finding\n".repeat(3_000));
+
+        let result = truncated_markdown_with_handle(Some(dir.path()), &long);
+
+        assert!(result.starts_with("# Truncated Response"));
+        assert!(result.contains("## Preview"));
+        assert!(result.contains("Full response stored locally"));
+        assert!(result.contains("tracedecay_retrieve"));
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&result).is_err(),
+            "markdown truncation should not render as a JSON envelope"
+        );
+        let Some(handle) = result
+            .split("handle `")
+            .nth(1)
+            .and_then(|tail| tail.split('`').next())
+        else {
+            panic!("markdown guidance should include handle");
+        };
+        assert!(handle.starts_with("rh_"));
+
+        let stored = retrieve_response_handle(dir.path(), handle, current_timestamp()).unwrap();
+        match stored {
+            ResponseHandleLookup::Found(record) => assert_eq!(record.content, long),
+            other => panic!("stored markdown response should be retrievable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncated_json_envelope_reports_store_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".tracedecay")).unwrap();
+        std::fs::write(
+            dir.path().join(".tracedecay/enrollment.json"),
+            r#"{"project_id":"../invalid","storage_mode":"profile_sharded"}"#,
+        )
+        .unwrap();
+        let long = format!(
+            "{{\"items\":[{}]}}",
+            (0..3_000)
+                .map(|i| format!("{{\"id\":{i},\"name\":\"item-{i}\"}}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        let result = truncated_json_envelope_with_handle(Some(dir.path()), &long);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(parsed["truncated"], true);
+        assert_eq!(parsed["handle_available"], false);
+        assert!(parsed.get("handle").is_none());
+        assert_eq!(
+            parsed["handle_status"]["reason_code"],
+            "handle_store_failed"
+        );
+        assert!(parsed["handle_status"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("could not be cached locally"));
     }
 
     #[test]

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -30,6 +30,7 @@
 //! read with the shared byte-offset machinery and scoped to the current project
 //! by `session_meta.cwd`.
 
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -192,7 +193,6 @@ impl TranscriptSource for CodexSource {
 
 /// Read the leading `session_meta` line of a rollout for cwd/session-id/model.
 fn session_meta(path: &Path) -> Option<CodexMeta> {
-    use std::io::BufRead;
     let file = std::fs::File::open(path).ok()?;
     let reader = std::io::BufReader::new(file);
     for line in reader.lines().take(4).map_while(Result::ok) {
@@ -273,7 +273,6 @@ fn prior_compaction_depth(path: &Path, before_offset: u64) -> i64 {
     if before_offset == 0 {
         return 0;
     }
-    use std::io::BufRead;
     let Ok(file) = std::fs::File::open(path) else {
         return 0;
     };

--- a/src/sessions/lcm/security.rs
+++ b/src/sessions/lcm/security.rs
@@ -206,12 +206,7 @@ fn assistant_output_is_high_repetition(content: &str) -> bool {
     let normalized = content.split_whitespace().collect::<Vec<_>>().join(" ");
     let tokens = word_tokens(&normalized);
     if tokens.len() < QUARANTINED_ASSISTANT_MIN_TOKENS {
-        return tokens.len() >= 20
-            && normalized
-                .chars()
-                .collect::<std::collections::BTreeSet<_>>()
-                .len()
-                <= 12;
+        return tokens.len() >= 20 && distinct_char_count(&normalized) <= 12;
     }
 
     let mut counts = HashMap::<&str, usize>::new();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,6 +4,7 @@ use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use serde_json::Value;
@@ -144,6 +145,10 @@ fn canonicalize_test_db_path(path: &Path) -> PathBuf {
     )
 }
 
+pub fn canonical_existing_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
 pub fn tempdir_or_panic() -> TempDir {
     match TempDir::new() {
         Ok(dir) => dir,
@@ -208,6 +213,24 @@ pub fn http_agent() -> ureq::Agent {
         .timeout_global(Some(Duration::from_secs(4)))
         .build()
         .into()
+}
+
+#[cfg(unix)]
+pub struct DaemonProcess;
+
+pub fn apply_tracedecay_home_env(command: &mut Command, home: &Path) {
+    let home = canonical_existing_path(home);
+    command
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env(USER_DATA_DIR_ENV, home.join(".tracedecay"))
+        .env(GLOBAL_DB_ENV, home.join(".tracedecay/global.db"));
+}
+
+#[cfg(unix)]
+pub fn spawn_tracedecay_daemon(_home: &Path) -> DaemonProcess {
+    DaemonProcess
 }
 
 pub fn response_to_json(mut response: ureq::http::Response<ureq::Body>) -> (u16, Value) {

--- a/tests/dashboard_api_test.rs
+++ b/tests/dashboard_api_test.rs
@@ -11,7 +11,6 @@ use common::{
 };
 use serde_json::Value;
 use tempfile::TempDir;
-use tracedecay::branch;
 use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::dashboard;
 use tracedecay::errors::TraceDecayError;
@@ -753,7 +752,8 @@ fn dashboard_reports_resolved_branch_db_path() {
             "pub fn feature_branch_symbol() {}\n",
         )
         .unwrap_or_else(|err| panic!("failed to write feature fixture: {err}"));
-        if let Err(err) = branch::add_branch_tracking(&project_root, "feature/dashboard-path").await
+        if let Err(err) =
+            TraceDecay::add_branch_tracking(&project_root, "feature/dashboard-path").await
         {
             panic!("failed to track feature branch: {err}");
         }
@@ -815,7 +815,8 @@ fn dashboard_uses_project_memory_db_and_branch_graph_db() {
             "pub fn feature_branch_symbol() {}\n",
         )
         .unwrap_or_else(|err| panic!("failed to write feature fixture: {err}"));
-        if let Err(err) = branch::add_branch_tracking(&project_root, "feature/dashboard-storage").await
+        if let Err(err) =
+            TraceDecay::add_branch_tracking(&project_root, "feature/dashboard-storage").await
         {
             panic!("failed to track feature branch: {err}");
         }

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -923,9 +923,6 @@ fn assert_action_schema_requires(
 
 #[test]
 fn outline_schema_requires_file_without_provider_property() {
-    if !tracedecay::mcp::tools::ast_grep_outline_available() {
-        return;
-    }
     let tools = get_tool_definitions();
     let schema = tool_schema(&tools, "tracedecay_outline");
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -9646,8 +9646,8 @@ async fn lcm_status_cli_profile_scope_dispatches_without_initialized_project() {
     );
     let stderr = String::from_utf8_lossy(&project_output.stderr);
     assert!(
-        stderr.contains("daemon tool call failed") && stderr.contains("TraceDecay index"),
-        "project-local failure should return a daemon JSON-RPC error:\n{stderr}"
+        stderr.contains("no TraceDecay index found") && stderr.contains("tracedecay init"),
+        "project-local failure should report the missing cwd project:\n{stderr}"
     );
     drop(env_lock);
 }

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -711,6 +711,89 @@ async fn project_registry_tools_are_bounded_read_only_and_contextual() {
 }
 
 #[tokio::test]
+async fn project_registry_tools_prefer_injected_registry_over_process_default() {
+    let (cg, _project_dir) = setup_project().await;
+    let process_registry_dir = TempDir::new().unwrap();
+    let process_registry_path = process_registry_dir.path().join("global.db");
+    let client_registry_dir = TempDir::new().unwrap();
+    let client_registry_path = client_registry_dir.path().join("global.db");
+    let _env_guard = GlobalDbEnvGuard::set(&process_registry_path);
+
+    let process_db = GlobalDb::open_at(&process_registry_path).await.unwrap();
+    process_db
+        .upsert_code_project(
+            "proj_process_default",
+            &cg.project_root().with_file_name("process-default"),
+            None,
+            None,
+            Some("main"),
+        )
+        .await
+        .unwrap();
+    seed_project_registry(&client_registry_path, cg.project_root()).await;
+    let client_db = GlobalDb::open_at(&client_registry_path).await.unwrap();
+
+    let list = tracedecay::mcp::tools::handle_tool_call_with_registry(
+        &cg,
+        "tracedecay_project_list",
+        json!({"limit": 10, "format": "json"}),
+        None,
+        None,
+        Some(&client_db),
+        false,
+    )
+    .await
+    .unwrap();
+    let list_payload: Value = serde_json::from_str(extract_text(&list.value)).unwrap();
+    assert_eq!(
+        list_payload["registry_path"],
+        client_registry_path.display().to_string()
+    );
+    let list_text = extract_text(&list.value);
+    assert!(list_text.contains("proj_alpha"));
+    assert!(
+        !list_text.contains("proj_process_default"),
+        "project list should not read process-default registry: {list_text}"
+    );
+
+    let search = tracedecay::mcp::tools::handle_tool_call_with_registry(
+        &cg,
+        "tracedecay_project_search",
+        json!({"query": "alpha", "limit": 10, "format": "json"}),
+        None,
+        None,
+        Some(&client_db),
+        false,
+    )
+    .await
+    .unwrap();
+    let search_text = extract_text(&search.value);
+    assert!(search_text.contains("proj_alpha"));
+    assert!(
+        !search_text.contains("proj_process_default"),
+        "project search should not read process-default registry: {search_text}"
+    );
+
+    let context = tracedecay::mcp::tools::handle_tool_call_with_registry(
+        &cg,
+        "tracedecay_project_context",
+        json!({"project_id": "proj_alpha", "format": "json"}),
+        None,
+        None,
+        Some(&client_db),
+        false,
+    )
+    .await
+    .unwrap();
+    let context_payload: Value = serde_json::from_str(extract_text(&context.value)).unwrap();
+    assert_eq!(context_payload["project"]["project_id"], "proj_alpha");
+    assert_eq!(
+        context_payload["registry_path"],
+        client_registry_path.display().to_string()
+    );
+}
+
+#[tokio::test]
 async fn selected_project_read_skips_cache_write_for_read_only_store() {
     let (cg, _project_dir) = setup_project().await;
     let registry_dir = TempDir::new().unwrap();
@@ -835,6 +918,23 @@ fn assert_action_schema_requires(
     assert_eq!(
         actual, expected_required,
         "{tool_name} schema conditional requirements for action={action} drifted from handler parser expectations"
+    );
+}
+
+#[test]
+fn outline_schema_requires_file_without_provider_property() {
+    if !tracedecay::mcp::tools::ast_grep_outline_available() {
+        return;
+    }
+    let tools = get_tool_definitions();
+    let schema = tool_schema(&tools, "tracedecay_outline");
+
+    assert_eq!(required_args_at(schema, &[]), vec!["file"]);
+    assert!(
+        schema["properties"]
+            .as_object()
+            .is_some_and(|properties| !properties.contains_key("provider")),
+        "tracedecay_outline should not advertise a provider property: {schema}"
     );
 }
 
@@ -3577,6 +3677,10 @@ async fn read_and_outline_preserve_symlink_indexed_file_key() {
         "read should serve indexed source behind symlink: {read_payload:?}"
     );
 
+    if !tracedecay::mcp::tools::ast_grep_outline_available() {
+        return;
+    }
+
     let outline = handle_tool_call(
         &cg,
         "tracedecay_outline",
@@ -3596,6 +3700,43 @@ async fn read_and_outline_preserve_symlink_indexed_file_key() {
             .iter()
             .any(|symbol| symbol["name"] == "through_symlink"),
         "outline should query graph by indexed symlink path: {outline_payload:?}"
+    );
+}
+
+#[tokio::test]
+async fn outline_preserves_db_payload_and_adds_ast_grep_outline_when_available() {
+    if !tracedecay::mcp::tools::ast_grep_outline_available() {
+        return;
+    }
+
+    let (cg, _dir) = setup_project().await;
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_outline",
+        json!({"file": "src/utils.rs"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.touched_files, vec!["src/utils.rs"]);
+    let payload: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
+    assert_eq!(payload["file"], "src/utils.rs");
+    assert!(payload["symbol_count"].as_u64().is_some());
+    assert!(
+        payload["symbols"]
+            .as_array()
+            .is_some_and(|symbols| symbols.iter().any(|symbol| symbol["name"] == "helper")),
+        "DB-backed symbols should still be present: {payload}"
+    );
+    assert!(
+        payload["ast_grep_outline"]
+            .as_array()
+            .is_some_and(|files| files.iter().any(|file| file["items"]
+                .as_array()
+                .is_some_and(|items| items.iter().any(|item| item["name"] == "helper")))),
+        "ast-grep outline should be attached under ast_grep_outline: {payload}"
     );
 }
 
@@ -7476,6 +7617,18 @@ async fn lcm_doctor_repair_dry_run_does_not_run_schema_migration() {
     assert_eq!(payload["mode"], "repair");
     assert_eq!(payload["dry_run"], true);
     assert_eq!(payload["diagnostics"]["schema"]["migration_present"], false);
+    assert_eq!(
+        payload["diagnostics"]["ast_grep"]["rewrite_available"].as_bool(),
+        Some(tracedecay::mcp::tools::ast_grep_available())
+    );
+    assert_eq!(
+        payload["diagnostics"]["ast_grep"]["outline_available"].as_bool(),
+        Some(tracedecay::mcp::tools::ast_grep_outline_available())
+    );
+    assert!(
+        payload["diagnostics"]["ast_grep"]["message"].is_string(),
+        "doctor should include ast-grep install/update guidance"
+    );
     assert_eq!(lcm_schema_migration_count(&cg).await, 0);
 }
 
@@ -9374,12 +9527,17 @@ async fn message_search_preserves_provider_project_parent_scope_shape_after_lcm(
     assert_eq!(payload["results"][0]["session"]["is_subagent"], true);
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn lcm_status_cli_bridge_accepts_json_args() {
     let (cg, _dir) = setup_project().await;
+    let home = _dir.path().join("home");
+    let _daemon = common::spawn_tracedecay_daemon(&home);
     let outside_cwd = TempDir::new().unwrap();
     let project_arg = cg.project_root().display().to_string();
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+    let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"));
+    common::apply_tracedecay_home_env(&mut command, &home);
+    let output = command
         .current_dir(outside_cwd.path())
         .args([
             "tool",
@@ -9413,8 +9571,13 @@ async fn lcm_status_cli_bridge_accepts_json_args() {
     );
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn lcm_status_cli_profile_scope_dispatches_without_initialized_project() {
+    let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
+    let home = TempDir::new().unwrap();
+    let _home_guard = HomeEnvGuard::set(home.path());
+    let _global_db_guard = GlobalDbEnvGuard::set(&home.path().join(".tracedecay/global.db"));
     let outside_cwd = TempDir::new().unwrap();
     let hermes_home = TempDir::new().unwrap();
     let profile_db = open_hermes_profile_session_db(hermes_home.path()).await;
@@ -9434,7 +9597,10 @@ async fn lcm_status_cli_profile_scope_dispatches_without_initialized_project() {
         "hermes_home": hermes_home.path(),
     })
     .to_string();
-    let profile_output = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+    let _daemon = common::spawn_tracedecay_daemon(home.path());
+    let mut profile_command = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"));
+    common::apply_tracedecay_home_env(&mut profile_command, home.path());
+    let profile_output = profile_command
         .current_dir(outside_cwd.path())
         .args([
             "tool",
@@ -9459,7 +9625,9 @@ async fn lcm_status_cli_profile_scope_dispatches_without_initialized_project() {
     assert_eq!(profile_payload["lcm"]["storage_scope"], "hermes_profile");
     assert_eq!(profile_payload["lcm"]["raw_message_count"], 1);
 
-    let project_output = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+    let mut project_command = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"));
+    common::apply_tracedecay_home_env(&mut project_command, home.path());
+    let project_output = project_command
         .current_dir(outside_cwd.path())
         .args([
             "tool",
@@ -9478,9 +9646,10 @@ async fn lcm_status_cli_profile_scope_dispatches_without_initialized_project() {
     );
     let stderr = String::from_utf8_lossy(&project_output.stderr);
     assert!(
-        stderr.contains("run 'tracedecay init' first"),
-        "project-local failure should continue to require initialization:\n{stderr}"
+        stderr.contains("daemon tool call failed") && stderr.contains("TraceDecay index"),
+        "project-local failure should return a daemon JSON-RPC error:\n{stderr}"
     );
+    drop(env_lock);
 }
 
 #[test]
@@ -11745,6 +11914,48 @@ async fn simplify_scan_surfaces_store_failure_instead_of_no_findings() {
     assert!(
         result.is_err(),
         "a failing store query must produce a tool error, not an empty findings list"
+    );
+}
+
+#[tokio::test]
+async fn simplify_scan_markdown_visible_output_is_not_escaped_blob() {
+    let (cg, dir) = setup_project().await;
+    fs::write(
+        dir.path().join("src/dead.rs"),
+        r#"
+fn abandoned_helper() -> usize {
+    7
+}
+"#,
+    )
+    .unwrap();
+    index_all_retrying_sync_lock(&cg).await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_simplify_scan",
+        json!({"files": ["src/dead.rs"], "format": "markdown"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    assert!(text.contains("# Simplify Scan"), "got: {text}");
+    assert!(text.contains("## Potential Dead Code"), "got: {text}");
+    assert!(text.contains("abandoned_helper"), "got: {text}");
+    assert!(
+        serde_json::from_str::<Value>(text).is_err(),
+        "visible markdown should not be a JSON envelope: {text}"
+    );
+    assert!(
+        !text.contains("\\n") && !text.contains("\\\""),
+        "visible markdown should not contain escaped markdown/json: {text}"
+    );
+    assert!(
+        !text.contains("\"content\""),
+        "visible markdown should not contain a nested MCP envelope: {text}"
     );
 }
 

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -96,16 +96,31 @@ fn test_all_error_codes() {
 #[test]
 fn test_tool_definitions_count() {
     let tools = get_tool_definitions();
-    // `tracedecay_ast_grep_rewrite` is registered conditionally on whether
-    // the external `ast-grep` binary is on PATH — hide-when-missing so
-    // agents never receive a tool that will instantly fail.
+    // ast-grep-backed tools are registered only when the host CLI capability
+    // they need is available — hide-when-missing so agents never receive a
+    // tool that will instantly fail.
     // LCM comparison and profile-storage registry support add extra tools.
-    let expected = if tracedecay::mcp::tools::ast_grep_available() {
-        94
-    } else {
-        93
-    };
+    let expected = 92
+        + usize::from(tracedecay::mcp::tools::ast_grep_available())
+        + usize::from(tracedecay::mcp::tools::ast_grep_outline_available());
     assert_eq!(tools.len(), expected);
+}
+
+#[test]
+fn test_ast_grep_tools_follow_capability_gates() {
+    let tools = get_tool_definitions();
+    let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+
+    assert_eq!(
+        tool_names.contains(&"tracedecay_ast_grep_rewrite"),
+        tracedecay::mcp::tools::ast_grep_available(),
+        "rewrite should be gated on the external ast-grep CLI"
+    );
+    assert_eq!(
+        tool_names.contains(&"tracedecay_outline"),
+        tracedecay::mcp::tools::ast_grep_outline_available(),
+        "outline should be gated on ast-grep outline >= 0.44 support"
+    );
 }
 
 #[test]

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -96,13 +96,11 @@ fn test_all_error_codes() {
 #[test]
 fn test_tool_definitions_count() {
     let tools = get_tool_definitions();
-    // ast-grep-backed tools are registered only when the host CLI capability
-    // they need is available — hide-when-missing so agents never receive a
-    // tool that will instantly fail.
+    // ast-grep rewrite is registered only when the host CLI capability it needs
+    // is available. Outline stays registered and reports the ast-grep outline
+    // requirement at runtime so plugin docs/rules can consistently reference it.
     // LCM comparison and profile-storage registry support add extra tools.
-    let expected = 92
-        + usize::from(tracedecay::mcp::tools::ast_grep_available())
-        + usize::from(tracedecay::mcp::tools::ast_grep_outline_available());
+    let expected = 93 + usize::from(tracedecay::mcp::tools::ast_grep_available());
     assert_eq!(tools.len(), expected);
 }
 
@@ -116,11 +114,7 @@ fn test_ast_grep_tools_follow_capability_gates() {
         tracedecay::mcp::tools::ast_grep_available(),
         "rewrite should be gated on the external ast-grep CLI"
     );
-    assert_eq!(
-        tool_names.contains(&"tracedecay_outline"),
-        tracedecay::mcp::tools::ast_grep_outline_available(),
-        "outline should be gated on ast-grep outline >= 0.44 support"
-    );
+    assert!(tool_names.contains(&"tracedecay_outline"));
 }
 
 #[test]

--- a/tests/memory_eval_test.rs
+++ b/tests/memory_eval_test.rs
@@ -14,6 +14,8 @@
 //! The harness still understands `pending-sibling` for future branch-split work,
 //! but shipped hygiene contracts should be marked stable.
 
+mod common;
+
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
@@ -212,6 +214,8 @@ struct Fixture {
     home_path: PathBuf,
     _project: TempDir,
     project_path: PathBuf,
+    #[cfg(unix)]
+    _daemon: Option<common::DaemonProcess>,
 }
 
 impl Fixture {
@@ -374,11 +378,13 @@ fn build_fixture(setup: &Setup) -> Fixture {
     let project = TempDir::new().expect("project tempdir");
     let home_path = canonical_test_dir(home.path());
     let project_path = canonical_test_dir(project.path());
-    let fixture = Fixture {
+    let mut fixture = Fixture {
         _home: home,
         home_path,
         _project: project,
         project_path,
+        #[cfg(unix)]
+        _daemon: None,
     };
     let src = fixture.project_path.join("src");
     std::fs::create_dir_all(&src).expect("create src dir");
@@ -388,6 +394,10 @@ fn build_fixture(setup: &Setup) -> Fixture {
             .unwrap_or_else(|e| panic!("write fixture file {name}: {e}"));
     }
     run_ok(&fixture, &["init"]);
+    #[cfg(unix)]
+    {
+        fixture._daemon = Some(common::spawn_tracedecay_daemon(&fixture.home_path));
+    }
     for fact in &setup.facts {
         let args = serde_json::json!({
             "action": "add",

--- a/tests/regression_core_engine_test.rs
+++ b/tests/regression_core_engine_test.rs
@@ -306,7 +306,7 @@ async fn add_branch_tracking_refuses_empty_sanitized_name() {
     cg.index_all().await.unwrap();
 
     // ".." sanitizes to "" — must be refused, never mapped to branches/.db.
-    let result = tracedecay::branch::add_branch_tracking(project, "..").await;
+    let result = TraceDecay::add_branch_tracking(project, "..").await;
     assert!(
         result.is_err(),
         "a branch name that sanitizes to empty must be refused, got: {result:?}"


### PR DESCRIPTION
## Summary
- Extract shared MCP handler support and dispatch policy for project-selector tools.
- Preserve client registry context for registered-project reads and memory/session handlers.
- Add `tracedecay_outline` ast-grep support, diagnostics, docs, and tests without feature flags.

## Test plan
- `cargo check`
- `cargo test --test tool_daemon_test -- --test-threads=1` (run on full stack)