### PR TITLE
ci: increase Windows test sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
         run: cargo nextest run --workspace --profile ci
 
   windows-test-shards:
-    name: Test Windows ${{ matrix.partition }}/4
+    name: Test Windows ${{ matrix.partition }}/8
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
@@ -95,7 +95,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           $partition = [int]"${{ matrix.partition }}"
-          $partitions = 4
+          $partitions = 8
           $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
           $package = $metadata.packages | Where-Object { $_.name -eq "tracedecay" } | Select-Object -First 1
           $targets = @($package.targets | Where-Object { $_.kind -contains "test" } | Sort-Object name)


### PR DESCRIPTION
## Summary
- Increase the Windows test matrix from 4 shards to 8 shards.
- Keep the Windows job name and PowerShell nextest partition count aligned with the new shard count.

## Test plan
- `git diff --check`
- Parsed `.github/workflows/ci.yml` locally and checked the Windows matrix, job label, and `$partitions` value are all 8.
- Ran `cargo metadata --no-deps --format-version 1` and dry-ran the shard assignment: 8 non-empty shards over 114 integration test targets.
- Checked for `actionlint`; not installed locally, so skipped.