### PR TITLE
ci: pass flaky Windows retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             throw "No integration test targets selected for Windows shard $partition/$partitions"
           }
           Write-Host "Windows shard $partition/$partitions running $($selected.Count) integration test targets"
-          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci", "--retries", "2")
+          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci", "--retries", "2", "--flaky-result", "pass")
           if ($partition -eq 1) {
             $nextestArgs += @("--lib", "--bin", "tracedecay")
           }


### PR DESCRIPTION
## Summary
- Treat retried Windows nextest flakes as passing when a retry succeeds.
- Complements the existing Windows-only `--retries 2` setting, since the CI profile otherwise marks flaky results as failures.

## Test plan
- CI on this PR should validate the workflow change.
- PR #100 previously reproduced the Windows `0xc0000005` access violation and passed once retries were enabled.