### PR TITLE
chore: release v0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.11](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.10...v0.0.11) - 2026-06-24
+
+### Added
+
+- make update refresh plugins and daemon
+
+### Fixed
+
+- simplify compact path list rendering
+- keep daemon MCP proxy alive across restarts
+- *(db)* disable SQLite mmap on Windows to stop teardown crash
+
 ## [0.0.10](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.9...v0.0.10) - 2026-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,7 +4499,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.10 -> 0.0.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.11](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.10...v0.0.11) - 2026-06-24

### Added

- make update refresh plugins and daemon

### Fixed

- simplify compact path list rendering
- keep daemon MCP proxy alive across restarts
- *(db)* disable SQLite mmap on Windows to stop teardown crash
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).