### PR TITLE
ci: remove Windows nextest retry mask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
             throw "No integration test targets selected for Windows shard $partition/$partitions"
           }
           Write-Host "Windows shard $partition/$partitions running $($selected.Count) integration test targets"
-          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci", "--retries", "2", "--flaky-result", "pass")
+          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci")
           if ($partition -eq 1) {
             $nextestArgs += @("--lib", "--bin", "tracedecay")
           }


### PR DESCRIPTION
## Summary
- Remove the `--retries 2 --flaky-result pass` mask from the Windows nextest invocation in `.github/workflows/ci.yml`.
- The mask was added in #105 as a temporary belt-and-suspenders while the Windows `0xc0000005` teardown crash was being diagnosed.
- #106 fixed the root cause (disable SQLite `mmap` on Windows). A clean Windows CI run (8/8 shards) showed zero aborts and zero nextest retries, so the mask is no longer needed.

## Why
Keeping the mask would silently retry-and-pass any future Windows crash or flake. Removing it ensures real failures surface immediately.

## Test plan
- [ ] CI green on all 8 `Test Windows i/8` shards with no retries/flaky results in the logs.