### PR TITLE
[codex] Fix daemon proxy resilience and ast-grep lookup

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,14 +11,14 @@ use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use serde_json::json;
 #[cfg(unix)]
-use tokio::io::{copy, AsyncBufReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 
 use crate::client_identity::DaemonClientIdentity;
 use crate::errors::{Result, TraceDecayError};
 #[cfg(unix)]
-use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport};
+use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, StdioTransport};
 
 pub const SERVICE_NAME: &str = "tracedecay.service";
 pub const SOCKET_ENV: &str = "TRACEDECAY_DAEMON_SOCKET";
@@ -77,6 +77,7 @@ impl DaemonHandshake {
 
 impl DaemonServiceSpec {
     pub fn render_systemd_user_unit(&self) -> String {
+        let service_path = daemon_service_path_env(&self.tracedecay_bin);
         format!(
             "[Unit]\n\
              Description=TraceDecay daemon\n\
@@ -84,16 +85,77 @@ impl DaemonServiceSpec {
              \n\
              [Service]\n\
              Type=simple\n\
+             Environment=\"PATH={}\"\n\
              ExecStart={} daemon run --socket {}\n\
              Restart=on-failure\n\
              RestartSec=2\n\
              \n\
              [Install]\n\
              WantedBy=default.target\n",
+            systemd_escape_env_value(&service_path),
             self.tracedecay_bin.display(),
             self.socket_path.display()
         )
     }
+}
+
+fn daemon_service_path_env(tracedecay_bin: &Path) -> String {
+    let mut dirs = Vec::new();
+
+    if let Some(parent) = tracedecay_bin
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        push_unique_path(&mut dirs, parent.to_path_buf());
+    }
+
+    if let Some(home) = std::env::var_os("HOME").filter(|home| !home.is_empty()) {
+        let home = PathBuf::from(home);
+        push_unique_path(&mut dirs, home.join(".cargo/bin"));
+        push_unique_path(&mut dirs, home.join(".local/bin"));
+    }
+
+    if let Some(path) = std::env::var_os("PATH").filter(|path| !path.is_empty()) {
+        for dir in std::env::split_paths(&path) {
+            push_unique_path(&mut dirs, dir);
+        }
+    }
+
+    for dir in [
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/sbin",
+        "/bin",
+        "/opt/homebrew/bin",
+    ] {
+        push_unique_path(&mut dirs, PathBuf::from(dir));
+    }
+
+    std::env::join_paths(&dirs).map_or_else(
+        |_| {
+            dirs.iter()
+                .map(|path| path.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(":")
+        },
+        |path| path.to_string_lossy().into_owned(),
+    )
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if path.as_os_str().is_empty() || paths.iter().any(|existing| existing == &path) {
+        return;
+    }
+    paths.push(path);
+}
+
+fn systemd_escape_env_value(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('%', "%%")
 }
 
 pub fn default_socket_path() -> Result<PathBuf> {
@@ -218,33 +280,122 @@ pub async fn proxy_stdio_to_daemon(
     handshake: &DaemonHandshake,
     replay_line: Option<String>,
 ) -> Result<()> {
-    let stream = UnixStream::connect(socket_path).await?;
-    let (mut socket_reader, mut socket_writer) = stream.into_split();
+    let mut transport = StdioTransport::new();
+    proxy_transport_to_daemon(socket_path, handshake, replay_line, &mut transport).await
+}
 
-    socket_writer
-        .write_all(handshake.to_line()?.as_bytes())
-        .await?;
-    socket_writer.write_all(b"\n").await?;
+#[cfg(unix)]
+pub async fn proxy_transport_to_daemon(
+    socket_path: &Path,
+    handshake: &DaemonHandshake,
+    replay_line: Option<String>,
+    transport: &mut impl McpTransport,
+) -> Result<()> {
     if let Some(line) = replay_line {
-        socket_writer.write_all(line.as_bytes()).await?;
-        if !line.ends_with('\n') {
-            socket_writer.write_all(b"\n").await?;
+        proxy_request_line_to_daemon(socket_path, handshake, &line, transport).await?;
+    }
+
+    while let Some(line) = transport.read_line().await? {
+        proxy_request_line_to_daemon(socket_path, handshake, &line, transport).await?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn proxy_request_line_to_daemon(
+    socket_path: &Path,
+    handshake: &DaemonHandshake,
+    line: &str,
+    transport: &mut impl McpTransport,
+) -> Result<()> {
+    if line.trim().is_empty() {
+        return Ok(());
+    }
+
+    match send_daemon_request_line(socket_path, handshake, line).await {
+        Ok(responses) => {
+            for response in responses {
+                transport.write_line(&response).await?;
+                if !response.ends_with('\n') {
+                    transport.write_line("\n").await?;
+                }
+            }
+            transport.flush().await?;
+        }
+        Err(err) => {
+            if let Some(response) = daemon_proxy_error_response(line, &err) {
+                let json_line = serde_json::to_string(&response)?;
+                transport.write_line(&json_line).await?;
+                transport.write_line("\n").await?;
+                transport.flush().await?;
+            } else {
+                eprintln!("[tracedecay] daemon proxy dropped notification after error: {err}");
+            }
         }
     }
-    socket_writer.flush().await?;
-
-    let mut stdin = tokio::io::stdin();
-    let mut stdout = tokio::io::stdout();
-    let stdin_to_daemon = async {
-        copy(&mut stdin, &mut socket_writer).await?;
-        socket_writer.shutdown().await
-    };
-    let daemon_to_stdout = async {
-        copy(&mut socket_reader, &mut stdout).await?;
-        stdout.flush().await
-    };
-    tokio::try_join!(stdin_to_daemon, daemon_to_stdout)?;
     Ok(())
+}
+
+#[cfg(unix)]
+async fn send_daemon_request_line(
+    socket_path: &Path,
+    handshake: &DaemonHandshake,
+    line: &str,
+) -> Result<Vec<String>> {
+    let stream = UnixStream::connect(socket_path).await?;
+    let (reader, mut writer) = stream.into_split();
+
+    writer.write_all(handshake.to_line()?.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.write_all(line.as_bytes()).await?;
+    if !line.ends_with('\n') {
+        writer.write_all(b"\n").await?;
+    }
+    writer.flush().await?;
+    writer.shutdown().await?;
+
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    let request_id = serde_json::from_str::<JsonRpcRequest>(line)
+        .ok()
+        .and_then(|request| request.id);
+    let mut responses = Vec::new();
+    let mut matched_response = request_id.is_none();
+    while let Some(response_line) = lines.next_line().await? {
+        if response_line.trim().is_empty() {
+            continue;
+        }
+        let is_matching_response = request_id.as_ref().is_some_and(|id| {
+            serde_json::from_str::<serde_json::Value>(&response_line)
+                .ok()
+                .and_then(|value| value.get("id").cloned())
+                .as_ref()
+                == Some(id)
+        });
+        responses.push(format!("{response_line}\n"));
+        if is_matching_response {
+            matched_response = true;
+            break;
+        }
+    }
+    if !matched_response {
+        return Err(TraceDecayError::Config {
+            message: "daemon closed the connection before returning a matching response"
+                .to_string(),
+        });
+    }
+    Ok(responses)
+}
+
+#[cfg(unix)]
+fn daemon_proxy_error_response(line: &str, err: &TraceDecayError) -> Option<JsonRpcResponse> {
+    let request = serde_json::from_str::<JsonRpcRequest>(line).ok()?;
+    request.id.map(|id| {
+        JsonRpcResponse::error(
+            id,
+            ErrorCode::InternalError,
+            format!("TraceDecay daemon connection failed: {err}"),
+        )
+    })
 }
 
 #[cfg(not(unix))]
@@ -865,6 +1016,7 @@ mod tests {
         assert!(unit.contains(
             "ExecStart=/usr/local/bin/tracedecay daemon run --socket /tmp/tracedecay.sock"
         ));
+        assert!(unit.contains("Environment=\"PATH="));
         assert!(unit.contains("Restart=on-failure"));
     }
 

--- a/src/external_tools.rs
+++ b/src/external_tools.rs
@@ -1,0 +1,72 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const AST_GREP_BIN_ENV: &str = "TRACEDECAY_AST_GREP_BIN";
+
+pub fn ast_grep_command() -> Command {
+    Command::new(resolve_ast_grep_bin())
+}
+
+fn resolve_ast_grep_bin() -> PathBuf {
+    if let Some(path) = std::env::var_os(AST_GREP_BIN_ENV).filter(|path| !path.is_empty()) {
+        return PathBuf::from(path);
+    }
+
+    find_on_path("ast-grep")
+        .or_else(|| {
+            common_tool_paths("ast-grep")
+                .into_iter()
+                .find(|path| is_executable_file(path))
+        })
+        .unwrap_or_else(|| PathBuf::from("ast-grep"))
+}
+
+fn find_on_path(tool: &str) -> Option<PathBuf> {
+    let paths = std::env::var_os("PATH")?;
+    std::env::split_paths(&paths)
+        .map(|dir| dir.join(tool))
+        .find(|path| is_executable_file(path))
+}
+
+fn common_tool_paths(tool: &str) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(parent) = current_exe.parent() {
+            candidates.push(parent.join(tool));
+        }
+    }
+
+    if let Some(home) = std::env::var_os("HOME").filter(|home| !home.is_empty()) {
+        let home = PathBuf::from(home);
+        candidates.push(home.join(".local/bin").join(tool));
+        candidates.push(home.join(".cargo/bin").join(tool));
+    }
+
+    candidates.push(PathBuf::from("/usr/local/bin").join(tool));
+    candidates.push(PathBuf::from("/opt/homebrew/bin").join(tool));
+    candidates.push(PathBuf::from("/usr/bin").join(tool));
+    candidates.push(PathBuf::from("/bin").join(tool));
+
+    candidates
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod diagnostics;
 pub mod display;
 pub mod doctor;
 pub mod errors;
+pub mod external_tools;
 pub mod extraction;
 pub mod extraction_worker;
 pub mod global_db;

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -514,7 +514,7 @@ fn parse_ast_grep_version(text: &str) -> Option<(String, (u64, u64, u64))> {
 }
 
 fn ast_grep_diagnostics_uncached() -> AstGrepDiagnostics {
-    let version_output = match std::process::Command::new("ast-grep")
+    let version_output = match crate::external_tools::ast_grep_command()
         .arg("--version")
         .output()
     {
@@ -552,7 +552,7 @@ fn ast_grep_diagnostics_uncached() -> AstGrepDiagnostics {
     let (version, version_tuple) =
         parse_ast_grep_version(&version_text).unwrap_or_else(|| (version_text.clone(), (0, 0, 0)));
     let outline_version_ok = version_tuple >= MIN_AST_GREP_OUTLINE_VERSION;
-    let help_output = std::process::Command::new("ast-grep")
+    let help_output = crate::external_tools::ast_grep_command()
         .args(["outline", "--help"])
         .output();
     let (outline_flags_ok, help_detail) = match help_output {

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -2191,7 +2191,7 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
 fn ast_grep_outline(abs_path: &Path) -> Result<Value> {
     ensure_ast_grep_outline_available()?;
 
-    let output = std::process::Command::new("ast-grep")
+    let output = crate::external_tools::ast_grep_command()
         .args([
             "outline",
             "--json=compact",

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -3005,8 +3005,6 @@ impl TraceDecay {
         pattern: &str,
         rewrite: &str,
     ) -> Result<AstGrepResult> {
-        use std::process::Command;
-
         let rel_path = self
             .resolve_path(path)
             .ok_or_else(|| TraceDecayError::Config {
@@ -3015,7 +3013,9 @@ impl TraceDecay {
 
         let abs_path = self.absolute_path(&rel_path);
 
-        let check_output = Command::new("ast-grep").args(["--version"]).output();
+        let check_output = crate::external_tools::ast_grep_command()
+            .args(["--version"])
+            .output();
 
         if check_output.is_err() {
             if can_use_literal_rewrite_fallback(pattern) {
@@ -3049,7 +3049,7 @@ impl TraceDecay {
             });
         }
 
-        let output = Command::new("ast-grep")
+        let output = crate::external_tools::ast_grep_command()
             .args([
                 "run",
                 "-p",

--- a/tests/mcp_cli_serve_test.rs
+++ b/tests/mcp_cli_serve_test.rs
@@ -326,6 +326,80 @@ async fn serve_without_daemon_socket_falls_back_to_in_process_mcp() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn serve_daemon_proxy_reports_daemon_disconnect_as_json_rpc_error() {
+    use std::io::Read;
+    use std::os::unix::net::UnixListener;
+    use std::sync::mpsc;
+
+    let home = TempDir::new().unwrap();
+    let project = init_project_with_file(home.path(), "pub fn disconnect_marker() {}\n").await;
+    let socket_dir = TempDir::new().unwrap();
+    let socket_path = socket_dir.path().join("tracedecay.sock");
+    let (ready_tx, ready_rx) = mpsc::channel();
+
+    let listener_path = socket_path.clone();
+    let fake_daemon = std::thread::spawn(move || {
+        let listener = UnixListener::bind(&listener_path).expect("bind fake daemon socket");
+        ready_tx.send(()).expect("notify fake daemon readiness");
+        if let Ok((mut stream, _addr)) = listener.accept() {
+            let mut scratch = [0_u8; 512];
+            let _ = stream.read(&mut scratch);
+        }
+    });
+    ready_rx.recv().expect("fake daemon should be ready");
+
+    let mut child = tracedecay_command_with_home(home.path())
+        .arg("serve")
+        .arg("--path")
+        .arg(project.path())
+        .env("TRACEDECAY_DAEMON_SOCKET", &socket_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("tracedecay serve should run");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            })
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+
+    let output = child
+        .wait_with_output()
+        .expect("tracedecay serve should exit after stdin closes");
+    fake_daemon.join().expect("fake daemon thread should exit");
+
+    assert!(
+        output.status.success(),
+        "serve should keep stdio healthy after daemon disconnect\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let response: Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|err| {
+        panic!("stdout should contain one JSON-RPC response: {err}\n{stdout}")
+    });
+    assert_eq!(response["id"], json!(1));
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("TraceDecay daemon connection failed")),
+        "disconnect should be reported as a JSON-RPC error response, got:\n{response}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn ensure_initialized_rejects_read_only_db_with_pending_migrations() {
     let _env_guard = READ_ONLY_SERVE_ENV_LOCK.lock().await;
     let home = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- keep `tracedecay serve` stdio alive when the daemon socket disconnects by proxying per JSON-RPC request and returning JSON-RPC errors instead of exiting on broken pipes
- add a shared ast-grep resolver with env override, PATH lookup, and common user-bin fallbacks
- generate systemd service units with an explicit PATH that includes cargo/local bin locations

## Root Cause
The systemd daemon could restart correctly, but existing MCP clients were attached to a single Unix socket stream. When that daemon socket closed, the stdio proxy exited with `Broken pipe`, which surfaced to Codex as `Transport closed`. Separately, the daemon service environment could miss `~/.local/bin`, causing daemon-served tools to report ast-grep as unavailable even when the shell could find it.

## Validation
- `cargo test --test mcp_cli_serve_test`
- `cargo test --test tool_daemon_test`
- `cargo check --lib --tests`
- `cargo clippy --lib --tests` (existing large-future warnings only)
- `tracedecay doctor`
- daemon-backed `tracedecay tool lcm_doctor --provider codex --mode diagnose --json`

## Local Install Check
Installed the patched binary locally, regenerated the user service, restarted `tracedecay.service`, and confirmed daemon-backed tool calls see ast-grep 0.44.0 with outline JSON support.