### PR TITLE
test: keep fake daemon streams blocking

### DIFF
--- a/tests/tool_daemon_test.rs
+++ b/tests/tool_daemon_test.rs
@@ -151,6 +151,9 @@ fn spawn_sentinel_daemon_with_notification(
             }
         };
         stream
+            .set_nonblocking(false)
+            .expect("set accepted stream blocking");
+        stream
             .set_read_timeout(Some(Duration::from_secs(2)))
             .expect("read timeout");
         stream


### PR DESCRIPTION
## Summary
- force accepted fake daemon Unix streams back into blocking mode before line-oriented reads

## Root Cause
The sentinel daemon test listener uses nonblocking accept polling. On macOS, the accepted stream can surface `WouldBlock` during the subsequent `BufReader::read_line`, making daemon CLI tests fail even though the client behavior is correct.

## Validation
- `cargo test --test tool_daemon_test`
- `cargo fmt --all -- --check`