### PR TITLE
[codex] Compact repeated path lists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod mcp;
 pub mod memory;
 pub mod migrate;
 pub mod monitor;
+mod path_tree;
 pub mod redundancy;
 pub mod resolution;
 pub mod runtime_telemetry;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -17,6 +17,7 @@ use crate::global_db::{AnalyticsEventInsert, GlobalDb};
 use crate::mcp::response_handles::{
     cleanup_expired_response_handles, response_handle_stats_json, RESPONSE_RETRIEVE_TOOL,
 };
+use crate::path_tree::format_annotated_path_tree;
 use crate::tracedecay::TraceDecay;
 
 use super::tools::{
@@ -204,9 +205,27 @@ fn format_per_file_staleness_banner(
          Read these directly; the rest of this response reflects the current index:",
         stale_files.len()
     ));
-    for path in stale_files {
-        let age = file_mtime_secs(project_root, path).map_or(0, |m| now_secs.saturating_sub(m));
-        lines.push(format!("  - {path} (edited {})", humanize_age(age)));
+    let annotated_paths = stale_files
+        .iter()
+        .map(|path| {
+            let age = file_mtime_secs(project_root, path).map_or(0, |m| now_secs.saturating_sub(m));
+            (path.as_str(), format!(" (edited {})", humanize_age(age)))
+        })
+        .collect::<Vec<_>>();
+    let bullet_list = annotated_paths
+        .iter()
+        .map(|(path, suffix)| format!("  - {path}{suffix}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tree = format_annotated_path_tree(annotated_paths)
+        .lines()
+        .map(|line| format!("  {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !tree.is_empty() && tree.len() < bullet_list.len() {
+        lines.push(tree);
+    } else if !bullet_list.is_empty() {
+        lines.push(bullet_list);
     }
     lines.push("Run `tracedecay sync` to refresh the index.".to_string());
     lines.join("\n")
@@ -2084,8 +2103,9 @@ mod staleness_banner_tests {
         let stale = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
         let banner = format_per_file_staleness_banner(root, &stale);
         assert!(banner.contains("2 file(s) referenced below were edited"));
-        assert!(banner.contains("src/a.rs ("));
-        assert!(banner.contains("src/b.rs ("));
+        assert!(banner.contains("src/"));
+        assert!(banner.contains("a.rs ("));
+        assert!(banner.contains("b.rs ("));
         assert!(banner.contains("ago)"));
         assert!(banner.contains("tracedecay sync"));
         // Critical UX shift: should NOT say "STALE INDEX" — the whole

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 
 use crate::context::format_context_as_markdown;
 use crate::errors::{Result, TraceDecayError};
+use crate::path_tree::format_path_tree;
 use crate::tracedecay::TraceDecay;
 use crate::types::{BuildContextOptions, EdgeKind, Node, NodeKind, TaskContext, Visibility};
 
@@ -320,12 +321,25 @@ async fn append_plan_test_coverage(
     } else {
         let mut sorted: Vec<_> = test_files.into_iter().collect();
         sorted.sort();
-        for tf in &sorted {
-            let _ = writeln!(output, "- {tf}");
-        }
+        output.push_str(&compact_path_list_markdown(&sorted));
+        output.push('\n');
     }
 
     Ok(())
+}
+
+fn compact_path_list_markdown(paths: &[String]) -> String {
+    let bullets = paths
+        .iter()
+        .map(|path| format!("- {path}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tree = format_path_tree(paths.iter().map(String::as_str));
+    if !tree.is_empty() && tree.len() < bullets.len() {
+        tree
+    } else {
+        bullets
+    }
 }
 
 /// Handles `tracedecay_callers` tool calls.

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -9,6 +9,7 @@ use crate::mcp::response_handles::{
     note_response_handle_store_skipped_no_project_root, observe_response_truncation,
     store_response_handle, ResponseHandleRecord, RESPONSE_HANDLE_TTL_SECS, RESPONSE_RETRIEVE_TOOL,
 };
+use crate::path_tree::format_path_tree;
 use crate::tracedecay::current_timestamp;
 
 use super::MAX_RESPONSE_CHARS;
@@ -406,6 +407,10 @@ fn render_array(md: &mut Md, arr: &[Value], depth: u8) {
         md.empty_note("None.");
         return;
     }
+    if let Some(paths) = compact_path_array(arr) {
+        md.line(&paths);
+        return;
+    }
     if arr.iter().all(Value::is_object) {
         let mut cols: Vec<String> = Vec::new();
         for e in arr {
@@ -437,6 +442,35 @@ fn render_array(md: &mut Md, arr: &[Value], depth: u8) {
             }
         }
     }
+}
+
+fn compact_path_array(arr: &[Value]) -> Option<String> {
+    if arr.len() < 2 || !arr.iter().all(Value::is_string) {
+        return None;
+    }
+    let paths = arr.iter().filter_map(Value::as_str).collect::<Vec<_>>();
+    if !paths.iter().all(|path| looks_like_path(path)) {
+        return None;
+    }
+    let bullets = paths
+        .iter()
+        .map(|path| format!("- {path}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tree = format_path_tree(paths);
+    if !tree.is_empty() && tree.len() < bullets.len() {
+        Some(tree)
+    } else {
+        None
+    }
+}
+
+fn looks_like_path(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && !trimmed.contains('\n')
+        && !trimmed.contains("://")
+        && (trimmed.contains('/') || trimmed.contains('\\'))
 }
 
 fn render_object(md: &mut Md, map: &serde_json::Map<String, Value>, depth: u8) {
@@ -643,6 +677,32 @@ mod tests {
     fn generic_md_empty_is_noted() {
         assert!(generic_md(&json!([])).contains("None."));
         assert!(generic_md(&json!({})).contains("No results."));
+    }
+
+    #[test]
+    fn generic_md_compacts_scalar_path_arrays() {
+        let out = generic_md(&json!({
+            "changed_files": [
+                "tests/gateway/test_gateway_shutdown.py",
+                "tests/gateway/test_goal_verdict_send.py",
+                "tests/gateway/test_homeassistant.py"
+            ]
+        }));
+
+        assert!(out.contains("## changed_files"));
+        assert!(out.contains("tests/gateway/"));
+        assert!(out.contains("  test_gateway_shutdown.py"));
+        assert!(!out.contains("- tests/gateway/test_gateway_shutdown.py"));
+    }
+
+    #[test]
+    fn generic_md_keeps_non_path_scalar_arrays_as_bullets() {
+        let out = generic_md(&json!({
+            "warnings": ["first warning", "second warning"]
+        }));
+
+        assert!(out.contains("- first warning"));
+        assert!(out.contains("- second warning"));
     }
 
     #[test]

--- a/src/path_tree.rs
+++ b/src/path_tree.rs
@@ -1,0 +1,111 @@
+//! Compact rendering for lists of related file paths.
+
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+struct PathNode {
+    children: BTreeMap<String, PathNode>,
+    suffix: Option<String>,
+}
+
+impl PathNode {
+    fn insert(&mut self, path: &str, suffix: &str) {
+        let normalized = path.replace('\\', "/");
+        let parts = normalized
+            .split('/')
+            .filter(|part| !part.is_empty() && *part != ".")
+            .collect::<Vec<_>>();
+        if parts.is_empty() {
+            return;
+        }
+
+        let mut node = self;
+        for part in parts {
+            node = node.children.entry(part.to_string()).or_default();
+        }
+        node.suffix = Some(suffix.to_string());
+    }
+}
+
+pub(crate) fn format_path_tree<'a>(paths: impl IntoIterator<Item = &'a str>) -> String {
+    format_annotated_path_tree(paths.into_iter().map(|path| (path, String::new())))
+}
+
+pub(crate) fn format_annotated_path_tree<'a>(
+    paths: impl IntoIterator<Item = (&'a str, String)>,
+) -> String {
+    let mut root = PathNode::default();
+    for (path, suffix) in paths {
+        root.insert(path, &suffix);
+    }
+
+    let mut lines = Vec::new();
+    render_children(&root.children, 0, &mut lines);
+    lines.join("\n")
+}
+
+fn render_children(children: &BTreeMap<String, PathNode>, indent: usize, lines: &mut Vec<String>) {
+    for (segment, child) in children {
+        render_entry(segment, child, indent, lines);
+    }
+}
+
+fn render_entry(segment: &str, node: &PathNode, indent: usize, lines: &mut Vec<String>) {
+    let padding = " ".repeat(indent);
+    if let Some(suffix) = &node.suffix {
+        lines.push(format!("{padding}{segment}{suffix}"));
+    }
+
+    if node.children.is_empty() {
+        return;
+    }
+
+    let (label, remainder) = compact_directory_chain(segment, node);
+    lines.push(format!("{padding}{label}/"));
+    render_children(&remainder.children, indent + 2, lines);
+}
+
+fn compact_directory_chain<'a>(segment: &str, mut node: &'a PathNode) -> (String, &'a PathNode) {
+    let mut label = segment.to_string();
+    while node.suffix.is_none() && node.children.len() == 1 {
+        let Some((next_segment, next_node)) = node.children.iter().next() else {
+            break;
+        };
+        if next_node.children.is_empty() {
+            break;
+        }
+        label.push('/');
+        label.push_str(next_segment);
+        node = next_node;
+    }
+    (label, node)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_annotated_path_tree, format_path_tree};
+
+    #[test]
+    fn compacts_shared_directory_prefixes() {
+        let tree = format_path_tree([
+            "tests/gateway/test_gateway_shutdown.py",
+            "tests/gateway/test_goal_verdict_send.py",
+            "tests/gateway/test_homeassistant.py",
+        ]);
+
+        assert_eq!(
+            tree,
+            "tests/gateway/\n  test_gateway_shutdown.py\n  test_goal_verdict_send.py\n  test_homeassistant.py"
+        );
+    }
+
+    #[test]
+    fn preserves_leaf_suffixes() {
+        let tree = format_annotated_path_tree([
+            ("src/a.rs", " (edited 1m ago)".to_string()),
+            ("src/b.rs", " (edited 2m ago)".to_string()),
+        ]);
+
+        assert_eq!(tree, "src/\n  a.rs (edited 1m ago)\n  b.rs (edited 2m ago)");
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared path-tree renderer for compact file path lists
- use the compact form for context plan test coverage and stale-file banners when it is shorter
- teach generic MCP Markdown rendering to compact scalar arrays of path-shaped strings, covering responses like changed_files and affected_tests across handlers
- preserve JSON output contracts; this only changes Markdown/text presentation

## Audit notes
- MCP graph/git/analysis handlers mostly route through render::generic_md, so the scalar path-array patch gives broad coverage without one-off edits.
- LCM/session MCP handlers already use bounded limits, pagination/content slices, compact preflight/expand-query tiers, and response-handle truncation for oversized JSON.
- Existing file-list resources already group by directory; no separate patch needed there.

## Validation
- cargo test generic_md_ --lib
- cargo test --lib
- cargo clippy --lib (existing large-future warnings in src/daemon.rs)