### PR TITLE
feat: make update refresh plugins and daemon

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -251,6 +251,11 @@ pub enum Commands {
     },
     /// Download and install the latest version from GitHub
     Upgrade,
+    /// Refresh the tracedecay binary, generated plugins, and daemon
+    Update,
+    /// Refresh plugins and daemon after the binary has been updated.
+    #[command(name = "post-update", hide = true)]
+    PostUpdate,
     /// Show or switch the update channel (stable or beta)
     Channel {
         /// Target channel: "stable" or "beta" (omit to show current)
@@ -631,7 +636,7 @@ mod cli_parse_tests {
     use super::{
         BranchAction, Cli, Commands, DaemonAction, MemoryAction, MigrateAction, SessionsAction,
     };
-    use clap::{error::ErrorKind, Parser};
+    use clap::{error::ErrorKind, CommandFactory, Parser};
 
     fn strings(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
@@ -709,6 +714,29 @@ mod cli_parse_tests {
             .expect("update-plugin alias should parse");
 
         assert!(matches!(cli.command, Some(Commands::UpdatePlugin)));
+    }
+
+    #[test]
+    fn update_upgrade_and_update_plugin_parse_to_distinct_commands() {
+        let update = Cli::try_parse_from(["tracedecay", "update"]).expect("update should parse");
+        let upgrade = Cli::try_parse_from(["tracedecay", "upgrade"]).expect("upgrade should parse");
+        let update_plugin = Cli::try_parse_from(["tracedecay", "update-plugin"])
+            .expect("update-plugin should parse");
+
+        assert!(matches!(update.command, Some(Commands::Update)));
+        assert!(matches!(upgrade.command, Some(Commands::Upgrade)));
+        assert!(matches!(
+            update_plugin.command,
+            Some(Commands::UpdatePlugin)
+        ));
+    }
+
+    #[test]
+    fn update_help_describes_refresh_scope() {
+        let help = Cli::command().render_long_help().to_string();
+
+        assert!(help.contains("update"));
+        assert!(help.contains("Refresh the tracedecay binary, generated plugins, and daemon"));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -183,6 +183,33 @@ pub fn service_spec(
 }
 
 pub fn install_service(spec: &DaemonServiceSpec, start: bool) -> Result<PathBuf> {
+    let service_path = write_service_unit(spec)?;
+
+    if start {
+        run_systemctl(&["daemon-reload"])?;
+        run_systemctl(&["enable", "--now", SERVICE_NAME])?;
+    }
+
+    Ok(service_path)
+}
+
+pub fn refresh_service(spec: &DaemonServiceSpec) -> Result<PathBuf> {
+    let service_path = write_service_unit(spec)?;
+    run_systemctl(&["daemon-reload"])?;
+    run_systemctl(&["enable", SERVICE_NAME])?;
+    run_systemctl(&["restart", SERVICE_NAME])?;
+    Ok(service_path)
+}
+
+pub fn refresh_installed_service(spec: &DaemonServiceSpec) -> Result<Option<PathBuf>> {
+    let service_path = systemd_user_service_path()?;
+    if !service_path.exists() {
+        return Ok(None);
+    }
+    refresh_service(spec).map(Some)
+}
+
+fn write_service_unit(spec: &DaemonServiceSpec) -> Result<PathBuf> {
     let service_path = systemd_user_service_path()?;
     let parent = service_path
         .parent()
@@ -200,11 +227,6 @@ pub fn install_service(spec: &DaemonServiceSpec, start: bool) -> Result<PathBuf>
             message: format!("failed to write service '{}': {e}", service_path.display()),
         }
     })?;
-
-    if start {
-        run_systemctl(&["daemon-reload"])?;
-        run_systemctl(&["enable", "--now", SERVICE_NAME])?;
-    }
 
     Ok(service_path)
 }
@@ -937,6 +959,8 @@ mod tests {
     use serde_json::json;
     #[cfg(unix)]
     use serde_json::Value;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
     #[cfg(unix)]
     use tempfile::TempDir;
     #[cfg(unix)]
@@ -1018,6 +1042,78 @@ mod tests {
         ));
         assert!(unit.contains("Environment=\"PATH="));
         assert!(unit.contains("Restart=on-failure"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refresh_service_rewrites_unit_and_restarts_daemon() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let dir = TempDir::new().expect("temp dir");
+        let config_home = dir.path().join("config");
+        let fake_bin = dir.path().join("bin");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+        std::fs::create_dir_all(&home).expect("home dir");
+
+        let systemctl = fake_bin.join("systemctl");
+        let log = dir.path().join("systemctl.log");
+        std::fs::write(
+            &systemctl,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TRACEDECAY_SYSTEMCTL_LOG\"\n",
+        )
+        .expect("fake systemctl");
+        std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+            .expect("systemctl permissions");
+
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _home_guard = EnvVarGuard::set("HOME", &home);
+        let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+        let _log_guard = EnvVarGuard::set("TRACEDECAY_SYSTEMCTL_LOG", &log);
+        let spec = DaemonServiceSpec {
+            tracedecay_bin: PathBuf::from("/opt/tracedecay/bin/tracedecay"),
+            socket_path: PathBuf::from("/run/user/1000/tracedecay.sock"),
+        };
+
+        let service_path = super::refresh_service(&spec).expect("refresh service");
+
+        assert_eq!(
+            service_path,
+            config_home.join("systemd/user").join(super::SERVICE_NAME)
+        );
+        let unit = std::fs::read_to_string(&service_path).expect("service unit");
+        assert!(unit.contains(
+            "ExecStart=/opt/tracedecay/bin/tracedecay daemon run --socket /run/user/1000/tracedecay.sock"
+        ));
+        assert_eq!(
+            std::fs::read_to_string(log).expect("systemctl log"),
+            "--user daemon-reload\n--user enable tracedecay.service\n--user restart tracedecay.service\n"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refresh_installed_service_skips_missing_unit() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let dir = TempDir::new().expect("temp dir");
+        let config_home = dir.path().join("config");
+        let fake_bin = dir.path().join("bin");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+        std::fs::create_dir_all(&home).expect("home dir");
+
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _home_guard = EnvVarGuard::set("HOME", &home);
+        let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+        let spec = DaemonServiceSpec {
+            tracedecay_bin: PathBuf::from("/opt/tracedecay/bin/tracedecay"),
+            socket_path: PathBuf::from("/run/user/1000/tracedecay.sock"),
+        };
+
+        let service_path = config_home.join("systemd/user").join(super::SERVICE_NAME);
+        let outcome = super::refresh_installed_service(&spec).expect("refresh service");
+
+        assert_eq!(outcome, None);
+        assert!(!service_path.exists());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -206,7 +206,11 @@ pub fn refresh_installed_service(spec: &DaemonServiceSpec) -> Result<Option<Path
     if !service_path.exists() {
         return Ok(None);
     }
-    refresh_service(spec).map(Some)
+    let mut refreshed_spec = spec.clone();
+    if let Some(socket_path) = service_socket_path_from_unit_file(&service_path)? {
+        refreshed_spec.socket_path = socket_path;
+    }
+    refresh_service(&refreshed_spec).map(Some)
 }
 
 fn write_service_unit(spec: &DaemonServiceSpec) -> Result<PathBuf> {
@@ -229,6 +233,38 @@ fn write_service_unit(spec: &DaemonServiceSpec) -> Result<PathBuf> {
     })?;
 
     Ok(service_path)
+}
+
+pub fn installed_service_socket_path() -> Result<Option<PathBuf>> {
+    let service_path = systemd_user_service_path()?;
+    if !service_path.exists() {
+        return Ok(None);
+    }
+    service_socket_path_from_unit_file(&service_path)
+}
+
+fn service_socket_path_from_unit_file(service_path: &Path) -> Result<Option<PathBuf>> {
+    let unit = std::fs::read_to_string(service_path).map_err(|e| TraceDecayError::Config {
+        message: format!("failed to read service '{}': {e}", service_path.display()),
+    })?;
+    Ok(socket_path_from_service_unit(&unit))
+}
+
+fn socket_path_from_service_unit(unit: &str) -> Option<PathBuf> {
+    unit.lines()
+        .filter_map(|line| line.trim().strip_prefix("ExecStart="))
+        .find_map(|exec_start| {
+            let mut args = exec_start.split_whitespace();
+            while let Some(arg) = args.next() {
+                if arg == "--socket" {
+                    return args.next().map(PathBuf::from);
+                }
+                if let Some(path) = arg.strip_prefix("--socket=") {
+                    return Some(PathBuf::from(path));
+                }
+            }
+            None
+        })
 }
 
 pub fn uninstall_service(stop: bool) -> Result<PathBuf> {
@@ -1114,6 +1150,64 @@ mod tests {
 
         assert_eq!(outcome, None);
         assert!(!service_path.exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refresh_installed_service_preserves_existing_socket_path() {
+        let _env_lock = ENV_LOCK.lock().expect("env lock");
+        let dir = TempDir::new().expect("temp dir");
+        let config_home = dir.path().join("config");
+        let fake_bin = dir.path().join("bin");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+        std::fs::create_dir_all(&home).expect("home dir");
+
+        let systemctl = fake_bin.join("systemctl");
+        let log = dir.path().join("systemctl.log");
+        std::fs::write(
+            &systemctl,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TRACEDECAY_SYSTEMCTL_LOG\"\n",
+        )
+        .expect("fake systemctl");
+        std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+            .expect("systemctl permissions");
+
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _home_guard = EnvVarGuard::set("HOME", &home);
+        let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+        let _log_guard = EnvVarGuard::set("TRACEDECAY_SYSTEMCTL_LOG", &log);
+
+        let service_path = config_home.join("systemd/user").join(super::SERVICE_NAME);
+        std::fs::create_dir_all(service_path.parent().expect("service parent"))
+            .expect("service dir");
+        std::fs::write(
+            &service_path,
+            "[Unit]\n\
+             Description=TraceDecay daemon\n\
+             \n\
+             [Service]\n\
+             ExecStart=/old/tracedecay daemon run --socket /custom/tracedecay.sock\n",
+        )
+        .expect("existing service unit");
+
+        let spec = DaemonServiceSpec {
+            tracedecay_bin: PathBuf::from("/opt/tracedecay/bin/tracedecay"),
+            socket_path: PathBuf::from("/run/user/1000/tracedecay.sock"),
+        };
+
+        let outcome = super::refresh_installed_service(&spec).expect("refresh service");
+
+        assert_eq!(outcome, Some(service_path.clone()));
+        let unit = std::fs::read_to_string(service_path).expect("service unit");
+        assert!(unit.contains(
+            "ExecStart=/opt/tracedecay/bin/tracedecay daemon run --socket /custom/tracedecay.sock"
+        ));
+        assert!(!unit.contains("/run/user/1000/tracedecay.sock"));
+        assert_eq!(
+            std::fs::read_to_string(log).expect("systemctl log"),
+            "--user daemon-reload\n--user enable tracedecay.service\n--user restart tracedecay.service\n"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -519,13 +519,15 @@ fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
 fn refresh_daemon_service() -> tracedecay::errors::Result<()> {
     let tracedecay_bin = tracedecay_bin_on_path()?;
     let spec = tracedecay::daemon::service_spec(tracedecay_bin, None)?;
+    let socket_path = tracedecay::daemon::installed_service_socket_path()?
+        .unwrap_or_else(|| spec.socket_path.clone());
     match tracedecay::daemon::refresh_installed_service(&spec)? {
         Some(service_path) => {
             eprintln!(
                 "\x1b[32m✔\x1b[0m Daemon service refreshed at {}",
                 service_path.display()
             );
-            eprintln!("Daemon socket: {}", spec.socket_path.display());
+            eprintln!("Daemon socket: {}", socket_path.display());
         }
         None => {
             eprintln!("TraceDecay daemon service is not installed; skipping daemon restart.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -458,6 +458,137 @@ fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::UserCon
     }
 }
 
+fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
+    let home = tracedecay_home_dir()?;
+    let tracedecay_bin = tracedecay_bin_on_path()?;
+    eprintln!("Refreshing tracedecay-generated plugin artifacts (agent configs are not touched)");
+
+    // Detection-driven, not `installed_agents`-driven: each integration
+    // decides whether generated artifacts exist on this machine, so stale
+    // tracking state can neither skip a real install nor install anywhere new.
+    let mut refreshed_any = false;
+    let mut config_only_installed: Vec<&'static str> = Vec::new();
+    let mut failures: Vec<String> = Vec::new();
+    for ag in tracedecay::agents::all_integrations() {
+        let ctx = tracedecay::agents::InstallContext {
+            home: home.clone(),
+            tracedecay_bin: tracedecay_bin.clone(),
+            tool_permissions: tracedecay::agents::expected_tool_perms(),
+            profile: None,
+            project_root: None,
+            dashboard: true,
+        };
+        match ag.update_plugin(&ctx) {
+            Ok(tracedecay::agents::UpdatePluginOutcome::Refreshed(paths)) => {
+                refreshed_any = true;
+                for path in paths {
+                    eprintln!(
+                        "  \x1b[32m✔\x1b[0m {}: refreshed {}",
+                        ag.id(),
+                        path.display()
+                    );
+                }
+            }
+            Ok(tracedecay::agents::UpdatePluginOutcome::NotInstalled) => {}
+            Ok(tracedecay::agents::UpdatePluginOutcome::ConfigOnly) => {
+                if ag.has_tracedecay(&home) {
+                    config_only_installed.push(ag.id());
+                }
+            }
+            Err(e) => failures.push(format!("{}: {e}", ag.id())),
+        }
+    }
+    if !config_only_installed.is_empty() {
+        eprintln!(
+            "  Config-managed integrations left untouched: {} (run `tracedecay reinstall` to refresh their config entries)",
+            config_only_installed.join(", ")
+        );
+    }
+    if !refreshed_any {
+        eprintln!("No generated plugin installs detected — nothing to update.");
+    }
+    if !failures.is_empty() {
+        return Err(tracedecay::errors::TraceDecayError::Config {
+            message: format!("update-plugin failed for {}", failures.join("; ")),
+        });
+    }
+
+    Ok(())
+}
+
+fn refresh_daemon_service() -> tracedecay::errors::Result<()> {
+    let tracedecay_bin = tracedecay_bin_on_path()?;
+    let spec = tracedecay::daemon::service_spec(tracedecay_bin, None)?;
+    match tracedecay::daemon::refresh_installed_service(&spec)? {
+        Some(service_path) => {
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Daemon service refreshed at {}",
+                service_path.display()
+            );
+            eprintln!("Daemon socket: {}", spec.socket_path.display());
+        }
+        None => {
+            eprintln!("TraceDecay daemon service is not installed; skipping daemon restart.");
+        }
+    }
+    Ok(())
+}
+
+fn tracedecay_home_dir() -> tracedecay::errors::Result<PathBuf> {
+    tracedecay::agents::home_dir().ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+        message: "could not determine home directory".to_string(),
+    })
+}
+
+fn tracedecay_bin_on_path() -> tracedecay::errors::Result<String> {
+    tracedecay::agents::which_tracedecay().ok_or_else(|| {
+        tracedecay::errors::TraceDecayError::Config {
+            message: "tracedecay not found on PATH".to_string(),
+        }
+    })
+}
+
+fn run_update_steps<U, P>(mut upgrade: U, mut post_update: P) -> tracedecay::errors::Result<()>
+where
+    U: FnMut() -> tracedecay::errors::Result<()>,
+    P: FnMut() -> tracedecay::errors::Result<()>,
+{
+    upgrade()?;
+    post_update()?;
+    Ok(())
+}
+
+fn run_update_command() -> tracedecay::errors::Result<()> {
+    run_update_steps(
+        || tracedecay::upgrade::run_upgrade().map(|_| ()),
+        run_post_update_subcommand,
+    )
+}
+
+fn run_post_update_subcommand() -> tracedecay::errors::Result<()> {
+    let tracedecay_bin = tracedecay_bin_on_path()?;
+    let status = std::process::Command::new(&tracedecay_bin)
+        .arg("post-update")
+        .status()
+        .map_err(|e| tracedecay::errors::TraceDecayError::Config {
+            message: format!("failed to run post-update with '{tracedecay_bin}': {e}"),
+        })?;
+    if status.success() {
+        return Ok(());
+    }
+    Err(tracedecay::errors::TraceDecayError::Config {
+        message: format!("post-update failed with status: {status}"),
+    })
+}
+
+fn run_post_update_tasks() -> tracedecay::errors::Result<()> {
+    refresh_generated_plugins()?;
+    if let Err(error) = refresh_daemon_service() {
+        eprintln!("  \x1b[33mwarning:\x1b[0m daemon service refresh failed: {error}");
+    }
+    Ok(())
+}
+
 async fn largest_memory_bank_fact_count_at(db_path: &Path) -> tracedecay::errors::Result<usize> {
     let db = libsql::Builder::new_local(db_path).build().await?;
     let conn = db.connect()?;
@@ -995,70 +1126,7 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             }
         }
         Commands::UpdatePlugin => {
-            let home = tracedecay::agents::home_dir().ok_or_else(|| {
-                tracedecay::errors::TraceDecayError::Config {
-                    message: "could not determine home directory".to_string(),
-                }
-            })?;
-            let tracedecay_bin = tracedecay::agents::which_tracedecay().ok_or_else(|| {
-                tracedecay::errors::TraceDecayError::Config {
-                    message: "tracedecay not found on PATH".to_string(),
-                }
-            })?;
-            eprintln!(
-                "Refreshing tracedecay-generated plugin artifacts (agent configs are not touched)"
-            );
-
-            // Detection-driven, not `installed_agents`-driven: each
-            // integration decides whether generated artifacts exist on this
-            // machine, so stale tracking state can neither skip a real
-            // install nor install anywhere new.
-            let mut refreshed_any = false;
-            let mut config_only_installed: Vec<&'static str> = Vec::new();
-            let mut failures: Vec<String> = Vec::new();
-            for ag in tracedecay::agents::all_integrations() {
-                let ctx = tracedecay::agents::InstallContext {
-                    home: home.clone(),
-                    tracedecay_bin: tracedecay_bin.clone(),
-                    tool_permissions: tracedecay::agents::expected_tool_perms(),
-                    profile: None,
-                    project_root: None,
-                    dashboard: true,
-                };
-                match ag.update_plugin(&ctx) {
-                    Ok(tracedecay::agents::UpdatePluginOutcome::Refreshed(paths)) => {
-                        refreshed_any = true;
-                        for path in paths {
-                            eprintln!(
-                                "  \x1b[32m✔\x1b[0m {}: refreshed {}",
-                                ag.id(),
-                                path.display()
-                            );
-                        }
-                    }
-                    Ok(tracedecay::agents::UpdatePluginOutcome::NotInstalled) => {}
-                    Ok(tracedecay::agents::UpdatePluginOutcome::ConfigOnly) => {
-                        if ag.has_tracedecay(&home) {
-                            config_only_installed.push(ag.id());
-                        }
-                    }
-                    Err(e) => failures.push(format!("{}: {e}", ag.id())),
-                }
-            }
-            if !config_only_installed.is_empty() {
-                eprintln!(
-                    "  Config-managed integrations left untouched: {} (run `tracedecay reinstall` to refresh their config entries)",
-                    config_only_installed.join(", ")
-                );
-            }
-            if !refreshed_any {
-                eprintln!("No generated plugin installs detected — nothing to update.");
-            }
-            if !failures.is_empty() {
-                return Err(tracedecay::errors::TraceDecayError::Config {
-                    message: format!("update-plugin failed for {}", failures.join("; ")),
-                });
-            }
+            refresh_generated_plugins()?;
         }
         Commands::Uninstall {
             agent,
@@ -1346,6 +1414,12 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
         },
         Commands::Upgrade => {
             tracedecay::upgrade::run_upgrade()?;
+        }
+        Commands::Update => {
+            run_update_command()?;
+        }
+        Commands::PostUpdate => {
+            run_post_update_tasks()?;
         }
         Commands::Channel { channel } => match channel {
             Some(target) => {
@@ -1730,6 +1804,8 @@ fn should_skip_startup_maintenance(command: &Commands) -> bool {
         Commands::Install { .. }
             | Commands::Reinstall
             | Commands::UpdatePlugin
+            | Commands::Update
+            | Commands::PostUpdate
             | Commands::Uninstall { .. }
             | Commands::Doctor { .. }
             | Commands::Migrate { .. }
@@ -1775,9 +1851,9 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
     //     can blow that budget, so it must stay off `serve`.
     //   - `Install` / `Reinstall`: already perform installation — don't
     //     double-install as an implicit prelude to the explicit command.
-    //   - `UpdatePlugin`: guarantees that agent config files are not written;
-    //     an implicit silent reinstall beforehand would rewrite configs and
-    //     break that contract.
+    //   - `UpdatePlugin` / `Update`: explicit maintenance paths that manage
+    //     plugin refresh themselves; an implicit silent reinstall beforehand
+    //     would rewrite configs and break the update-plugin contract.
     //   - `Uninstall`: about to remove agent configs — don't reinstall them
     //     first (per the original #84 intent).
     //   - `Doctor` / `Migrate`: read-only diagnostics — must not mutate agent
@@ -1791,6 +1867,8 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
             | Commands::Install { .. }
             | Commands::Reinstall
             | Commands::UpdatePlugin
+            | Commands::Update
+            | Commands::PostUpdate
             | Commands::Uninstall { .. }
             | Commands::Doctor { .. }
             | Commands::Migrate { .. }
@@ -1807,9 +1885,10 @@ fn is_local_install_command(command: &Commands) -> bool {
 mod startup_tests {
     use super::{
         hermes_profile_targets, hermes_selected_profile_targets, is_local_install_command,
-        should_skip_agent_install_maintenance, should_skip_startup_maintenance,
+        run_update_steps, should_skip_agent_install_maintenance, should_skip_startup_maintenance,
         validate_hermes_profile_flags, validate_hermes_project_root_flag, Commands,
     };
+    use std::cell::RefCell;
     use tempfile::TempDir;
 
     #[test]
@@ -1833,6 +1912,8 @@ mod startup_tests {
         }));
         assert!(should_skip_startup_maintenance(&Commands::Reinstall));
         assert!(should_skip_startup_maintenance(&Commands::UpdatePlugin));
+        assert!(should_skip_startup_maintenance(&Commands::Update));
+        assert!(should_skip_startup_maintenance(&Commands::PostUpdate));
         assert!(should_skip_startup_maintenance(&Commands::Uninstall {
             agent: Some("kiro".to_string()),
             profile: None,
@@ -1877,6 +1958,8 @@ mod startup_tests {
         assert!(should_skip_agent_install_maintenance(
             &Commands::UpdatePlugin
         ));
+        assert!(should_skip_agent_install_maintenance(&Commands::Update));
+        assert!(should_skip_agent_install_maintenance(&Commands::PostUpdate));
         assert!(should_skip_agent_install_maintenance(&Commands::Tool {
             project: None,
             name: Some("message_search".to_string()),
@@ -1912,6 +1995,46 @@ mod startup_tests {
             details: false,
             runtime: false,
         }));
+    }
+
+    #[test]
+    fn update_steps_run_post_update_after_upgrade() {
+        let calls = RefCell::new(Vec::new());
+
+        run_update_steps(
+            || {
+                calls.borrow_mut().push("upgrade");
+                Ok(())
+            },
+            || {
+                calls.borrow_mut().push("post-update");
+                Ok(())
+            },
+        )
+        .expect("update steps should succeed");
+
+        assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+    }
+
+    #[test]
+    fn update_steps_stop_after_upgrade_failure() {
+        let calls = RefCell::new(Vec::new());
+
+        let result = run_update_steps(
+            || {
+                calls.borrow_mut().push("upgrade");
+                Err(tracedecay::errors::TraceDecayError::Config {
+                    message: "upgrade failed".to_string(),
+                })
+            },
+            || {
+                calls.borrow_mut().push("post-update");
+                Ok(())
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls.into_inner(), vec!["upgrade"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `tracedecay update` as the aggregate maintenance command
- run post-update plugin refresh from the freshly installed binary via hidden `post-update`
- refresh/restart an existing daemon service without creating a new service for users who never installed it

## Tests
- cargo fmt --all -- --check
- cargo test --bin tracedecay cli_parse_tests::update -- --nocapture
- cargo test --lib daemon::tests::refresh -- --nocapture
- cargo test --bin tracedecay startup_tests::update_steps -- --nocapture
- cargo check