### PR TITLE
fix: simplify compact path list rendering

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -17,7 +17,7 @@ use crate::global_db::{AnalyticsEventInsert, GlobalDb};
 use crate::mcp::response_handles::{
     cleanup_expired_response_handles, response_handle_stats_json, RESPONSE_RETRIEVE_TOOL,
 };
-use crate::path_tree::format_annotated_path_tree;
+use crate::path_tree::format_compact_annotated_path_list;
 use crate::tracedecay::TraceDecay;
 
 use super::tools::{
@@ -212,20 +212,9 @@ fn format_per_file_staleness_banner(
             (path.as_str(), format!(" (edited {})", humanize_age(age)))
         })
         .collect::<Vec<_>>();
-    let bullet_list = annotated_paths
-        .iter()
-        .map(|(path, suffix)| format!("  - {path}{suffix}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let tree = format_annotated_path_tree(annotated_paths)
-        .lines()
-        .map(|line| format!("  {line}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    if !tree.is_empty() && tree.len() < bullet_list.len() {
-        lines.push(tree);
-    } else if !bullet_list.is_empty() {
-        lines.push(bullet_list);
+    let path_list = format_compact_annotated_path_list(annotated_paths, "  - ", "  ");
+    if !path_list.is_empty() {
+        lines.push(path_list);
     }
     lines.push("Run `tracedecay sync` to refresh the index.".to_string());
     lines.join("\n")

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 
 use crate::context::format_context_as_markdown;
 use crate::errors::{Result, TraceDecayError};
-use crate::path_tree::format_path_tree;
+use crate::path_tree::format_compact_path_list;
 use crate::tracedecay::TraceDecay;
 use crate::types::{BuildContextOptions, EdgeKind, Node, NodeKind, TaskContext, Visibility};
 
@@ -329,17 +329,7 @@ async fn append_plan_test_coverage(
 }
 
 fn compact_path_list_markdown(paths: &[String]) -> String {
-    let bullets = paths
-        .iter()
-        .map(|path| format!("- {path}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let tree = format_path_tree(paths.iter().map(String::as_str));
-    if !tree.is_empty() && tree.len() < bullets.len() {
-        tree
-    } else {
-        bullets
-    }
+    format_compact_path_list(paths.iter().map(String::as_str), "- ", "")
 }
 
 /// Handles `tracedecay_callers` tool calls.

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -9,7 +9,7 @@ use crate::mcp::response_handles::{
     note_response_handle_store_skipped_no_project_root, observe_response_truncation,
     store_response_handle, ResponseHandleRecord, RESPONSE_HANDLE_TTL_SECS, RESPONSE_RETRIEVE_TOOL,
 };
-use crate::path_tree::format_path_tree;
+use crate::path_tree::format_compact_path_list;
 use crate::tracedecay::current_timestamp;
 
 use super::MAX_RESPONSE_CHARS;
@@ -457,11 +457,11 @@ fn compact_path_array(arr: &[Value]) -> Option<String> {
         .map(|path| format!("- {path}"))
         .collect::<Vec<_>>()
         .join("\n");
-    let tree = format_path_tree(paths);
-    if !tree.is_empty() && tree.len() < bullets.len() {
-        Some(tree)
-    } else {
+    let compact = format_compact_path_list(paths.iter().copied(), "- ", "");
+    if compact == bullets {
         None
+    } else {
+        Some(compact)
     }
 }
 

--- a/src/path_tree.rs
+++ b/src/path_tree.rs
@@ -10,38 +10,79 @@ struct PathNode {
 
 impl PathNode {
     fn insert(&mut self, path: &str, suffix: &str) {
-        let normalized = path.replace('\\', "/");
-        let parts = normalized
-            .split('/')
-            .filter(|part| !part.is_empty() && *part != ".")
-            .collect::<Vec<_>>();
-        if parts.is_empty() {
-            return;
-        }
-
         let mut node = self;
-        for part in parts {
+        let mut inserted = false;
+        for part in path
+            .split(['/', '\\'])
+            .filter(|part| !part.is_empty() && *part != ".")
+        {
+            inserted = true;
             node = node.children.entry(part.to_string()).or_default();
         }
-        node.suffix = Some(suffix.to_string());
+        if inserted {
+            node.suffix = Some(suffix.to_string());
+        }
     }
 }
 
-pub(crate) fn format_path_tree<'a>(paths: impl IntoIterator<Item = &'a str>) -> String {
-    format_annotated_path_tree(paths.into_iter().map(|path| (path, String::new())))
-}
-
-pub(crate) fn format_annotated_path_tree<'a>(
-    paths: impl IntoIterator<Item = (&'a str, String)>,
+pub(crate) fn format_compact_path_list<'a>(
+    paths: impl IntoIterator<Item = &'a str>,
+    bullet_prefix: &str,
+    tree_prefix: &str,
 ) -> String {
+    format_compact_annotated_path_list(
+        paths.into_iter().map(|path| (path, "")),
+        bullet_prefix,
+        tree_prefix,
+    )
+}
+
+pub(crate) fn format_compact_annotated_path_list<'a, S>(
+    paths: impl IntoIterator<Item = (&'a str, S)>,
+    bullet_prefix: &str,
+    tree_prefix: &str,
+) -> String
+where
+    S: AsRef<str>,
+{
     let mut root = PathNode::default();
+    let mut bullet_lines = Vec::new();
     for (path, suffix) in paths {
-        root.insert(path, &suffix);
+        let suffix = suffix.as_ref();
+        bullet_lines.push(format!("{bullet_prefix}{path}{suffix}"));
+        root.insert(path, suffix);
     }
 
+    let bullet_list = bullet_lines.join("\n");
+    let tree = prefix_lines(&render_path_tree(&root), tree_prefix);
+    if has_directory_shape(&root) && tree.len() < bullet_list.len() {
+        tree
+    } else {
+        bullet_list
+    }
+}
+
+fn render_path_tree(root: &PathNode) -> String {
     let mut lines = Vec::new();
     render_children(&root.children, 0, &mut lines);
     lines.join("\n")
+}
+
+fn prefix_lines(text: &str, prefix: &str) -> String {
+    if prefix.is_empty() {
+        return text.to_string();
+    }
+
+    text.lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn has_directory_shape(node: &PathNode) -> bool {
+    node.children
+        .values()
+        .any(|child| !child.children.is_empty() || has_directory_shape(child))
 }
 
 fn render_children(children: &BTreeMap<String, PathNode>, indent: usize, lines: &mut Vec<String>) {
@@ -83,29 +124,68 @@ fn compact_directory_chain<'a>(segment: &str, mut node: &'a PathNode) -> (String
 
 #[cfg(test)]
 mod tests {
-    use super::{format_annotated_path_tree, format_path_tree};
+    use super::{format_compact_annotated_path_list, format_compact_path_list};
 
     #[test]
     fn compacts_shared_directory_prefixes() {
-        let tree = format_path_tree([
-            "tests/gateway/test_gateway_shutdown.py",
-            "tests/gateway/test_goal_verdict_send.py",
-            "tests/gateway/test_homeassistant.py",
-        ]);
+        let list = format_compact_path_list(
+            [
+                "tests/gateway/test_gateway_shutdown.py",
+                "tests/gateway/test_goal_verdict_send.py",
+                "tests/gateway/test_homeassistant.py",
+            ],
+            "- ",
+            "",
+        );
 
         assert_eq!(
-            tree,
+            list,
             "tests/gateway/\n  test_gateway_shutdown.py\n  test_goal_verdict_send.py\n  test_homeassistant.py"
         );
     }
 
     #[test]
     fn preserves_leaf_suffixes() {
-        let tree = format_annotated_path_tree([
-            ("src/a.rs", " (edited 1m ago)".to_string()),
-            ("src/b.rs", " (edited 2m ago)".to_string()),
-        ]);
+        let list = format_compact_annotated_path_list(
+            [
+                ("src/a.rs", " (edited 1m ago)"),
+                ("src/b.rs", " (edited 2m ago)"),
+            ],
+            "- ",
+            "",
+        );
 
-        assert_eq!(tree, "src/\n  a.rs (edited 1m ago)\n  b.rs (edited 2m ago)");
+        assert_eq!(list, "src/\n  a.rs (edited 1m ago)\n  b.rs (edited 2m ago)");
+    }
+
+    #[test]
+    fn keeps_bullets_when_tree_is_not_shorter() {
+        let list = format_compact_path_list(["src/main.rs"], "- ", "");
+
+        assert_eq!(list, "- src/main.rs");
+    }
+
+    #[test]
+    fn keeps_bullets_for_flat_paths() {
+        let list = format_compact_path_list(["a.rs", "b.rs"], "- ", "");
+
+        assert_eq!(list, "- a.rs\n- b.rs");
+    }
+
+    #[test]
+    fn indents_compact_annotated_tree() {
+        let list = format_compact_annotated_path_list(
+            [
+                ("src/a.rs", " (edited 1m ago)"),
+                ("src/b.rs", " (edited 2m ago)"),
+            ],
+            "  - ",
+            "  ",
+        );
+
+        assert_eq!(
+            list,
+            "  src/\n    a.rs (edited 1m ago)\n    b.rs (edited 2m ago)"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- simplify compact path-list rendering after PR #111
- centralize repeated tree rendering paths for MCP output
- keep behavior covered by focused path tree and MCP handler tests

## Tests
- cargo fmt --check
- cargo test path_tree --lib
- cargo test mcp::tools::render::tests --lib
- cargo test staleness_banner_tests --lib
- cargo test test_context_scope_prefix_filters --test mcp_handler_test
- cargo test test_files_grouped_format --test mcp_handler_test
- cargo clippy --lib