### PR TITLE
fix: disable GlobalDb mmap on Windows

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,5 +15,6 @@ mod stats;
 mod tx;
 mod unresolved;
 
+pub(crate) use connection::platform_safe_mmap_size;
 pub use connection::Database;
 pub use fingerprints::StoredFingerprint;

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -283,6 +283,13 @@ fn global_db_path_override() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+fn global_db_mmap_size_guard() -> Option<u64> {
+    const PROBE_MMAP_SIZE: u64 = 1;
+
+    let safe_mmap = crate::db::platform_safe_mmap_size(PROBE_MMAP_SIZE);
+    (safe_mmap != PROBE_MMAP_SIZE).then_some(safe_mmap)
+}
+
 /// Returns the path to the global database: `global.db` inside the user-level
 /// data dir (`~/.tracedecay/` by default).
 pub fn global_db_path() -> Option<PathBuf> {
@@ -739,6 +746,12 @@ impl GlobalDb {
         };
         let db = builder.build().await.ok()?;
         let conn = db.connect().ok()?;
+
+        if let Some(mmap_size) = global_db_mmap_size_guard() {
+            conn.execute_batch(&format!("PRAGMA mmap_size = {mmap_size};"))
+                .await
+                .ok()?;
+        }
 
         let pragmas = if read_only {
             "PRAGMA busy_timeout = 5000;
@@ -3261,6 +3274,15 @@ impl GlobalDb {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn global_db_mmap_guard_matches_connection_platform_guard() {
+        if cfg!(windows) {
+            assert_eq!(global_db_mmap_size_guard(), Some(0));
+        } else {
+            assert_eq!(global_db_mmap_size_guard(), None);
+        }
+    }
 
     #[tokio::test]
     async fn session_column_migration_tolerates_duplicate_column_race() {


### PR DESCRIPTION
## Summary
- reuse the graph DB platform mmap guard for GlobalDb local connections
- apply `PRAGMA mmap_size = 0` before GlobalDb WAL/read pragmas on Windows
- add a focused regression test proving the GlobalDb guard matches the connection guard

## Why
Fresh master CI after the v0.0.11 release merge still hit native Windows aborts (`0xc0000005`, os error 998) in rotating tests:
- Windows 8/8: `branch_diagnostics_reports_auto_tracked_live_branch`
- Windows 6/8: `lcm_doctor_clean_apply_backs_up_and_deletes_only_safe_candidates`, `lcm_status_response_is_valid_json_and_omits_payload_secrets`, `retrieve_tool_reports_missing_and_expired_handles_actionably`, `test_multi_str_replace_unicode_preview_does_not_panic`

That matches the existing libsql/SQLite mmap/WAL teardown risk already guarded in the graph DB path.

## Verification
- `cargo fmt --check`
- `cargo test global_db_mmap_guard_matches_connection_platform_guard`
