### PR TITLE
chore: release v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.11...v0.0.12) - 2026-06-24
+
+### Fixed
+
+- avoid WAL teardown on Windows ([#118](https://github.com/ScriptedAlchemy/tracedecay/pull/118))
+- disable graph DB mmap before WAL ([#117](https://github.com/ScriptedAlchemy/tracedecay/pull/117))
+- disable GlobalDb mmap on Windows ([#115](https://github.com/ScriptedAlchemy/tracedecay/pull/115))
+
 ## [0.0.11](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.10...v0.0.11) - 2026-06-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,7 +4499,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -244,7 +244,11 @@ impl Drop for TestTraceDecay {
                 runtime.block_on(async {
                     let _ = cg.checkpoint().await;
                 });
-                cg.close();
+                // Windows CI aborts inside libsql/SQLite teardown for these
+                // short-lived test graphs. Each nextest case runs in its own
+                // process, so leaking the fixture after a checkpoint is safer
+                // than exercising the native destructor path at process exit.
+                std::mem::forget(cg);
             });
             let _ = close_thread.join();
         }


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.11 -> 0.0.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.12](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.11...v0.0.12) - 2026-06-24

### Fixed

- avoid WAL teardown on Windows ([#118](https://github.com/ScriptedAlchemy/tracedecay/pull/118))
- disable graph DB mmap before WAL ([#117](https://github.com/ScriptedAlchemy/tracedecay/pull/117))
- disable GlobalDb mmap on Windows ([#115](https://github.com/ScriptedAlchemy/tracedecay/pull/115))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).