### PR TITLE
fix: disable graph DB mmap before WAL

### DIFF
--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -262,14 +262,14 @@ impl Database {
         let (cache_kb, mmap) = adaptive_cache_sizes(db_file_size);
         let mmap = platform_safe_mmap_size(mmap);
         conn.execute_batch(&format!(
-            "PRAGMA page_size = 8192;
+            "PRAGMA mmap_size = {mmap};
+             PRAGMA page_size = 8192;
              PRAGMA journal_mode = WAL;
              PRAGMA foreign_keys = ON;
              PRAGMA busy_timeout = 120000;
              PRAGMA synchronous = NORMAL;
              PRAGMA cache_size = -{cache_kb};
-             PRAGMA temp_store = MEMORY;
-             PRAGMA mmap_size = {mmap};",
+             PRAGMA temp_store = MEMORY;",
         ))
         .await
         .map_err(|e| TraceDecayError::Database {
@@ -283,11 +283,11 @@ impl Database {
         let (cache_kb, mmap) = adaptive_cache_sizes(db_file_size);
         let mmap = platform_safe_mmap_size(mmap);
         conn.execute_batch(&format!(
-            "PRAGMA foreign_keys = ON;
+            "PRAGMA mmap_size = {mmap};
+             PRAGMA foreign_keys = ON;
              PRAGMA busy_timeout = 120000;
              PRAGMA cache_size = -{cache_kb};
-             PRAGMA temp_store = MEMORY;
-             PRAGMA mmap_size = {mmap};",
+             PRAGMA temp_store = MEMORY;",
         ))
         .await
         .map_err(|e| TraceDecayError::Database {


### PR DESCRIPTION
## Summary
- move graph DB PRAGMA mmap_size ahead of journal_mode = WAL
- mirror the GlobalDb Windows mmap ordering used by #115
- target the Windows 6/8 master failure from run 28077056988, where mcp_handler_test aborted with 0xc0000005/os error 998

## Verification
- cargo fmt --check
- cargo test -p tracedecay --test mcp_handler_test path_containment_read_rejects_parent_traversal_before_serving_file -- --exact
- cargo test -p tracedecay --test mcp_handler_test test_by_qualified_name_finds_indexed_node -- --exact
- cargo test -p tracedecay mmap -- --nocapture