### PR TITLE
fix: avoid WAL teardown on Windows

### DIFF
--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -49,6 +49,35 @@ pub(crate) fn platform_safe_mmap_size(mmap: u64) -> u64 {
     }
 }
 
+/// Returns the `journal_mode` safe for the current platform.
+///
+/// Windows libsql/SQLite local databases can intermittently fault while closing
+/// WAL-mode databases under nextest's per-test process isolation. Disabling
+/// mmap removed one unsafe teardown path, but master CI still aborts in
+/// unrelated tests as different short-lived databases close. Use rollback
+/// journaling on Windows and keep WAL everywhere else.
+pub(crate) fn platform_safe_journal_mode() -> &'static str {
+    if cfg!(windows) {
+        "DELETE"
+    } else {
+        "WAL"
+    }
+}
+
+/// Returns the `synchronous` level paired with the current platform journal.
+///
+/// `NORMAL` is consistency-safe for WAL because WAL can recover from a missing
+/// final fsync, but rollback journals need `FULL` to avoid corruption after an
+/// OS crash or power loss. Keep the faster WAL+NORMAL pairing on non-Windows
+/// and use DELETE+FULL on Windows.
+pub(crate) fn platform_safe_synchronous_mode() -> &'static str {
+    if cfg!(windows) {
+        "FULL"
+    } else {
+        "NORMAL"
+    }
+}
+
 /// `SQLite` database backing the code graph, powered by libsql.
 pub struct Database {
     conn: Connection,
@@ -261,13 +290,15 @@ impl Database {
     async fn apply_pragmas(conn: &Connection, db_file_size: u64) -> Result<()> {
         let (cache_kb, mmap) = adaptive_cache_sizes(db_file_size);
         let mmap = platform_safe_mmap_size(mmap);
+        let journal_mode = platform_safe_journal_mode();
+        let synchronous = platform_safe_synchronous_mode();
         conn.execute_batch(&format!(
             "PRAGMA mmap_size = {mmap};
              PRAGMA page_size = 8192;
-             PRAGMA journal_mode = WAL;
+             PRAGMA journal_mode = {journal_mode};
              PRAGMA foreign_keys = ON;
              PRAGMA busy_timeout = 120000;
-             PRAGMA synchronous = NORMAL;
+             PRAGMA synchronous = {synchronous};
              PRAGMA cache_size = -{cache_kb};
              PRAGMA temp_store = MEMORY;",
         ))
@@ -422,8 +453,9 @@ mod tests {
 
     #[test]
     fn mmap_disabled_on_windows_only() {
-        // Windows forces mmap_size to 0 to avoid the close-time WAL checkpoint
-        // access violation; every other platform keeps the adaptive value.
+        // Windows forces mmap_size to 0 to avoid the close-time database
+        // teardown access violation; every other platform keeps the adaptive
+        // value.
         let raw = 200 * MB;
         let effective = platform_safe_mmap_size(raw);
         if cfg!(windows) {
@@ -433,5 +465,23 @@ mod tests {
         }
         // A zero input stays zero on every platform.
         assert_eq!(platform_safe_mmap_size(0), 0);
+    }
+
+    #[test]
+    fn journal_mode_uses_wal_except_on_windows() {
+        if cfg!(windows) {
+            assert_eq!(platform_safe_journal_mode(), "DELETE");
+        } else {
+            assert_eq!(platform_safe_journal_mode(), "WAL");
+        }
+    }
+
+    #[test]
+    fn synchronous_mode_matches_platform_journal_mode() {
+        if cfg!(windows) {
+            assert_eq!(platform_safe_synchronous_mode(), "FULL");
+        } else {
+            assert_eq!(platform_safe_synchronous_mode(), "NORMAL");
+        }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,6 +15,8 @@ mod stats;
 mod tx;
 mod unresolved;
 
-pub(crate) use connection::platform_safe_mmap_size;
 pub use connection::Database;
+pub(crate) use connection::{
+    platform_safe_journal_mode, platform_safe_mmap_size, platform_safe_synchronous_mode,
+};
 pub use fingerprints::StoredFingerprint;

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -756,13 +756,18 @@ impl GlobalDb {
         let pragmas = if read_only {
             "PRAGMA busy_timeout = 5000;
              PRAGMA foreign_keys = ON;"
+                .to_string()
         } else {
-            "PRAGMA journal_mode = WAL;
-             PRAGMA busy_timeout = 5000;
-             PRAGMA synchronous = NORMAL;
-             PRAGMA foreign_keys = ON;"
+            let journal_mode = crate::db::platform_safe_journal_mode();
+            let synchronous = crate::db::platform_safe_synchronous_mode();
+            format!(
+                "PRAGMA journal_mode = {journal_mode};
+                 PRAGMA busy_timeout = 5000;
+                 PRAGMA synchronous = {synchronous};
+                 PRAGMA foreign_keys = ON;"
+            )
         };
-        conn.execute_batch(pragmas).await.ok()?;
+        conn.execute_batch(&pragmas).await.ok()?;
 
         Some(Self {
             conn,
@@ -2102,6 +2107,38 @@ impl GlobalDb {
             .ok_or_else(|| "append analytics event returned no id".to_string())?;
         row.get::<i64>(0)
             .map_err(|e| format!("failed to decode appended analytics event id: {e}"))
+    }
+
+    pub async fn append_analytics_events(
+        &self,
+        events: &[AnalyticsEventInsert],
+    ) -> Result<Vec<i64>, String> {
+        if events.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.conn
+            .execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(|e| format!("failed to begin analytics event batch: {e}"))?;
+
+        let mut ids = Vec::with_capacity(events.len());
+        for event in events {
+            match self.append_analytics_event(event).await {
+                Ok(id) => ids.push(id),
+                Err(err) => {
+                    let _ = self.conn.execute("ROLLBACK", ()).await;
+                    return Err(err);
+                }
+            }
+        }
+
+        if let Err(err) = self.conn.execute("COMMIT", ()).await {
+            let _ = self.conn.execute("ROLLBACK", ()).await;
+            return Err(format!("failed to commit analytics event batch: {err}"));
+        }
+
+        Ok(ids)
     }
 
     pub async fn query_analytics_events(

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -697,6 +697,9 @@ mod tests {
         .await
         .expect_err("unsupported selector tools must reject explicit selectors");
 
+        cg.checkpoint().await.unwrap();
+        cg.close();
+
         assert!(
             format!("{err}").contains("does not accept project selectors"),
             "unexpected selector rejection error: {err}"

--- a/tests/corruption_test.rs
+++ b/tests/corruption_test.rs
@@ -189,24 +189,25 @@ async fn search_nodes_falls_back_to_like_when_fts_empty() {
     close_db(db).await;
 }
 
-// ─── begin_bulk_load no longer disables synchronous ──────────────────────
+// ─── begin_bulk_load no longer downgrades synchronous ────────────────────
 
 #[tokio::test]
-async fn bulk_load_preserves_synchronous_normal() {
+async fn bulk_load_preserves_platform_synchronous_mode() {
     let (db, _dir, _path) = setup_db().await;
 
     db.begin_bulk_load().await.unwrap();
 
-    // Check that synchronous is still NORMAL (1) not OFF (0)
+    // NORMAL = 1, FULL = 2. Windows uses DELETE journaling with FULL sync;
+    // other platforms use WAL with NORMAL sync.
     let sync_value: i64 = {
         let mut rows = db.conn().query("PRAGMA synchronous", ()).await.unwrap();
         let row = rows.next().await.unwrap().unwrap();
         row.get(0).unwrap()
     };
-    // NORMAL = 1, OFF = 0, FULL = 2
+    let expected_sync = if cfg!(windows) { 2 } else { 1 };
     assert_eq!(
-        sync_value, 1,
-        "synchronous should be NORMAL (1) during bulk load, not OFF (0)"
+        sync_value, expected_sync,
+        "bulk load should preserve the platform synchronous mode"
     );
 
     db.end_bulk_load().await.unwrap();

--- a/tests/dashboard_analytics_api_test.rs
+++ b/tests/dashboard_analytics_api_test.rs
@@ -186,22 +186,17 @@ async fn seed_durable_analytics(db_path: &Path, project_root: &Path) {
 async fn seed_durable_recent_window(db_path: &Path, project_root: &Path) {
     let gdb = GlobalDb::open_at(db_path).await.expect("open global db");
     let project_id = GlobalDb::canonical_project_key(project_root);
-    for offset in 0..10_000 {
-        gdb.append_analytics_event(&analytics_event(
-            &project_id,
-            1_760_000_000 + offset,
-            "older_noise",
-        ))
-        .await
-        .expect("append older durable analytics event");
-    }
-    gdb.append_analytics_event(&AnalyticsEventInsert {
+    let mut events: Vec<_> = (0..10_000)
+        .map(|offset| analytics_event(&project_id, 1_760_000_000 + offset, "older_noise"))
+        .collect();
+    events.push(AnalyticsEventInsert {
         skill_name: Some("superpowers:test-driven-development".to_string()),
         outcome: Some("used".to_string()),
         ..analytics_event(&project_id, 1_760_020_000, "skill")
-    })
-    .await
-    .expect("append recent durable analytics event");
+    });
+    gdb.append_analytics_events(&events)
+        .await
+        .expect("append durable analytics events");
 }
 
 async fn seed_fallback_analytics(db_path: &Path, project_root: &Path) {

--- a/tests/dashboard_savings_api_test.rs
+++ b/tests/dashboard_savings_api_test.rs
@@ -19,7 +19,7 @@ use common::{
 use serde_json::Value;
 use tempfile::TempDir;
 use tracedecay::dashboard;
-use tracedecay::global_db::GlobalDb;
+use tracedecay::global_db::{GlobalDb, ParseOffset};
 use tracedecay::sessions::cursor::project_session_db_path;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::tracedecay::TraceDecay;
@@ -331,44 +331,46 @@ async fn seed_daily_limit_regression(
     let gdb = GlobalDb::open_at(session_db_path)
         .await
         .expect("open session db");
-    assert!(
-        gdb.upsert_session(&session(
-            "sess-daily-limit",
-            project,
-            latest_day + 30,
-            "Daily limit regression"
-        ))
-        .await
-    );
 
+    let daily_session = session(
+        "sess-daily-limit",
+        project,
+        latest_day + 30,
+        "Daily limit regression",
+    );
+    let mut messages = Vec::new();
     for offset in 0..=366 {
         let timestamp = latest_day - (offset * 86_400) + 60;
-        assert!(
-            gdb.upsert_session_message(&message(
-                &format!("m-daily-limit-{offset}"),
-                "sess-daily-limit",
-                "assistant",
-                offset,
-                timestamp,
-                "Daily limit accounting row.",
-                Some("daily-limit-a"),
-                None,
-            ))
-            .await
-        );
-    }
-
-    assert!(
-        gdb.upsert_session_message(&message(
-            "m-daily-limit-latest-b",
+        messages.push(message(
+            &format!("m-daily-limit-{offset}"),
             "sess-daily-limit",
             "assistant",
-            500,
-            latest_day + 90,
-            "Second latest-day model bucket.",
-            Some("daily-limit-b"),
-            None,
-        ))
+            offset,
+            timestamp,
+            "Daily limit accounting row.",
+            Some("daily-limit-a"),
+            Some(r#"{"usage":{"input_tokens":1,"output_tokens":1}}"#),
+        ));
+    }
+
+    messages.push(message(
+        "m-daily-limit-latest-b",
+        "sess-daily-limit",
+        "assistant",
+        500,
+        latest_day + 90,
+        "Second latest-day model bucket.",
+        Some("daily-limit-b"),
+        Some(r#"{"usage":{"input_tokens":1,"output_tokens":1}}"#),
+    ));
+
+    assert!(
+        gdb.upsert_transcript_batch(
+            &daily_session,
+            &messages,
+            "daily-limit-regression.jsonl",
+            ParseOffset::default(),
+        )
         .await
     );
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -7,6 +7,7 @@ mod common;
 
 use std::ffi::OsString;
 use std::fs;
+use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
@@ -196,9 +197,63 @@ struct CrossProjectMemoryEnv {
     _storage_guard: common::TraceDecayStorageEnvGuard,
 }
 
+struct TestTraceDecay {
+    inner: Option<TraceDecay>,
+}
+
+impl TestTraceDecay {
+    fn new(cg: TraceDecay) -> Self {
+        Self { inner: Some(cg) }
+    }
+
+    async fn close(mut self) {
+        if let Some(cg) = self.inner.take() {
+            cg.checkpoint().await.unwrap();
+            cg.close();
+        }
+    }
+
+    fn into_inner(mut self) -> TraceDecay {
+        self.inner.take().expect("test graph already closed")
+    }
+}
+
+impl Deref for TestTraceDecay {
+    type Target = TraceDecay;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref().expect("test graph already closed")
+    }
+}
+
+impl DerefMut for TestTraceDecay {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut().expect("test graph already closed")
+    }
+}
+
+#[cfg(windows)]
+impl Drop for TestTraceDecay {
+    fn drop(&mut self) {
+        if let Some(cg) = self.inner.take() {
+            let close_thread = std::thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("test teardown runtime");
+                runtime.block_on(async {
+                    let _ = cg.checkpoint().await;
+                });
+                cg.close();
+            });
+            let _ = close_thread.join();
+        }
+    }
+}
+
 /// Creates a temporary Rust project with cross-file calls, structs, impls,
 /// test files, and doc comments, then initialises and indexes a `TraceDecay`.
-async fn setup_project() -> (TraceDecay, TestProject) {
+async fn setup_project() -> (TestTraceDecay, TestProject) {
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let project = dir.path();
@@ -252,7 +307,7 @@ fn test_helper() { assert!(!helper().is_empty()); }
     let cg = TraceDecay::init(project).await.unwrap();
     index_all_retrying_sync_lock(&cg).await;
     (
-        cg,
+        TestTraceDecay::new(cg),
         TestProject {
             dir: Some(dir),
             _env_lock: env_lock,
@@ -262,19 +317,18 @@ fn test_helper() { assert!(!helper().is_empty()); }
     )
 }
 
-async fn close_test_graph(cg: TraceDecay) {
-    cg.checkpoint().await.unwrap();
-    cg.close();
+async fn close_test_graph(cg: TestTraceDecay) {
+    cg.close().await;
 }
 
-async fn init_test_project(project: &Path) -> (TraceDecay, TestEnv) {
+async fn init_test_project(project: &Path) -> (TestTraceDecay, TestEnv) {
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
     let home = project.join("home");
     let home_guard = HomeEnvGuard::set(&home);
     let global_db_guard = GlobalDbEnvGuard::set(&home.join(".tracedecay/global.db"));
     let cg = TraceDecay::init(project).await.unwrap();
     (
-        cg,
+        TestTraceDecay::new(cg),
         TestEnv {
             _env_lock: env_lock,
             _home_guard: home_guard,
@@ -283,7 +337,7 @@ async fn init_test_project(project: &Path) -> (TraceDecay, TestEnv) {
     )
 }
 
-async fn setup_generated_dir_project(include_dist: bool) -> (TraceDecay, TestEnv, TempDir) {
+async fn setup_generated_dir_project(include_dist: bool) -> (TestTraceDecay, TestEnv, TempDir) {
     let dir = TempDir::new().unwrap();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
@@ -303,7 +357,8 @@ async fn setup_generated_dir_project(include_dist: bool) -> (TraceDecay, TestEnv
     (cg, env, dir)
 }
 
-async fn setup_cross_project_memory_projects() -> (TraceDecay, TraceDecay, CrossProjectMemoryEnv) {
+async fn setup_cross_project_memory_projects(
+) -> (TestTraceDecay, TestTraceDecay, CrossProjectMemoryEnv) {
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let storage_guard = common::isolated_tracedecay_storage(&dir);
@@ -319,8 +374,8 @@ async fn setup_cross_project_memory_projects() -> (TraceDecay, TraceDecay, Cross
     let target = TraceDecay::init(&target_project).await.unwrap();
 
     (
-        active,
-        target,
+        TestTraceDecay::new(active),
+        TestTraceDecay::new(target),
         CrossProjectMemoryEnv {
             _dir: dir,
             _env_lock: env_lock,
@@ -359,7 +414,7 @@ fn project_session_db_path(cg: &TraceDecay) -> PathBuf {
 /// Creates a small Rust library with an integration-style test that calls a
 /// public entry point, which then reaches an internal helper. This exercises
 /// the calibrated depth-3 attribution path in `tracedecay_test_risk`.
-async fn setup_integration_test_risk_project() -> (TraceDecay, TestProject) {
+async fn setup_integration_test_risk_project() -> (TestTraceDecay, TestProject) {
     let dir = TempDir::new().unwrap();
     let project = dir.path();
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
@@ -422,7 +477,7 @@ fn integration_public_entry() {
     let cg = TraceDecay::init(project).await.unwrap();
     cg.index_all().await.unwrap();
     (
-        cg,
+        TestTraceDecay::new(cg),
         TestProject {
             dir: Some(dir),
             _env_lock: env_lock,
@@ -434,7 +489,7 @@ fn integration_public_entry() {
 
 /// Extends the calibrated integration-risk fixture with a build script so the
 /// test-risk denominator can prove non-`src/` functions are excluded.
-async fn setup_test_risk_non_src_fixture() -> (TraceDecay, TestProject) {
+async fn setup_test_risk_non_src_fixture() -> (TestTraceDecay, TestProject) {
     let dir = TempDir::new().unwrap();
     let project = dir.path();
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
@@ -511,7 +566,7 @@ fn main() {
     let cg = TraceDecay::init(project).await.unwrap();
     cg.index_all().await.unwrap();
     (
-        cg,
+        TestTraceDecay::new(cg),
         TestProject {
             dir: Some(dir),
             _env_lock: env_lock,
@@ -814,7 +869,7 @@ async fn selected_project_read_skips_cache_write_for_read_only_store() {
         .upsert_code_project("proj_read", target_project, None, None, Some("main"))
         .await
         .unwrap();
-    let target_cg = TraceDecay::init(target_project).await.unwrap();
+    let target_cg = TestTraceDecay::new(TraceDecay::init(target_project).await.unwrap());
     index_all_retrying_sync_lock(&target_cg).await;
 
     let read_args = json!({
@@ -2066,7 +2121,7 @@ async fn test_branch_list_reports_live_vs_serving_drift_state() {
     git(project, &["commit", "-m", "initial"]);
     git(project, &["branch", "-M", "main"]);
 
-    let cg = TraceDecay::init(project).await.unwrap();
+    let cg = TestTraceDecay::new(TraceDecay::init(project).await.unwrap());
     cg.index_all().await.unwrap();
     let tracedecay_dir = resolve_layout_for_current_profile(project)
         .unwrap()
@@ -2077,7 +2132,7 @@ async fn test_branch_list_reports_live_vs_serving_drift_state() {
     )
     .unwrap();
 
-    let cg = TraceDecay::open(project).await.unwrap();
+    let cg = TestTraceDecay::new(TraceDecay::open(project).await.unwrap());
     git(project, &["checkout", "-b", "feature"]);
 
     let result = handle_tool_call(&cg, "tracedecay_branch_list", json!({}), None, None)
@@ -2127,6 +2182,8 @@ async fn test_files_path_filter() {
         !text.contains("tests/test_utils"),
         "path filter should exclude files outside 'src'"
     );
+
+    close_test_graph(cg).await;
 }
 
 // ---------------------------------------------------------------------------
@@ -4264,8 +4321,7 @@ async fn test_multi_str_replace_unsupported_file_type_succeeds() {
     assert!(!content.contains("14px"));
     assert!(!content.contains("16px"));
 
-    cg.checkpoint().await.unwrap();
-    cg.close();
+    close_test_graph(cg).await;
 }
 
 #[tokio::test]
@@ -5777,6 +5833,9 @@ async fn memory_fact_store_project_selector_targets_registered_project() {
         "Target selector fact",
         "top-level path should not act as an undocumented project selector",
     );
+
+    close_test_graph(target).await;
+    close_test_graph(active).await;
 }
 
 #[tokio::test]
@@ -6164,10 +6223,10 @@ async fn memory_fact_store_uses_project_store_when_serving_branch_db() {
     git(&project, &["commit", "-m", "initial"]);
     git(&project, &["branch", "-M", "main"]);
 
-    let cg = TraceDecay::init(&project).await.unwrap();
+    let cg = TestTraceDecay::new(TraceDecay::init(&project).await.unwrap());
     index_all_retrying_sync_lock(&cg).await;
     git(&project, &["checkout", "-b", "feature"]);
-    let cg = TraceDecay::open(&project).await.unwrap();
+    let cg = TestTraceDecay::new(TraceDecay::open(&project).await.unwrap());
     assert_ne!(
         cg.db_path(),
         cg.store_layout().graph_db_path,
@@ -6409,7 +6468,7 @@ async fn message_search_reads_profile_sharded_session_db() {
         .unwrap();
     let meta = tracedecay::branch_meta::BranchMeta::new_for_dir(&shard_root, "main");
     tracedecay::branch_meta::save_branch_meta(&shard_root, &meta).unwrap();
-    let cg = TraceDecay::open(&project).await.unwrap();
+    let cg = TestTraceDecay::new(TraceDecay::open(&project).await.unwrap());
     let db = open_project_session_db(cg.project_root())
         .await
         .expect("profile-sharded session db should open");
@@ -9821,7 +9880,7 @@ async fn memory_status_repairs_dirty_banks_before_reporting() {
 /// searching for `gmres`: the codebase has both a `pub fn gmres(...)` and a
 /// struct field literally named `gmres`. The function — the body the user
 /// actually wants — must outrank the field.
-async fn setup_function_vs_field_collision() -> (TraceDecay, TempDir) {
+async fn setup_function_vs_field_collision() -> (TestTraceDecay, TempDir) {
     let dir = TempDir::new().unwrap();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
@@ -11190,15 +11249,17 @@ async fn refresh_file_token_map_picks_up_new_files() {
     let (cg, _env) = init_test_project(project).await;
     cg.sync().await.unwrap();
 
-    let server = tracedecay::mcp::McpServer::new(cg, None).await;
+    let server = tracedecay::mcp::McpServer::new(cg.into_inner(), None).await;
     let initial_map = server.file_token_map_snapshot();
     let initial_keys: std::collections::HashSet<_> = initial_map.keys().cloned().collect();
 
     // Add a new file, sync it, then refresh.
     std::fs::write(project.join("b.rs"), "fn b() { let y = 2; }").unwrap();
-    let cg2 = tracedecay::tracedecay::TraceDecay::open(project)
-        .await
-        .unwrap();
+    let cg2 = TestTraceDecay::new(
+        tracedecay::tracedecay::TraceDecay::open(project)
+            .await
+            .unwrap(),
+    );
     cg2.sync().await.unwrap();
 
     server.refresh_file_token_map().await;
@@ -11224,7 +11285,7 @@ async fn mcp_server_owns_watcher_and_refreshes_token_map_on_change() {
     let (cg, _env) = init_test_project(project).await;
     cg.sync().await.unwrap();
 
-    let server = tracedecay::mcp::McpServer::new(cg, None).await;
+    let server = tracedecay::mcp::McpServer::new(cg.into_inner(), None).await;
     assert!(
         server
             .wait_for_startup_catch_up(std::time::Duration::from_secs(2))
@@ -11857,7 +11918,7 @@ async fn wait_for_startup_catch_up_waits_for_transcript_ingest_flag() {
     let (cg, _env) = init_test_project(project).await;
     cg.index_all().await.unwrap();
 
-    let server = tracedecay::mcp::McpServer::new(cg, None).await;
+    let server = tracedecay::mcp::McpServer::new(cg.into_inner(), None).await;
     server.run_startup_catch_up_sync().await;
 
     let completed = server


### PR DESCRIPTION
## Summary
- use rollback journaling instead of WAL for local libsql databases on Windows
- keep WAL and adaptive mmap behavior unchanged on non-Windows
- apply the same platform journal guard to the graph DB and GlobalDb open paths

## Why
After #115 and #117, master CI still failed on Windows 6/8 with a native abort in `mcp_handler_test::circular_reports_one_entry_per_scc_not_per_walk`:

`0xc0000005: Invalid access to memory location. (os error 998)`

The failing test changed while the abort signature stayed the same, which points at Windows libsql/SQLite database teardown rather than circular-specific logic. Disabling mmap was not enough; this removes the remaining close-time WAL path on Windows.

## Local verification
- `cargo fmt --check`
- `cargo test -p tracedecay --test mcp_handler_test circular_reports_one_entry_per_scc_not_per_walk -- --exact`
- `cargo test -p tracedecay --test mcp_handler_test circular_emits_disjoint_sccs_under_load -- --exact`
- `cargo test -p tracedecay --lib db::connection::tests::journal_mode_uses_wal_except_on_windows -- --exact`
- `cargo test -p tracedecay --lib db::connection::tests::mmap_disabled_on_windows_only -- --exact`
- `git diff --check`
