### PR TITLE
[codex] Default transcript search to all providers

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -793,7 +793,7 @@ tracedecay status /path/to/project --json
 tracedecay memory status --path /path/to/project --json
 ```
 
-`tracedecay sessions search` searches previously ingested sessions for the current context and does not accept a project selector in this branch.
+`tracedecay sessions search` searches previously ingested sessions for the active project. By default it searches all ingested transcript providers; pass `--provider <id>` only when intentionally constraining the search. Use `--project-id` or `--project-path` to search a registered project other than the current directory.
 
 ### Per-user: `~/.tracedecay/`
 

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -380,7 +380,7 @@ fn install_claude_md_rules(claude_md_path: &Path) -> Result<()> {
         queries that go beyond what the built-in tools expose.\n\
         - For durable project/user facts, prefer `tracedecay_fact_store`, \
         `tracedecay_fact_feedback`, and `tracedecay_memory_status` over ad-hoc notes. \
-        Use `tracedecay_message_search` for project-local Cursor transcript recall when \
+        Use `tracedecay_message_search` for active-project transcript recall when \
         prior conversation context matters. Do not store secrets, credentials, or \
         unnecessary PII in persistent facts.\n\
         - If you discover a gap where an extractor, schema, or tracedecay tool could be \

--- a/src/agents/copilot.rs
+++ b/src/agents/copilot.rs
@@ -401,7 +401,7 @@ fn install_prompt_rules(instructions_path: &Path) -> Result<()> {
         queries that go beyond what the built-in tools expose.\n\n\
         For durable project/user facts, prefer `tracedecay_fact_store`, \
         `tracedecay_fact_feedback`, and `tracedecay_memory_status` over ad-hoc notes. \
-        Use `tracedecay_message_search` for project-local Cursor transcript recall when \
+        Use `tracedecay_message_search` for active-project transcript recall when \
         prior conversation context matters. Do not store secrets, credentials, or \
         unnecessary PII in persistent facts.\n\n\
         If you find a gap where tracedecay could answer a question natively, propose opening \

--- a/src/agents/kimi.rs
+++ b/src/agents/kimi.rs
@@ -167,7 +167,7 @@ fn install_prompt_rules(agents_md: &Path) -> Result<()> {
         queries that go beyond what the built-in tools expose.\n\n\
         For durable project/user facts, prefer `tracedecay_fact_store`, \
         `tracedecay_fact_feedback`, and `tracedecay_memory_status` over ad-hoc notes. \
-        Use `tracedecay_message_search` for project-local Cursor transcript recall when \
+        Use `tracedecay_message_search` for active-project transcript recall when \
         prior conversation context matters. Do not store secrets, credentials, or \
         unnecessary PII in persistent facts.\n\n\
         If you discover a gap where an extractor, schema, or tracedecay tool could be \

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -201,7 +201,7 @@ fn install_prompt_rules(prompt_path: &Path) -> Result<()> {
         queries that go beyond what the built-in tools expose.\n\n\
         For durable project/user facts, prefer `tracedecay_fact_store`, \
         `tracedecay_fact_feedback`, and `tracedecay_memory_status` over ad-hoc notes. \
-        Use `tracedecay_message_search` for project-local Cursor transcript recall when \
+        Use `tracedecay_message_search` for active-project transcript recall when \
         prior conversation context matters. Do not store secrets, credentials, or \
         unnecessary PII in persistent facts.\n\n\
         If you discover a gap where an extractor, schema, or tracedecay tool could be \

--- a/src/agents/vibe.rs
+++ b/src/agents/vibe.rs
@@ -194,7 +194,7 @@ fn install_prompt_rules(prompt_path: &Path) -> Result<()> {
         queries that go beyond what the built-in tools expose.\n\n\
         For durable project/user facts, prefer `tracedecay_fact_store`, \
         `tracedecay_fact_feedback`, and `tracedecay_memory_status` over ad-hoc notes. \
-        Use `tracedecay_message_search` for project-local Cursor transcript recall when \
+        Use `tracedecay_message_search` for active-project transcript recall when \
         prior conversation context matters. Do not store secrets, credentials, or \
         unnecessary PII in persistent facts.\n\n\
         If you find a gap where tracedecay could answer a question natively, propose opening \

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -424,7 +424,7 @@ pub enum SessionsAction {
     Search {
         /// Full-text query to search for
         query: String,
-        /// Provider to search: cursor, codex, or all
+        /// Optional provider to search; omit or use all to search all ingested providers
         #[arg(long)]
         provider: Option<String>,
         /// Maximum number of matches per provider
@@ -1228,6 +1228,25 @@ mod cli_parse_tests {
                 assert_eq!(limit, 5);
                 assert!(project_id.is_none());
                 assert!(project_path.is_none());
+            }
+            _ => panic!("expected sessions search command"),
+        }
+
+        let all_provider_search =
+            Cli::try_parse_from(["tracedecay", "sessions", "search", "needle"]).unwrap();
+        match all_provider_search.command {
+            Some(Commands::Sessions {
+                action:
+                    SessionsAction::Search {
+                        query,
+                        provider,
+                        limit,
+                        ..
+                    },
+            }) => {
+                assert_eq!(query, "needle");
+                assert!(provider.is_none());
+                assert_eq!(limit, 10);
             }
             _ => panic!("expected sessions search command"),
         }

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -3006,6 +3006,46 @@ impl GlobalDb {
         scope: SessionSearchScope,
         parent_session_id: Option<&str>,
     ) -> Vec<SessionMessageSearchResult> {
+        self.search_session_messages_filtered_inner(
+            Some(provider),
+            project_key,
+            query,
+            limit,
+            scope,
+            parent_session_id,
+        )
+        .await
+    }
+
+    /// Searches message text across all providers with optional parent/subagent filters.
+    pub async fn search_session_messages_all_providers_filtered(
+        &self,
+        project_key: Option<&str>,
+        query: &str,
+        limit: usize,
+        scope: SessionSearchScope,
+        parent_session_id: Option<&str>,
+    ) -> Vec<SessionMessageSearchResult> {
+        self.search_session_messages_filtered_inner(
+            None,
+            project_key,
+            query,
+            limit,
+            scope,
+            parent_session_id,
+        )
+        .await
+    }
+
+    async fn search_session_messages_filtered_inner(
+        &self,
+        provider: Option<&str>,
+        project_key: Option<&str>,
+        query: &str,
+        limit: usize,
+        scope: SessionSearchScope,
+        parent_session_id: Option<&str>,
+    ) -> Vec<SessionMessageSearchResult> {
         let fts_query = session_fts_query(query);
         if fts_query.is_empty() || limit == 0 {
             return Vec::new();
@@ -3026,9 +3066,13 @@ impl GlobalDb {
              FROM session_messages_fts
              JOIN session_messages m ON session_messages_fts.rowid = m.rowid
              JOIN sessions s ON s.provider = m.provider AND s.session_id = m.session_id
-             WHERE session_messages_fts MATCH ?1 AND m.provider = ?2"
+             WHERE session_messages_fts MATCH ?1"
             .to_string();
-        let mut query_params = vec![Value::Text(fts_query), Value::Text(provider.to_string())];
+        let mut query_params = vec![Value::Text(fts_query)];
+        if let Some(provider) = provider {
+            query_params.push(Value::Text(provider.to_string()));
+            let _ = write!(sql, " AND m.provider = ?{}", query_params.len());
+        }
         if let Some(project_key) = project_key {
             query_params.push(Value::Text(project_key.to_string()));
             let _ = write!(sql, " AND s.project_key = ?{}", query_params.len());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1738,19 +1738,30 @@ async fn handle_sessions_action(action: SessionsAction) -> tracedecay::errors::R
                         project_path.display()
                     ),
                 })?;
-            for provider in session_search_providers(provider.as_deref())? {
-                for result in db
-                    .search_session_messages(provider, None, &query, limit)
-                    .await
-                {
-                    println!(
-                        "[{}] {} {}: {}",
-                        result.session.provider,
-                        result.session.project_key,
-                        result.message.role,
-                        result.message.text.replace('\n', " ")
-                    );
+            let results = match optional_session_search_provider(provider.as_deref()) {
+                Some(provider) => {
+                    db.search_session_messages(provider, None, &query, limit)
+                        .await
                 }
+                None => {
+                    db.search_session_messages_all_providers_filtered(
+                        None,
+                        &query,
+                        limit,
+                        tracedecay::sessions::SessionSearchScope::All,
+                        None,
+                    )
+                    .await
+                }
+            };
+            for result in results {
+                println!(
+                    "[{}] {} {}: {}",
+                    result.session.provider,
+                    result.session.project_key,
+                    result.message.role,
+                    result.message.text.replace('\n', " ")
+                );
             }
         }
     }
@@ -1790,14 +1801,10 @@ fn parse_session_provider(provider: Option<&str>) -> tracedecay::errors::Result<
     }
 }
 
-fn session_search_providers(
-    provider: Option<&str>,
-) -> tracedecay::errors::Result<Vec<&'static str>> {
-    match parse_session_provider(provider)? {
-        SessionProvider::Cursor => Ok(vec!["cursor"]),
-        SessionProvider::Codex => Ok(vec!["codex"]),
-        SessionProvider::All => Ok(vec!["cursor", "codex"]),
-    }
+fn optional_session_search_provider(provider: Option<&str>) -> Option<&str> {
+    provider
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty() && *provider != "all")
 }
 
 fn should_skip_startup_maintenance(command: &Commands) -> bool {

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -2176,7 +2176,7 @@ fn def_message_search() -> ToolDefinition {
     def(
         "tracedecay_message_search",
         "Message Search",
-        "Search ingested Cursor/Codex/agent transcript messages. Defaults to the active project's session-message FTS index; pass project_id or project_path only when intentionally searching another registered project.",
+        "Search ingested Cursor/Codex/agent transcript messages. Defaults to all transcript providers in the active project's session-message FTS index; pass provider to constrain one provider, or project_id/project_path only when intentionally searching another registered project.",
         json!({
             "type": "object",
             "properties": {
@@ -2186,8 +2186,8 @@ fn def_message_search() -> ToolDefinition {
                 },
                 "provider": {
                     "type": "string",
-                    "description": "Message provider to search (default: cursor). Use 'hermes' for Hermes agent conversation history ingested from per-profile state.db stores.",
-                    "enum": ["cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "hermes"]
+                    "description": "Optional message provider to search. Omit or use 'all' to search all ingested providers. Use 'hermes' for Hermes agent conversation history ingested from per-profile state.db stores.",
+                    "enum": ["all", "cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "hermes"]
                 },
                 "project_key": {
                     "type": "string",
@@ -2421,13 +2421,13 @@ fn def_lcm_grep() -> ToolDefinition {
     def(
         "tracedecay_lcm_grep",
         "LCM Grep",
-        "Search bounded LCM raw-message snippets and optional summary text in the active project or Hermes profile session store.",
+        "Search bounded LCM raw-message snippets and optional summary text across all providers in the active project or Hermes profile session store. Pass provider to constrain one provider.",
         json!({
             "type": "object",
             "properties": {
                 "provider": {
                     "type": "string",
-                    "description": "Provider id, default cursor."
+                    "description": "Optional provider id. Omit or use 'all' to search all providers."
                 },
                 "query": {
                     "type": "string",

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -815,6 +815,12 @@ fn provider_arg(args: &Value) -> &str {
     string_arg(args, "provider").unwrap_or("cursor")
 }
 
+fn optional_search_provider_arg(args: &Value) -> Option<&str> {
+    string_arg(args, "provider")
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty() && *provider != "all")
+}
+
 fn messages_arg(args: &Value) -> Result<Vec<Value>> {
     let Some(messages) = args.get("messages") else {
         return Ok(Vec::new());
@@ -1366,12 +1372,7 @@ pub(super) async fn handle_message_search(
         .ok_or_else(|| TraceDecayError::Config {
             message: "missing required parameter: query".to_string(),
         })?;
-    let provider = args
-        .get("provider")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|provider| !provider.is_empty())
-        .unwrap_or("cursor");
+    let provider = optional_search_provider_arg(&args);
     let project_key = args
         .get("project_key")
         .and_then(Value::as_str)
@@ -1426,15 +1427,15 @@ pub(super) async fn handle_message_search(
             }),
         ));
     };
-    if provider == "hermes" {
+    if provider.is_none() || provider == Some("hermes") {
         // Hermes history lives in per-profile state.db stores normally swept
         // by the serve/dashboard startup catch-ups; an incremental
         // search-time catch-up makes the `tracedecay tool` / generated-plugin
         // path self-sufficient (cursor-based, so it is cheap when fresh).
         let _ = crate::sessions::hermes::ingest_for_project(&db, &target_root).await;
     }
-    let results = db
-        .search_session_messages_filtered(
+    let results = if let Some(provider) = provider {
+        db.search_session_messages_filtered(
             provider,
             project_key,
             query,
@@ -1442,13 +1443,23 @@ pub(super) async fn handle_message_search(
             scope,
             parent_session_id,
         )
-        .await;
+        .await
+    } else {
+        db.search_session_messages_all_providers_filtered(
+            project_key,
+            query,
+            limit,
+            scope,
+            parent_session_id,
+        )
+        .await
+    };
 
     Ok(tool_json(
         Some(&target_root),
         &json!({
             "status": "ok",
-            "provider": provider,
+            "provider": provider.unwrap_or("all"),
             "selected_project_root": target_root,
             "project_key": project_key,
             "parent_session_id": parent_session_id,
@@ -1640,7 +1651,7 @@ pub(super) async fn handle_lcm_grep(
     context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
-    let provider = provider_arg(&args);
+    let provider = optional_search_provider_arg(&args).unwrap_or("all");
     let query = required_string_arg(&args, "query")?;
     // Validate scope before opening storage so argument errors are reported
     // even when the sessions DB does not exist yet.

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -1270,6 +1270,18 @@ fn parse_lcm_scope(args: &Value) -> Result<LcmScope> {
     }
 }
 
+fn lcm_grep_provider_arg(args: &Value, scope: LcmScope) -> &str {
+    if let Some(provider) = optional_search_provider_arg(args) {
+        return provider;
+    }
+    if matches!(scope, LcmScope::Current | LcmScope::Session)
+        && string_arg(args, "provider").is_none()
+    {
+        return provider_arg(args);
+    }
+    "all"
+}
+
 fn parse_lcm_grep_sort(args: &Value) -> Result<LcmGrepSort> {
     let Some(sort) = string_arg(args, "sort") else {
         return Ok(LcmGrepSort::Recency);
@@ -1651,11 +1663,11 @@ pub(super) async fn handle_lcm_grep(
     context: LcmHandlerContext<'_>,
     args: Value,
 ) -> Result<ToolResult> {
-    let provider = optional_search_provider_arg(&args).unwrap_or("all");
     let query = required_string_arg(&args, "query")?;
     // Validate scope before opening storage so argument errors are reported
     // even when the sessions DB does not exist yet.
     let scope = parse_lcm_scope(&args)?;
+    let provider = lcm_grep_provider_arg(&args, scope);
     let storage = lcm_open_storage_ro!(context, &args);
     let hits = storage
         .db

--- a/src/sessions/lcm/query.rs
+++ b/src/sessions/lcm/query.rs
@@ -1083,6 +1083,27 @@ fn expand_query_synthesis_prompt(
     LcmExpandQuerySynthesisPrompt { system, user }
 }
 
+fn grep_provider_filter(request: &LcmGrepRequest) -> Option<&str> {
+    let provider = request.provider.trim();
+    if provider.is_empty() || provider == "all" {
+        None
+    } else {
+        Some(provider)
+    }
+}
+
+fn push_grep_provider_filter(
+    request: &LcmGrepRequest,
+    column: &str,
+    filters: &mut Vec<String>,
+    values: &mut Vec<Value>,
+) {
+    if let Some(provider) = grep_provider_filter(request) {
+        filters.push(format!("{column} = ?"));
+        values.push(Value::Text(provider.to_string()));
+    }
+}
+
 async fn raw_grep_hits(
     conn: &Connection,
     request: &LcmGrepRequest,
@@ -1093,11 +1114,9 @@ async fn raw_grep_hits(
     if query_plan.requires_like_fallback {
         return raw_like_grep_hits(conn, request, session_id, query_plan, limit).await;
     }
-    let mut values = vec![
-        Value::Text(query_plan.fts_query.clone()),
-        Value::Text(request.provider.clone()),
-    ];
+    let mut values = vec![Value::Text(query_plan.fts_query.clone())];
     let mut filters = Vec::new();
+    push_grep_provider_filter(request, "r.provider", &mut filters, &mut values);
     push_raw_grep_filters(request, session_id, &mut filters, &mut values);
     values.push(Value::Integer(limit as i64));
     let filter_sql = if filters.is_empty() {
@@ -1115,7 +1134,6 @@ async fn raw_grep_hits(
          FROM lcm_raw_messages_fts
          JOIN lcm_raw_messages r ON r.store_id = lcm_raw_messages_fts.rowid
          WHERE lcm_raw_messages_fts MATCH ?
-           AND r.provider = ?
            {filter_sql}
          ORDER BY {order_by}
          LIMIT ?"
@@ -1139,11 +1157,9 @@ async fn summary_grep_hits(
     if query_plan.requires_like_fallback {
         return summary_like_grep_hits(conn, request, session_id, query_plan, limit).await;
     }
-    let mut values = vec![
-        Value::Text(query_plan.fts_query.clone()),
-        Value::Text(request.provider.clone()),
-    ];
+    let mut values = vec![Value::Text(query_plan.fts_query.clone())];
     let mut filters = Vec::new();
+    push_grep_provider_filter(request, "n.provider", &mut filters, &mut values);
     push_summary_grep_filters(request, session_id, &mut filters, &mut values);
     values.push(Value::Integer(limit as i64));
     let filter_sql = if filters.is_empty() {
@@ -1157,7 +1173,6 @@ async fn summary_grep_hits(
          FROM lcm_summary_nodes_fts
          JOIN lcm_summary_nodes n ON n.rowid = lcm_summary_nodes_fts.rowid
          WHERE lcm_summary_nodes_fts MATCH ?
-           AND n.provider = ?
            {filter_sql}
          ORDER BY {order_by}, n.node_id
          LIMIT ?"
@@ -1183,8 +1198,9 @@ async fn raw_like_grep_hits(
     }
     let fetch_limit = compute_like_fallback_fetch_limit(limit, query_plan);
 
-    let mut values = vec![Value::Text(request.provider.clone())];
+    let mut values = Vec::new();
     let mut filters = Vec::new();
+    push_grep_provider_filter(request, "r.provider", &mut filters, &mut values);
     push_raw_grep_filters(request, session_id, &mut filters, &mut values);
 
     let like_sql = like_predicate_sql(
@@ -1209,8 +1225,7 @@ async fn raw_like_grep_hits(
     let sql = format!(
         "SELECT r.provider, r.session_id, r.message_id, r.store_id, r.snippet_text, 0.0 AS rank
          FROM lcm_raw_messages r
-         WHERE r.provider = ?
-           AND {}
+         WHERE {}
          ORDER BY {order_by}
          LIMIT ?",
         filters.join(" AND "),
@@ -1238,8 +1253,9 @@ async fn summary_like_grep_hits(
     }
     let fetch_limit = compute_like_fallback_fetch_limit(limit, query_plan);
 
-    let mut values = vec![Value::Text(request.provider.clone())];
+    let mut values = Vec::new();
     let mut filters = Vec::new();
+    push_grep_provider_filter(request, "n.provider", &mut filters, &mut values);
     push_summary_grep_filters(request, session_id, &mut filters, &mut values);
 
     filters.push(like_predicate_sql(
@@ -1255,8 +1271,7 @@ async fn summary_like_grep_hits(
     let sql = format!(
         "SELECT n.provider, n.session_id, n.node_id, n.summary_text, 0.0 AS rank
          FROM lcm_summary_nodes n
-         WHERE n.provider = ?
-           AND {}
+         WHERE {}
          ORDER BY {order_by}, n.node_id
          LIMIT ?",
         filters.join(" AND "),

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -6609,12 +6609,24 @@ async fn seed_lcm_session_message(
     text: impl Into<String>,
     ordinal: i64,
 ) {
+    seed_lcm_session_message_for_provider(cg, "cursor", session_id, message_id, text, ordinal)
+        .await;
+}
+
+async fn seed_lcm_session_message_for_provider(
+    cg: &TraceDecay,
+    provider: &str,
+    session_id: &str,
+    message_id: &str,
+    text: impl Into<String>,
+    ordinal: i64,
+) {
     let db = open_project_session_db(cg.project_root())
         .await
         .expect("project-local session db should open");
     assert!(
         db.upsert_session(&SessionRecord {
-            provider: "cursor".to_string(),
+            provider: provider.to_string(),
             session_id: session_id.to_string(),
             project_key: cg.project_root().to_string_lossy().to_string(),
             project_path: cg.project_root().to_string_lossy().to_string(),
@@ -6632,7 +6644,7 @@ async fn seed_lcm_session_message(
     );
     assert!(
         db.upsert_session_message(&SessionMessageRecord {
-            provider: "cursor".to_string(),
+            provider: provider.to_string(),
             message_id: message_id.to_string(),
             session_id: session_id.to_string(),
             role: "assistant".to_string(),
@@ -8011,6 +8023,53 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
             .unwrap()
             .len(),
         1
+    );
+
+    seed_lcm_session_message_for_provider(
+        &cg,
+        "cursor",
+        "provider-local-session",
+        "cursor-provider-local-message",
+        "provider local collision belongs to cursor",
+        2,
+    )
+    .await;
+    seed_lcm_session_message_for_provider(
+        &cg,
+        "codex",
+        "provider-local-session",
+        "codex-provider-local-message",
+        "provider local collision belongs to codex",
+        3,
+    )
+    .await;
+
+    let scoped_default_provider_grep = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_grep",
+        json!({
+            "query": "provider local collision",
+            "scope": "session",
+            "session_id": "provider-local-session",
+            "limit": 5
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let scoped_default_provider_grep_payload: Value =
+        serde_json::from_str(extract_text(&scoped_default_provider_grep.value)).unwrap();
+    assert_eq!(scoped_default_provider_grep_payload["status"], "ok");
+    assert_eq!(scoped_default_provider_grep_payload["provider"], "cursor");
+    assert_eq!(scoped_default_provider_grep_payload["count"], 1);
+    assert_eq!(
+        scoped_default_provider_grep_payload["hits"][0]["provider"],
+        "cursor"
+    );
+    assert_eq!(
+        scoped_default_provider_grep_payload["hits"][0]["message_id"],
+        "cursor-provider-local-message"
     );
 
     let described = handle_tool_call(

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1358,6 +1358,18 @@ fn lcm_tool_schemas_are_registered_with_stable_names() {
         .iter()
         .find(|tool| tool.name == "tracedecay_lcm_grep")
         .expect("tracedecay_lcm_grep definition");
+    assert!(
+        !grep
+            .input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .is_some_and(|required| required.iter().any(|field| field == "provider")),
+        "tracedecay_lcm_grep provider must stay optional"
+    );
+    assert!(grep.input_schema["properties"]["provider"]["description"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("all providers"));
     assert_eq!(
         grep.input_schema["properties"]["limit"]["type"],
         json!("integer")
@@ -6356,6 +6368,22 @@ async fn message_search_reads_project_local_session_db() {
         parent_tool_use_id: None,
     };
     assert!(db.upsert_session(&child_session).await);
+    let codex_session = SessionRecord {
+        provider: "codex".to_string(),
+        session_id: "codex-session".to_string(),
+        project_key: cg.project_root().to_string_lossy().to_string(),
+        project_path: cg.project_root().to_string_lossy().to_string(),
+        title: Some("Codex transcript".to_string()),
+        started_at: Some(5),
+        ended_at: None,
+        transcript_path: Some("codex-session.jsonl".to_string()),
+        metadata_json: None,
+        parent_session_id: None,
+        is_subagent: false,
+        agent_id: None,
+        parent_tool_use_id: None,
+    };
+    assert!(db.upsert_session(&codex_session).await);
     assert!(
         db.upsert_session_message(&SessionMessageRecord {
             provider: "cursor".to_string(),
@@ -6369,6 +6397,24 @@ async fn message_search_reads_project_local_session_db() {
             model: Some("test-model".to_string()),
             tool_names: None,
             source_path: Some("cursor-session.jsonl".to_string()),
+            source_offset: Some(0),
+            metadata_json: None,
+        })
+        .await
+    );
+    assert!(
+        db.upsert_session_message(&SessionMessageRecord {
+            provider: "codex".to_string(),
+            message_id: "codex-message".to_string(),
+            session_id: "codex-session".to_string(),
+            role: "assistant".to_string(),
+            timestamp: Some(6),
+            ordinal: 1,
+            text: "Project-local transcript search is also working for Codex.".to_string(),
+            kind: Some("message".to_string()),
+            model: Some("test-model".to_string()),
+            tool_names: None,
+            source_path: Some("codex-session.jsonl".to_string()),
             source_offset: Some(0),
             metadata_json: None,
         })
@@ -6413,6 +6459,28 @@ async fn message_search_reads_project_local_session_db() {
         parsed["results"][0]["session"]["project_key"],
         cg.project_root().to_string_lossy().to_string()
     );
+
+    let all_provider_result = handle_tool_call(
+        &cg,
+        "tracedecay_message_search",
+        json!({"query": "transcript search", "limit": 5}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let all_provider_parsed = extract_json(&all_provider_result.value);
+    assert_eq!(all_provider_parsed["status"], "ok");
+    assert_eq!(all_provider_parsed["provider"], "all");
+    assert_eq!(all_provider_parsed["count"], 2);
+    let providers = all_provider_parsed["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|result| result["message"]["provider"].as_str().unwrap())
+        .collect::<std::collections::HashSet<_>>();
+    assert!(providers.contains("cursor"));
+    assert!(providers.contains("codex"));
 
     let subagent_result = handle_tool_call(
         &cg,
@@ -7922,6 +7990,27 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
             .count()
             <= 4096,
         "grep snippets must stay bounded"
+    );
+
+    let default_provider_grep = handle_tool_call(
+        &cg,
+        "tracedecay_lcm_grep",
+        json!({"query": "orchard dispatch", "limit": 5}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let default_provider_grep_payload: Value =
+        serde_json::from_str(extract_text(&default_provider_grep.value)).unwrap();
+    assert_eq!(default_provider_grep_payload["status"], "ok");
+    assert_eq!(default_provider_grep_payload["provider"], "all");
+    assert_eq!(
+        default_provider_grep_payload["hits"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
     );
 
     let described = handle_tool_call(
@@ -9800,8 +9889,16 @@ fn message_search_provider_schema_matches_ingested_providers() {
     assert_eq!(
         message_search.input_schema["properties"]["provider"]["enum"],
         serde_json::json!([
-            "cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "hermes"
+            "all", "cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "hermes"
         ])
+    );
+    assert!(
+        !message_search
+            .input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .is_some_and(|required| required.iter().any(|field| field == "provider")),
+        "tracedecay_message_search provider must stay optional"
     );
     assert_eq!(
         message_search.input_schema["properties"]["scope"]["enum"],

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -161,8 +161,46 @@ fn canonicalize_test_db_path(path: &Path) -> PathBuf {
 // Shared setup
 // ---------------------------------------------------------------------------
 
-struct TestProject {
+struct TestTempDir {
     dir: Option<TempDir>,
+}
+
+impl TestTempDir {
+    fn new() -> Self {
+        Self {
+            dir: Some(TempDir::new().unwrap()),
+        }
+    }
+
+    #[cfg(windows)]
+    fn keep(mut self) -> PathBuf {
+        self.dir.take().expect("test temp dir already kept").keep()
+    }
+}
+
+impl std::ops::Deref for TestTempDir {
+    type Target = TempDir;
+
+    fn deref(&self) -> &Self::Target {
+        self.dir.as_ref().expect("test temp dir already kept")
+    }
+}
+
+impl Drop for TestTempDir {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        if let Some(dir) = self.dir.take() {
+            let _ = dir.keep();
+        }
+    }
+}
+
+fn test_temp_dir() -> TestTempDir {
+    TestTempDir::new()
+}
+
+struct TestProject {
+    dir: Option<TestTempDir>,
     _env_lock: MutexGuard<'static, ()>,
     _home_guard: HomeEnvGuard,
     _global_db_guard: GlobalDbEnvGuard,
@@ -178,10 +216,7 @@ impl std::ops::Deref for TestProject {
 
 impl Drop for TestProject {
     fn drop(&mut self) {
-        #[cfg(windows)]
-        if let Some(dir) = self.dir.take() {
-            let _ = dir.keep();
-        }
+        let _ = self.dir.take();
     }
 }
 
@@ -192,7 +227,7 @@ struct TestEnv {
 }
 
 struct CrossProjectMemoryEnv {
-    _dir: TempDir,
+    _dir: TestTempDir,
     _env_lock: MutexGuard<'static, ()>,
     _storage_guard: common::TraceDecayStorageEnvGuard,
 }
@@ -259,7 +294,7 @@ impl Drop for TestTraceDecay {
 /// test files, and doc comments, then initialises and indexes a `TraceDecay`.
 async fn setup_project() -> (TestTraceDecay, TestProject) {
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     let home = project.join("home");
     let home_guard = HomeEnvGuard::set(&home);
@@ -341,8 +376,8 @@ async fn init_test_project(project: &Path) -> (TestTraceDecay, TestEnv) {
     )
 }
 
-async fn setup_generated_dir_project(include_dist: bool) -> (TestTraceDecay, TestEnv, TempDir) {
-    let dir = TempDir::new().unwrap();
+async fn setup_generated_dir_project(include_dist: bool) -> (TestTraceDecay, TestEnv, TestTempDir) {
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::create_dir_all(project.join("dist")).unwrap();
@@ -364,7 +399,7 @@ async fn setup_generated_dir_project(include_dist: bool) -> (TestTraceDecay, Tes
 async fn setup_cross_project_memory_projects(
 ) -> (TestTraceDecay, TestTraceDecay, CrossProjectMemoryEnv) {
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let storage_guard = common::isolated_tracedecay_storage(&dir);
 
     let active_project = dir.path().join("active");
@@ -419,7 +454,7 @@ fn project_session_db_path(cg: &TraceDecay) -> PathBuf {
 /// public entry point, which then reaches an internal helper. This exercises
 /// the calibrated depth-3 attribution path in `tracedecay_test_risk`.
 async fn setup_integration_test_risk_project() -> (TestTraceDecay, TestProject) {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
     let home = project.join("home");
@@ -494,7 +529,7 @@ fn integration_public_entry() {
 /// Extends the calibrated integration-risk fixture with a build script so the
 /// test-risk denominator can prove non-`src/` functions are excluded.
 async fn setup_test_risk_non_src_fixture() -> (TestTraceDecay, TestProject) {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
     let home = project.join("home");
@@ -699,7 +734,7 @@ async fn seed_project_registry(db_path: &Path, project_root: &Path) {
 #[tokio::test]
 async fn project_registry_tools_are_bounded_read_only_and_contextual() {
     let (cg, _project_dir) = setup_project().await;
-    let registry_dir = TempDir::new().unwrap();
+    let registry_dir = test_temp_dir();
     let registry_path = registry_dir.path().join("global.db");
     seed_project_registry(&registry_path, cg.project_root()).await;
     let _env_guard = GlobalDbEnvGuard::set(&registry_path);
@@ -772,9 +807,9 @@ async fn project_registry_tools_are_bounded_read_only_and_contextual() {
 #[tokio::test]
 async fn project_registry_tools_prefer_injected_registry_over_process_default() {
     let (cg, _project_dir) = setup_project().await;
-    let process_registry_dir = TempDir::new().unwrap();
+    let process_registry_dir = test_temp_dir();
     let process_registry_path = process_registry_dir.path().join("global.db");
-    let client_registry_dir = TempDir::new().unwrap();
+    let client_registry_dir = test_temp_dir();
     let client_registry_path = client_registry_dir.path().join("global.db");
     let _env_guard = GlobalDbEnvGuard::set(&process_registry_path);
 
@@ -855,10 +890,10 @@ async fn project_registry_tools_prefer_injected_registry_over_process_default() 
 #[tokio::test]
 async fn selected_project_read_skips_cache_write_for_read_only_store() {
     let (cg, _project_dir) = setup_project().await;
-    let registry_dir = TempDir::new().unwrap();
+    let registry_dir = test_temp_dir();
     let registry_path = registry_dir.path().join("global.db");
     let _env_guard = GlobalDbEnvGuard::set(&registry_path);
-    let target_dir = TempDir::new().unwrap();
+    let target_dir = test_temp_dir();
     let target_project = target_dir.path();
 
     fs::create_dir_all(target_project.join("src")).unwrap();
@@ -2122,7 +2157,7 @@ async fn test_branch_list_reports_live_vs_serving_drift_state() {
         );
     }
 
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     let _env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
     let home = project.join("home");
@@ -2800,7 +2835,7 @@ async fn test_port_status() {
 /// distinct owners stay unmatched.
 #[tokio::test]
 async fn port_status_does_not_match_methods_of_different_parents() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src_a")).unwrap();
     fs::create_dir_all(project.join("src_b")).unwrap();
@@ -2858,7 +2893,7 @@ async fn port_status_does_not_match_methods_of_different_parents() {
 /// match — confirming the parent-aware key isn't too strict.
 #[tokio::test]
 async fn port_status_matches_methods_with_same_parent_type() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src_a")).unwrap();
     fs::create_dir_all(project.join("src_b")).unwrap();
@@ -3190,7 +3225,7 @@ async fn test_port_order_missing_source_dir() {
 
 #[tokio::test]
 async fn commit_context_clean_worktree_returns_json() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fn git(cwd: &std::path::Path, args: &[&str]) {
         std::process::Command::new("git")
@@ -3235,7 +3270,7 @@ async fn commit_context_clean_worktree_returns_json() {
 
 #[tokio::test]
 async fn test_changelog_with_real_git() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -3618,7 +3653,7 @@ async fn test_status_no_scope_prefix() {
 
 #[tokio::test]
 async fn test_str_replace_success() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -3658,7 +3693,7 @@ async fn test_str_replace_success() {
 
 #[tokio::test]
 async fn path_containment_config_rejects_parent_traversal_before_serving_config() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path().join("repo");
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/main.rs"), "fn main() {}\n").unwrap();
@@ -3689,7 +3724,7 @@ async fn path_containment_config_rejects_parent_traversal_before_serving_config(
 
 #[tokio::test]
 async fn path_containment_read_rejects_parent_traversal_before_serving_file() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path().join("repo");
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/main.rs"), "fn main() {}\n").unwrap();
@@ -3716,7 +3751,7 @@ async fn path_containment_read_rejects_parent_traversal_before_serving_file() {
 #[cfg(unix)]
 #[tokio::test]
 async fn read_and_outline_preserve_symlink_indexed_file_key() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path().join("repo");
     let external = dir.path().join("external-src");
     fs::create_dir_all(&project).unwrap();
@@ -3813,7 +3848,7 @@ async fn outline_preserves_db_payload_and_adds_ast_grep_outline_when_available()
 #[cfg(unix)]
 #[tokio::test]
 async fn path_containment_config_rejects_symlink_escape_before_serving_config() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path().join("repo");
     let outside_dir = dir.path().join("outside");
     fs::create_dir_all(project.join("src")).unwrap();
@@ -3923,7 +3958,7 @@ async fn lcm_project_path_selector_is_rejected_before_dispatch() {
 
 #[tokio::test]
 async fn test_str_replace_not_found() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -3954,7 +3989,7 @@ async fn test_str_replace_not_found() {
 
 #[tokio::test]
 async fn test_str_replace_multiple_matches_fails() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -3988,7 +4023,7 @@ async fn test_str_replace_multiple_matches_fails() {
 
 #[tokio::test]
 async fn test_multi_str_replace_success() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4030,7 +4065,7 @@ async fn test_multi_str_replace_success() {
 
 #[tokio::test]
 async fn test_multi_str_replace_atomic_failure() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4071,7 +4106,7 @@ async fn test_multi_str_replace_atomic_failure() {
 
 #[tokio::test]
 async fn test_multi_str_replace_unicode_preview_does_not_panic() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4112,7 +4147,7 @@ async fn test_multi_str_replace_unicode_preview_does_not_panic() {
 async fn test_str_replace_unsupported_file_type_succeeds() {
     // Regression: editing unsupported types (e.g. .css) previously wrote the
     // file then returned a reindex error, silently mutating the file.
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
 
     fs::write(project.join("style.css"), ".foo {\n\tfont-size: 14px;\n}\n").unwrap();
@@ -4148,7 +4183,7 @@ async fn ast_grep_rewrite_has_literal_fallback_when_binary_missing() {
     if tracedecay::mcp::tools::ast_grep_available() {
         return;
     }
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub fn old_name() {}\n").unwrap();
@@ -4180,7 +4215,7 @@ async fn ast_grep_rewrite_uses_current_cli_update_flag() {
     if !tracedecay::mcp::tools::ast_grep_available() {
         return;
     }
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -4261,7 +4296,7 @@ async fn ast_grep_rewrite_surfaces_useful_error_on_empty_stderr() {
     if !tracedecay::mcp::tools::ast_grep_available() {
         return;
     }
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub fn foo() {}\n").unwrap();
@@ -4298,7 +4333,7 @@ async fn ast_grep_rewrite_surfaces_useful_error_on_empty_stderr() {
 
 #[tokio::test]
 async fn test_multi_str_replace_unsupported_file_type_succeeds() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
 
     fs::write(
@@ -4342,7 +4377,7 @@ async fn test_multi_str_replace_unsupported_file_type_succeeds() {
 
 #[tokio::test]
 async fn test_insert_at_string_anchor_before() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4388,7 +4423,7 @@ async fn test_insert_at_string_anchor_before() {
 
 #[tokio::test]
 async fn test_insert_at_line_number() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4435,7 +4470,7 @@ async fn test_insert_at_line_number() {
 
 #[tokio::test]
 async fn test_insert_at_anchor_not_found() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4467,7 +4502,7 @@ async fn test_insert_at_anchor_not_found() {
 
 #[tokio::test]
 async fn test_insert_at_unicode_anchor_prefix_does_not_panic() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4504,7 +4539,7 @@ async fn test_insert_at_unicode_anchor_prefix_does_not_panic() {
 
 #[tokio::test]
 async fn test_insert_at_ambiguous_anchor() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4544,7 +4579,7 @@ async fn test_insert_at_ambiguous_anchor() {
 // Regression: insert_at must not strip trailing newline (#57)
 #[tokio::test]
 async fn test_insert_at_preserves_trailing_newline() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -4711,7 +4746,7 @@ async fn test_health_detailed() {
 /// top hit with the `definite` severity bucket.
 #[tokio::test]
 async fn test_redundancy_finds_planted_duplicate() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
 
@@ -5255,7 +5290,7 @@ async fn test_body_missing_symbol_param() {
 
 #[tokio::test]
 async fn test_todos_finds_markers() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -5308,7 +5343,7 @@ fn helper() {
 
 #[tokio::test]
 async fn test_todos_filters_by_kind() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -6224,7 +6259,7 @@ async fn memory_fact_store_uses_project_store_when_serving_branch_db() {
     }
 
     let _guard = GLOBAL_DB_ENV_LOCK.lock().await;
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path().join("repo");
     let home = dir.path().join("home");
     let _home_guard = HomeEnvGuard::set(&home);
@@ -6514,7 +6549,7 @@ async fn message_search_reads_project_local_session_db() {
 #[tokio::test]
 async fn message_search_reads_profile_sharded_session_db() {
     let _guard = GLOBAL_DB_ENV_LOCK.lock().await;
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path().join("repo");
     let home = dir.path().join("home");
     let shard_root = home.join(".tracedecay/projects/proj_123");
@@ -7896,7 +7931,7 @@ async fn lcm_doctor_uses_explicit_hermes_profile_session_db() {
     )
     .await;
 
-    let hermes_home = TempDir::new().unwrap();
+    let hermes_home = test_temp_dir();
     let profile_db = open_hermes_profile_session_db(hermes_home.path()).await;
     seed_lcm_session_message_in_db(
         &profile_db,
@@ -9078,7 +9113,7 @@ async fn lcm_status_uses_explicit_hermes_profile_session_db() {
     )
     .await;
 
-    let hermes_home = TempDir::new().unwrap();
+    let hermes_home = test_temp_dir();
     let profile_db = open_hermes_profile_session_db(hermes_home.path()).await;
     seed_lcm_session_message_in_db(
         &profile_db,
@@ -9135,7 +9170,7 @@ async fn lcm_load_and_grep_use_explicit_hermes_profile_session_db() {
     )
     .await;
 
-    let hermes_home = TempDir::new().unwrap();
+    let hermes_home = test_temp_dir();
     let profile_db = open_hermes_profile_session_db(hermes_home.path()).await;
     seed_lcm_session_message_in_db(
         &profile_db,
@@ -9284,8 +9319,8 @@ async fn lcm_hermes_profile_requires_explicit_valid_home_without_fallback() {
 #[tokio::test]
 async fn lcm_hermes_profile_rejects_symlinked_tracedecay_dir_escape() {
     let (cg, _dir) = setup_project().await;
-    let hermes_home = TempDir::new().unwrap();
-    let outside = TempDir::new().unwrap();
+    let hermes_home = test_temp_dir();
+    let outside = test_temp_dir();
     unix_fs::symlink(outside.path(), hermes_home.path().join(".tracedecay")).unwrap();
 
     let result = handle_tool_call(
@@ -9318,7 +9353,7 @@ async fn lcm_hermes_profile_rejects_symlinked_tracedecay_dir_escape() {
 #[tokio::test]
 async fn lcm_hermes_profile_rejects_non_directory_home() {
     let (cg, _dir) = setup_project().await;
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let hermes_home = dir.path().join("hermes-home-file");
     fs::write(&hermes_home, "not a directory").unwrap();
 
@@ -9742,7 +9777,7 @@ async fn lcm_status_cli_bridge_accepts_json_args() {
     let (cg, _dir) = setup_project().await;
     let home = _dir.path().join("home");
     let _daemon = common::spawn_tracedecay_daemon(&home);
-    let outside_cwd = TempDir::new().unwrap();
+    let outside_cwd = test_temp_dir();
     let project_arg = cg.project_root().display().to_string();
     let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_tracedecay"));
     common::apply_tracedecay_home_env(&mut command, &home);
@@ -9784,11 +9819,11 @@ async fn lcm_status_cli_bridge_accepts_json_args() {
 #[tokio::test]
 async fn lcm_status_cli_profile_scope_dispatches_without_initialized_project() {
     let env_lock = GLOBAL_DB_ENV_LOCK.lock().await;
-    let home = TempDir::new().unwrap();
+    let home = test_temp_dir();
     let _home_guard = HomeEnvGuard::set(home.path());
     let _global_db_guard = GlobalDbEnvGuard::set(&home.path().join(".tracedecay/global.db"));
-    let outside_cwd = TempDir::new().unwrap();
-    let hermes_home = TempDir::new().unwrap();
+    let outside_cwd = test_temp_dir();
+    let hermes_home = test_temp_dir();
     let profile_db = open_hermes_profile_session_db(hermes_home.path()).await;
     seed_lcm_session_message_in_db(
         &profile_db,
@@ -10040,8 +10075,8 @@ async fn memory_status_repairs_dirty_banks_before_reporting() {
 /// searching for `gmres`: the codebase has both a `pub fn gmres(...)` and a
 /// struct field literally named `gmres`. The function — the body the user
 /// actually wants — must outrank the field.
-async fn setup_function_vs_field_collision() -> (TestTraceDecay, TempDir) {
-    let dir = TempDir::new().unwrap();
+async fn setup_function_vs_field_collision() -> (TestTraceDecay, TestTempDir) {
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10096,7 +10131,7 @@ async fn body_prefers_function_over_field_with_same_name() {
 /// symbols all reached the same dependent.
 #[tokio::test]
 async fn diff_context_dedupes_impacted_symbols() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     // Two functions in `mod.rs` both call `shared` in `dep.rs`. Without dedup,
@@ -10141,7 +10176,7 @@ pub fn second() { dep::shared(); }
 /// genuine direct recursion while filtering length-1 self-edge artifacts.
 #[tokio::test]
 async fn recursion_keeps_direct_recursion() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10181,7 +10216,7 @@ pub fn nonrecursive() -> u32 { 42 }
 
 #[tokio::test]
 async fn recursion_filters_self_edge_artifacts() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10220,7 +10255,7 @@ impl Triplet {
 
 #[tokio::test]
 async fn recursion_reports_real_cycle_path() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10264,7 +10299,7 @@ pub fn c() { a(); }
 /// directory.
 #[tokio::test]
 async fn changelog_filters_directory_paths() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     std::process::Command::new("git")
         .args(["init"])
@@ -10347,7 +10382,7 @@ async fn changelog_filters_directory_paths() {
 /// condition never fired and the tool returned 0 on every real codebase.
 #[tokio::test]
 async fn unused_imports_detects_truly_unused() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10385,7 +10420,7 @@ pub fn used_one() -> HashMap<u32, u32> { HashMap::new() }
 /// is mostly `pub` the tool reported 0 dead symbols.
 #[tokio::test]
 async fn dead_code_with_include_public_finds_pub_unreferenced() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10442,7 +10477,7 @@ pub fn caller() { called(); }
 async fn dependency_depth_excludes_implements_and_extends() {
     // Public helper exposed from the lib for unit-test inspection.
     use tracedecay::graph::queries::GraphQueryManager;
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     // file_a derives Debug — extractor emits derives_macro and the
@@ -10498,7 +10533,7 @@ pub trait T {}
 /// paths" and skip running anything.
 #[tokio::test]
 async fn run_affected_tests_dispatches_directly_changed_test_files() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::create_dir_all(project.join("tests")).unwrap();
@@ -10567,7 +10602,7 @@ fn edited_only_test() {
 /// to `node: null` even though the file is indexed.
 #[tokio::test]
 async fn diagnose_normalizes_absolute_and_backslash_paths() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub fn target() {}\n").unwrap();
@@ -10607,7 +10642,7 @@ async fn diagnose_normalizes_absolute_and_backslash_paths() {
 /// name.
 #[tokio::test]
 async fn resolver_blocklist_branch_respects_kind_filter() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     // Use a struct named after a blocklisted identifier ("new") plus a
@@ -10668,7 +10703,7 @@ pub fn helper() {}
 /// references must only resolve to trait-shaped targets.
 #[tokio::test]
 async fn implements_refs_dont_resolve_to_enum_variants() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10716,7 +10751,7 @@ impl Default for B { fn default() -> Self { B } }
 /// one entry per genuine component.
 #[tokio::test]
 async fn circular_reports_one_entry_per_scc_not_per_walk() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     // Three-file cycle: a uses b, b uses c, c uses a. Multiple DFS walks
@@ -10765,7 +10800,7 @@ async fn circular_reports_one_entry_per_scc_not_per_walk() {
 /// agent had no way to know what to break first.
 #[tokio::test]
 async fn port_order_reports_separate_scc_groups() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     // Two disjoint mutually-recursive pairs: (a, b) and (c, d). Before
@@ -10830,7 +10865,7 @@ pub fn leaf() {}
 /// / `break_point_candidate` suggestions.
 #[tokio::test]
 async fn port_order_provides_intra_cycle_ordering() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     // a → b → c → a, plus a "hub" h that all three call into and that
@@ -10905,7 +10940,7 @@ pub fn h() { a(); }
 /// not make singleton symbols appear as cycles.
 #[tokio::test]
 async fn port_order_ignores_self_edges() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub mod m;\n").unwrap();
@@ -10948,7 +10983,7 @@ impl Triplet {
 /// supertrait chains (`trait T: U`) as `Extends` edges.
 #[tokio::test]
 async fn inheritance_depth_walks_rust_supertraits() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -10989,7 +11024,7 @@ pub trait Leaf: Middle {}
 /// them and asserts no file leaks into a second cycle entry.
 #[tokio::test]
 async fn circular_emits_disjoint_sccs_under_load() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     let mut lib_rs = String::new();
@@ -11052,7 +11087,7 @@ async fn circular_emits_disjoint_sccs_under_load() {
 /// same file path duplicated upstream.
 #[tokio::test]
 async fn diff_context_dedupes_modified_symbols_on_duplicate_input() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -11094,7 +11129,7 @@ async fn diff_context_dedupes_modified_symbols_on_duplicate_input() {
 /// before they're ever pushed into the change list.
 #[tokio::test]
 async fn changelog_filters_deleted_directory_entries() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fn git(cwd: &std::path::Path, args: &[&str]) {
         std::process::Command::new("git")
@@ -11151,7 +11186,7 @@ async fn changelog_filters_deleted_directory_entries() {
 /// a single summary symbol.
 #[tokio::test]
 async fn pr_context_collapses_cargo_toml_keys() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fn git(cwd: &std::path::Path, args: &[&str]) {
         std::process::Command::new("git")
@@ -11237,7 +11272,7 @@ async fn pr_context_collapses_cargo_toml_keys() {
 /// nodes.
 #[tokio::test]
 async fn unused_imports_handles_grouped_use() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -11298,7 +11333,7 @@ pub fn used() -> HashMap<u32, u32> { HashMap::new() }
 /// across 5,715.
 #[tokio::test]
 async fn dead_code_flags_unreferenced_fn_with_attribute() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(
@@ -11344,7 +11379,7 @@ fn dead_helper_with_attr() {}
 /// real def always beats `use` rows.
 #[tokio::test]
 async fn search_ranks_trait_definition_above_use_reexports() {
-    let dir = TempDir::new().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src/a")).unwrap();
     fs::create_dir_all(project.join("src/b")).unwrap();
@@ -11402,7 +11437,7 @@ pub mod e;
 
 #[tokio::test]
 async fn refresh_file_token_map_picks_up_new_files() {
-    let tmp = tempfile::tempdir().unwrap();
+    let tmp = test_temp_dir();
     let project = tmp.path();
     std::fs::write(project.join("a.rs"), "fn a() {}").unwrap();
 
@@ -11438,7 +11473,7 @@ async fn refresh_file_token_map_picks_up_new_files() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcp_server_owns_watcher_and_refreshes_token_map_on_change() {
-    let tmp = tempfile::tempdir().unwrap();
+    let tmp = test_temp_dir();
     let project = tmp.path();
     std::fs::write(project.join("a.rs"), "fn a() {}").unwrap();
 
@@ -11953,7 +11988,7 @@ async fn message_search_rejects_invalid_scope() {
 ///   3. NOT create the sessions.db file on disk.
 #[tokio::test]
 async fn lcm_read_only_tools_return_not_ingested_without_creating_sessions_db() {
-    let dir = tempfile::tempdir().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     std::fs::write(project.join("lib.rs"), "fn f() {}").unwrap();
     let (cg, _env) = init_test_project(project).await;
@@ -12025,7 +12060,7 @@ async fn lcm_read_only_tools_return_not_ingested_without_creating_sessions_db() 
 /// payload reflects it.
 #[tokio::test]
 async fn lcm_expand_query_context_max_tokens_is_independent_of_max_tokens() {
-    let dir = tempfile::tempdir().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     std::fs::write(project.join("lib.rs"), "fn f() {}").unwrap();
     let (cg, _env) = init_test_project(project).await;
@@ -12071,7 +12106,7 @@ async fn lcm_expand_query_context_max_tokens_is_independent_of_max_tokens() {
 /// `transcript_ingest_done` flag is always true.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn wait_for_startup_catch_up_waits_for_transcript_ingest_flag() {
-    let dir = tempfile::tempdir().unwrap();
+    let dir = test_temp_dir();
     let project = dir.path();
     std::fs::write(project.join("lib.rs"), "fn f() {}").unwrap();
 

--- a/tests/session_lcm_query_test.rs
+++ b/tests/session_lcm_query_test.rs
@@ -1928,6 +1928,47 @@ fn grep_request(query: &str) -> LcmGrepRequest {
     }
 }
 
+#[tokio::test]
+async fn grep_all_provider_searches_raw_messages_across_providers() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    insert_session(&db, "cursor", "cursor-session").await;
+    insert_session(&db, "codex", "codex-session").await;
+    assert!(
+        db.upsert_session_message(&raw_message(
+            "cursor",
+            "cursor-cross-provider",
+            "cursor-session",
+            1,
+            "Cross provider grep search should find cursor."
+        ))
+        .await
+    );
+    assert!(
+        db.upsert_session_message(&raw_message(
+            "codex",
+            "codex-cross-provider",
+            "codex-session",
+            1,
+            "Cross provider grep search should find codex."
+        ))
+        .await
+    );
+
+    let mut request = grep_request("cross provider grep search");
+    request.provider = "all".into();
+    let hits = db
+        .lcm_grep(request)
+        .await
+        .expect("all-provider grep should succeed");
+    let providers = hits
+        .iter()
+        .map(|hit| hit.provider.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert!(providers.contains("cursor"));
+    assert!(providers.contains("codex"));
+}
+
 // Hermes scopes message FTS matches to the content column only
 // (store.py:173-204 `build_message_fts_spec` indexes nothing but `content`).
 // Role and metadata text must therefore never satisfy an unqualified grep.


### PR DESCRIPTION
## Summary

- make `tracedecay_message_search`, `tracedecay_lcm_grep`, and `tracedecay sessions search` default to all ingested providers when provider is omitted or set to `all`
- keep explicit provider filters working for narrowed searches
- update tool schemas, generated agent guidance, docs, and focused coverage for optional provider behavior

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test --test mcp_handler_test message_search_reads_project_local_session_db`
- `cargo test --test mcp_handler_test message_search_provider_schema_matches_ingested_providers`
- `cargo test --test mcp_handler_test lcm_tool_schemas_are_registered_with_stable_names`
- `cargo test --test mcp_handler_test lcm_session_handlers_expose_bounded_read_apis_and_placeholders`
- `cargo test --test session_lcm_query_test grep_all_provider_searches_raw_messages_across_providers`
- `cargo test --bin tracedecay cli::cli_parse_tests::parses_sessions_ingest_and_search_commands`
- `cargo check --bin tracedecay`