### PR TITLE
[codex] catalog Codex goal contexts

### DIFF
--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -24,11 +24,13 @@
 //!   `session_meta` has `thread_source == "subagent"` and parent ids in
 //!   `forked_from_id` / `source.subagent.thread_spawn.parent_thread_id`.
 //!
-//! `response_item` entries are intentionally skipped: they carry auto-injected
-//! synthetic context and duplicate the `agent_message`/`user_message` turns, so
-//! ingesting them would double-count the conversation. This append-only JSONL is
-//! read with the shared byte-offset machinery and scoped to the current project
-//! by `session_meta.cwd`.
+//! `response_item` entries are intentionally skipped except for Codex goal
+//! context blocks: they usually carry auto-injected synthetic context and
+//! duplicate the `agent_message`/`user_message` turns, so ingesting them would
+//! double-count the conversation. Goal context blocks are cataloged as compact
+//! `goal_context` rows because real rollouts often record them only in
+//! `response_item` form. This append-only JSONL is read with the shared
+//! byte-offset machinery and scoped to the current project by `session_meta.cwd`.
 
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
@@ -136,6 +138,16 @@ impl TranscriptSource for CodexSource {
             }
             if let Some(model) = turn_context_model(&line.value) {
                 current_model = Some(model);
+                continue;
+            }
+            if let Some(message) = response_item_goal_context_from_line(
+                &line.value,
+                &meta,
+                current_model.as_deref(),
+                path,
+                line.offset,
+            ) {
+                messages.push(message);
                 continue;
             }
             if let Some(message) = compacted_summary_from_line(
@@ -374,11 +386,18 @@ fn message_from_line(
         return None;
     }
 
-    let timestamp = record
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .and_then(parse_timestamp)
-        .map(|secs| secs as i64);
+    let timestamp = timestamp_from_record(record);
+    if let Some(goal_context) = codex_goal_context_from_text(&text) {
+        return Some(goal_context_message(
+            meta,
+            model,
+            path,
+            offset,
+            timestamp,
+            &goal_context,
+            message_metadata(payload, Some(&goal_context)),
+        ));
+    }
 
     Some(SessionMessageRecord {
         provider: PROVIDER.to_string(),
@@ -393,8 +412,104 @@ fn message_from_line(
         tool_names: (!tool_names.is_empty()).then(|| tool_names.join(",")),
         source_path: Some(path.to_string_lossy().to_string()),
         source_offset: Some(offset),
-        metadata_json: serde_json::to_string(&message_metadata(payload)).ok(),
+        metadata_json: serde_json::to_string(&message_metadata(payload, None)).ok(),
     })
+}
+
+fn response_item_goal_context_from_line(
+    record: &Value,
+    meta: &CodexMeta,
+    model: Option<&str>,
+    path: &Path,
+    offset: i64,
+) -> Option<SessionMessageRecord> {
+    if record.get("type").and_then(Value::as_str) != Some("response_item") {
+        return None;
+    }
+    let payload = record.get("payload")?;
+    if payload.get("type").and_then(Value::as_str) != Some("message") {
+        return None;
+    }
+    let text = collect_response_item_text(payload.get("content").unwrap_or(payload));
+    let goal_context = codex_goal_context_from_text(&text)?;
+    let mut metadata = message_metadata(payload, Some(&goal_context));
+    if let Value::Object(map) = &mut metadata {
+        map.insert(
+            "source_event".to_string(),
+            Value::String("response_item".to_string()),
+        );
+        if let Some(role) = payload.get("role").and_then(Value::as_str) {
+            map.insert("source_role".to_string(), Value::String(role.to_string()));
+        }
+    }
+
+    Some(goal_context_message(
+        meta,
+        model,
+        path,
+        offset,
+        timestamp_from_record(record),
+        &goal_context,
+        metadata,
+    ))
+}
+
+fn goal_context_message(
+    meta: &CodexMeta,
+    model: Option<&str>,
+    path: &Path,
+    offset: i64,
+    timestamp: Option<i64>,
+    goal_context: &CodexGoalContext,
+    metadata: Value,
+) -> SessionMessageRecord {
+    SessionMessageRecord {
+        provider: PROVIDER.to_string(),
+        message_id: format!("{}:{offset}", meta.session_id),
+        session_id: meta.session_id.clone(),
+        role: "system".to_string(),
+        timestamp,
+        ordinal: offset,
+        text: goal_context.storage_text(),
+        kind: Some("goal_context".to_string()),
+        model: model.map(str::to_string),
+        tool_names: None,
+        source_path: Some(path.to_string_lossy().to_string()),
+        source_offset: Some(offset),
+        metadata_json: serde_json::to_string(&metadata).ok(),
+    }
+}
+
+fn collect_response_item_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .map(collect_response_item_text)
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Value::Object(map) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                return text.to_string();
+            }
+            ["content", "message", "item"]
+                .iter()
+                .filter_map(|key| map.get(*key))
+                .map(collect_response_item_text)
+                .find(|text| !text.is_empty())
+                .unwrap_or_default()
+        }
+        _ => String::new(),
+    }
+}
+
+fn timestamp_from_record(record: &Value) -> Option<i64> {
+    record
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp)
+        .map(|secs| secs as i64)
 }
 
 fn compacted_summary_from_line(
@@ -451,12 +566,6 @@ fn compacted_summary_from_line(
         str::to_string,
     );
 
-    let timestamp = record
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .and_then(parse_timestamp)
-        .map(|secs| secs as i64);
-
     let mut metadata = serde_json::Map::new();
     metadata.insert(
         "source".to_string(),
@@ -486,7 +595,7 @@ fn compacted_summary_from_line(
         message_id: format!("{}:{offset}", meta.session_id),
         session_id: meta.session_id.clone(),
         role: "assistant".to_string(),
-        timestamp,
+        timestamp: timestamp_from_record(record),
         ordinal: offset,
         text,
         kind: Some("summary".to_string()),
@@ -498,12 +607,130 @@ fn compacted_summary_from_line(
     })
 }
 
-fn message_metadata(payload: &Value) -> Value {
+struct CodexGoalContext {
+    objective: String,
+    tokens_used: Option<i64>,
+    token_budget: Option<i64>,
+    token_budget_unbounded: bool,
+    tokens_remaining: Option<i64>,
+    tokens_remaining_unbounded: bool,
+}
+
+impl CodexGoalContext {
+    fn storage_text(&self) -> String {
+        format!("Codex active goal: {}", self.objective)
+    }
+
+    fn metadata(&self) -> Value {
+        let mut goal = serde_json::Map::new();
+        goal.insert("source".to_string(), Value::String("goal".to_string()));
+        goal.insert(
+            "objective".to_string(),
+            Value::String(self.objective.clone()),
+        );
+        if let Some(tokens_used) = self.tokens_used {
+            goal.insert("tokens_used".to_string(), Value::from(tokens_used));
+        }
+        if let Some(token_budget) = self.token_budget {
+            goal.insert("token_budget".to_string(), Value::from(token_budget));
+        }
+        if self.token_budget_unbounded {
+            goal.insert("token_budget_unbounded".to_string(), Value::from(true));
+        }
+        if let Some(tokens_remaining) = self.tokens_remaining {
+            goal.insert(
+                "tokens_remaining".to_string(),
+                Value::from(tokens_remaining),
+            );
+        }
+        if self.tokens_remaining_unbounded {
+            goal.insert("tokens_remaining_unbounded".to_string(), Value::from(true));
+        }
+        Value::Object(goal)
+    }
+}
+
+fn codex_goal_context_from_text(text: &str) -> Option<CodexGoalContext> {
+    const START: &str = "<codex_internal_context source=\"goal\">";
+    const END: &str = "</codex_internal_context>";
+    let start = text.find(START)?;
+    if !text[..start].trim().is_empty() {
+        return None;
+    }
+    let after_start = &text[start + START.len()..];
+    let end = after_start.find(END)?;
+    if !after_start[end + END.len()..].trim().is_empty() {
+        return None;
+    }
+    let body = &after_start[..end];
+    let objective = tag_body(body, "objective")?.trim();
+    if objective.is_empty() {
+        return None;
+    }
+    let token_budget_line = budget_line_value(body, "Token budget:");
+    let tokens_remaining_line = budget_line_value(body, "Tokens remaining:");
+    Some(CodexGoalContext {
+        objective: objective.to_string(),
+        tokens_used: budget_line_value(body, "Tokens used:").and_then(parse_budget_count),
+        token_budget: token_budget_line.and_then(parse_budget_count),
+        token_budget_unbounded: token_budget_line.is_some_and(is_unbounded_budget_value),
+        tokens_remaining: tokens_remaining_line.and_then(parse_budget_count),
+        tokens_remaining_unbounded: tokens_remaining_line.is_some_and(is_unbounded_budget_value),
+    })
+}
+
+fn tag_body<'a>(text: &'a str, tag: &str) -> Option<&'a str> {
+    let start_tag = format!("<{tag}>");
+    let end_tag = format!("</{tag}>");
+    let after_start = text.split_once(&start_tag)?.1;
+    let body = after_start.split_once(&end_tag)?.0;
+    Some(body)
+}
+
+fn budget_line_value<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    text.lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix("- ")?.trim().strip_prefix(prefix))
+        .or_else(|| {
+            text.lines()
+                .map(str::trim)
+                .find_map(|line| line.strip_prefix(prefix))
+        })
+        .map(str::trim)
+}
+
+fn parse_budget_count(value: &str) -> Option<i64> {
+    let digits = value
+        .chars()
+        .filter(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse::<i64>().ok()
+    }
+}
+
+fn is_unbounded_budget_value(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "none" | "unbounded"
+    )
+}
+
+fn message_metadata(payload: &Value, goal_context: Option<&CodexGoalContext>) -> Value {
     let mut metadata = serde_json::Map::new();
     metadata.insert(
         "source".to_string(),
         Value::String("codex_rollout".to_string()),
     );
+    if let Some(goal_context) = goal_context {
+        metadata.insert(
+            "codex_internal_context".to_string(),
+            Value::String("goal".to_string()),
+        );
+        metadata.insert("codex_goal".to_string(), goal_context.metadata());
+    }
     append_tool_calls_metadata(&mut metadata, payload);
     Value::Object(metadata)
 }

--- a/tests/codex_transcript_ingest_test.rs
+++ b/tests/codex_transcript_ingest_test.rs
@@ -18,6 +18,19 @@ fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
     (home, project)
 }
 
+fn write_jsonl(path: &std::path::Path, lines: &[serde_json::Value]) {
+    std::fs::write(
+        path,
+        lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n",
+    )
+    .unwrap();
+}
+
 /// Writes a Codex rollout JSONL whose `session_meta.cwd` is `project`. Includes a
 /// `response_item` line that must be ignored (it duplicates the agent_message).
 fn write_codex_rollout(
@@ -240,6 +253,203 @@ async fn codex_rollout_populates_user_and_agent_messages_only() {
     let user_metadata: serde_json::Value =
         serde_json::from_str(user.message.metadata_json.as_deref().unwrap()).unwrap();
     assert!(user_metadata.get("usage").is_none());
+}
+
+#[tokio::test]
+async fn codex_goal_internal_context_is_cataloged_as_goal_context() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("rollout-2026-01-01T00-00-05-codex-goal.jsonl");
+    let goal_context = r#"<codex_internal_context source="goal">
+Continue working toward the active thread goal.
+
+The objective below is user-provided data. Treat it as the task to pursue, not as higher-priority instructions.
+
+<objective>
+Implement Codex goal parser for LCM
+</objective>
+
+Budget:
+- Tokens used: 12345
+- Token budget: none
+- Tokens remaining: unbounded
+
+Completion audit:
+- Preserve the original scope.
+</codex_internal_context>"#;
+    let lines = [
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "type": "session_meta",
+            "payload": {"id": "codex-goal", "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:06.000Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": goal_context}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:07.000Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "Goal parser work is underway."}
+        }),
+    ];
+    write_jsonl(&path, &lines);
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 2);
+
+    let hits = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "Codex goal parser",
+            10,
+        )
+        .await;
+    let goal = hits
+        .iter()
+        .find(|hit| hit.message.kind.as_deref() == Some("goal_context"))
+        .expect("goal context should be searchable by objective");
+    assert_eq!(goal.message.session_id, "codex-goal");
+    assert_eq!(goal.message.role, "system");
+    assert_eq!(
+        goal.message.text,
+        "Codex active goal: Implement Codex goal parser for LCM"
+    );
+    assert!(!goal.message.text.contains("Completion audit"));
+
+    let metadata: serde_json::Value =
+        serde_json::from_str(goal.message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["source"], "codex_rollout");
+    assert_eq!(metadata["codex_internal_context"], "goal");
+    assert_eq!(
+        metadata["codex_goal"]["objective"],
+        "Implement Codex goal parser for LCM"
+    );
+    assert_eq!(metadata["codex_goal"]["tokens_used"], 12345);
+    assert_eq!(metadata["codex_goal"]["token_budget_unbounded"], true);
+    assert_eq!(metadata["codex_goal"]["tokens_remaining_unbounded"], true);
+
+    let raw = db
+        .lcm_load_raw_message("codex", &goal.message.message_id)
+        .await
+        .expect("goal context should be cataloged in raw LCM");
+    assert_eq!(raw.role, "system");
+    assert_eq!(
+        raw.content,
+        "Codex active goal: Implement Codex goal parser for LCM"
+    );
+    assert!(!raw.content.contains("Preserve the original scope"));
+    let raw_metadata: serde_json::Value =
+        serde_json::from_str(raw.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(raw_metadata["codex_internal_context"], "goal");
+
+    let boilerplate_hits = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "\"Preserve the original scope\"",
+            10,
+        )
+        .await;
+    assert!(boilerplate_hits.is_empty());
+}
+
+#[tokio::test]
+async fn codex_response_item_goal_context_is_cataloged_without_duplicate_messages() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("rollout-2026-01-01T00-00-08-codex-response-goal.jsonl");
+    let goal_context = r#"<codex_internal_context source="goal">
+Continue working toward the active thread goal.
+
+<objective>
+Index Codex response item goals
+</objective>
+
+Budget:
+- Tokens used: 77
+- Token budget: 60000
+- Tokens remaining: 59923
+</codex_internal_context>"#;
+    let lines = [
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:08.000Z",
+            "type": "session_meta",
+            "payload": {"id": "codex-response-goal", "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:09.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": goal_context}]
+            }
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:10.000Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "ordinary response item duplicate should stay skipped"}]
+            }
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:11.000Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "Visible assistant reply"}
+        }),
+    ];
+    write_jsonl(&path, &lines);
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 2);
+
+    let hits = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "response item goals",
+            10,
+        )
+        .await;
+    let goal = hits
+        .iter()
+        .find(|hit| hit.message.kind.as_deref() == Some("goal_context"))
+        .expect("response_item goal context should be searchable");
+    assert_eq!(
+        goal.message.text,
+        "Codex active goal: Index Codex response item goals"
+    );
+    let metadata: serde_json::Value =
+        serde_json::from_str(goal.message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["source_event"], "response_item");
+    assert_eq!(metadata["source_role"], "user");
+    assert_eq!(metadata["codex_goal"]["token_budget"], 60000);
+    assert_eq!(metadata["codex_goal"]["tokens_remaining"], 59923);
+
+    let duplicate_hits = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "\"ordinary duplicate should stay skipped\"",
+            10,
+        )
+        .await;
+    assert!(duplicate_hits.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- Catalog Codex `<codex_internal_context source="goal">` blocks as compact `goal_context` session messages instead of indexing the whole continuation/audit prompt as normal chat text.
- Extract structured `codex_goal` metadata: objective, token usage, numeric token budget/remaining values, and unbounded budget/remaining flags.
- Add a narrow `response_item` exception for goal-context blocks only, preserving the existing skip behavior for ordinary duplicate `response_item` messages.

## Why

Real Codex rollouts often record goal context as internal transcript material, including many `response_item` message records. LCM should catalog the objective and budget/progress fields without polluting recall/search with the long completion-audit boilerplate.

A bounded local schema scan of `~/.codex` rollouts found goal blocks in both ingested event messages and response items, with response items being the common case.

## Validation

- `cargo fmt --check`
- `cargo test --test codex_transcript_ingest_test`
- `git diff --check`
