### PR TITLE
feat: support linked worktree store resolution

### DIFF
--- a/.changeset/worktree-store-resolution.md
+++ b/.changeset/worktree-store-resolution.md
@@ -1,0 +1,5 @@
+---
+"tracedecay": patch
+---
+
+Support linked git worktrees resolving the initialized repository store by git common directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- support linked git worktrees resolving the initialized repository store by git common directory
+
 ## [0.0.12](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.11...v0.0.12) - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ tracedecay init
 
 This creates the active project's TraceDecay store. Graph/session artifacts live in a user-level profile shard scoped to this project; `.tracedecay/` in the repo is only a lightweight marker/config directory. `init` is the explicit opt-in; `sync` only updates already-initialized projects, so the global post-commit hook does not create stores in repos you never intended to index. After `init`, use `tracedecay sync` for incremental updates.
 
+Linked git worktrees do not need their own `tracedecay init`. Once the repository has been initialized from any checkout, TraceDecay resolves sibling or nested worktrees through the repository's shared git common directory and keeps the current worktree as the active file root. Do not copy `.tracedecay/` into worktrees; branch database tracking isolates the checked-out branch inside the shared project store.
+
 <details>
 <summary><strong>What install writes for Claude Code</strong></summary>
 
@@ -673,7 +675,7 @@ tracedecay keeps the graph up to date without a background daemon or an OS-level
 
 **Catch-up sync on connect.** When the MCP server starts, it immediately runs a non-blocking catch-up sync that picks up any changes made while no agent was attached — a `git pull`, an IDE edit, a build step — so the very first tool call of a session sees a fresh index.
 
-**Multi-agent work and git worktrees.** When multiple agents work on a project concurrently, each is expected to operate in its own git worktree — an independent filesystem checkout of the same repository, so agents never overwrite each other's in-flight edits. tracedecay detects when a query comes from a worktree nested inside the main checkout and serves results from the correct branch graph. Changes accumulate independently and are reconciled via git merge or rebase, avoiding the complexity and failure modes of cross-agent locking over a shared mutable directory.
+**Multi-agent work and git worktrees.** When multiple agents work on a project concurrently, each is expected to operate in its own git worktree — an independent filesystem checkout of the same repository, so agents never overwrite each other's in-flight edits. After one checkout has been initialized, tracedecay automatically resolves linked worktrees by `git rev-parse --git-common-dir`, uses the shared project store, and keeps the invoking worktree as the active file root for scans and syncs. This works for sibling worktrees, nested `repo/.worktrees/*` layouts, and agent-managed worktrees such as Codex or Conductor. Changes accumulate independently and are reconciled via git merge or rebase, avoiding the complexity and failure modes of cross-agent locking over a shared mutable directory.
 
 **CLI-only workflows.** If you run `tracedecay` commands without an attached agent (no MCP server), the staleness check is not running between commands. Install a git post-commit hook to keep the index fresh automatically after every commit:
 
@@ -963,6 +965,8 @@ TraceDecay could not find an initialized project store. Run `tracedecay init` fr
 ```bash
 tracedecay init
 ```
+
+If you are inside a linked git worktree, initialize the repository once from any checkout instead of running `init` in every worktree. A separate clone with the same remote URL is not considered initialized; only the original checkout and its linked worktrees share the store.
 
 ### MCP server not connecting
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -98,6 +98,11 @@ In short:
 - **`tracedecay init`** -- one-time setup. Creates the active project store and performs a full index. Errors if already initialized.
 - **`tracedecay sync`** -- ongoing updates. Requires an existing project store. Errors if the project was never initialized.
 
+Linked git worktrees do not need their own `tracedecay init`. Once the main
+repository has been initialized, TraceDecay resolves linked worktrees through
+the repository's shared git common directory and uses the existing branch
+database tracking to keep the checked-out branch isolated.
+
 ### Incremental syncs
 
 After the initial full index, every subsequent `tracedecay sync` is incremental. It detects which files changed since the last sync (via content hashing) and only re-indexes those files. On a typical commit-sized change, this takes under a second.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -455,12 +455,19 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
     match action {
         BranchAction::List { path } => {
             let project_path = tracedecay::config::resolve_path(path);
-            let tracedecay_dir = resolve_branch_data_root(&project_path);
+            let opened = TraceDecay::open_read_only(&project_path).await.ok();
+            let tracedecay_dir = opened
+                .as_ref()
+                .map(|cg| cg.store_layout().data_root.clone())
+                .unwrap_or_else(|| fallback_branch_data_root(&project_path));
             let Some(_meta) = branch_meta::load_branch_meta(&tracedecay_dir) else {
                 eprintln!("No branch tracking configured. Run `tracedecay branch add` to start.");
                 return Ok(());
             };
-            let diagnostics = TraceDecay::project_branch_diagnostics(&project_path);
+            let diagnostics = opened
+                .as_ref()
+                .map(TraceDecay::branch_diagnostics)
+                .unwrap_or_else(|| TraceDecay::project_branch_diagnostics(&project_path));
             eprintln!(
                 "Default branch: {}",
                 diagnostics.default_branch.as_deref().unwrap_or("<unknown>")
@@ -566,7 +573,7 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
         }
         BranchAction::Remove { name, path } => {
             let project_path = tracedecay::config::resolve_path(path);
-            let tracedecay_dir = resolve_branch_data_root(&project_path);
+            let tracedecay_dir = resolve_branch_data_root(&project_path).await;
             let Some(mut meta) = branch_meta::load_branch_meta(&tracedecay_dir) else {
                 eprintln!("No branch tracking configured.");
                 return Ok(());
@@ -592,7 +599,7 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
         }
         BranchAction::Removeall { path } => {
             let project_path = tracedecay::config::resolve_path(path);
-            let tracedecay_dir = resolve_branch_data_root(&project_path);
+            let tracedecay_dir = resolve_branch_data_root(&project_path).await;
             let Some(mut meta) = branch_meta::load_branch_meta(&tracedecay_dir) else {
                 eprintln!("No branch tracking configured.");
                 return Ok(());
@@ -620,7 +627,7 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
         }
         BranchAction::Gc { path } => {
             let project_path = tracedecay::config::resolve_path(path);
-            let tracedecay_dir = resolve_branch_data_root(&project_path);
+            let tracedecay_dir = resolve_branch_data_root(&project_path).await;
             let Some(mut meta) = branch_meta::load_branch_meta(&tracedecay_dir) else {
                 eprintln!("No branch tracking configured.");
                 return Ok(());
@@ -669,7 +676,14 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
     Ok(())
 }
 
-fn resolve_branch_data_root(project_path: &Path) -> PathBuf {
+async fn resolve_branch_data_root(project_path: &Path) -> PathBuf {
+    TraceDecay::open_read_only(project_path)
+        .await
+        .map(|cg| cg.store_layout().data_root.clone())
+        .unwrap_or_else(|_| fallback_branch_data_root(project_path))
+}
+
+fn fallback_branch_data_root(project_path: &Path) -> PathBuf {
     tracedecay::storage::resolve_layout_for_current_profile(project_path)
         .map(|layout| layout.data_root)
         .unwrap_or_else(|_| tracedecay::config::get_tracedecay_dir(project_path))
@@ -940,7 +954,7 @@ async fn is_fresh_install() -> bool {
 /// When invoked with no subcommand, offer to create the index if none exists.
 pub(crate) async fn handle_no_command() -> tracedecay::errors::Result<()> {
     let project_path = tracedecay::config::resolve_path(None);
-    if TraceDecay::is_initialized(&project_path) {
+    if TraceDecay::has_initialized_store(&project_path).await {
         // Already initialized — show help via clap
         let _ = <crate::cli::Cli as clap::CommandFactory>::command().print_help();
         eprintln!();
@@ -985,7 +999,7 @@ pub(crate) async fn handle_init(
     include_folders: Vec<String>,
 ) -> tracedecay::errors::Result<()> {
     let project_path = tracedecay::config::resolve_path(path);
-    if TraceDecay::is_initialized(&project_path) {
+    if TraceDecay::has_initialized_store(&project_path).await {
         eprintln!(
             "\x1b[31merror:\x1b[0m TraceDecay is already initialized at '{}'.\n\
              Use \x1b[1mtracedecay sync\x1b[0m to update the index, or \
@@ -1011,7 +1025,7 @@ pub(crate) async fn handle_sync(
     verbose: bool,
 ) -> tracedecay::errors::Result<()> {
     let project_path = tracedecay::config::resolve_path_with_discovery(path);
-    if !TraceDecay::is_initialized(&project_path) {
+    if !TraceDecay::has_initialized_store(&project_path).await {
         eprintln!(
             "\x1b[31merror:\x1b[0m no TraceDecay index found at '{}'.\n\
              Run \x1b[1mtracedecay init\x1b[0m to create one first.",
@@ -1226,7 +1240,7 @@ pub(crate) async fn init_and_index(
             message: format!("project path must be absolute: {}", project_path.display()),
         });
     }
-    let mut cg = if TraceDecay::is_initialized(project_path) {
+    let mut cg = if TraceDecay::has_initialized_store(project_path).await {
         TraceDecay::open(project_path).await?
     } else {
         let cg = TraceDecay::init(project_path).await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,6 +375,7 @@ fn absolutize_path(path: PathBuf) -> PathBuf {
 ///    ambiguous and require an explicit path.
 pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
     let mut dir = start.to_path_buf();
+    let worktree_root = crate::worktree::git_worktree_root(start);
     loop {
         if has_project_database(&dir)
             || crate::storage::has_enrollment_marker(&dir)
@@ -384,6 +385,12 @@ pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
             })
         {
             return Some(dir);
+        }
+        if worktree_root
+            .as_ref()
+            .is_some_and(|root| paths_same(&dir, root))
+        {
+            return None;
         }
         if !dir.pop() {
             return None;
@@ -402,8 +409,16 @@ pub fn resolve_path_with_discovery(path: Option<String>) -> PathBuf {
         PathBuf::from(p)
     } else {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        discover_project_root(&cwd).unwrap_or(cwd)
+        discover_project_root(&cwd)
+            .or_else(|| crate::worktree::git_worktree_root(&cwd))
+            .unwrap_or(cwd)
     }
+}
+
+fn paths_same(left: &Path, right: &Path) -> bool {
+    let left = std::fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
+    let right = std::fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
+    left == right
 }
 
 /// Returns `true` if the path matches any of the configured `include` patterns.

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -554,7 +554,7 @@ pub async fn hook_cursor_session_start() -> i32 {
 /// tokens-saved counter.
 async fn cursor_session_context_for_root(root: Option<&Path>) -> String {
     let (initialized, staleness, tokens_saved) = match root {
-        Some(r) if crate::tracedecay::TraceDecay::is_initialized(r) => {
+        Some(r) if crate::tracedecay::TraceDecay::has_initialized_store(r).await => {
             let (staleness, tokens_saved) = cursor_index_signals_for_root(r).await;
             (true, staleness, tokens_saved)
         }
@@ -1470,7 +1470,7 @@ async fn targeted_sync_for_cursor_after_file_edit(event_json: &str) {
     let Some(root) = cursor_project_root_from_event(event_json) else {
         return;
     };
-    if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
     let rels = cursor_after_file_edit_rel_paths(event_json, &root);
@@ -1502,7 +1502,7 @@ async fn sync_after_cursor_shell_event(event_json: &str) {
         return;
     };
     // Never bootstrap indexing in an unindexed repo.
-    if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
     let cwd = cursor_event_cwd(&parsed).unwrap_or_else(|| root.clone());
@@ -1564,7 +1564,7 @@ async fn workspace_open_for_cursor_event(event_json: &str) {
     let Some(root) = cursor_project_root_from_event(event_json) else {
         return;
     };
-    if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
 
@@ -2028,11 +2028,13 @@ async fn codex_post_tool_use(event_json: &str) {
     let Some(cwd) = event_cwd(event_json) else {
         return;
     };
-    let Some(root) = crate::config::discover_project_root(&cwd) else {
+    let Some(root) = crate::config::discover_project_root(&cwd)
+        .or_else(|| crate::worktree::git_worktree_root(&cwd))
+    else {
         return;
     };
     // Never bootstrap indexing in an unindexed repo.
-    if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
 
@@ -2077,7 +2079,7 @@ async fn codex_post_compact(event_json: &str) {
         let Some(project_root) = codex_project_root_from_event(event_json) else {
             return;
         };
-        if !crate::tracedecay::TraceDecay::is_initialized(&project_root) {
+        if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
             return;
         }
         let Some(db) = crate::sessions::cursor::open_project_session_db(&project_root).await else {
@@ -2442,7 +2444,7 @@ async fn sync_for_kiro_event(event_json: &str) -> crate::errors::Result<()> {
     let Some(project_root) = kiro_project_root(event_json) else {
         return Ok(());
     };
-    if !crate::tracedecay::TraceDecay::is_initialized(&project_root) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
         return Ok(());
     }
     let cg = crate::tracedecay::TraceDecay::open(&project_root).await?;
@@ -2456,7 +2458,7 @@ async fn sync_for_cursor_event(event_json: &str) -> crate::errors::Result<()> {
     let Some(project_root) = cursor_project_root_from_event(event_json) else {
         return Ok(());
     };
-    if !crate::tracedecay::TraceDecay::is_initialized(&project_root) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
         return Ok(());
     }
     let cg = crate::tracedecay::TraceDecay::open(&project_root).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -722,7 +722,7 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             runtime,
         } => {
             let project_path = resolve_cli_project_root(path, project_id, project_path).await?;
-            let cg = if TraceDecay::is_initialized(&project_path) {
+            let cg = if TraceDecay::has_initialized_store(&project_path).await {
                 match TraceDecay::open(&project_path).await {
                     Ok(cg) => cg,
                     Err(_) => TraceDecay::open_read_only(&project_path).await?,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -56,19 +56,21 @@ pub async fn ensure_initialized_with_options(
     project_path: &Path,
     open_options: TraceDecayOpenOptions,
 ) -> Result<TraceDecay> {
-    if TraceDecay::has_initialized_store_with_options(project_path, &open_options).await {
-        return match TraceDecay::open_with_options(project_path, open_options.clone()).await {
-            Ok(cg) => Ok(cg),
-            Err(open_err) => {
-                match TraceDecay::open_read_only_with_options(project_path, open_options).await {
-                    Ok(cg) => {
-                        cg.ensure_schema_current().await?;
-                        Ok(cg)
+    match TraceDecay::open_with_options(project_path, open_options.clone()).await {
+        Ok(cg) => return Ok(cg),
+        Err(open_err) => {
+            match TraceDecay::open_read_only_with_options(project_path, open_options).await {
+                Ok(cg) => {
+                    cg.ensure_schema_current().await?;
+                    return Ok(cg);
+                }
+                Err(_) => {
+                    if !matches!(open_err, TraceDecayError::Config { .. }) {
+                        return Err(open_err);
                     }
-                    Err(_) => Err(open_err),
                 }
             }
-        };
+        }
     }
     Err(TraceDecayError::Config {
         message: format!(

--- a/src/sessions/cursor.rs
+++ b/src/sessions/cursor.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use serde_json::Value;
 
@@ -49,19 +50,31 @@ pub async fn resolved_project_session_db_path(project_root: &Path) -> Option<Pat
     if is_hermes_profile_home(project_root) {
         return Some(hermes_profile_session_db_path(project_root));
     }
-    if let Ok(layout) = resolve_layout_for_current_profile(project_root) {
-        return Some(layout.sessions_db_path);
+
+    match crate::storage::read_enrollment_marker(project_root) {
+        Ok(Some(_)) => {
+            return resolve_layout_for_current_profile(project_root)
+                .ok()
+                .map(|layout| layout.sessions_db_path);
+        }
+        Ok(None) => {}
+        Err(_) => return None,
     }
     if let Some(db_path) = registry_profile_session_db_path(project_root).await {
         return Some(db_path);
     }
-    None
+    resolve_layout_for_current_profile(project_root)
+        .ok()
+        .map(|layout| layout.sessions_db_path)
 }
 
 async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf> {
     let profile_root = crate::storage::default_profile_root().ok()?;
     let global = GlobalDb::open().await?;
-    let resolution = global.resolve_project_store_by_alias(project_root).await?;
+    let git_common_dir = git_common_dir(project_root);
+    let resolution = global
+        .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
+        .await?;
     if resolution.store.storage_mode != "profile_sharded" {
         return None;
     }
@@ -70,6 +83,29 @@ async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf
             .join(resolution.store.store_relpath)
             .join(PROJECT_SESSION_DB_FILENAME),
     )
+}
+
+fn git_common_dir(project_root: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let common_dir = PathBuf::from(text);
+    let resolved = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        project_root.join(common_dir)
+    };
+    Some(resolved.canonicalize().unwrap_or(resolved))
 }
 
 fn is_hermes_profile_home(path: &Path) -> bool {

--- a/src/sessions/cursor.rs
+++ b/src/sessions/cursor.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde_json::Value;
 
@@ -71,7 +70,7 @@ pub async fn resolved_project_session_db_path(project_root: &Path) -> Option<Pat
 async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf> {
     let profile_root = crate::storage::default_profile_root().ok()?;
     let global = GlobalDb::open().await?;
-    let git_common_dir = git_common_dir(project_root);
+    let git_common_dir = crate::worktree::git_common_dir(project_root);
     let resolution = global
         .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
         .await?;
@@ -83,29 +82,6 @@ async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf
             .join(resolution.store.store_relpath)
             .join(PROJECT_SESSION_DB_FILENAME),
     )
-}
-
-fn git_common_dir(project_root: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .current_dir(project_root)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let text = String::from_utf8(output.stdout).ok()?;
-    let text = text.trim();
-    if text.is_empty() {
-        return None;
-    }
-    let common_dir = PathBuf::from(text);
-    let resolved = if common_dir.is_absolute() {
-        common_dir
-    } else {
-        project_root.join(common_dir)
-    };
-    Some(resolved.canonicalize().unwrap_or(resolved))
 }
 
 fn is_hermes_profile_home(path: &Path) -> bool {

--- a/src/tool_command.rs
+++ b/src/tool_command.rs
@@ -234,10 +234,12 @@ async fn call_in_process_tool(
         global_db_path: Some(handshake.client_identity.global_db_path.clone()),
     };
     let cg = if handshake.allow_init
-        && !tracedecay::tracedecay::TraceDecay::is_initialized_with_options(
+        && !tracedecay::tracedecay::TraceDecay::has_initialized_store_with_options(
             project_path,
             &open_options,
-        ) {
+        )
+        .await
+    {
         tracedecay::tracedecay::TraceDecay::init_with_options(project_path, open_options).await?
     } else {
         tracedecay::tracedecay::TraceDecay::open_with_options(project_path, open_options).await?

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -1154,13 +1154,47 @@ impl TraceDecay {
             || crate::storage::has_enrollment_marker(project_root)
     }
 
-    pub(crate) async fn has_initialized_store_with_options(
+    pub async fn has_initialized_store(project_root: &Path) -> bool {
+        Self::has_initialized_store_with_options(project_root, &TraceDecayOpenOptions::default())
+            .await
+    }
+
+    pub async fn has_initialized_store_with_options(
         project_root: &Path,
         open_options: &TraceDecayOpenOptions,
     ) -> bool {
-        Self::resolve_store_layout_for_project(project_root, open_options)
+        Self::resolve_store_layout_for_local_identity(project_root, open_options)
             .await
             .is_ok_and(|layout| layout.graph_db_path.is_file())
+    }
+
+    async fn resolve_store_layout_for_local_identity(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> Result<StoreLayout> {
+        let profile_root = open_options.resolved_profile_root()?;
+        if storage::read_enrollment_marker(project_root)?.is_some() {
+            return storage::resolve_layout(project_root, &profile_root);
+        }
+
+        let git_common_dir = git_common_dir(project_root);
+        if let Some(global_db) = open_options.open_global_db().await {
+            if let Some(resolution) = global_db
+                .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
+                .await
+            {
+                return storage::profile_sharded_layout(
+                    project_root,
+                    &profile_root,
+                    &storage::EnrollmentMarker {
+                        project_id: resolution.project.project_id,
+                        storage_mode: storage::StorageMode::ProfileSharded,
+                    },
+                );
+            }
+        }
+
+        storage::default_profile_sharded_layout(project_root, &profile_root)
     }
 }
 

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -532,7 +532,7 @@ impl TraceDecay {
             return storage::resolve_layout(project_root, &profile_root);
         }
 
-        let git_common_dir = git_common_dir(project_root);
+        let git_common_dir = crate::worktree::git_common_dir(project_root);
         let git_remote_url = git_remote_url(project_root);
         if let Some(global_db) = open_options.open_global_db().await {
             let resolution = match global_db
@@ -1024,7 +1024,7 @@ impl TraceDecay {
 
         let meta = branch_meta::load_branch_meta(&self.store_layout.data_root);
         let default_branch = meta.as_ref().map(|meta| meta.default_branch.as_str());
-        let git_common_dir = git_common_dir(&self.project_root);
+        let git_common_dir = crate::worktree::git_common_dir(&self.project_root);
         let git_remote_url = git_remote_url(&self.project_root);
         let Some(project) = global_db
             .upsert_code_project(
@@ -1177,7 +1177,7 @@ impl TraceDecay {
             return storage::resolve_layout(project_root, &profile_root);
         }
 
-        let git_common_dir = git_common_dir(project_root);
+        let git_common_dir = crate::worktree::git_common_dir(project_root);
         if let Some(global_db) = open_options.open_global_db().await {
             if let Some(resolution) = global_db
                 .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
@@ -1243,18 +1243,6 @@ fn profile_root_for_layout(layout: &StoreLayout) -> Option<PathBuf> {
 
 fn profile_store_id(project_id: &str) -> String {
     format!("store:{project_id}:profile_sharded")
-}
-
-fn git_common_dir(project_root: &Path) -> Option<PathBuf> {
-    git_output(project_root, &["rev-parse", "--git-common-dir"]).map(|path| {
-        let common_dir = PathBuf::from(path);
-        let resolved = if common_dir.is_absolute() {
-            common_dir
-        } else {
-            project_root.join(common_dir)
-        };
-        resolved.canonicalize().unwrap_or(resolved)
-    })
 }
 
 fn git_remote_url(project_root: &Path) -> Option<String> {

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -39,20 +39,23 @@ pub struct WorktreeIndexMismatch {
 /// checkout and each linked worktree report their own distinct directory,
 /// which is exactly the distinction this module relies on.
 pub fn git_worktree_root(dir: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .current_dir(dir)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let raw = String::from_utf8(output.stdout).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    realpath(Path::new(trimmed))
+    let trimmed = git_output(dir, &["rev-parse", "--show-toplevel"])?;
+    realpath(Path::new(&trimmed))
+}
+
+/// Absolute, symlink-resolved path to the repository's git common directory.
+///
+/// For a linked worktree this is the main checkout's `.git` directory, which is
+/// the stable local identity all linked worktrees share.
+pub fn git_common_dir(dir: &Path) -> Option<PathBuf> {
+    let raw = git_output(dir, &["rev-parse", "--git-common-dir"])?;
+    let common_dir = PathBuf::from(raw);
+    let resolved = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        dir.join(common_dir)
+    };
+    Some(resolved.canonicalize().unwrap_or(resolved))
 }
 
 /// Detect when `start_path` lives in one git working tree but the resolved
@@ -121,6 +124,20 @@ pub fn worktree_mismatch_notice(m: &WorktreeIndexMismatch) -> String {
 /// fails (e.g. directory was deleted between rev-parse and the fs call).
 fn realpath(p: &Path) -> Option<PathBuf> {
     std::fs::canonicalize(p).ok()
+}
+
+fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(output.stdout).ok()?;
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
 #[cfg(test)]

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -35,6 +35,38 @@ use tracedecay::tracedecay::TraceDecay;
 
 static GLOBAL_DB_ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
+struct TestDbConnection {
+    _db: libsql::Database,
+    conn: libsql::Connection,
+}
+
+impl Deref for TestDbConnection {
+    type Target = libsql::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.conn
+    }
+}
+
+async fn open_test_db_connection(db_path: &Path) -> TestDbConnection {
+    let db = libsql::Builder::new_local(db_path).build().await.unwrap();
+    let conn = db.connect().unwrap();
+    let pragmas = if cfg!(windows) {
+        "PRAGMA mmap_size = 0;
+         PRAGMA journal_mode = DELETE;
+         PRAGMA busy_timeout = 5000;
+         PRAGMA synchronous = FULL;
+         PRAGMA foreign_keys = ON;"
+    } else {
+        "PRAGMA journal_mode = WAL;
+         PRAGMA busy_timeout = 5000;
+         PRAGMA synchronous = NORMAL;
+         PRAGMA foreign_keys = ON;"
+    };
+    conn.execute_batch(pragmas).await.unwrap();
+    TestDbConnection { _db: db, conn }
+}
+
 async fn handle_tool_call(
     cg: &TraceDecay,
     tool_name: &str,
@@ -6734,12 +6766,8 @@ async fn seed_lcm_session_message_in_db(
     );
 }
 
-async fn project_lcm_conn(cg: &TraceDecay) -> libsql::Connection {
-    let db = libsql::Builder::new_local(project_session_db_path(cg))
-        .build()
-        .await
-        .unwrap();
-    db.connect().unwrap()
+async fn project_lcm_conn(cg: &TraceDecay) -> TestDbConnection {
+    open_test_db_connection(&project_session_db_path(cg)).await
 }
 
 async fn lcm_fts_match_count(cg: &TraceDecay, query: &str) -> i64 {
@@ -6779,8 +6807,7 @@ async fn lcm_raw_message_count(cg: &TraceDecay, session_id: &str) -> i64 {
 }
 
 async fn lcm_raw_message_count_at_path(db_path: &Path, session_id: &str) -> i64 {
-    let db = libsql::Builder::new_local(db_path).build().await.unwrap();
-    let conn = db.connect().unwrap();
+    let conn = open_test_db_connection(db_path).await;
     let mut rows = conn
         .query(
             "SELECT COUNT(*) FROM lcm_raw_messages WHERE session_id = ?1",
@@ -11699,8 +11726,7 @@ async fn repeated_lcm_calls_skip_schema_reensure_per_process() {
 
     let db_path = project_session_db_path(&cg);
     {
-        let db = libsql::Builder::new_local(&db_path).build().await.unwrap();
-        let conn = db.connect().unwrap();
+        let conn = open_test_db_connection(&db_path).await;
         conn.execute(
             "UPDATE session_schema_migrations SET version = 1 WHERE name = 'lcm'",
             (),
@@ -11724,8 +11750,7 @@ async fn repeated_lcm_calls_skip_schema_reensure_per_process() {
     );
 
     // The on-disk marker is untouched as well.
-    let db = libsql::Builder::new_local(&db_path).build().await.unwrap();
-    let conn = db.connect().unwrap();
+    let conn = open_test_db_connection(&db_path).await;
     let mut rows = conn
         .query(
             "SELECT version FROM session_schema_migrations WHERE name = 'lcm'",

--- a/tests/storage_resolver_test.rs
+++ b/tests/storage_resolver_test.rs
@@ -109,6 +109,14 @@ fn git(cwd: &Path, args: &[&str]) {
     );
 }
 
+fn init_repo_with_commit(project: &Path) {
+    git(project, &["init", "-b", "main"]);
+    git(project, &["config", "user.email", "test@example.com"]);
+    git(project, &["config", "user.name", "TraceDecay Test"]);
+    git(project, &["add", "."]);
+    git(project, &["commit", "-m", "initial"]);
+}
+
 #[test]
 fn enrollment_marker_is_discovered_without_graph_db() {
     let dir = TempDir::new().unwrap();
@@ -672,11 +680,7 @@ async fn linked_worktree_uses_initialized_git_common_dir_store_without_init() {
     fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
     let _home_guard = HomeGuard::set(&home);
 
-    git(&project, &["init", "-b", "main"]);
-    git(&project, &["config", "user.email", "test@example.com"]);
-    git(&project, &["config", "user.name", "TraceDecay Test"]);
-    git(&project, &["add", "."]);
-    git(&project, &["commit", "-m", "initial"]);
+    init_repo_with_commit(&project);
 
     let main = TraceDecay::init(&project).await.unwrap();
     main.index_all().await.unwrap();
@@ -783,11 +787,7 @@ async fn nested_linked_worktree_does_not_discover_parent_checkout_marker() {
     fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
     let _home_guard = HomeGuard::set(&home);
 
-    git(&project, &["init", "-b", "main"]);
-    git(&project, &["config", "user.email", "test@example.com"]);
-    git(&project, &["config", "user.name", "TraceDecay Test"]);
-    git(&project, &["add", "."]);
-    git(&project, &["commit", "-m", "initial"]);
+    init_repo_with_commit(&project);
     TraceDecay::init(&project).await.unwrap();
 
     git(

--- a/tests/storage_resolver_test.rs
+++ b/tests/storage_resolver_test.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
@@ -14,7 +15,7 @@ use tracedecay::global_db::GlobalDb;
 use tracedecay::mcp::response_handles::{
     retrieve_response_handle, store_response_handle, ResponseHandleLookup,
 };
-use tracedecay::sessions::cursor::project_session_db_path;
+use tracedecay::sessions::cursor::{project_session_db_path, resolved_project_session_db_path};
 use tracedecay::storage::{
     default_profile_project_id, default_profile_sharded_layout, profile_sharded_layout,
     read_enrollment_marker, read_store_manifest, resolve_layout, resolve_lcm_payload_root,
@@ -91,6 +92,21 @@ fn test_home(dir: &TempDir) -> PathBuf {
     let home = dir.path().join("home");
     fs::create_dir_all(&home).unwrap();
     canonical_temp_path(&home)
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run git {args:?}: {err}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+        cwd.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -643,6 +659,157 @@ async fn trace_decay_init_registers_default_profile_shard_globally() {
     let resolution = db.resolve_project_store_by_alias(&project).await.unwrap();
 
     assert_eq!(resolution.project.project_id, project_id);
+}
+
+#[tokio::test]
+async fn linked_worktree_uses_initialized_git_common_dir_store_without_init() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let worktree = dir.path().join("repo-wt");
+    let home = test_home(&dir);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+
+    git(&project, &["init", "-b", "main"]);
+    git(&project, &["config", "user.email", "test@example.com"]);
+    git(&project, &["config", "user.name", "TraceDecay Test"]);
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "-m", "initial"]);
+
+    let main = TraceDecay::init(&project).await.unwrap();
+    main.index_all().await.unwrap();
+    let main_store = main.store_layout().data_root.clone();
+    drop(main);
+
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/worktree-auto",
+            worktree.to_str().unwrap(),
+        ],
+    );
+    fs::write(
+        worktree.join("src/lib.rs"),
+        "pub fn main_only() {}\npub fn worktree_only() {}\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        discover_project_root(&worktree.join("src")),
+        None,
+        "discovery must not walk from a linked worktree into the main checkout"
+    );
+    assert!(
+        TraceDecay::has_initialized_store(&worktree).await,
+        "linked worktree should resolve the already-initialized shared git store"
+    );
+
+    let worktree_cg = TraceDecay::open(&worktree).await.unwrap();
+    assert_eq!(worktree_cg.project_root(), worktree.as_path());
+    assert_eq!(worktree_cg.store_layout().data_root, main_store);
+    assert_eq!(
+        resolved_project_session_db_path(&worktree).await.unwrap(),
+        worktree_cg.store_layout().sessions_db_path,
+        "session storage should follow the shared git-common-dir store too"
+    );
+    assert!(
+        !worktree_cg
+            .search("worktree_only", 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "opening a linked worktree should auto-track and sync its branch DB"
+    );
+    assert!(
+        !worktree.join(".tracedecay").exists(),
+        "automatic worktree support must not require or create a per-worktree marker"
+    );
+
+    let meta = branch_meta::load_branch_meta(&main_store).unwrap();
+    assert!(
+        meta.is_tracked("feature/worktree-auto"),
+        "linked worktree branch should be tracked in the shared store"
+    );
+}
+
+#[tokio::test]
+async fn same_remote_clone_is_not_considered_initialized_without_local_identity() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let remote = dir.path().join("remote.git");
+    let project = dir.path().join("repo");
+    let clone = dir.path().join("repo-clone");
+    let home = test_home(&dir);
+    let _home_guard = HomeGuard::set(&home);
+
+    git(dir.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), project.to_str().unwrap()],
+    );
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    git(&project, &["config", "user.email", "test@example.com"]);
+    git(&project, &["config", "user.name", "TraceDecay Test"]);
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "-m", "initial"]);
+    git(&project, &["push", "origin", "HEAD:master"]);
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), clone.to_str().unwrap()],
+    );
+
+    TraceDecay::init(&project).await.unwrap();
+
+    assert!(
+        !TraceDecay::has_initialized_store(&clone).await,
+        "a separate clone with the same origin is not a linked worktree and must not borrow the initialized store"
+    );
+}
+
+#[tokio::test]
+async fn nested_linked_worktree_does_not_discover_parent_checkout_marker() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let worktree = project.join(".worktrees/feature-nested");
+    let home = test_home(&dir);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+
+    git(&project, &["init", "-b", "main"]);
+    git(&project, &["config", "user.email", "test@example.com"]);
+    git(&project, &["config", "user.name", "TraceDecay Test"]);
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "-m", "initial"]);
+    TraceDecay::init(&project).await.unwrap();
+
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/nested",
+            worktree.to_str().unwrap(),
+        ],
+    );
+
+    assert_eq!(
+        discover_project_root(&worktree.join("src")),
+        None,
+        "a linked worktree inside the main checkout must not inherit the parent marker"
+    );
+    assert!(
+        TraceDecay::has_initialized_store(&worktree).await,
+        "nested linked worktree should still find the shared git store"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Previously, each linked worktree needed its own TraceDecay initialization to behave reliably. This change lets TraceDecay recognize linked git worktrees as part of the already-initialized repository, then use that initialized repo context while scanning and syncing the current worktree's files and branch.

```mermaid
flowchart TD
    A[Main checkout] -->|tracedecay init once| B[Initialized TraceDecay repo context]
    C[Linked worktree: feature-a] -->|git common dir match| B
    D[Linked worktree: feature-b] -->|git common dir match| B
    C -->|sync/search from worktree root| E[Feature-a branch graph]
    D -->|sync/search from worktree root| F[Feature-b branch graph]
    B --> E
    B --> F
```

## Summary

- Resolve linked git worktrees through the initialized repository store by git common directory.
- Keep worktree paths as the active project root while sharing graph, session, and branch storage.
- Add focused coverage for sibling and nested worktrees.

## Motivation

Codex, Conductor, Cursor, and plain `git worktree` workflows create separate working directories for the same repository. TraceDecay should recognize those linked worktrees as the same initialized repo context while still operating on the invoking worktree's files.

## Changes

- Stop project-root discovery from walking past the current git worktree root.
- Use registry/git-common-dir store lookup in init/sync/hook guards and session DB resolution.
- Make branch commands resolve metadata through `TraceDecay::open` when possible.
- Document linked worktree behavior in the README, user guide, and changelog.
