### PR TITLE
[codex] Relax startup catch-up waits for Windows CI

### DIFF
--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -11510,7 +11510,7 @@ async fn mcp_server_owns_watcher_and_refreshes_token_map_on_change() {
     let server = tracedecay::mcp::McpServer::new(cg.into_inner(), None).await;
     assert!(
         server
-            .wait_for_startup_catch_up(std::time::Duration::from_secs(2))
+            .wait_for_startup_catch_up(std::time::Duration::from_secs(30))
             .await,
         "startup catch-up sync should finish before mutating the project"
     );
@@ -12142,10 +12142,10 @@ async fn wait_for_startup_catch_up_waits_for_transcript_ingest_flag() {
     server.run_startup_catch_up_sync().await;
 
     let completed = server
-        .wait_for_startup_catch_up(std::time::Duration::from_secs(5))
+        .wait_for_startup_catch_up(std::time::Duration::from_secs(30))
         .await;
 
-    assert!(completed, "wait_for_startup_catch_up timed out after 5s");
+    assert!(completed, "wait_for_startup_catch_up timed out after 30s");
 
     // After the wait returns true, both flags must be set.
     assert!(

--- a/tests/multi_mcp_coordination_test.rs
+++ b/tests/multi_mcp_coordination_test.rs
@@ -28,9 +28,9 @@ async fn two_mcps_on_same_project_coordinate_via_sync_lock() {
     for (label, server) in [("server1", &server1), ("server2", &server2)] {
         assert!(
             server
-                .wait_for_startup_catch_up(Duration::from_secs(10))
+                .wait_for_startup_catch_up(Duration::from_secs(30))
                 .await,
-            "{label}: startup catch-up should finish within 10s"
+            "{label}: startup catch-up should finish within 30s"
         );
     }
 


### PR DESCRIPTION
## Summary
- Increase MCP startup catch-up test waits from 2s/5s/10s to 30s.
- Keep the same assertions; this only aligns test budgets with the server's 20s transcript-ingest timeout guard.

## Why
Release PR #122 is blocked by Windows CI shard 6/8. The failing test waits for `wait_for_startup_catch_up`, which includes the detached transcript ingest task. That task can legally take up to 20s before its timeout guard completes, so shorter waits are flaky on loaded Windows runners.

## Verification
- `cargo fmt --check`
- `cargo test mcp_server_owns_watcher_and_refreshes_token_map_on_change --test mcp_handler_test`
- `cargo test wait_for_startup_catch_up_waits_for_transcript_ingest_flag --test mcp_handler_test`
- `cargo test two_mcps_on_same_project_coordinate_via_sync_lock --test multi_mcp_coordination_test`
