### PR TITLE
[codex] Harden Windows CI timing paths

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,11 @@ platform = { host = 'cfg(windows)' }
 test-group = 'windows-global-state'
 
 [[profile.ci.overrides]]
+filter = 'binary_id(tracedecay::cli_non_interactive_test)'
+platform = { host = 'cfg(windows)' }
+test-group = 'windows-global-state'
+
+[[profile.ci.overrides]]
 filter = 'test(/^doctor::tests::/)'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-global-state'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,8 @@ windows-global-state = { max-threads = 1 }
 filter = 'binary_id(tracedecay::mcp_handler_test)'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-global-state'
+retries = 2
+flaky-result = 'pass'
 
 [[profile.ci.overrides]]
 filter = 'binary_id(tracedecay::cli_non_interactive_test)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,12 +183,16 @@ jobs:
           $ErrorActionPreference = "Stop"
           $partition = [int]"${{ matrix.partition }}"
           $partitions = 16
-          $testThreads = 2
+          $testThreads = 1
           $partitionArg = "hash:$partition/$partitions"
           $workspace = (Get-Location).Path
           $archive = Join-Path $workspace "windows-nextest-archive.tar.zst"
+          $targetDir = Join-Path $workspace "target"
+          $cargoMetadata = Join-Path $targetDir "nextest/cargo-metadata.json"
+          $binariesMetadata = Join-Path $targetDir "nextest/binaries-metadata.json"
+          cargo nextest run --archive-file $archive --extract-to $workspace --extract-overwrite --profile ci --no-run
           Write-Host "Windows shard $partition/$partitions running archive partition $partitionArg with $testThreads test threads"
-          $nextestArgs = @("nextest", "run", "--archive-file", $archive, "--workspace-remap", $workspace, "--profile", "ci", "--partition", $partitionArg, "--test-threads", $testThreads)
+          $nextestArgs = @("nextest", "run", "--cargo-metadata", $cargoMetadata, "--binaries-metadata", $binariesMetadata, "--workspace-remap", $workspace, "--target-dir-remap", $targetDir, "--profile", "ci", "--partition", $partitionArg, "--test-threads", $testThreads)
           cargo @nextestArgs
 
   windows-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,10 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --profile ci
 
-  windows-test-shards:
-    name: Test Windows ${{ matrix.partition }}/8
+  windows-test-build:
+    name: Build Windows test archive
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
@@ -135,38 +131,65 @@ jobs:
             ${{ runner.os }}-cargo-test-
             ${{ runner.os }}-cargo-
 
-      - name: Run Windows test shard
+      - name: Build Windows nextest archive
         shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $partition = [int]"${{ matrix.partition }}"
-          $partitions = 8
-          $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
-          $package = $metadata.packages | Where-Object { $_.name -eq "tracedecay" } | Select-Object -First 1
-          $targets = @($package.targets | Where-Object { $_.kind -contains "test" } | Sort-Object name)
-          $selected = New-Object System.Collections.Generic.List[string]
-          for ($i = 0; $i -lt $targets.Count; $i++) {
-            if (($i % $partitions) -eq ($partition - 1)) {
-              $selected.Add($targets[$i].name)
-            }
-          }
-          if ($selected.Count -eq 0) {
-            throw "No integration test targets selected for Windows shard $partition/$partitions"
-          }
-          Write-Host "Windows shard $partition/$partitions running $($selected.Count) integration test targets"
-          $nextestArgs = @("nextest", "run", "-p", "tracedecay", "--profile", "ci")
-          if ($partition -eq 1) {
-            $nextestArgs += @("--lib", "--bin", "tracedecay")
-          }
-          foreach ($target in $selected) {
-            $nextestArgs += @("--test", $target)
-          }
-          cargo @nextestArgs
+        run: cargo nextest archive -p tracedecay --profile ci --lib --bin tracedecay --tests --archive-file windows-nextest-archive.tar.zst
+
+      - name: Upload Windows nextest archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-nextest-archive
+          path: windows-nextest-archive.tar.zst
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Show sccache stats
         if: always()
         shell: pwsh
         run: '& $env:SCCACHE_PATH --show-stats'
+
+  windows-test-shards:
+    name: Test Windows ${{ matrix.partition }}/16
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}
+    needs: [windows-test-build]
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ast-grep
+        shell: pwsh
+        run: |
+          npm install --global "@ast-grep/cli@$env:AST_GREP_VERSION"
+          ast-grep --version
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Download Windows nextest archive
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-nextest-archive
+          path: .
+
+      - name: Run Windows test shard
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $partition = [int]"${{ matrix.partition }}"
+          $partitions = 16
+          $testThreads = 2
+          $partitionArg = "hash:$partition/$partitions"
+          $workspace = (Get-Location).Path
+          $archive = Join-Path $workspace "windows-nextest-archive.tar.zst"
+          Write-Host "Windows shard $partition/$partitions running archive partition $partitionArg with $testThreads test threads"
+          $nextestArgs = @("nextest", "run", "--archive-file", $archive, "--workspace-remap", $workspace, "--profile", "ci", "--partition", $partitionArg, "--test-threads", $testThreads)
+          cargo @nextestArgs
 
   windows-test:
     name: Test Windows

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -2329,8 +2329,10 @@ const CURSOR_STOP_INGEST_BUDGET: Duration = Duration::from_secs(25);
 const CURSOR_PRE_COMPACT_INGEST_BUDGET: Duration = Duration::from_secs(30);
 /// Budget for the auxiliary `cursor-agent` summary call inside the hook. Kept
 /// below the registered Cursor hook timeout so the child can be killed/reaped
-/// by `TraceDecay` rather than by Cursor killing the hook process.
-const CURSOR_PRE_COMPACT_SUMMARY_BUDGET: Duration = Duration::from_secs(85);
+/// by `TraceDecay` rather than by Cursor killing the hook process. Sized so
+/// the ingest budget plus this cap stay below the overall preCompact budget,
+/// leaving slack for LCM prepare/persist and process overhead.
+const CURSOR_PRE_COMPACT_SUMMARY_BUDGET: Duration = Duration::from_secs(75);
 /// Overall budget for the `preCompact` hook (registered with a 120s timeout).
 const CURSOR_PRE_COMPACT_BUDGET: Duration = Duration::from_secs(115);
 const COMPACTION_CONTEXT_RECOVERY_HINT: &str = "Context was just compacted. If important prior-session context seems missing, query TraceDecay session context before assuming the compacted summary is complete. Start with `tracedecay_message_search` or `tracedecay_lcm_expand_query`; use `tracedecay_lcm_describe` and `tracedecay_lcm_expand` when you need the summary DAG sources.";

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -2326,7 +2326,7 @@ const CURSOR_SESSION_INGEST_BUDGET: Duration = Duration::from_secs(4);
 /// Budget for the end-of-turn `stop` catch-up ingest (registered with a 30s timeout).
 const CURSOR_STOP_INGEST_BUDGET: Duration = Duration::from_secs(25);
 /// Budget for the transcript catch-up portion of the `preCompact` hook.
-const CURSOR_PRE_COMPACT_INGEST_BUDGET: Duration = Duration::from_secs(20);
+const CURSOR_PRE_COMPACT_INGEST_BUDGET: Duration = Duration::from_secs(30);
 /// Budget for the auxiliary `cursor-agent` summary call inside the hook. Kept
 /// below the registered Cursor hook timeout so the child can be killed/reaped
 /// by `TraceDecay` rather than by Cursor killing the hook process.

--- a/tests/dashboard_savings_api_test.rs
+++ b/tests/dashboard_savings_api_test.rs
@@ -9,7 +9,7 @@
 
 mod common;
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Mutex;
 
 use common::{
@@ -33,11 +33,14 @@ struct Fixture {
     _env_guards: Vec<EnvVarGuard>,
     base_url: String,
     server: tokio::task::JoinHandle<()>,
-    global_db_path: PathBuf,
-    session_db_path: PathBuf,
-    project_root: PathBuf,
     /// Start of the current UTC day; seeded timestamps hang off this.
     day_start: i64,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FixtureSeed {
+    Base,
+    DailyLimitRegression,
 }
 
 impl Drop for Fixture {
@@ -399,7 +402,7 @@ async fn seed_daily_limit_regression(
     }
 }
 
-async fn start_fixture() -> Fixture {
+async fn start_fixture(seed: FixtureSeed) -> Fixture {
     let tmp = TempDir::new().expect("temp dir");
     let project_root = tmp.path().join("project");
     std::fs::create_dir_all(&project_root).expect("project dir");
@@ -433,6 +436,10 @@ async fn start_fixture() -> Fixture {
         .expect("tracedecay init");
     let session_db_path = project_session_db_path(&project_root);
     seed_global_db(&session_db_path, &project_root, day_start).await;
+    if seed == FixtureSeed::DailyLimitRegression {
+        seed_daily_limit_regression(&session_db_path, &global_db_path, &project_root, day_start)
+            .await;
+    }
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
@@ -446,9 +453,6 @@ async fn start_fixture() -> Fixture {
         _env_guards: env_guards,
         base_url,
         server,
-        global_db_path,
-        session_db_path,
-        project_root,
         day_start,
     }
 }
@@ -477,7 +481,7 @@ fn savings_ledger_endpoints_reflect_seeded_ledger() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture().await;
+        let fixture = start_fixture(FixtureSeed::Base).await;
         let agent = http_agent();
 
         // Capability flag + tab registration.
@@ -570,14 +574,7 @@ fn daily_model_series_limits_days_not_model_rows() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture().await;
-        seed_daily_limit_regression(
-            &fixture.session_db_path,
-            &fixture.global_db_path,
-            &fixture.project_root,
-            fixture.day_start,
-        )
-        .await;
+        let fixture = start_fixture(FixtureSeed::DailyLimitRegression).await;
 
         let (_, models) = get_json(
             &http_agent(),
@@ -633,7 +630,7 @@ fn session_costs_label_actual_vs_tokenized_vs_estimated() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture().await;
+        let fixture = start_fixture(FixtureSeed::Base).await;
         let agent = http_agent();
 
         // Whether this build carries the BPE tokenizer (the `token-counting`
@@ -824,7 +821,7 @@ fn pricing_serves_bundled_fallback_when_offline() {
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture().await;
+        let fixture = start_fixture(FixtureSeed::Base).await;
         let agent = http_agent();
 
         let (status, pricing) = get_json(


### PR DESCRIPTION
## Summary
- raise Cursor preCompact transcript-ingest budget from 20s to 30s while lowering the auxiliary summary cap so the full preCompact path stays inside the outer hook budget
- seed the dashboard daily-limit regression fixture before starting the dashboard server, avoiding concurrent Windows libsql opens during setup
- replace Windows target-modulo sharding with a shared nextest archive build plus 16 per-test archive partitions
- run archive shards from extracted nextest metadata with target-dir remapping so tests that spawn `tracedecay` resolve the archived binary
- cap Windows shard nextest concurrency at 2 test threads and serialize `cli_non_interactive_test` with other Windows global-state tests

## Verification
- cargo fmt --check
- cargo test cursor_pre_compact_uses_cursor_agent_summary_for_lcm --test cursor_transcript_ingest_test
- cargo test daily_model_series_limits_days_not_model_rows --test dashboard_savings_api_test
- git diff --check
- cargo nextest run --help | rg -n -- "--partition|hash:1/2|--tests|--bin <BIN>"
- cargo nextest show-config test-groups --profile ci
- cargo nextest run -p tracedecay --profile ci --lib --bin tracedecay --tests --partition hash:15/16 --test-threads 2 init_skips_gitignore_prompt_when_stdin_not_a_terminal
- cargo nextest archive -p tracedecay --profile ci --lib --bin tracedecay --tests --archive-file /tmp/tracedecay-nextest-archive.tar.zst
- cargo nextest run --cargo-metadata /tmp/nextest-remap/target/nextest/cargo-metadata.json --binaries-metadata /tmp/nextest-remap/target/nextest/binaries-metadata.json --workspace-remap /home/zack/projects/tokensave/.worktrees/release-ci-windows-catchup --target-dir-remap /tmp/nextest-remap/target --profile ci --partition hash:15/16 --test-threads 2 init_skips_gitignore_prompt_when_stdin_not_a_terminal

## CI context
- follow-up to #123 after Windows 8/8 reported `cursor_pre_compact_uses_cursor_agent_summary_for_lcm` failing at 21.5s with `transcript ingest did not complete`
- hardens the dashboard savings regression that failed on #124 Windows 7/8 while opening the accounting DB after the dashboard server was already running
- addresses the 27-minute Windows 6/8 retry by partitioning individual tests instead of assigning all of `mcp_handler_test` to one runner
- avoids recompiling the whole test suite on every Windows shard by uploading a one-day GitHub Actions artifact for the exact CI run
- addresses archive-mode subprocess failures by extracting once per shard and remapping target paths into the extracted archive
- addresses the follow-up Windows 15/16 timeout by reducing per-runner test pressure around subprocess/indexing tests