### PR TITLE
fix: catalog Codex goal context response items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ env:
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
   AST_GREP_VERSION: "0.44.0"
+  WINDOWS_NEXTEST_ARTIFACT: windows-nextest-archive
+  WINDOWS_NEXTEST_ARCHIVE: windows-nextest-archive.tar.zst
+  WINDOWS_TEST_PARTITIONS: "16"
+  WINDOWS_TEST_THREADS: "1"
 
 jobs:
   commit-messages:
@@ -81,7 +85,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index/
@@ -126,31 +130,51 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Cache Cargo
-        uses: actions/cache@v4
+      - name: Restore Windows Rust cache
+        id: windows-rust-cache
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+            target
+          key: ${{ runner.os }}-windows-nextest-archive-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '.cargo/config.toml', '.config/nextest.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-windows-nextest-archive-
             ${{ runner.os }}-cargo-
+
+      - name: Report Windows cache mode
+        shell: pwsh
+        run: |
+          "Windows Rust cache hit: ${{ steps.windows-rust-cache.outputs.cache-hit }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          "Windows Rust cache matched key: ${{ steps.windows-rust-cache.outputs.cache-matched-key }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
       - name: Build Windows nextest archive
         shell: pwsh
-        run: cargo nextest archive -p tracedecay --profile ci --lib --bin tracedecay --tests --archive-file windows-nextest-archive.tar.zst
+        run: cargo nextest archive -p tracedecay --profile ci --lib --bin tracedecay --tests --archive-file $env:WINDOWS_NEXTEST_ARCHIVE
+
+      - name: Save Windows Rust cache
+        if: steps.windows-rust-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target
+          key: ${{ steps.windows-rust-cache.outputs.cache-primary-key }}
 
       - name: Upload Windows nextest archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: windows-nextest-archive
+          name: ${{ env.WINDOWS_NEXTEST_ARTIFACT }}
           path: |
-            windows-nextest-archive.tar.zst
+            ${{ env.WINDOWS_NEXTEST_ARCHIVE }}
             windows-test-tools
+          compression-level: 0
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 3
 
       - name: Show sccache stats
         if: always()
@@ -175,15 +199,23 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Download Windows nextest archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: windows-nextest-archive
+          name: ${{ env.WINDOWS_NEXTEST_ARTIFACT }}
           path: .
 
-      - name: Add archived ast-grep to PATH
+      - name: Verify Windows test artifact
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          $archive = Join-Path (Get-Location).Path $env:WINDOWS_NEXTEST_ARCHIVE
+          if (!(Test-Path $archive)) {
+            throw "Missing Windows nextest archive at $archive"
+          }
+          $archiveInfo = Get-Item $archive
+          if ($archiveInfo.Length -le 0) {
+            throw "Windows nextest archive is empty at $archive"
+          }
           $toolsDir = Join-Path (Get-Location).Path "windows-test-tools"
           $binDir = Join-Path $toolsDir "node_modules/@ast-grep/cli"
           $astGrepExe = Join-Path $binDir "ast-grep.exe"
@@ -192,17 +224,19 @@ jobs:
           }
           $binDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & $astGrepExe --version
+          $archiveMiB = [math]::Round($archiveInfo.Length / 1MB, 2)
+          "Windows nextest archive: ${archiveMiB} MiB" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
 
       - name: Run Windows test shard
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           $partition = [int]"${{ matrix.partition }}"
-          $partitions = 16
-          $testThreads = 1
+          $partitions = [int]"$env:WINDOWS_TEST_PARTITIONS"
+          $testThreads = [int]"$env:WINDOWS_TEST_THREADS"
           $partitionArg = "slice:$partition/$partitions"
           $workspace = (Get-Location).Path
-          $archive = Join-Path $workspace "windows-nextest-archive.tar.zst"
+          $archive = Join-Path $workspace $env:WINDOWS_NEXTEST_ARCHIVE
           $targetDir = Join-Path $workspace "target"
           $cargoMetadata = Join-Path $targetDir "nextest/cargo-metadata.json"
           $binariesMetadata = Join-Path $targetDir "nextest/binaries-metadata.json"
@@ -210,6 +244,16 @@ jobs:
           Write-Host "Windows shard $partition/$partitions running archive partition $partitionArg with $testThreads test threads"
           $nextestArgs = @("nextest", "run", "--cargo-metadata", $cargoMetadata, "--binaries-metadata", $binariesMetadata, "--workspace-remap", $workspace, "--target-dir-remap", $targetDir, "--profile", "ci", "--partition", $partitionArg, "--test-threads", $testThreads)
           cargo @nextestArgs
+
+      - name: Upload Windows shard diagnostics
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-shard-${{ matrix.partition }}-diagnostics
+          path: target/nextest
+          compression-level: 0
+          if-no-files-found: warn
+          retention-days: 3
 
   windows-test:
     name: Test Windows
@@ -235,7 +279,7 @@ jobs:
         with:
           components: clippy
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index/
@@ -323,7 +367,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index/
@@ -338,7 +382,7 @@ jobs:
         run: cargo nextest run --test dashboard_api_test --no-fail-fast
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('dashboard/package-lock.json') }}
@@ -405,7 +449,7 @@ jobs:
           ast-grep --version
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index/

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -20,15 +20,19 @@
 //!   replacement history and an encrypted compaction body, so `TraceDecay` records
 //!   the boundary/provenance as a summary record without claiming plaintext
 //!   access to Codex's private summary.
+//! * `response_item` goal context — Codex replays active thread goals as
+//!   synthetic user context. `TraceDecay` indexes those as compact goal-context
+//!   records so LCM can catalog the objective and budget without treating the
+//!   instruction boilerplate as normal conversation.
 //! * subagent rollouts — separate `rollout-*.jsonl` files whose leading
 //!   `session_meta` has `thread_source == "subagent"` and parent ids in
 //!   `forked_from_id` / `source.subagent.thread_spawn.parent_thread_id`.
 //!
-//! `response_item` entries are intentionally skipped: they carry auto-injected
-//! synthetic context and duplicate the `agent_message`/`user_message` turns, so
-//! ingesting them would double-count the conversation. This append-only JSONL is
-//! read with the shared byte-offset machinery and scoped to the current project
-//! by `session_meta.cwd`.
+//! Other `response_item` entries are intentionally skipped: they carry
+//! auto-injected synthetic context and duplicate the `agent_message`/`user_message`
+//! turns, so ingesting them would double-count the conversation. This append-only
+//! JSONL is read with the shared byte-offset machinery and scoped to the current
+//! project by `session_meta.cwd`.
 
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
@@ -148,6 +152,16 @@ impl TranscriptSource for CodexSource {
             ) {
                 flush_turn_usage(&mut messages, &mut turn_usage);
                 compaction_depth += 1;
+                messages.push(message);
+                continue;
+            }
+            if let Some(message) = goal_context_from_line(
+                &line.value,
+                &meta,
+                current_model.as_deref(),
+                path,
+                line.offset,
+            ) {
                 messages.push(message);
                 continue;
             }
@@ -496,6 +510,95 @@ fn compacted_summary_from_line(
         source_offset: Some(offset),
         metadata_json: serde_json::to_string(&Value::Object(metadata)).ok(),
     })
+}
+
+fn goal_context_from_line(
+    record: &Value,
+    meta: &CodexMeta,
+    model: Option<&str>,
+    path: &Path,
+    offset: i64,
+) -> Option<SessionMessageRecord> {
+    if record.get("type").and_then(Value::as_str) != Some("response_item") {
+        return None;
+    }
+    let payload = record.get("payload")?;
+    if payload.get("type").and_then(Value::as_str) != Some("message")
+        || payload.get("role").and_then(Value::as_str) != Some("user")
+    {
+        return None;
+    }
+    let text = response_item_text(payload.get("content")?)?;
+    if !is_goal_context_text(&text) {
+        return None;
+    }
+
+    let timestamp = record
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp)
+        .map(|secs| secs as i64);
+
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        "source".to_string(),
+        Value::String("codex_goal_context".to_string()),
+    );
+    metadata.insert(
+        "source_event".to_string(),
+        Value::String("response_item".to_string()),
+    );
+    metadata.insert("source_offset".to_string(), Value::from(offset));
+
+    Some(SessionMessageRecord {
+        provider: PROVIDER.to_string(),
+        message_id: format!("{}:{offset}", meta.session_id),
+        session_id: meta.session_id.clone(),
+        role: "system".to_string(),
+        timestamp,
+        ordinal: offset,
+        text,
+        kind: Some("context".to_string()),
+        model: model.map(str::to_string),
+        tool_names: None,
+        source_path: Some(path.to_string_lossy().to_string()),
+        source_offset: Some(offset),
+        metadata_json: serde_json::to_string(&Value::Object(metadata)).ok(),
+    })
+}
+
+fn response_item_text(content: &Value) -> Option<String> {
+    let Value::Array(items) = content else {
+        return None;
+    };
+    let parts = items
+        .iter()
+        .filter_map(|item| item.get("text").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>();
+    (!parts.is_empty()).then(|| parts.join("\n\n"))
+}
+
+fn is_goal_context_text(text: &str) -> bool {
+    let mut lines = text.lines().map(str::trim).filter(|line| !line.is_empty());
+    let Some(header) = lines.next() else {
+        return false;
+    };
+    let header = header.trim_end_matches(':').to_ascii_lowercase();
+    if header != "current goal for this thread" && header != "active goal for this thread" {
+        return false;
+    }
+
+    let mut has_objective = false;
+    let mut has_budget = false;
+    for line in lines {
+        let lower = line.to_ascii_lowercase();
+        has_objective |= lower.starts_with("objective:");
+        has_budget |=
+            lower.starts_with("remaining token budget:") || lower.starts_with("token budget:");
+    }
+    has_objective && has_budget
 }
 
 fn message_metadata(payload: &Value) -> Value {

--- a/tests/codex_transcript_ingest_test.rs
+++ b/tests/codex_transcript_ingest_test.rs
@@ -125,6 +125,85 @@ fn write_codex_subagent_rollout(
     path
 }
 
+fn write_codex_rollout_with_goal_context(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("rollout-2026-01-01T00-00-15-{session}.jsonl"));
+    let contents = format!(
+        "{}\n{}\n{}\n{}\n",
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:15.000Z",
+            "type": "session_meta",
+            "payload": {"id": session, "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:15.100Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "Current goal for this thread\nobjective: ensure all provider session messages are ingested\nremaining token budget: 12000"
+                }]
+            }
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:15.200Z",
+            "type": "response_item",
+            "payload": {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "duplicate assistant response"}]}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:16.000Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Continue implementation"}
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+fn write_codex_rollout_with_non_goal_response_item(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("rollout-2026-01-01T00-00-16-{session}.jsonl"));
+    let contents = format!(
+        "{}\n{}\n{}\n",
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:16.000Z",
+            "type": "session_meta",
+            "payload": {"id": session, "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:16.100Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "what is the current goal and remaining token budget?"
+                }]
+            }
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:17.000Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Continue implementation"}
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
 fn write_codex_rollout_with_compaction(
     home: &std::path::Path,
     project: &std::path::Path,
@@ -175,6 +254,61 @@ fn write_codex_rollout_with_compaction(
     );
     std::fs::write(&path, contents).unwrap();
     path
+}
+
+#[tokio::test]
+async fn codex_goal_response_item_is_cataloged_as_context() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_codex_rollout_with_goal_context(&home, &project, "codex-goal-context");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 2);
+
+    let results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "provider session messages",
+            10,
+        )
+        .await;
+    assert_eq!(results.len(), 1);
+    let goal = &results[0].message;
+    assert_eq!(goal.role, "system");
+    assert_eq!(goal.kind.as_deref(), Some("context"));
+    assert!(goal.text.contains("remaining token budget: 12000"));
+
+    let metadata: serde_json::Value =
+        serde_json::from_str(goal.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["source"], "codex_goal_context");
+    assert_eq!(metadata["source_event"], "response_item");
+}
+
+#[tokio::test]
+async fn codex_regular_response_item_goal_words_are_not_cataloged() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_codex_rollout_with_non_goal_response_item(&home, &project, "codex-non-goal-context");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 1);
+
+    let results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "remaining token budget",
+            10,
+        )
+        .await;
+    assert!(results.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- catalog Codex `response_item` active-goal context as system context messages
- keep non-goal `response_item` entries skipped to avoid duplicate conversation ingest
- add a regression test covering searchable goal context metadata

## Verification
- cargo nextest run -p tracedecay --test codex_transcript_ingest_test --test-threads 1
- cargo fmt --check && git diff --check