### PR TITLE
feat(dashboard): add curation automation controls

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,7 +6,7 @@ slow-timeout = { period = "10s", terminate-after = 36 }
 final-status-level = "slow"
 
 [[profile.ci.overrides]]
-filter = 'binary_id(tracedecay::mcp_handler_test)'
+filter = 'all()'
 platform = { host = 'cfg(windows)' }
 retries = 2
 flaky-result = 'pass'

--- a/dashboard/build.shared.mjs
+++ b/dashboard/build.shared.mjs
@@ -237,6 +237,7 @@ export async function buildPlugin(
 export async function buildHolographicPlugin() {
   await buildPlugin("holographic", "holographic-memory", {
     tailwind: true,
+    primitives: true,
   });
 }
 

--- a/dashboard/graph/src/OverviewPanel.tsx
+++ b/dashboard/graph/src/OverviewPanel.tsx
@@ -16,16 +16,23 @@ import {
 } from "./types";
 import type { GraphNode, GraphOverview } from "./types";
 
+// Language → design token (with the historical dark hex as fallback), mirroring
+// KIND_FAMILY_COLORS in ./types so the bar swatches re-theme with the shell's
+// light palette instead of pinning dark-only hex. Each language rides a
+// matching --ts-* accent token (javascript shares --ts-amber by hue family).
 const LANGUAGE_COLORS: Record<string, string> = {
-  rust: "#f7c76a",
-  typescript: "#7aa7ff",
-  javascript: "#ffd97a",
-  python: "#67e8a9",
-  markdown: "#a8c8c0",
-  json: "#6f9189",
-  toml: "#6f9189",
-  shell: "#75f4d2",
-  web: "#ff7ab6",
+  rust: "var(--ts-amber, #f7c76a)",
+  typescript: "var(--ts-blue, #7aa7ff)",
+  // Reuse the warm amber token (same hue family as the historical JS yellow)
+  // with the original dark hex as fallback, so the swatch re-themes in light
+  // mode instead of pinning a dark-only literal. See ./types KIND_FAMILY_COLORS.
+  javascript: "var(--ts-amber, #ffd97a)",
+  python: "var(--ts-green, #67e8a9)",
+  markdown: "var(--ts-text-2, #a8c8c0)",
+  json: "var(--ts-text-3, #6f9189)",
+  toml: "var(--ts-text-3, #6f9189)",
+  shell: "var(--ts-cyan, #75f4d2)",
+  web: "var(--ts-pink, #ff7ab6)",
 };
 
 export default function OverviewPanel({
@@ -84,7 +91,7 @@ export default function OverviewPanel({
               keyName="label"
               rows={overview.files_by_language.slice(0, 9).map((row) => ({
                 label: row.language,
-                color: LANGUAGE_COLORS[row.language] || "#6f9189",
+                color: LANGUAGE_COLORS[row.language] || "var(--ts-text-3, #6f9189)",
                 value: fmt(row.count),
               }))}
               onPick={(row) => onFilterLanguage(String(row.label))}

--- a/dashboard/hermes-wrapper/plugin_api.py
+++ b/dashboard/hermes-wrapper/plugin_api.py
@@ -12,6 +12,8 @@ It does not reimplement any data access. The wrapper:
   ``/lcm/*`` -> upstream ``/api/plugins/hermes-lcm/*``,
   ``/graph/*`` -> upstream ``/api/plugins/graph/*``, and
   ``/savings/*`` -> upstream ``/api/plugins/savings/*``,
+  ``/analytics/*`` -> upstream ``/api/plugins/analytics/*``,
+  ``/automation/*`` -> upstream ``/api/automation/*``,
 - exposes upstream ``/api/capabilities`` at ``/capabilities`` so the UI (and
   future Hermes-specific extensions) can feature-detect the backend.
 
@@ -583,6 +585,24 @@ async def post_savings(path: str, request: Request) -> JSONResponse:
     body = await request.body()
     return await run_in_threadpool(
         _proxy, "POST", f"/api/plugins/savings/{path}", request, body
+    )
+
+
+@router.get("/analytics/{path:path}")
+def get_analytics(path: str, request: Request) -> JSONResponse:
+    return _proxy("GET", f"/api/plugins/analytics/{path}", request, None)
+
+
+@router.get("/automation/{path:path}")
+def get_automation(path: str, request: Request) -> JSONResponse:
+    return _proxy("GET", f"/api/automation/{path}", request, None)
+
+
+@router.post("/automation/{path:path}")
+async def post_automation(path: str, request: Request) -> JSONResponse:
+    body = await request.body()
+    return await run_in_threadpool(
+        _proxy, "POST", f"/api/automation/{path}", request, body
     )
 
 

--- a/dashboard/hermes-wrapper/src/entry.js
+++ b/dashboard/hermes-wrapper/src/entry.js
@@ -10,7 +10,8 @@
  *   1. evaluates each child bundle against a window Proxy whose
  *      `__HERMES_PLUGIN_SDK__.fetchJSON` rewrites the child's API base
  *      (`/api/plugins/holographic`, `/api/plugins/hermes-lcm`,
- *      `/api/plugins/graph`, `/api/plugins/savings`) onto this plugin's API
+ *      `/api/plugins/graph`, `/api/plugins/savings`, `/api/automation`,
+ *      `/api/plugins/analytics`) onto this plugin's API
  *      prefix (`/api/plugins/tracedecay/...`), which plugin_api.py
  *      reverse-proxies to a local `tracedecay dashboard` server;
  *   2. captures the components the child bundles register (without touching
@@ -36,6 +37,8 @@
     ["/api/plugins/hermes-lcm", "/api/plugins/" + PLUGIN + "/lcm"],
     ["/api/plugins/graph", "/api/plugins/" + PLUGIN + "/graph"],
     ["/api/plugins/savings", "/api/plugins/" + PLUGIN + "/savings"],
+    ["/api/automation", "/api/plugins/" + PLUGIN + "/automation"],
+    ["/api/plugins/analytics", "/api/plugins/" + PLUGIN + "/analytics"],
   ];
 
   function rewriteUrl(url) {

--- a/dashboard/hermes-wrapper/src/wrapper.css
+++ b/dashboard/hermes-wrapper/src/wrapper.css
@@ -127,6 +127,10 @@
   --color-muted: rgba(117, 244, 210, 0.1);
   --color-muted-foreground: var(--ts-text-3);
   --color-secondary: rgba(122, 167, 255, 0.1);
+  /* Gotcha: --color-secondary is a 10%-opacity blue TINT, not a readable text
+     color, so the Tailwind `text-secondary` utility is near-invisible as
+     foreground. Use `text-text-secondary` (maps to --ts-text-2) for copy;
+     reserve `bg-secondary`/`border-secondary` for surfaces. */
   --color-destructive: var(--ts-red);
   --color-warning: var(--ts-amber);
   --color-success: var(--ts-green);

--- a/dashboard/holographic/src/CurationPanel.tsx
+++ b/dashboard/holographic/src/CurationPanel.tsx
@@ -1,44 +1,26 @@
 import {
-  type Key,
-  type ReactNode,
-  type RefObject,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
-import { createPortal } from "react-dom";
-import {
-  ChevronDown,
-  ChevronRight,
   History,
   ListChecks,
   ScrollText,
   Wand2,
 } from "lucide-react";
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from "./sdk";
+import { Button, Card, CardContent, CardHeader, CardTitle } from "./sdk";
 import { Spinner } from "./Spinner";
 import {
-  describe,
-  diffTags,
+  countLabel,
   formatHistoryTime,
-  formatOplogTime,
-  isBookkeepingTag,
-  splitTags,
 } from "./curation/format";
+import { groupActions } from "./curation/risk";
+import { ActivityScroller } from "./curation/ActivityScroller";
+import { ActionReviewGroup } from "./curation/ActionReviewGroup";
 import {
-  actionRisk,
-  groupActions,
-  riskClass,
-  type ActionGroupDef,
-  type ActionRisk,
-} from "./curation/risk";
-import { useCurationData, type CurationTab } from "./curation/useCurationData";
-import type {
-  MemoryCurateAction,
-  MemoryCuratorActivityEvent,
-  MemoryOplogEvent,
-} from "./types";
+  useCurationData,
+  type CurationTab,
+} from "./curation/useCurationData";
+import { CurationHistoryPanel } from "./curation/CurationHistoryPanel";
+import { InlineConfirm } from "./curation/InlineConfirm";
+import { isActiveAutomationStatus, type AutomationRunTask } from "./curation/automationTasks";
+import type { SecondsField, TaskField } from "./curation/configTypes";
 
 const DIAGNOSTIC_COUNT_KEYS = new Set([
   "contradictions_detected",
@@ -49,552 +31,6 @@ const DIAGNOSTIC_COUNT_KEYS = new Set([
   "orphan_entities_pruned",
   "related_clusters",
 ]);
-
-const COUNT_LABELS: Record<string, string> = {
-  delete: "delete",
-  entity_merge: "entity merges",
-  entity_classify: "entity classifications",
-  entity_prune: "junk entities pruned",
-  junk_entities_pruned: "junk entities pruned",
-  merge: "fact merges",
-  orphan_entities: "orphan entities",
-  orphan_entities_pruned: "orphan entities pruned",
-  recategorize: "recategorize",
-  reflect: "reflections",
-  retag: "retag",
-};
-
-function countLabel(key: string): string {
-  return COUNT_LABELS[key] ?? key;
-}
-
-function formatCounts(counts: Array<[string, number]>): string {
-  if (!counts.length) return "no changes";
-  return counts.map(([key, value]) => `${countLabel(key)}=${value}`).join(", ");
-}
-
-function MetadataRow({
-  label,
-  value,
-}: {
-  label: string;
-  value: ReactNode;
-}) {
-  return (
-    <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border/50 py-2 last:border-b-0">
-      <span className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
-        {label}
-      </span>
-      <span className="min-w-0 text-right font-mono-ui text-xs text-text-secondary break-all">
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function metadataValue(value: unknown, fallback = "auto"): ReactNode {
-  if (value === null || value === undefined || value === "") return fallback;
-  if (typeof value === "boolean") return value ? "yes" : "no";
-  return String(value);
-}
-
-function activityTone(level?: string) {
-  switch ((level || "info").toLowerCase()) {
-    case "success":
-      return "text-success";
-    case "warning":
-      return "text-warning";
-    case "error":
-      return "text-destructive";
-    default:
-      return "text-text-secondary";
-  }
-}
-
-function formatActivityTime(ts: string): string {
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return "--:--:--";
-  try {
-    return d.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
-    return "--:--:--";
-  }
-}
-
-function activityStatus(events: MemoryCuratorActivityEvent[], loading: boolean): string {
-  const latest = events[events.length - 1];
-  if (!latest) return "idle";
-  if (latest.phase === "stale") return "stale";
-  if (loading) return "live";
-  if (latest.phase === "finish") return "complete";
-  if (latest.phase === "lock") return "skipped";
-  return "recent";
-}
-
-function activityStatusClass(status: string): string {
-  switch (status) {
-    case "live":
-      return "border-success/30 bg-success/10 text-success";
-    case "stale":
-      return "border-warning/30 bg-warning/10 text-warning";
-    case "complete":
-      return "border-primary/30 bg-primary/10 text-primary";
-    default:
-      return "border-border bg-muted/30 text-text-tertiary";
-  }
-}
-
-/**
- * One consistent localized timestamp for every curation history surface
- * (plan "saved" chip, history rows, preview metadata). Falls back to the raw
- * value when it is not a parseable date.
- */
-/** Compact one-line summary of an oplog row's detail payload. */
-function oplogDetailSummary(event: MemoryOplogEvent): string {
-  const detail = event.detail ?? {};
-  const parts = Object.entries(detail)
-    .filter(([, value]) => value !== null && value !== undefined && value !== "")
-    .slice(0, 4)
-    .map(([key, value]) => `${key}=${String(value)}`);
-  return parts.join(" · ");
-}
-
-function ActivityScroller({
-  events,
-  loading,
-  error,
-  scrollRef,
-}: {
-  events: MemoryCuratorActivityEvent[];
-  loading: boolean;
-  error: string;
-  scrollRef: RefObject<HTMLDivElement>;
-}) {
-  const status = activityStatus(events, loading);
-  const stale = status === "stale";
-  return (
-    <div className="flex min-h-0 flex-1 flex-col border border-border bg-background/40">
-      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <ScrollText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <span className="text-xs font-medium text-foreground">Live Activity</span>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 text-[11px] text-text-tertiary">
-          {loading && !stale ? <Spinner /> : null}
-          <span
-            className={`rounded border px-1.5 py-0.5 uppercase tracking-[0.08em] ${activityStatusClass(status)}`}
-          >
-            {status}
-          </span>
-          <span>{events.length} events</span>
-        </div>
-      </div>
-      {error ? (
-        <div className="border-b border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-          {error}
-        </div>
-      ) : null}
-      {stale ? (
-        <div className="border-b border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
-          The last curator run stopped reporting activity. Refresh or start a new preview to resume from a fresh run.
-        </div>
-      ) : null}
-      <div
-        ref={scrollRef}
-        className="min-h-[12rem] flex-1 overflow-y-auto overflow-x-hidden p-3 font-mono-ui text-xs"
-      >
-        {events.length === 0 ? (
-          <div className="text-text-tertiary">
-            Start a preview or apply run to watch curator activity here.
-          </div>
-        ) : (
-          <div className="flex flex-col gap-1.5">
-            {events.map((event, index) => (
-              <div
-                key={`${event.ts}-${index}`}
-                className="grid grid-cols-[4.5rem_5.5rem_minmax(0,1fr)] gap-2"
-              >
-                <span className="text-text-tertiary">{formatActivityTime(event.ts)}</span>
-                <span className="truncate uppercase tracking-[0.08em] text-text-tertiary">
-                  {event.phase}
-                </span>
-                <span className={`min-w-0 break-words ${activityTone(event.level)}`}>
-                  {event.message}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function TagBucket({
-  label,
-  tags,
-  tone,
-}: {
-  label: string;
-  tags: string[];
-  tone: "neutral" | "removed" | "added";
-}) {
-  if (!tags.length) return null;
-  const chipClass =
-    tone === "removed"
-      ? "border-destructive/30 bg-destructive/10 text-destructive/90 line-through"
-      : tone === "added"
-        ? "border-success/30 bg-success/10 text-success"
-        : "border-border bg-secondary/60 text-text-secondary";
-  return (
-    <div className="flex flex-col gap-1 min-w-0">
-      <div className="text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
-        {label}
-      </div>
-      <div className="flex flex-wrap gap-1.5">
-        {tags.map((tag) => (
-          <span
-            key={`${label}-${tag}`}
-            className={`rounded-sm border px-1.5 py-0.5 font-mono-ui text-[10px] leading-4 break-all ${chipClass}`}
-          >
-            {tag}
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function ActionRow({ action }: { action: MemoryCurateAction; key?: Key }) {
-  const content = action.content ?? "";
-  const [expanded, setExpanded] = useState(false);
-  const risk = actionRisk(action.op);
-  const isRetag = action.op === "retag";
-  const isDelete = action.op === "delete";
-  const isEntityMerge = action.op === "entity_merge";
-  const isEntityPrune = action.op === "entity_prune";
-  const isEntityClassify = action.op === "entity_classify";
-  const isReflect = action.op === "reflect";
-  const { oldTags, newTags, kept, removed, added } = isRetag
-    ? diffTags(action.old_tags, action.tags)
-    : { oldTags: [], newTags: [], kept: [], removed: [], added: [] };
-  const tagsOnlyReordered = isRetag && removed.length === 0 && added.length === 0;
-  const normalizationOnly =
-    isRetag &&
-    removed.length > 0 &&
-    added.length === 0 &&
-    removed.every(isBookkeepingTag);
-
-  return (
-    <div className="flex flex-col gap-2 border border-border bg-background/40 px-3 py-2.5">
-      {/* Header row: badge + operation + tier */}
-      <div className="flex items-start gap-2">
-        <Badge className="shrink-0 text-[10px] uppercase mt-0.5">{action.op}</Badge>
-        <span
-          className={`shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] mt-0.5 ${riskClass(risk)}`}
-          title={risk === "review" ? "Unknown operation; review carefully before applying." : `${risk} risk`}
-        >
-          {risk}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="text-xs font-medium text-foreground break-words">{describe(action)}</div>
-        </div>
-        {action.tier && (
-          <span className="shrink-0 text-[10px] tracking-[0.08em] text-text-tertiary mt-0.5">
-            {action.tier}
-          </span>
-        )}
-      </div>
-
-      {/* Memory content — tap to expand the full fact (clamped by default) */}
-      {content && (
-        <div className="flex flex-col gap-1 border-l-2 border-border pl-2.5">
-          <div className="text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
-            Memory
-          </div>
-          <button
-            type="button"
-            onClick={() => setExpanded((v) => !v)}
-            className="text-left"
-            title={expanded ? "Show less" : "Show full fact"}
-          >
-            <p
-              className={`text-xs text-text-secondary leading-relaxed break-words ${
-                expanded ? "" : "line-clamp-3"
-              }`}
-            >
-              {content}
-            </p>
-            <span className="text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
-              {expanded ? "show less" : "tap to expand"}
-            </span>
-          </button>
-        </div>
-      )}
-
-      {/* Retag: show kept tags and the delta so normalization does not look destructive. */}
-      {isRetag && (
-        <div className="flex flex-col gap-2 border border-border/60 bg-secondary/30 p-2 text-[11px] min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="font-medium text-text-secondary">Tag change</span>
-            {normalizationOnly && (
-              <span className="rounded-sm border border-border bg-background/60 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
-                normalization only
-              </span>
-            )}
-          </div>
-          <TagBucket label="Kept" tags={kept} tone="neutral" />
-          <TagBucket label="Removed" tags={removed} tone="removed" />
-          <TagBucket label="Added" tags={added} tone="added" />
-          {tagsOnlyReordered && (
-            <span className="text-text-tertiary italic">
-              Tags reordered/normalized — no tags added or removed.
-            </span>
-          )}
-          {oldTags.length > 0 && newTags.length === 0 && (
-            <span className="text-warning">
-              This would leave the memory with no tags.
-            </span>
-          )}
-        </div>
-      )}
-
-      {isDelete && (
-        <div className="text-[11px] text-warning italic">
-          Will be permanently deleted. This cannot be undone.
-        </div>
-      )}
-
-      {isEntityMerge && (
-        <div className="flex flex-col gap-1 text-[11px] text-text-tertiary">
-          <span>
-            Consolidates duplicate entity records and preserves their linked memories
-            under the surviving entity.
-          </span>
-          {action.normalized_identity || action.fact_links_moved != null ? (
-            <span className="font-mono-ui">
-              {action.normalized_identity ? `identity=${action.normalized_identity}` : ""}
-              {action.normalized_identity && action.fact_links_moved != null ? " · " : ""}
-              {action.fact_links_moved != null ? `links moved=${action.fact_links_moved}` : ""}
-            </span>
-          ) : null}
-        </div>
-      )}
-
-      {isEntityPrune && (
-        <div className="flex flex-col gap-1 text-[11px] text-text-tertiary">
-          <span>
-            Removes a low-value, junk, or orphan entity reference without changing
-            the underlying fact text.
-          </span>
-          {action.fact_links_removed != null ? (
-            <span className="font-mono-ui">links removed={action.fact_links_removed}</span>
-          ) : null}
-        </div>
-      )}
-
-      {isEntityClassify && (
-        <div className="flex flex-col gap-1 text-[11px] text-text-tertiary">
-          <span>
-            Adds a coarse type label used by the entity list, graph, and
-            curator filters. The entity links and facts are unchanged.
-          </span>
-          <span className="font-mono-ui">
-            {action.old_entity_type ?? "unknown"} → {action.entity_type}
-            {action.fact_count != null ? ` · linked facts=${action.fact_count}` : ""}
-          </span>
-        </div>
-      )}
-
-      {isReflect && (
-        <div className="text-[11px] text-text-tertiary">
-          Creates a new {action.category ?? "general"} fact
-          {action.supersedes?.length
-            ? `, supersedes ${action.supersedes.map((s) => `#${s}`).join(", ")}`
-            : ""}
-          .
-        </div>
-      )}
-
-      {/* Reason from AI */}
-      {action.reason && (
-        <div className="text-[11px] text-text-tertiary leading-relaxed border-t border-border/50 pt-1.5 mt-0.5">
-          {action.reason}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ActionGroup({
-  group,
-  defaultOpen,
-}: {
-  group: ActionGroupDef & { actions: MemoryCurateAction[] };
-  defaultOpen: boolean;
-  key?: Key;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  if (group.actions.length === 0) return null;
-  const riskCounts = group.actions.reduce<Record<ActionRisk, number>>(
-    (acc, action) => {
-      acc[actionRisk(action.op)] += 1;
-      return acc;
-    },
-    { low: 0, medium: 0, high: 0, review: 0 },
-  );
-
-  return (
-    <section className="border border-border bg-background/30">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full min-w-0 items-start gap-2 px-3 py-2 text-left"
-      >
-        {open ? (
-          <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary" />
-        ) : (
-          <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary" />
-        )}
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs font-medium text-foreground">{group.label}</span>
-            <Badge tone="outline" className="text-[10px]">
-              {group.actions.length}
-            </Badge>
-            {(["high", "medium", "low", "review"] as ActionRisk[]).map((risk) =>
-              riskCounts[risk] ? (
-                <span
-                  key={risk}
-                  className={`rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] ${riskClass(risk)}`}
-                >
-                  {risk} {riskCounts[risk]}
-                </span>
-              ) : null,
-            )}
-          </div>
-          <div className="mt-0.5 text-[11px] text-text-tertiary">
-            {group.description}
-          </div>
-        </div>
-      </button>
-      {open ? (
-        <div className="flex flex-col gap-2 border-t border-border/70 p-2">
-          {group.actions.map((action, i) => (
-            <ActionRow key={`${group.key}-${action.op}-${i}`} action={action} />
-          ))}
-        </div>
-      ) : null}
-    </section>
-  );
-}
-
-/**
- * Minimal confirm modal — local replacement for the core SPA's `ConfirmDialog`
- * (not exposed on the plugin SDK). Rendered through a React portal to
- * `document.body` so the `fixed inset-0` overlay escapes `.ts-card`'s
- * containing block (`backdrop-filter`) and `overflow-hidden`/`max-h` clipping,
- * and reliably covers the full viewport.
- */
-function InlineConfirm({
-  open,
-  title,
-  description,
-  children,
-  confirmLabel,
-  loading,
-  onCancel,
-  onConfirm,
-}: {
-  open: boolean;
-  title: string;
-  description?: string;
-  children?: ReactNode;
-  confirmLabel: string;
-  loading?: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  const titleId = useId();
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const previouslyFocused = useRef<HTMLElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    previouslyFocused.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    const dialog = dialogRef.current;
-    const focusTarget =
-      dialog?.querySelector<HTMLElement>(
-        "button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
-      ) ?? dialog;
-    focusTarget?.focus();
-    return () => {
-      previouslyFocused.current?.focus?.();
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onCancel();
-      }
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [open, onCancel]);
-
-  if (!open) return null;
-  if (typeof document === "undefined") return null;
-
-  return createPortal(
-    <div
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
-      }}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        tabIndex={-1}
-        className="relative mx-4 w-full max-w-md border border-border bg-card shadow-lg"
-      >
-        <div className="flex flex-col gap-1 border-b border-border p-4">
-          <h2
-            id={titleId}
-            className="font-mondwest text-display text-sm font-bold tracking-[0.12em]"
-          >
-            {title}
-          </h2>
-          {description && (
-            <p className="font-sans text-xs leading-relaxed text-muted-foreground">
-              {description}
-            </p>
-          )}
-        </div>
-        {children ? <div className="border-b border-border p-4">{children}</div> : null}
-        <div className="flex items-center justify-end gap-2 p-3">
-          <Button type="button" outlined onClick={onCancel} disabled={loading}>
-            Cancel
-          </Button>
-          <Button type="button" onClick={onConfirm} disabled={loading}>
-            {loading ? "…" : confirmLabel}
-          </Button>
-        </div>
-      </div>
-    </div>,
-    document.body,
-  );
-}
 
 export default function CurationPanel({
   onApplied,
@@ -616,9 +52,42 @@ export default function CurationPanel({
     statusError,
     oplog,
     oplogError,
+    automationRuns,
+    automationRunsError,
+    automationRunActioning,
+    automationRunError,
+    automationRunArtifacts,
+    automationRunArtifact,
+    automationRunArtifactLoading,
+    automationRunArtifactError,
+    factProposals,
+    factProposalsLoading,
+    factProposalsError,
+    factProposalActioning,
+    managedSkills,
+    selectedManagedSkillId,
+    selectedManagedSkill,
+    managedSkillUsage,
+    managedSkillRecommendations,
+    managedSkillImprovementRecommendations,
+    managedSkillsLoading,
+    managedSkillsError,
+    managedSkillActioning,
     activity,
     activityLoading,
     activityError,
+    configResponse,
+    configDraft,
+    configLoading,
+    configSaving,
+    configResetting,
+    configError,
+    configFieldErrors,
+    schedulerStatus,
+    schedulerStatusLoading,
+    schedulerStatusError,
+    schedulerActioning,
+    configDirty,
     activityRef,
     panelRef,
     setConfirmOpen,
@@ -627,6 +96,22 @@ export default function CurationPanel({
     apply,
     loadActivity,
     loadStatus,
+    loadOplog,
+    loadAutomationRuns,
+    loadSchedulerStatus,
+    loadAutomationRunArtifact,
+    loadFactProposals,
+    loadManagedSkills,
+    loadManagedSkill,
+    runAutomationTask,
+    runFactProposalAction,
+    runManagedSkillAction,
+    setSchedulerPaused,
+    updateConfigDraft,
+    updateConfigTaskDraft,
+    resetConfigDraft,
+    resetConfigToDefaults,
+    saveConfigDraft,
   } = useCurationData({ onApplied });
 
   const actions = report?.actions ?? [];
@@ -641,11 +126,78 @@ export default function CurationPanel({
   );
   const actionGroups = groupActions(actions);
   const nonEmptyActionGroups = actionGroups.filter((group) => group.actions.length > 0);
+  const backendAvailability = configResponse?.backend_availability;
+  const backendUnavailable =
+    !configDirty &&
+    configDraft?.backend === "codex_app_server" &&
+    configDraft?.host_mode === "standalone" &&
+    backendAvailability?.available === false;
+  const backendUnavailableReason =
+    backendAvailability?.reason ?? "Codex app-server backend is unavailable";
+  const automationCanRun =
+    Boolean(configDraft?.enabled) &&
+    configDraft?.backend === "codex_app_server" &&
+    configDraft?.host_mode === "standalone" &&
+    !backendUnavailable &&
+    !configDirty &&
+    !configSaving &&
+    !automationRunActioning;
+  const activeAutomationStatus = (task: AutomationRunTask) =>
+    automationRuns.find(
+      (record) => record.task === task && isActiveAutomationStatus(record.status),
+    )?.status;
+  const automationRunTitle = configDirty
+    ? "Save automation config before running"
+    : configDraft?.host_mode === "delegated_host"
+      ? "Delegated host mode owns intelligence runs"
+      : configDraft?.backend !== "codex_app_server"
+        ? "Select the Codex app-server backend before running"
+        : backendUnavailable
+          ? backendUnavailableReason
+          : !configDraft?.enabled
+            ? "Enable automation before running"
+            : "Run now";
+  const automationTaskTitle = (task: AutomationRunTask) => {
+    const status = activeAutomationStatus(task);
+    if (status === "queued") return "Automation run is queued";
+    if (status === "running") return "Automation run is running";
+    return automationRunTitle;
+  };
+  const automationTaskLabel = (task: AutomationRunTask) => {
+    const status = activeAutomationStatus(task);
+    if (status === "queued") return "Queued";
+    if (status === "running") return "Running";
+    return "Run";
+  };
+  const automationTaskCanRun = (task: AutomationRunTask) =>
+    automationCanRun && !activeAutomationStatus(task);
+  const updateTaskSeconds = (
+    task: AutomationRunTask,
+    key: SecondsField,
+    value: string,
+  ) => {
+    updateConfigTaskDraft(task, {
+      [key]: value ? Math.max(1, Number(value) || 1) : null,
+    });
+  };
+  const taskFieldError = (
+    task: AutomationRunTask,
+    field: TaskField,
+  ) => configFieldErrors[`${task}.${field}`];
   const planLabel = actions.length ? `Plan ${actions.length}` : "Plan";
   const confirmGroupCounts = nonEmptyActionGroups.map((group) => [
     group.label,
     group.actions.length,
   ] as const);
+  const selectedUsage = selectedManagedSkill
+    ? managedSkillUsage[selectedManagedSkill.metadata.id]
+    : null;
+  const selectedRecommendation = selectedManagedSkill
+    ? managedSkillRecommendations[selectedManagedSkill.metadata.id]
+    : null;
+  const selectedImprovementRecommendation = selectedManagedSkill
+    ? managedSkillImprovementRecommendations[selectedManagedSkill.metadata.id]
+    : null;
   const tabs: Array<{ id: CurationTab; label: string; Icon: typeof Wand2 }> = [
     { id: "plan", label: planLabel, Icon: ListChecks },
     { id: "history", label: "History", Icon: History },
@@ -802,7 +354,7 @@ export default function CurationPanel({
             {actions.length > 0 ? (
               <div className="flex flex-1 min-h-0 flex-col gap-2 overflow-y-auto overflow-x-hidden pr-1">
                 {nonEmptyActionGroups.map((group, i) => (
-                  <ActionGroup
+                  <ActionReviewGroup
                     key={group.key}
                     group={group}
                     defaultOpen={i === 0}
@@ -855,217 +407,78 @@ export default function CurationPanel({
         ) : null}
 
         {activeTab === "history" ? (
-          <div
-            role="tabpanel"
-            id="curation-panel-history"
-            aria-labelledby="curation-tab-history"
-            className="flex flex-1 min-h-0 flex-col gap-3 overflow-y-auto overflow-x-hidden pr-1"
-          >
-            <div className="flex min-w-0 items-center justify-between gap-2 shrink-0">
-              <div className="min-w-0">
-                <div className="text-xs font-medium text-foreground">
-                  Curator Status
-                </div>
-                <div className="text-[11px] text-text-tertiary">
-                  Scheduler state, last run summary, and recent snapshots.
-                </div>
-              </div>
-              <Button
-                size="xs"
-                ghost
-                disabled={statusLoading}
-                onClick={loadStatus}
-                className="shrink-0 gap-2"
-              >
-                {statusLoading ? <Spinner /> : null}
-                Refresh
-              </Button>
-            </div>
-            {statusError ? (
-              <div className="border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive shrink-0">
-                {statusError}
-              </div>
-            ) : null}
-            {status ? (
-              <>
-                <div className="border border-border bg-background/30 px-3">
-                  <div className="pt-2 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
-                    Run history
-                  </div>
-                  <MetadataRow label="Provider" value={status.provider || "none"} />
-                  <MetadataRow label="Run count" value={status.state.run_count} />
-                  <MetadataRow
-                    label="Last apply"
-                    value={formatHistoryTime(status.state.last_run_at) || "never"}
-                  />
-                  <MetadataRow label="Last applied summary" value={status.state.last_run_summary || "none"} />
-                  <MetadataRow
-                    label="Last preview"
-                    value={formatHistoryTime(status.state.last_preview_at) || "never"}
-                  />
-                  <MetadataRow label="Last preview summary" value={status.state.last_preview_summary || "none"} />
-                </div>
-                <div className="border border-border bg-background/30 px-3">
-                  <div className="pt-2 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
-                    Curator configuration
-                  </div>
-                  <div className="pt-1 text-[11px] text-text-tertiary">
-                    Settings, not run results — "auto" means the provider
-                    default is used.
-                  </div>
-                  <MetadataRow label="Enabled" value={status.config.enabled ? "yes" : "no"} />
-                  <MetadataRow label="Paused" value={status.state.paused ? "yes" : "no"} />
-                  <MetadataRow label="Interval hours" value={metadataValue(status.config.interval_hours)} />
-                  <MetadataRow label="Idle gate hours" value={metadataValue(status.config.min_idle_hours)} />
-                  <MetadataRow label="Resolved mode" value={metadataValue(status.config.mode, "fast")} />
-                  <MetadataRow label="Dry-run first" value={metadataValue(status.config.dry_run_first, "no")} />
-                  <MetadataRow label="Scan cap" value={metadataValue(status.config.scan_cap)} />
-                  <MetadataRow label="Scan cap grace" value={metadataValue(status.config.scan_cap_grace, "0")} />
-                  <MetadataRow label="Max candidates" value={metadataValue(status.config.max_candidates)} />
-                  <MetadataRow
-                    label="Related threshold"
-                    value={metadataValue(status.config.related_cluster_threshold)}
-                  />
-                  <MetadataRow
-                    label="Batch size"
-                    value={metadataValue(status.config.batch_size)}
-                  />
-                  <MetadataRow
-                    label="Tool calls / batch"
-                    value={metadataValue(status.config.max_tool_calls_per_batch)}
-                  />
-                  <MetadataRow
-                    label="LLM calls / run"
-                    value={metadataValue(status.config.max_llm_calls_per_run)}
-                  />
-                  <MetadataRow label="Facts / run" value={metadataValue(status.config.per_run_facts)} />
-                  <MetadataRow
-                    label="Candidates / fact"
-                    value={metadataValue(status.config.candidates_per_fact)}
-                  />
-                  <MetadataRow
-                    label="Source cap"
-                    value={metadataValue(status.config.candidate_source_cap)}
-                  />
-                  <MetadataRow
-                    label="Expansion scan cap"
-                    value={metadataValue(status.config.candidate_expansion_scan_cap)}
-                  />
-                  <MetadataRow
-                    label="Parallel LLM"
-                    value={metadataValue(status.config.max_parallel_llm)}
-                  />
-                </div>
-                <div className="border border-border bg-background/30 px-3 py-2">
-                  <div className="mb-1 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
-                    Recent snapshots
-                  </div>
-                  {status.snapshots.length ? (
-                    <div className="flex flex-col gap-1">
-                      {status.snapshots.map((snapshot) => (
-                        <div
-                          key={snapshot.path}
-                          className="min-w-0 font-mono-ui text-xs text-text-secondary break-all"
-                        >
-                          {snapshot.name}
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="text-xs text-text-tertiary">No snapshots found.</div>
-                  )}
-                </div>
-              </>
-            ) : null}
-            <div className="border border-border bg-background/30 px-3 py-2">
-              <div className="mb-1 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
-                Recent memory operations
-              </div>
-              {oplogError ? (
-                <div className="text-xs text-destructive">{oplogError}</div>
-              ) : null}
-              {oplog.length ? (
-                <div className="flex flex-col gap-1">
-                  {oplog.map((event) => (
-                    <div
-                      key={event.id}
-                      className="grid grid-cols-[7.5rem_5.5rem_minmax(0,1fr)] gap-2 font-mono-ui text-xs"
-                    >
-                      <span className="text-text-tertiary">{formatOplogTime(event.ts)}</span>
-                      <span className="truncate uppercase tracking-[0.08em] text-text-secondary">
-                        {event.op}
-                      </span>
-                      <span className="min-w-0 break-all text-text-tertiary">
-                        {event.fact_id != null ? `#${event.fact_id} ` : ""}
-                        {oplogDetailSummary(event)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-xs text-text-tertiary">
-                  No memory operations recorded yet.
-                </div>
-              )}
-            </div>
-            {report ? (
-              <>
-                <div className="text-xs font-medium text-foreground">
-                  Current Preview
-                </div>
-                <div className="border border-border bg-background/30 px-3">
-                  <MetadataRow label="Run mode" value={isPlan ? "preview" : "applied"} />
-                  {previewSavedAt ? (
-                    <MetadataRow label="Saved" value={formatHistoryTime(previewSavedAt)} />
-                  ) : null}
-                  {previewStale ? (
-                    <MetadataRow
-                      label="Preview state"
-                      value={previewStaleReason || "stale"}
-                    />
-                  ) : null}
-                  <MetadataRow label="Actions" value={actions.length} />
-                  <MetadataRow label="Counts" value={formatCounts(actionCounts)} />
-                  <MetadataRow label="Signals" value={formatCounts(diagnosticCounts)} />
-                  <MetadataRow label="LLM calls" value={report.llm_calls} />
-                  {report.skipped_actions != null ? (
-                    <MetadataRow label="Skipped" value={report.skipped_actions} />
-                  ) : null}
-                  {report.snapshot ? (
-                    <MetadataRow label="Snapshot" value={report.snapshot} />
-                  ) : null}
-                </div>
-                {report.coverage ? (
-                  <div className="border border-border bg-background/30 px-3">
-                    <MetadataRow
-                      label="Facts scanned"
-                      value={`${report.coverage.scanned}/${report.coverage.active_total}`}
-                    />
-                    <MetadataRow
-                      label="Facts due"
-                      value={report.coverage.due_remaining}
-                    />
-                    {report.coverage.entity_total != null ? (
-                      <MetadataRow
-                        label="Entities scanned"
-                        value={`${report.coverage.entities_scanned ?? 0}/${report.coverage.entity_total}`}
-                      />
-                    ) : null}
-                    {report.coverage.entity_scan_remaining != null ? (
-                      <MetadataRow
-                        label="Entities due"
-                        value={report.coverage.entity_scan_remaining}
-                      />
-                    ) : null}
-                  </div>
-                ) : null}
-              </>
-            ) : (
-              <div className="border border-border bg-background/30 px-3 py-4 text-xs text-text-tertiary">
-                Preview a plan to see current run metadata, signals, and coverage.
-              </div>
-            )}
-          </div>
+          <CurationHistoryPanel
+            report={report}
+            previewSavedAt={previewSavedAt}
+            previewStale={previewStale}
+            previewStaleReason={previewStaleReason}
+            actionsLength={actions.length}
+            actionCounts={actionCounts}
+            diagnosticCounts={diagnosticCounts}
+            isPlan={isPlan}
+            status={status}
+            statusLoading={statusLoading}
+            statusError={statusError}
+            oplog={oplog}
+            oplogError={oplogError}
+            automationRuns={automationRuns}
+            automationRunsError={automationRunsError}
+            automationRunActioning={automationRunActioning}
+            automationRunError={automationRunError}
+            automationRunArtifacts={automationRunArtifacts}
+            automationRunArtifact={automationRunArtifact}
+            automationRunArtifactLoading={automationRunArtifactLoading}
+            automationRunArtifactError={automationRunArtifactError}
+            factProposals={factProposals}
+            factProposalsLoading={factProposalsLoading}
+            factProposalsError={factProposalsError}
+            factProposalActioning={factProposalActioning}
+            managedSkills={managedSkills}
+            selectedManagedSkillId={selectedManagedSkillId}
+            selectedManagedSkill={selectedManagedSkill}
+            selectedUsage={selectedUsage}
+            selectedRecommendation={selectedRecommendation}
+            selectedImprovementRecommendation={selectedImprovementRecommendation}
+            managedSkillsLoading={managedSkillsLoading}
+            managedSkillsError={managedSkillsError}
+            managedSkillActioning={managedSkillActioning}
+            configDraft={configDraft}
+            configLoading={configLoading}
+            configSaving={configSaving}
+            configResetting={configResetting}
+            configError={configError}
+            configFieldErrors={configFieldErrors}
+            schedulerStatus={schedulerStatus}
+            schedulerStatusLoading={schedulerStatusLoading}
+            schedulerStatusError={schedulerStatusError}
+            schedulerActioning={schedulerActioning}
+            configDirty={configDirty}
+            backendUnavailable={backendUnavailable}
+            backendUnavailableReason={backendUnavailableReason}
+            activeAutomationStatus={activeAutomationStatus}
+            automationTaskCanRun={automationTaskCanRun}
+            automationTaskTitle={automationTaskTitle}
+            automationTaskLabel={automationTaskLabel}
+            taskFieldError={taskFieldError}
+            loadStatus={loadStatus}
+            loadOplog={loadOplog}
+            loadAutomationRuns={loadAutomationRuns}
+            loadSchedulerStatus={loadSchedulerStatus}
+            loadAutomationRunArtifact={loadAutomationRunArtifact}
+            loadFactProposals={loadFactProposals}
+            loadManagedSkills={loadManagedSkills}
+            loadManagedSkill={loadManagedSkill}
+            runAutomationTask={runAutomationTask}
+            runFactProposalAction={runFactProposalAction}
+            runManagedSkillAction={runManagedSkillAction}
+            setSchedulerPaused={setSchedulerPaused}
+            updateConfigDraft={updateConfigDraft}
+            updateConfigTaskDraft={updateConfigTaskDraft}
+            updateTaskSeconds={updateTaskSeconds}
+            resetConfigDraft={resetConfigDraft}
+            resetConfigToDefaults={resetConfigToDefaults}
+            saveConfigDraft={saveConfigDraft}
+          />
         ) : null}
       </CardContent>
 

--- a/dashboard/holographic/src/HolographicMemoryPage.tsx
+++ b/dashboard/holographic/src/HolographicMemoryPage.tsx
@@ -41,6 +41,7 @@ import AssociationGraph from "./AssociationGraph";
 import CurationPanel from "./CurationPanel";
 import { NUM_BADGE } from "./ui";
 import { MiniBar } from "./MiniBar";
+import { Stat } from "../../lib/primitives";
 import { categoryColorMap, slotColor } from "./viz/colors";
 import { PanelError, PanelLoading } from "./viz/Status";
 import { Sparkline } from "./viz/Sparkline";
@@ -105,32 +106,6 @@ function highlighted(snippet?: string, fallback?: string | null) {
   }
   if (last < text.length) parts.push(text.slice(last));
   return parts;
-}
-
-function Stat({
-  label,
-  value,
-  hint,
-}: {
-  label: string;
-  value: string | number;
-  /** Plain-language explanation surfaced as a native tooltip. */
-  hint?: string;
-}) {
-  return (
-    <div
-      className="hm-stat border border-border bg-background/50 px-3 py-2"
-      title={hint}
-      style={hint ? { cursor: "help" } : undefined}
-    >
-      <div className="hm-stat-value font-mono-ui text-lg leading-none text-foreground">
-        {value}
-      </div>
-      <div className="hm-stat-label mt-1 text-xs tracking-[0.08em] text-text-tertiary">
-        {label}
-      </div>
-    </div>
-  );
 }
 
 function DataBars<T>({
@@ -215,36 +190,35 @@ function SystemStrip({
 
   return (
     <div className="hm-system-strip grid gap-3 sm:grid-cols-[repeat(2,minmax(0,1fr))] xl:grid-cols-[repeat(7,minmax(0,1fr))]">
-      <Stat label="memory provider" value={activeMemory} />
-      <Stat label="context engine" value={provider.context_engine || "compressor"} />
-      <Stat label="context engine tools" value={pluginEngine?.tools?.length ?? 0} />
+      <Stat className="hm-stat" label="memory provider" value={activeMemory} />
+      <Stat className="hm-stat" label="context engine" value={provider.context_engine || "compressor"} />
+      <Stat className="hm-stat" label="context engine tools" value={pluginEngine?.tools?.length ?? 0} />
       <Stat
+        className="hm-stat"
         label="curator tools"
         value={curatorTools?.enabled ? `${curatorTools.count ?? 0} enabled` : "not used"}
-        hint={
+        title={
           curatorTools?.enabled
             ? "Evidence-gathering tools the memory curator can call while reviewing facts."
             : "The memory curator runs without LLM tool calls here — duplicates are detected with built-in vector-similarity analysis instead."
         }
       />
       <Stat
+        className="hm-stat"
         label="curator agents"
         value={agentToolsets > 0 ? agentToolsets : "none"}
-        hint={
+        title={
           agentToolsets > 0
             ? "Agent toolsets the curator can delegate cleanup work to."
             : "No agent-driven curation is configured. Curation previews and applies still work — they use the built-in deduplication planner."
         }
       />
-      <Stat label="database" value={db.exists ? "ready" : "missing"} />
-      <div className="hm-stat hm-path-stat min-w-0 border border-border bg-background/50 px-3 py-2 sm:col-span-2 xl:col-span-1">
-        <div className="hm-stat-value truncate font-mono-ui text-xs text-foreground">
-          {db.path}
-        </div>
-        <div className="hm-stat-label mt-1 text-xs tracking-[0.08em] text-text-tertiary">
-          storage path
-        </div>
-      </div>
+      <Stat className="hm-stat" label="database" value={db.exists ? "ready" : "missing"} />
+      <Stat
+        className="hm-stat hm-path-stat min-w-0 sm:col-span-2 xl:col-span-1"
+        label="storage path"
+        value={db.path}
+      />
     </div>
   );
 }
@@ -308,25 +282,28 @@ function MemoryHealthCard({
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <div className="grid min-w-0 gap-3 grid-cols-2 xl:grid-cols-4">
-          <Stat label="facts" value={memory.fact_count} />
-          <Stat label="entities" value={memory.entity_count} />
-          <Stat label="banks" value={memory.bank_count} />
-          <Stat label="capacity / bank" value={memory.estimated_capacity} />
+          <Stat className="hm-stat" label="facts" value={memory.fact_count} />
+          <Stat className="hm-stat" label="entities" value={memory.entity_count} />
+          <Stat className="hm-stat" label="banks" value={memory.bank_count} />
+          <Stat className="hm-stat" label="capacity / bank" value={memory.estimated_capacity} />
           <Stat
+            className="hm-stat"
             label="largest bank utilization"
             value={`${status.largest_bank_fact_count}/${memory.estimated_capacity} (${utilizationPct.toFixed(1)}%)`}
-            hint={`Largest bank: ${largestBank.bank_name}`}
+            title={`Largest bank: ${largestBank.bank_name}`}
           />
-          <Stat label="missing vectors" value={memory.missing_vector_count} />
+          <Stat className="hm-stat" label="missing vectors" value={memory.missing_vector_count} />
           <Stat
+            className="hm-stat"
             label="below recall floor"
             value={memory.below_default_recall_threshold_count}
-            hint="Facts currently below the default recall trust threshold (0.30)."
+            title="Facts currently below the default recall trust threshold (0.30)."
           />
           <Stat
+            className="hm-stat"
             label="feedback"
             value={`${memory.helpful_count}/${memory.unhelpful_count}`}
-            hint="Helpful vs unhelpful feedback events recorded against stored facts."
+            title="Helpful vs unhelpful feedback events recorded against stored facts."
           />
         </div>
         <div className="grid min-w-0 gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">

--- a/dashboard/holographic/src/api.ts
+++ b/dashboard/holographic/src/api.ts
@@ -9,6 +9,17 @@
 
 import { fetchJSON } from "./sdk";
 import type {
+  AutomationRunRequest,
+  AutomationSchedulerStatusResponse,
+  FactProposalListResponse,
+  FactProposalResponse,
+  MemoryAgentPlanResponse,
+  MemoryAutomationConfigPatch,
+  MemoryAutomationConfigResponse,
+  MemoryAutomationRunArtifactPayloadResponse,
+  MemoryAutomationRunArtifactsResponse,
+  MemoryAutomationRunResponse,
+  MemoryAutomationRunsResponse,
   MemoryCurateApplyResponse,
   MemoryCurateOp,
   MemoryCurateResponse,
@@ -21,9 +32,46 @@ import type {
   MemoryProjectionResponse,
   MemorySimilarityResponse,
   MemoryStatusResponse,
+  ManagedSkillListResponse,
+  ManagedSkillResponse,
 } from "./types";
 
 const BASE = "/api/plugins/holographic";
+const AUTOMATION_BASE = "/api/automation";
+
+function withLimit(path: string, limit?: number): string {
+  const qs = new URLSearchParams();
+  if (limit) qs.set("limit", String(limit));
+  const suffix = qs.toString();
+  return `${path}${suffix ? `?${suffix}` : ""}`;
+}
+
+function managedSkillPath(id: string, action?: string): string {
+  const path = `${AUTOMATION_BASE}/skills/${encodeURIComponent(id)}`;
+  return action ? `${path}/${action}` : path;
+}
+
+function factProposalPath(id: string, action?: string): string {
+  const path = `${AUTOMATION_BASE}/fact-proposals/${encodeURIComponent(id)}`;
+  return action ? `${path}/${action}` : path;
+}
+
+function postAutomationRun<TReport = Record<string, unknown>>(
+  path: string,
+  body: AutomationRunRequest = {},
+) {
+  return fetchJSON<MemoryAutomationRunResponse<TReport>>(`${AUTOMATION_BASE}/run/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ dry_run: true, ...body }),
+  });
+}
+
+function postManagedSkillAction(id: string, action: string) {
+  return fetchJSON<ManagedSkillResponse>(managedSkillPath(id, action), {
+    method: "POST",
+  });
+}
 
 export const api = {
   /** Overview + facts + entities + graph (GET /). */
@@ -89,6 +137,28 @@ export const api = {
       body: JSON.stringify(body),
     }),
 
+  /** Standalone backend memory-curator review (POST /curation/agent-plan). */
+  postMemoryAgentPlan: (
+    body: { dry_run?: true; max_clusters?: number; min_confidence?: number } = {},
+  ) =>
+    fetchJSON<MemoryAgentPlanResponse>(`${BASE}/curation/agent-plan`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ dry_run: true, ...body }),
+    }),
+
+  /** Standalone memory-curator run (POST /api/automation/run/memory-curator). */
+  postAutomationRunMemoryCurator: (body: AutomationRunRequest = {}) =>
+    postAutomationRun<MemoryCurateResponse>("memory-curator", body),
+
+  /** Standalone session-reflection run (POST /api/automation/run/session-reflection). */
+  postAutomationRunSessionReflection: (body: AutomationRunRequest = {}) =>
+    postAutomationRun("session-reflection", body),
+
+  /** Standalone managed skill-writer run (POST /api/automation/run/skill-writing). */
+  postAutomationRunSkillWriting: (body: AutomationRunRequest = {}) =>
+    postAutomationRun("skill-writing", body),
+
   /** Apply explicit curation ops — delete/merge (POST /curate/apply). */
   postMemoryCurateApply: (body: { ops: MemoryCurateOp[] }) =>
     fetchJSON<MemoryCurateApplyResponse>(`${BASE}/curate/apply`, {
@@ -97,7 +167,7 @@ export const api = {
       body: JSON.stringify(body),
     }),
 
-  /** Last saved dry-run preview for this Hermes profile (GET /curation/preview). */
+  /** Last saved dry-run preview for this project/profile (GET /curation/preview). */
   getMemoryCuratorPreview: () =>
     fetchJSON<MemoryCuratorPreviewResponse>(`${BASE}/curation/preview`),
 
@@ -105,24 +175,113 @@ export const api = {
   getMemoryCuratorStatus: () =>
     fetchJSON<MemoryCuratorStatusResponse>(`${BASE}/curation/status`),
 
+  /** Effective automation config plus project override sidecar (GET /curation/config). */
+  getMemoryAutomationConfig: () =>
+    fetchJSON<MemoryAutomationConfigResponse>(`${BASE}/curation/config`),
+
+  /** Persist project automation config overrides (PATCH /curation/config). */
+  patchMemoryAutomationConfig: (body: MemoryAutomationConfigPatch) =>
+    fetchJSON<MemoryAutomationConfigResponse>(`${BASE}/curation/config`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+
+  /** Remove project automation overrides and return effective defaults (DELETE /curation/config). */
+  resetMemoryAutomationConfig: () =>
+    fetchJSON<MemoryAutomationConfigResponse>(`${BASE}/curation/config`, {
+      method: "DELETE",
+    }),
+
+  /** Dashboard-visible automation scheduler state. */
+  getAutomationSchedulerStatus: () =>
+    fetchJSON<AutomationSchedulerStatusResponse>(`${AUTOMATION_BASE}/scheduler/status`),
+
+  /** Pause scheduler dispatch through the scheduler control sidecar. */
+  pauseAutomationScheduler: () =>
+    fetchJSON<AutomationSchedulerStatusResponse>(`${AUTOMATION_BASE}/scheduler/pause`, {
+      method: "POST",
+    }),
+
+  /** Resume scheduler dispatch through the scheduler control sidecar. */
+  resumeAutomationScheduler: () =>
+    fetchJSON<AutomationSchedulerStatusResponse>(`${AUTOMATION_BASE}/scheduler/resume`, {
+      method: "POST",
+    }),
+
+  /** Recent standalone automation backend runs (GET /curation/runs). */
+  getMemoryAutomationRuns: (params: { limit?: number } = {}) =>
+    fetchJSON<MemoryAutomationRunsResponse>(
+      withLimit(`${BASE}/curation/runs`, params.limit),
+    ),
+
+  /** Artifact metadata for one automation run (GET /api/automation/runs/{run_id}/artifacts). */
+  getMemoryAutomationRunArtifacts: (runId: string) =>
+    fetchJSON<MemoryAutomationRunArtifactsResponse>(
+      `${AUTOMATION_BASE}/runs/${encodeURIComponent(runId)}/artifacts`,
+    ),
+
+  /** Verified artifact payload for one automation run artifact kind. */
+  getMemoryAutomationRunArtifact: (runId: string, kind: string) =>
+    fetchJSON<MemoryAutomationRunArtifactPayloadResponse>(
+      `${AUTOMATION_BASE}/runs/${encodeURIComponent(runId)}/artifacts/${encodeURIComponent(kind)}`,
+    ),
+
   /** Recent structured curator activity (GET /curation/activity). */
-  getMemoryCuratorActivity: (params: { limit?: number } = {}) => {
-    const qs = new URLSearchParams();
-    if (params.limit) qs.set("limit", String(params.limit));
-    const suffix = qs.toString();
-    return fetchJSON<MemoryCuratorActivityResponse>(
-      `${BASE}/curation/activity${suffix ? `?${suffix}` : ""}`,
-    );
-  },
+  getMemoryCuratorActivity: (params: { limit?: number } = {}) =>
+    fetchJSON<MemoryCuratorActivityResponse>(
+      withLimit(`${BASE}/curation/activity`, params.limit),
+    ),
 
   /** Recent memory operations from the append-only oplog (GET /oplog). */
-  getMemoryOplog: (params: { limit?: number } = {}) => {
+  getMemoryOplog: (params: { limit?: number } = {}) =>
+    fetchJSON<MemoryOplogResponse>(withLimit(`${BASE}/oplog`, params.limit)),
+
+  /** Profile-owned managed skill packages (GET /api/automation/skills). */
+  getManagedSkills: () =>
+    fetchJSON<ManagedSkillListResponse>(`${AUTOMATION_BASE}/skills`),
+
+  /** Full managed skill body and metadata (GET /api/automation/skills/{id}). */
+  getManagedSkill: (id: string) =>
+    fetchJSON<ManagedSkillResponse>(managedSkillPath(id)),
+
+  /** Approve a pending managed skill (POST /api/automation/skills/{id}/approve). */
+  approveManagedSkill: (id: string) => postManagedSkillAction(id, "approve"),
+
+  /** Discard a staged managed skill update without mutating the active revision. */
+  discardManagedSkillUpdate: (id: string) => postManagedSkillAction(id, "discard-update"),
+
+  /** Disable an active managed skill (POST /api/automation/skills/{id}/disable). */
+  disableManagedSkill: (id: string) => postManagedSkillAction(id, "disable"),
+
+  /** Archive a managed skill without deleting its package. */
+  archiveManagedSkill: (id: string) => postManagedSkillAction(id, "archive"),
+
+  /** Restore an archived/disabled skill to pending approval. */
+  restoreManagedSkill: (id: string) => postManagedSkillAction(id, "restore"),
+
+  /** Durable session-reflection fact proposals awaiting approval. */
+  getFactProposals: (params: { state?: string; limit?: number } = {}) => {
     const qs = new URLSearchParams();
+    if (params.state) qs.set("state", params.state);
     if (params.limit) qs.set("limit", String(params.limit));
     const suffix = qs.toString();
-    return fetchJSON<MemoryOplogResponse>(
-      `${BASE}/oplog${suffix ? `?${suffix}` : ""}`,
+    return fetchJSON<FactProposalListResponse>(
+      `${AUTOMATION_BASE}/fact-proposals${suffix ? `?${suffix}` : ""}`,
     );
   },
 
+  /** Apply an approved fact proposal to the memory store. */
+  applyFactProposal: (id: string) =>
+    fetchJSON<FactProposalResponse>(factProposalPath(id, "apply"), {
+      method: "POST",
+    }),
+
+  /** Reject a pending fact proposal without mutating memory. */
+  rejectFactProposal: (id: string, reason?: string) =>
+    fetchJSON<FactProposalResponse>(factProposalPath(id, "reject"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason: reason || null }),
+    }),
 };

--- a/dashboard/holographic/src/curation/ActionReviewGroup.tsx
+++ b/dashboard/holographic/src/curation/ActionReviewGroup.tsx
@@ -1,0 +1,268 @@
+import { type Key, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { Badge } from "../sdk";
+import { describe, diffTags, isBookkeepingTag } from "./format";
+import {
+  actionRisk,
+  riskClass,
+  type ActionGroupDef,
+  type ActionRisk,
+} from "./risk";
+import type { MemoryCurateAction } from "../types";
+
+const RISK_ORDER: ActionRisk[] = ["high", "medium", "low", "review"];
+
+function TagBucket({
+  label,
+  tags,
+  tone,
+}: {
+  label: string;
+  tags: string[];
+  tone: "neutral" | "removed" | "added";
+}) {
+  if (!tags.length) return null;
+  const chipClass =
+    tone === "removed"
+      ? "border-destructive/30 bg-destructive/10 text-destructive/90 line-through"
+      : tone === "added"
+        ? "border-success/30 bg-success/10 text-success"
+        : "border-border bg-secondary/60 text-text-secondary";
+  return (
+    <div className="flex flex-col gap-1 min-w-0">
+      <div className="text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
+        {label}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {tags.map((tag) => (
+          <span
+            key={`${label}-${tag}`}
+            className={`rounded-sm border px-1.5 py-0.5 font-mono-ui text-[10px] leading-4 break-all ${chipClass}`}
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ActionRow({ action }: { action: MemoryCurateAction; key?: Key }) {
+  const content = action.content ?? "";
+  const [expanded, setExpanded] = useState(false);
+  const risk = actionRisk(action.op);
+  const isRetag = action.op === "retag";
+  const isDelete = action.op === "delete";
+  const isEntityMerge = action.op === "entity_merge";
+  const isEntityPrune = action.op === "entity_prune";
+  const isEntityClassify = action.op === "entity_classify";
+  const isReflect = action.op === "reflect";
+  const { oldTags, newTags, kept, removed, added } = isRetag
+    ? diffTags(action.old_tags, action.tags)
+    : { oldTags: [], newTags: [], kept: [], removed: [], added: [] };
+  const tagsOnlyReordered = isRetag && removed.length === 0 && added.length === 0;
+  const normalizationOnly =
+    isRetag &&
+    removed.length > 0 &&
+    added.length === 0 &&
+    removed.every(isBookkeepingTag);
+
+  return (
+    <div className="flex flex-col gap-2 border border-border bg-background/40 px-3 py-2.5">
+      <div className="flex items-start gap-2">
+        <Badge className="shrink-0 text-[10px] uppercase mt-0.5">{action.op}</Badge>
+        <span
+          className={`shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] mt-0.5 ${riskClass(risk)}`}
+          title={risk === "review" ? "Unknown operation; review carefully before applying." : `${risk} risk`}
+        >
+          {risk}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-foreground break-words">{describe(action)}</div>
+        </div>
+        {action.tier && (
+          <span className="shrink-0 text-[10px] tracking-[0.08em] text-text-tertiary mt-0.5">
+            {action.tier}
+          </span>
+        )}
+      </div>
+
+      {content && (
+        <div className="flex flex-col gap-1 border-l-2 border-border pl-2.5">
+          <div className="text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
+            Memory
+          </div>
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-left"
+            title={expanded ? "Show less" : "Show full fact"}
+          >
+            <p
+              className={`text-xs text-text-secondary leading-relaxed break-words ${
+                expanded ? "" : "line-clamp-3"
+              }`}
+            >
+              {content}
+            </p>
+            <span className="text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
+              {expanded ? "show less" : "tap to expand"}
+            </span>
+          </button>
+        </div>
+      )}
+
+      {isRetag && (
+        <div className="flex flex-col gap-2 border border-border/60 bg-secondary/30 p-2 text-[11px] min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-text-secondary">Tag change</span>
+            {normalizationOnly && (
+              <span className="rounded-sm border border-border bg-background/60 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] text-text-tertiary">
+                normalization only
+              </span>
+            )}
+          </div>
+          <TagBucket label="Kept" tags={kept} tone="neutral" />
+          <TagBucket label="Removed" tags={removed} tone="removed" />
+          <TagBucket label="Added" tags={added} tone="added" />
+          {tagsOnlyReordered && (
+            <span className="text-text-tertiary italic">
+              Tags reordered/normalized — no tags added or removed.
+            </span>
+          )}
+          {oldTags.length > 0 && newTags.length === 0 && (
+            <span className="text-warning">
+              This would leave the memory with no tags.
+            </span>
+          )}
+        </div>
+      )}
+
+      {isDelete && (
+        <div className="text-[11px] text-warning italic">
+          Will be permanently deleted. This cannot be undone.
+        </div>
+      )}
+
+      {isEntityMerge && (
+        <div className="flex flex-col gap-1 text-[11px] text-text-tertiary">
+          <span>
+            Consolidates duplicate entity records and preserves their linked memories
+            under the surviving entity.
+          </span>
+          {action.normalized_identity || action.fact_links_moved != null ? (
+            <span className="font-mono-ui">
+              {action.normalized_identity ? `identity=${action.normalized_identity}` : ""}
+              {action.normalized_identity && action.fact_links_moved != null ? " · " : ""}
+              {action.fact_links_moved != null ? `links moved=${action.fact_links_moved}` : ""}
+            </span>
+          ) : null}
+        </div>
+      )}
+
+      {isEntityPrune && (
+        <div className="flex flex-col gap-1 text-[11px] text-text-tertiary">
+          <span>
+            Removes a low-value, junk, or orphan entity reference without changing
+            the underlying fact text.
+          </span>
+          {action.fact_links_removed != null ? (
+            <span className="font-mono-ui">links removed={action.fact_links_removed}</span>
+          ) : null}
+        </div>
+      )}
+
+      {isEntityClassify && (
+        <div className="flex flex-col gap-1 text-[11px] text-text-tertiary">
+          <span>
+            Adds a coarse type label used by the entity list, graph, and
+            curator filters. The entity links and facts are unchanged.
+          </span>
+          <span className="font-mono-ui">
+            {action.old_entity_type ?? "unknown"} → {action.entity_type}
+            {action.fact_count != null ? ` · linked facts=${action.fact_count}` : ""}
+          </span>
+        </div>
+      )}
+
+      {isReflect && (
+        <div className="text-[11px] text-text-tertiary">
+          Creates a new {action.category ?? "general"} fact
+          {action.supersedes?.length
+            ? `, supersedes ${action.supersedes.map((s) => `#${s}`).join(", ")}`
+            : ""}
+          .
+        </div>
+      )}
+
+      {action.reason && (
+        <div className="text-[11px] text-text-tertiary leading-relaxed border-t border-border/50 pt-1.5 mt-0.5">
+          {action.reason}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ActionReviewGroup({
+  group,
+  defaultOpen,
+}: {
+  group: ActionGroupDef & { actions: MemoryCurateAction[] };
+  defaultOpen: boolean;
+  key?: Key;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  if (group.actions.length === 0) return null;
+  const riskCounts = group.actions.reduce<Record<ActionRisk, number>>(
+    (acc, action) => {
+      acc[actionRisk(action.op)] += 1;
+      return acc;
+    },
+    { low: 0, medium: 0, high: 0, review: 0 },
+  );
+
+  return (
+    <section className="border border-border bg-background/30">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full min-w-0 items-start gap-2 px-3 py-2 text-left"
+      >
+        {open ? (
+          <ChevronDown className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+        ) : (
+          <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-medium text-foreground">{group.label}</span>
+            <Badge tone="outline" className="text-[10px]">
+              {group.actions.length}
+            </Badge>
+            {RISK_ORDER.map((risk) =>
+              riskCounts[risk] ? (
+                <span
+                  key={risk}
+                  className={`rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] ${riskClass(risk)}`}
+                >
+                  {risk} {riskCounts[risk]}
+                </span>
+              ) : null,
+            )}
+          </div>
+          <div className="mt-0.5 text-[11px] text-text-tertiary">
+            {group.description}
+          </div>
+        </div>
+      </button>
+      {open ? (
+        <div className="flex flex-col gap-2 border-t border-border/70 p-2">
+          {group.actions.map((action, i) => (
+            <ActionRow key={`${group.key}-${action.op}-${i}`} action={action} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/dashboard/holographic/src/curation/ActivityScroller.tsx
+++ b/dashboard/holographic/src/curation/ActivityScroller.tsx
@@ -1,0 +1,126 @@
+import type { RefObject } from "react";
+import { ScrollText } from "lucide-react";
+
+import { Spinner } from "../Spinner";
+import type { MemoryCuratorActivityEvent } from "../types";
+
+function activityTone(level?: string) {
+  switch ((level || "info").toLowerCase()) {
+    case "success":
+      return "text-success";
+    case "warning":
+      return "text-warning";
+    case "error":
+      return "text-destructive";
+    default:
+      return "text-text-secondary";
+  }
+}
+
+function formatActivityTime(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return "--:--:--";
+  try {
+    return d.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return "--:--:--";
+  }
+}
+
+function activityStatus(events: MemoryCuratorActivityEvent[], loading: boolean): string {
+  const latest = events[events.length - 1];
+  if (!latest) return "idle";
+  if (latest.phase === "stale") return "stale";
+  if (loading) return "live";
+  if (latest.phase === "finish") return "complete";
+  if (latest.phase === "lock") return "skipped";
+  return "recent";
+}
+
+function activityStatusClass(status: string): string {
+  switch (status) {
+    case "live":
+      return "border-success/30 bg-success/10 text-success";
+    case "stale":
+      return "border-warning/30 bg-warning/10 text-warning";
+    case "complete":
+      return "border-primary/30 bg-primary/10 text-primary";
+    default:
+      return "border-border bg-muted/30 text-text-tertiary";
+  }
+}
+
+export function ActivityScroller({
+  events,
+  loading,
+  error,
+  scrollRef,
+}: {
+  events: MemoryCuratorActivityEvent[];
+  loading: boolean;
+  error: string;
+  scrollRef: RefObject<HTMLDivElement>;
+}) {
+  const status = activityStatus(events, loading);
+  const stale = status === "stale";
+  return (
+    <div className="flex min-h-0 flex-1 flex-col border border-border bg-background/40">
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <ScrollText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="text-xs font-medium text-foreground">Live Activity</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 text-[11px] text-text-tertiary">
+          {loading && !stale ? <Spinner /> : null}
+          <span
+            className={`rounded border px-1.5 py-0.5 uppercase tracking-[0.08em] ${activityStatusClass(status)}`}
+          >
+            {status}
+          </span>
+          <span>{events.length} events</span>
+        </div>
+      </div>
+      {error ? (
+        <div className="border-b border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+      {stale ? (
+        <div className="border-b border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+          The last curator run stopped reporting activity. Refresh or start a new preview to resume from a fresh run.
+        </div>
+      ) : null}
+      <div
+        ref={scrollRef}
+        className="min-h-[12rem] flex-1 overflow-y-auto overflow-x-hidden p-3 font-mono-ui text-xs"
+      >
+        {events.length === 0 ? (
+          <div className="text-text-tertiary">
+            Start a preview or apply run to watch curator activity here.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            {events.map((event, index) => (
+              <div
+                key={`${event.ts}-${index}`}
+                className="grid grid-cols-[4.5rem_5.5rem_minmax(0,1fr)] gap-2"
+              >
+                <span className="text-text-tertiary">{formatActivityTime(event.ts)}</span>
+                <span className="truncate uppercase tracking-[0.08em] text-text-tertiary">
+                  {event.phase}
+                </span>
+                <span className={`min-w-0 break-words ${activityTone(event.level)}`}>
+                  {event.message}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/AutomationConfigSection.tsx
+++ b/dashboard/holographic/src/curation/AutomationConfigSection.tsx
@@ -1,0 +1,327 @@
+import type { ChangeEvent } from "react";
+import { RotateCcw, Save } from "lucide-react";
+
+import { Button, Input } from "../sdk";
+import { Spinner } from "../Spinner";
+import type {
+  AutomationTaskConfig,
+  MemoryAutomationConfig,
+  MemoryAutomationConfigPatch,
+  SelectableAutomationBackend,
+} from "../types";
+import { AutomationTaskConfigRow, ConfigFieldError } from "./AutomationTaskConfigRow";
+import { AUTOMATION_TASKS, type AutomationRunTask } from "./automationTasks";
+import type { ConfigFieldErrors, SecondsField, TaskField } from "./configTypes";
+import { MetadataRow } from "./MetadataRow";
+
+function ConfigCheckbox({
+  label,
+  ariaLabel,
+  checked,
+  error,
+  onCheckedChange,
+}: {
+  label: string;
+  ariaLabel: string;
+  checked: boolean;
+  error?: string;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="grid gap-1">
+      <label className="flex items-center gap-2 text-xs text-text-secondary">
+        <input
+          aria-label={ariaLabel}
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => onCheckedChange(event.currentTarget.checked)}
+        />
+        {label}
+      </label>
+      <ConfigFieldError message={error} />
+    </div>
+  );
+}
+
+export function AutomationConfigSection({
+  configDraft,
+  configLoading,
+  configSaving,
+  configResetting,
+  configError,
+  configFieldErrors,
+  configDirty,
+  backendUnavailable,
+  backendUnavailableReason,
+  automationRunActioning,
+  automationRunError,
+  paused,
+  activeAutomationStatus,
+  automationTaskCanRun,
+  automationTaskTitle,
+  automationTaskLabel,
+  taskFieldError,
+  runAutomationTask,
+  updateConfigDraft,
+  updateConfigTaskDraft,
+  updateTaskSeconds,
+  resetConfigDraft,
+  resetConfigToDefaults,
+  saveConfigDraft,
+}: {
+  configDraft: MemoryAutomationConfig | null;
+  configLoading: boolean;
+  configSaving: boolean;
+  configResetting: boolean;
+  configError: string;
+  configFieldErrors: ConfigFieldErrors;
+  configDirty: boolean;
+  backendUnavailable: boolean;
+  backendUnavailableReason: string;
+  automationRunActioning: AutomationRunTask | null;
+  automationRunError: string;
+  paused: boolean;
+  activeAutomationStatus: (task: AutomationRunTask) => string | undefined;
+  automationTaskCanRun: (task: AutomationRunTask) => boolean;
+  automationTaskTitle: (task: AutomationRunTask) => string;
+  automationTaskLabel: (task: AutomationRunTask) => string;
+  taskFieldError: (task: AutomationRunTask, field: TaskField) => string | undefined;
+  runAutomationTask: (task: AutomationRunTask) => void;
+  updateConfigDraft: (patch: MemoryAutomationConfigPatch) => void;
+  updateConfigTaskDraft: (task: AutomationRunTask, patch: Partial<AutomationTaskConfig>) => void;
+  updateTaskSeconds: (task: AutomationRunTask, key: SecondsField, value: string) => void;
+  resetConfigDraft: () => void;
+  resetConfigToDefaults: () => Promise<void>;
+  saveConfigDraft: () => Promise<void>;
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+          Automation config
+        </div>
+        {configLoading ? <Spinner /> : null}
+      </div>
+      {configError ? (
+        <div className="mt-2 border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          {configError}
+        </div>
+      ) : null}
+      {backendUnavailable ? (
+        <div className="mt-2 border border-warning/30 bg-warning/10 px-2 py-1 text-xs text-warning">
+          {backendUnavailableReason}
+        </div>
+      ) : null}
+      {automationRunError ? (
+        <div className="mt-2 border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          {automationRunError}
+        </div>
+      ) : null}
+      {configDraft ? (
+        <div className="mt-2 grid gap-2">
+          <div className="grid gap-2 sm:grid-cols-2">
+            <ConfigCheckbox
+              label="Enable automation"
+              ariaLabel="Enable automation"
+              checked={configDraft.enabled}
+              onCheckedChange={(enabled) => updateConfigDraft({ enabled })}
+            />
+            <ConfigCheckbox
+              label="Require approval"
+              ariaLabel="Require dashboard approval"
+              checked={configDraft.require_dashboard_approval}
+              error={configFieldErrors.require_dashboard_approval}
+              onCheckedChange={(require_dashboard_approval) =>
+                updateConfigDraft({ require_dashboard_approval })
+              }
+            />
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Backend
+              <select
+                aria-label="Backend"
+                className="h-8 border border-border bg-background px-2 text-xs"
+                value={configDraft.backend}
+                onChange={(event) =>
+                  updateConfigDraft({
+                    backend: event.currentTarget.value as SelectableAutomationBackend,
+                  })
+                }
+              >
+                <option value="disabled">Disabled</option>
+                <option value="codex_app_server">Codex app server</option>
+              </select>
+              <ConfigFieldError message={configFieldErrors.backend} />
+            </label>
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Host mode
+              <select
+                aria-label="Host mode"
+                className="h-8 border border-border bg-background px-2 text-xs"
+                value={configDraft.host_mode}
+                onChange={(event) =>
+                  updateConfigDraft({
+                    host_mode: event.currentTarget.value as typeof configDraft.host_mode,
+                  })
+                }
+              >
+                <option value="standalone">Standalone</option>
+                <option value="delegated_host">Delegated host</option>
+              </select>
+              <ConfigFieldError message={configFieldErrors.host_mode} />
+            </label>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-[1fr_8rem_8rem]">
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Model
+              <Input
+                aria-label="Model"
+                value={configDraft.model ?? ""}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  updateConfigDraft({ model: event.currentTarget.value || null })
+                }
+              />
+            </label>
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Timeout
+              <Input
+                aria-label="Timeout seconds"
+                type="number"
+                min={1}
+                value={configDraft.timeout_secs}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  updateConfigDraft({
+                    timeout_secs: Math.max(1, Number(event.currentTarget.value) || 1),
+                  })
+                }
+              />
+              <ConfigFieldError message={configFieldErrors.timeout_secs} />
+            </label>
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Scheduler tick
+              <Input
+                aria-label="Scheduler tick seconds"
+                type="number"
+                min={1}
+                value={configDraft.scheduler_tick_secs}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  updateConfigDraft({
+                    scheduler_tick_secs: Math.max(1, Number(event.currentTarget.value) || 1),
+                  })
+                }
+              />
+              <ConfigFieldError message={configFieldErrors.scheduler_tick_secs} />
+            </label>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Max tokens
+              <Input
+                aria-label="Max tokens"
+                type="number"
+                min={1}
+                value={configDraft.max_tokens ?? ""}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  updateConfigDraft({
+                    max_tokens: event.currentTarget.value
+                      ? Math.max(1, Number(event.currentTarget.value) || 1)
+                      : null,
+                  })
+                }
+              />
+              <ConfigFieldError message={configFieldErrors.max_tokens} />
+            </label>
+            <label className="grid gap-1 text-xs text-text-secondary">
+              Temperature
+              <Input
+                aria-label="Temperature"
+                type="number"
+                min={0}
+                step={0.1}
+                value={configDraft.temperature ?? ""}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  updateConfigDraft({
+                    temperature: event.currentTarget.value
+                      ? Math.max(0, Number(event.currentTarget.value) || 0)
+                      : null,
+                  })
+                }
+              />
+              <ConfigFieldError message={configFieldErrors.temperature} />
+            </label>
+          </div>
+          {AUTOMATION_TASKS.map((descriptor) => (
+            <div key={descriptor.id}>
+              <AutomationTaskConfigRow
+                descriptor={descriptor}
+                config={configDraft.tasks[descriptor.id]}
+                actioningTask={automationRunActioning}
+                activeStatus={activeAutomationStatus(descriptor.id)}
+                canRun={automationTaskCanRun(descriptor.id)}
+                runTitle={automationTaskTitle(descriptor.id)}
+                runLabel={automationTaskLabel(descriptor.id)}
+                fieldError={taskFieldError}
+                onTaskPatch={updateConfigTaskDraft}
+                onTaskSecondsPatch={updateTaskSeconds}
+                onRun={runAutomationTask}
+              />
+            </div>
+          ))}
+          <div className="grid gap-2 sm:grid-cols-2">
+            <ConfigCheckbox
+              label="Auto-apply memory ops"
+              ariaLabel="Auto-apply memory ops"
+              checked={configDraft.auto_apply_memory_ops}
+              error={configFieldErrors.auto_apply_memory_ops}
+              onCheckedChange={(auto_apply_memory_ops) =>
+                updateConfigDraft({ auto_apply_memory_ops })
+              }
+            />
+            <ConfigCheckbox
+              label="Auto-enable skills"
+              ariaLabel="Auto-enable skills"
+              checked={configDraft.auto_enable_skills}
+              error={configFieldErrors.auto_enable_skills}
+              onCheckedChange={(auto_enable_skills) => updateConfigDraft({ auto_enable_skills })}
+            />
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <Button
+              size="xs"
+              outlined
+              disabled={!configDirty || configSaving || configResetting}
+              onClick={resetConfigDraft}
+            >
+              Discard edits
+            </Button>
+            <Button
+              size="xs"
+              outlined
+              disabled={configSaving || configResetting}
+              onClick={() => {
+                void resetConfigToDefaults().catch(() => {});
+              }}
+              className="gap-1.5"
+            >
+              {configResetting ? <Spinner /> : <RotateCcw className="h-3.5 w-3.5" />}
+              Reset defaults
+            </Button>
+            <Button
+              size="xs"
+              disabled={!configDirty || configSaving || configResetting}
+              onClick={() => {
+                void saveConfigDraft().catch(() => {});
+              }}
+              className="gap-1.5"
+            >
+              {configSaving ? <Spinner /> : <Save className="h-3.5 w-3.5" />}
+              Save config
+            </Button>
+          </div>
+        </div>
+      ) : null}
+      <MetadataRow label="Paused" value={paused ? "yes" : "no"} />
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/AutomationRunsSection.tsx
+++ b/dashboard/holographic/src/curation/AutomationRunsSection.tsx
@@ -1,0 +1,145 @@
+import { Eye } from "lucide-react";
+import type { Key } from "react";
+
+import { Badge, Button } from "../sdk";
+import { Spinner } from "../Spinner";
+import { formatHistoryTime } from "./format";
+import {
+  automationArtifactPreview,
+  automationRunStatusClass,
+  automationRunSummary,
+} from "./historyFormat";
+import type {
+  MemoryAutomationRunArtifact,
+  MemoryAutomationRunArtifactPayloadResponse,
+  MemoryAutomationRunArtifactsResponse,
+  MemoryAutomationRunRecord,
+} from "../types";
+
+function ArtifactButton({
+  runId,
+  artifact,
+  artifactLoading,
+  onLoadArtifact,
+}: {
+  key?: Key;
+  runId: string;
+  artifact: MemoryAutomationRunArtifact;
+  artifactLoading: string | null;
+  onLoadArtifact: (runId: string, kind: string) => void;
+}) {
+  const loadingKey = `${runId}:${artifact.kind}`;
+  const loading = artifactLoading === loadingKey;
+
+  return (
+    <Button
+      size="xs"
+      outlined
+      disabled={loading}
+      onClick={() => onLoadArtifact(runId, artifact.kind)}
+      className="gap-1.5"
+    >
+      {loading ? <Spinner /> : <Eye className="h-3.5 w-3.5" />}
+      {artifact.kind}
+    </Button>
+  );
+}
+
+export function AutomationRunsSection({
+  runs,
+  error,
+  artifacts,
+  artifact,
+  artifactLoading,
+  artifactError,
+  onLoadArtifact,
+}: {
+  runs: MemoryAutomationRunRecord[];
+  error: string;
+  artifacts: MemoryAutomationRunArtifactsResponse | null;
+  artifact: MemoryAutomationRunArtifactPayloadResponse | null;
+  artifactLoading: string | null;
+  artifactError: string;
+  onLoadArtifact: (runId: string, kind: string) => void;
+}) {
+  const artifactPreview = automationArtifactPreview(artifact);
+
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="mb-1 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+        Automation runs
+      </div>
+      {error ? <div className="text-xs text-destructive">{error}</div> : null}
+      {runs.length ? (
+        <div className="flex flex-col gap-1.5">
+          {runs.map((record) => (
+            <div
+              key={record.run_id}
+              className="grid grid-cols-[7.5rem_5.5rem_minmax(0,1fr)] gap-2 font-mono-ui text-xs"
+            >
+              <span className="text-text-tertiary">
+                {formatHistoryTime(record.completed_at || record.started_at)}
+              </span>
+              <span
+                className={`truncate border px-1.5 py-0.5 text-center uppercase tracking-[0.08em] ${automationRunStatusClass(record.status)}`}
+              >
+                {record.status}
+              </span>
+              <div className="min-w-0">
+                <div className="break-all text-text-tertiary">
+                  {automationRunSummary(record)}
+                </div>
+                {record.artifacts?.length ? (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {record.artifacts.map((runArtifact) => (
+                      <ArtifactButton
+                        key={`${record.run_id}:${runArtifact.kind}`}
+                        runId={record.run_id}
+                        artifact={runArtifact}
+                        artifactLoading={artifactLoading}
+                        onLoadArtifact={onLoadArtifact}
+                      />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-xs text-text-tertiary">
+          No automation runs recorded yet.
+        </div>
+      )}
+      {artifactError ? (
+        <div className="mt-2 text-xs text-destructive">{artifactError}</div>
+      ) : null}
+      {artifact ? (
+        <div className="mt-2 border border-border bg-background/40 px-3 py-2">
+          <div className="mb-1 flex flex-wrap items-center gap-2 text-xs">
+            <span className="font-mono-ui text-text-secondary">
+              {artifact.run_id}
+            </span>
+            <Badge>{artifact.artifact.kind}</Badge>
+            <span className="min-w-0 break-all font-mono-ui text-text-tertiary">
+              {artifact.artifact.sha256}
+            </span>
+          </div>
+          {artifacts?.run_id === artifact.run_id && artifacts.artifact_chain ? (
+            <div className="mb-2 flex flex-wrap items-center gap-1.5 font-mono-ui text-[11px] text-text-tertiary">
+              <Badge>
+                {artifacts.artifact_chain.complete ? "chain complete" : "chain pending"}
+              </Badge>
+              {(artifacts.artifact_chain.present_kinds || []).map((kind) => (
+                <span key={`${artifact.run_id}:${kind}`}>{kind}</span>
+              ))}
+            </div>
+          ) : null}
+          <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words font-mono-ui text-xs text-text-secondary">
+            {artifactPreview}
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/AutomationTaskConfigRow.tsx
+++ b/dashboard/holographic/src/curation/AutomationTaskConfigRow.tsx
@@ -1,0 +1,110 @@
+import type { ChangeEvent } from "react";
+import { Power } from "lucide-react";
+
+import { Button, Input } from "../sdk";
+import { Spinner } from "../Spinner";
+import type { AutomationTaskConfig } from "../types";
+import type { AutomationRunTask, AutomationTaskDescriptor } from "./automationTasks";
+import type { SecondsField, TaskField } from "./configTypes";
+
+const SECONDS_FIELDS: Array<{ key: SecondsField; label: string }> = [
+  { key: "interval_secs", label: "Interval seconds" },
+  { key: "cooldown_secs", label: "Cooldown seconds" },
+  { key: "min_idle_secs", label: "Idle seconds" },
+  { key: "stale_lock_secs", label: "Stale lock seconds" },
+];
+
+export function ConfigFieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <div className="text-[11px] leading-snug text-destructive">{message}</div>;
+}
+
+export function AutomationTaskConfigRow({
+  descriptor,
+  config,
+  actioningTask,
+  activeStatus,
+  canRun,
+  runTitle,
+  runLabel,
+  fieldError,
+  onTaskPatch,
+  onTaskSecondsPatch,
+  onRun,
+}: {
+  descriptor: AutomationTaskDescriptor;
+  config: AutomationTaskConfig;
+  actioningTask: AutomationRunTask | null;
+  activeStatus?: string;
+  canRun: boolean;
+  runTitle: string;
+  runLabel: string;
+  fieldError: (task: AutomationRunTask, field: TaskField) => string | undefined;
+  onTaskPatch: (task: AutomationRunTask, patch: Partial<AutomationTaskConfig>) => void;
+  onTaskSecondsPatch: (task: AutomationRunTask, key: SecondsField, value: string) => void;
+  onRun: (task: AutomationRunTask) => void;
+}) {
+  const task = descriptor.id;
+  const running = actioningTask === task || activeStatus === "running";
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <label className="flex items-center gap-2 text-xs text-text-secondary">
+        <input
+          aria-label={descriptor.enabledLabel}
+          type="checkbox"
+          checked={config.enabled}
+          onChange={(event) =>
+            onTaskPatch(task, {
+              enabled: event.currentTarget.checked,
+            })
+          }
+        />
+        {descriptor.enabledLabel}
+      </label>
+      <div className="flex min-w-0 items-end gap-2">
+        <label className="grid min-w-0 flex-1 gap-1 text-xs text-text-secondary">
+          {descriptor.scheduleLabel}
+          <Input
+            aria-label={descriptor.scheduleLabel}
+            value={config.schedule ?? ""}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onTaskPatch(task, {
+                schedule: event.currentTarget.value || null,
+              })
+            }
+          />
+          <ConfigFieldError message={fieldError(task, "schedule")} />
+        </label>
+        <Button
+          size="xs"
+          outlined
+          disabled={!canRun || !config.enabled}
+          title={runTitle}
+          onClick={() => onRun(task)}
+          className="shrink-0 gap-1.5"
+        >
+          {running ? <Spinner /> : <Power className="h-3.5 w-3.5" />}
+          {runLabel}
+        </Button>
+      </div>
+      <div className="grid gap-2 sm:col-span-2 sm:grid-cols-4">
+        {SECONDS_FIELDS.map(({ key, label }) => (
+          <label key={key} className="grid gap-1 text-xs text-text-secondary">
+            {label}
+            <Input
+              aria-label={`${descriptor.runAriaLabel} ${label.toLowerCase()}`}
+              type="number"
+              min={1}
+              value={config[key] ?? ""}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                onTaskSecondsPatch(task, key, event.currentTarget.value)
+              }
+            />
+            <ConfigFieldError message={fieldError(task, key)} />
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/CurationHistoryPanel.tsx
+++ b/dashboard/holographic/src/curation/CurationHistoryPanel.tsx
@@ -1,0 +1,299 @@
+import { Button } from "../sdk";
+import { Spinner } from "../Spinner";
+import { AutomationConfigSection } from "./AutomationConfigSection";
+import { AutomationRunsSection } from "./AutomationRunsSection";
+import { CurrentPreviewSection } from "./CurrentPreviewSection";
+import { FactProposalsSection } from "./FactProposalsSection";
+import { ManagedSkillsSection } from "./ManagedSkillsSection";
+import { MemoryOperationsSection } from "./MemoryOperationsSection";
+import { RunHistorySection } from "./RunHistorySection";
+import { SchedulerStatusSection } from "./SchedulerStatusSection";
+import { SnapshotsSection } from "./SnapshotsSection";
+import type { AutomationRunTask } from "./automationTasks";
+import type { ConfigFieldErrors, SecondsField, TaskField } from "./configTypes";
+import type {
+  AutomationSchedulerStatusResponse,
+  AutomationTaskConfig,
+  FactProposalRecord,
+  ManagedSkill,
+  MemoryAutomationConfig,
+  MemoryAutomationConfigPatch,
+  MemoryAutomationRunArtifactPayloadResponse,
+  MemoryAutomationRunArtifactsResponse,
+  MemoryAutomationRunRecord,
+  MemoryCurateResponse,
+  MemoryCuratorStatusResponse,
+  MemoryOplogEvent,
+  SkillImprovementRecommendation,
+  SkillStaleRecommendation,
+  SkillUsageSummary,
+} from "../types";
+
+interface CurationHistoryPanelProps {
+  report: MemoryCurateResponse | null;
+  previewSavedAt: string | null;
+  previewStale: boolean;
+  previewStaleReason: string;
+  actionsLength: number;
+  actionCounts: Array<[string, number]>;
+  diagnosticCounts: Array<[string, number]>;
+  isPlan: boolean;
+  status: MemoryCuratorStatusResponse | null;
+  statusLoading: boolean;
+  statusError: string;
+  oplog: MemoryOplogEvent[];
+  oplogError: string;
+  automationRuns: MemoryAutomationRunRecord[];
+  automationRunsError: string;
+  automationRunActioning: AutomationRunTask | null;
+  automationRunError: string;
+  automationRunArtifacts: MemoryAutomationRunArtifactsResponse | null;
+  automationRunArtifact: MemoryAutomationRunArtifactPayloadResponse | null;
+  automationRunArtifactLoading: string | null;
+  automationRunArtifactError: string;
+  factProposals: FactProposalRecord[];
+  factProposalsLoading: boolean;
+  factProposalsError: string;
+  factProposalActioning: string | null;
+  managedSkills: ManagedSkill[];
+  selectedManagedSkillId: string | null;
+  selectedManagedSkill: ManagedSkill | null;
+  selectedUsage: SkillUsageSummary | null;
+  selectedRecommendation: SkillStaleRecommendation | null;
+  selectedImprovementRecommendation: SkillImprovementRecommendation | null;
+  managedSkillsLoading: boolean;
+  managedSkillsError: string;
+  managedSkillActioning: string | null;
+  configDraft: MemoryAutomationConfig | null;
+  configLoading: boolean;
+  configSaving: boolean;
+  configResetting: boolean;
+  configError: string;
+  configFieldErrors: ConfigFieldErrors;
+  schedulerStatus: AutomationSchedulerStatusResponse | null;
+  schedulerStatusLoading: boolean;
+  schedulerStatusError: string;
+  schedulerActioning: boolean;
+  configDirty: boolean;
+  backendUnavailable: boolean;
+  backendUnavailableReason: string;
+  activeAutomationStatus: (task: AutomationRunTask) => string | undefined;
+  automationTaskCanRun: (task: AutomationRunTask) => boolean;
+  automationTaskTitle: (task: AutomationRunTask) => string;
+  automationTaskLabel: (task: AutomationRunTask) => string;
+  taskFieldError: (task: AutomationRunTask, field: TaskField) => string | undefined;
+  loadStatus: () => void;
+  loadOplog: () => void;
+  loadAutomationRuns: () => void;
+  loadSchedulerStatus: (force?: boolean) => void;
+  loadAutomationRunArtifact: (runId: string, kind: string) => void;
+  loadFactProposals: (force?: boolean) => void;
+  loadManagedSkills: (force?: boolean) => void;
+  loadManagedSkill: (skillId: string) => void;
+  runAutomationTask: (task: AutomationRunTask) => void;
+  runFactProposalAction: (action: "apply" | "reject", proposalId: string) => void;
+  runManagedSkillAction: (action: string, skillId: string) => void;
+  setSchedulerPaused: (paused: boolean) => void;
+  updateConfigDraft: (patch: MemoryAutomationConfigPatch) => void;
+  updateConfigTaskDraft: (task: AutomationRunTask, patch: Partial<AutomationTaskConfig>) => void;
+  updateTaskSeconds: (task: AutomationRunTask, key: SecondsField, value: string) => void;
+  resetConfigDraft: () => void;
+  resetConfigToDefaults: () => Promise<void>;
+  saveConfigDraft: () => Promise<void>;
+}
+
+export function CurationHistoryPanel({
+  report,
+  previewSavedAt,
+  previewStale,
+  previewStaleReason,
+  actionsLength,
+  actionCounts,
+  diagnosticCounts,
+  isPlan,
+  status,
+  statusLoading,
+  statusError,
+  oplog,
+  oplogError,
+  automationRuns,
+  automationRunsError,
+  automationRunActioning,
+  automationRunError,
+  automationRunArtifacts,
+  automationRunArtifact,
+  automationRunArtifactLoading,
+  automationRunArtifactError,
+  factProposals,
+  factProposalsLoading,
+  factProposalsError,
+  factProposalActioning,
+  managedSkills,
+  selectedManagedSkillId,
+  selectedManagedSkill,
+  selectedUsage,
+  selectedRecommendation,
+  selectedImprovementRecommendation,
+  managedSkillsLoading,
+  managedSkillsError,
+  managedSkillActioning,
+  configDraft,
+  configLoading,
+  configSaving,
+  configResetting,
+  configError,
+  configFieldErrors,
+  schedulerStatus,
+  schedulerStatusLoading,
+  schedulerStatusError,
+  schedulerActioning,
+  configDirty,
+  backendUnavailable,
+  backendUnavailableReason,
+  activeAutomationStatus,
+  automationTaskCanRun,
+  automationTaskTitle,
+  automationTaskLabel,
+  taskFieldError,
+  loadStatus,
+  loadOplog,
+  loadAutomationRuns,
+  loadSchedulerStatus,
+  loadAutomationRunArtifact,
+  loadFactProposals,
+  loadManagedSkills,
+  loadManagedSkill,
+  runAutomationTask,
+  runFactProposalAction,
+  runManagedSkillAction,
+  setSchedulerPaused,
+  updateConfigDraft,
+  updateConfigTaskDraft,
+  updateTaskSeconds,
+  resetConfigDraft,
+  resetConfigToDefaults,
+  saveConfigDraft,
+}: CurationHistoryPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      id="curation-panel-history"
+      aria-labelledby="curation-tab-history"
+      className="flex flex-1 min-h-0 flex-col gap-3 overflow-y-auto overflow-x-hidden pr-1"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2 shrink-0">
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-foreground">
+            Curator Status
+          </div>
+          <div className="text-[11px] text-text-tertiary">
+            Scheduler state, last run summary, and recent snapshots.
+          </div>
+        </div>
+        <Button
+          size="xs"
+          ghost
+          disabled={statusLoading}
+          onClick={() => {
+            loadStatus();
+            loadSchedulerStatus(true);
+            loadOplog();
+            loadAutomationRuns();
+            loadFactProposals(true);
+            loadManagedSkills(true);
+          }}
+          className="shrink-0 gap-2"
+        >
+          {statusLoading ? <Spinner /> : null}
+          Refresh
+        </Button>
+      </div>
+      {statusError ? (
+        <div className="border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive shrink-0">
+          {statusError}
+        </div>
+      ) : null}
+      {status ? (
+        <>
+          <RunHistorySection status={status} />
+          <SchedulerStatusSection
+            status={schedulerStatus}
+            loading={schedulerStatusLoading}
+            error={schedulerStatusError}
+            actioning={Boolean(schedulerActioning)}
+            onSetPaused={setSchedulerPaused}
+          />
+          <AutomationConfigSection
+            configDraft={configDraft}
+            configLoading={configLoading}
+            configSaving={configSaving}
+            configResetting={configResetting}
+            configError={configError}
+            configFieldErrors={configFieldErrors}
+            configDirty={configDirty}
+            backendUnavailable={backendUnavailable}
+            backendUnavailableReason={backendUnavailableReason}
+            automationRunActioning={automationRunActioning}
+            automationRunError={automationRunError}
+            paused={status.state.paused}
+            activeAutomationStatus={activeAutomationStatus}
+            automationTaskCanRun={automationTaskCanRun}
+            automationTaskTitle={automationTaskTitle}
+            automationTaskLabel={automationTaskLabel}
+            taskFieldError={taskFieldError}
+            runAutomationTask={runAutomationTask}
+            updateConfigDraft={updateConfigDraft}
+            updateConfigTaskDraft={updateConfigTaskDraft}
+            updateTaskSeconds={updateTaskSeconds}
+            resetConfigDraft={resetConfigDraft}
+            resetConfigToDefaults={resetConfigToDefaults}
+            saveConfigDraft={saveConfigDraft}
+          />
+          <FactProposalsSection
+            proposals={factProposals}
+            loading={factProposalsLoading}
+            error={factProposalsError}
+            actioning={factProposalActioning}
+            onRefresh={() => loadFactProposals(true)}
+            onAction={runFactProposalAction}
+          />
+          <ManagedSkillsSection
+            skills={managedSkills}
+            selectedSkillId={selectedManagedSkillId}
+            selectedSkill={selectedManagedSkill}
+            selectedUsage={selectedUsage}
+            selectedRecommendation={selectedRecommendation}
+            selectedImprovementRecommendation={selectedImprovementRecommendation}
+            loading={managedSkillsLoading}
+            error={managedSkillsError}
+            actioning={managedSkillActioning}
+            onRefresh={() => loadManagedSkills(true)}
+            onLoadSkill={loadManagedSkill}
+            onAction={runManagedSkillAction}
+          />
+          <SnapshotsSection snapshots={status.snapshots} />
+        </>
+      ) : null}
+      <AutomationRunsSection
+        runs={automationRuns}
+        error={automationRunsError}
+        artifacts={automationRunArtifacts}
+        artifact={automationRunArtifact}
+        artifactLoading={automationRunArtifactLoading}
+        artifactError={automationRunArtifactError}
+        onLoadArtifact={loadAutomationRunArtifact}
+      />
+      <MemoryOperationsSection events={oplog} error={oplogError} />
+      <CurrentPreviewSection
+        report={report}
+        previewSavedAt={previewSavedAt}
+        previewStale={previewStale}
+        previewStaleReason={previewStaleReason}
+        actionsLength={actionsLength}
+        actionCounts={actionCounts}
+        diagnosticCounts={diagnosticCounts}
+        isPlan={isPlan}
+      />
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/CurrentPreviewSection.tsx
+++ b/dashboard/holographic/src/curation/CurrentPreviewSection.tsx
@@ -1,0 +1,85 @@
+import { formatCounts, formatHistoryTime } from "./format";
+import { MetadataRow } from "./MetadataRow";
+import type { MemoryCurateResponse } from "../types";
+
+export function CurrentPreviewSection({
+  report,
+  previewSavedAt,
+  previewStale,
+  previewStaleReason,
+  actionsLength,
+  actionCounts,
+  diagnosticCounts,
+  isPlan,
+}: {
+  report: MemoryCurateResponse | null;
+  previewSavedAt: string | null;
+  previewStale: boolean;
+  previewStaleReason: string;
+  actionsLength: number;
+  actionCounts: Array<[string, number]>;
+  diagnosticCounts: Array<[string, number]>;
+  isPlan: boolean;
+}) {
+  if (!report) {
+    return (
+      <div className="border border-border bg-background/30 px-3 py-4 text-xs text-text-tertiary">
+        Preview a plan to see current run metadata, signals, and coverage.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="text-xs font-medium text-foreground">
+        Current Preview
+      </div>
+      <div className="border border-border bg-background/30 px-3">
+        <MetadataRow label="Run mode" value={isPlan ? "preview" : "applied"} />
+        {previewSavedAt ? (
+          <MetadataRow label="Saved" value={formatHistoryTime(previewSavedAt)} />
+        ) : null}
+        {previewStale ? (
+          <MetadataRow
+            label="Preview state"
+            value={previewStaleReason || "stale"}
+          />
+        ) : null}
+        <MetadataRow label="Actions" value={actionsLength} />
+        <MetadataRow label="Counts" value={formatCounts(actionCounts)} />
+        <MetadataRow label="Signals" value={formatCounts(diagnosticCounts)} />
+        <MetadataRow label="LLM calls" value={report.llm_calls} />
+        {report.skipped_actions != null ? (
+          <MetadataRow label="Skipped" value={report.skipped_actions} />
+        ) : null}
+        {report.snapshot ? (
+          <MetadataRow label="Snapshot" value={report.snapshot} />
+        ) : null}
+      </div>
+      {report.coverage ? (
+        <div className="border border-border bg-background/30 px-3">
+          <MetadataRow
+            label="Facts scanned"
+            value={`${report.coverage.scanned}/${report.coverage.active_total}`}
+          />
+          <MetadataRow
+            label="Facts due"
+            value={report.coverage.due_remaining}
+          />
+          {report.coverage.entity_total != null ? (
+            <MetadataRow
+              label="Entities scanned"
+              value={`${report.coverage.entities_scanned ?? 0}/${report.coverage.entity_total}`}
+            />
+          ) : null}
+          {report.coverage.entity_scan_remaining != null ? (
+            <MetadataRow
+              label="Entities due"
+              value={report.coverage.entity_scan_remaining}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/dashboard/holographic/src/curation/FactProposalsSection.tsx
+++ b/dashboard/holographic/src/curation/FactProposalsSection.tsx
@@ -1,0 +1,152 @@
+import { Archive, CheckCircle2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "../sdk";
+import { Spinner } from "../Spinner";
+import {
+  factProposalDetail,
+  factProposalSummary,
+  formatUnixTime,
+  managedSkillStateClass,
+} from "./historyFormat";
+import type { FactProposalRecord } from "../types";
+
+type FactProposalAction = "apply" | "reject";
+
+function ProposalActionButton({
+  action,
+  label,
+  icon,
+  proposalId,
+  pending,
+  actioning,
+  outlined = false,
+  onAction,
+}: {
+  action: FactProposalAction;
+  label: string;
+  icon: ReactNode;
+  proposalId: string;
+  pending: boolean;
+  actioning: string | null;
+  outlined?: boolean;
+  onAction: (action: FactProposalAction, proposalId: string) => void;
+}) {
+  const loading = actioning?.endsWith(`:${action}`);
+
+  return (
+    <Button
+      size="xs"
+      outlined={outlined}
+      disabled={!pending || Boolean(actioning)}
+      onClick={() => onAction(action, proposalId)}
+      className="gap-1.5"
+    >
+      {loading ? <Spinner /> : icon}
+      {label}
+    </Button>
+  );
+}
+
+export function FactProposalsSection({
+  proposals,
+  loading,
+  error,
+  actioning,
+  onRefresh,
+  onAction,
+}: {
+  proposals: FactProposalRecord[];
+  loading: boolean;
+  error: string;
+  actioning: string | null;
+  onRefresh: () => void;
+  onAction: (action: FactProposalAction, proposalId: string) => void;
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+            Fact proposals
+          </div>
+          <div className="mt-0.5 text-[11px] text-text-tertiary">
+            Session-reflection facts staged for dashboard approval.
+          </div>
+        </div>
+        <Button
+          size="xs"
+          ghost
+          disabled={loading}
+          onClick={onRefresh}
+          className="shrink-0 gap-2"
+        >
+          {loading ? <Spinner /> : null}
+          Refresh
+        </Button>
+      </div>
+      {error ? (
+        <div className="mt-2 border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+      {proposals.length ? (
+        <div className="mt-2 grid gap-1.5">
+          {proposals.map((proposal) => {
+            const pending = proposal.state === "pending_approval";
+            return (
+              <div
+                key={proposal.proposal_id}
+                className="min-w-0 border border-border bg-background/40 px-2 py-1.5"
+              >
+                <div className="flex min-w-0 items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="line-clamp-2 text-xs font-medium text-foreground">
+                      {factProposalSummary(proposal)}
+                    </div>
+                    <div className="mt-0.5 font-mono-ui text-[11px] text-text-tertiary break-all">
+                      {factProposalDetail(proposal)}
+                    </div>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] ${managedSkillStateClass(proposal.state)}`}
+                  >
+                    {proposal.state}
+                  </span>
+                </div>
+                <div className="mt-1 flex flex-wrap items-center justify-between gap-2 text-[11px] text-text-tertiary">
+                  <span>updated={formatUnixTime(proposal.updated_at)}</span>
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <ProposalActionButton
+                      action="apply"
+                      label="Apply fact"
+                      icon={<CheckCircle2 className="h-3.5 w-3.5" />}
+                      proposalId={proposal.proposal_id}
+                      pending={pending}
+                      actioning={actioning}
+                      onAction={onAction}
+                    />
+                    <ProposalActionButton
+                      action="reject"
+                      label="Reject"
+                      icon={<Archive className="h-3.5 w-3.5" />}
+                      proposalId={proposal.proposal_id}
+                      pending={pending}
+                      actioning={actioning}
+                      outlined
+                      onAction={onAction}
+                    />
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-2 text-xs text-text-tertiary">
+          No fact proposals are waiting in this profile.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/InlineConfirm.tsx
+++ b/dashboard/holographic/src/curation/InlineConfirm.tsx
@@ -1,0 +1,104 @@
+import {
+  type ReactNode,
+  useEffect,
+  useId,
+  useRef,
+} from "react";
+import { createPortal } from "react-dom";
+import { Button } from "../sdk";
+
+export function InlineConfirm({
+  open,
+  title,
+  description,
+  children,
+  confirmLabel,
+  loading,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+  confirmLabel: string;
+  loading?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocused.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const dialog = dialogRef.current;
+    const focusTarget =
+      dialog?.querySelector<HTMLElement>(
+        "button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
+      ) ?? dialog;
+    focusTarget?.focus();
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className="relative mx-4 w-full max-w-md border border-border bg-card shadow-lg"
+      >
+        <div className="flex flex-col gap-1 border-b border-border p-4">
+          <h2
+            id={titleId}
+            className="font-mondwest text-display text-sm font-bold tracking-[0.12em]"
+          >
+            {title}
+          </h2>
+          {description && (
+            <p className="font-sans text-xs leading-relaxed text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        {children ? <div className="border-b border-border p-4">{children}</div> : null}
+        <div className="flex items-center justify-end gap-2 p-3">
+          <Button type="button" outlined onClick={onCancel} disabled={loading}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={onConfirm} disabled={loading}>
+            {loading ? "…" : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/dashboard/holographic/src/curation/ManagedSkillsSection.tsx
+++ b/dashboard/holographic/src/curation/ManagedSkillsSection.tsx
@@ -1,0 +1,298 @@
+import { Archive, CheckCircle2, Eye, Power, RotateCcw } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "../sdk";
+import { Spinner } from "../Spinner";
+import {
+  formatUnixTime,
+  managedSkillStateClass,
+  managedSkillSummary,
+} from "./historyFormat";
+import type {
+  ManagedSkill,
+  ManagedSkillState,
+  SkillImprovementRecommendation,
+  SkillStaleRecommendation,
+  SkillUsageSummary,
+} from "../types";
+
+type ManagedSkillAction = "approve" | "discard-update" | "disable" | "archive" | "restore";
+
+function SkillStateBadge({ state }: { state: ManagedSkillState }) {
+  return (
+    <span
+      className={`shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] ${managedSkillStateClass(state)}`}
+    >
+      {state}
+    </span>
+  );
+}
+
+function SkillActionButton({
+  action,
+  label,
+  icon,
+  skillId,
+  actioning,
+  outlined = true,
+  onAction,
+}: {
+  action: ManagedSkillAction;
+  label: string;
+  icon: ReactNode;
+  skillId: string;
+  actioning: string | null;
+  outlined?: boolean;
+  onAction: (action: string, skillId: string) => void;
+}) {
+  const loading = actioning?.endsWith(`:${action}`);
+
+  return (
+    <Button
+      size="xs"
+      outlined={outlined}
+      disabled={Boolean(actioning)}
+      onClick={() => onAction(action, skillId)}
+      className="gap-1.5"
+    >
+      {loading ? <Spinner /> : icon}
+      {label}
+    </Button>
+  );
+}
+
+export function ManagedSkillsSection({
+  skills,
+  selectedSkillId,
+  selectedSkill,
+  selectedUsage,
+  selectedRecommendation,
+  selectedImprovementRecommendation,
+  loading,
+  error,
+  actioning,
+  onRefresh,
+  onLoadSkill,
+  onAction,
+}: {
+  skills: ManagedSkill[];
+  selectedSkillId: string | null;
+  selectedSkill: ManagedSkill | null;
+  selectedUsage: SkillUsageSummary | null;
+  selectedRecommendation: SkillStaleRecommendation | null;
+  selectedImprovementRecommendation: SkillImprovementRecommendation | null;
+  loading: boolean;
+  error: string;
+  actioning: string | null;
+  onRefresh: () => void;
+  onLoadSkill: (skillId: string) => void;
+  onAction: (action: string, skillId: string) => void;
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+            Managed skills
+          </div>
+          <div className="mt-0.5 text-[11px] text-text-tertiary">
+            Profile-owned skill drafts and approval state.
+          </div>
+        </div>
+        <Button
+          size="xs"
+          ghost
+          disabled={loading}
+          onClick={onRefresh}
+          className="shrink-0 gap-2"
+        >
+          {loading ? <Spinner /> : null}
+          Refresh
+        </Button>
+      </div>
+      {error ? (
+        <div className="mt-2 border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+      {skills.length ? (
+        <div className="mt-2 grid gap-2 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div className="flex min-w-0 flex-col gap-1.5">
+            {skills.map((skill) => {
+              const selected = selectedSkillId === skill.metadata.id;
+              return (
+                <button
+                  key={skill.metadata.id}
+                  type="button"
+                  onClick={() => onLoadSkill(skill.metadata.id)}
+                  className={`min-w-0 border px-2 py-1.5 text-left ${
+                    selected
+                      ? "border-primary/60 bg-primary/10"
+                      : "border-border bg-background/40 hover:border-primary/40"
+                  }`}
+                >
+                  <div className="flex min-w-0 items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-xs font-medium text-foreground">
+                        {skill.metadata.title}
+                      </div>
+                      <div className="mt-0.5 truncate font-mono-ui text-[11px] text-text-tertiary">
+                        {skill.metadata.id}
+                      </div>
+                    </div>
+                    <SkillStateBadge state={skill.metadata.state} />
+                  </div>
+                  <div className="mt-1 line-clamp-2 text-[11px] text-text-secondary">
+                    {skill.metadata.summary}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          {selectedSkill ? (
+            <div className="min-w-0 border border-border bg-background/40 px-3 py-2">
+              <div className="flex min-w-0 items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="text-xs font-medium text-foreground">
+                    {selectedSkill.metadata.title}
+                  </div>
+                  <div className="mt-0.5 font-mono-ui text-[11px] text-text-tertiary break-all">
+                    {managedSkillSummary(selectedSkill)}
+                  </div>
+                </div>
+                <SkillStateBadge state={selectedSkill.metadata.state} />
+              </div>
+              <div className="mt-2 grid gap-1 text-[11px] text-text-tertiary sm:grid-cols-2">
+                <span className="font-mono-ui break-all">
+                  checksum={selectedSkill.metadata.checksum}
+                </span>
+                <span>updated={formatUnixTime(selectedSkill.metadata.updated_at)}</span>
+                <span>support files={selectedSkill.support_files.length}</span>
+                <span>pinned={selectedSkill.metadata.pinned ? "yes" : "no"}</span>
+              </div>
+              {selectedUsage ? (
+                <div className="mt-2 grid gap-1 border border-border/60 bg-secondary/20 p-2 text-[11px] text-text-tertiary sm:grid-cols-2">
+                  <span className="font-mono-ui">
+                    views={selectedUsage.view_count}
+                  </span>
+                  <span className="font-mono-ui">
+                    uses={selectedUsage.use_count}
+                  </span>
+                  <span className="font-mono-ui">
+                    patches={selectedUsage.patch_count}
+                  </span>
+                  <span>last={formatUnixTime(selectedUsage.last_activity_at)}</span>
+                  <span className="sm:col-span-2">
+                    targets={selectedUsage.targets.length ? selectedUsage.targets.join(", ") : "none"}
+                  </span>
+                </div>
+              ) : null}
+              {selectedRecommendation ? (
+                <div
+                  className={`mt-2 border px-2 py-1.5 text-[11px] ${
+                    selectedRecommendation.stale || selectedRecommendation.recommendation !== "keep"
+                      ? "border-warning/30 bg-warning/10 text-warning"
+                      : "border-border bg-background/50 text-text-tertiary"
+                  }`}
+                >
+                  <span className="font-mono-ui">
+                    {selectedRecommendation.recommendation}
+                  </span>
+                  <span> · {selectedRecommendation.reason}</span>
+                </div>
+              ) : null}
+              {selectedImprovementRecommendation?.improvement ? (
+                <div className="mt-2 border border-warning/30 bg-warning/10 px-2 py-1.5 text-[11px] text-warning">
+                  <span className="font-mono-ui">
+                    {selectedImprovementRecommendation.recommendation}
+                  </span>
+                  <span> · {selectedImprovementRecommendation.reason}</span>
+                  <span className="ml-1 font-mono-ui">
+                    priority={selectedImprovementRecommendation.priority}
+                  </span>
+                </div>
+              ) : null}
+              {selectedSkill.pending_update ? (
+                <div className="mt-2 border border-warning/30 bg-warning/10 p-2 text-[11px] text-warning">
+                  <div className="font-mono-ui">
+                    staged update · checksum={selectedSkill.pending_update.metadata.checksum}
+                  </div>
+                  <div className="mt-1 text-text-secondary">
+                    {selectedSkill.pending_update.metadata.summary}
+                  </div>
+                  <div className="mt-1 text-text-tertiary">
+                    staged={formatUnixTime(selectedSkill.pending_update.staged_at)}
+                    {" · "}
+                    support files={selectedSkill.pending_update.support_files.length}
+                  </div>
+                </div>
+              ) : null}
+              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap border border-border bg-background/70 p-2 font-mono-ui text-[11px] leading-relaxed text-text-secondary">
+                {selectedSkill.body_markdown || "No skill body."}
+              </pre>
+              <div className="mt-2 flex flex-wrap justify-end gap-2">
+                <Button
+                  size="xs"
+                  outlined
+                  disabled={Boolean(actioning)}
+                  onClick={() => onLoadSkill(selectedSkill.metadata.id)}
+                  className="gap-1.5"
+                >
+                  <Eye className="h-3.5 w-3.5" />
+                  View
+                </Button>
+                <SkillActionButton
+                  action="approve"
+                  label="Approve"
+                  icon={<CheckCircle2 className="h-3.5 w-3.5" />}
+                  skillId={selectedSkill.metadata.id}
+                  actioning={actioning}
+                  outlined={false}
+                  onAction={onAction}
+                />
+                {selectedSkill.pending_update ? (
+                  <SkillActionButton
+                    action="discard-update"
+                    label="Discard"
+                    icon={<RotateCcw className="h-3.5 w-3.5" />}
+                    skillId={selectedSkill.metadata.id}
+                    actioning={actioning}
+                    onAction={onAction}
+                  />
+                ) : null}
+                <SkillActionButton
+                  action="disable"
+                  label="Disable"
+                  icon={<Power className="h-3.5 w-3.5" />}
+                  skillId={selectedSkill.metadata.id}
+                  actioning={actioning}
+                  onAction={onAction}
+                />
+                <SkillActionButton
+                  action="archive"
+                  label="Archive"
+                  icon={<Archive className="h-3.5 w-3.5" />}
+                  skillId={selectedSkill.metadata.id}
+                  actioning={actioning}
+                  onAction={onAction}
+                />
+                <SkillActionButton
+                  action="restore"
+                  label="Restore"
+                  icon={<RotateCcw className="h-3.5 w-3.5" />}
+                  skillId={selectedSkill.metadata.id}
+                  actioning={actioning}
+                  onAction={onAction}
+                />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div className="mt-2 text-xs text-text-tertiary">
+          No managed skill drafts are waiting in this profile.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/MemoryOperationsSection.tsx
+++ b/dashboard/holographic/src/curation/MemoryOperationsSection.tsx
@@ -1,0 +1,43 @@
+import { formatOplogTime } from "./format";
+import { oplogDetailSummary } from "./historyFormat";
+import type { MemoryOplogEvent } from "../types";
+
+export function MemoryOperationsSection({
+  events,
+  error,
+}: {
+  events: MemoryOplogEvent[];
+  error: string;
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="mb-1 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+        Recent memory operations
+      </div>
+      {error ? <div className="text-xs text-destructive">{error}</div> : null}
+      {events.length ? (
+        <div className="flex flex-col gap-1">
+          {events.map((event) => (
+            <div
+              key={event.id}
+              className="grid grid-cols-[7.5rem_5.5rem_minmax(0,1fr)] gap-2 font-mono-ui text-xs"
+            >
+              <span className="text-text-tertiary">{formatOplogTime(event.ts)}</span>
+              <span className="truncate uppercase tracking-[0.08em] text-text-secondary">
+                {event.op}
+              </span>
+              <span className="min-w-0 break-all text-text-tertiary">
+                {event.fact_id != null ? `#${event.fact_id} ` : ""}
+                {oplogDetailSummary(event)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-xs text-text-tertiary">
+          No memory operations recorded yet.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/MetadataRow.tsx
+++ b/dashboard/holographic/src/curation/MetadataRow.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+export function MetadataRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border/50 py-2 last:border-b-0">
+      <span className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+        {label}
+      </span>
+      <span className="min-w-0 text-right font-mono-ui text-xs text-text-secondary break-all">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/RunHistorySection.tsx
+++ b/dashboard/holographic/src/curation/RunHistorySection.tsx
@@ -1,0 +1,35 @@
+import { formatHistoryTime } from "./format";
+import { MetadataRow } from "./MetadataRow";
+import type { MemoryCuratorStatusResponse } from "../types";
+
+export function RunHistorySection({
+  status,
+}: {
+  status: MemoryCuratorStatusResponse;
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3">
+      <div className="pt-2 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+        Run history
+      </div>
+      <MetadataRow label="Provider" value={status.provider || "none"} />
+      <MetadataRow label="Run count" value={status.state.run_count} />
+      <MetadataRow
+        label="Last apply"
+        value={formatHistoryTime(status.state.last_run_at) || "never"}
+      />
+      <MetadataRow
+        label="Last applied summary"
+        value={status.state.last_run_summary || "none"}
+      />
+      <MetadataRow
+        label="Last preview"
+        value={formatHistoryTime(status.state.last_preview_at) || "never"}
+      />
+      <MetadataRow
+        label="Last preview summary"
+        value={status.state.last_preview_summary || "none"}
+      />
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/SchedulerStatusSection.tsx
+++ b/dashboard/holographic/src/curation/SchedulerStatusSection.tsx
@@ -1,0 +1,74 @@
+import { Button } from "../sdk";
+import { Spinner } from "../Spinner";
+import { schedulerTaskLabel } from "./automationTasks";
+import type { AutomationSchedulerStatusResponse } from "../types";
+
+export function SchedulerStatusSection({
+  status,
+  loading,
+  error,
+  actioning,
+  onSetPaused,
+}: {
+  status: AutomationSchedulerStatusResponse | null;
+  loading: boolean;
+  error: string;
+  actioning: boolean;
+  onSetPaused: (paused: boolean) => void;
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+            Scheduler
+          </div>
+          <div className="mt-0.5 text-xs text-text-secondary">
+            {status?.status ?? "unknown"}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {loading ? <Spinner /> : null}
+          <Button
+            size="xs"
+            outlined
+            disabled={actioning}
+            onClick={() => onSetPaused(!status?.paused)}
+            className="gap-2"
+          >
+            {actioning ? <Spinner /> : null}
+            {status?.paused ? "Resume" : "Pause"}
+          </Button>
+        </div>
+      </div>
+      {error ? (
+        <div className="mt-2 border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+      {status?.tasks?.length ? (
+        <div className="mt-2 grid gap-1.5">
+          {status.tasks.map((task) => (
+            <div
+              key={task.task}
+              className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 border border-border/60 bg-background/40 px-2 py-1.5 text-xs"
+            >
+              <span className="min-w-0 truncate text-text-secondary">
+                {schedulerTaskLabel(task.task)}
+              </span>
+              <span
+                className={`rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] ${
+                  task.due
+                    ? "border-success/30 bg-success/10 text-success"
+                    : "border-border bg-muted/30 text-text-tertiary"
+                }`}
+              >
+                {task.due ? "due" : (task.skip_reason ?? "skipped")}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/SnapshotsSection.tsx
+++ b/dashboard/holographic/src/curation/SnapshotsSection.tsx
@@ -1,0 +1,29 @@
+import type { MemoryCuratorStatusResponse } from "../types";
+
+export function SnapshotsSection({
+  snapshots,
+}: {
+  snapshots: MemoryCuratorStatusResponse["snapshots"];
+}) {
+  return (
+    <div className="border border-border bg-background/30 px-3 py-2">
+      <div className="mb-1 text-[11px] uppercase tracking-[0.08em] text-text-tertiary">
+        Recent snapshots
+      </div>
+      {snapshots.length ? (
+        <div className="flex flex-col gap-1">
+          {snapshots.map((snapshot) => (
+            <div
+              key={snapshot.path}
+              className="min-w-0 font-mono-ui text-xs text-text-secondary break-all"
+            >
+              {snapshot.name}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-xs text-text-tertiary">No snapshots found.</div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/holographic/src/curation/automationTasks.ts
+++ b/dashboard/holographic/src/curation/automationTasks.ts
@@ -1,0 +1,59 @@
+export type AutomationRunTask = "memory_curator" | "session_reflector" | "skill_writer";
+
+export type AutomationRunApiMethod =
+  | "postAutomationRunMemoryCurator"
+  | "postAutomationRunSessionReflection"
+  | "postAutomationRunSkillWriting";
+
+export type AutomationRunRefreshTarget =
+  | "memory_preview"
+  | "fact_proposals"
+  | "managed_skills";
+
+export interface AutomationTaskDescriptor {
+  id: AutomationRunTask;
+  runMethod: AutomationRunApiMethod;
+  refreshTarget: AutomationRunRefreshTarget;
+  enabledLabel: string;
+  scheduleLabel: string;
+  runAriaLabel: string;
+}
+
+export const AUTOMATION_TASKS = [
+  {
+    id: "memory_curator",
+    runMethod: "postAutomationRunMemoryCurator",
+    refreshTarget: "memory_preview",
+    enabledLabel: "Run memory curator",
+    scheduleLabel: "Memory curator schedule",
+    runAriaLabel: "Memory curator",
+  },
+  {
+    id: "session_reflector",
+    runMethod: "postAutomationRunSessionReflection",
+    refreshTarget: "fact_proposals",
+    enabledLabel: "Run session reflector",
+    scheduleLabel: "Session reflector schedule",
+    runAriaLabel: "Session reflector",
+  },
+  {
+    id: "skill_writer",
+    runMethod: "postAutomationRunSkillWriting",
+    refreshTarget: "managed_skills",
+    enabledLabel: "Run skill writer",
+    scheduleLabel: "Skill writer schedule",
+    runAriaLabel: "Skill writer",
+  },
+] satisfies AutomationTaskDescriptor[];
+
+export const AUTOMATION_TASK_BY_ID = Object.fromEntries(
+  AUTOMATION_TASKS.map((descriptor) => [descriptor.id, descriptor]),
+) as Record<AutomationRunTask, AutomationTaskDescriptor>;
+
+export function isActiveAutomationStatus(status?: string | null): boolean {
+  return status === "queued" || status === "running";
+}
+
+export function schedulerTaskLabel(task: string): string {
+  return AUTOMATION_TASK_BY_ID[task as AutomationRunTask]?.runAriaLabel.toLowerCase() ?? task;
+}

--- a/dashboard/holographic/src/curation/configTypes.ts
+++ b/dashboard/holographic/src/curation/configTypes.ts
@@ -1,0 +1,7 @@
+export type SecondsField =
+  | "interval_secs"
+  | "cooldown_secs"
+  | "min_idle_secs"
+  | "stale_lock_secs";
+export type TaskField = "schedule" | SecondsField;
+export type ConfigFieldErrors = Partial<Record<string, string>>;

--- a/dashboard/holographic/src/curation/errors.ts
+++ b/dashboard/holographic/src/curation/errors.ts
@@ -1,0 +1,3 @@
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/dashboard/holographic/src/curation/format.ts
+++ b/dashboard/holographic/src/curation/format.ts
@@ -1,5 +1,28 @@
 import type { MemoryCurateAction } from "../types";
 
+const COUNT_LABELS: Record<string, string> = {
+  delete: "delete",
+  entity_merge: "entity merges",
+  entity_classify: "entity classifications",
+  entity_prune: "junk entities pruned",
+  junk_entities_pruned: "junk entities pruned",
+  merge: "fact merges",
+  orphan_entities: "orphan entities",
+  orphan_entities_pruned: "orphan entities pruned",
+  recategorize: "recategorize",
+  reflect: "reflections",
+  retag: "retag",
+};
+
+export function countLabel(key: string): string {
+  return COUNT_LABELS[key] ?? key;
+}
+
+export function formatCounts(counts: Array<[string, number]>): string {
+  if (!counts.length) return "no changes";
+  return counts.map(([key, value]) => `${countLabel(key)}=${value}`).join(", ");
+}
+
 export function describe(a: MemoryCurateAction): string {
   switch (a.op) {
     case "merge":

--- a/dashboard/holographic/src/curation/historyFormat.ts
+++ b/dashboard/holographic/src/curation/historyFormat.ts
@@ -1,0 +1,98 @@
+import { formatHistoryTime } from "./format";
+import type {
+  FactProposalRecord,
+  ManagedSkill,
+  MemoryAutomationRunArtifactPayloadResponse,
+  MemoryAutomationRunRecord,
+  MemoryOplogEvent,
+} from "../types";
+
+export function automationRunStatusClass(status: string): string {
+  switch (status) {
+    case "queued":
+      return "border-primary/30 bg-primary/10 text-primary";
+    case "running":
+      return "border-accent/30 bg-accent/10 text-accent";
+    case "succeeded":
+      return "border-success/30 bg-success/10 text-success";
+    case "failed":
+      return "border-destructive/30 bg-destructive/10 text-destructive";
+    case "skipped":
+      return "border-warning/30 bg-warning/10 text-warning";
+    default:
+      return "border-border bg-muted/30 text-text-tertiary";
+  }
+}
+
+export function oplogDetailSummary(event: MemoryOplogEvent): string {
+  const detail = event.detail ?? {};
+  const parts = Object.entries(detail)
+    .filter(([, value]) => value !== null && value !== undefined && value !== "")
+    .slice(0, 4)
+    .map(([key, value]) => `${key}=${String(value)}`);
+  return parts.join(" · ");
+}
+
+export function automationRunSummary(record: MemoryAutomationRunRecord): string {
+  const backend = record.model ? `${record.backend}/${record.model}` : record.backend;
+  const host = record.host_mode ? ` · ${record.host_mode}` : "";
+  const counts = `accepted=${record.accepted_count} rejected=${record.rejected_count}`;
+  const artifacts = record.artifacts?.length ? ` · artifacts=${record.artifacts.length}` : "";
+  const fallback = record.fallback_status ? ` · ${record.fallback_status}` : "";
+  const suffix = record.error && record.error !== record.fallback_status ? ` · ${record.error}` : "";
+  return `${record.task} · ${record.trigger} · ${backend}${host} · ${counts}${artifacts}${fallback}${suffix}`;
+}
+
+export function automationArtifactPreview(
+  artifact: MemoryAutomationRunArtifactPayloadResponse | null,
+): string {
+  if (!artifact) return "";
+  return JSON.stringify(artifact.payload, null, 2);
+}
+
+export function factProposalSummary(proposal: FactProposalRecord): string {
+  const request = proposal.add_fact_request;
+  if (request?.content) return request.content;
+  if (proposal.validation_reason) return proposal.validation_reason;
+  return proposal.proposal_id;
+}
+
+export function factProposalDetail(proposal: FactProposalRecord): string {
+  const tags = proposal.add_fact_request?.tags;
+  const tagsText = Array.isArray(tags) && tags.length ? ` · tags=${tags.join(",")}` : "";
+  const category = proposal.add_fact_request?.category
+    ? ` · category=${proposal.add_fact_request.category}`
+    : "";
+  const factId = proposal.applied_fact_id ? ` · fact=${proposal.applied_fact_id}` : "";
+  return `${proposal.run_id}${category}${tagsText}${factId}`;
+}
+
+export function managedSkillStateClass(state: string): string {
+  switch (state) {
+    case "active":
+      return "border-success/30 bg-success/10 text-success";
+    case "pending_approval":
+      return "border-warning/30 bg-warning/10 text-warning";
+    case "disabled":
+      return "border-muted-foreground/30 bg-muted/40 text-text-tertiary";
+    case "archived":
+      return "border-border bg-background/50 text-text-tertiary";
+    default:
+      return "border-border bg-muted/30 text-text-tertiary";
+  }
+}
+
+export function managedSkillSummary(skill: ManagedSkill): string {
+  const source = skill.metadata.provenance?.source || "unknown";
+  const actor = skill.metadata.provenance?.actor || "unknown";
+  const runId = skill.metadata.provenance?.run_id
+    ? ` · ${skill.metadata.provenance.run_id}`
+    : "";
+  const pinned = skill.metadata.pinned ? " · pinned" : "";
+  return `${skill.metadata.category} · ${source}/${actor}${runId}${pinned}`;
+}
+
+export function formatUnixTime(ts?: number | null): string {
+  if (!ts) return "never";
+  return formatHistoryTime(new Date(ts * 1000).toISOString()) || String(ts);
+}

--- a/dashboard/holographic/src/curation/useAutomationConfig.ts
+++ b/dashboard/holographic/src/curation/useAutomationConfig.ts
@@ -1,0 +1,251 @@
+import { useCallback, useState } from "react";
+
+import type { api as defaultApi } from "../api";
+import type {
+  AutomationSchedulerStatusResponse,
+  AutomationTaskConfig,
+  AutomationTaskSet,
+  MemoryAutomationConfig,
+  MemoryAutomationConfigPatch,
+  MemoryAutomationConfigResponse,
+} from "../types";
+import { AUTOMATION_TASKS } from "./automationTasks";
+import { errorMessage } from "./errors";
+import type { ConfigFieldErrors } from "./configTypes";
+
+type AutomationTaskKey = keyof AutomationTaskSet;
+type AutomationConfigApi = Pick<
+  typeof defaultApi,
+  | "getAutomationSchedulerStatus"
+  | "getMemoryAutomationConfig"
+  | "patchMemoryAutomationConfig"
+  | "pauseAutomationScheduler"
+  | "resetMemoryAutomationConfig"
+  | "resumeAutomationScheduler"
+>;
+
+interface ConfigValidationError {
+  field?: unknown;
+  message?: unknown;
+}
+
+interface ErrorWithBody {
+  body?: {
+    validation_errors?: ConfigValidationError[];
+  };
+}
+
+function cloneTaskSet(tasks: AutomationTaskSet): AutomationTaskSet {
+  const cloned: Partial<AutomationTaskSet> = {};
+  for (const { id } of AUTOMATION_TASKS) {
+    cloned[id] = { ...tasks[id] };
+  }
+  return cloned as AutomationTaskSet;
+}
+
+function cloneConfig(config: MemoryAutomationConfig): MemoryAutomationConfig {
+  return {
+    ...config,
+    tasks: cloneTaskSet(config.tasks),
+  };
+}
+
+function configToPatch(config: MemoryAutomationConfig): MemoryAutomationConfigPatch {
+  const patch: MemoryAutomationConfigPatch = {
+    enabled: config.enabled,
+    host_mode: config.host_mode,
+    model: config.model || null,
+    timeout_secs: config.timeout_secs,
+    scheduler_tick_secs: config.scheduler_tick_secs,
+    max_tokens: config.max_tokens ?? null,
+    temperature: config.temperature ?? null,
+    require_dashboard_approval: config.require_dashboard_approval,
+    auto_apply_memory_ops: config.auto_apply_memory_ops,
+    auto_enable_skills: config.auto_enable_skills,
+    ...cloneTaskSet(config.tasks),
+  };
+  if (config.backend !== "external_command") {
+    patch.backend = config.backend;
+  }
+  return patch;
+}
+
+function sameConfig(a: MemoryAutomationConfig | null, b: MemoryAutomationConfig | null) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function configFieldErrorsFromError(err: unknown): ConfigFieldErrors {
+  const errors = (err as ErrorWithBody)?.body?.validation_errors;
+  if (!Array.isArray(errors)) return {};
+  return Object.fromEntries(
+    errors
+      .filter((error) => typeof error.field === "string" && typeof error.message === "string")
+      .map((error) => [error.field as string, error.message as string]),
+  );
+}
+
+export function useAutomationConfig(api: AutomationConfigApi) {
+  const [configResponse, setConfigResponse] = useState<MemoryAutomationConfigResponse | null>(null);
+  const [configDraft, setConfigDraft] = useState<MemoryAutomationConfig | null>(null);
+  const [savedConfig, setSavedConfig] = useState<MemoryAutomationConfig | null>(null);
+  const [configLoading, setConfigLoading] = useState(false);
+  const [configSaving, setConfigSaving] = useState(false);
+  const [configResetting, setConfigResetting] = useState(false);
+  const [configError, setConfigError] = useState("");
+  const [configFieldErrors, setConfigFieldErrors] = useState<ConfigFieldErrors>({});
+  const [schedulerStatus, setSchedulerStatus] =
+    useState<AutomationSchedulerStatusResponse | null>(null);
+  const [schedulerStatusLoading, setSchedulerStatusLoading] = useState(false);
+  const [schedulerStatusError, setSchedulerStatusError] = useState("");
+  const [schedulerActioning, setSchedulerActioning] = useState<"pause" | "resume" | null>(null);
+  const configDirty = !sameConfig(configDraft, savedConfig);
+
+  const applyConfigResponse = useCallback((response: MemoryAutomationConfigResponse) => {
+    const effective = cloneConfig(response.effective);
+    setConfigResponse(response);
+    setConfigDraft(effective);
+    setSavedConfig(cloneConfig(response.effective));
+    setConfigFieldErrors({});
+  }, []);
+
+  const loadConfig = useCallback(() => {
+    setConfigLoading(true);
+    setConfigError("");
+    setConfigFieldErrors({});
+    return api
+      .getMemoryAutomationConfig()
+      .then((response) => {
+        applyConfigResponse(response);
+        return response;
+      })
+      .catch((err) => {
+        setConfigError(errorMessage(err));
+        throw err;
+      })
+      .finally(() => setConfigLoading(false));
+  }, [api, applyConfigResponse]);
+
+  const loadSchedulerStatus = useCallback((showSpinner = false) => {
+    if (showSpinner) setSchedulerStatusLoading(true);
+    setSchedulerStatusError("");
+    return api
+      .getAutomationSchedulerStatus()
+      .then((response) => {
+        setSchedulerStatus(response);
+        return response;
+      })
+      .catch((err) => {
+        setSchedulerStatusError(errorMessage(err));
+        throw err;
+      })
+      .finally(() => {
+        if (showSpinner) setSchedulerStatusLoading(false);
+      });
+  }, [api]);
+
+  const setSchedulerPaused = useCallback(async (paused: boolean) => {
+    const action = paused ? "pause" : "resume";
+    setSchedulerActioning(action);
+    setSchedulerStatusError("");
+    try {
+      const response = paused
+        ? await api.pauseAutomationScheduler()
+        : await api.resumeAutomationScheduler();
+      setSchedulerStatus(response);
+      await loadConfig();
+      return response;
+    } catch (err) {
+      setSchedulerStatusError(errorMessage(err));
+      throw err;
+    } finally {
+      setSchedulerActioning(null);
+    }
+  }, [api, loadConfig]);
+
+  const updateConfigDraft = useCallback((patch: Partial<MemoryAutomationConfig>) => {
+    setConfigDraft((current) => (current ? { ...current, ...patch } : current));
+  }, []);
+
+  const updateConfigTaskDraft = useCallback((
+    task: AutomationTaskKey,
+    patch: Partial<AutomationTaskConfig>,
+  ) => {
+    setConfigDraft((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        tasks: {
+          ...current.tasks,
+          [task]: {
+            ...current.tasks[task],
+            ...patch,
+          },
+        },
+      };
+    });
+  }, []);
+
+  const resetConfigDraft = useCallback(() => {
+    setConfigDraft(savedConfig ? cloneConfig(savedConfig) : null);
+    setConfigError("");
+    setConfigFieldErrors({});
+  }, [savedConfig]);
+
+  const saveConfigDraft = useCallback(async () => {
+    if (!configDraft) return null;
+    setConfigSaving(true);
+    setConfigError("");
+    setConfigFieldErrors({});
+    try {
+      const response = await api.patchMemoryAutomationConfig(configToPatch(configDraft));
+      applyConfigResponse(response);
+      return response;
+    } catch (err) {
+      setConfigError(errorMessage(err));
+      setConfigFieldErrors(configFieldErrorsFromError(err));
+      throw err;
+    } finally {
+      setConfigSaving(false);
+    }
+  }, [api, applyConfigResponse, configDraft]);
+
+  const resetConfigToDefaults = useCallback(async () => {
+    setConfigResetting(true);
+    setConfigError("");
+    setConfigFieldErrors({});
+    try {
+      const response = await api.resetMemoryAutomationConfig();
+      applyConfigResponse(response);
+      return response;
+    } catch (err) {
+      setConfigError(errorMessage(err));
+      setConfigFieldErrors(configFieldErrorsFromError(err));
+      throw err;
+    } finally {
+      setConfigResetting(false);
+    }
+  }, [api, applyConfigResponse]);
+
+  return {
+    configResponse,
+    configDraft,
+    configLoading,
+    configSaving,
+    configResetting,
+    configError,
+    configFieldErrors,
+    schedulerStatus,
+    schedulerStatusLoading,
+    schedulerStatusError,
+    schedulerActioning,
+    configDirty,
+    loadConfig,
+    loadSchedulerStatus,
+    setSchedulerPaused,
+    updateConfigDraft,
+    updateConfigTaskDraft,
+    resetConfigDraft,
+    resetConfigToDefaults,
+    saveConfigDraft,
+  };
+}

--- a/dashboard/holographic/src/curation/useAutomationRuns.ts
+++ b/dashboard/holographic/src/curation/useAutomationRuns.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { api as defaultApi } from "../api";
+import type {
+  MemoryAutomationRunArtifactPayloadResponse,
+  MemoryAutomationRunArtifactsResponse,
+  MemoryAutomationRunRecord,
+  MemoryAutomationRunResponse,
+  MemoryCurateResponse,
+} from "../types";
+import {
+  AUTOMATION_TASK_BY_ID,
+  isActiveAutomationStatus,
+  type AutomationRunApiMethod,
+  type AutomationRunTask,
+} from "./automationTasks";
+import { errorMessage } from "./errors";
+
+type AutomationRunsApi = Pick<
+  typeof defaultApi,
+  | "getMemoryAutomationRunArtifact"
+  | "getMemoryAutomationRunArtifacts"
+  | "getMemoryAutomationRuns"
+  | AutomationRunApiMethod
+>;
+
+function upsertAutomationRun(
+  records: MemoryAutomationRunRecord[],
+  record: MemoryAutomationRunRecord,
+): MemoryAutomationRunRecord[] {
+  return [record, ...records.filter((existing) => existing.run_id !== record.run_id)];
+}
+
+export function useAutomationRuns({
+  api,
+  pollFastMs,
+  setActiveTab,
+  setMemoryPreviewFromRun,
+  loadActivity,
+  loadStatus,
+  loadFactProposals,
+  loadManagedSkills,
+}: {
+  api: AutomationRunsApi;
+  pollFastMs: number;
+  setActiveTab: (tab: "history") => void;
+  setMemoryPreviewFromRun: (report: MemoryCurateResponse) => void;
+  loadActivity: (showSpinner?: boolean) => void;
+  loadStatus: () => void;
+  loadFactProposals: (showSpinner?: boolean) => Promise<unknown>;
+  loadManagedSkills: (showSpinner?: boolean) => Promise<unknown>;
+}) {
+  const [automationRuns, setAutomationRuns] = useState<MemoryAutomationRunRecord[]>([]);
+  const [automationRunsError, setAutomationRunsError] = useState("");
+  const [automationRunActioning, setAutomationRunActioning] =
+    useState<AutomationRunTask | null>(null);
+  const [automationRunError, setAutomationRunError] = useState("");
+  const [automationRunArtifact, setAutomationRunArtifact] =
+    useState<MemoryAutomationRunArtifactPayloadResponse | null>(null);
+  const [automationRunArtifacts, setAutomationRunArtifacts] =
+    useState<MemoryAutomationRunArtifactsResponse | null>(null);
+  const [automationRunArtifactLoading, setAutomationRunArtifactLoading] = useState<string | null>(
+    null,
+  );
+  const [automationRunArtifactError, setAutomationRunArtifactError] = useState("");
+
+  const loadAutomationRuns = useCallback(() => {
+    setAutomationRunsError("");
+    return api
+      .getMemoryAutomationRuns({ limit: 20 })
+      .then((response) => {
+        setAutomationRuns(response.records || []);
+        if (response.error) setAutomationRunsError(response.error);
+        return response;
+      })
+      .catch((err) => setAutomationRunsError(errorMessage(err)));
+  }, [api]);
+
+  const loadAutomationRunArtifact = useCallback((runId: string, kind: string) => {
+    const key = `${runId}:${kind}`;
+    setAutomationRunArtifactLoading(key);
+    setAutomationRunArtifactError("");
+    return Promise.all([
+      api.getMemoryAutomationRunArtifacts(runId),
+      api.getMemoryAutomationRunArtifact(runId, kind),
+    ])
+      .then(([artifactsResponse, payloadResponse]) => {
+        setAutomationRunArtifacts(artifactsResponse);
+        setAutomationRunArtifact(payloadResponse);
+        if (artifactsResponse.error || payloadResponse.error) {
+          setAutomationRunArtifactError(artifactsResponse.error || payloadResponse.error || "");
+        }
+        return payloadResponse;
+      })
+      .catch((err) => {
+        setAutomationRunArtifactError(errorMessage(err));
+        throw err;
+      })
+      .finally(() => setAutomationRunArtifactLoading(null));
+  }, [api]);
+
+  const runAutomationTask = useCallback(async (task: AutomationRunTask) => {
+    setAutomationRunActioning(task);
+    setAutomationRunError("");
+    setActiveTab("history");
+    try {
+      const descriptor = AUTOMATION_TASK_BY_ID[task];
+      const response = await api[descriptor.runMethod]({ dry_run: true });
+      if (response.ledger_record) {
+        setAutomationRuns((records) => upsertAutomationRun(records, response.ledger_record));
+      }
+      await loadAutomationRuns();
+      if (
+        descriptor.refreshTarget === "memory_preview" &&
+        response.report &&
+        !isActiveAutomationStatus(response.status)
+      ) {
+        const report = (response as MemoryAutomationRunResponse<MemoryCurateResponse>).report;
+        if (report) setMemoryPreviewFromRun(report);
+        loadActivity(false);
+        loadStatus();
+      } else if (descriptor.refreshTarget === "fact_proposals") {
+        await loadFactProposals(false);
+      } else if (descriptor.refreshTarget === "managed_skills") {
+        await loadManagedSkills(false);
+      }
+      return response;
+    } catch (err) {
+      setAutomationRunError(errorMessage(err));
+      throw err;
+    } finally {
+      setAutomationRunActioning(null);
+    }
+  }, [
+    api,
+    loadActivity,
+    loadAutomationRuns,
+    loadFactProposals,
+    loadManagedSkills,
+    loadStatus,
+    setActiveTab,
+    setMemoryPreviewFromRun,
+  ]);
+
+  useEffect(() => {
+    if (!automationRuns.some((record) => isActiveAutomationStatus(record.status))) return;
+    const timer = setTimeout(() => {
+      void loadAutomationRuns();
+    }, pollFastMs);
+    return () => clearTimeout(timer);
+  }, [automationRuns, loadAutomationRuns, pollFastMs]);
+
+  return {
+    automationRuns,
+    automationRunsError,
+    automationRunActioning,
+    automationRunError,
+    automationRunArtifacts,
+    automationRunArtifact,
+    automationRunArtifactLoading,
+    automationRunArtifactError,
+    loadAutomationRuns,
+    loadAutomationRunArtifact,
+    runAutomationTask,
+  };
+}

--- a/dashboard/holographic/src/curation/useAutomationRuns.ts
+++ b/dashboard/holographic/src/curation/useAutomationRuns.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { api as defaultApi } from "../api";
 import type {
@@ -36,6 +36,7 @@ export function useAutomationRuns({
   pollFastMs,
   setActiveTab,
   setMemoryPreviewFromRun,
+  loadMemoryPreview,
   loadActivity,
   loadStatus,
   loadFactProposals,
@@ -45,12 +46,14 @@ export function useAutomationRuns({
   pollFastMs: number;
   setActiveTab: (tab: "history") => void;
   setMemoryPreviewFromRun: (report: MemoryCurateResponse) => void;
+  loadMemoryPreview: (force?: boolean) => Promise<unknown>;
   loadActivity: (showSpinner?: boolean) => void;
   loadStatus: () => void;
   loadFactProposals: (showSpinner?: boolean) => Promise<unknown>;
   loadManagedSkills: (showSpinner?: boolean) => Promise<unknown>;
 }) {
   const [automationRuns, setAutomationRuns] = useState<MemoryAutomationRunRecord[]>([]);
+  const automationRunsRef = useRef<MemoryAutomationRunRecord[]>([]);
   const [automationRunsError, setAutomationRunsError] = useState("");
   const [automationRunActioning, setAutomationRunActioning] =
     useState<AutomationRunTask | null>(null);
@@ -64,17 +67,63 @@ export function useAutomationRuns({
   );
   const [automationRunArtifactError, setAutomationRunArtifactError] = useState("");
 
+  const refreshCompletedRuns = useCallback(async (
+    completedRuns: MemoryAutomationRunRecord[],
+  ) => {
+    let refreshMemoryPreview = false;
+    let refreshFactProposals = false;
+    let refreshManagedSkills = false;
+
+    for (const run of completedRuns) {
+      const descriptor = AUTOMATION_TASK_BY_ID[run.task as AutomationRunTask];
+      if (!descriptor) continue;
+      if (descriptor.refreshTarget === "memory_preview") refreshMemoryPreview = true;
+      if (descriptor.refreshTarget === "fact_proposals") refreshFactProposals = true;
+      if (descriptor.refreshTarget === "managed_skills") refreshManagedSkills = true;
+    }
+
+    const refreshes: Promise<unknown>[] = [];
+    if (refreshMemoryPreview) {
+      refreshes.push(loadMemoryPreview(true));
+      loadActivity(false);
+      loadStatus();
+    }
+    if (refreshFactProposals) refreshes.push(loadFactProposals(false));
+    if (refreshManagedSkills) refreshes.push(loadManagedSkills(false));
+    await Promise.all(refreshes);
+  }, [
+    loadActivity,
+    loadFactProposals,
+    loadManagedSkills,
+    loadMemoryPreview,
+    loadStatus,
+  ]);
+
   const loadAutomationRuns = useCallback(() => {
     setAutomationRunsError("");
     return api
       .getMemoryAutomationRuns({ limit: 20 })
-      .then((response) => {
-        setAutomationRuns(response.records || []);
+      .then(async (response) => {
+        const nextRuns = response.records || [];
+        const previousById = new Map<string, MemoryAutomationRunRecord>(
+          automationRunsRef.current.map((run) => [run.run_id, run]),
+        );
+        const completedRuns = nextRuns.filter((run) => {
+          const previous = previousById.get(run.run_id);
+          return (
+            previous &&
+            isActiveAutomationStatus(previous.status) &&
+            !isActiveAutomationStatus(run.status)
+          );
+        });
+        automationRunsRef.current = nextRuns;
+        setAutomationRuns(nextRuns);
         if (response.error) setAutomationRunsError(response.error);
+        if (completedRuns.length > 0) await refreshCompletedRuns(completedRuns);
         return response;
       })
       .catch((err) => setAutomationRunsError(errorMessage(err)));
-  }, [api]);
+  }, [api, refreshCompletedRuns]);
 
   const loadAutomationRunArtifact = useCallback((runId: string, kind: string) => {
     const key = `${runId}:${kind}`;
@@ -102,12 +151,17 @@ export function useAutomationRuns({
   const runAutomationTask = useCallback(async (task: AutomationRunTask) => {
     setAutomationRunActioning(task);
     setAutomationRunError("");
-    setActiveTab("history");
+      setActiveTab("history");
     try {
       const descriptor = AUTOMATION_TASK_BY_ID[task];
       const response = await api[descriptor.runMethod]({ dry_run: true });
-      if (response.ledger_record) {
-        setAutomationRuns((records) => upsertAutomationRun(records, response.ledger_record));
+      const ledgerRecord = response.ledger_record;
+      if (ledgerRecord) {
+        setAutomationRuns((records) => {
+          const nextRuns = upsertAutomationRun(records, ledgerRecord);
+          automationRunsRef.current = nextRuns;
+          return nextRuns;
+        });
       }
       await loadAutomationRuns();
       if (

--- a/dashboard/holographic/src/curation/useCurationData.ts
+++ b/dashboard/holographic/src/curation/useCurationData.ts
@@ -6,8 +6,43 @@ import type {
   MemoryCuratorStatusResponse,
   MemoryOplogEvent,
 } from "../types";
+import type { AutomationRunApiMethod } from "./automationTasks";
+import { errorMessage } from "./errors";
+import { useAutomationConfig } from "./useAutomationConfig";
+import { useAutomationRuns } from "./useAutomationRuns";
+import { useFactProposals } from "./useFactProposals";
+import { useManagedSkills } from "./useManagedSkills";
 
 export type CurationTab = "plan" | "history" | "activity";
+
+export type CurationApi = Pick<
+  typeof defaultApi,
+  | "applyFactProposal"
+  | "approveManagedSkill"
+  | "archiveManagedSkill"
+  | "disableManagedSkill"
+  | "discardManagedSkillUpdate"
+  | "getAutomationSchedulerStatus"
+  | "getFactProposals"
+  | "getManagedSkill"
+  | "getManagedSkills"
+  | "getMemoryAutomationConfig"
+  | "getMemoryAutomationRunArtifact"
+  | "getMemoryAutomationRunArtifacts"
+  | "getMemoryAutomationRuns"
+  | "getMemoryCuratorActivity"
+  | "getMemoryCuratorPreview"
+  | "getMemoryCuratorStatus"
+  | "getMemoryOplog"
+  | "patchMemoryAutomationConfig"
+  | "pauseAutomationScheduler"
+  | AutomationRunApiMethod
+  | "postMemoryCurate"
+  | "rejectFactProposal"
+  | "resetMemoryAutomationConfig"
+  | "restoreManagedSkill"
+  | "resumeAutomationScheduler"
+>;
 
 export function useCurationData({
   api = defaultApi,
@@ -16,7 +51,7 @@ export function useCurationData({
   pollFastMs = 900,
   pollIdleMs = 2500,
 }: {
-  api?: typeof defaultApi;
+  api?: CurationApi;
   onApplied?: () => void;
   now?: () => string;
   pollFastMs?: number;
@@ -39,6 +74,50 @@ export function useCurationData({
   const [activity, setActivity] = useState<MemoryCuratorActivityEvent[]>([]);
   const [activityLoading, setActivityLoading] = useState(false);
   const [activityError, setActivityError] = useState("");
+  const {
+    configResponse,
+    configDraft,
+    configLoading,
+    configSaving,
+    configResetting,
+    configError,
+    configFieldErrors,
+    schedulerStatus,
+    schedulerStatusLoading,
+    schedulerStatusError,
+    schedulerActioning,
+    configDirty,
+    loadConfig,
+    loadSchedulerStatus,
+    setSchedulerPaused,
+    updateConfigDraft,
+    updateConfigTaskDraft,
+    resetConfigDraft,
+    resetConfigToDefaults,
+    saveConfigDraft,
+  } = useAutomationConfig(api);
+  const {
+    managedSkills,
+    selectedManagedSkillId,
+    selectedManagedSkill,
+    managedSkillUsage,
+    managedSkillRecommendations,
+    managedSkillImprovementRecommendations,
+    managedSkillsLoading,
+    managedSkillsError,
+    managedSkillActioning,
+    loadManagedSkills,
+    loadManagedSkill,
+    runManagedSkillAction,
+  } = useManagedSkills(api);
+  const {
+    factProposals,
+    factProposalsLoading,
+    factProposalsError,
+    factProposalActioning,
+    loadFactProposals,
+    runFactProposalAction,
+  } = useFactProposals({ api, onApplied });
   const activityRef = useRef<HTMLDivElement>(null);
   const previewSavedAtRef = useRef<string | null>(null);
   const previewLoadSeq = useRef(0);
@@ -57,6 +136,21 @@ export function useCurationData({
     setPreviewStaleReason(staleReason);
   }, []);
 
+  const clearSavedPreview = useCallback(() => {
+    previewSavedAtRef.current = null;
+    setReport(null);
+    setPreviewSavedAt(null);
+    setPreviewStale(false);
+    setPreviewStaleReason("");
+  }, []);
+
+  const setMemoryPreviewFromRun = useCallback((nextReport: MemoryCurateResponse) => {
+    setReport(nextReport);
+    setPreviewSavedAt(null);
+    setPreviewStale(false);
+    setPreviewStaleReason("");
+  }, []);
+
   const loadSavedPreview = useCallback((force = false) => {
     const ticket = ++previewLoadSeq.current;
     return api
@@ -71,16 +165,12 @@ export function useCurationData({
             response.stale_reason || "",
           );
         } else if (!response.report && !loading && !applying) {
-          previewSavedAtRef.current = null;
-          setReport(null);
-          setPreviewSavedAt(null);
-          setPreviewStale(false);
-          setPreviewStaleReason("");
+          clearSavedPreview();
         }
         return response;
       })
       .catch(() => {});
-  }, [api, applySavedPreview, applying, loading]);
+  }, [api, applySavedPreview, applying, clearSavedPreview, loading]);
 
   const loadActivity = useCallback((showSpinner = false) => {
     if (showSpinner) setActivityLoading(true);
@@ -97,7 +187,7 @@ export function useCurationData({
           loadSavedPreview(false);
         }
       })
-      .catch((err) => setActivityError(err instanceof Error ? err.message : String(err)))
+      .catch((err) => setActivityError(errorMessage(err)))
       .finally(() => {
         if (showSpinner) setActivityLoading(false);
       });
@@ -109,7 +199,7 @@ export function useCurationData({
     api
       .getMemoryCuratorStatus()
       .then((response) => setStatus(response))
-      .catch((err) => setStatusError(err instanceof Error ? err.message : String(err)))
+      .catch((err) => setStatusError(errorMessage(err)))
       .finally(() => setStatusLoading(false));
   }, [api]);
 
@@ -121,12 +211,43 @@ export function useCurationData({
         setOplog(response.events || []);
         if (response.error) setOplogError(response.error);
       })
-      .catch((err) => setOplogError(err instanceof Error ? err.message : String(err)));
+      .catch((err) => setOplogError(errorMessage(err)));
   }, [api]);
+
+  const {
+    automationRuns,
+    automationRunsError,
+    automationRunActioning,
+    automationRunError,
+    automationRunArtifacts,
+    automationRunArtifact,
+    automationRunArtifactLoading,
+    automationRunArtifactError,
+    loadAutomationRuns,
+    loadAutomationRunArtifact,
+    runAutomationTask,
+  } = useAutomationRuns({
+    api,
+    pollFastMs,
+    setActiveTab,
+    setMemoryPreviewFromRun,
+    loadActivity,
+    loadStatus,
+    loadFactProposals,
+    loadManagedSkills,
+  });
 
   useEffect(() => {
     loadSavedPreview(true);
   }, [loadSavedPreview]);
+
+  useEffect(() => {
+    loadConfig().catch(() => {});
+  }, [loadConfig]);
+
+  useEffect(() => {
+    loadSchedulerStatus(false).catch(() => {});
+  }, [loadSchedulerStatus]);
 
   const preview = useCallback(async () => {
     setLoading(true);
@@ -135,24 +256,20 @@ export function useCurationData({
     loadActivity(true);
     try {
       const response = await api.postMemoryCurate({ dry_run: true });
-      setReport(response);
       const savedAt = now();
-      previewSavedAtRef.current = savedAt;
-      setPreviewSavedAt(savedAt);
-      setPreviewStale(false);
-      setPreviewStaleReason("");
+      applySavedPreview(response, savedAt);
       await loadSavedPreview(true);
       loadActivity();
       loadStatus();
       setActiveTab("plan");
       return response;
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
       throw err;
     } finally {
       setLoading(false);
     }
-  }, [api, loadActivity, loadSavedPreview, loadStatus, now]);
+  }, [api, applySavedPreview, loadActivity, loadSavedPreview, loadStatus, now]);
 
   const apply = useCallback(async () => {
     previewLoadSeq.current += 1;
@@ -162,23 +279,19 @@ export function useCurationData({
     loadActivity(true);
     try {
       const response = await api.postMemoryCurate({ dry_run: false });
-      setReport(response);
-      previewSavedAtRef.current = null;
-      setPreviewSavedAt(null);
-      setPreviewStale(false);
-      setPreviewStaleReason("");
+      applySavedPreview(response, null);
       setConfirmOpen(false);
       loadActivity();
       loadStatus();
       onApplied?.();
       return response;
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errorMessage(err));
       throw err;
     } finally {
       setApplying(false);
     }
-  }, [api, loadActivity, loadStatus, onApplied]);
+  }, [api, applySavedPreview, loadActivity, loadStatus, onApplied]);
 
   useEffect(() => {
     if (activeTab === "plan" && !loading && !applying) {
@@ -195,8 +308,19 @@ export function useCurationData({
   useEffect(() => {
     if (activeTab === "history") {
       loadOplog();
+      loadAutomationRuns();
+      loadSchedulerStatus(false).catch(() => {});
+      loadFactProposals();
+      loadManagedSkills();
     }
-  }, [activeTab, loadOplog]);
+  }, [
+    activeTab,
+    loadAutomationRuns,
+    loadFactProposals,
+    loadManagedSkills,
+    loadOplog,
+    loadSchedulerStatus,
+  ]);
 
   useEffect(() => {
     if (activeTab === "activity" && activity.length === 0) {
@@ -234,17 +358,66 @@ export function useCurationData({
     statusError,
     oplog,
     oplogError,
+    automationRuns,
+    automationRunsError,
+    automationRunActioning,
+    automationRunError,
+    automationRunArtifacts,
+    automationRunArtifact,
+    automationRunArtifactLoading,
+    automationRunArtifactError,
+    factProposals,
+    factProposalsLoading,
+    factProposalsError,
+    factProposalActioning,
+    managedSkills,
+    selectedManagedSkillId,
+    selectedManagedSkill,
+    managedSkillUsage,
+    managedSkillRecommendations,
+    managedSkillImprovementRecommendations,
+    managedSkillsLoading,
+    managedSkillsError,
+    managedSkillActioning,
     activity,
     activityLoading,
     activityError,
+    configResponse,
+    configDraft,
+    configLoading,
+    configSaving,
+    configResetting,
+    configError,
+    configFieldErrors,
+    schedulerStatus,
+    schedulerStatusLoading,
+    schedulerStatusError,
+    schedulerActioning,
+    configDirty,
     activityRef,
     panelRef,
     setConfirmOpen,
     setActiveTab,
     preview,
     apply,
+    runAutomationTask,
     loadActivity,
     loadStatus,
     loadOplog,
+    loadAutomationRuns,
+    loadAutomationRunArtifact,
+    loadFactProposals,
+    runFactProposalAction,
+    loadManagedSkills,
+    loadManagedSkill,
+    runManagedSkillAction,
+    loadConfig,
+    loadSchedulerStatus,
+    setSchedulerPaused,
+    updateConfigDraft,
+    updateConfigTaskDraft,
+    resetConfigDraft,
+    resetConfigToDefaults,
+    saveConfigDraft,
   };
 }

--- a/dashboard/holographic/src/curation/useCurationData.ts
+++ b/dashboard/holographic/src/curation/useCurationData.ts
@@ -231,6 +231,7 @@ export function useCurationData({
     pollFastMs,
     setActiveTab,
     setMemoryPreviewFromRun,
+    loadMemoryPreview: loadSavedPreview,
     loadActivity,
     loadStatus,
     loadFactProposals,

--- a/dashboard/holographic/src/curation/useFactProposals.ts
+++ b/dashboard/holographic/src/curation/useFactProposals.ts
@@ -1,0 +1,78 @@
+import { useCallback, useState } from "react";
+
+import type { FactProposalRecord } from "../types";
+import { errorMessage } from "./errors";
+import type { CurationApi } from "./useCurationData";
+
+type FactProposalAction = "apply" | "reject";
+
+export function useFactProposals({
+  api,
+  onApplied,
+}: {
+  api: CurationApi;
+  onApplied?: () => void;
+}) {
+  const [factProposals, setFactProposals] = useState<FactProposalRecord[]>([]);
+  const [factProposalsLoading, setFactProposalsLoading] = useState(false);
+  const [factProposalsError, setFactProposalsError] = useState("");
+  const [factProposalActioning, setFactProposalActioning] = useState<string | null>(null);
+
+  const loadFactProposals = useCallback((showSpinner = false) => {
+    if (showSpinner) setFactProposalsLoading(true);
+    setFactProposalsError("");
+    return api
+      .getFactProposals({ limit: 50 })
+      .then((response) => {
+        setFactProposals(response.proposals || []);
+        if (response.error) setFactProposalsError(response.error);
+        return response;
+      })
+      .catch((err) => {
+        setFactProposalsError(errorMessage(err));
+        throw err;
+      })
+      .finally(() => {
+        if (showSpinner) setFactProposalsLoading(false);
+      });
+  }, [api]);
+
+  const runFactProposalAction = useCallback(async (
+    action: FactProposalAction,
+    id: string,
+  ) => {
+    setFactProposalActioning(`${id}:${action}`);
+    setFactProposalsError("");
+    try {
+      const response = action === "apply"
+        ? await api.applyFactProposal(id)
+        : await api.rejectFactProposal(id, "rejected from dashboard");
+      setFactProposals((current) =>
+        current.map((proposal) =>
+          proposal.proposal_id === response.proposal.proposal_id
+            ? response.proposal
+            : proposal
+        )
+      );
+      await loadFactProposals(false);
+      if (action === "apply") {
+        onApplied?.();
+      }
+      return response;
+    } catch (err) {
+      setFactProposalsError(errorMessage(err));
+      throw err;
+    } finally {
+      setFactProposalActioning(null);
+    }
+  }, [api, loadFactProposals, onApplied]);
+
+  return {
+    factProposals,
+    factProposalsLoading,
+    factProposalsError,
+    factProposalActioning,
+    loadFactProposals,
+    runFactProposalAction,
+  };
+}

--- a/dashboard/holographic/src/curation/useManagedSkills.ts
+++ b/dashboard/holographic/src/curation/useManagedSkills.ts
@@ -1,0 +1,150 @@
+import { useCallback, useState } from "react";
+
+import type {
+  ManagedSkill,
+  ManagedSkillResponse,
+  SkillImprovementRecommendation,
+  SkillStaleRecommendation,
+  SkillUsageSummary,
+} from "../types";
+import { errorMessage } from "./errors";
+import type { CurationApi } from "./useCurationData";
+
+type ManagedSkillAction = "approve" | "discard-update" | "disable" | "archive" | "restore";
+
+function indexBySkillId<T extends { skill_id: string }>(items: T[] = []): Record<string, T> {
+  return Object.fromEntries(items.map((item) => [item.skill_id, item]));
+}
+
+export function useManagedSkills(api: CurationApi) {
+  const [managedSkills, setManagedSkills] = useState<ManagedSkill[]>([]);
+  const [selectedManagedSkillId, setSelectedManagedSkillId] = useState<string | null>(null);
+  const [selectedManagedSkill, setSelectedManagedSkill] = useState<ManagedSkill | null>(null);
+  const [managedSkillUsage, setManagedSkillUsage] = useState<Record<string, SkillUsageSummary>>({});
+  const [managedSkillRecommendations, setManagedSkillRecommendations] = useState<
+    Record<string, SkillStaleRecommendation>
+  >({});
+  const [
+    managedSkillImprovementRecommendations,
+    setManagedSkillImprovementRecommendations,
+  ] = useState<Record<string, SkillImprovementRecommendation>>({});
+  const [managedSkillsLoading, setManagedSkillsLoading] = useState(false);
+  const [managedSkillsError, setManagedSkillsError] = useState("");
+  const [managedSkillActioning, setManagedSkillActioning] = useState<string | null>(null);
+
+  const applyManagedSkillResponse = useCallback((response: ManagedSkillResponse) => {
+    const skillId = response.skill.metadata.id;
+    setSelectedManagedSkillId(skillId);
+    setSelectedManagedSkill(response.skill);
+    if (response.usage_summary) {
+      setManagedSkillUsage((current) => ({
+        ...current,
+        [skillId]: response.usage_summary,
+      }));
+    }
+    if (response.stale_recommendation) {
+      setManagedSkillRecommendations((current) => ({
+        ...current,
+        [skillId]: response.stale_recommendation,
+      }));
+    }
+    if (response.improvement_recommendation) {
+      setManagedSkillImprovementRecommendations((current) => ({
+        ...current,
+        [skillId]: response.improvement_recommendation,
+      }));
+    }
+  }, []);
+
+  const loadManagedSkill = useCallback((id: string) => {
+    setManagedSkillsError("");
+    return api
+      .getManagedSkill(id)
+      .then((response) => {
+        applyManagedSkillResponse(response);
+        return response.skill;
+      })
+      .catch((err) => {
+        setManagedSkillsError(errorMessage(err));
+        throw err;
+      });
+  }, [api, applyManagedSkillResponse]);
+
+  const loadManagedSkills = useCallback((showSpinner = false) => {
+    if (showSpinner) setManagedSkillsLoading(true);
+    setManagedSkillsError("");
+    return api
+      .getManagedSkills()
+      .then(async (response) => {
+        const skills = response.skills || [];
+        setManagedSkills(skills);
+        setManagedSkillUsage(indexBySkillId(response.usage_summaries));
+        setManagedSkillRecommendations(indexBySkillId(response.stale_recommendations));
+        setManagedSkillImprovementRecommendations(
+          indexBySkillId(response.improvement_recommendations),
+        );
+        const nextId = selectedManagedSkillId && skills.some((skill) =>
+          skill.metadata.id === selectedManagedSkillId
+        )
+          ? selectedManagedSkillId
+          : (skills[0]?.metadata.id ?? null);
+        setSelectedManagedSkillId(nextId);
+        if (nextId) {
+          await loadManagedSkill(nextId);
+        } else {
+          setSelectedManagedSkill(null);
+        }
+        if (response.error) setManagedSkillsError(response.error);
+        return response;
+      })
+      .catch((err) => {
+        setManagedSkillsError(errorMessage(err));
+        throw err;
+      })
+      .finally(() => {
+        if (showSpinner) setManagedSkillsLoading(false);
+      });
+  }, [api, loadManagedSkill, selectedManagedSkillId]);
+
+  const runManagedSkillAction = useCallback(async (
+    action: ManagedSkillAction,
+    id = selectedManagedSkillId,
+  ) => {
+    if (!id) return null;
+    setManagedSkillActioning(`${id}:${action}`);
+    setManagedSkillsError("");
+    try {
+      const call = {
+        approve: api.approveManagedSkill,
+        "discard-update": api.discardManagedSkillUpdate,
+        disable: api.disableManagedSkill,
+        archive: api.archiveManagedSkill,
+        restore: api.restoreManagedSkill,
+      }[action];
+      const response = await call(id);
+      applyManagedSkillResponse(response);
+      await loadManagedSkills(false);
+      return response;
+    } catch (err) {
+      setManagedSkillsError(errorMessage(err));
+      throw err;
+    } finally {
+      setManagedSkillActioning(null);
+    }
+  }, [api, applyManagedSkillResponse, loadManagedSkills, selectedManagedSkillId]);
+
+  return {
+    managedSkills,
+    selectedManagedSkillId,
+    selectedManagedSkill,
+    managedSkillUsage,
+    managedSkillRecommendations,
+    managedSkillImprovementRecommendations,
+    managedSkillsLoading,
+    managedSkillsError,
+    managedSkillActioning,
+    loadManagedSkills,
+    loadManagedSkill,
+    runManagedSkillAction,
+  };
+}

--- a/dashboard/holographic/src/styles.css
+++ b/dashboard/holographic/src/styles.css
@@ -27,6 +27,7 @@
   --color-border: rgba(139, 255, 218, 0.16);
   --color-primary: #75f4d2;
   --color-secondary: #7aa7ff;
+  --color-accent: #7aa7ff;
   --color-muted: rgba(117, 244, 210, 0.1);
   --color-muted-foreground: #6f9189;
   --color-destructive: #ff6b7a;
@@ -191,23 +192,40 @@ input[type="range"] {
   gap: 0.35rem;
   min-height: 4.1rem;
   align-content: start;
+  /* Override the shared .tdp-stat defaults with tighter radius, holographic
+   * sheen, and SystemStrip's denser padding. */
+  border: 1px solid var(--hm-line);
   border-radius: 14px;
+  padding: 0.5rem 0.75rem;
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--hm-text) 4%, transparent), transparent 42%),
     color-mix(in srgb, var(--hm-bg) 48%, transparent);
 }
 
-.hm-stat-value {
+.hm-stat .tdp-stat-value {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   overflow-wrap: anywhere;
+  color: var(--hm-text);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 1.125rem;
+  line-height: 1;
 }
 
-.hm-stat-label {
+.hm-stat .tdp-stat-label {
   margin-top: 0;
   line-height: 1.25;
   text-transform: lowercase;
+  color: var(--hm-text-3);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+/* The storage-path stat shows a long filesystem path; shrink it and let the
+ * shared .tdp-stat-value ellipsis handle truncation. */
+.hm-path-stat .tdp-stat-value {
+  font-size: 0.75rem;
 }
 
 /* Reset default browser paragraph margins for plain card copy only. Paragraphs
@@ -282,12 +300,12 @@ input[type="range"] {
     border-radius: 12px;
   }
 
-  .hm-system-strip .hm-stat-value {
+  .hm-system-strip .hm-stat .tdp-stat-value {
     font-size: 0.95rem;
     line-height: 1.1;
   }
 
-  .hm-system-strip .hm-stat-label {
+  .hm-system-strip .hm-stat .tdp-stat-label {
     font-size: 0.66rem;
     letter-spacing: 0.05em;
   }

--- a/dashboard/holographic/src/types.ts
+++ b/dashboard/holographic/src/types.ts
@@ -45,8 +45,8 @@ export interface HolographicFact {
   trust_score: number;
   retrieval_count: number;
   helpful_count: number;
-  created_at: string;
-  updated_at: string;
+  created_at: number;
+  updated_at: number;
   has_hrr?: boolean | number;
   snippet?: string;
 }
@@ -282,11 +282,14 @@ export interface MemoryCurateAction {
   op: string;
   tier?: string;
   reason?: string;
+  confidence?: number;
   fact_id?: number;
   duplicate_of?: number;
   entity_id?: number;
   loser?: number;
   winner?: number;
+  loser_ids?: number[];
+  winner_id?: number;
   loser_entity?: number;
   winner_entity?: number;
   name?: string;
@@ -322,11 +325,6 @@ export interface MemoryCurateHygieneCandidate {
   content?: string;
 }
 
-/**
- * Wire contract for `POST /api/plugins/holographic/curate`: the curation
- * plan/report. With `dry_run` the actions are proposals; otherwise
- * `applied_counts`/`apply_errors` describe what was actually executed.
- */
 /** Deterministic rule-based hygiene candidates (never auto-applied). */
 export interface MemoryCurateHygieneCandidates {
   secret_like: MemoryCurateHygieneCandidate[];
@@ -334,11 +332,22 @@ export interface MemoryCurateHygieneCandidates {
   supersession: MemoryCurateHygieneCandidate[];
 }
 
+/**
+ * Wire contract for `POST /api/plugins/holographic/curate`: the curation
+ * plan/report. With `dry_run` the actions are proposals; otherwise
+ * `applied_counts`/`apply_errors` describe what was actually executed.
+ */
 export interface MemoryCurateResponse {
   provider?: string;
   ran: boolean;
   dry_run: boolean;
   actions: MemoryCurateAction[];
+  llm_apply?: {
+    ops?: MemoryCurateAction[];
+    rejected_ops?: unknown[];
+    note?: string;
+    [key: string]: unknown;
+  };
   hygiene_candidates?: MemoryCurateHygieneCandidates;
   counts: Record<string, number>;
   applied_counts?: Record<string, number>;
@@ -369,6 +378,367 @@ export interface MemoryCuratorPreviewResponse {
   saved_at?: string | null;
   stale?: boolean;
   stale_reason?: string;
+  error?: string;
+}
+
+export type AutomationBackend = "disabled" | "codex_app_server" | "external_command";
+export type SelectableAutomationBackend = Exclude<AutomationBackend, "external_command">;
+
+export type AutomationHostMode = "standalone" | "delegated_host";
+
+export interface AutomationBackendAvailability {
+  backend: AutomationBackend;
+  available: boolean;
+  executable?: string | null;
+  reason?: string | null;
+}
+
+export interface AutomationTaskConfig {
+  enabled: boolean;
+  schedule?: string | null;
+  interval_secs?: number | null;
+  cooldown_secs?: number | null;
+  min_idle_secs?: number | null;
+  stale_lock_secs?: number | null;
+}
+
+export interface AutomationTaskSet {
+  memory_curator: AutomationTaskConfig;
+  session_reflector: AutomationTaskConfig;
+  skill_writer: AutomationTaskConfig;
+}
+
+export interface MemoryAutomationConfig {
+  enabled: boolean;
+  backend: AutomationBackend;
+  host_mode: AutomationHostMode;
+  model?: string | null;
+  timeout_secs: number;
+  scheduler_tick_secs: number;
+  max_tokens?: number | null;
+  temperature?: number | null;
+  require_dashboard_approval: boolean;
+  auto_apply_memory_ops: boolean;
+  auto_enable_skills: boolean;
+  tasks: AutomationTaskSet;
+}
+
+export interface AutomationTaskPatch {
+  enabled?: boolean;
+  schedule?: string | null;
+  interval_secs?: number | null;
+  cooldown_secs?: number | null;
+  min_idle_secs?: number | null;
+  stale_lock_secs?: number | null;
+}
+
+export interface MemoryAutomationConfigPatch {
+  enabled?: boolean;
+  backend?: SelectableAutomationBackend;
+  host_mode?: AutomationHostMode;
+  model?: string | null;
+  timeout_secs?: number;
+  scheduler_tick_secs?: number;
+  max_tokens?: number | null;
+  temperature?: number | null;
+  require_dashboard_approval?: boolean;
+  auto_apply_memory_ops?: boolean;
+  auto_enable_skills?: boolean;
+  memory_curator?: AutomationTaskPatch;
+  session_reflector?: AutomationTaskPatch;
+  skill_writer?: AutomationTaskPatch;
+}
+
+export interface MemoryAutomationConfigResponse {
+  global: MemoryAutomationConfig;
+  project: MemoryAutomationConfigPatch | null;
+  effective: MemoryAutomationConfig;
+  backend_availability?: AutomationBackendAvailability;
+  project_config_path?: string;
+}
+
+export interface AutomationSchedulerTaskStatus {
+  task: "memory_curator" | "session_reflector" | "skill_writer" | string;
+  due: boolean;
+  skip_reason?: string | null;
+  last_scheduler_run?: MemoryAutomationRunRecord | null;
+}
+
+export interface AutomationSchedulerStatusResponse {
+  status: string;
+  paused: boolean;
+  enabled: boolean;
+  scheduler_tick_secs: number;
+  now: number;
+  project_config_path?: string;
+  control_path?: string;
+  tasks: AutomationSchedulerTaskStatus[];
+}
+
+export interface MemoryAgentPlanResponse<TReport = Record<string, unknown>> {
+  run_id: string;
+  dry_run: true;
+  status: string;
+  report?: TReport;
+  ledger_record: MemoryAutomationRunRecord;
+  backend_response?: unknown;
+  error?: string;
+}
+
+export interface AutomationRunRequest {
+  dry_run?: true;
+  provider?: string;
+  query?: string;
+  evidence_limit?: number;
+  storage_scope?: "project_local" | "hermes_profile" | string;
+  hermes_home?: string;
+  scope?: "all" | "session" | "current" | string;
+  session_id?: string;
+  include_summaries?: boolean;
+  sort?: "recency" | "relevance" | "hybrid" | string;
+  source?: string;
+  role?: string;
+  start_time?: number;
+  end_time?: number;
+}
+
+export type MemoryAutomationRunResponse<TReport = Record<string, unknown>> =
+  MemoryAgentPlanResponse<TReport>;
+
+export interface MemoryAutomationRunRecord {
+  schema_version: number;
+  run_id: string;
+  trigger: "manual_cli" | "dashboard" | "scheduler" | string;
+  task: "memory_curator" | "session_reflector" | "skill_writer" | string;
+  task_key?: string | null;
+  backend: string;
+  host_mode?: "standalone" | "delegated_host" | string | null;
+  prompt_version?: string | null;
+  response_schema?: unknown;
+  strict_json?: boolean | null;
+  model?: string | null;
+  status: "queued" | "running" | "succeeded" | "failed" | "skipped" | string;
+  evidence_hash?: string | null;
+  input_hash?: string | null;
+  output_hash?: string | null;
+  proposed_ops?: unknown;
+  applied_ops?: unknown;
+  rejected_ops?: unknown;
+  validation_report?: unknown;
+  reviewed_count?: number;
+  accepted_count: number;
+  rejected_count: number;
+  skipped_count?: number;
+  error?: string | null;
+  error_classification?:
+    | "retryable"
+    | "permanent"
+    | "timeout"
+    | "unavailable"
+    | "malformed_output"
+    | string
+    | null;
+  error_retryable?: boolean | null;
+  fallback_status?: string | null;
+  report_ref?: unknown;
+  artifacts?: MemoryAutomationRunArtifact[];
+  started_at: string;
+  completed_at: string;
+}
+
+export interface MemoryAutomationRunArtifact {
+  schema_version: number;
+  kind: string;
+  path: string;
+  sha256: string;
+  summary?: string | null;
+  created_at: string;
+}
+
+export interface MemoryAutomationRunArtifactsResponse {
+  run_id: string;
+  artifacts: MemoryAutomationRunArtifact[];
+  artifact_chain?: {
+    expected_kinds?: string[];
+    present_kinds?: string[];
+    complete?: boolean;
+  };
+  count: number;
+  error?: string;
+}
+
+export interface MemoryAutomationRunArtifactPayloadResponse {
+  run_id: string;
+  artifact: MemoryAutomationRunArtifact;
+  payload: unknown;
+  error?: string;
+}
+
+export interface MemoryAutomationRunsResponse {
+  records: MemoryAutomationRunRecord[];
+  count: number;
+  limit: number;
+  error?: string;
+}
+
+export type ManagedSkillSource = "automation_run" | "user_draft" | "import" | string;
+
+export type ManagedSkillState =
+  | "pending_approval"
+  | "active"
+  | "disabled"
+  | "archived"
+  | string;
+
+export type SkillInstallTarget =
+  | "cursor"
+  | "codex"
+  | "claude"
+  | "agents"
+  | "opencode"
+  | "kimi"
+  | "kiro"
+  | "hermes"
+  | string;
+
+export interface ManagedSkillProvenance {
+  source: ManagedSkillSource;
+  actor: string;
+  run_id?: string | null;
+}
+
+export interface ManagedSkillMetadata {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  targets: SkillInstallTarget[];
+  state: ManagedSkillState;
+  checksum: string;
+  provenance: ManagedSkillProvenance;
+  pinned: boolean;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface ManagedSupportFile {
+  path: string;
+  bytes: number[];
+}
+
+export interface ManagedSkill {
+  metadata: ManagedSkillMetadata;
+  body_markdown: string;
+  support_files: ManagedSupportFile[];
+  pending_update?: ManagedSkillPendingUpdate | null;
+}
+
+export interface ManagedSkillPendingUpdate {
+  base_checksum: string;
+  staged_at: number;
+  metadata: ManagedSkillMetadata;
+  body_markdown: string;
+  support_files: ManagedSupportFile[];
+}
+
+export interface SkillUsageSummary {
+  schema_version: number;
+  skill_id: string;
+  title?: string | null;
+  category?: string | null;
+  state?: ManagedSkillState | null;
+  pinned: boolean;
+  created_by?: string | null;
+  provenance_source?: ManagedSkillSource | null;
+  targets: string[];
+  view_count: number;
+  use_count: number;
+  patch_count: number;
+  first_seen_at: number;
+  last_activity_at: number;
+  last_viewed_at?: number | null;
+  last_used_at?: number | null;
+  last_patched_at?: number | null;
+}
+
+export interface SkillStaleRecommendation {
+  skill_id: string;
+  stale: boolean;
+  recommendation: string;
+  reason: string;
+  evidence: string[];
+}
+
+export interface SkillImprovementRecommendation {
+  skill_id: string;
+  improvement: boolean;
+  recommendation: string;
+  reason: string;
+  priority: string;
+  evidence: string[];
+}
+
+export interface ManagedSkillListResponse {
+  profile_root: string;
+  skills_root: string;
+  count: number;
+  skills: ManagedSkill[];
+  skill_metadata: ManagedSkillMetadata[];
+  usage_summaries?: SkillUsageSummary[];
+  stale_recommendations?: SkillStaleRecommendation[];
+  improvement_recommendations?: SkillImprovementRecommendation[];
+  error?: string;
+}
+
+export interface ManagedSkillResponse {
+  profile_root: string;
+  skills_root: string;
+  skill_dir: string;
+  skill: ManagedSkill;
+  usage_summary?: SkillUsageSummary;
+  stale_recommendation?: SkillStaleRecommendation | null;
+  improvement_recommendation?: SkillImprovementRecommendation | null;
+  error?: string;
+}
+
+export type FactProposalState =
+  | "pending_approval"
+  | "applied"
+  | "rejected"
+  | string;
+
+export interface FactProposalRecord {
+  schema_version: number;
+  proposal_id: string;
+  run_id: string;
+  evidence_hash?: string | null;
+  state: FactProposalState;
+  add_fact_request?: {
+    content?: string;
+    type?: string;
+    category?: string;
+    tags?: string[];
+    [key: string]: unknown;
+  } | null;
+  proposal?: unknown;
+  validation_reason?: string | null;
+  validation?: unknown;
+  reviewer?: string | null;
+  applied_fact_id?: number | null;
+  apply_outcome?: unknown;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface FactProposalListResponse {
+  proposals: FactProposalRecord[];
+  count: number;
+  limit: number;
+  error?: string;
+}
+
+export interface FactProposalResponse {
+  proposal: FactProposalRecord;
   error?: string;
 }
 

--- a/dashboard/lib/primitives.css
+++ b/dashboard/lib/primitives.css
@@ -1,4 +1,13 @@
-/* Shared dashboard primitives (`tdp-*`), prepended to opted-in plugin CSS. */
+/* Shared dashboard primitives (`tdp-*`), prepended to opted-in plugin CSS.
+ *
+ * Wrapped in `@layer hermes-plugin` so that, inside a plugin bundle, these
+ * defaults are merged into the same layer as the plugin's own rules and LOSE
+ * ties to plugin overrides by source order (primitives are prepended first).
+ * Plugins whose sheets compile unlayered (tailwind:false — lcm/savings/graph)
+ * still beat this layer, so their `.hermes-* .tdp-*` overrides continue to win.
+ * Without this layer, an unlayered `.tdp-stat` would defeat a layered `.hm-stat`
+ * in the holographic (tailwind:true) bundle, regressing the Stat visuals. */
+@layer hermes-plugin {
 
 /* ----------------------------------------------------------- EmptyState */
 .tdp-empty {
@@ -92,6 +101,11 @@
   border: 1px solid var(--color-border);
   border-radius: var(--ts-radius, 18px);
   background: color-mix(in srgb, var(--color-background) 26%, transparent);
+}
+
+/* When a native tooltip (title) is attached, signal it's hoverable help. */
+.tdp-stat[title] {
+  cursor: help;
 }
 
 .tdp-stat-value {
@@ -231,3 +245,5 @@
   border-radius: inherit;
   background: color-mix(in srgb, var(--color-primary, #5a7fff) 90%, white 10%);
 }
+
+} /* end @layer hermes-plugin */

--- a/dashboard/lib/primitives.tsx
+++ b/dashboard/lib/primitives.tsx
@@ -70,22 +70,32 @@ export function SkeletonLines({
   );
 }
 
-/** Big-value + small-label stat tile. */
+/** Big-value + small-label stat tile.
+ *
+ * `title` surfaces a plain-language explanation as a native browser tooltip
+ * (and a `help` cursor) on the whole tile — used by holographic stat rows that
+ * need to explain what a number means without adding visible chrome. */
 export function Stat({
   label,
   value,
   hint,
+  title,
   variant = "default",
   className,
 }: {
   label: string;
   value: React.ReactNode;
   hint?: string;
+  /** Native tooltip text for the whole tile; sets cursor: help when present. */
+  title?: string;
   variant?: "default" | "compact";
   className?: string;
 }) {
   return (
-    <div className={cn("tdp-stat", variant === "compact" && "tdp-stat-compact", className)}>
+    <div
+      className={cn("tdp-stat", variant === "compact" && "tdp-stat-compact", className)}
+      title={title}
+    >
       <div className="tdp-stat-value">{value}</div>
       <div className="tdp-stat-label">{label}</div>
       {hint && <div className="tdp-stat-hint">{hint}</div>}

--- a/dashboard/savings/src/DiagnosticsPanel.tsx
+++ b/dashboard/savings/src/DiagnosticsPanel.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../../lib/sdk";
+import { BarList, EmptyState, Stat } from "../../lib/primitives";
+import { fmtTokens } from "./logic";
+import type {
+  DiagnosticsCountRow,
+  DiagnosticsRecentEvent,
+  DiagnosticsRecentHook,
+  DiagnosticsResponse,
+} from "./types";
+
+function fmtRatio(value: number | undefined): string {
+  return value == null ? "0.00" : value.toFixed(2);
+}
+
+function rowLabel(row: DiagnosticsCountRow, key: string): string {
+  return String(row[key] || "(none)");
+}
+
+function countRows(
+  rows: DiagnosticsCountRow[],
+  key: string,
+): Array<{ label: string; value: number }> {
+  return rows
+    .slice(0, 12)
+    .map((row) => ({ label: rowLabel(row, key), value: Number(row.count) || 0 }));
+}
+
+function EventTable({ rows }: { rows: DiagnosticsRecentEvent[] }) {
+  if (!rows.length) return <EmptyState variant="dashed">No recent events</EmptyState>;
+  return (
+    <div className="tss-table-scroll">
+      <table className="tss-table">
+        <thead>
+          <tr>
+            <th>Kind</th>
+            <th>Tool</th>
+            <th>Hook</th>
+            <th>Outcome</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 10).map((row, index) => (
+            <tr key={`${row.timestamp || 0}-${index}`}>
+              <td>{row.event_kind || "-"}</td>
+              <td>{row.tool_name || "-"}</td>
+              <td>{row.hook_name || "-"}</td>
+              <td>{row.outcome || "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HookTable({ rows }: { rows: DiagnosticsRecentHook[] }) {
+  if (!rows.length) return <EmptyState variant="dashed">No recent hooks</EmptyState>;
+  return (
+    <div className="tss-table-scroll">
+      <table className="tss-table">
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th>Hook</th>
+            <th>Tool</th>
+            <th>Prompt</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 10).map((row, index) => (
+            <tr key={`${row.ts_unix_ms || 0}-${index}`}>
+              <td>{row.agent || "-"}</td>
+              <td>{row.hook_name || "-"}</td>
+              <td>{row.tool_name || "-"}</td>
+              <td>{row.prompt_category || "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function DiagnosticsPanel({ data }: { data: DiagnosticsResponse | null }) {
+  if (!data) return <EmptyState variant="dashed">Loading diagnostics...</EmptyState>;
+
+  return (
+    <div className="tss-grid">
+      <div className="tss-stat-row">
+        <Stat label="messages" value={fmtTokens(data.message_count)} />
+        <Stat label="events" value={fmtTokens(data.event_count)} />
+        <Stat label="MCP tools" value={fmtTokens(data.mcp_tool_call_count)} />
+        <Stat label="TraceDecay calls" value={fmtTokens(data.tracedecay_call_count)} />
+        <Stat label="hooks" value={fmtTokens(data.hook_call_count)} />
+      </div>
+
+      <div className="tss-stat-row">
+        <Stat
+          label="tools / message"
+          value={fmtRatio(data.ratios?.tool_calls_per_message)}
+        />
+        <Stat
+          label="MCP / message"
+          value={fmtRatio(data.ratios?.mcp_tool_calls_per_message)}
+        />
+        <Stat
+          label="hooks / message"
+          value={fmtRatio(data.ratios?.hook_calls_per_message)}
+        />
+        <Stat label="events / hour" value={fmtRatio(data.events_per_hour)} />
+      </div>
+
+      <div className="tss-card-grid">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tool Categories</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList rows={countRows(data.by_tool_category, "tool_category")} keyName="label" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>MCP Tools</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList rows={countRows(data.by_mcp_tool, "tool_name")} keyName="label" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Hooks</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList rows={countRows(data.by_hook, "hook_name")} keyName="label" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Prompt Categories</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList
+              rows={countRows(data.by_prompt_category || [], "prompt_category")}
+              keyName="label"
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Outcomes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList rows={countRows(data.by_outcome, "outcome")} keyName="label" />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="tss-card-grid">
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Events</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <EventTable rows={data.recent_events || []} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent Hooks</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <HookTable rows={data.recent_hooks || []} />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="tss-meta-strip">
+        <span className="tss-meta-item">source: {data.source}</span>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/savings/src/DiagnosticsPanel.tsx
+++ b/dashboard/savings/src/DiagnosticsPanel.tsx
@@ -9,6 +9,11 @@ import type {
   DiagnosticsResponse,
 } from "./types";
 
+type RecentTableColumn<T> = {
+  header: string;
+  value: (row: T) => string | number | null | undefined;
+};
+
 function fmtRatio(value: number | undefined): string {
   return value == null ? "0.00" : value.toFixed(2);
 }
@@ -26,26 +31,34 @@ function countRows(
     .map((row) => ({ label: rowLabel(row, key), value: Number(row.count) || 0 }));
 }
 
-function EventTable({ rows }: { rows: DiagnosticsRecentEvent[] }) {
-  if (!rows.length) return <EmptyState variant="dashed">No recent events</EmptyState>;
+function RecentTable<T>({
+  rows,
+  empty,
+  columns,
+  rowKey,
+}: {
+  rows: T[];
+  empty: string;
+  columns: Array<RecentTableColumn<T>>;
+  rowKey: (row: T, index: number) => string;
+}) {
+  if (!rows.length) return <EmptyState variant="dashed">{empty}</EmptyState>;
   return (
     <div className="tss-table-scroll">
       <table className="tss-table">
         <thead>
           <tr>
-            <th>Kind</th>
-            <th>Tool</th>
-            <th>Hook</th>
-            <th>Outcome</th>
+            {columns.map((column) => (
+              <th key={column.header}>{column.header}</th>
+            ))}
           </tr>
         </thead>
         <tbody>
           {rows.slice(0, 10).map((row, index) => (
-            <tr key={`${row.timestamp || 0}-${index}`}>
-              <td>{row.event_kind || "-"}</td>
-              <td>{row.tool_name || "-"}</td>
-              <td>{row.hook_name || "-"}</td>
-              <td>{row.outcome || "-"}</td>
+            <tr key={rowKey(row, index)}>
+              {columns.map((column) => (
+                <td key={column.header}>{column.value(row) || "-"}</td>
+              ))}
             </tr>
           ))}
         </tbody>
@@ -54,31 +67,35 @@ function EventTable({ rows }: { rows: DiagnosticsRecentEvent[] }) {
   );
 }
 
-function HookTable({ rows }: { rows: DiagnosticsRecentHook[] }) {
-  if (!rows.length) return <EmptyState variant="dashed">No recent hooks</EmptyState>;
+function EventTable({ rows }: { rows: DiagnosticsRecentEvent[] }) {
   return (
-    <div className="tss-table-scroll">
-      <table className="tss-table">
-        <thead>
-          <tr>
-            <th>Agent</th>
-            <th>Hook</th>
-            <th>Tool</th>
-            <th>Prompt</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.slice(0, 10).map((row, index) => (
-            <tr key={`${row.ts_unix_ms || 0}-${index}`}>
-              <td>{row.agent || "-"}</td>
-              <td>{row.hook_name || "-"}</td>
-              <td>{row.tool_name || "-"}</td>
-              <td>{row.prompt_category || "-"}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <RecentTable
+      rows={rows}
+      empty="No recent events"
+      rowKey={(row, index) => `${row.timestamp || 0}-${index}`}
+      columns={[
+        { header: "Kind", value: (row) => row.event_kind },
+        { header: "Tool", value: (row) => row.tool_name },
+        { header: "Hook", value: (row) => row.hook_name },
+        { header: "Outcome", value: (row) => row.outcome },
+      ]}
+    />
+  );
+}
+
+function HookTable({ rows }: { rows: DiagnosticsRecentHook[] }) {
+  return (
+    <RecentTable
+      rows={rows}
+      empty="No recent hooks"
+      rowKey={(row, index) => `${row.ts_unix_ms || 0}-${index}`}
+      columns={[
+        { header: "Agent", value: (row) => row.agent },
+        { header: "Hook", value: (row) => row.hook_name },
+        { header: "Tool", value: (row) => row.tool_name },
+        { header: "Prompt", value: (row) => row.prompt_category },
+      ]}
+    />
   );
 }
 

--- a/dashboard/savings/src/SavingsExplorer.tsx
+++ b/dashboard/savings/src/SavingsExplorer.tsx
@@ -13,7 +13,9 @@ import type { PriceTable } from "./pricing";
 import SavingsOverviewPanel from "./SavingsOverviewPanel";
 import SessionsPanel from "./SessionsPanel";
 import ModelsPanel from "./ModelsPanel";
+import DiagnosticsPanel from "./DiagnosticsPanel";
 import type {
+  DiagnosticsResponse,
   LedgerResponse,
   ModelsResponse,
   PricingResponse,
@@ -25,6 +27,7 @@ const VIEWS = [
   { id: "savings", label: "Savings" },
   { id: "sessions", label: "Sessions" },
   { id: "models", label: "Models & Pricing" },
+  { id: "diagnostics", label: "Diagnostics" },
 ] as const;
 
 type ViewId = (typeof VIEWS)[number]["id"];
@@ -46,6 +49,7 @@ export default function SavingsExplorer() {
   const [ledger, setLedger] = useState<LedgerResponse | null>(null);
   const [sessions, setSessions] = useState<SessionsResponse | null>(null);
   const [models, setModels] = useState<ModelsResponse | null>(null);
+  const [diagnostics, setDiagnostics] = useState<DiagnosticsResponse | null>(null);
   const [pricing, setPricing] = useState<PricingResponse | null>(null);
   const [error, setError] = useState<string>("");
   // Bumped by the Retry button; every fetch effect below depends on it.
@@ -111,6 +115,11 @@ export default function SavingsExplorer() {
     if (view !== "models") return;
     return fetchIntoState(() => api.models({ range }), setModels, { clearBeforeLoad: true });
   }, [view, range, retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (view !== "diagnostics") return;
+    return fetchIntoState(() => api.diagnostics(), setDiagnostics, { clearBeforeLoad: true });
+  }, [view, retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const sessionStats = overview?.sessions;
 
@@ -193,6 +202,7 @@ export default function SavingsExplorer() {
       {view === "models" && (
         <ModelsPanel data={models} pricing={pricing} prices={prices} />
       )}
+      {view === "diagnostics" && <DiagnosticsPanel data={diagnostics} />}
     </div>
   );
 }

--- a/dashboard/savings/src/SavingsExplorer.tsx
+++ b/dashboard/savings/src/SavingsExplorer.tsx
@@ -1,9 +1,3 @@
-/**
- * Savings & Cost tab root: view switcher (Savings / Sessions / Models &
- * Pricing) + time-range selector, loading data from
- * `/api/plugins/savings/*` and the shared price table from `/pricing`.
- */
-
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { cn } from "../../lib/sdk";
 import { ErrorPanel } from "../../lib/primitives";
@@ -59,15 +53,11 @@ export default function SavingsExplorer() {
 
   const retry = useCallback(() => setRetryToken((token) => token + 1), []);
 
-  /**
-   * Runs `fetch()` inside an effect, dropping the response after unmount or
-   * a dependency change so stale results never overwrite newer ones.
-   */
-  function fetchIntoState<T>(
+  const fetchIntoState = useCallback(<T,>(
     fetch: () => Promise<T>,
     setState: (value: T | null) => void,
     { clearBeforeLoad = false }: { clearBeforeLoad?: boolean } = {},
-  ): () => void {
+  ): () => void => {
     let active = true;
     setError("");
     if (clearBeforeLoad) setState(null);
@@ -82,12 +72,8 @@ export default function SavingsExplorer() {
     return () => {
       active = false;
     };
-  }
+  }, []);
 
-  // Each view fetches only what it renders. The overview (meta strip +
-  // savings stats) and the price table take no range/page params, so they
-  // load once; `sessions` is the only request that depends on the page, so
-  // paging the sessions table costs exactly one request.
   useEffect(() => {
     const cancelOverview = fetchIntoState(() => api.overview(), setOverview);
     const cancelPricing = fetchIntoState(() => api.pricing(), setPricing);
@@ -95,12 +81,12 @@ export default function SavingsExplorer() {
       cancelOverview();
       cancelPricing();
     };
-  }, [retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fetchIntoState, retryToken]);
 
   useEffect(() => {
     if (view !== "savings") return;
     return fetchIntoState(() => api.ledger({ range }), setLedger, { clearBeforeLoad: true });
-  }, [view, range, retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fetchIntoState, view, range, retryToken]);
 
   useEffect(() => {
     if (view !== "sessions") return;
@@ -109,17 +95,17 @@ export default function SavingsExplorer() {
       setSessions,
       { clearBeforeLoad: true },
     );
-  }, [view, range, page, retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fetchIntoState, view, range, page, retryToken]);
 
   useEffect(() => {
     if (view !== "models") return;
     return fetchIntoState(() => api.models({ range }), setModels, { clearBeforeLoad: true });
-  }, [view, range, retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fetchIntoState, view, range, retryToken]);
 
   useEffect(() => {
     if (view !== "diagnostics") return;
     return fetchIntoState(() => api.diagnostics(), setDiagnostics, { clearBeforeLoad: true });
-  }, [view, retryToken]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fetchIntoState, view, retryToken]);
 
   const sessionStats = overview?.sessions;
 

--- a/dashboard/savings/src/api.ts
+++ b/dashboard/savings/src/api.ts
@@ -1,6 +1,7 @@
 import { fetchJSON } from "../../lib/sdk";
 import { qs } from "../../lib/qs";
 import type {
+  DiagnosticsResponse,
   LedgerResponse,
   ModelsResponse,
   PricingResponse,
@@ -9,6 +10,7 @@ import type {
 } from "./types";
 
 const BASE = "/api/plugins/savings";
+const ANALYTICS_BASE = "/api/plugins/analytics";
 
 export const api = {
   overview: () => fetchJSON<SavingsOverview>(`${BASE}/overview`),
@@ -18,5 +20,7 @@ export const api = {
     fetchJSON<SessionsResponse>(`${BASE}/sessions${qs(params)}`),
   models: (params: { range?: string } = {}) =>
     fetchJSON<ModelsResponse>(`${BASE}/models${qs(params)}`),
+  diagnostics: () =>
+    fetchJSON<DiagnosticsResponse>(`${ANALYTICS_BASE}/diagnostics`),
   pricing: () => fetchJSON<PricingResponse>(`${BASE}/pricing`),
 };

--- a/dashboard/savings/src/styles.css
+++ b/dashboard/savings/src/styles.css
@@ -343,28 +343,6 @@
   background: color-mix(in srgb, var(--ts-red, #ff7a7a) 8%, transparent);
 }
 
-.tss-empty {
-  border: 1px dashed var(--ts-line-strong);
-  border-radius: var(--ts-radius);
-  color: var(--ts-text-2);
-  display: grid;
-  gap: 0.4rem;
-  justify-items: start;
-  padding: 1.4rem 1.2rem;
-}
-
-.tss-empty h3 {
-  color: var(--ts-text);
-  font-size: 0.95rem;
-  margin: 0;
-}
-
-.tss-empty p {
-  font-size: 0.8rem;
-  line-height: 1.5;
-  margin: 0;
-}
-
 .tss-empty-mini {
   color: var(--ts-text-3);
   font-size: 0.78rem;

--- a/dashboard/savings/src/types.ts
+++ b/dashboard/savings/src/types.ts
@@ -142,6 +142,55 @@ export interface ModelsResponse {
   };
 }
 
+export interface DiagnosticsCountRow {
+  count: number;
+  [key: string]: string | number;
+}
+
+export interface DiagnosticsRecentEvent {
+  timestamp?: number | null;
+  event_kind?: string;
+  hook_name?: string;
+  tool_name?: string;
+  outcome?: string;
+}
+
+export interface DiagnosticsRecentHook {
+  ts_unix_ms?: number | null;
+  agent?: string;
+  hook_name?: string;
+  session_id?: string;
+  tool_name?: string;
+  prompt_category?: string;
+}
+
+export interface DiagnosticsResponse {
+  available: boolean;
+  source: string;
+  message_count: number;
+  event_count: number;
+  tool_call_count: number;
+  mcp_tool_call_count: number;
+  tracedecay_call_count: number;
+  hook_call_count: number;
+  events_per_hour?: number;
+  ratios: {
+    events_per_message: number;
+    tool_calls_per_message: number;
+    mcp_tool_calls_per_message: number;
+    hook_calls_per_message: number;
+  };
+  by_event_kind: DiagnosticsCountRow[];
+  by_tool: DiagnosticsCountRow[];
+  by_mcp_tool: DiagnosticsCountRow[];
+  by_tool_category: DiagnosticsCountRow[];
+  by_outcome: DiagnosticsCountRow[];
+  by_hook: DiagnosticsCountRow[];
+  by_prompt_category: DiagnosticsCountRow[];
+  recent_events: DiagnosticsRecentEvent[];
+  recent_hooks: DiagnosticsRecentHook[];
+}
+
 export interface PricingResponse {
   source: string;
   fetched_at: number | null;

--- a/dashboard/shell/src/sdk.jsx
+++ b/dashboard/shell/src/sdk.jsx
@@ -33,13 +33,16 @@ export async function fetchJSON(url, init) {
   const res = await fetch(url, init);
   if (!res.ok) {
     let detail = `${res.status} ${res.statusText}`;
+    let body;
     try {
-      const body = await res.json();
+      body = await res.json();
       if (body && body.detail) detail = String(body.detail);
     } catch {
       /* non-JSON error body */
     }
-    throw new Error(detail);
+    const error = new Error(detail);
+    if (body !== undefined) error.body = body;
+    throw error;
   }
   return res.json();
 }

--- a/dashboard/shell/src/styles.css
+++ b/dashboard/shell/src/styles.css
@@ -137,6 +137,11 @@
   --color-muted: rgba(117, 244, 210, 0.1);
   --color-muted-foreground: var(--ts-text-3);
   --color-secondary: rgba(122, 167, 255, 0.1);
+  /* Gotcha: --color-secondary is a 10%-opacity blue TINT, not a readable text
+     color, so the Tailwind `text-secondary` utility is near-invisible as
+     foreground. Use `text-text-secondary` (which maps to --ts-text-2) for
+     secondary copy; reserve `bg-secondary`/`border-secondary` for surfaces. */
+  --color-accent: var(--ts-blue);
   --color-destructive: var(--ts-red);
   --color-warning: var(--ts-amber);
   --color-success: var(--ts-green);
@@ -779,6 +784,7 @@ select:focus-visible {
   --color-muted: rgba(0, 137, 123, 0.08);
   --color-muted-foreground: var(--ts-text-3);
   --color-secondary: rgba(58, 95, 192, 0.08);
+  --color-accent: var(--ts-blue);
   --color-destructive: var(--ts-red);
   --color-warning: var(--ts-amber);
   --color-success: var(--ts-green);

--- a/dashboard/test/curation-data.vitest.tsx
+++ b/dashboard/test/curation-data.vitest.tsx
@@ -754,6 +754,79 @@ describe("useCurationData", () => {
     });
   });
 
+  it("refreshes automation outputs when polling observes terminal runs", async () => {
+    const queuedMemoryRun = {
+      schema_version: 2,
+      run_id: "queued-memory-run",
+      trigger: "dashboard",
+      task: "memory_curator",
+      backend: "codex_app_server",
+      status: "queued",
+      accepted_count: 0,
+      rejected_count: 0,
+      started_at: "2026-06-24T00:00:00Z",
+      completed_at: "2026-06-24T00:00:00Z",
+    };
+    const queuedReflectionRun = {
+      ...queuedMemoryRun,
+      run_id: "queued-reflection-run",
+      task: "session_reflector",
+    };
+    const queuedSkillRun = {
+      ...queuedMemoryRun,
+      run_id: "queued-skill-run",
+      task: "skill_writer",
+    };
+    const api = makeApi({
+      getMemoryAutomationRuns: vi.fn()
+        .mockResolvedValueOnce({
+          records: [queuedMemoryRun, queuedReflectionRun, queuedSkillRun],
+          count: 3,
+          limit: 20,
+          error: "",
+        })
+        .mockResolvedValueOnce({
+          records: [
+            { ...queuedMemoryRun, status: "succeeded" },
+            { ...queuedReflectionRun, status: "succeeded" },
+            { ...queuedSkillRun, status: "succeeded" },
+          ],
+          count: 3,
+          limit: 20,
+          error: "",
+        }),
+    });
+    const { result } = renderHook(() =>
+      useCurationData({ api, pollFastMs: 25 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+
+    await act(async () => {
+      await result.current.loadAutomationRuns();
+    });
+
+    vi.mocked(api.getMemoryCuratorPreview).mockClear();
+    vi.mocked(api.getMemoryCuratorActivity).mockClear();
+    vi.mocked(api.getMemoryCuratorStatus).mockClear();
+    vi.mocked(api.getFactProposals).mockClear();
+    vi.mocked(api.getManagedSkills).mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(25);
+    });
+
+    expect(api.getMemoryCuratorPreview).toHaveBeenCalledTimes(1);
+    expect(api.getMemoryCuratorActivity).toHaveBeenCalledTimes(1);
+    expect(api.getMemoryCuratorStatus).toHaveBeenCalledTimes(1);
+    expect(api.getFactProposals).toHaveBeenCalledTimes(1);
+    expect(api.getManagedSkills).toHaveBeenCalledTimes(1);
+  });
+
   it("loads and applies fact proposals from the history tab", async () => {
     const pendingProposal = {
       schema_version: 1,

--- a/dashboard/test/curation-data.vitest.tsx
+++ b/dashboard/test/curation-data.vitest.tsx
@@ -1,24 +1,210 @@
-import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useCurationData } from "../holographic/src/curation/useCurationData";
+import { useCurationData, type CurationApi } from "../holographic/src/curation/useCurationData";
 
-function deferred() {
-  let resolve;
-  let reject;
-  const promise = new Promise((res, rej) => {
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T = unknown>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"];
+  let reject!: Deferred<T>["reject"];
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
   });
   return { promise, resolve, reject };
 }
 
-function makeApi(overrides = {}): any {
+function makeApi(overrides: Partial<CurationApi> = {}): CurationApi {
   return {
     getMemoryCuratorPreview: vi.fn().mockResolvedValue({ report: null, saved_at: null }),
     getMemoryCuratorActivity: vi.fn().mockResolvedValue({ events: [] }),
+    getMemoryAutomationRuns: vi.fn().mockResolvedValue({ records: [] }),
+    getAutomationSchedulerStatus: vi.fn().mockResolvedValue({
+      status: "paused",
+      paused: true,
+      enabled: false,
+      scheduler_tick_secs: 60,
+      now: 1782283200,
+      tasks: [
+        { task: "memory_curator", due: false, skip_reason: "automation_disabled" },
+        { task: "session_reflector", due: false, skip_reason: "automation_disabled" },
+        { task: "skill_writer", due: false, skip_reason: "automation_disabled" },
+      ],
+    }),
+    pauseAutomationScheduler: vi.fn().mockResolvedValue({
+      status: "paused",
+      paused: true,
+      enabled: false,
+      scheduler_tick_secs: 60,
+      now: 1782283200,
+      tasks: [],
+    }),
+    resumeAutomationScheduler: vi.fn().mockResolvedValue({
+      status: "configured",
+      paused: false,
+      enabled: true,
+      scheduler_tick_secs: 60,
+      now: 1782283200,
+      tasks: [],
+    }),
+    getMemoryAutomationRunArtifacts: vi.fn().mockResolvedValue({ artifacts: [], count: 0 }),
+    getMemoryAutomationRunArtifact: vi.fn().mockResolvedValue({
+      run_id: "memory-run",
+      artifact: {
+        schema_version: 1,
+        kind: "codex_handoff",
+        path: "automation_artifacts/memory-run/codex_handoff.json",
+        sha256: "sha256:test",
+        created_at: "2026-06-24T00:00:00Z",
+      },
+      payload: {},
+    }),
+    getFactProposals: vi.fn().mockResolvedValue({ proposals: [], count: 0, limit: 50 }),
+    applyFactProposal: vi.fn(),
+    rejectFactProposal: vi.fn(),
+    getManagedSkills: vi.fn().mockResolvedValue({ skills: [], skill_metadata: [], count: 0 }),
+    getManagedSkill: vi.fn(),
+    approveManagedSkill: vi.fn(),
+    discardManagedSkillUpdate: vi.fn(),
+    disableManagedSkill: vi.fn(),
+    archiveManagedSkill: vi.fn(),
+    restoreManagedSkill: vi.fn(),
     postMemoryCurate: vi.fn().mockResolvedValue({ dry_run: true, actions: [], counts: {} }),
+    postAutomationRunMemoryCurator: vi.fn().mockResolvedValue({
+      run_id: "memory-run",
+      dry_run: true,
+      status: "skipped",
+      report: { dry_run: true, actions: [], counts: {}, reason: "automation_disabled" },
+      ledger_record: {
+        schema_version: 1,
+        run_id: "memory-run",
+        trigger: "dashboard",
+        task: "memory_curator",
+        backend: "disabled",
+        status: "skipped",
+        accepted_count: 0,
+        rejected_count: 0,
+        error: "automation_disabled",
+        started_at: "2026-06-24T00:00:00Z",
+        completed_at: "2026-06-24T00:00:01Z",
+      },
+    }),
+    postAutomationRunSessionReflection: vi.fn().mockResolvedValue({
+      run_id: "reflection-run",
+      dry_run: true,
+      status: "skipped",
+      report: { status: "skipped", reason: "automation_disabled" },
+      ledger_record: {
+        schema_version: 1,
+        run_id: "reflection-run",
+        trigger: "dashboard",
+        task: "session_reflector",
+        backend: "disabled",
+        status: "skipped",
+        accepted_count: 0,
+        rejected_count: 0,
+        error: "automation_disabled",
+        started_at: "2026-06-24T00:00:00Z",
+        completed_at: "2026-06-24T00:00:01Z",
+      },
+    }),
+    postAutomationRunSkillWriting: vi.fn().mockResolvedValue({
+      run_id: "skill-run",
+      dry_run: true,
+      status: "skipped",
+      report: { status: "skipped", reason: "automation_disabled" },
+      ledger_record: {
+        schema_version: 1,
+        run_id: "skill-run",
+        trigger: "dashboard",
+        task: "skill_writer",
+        backend: "disabled",
+        status: "skipped",
+        accepted_count: 0,
+        rejected_count: 0,
+        error: "automation_disabled",
+        started_at: "2026-06-24T00:00:00Z",
+        completed_at: "2026-06-24T00:00:01Z",
+      },
+    }),
     getMemoryCuratorStatus: vi.fn().mockResolvedValue({ runs: [] }),
+    getMemoryAutomationConfig: vi.fn().mockResolvedValue({
+      global: null,
+      project: null,
+      effective: {
+        enabled: false,
+        backend: "disabled",
+        host_mode: "standalone",
+        model: null,
+        timeout_secs: 60,
+        scheduler_tick_secs: 60,
+        max_tokens: null,
+        temperature: null,
+        require_dashboard_approval: true,
+        auto_apply_memory_ops: false,
+        auto_enable_skills: false,
+        tasks: {
+          memory_curator: { enabled: false, schedule: null },
+          session_reflector: { enabled: false, schedule: null },
+          skill_writer: { enabled: false, schedule: null },
+        },
+      },
+    }),
+    patchMemoryAutomationConfig: vi.fn().mockImplementation((patch) =>
+      Promise.resolve({
+        global: null,
+        project: patch,
+        effective: {
+          enabled: patch.enabled ?? false,
+          backend: patch.backend ?? "disabled",
+          host_mode: patch.host_mode ?? "standalone",
+          model: patch.model ?? null,
+          timeout_secs: patch.timeout_secs ?? 60,
+          scheduler_tick_secs: patch.scheduler_tick_secs ?? 60,
+          max_tokens: patch.max_tokens ?? null,
+          temperature: patch.temperature ?? null,
+          require_dashboard_approval: patch.require_dashboard_approval ?? true,
+          auto_apply_memory_ops: patch.auto_apply_memory_ops ?? false,
+          auto_enable_skills: patch.auto_enable_skills ?? false,
+          tasks: {
+            memory_curator: patch.memory_curator ?? { enabled: false, schedule: null },
+            session_reflector: patch.session_reflector ?? { enabled: false, schedule: null },
+            skill_writer: patch.skill_writer ?? { enabled: false, schedule: null },
+          },
+        },
+      }),
+    ),
+    resetMemoryAutomationConfig: vi.fn().mockResolvedValue({
+      global: null,
+      project: null,
+      effective: {
+        enabled: false,
+        backend: "disabled",
+        host_mode: "standalone",
+        model: null,
+        timeout_secs: 60,
+        scheduler_tick_secs: 60,
+        max_tokens: null,
+        temperature: null,
+        require_dashboard_approval: true,
+        auto_apply_memory_ops: false,
+        auto_enable_skills: false,
+        tasks: {
+          memory_curator: { enabled: false, schedule: null },
+          session_reflector: { enabled: false, schedule: null },
+          skill_writer: { enabled: false, schedule: null },
+        },
+      },
+    }),
     getMemoryOplog: vi.fn().mockResolvedValue({ events: [] }),
     ...overrides,
   };
@@ -47,7 +233,7 @@ describe("useCurationData", () => {
       await Promise.resolve();
     });
 
-    let pending;
+    let pending!: Promise<unknown>;
     act(() => {
       pending = result.current.preview();
     });
@@ -97,7 +283,7 @@ describe("useCurationData", () => {
     expect(result.current.previewSavedAt).toBe("2026-06-14T12:00:00.000Z");
     act(() => result.current.setConfirmOpen(true));
 
-    let pending;
+    let pending!: Promise<unknown>;
     act(() => {
       pending = result.current.apply();
     });
@@ -131,7 +317,7 @@ describe("useCurationData", () => {
     Object.defineProperty(panel, "offsetParent", { configurable: true, get: () => null });
     result.current.panelRef.current = panel;
     act(() => result.current.setActiveTab("activity"));
-    api.getMemoryCuratorActivity.mockClear();
+    vi.mocked(api.getMemoryCuratorActivity).mockClear();
 
     await act(async () => {
       vi.advanceTimersByTime(2500);
@@ -144,5 +330,560 @@ describe("useCurationData", () => {
     });
     expect(api.getMemoryCuratorActivity).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
+  });
+
+  it("loads, edits, saves, and resets the automation config draft", async () => {
+    const api = makeApi();
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft?.enabled).toBe(false);
+    });
+
+    expect(result.current.configDraft?.enabled).toBe(false);
+
+    act(() => {
+      result.current.updateConfigDraft({
+        enabled: true,
+        model: "project-model",
+        scheduler_tick_secs: 15,
+        max_tokens: 4096,
+        temperature: 0.2,
+      });
+      result.current.updateConfigTaskDraft("memory_curator", {
+        enabled: true,
+        schedule: "manual",
+        interval_secs: 900,
+        cooldown_secs: 300,
+        min_idle_secs: 120,
+        stale_lock_secs: 3600,
+      });
+    });
+
+    expect(result.current.configDirty).toBe(true);
+    expect(result.current.configDraft.enabled).toBe(true);
+    expect(result.current.configDraft.tasks.memory_curator.schedule).toBe("manual");
+
+    await act(async () => {
+      await result.current.saveConfigDraft();
+    });
+
+    expect(api.patchMemoryAutomationConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        model: "project-model",
+        scheduler_tick_secs: 15,
+        max_tokens: 4096,
+        temperature: 0.2,
+        memory_curator: {
+          enabled: true,
+          schedule: "manual",
+          interval_secs: 900,
+          cooldown_secs: 300,
+          min_idle_secs: 120,
+          stale_lock_secs: 3600,
+        },
+      }),
+    );
+    expect(result.current.configDirty).toBe(false);
+
+    act(() => result.current.updateConfigDraft({ model: "changed" }));
+    expect(result.current.configDirty).toBe(true);
+    act(() => result.current.resetConfigDraft());
+    expect(result.current.configDraft.model).toBe("project-model");
+    expect(result.current.configDirty).toBe(false);
+  });
+
+  it("resets persisted automation overrides back to defaults", async () => {
+    const api = makeApi({
+      getMemoryAutomationConfig: vi.fn().mockResolvedValue({
+        global: null,
+        project: { model: "project-model" },
+        effective: {
+          enabled: true,
+          backend: "codex_app_server",
+          host_mode: "standalone",
+          model: "project-model",
+          timeout_secs: 90,
+          scheduler_tick_secs: 20,
+          max_tokens: 4096,
+          temperature: 0.2,
+          require_dashboard_approval: true,
+          auto_apply_memory_ops: false,
+          auto_enable_skills: false,
+          tasks: {
+            memory_curator: { enabled: true, schedule: "manual" },
+            session_reflector: { enabled: false, schedule: null },
+            skill_writer: { enabled: false, schedule: null },
+          },
+        },
+      }),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft?.model).toBe("project-model");
+    });
+
+    await act(async () => {
+      await result.current.resetConfigToDefaults();
+    });
+
+    expect(api.resetMemoryAutomationConfig).toHaveBeenCalledTimes(1);
+    expect(result.current.configResponse?.project).toBeNull();
+    expect(result.current.configDraft?.model).toBeNull();
+    expect(result.current.configDirty).toBe(false);
+  });
+
+  it("pauses and resumes scheduler through the dashboard scheduler API", async () => {
+    const api = makeApi({
+      getMemoryAutomationConfig: vi
+        .fn()
+        .mockResolvedValueOnce({
+          global: null,
+          project: null,
+          effective: {
+            enabled: true,
+            backend: "codex_app_server",
+            host_mode: "standalone",
+            model: null,
+            timeout_secs: 60,
+            scheduler_tick_secs: 60,
+            max_tokens: null,
+            temperature: null,
+            require_dashboard_approval: true,
+            auto_apply_memory_ops: false,
+            auto_enable_skills: false,
+            tasks: {
+              memory_curator: { enabled: true, schedule: "interval" },
+              session_reflector: { enabled: false, schedule: null },
+              skill_writer: { enabled: false, schedule: null },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          global: null,
+          project: null,
+          effective: {
+            enabled: true,
+            backend: "codex_app_server",
+            host_mode: "standalone",
+            model: null,
+            timeout_secs: 60,
+            scheduler_tick_secs: 60,
+            max_tokens: null,
+            temperature: null,
+            require_dashboard_approval: true,
+            auto_apply_memory_ops: false,
+            auto_enable_skills: false,
+            tasks: {
+              memory_curator: { enabled: true, schedule: "interval" },
+              session_reflector: { enabled: false, schedule: null },
+              skill_writer: { enabled: false, schedule: null },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          global: null,
+          project: null,
+          effective: {
+            enabled: true,
+            backend: "codex_app_server",
+            host_mode: "standalone",
+            model: null,
+            timeout_secs: 60,
+            scheduler_tick_secs: 60,
+            max_tokens: null,
+            temperature: null,
+            require_dashboard_approval: true,
+            auto_apply_memory_ops: false,
+            auto_enable_skills: false,
+            tasks: {
+              memory_curator: { enabled: true, schedule: "interval" },
+              session_reflector: { enabled: false, schedule: null },
+              skill_writer: { enabled: false, schedule: null },
+            },
+          },
+        }),
+      pauseAutomationScheduler: vi.fn().mockResolvedValue({
+        status: "paused",
+        paused: true,
+        enabled: true,
+        scheduler_tick_secs: 60,
+        now: 1782283200,
+        tasks: [{ task: "memory_curator", due: false, skip_reason: "scheduler_paused" }],
+      }),
+      resumeAutomationScheduler: vi.fn().mockResolvedValue({
+        status: "configured",
+        paused: false,
+        enabled: true,
+        scheduler_tick_secs: 60,
+        now: 1782283200,
+        tasks: [{ task: "memory_curator", due: true, skip_reason: null }],
+      }),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft?.enabled).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.setSchedulerPaused(true);
+    });
+
+    expect(api.pauseAutomationScheduler).toHaveBeenCalledTimes(1);
+    expect(api.getMemoryAutomationConfig).toHaveBeenCalledTimes(2);
+    expect(result.current.schedulerStatus?.paused).toBe(true);
+    expect(result.current.configDraft?.enabled).toBe(true);
+
+    await act(async () => {
+      await result.current.setSchedulerPaused(false);
+    });
+
+    expect(api.resumeAutomationScheduler).toHaveBeenCalledTimes(1);
+    expect(api.getMemoryAutomationConfig).toHaveBeenCalledTimes(3);
+    expect(result.current.schedulerStatus?.paused).toBe(false);
+    expect(result.current.configDraft?.enabled).toBe(true);
+  });
+
+  it("indexes backend automation config validation errors by field", async () => {
+    const validationError = Object.assign(
+      new Error("automation timeout_secs must be greater than zero"),
+      {
+        body: {
+          validation_errors: [
+            {
+              field: "timeout_secs",
+              message: "automation timeout_secs must be greater than zero",
+            },
+          ],
+        },
+      },
+    );
+    const api = makeApi({
+      patchMemoryAutomationConfig: vi.fn().mockRejectedValue(validationError),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    act(() => {
+      result.current.updateConfigDraft({
+        timeout_secs: 0,
+      });
+    });
+
+    let saveError: unknown;
+    await act(async () => {
+      try {
+        await result.current.saveConfigDraft();
+      } catch (err) {
+        saveError = err;
+      }
+    });
+
+    expect(saveError).toBe(validationError);
+    expect(result.current.configFieldErrors.timeout_secs).toContain(
+      "timeout_secs",
+    );
+    expect(result.current.configDirty).toBe(true);
+  });
+
+  it("loads automation run history when the history tab opens", async () => {
+    const api = makeApi({
+      getMemoryAutomationRuns: vi.fn().mockResolvedValue({
+        records: [
+          {
+            schema_version: 1,
+            run_id: "run-1",
+            trigger: "dashboard",
+            task: "memory_curator",
+            backend: "disabled",
+            status: "skipped",
+            accepted_count: 0,
+            rejected_count: 0,
+            error: "automation_disabled",
+            started_at: "2026-06-24T00:00:00Z",
+            completed_at: "2026-06-24T00:00:01Z",
+          },
+        ],
+        count: 1,
+        limit: 20,
+        error: "",
+      }),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    act(() => result.current.setActiveTab("history"));
+
+    await waitFor(() => {
+      expect(api.getMemoryAutomationRuns).toHaveBeenCalledWith({ limit: 20 });
+      expect(result.current.automationRuns).toHaveLength(1);
+    });
+  });
+
+  it("loads verified automation run artifact payloads", async () => {
+    const api = makeApi({
+      getMemoryAutomationRunArtifact: vi.fn().mockResolvedValue({
+        run_id: "run-1",
+        artifact: {
+          schema_version: 1,
+          kind: "codex_handoff",
+          path: "automation_artifacts/run-1/codex_handoff.json",
+          sha256: "sha256:payload",
+          created_at: "2026-06-24T00:00:00Z",
+        },
+        payload: {
+          status: "ready_for_review",
+          next_actions: ["review dashboard artifact payload"],
+        },
+        error: "",
+      }),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    await act(async () => {
+      await result.current.loadAutomationRunArtifact("run-1", "codex_handoff");
+    });
+
+    expect(api.getMemoryAutomationRunArtifact).toHaveBeenCalledWith("run-1", "codex_handoff");
+    expect(result.current.automationRunArtifact?.payload).toMatchObject({
+      status: "ready_for_review",
+    });
+  });
+
+  it("runs standalone automation tasks and refreshes dependent dashboard data", async () => {
+    const api = makeApi();
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    await act(async () => {
+      await result.current.runAutomationTask("session_reflector");
+    });
+
+    expect(api.postAutomationRunSessionReflection).toHaveBeenCalledWith({ dry_run: true });
+    expect(api.getMemoryAutomationRuns).toHaveBeenCalledWith({ limit: 20 });
+    expect(api.getFactProposals).toHaveBeenCalledWith({ limit: 50 });
+
+    await act(async () => {
+      await result.current.runAutomationTask("skill_writer");
+    });
+
+    expect(api.postAutomationRunSkillWriting).toHaveBeenCalledWith({ dry_run: true });
+    expect(api.getManagedSkills).toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.runAutomationTask("memory_curator");
+    });
+
+    expect(api.postAutomationRunMemoryCurator).toHaveBeenCalledWith({ dry_run: true });
+    expect(api.getMemoryCuratorActivity).toHaveBeenCalled();
+  });
+
+  it("tracks queued automation runs without requiring a report and polls until terminal", async () => {
+    const queuedRun = {
+      schema_version: 2,
+      run_id: "queued-memory-run",
+      trigger: "dashboard",
+      task: "memory_curator",
+      backend: "codex_app_server",
+      status: "queued",
+      accepted_count: 0,
+      rejected_count: 0,
+      started_at: "2026-06-24T00:00:00Z",
+      completed_at: "2026-06-24T00:00:00Z",
+    };
+    const succeededRun = {
+      ...queuedRun,
+      status: "succeeded",
+      completed_at: "2026-06-24T00:00:01Z",
+    };
+    const api = makeApi({
+      postAutomationRunMemoryCurator: vi.fn().mockResolvedValue({
+        run_id: "queued-memory-run",
+        dry_run: true,
+        status: "queued",
+        ledger_record: queuedRun,
+      }),
+      getMemoryAutomationRuns: vi.fn()
+        .mockResolvedValueOnce({ records: [queuedRun], count: 1, limit: 20, error: "" })
+        .mockResolvedValueOnce({ records: [queuedRun], count: 1, limit: 20, error: "" })
+        .mockResolvedValueOnce({ records: [succeededRun], count: 1, limit: 20, error: "" }),
+    });
+    const { result } = renderHook(() =>
+      useCurationData({ api, pollFastMs: 25 }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+
+    await act(async () => {
+      await result.current.runAutomationTask("memory_curator");
+    });
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.automationRuns[0]).toMatchObject({
+      run_id: "queued-memory-run",
+      status: "queued",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(25);
+    });
+
+    expect(result.current.automationRuns[0]).toMatchObject({
+      run_id: "queued-memory-run",
+      status: "succeeded",
+    });
+  });
+
+  it("loads and applies fact proposals from the history tab", async () => {
+    const pendingProposal = {
+      schema_version: 1,
+      proposal_id: "prop-1",
+      run_id: "run-1",
+      state: "pending_approval",
+      add_fact_request: { content: "Prefer bounded evidence." },
+      created_at: 1782283200,
+      updated_at: 1782283200,
+    };
+    const appliedProposal = {
+      ...pendingProposal,
+      state: "applied",
+      applied_fact_id: 42,
+      updated_at: 1782283300,
+    };
+    const api = makeApi({
+      getFactProposals: vi.fn()
+        .mockResolvedValueOnce({
+          proposals: [pendingProposal],
+          count: 1,
+          limit: 50,
+        })
+        .mockResolvedValue({
+          proposals: [appliedProposal],
+          count: 1,
+          limit: 50,
+        }),
+      applyFactProposal: vi.fn().mockResolvedValue({ proposal: appliedProposal }),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    act(() => result.current.setActiveTab("history"));
+
+    await waitFor(() => {
+      expect(api.getFactProposals).toHaveBeenCalledWith({ limit: 50 });
+      expect(result.current.factProposals[0].proposal_id).toBe("prop-1");
+    });
+
+    await act(async () => {
+      await result.current.runFactProposalAction("apply", "prop-1");
+    });
+
+    expect(api.applyFactProposal).toHaveBeenCalledWith("prop-1");
+    expect(result.current.factProposals[0].state).toBe("applied");
+  });
+
+  it("loads and approves managed skills from the history tab", async () => {
+    const pendingSkill = {
+      metadata: {
+        id: "repo-hygiene",
+        title: "Repo Hygiene",
+        summary: "Keep repo maintenance consistent.",
+        category: "workflow",
+        state: "pending_approval",
+        checksum: "abc123",
+        pinned: false,
+        created_at: 1782259200,
+        updated_at: 1782259200,
+        provenance: { source: "automation_run", actor: "skill_writer", run_id: "run-1" },
+      },
+      body_markdown: "Use focused checks before broad suites.",
+      support_files: [],
+    };
+    const activeSkill = {
+      ...pendingSkill,
+      metadata: { ...pendingSkill.metadata, state: "active" },
+    };
+    const api = makeApi({
+      getManagedSkills: vi.fn()
+        .mockResolvedValueOnce({
+          skills: [pendingSkill],
+          skill_metadata: [pendingSkill.metadata],
+          improvement_recommendations: [
+            {
+              skill_id: "repo-hygiene",
+              improvement: true,
+              recommendation: "patch_review",
+              reason: "repeated patches suggest the skill instructions may still be unstable",
+              priority: "medium",
+              evidence: ["patches=2"],
+            },
+          ],
+          count: 1,
+        })
+        .mockResolvedValue({
+          skills: [activeSkill],
+          skill_metadata: [activeSkill.metadata],
+          improvement_recommendations: [
+            {
+              skill_id: "repo-hygiene",
+              improvement: true,
+              recommendation: "patch_review",
+              reason: "repeated patches suggest the skill instructions may still be unstable",
+              priority: "medium",
+              evidence: ["patches=2"],
+            },
+          ],
+          count: 1,
+        }),
+      getManagedSkill: vi.fn()
+        .mockResolvedValueOnce({ skill: pendingSkill })
+        .mockResolvedValue({ skill: activeSkill }),
+      approveManagedSkill: vi.fn().mockResolvedValue({ skill: activeSkill }),
+    });
+    const { result } = renderHook(() => useCurationData({ api }));
+
+    await waitFor(() => {
+      expect(result.current.configDraft).toBeTruthy();
+    });
+
+    act(() => result.current.setActiveTab("history"));
+
+    await waitFor(() => {
+      expect(api.getManagedSkills).toHaveBeenCalled();
+      expect(result.current.selectedManagedSkill?.metadata.id).toBe("repo-hygiene");
+    });
+    expect(
+      result.current.managedSkillImprovementRecommendations["repo-hygiene"].recommendation,
+    ).toBe("patch_review");
+
+    await act(async () => {
+      await result.current.runManagedSkillAction("approve", "repo-hygiene");
+    });
+
+    expect(api.approveManagedSkill).toHaveBeenCalledWith("repo-hygiene");
+    expect(result.current.selectedManagedSkill?.metadata.state).toBe("active");
   });
 });

--- a/dashboard/test/curation-panel.vitest.tsx
+++ b/dashboard/test/curation-panel.vitest.tsx
@@ -1,16 +1,456 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import CurationPanel from "../holographic/src/CurationPanel";
 
+const apiMock = vi.hoisted(() => ({
+  getMemoryCuratorPreview: vi.fn().mockResolvedValue({ report: null, saved_at: null }),
+  getMemoryCuratorActivity: vi.fn().mockResolvedValue({ events: [] }),
+  getMemoryCuratorStatus: vi.fn().mockResolvedValue({
+    provider: "tracedecay",
+    state: { paused: false, run_count: 0 },
+    config: { enabled: false },
+    snapshots: [],
+  }),
+  getMemoryAutomationConfig: vi.fn().mockResolvedValue({
+    global: null,
+    project: null,
+    effective: {
+      enabled: true,
+      backend: "codex_app_server",
+      host_mode: "standalone",
+      model: null,
+      timeout_secs: 60,
+      scheduler_tick_secs: 60,
+      max_tokens: null,
+      temperature: null,
+      require_dashboard_approval: true,
+      auto_apply_memory_ops: false,
+      auto_enable_skills: false,
+      tasks: {
+        memory_curator: { enabled: true, schedule: null },
+        session_reflector: { enabled: true, schedule: null },
+        skill_writer: { enabled: true, schedule: null },
+      },
+    },
+    backend_availability: {
+      backend: "codex_app_server",
+      available: true,
+      executable: "/usr/bin/codex",
+      reason: null,
+    },
+  }),
+  patchMemoryAutomationConfig: vi.fn().mockImplementation((patch) =>
+    Promise.resolve({
+      global: null,
+      project: patch,
+      effective: {
+        enabled: patch.enabled ?? false,
+        backend: patch.backend ?? "disabled",
+        host_mode: patch.host_mode ?? "standalone",
+        model: patch.model ?? null,
+        timeout_secs: patch.timeout_secs ?? 60,
+        scheduler_tick_secs: patch.scheduler_tick_secs ?? 60,
+        max_tokens: patch.max_tokens ?? null,
+        temperature: patch.temperature ?? null,
+        require_dashboard_approval: patch.require_dashboard_approval ?? true,
+        auto_apply_memory_ops: patch.auto_apply_memory_ops ?? false,
+        auto_enable_skills: patch.auto_enable_skills ?? false,
+        tasks: {
+          memory_curator: patch.memory_curator ?? { enabled: false, schedule: null },
+          session_reflector: patch.session_reflector ?? { enabled: false, schedule: null },
+          skill_writer: patch.skill_writer ?? { enabled: false, schedule: null },
+        },
+      },
+      backend_availability: {
+        backend: patch.backend ?? "disabled",
+        available: (patch.backend ?? "disabled") === "codex_app_server",
+        executable: "/usr/bin/codex",
+        reason: null,
+      },
+    }),
+  ),
+  resetMemoryAutomationConfig: vi.fn().mockResolvedValue({
+    global: null,
+    project: null,
+    effective: {
+      enabled: true,
+      backend: "codex_app_server",
+      host_mode: "standalone",
+      model: null,
+      timeout_secs: 60,
+      scheduler_tick_secs: 60,
+      max_tokens: null,
+      temperature: null,
+      require_dashboard_approval: true,
+      auto_apply_memory_ops: false,
+      auto_enable_skills: false,
+      tasks: {
+        memory_curator: { enabled: true, schedule: null },
+        session_reflector: { enabled: true, schedule: null },
+        skill_writer: { enabled: true, schedule: null },
+      },
+    },
+    backend_availability: {
+      backend: "codex_app_server",
+      available: true,
+      executable: "/usr/bin/codex",
+      reason: null,
+    },
+  }),
+  getAutomationSchedulerStatus: vi.fn().mockResolvedValue({
+    status: "configured",
+    paused: false,
+    enabled: true,
+    scheduler_tick_secs: 60,
+    now: 1782283200,
+    tasks: [
+      { task: "memory_curator", due: true, skip_reason: null },
+      { task: "session_reflector", due: false, skip_reason: "task_disabled" },
+      { task: "skill_writer", due: false, skip_reason: "scheduler_schedule_manual" },
+    ],
+  }),
+  pauseAutomationScheduler: vi.fn().mockResolvedValue({
+    status: "paused",
+    paused: true,
+    enabled: false,
+    scheduler_tick_secs: 60,
+    now: 1782283200,
+    tasks: [],
+  }),
+  resumeAutomationScheduler: vi.fn().mockResolvedValue({
+    status: "configured",
+    paused: false,
+    enabled: true,
+    scheduler_tick_secs: 60,
+    now: 1782283200,
+    tasks: [],
+  }),
+  getMemoryAutomationRuns: vi.fn().mockResolvedValue({
+    records: [
+      {
+        schema_version: 1,
+        run_id: "run-dashboard-1",
+        trigger: "dashboard",
+        task: "memory_curator",
+        backend: "codex_app_server",
+        model: "gpt-test",
+        status: "skipped",
+        evidence_hash: null,
+        proposed_ops: null,
+        accepted_count: 0,
+        rejected_count: 0,
+        error: "automation_disabled",
+        artifacts: [
+          {
+            schema_version: 1,
+            kind: "codex_handoff",
+            path: "automation_artifacts/run-dashboard-1/codex_handoff.json",
+            sha256: "sha256:handoff",
+            summary: "handoff ready",
+            created_at: "2026-06-24T12:00:01Z",
+          },
+        ],
+        started_at: "2026-06-24T12:00:00Z",
+        completed_at: "2026-06-24T12:00:01Z",
+      },
+    ],
+    count: 1,
+    limit: 20,
+    error: "",
+  }),
+  getMemoryAutomationRunArtifacts: vi.fn().mockResolvedValue({
+    run_id: "run-dashboard-1",
+    artifacts: [
+      {
+        schema_version: 1,
+        kind: "codex_handoff",
+        path: "automation_artifacts/run-dashboard-1/codex_handoff.json",
+        sha256: "sha256:handoff",
+        summary: "handoff ready",
+        created_at: "2026-06-24T12:00:01Z",
+      },
+    ],
+    artifact_chain: {
+      expected_kinds: [
+        "traces",
+        "feedback",
+        "generated_evals",
+        "validation_gate",
+        "optimizer_diagnosis",
+        "codex_handoff",
+      ],
+      present_kinds: ["codex_handoff"],
+      complete: false,
+    },
+    count: 1,
+    error: "",
+  }),
+  getMemoryAutomationRunArtifact: vi.fn().mockResolvedValue({
+    run_id: "run-dashboard-1",
+    artifact: {
+      schema_version: 1,
+      kind: "codex_handoff",
+      path: "automation_artifacts/run-dashboard-1/codex_handoff.json",
+      sha256: "sha256:handoff",
+      summary: "handoff ready",
+      created_at: "2026-06-24T12:00:01Z",
+    },
+    payload: {
+      status: "ready_for_review",
+      next_actions: ["review dashboard artifact payload"],
+    },
+    error: "",
+  }),
+  getFactProposals: vi.fn().mockResolvedValue({
+    proposals: [
+      {
+        schema_version: 1,
+        proposal_id: "prop-dashboard-1",
+        run_id: "run-dashboard-1",
+        state: "pending_approval",
+        add_fact_request: {
+          content: "Prefer bounded evidence before adding durable memory.",
+          category: "workflow",
+          tags: ["memory", "review"],
+        },
+        created_at: 1782283200,
+        updated_at: 1782283200,
+      },
+    ],
+    count: 1,
+    limit: 50,
+    error: "",
+  }),
+  applyFactProposal: vi.fn().mockResolvedValue({
+    proposal: {
+      schema_version: 1,
+      proposal_id: "prop-dashboard-1",
+      run_id: "run-dashboard-1",
+      state: "applied",
+      add_fact_request: {
+        content: "Prefer bounded evidence before adding durable memory.",
+        category: "workflow",
+        tags: ["memory", "review"],
+      },
+      applied_fact_id: 42,
+      created_at: 1782283200,
+      updated_at: 1782283300,
+    },
+  }),
+  rejectFactProposal: vi.fn(),
+  getManagedSkills: vi.fn().mockResolvedValue({
+    skills: [
+      {
+        metadata: {
+          id: "repo-hygiene",
+          title: "Repo Hygiene",
+          summary: "Keep repository maintenance tasks consistent.",
+          category: "workflow",
+          state: "pending_approval",
+          checksum: "abc123",
+          pinned: false,
+          created_at: 1782302400,
+          updated_at: 1782302400,
+          provenance: {
+            source: "automation_run",
+            actor: "skill_writer",
+            run_id: "run-dashboard-1",
+          },
+        },
+        body_markdown: "Use focused checks before broad suites.",
+        support_files: [],
+      },
+    ],
+    skill_metadata: [],
+    usage_summaries: [
+      {
+        schema_version: 1,
+        skill_id: "repo-hygiene",
+        title: "Repo Hygiene",
+        category: "workflow",
+        state: "pending_approval",
+        pinned: false,
+        created_by: "skill_writer",
+        provenance_source: "automation_run",
+        targets: ["codex", "cursor"],
+        view_count: 2,
+        use_count: 1,
+        patch_count: 0,
+        first_seen_at: 1782283200,
+        last_activity_at: 1782283200,
+        last_viewed_at: 1782283200,
+        last_used_at: 1782283200,
+        last_patched_at: null,
+      },
+    ],
+    stale_recommendations: [
+      {
+        skill_id: "repo-hygiene",
+        stale: false,
+        recommendation: "keep",
+        reason: "recent or meaningful activity is present",
+        evidence: ["uses=1"],
+      },
+    ],
+    improvement_recommendations: [
+      {
+        skill_id: "repo-hygiene",
+        improvement: true,
+        recommendation: "patch_review",
+        reason: "repeated patches suggest the skill instructions may still be unstable",
+        priority: "medium",
+        evidence: ["patches=2"],
+      },
+    ],
+    count: 1,
+    error: "",
+  }),
+  getManagedSkill: vi.fn().mockResolvedValue({
+    skill: {
+      metadata: {
+        id: "repo-hygiene",
+        title: "Repo Hygiene",
+        summary: "Keep repository maintenance tasks consistent.",
+        category: "workflow",
+        state: "pending_approval",
+        checksum: "abc123",
+        pinned: false,
+        created_at: 1782302400,
+        updated_at: 1782302400,
+        provenance: {
+          source: "automation_run",
+          actor: "skill_writer",
+          run_id: "run-dashboard-1",
+        },
+      },
+      body_markdown: "Use focused checks before broad suites.",
+      support_files: [],
+    },
+    usage_summary: {
+      schema_version: 1,
+      skill_id: "repo-hygiene",
+      title: "Repo Hygiene",
+      category: "workflow",
+      state: "pending_approval",
+      pinned: false,
+      created_by: "skill_writer",
+      provenance_source: "automation_run",
+      targets: ["codex", "cursor"],
+      view_count: 2,
+      use_count: 1,
+      patch_count: 0,
+      first_seen_at: 1782283200,
+      last_activity_at: 1782283200,
+      last_viewed_at: 1782283200,
+      last_used_at: 1782283200,
+      last_patched_at: null,
+    },
+    stale_recommendation: {
+      skill_id: "repo-hygiene",
+      stale: false,
+      recommendation: "keep",
+      reason: "recent or meaningful activity is present",
+      evidence: ["uses=1"],
+    },
+    improvement_recommendation: {
+      skill_id: "repo-hygiene",
+      improvement: true,
+      recommendation: "patch_review",
+      reason: "repeated patches suggest the skill instructions may still be unstable",
+      priority: "medium",
+      evidence: ["patches=2"],
+    },
+  }),
+  approveManagedSkill: vi.fn().mockResolvedValue({
+    skill: {
+      metadata: {
+        id: "repo-hygiene",
+        title: "Repo Hygiene",
+        summary: "Keep repository maintenance tasks consistent.",
+        category: "workflow",
+        state: "active",
+        checksum: "abc123",
+        pinned: false,
+        created_at: 1782302400,
+        updated_at: 1782302460,
+        provenance: {
+          source: "automation_run",
+          actor: "skill_writer",
+          run_id: "run-dashboard-1",
+        },
+      },
+      body_markdown: "Use focused checks before broad suites.",
+      support_files: [],
+    },
+  }),
+  disableManagedSkill: vi.fn(),
+  archiveManagedSkill: vi.fn(),
+  restoreManagedSkill: vi.fn(),
+  getMemoryOplog: vi.fn().mockResolvedValue({ events: [] }),
+  postAutomationRunMemoryCurator: vi.fn().mockResolvedValue({
+    run_id: "queued-memory-curator",
+    dry_run: true,
+    status: "queued",
+    report: { queued: true },
+    ledger_record: {
+      schema_version: 2,
+      run_id: "queued-memory-curator",
+      trigger: "dashboard",
+      task: "memory_curator",
+      backend: "codex_app_server",
+      host_mode: "standalone",
+      model: null,
+      status: "queued",
+      accepted_count: 0,
+      rejected_count: 0,
+      started_at: "2026-06-24T12:00:02Z",
+      completed_at: "2026-06-24T12:00:02Z",
+    },
+  }),
+  postAutomationRunSessionReflection: vi.fn().mockResolvedValue({
+    run_id: "queued-session-reflector",
+    dry_run: true,
+    status: "queued",
+    ledger_record: {
+      schema_version: 2,
+      run_id: "queued-session-reflector",
+      trigger: "dashboard",
+      task: "session_reflector",
+      backend: "codex_app_server",
+      host_mode: "standalone",
+      model: null,
+      status: "queued",
+      accepted_count: 0,
+      rejected_count: 0,
+      started_at: "2026-06-24T12:00:03Z",
+      completed_at: "2026-06-24T12:00:03Z",
+    },
+  }),
+  postAutomationRunSkillWriting: vi.fn().mockResolvedValue({
+    run_id: "queued-skill-writer",
+    dry_run: true,
+    status: "queued",
+    ledger_record: {
+      schema_version: 2,
+      run_id: "queued-skill-writer",
+      trigger: "dashboard",
+      task: "skill_writer",
+      backend: "codex_app_server",
+      host_mode: "standalone",
+      model: null,
+      status: "queued",
+      accepted_count: 0,
+      rejected_count: 0,
+      started_at: "2026-06-24T12:00:04Z",
+      completed_at: "2026-06-24T12:00:04Z",
+    },
+  }),
+  postMemoryCurate: vi.fn(),
+}));
+
 vi.mock("../holographic/src/api", () => ({
-  api: {
-    getMemoryCuratorPreview: vi.fn().mockResolvedValue({ report: null, saved_at: null }),
-    getMemoryCuratorActivity: vi.fn().mockResolvedValue({ events: [] }),
-    getMemoryCuratorStatus: vi.fn().mockResolvedValue({ runs: [] }),
-    getMemoryOplog: vi.fn().mockResolvedValue({ events: [] }),
-    postMemoryCurate: vi.fn(),
-  },
+  api: apiMock,
 }));
 
 describe("CurationPanel", () => {
@@ -21,5 +461,270 @@ describe("CurationPanel", () => {
 
     expect(tabs).toHaveLength(3);
     expect(tabs.map((tab) => tab.getAttribute("tabindex"))).toEqual(["0", "0", "0"]);
+  });
+
+  it("saves automation runtime limits from dashboard controls", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    const maxTokens = await screen.findByLabelText("Max tokens");
+    const temperature = await screen.findByLabelText("Temperature");
+    const schedulerTick = await screen.findByLabelText("Scheduler tick seconds");
+
+    fireEvent.change(maxTokens, { target: { value: "4096" } });
+    fireEvent.change(temperature, { target: { value: "0.2" } });
+    fireEvent.change(schedulerTick, { target: { value: "15" } });
+    fireEvent.click(screen.getByRole("button", { name: /save config/i }));
+
+    await waitFor(() => {
+      expect(apiMock.patchMemoryAutomationConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scheduler_tick_secs: 15,
+          max_tokens: 4096,
+          temperature: 0.2,
+        }),
+      );
+    });
+  });
+
+  it("resets automation overrides from dashboard controls", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    await screen.findByLabelText("Max tokens");
+    fireEvent.click(screen.getByRole("button", { name: /reset defaults/i }));
+
+    await waitFor(() => {
+      expect(apiMock.resetMemoryAutomationConfig).toHaveBeenCalled();
+    });
+  });
+
+  it("shows scheduler state and pauses scheduler from dashboard controls", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    expect(await screen.findByText("Scheduler")).toBeTruthy();
+    expect(await screen.findByText("memory curator")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /^pause$/i }));
+
+    await waitFor(() => {
+      expect(apiMock.pauseAutomationScheduler).toHaveBeenCalled();
+    });
+  });
+
+  it("disables automation runs when the configured backend is unavailable", async () => {
+    apiMock.getMemoryAutomationConfig.mockResolvedValueOnce({
+      global: null,
+      project: null,
+      effective: {
+        enabled: true,
+        backend: "codex_app_server",
+        host_mode: "standalone",
+        model: null,
+        timeout_secs: 60,
+        scheduler_tick_secs: 60,
+        max_tokens: null,
+        temperature: null,
+        require_dashboard_approval: true,
+        auto_apply_memory_ops: false,
+        auto_enable_skills: false,
+        tasks: {
+          memory_curator: { enabled: true, schedule: null },
+          session_reflector: { enabled: true, schedule: null },
+          skill_writer: { enabled: true, schedule: null },
+        },
+      },
+      backend_availability: {
+        backend: "codex_app_server",
+        available: false,
+        executable: "/missing/codex",
+        reason: "codex app-server backend executable '/missing/codex' was not found",
+      },
+    });
+
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    expect(await screen.findByText(/was not found/i)).toBeTruthy();
+    const runButtons = await screen.findAllByRole("button", { name: /^run$/i });
+    expect((runButtons[0] as HTMLButtonElement).disabled).toBe(true);
+    expect(runButtons[0].getAttribute("title")).toContain("was not found");
+  });
+
+  it("renders automation config validation errors inline", async () => {
+    apiMock.patchMemoryAutomationConfig.mockRejectedValueOnce(
+      Object.assign(
+        new Error("automation config validation failed"),
+        {
+          body: {
+            validation_errors: [
+              {
+                field: "timeout_secs",
+                message: "automation timeout_secs must be greater than zero",
+              },
+              {
+                field: "backend",
+                message: "automation backend is not selectable",
+              },
+              {
+                field: "host_mode",
+                message: "automation host_mode is invalid",
+              },
+              {
+                field: "memory_curator.schedule",
+                message: "memory curator schedule is invalid",
+              },
+              {
+                field: "session_reflector.interval_secs",
+                message: "session reflector interval_secs must be greater than zero",
+              },
+              {
+                field: "skill_writer.stale_lock_secs",
+                message: "skill writer stale_lock_secs must be greater than zero",
+              },
+            ],
+          },
+        },
+      ),
+    );
+
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    const timeoutInput = await screen.findByLabelText("Timeout seconds");
+    fireEvent.change(timeoutInput, { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: /save config/i }));
+
+    expect(await screen.findByText("automation config validation failed")).toBeTruthy();
+    expect(await screen.findByText("automation timeout_secs must be greater than zero")).toBeTruthy();
+    expect(await screen.findByText("automation backend is not selectable")).toBeTruthy();
+    expect(await screen.findByText("automation host_mode is invalid")).toBeTruthy();
+    expect(await screen.findByText("memory curator schedule is invalid")).toBeTruthy();
+    expect(
+      await screen.findByText("session reflector interval_secs must be greater than zero"),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText("skill writer stale_lock_secs must be greater than zero"),
+    ).toBeTruthy();
+  });
+
+  it("does not offer the unimplemented external command backend", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    const backend = (await screen.findByLabelText("Backend")) as HTMLSelectElement;
+    const values = Array.from(backend.options).map((option) => option.value);
+    expect(values).toEqual(["disabled", "codex_app_server"]);
+  });
+
+  it("renders automation run ledger entries in history", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    await waitFor(() => {
+      expect(apiMock.getMemoryAutomationRuns).toHaveBeenCalledWith({ limit: 20 });
+    });
+    expect(await screen.findByText("Automation runs")).toBeTruthy();
+    expect(
+      screen.getAllByText(/memory_curator · dashboard · codex_app_server\/gpt-test/).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/automation_disabled/).length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /codex_handoff/i }));
+
+    await waitFor(() => {
+      expect(apiMock.getMemoryAutomationRunArtifacts).toHaveBeenCalledWith(
+        "run-dashboard-1",
+      );
+      expect(apiMock.getMemoryAutomationRunArtifact).toHaveBeenCalledWith(
+        "run-dashboard-1",
+        "codex_handoff",
+      );
+    });
+    expect(await screen.findByText("chain pending")).toBeTruthy();
+    expect(await screen.findByText(/ready_for_review/)).toBeTruthy();
+    expect(screen.getByText(/review dashboard artifact payload/)).toBeTruthy();
+  });
+
+  it("runs standalone automation tasks from history controls", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    await screen.findByLabelText("Session reflector schedule");
+    const runButtons = screen.getAllByRole("button", { name: /^run$/i });
+
+    fireEvent.click(runButtons[1]);
+
+    await waitFor(() => {
+      expect(apiMock.postAutomationRunSessionReflection).toHaveBeenCalledWith({
+        dry_run: true,
+      });
+    });
+
+    fireEvent.click(runButtons[2]);
+
+    await waitFor(() => {
+      expect(apiMock.postAutomationRunSkillWriting).toHaveBeenCalledWith({
+        dry_run: true,
+      });
+    });
+
+    fireEvent.click(runButtons[0]);
+
+    await waitFor(() => {
+      expect(apiMock.postAutomationRunMemoryCurator).toHaveBeenCalledWith({
+        dry_run: true,
+      });
+    });
+  });
+
+  it("renders and applies fact proposals in history", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    await waitFor(() => {
+      expect(apiMock.getFactProposals).toHaveBeenCalledWith({ limit: 50 });
+    });
+    expect(await screen.findByText("Fact proposals")).toBeTruthy();
+    expect(screen.getByText(/Prefer bounded evidence/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /apply fact/i }));
+
+    await waitFor(() => {
+      expect(apiMock.applyFactProposal).toHaveBeenCalledWith("prop-dashboard-1");
+    });
+  });
+
+  it("renders managed skill approvals in history", async () => {
+    render(<CurationPanel />);
+
+    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+
+    await waitFor(() => {
+      expect(apiMock.getManagedSkills).toHaveBeenCalled();
+    });
+    expect(await screen.findByText("Managed skills")).toBeTruthy();
+    expect(screen.getAllByText("Repo Hygiene").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Use focused checks before broad suites/)).toBeTruthy();
+    expect(screen.getByText("uses=1")).toBeTruthy();
+    expect(screen.getByText(/recent or meaningful activity/)).toBeTruthy();
+    expect(screen.getByText("patch_review")).toBeTruthy();
+    expect(screen.getByText(/repeated patches/)).toBeTruthy();
+    expect(screen.getByText(/priority=medium/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+
+    await waitFor(() => {
+      expect(apiMock.approveManagedSkill).toHaveBeenCalledWith("repo-hygiene");
+    });
   });
 });

--- a/dashboard/test/curation-panel.vitest.tsx
+++ b/dashboard/test/curation-panel.vitest.tsx
@@ -453,6 +453,11 @@ vi.mock("../holographic/src/api", () => ({
   api: apiMock,
 }));
 
+function renderHistoryPanel() {
+  render(<CurationPanel />);
+  fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+}
+
 describe("CurationPanel", () => {
   it("keeps inactive curation tabs keyboard reachable", () => {
     render(<CurationPanel />);
@@ -464,9 +469,7 @@ describe("CurationPanel", () => {
   });
 
   it("saves automation runtime limits from dashboard controls", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     const maxTokens = await screen.findByLabelText("Max tokens");
     const temperature = await screen.findByLabelText("Temperature");
@@ -489,9 +492,7 @@ describe("CurationPanel", () => {
   });
 
   it("resets automation overrides from dashboard controls", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     await screen.findByLabelText("Max tokens");
     fireEvent.click(screen.getByRole("button", { name: /reset defaults/i }));
@@ -502,9 +503,7 @@ describe("CurationPanel", () => {
   });
 
   it("shows scheduler state and pauses scheduler from dashboard controls", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     expect(await screen.findByText("Scheduler")).toBeTruthy();
     expect(await screen.findByText("memory curator")).toBeTruthy();
@@ -545,9 +544,7 @@ describe("CurationPanel", () => {
       },
     });
 
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     expect(await screen.findByText(/was not found/i)).toBeTruthy();
     const runButtons = await screen.findAllByRole("button", { name: /^run$/i });
@@ -592,9 +589,7 @@ describe("CurationPanel", () => {
       ),
     );
 
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     const timeoutInput = await screen.findByLabelText("Timeout seconds");
     fireEvent.change(timeoutInput, { target: { value: "0" } });
@@ -614,9 +609,7 @@ describe("CurationPanel", () => {
   });
 
   it("does not offer the unimplemented external command backend", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     const backend = (await screen.findByLabelText("Backend")) as HTMLSelectElement;
     const values = Array.from(backend.options).map((option) => option.value);
@@ -624,9 +617,7 @@ describe("CurationPanel", () => {
   });
 
   it("renders automation run ledger entries in history", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     await waitFor(() => {
       expect(apiMock.getMemoryAutomationRuns).toHaveBeenCalledWith({ limit: 20 });
@@ -654,9 +645,7 @@ describe("CurationPanel", () => {
   });
 
   it("runs standalone automation tasks from history controls", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     await screen.findByLabelText("Session reflector schedule");
     const runButtons = screen.getAllByRole("button", { name: /^run$/i });
@@ -687,9 +676,7 @@ describe("CurationPanel", () => {
   });
 
   it("renders and applies fact proposals in history", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     await waitFor(() => {
       expect(apiMock.getFactProposals).toHaveBeenCalledWith({ limit: 50 });
@@ -705,9 +692,7 @@ describe("CurationPanel", () => {
   });
 
   it("renders managed skill approvals in history", async () => {
-    render(<CurationPanel />);
-
-    fireEvent.click(screen.getByRole("tab", { name: /history/i }));
+    renderHistoryPanel();
 
     await waitFor(() => {
       expect(apiMock.getManagedSkills).toHaveBeenCalled();

--- a/dashboard/test/hermes-wrapper.test.mjs
+++ b/dashboard/test/hermes-wrapper.test.mjs
@@ -108,6 +108,8 @@ test("wrapper rewrites child API calls and keeps child registrations isolated", 
     [`${assetBase}/holographic.js`]: `
 window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/plugins/holographic");
 window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/plugins/holographic/similarity?limit=2");
+window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/automation/run/memory-curator");
+window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/automation/skills?state=pending");
 window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/plugins/other");
 window.__HERMES_PLUGIN_SDK__.authedFetch("/api/plugins/hermes-lcm/search?q=abc");
 window.__boundResult = window.boundProbe();
@@ -126,6 +128,7 @@ window.__HERMES_PLUGINS__.register("graph", function Graph(){ return null; });
     [`${assetBase}/savings.js`]: `
 window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/plugins/savings/overview");
 window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/plugins/savings/ledger?range=30d");
+window.__HERMES_PLUGIN_SDK__.fetchJSON("/api/plugins/analytics/diagnostics");
 window.__HERMES_PLUGINS__.register("savings", function Savings(){ return null; });
 `,
   };
@@ -154,12 +157,15 @@ window.__HERMES_PLUGINS__.register("savings", function Savings(){ return null; }
     [
       "/api/plugins/tracedecay/holographic",
       "/api/plugins/tracedecay/holographic/similarity?limit=2",
+      "/api/plugins/tracedecay/automation/run/memory-curator",
+      "/api/plugins/tracedecay/automation/skills?state=pending",
       "/api/plugins/other",
       "/api/plugins/tracedecay/lcm/overview",
       "/api/plugins/tracedecay/graph",
       "/api/plugins/tracedecay/graph/nodes?limit=5",
       "/api/plugins/tracedecay/savings/overview",
       "/api/plugins/tracedecay/savings/ledger?range=30d",
+      "/api/plugins/tracedecay/analytics/diagnostics",
     ].sort(),
   );
   assert.deepEqual(loaded.authedFetchCalls.map(([url]) => url).sort(), [

--- a/dashboard/test/shell-sdk.test.mjs
+++ b/dashboard/test/shell-sdk.test.mjs
@@ -41,15 +41,26 @@ test("fetchJSON returns parsed body on success", async () => {
 });
 
 test("fetchJSON prefers JSON detail on failure", async () => {
+  const body = {
+    detail: "token expired",
+    validation_errors: [{ field: "token", message: "token expired" }],
+  };
   await withMockedFetch(
     async () => ({
       ok: false,
       status: 403,
       statusText: "Forbidden",
-      json: async () => ({ detail: "token expired" }),
+      json: async () => body,
     }),
     async () => {
-      await assert.rejects(() => sdk.fetchJSON("/nope"), /token expired/);
+      await assert.rejects(
+        async () => sdk.fetchJSON("/nope"),
+        (err) => {
+          assert.match(err.message, /token expired/);
+          assert.deepEqual(err.body, body);
+          return true;
+        },
+      );
     },
   );
 });


### PR DESCRIPTION
## Stack

This is PR 4 of 5 replacing #114. It stacks on #129; review this PR against `split/self-improving-03-dashboard-apis`.

## Summary

- Refactors the holographic curation page into focused curation components and hooks.
- Adds UI controls for automation config, scheduler status, run history, managed skills, fact proposals, snapshots, and action review.
- Adds savings diagnostics panel support plus shared dashboard primitive/style updates.
- Expands dashboard frontend tests for curation data, panel behavior, and shell SDK behavior.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- CI on the original equivalent tip was green before splitting.

Replaces part of #114.
