### PR TITLE
ci: use three Windows test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,9 @@ jobs:
       fail-fast: false
       matrix:
         partition:
-          - hash:1/2
-          - hash:2/2
+          - hash:1/3
+          - hash:2/3
+          - hash:3/3
     runs-on:
       - self-hosted
       - Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,6 @@ jobs:
           - hash:2/3
           - hash:3/3
     runs-on:
-      - self-hosted
-      - Windows
-      - X64
       - windows-runner
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -41,7 +41,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             archive: tar.gz
           - name: x86_64-windows
-            runner: [self-hosted, Windows, X64, windows-runner]
+            runner: [windows-runner]
             target: x86_64-pc-windows-msvc
             archive: zip
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             archive: tar.gz
           - name: x86_64-windows
-            runner: [self-hosted, Windows, X64, windows-runner]
+            runner: [windows-runner]
             target: x86_64-pc-windows-msvc
             archive: zip
 


### PR DESCRIPTION
## Summary
- shard Windows nextest CI across three partitions to match the three self-hosted Windows runner pools

## Verification
- python3 YAML parse for .github/workflows/ci.yml
- Proxmox clean-ci snapshots refreshed for VMs 102/103/104 with VirtIO QGA verified
