### PR TITLE
[codex] clarify plugin design doc status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,13 @@ cargo nextest run --no-default-features --features lite
    cargo clippy --workspace --all-targets
    ```
 
+### Rebrand compatibility changes
+
+For changes touching naming, legacy env vars, storage paths, generated agent
+config, plugin paths, or cleanup behavior, follow
+[`docs/REBRAND-COMPATIBILITY-POLICY.md`](docs/REBRAND-COMPATIBILITY-POLICY.md).
+Update compatibility warnings, migration cleanup, and docs together.
+
 ### Clippy policy
 
 The CI `Clippy` job runs the same command contributors should run locally before

--- a/docs/PLUGINS-DESIGN.md
+++ b/docs/PLUGINS-DESIGN.md
@@ -2,6 +2,10 @@
 
 Replace compile-time, feature-gated language extractors with dynamically loaded plugins so that new languages can be added without recompiling or releasing the main binary.
 
+This is a target design. TraceDecay still uses compile-time language extractor
+features today; plugin discovery and management commands remain implementation
+work.
+
 ---
 
 ## Problem with the current model
@@ -135,12 +139,14 @@ impl LanguageExtractor for ElixirExtractor { … }
 
 ---
 
-## Plugin discovery
+## Plugin discovery (target)
 
-tracedecay searches the following directories in order, stopping at the first match for a given extension:
+When implemented, TraceDecay should search the following directories in order,
+stopping at the first match for a given extension:
 
-1. `$TRACEDECAY_PLUGIN_PATH` (colon-separated, same convention as `PATH`; the legacy `TRACEDECAY_PLUGIN_PATH` is still honored as a fallback)
-2. `.tracedecay/plugins/` in the current project root (an existing `.tracedecay/plugins/` is still honored as a fallback)
+1. `$TRACEDECAY_PLUGIN_PATH` (colon-separated, same convention as `PATH`)
+2. `.tracedecay/plugins/` in the current project root only if project-local
+   plugin discovery is approved for the active storage mode
 3. `~/.tracedecay/plugins/`
 4. Platform config dir (`%APPDATA%\tracedecay\plugins` on Windows, `~/Library/Application Support/tracedecay/plugins` on macOS)
 


### PR DESCRIPTION
## Summary

- Clarify that `docs/PLUGINS-DESIGN.md` describes target plugin discovery and management behavior, not the current runtime contract.
- Point contributors at the rebrand compatibility policy when touching naming, legacy env vars, storage paths, generated config, plugin paths, or cleanup behavior.

## Impact

This keeps contributor-facing documentation from implying runtime plugin discovery already exists or that legacy plugin fallback behavior is currently supported without policy review and tests.

## Verification

- `git diff --check`
- `cargo test --no-run`