### PR TITLE
[codex] fix CLI help for dynamic tool command

### DIFF
--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -3,10 +3,52 @@ use super::{
     AutomationRunsAction, AutomationSkillsAction, AutomationSkillsInstallTarget, BranchAction, Cli,
     Commands, DaemonAction, LspAction, MemoryAction, MigrateAction, SessionsAction,
 };
-use clap::{error::ErrorKind, CommandFactory, Parser};
+use clap::{error::ErrorKind, Command, CommandFactory, Parser};
 
 fn strings(values: &[&str]) -> Vec<String> {
     values.iter().map(|value| value.to_string()).collect()
+}
+
+fn visible_subcommand_paths(command: &Command) -> Vec<Vec<String>> {
+    fn collect(command: &Command, prefix: Vec<String>, paths: &mut Vec<Vec<String>>) {
+        for subcommand in command.get_subcommands().filter(|sub| !sub.is_hide_set()) {
+            let mut path = prefix.clone();
+            path.push(subcommand.get_name().to_string());
+            paths.push(path.clone());
+            collect(subcommand, path, paths);
+        }
+    }
+
+    let mut paths = Vec::new();
+    collect(command, Vec::new(), &mut paths);
+    paths
+}
+
+#[test]
+fn visible_subcommands_accept_clap_help() {
+    let command = Cli::command();
+    for path in visible_subcommand_paths(&command) {
+        if path == ["tool"] {
+            continue;
+        }
+
+        let args = std::iter::once("tracedecay".to_string())
+            .chain(path.iter().cloned())
+            .chain(std::iter::once("--help".to_string()));
+        let err = match Cli::try_parse_from(args) {
+            Ok(_) => panic!(
+                "`tracedecay {} --help` should short-circuit parsing",
+                path.join(" ")
+            ),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.kind(),
+            ErrorKind::DisplayHelp,
+            "`tracedecay {} --help` should display help",
+            path.join(" ")
+        );
+    }
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 // Rust guideline compliant 2025-10-17
 // Updated 2026-03-23: compact bordered table for status output
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -194,7 +194,11 @@ fn main() {
 }
 
 fn async_main() -> tracedecay::errors::Result<()> {
-    let cli = Cli::parse();
+    let args: Vec<String> = std::env::args().collect();
+    if render_dynamic_command_help(&args) {
+        return Ok(());
+    }
+    let cli = Cli::parse_from(args);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(ASYNC_STACK_BYTES)
@@ -203,6 +207,24 @@ fn async_main() -> tracedecay::errors::Result<()> {
             message: format!("failed to start async runtime: {e}"),
         })?;
     runtime.block_on(run(cli))
+}
+
+fn render_dynamic_command_help(args: &[String]) -> bool {
+    let command_args = args.get(1..).unwrap_or_default();
+    let is_tool_command_help = matches!(
+        command_args,
+        [command, help] if command == "tool" && matches!(help.as_str(), "-h" | "--help")
+    );
+    if !is_tool_command_help {
+        return false;
+    }
+
+    let mut command = Cli::command();
+    if let Some(tool) = command.find_subcommand_mut("tool") {
+        let _ = tool.print_long_help();
+        println!();
+    }
+    true
 }
 
 async fn run(cli: Cli) -> tracedecay::errors::Result<()> {

--- a/tests/cli_help_test.rs
+++ b/tests/cli_help_test.rs
@@ -1,0 +1,93 @@
+use std::process::Command;
+
+fn tracedecay_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_tracedecay")
+}
+
+fn assert_help_succeeds(args: &[&str], expected: &str) {
+    let output = Command::new(tracedecay_bin())
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("run tracedecay {args:?}: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "tracedecay {args:?} should exit successfully\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains(expected) || stderr.contains(expected),
+        "tracedecay {args:?} should print help containing {expected:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn top_level_subcommands_accept_help() {
+    for command in [
+        "init",
+        "sync",
+        "status",
+        "tool",
+        "lsp",
+        "install",
+        "reinstall",
+        "update-plugin",
+        "uninstall",
+        "dashboard",
+        "serve",
+        "daemon",
+        "upgrade",
+        "update",
+        "channel",
+        "current-counter",
+        "reset-counter",
+        "disable-upload-counter",
+        "enable-upload-counter",
+        "gitignore",
+        "doctor",
+        "cost",
+        "bench",
+        "gain",
+        "monitor",
+        "sessions",
+        "branch",
+        "memory",
+        "automation",
+        "migrate",
+        "wipe",
+        "list",
+    ] {
+        assert_help_succeeds(&[command, "--help"], "Usage:");
+    }
+}
+
+#[test]
+fn nested_subcommands_accept_help() {
+    for args in [
+        &["lsp", "servers", "--help"][..],
+        &["daemon", "run", "--help"],
+        &["daemon", "install-service", "--help"],
+        &["sessions", "ingest", "--help"],
+        &["sessions", "search", "--help"],
+        &["branch", "list", "--help"],
+        &["branch", "add", "--help"],
+        &["memory", "status", "--help"],
+        &["memory", "curate", "--help"],
+        &["automation", "config", "--help"],
+        &["automation", "config", "get", "--help"],
+        &["automation", "run", "--help"],
+        &["automation", "run", "memory-curation", "--help"],
+        &["automation", "runs", "list", "--help"],
+        &["automation", "skills", "list", "--help"],
+        &["automation", "facts", "list", "--help"],
+        &["migrate", "plan", "--help"],
+        &["migrate", "registry-gc", "--help"],
+    ] {
+        assert_help_succeeds(args, "Usage:");
+    }
+}
+
+#[test]
+fn tool_name_help_still_prints_tool_schema() {
+    assert_help_succeeds(&["tool", "search", "--help"], "tracedecay tool search");
+}


### PR DESCRIPTION
## What changed

- Handles `tracedecay tool --help` and `tracedecay tool -h` before dynamic tool dispatch so command-level help exits successfully.
- Keeps per-tool schema help working for commands like `tracedecay tool search --help`.
- Adds binary-level regression tests for top-level and representative nested subcommand help.
- Adds recursive parser coverage so visible clap subcommands continue to return `DisplayHelp` for `--help`.

## Why

`tool` disables clap's built-in help flag so `--help` can be forwarded to dynamic MCP tool schemas. That made `tracedecay tool --help` error at the command boundary instead of printing help.

## Impact

Users can now ask for help at the `tool` command level consistently with the rest of the CLI, while dynamic per-tool help remains intact.

## Validation

- `cargo fmt --check`
- `cargo test -q --test cli_help_test`
- `cargo test -q --bin tracedecay parse_tests`
- `cargo run -q -- tool --help`