### PR TITLE
[codex] Improve TraceDecay follow-up diagnostics

### DIFF
--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -923,6 +923,17 @@ fn doctor_check_session_ingest(dc: &mut DoctorCounters, project_path: &Path) {
     let health = tokio::task::block_in_place(|| {
         handle.block_on(async {
             let db = crate::sessions::cursor::open_project_session_db(project_path).await?;
+            let placeholder_paths = db.literal_workspace_placeholder_transcript_paths(10).await;
+            if !placeholder_paths.is_empty() {
+                dc.warn(&format!(
+                    "Cursor transcript ingest has {} path(s) with a literal workspace placeholder; \
+                     Cursor did not expand `${{workspaceFolder}}`, so session recall will miss those transcripts",
+                    placeholder_paths.len(),
+                ));
+                for path in &placeholder_paths {
+                    dc.info(&format!("  - {path}"));
+                }
+            }
             Some(db.session_ingest_health().await)
         })
     });

--- a/src/automation/fact_proposals.rs
+++ b/src/automation/fact_proposals.rs
@@ -166,6 +166,9 @@ pub async fn record_session_fact_proposals(
             .ok_or_else(|| config_error("accepted fact proposal missing add_fact_request"))?;
         let add_fact_request = serde_json::from_value::<AddFactRequest>(add_fact_request)
             .map_err(|e| config_error(format!("invalid accepted fact add_fact_request: {e}")))?;
+        if pending_add_fact_request_exists(&store, &add_fact_request) {
+            continue;
+        }
         let proposal = value.get("proposal").cloned();
         let validation = value.get("validation").cloned();
         let record = FactProposalRecord {
@@ -212,6 +215,21 @@ pub async fn record_session_fact_proposals(
     }
     save_fact_proposal_store(dashboard_root, &store).await?;
     Ok(records)
+}
+
+fn pending_add_fact_request_exists(store: &FactProposalStore, request: &AddFactRequest) -> bool {
+    let content = normalize_fact_content(&request.content);
+    store.proposals.iter().any(|proposal| {
+        proposal.state == FactProposalState::PendingApproval
+            && proposal.add_fact_request.as_ref().is_some_and(|existing| {
+                existing.category == request.category
+                    && normalize_fact_content(&existing.content) == content
+            })
+    })
+}
+
+fn normalize_fact_content(content: &str) -> String {
+    content.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 pub async fn apply_fact_proposal(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::fmt::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::net::UnixStream as StdUnixStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 #[cfg(unix)]
@@ -293,11 +295,7 @@ pub fn uninstall_service(stop: bool) -> Result<PathBuf> {
 }
 
 pub fn service_status(socket_path: &Path) -> String {
-    let socket_state = if socket_path.exists() {
-        "present"
-    } else {
-        "missing"
-    };
+    let socket_state = daemon_socket_state(socket_path);
     format!(
         "service: {}\nsocket: {} ({})\nlogs: journalctl --user -u {} -f\n",
         systemd_user_service_path().map_or_else(
@@ -308,6 +306,28 @@ pub fn service_status(socket_path: &Path) -> String {
         socket_state,
         SERVICE_NAME
     )
+}
+
+#[cfg(unix)]
+fn daemon_socket_state(socket_path: &Path) -> &'static str {
+    if !socket_path.exists() {
+        return "missing";
+    }
+    match StdUnixStream::connect(socket_path) {
+        Ok(_) => "connectable",
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => "stale",
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => "present but not accessible",
+        Err(_) => "present but unreachable",
+    }
+}
+
+#[cfg(not(unix))]
+fn daemon_socket_state(socket_path: &Path) -> &'static str {
+    if socket_path.exists() {
+        "present"
+    } else {
+        "missing"
+    }
 }
 
 fn format_daemon_log_line(event: &str, fields: &[(&str, String)]) -> String {
@@ -1600,6 +1620,54 @@ mod tests {
         let status = super::service_status(&PathBuf::from("/tmp/tracedecay.sock"));
 
         assert!(status.contains("logs: journalctl --user -u tracedecay.service -f"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn service_status_reports_missing_socket() {
+        let dir = TempDir::new().expect("temp dir");
+        let socket = dir.path().join("missing.sock");
+
+        let status = super::service_status(&socket);
+
+        assert!(
+            status.contains(&format!("socket: {} (missing)", socket.display())),
+            "status should report missing socket, got:\n{status}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn service_status_reports_unconnectable_socket_file() {
+        let dir = TempDir::new().expect("temp dir");
+        let socket = dir.path().join("unconnectable.sock");
+        std::fs::write(&socket, "").expect("unconnectable socket placeholder");
+
+        let status = super::service_status(&socket);
+
+        assert!(
+            status.contains(&format!("socket: {} (stale)", socket.display()))
+                || status.contains(&format!(
+                    "socket: {} (present but unreachable)",
+                    socket.display()
+                )),
+            "status should report an unconnectable socket, got:\n{status}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn service_status_reports_connectable_socket() {
+        let dir = TempDir::new().expect("temp dir");
+        let socket = dir.path().join("daemon.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&socket).expect("bind socket");
+
+        let status = super::service_status(&socket);
+
+        assert!(
+            status.contains(&format!("socket: {} (connectable)", socket.display())),
+            "status should report connectable socket, got:\n{status}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/db/unresolved.rs
+++ b/src/db/unresolved.rs
@@ -91,6 +91,51 @@ impl Database {
         collect_rows(&mut rows, row_to_unresolved_ref, "get_unresolved_refs").await
     }
 
+    /// Returns bounded ignored-dependency unresolved references matching `query`.
+    pub async fn search_ignored_dependency_refs(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<UnresolvedRef>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let query = query.trim().to_ascii_lowercase();
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+        let pattern = format!(
+            "%{}%",
+            query
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_")
+        );
+        let mut rows = self
+            .conn()
+            .query(
+                "SELECT from_node_id, reference_name, reference_kind, line, col, file_path
+                 FROM unresolved_refs
+                 WHERE reference_name >= 'npm:'
+                   AND reference_name < 'npm;'
+                   AND lower(replace(substr(reference_name, 5), '#', ' ')) LIKE ?1 ESCAPE '\\'
+                 LIMIT ?2",
+                params![pattern, i64::try_from(limit).unwrap_or(i64::MAX)],
+            )
+            .await
+            .map_err(|e| TraceDecayError::Database {
+                message: format!("failed to query ignored dependency refs: {e}"),
+                operation: "search_ignored_dependency_refs".to_string(),
+            })?;
+
+        collect_rows(
+            &mut rows,
+            row_to_unresolved_ref,
+            "search_ignored_dependency_refs",
+        )
+        .await
+    }
+
     /// Removes all unresolved references.
     pub async fn clear_unresolved_refs(&self) -> Result<()> {
         self.conn()

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -336,7 +336,10 @@ async fn registry_drift_findings(
         };
         for store_context in context.stores {
             let store = store_context.store;
-            let Some(manifest_path) = resolve_registry_manifest_path(profile_root, &store) else {
+            let Some(manifest_path) = registry_store_artifacts(profile_root, &store)
+                .into_iter()
+                .find_map(|artifacts| artifacts.manifest_path)
+            else {
                 continue;
             };
             let Ok(manifest) = crate::storage::read_store_manifest(&manifest_path) else {
@@ -436,63 +439,43 @@ fn classify_registry_storage(
     if store.storage_mode != "profile_sharded" {
         return None;
     }
-    let store_relpath = registry_relpath(&store.store_relpath);
-    let manifest_relpath = store
-        .manifest_relpath
-        .as_ref()
-        .map(|relpath| registry_relpath(relpath));
-    let mut resolved_any_root = false;
-    let mut manifest_exists = false;
-    for profile_root in registry_profile_roots(profile_root) {
-        let Ok(data_root) =
-            crate::storage::StoreArtifactPath::resolve(&profile_root, &store_relpath)
-        else {
-            continue;
-        };
-        resolved_any_root = true;
-        let data_root = data_root.absolute_path();
-        if data_root
-            .join(crate::config::db_filename(&data_root))
-            .exists()
-        {
-            return Some(DoctorStorageStatus::ProfileSharded);
-        }
-        manifest_exists |= manifest_relpath.as_ref().map_or_else(
-            || {
-                data_root
-                    .join(crate::storage::STORE_MANIFEST_FILENAME)
-                    .is_file()
-            },
-            |relpath| {
-                [&profile_root, &data_root].iter().any(|root| {
-                    crate::storage::StoreArtifactPath::resolve(root, relpath)
-                        .ok()
-                        .is_some_and(|path| path.absolute_path().is_file())
-                })
-            },
-        );
-    }
-    if manifest_exists {
+    let artifacts = registry_store_artifacts(profile_root, store);
+    if artifacts
+        .iter()
+        .any(|artifacts| artifacts.graph_db_path.exists())
+    {
+        Some(DoctorStorageStatus::ProfileSharded)
+    } else if artifacts
+        .iter()
+        .any(|artifacts| artifacts.manifest_path.is_some())
+    {
         Some(DoctorStorageStatus::ManifestReconstructable)
-    } else if resolved_any_root {
-        Some(DoctorStorageStatus::Stale)
-    } else {
+    } else if artifacts.is_empty() {
         None
+    } else {
+        Some(DoctorStorageStatus::Stale)
     }
 }
 
-fn resolve_registry_manifest_path(
+#[derive(Debug, Clone)]
+struct RegistryStoreArtifacts {
+    graph_db_path: PathBuf,
+    manifest_path: Option<PathBuf>,
+}
+
+fn registry_store_artifacts(
     profile_root: &Path,
     store: &crate::global_db::StoreInstanceRecord,
-) -> Option<PathBuf> {
+) -> Vec<RegistryStoreArtifacts> {
     if store.storage_mode != "profile_sharded" {
-        return None;
+        return Vec::new();
     }
     let store_relpath = registry_relpath(&store.store_relpath);
     let manifest_relpath = store
         .manifest_relpath
         .as_ref()
         .map(|relpath| registry_relpath(relpath));
+    let mut artifacts = Vec::new();
     for profile_root in registry_profile_roots(profile_root) {
         let Ok(data_root) =
             crate::storage::StoreArtifactPath::resolve(&profile_root, &store_relpath)
@@ -500,24 +483,33 @@ fn resolve_registry_manifest_path(
             continue;
         };
         let data_root = data_root.absolute_path();
-        if let Some(relpath) = manifest_relpath.as_ref() {
-            for root in [&profile_root, &data_root] {
-                let Ok(path) = crate::storage::StoreArtifactPath::resolve(root, relpath) else {
-                    continue;
-                };
-                let path = path.absolute_path();
-                if path.is_file() {
-                    return Some(path);
-                }
-            }
-        } else {
-            let path = data_root.join(crate::storage::STORE_MANIFEST_FILENAME);
-            if path.is_file() {
-                return Some(path);
-            }
-        }
+        artifacts.push(RegistryStoreArtifacts {
+            graph_db_path: data_root.join(crate::config::db_filename(&data_root)),
+            manifest_path: registry_manifest_path(
+                &profile_root,
+                &data_root,
+                manifest_relpath.as_deref(),
+            ),
+        });
     }
-    None
+    artifacts
+}
+
+fn registry_manifest_path(
+    profile_root: &Path,
+    data_root: &Path,
+    manifest_relpath: Option<&Path>,
+) -> Option<PathBuf> {
+    if let Some(relpath) = manifest_relpath {
+        return [profile_root, data_root].iter().find_map(|root| {
+            crate::storage::StoreArtifactPath::resolve(root, relpath)
+                .ok()
+                .map(|path| path.absolute_path())
+                .filter(|path| path.is_file())
+        });
+    }
+    let path = data_root.join(crate::storage::STORE_MANIFEST_FILENAME);
+    path.is_file().then_some(path)
 }
 
 fn registry_relpath(value: &str) -> PathBuf {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -179,6 +179,31 @@ async fn check_stale_stores(dc: &mut DoctorCounters) {
 
     check_orphan_store_manifests(dc, &project_paths);
     check_stale_code_projects(dc, &gdb).await;
+    if let Some(profile_root) = profile_root.as_deref() {
+        let drift = registry_drift_findings(&gdb, profile_root).await;
+        if drift.is_empty() {
+            dc.pass("No registry/store manifest identity drift");
+        } else {
+            dc.warn(&format!(
+                "{} registry/store manifest identity drift finding(s):",
+                drift.len()
+            ));
+            for finding in drift.iter().take(10) {
+                dc.info(&format!(
+                    "  • {} {} {}: registry={} manifest={} ({})",
+                    finding.project_id,
+                    finding.store_id,
+                    finding.field,
+                    finding.registry_value,
+                    finding.manifest_value,
+                    finding.manifest_path.display()
+                ));
+            }
+            if drift.len() > 10 {
+                dc.info(&format!("  … and {} more", drift.len() - 10));
+            }
+        }
+    }
     if stale.is_empty() {
         dc.pass("No stale projects in global DB");
         return;
@@ -287,6 +312,76 @@ fn code_project_root_exists(project: &crate::global_db::CodeProjectRecord) -> bo
     Path::new(&project.canonical_root).exists() || Path::new(&project.display_root).exists()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegistryDriftFinding {
+    project_id: String,
+    store_id: String,
+    field: &'static str,
+    registry_value: String,
+    manifest_value: String,
+    manifest_path: PathBuf,
+}
+
+async fn registry_drift_findings(
+    global_db: &crate::global_db::GlobalDb,
+    profile_root: &Path,
+) -> Vec<RegistryDriftFinding> {
+    let mut findings = Vec::new();
+    for project in global_db.list_code_projects(usize::MAX).await {
+        let Some(context) = global_db
+            .project_registry_context_by_id(&project.project_id)
+            .await
+        else {
+            continue;
+        };
+        for store_context in context.stores {
+            let store = store_context.store;
+            let Some(manifest_path) = resolve_registry_manifest_path(profile_root, &store) else {
+                continue;
+            };
+            let Ok(manifest) = crate::storage::read_store_manifest(&manifest_path) else {
+                continue;
+            };
+            let manifest_project_id = manifest
+                .project_id
+                .as_deref()
+                .unwrap_or("<missing>")
+                .to_string();
+            if manifest_project_id != store.project_id {
+                findings.push(RegistryDriftFinding {
+                    project_id: project.project_id.clone(),
+                    store_id: store.store_id.clone(),
+                    field: "project_id",
+                    registry_value: store.project_id.clone(),
+                    manifest_value: manifest_project_id,
+                    manifest_path: manifest_path.clone(),
+                });
+            }
+
+            let registry_project_root = comparable_path(Path::new(&project.canonical_root));
+            let manifest_project_root = comparable_path(&manifest.project_root);
+            if registry_project_root != manifest_project_root {
+                findings.push(RegistryDriftFinding {
+                    project_id: project.project_id.clone(),
+                    store_id: store.store_id.clone(),
+                    field: "project_root",
+                    registry_value: registry_project_root,
+                    manifest_value: manifest_project_root,
+                    manifest_path,
+                });
+            }
+        }
+    }
+    findings
+}
+
+fn comparable_path(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DoctorStorageStatus {
     RepoLocal,
@@ -384,6 +479,45 @@ fn classify_registry_storage(
     } else {
         None
     }
+}
+
+fn resolve_registry_manifest_path(
+    profile_root: &Path,
+    store: &crate::global_db::StoreInstanceRecord,
+) -> Option<PathBuf> {
+    if store.storage_mode != "profile_sharded" {
+        return None;
+    }
+    let store_relpath = registry_relpath(&store.store_relpath);
+    let manifest_relpath = store
+        .manifest_relpath
+        .as_ref()
+        .map(|relpath| registry_relpath(relpath));
+    for profile_root in registry_profile_roots(profile_root) {
+        let Ok(data_root) =
+            crate::storage::StoreArtifactPath::resolve(&profile_root, &store_relpath)
+        else {
+            continue;
+        };
+        let data_root = data_root.absolute_path();
+        if let Some(relpath) = manifest_relpath.as_ref() {
+            for root in [&profile_root, &data_root] {
+                let Ok(path) = crate::storage::StoreArtifactPath::resolve(root, relpath) else {
+                    continue;
+                };
+                let path = path.absolute_path();
+                if path.is_file() {
+                    return Some(path);
+                }
+            }
+        } else {
+            let path = data_root.join(crate::storage::STORE_MANIFEST_FILENAME);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+    }
+    None
 }
 
 fn registry_relpath(value: &str) -> PathBuf {
@@ -549,6 +683,10 @@ fn print_summary(dc: &DoctorCounters) {
 mod tests {
     use super::*;
     use crate::global_db::StoreInstanceUpsert;
+    use crate::storage::{
+        StorageMode, StoreKind, StoreManifest, STORE_MANIFEST_FILENAME,
+        STORE_MANIFEST_SCHEMA_VERSION,
+    };
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
@@ -727,6 +865,82 @@ mod tests {
             classify_project_storage_with_registry(&project_root, &db, Some(&profile_root)).await,
             DoctorStorageStatus::Stale
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn registry_drift_findings_report_manifest_identity_mismatches(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::TempDir::new()?;
+        let profile_root = canonical_temp_path(&dir.path().join("profile"));
+        let registry_root = canonical_temp_path(&dir.path().join("registry-repo"));
+        let manifest_root = canonical_temp_path(&dir.path().join("manifest-repo"));
+        let shard_relpath = Path::new("projects").join("proj_registry");
+        let shard_root = profile_root.join(&shard_relpath);
+        std::fs::create_dir_all(&registry_root)?;
+        std::fs::create_dir_all(&manifest_root)?;
+        std::fs::create_dir_all(&shard_root)?;
+        std::fs::write(shard_root.join("tracedecay.db"), b"graph")?;
+        std::fs::write(shard_root.join("sessions.db"), b"sessions")?;
+        std::fs::write(shard_root.join("branch-meta.json"), b"{}")?;
+        let manifest = StoreManifest {
+            schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+            project_id: Some("proj_manifest".to_string()),
+            store_kind: StoreKind::CodeProject,
+            storage_mode: StorageMode::ProfileSharded,
+            project_root: manifest_root.clone(),
+            data_root: shard_root.clone(),
+            graph_db_relpath: "tracedecay.db".into(),
+            sessions_db_relpath: "sessions.db".into(),
+            branch_meta_relpath: "branch-meta.json".into(),
+        };
+        std::fs::write(
+            shard_root.join(STORE_MANIFEST_FILENAME),
+            serde_json::to_string_pretty(&manifest)?,
+        )?;
+
+        let db = crate::global_db::GlobalDb::open_at(&dir.path().join("global.db"))
+            .await
+            .ok_or_else(|| std::io::Error::other("could not open global db"))?;
+        db.upsert_code_project("proj_registry", &registry_root, None, None, Some("main"))
+            .await
+            .ok_or_else(|| std::io::Error::other("could not upsert project"))?;
+        db.upsert_store_instance(StoreInstanceUpsert {
+            store_id: "store:proj_registry:profile_sharded".to_string(),
+            project_id: "proj_registry".to_string(),
+            store_kind: "code_project".to_string(),
+            storage_mode: "profile_sharded".to_string(),
+            store_relpath: shard_relpath.to_string_lossy().to_string(),
+            manifest_relpath: Some(
+                shard_relpath
+                    .join(STORE_MANIFEST_FILENAME)
+                    .to_string_lossy()
+                    .to_string(),
+            ),
+            last_verified_at: Some(1_800_000_000),
+            last_write_at: Some(1_800_000_000),
+        })
+        .await
+        .ok_or_else(|| std::io::Error::other("could not upsert store"))?;
+
+        let findings = registry_drift_findings(&db, &profile_root).await;
+        let fields: Vec<_> = findings.iter().map(|finding| finding.field).collect();
+        assert!(
+            fields.contains(&"project_id"),
+            "expected project_id drift finding, got {findings:#?}"
+        );
+        assert!(
+            fields.contains(&"project_root"),
+            "expected project_root drift finding, got {findings:#?}"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding.registry_value == "proj_registry"
+                    && finding.manifest_value == "proj_manifest"),
+            "project_id finding should include registry and manifest values: {findings:#?}"
+        );
+
         Ok(())
     }
 }

--- a/src/extraction/typescript_extractor.rs
+++ b/src/extraction/typescript_extractor.rs
@@ -1080,13 +1080,25 @@ impl TypeScriptExtractor {
 
         // Unresolved Uses reference.
         state.unresolved_refs.push(UnresolvedRef {
-            from_node_id: id,
+            from_node_id: id.clone(),
             reference_name: name,
             reference_kind: EdgeKind::Uses,
             line: start_line,
             column: start_column,
             file_path: state.file_path.clone(),
         });
+        if let Some(module_path) = module_path.as_deref() {
+            for candidate in Self::ignored_dependency_import_candidates(&text, module_path) {
+                state.unresolved_refs.push(UnresolvedRef {
+                    from_node_id: id.clone(),
+                    reference_name: candidate,
+                    reference_kind: EdgeKind::Uses,
+                    line: start_line,
+                    column: start_column,
+                    file_path: state.file_path.clone(),
+                });
+            }
+        }
     }
 
     /// Extract a namespace (`internal_module`) declaration.
@@ -1290,6 +1302,44 @@ impl TypeScriptExtractor {
             }
         }
         None
+    }
+
+    fn ignored_dependency_import_candidates(import_text: &str, module_path: &str) -> Vec<String> {
+        if Self::is_project_relative_import(module_path) || !Self::is_type_only_import(import_text)
+        {
+            return Vec::new();
+        }
+        let Some((_, after_open)) = import_text.split_once('{') else {
+            return Vec::new();
+        };
+        let Some((named_imports, _)) = after_open.split_once('}') else {
+            return Vec::new();
+        };
+        named_imports
+            .split(',')
+            .filter_map(Self::named_import_exported_name)
+            .map(|name| format!("npm:{module_path}#{name}"))
+            .collect()
+    }
+
+    fn is_type_only_import(import_text: &str) -> bool {
+        import_text.trim_start().starts_with("import type ")
+    }
+
+    fn is_project_relative_import(module_path: &str) -> bool {
+        module_path.starts_with('.') || module_path.starts_with('/')
+    }
+
+    fn named_import_exported_name(raw: &str) -> Option<String> {
+        let without_type_prefix = raw.trim().strip_prefix("type ").unwrap_or(raw.trim());
+        let exported = without_type_prefix
+            .split_once(" as ")
+            .map_or(without_type_prefix, |(name, _)| name)
+            .trim();
+        if exported.is_empty() {
+            return None;
+        }
+        Some(exported.to_string())
     }
 
     /// Recursively find `call_expression` nodes inside a node and create

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -1106,6 +1106,42 @@ impl GlobalDb {
         health
     }
 
+    /// Returns tracked transcript paths that still contain an unresolved
+    /// workspace placeholder. Cursor should expand `${workspaceFolder}` before
+    /// a transcript path is persisted; if it reaches the session DB literally,
+    /// catch-up and recall will look at a non-existent path.
+    pub async fn literal_workspace_placeholder_transcript_paths(
+        &self,
+        limit: usize,
+    ) -> Vec<String> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        let Ok(mut rows) = self
+            .conn
+            .query(
+                "SELECT DISTINCT transcript_path FROM sessions
+                 WHERE transcript_path IS NOT NULL
+                   AND transcript_path != ''
+                   AND (transcript_path LIKE '%${workspaceFolder}%'
+                        OR transcript_path LIKE '%$workspaceFolder%')
+                 ORDER BY transcript_path
+                 LIMIT ?1",
+                params![i64::try_from(limit).unwrap_or(i64::MAX)],
+            )
+            .await
+        else {
+            return Vec::new();
+        };
+        let mut paths = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            if let Ok(path) = row.get::<String>(0) {
+                paths.push(path);
+            }
+        }
+        paths
+    }
+
     /// Canonical registry key for a project path. Falls back to the lossy path
     /// string when canonicalization fails (e.g. the path no longer exists) so
     /// upserts and lookups always agree on a single key per project, instead of

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1426,6 +1426,7 @@ pub fn build_codex_session_context_for_workspace(
                  or shell search for codebase exploration, symbol lookup, call graphs, and \
                  impact analysis. Fall back to file reads only when tracedecay cannot answer.\n",
             );
+            append_codex_recall_and_registry_guidance(&mut s);
             match status {
                 HookWorkspaceStatus::Initialized => match staleness_hint {
                     Some(hint) => {
@@ -1446,13 +1447,31 @@ pub fn build_codex_session_context_for_workspace(
             s.push_str(
                 "TraceDecay session context is available via MCP. For prior conversation \
                  recovery, use tracedecay_lcm_expand_query, tracedecay_message_search, and \
-                 tracedecay_lcm_describe; use project memory tools only when durable \
-                 preferences or decisions matter.\n",
+                 tracedecay_lcm_describe before asking the user to repeat themselves. Use \
+                 tracedecay_fact_store only for durable preferences, environment details, \
+                 tool quirks, or decisions that will still matter later. Do not store task \
+                 progress, temporary TODOs, or soon-stale session outcomes; recover those \
+                 from transcripts instead.\n",
             );
             s.push_str("Workspace status: no active project workspace; no setup guidance needed for this prompt.\n");
         }
     }
     s
+}
+
+fn append_codex_recall_and_registry_guidance(s: &mut String) {
+    s.push_str(
+        "For other registered projects or sibling workspaces, check \
+         tracedecay_project_list or tracedecay_project_search first; use \
+         tracedecay_project_context to confirm the target and pass project_id or \
+         project_path to tracedecay_context/search for cross-project code context before \
+         scanning parent directories. When the user references prior conversation or \
+         missing context, use tracedecay_message_search or tracedecay_lcm_expand_query \
+         before asking the user to repeat themselves. Use tracedecay_fact_store only for \
+         durable preferences, environment details, tool quirks, or decisions that will \
+         still matter later. Do not store task progress, temporary TODOs, or soon-stale \
+         session outcomes; recover those from transcripts instead.\n",
+    );
 }
 
 fn append_context_recovery_hint(context: &mut String) {

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -36,6 +36,8 @@ pub enum HintCategory {
     Impact,
     SymbolLookup,
     FileLookup,
+    ProjectContext,
+    SessionRecall,
     ExploreSubagent,
     SubagentStartContext,
 }
@@ -51,6 +53,8 @@ impl HintCategory {
             HintCategory::Impact => "impact",
             HintCategory::SymbolLookup => "symbol_lookup",
             HintCategory::FileLookup => "file_lookup",
+            HintCategory::ProjectContext => "project_context",
+            HintCategory::SessionRecall => "session_recall",
             HintCategory::ExploreSubagent => "explore_subagent",
             HintCategory::SubagentStartContext => "subagent_start_context",
         }
@@ -66,6 +70,8 @@ impl HintCategory {
             "impact" => Some(HintCategory::Impact),
             "symbol_lookup" => Some(HintCategory::SymbolLookup),
             "file_lookup" => Some(HintCategory::FileLookup),
+            "project_context" => Some(HintCategory::ProjectContext),
+            "session_recall" => Some(HintCategory::SessionRecall),
             "explore_subagent" => Some(HintCategory::ExploreSubagent),
             "subagent_start_context" => Some(HintCategory::SubagentStartContext),
             _ => None,
@@ -197,6 +203,30 @@ pub fn decide_hint(input: &ToolHintInput) -> Option<ToolHint> {
         ));
     }
 
+    let text = combined_text(input);
+    if asks_for_session_recall(&text) {
+        return Some(hint(
+            HintCategory::SessionRecall,
+            "For prior conversation context, consider TraceDecay session search.",
+            "tracedecay_message_search searches ingested agent transcripts across providers; tracedecay_lcm_grep can search bounded raw-message snippets and summaries when you need session-level recall before re-discovering context.",
+            false,
+        ));
+    }
+
+    if asks_for_project_context(&text)
+        || input
+            .command
+            .as_deref()
+            .is_some_and(is_project_discovery_command)
+    {
+        return Some(hint(
+            HintCategory::ProjectContext,
+            "For other repos or registered projects, consider TraceDecay project registry tools.",
+            "tracedecay_project_list shows known projects; tracedecay_project_search can find a sibling repo by name/path/remote; pass project_path or project_id to tracedecay_context/search for cross-project code context before scanning parent directories.",
+            false,
+        ));
+    }
+
     if input
         .command
         .as_deref()
@@ -245,7 +275,6 @@ pub fn decide_hint(input: &ToolHintInput) -> Option<ToolHint> {
         ));
     }
 
-    let text = combined_text(input);
     if text.is_empty() {
         return None;
     }
@@ -377,6 +406,34 @@ fn is_shell_search_command(command: &str) -> bool {
     }
 }
 
+fn is_project_discovery_command(command: &str) -> bool {
+    let tokens = super::shell_words(command);
+    let Some(first) = tokens.first() else {
+        return false;
+    };
+    let program = first.trim_start_matches('(').to_ascii_lowercase();
+    match program.as_str() {
+        "find" | "fd" | "fdfind" => tokens
+            .iter()
+            .skip(1)
+            .any(|token| is_parent_or_projects_path(token)),
+        "rg" | "ripgrep" | "grep" => tokens
+            .iter()
+            .skip(1)
+            .any(|token| is_parent_or_projects_path(token)),
+        _ => false,
+    }
+}
+
+fn is_parent_or_projects_path(token: &str) -> bool {
+    let token = token.trim_matches(|c| matches!(c, '(' | ')' | '"' | '\''));
+    token == ".."
+        || token.starts_with("../")
+        || token.contains("/../")
+        || token.contains("/projects/")
+        || token.ends_with("/projects")
+}
+
 fn is_recursive_grep_flag(token: &str) -> bool {
     if token == "--recursive" {
         return true;
@@ -442,6 +499,67 @@ fn asks_for_broad_read(text: &str) -> bool {
     )
 }
 
+fn asks_for_project_context(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "another repo",
+            "another repository",
+            "other repo",
+            "other repository",
+            "external repo",
+            "external repository",
+            "sibling repo",
+            "sibling repository",
+            "neighbor repo",
+            "neighbor repository",
+            "nearby repo",
+            "nearby repository",
+            "next door",
+            "registered project",
+            "project registry",
+            "project listing",
+            "project list",
+            "project search",
+            "cross-project",
+            "cross project",
+        ],
+    ) || (contains_any(text, &[" repo", " repository", "workspace"])
+        && contains_any(
+            text,
+            &[
+                "find",
+                "locate",
+                "search",
+                "where",
+                "defined",
+                "lives",
+                "orchestrator",
+            ],
+        ))
+}
+
+fn asks_for_session_recall(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "where did we",
+            "what did we",
+            "when did we",
+            "did we talk",
+            "talk about",
+            "discuss before",
+            "mentioned before",
+            "prior conversation",
+            "previous conversation",
+            "earlier conversation",
+            "session search",
+            "session recall",
+            "conversation history",
+        ],
+    )
+}
+
 fn asks_for_symbol_lookup(text: &str) -> bool {
     contains_any(
         text,
@@ -495,6 +613,57 @@ mod tests {
             assert!(hint.context.contains("tracedecay_context"), "{name}");
             assert!(hint.nonblocking, "semantic-search hints must stay soft");
         }
+    }
+
+    #[test]
+    fn parent_directory_find_gets_project_registry_hint() {
+        let hint = decide_hint(&ToolHintInput {
+            tool_name: Some("shell".to_string()),
+            command: Some("find .. -maxdepth 3 -type f -iname '*runner*'".to_string()),
+            prompt: Some(
+                "Find where the clean-ci Windows runner orchestrator is defined".to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "project_context");
+        assert!(hint.context.contains("tracedecay_project_list"));
+        assert!(hint.context.contains("tracedecay_project_search"));
+    }
+
+    #[test]
+    fn external_repo_shell_search_prefers_project_registry_hint() {
+        let hint = decide_hint(&ToolHintInput {
+            tool_name: Some("shell".to_string()),
+            command: Some("rg -n \"proxmox|windows|runner|clean-ci\" .".to_string()),
+            prompt: Some(
+                "Find the runner orchestrator repo and update its Windows boxes".to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "project_context");
+        assert!(hint.message.contains("registered projects"));
+    }
+
+    #[test]
+    fn prior_conversation_prompt_gets_session_recall_hint() {
+        let hint = decide_hint(&ToolHintInput {
+            prompt: Some(
+                "Where did we talk about clean-ci and the runner orchestrator before?".to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "session_recall");
+        assert!(hint.context.contains("tracedecay_message_search"));
+        assert!(hint.context.contains("tracedecay_lcm_grep"));
     }
 
     #[test]

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -523,20 +523,10 @@ fn asks_for_project_context(text: &str) -> bool {
             "project search",
             "cross-project",
             "cross project",
+            "orchestrator repo",
+            "orchestrator repository",
         ],
-    ) || (contains_any(text, &[" repo", " repository", "workspace"])
-        && contains_any(
-            text,
-            &[
-                "find",
-                "locate",
-                "search",
-                "where",
-                "defined",
-                "lives",
-                "orchestrator",
-            ],
-        ))
+    )
 }
 
 fn asks_for_session_recall(text: &str) -> bool {
@@ -648,6 +638,20 @@ mod tests {
 
         assert_eq!(hint.category.as_key(), "project_context");
         assert!(hint.message.contains("registered projects"));
+    }
+
+    #[test]
+    fn ordinary_workspace_search_stays_a_search_hint() {
+        let hint = decide_hint(&ToolHintInput {
+            tool_name: Some("shell".to_string()),
+            command: Some("rg -n \"helper\" .".to_string()),
+            prompt: Some("Search the workspace for the helper definition".to_string()),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category, HintCategory::Search);
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -22,6 +22,7 @@ use crate::tracedecay::TraceDecay;
 
 use super::tools::{
     explore_call_budget, get_tool_definitions_with_budget, handle_tool_call_with_registry,
+    INTERNAL_TOOL_ANALYTICS_KEY,
 };
 use super::transport::{ErrorCode, JsonRpcRequest, JsonRpcResponse};
 
@@ -1937,6 +1938,7 @@ impl McpServer {
                 }
 
                 mark_semantic_tool_error(&mut result.value);
+                strip_internal_tool_analytics(&mut result.value);
                 JsonRpcResponse::success(id, result.value)
             }
             Err(e) => {
@@ -2165,43 +2167,30 @@ fn append_tool_response_analytics(
         .and_then(Value::as_f64)
         .unwrap_or(0.5)
         .clamp(0.0, 1.0);
-    let payload = response.and_then(tool_result_json_payload);
-    let memory_matches = payload
-        .as_ref()
-        .and_then(|payload| payload.get("memory_matches"))
-        .and_then(Value::as_array);
-    let fact_ids: Vec<Value> = memory_matches
-        .into_iter()
-        .flatten()
-        .filter_map(|hit| {
-            hit.get("fact")
-                .and_then(|fact| fact.get("fact_id"))
-                .and_then(Value::as_i64)
-        })
-        .map(Value::from)
-        .collect();
-    let match_count = fact_ids.len();
-    let memory_error = payload
-        .as_ref()
-        .and_then(|payload| payload.get("memory_matches_error"))
-        .and_then(Value::as_str);
+    if let Some(context_memory) = response.and_then(tool_result_context_memory_analytics) {
+        metadata["context_memory"] = context_memory.clone();
+        return;
+    }
     metadata["context_memory"] = json!({
         "include_memory": include_memory,
         "limit": limit,
         "min_trust": min_trust,
-        "match_count": match_count,
-        "fact_ids": fact_ids,
-        "error": memory_error,
+        "match_count": 0,
+        "fact_ids": [],
+        "error": null,
     });
 }
 
-fn tool_result_json_payload(response: &Value) -> Option<Value> {
+fn tool_result_context_memory_analytics(response: &Value) -> Option<&Value> {
     response
-        .get("content")
-        .and_then(Value::as_array)?
-        .iter()
-        .filter_map(|item| item.get("text").and_then(Value::as_str))
-        .find_map(|text| serde_json::from_str::<Value>(text).ok())
+        .get(INTERNAL_TOOL_ANALYTICS_KEY)?
+        .get("context_memory")
+}
+
+fn strip_internal_tool_analytics(value: &mut Value) {
+    if let Some(object) = value.as_object_mut() {
+        object.remove(INTERNAL_TOOL_ANALYTICS_KEY);
+    }
 }
 
 fn json_rpc_request_id_string(id: &Value) -> Option<String> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -22,7 +22,6 @@ use crate::tracedecay::TraceDecay;
 
 use super::tools::{
     explore_call_budget, get_tool_definitions_with_budget, handle_tool_call_with_registry,
-    INTERNAL_TOOL_ANALYTICS_KEY,
 };
 use super::transport::{ErrorCode, JsonRpcRequest, JsonRpcResponse};
 
@@ -1793,7 +1792,7 @@ impl McpServer {
                         timestamp: ts,
                         request_id: &request_id,
                         arguments: &analytics_arguments,
-                        response: Some(&result.value),
+                        internal_analytics: result.internal_analytics.as_ref(),
                     });
                     self.spawn_observed_ledger_write(async move {
                         gdb.record_savings(
@@ -1938,7 +1937,6 @@ impl McpServer {
                 }
 
                 mark_semantic_tool_error(&mut result.value);
-                strip_internal_tool_analytics(&mut result.value);
                 JsonRpcResponse::success(id, result.value)
             }
             Err(e) => {
@@ -1976,7 +1974,7 @@ impl McpServer {
             timestamp: crate::tracedecay::current_timestamp(),
             request_id,
             arguments,
-            response: None,
+            internal_analytics: None,
         });
         self.spawn_observed_ledger_write(async move {
             if let Err(e) = gdb.append_analytics_event(&event).await {
@@ -2098,7 +2096,7 @@ struct McpToolAnalyticsEvent<'a> {
     timestamp: i64,
     request_id: &'a Value,
     arguments: &'a Value,
-    response: Option<&'a Value>,
+    internal_analytics: Option<&'a Value>,
 }
 
 fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventInsert {
@@ -2124,7 +2122,7 @@ fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventI
     append_tool_response_analytics(
         input.tool_name,
         input.arguments,
-        input.response,
+        input.internal_analytics,
         &mut metadata,
     );
     AnalyticsEventInsert {
@@ -2147,7 +2145,7 @@ fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventI
 fn append_tool_response_analytics(
     tool_name: &str,
     arguments: &Value,
-    response: Option<&Value>,
+    internal_analytics: Option<&Value>,
     metadata: &mut Value,
 ) {
     if tool_name != "tracedecay_context" {
@@ -2167,7 +2165,7 @@ fn append_tool_response_analytics(
         .and_then(Value::as_f64)
         .unwrap_or(0.5)
         .clamp(0.0, 1.0);
-    if let Some(context_memory) = response.and_then(tool_result_context_memory_analytics) {
+    if let Some(context_memory) = internal_analytics.and_then(|value| value.get("context_memory")) {
         metadata["context_memory"] = context_memory.clone();
         return;
     }
@@ -2179,18 +2177,6 @@ fn append_tool_response_analytics(
         "fact_ids": [],
         "error": null,
     });
-}
-
-fn tool_result_context_memory_analytics(response: &Value) -> Option<&Value> {
-    response
-        .get(INTERNAL_TOOL_ANALYTICS_KEY)?
-        .get("context_memory")
-}
-
-fn strip_internal_tool_analytics(value: &mut Value) {
-    if let Some(object) = value.as_object_mut() {
-        object.remove(INTERNAL_TOOL_ANALYTICS_KEY);
-    }
 }
 
 fn json_rpc_request_id_string(id: &Value) -> Option<String> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1792,6 +1792,7 @@ impl McpServer {
                         timestamp: ts,
                         request_id: &request_id,
                         arguments: &analytics_arguments,
+                        response: Some(&result.value),
                     });
                     self.spawn_observed_ledger_write(async move {
                         gdb.record_savings(
@@ -1973,6 +1974,7 @@ impl McpServer {
             timestamp: crate::tracedecay::current_timestamp(),
             request_id,
             arguments,
+            response: None,
         });
         self.spawn_observed_ledger_write(async move {
             if let Err(e) = gdb.append_analytics_event(&event).await {
@@ -2094,16 +2096,22 @@ struct McpToolAnalyticsEvent<'a> {
     timestamp: i64,
     request_id: &'a Value,
     arguments: &'a Value,
+    response: Option<&'a Value>,
 }
 
 fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventInsert {
     let category = crate::accounting::classifier::classify(&[input.tool_name], &[]);
     let mut metadata = json!({
         "request_id": input.request_id,
+        "transport": "mcp",
+        "tool_kind": "mcp_tool",
         "before_tokens": input.raw_file_tokens,
         "after_tokens": input.response_tokens,
         "tokens_saved": input.net_saved_tokens,
     });
+    if input.outcome == "error" {
+        metadata["failure_reason"] = json!("tool_dispatch_error");
+    }
     if crate::analytics::is_skill_view_tool(input.tool_name) {
         metadata["arguments"] = input.arguments.clone();
         metadata["function"] = json!({
@@ -2111,6 +2119,12 @@ fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventI
             "arguments": input.arguments,
         });
     }
+    append_tool_response_analytics(
+        input.tool_name,
+        input.arguments,
+        input.response,
+        &mut metadata,
+    );
     AnalyticsEventInsert {
         provider: "mcp".to_string(),
         project_id: GlobalDb::canonical_project_key(input.project_root),
@@ -2126,6 +2140,68 @@ fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventI
         outcome: Some(input.outcome.to_string()),
         metadata_json: Some(metadata.to_string()),
     }
+}
+
+fn append_tool_response_analytics(
+    tool_name: &str,
+    arguments: &Value,
+    response: Option<&Value>,
+    metadata: &mut Value,
+) {
+    if tool_name != "tracedecay_context" {
+        return;
+    }
+    let include_memory = arguments
+        .get("include_memory")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+    let limit = arguments
+        .get("memory_limit")
+        .and_then(Value::as_u64)
+        .unwrap_or(3)
+        .clamp(1, 10);
+    let min_trust = arguments
+        .get("memory_min_trust")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.5)
+        .clamp(0.0, 1.0);
+    let payload = response.and_then(tool_result_json_payload);
+    let memory_matches = payload
+        .as_ref()
+        .and_then(|payload| payload.get("memory_matches"))
+        .and_then(Value::as_array);
+    let fact_ids: Vec<Value> = memory_matches
+        .into_iter()
+        .flatten()
+        .filter_map(|hit| {
+            hit.get("fact")
+                .and_then(|fact| fact.get("fact_id"))
+                .and_then(Value::as_i64)
+        })
+        .map(Value::from)
+        .collect();
+    let match_count = fact_ids.len();
+    let memory_error = payload
+        .as_ref()
+        .and_then(|payload| payload.get("memory_matches_error"))
+        .and_then(Value::as_str);
+    metadata["context_memory"] = json!({
+        "include_memory": include_memory,
+        "limit": limit,
+        "min_trust": min_trust,
+        "match_count": match_count,
+        "fact_ids": fact_ids,
+        "error": memory_error,
+    });
+}
+
+fn tool_result_json_payload(response: &Value) -> Option<Value> {
+    response
+        .get("content")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|item| item.get("text").and_then(Value::as_str))
+        .find_map(|text| serde_json::from_str::<Value>(text).ok())
 }
 
 fn json_rpc_request_id_string(id: &Value) -> Option<String> {

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -216,6 +216,7 @@ pub(super) async fn handle_dead_code(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -282,6 +283,7 @@ pub(super) async fn handle_module_api(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -304,6 +306,7 @@ pub(super) async fn handle_circular(cg: &TraceDecay, args: Value) -> Result<Tool
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -379,6 +382,7 @@ pub(super) async fn handle_hotspots(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -486,6 +490,7 @@ pub(super) async fn handle_unused_imports(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -576,6 +581,7 @@ pub(super) async fn handle_rank(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -632,6 +638,7 @@ pub(super) async fn handle_largest(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -689,6 +696,7 @@ pub(super) async fn handle_coupling(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -736,6 +744,7 @@ pub(super) async fn handle_inheritance_depth(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -812,6 +821,7 @@ pub(super) async fn handle_distribution(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -913,6 +923,7 @@ pub(super) async fn handle_recursion(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1192,6 +1203,7 @@ pub(super) async fn handle_complexity(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1256,6 +1268,7 @@ pub(super) async fn handle_doc_coverage(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1305,6 +1318,7 @@ pub(super) async fn handle_god_class(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1488,6 +1502,7 @@ pub(super) async fn handle_unsafe_patterns(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 
@@ -1604,6 +1619,7 @@ pub(super) async fn handle_diagnostics(cg: &TraceDecay, args: Value) -> Result<T
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: unique_file_paths(diagnostics.iter().map(|d| d.file.as_str())),
+        internal_analytics: None,
     })
 }
 
@@ -1647,6 +1663,7 @@ pub(super) async fn handle_constructors(
                 "content": [{ "type": "text", "text": format!("No struct, class, or case-class named '{struct_name}' found.") }]
             }),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -1717,6 +1734,7 @@ pub(super) async fn handle_constructors(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 
@@ -2096,6 +2114,7 @@ pub(super) async fn handle_field_sites(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 

--- a/src/mcp/tools/handlers/dashboard.rs
+++ b/src/mcp/tools/handlers/dashboard.rs
@@ -50,6 +50,7 @@ fn dashboard_tool_result(cg: &TraceDecay, payload: &Value) -> ToolResult {
             "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/handlers/dependency_hints.rs
+++ b/src/mcp/tools/handlers/dependency_hints.rs
@@ -1,0 +1,79 @@
+use std::collections::BTreeSet;
+
+use serde_json::{json, Value};
+
+use crate::errors::Result;
+use crate::tracedecay::TraceDecay;
+
+use super::support::filter_by_scope;
+
+pub(super) fn should_check_ignored_dependency_hint(result_count: usize, limit: usize) -> bool {
+    result_count == 0 || result_count < limit.clamp(1, 20)
+}
+
+pub(super) async fn ignored_dependency_hint(
+    cg: &TraceDecay,
+    query: &str,
+    limit: usize,
+    scope_prefix: Option<&str>,
+) -> Result<Option<Value>> {
+    let query = query.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return Ok(None);
+    }
+    let candidate_limit = limit.clamp(1, 20);
+    let db = if cg.is_read_only() {
+        cg.open_project_store_db_read_only().await?
+    } else {
+        cg.open_project_store_db().await?
+    };
+    let refs = db
+        .search_ignored_dependency_refs(&query, candidate_limit)
+        .await?;
+    let refs = filter_by_scope(refs, scope_prefix, |unresolved| &unresolved.file_path);
+    let mut seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+    for unresolved in refs {
+        let Some((module, symbol)) = parse_ignored_dependency_candidate(&unresolved.reference_name)
+        else {
+            continue;
+        };
+        let haystack = format!("{module} {symbol}").to_ascii_lowercase();
+        if !haystack.contains(&query) {
+            continue;
+        }
+        if !seen.insert((
+            module.to_string(),
+            symbol.to_string(),
+            unresolved.file_path.clone(),
+            unresolved.line,
+        )) {
+            continue;
+        }
+        candidates.push(json!({
+            "module": module,
+            "symbol": symbol,
+            "import_file": unresolved.file_path,
+            "line": user_line(unresolved.line),
+        }));
+        if candidates.len() >= candidate_limit {
+            break;
+        }
+    }
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(json!({
+        "message": "No indexed symbol matched, but project imports reference matching symbols from an ignored dependency. Keep node_modules ignored for normal sync; use bounded lazy dependency indexing for the listed module if this symbol is needed.",
+        "candidates": candidates,
+        "suggested_action": "lazy_index_ignored_dependency",
+    })))
+}
+
+fn parse_ignored_dependency_candidate(reference_name: &str) -> Option<(&str, &str)> {
+    reference_name.strip_prefix("npm:")?.split_once('#')
+}
+
+fn user_line(line: u32) -> u32 {
+    line.saturating_add(1)
+}

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -34,6 +34,7 @@ fn text_tool_result<T: Serialize>(result: &T, touched_files: Vec<String>) -> Too
             "content": [{ "type": "text", "text": serde_json::to_string(result).unwrap_or_default() }]
         }),
         touched_files,
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/handlers/git.rs
+++ b/src/mcp/tools/handlers/git.rs
@@ -36,6 +36,7 @@ fn git_error_result(cg: &TraceDecay, operation: &str, message: &str) -> ToolResu
             "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 
@@ -146,6 +147,7 @@ pub(super) async fn handle_affected(cg: &TraceDecay, args: Value) -> Result<Tool
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -256,6 +258,7 @@ pub(super) async fn handle_diff_context(cg: &TraceDecay, args: Value) -> Result<
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -665,6 +668,7 @@ pub(super) async fn handle_changelog(cg: &TraceDecay, args: Value) -> Result<Too
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -696,6 +700,7 @@ pub(super) async fn handle_commit_context(cg: &TraceDecay, args: Value) -> Resul
         return Ok(ToolResult {
             value: json!({"content": [{"type": "text", "text": text}]}),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -758,6 +763,7 @@ pub(super) async fn handle_commit_context(cg: &TraceDecay, args: Value) -> Resul
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": text}]}),
         touched_files: changed_files,
+        internal_analytics: None,
     })
 }
 
@@ -895,6 +901,7 @@ pub(super) async fn handle_pr_context(cg: &TraceDecay, args: Value) -> Result<To
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": text}]}),
         touched_files: changed_files,
+        internal_analytics: None,
     })
 }
 
@@ -917,6 +924,7 @@ pub(super) fn handle_branch_list(cg: &TraceDecay) -> ToolResult {
             "content": [{ "type": "text", "text": project_response_text(cg, &output) }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 
@@ -967,6 +975,7 @@ pub(super) async fn handle_branch_search(cg: &TraceDecay, args: Value) -> Result
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -1019,6 +1028,7 @@ pub(super) async fn handle_branch_diff(cg: &TraceDecay, args: Value) -> Result<T
                 "content": [{ "type": "text", "text": text }]
             }),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -1153,6 +1163,7 @@ pub(super) async fn handle_branch_diff(cg: &TraceDecay, args: Value) -> Result<T
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -2,7 +2,7 @@
 //! `impact`, `node`, `similar`, `rename_preview`, `callers_for`, `by_qualified_name`,
 //! `signature`.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 use serde_json::{json, Value};
@@ -17,9 +17,11 @@ use crate::types::{BuildContextOptions, EdgeKind, Node, NodeKind, TaskContext, V
 const CONTEXT_MEMORY_MATCH_LIMIT: usize = 3;
 const CONTEXT_MEMORY_MATCH_LIMIT_MAX: usize = 10;
 const CONTEXT_MEMORY_SNIPPET_CHARS: usize = 240;
+const CONTEXT_MEMORY_ANALYTICS_KEY: &str = "context_memory_analytics";
 
 use super::super::render::{self, Md};
-use super::super::{ToolResult, INTERNAL_TOOL_ANALYTICS_KEY};
+use super::super::ToolResult;
+use super::dependency_hints;
 use super::support::{
     effective_path, filter_by_scope, require_node_id, string_array_values, unique_file_paths,
 };
@@ -38,14 +40,26 @@ fn rendered_tool_result<F>(
 where
     F: FnOnce() -> String,
 {
+    let internal_analytics = value.get(CONTEXT_MEMORY_ANALYTICS_KEY).cloned();
+    let public_value;
+    let value = if internal_analytics.is_some() {
+        public_value = strip_internal_context_memory_analytics(value);
+        &public_value
+    } else {
+        value
+    };
     let text = render::finalize(Some(cg.project_root()), args, value, md);
     let mut result = text_tool_result(&text, touched_files);
-    if let Some(analytics) = value.get(INTERNAL_TOOL_ANALYTICS_KEY).cloned() {
-        if let Some(object) = result.value.as_object_mut() {
-            object.insert(INTERNAL_TOOL_ANALYTICS_KEY.to_string(), analytics);
-        }
-    }
+    result.internal_analytics = internal_analytics;
     result
+}
+
+fn strip_internal_context_memory_analytics(value: &Value) -> Value {
+    let mut value = value.clone();
+    if let Some(object) = value.as_object_mut() {
+        object.remove(CONTEXT_MEMORY_ANALYTICS_KEY);
+    }
+    value
 }
 
 fn text_tool_result(text: &str, touched_files: Vec<String>) -> ToolResult {
@@ -54,6 +68,7 @@ fn text_tool_result(text: &str, touched_files: Vec<String>) -> ToolResult {
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     }
 }
 
@@ -78,11 +93,12 @@ pub(super) async fn handle_search(
     let results = cg.search(query, limit).await?;
     let results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
     let coverage_hint = cg.index_coverage_hint(results.len());
-    let ignored_dependency_hint = if should_check_ignored_dependency_hint(results.len(), limit) {
-        ignored_dependency_hint(cg, query, limit).await?
-    } else {
-        None
-    };
+    let ignored_dependency_hint =
+        if dependency_hints::should_check_ignored_dependency_hint(results.len(), limit) {
+            dependency_hints::ignored_dependency_hint(cg, query, limit, scope_prefix).await?
+        } else {
+            None
+        };
 
     let touched_files = unique_file_paths(results.iter().map(|r| r.node.file_path.as_str()));
 
@@ -120,71 +136,6 @@ pub(super) async fn handle_search(
         touched_files,
         || render_search_md(&output_value),
     ))
-}
-
-fn should_check_ignored_dependency_hint(result_count: usize, limit: usize) -> bool {
-    result_count == 0 || result_count < limit.clamp(1, 20)
-}
-
-async fn ignored_dependency_hint(
-    cg: &TraceDecay,
-    query: &str,
-    limit: usize,
-) -> Result<Option<Value>> {
-    let query = query.trim().to_ascii_lowercase();
-    if query.is_empty() {
-        return Ok(None);
-    }
-    let candidate_limit = limit.clamp(1, 20);
-    let db = if cg.is_read_only() {
-        cg.open_project_store_db_read_only().await?
-    } else {
-        cg.open_project_store_db().await?
-    };
-    let refs = db
-        .search_ignored_dependency_refs(&query, candidate_limit)
-        .await?;
-    let mut seen = BTreeSet::new();
-    let mut candidates = Vec::new();
-    for unresolved in refs {
-        let Some((module, symbol)) = parse_ignored_dependency_candidate(&unresolved.reference_name)
-        else {
-            continue;
-        };
-        let haystack = format!("{module} {symbol}").to_ascii_lowercase();
-        if !haystack.contains(&query) {
-            continue;
-        }
-        if !seen.insert((
-            module.to_string(),
-            symbol.to_string(),
-            unresolved.file_path.clone(),
-            unresolved.line,
-        )) {
-            continue;
-        }
-        candidates.push(json!({
-            "module": module,
-            "symbol": symbol,
-            "import_file": unresolved.file_path,
-            "line": user_line(unresolved.line),
-        }));
-        if candidates.len() >= candidate_limit {
-            break;
-        }
-    }
-    if candidates.is_empty() {
-        return Ok(None);
-    }
-    Ok(Some(json!({
-        "message": "No indexed symbol matched, but project imports reference matching symbols from an ignored dependency. Keep node_modules ignored for normal sync; use bounded lazy dependency indexing for the listed module if this symbol is needed.",
-        "candidates": candidates,
-        "suggested_action": "lazy_index_ignored_dependency",
-    })))
-}
-
-fn parse_ignored_dependency_candidate(reference_name: &str) -> Option<(&str, &str)> {
-    reference_name.strip_prefix("npm:")?.split_once('#')
 }
 
 fn render_search_md(value: &Value) -> String {
@@ -337,7 +288,7 @@ pub(super) async fn handle_context(
             serde_json::to_value(&memory_matches).unwrap_or_else(|_| json!([])),
         );
         object.insert(
-            INTERNAL_TOOL_ANALYTICS_KEY.to_string(),
+            CONTEXT_MEMORY_ANALYTICS_KEY.to_string(),
             json!({
                 "context_memory": context_memory_analytics_value(
                     &memory_options,

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -78,7 +78,11 @@ pub(super) async fn handle_search(
     let results = cg.search(query, limit).await?;
     let results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
     let coverage_hint = cg.index_coverage_hint(results.len());
-    let ignored_dependency_hint = ignored_dependency_hint(cg, query, limit).await?;
+    let ignored_dependency_hint = if should_check_ignored_dependency_hint(results.len(), limit) {
+        ignored_dependency_hint(cg, query, limit).await?
+    } else {
+        None
+    };
 
     let touched_files = unique_file_paths(results.iter().map(|r| r.node.file_path.as_str()));
 
@@ -116,6 +120,10 @@ pub(super) async fn handle_search(
         touched_files,
         || render_search_md(&output_value),
     ))
+}
+
+fn should_check_ignored_dependency_hint(result_count: usize, limit: usize) -> bool {
+    result_count == 0 || result_count < limit.clamp(1, 20)
 }
 
 async fn ignored_dependency_hint(

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -2,7 +2,7 @@
 //! `impact`, `node`, `similar`, `rename_preview`, `callers_for`, `by_qualified_name`,
 //! `signature`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::Write as _;
 
 use serde_json::{json, Value};
@@ -72,6 +72,7 @@ pub(super) async fn handle_search(
     let results = cg.search(query, limit).await?;
     let results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
     let coverage_hint = cg.index_coverage_hint(results.len());
+    let ignored_dependency_hint = ignored_dependency_hint(cg, query, limit).await?;
 
     let touched_files = unique_file_paths(results.iter().map(|r| r.node.file_path.as_str()));
 
@@ -90,11 +91,15 @@ pub(super) async fn handle_search(
         })
         .collect();
 
-    let output_value = if let Some(hint) = coverage_hint {
-        json!({
-            "results": items,
-            "index_coverage_hint": hint,
-        })
+    let output_value = if coverage_hint.is_some() || ignored_dependency_hint.is_some() {
+        let mut value = json!({ "results": items });
+        if let Some(hint) = coverage_hint {
+            value["index_coverage_hint"] = json!(hint);
+        }
+        if let Some(hint) = ignored_dependency_hint {
+            value["ignored_dependency_hint"] = hint;
+        }
+        value
     } else {
         json!(items)
     };
@@ -105,6 +110,64 @@ pub(super) async fn handle_search(
         touched_files,
         || render_search_md(&output_value),
     ))
+}
+
+async fn ignored_dependency_hint(
+    cg: &TraceDecay,
+    query: &str,
+    limit: usize,
+) -> Result<Option<Value>> {
+    let query = query.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return Ok(None);
+    }
+    let db = if cg.is_read_only() {
+        cg.open_project_store_db_read_only().await?
+    } else {
+        cg.open_project_store_db().await?
+    };
+    let refs = db.get_unresolved_refs().await?;
+    let mut seen = BTreeSet::new();
+    let mut candidates = Vec::new();
+    for unresolved in refs {
+        let Some((module, symbol)) = parse_ignored_dependency_candidate(&unresolved.reference_name)
+        else {
+            continue;
+        };
+        let haystack = format!("{module} {symbol}").to_ascii_lowercase();
+        if !haystack.contains(&query) {
+            continue;
+        }
+        if !seen.insert((
+            module.to_string(),
+            symbol.to_string(),
+            unresolved.file_path.clone(),
+            unresolved.line,
+        )) {
+            continue;
+        }
+        candidates.push(json!({
+            "module": module,
+            "symbol": symbol,
+            "import_file": unresolved.file_path,
+            "line": user_line(unresolved.line),
+        }));
+        if candidates.len() >= limit.clamp(1, 20) {
+            break;
+        }
+    }
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(json!({
+        "message": "No indexed symbol matched, but project imports reference matching symbols from an ignored dependency. Keep node_modules ignored for normal sync; use bounded lazy dependency indexing for the listed module if this symbol is needed.",
+        "candidates": candidates,
+        "suggested_action": "lazy_index_ignored_dependency",
+    })))
+}
+
+fn parse_ignored_dependency_candidate(reference_name: &str) -> Option<(&str, &str)> {
+    reference_name.strip_prefix("npm:")?.split_once('#')
 }
 
 fn render_search_md(value: &Value) -> String {
@@ -145,6 +208,24 @@ fn render_search_md(value: &Value) -> String {
         .and_then(Value::as_str)
     {
         md.blank().heading(3, "Index Coverage Hint").line(msg);
+    }
+    if let Some(hint) = value.get("ignored_dependency_hint") {
+        let msg = hint
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("Matching ignored dependency candidates were found.");
+        md.blank().heading(3, "Ignored Dependency Hint").line(msg);
+        if let Some(candidates) = hint.get("candidates").and_then(Value::as_array) {
+            for candidate in candidates {
+                let module = render::field_str(candidate, "module");
+                let symbol = render::field_str(candidate, "symbol");
+                let file = render::field_str(candidate, "import_file");
+                let line = render::field_i64(candidate, "line");
+                md.bullet(&format!(
+                    "`{module}` exports `{symbol}` referenced at {file}:{line}"
+                ));
+            }
+        }
     }
     md.render()
 }

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -19,7 +19,7 @@ const CONTEXT_MEMORY_MATCH_LIMIT_MAX: usize = 10;
 const CONTEXT_MEMORY_SNIPPET_CHARS: usize = 240;
 
 use super::super::render::{self, Md};
-use super::super::ToolResult;
+use super::super::{ToolResult, INTERNAL_TOOL_ANALYTICS_KEY};
 use super::support::{
     effective_path, filter_by_scope, require_node_id, string_array_values, unique_file_paths,
 };
@@ -39,7 +39,13 @@ where
     F: FnOnce() -> String,
 {
     let text = render::finalize(Some(cg.project_root()), args, value, md);
-    text_tool_result(&text, touched_files)
+    let mut result = text_tool_result(&text, touched_files);
+    if let Some(analytics) = value.get(INTERNAL_TOOL_ANALYTICS_KEY).cloned() {
+        if let Some(object) = result.value.as_object_mut() {
+            object.insert(INTERNAL_TOOL_ANALYTICS_KEY.to_string(), analytics);
+        }
+    }
+    result
 }
 
 fn text_tool_result(text: &str, touched_files: Vec<String>) -> ToolResult {
@@ -121,12 +127,15 @@ async fn ignored_dependency_hint(
     if query.is_empty() {
         return Ok(None);
     }
+    let candidate_limit = limit.clamp(1, 20);
     let db = if cg.is_read_only() {
         cg.open_project_store_db_read_only().await?
     } else {
         cg.open_project_store_db().await?
     };
-    let refs = db.get_unresolved_refs().await?;
+    let refs = db
+        .search_ignored_dependency_refs(&query, candidate_limit)
+        .await?;
     let mut seen = BTreeSet::new();
     let mut candidates = Vec::new();
     for unresolved in refs {
@@ -152,7 +161,7 @@ async fn ignored_dependency_hint(
             "import_file": unresolved.file_path,
             "line": user_line(unresolved.line),
         }));
-        if candidates.len() >= limit.clamp(1, 20) {
+        if candidates.len() >= candidate_limit {
             break;
         }
     }
@@ -319,6 +328,16 @@ pub(super) async fn handle_context(
             "memory_matches".to_string(),
             serde_json::to_value(&memory_matches).unwrap_or_else(|_| json!([])),
         );
+        object.insert(
+            INTERNAL_TOOL_ANALYTICS_KEY.to_string(),
+            json!({
+                "context_memory": context_memory_analytics_value(
+                    &memory_options,
+                    &memory_matches,
+                    memory_matches_error.as_deref()
+                ),
+            }),
+        );
         if let Some(err) = memory_matches_error {
             object.insert("memory_matches_error".to_string(), json!(err));
         }
@@ -358,6 +377,25 @@ fn context_memory_options(args: &Value) -> ContextMemoryOptions {
         limit,
         min_trust,
     }
+}
+
+fn context_memory_analytics_value(
+    options: &ContextMemoryOptions,
+    memory_matches: &[FactSearchResult],
+    memory_matches_error: Option<&str>,
+) -> Value {
+    let fact_ids: Vec<Value> = memory_matches
+        .iter()
+        .map(|hit| Value::from(hit.fact.fact_id))
+        .collect();
+    json!({
+        "include_memory": options.include_memory,
+        "limit": options.limit,
+        "min_trust": options.min_trust,
+        "match_count": fact_ids.len(),
+        "fact_ids": fact_ids,
+        "error": memory_matches_error,
+    })
 }
 
 async fn context_memory_matches(

--- a/src/mcp/tools/handlers/health.rs
+++ b/src/mcp/tools/handlers/health.rs
@@ -339,6 +339,7 @@ pub(super) async fn handle_gini(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -388,6 +389,7 @@ pub(super) async fn handle_dependency_depth(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -466,6 +468,7 @@ pub(super) async fn handle_health(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -485,6 +488,7 @@ pub(super) async fn handle_runtime(cg: &TraceDecay, args: Value) -> Result<ToolR
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -630,6 +634,7 @@ pub(super) async fn handle_dsm(
             "content": [{ "type": "text", "text": truncated_json_envelope_with_handle(Some(cg.project_root()), &formatted) }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -984,6 +989,7 @@ pub(super) async fn handle_test_risk(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -1071,6 +1077,7 @@ pub(super) async fn handle_test_map(
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": text}]}),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1146,6 +1153,7 @@ fn session_tool_result(cg: &TraceDecay, args: &Value, output: &Value) -> ToolRes
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -146,6 +146,7 @@ pub(super) async fn handle_status(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -265,6 +266,7 @@ pub(super) fn handle_active_project(
             "content": [{ "type": "text", "text": project_response_text(cg, &formatted) }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 
@@ -331,6 +333,7 @@ pub(super) async fn handle_storage_status(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 
@@ -402,6 +405,7 @@ fn render_registry_result(root: Option<&Path>, args: &Value, payload: &Value) ->
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 
@@ -625,6 +629,7 @@ pub(super) async fn handle_files(
             "content": [{ "type": "text", "text": truncate_response(&output) }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -752,6 +757,7 @@ pub(super) async fn handle_port_status(cg: &TraceDecay, args: Value) -> Result<T
                 "content": [{ "type": "text", "text": "No valid node kinds specified." }]
             }),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -856,6 +862,7 @@ pub(super) async fn handle_port_status(cg: &TraceDecay, args: Value) -> Result<T
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -903,6 +910,7 @@ pub(super) async fn handle_port_order(cg: &TraceDecay, args: Value) -> Result<To
                 "content": [{ "type": "text", "text": "No valid node kinds specified." }]
             }),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -925,6 +933,7 @@ pub(super) async fn handle_port_order(cg: &TraceDecay, args: Value) -> Result<To
                 "content": [{ "type": "text", "text": text }]
             }),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -1232,6 +1241,7 @@ pub(super) async fn handle_port_order(cg: &TraceDecay, args: Value) -> Result<To
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1355,6 +1365,7 @@ pub(super) async fn handle_simplify_scan(
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": text}]}),
         touched_files: files,
+        internal_analytics: None,
     })
 }
 
@@ -1527,6 +1538,7 @@ pub(super) async fn handle_type_hierarchy(cg: &TraceDecay, args: Value) -> Resul
     Ok(ToolResult {
         value: json!({"content": [{"type": "text", "text": truncate_response(&output)}]}),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -1613,6 +1625,7 @@ pub(super) async fn handle_body(
                 "content": [{ "type": "text", "text": format!("No symbol named '{symbol}' found.") }]
             }),
             touched_files: vec![],
+            internal_analytics: None,
         });
     }
 
@@ -1654,6 +1667,7 @@ pub(super) async fn handle_body(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 
@@ -1889,6 +1903,7 @@ pub(super) async fn handle_todos(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 
@@ -2061,6 +2076,7 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
                 "content": [{ "type": "text", "text": serde_json::to_string(&stub).unwrap_or_default() }]
             }),
             touched_files: vec![display_file],
+            internal_analytics: None,
         });
     }
 
@@ -2127,6 +2143,7 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![display_file],
+        internal_analytics: None,
     })
 }
 
@@ -2185,6 +2202,7 @@ pub(super) async fn handle_outline(cg: &TraceDecay, args: Value) -> Result<ToolR
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![display_file],
+        internal_analytics: None,
     })
 }
 
@@ -2359,6 +2377,7 @@ pub(super) fn handle_config(cg: &TraceDecay, args: &Value) -> Result<ToolResult>
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 
@@ -2563,6 +2582,7 @@ pub(super) async fn handle_signature_search(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched,
+        internal_analytics: None,
     })
 }
 

--- a/src/mcp/tools/handlers/memory.rs
+++ b/src/mcp/tools/handlers/memory.rs
@@ -35,6 +35,7 @@ fn text_tool_result(text: &str) -> ToolResult {
     ToolResult {
         value: json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod analysis;
 pub mod dashboard;
+mod dependency_hints;
 pub mod edit;
 pub mod git;
 pub mod graph;
@@ -147,6 +148,7 @@ fn handle_retrieve(cg: &TraceDecay, args: &Value) -> Result<ToolResult> {
     Ok(ToolResult {
         value: json!({ "content": [{ "type": "text", "text": formatted }] }),
         touched_files: Vec::new(),
+        internal_analytics: None,
     })
 }
 

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -64,6 +64,7 @@ pub(super) async fn handle_redundancy(
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     })
 }
 

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -41,6 +41,7 @@ fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
     ToolResult {
         value: json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files: Vec::new(),
+        internal_analytics: None,
     }
 }
 
@@ -147,6 +148,7 @@ fn lcm_preflight_tool_json(value: &Value) -> ToolResult {
     ToolResult {
         value: json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files: Vec::new(),
+        internal_analytics: None,
     }
 }
 
@@ -308,6 +310,7 @@ fn lcm_expand_query_tool_json(project_root: Option<&Path>, value: &Value) -> Too
     ToolResult {
         value: json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files: Vec::new(),
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/handlers/skills.rs
+++ b/src/mcp/tools/handlers/skills.rs
@@ -34,6 +34,7 @@ fn tool_json(value: &Value) -> ToolResult {
     ToolResult {
         value: json!({ "content": [{ "type": "text", "text": formatted }] }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/handlers/workflow.rs
+++ b/src/mcp/tools/handlers/workflow.rs
@@ -209,6 +209,7 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files: touched.into_iter().collect(),
+        internal_analytics: None,
     })
 }
 
@@ -292,6 +293,7 @@ pub(super) async fn handle_run_affected_tests(cg: &TraceDecay, args: Value) -> R
             "content": [{ "type": "text", "text": text }]
         }),
         touched_files,
+        internal_analytics: None,
     })
 }
 
@@ -493,6 +495,7 @@ fn empty_result(message: &str) -> ToolResult {
             })).unwrap_or_default() }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 
@@ -511,6 +514,7 @@ fn error_result(kind: &str, operation: &str, message: &str) -> ToolResult {
             })).unwrap_or_default() }]
         }),
         touched_files: vec![],
+        internal_analytics: None,
     }
 }
 

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -24,6 +24,8 @@ pub use handlers::{
 /// Maximum character length for a tool response before truncation.
 const MAX_RESPONSE_CHARS: usize = 15_000;
 
+pub(crate) const INTERNAL_TOOL_ANALYTICS_KEY: &str = "_tracedecay_analytics";
+
 /// A tool definition exposed by the MCP server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDefinition {

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -24,8 +24,6 @@ pub use handlers::{
 /// Maximum character length for a tool response before truncation.
 const MAX_RESPONSE_CHARS: usize = 15_000;
 
-pub(crate) const INTERNAL_TOOL_ANALYTICS_KEY: &str = "_tracedecay_analytics";
-
 /// A tool definition exposed by the MCP server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDefinition {
@@ -52,4 +50,7 @@ pub struct ToolResult {
     pub value: Value,
     /// Unique file paths referenced in the result.
     pub touched_files: Vec<String>,
+    /// Internal analytics metadata for the server runtime. This must never be
+    /// serialized into the tool response payload.
+    pub internal_analytics: Option<Value>,
 }

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -3862,6 +3862,11 @@ impl TraceDecay {
         Ok(db)
     }
 
+    pub async fn open_project_store_db_read_only(&self) -> Result<Database> {
+        let (db, _) = Database::open_read_only(&self.store_layout.graph_db_path).await?;
+        Ok(db)
+    }
+
     fn build_branch_diagnostics(
         project_root: &Path,
         data_root: &Path,

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -12,6 +12,7 @@ use tracedecay::automation::managed_skills::{
 };
 use tracedecay::branch_meta;
 use tracedecay::config::USER_DATA_DIR_ENV;
+use tracedecay::sessions::SessionRecord;
 use tracedecay::storage::resolve_layout_for_current_profile;
 use tracedecay::tracedecay::TraceDecay;
 
@@ -4557,6 +4558,52 @@ fn test_healthcheck_cursor_local_install_checks_project_config() {
     assert_eq!(
         dc.issues, 0,
         "local Cursor healthcheck should pass without global ~/.cursor config"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cursor_healthcheck_warns_on_literal_workspace_folder_transcript_path() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    CursorIntegration
+        .install(&make_install_ctx(home.path()))
+        .unwrap();
+    let cg = TraceDecay::init(project.path()).await.unwrap();
+    let db = tracedecay::sessions::cursor::open_project_session_db(project.path())
+        .await
+        .expect("session db should open for initialized project");
+    assert!(
+        db.upsert_session(&SessionRecord {
+            provider: "cursor".to_string(),
+            session_id: "cursor-placeholder-session".to_string(),
+            project_key: project.path().to_string_lossy().to_string(),
+            project_path: project.path().to_string_lossy().to_string(),
+            title: Some("placeholder path".to_string()),
+            started_at: Some(1_715_000_000),
+            ended_at: None,
+            transcript_path: Some(
+                "${workspaceFolder}/.cursor/sessions/cursor-placeholder-session.jsonl".to_string(),
+            ),
+            metadata_json: None,
+            parent_session_id: None,
+            is_subagent: false,
+            agent_id: None,
+            parent_tool_use_id: None,
+        })
+        .await,
+        "session row should insert"
+    );
+    cg.close();
+
+    let mut dc = DoctorCounters::new();
+    let hctx = HealthcheckContext {
+        home: home.path().to_path_buf(),
+        project_path: project.path().to_path_buf(),
+    };
+    CursorIntegration.healthcheck(&mut dc, &hctx);
+    assert!(
+        dc.warnings > 0,
+        "literal workspaceFolder transcript paths should be reported"
     );
 }
 

--- a/tests/automation_session_reflector_runner_test.rs
+++ b/tests/automation_session_reflector_runner_test.rs
@@ -1,6 +1,7 @@
 mod automation_runner_support;
 
 use automation_runner_support::*;
+use tracedecay::automation::fact_proposals::record_session_fact_proposals;
 
 #[tokio::test]
 async fn session_reflector_runner_skips_when_task_is_disabled() {
@@ -312,6 +313,68 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(records[0].accepted_count, 1);
     assert_eq!(records[0].rejected_count, 7);
     assert!(records[0].applied_ops.is_none());
+}
+
+#[tokio::test]
+async fn session_fact_proposals_dedupe_repeated_pending_facts_across_runs() {
+    let temp = tempdir().unwrap();
+    let dashboard_root = temp.path().join("dashboard");
+    let accepted = json!({
+        "add_fact_request": {
+            "content": "Repeated session evidence should produce one pending fact proposal",
+            "category": "project",
+            "source": "session_reflector",
+            "tags": ["session-reflector"],
+            "entities": ["session reflector"],
+            "trust": 0.91,
+            "metadata": {
+                "source_span": {
+                    "session_id": "session-a",
+                    "message_id": "message-a"
+                },
+                "trust_reason": "same durable fact repeated"
+            }
+        },
+        "proposal": {
+            "content": "Repeated session evidence should produce one pending fact proposal"
+        },
+        "validation": {
+            "dedupe": {
+                "nearest_existing_fact_id": null
+            }
+        }
+    });
+
+    let first = record_session_fact_proposals(
+        &dashboard_root,
+        "run-a",
+        Some("evidence-a"),
+        std::slice::from_ref(&accepted),
+        &[],
+    )
+    .await
+    .unwrap();
+    let second = record_session_fact_proposals(
+        &dashboard_root,
+        "run-b",
+        Some("evidence-b"),
+        std::slice::from_ref(&accepted),
+        &[],
+    )
+    .await
+    .unwrap();
+    let proposals = list_fact_proposals(
+        &dashboard_root,
+        Some(FactProposalState::PendingApproval),
+        10,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 0);
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals[0].run_id, "run-a");
 }
 
 #[tokio::test]

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -350,6 +350,66 @@ async fn test_unresolved_refs() {
 }
 
 #[tokio::test]
+async fn test_search_ignored_dependency_refs_is_bounded_and_filtered() {
+    let (db, _dir) = setup_db().await;
+
+    let node = sample_node("ref-node", "my_func", "src/lib.rs");
+    db.insert_node(&node).await.expect("failed to insert node");
+
+    for (index, reference_name) in [
+        "HashMap",
+        "npm:pkg#Foo",
+        "npm:pkg#Food",
+        "npm:pkg#Bar",
+        "npm:other#Foo",
+    ]
+    .iter()
+    .enumerate()
+    {
+        db.insert_unresolved_ref(&UnresolvedRef {
+            from_node_id: "ref-node".to_string(),
+            reference_name: (*reference_name).to_string(),
+            reference_kind: EdgeKind::Uses,
+            line: index as u32,
+            column: 5,
+            file_path: format!("src/{index}.ts"),
+        })
+        .await
+        .expect("failed to insert unresolved ref");
+    }
+
+    let refs = db
+        .search_ignored_dependency_refs("foo", 2)
+        .await
+        .expect("failed to query ignored dependency refs");
+
+    assert_eq!(refs.len(), 2, "query should honor the limit");
+    assert!(refs
+        .iter()
+        .all(|reference| reference.reference_name.starts_with("npm:")));
+    assert!(refs.iter().all(|reference| reference
+        .reference_name
+        .to_ascii_lowercase()
+        .contains("foo")));
+
+    let module_symbol_refs = db
+        .search_ignored_dependency_refs("pkg food", 10)
+        .await
+        .expect("failed to query ignored dependency refs by module and symbol");
+    assert_eq!(module_symbol_refs.len(), 1);
+    assert_eq!(module_symbol_refs[0].reference_name, "npm:pkg#Food");
+
+    let wildcard_refs = db
+        .search_ignored_dependency_refs("%", 10)
+        .await
+        .expect("failed to query ignored dependency refs with escaped wildcard");
+    assert!(
+        wildcard_refs.is_empty(),
+        "wildcard queries should be treated literally"
+    );
+}
+
+#[tokio::test]
 async fn test_batch_insert_nodes() {
     let (db, _dir) = setup_db().await;
 

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -781,8 +781,14 @@ fn test_build_codex_session_context_carries_full_steering() {
     assert!(context.contains("tracedecay_context"));
     assert!(context.contains("tracedecay_callers"));
     assert!(context.contains("last indexed 2m ago"));
+    assert!(context.contains("tracedecay_project_search"));
+    assert!(context.contains("tracedecay_message_search"));
+    assert!(context.contains("tracedecay_fact_store"));
+    assert!(context.contains("before asking the user to repeat"));
     let uninit = tracedecay::hooks::build_codex_session_context(false, None);
     assert!(uninit.contains("tracedecay init"));
+    assert!(uninit.contains("tracedecay_project_search"));
+    assert!(uninit.contains("tracedecay_message_search"));
 }
 
 #[test]
@@ -794,6 +800,9 @@ fn test_build_codex_session_context_for_unindexed_project_suggests_init() {
 
     assert!(context.contains("tracedecay_context"));
     assert!(context.contains("tracedecay init"));
+    assert!(context.contains("tracedecay_project_list"));
+    assert!(context.contains("tracedecay_project_search"));
+    assert!(context.contains("tracedecay_message_search"));
 }
 
 #[test]
@@ -806,6 +815,9 @@ fn test_build_codex_session_context_for_generic_workspace_uses_session_guidance(
     assert!(context.contains("TraceDecay session context"));
     assert!(context.contains("tracedecay_lcm_expand_query"));
     assert!(context.contains("tracedecay_message_search"));
+    assert!(context.contains("tracedecay_fact_store"));
+    assert!(context.contains("before asking the user to repeat"));
+    assert!(context.contains("Do not store task progress"));
     assert!(
         !context.contains("tracedecay init"),
         "non-project chats should not be told to initialize a code graph: {context}"

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1654,6 +1654,52 @@ async fn test_search_returns_index_coverage_hint_for_skipped_generated_dirs() {
 }
 
 #[tokio::test]
+async fn test_search_hints_at_ignored_dependency_candidates() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(project.join("node_modules/pkg")).unwrap();
+    fs::write(
+        project.join("src/app.ts"),
+        r#"import type { Foo } from "pkg";
+export const value = 1;
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("node_modules/pkg/index.d.ts"),
+        "export interface Foo { value: string }\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_search",
+        json!({"query": "Foo", "limit": 5, "format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
+    assert_eq!(
+        payload["ignored_dependency_hint"]["candidates"][0]["module"].as_str(),
+        Some("pkg")
+    );
+    assert_eq!(
+        payload["ignored_dependency_hint"]["candidates"][0]["symbol"].as_str(),
+        Some("Foo")
+    );
+    assert!(payload["ignored_dependency_hint"]["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("ignored dependency"));
+}
+
+#[tokio::test]
 async fn test_context_appends_index_coverage_hint_for_skipped_generated_dirs() {
     let (cg, _env, _dir) = setup_generated_dir_project(false).await;
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1700,6 +1700,55 @@ export const value = 1;
 }
 
 #[tokio::test]
+async fn test_search_ignored_dependency_hint_respects_scope_prefix() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(project.join("tests")).unwrap();
+    fs::create_dir_all(project.join("node_modules/pkg")).unwrap();
+    fs::write(
+        project.join("src/app.ts"),
+        r#"import type { Foo } from "pkg";
+export const value = 1;
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("tests/app.ts"),
+        r#"import type { Foo } from "pkg";
+export const value = 1;
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("node_modules/pkg/index.d.ts"),
+        "export interface Foo { value: string }\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_search",
+        json!({"query": "Foo", "limit": 5, "format": "json"}),
+        None,
+        Some("tests"),
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
+    let candidates = payload["ignored_dependency_hint"]["candidates"]
+        .as_array()
+        .expect("scoped ignored dependency candidates");
+    assert!(!candidates.is_empty());
+    assert!(candidates.iter().all(|candidate| candidate["import_file"]
+        .as_str()
+        .is_some_and(|path| path.starts_with("tests/"))));
+}
+
+#[tokio::test]
 async fn test_search_skips_ignored_dependency_hint_when_results_fill_limit() {
     let dir = test_temp_dir();
     let project = dir.path();
@@ -2166,6 +2215,14 @@ async fn context_includes_matching_memory_facts() {
     .await
     .unwrap();
     let payload: Value = serde_json::from_str(extract_text(&json_result.value)).unwrap();
+    assert!(
+        payload.get("context_memory_analytics").is_none(),
+        "internal context analytics must not be serialized in direct tool payloads"
+    );
+    assert!(
+        json_result.internal_analytics.is_some(),
+        "direct tool results should carry context analytics on the internal side channel"
+    );
     assert!(payload["memory_matches"]
         .as_array()
         .is_some_and(|matches| matches

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1700,6 +1700,43 @@ export const value = 1;
 }
 
 #[tokio::test]
+async fn test_search_skips_ignored_dependency_hint_when_results_fill_limit() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(project.join("node_modules/pkg")).unwrap();
+    fs::write(
+        project.join("src/app.ts"),
+        r#"export function Foo() {
+  return "local";
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("node_modules/pkg/index.d.ts"),
+        "export interface Foo { value: string }\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_search",
+        json!({"query": "Foo", "limit": 1, "format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
+    assert_eq!(payload.as_array().map(Vec::len), Some(1));
+    assert_eq!(payload[0]["name"].as_str(), Some("Foo"));
+}
+
+#[tokio::test]
 async fn test_context_appends_index_coverage_hint_for_skipped_generated_dirs() {
     let (cg, _env, _dir) = setup_generated_dir_project(false).await;
 

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -2162,12 +2162,15 @@ async fn context_call_writes_memory_match_analytics_without_fact_bodies() {
         "tracedecay_context",
         json!({
             "task": "context memory analytics",
-            "format": "json",
             "session_id": "mcp-session-9006"
         }),
     )
     .await;
     assert!(resp["error"].is_null(), "context should not error");
+    assert!(
+        resp["result"].get("_tracedecay_analytics").is_none(),
+        "internal analytics metadata must not leak to clients"
+    );
 
     server_handle.ledger_writes_settled().await;
     let event = expect_mcp_runtime_event(

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -2171,6 +2171,13 @@ async fn context_call_writes_memory_match_analytics_without_fact_bodies() {
         resp["result"].get("_tracedecay_analytics").is_none(),
         "internal analytics metadata must not leak to clients"
     );
+    assert!(
+        !resp["result"]
+            .to_string()
+            .contains("context_memory_analytics")
+            && !resp["result"].to_string().contains("_tracedecay_analytics"),
+        "internal analytics metadata must not leak inside response content"
+    );
 
     server_handle.ledger_writes_settled().await;
     let event = expect_mcp_runtime_event(

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -2119,6 +2119,78 @@ async fn search_call_writes_mcp_runtime_analytics_event() {
     assert_eq!(metadata["before_tokens"], before);
     assert_eq!(metadata["after_tokens"], after);
     assert_eq!(metadata["tokens_saved"], before - after);
+    assert_eq!(metadata["transport"], "mcp");
+    assert_eq!(metadata["tool_kind"], "mcp_tool");
+}
+
+#[tokio::test]
+// Intentional: serializes env-mutating savings tests; #[tokio::test]
+// defaults to a current-thread runtime, so no executor thread blocks.
+#[allow(clippy::await_holding_lock)]
+async fn context_call_writes_memory_match_analytics_without_fact_bodies() {
+    let _env_guard = SAVINGS_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
+
+    let (server, _proj_tmp) = setup_server().await;
+    let server_handle = server.clone();
+    let db_path = locked_global_db_path();
+
+    let fact_content =
+        "Durable context memory analytics should report counts without leaking fact bodies.";
+    let added = call_tool(
+        server.clone(),
+        9005,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": fact_content,
+            "category": "decision",
+            "entity": "context memory analytics",
+            "trust": 0.94,
+            "source": "mcp-server-memory-analytics-test"
+        }),
+    )
+    .await;
+    assert!(added["error"].is_null(), "fact add should not error");
+
+    let resp = call_tool(
+        server,
+        9006,
+        "tracedecay_context",
+        json!({
+            "task": "context memory analytics",
+            "format": "json",
+            "session_id": "mcp-session-9006"
+        }),
+    )
+    .await;
+    assert!(resp["error"].is_null(), "context should not error");
+
+    server_handle.ledger_writes_settled().await;
+    let event = expect_mcp_runtime_event(
+        &db_path,
+        "tracedecay_context",
+        "mcp-session-9006",
+        "durable context MCP runtime analytics event",
+    )
+    .await;
+    let metadata = analytics_metadata(&event);
+
+    assert_eq!(event.outcome.as_deref(), Some("success"));
+    assert_eq!(metadata["context_memory"]["include_memory"], true);
+    assert!(
+        metadata["context_memory"]["match_count"]
+            .as_u64()
+            .is_some_and(|count| count >= 1),
+        "context analytics should expose bounded memory match counts: {metadata}"
+    );
+    assert!(
+        !metadata.to_string().contains(fact_content),
+        "analytics metadata must not persist fact bodies"
+    );
 }
 
 #[tokio::test]
@@ -2166,6 +2238,9 @@ async fn failed_tool_call_writes_mcp_runtime_analytics_event() {
     assert_eq!(metadata["before_tokens"], 0);
     assert_eq!(metadata["after_tokens"], 0);
     assert_eq!(metadata["tokens_saved"], 0);
+    assert_eq!(metadata["transport"], "mcp");
+    assert_eq!(metadata["tool_kind"], "mcp_tool");
+    assert_eq!(metadata["failure_reason"], "tool_dispatch_error");
 }
 
 #[tokio::test]

--- a/tests/typescript_extraction_test.rs
+++ b/tests/typescript_extraction_test.rs
@@ -306,6 +306,38 @@ import * as path from 'path';
 }
 
 #[test]
+fn test_ts_import_type_records_ignored_dependency_candidates() {
+    let source = r#"
+import type { Foo, Bar as Baz } from "pkg";
+import { localThing } from "./local";
+"#;
+    let extractor = TypeScriptExtractor;
+    let result = extractor.extract("imports.ts", source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let use_refs: Vec<_> = result
+        .unresolved_refs
+        .iter()
+        .filter(|r| r.reference_kind == EdgeKind::Uses)
+        .collect();
+
+    assert!(
+        use_refs.iter().any(|r| r.reference_name == "npm:pkg#Foo"),
+        "expected npm dependency candidate for Foo, got {use_refs:#?}"
+    );
+    assert!(
+        use_refs.iter().any(|r| r.reference_name == "npm:pkg#Bar"),
+        "expected npm dependency candidate to use exported name before alias, got {use_refs:#?}"
+    );
+    assert!(
+        !use_refs
+            .iter()
+            .any(|r| r.reference_name == "npm:./local#localThing"),
+        "relative project imports should not be dependency candidates"
+    );
+}
+
+#[test]
 fn test_ts_async_function() {
     let source = r#"
 export async function fetchData(url: string): Promise<string> {


### PR DESCRIPTION
## Summary
- add doctor reporting for registry/store manifest identity drift
- persist richer MCP analytics for transport/tool kind, failures, and context memory matches without fact bodies
- record TypeScript ignored-dependency candidates and surface MCP search hints for symbols behind ignored dependencies
- dedupe repeated pending session fact proposals and add project/session hint coverage
- warn when Cursor transcript rows contain literal `${workspaceFolder}` placeholders that would break session recall
- make daemon status distinguish missing, stale, inaccessible, unreachable, and connectable sockets
- keep selected-project graph-reader search hints read-only when dispatching through registered project selectors

## Verification
- cargo test --lib doctor::tests::registry_drift_findings_report_manifest_identity_mismatches -- --nocapture
- cargo test --test typescript_extraction_test test_ts_import_type_records_ignored_dependency_candidates -- --nocapture
- cargo test --test mcp_handler_test test_search_hints_at_ignored_dependency_candidates -- --nocapture
- cargo test --test automation_session_reflector_runner_test session_fact_proposals_dedupe_repeated_pending_facts_across_runs -- --nocapture
- cargo test --features test-transport --test mcp_server_test context_call_writes_memory_match_analytics_without_fact_bodies -- --nocapture
- cargo test --features test-transport --test mcp_server_test failed_tool_call_writes_mcp_runtime_analytics_event -- --nocapture
- cargo test --lib tool_hints -- --nocapture
- cargo test --test hooks_test test_build_codex_session_context -- --nocapture
- cargo test --test agent_test test_cursor_healthcheck_warns_on_literal_workspace_folder_transcript_path -- --nocapture
- cargo test --lib daemon::tests::service_status -- --nocapture
- cargo test --lib mcp::tools::handlers::tests::graph_reader_selector -- --nocapture
- cargo test --lib mcp::tools::handlers::tests::selected_project_retrieve_finds_selected_project_response_handle -- --nocapture
- cargo fmt --check
- cargo check --workspace
- tracedecay sync
