### PR TITLE
[codex] Balance Windows nextest shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           cache-on-failure: true
 
       - name: Run Windows tests
-        run: cargo nextest run --workspace --profile ci --locked --partition hash:${{ matrix.partition }}/10 --test-threads num-cpus --status-level slow
+        run: cargo nextest run --workspace --profile ci --locked --partition slice:${{ matrix.partition }}/10 --test-threads num-cpus --status-level slow
 
       - name: Clean abandoned Windows test children
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ docs/superpowers
 cache/
 generated-illustrations/
 *.log
+__pycache__/
 *~
 *#

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -6400,20 +6400,24 @@ async fn memory_fact_store_update_trust_delta_uses_direct_fact_lookup() {
     let first: Value = serde_json::from_str(extract_text(&first.value)).unwrap();
     let first_id = first["fact"]["fact_id"].as_i64().unwrap();
 
-    for i in 0..205 {
-        handle_tool_call(
-            &cg,
-            "tracedecay_fact_store",
-            json!({
-                "action": "add",
-                "content": format!("Later fact {i} should not hide the first fact"),
-            }),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
+    let db = cg.open_project_store_db().await.unwrap();
+    db.conn().execute("BEGIN IMMEDIATE", ()).await.unwrap();
+    for i in 0..205i64 {
+        db.conn()
+            .execute(
+                "INSERT INTO memory_facts (
+                    content, category, tags, trust_score, created_at, updated_at, source, metadata
+                 )
+                 VALUES (?1, 'general', '[]', 0.5, ?2, ?2, 'test', '{}')",
+                libsql::params![
+                    format!("Later fact {i} should not hide the first fact"),
+                    9_000_000_000i64 + i,
+                ],
+            )
+            .await
+            .unwrap();
     }
+    db.conn().execute("COMMIT", ()).await.unwrap();
 
     let updated = handle_tool_call(
         &cg,


### PR DESCRIPTION
## Summary
- keep the Windows CI matrix at 10 jobs, but switch nextest partitioning from `hash:N/10` to native `slice:N/10`
- use nextest's maintained even partitioning instead of a custom shard planner
- speed up the slowest observed MCP memory regression test by seeding bulk filler facts directly while keeping the MCP update path under test
- ignore Python `__pycache__/` output from local helper/check scripts

## Why
The previous hash partitioning let one shard own too much of `mcp_handler_test`; PR CI timed out after shard 3 ran only 221/446 selected tests. Native `slice:` partitioning spreads the full suite evenly and also spreads `mcp_handler_test` itself across all 10 shards.

The cancelled Windows run also showed `memory_fact_store_update_trust_delta_uses_direct_fact_lookup` as the slowest completed testcase. Locally, that test spent most of its time creating 205 filler facts through the MCP add path; the optimized fixture keeps the regression condition but reduces the single-test runtime from ~17.9s to ~0.2s on this machine.

## Validation
- `cargo nextest list --workspace --profile ci --locked --partition slice:N/10 --message-format oneline` for all 10 partitions
- full-suite partition counts: 321 tests for shards 1-9, 320 tests for shard 10
- `mcp_handler_test` partition counts: 27 tests for shard 1, 26 tests for shards 2-10
- `cargo nextest run --workspace --profile ci --locked -E 'test(memory_fact_store_update_trust_delta_uses_direct_fact_lookup)' --test-threads 1 --status-level slow`
- `cargo nextest run --workspace --profile ci --locked -E 'test(memory_fact_store_update_trust_delta_uses_direct_fact_lookup) | test(memory_feedback_and_status_include_trust_fields) | test(message_search_catches_up_provider_transcripts_before_querying) | test(message_search_can_skip_catch_up_for_read_only_audits)' --test-threads 1 --status-level slow`
- `git diff --check`
- `cargo fmt --all -- --check`