### PR TITLE
[codex] Speed up slow Windows test fixtures

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -3205,6 +3205,54 @@ impl GlobalDb {
             .is_ok_and(|n| n > 0)
     }
 
+    /// Insert parsed turns in one transaction, returning the number of new rows.
+    pub async fn insert_turns(&self, turns: &[crate::types::CostTurn]) -> usize {
+        if self.conn.execute("BEGIN IMMEDIATE", ()).await.is_err() {
+            return 0;
+        }
+
+        let mut inserted = 0;
+        for turn in turns {
+            let result = self
+                .conn
+                .execute(
+                    "INSERT OR IGNORE INTO turns
+                     (message_id, project_hash, session_id, model, timestamp,
+                      input_tokens, output_tokens, cache_write_tokens, cache_read_tokens,
+                      cost_usd, category, tool_names)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                    params![
+                        turn.message_id.clone(),
+                        turn.project_hash.clone(),
+                        turn.session_id.clone(),
+                        turn.model.clone(),
+                        turn.timestamp as i64,
+                        turn.input_tokens as i64,
+                        turn.output_tokens as i64,
+                        turn.cache_write_tokens as i64,
+                        turn.cache_read_tokens as i64,
+                        turn.cost_usd,
+                        turn.category.clone(),
+                        turn.tool_names.clone(),
+                    ],
+                )
+                .await;
+            if let Ok(n) = result {
+                inserted += n as usize;
+            } else {
+                let _ = self.conn.execute("ROLLBACK", ()).await;
+                return 0;
+            }
+        }
+
+        if self.conn.execute("COMMIT", ()).await.is_ok() {
+            inserted
+        } else {
+            let _ = self.conn.execute("ROLLBACK", ()).await;
+            0
+        }
+    }
+
     /// Total cost in USD since a given unix timestamp.
     pub async fn total_cost_since(&self, since: u64) -> Option<f64> {
         let mut rows = self

--- a/tests/dashboard_savings_api_test.rs
+++ b/tests/dashboard_savings_api_test.rs
@@ -380,26 +380,24 @@ async fn seed_daily_limit_regression(
     let accounting = GlobalDb::open_at(global_db_path)
         .await
         .expect("open accounting db");
+    let mut turns = Vec::new();
     for offset in 0..=366 {
-        assert!(
-            accounting
-                .insert_turn(&CostTurn {
-                    message_id: format!("turn-daily-limit-{offset}"),
-                    project_hash: "fixture".to_string(),
-                    session_id: "turns-daily-limit".to_string(),
-                    model: "claude-opus-4-6".to_string(),
-                    timestamp: (latest_day - (offset * 86_400) + 120) as u64,
-                    input_tokens: 100 + offset as u64,
-                    output_tokens: 50,
-                    cache_write_tokens: 0,
-                    cache_read_tokens: 0,
-                    cost_usd: 0.01,
-                    category: "code".to_string(),
-                    tool_names: String::new(),
-                })
-                .await
-        );
+        turns.push(CostTurn {
+            message_id: format!("turn-daily-limit-{offset}"),
+            project_hash: "fixture".to_string(),
+            session_id: "turns-daily-limit".to_string(),
+            model: "claude-opus-4-6".to_string(),
+            timestamp: (latest_day - (offset * 86_400) + 120) as u64,
+            input_tokens: 100 + offset as u64,
+            output_tokens: 50,
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+            cost_usd: 0.01,
+            category: "code".to_string(),
+            tool_names: String::new(),
+        });
     }
+    assert_eq!(accounting.insert_turns(&turns).await, turns.len());
 }
 
 async fn start_fixture(seed: FixtureSeed) -> Fixture {

--- a/tests/memory_test.rs
+++ b/tests/memory_test.rs
@@ -62,6 +62,73 @@ fn fact_request(content: &str, category: MemoryCategory, trust: f64) -> AddFactR
     }
 }
 
+async fn seed_newer_unrelated_memory_facts(
+    db: &Database,
+    category: MemoryCategory,
+    content_prefix: &str,
+    entity_prefix: &str,
+    count: usize,
+) {
+    db.conn().execute("BEGIN IMMEDIATE", ()).await.unwrap();
+    for i in 0..count {
+        let fact_id = 10_000 + i as i64;
+        let entity_id = 20_000 + i as i64;
+        let content = format!("{content_prefix} {i}");
+        let entity = format!("{entity_prefix}{i}");
+        let normalized = normalize_entity(&entity).to_ascii_lowercase();
+        let updated_at = 1_900_000_000 + i as i64;
+
+        if let Err(err) = db
+            .conn()
+            .execute(
+                "INSERT INTO memory_facts
+                    (fact_id, content, category, trust_score, created_at, updated_at, source, metadata)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, ?7)",
+                libsql::params![
+                    fact_id,
+                    content,
+                    category.as_str(),
+                    0.9_f64,
+                    updated_at,
+                    "test",
+                    "{}"
+                ],
+            )
+            .await
+        {
+            db.conn().execute("ROLLBACK", ()).await.unwrap();
+            panic!("failed to insert unrelated memory fact: {err}");
+        }
+
+        if let Err(err) = db
+            .conn()
+            .execute(
+                "INSERT INTO memory_entities
+                    (entity_id, name, normalized_name, entity_type, aliases, created_at)
+                 VALUES (?1, ?2, ?3, 'unknown', '[]', ?4)",
+                libsql::params![entity_id, entity, normalized, updated_at],
+            )
+            .await
+        {
+            db.conn().execute("ROLLBACK", ()).await.unwrap();
+            panic!("failed to insert unrelated memory entity: {err}");
+        }
+
+        if let Err(err) = db
+            .conn()
+            .execute(
+                "INSERT INTO memory_fact_entities (fact_id, entity_id) VALUES (?1, ?2)",
+                libsql::params![fact_id, entity_id],
+            )
+            .await
+        {
+            db.conn().execute("ROLLBACK", ()).await.unwrap();
+            panic!("failed to link unrelated memory entity: {err}");
+        }
+    }
+    db.conn().execute("COMMIT", ()).await.unwrap();
+}
+
 async fn dirty_bank_names(db: &Database) -> Vec<String> {
     let mut rows = db
         .conn()
@@ -1323,20 +1390,14 @@ async fn fact_retriever_search_includes_old_entity_only_matches() {
         .fact
         .unwrap();
 
-    for i in 0..125 {
-        let mut unrelated = fact_request(
-            &format!("Newer unrelated project fact {i}"),
-            MemoryCategory::Project,
-            0.9,
-        );
-        unrelated.entities = vec![format!("UnrelatedEntity{i}")];
-        store
-            .add_fact(unrelated, DEFAULT_TRUST)
-            .await
-            .unwrap()
-            .fact
-            .unwrap();
-    }
+    seed_newer_unrelated_memory_facts(
+        &db,
+        MemoryCategory::Project,
+        "Newer unrelated project fact",
+        "UnrelatedEntity",
+        125,
+    )
+    .await;
 
     let results = retriever
         .search("EntityNeedle", Some(MemoryCategory::Project), Some(0.3), 5)
@@ -1448,20 +1509,14 @@ async fn fact_retriever_reason_applies_entity_predicates_before_limit() {
         .fact
         .unwrap();
 
-    for i in 0..125 {
-        let mut unrelated = fact_request(
-            &format!("Newer unrelated fact {i}"),
-            MemoryCategory::Decision,
-            0.9,
-        );
-        unrelated.entities = vec![format!("Unrelated {i}")];
-        store
-            .add_fact(unrelated, DEFAULT_TRUST)
-            .await
-            .unwrap()
-            .fact
-            .unwrap();
-    }
+    seed_newer_unrelated_memory_facts(
+        &db,
+        MemoryCategory::Decision,
+        "Newer unrelated fact",
+        "Unrelated",
+        125,
+    )
+    .await;
 
     let results = retriever
         .reason(


### PR DESCRIPTION
## Summary

- Add a batched `GlobalDb::insert_turns` helper and use it for the daily dashboard savings regression fixture.
- Seed retriever decoy memory facts directly in one transaction for the entity-only search and entity-predicate reason regression tests, while preserving the real `MemoryStore::add_fact` path for the fact under test.
- Based on the last green Windows run (`28469663988`), this targets the largest remaining fixture bottlenecks after the sharding PR: `daily_model_series_limits_days_not_model_rows` (111s on Windows), `fact_retriever_reason_applies_entity_predicates_before_limit` (49s), and `fact_retriever_search_includes_old_entity_only_matches` (44s).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --workspace --profile ci --locked -E 'test(daily_model_series_limits_days_not_model_rows) | test(fact_retriever_reason_applies_entity_predicates_before_limit) | test(fact_retriever_search_includes_old_entity_only_matches)' --test-threads 1 --status-level slow` -> 3 passed in 29.215s on a colder dashboard-server pass; earlier warm focused run passed in 1.465s
- `cargo nextest run --workspace --profile ci --locked --test memory_test --test dashboard_savings_api_test --status-level slow` -> 39 passed in 3.040s before commit-message-only amend
- `scripts/check-conventional-commits.sh origin/master..HEAD`
- `git diff --check`