### PR TITLE
test: trim Windows fixture overhead

### DIFF
--- a/src/sessions/lcm/summarizer.rs
+++ b/src/sessions/lcm/summarizer.rs
@@ -108,12 +108,12 @@ fn summary_request_for_backlog(
         focus_topic,
         prompt,
         source_range: source_range.clone(),
-        source_messages: source_messages.clone(),
         extraction_request: extraction::build_extraction_request(
             session_id,
             &source_range,
             &source_messages,
         ),
+        source_messages,
     }
 }
 

--- a/tests/branch_db_safety_test.rs
+++ b/tests/branch_db_safety_test.rs
@@ -117,13 +117,13 @@ async fn assert_main_db_missing_symbol(project: &Path, symbol: &str, message: &s
     assert!(results.is_empty(), "{message}");
 }
 
-fn assert_fallback_write_refused(err: impl std::fmt::Display) {
+fn assert_fallback_write_refused(operation: &str, err: impl std::fmt::Display) {
     let message = err.to_string();
     assert!(
         message.contains("fallback")
             && (message.contains("tracedecay branch add")
                 || message.contains("Check out a tracked branch")),
-        "unexpected error: {message}"
+        "unexpected {operation} error: {message}"
     );
 }
 
@@ -157,74 +157,39 @@ async fn open_auto_tracks_untracked_branch_and_syncs_its_db() {
 }
 
 #[tokio::test]
-async fn sync_refuses_to_write_when_opened_on_fallback_branch() {
+async fn fallback_writes_are_refused_by_all_sync_entry_points() {
     let (_dir, project, fallback) = open_detached_fallback_project().await;
 
-    let err = fallback.sync().await.unwrap_err();
-    assert_fallback_write_refused(err);
-
-    drop(fallback);
-    assert_main_db_missing_symbol(
-        &project,
-        "detached_only",
-        "fallback sync must not index detached files into main DB",
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn full_index_refuses_to_write_when_opened_on_fallback_branch() {
-    let (_dir, project, fallback) = open_detached_fallback_project().await;
+    let err = fallback
+        .sync()
+        .await
+        .expect_err("sync should refuse fallback writes");
+    assert_fallback_write_refused("sync", err);
 
     let err = match fallback.index_all().await {
         Ok(_) => panic!("full index should refuse fallback writes"),
         Err(err) => err,
     };
-    assert_fallback_write_refused(err);
+    assert_fallback_write_refused("full index", err);
 
-    drop(fallback);
-    assert_main_db_missing_symbol(
-        &project,
-        "detached_only",
-        "fallback full index must not index detached files into main DB",
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn stale_sync_refuses_to_write_when_opened_on_fallback_branch() {
-    let (_dir, project, fallback) = open_detached_fallback_project().await;
+    let stale_files = ["src/detached_only.rs".to_string()];
+    let err = fallback
+        .sync_if_stale(&stale_files)
+        .await
+        .expect_err("stale sync should refuse fallback writes");
+    assert_fallback_write_refused("stale sync", err);
 
     let err = fallback
-        .sync_if_stale(&["src/detached_only.rs".to_string()])
+        .sync_if_stale_silent(&stale_files)
         .await
-        .unwrap_err();
-    assert_fallback_write_refused(err);
+        .expect_err("silent stale sync should refuse fallback writes");
+    assert_fallback_write_refused("silent stale sync", err);
 
     drop(fallback);
     assert_main_db_missing_symbol(
         &project,
         "detached_only",
-        "fallback stale sync must not index detached files into main DB",
-    )
-    .await;
-}
-
-#[tokio::test]
-async fn silent_stale_sync_refuses_to_write_when_opened_on_fallback_branch() {
-    let (_dir, project, fallback) = open_detached_fallback_project().await;
-
-    let err = fallback
-        .sync_if_stale_silent(&["src/detached_only.rs".to_string()])
-        .await
-        .unwrap_err();
-    assert_fallback_write_refused(err);
-
-    drop(fallback);
-    assert_main_db_missing_symbol(
-        &project,
-        "detached_only",
-        "fallback silent stale sync must not index detached files into main DB",
+        "fallback write attempts must not index detached files into main DB",
     )
     .await;
 }

--- a/tests/branch_drift_test.rs
+++ b/tests/branch_drift_test.rs
@@ -7,7 +7,7 @@
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 use tempfile::TempDir;
 use tracedecay::branch_meta::{save_branch_meta, BranchMeta};
 use tracedecay::config::USER_DATA_DIR_ENV;
@@ -67,13 +67,17 @@ fn canonical_temp_path(path: &Path) -> PathBuf {
     }
 }
 
-fn git(project: &Path, args: &[&str]) {
-    let status = Command::new("git")
+fn git_output(project: &Path, args: &[&str]) -> Output {
+    Command::new("git")
         .args(["-c", "core.hooksPath=.git/no-hooks"])
         .args(args)
         .current_dir(project)
         .output()
-        .expect("git command failed to spawn");
+        .expect("git command failed to spawn")
+}
+
+fn git(project: &Path, args: &[&str]) {
+    let status = git_output(project, args);
     assert!(
         status.status.success(),
         "git {args:?} failed: {}",
@@ -81,17 +85,55 @@ fn git(project: &Path, args: &[&str]) {
     );
 }
 
+fn git_init_dash_b_unsupported(output: &Output) -> bool {
+    let message = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    )
+    .to_lowercase();
+    (message.contains("unknown switch") || message.contains("unknown option"))
+        && (message.contains("`b'") || message.contains("'b'") || message.contains("-b"))
+}
+
+fn init_git_on_main(project: &Path) {
+    let output = git_output(project, &["init", "-b", "main"]);
+    if output.status.success() {
+        return;
+    }
+    assert!(
+        git_init_dash_b_unsupported(&output),
+        "git {:?} failed: {}",
+        ["init", "-b", "main"],
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    git(project, &["init"]);
+    git(project, &["branch", "-M", "main"]);
+}
+
+fn commit_all(project: &Path, message: &str) {
+    git(project, &["add", "."]);
+    git(
+        project,
+        &[
+            "-c",
+            "user.name=TraceDecay Test",
+            "-c",
+            "user.email=tracedecay-test@example.com",
+            "commit",
+            "-m",
+            message,
+        ],
+    );
+}
+
 /// Initialize a git repo on branch `main` with one committed source file.
 fn init_repo_on_main(project: &Path) {
     fs::create_dir_all(project.join("src")).unwrap();
     fs::write(project.join("src/lib.rs"), "pub fn f() -> u32 { 1 }\n").unwrap();
-    git(project, &["init"]);
-    git(project, &["config", "user.email", "test@test.com"]);
-    git(project, &["config", "user.name", "Test"]);
-    git(project, &["add", "."]);
-    git(project, &["commit", "-m", "initial"]);
-    // Guarantee the branch is named `main` regardless of git's init default.
-    git(project, &["branch", "-M", "main"]);
+    init_git_on_main(project);
+    commit_all(project, "initial");
 }
 
 fn project_data_dir(project: &Path) -> PathBuf {
@@ -302,8 +344,7 @@ async fn open_repairs_missing_tracked_branch_db_before_diagnostics() {
         "pub fn tracked_only() {}\n",
     )
     .unwrap();
-    git(project, &["add", "."]);
-    git(project, &["commit", "-m", "feature"]);
+    commit_all(project, "feature");
 
     TraceDecay::add_branch_tracking(project, "feature/tracked")
         .await

--- a/tests/dashboard_api_support/mod.rs
+++ b/tests/dashboard_api_support/mod.rs
@@ -137,6 +137,10 @@ pub(crate) async fn seed_memory_fixture(cg: &TraceDecay) {
         Err(err) => panic!("failed to serialize bank_b: {err}"),
     };
 
+    if let Err(err) = conn.execute("BEGIN IMMEDIATE", ()).await {
+        panic!("failed to begin memory fixture transaction: {err}");
+    }
+
     let inserts = [
         (
             "INSERT INTO memory_facts
@@ -274,6 +278,11 @@ pub(crate) async fn seed_memory_fixture(cg: &TraceDecay) {
         {
             panic!("failed to insert memory bank: {err}");
         }
+    }
+
+    if let Err(err) = conn.execute("COMMIT", ()).await {
+        let _ = conn.execute("ROLLBACK", ()).await;
+        panic!("failed to commit memory fixture transaction: {err}");
     }
 }
 

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -8442,7 +8442,8 @@ async fn lcm_doctor_repair_apply_rebuilds_damaged_fts() {
 
 #[tokio::test]
 async fn lcm_doctor_retention_reports_candidates_without_deleting() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-retention",
@@ -8455,7 +8456,11 @@ async fn lcm_doctor_retention_reports_candidates_without_deleting() {
     let result = handle_tool_call(
         &cg,
         "tracedecay_lcm_doctor",
-        json!({"provider": "cursor", "mode": "retention"}),
+        json!({
+            "provider": "cursor",
+            "mode": "retention",
+            "session_id": "lcm-doctor-retention"
+        }),
         None,
         None,
     )
@@ -8974,8 +8979,9 @@ async fn lcm_compress_without_summarizer_requests_auxiliary_summary() {
 
 #[tokio::test]
 async fn lcm_compress_oversized_needs_summary_uses_retrievable_full_payload() {
-    let (cg, _dir) = setup_project().await;
-    let huge_source = "alpha oversized context ".repeat(8_000);
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
+    let huge_source = "alpha oversized context ".repeat(1_000);
 
     let compress = handle_tool_call(
         &cg,
@@ -8990,8 +8996,8 @@ async fn lcm_compress_oversized_needs_summary_uses_retrievable_full_payload() {
             ],
             "current_tokens": 30_000,
             "threshold_tokens": 1_000,
-            "fresh_tail_count": 64,
-            "leaf_chunk_tokens": 20_000,
+            "fresh_tail_count": 2,
+            "leaf_chunk_tokens": 1_000,
             "summarizer": {"mode": "hermes_auxiliary"}
         }),
         None,
@@ -9056,8 +9062,9 @@ async fn lcm_compress_oversized_needs_summary_uses_retrievable_full_payload() {
 
 #[tokio::test]
 async fn lcm_preflight_oversized_replay_preserves_bridge_contract() {
-    let (cg, _dir) = setup_project().await;
-    let huge_source = "preflight oversized active context ".repeat(8_000);
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
+    let huge_source = "preflight oversized active context ".repeat(1_000);
 
     let preflight = handle_tool_call(
         &cg,
@@ -9280,7 +9287,8 @@ async fn lcm_status_response_is_valid_json_and_omits_payload_secrets() {
 
 #[tokio::test]
 async fn lcm_status_reports_lifecycle_fields_and_resolved_storage_scope() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     seed_lcm_session_message(
         &cg,
         "lcm-status-frontier",
@@ -9594,7 +9602,8 @@ async fn lcm_grep_and_load_session_honor_native_filters_and_content_clamp() {
 
 #[tokio::test]
 async fn lcm_grep_accepts_string_timestamp_filters() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     seed_lcm_session_message_with_role_source_timestamp(
         &cg,
         "lcm-string-timestamps",

--- a/tests/memory_eval_test.rs
+++ b/tests/memory_eval_test.rs
@@ -27,6 +27,7 @@ use tempfile::TempDir;
 use tracedecay::memory::store::MemoryStore;
 use tracedecay::memory::trust::DEFAULT_TRUST;
 use tracedecay::memory::types::{AddFactRequest, MemoryCategory};
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 #[derive(Deserialize)]
 struct Scenario {
@@ -415,6 +416,26 @@ fn canonical_test_dir(path: &Path) -> PathBuf {
         .unwrap_or_else(|e| panic!("failed to canonicalize test dir {}: {e}", path.display()))
 }
 
+fn initialize_fixture_project(fixture: &Fixture) {
+    let profile_root = fixture.home_path.join(".tracedecay");
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(profile_root.join("global.db")),
+    };
+    runtime().block_on(async {
+        let cg = TraceDecay::init_with_options(&fixture.project_path, open_options)
+            .await
+            .unwrap_or_else(|e| panic!("initialize fixture project: {e}"));
+        cg.index_all_with_progress(|_, _, _| {})
+            .await
+            .unwrap_or_else(|e| panic!("index fixture project: {e}"));
+        cg.checkpoint()
+            .await
+            .unwrap_or_else(|e| panic!("checkpoint fixture project: {e}"));
+        cg.close();
+    });
+}
+
 fn build_fixture(setup: &Setup) -> Fixture {
     let home = TempDir::new().expect("home tempdir");
     let project = TempDir::new().expect("project tempdir");
@@ -435,7 +456,7 @@ fn build_fixture(setup: &Setup) -> Fixture {
         std::fs::write(fixture.project_path.join(name), contents)
             .unwrap_or_else(|e| panic!("write fixture file {name}: {e}"));
     }
-    run_ok(&fixture, &["init"]);
+    initialize_fixture_project(&fixture);
     seed_setup_facts(&fixture, &setup.facts);
     #[cfg(unix)]
     {

--- a/tests/memory_eval_test.rs
+++ b/tests/memory_eval_test.rs
@@ -24,6 +24,9 @@ use std::time::{Duration, Instant};
 use serde::Deserialize;
 use serde_json::Value;
 use tempfile::TempDir;
+use tracedecay::memory::store::MemoryStore;
+use tracedecay::memory::trust::DEFAULT_TRUST;
+use tracedecay::memory::types::{AddFactRequest, MemoryCategory};
 
 #[derive(Deserialize)]
 struct Scenario {
@@ -329,21 +332,6 @@ fn query_scalar(fixture: &Fixture, sql: &str) -> i64 {
     })
 }
 
-fn execute_sql(fixture: &Fixture, sql: &str, params: impl libsql::params::IntoParams) {
-    let db_path = fixture.db_path();
-    let sql = sql.to_string();
-    runtime().block_on(async move {
-        let db = libsql::Builder::new_local(&db_path)
-            .build()
-            .await
-            .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
-        let conn = db.connect().expect("db connect");
-        conn.execute(&sql, params)
-            .await
-            .unwrap_or_else(|e| panic!("execute `{sql}`: {e}"));
-    });
-}
-
 fn fact_ids_by_source(fixture: &Fixture) -> HashMap<String, HashSet<i64>> {
     let db_path = fixture.db_path();
     runtime().block_on(async move {
@@ -364,6 +352,60 @@ fn fact_ids_by_source(fixture: &Fixture) -> HashMap<String, HashSet<i64>> {
         }
         map
     })
+}
+
+fn seed_setup_facts(fixture: &Fixture, facts: &[SeedFact]) {
+    if facts.is_empty() {
+        return;
+    }
+
+    let db_path = fixture.db_path();
+    runtime().block_on(async move {
+        let db = libsql::Builder::new_local(&db_path)
+            .build()
+            .await
+            .unwrap_or_else(|e| panic!("open {}: {e}", db_path.display()));
+        let conn = db.connect().expect("db connect");
+        let store = MemoryStore::new(&conn);
+        for fact in facts {
+            let category = fact
+                .category
+                .parse::<MemoryCategory>()
+                .unwrap_or_else(|e| panic!("invalid seed fact category `{}`: {e}", fact.category));
+            let outcome = store
+                .add_fact(
+                    AddFactRequest {
+                        content: fact.content.clone(),
+                        category,
+                        source: Some(fact.source.clone()),
+                        tags: Vec::new(),
+                        entities: Vec::new(),
+                        trust: Some(fact.trust),
+                        metadata: serde_json::json!({}),
+                    },
+                    DEFAULT_TRUST,
+                )
+                .await
+                .unwrap_or_else(|e| panic!("seed setup fact `{}`: {e}", fact.content));
+            assert!(
+                outcome.fact.is_some(),
+                "seed setup fact should be stored: {}",
+                fact.content
+            );
+            conn.execute(
+                "UPDATE memory_facts SET trust_score = ?1, retrieval_count = ?2, source = ?3 \
+                 WHERE content = ?4",
+                libsql::params![
+                    fact.trust,
+                    fact.retrieval_count,
+                    fact.source.as_str(),
+                    fact.content.as_str()
+                ],
+            )
+            .await
+            .unwrap_or_else(|e| panic!("update seed setup fact `{}`: {e}", fact.content));
+        }
+    });
 }
 
 fn canonical_test_dir(path: &Path) -> PathBuf {
@@ -394,31 +436,10 @@ fn build_fixture(setup: &Setup) -> Fixture {
             .unwrap_or_else(|e| panic!("write fixture file {name}: {e}"));
     }
     run_ok(&fixture, &["init"]);
+    seed_setup_facts(&fixture, &setup.facts);
     #[cfg(unix)]
     {
         fixture._daemon = Some(common::spawn_tracedecay_daemon(&fixture.home_path));
-    }
-    for fact in &setup.facts {
-        let args = serde_json::json!({
-            "action": "add",
-            "content": fact.content,
-            "category": fact.category,
-        });
-        run_ok(
-            &fixture,
-            &["tool", "fact_store", "--args", &args.to_string()],
-        );
-        execute_sql(
-            &fixture,
-            "UPDATE memory_facts SET trust_score = ?1, retrieval_count = ?2, source = ?3 \
-             WHERE content = ?4",
-            libsql::params![
-                fact.trust,
-                fact.retrieval_count,
-                fact.source.as_str(),
-                fact.content.as_str()
-            ],
-        );
     }
     fixture
 }

--- a/tests/memory_test.rs
+++ b/tests/memory_test.rs
@@ -1061,23 +1061,38 @@ async fn remove_fact_incremental_vacuum_reclaims_blob_pages() {
     let store = MemoryStore::new(db.conn());
     let db_path = tmp.path().join("tracedecay.db");
     let mut fact_ids = Vec::new();
+    let vector = HolographicEncoder::serialize(&vec![0.0; HolographicEncoder::DIMENSIONS])
+        .expect("serialize compact HRR vector");
+    assert_eq!(vector.len(), HolographicEncoder::SERIALIZED_F32_BYTES);
 
-    for idx in 0..96 {
-        let fact = store
-            .add_fact(
-                fact_request(
-                    &format!("incremental vacuum blob reclamation fixture {idx}"),
-                    MemoryCategory::Project,
-                    0.8,
-                ),
-                DEFAULT_TRUST,
+    db.conn().execute("BEGIN IMMEDIATE", ()).await.unwrap();
+    for idx in 0..48 {
+        let fact_id = 50_000 + idx;
+        db.conn()
+            .execute(
+                "INSERT INTO memory_facts (
+                    fact_id, content, category, tags, trust_score, created_at,
+                    updated_at, source, metadata, hrr_vector, hrr_algebra, hrr_dim, hrr_precision
+                 )
+                 VALUES (?1, ?2, ?3, '[]', ?4, ?5, ?5, ?6, '{}', ?7, ?8, ?9, ?10)",
+                libsql::params![
+                    fact_id,
+                    format!("incremental vacuum blob reclamation fixture {idx}"),
+                    MemoryCategory::Project.as_str(),
+                    0.8_f64,
+                    1_900_000_000_i64 + idx,
+                    "test",
+                    vector.clone(),
+                    "amari_fhrr",
+                    HolographicEncoder::DIMENSIONS as i64,
+                    HolographicEncoder::HRR_PRECISION,
+                ],
             )
             .await
-            .unwrap()
-            .fact
             .unwrap();
-        fact_ids.push(fact.fact_id);
+        fact_ids.push(fact_id);
     }
+    db.conn().execute("COMMIT", ()).await.unwrap();
     db.conn()
         .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
         .await

--- a/tests/session_lcm_payload_test.rs
+++ b/tests/session_lcm_payload_test.rs
@@ -12,6 +12,45 @@ use common::{
     lcm_payload_session as sample_session, open_lcm_db,
 };
 
+fn externalized_tool_payload(prefix: &str, fill: char) -> String {
+    fn with_filler(prefix: &str, fill: char, filler_chars: usize) -> String {
+        format!("{prefix}{}", fill.to_string().repeat(filler_chars))
+    }
+
+    let externalizes = |candidate: &str| {
+        tracedecay::sessions::lcm::security::should_externalize(
+            "tool",
+            Some("tool_result"),
+            candidate,
+        )
+    };
+
+    let mut high = 1024;
+    while !externalizes(&with_filler(prefix, fill, high)) {
+        high = high
+            .checked_mul(2)
+            .filter(|next| *next <= 2 * 1024 * 1024)
+            .expect("tool payload fixture should externalize before 2 MiB");
+    }
+
+    let mut low = 0;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if externalizes(&with_filler(prefix, fill, mid)) {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+
+    let payload = with_filler(prefix, fill, low);
+    assert!(externalizes(&payload));
+    if low > 0 {
+        assert!(!externalizes(&with_filler(prefix, fill, low - 1)));
+    }
+    payload
+}
+
 async fn raw_snippet_and_index(
     db_path: &std::path::Path,
     provider: &str,
@@ -806,7 +845,7 @@ async fn externalized_payload_indexes_placeholder_without_body_text() {
 
     let unique_secret = "uniquebodysecretdonotindex";
     let metadata_secret = "uniquemetadatasecretdonotindex";
-    let payload = format!("tool output {unique_secret}\n{}", "B".repeat(900_000));
+    let payload = externalized_tool_payload(&format!("tool output {unique_secret}\n"), 'B');
     let mut message = raw_message("cursor", "tool-secret", "session-1", "tool", &payload);
     message.metadata_json = Some(format!(r#"{{"payload_preview":"{metadata_secret}"}}"#));
     let store = db.lcm_store(&storage_root);
@@ -863,7 +902,7 @@ async fn lcm_status_reports_missing_and_orphan_payloads_without_previewing_conte
             .await
     );
 
-    let secret = format!("SUPER_SECRET_PAYLOAD\n{}", "S".repeat(300_000));
+    let secret = externalized_tool_payload("SUPER_SECRET_PAYLOAD\n", 'S');
     let message = raw_message("cursor", "message-1", "session-1", "tool", &secret);
     let store = db.lcm_store(&storage_root);
     store
@@ -939,7 +978,7 @@ async fn denies_cross_session_payload_expansion() {
             .await
     );
 
-    let payload = format!("secret tool output\n{}", "S".repeat(300_000));
+    let payload = externalized_tool_payload("secret tool output\n", 'S');
     let message = raw_message("cursor", "message-a", "session-a", "tool", &payload);
     let store = db.lcm_store(&storage_root);
     store
@@ -970,7 +1009,7 @@ async fn delete_external_payload_rejects_referenced_payload_without_hash_verific
             .await
     );
 
-    let payload = format!("active referenced payload\n{}", "R".repeat(300_000));
+    let payload = externalized_tool_payload("active referenced payload\n", 'R');
     let message = raw_message(
         "cursor",
         "referenced-payload",
@@ -1037,7 +1076,7 @@ async fn denies_expansion_after_message_updates_to_new_payload_ref() {
             .await
     );
 
-    let first_payload = format!("first secret tool output\n{}", "F".repeat(300_000));
+    let first_payload = externalized_tool_payload("first secret tool output\n", 'F');
     let mut message = raw_message(
         "cursor",
         "message-update",
@@ -1057,7 +1096,7 @@ async fn denies_expansion_after_message_updates_to_new_payload_ref() {
         .payload_ref
         .expect("first payload ref");
 
-    let second_payload = format!("second secret tool output\n{}", "G".repeat(300_000));
+    let second_payload = externalized_tool_payload("second secret tool output\n", 'G');
     message.text = second_payload.clone();
     store
         .ingest_raw_message(&message)
@@ -1102,7 +1141,7 @@ async fn external_payload_write_rejects_preexisting_symlink_ref() {
             .await
     );
 
-    let payload = format!("tool output\n{}", "C".repeat(900_000));
+    let payload = externalized_tool_payload("tool output\n", 'C');
     let payload_ref = expected_payload_ref("cursor", "session-1", "tool-symlink", &payload);
     let payload_dir = tracedecay::sessions::lcm::payload::payload_dir(&storage_root);
     std::fs::create_dir_all(&payload_dir).unwrap();
@@ -1144,7 +1183,7 @@ async fn external_payload_write_rejects_symlinked_payload_directory() {
             .await
     );
 
-    let payload = format!("tool output\n{}", "D".repeat(900_000));
+    let payload = externalized_tool_payload("tool output\n", 'D');
     let payload_ref = expected_payload_ref("cursor", "session-1", "tool-dir-symlink", &payload);
     let message = raw_message("cursor", "tool-dir-symlink", "session-1", "tool", &payload);
     let store = db.lcm_store(&storage_root);
@@ -1237,9 +1276,9 @@ async fn redaction_applies_before_whole_message_externalization() {
     );
 
     let secret = "sk-prequel1234567890abcdef";
-    let content = format!(
-        "tool output api_key={secret} preexternalredactcanary\n{}",
-        "B".repeat(300_000)
+    let content = externalized_tool_payload(
+        &format!("tool output api_key={secret} preexternalredactcanary\n"),
+        'B',
     );
     let mut message = raw_message(
         "cursor",

--- a/tests/session_lcm_query_test.rs
+++ b/tests/session_lcm_query_test.rs
@@ -80,23 +80,70 @@ async fn insert_session(db: &GlobalDb, provider: &str, session_id: &str) {
 
 async fn insert_raw_messages(
     db: &GlobalDb,
+    db_path: &std::path::Path,
     provider: &str,
     session_id: &str,
     contents: &[String],
 ) -> Vec<i64> {
     insert_session(db, provider, session_id).await;
-    let mut store_ids = Vec::new();
+    let mut message_ids = Vec::new();
     for (idx, content) in contents.iter().enumerate() {
         let message_id = format!("{session_id}-message-{:03}", idx + 1);
         let message = raw_message(provider, &message_id, session_id, (idx + 1) as i64, content);
         assert!(db.upsert_session_message(&message).await);
-        let raw = db
-            .lcm_load_raw_message(provider, &message_id)
-            .await
-            .expect("raw message should exist");
-        store_ids.push(raw.store_id);
+        message_ids.push(message_id);
     }
-    store_ids
+
+    if message_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let mut store_ids_by_message_id = std::collections::BTreeMap::new();
+    let raw_db = libsql::Builder::new_local(db_path).build().await.unwrap();
+    let conn = raw_db.connect().unwrap();
+    let placeholders = std::iter::repeat_n("?", message_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT message_id, store_id
+         FROM lcm_raw_messages
+         WHERE provider = ?
+           AND session_id = ?
+           AND message_id IN ({placeholders})
+         ORDER BY message_id"
+    );
+    let mut values = vec![
+        libsql::Value::Text(provider.to_string()),
+        libsql::Value::Text(session_id.to_string()),
+    ];
+    values.extend(message_ids.iter().cloned().map(libsql::Value::Text));
+    let mut rows = conn
+        .query(&sql, libsql::params_from_iter(values))
+        .await
+        .expect("raw message store ids should query after insert");
+    while let Some(row) = rows
+        .next()
+        .await
+        .expect("raw message store id row should read")
+    {
+        let message_id = row
+            .get::<String>(0)
+            .expect("raw message message_id should decode");
+        let store_id = row
+            .get::<i64>(1)
+            .expect("raw message store_id should decode");
+        store_ids_by_message_id.insert(message_id, store_id);
+    }
+
+    assert_eq!(store_ids_by_message_id.len(), message_ids.len());
+    message_ids
+        .into_iter()
+        .map(|message_id| {
+            *store_ids_by_message_id
+                .get(&message_id)
+                .unwrap_or_else(|| panic!("raw message {message_id} should exist"))
+        })
+        .collect()
 }
 
 fn summary_draft(
@@ -152,7 +199,14 @@ async fn load_session_returns_ordered_raw_pages_with_stable_cursor() {
     let contents = (1..=105)
         .map(|idx| format!("message-{idx:03}"))
         .collect::<Vec<_>>();
-    let store_ids = insert_raw_messages(&db, "cursor", "session-1", &contents).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-1",
+        &contents,
+    )
+    .await;
 
     let first = db
         .lcm_load_session(LcmLoadSessionRequest {
@@ -232,6 +286,7 @@ async fn grep_searches_raw_snippets_and_summary_nodes() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -292,6 +347,7 @@ async fn grep_tokenizes_punctuation_heavy_path_like_queries() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -338,6 +394,7 @@ async fn grep_like_fallback_recalls_infix_hyphen_query_matches() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -387,6 +444,7 @@ async fn grep_like_fallback_recalls_infix_slash_query_matches() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["the docs mention srcfoo as a fused path token".to_string()],
@@ -422,6 +480,7 @@ async fn grep_like_fallback_handles_hash_separator_queries() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["the log references issue#123 inside a Cursor transcript".to_string()],
@@ -454,6 +513,7 @@ async fn grep_quotes_reserved_operator_looking_query_text() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -491,6 +551,7 @@ async fn grep_preserves_quoted_phrase_semantics() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -527,6 +588,7 @@ async fn grep_preserves_boolean_or_semantics() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -572,6 +634,7 @@ async fn grep_cjk_query_uses_like_fallback_substring_matching() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -744,6 +807,7 @@ async fn status_reports_schema_frontier_payload_and_debt_counts() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["alpha".to_string(), "beta".to_string()],
@@ -897,7 +961,14 @@ async fn describe_gives_session_overview_without_full_payload_bodies() {
     let tmp = TempDir::new().unwrap();
     let storage_root = tmp.path().join(".tracedecay");
     let db = open_lcm_db(&tmp).await;
-    let store_ids = insert_raw_messages(&db, "cursor", "session-1", &["alpha".to_string()]).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-1",
+        &["alpha".to_string()],
+    )
+    .await;
     let payload = format!("describe secret body\n{}", "D".repeat(300_000));
     let mut external = raw_message("cursor", "tool-describe", "session-1", 2, &payload);
     external.role = "tool".to_string();
@@ -947,6 +1018,7 @@ async fn describe_node_and_external_payload_return_metadata_without_body_leaks()
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -1056,6 +1128,7 @@ async fn expand_returns_sliced_raw_summary_and_payload_content_with_ranges() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["0123456789abcdef".to_string()],
@@ -1187,7 +1260,14 @@ async fn expand_slices_summary_source_content_and_nested_source_bodies() {
         .join(" ");
     let huge_source = format!("source-prefix-{filler}");
     let huge_source_chars = huge_source.chars().count() as u64;
-    let store_ids = insert_raw_messages(&db, "cursor", "session-1", &[huge_source]).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-1",
+        &[huge_source],
+    )
+    .await;
     let summary = db
         .lcm_insert_summary_node(summary_draft(
             "cursor",
@@ -1249,8 +1329,14 @@ async fn expand_slices_summary_source_content_and_nested_source_bodies() {
 async fn expand_wrapper_denies_cross_session_summary_nodes() {
     let tmp = TempDir::new().unwrap();
     let db = open_lcm_db(&tmp).await;
-    let store_ids =
-        insert_raw_messages(&db, "cursor", "session-1", &["owned by session one".into()]).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-1",
+        &["owned by session one".into()],
+    )
+    .await;
     insert_session(&db, "cursor", "session-2").await;
     let summary = db
         .lcm_insert_summary_node(summary_draft(
@@ -1287,6 +1373,7 @@ async fn expand_query_returns_no_match_without_synthesis() {
     let db = open_lcm_db(&tmp).await;
     insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["ordinary transcript without the target term".to_string()],
@@ -1324,6 +1411,7 @@ async fn expand_query_selects_summary_and_raw_context_blocks() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &[
@@ -1390,7 +1478,14 @@ async fn expand_query_reports_context_budget_truncation() {
     let tmp = TempDir::new().unwrap();
     let db = open_lcm_db(&tmp).await;
     let long_source = format!("raw lemon details {}", "L".repeat(4000));
-    let store_ids = insert_raw_messages(&db, "cursor", "session-1", &[long_source]).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-1",
+        &[long_source],
+    )
+    .await;
     let summary = db
         .lcm_insert_summary_node(summary_draft(
             "cursor",
@@ -1437,7 +1532,14 @@ async fn expand_paginates_summary_sources_with_offset_and_limit() {
     let contents: Vec<String> = (1..=5)
         .map(|index| format!("source body {index}"))
         .collect();
-    let store_ids = insert_raw_messages(&db, "cursor", "session-1", &contents).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-1",
+        &contents,
+    )
+    .await;
     let summary = db
         .lcm_insert_summary_node(summary_draft(
             "cursor",
@@ -1524,6 +1626,7 @@ async fn expand_allows_cross_session_raw_store_id_with_provenance() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["cross session body".to_string()],
@@ -1648,6 +1751,7 @@ async fn status_reports_dag_depth_distribution_store_estimate_and_config_default
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-1",
         &["alpha beta gamma".to_string(), "delta epsilon".to_string()],
@@ -1723,6 +1827,7 @@ async fn status_uses_python_half_even_rounding_for_ratio_ties() {
     let db = open_lcm_db(&tmp).await;
     let store_ids = insert_raw_messages(
         &db,
+        &isolated_db_path(&tmp),
         "cursor",
         "session-tie",
         &["alpha".to_string(), "beta".to_string()],
@@ -1756,7 +1861,14 @@ async fn load_session_exact_final_page_omits_next_cursor() {
     let contents = (1..=4)
         .map(|idx| format!("edge-message-{idx}"))
         .collect::<Vec<_>>();
-    let store_ids = insert_raw_messages(&db, "cursor", "session-edge", &contents).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-edge",
+        &contents,
+    )
+    .await;
     let request = |after_store_id: Option<i64>, limit: usize| LcmLoadSessionRequest {
         provider: "cursor".into(),
         session_id: "session-edge".into(),
@@ -1873,7 +1985,14 @@ async fn content_slices_use_char_offsets_for_multibyte_content() {
     let content = "αβγδε🦀abc".to_string();
     assert_eq!(content.chars().count(), 9);
     assert_eq!(content.len(), 17);
-    let store_ids = insert_raw_messages(&db, "cursor", "session-utf8", &[content]).await;
+    let store_ids = insert_raw_messages(
+        &db,
+        &isolated_db_path(&tmp),
+        "cursor",
+        "session-utf8",
+        &[content],
+    )
+    .await;
 
     let page = db
         .lcm_load_session(LcmLoadSessionRequest {


### PR DESCRIPTION
## Summary
- keep Windows at 10 nextest shards, after live timing showed weighted sharding was slower under the current GitHub scheduling model
- speed up memory fixtures by directly seeding expensive setup rows and initializing memory eval fixtures in-process while preserving CLI replay steps
- reduce Windows-heavy test setup across LCM, dashboard memory, branch safety, and MCP LCM fixtures
- keep test semantics covered while trimming repeated subprocess, SQLite, large-payload, and full-index setup work

## Verification
- cargo nextest run --test memory_eval_test --test session_lcm_query_test --test session_lcm_payload_test --test mcp_handler_test --test dashboard_memory_curation_api_test --test branch_drift_test --test branch_db_safety_test --profile ci --locked --status-level slow --no-fail-fast
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --test memory_eval_test --test session_lcm_query_test --test session_lcm_payload_test --test mcp_handler_test --test dashboard_memory_curation_api_test --test branch_drift_test --test branch_db_safety_test --locked -- -D warnings
- scripts/check-conventional-commits.sh origin/master..HEAD

## Timing Notes
- Previous fixture-only run completed all Windows test steps, but shard 4 failed during `actions/upload-artifact` finalization with HTTP 403.
- Usable JUnit from that run showed the vacuum memory fixture dropped from ~87s to ~27s versus the prior green run.
- The current run for this broader fixture pass is still in progress.
