### PR TITLE
test: simplify Windows payload fixture

### DIFF
--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -114,6 +114,7 @@ impl Database {
             operation: "initialize".to_string(),
         })?;
 
+        migrations::configure_fresh_auto_vacuum(&conn, "initialize").await?;
         Self::apply_pragmas(&conn, 0).await?;
         migrations::create_schema(&conn).await?;
 

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -107,10 +107,24 @@ async fn enable_incremental_auto_vacuum(
     Ok(())
 }
 
+/// Configures incremental auto-vacuum for a brand-new database before any
+/// schema-shaping pragmas or tables are created.
+pub(crate) async fn configure_fresh_auto_vacuum(conn: &Connection, operation: &str) -> Result<()> {
+    conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL;")
+        .await
+        .map_err(|e| TraceDecayError::Database {
+            message: format!("{operation}: failed to configure fresh auto_vacuum: {e}"),
+            operation: operation.to_string(),
+        })?;
+    Ok(())
+}
+
 /// Creates the complete latest schema from scratch for a brand-new database.
 /// This avoids running v0→v1→…→v6 migrations sequentially.
 pub async fn create_schema(conn: &Connection) -> Result<()> {
-    enable_incremental_auto_vacuum(conn, "create_schema", true).await?;
+    // Fresh databases only need the pragma before tables are created. Existing
+    // databases still get rebuilt through migrate's vacuuming repair path.
+    enable_incremental_auto_vacuum(conn, "create_schema", false).await?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS nodes (
             id TEXT PRIMARY KEY,

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -200,8 +200,13 @@ impl<'a> GraphQueryManager<'a> {
         kind_filter: &str,
     ) -> Result<Vec<Node>> {
         let marker_ids = self.db.collect_test_marker_ids().await?;
-        self.db.populate_test_marker_temp_table(&marker_ids).await?;
-        self.db.populate_test_annotated_targets_temp_table().await?;
+        let test_annotated_targets_filter = if marker_ids.is_empty() {
+            ""
+        } else {
+            self.db.populate_test_marker_temp_table(&marker_ids).await?;
+            self.db.populate_test_annotated_targets_temp_table().await?;
+            "AND id NOT IN (SELECT target FROM temp.test_annotated_targets)"
+        };
 
         let sql = format!(
             "SELECT id, kind, name, qualified_name, file_path, start_line, end_line,
@@ -218,7 +223,7 @@ impl<'a> GraphQueryManager<'a> {
                  WHERE target = nodes.id
                  AND kind IN ('calls', 'implements', 'extends', 'type_of', 'returns', 'receives', 'uses')
              )
-             AND id NOT IN (SELECT target FROM temp.test_annotated_targets)"
+             {test_annotated_targets_filter}"
         );
 
         let mut rows =

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -812,6 +812,9 @@ mod tests {
 
     #[tokio::test]
     async fn selected_project_retrieve_finds_selected_project_response_handle() {
+        const LARGE_RESPONSE_MARKER_COUNT: usize = 120;
+        const LAST_LARGE_RESPONSE_MARKER: usize = LARGE_RESPONSE_MARKER_COUNT - 1;
+
         let _env_lock = SELECTOR_ENV_LOCK.lock().await;
         let dir = TempDir::new().unwrap();
         let _env = SelectorEnv::new(dir.path());
@@ -826,7 +829,7 @@ mod tests {
         .unwrap();
 
         let mut target_source = String::new();
-        for i in 0..420 {
+        for i in 0..LARGE_RESPONSE_MARKER_COUNT {
             let _ = writeln!(
                 target_source,
                 "pub fn selected_project_handle_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}"
@@ -852,7 +855,7 @@ mod tests {
             json!({
                 "query": "selected_project_handle_marker",
                 "project_id": target_project_id,
-                "limit": 420,
+                "limit": LARGE_RESPONSE_MARKER_COUNT,
                 "format": "json"
             }),
             None,
@@ -901,7 +904,9 @@ mod tests {
         assert!(
             payload["content"]
                 .as_str()
-                .is_some_and(|content| content.contains("selected_project_handle_marker_419")),
+                .is_some_and(|content| content.contains(&format!(
+                    "selected_project_handle_marker_{LAST_LARGE_RESPONSE_MARKER:03}"
+                ))),
             "selected project retrieve should return the full selected-project response: {payload}"
         );
     }

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -334,7 +334,6 @@ mod tests {
             .ok_or_else(|| std::io::Error::other("failed to open test global db"))?;
 
         let first_exact = dir.path().join("first").join("target");
-        std::fs::create_dir_all(&first_exact)?;
         db.upsert_code_project("z_exact_old", &first_exact, None, None, Some("main"))
             .await
             .ok_or_else(|| std::io::Error::other("failed to insert first exact project"))?;
@@ -344,7 +343,6 @@ mod tests {
                 .path()
                 .join("noise")
                 .join(format!("target-noise-{index:03}"));
-            std::fs::create_dir_all(&root)?;
             db.upsert_code_project(
                 &format!("n_noise_{index:03}"),
                 &root,
@@ -357,7 +355,6 @@ mod tests {
         }
 
         let second_exact = dir.path().join("second").join("target");
-        std::fs::create_dir_all(&second_exact)?;
         db.upsert_code_project("a_exact_new", &second_exact, None, None, Some("main"))
             .await
             .ok_or_else(|| std::io::Error::other("failed to insert second exact project"))?;

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -279,12 +279,79 @@ fn unresolved_project_selector_error(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use libsql::{params, Connection};
     use serde_json::json;
     use tempfile::TempDir;
 
     use crate::global_db::GlobalDb;
 
     use super::{require_node_id, string_array_values, unique_project_basename_context};
+
+    struct TestProjectSeed {
+        project_id: String,
+        project_root: PathBuf,
+    }
+
+    async fn seed_code_project_registry_rows(
+        db: &GlobalDb,
+        projects: &[TestProjectSeed],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let conn = db.dashboard_connection();
+        conn.execute("BEGIN IMMEDIATE", ()).await?;
+        if let Err(err) = seed_code_project_registry_rows_in_tx(&conn, projects).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(Box::new(err));
+        }
+        if let Err(err) = conn.execute("COMMIT", ()).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(Box::new(err));
+        }
+        Ok(())
+    }
+
+    async fn seed_code_project_registry_rows_in_tx(
+        conn: &Connection,
+        projects: &[TestProjectSeed],
+    ) -> std::result::Result<(), libsql::Error> {
+        let now = crate::tracedecay::current_timestamp();
+        for project in projects {
+            let canonical_root = GlobalDb::canonical_project_key(&project.project_root);
+            let display_root = project.project_root.to_string_lossy().to_string();
+            conn.execute(
+                "INSERT INTO code_projects
+                 (project_id, canonical_root, display_root, git_common_dir, git_remote_url,
+                  default_branch, created_at, last_seen_at)
+                 VALUES (?1, ?2, ?3, NULL, NULL, ?4, ?5, ?5)
+                 ON CONFLICT(project_id) DO UPDATE SET
+                    canonical_root = excluded.canonical_root,
+                    display_root = excluded.display_root,
+                    git_common_dir = excluded.git_common_dir,
+                    git_remote_url = excluded.git_remote_url,
+                    default_branch = excluded.default_branch,
+                    last_seen_at = excluded.last_seen_at",
+                params![
+                    project.project_id.as_str(),
+                    canonical_root.as_str(),
+                    display_root.as_str(),
+                    "main",
+                    now,
+                ],
+            )
+            .await?;
+            conn.execute(
+                "INSERT INTO project_aliases (alias_path, project_id, last_seen_at)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(alias_path) DO UPDATE SET
+                    project_id = excluded.project_id,
+                    last_seen_at = excluded.last_seen_at",
+                params![canonical_root.as_str(), project.project_id.as_str(), now],
+            )
+            .await?;
+        }
+        Ok(())
+    }
 
     #[test]
     fn test_require_node_id_canonical() {
@@ -333,31 +400,25 @@ mod tests {
             .await
             .ok_or_else(|| std::io::Error::other("failed to open test global db"))?;
 
-        let first_exact = dir.path().join("first").join("target");
-        db.upsert_code_project("z_exact_old", &first_exact, None, None, Some("main"))
-            .await
-            .ok_or_else(|| std::io::Error::other("failed to insert first exact project"))?;
-
+        let mut projects = Vec::with_capacity(102);
+        projects.push(TestProjectSeed {
+            project_id: "z_exact_old".to_string(),
+            project_root: dir.path().join("first").join("target"),
+        });
         for index in 0..100 {
-            let root = dir
-                .path()
-                .join("noise")
-                .join(format!("target-noise-{index:03}"));
-            db.upsert_code_project(
-                &format!("n_noise_{index:03}"),
-                &root,
-                None,
-                None,
-                Some("main"),
-            )
-            .await
-            .ok_or_else(|| std::io::Error::other("failed to insert noise project"))?;
+            projects.push(TestProjectSeed {
+                project_id: format!("n_noise_{index:03}"),
+                project_root: dir
+                    .path()
+                    .join("noise")
+                    .join(format!("target-noise-{index:03}")),
+            });
         }
-
-        let second_exact = dir.path().join("second").join("target");
-        db.upsert_code_project("a_exact_new", &second_exact, None, None, Some("main"))
-            .await
-            .ok_or_else(|| std::io::Error::other("failed to insert second exact project"))?;
+        projects.push(TestProjectSeed {
+            project_id: "a_exact_new".to_string(),
+            project_root: dir.path().join("second").join("target"),
+        });
+        seed_code_project_registry_rows(&db, &projects).await?;
 
         assert!(
             unique_project_basename_context(&db, "target")

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -297,16 +297,16 @@ mod tests {
     async fn seed_code_project_registry_rows(
         db: &GlobalDb,
         projects: &[TestProjectSeed],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> std::result::Result<(), libsql::Error> {
         let conn = db.dashboard_connection();
         conn.execute("BEGIN IMMEDIATE", ()).await?;
         if let Err(err) = seed_code_project_registry_rows_in_tx(&conn, projects).await {
             let _ = conn.execute("ROLLBACK", ()).await;
-            return Err(Box::new(err));
+            return Err(err);
         }
         if let Err(err) = conn.execute("COMMIT", ()).await {
             let _ = conn.execute("ROLLBACK", ()).await;
-            return Err(Box::new(err));
+            return Err(err);
         }
         Ok(())
     }

--- a/tests/cli_non_interactive_test.rs
+++ b/tests/cli_non_interactive_test.rs
@@ -97,7 +97,9 @@ fn add_tracedecay_path_shim(command: &mut Command, home: &Path) -> PathBuf {
     } else {
         "tracedecay"
     });
-    std::fs::copy(env!("CARGO_BIN_EXE_tracedecay"), &shim).unwrap();
+    if std::fs::hard_link(env!("CARGO_BIN_EXE_tracedecay"), &shim).is_err() {
+        std::fs::copy(env!("CARGO_BIN_EXE_tracedecay"), &shim).unwrap();
+    }
     #[cfg(unix)]
     {
         let mut permissions = std::fs::metadata(&shim).unwrap().permissions();

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -34,6 +34,11 @@ struct DashboardFixture {
     linked_node_id: String,
 }
 
+#[derive(Clone, Copy, Default)]
+struct FixtureOptions {
+    external_payload: bool,
+}
+
 impl Drop for DashboardFixture {
     fn drop(&mut self) {
         self.server.abort();
@@ -111,13 +116,14 @@ fn summary_draft(
 }
 
 /// Seeds the session, four messages (two same-second messages inserted out of
-/// ordinal order, one with tool metadata, one externalized tool payload with
-/// `content = NULL`), and three summary nodes. Returns the node_id of the
-/// summary node that references msg-c.
+/// ordinal order, one with tool metadata, and one optional externalized tool
+/// payload with `content = NULL`), and three summary nodes. Returns the node_id
+/// of the summary node that references msg-c.
 async fn seed_lcm_fixture(
     global_db: &GlobalDb,
     storage_root: &Path,
     project_path: &Path,
+    external_payload: bool,
 ) -> String {
     let session = SessionRecord {
         provider: PROVIDER.to_string(),
@@ -170,28 +176,43 @@ async fn seed_lcm_fixture(
         }
     }
 
-    // Externalized tool payload: > 256k chars of tool output forces
-    // storage_kind = 'external' with content = NULL in lcm_raw_messages.
-    // The searchable needle is planted into snippet_text/index_text after
-    // ingest (see plant_external_needle), modeling the review scenario of a
-    // NULL-content row whose derived text is the only searchable surface.
-    let mut external_text = String::from("externalized tool payload head ");
-    external_text.push_str(&"x".repeat(300_000));
-    let mut external = message("msg-x", "tool", 4, 1_700_002_200, &external_text);
-    external.kind = Some("tool_result".to_string());
-    if let Err(err) = global_db
-        .lcm_store(storage_root)
-        .ingest_raw_message(&external)
-        .await
-    {
-        panic!("failed to ingest externalized message fixture: {err}");
-    }
-    match global_db.lcm_load_raw_message(PROVIDER, "msg-x").await {
-        Some(record) => assert!(
-            matches!(record.storage_kind, LcmStorageKind::External),
-            "fixture message msg-x must be externalized"
-        ),
-        None => panic!("missing seeded message msg-x"),
+    let msg_x = if external_payload {
+        let mut external_text = String::from("externalized tool payload head ");
+        external_text.push_str(&"x".repeat(300_000));
+        let mut external = message("msg-x", "tool", 4, 1_700_002_200, &external_text);
+        external.kind = Some("tool_result".to_string());
+        external
+    } else {
+        message(
+            "msg-x",
+            "assistant",
+            4,
+            1_700_002_200,
+            "delta lightweight fixture message",
+        )
+    };
+    if external_payload {
+        // Externalized tool payload: > 256k chars of tool output forces
+        // storage_kind = 'external' with content = NULL in lcm_raw_messages.
+        // The searchable needle is planted into snippet_text/index_text after
+        // ingest (see plant_external_needle), modeling the review scenario of a
+        // NULL-content row whose derived text is the only searchable surface.
+        if let Err(err) = global_db
+            .lcm_store(storage_root)
+            .ingest_raw_message(&msg_x)
+            .await
+        {
+            panic!("failed to ingest externalized message fixture: {err}");
+        }
+        match global_db.lcm_load_raw_message(PROVIDER, "msg-x").await {
+            Some(record) => assert!(
+                matches!(record.storage_kind, LcmStorageKind::External),
+                "fixture message msg-x must be externalized"
+            ),
+            None => panic!("missing seeded message msg-x"),
+        }
+    } else if !global_db.upsert_session_message(&msg_x).await {
+        panic!("failed to upsert message fixture {}", msg_x.message_id);
     }
 
     let store_a = store_id_of(global_db, "msg-a").await;
@@ -301,7 +322,7 @@ async fn corrupt_summary_node_metadata(global_db_path: &Path, node_id: &str) {
     }
 }
 
-async fn start_fixture(break_message_fts: bool) -> DashboardFixture {
+async fn start_fixture(options: FixtureOptions) -> DashboardFixture {
     let tmp = tempdir_or_panic();
     let project_root = tmp.path().join("project");
     let global_db_path = tmp.path().join("global").join("global.db");
@@ -323,14 +344,18 @@ async fn start_fixture(break_message_fts: bool) -> DashboardFixture {
     if let Err(err) = std::fs::create_dir_all(storage_root) {
         panic!("failed to create LCM storage root: {err}");
     }
-    let linked_node_id = seed_lcm_fixture(&global_db, storage_root, &project_root).await;
+    let linked_node_id = seed_lcm_fixture(
+        &global_db,
+        storage_root,
+        &project_root,
+        options.external_payload,
+    )
+    .await;
     drop(global_db);
 
-    plant_external_needle(&session_db_path).await;
-    if break_message_fts {
-        drop_raw_message_fts(&session_db_path).await;
+    if options.external_payload {
+        plant_external_needle(&session_db_path).await;
     }
-
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
@@ -392,7 +417,7 @@ fn timeline_excludes_null_timestamps_and_reports_undated_count() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(false).await;
+        let fixture = start_fixture(FixtureOptions::default()).await;
         insert_undated_message(&fixture.global_db_path).await;
         let agent = http_agent();
 
@@ -452,7 +477,7 @@ fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(false).await;
+        let fixture = start_fixture(FixtureOptions::default()).await;
         corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
         let agent = http_agent();
 
@@ -481,7 +506,7 @@ fn lcm_bad_params_and_missing_resources_return_json_errors() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(false).await;
+        let fixture = start_fixture(FixtureOptions::default()).await;
         let agent = http_agent();
 
         let (status, bad_query) = get_json(
@@ -541,7 +566,10 @@ fn session_endpoint_orders_by_ordinal_paginates_nodes_and_enriches_messages() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(false).await;
+        let fixture = start_fixture(FixtureOptions {
+            external_payload: true,
+        })
+        .await;
         let agent = http_agent();
 
         let (status, session) = get_json(
@@ -663,7 +691,10 @@ fn search_matches_externalized_messages_and_qualifies_summary_fts() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(false).await;
+        let fixture = start_fixture(FixtureOptions {
+            external_payload: true,
+        })
+        .await;
         let agent = http_agent();
 
         // Fix 1 (FTS mode): the externalized message is indexed via

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -793,18 +793,8 @@ fn search_matches_externalized_messages_and_qualifies_summary_fts() {
             "offset past the result set must return an empty page"
         );
         assert_eq!(page_4["total"]["messages"], 3);
-    });
-}
 
-#[test]
-fn search_engine_flag_reports_like_fallback_accurately() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(true).await;
-        let agent = http_agent();
+        drop_raw_message_fts(&fixture.global_db_path).await;
 
         // Fix 4: with the raw-message FTS table dropped, message search must
         // fall back to LIKE while node FTS still works; the top-level engine

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -34,11 +34,6 @@ struct DashboardFixture {
     linked_node_id: String,
 }
 
-#[derive(Clone, Copy, Default)]
-struct FixtureOptions {
-    external_payload: bool,
-}
-
 impl Drop for DashboardFixture {
     fn drop(&mut self) {
         self.server.abort();
@@ -322,7 +317,7 @@ async fn corrupt_summary_node_metadata(global_db_path: &Path, node_id: &str) {
     }
 }
 
-async fn start_fixture(options: FixtureOptions) -> DashboardFixture {
+async fn start_fixture(external_payload: bool) -> DashboardFixture {
     let tmp = tempdir_or_panic();
     let project_root = tmp.path().join("project");
     let global_db_path = tmp.path().join("global").join("global.db");
@@ -344,16 +339,11 @@ async fn start_fixture(options: FixtureOptions) -> DashboardFixture {
     if let Err(err) = std::fs::create_dir_all(storage_root) {
         panic!("failed to create LCM storage root: {err}");
     }
-    let linked_node_id = seed_lcm_fixture(
-        &global_db,
-        storage_root,
-        &project_root,
-        options.external_payload,
-    )
-    .await;
+    let linked_node_id =
+        seed_lcm_fixture(&global_db, storage_root, &project_root, external_payload).await;
     drop(global_db);
 
-    if options.external_payload {
+    if external_payload {
         plant_external_needle(&session_db_path).await;
     }
     let port = pick_free_port();
@@ -417,7 +407,7 @@ fn timeline_excludes_null_timestamps_and_reports_undated_count() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(FixtureOptions::default()).await;
+        let fixture = start_fixture(false).await;
         insert_undated_message(&fixture.global_db_path).await;
         let agent = http_agent();
 
@@ -477,7 +467,7 @@ fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(FixtureOptions::default()).await;
+        let fixture = start_fixture(false).await;
         corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
         let agent = http_agent();
 
@@ -506,7 +496,7 @@ fn lcm_bad_params_and_missing_resources_return_json_errors() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(FixtureOptions::default()).await;
+        let fixture = start_fixture(false).await;
         let agent = http_agent();
 
         let (status, bad_query) = get_json(
@@ -566,10 +556,7 @@ fn session_endpoint_orders_by_ordinal_paginates_nodes_and_enriches_messages() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(FixtureOptions {
-            external_payload: true,
-        })
-        .await;
+        let fixture = start_fixture(true).await;
         let agent = http_agent();
 
         let (status, session) = get_json(
@@ -691,10 +678,7 @@ fn search_matches_externalized_messages_and_qualifies_summary_fts() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let runtime = create_runtime();
     runtime.block_on(async {
-        let fixture = start_fixture(FixtureOptions {
-            external_payload: true,
-        })
-        .await;
+        let fixture = start_fixture(true).await;
         let agent = http_agent();
 
         // Fix 1 (FTS mode): the externalized message is indexed via

--- a/tests/dashboard_memory_curation_api_test.rs
+++ b/tests/dashboard_memory_curation_api_test.rs
@@ -388,75 +388,6 @@ fn curation_preview_marks_same_count_updates_stale() {
 }
 
 #[test]
-fn memory_oplog_endpoint_lists_recent_operations() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_dashboard_fixture(false).await;
-        let agent = http_agent();
-
-        // Fresh fixture: no operations recorded yet.
-        let (status, empty) = get_json(
-            &agent,
-            &format!(
-                "{}/api/plugins/holographic/oplog?limit=10",
-                fixture.base_url
-            ),
-        );
-        assert_eq!(status, 200);
-        assert_eq!(empty["count"], 0);
-        assert_eq!(empty["error"], "");
-
-        // An explicit-ops delete writes a per-fact "remove" row plus a
-        // "curate_apply" summary row.
-        let (status, applied) = post_json_body(
-            &agent,
-            &format!("{}/api/plugins/holographic/curate/apply", fixture.base_url),
-            &serde_json::json!({
-                "ops": [{ "op": "delete", "fact_id": 103, "reason": "oplog fixture" }]
-            }),
-        );
-        assert_eq!(status, 200);
-        assert_eq!(applied["counts"]["deleted"], 1);
-
-        let (status, oplog) = get_json(
-            &agent,
-            &format!(
-                "{}/api/plugins/holographic/oplog?limit=10",
-                fixture.base_url
-            ),
-        );
-        assert_eq!(status, 200);
-        assert_eq!(oplog["error"], "");
-        let events = oplog["events"]
-            .as_array()
-            .unwrap_or_else(|| panic!("expected oplog events array"));
-        assert_eq!(events.len(), 2, "expected remove + curate_apply rows");
-
-        // Newest first: the curate_apply summary follows the per-fact remove.
-        assert_eq!(events[0]["op"], "curate_apply");
-        assert_eq!(events[0]["detail"]["deleted"], 1);
-        assert_eq!(events[1]["op"], "remove");
-        assert_eq!(events[1]["fact_id"], 103);
-        let remove_detail = events[1]["detail"].to_string();
-        assert!(
-            remove_detail.contains("content_hash"),
-            "remove rows must carry a content hash: {remove_detail}"
-        );
-        assert!(
-            !remove_detail.contains("empty states"),
-            "remove rows must not leak deleted fact content: {remove_detail}"
-        );
-        assert!(
-            events.iter().all(|event| event["ts"].is_number()),
-            "every oplog row carries a timestamp"
-        );
-    });
-}
-
-#[test]
 fn curate_apply_ops_contract() {
     let _env_lock = GLOBAL_DB_ENV_LOCK
         .lock()
@@ -466,6 +397,13 @@ fn curate_apply_ops_contract() {
         let fixture = start_dashboard_fixture(false).await;
         let agent = http_agent();
         let apply_url = format!("{}/api/plugins/holographic/curate/apply", fixture.base_url);
+        let oplog_url = format!("{}/api/plugins/holographic/oplog?limit=10", fixture.base_url);
+
+        // Fresh fixture: no operations recorded yet.
+        let (status, empty_oplog) = get_json(&agent, &oplog_url);
+        assert_eq!(status, 200);
+        assert_eq!(empty_oplog["count"], 0);
+        assert_eq!(empty_oplog["error"], "");
 
         // Merge: fact 102 into 101 with rewritten content, plus an explicit
         // delete of 103, plus an invalid delete — partial failure stays per-op.
@@ -525,6 +463,43 @@ fn curate_apply_ops_contract() {
         assert_eq!(response["counts"]["deleted"], 1);
         assert_eq!(response["counts"]["merged"], 1);
         assert_eq!(response["counts"]["errors"], 2);
+
+        let (status, oplog) = get_json(&agent, &oplog_url);
+        assert_eq!(status, 200);
+        assert_eq!(oplog["error"], "");
+        let events = oplog["events"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected oplog events array"));
+        assert_eq!(
+            events.len(),
+            4,
+            "expected update + loser remove + explicit remove + curate_apply rows"
+        );
+
+        // Newest first: the curate_apply summary follows the per-fact rows.
+        assert_eq!(events[0]["op"], "curate_apply");
+        assert_eq!(events[0]["detail"]["deleted"], 1);
+        assert_eq!(events[0]["detail"]["merged"], 1);
+        assert_eq!(events[0]["detail"]["errors"], 2);
+        assert_eq!(events[1]["op"], "remove");
+        assert_eq!(events[1]["fact_id"], 103);
+        let explicit_remove_detail = events[1]["detail"].to_string();
+        assert!(
+            explicit_remove_detail.contains("content_hash"),
+            "remove rows must carry a content hash: {explicit_remove_detail}"
+        );
+        assert!(
+            !explicit_remove_detail.contains("empty states"),
+            "remove rows must not leak deleted fact content: {explicit_remove_detail}"
+        );
+        assert_eq!(events[2]["op"], "remove");
+        assert_eq!(events[2]["fact_id"], 102);
+        assert_eq!(events[3]["op"], "update");
+        assert_eq!(events[3]["fact_id"], 101);
+        assert!(
+            events.iter().all(|event| event["ts"].is_number()),
+            "every oplog row carries a timestamp"
+        );
 
         let (status, apply_activity) = get_json(
             &agent,

--- a/tests/db_query_test.rs
+++ b/tests/db_query_test.rs
@@ -2470,8 +2470,9 @@ async fn test_batch_incoming_call_counts() {
         .await
         .unwrap();
 
-    for (id, name) in [("fn:a", "alpha"), ("fn:b", "beta"), ("fn:c", "gamma")] {
-        db.insert_node(&Node {
+    let nodes = [("fn:a", "alpha"), ("fn:b", "beta"), ("fn:c", "gamma")]
+        .into_iter()
+        .map(|(id, name)| Node {
             id: id.to_string(),
             kind: NodeKind::Function,
             name: name.to_string(),
@@ -2496,21 +2497,20 @@ async fn test_batch_incoming_call_counts() {
             updated_at: 0,
             parent_id: None,
         })
-        .await
-        .unwrap();
-    }
+        .collect::<Vec<_>>();
+    db.insert_nodes(&nodes).await.unwrap();
 
     // alpha has 2 callers, beta has 1, gamma has 0
-    for (src, tgt) in [("fn:b", "fn:a"), ("fn:c", "fn:a"), ("fn:c", "fn:b")] {
-        db.insert_edge(&Edge {
+    let edges = [("fn:b", "fn:a"), ("fn:c", "fn:a"), ("fn:c", "fn:b")]
+        .into_iter()
+        .map(|(src, tgt)| Edge {
             source: src.to_string(),
             target: tgt.to_string(),
             kind: EdgeKind::Calls,
             line: None,
         })
-        .await
-        .unwrap();
-    }
+        .collect::<Vec<_>>();
+    db.insert_edges(&edges).await.unwrap();
 
     let counts = db
         .batch_incoming_call_counts(&["fn:a".to_string(), "fn:b".to_string(), "fn:c".to_string()])

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -47,6 +47,111 @@ fn make_node(id: &str, name: &str, file_path: &str, visibility: Visibility) -> N
     }
 }
 
+async fn seed_dead_code_marker_perf_fixture(db: &Database) {
+    db.conn()
+        .execute_batch(
+            "BEGIN;
+             WITH RECURSIVE seq(i) AS (
+                 SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i < 49999
+             )
+             INSERT OR REPLACE INTO nodes (
+                 id, kind, name, qualified_name, file_path,
+                 start_line, end_line, start_column, end_column,
+                 docstring, signature, visibility, is_async,
+                 branches, loops, returns, max_nesting,
+                 unsafe_blocks, unchecked_calls, assertions,
+                 updated_at, attrs_start_line, parent_id
+             )
+             SELECT
+                 printf('n-noise-%d', i),
+                 'annotation_usage',
+                 printf('derive_Foo_%d', i),
+                 printf('crate::derive_Foo_%d', i),
+                 'src/noise.rs',
+                 1, 10, 0, 1, NULL,
+                 printf('fn derive_Foo_%d()', i),
+                 'private',
+                 0, 0, 0, 0, 0, 0, 0, 0, 1000, 1, NULL
+             FROM seq;
+
+             WITH RECURSIVE seq(i) AS (
+                 SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i < 999
+             )
+             INSERT OR REPLACE INTO nodes (
+                 id, kind, name, qualified_name, file_path,
+                 start_line, end_line, start_column, end_column,
+                 docstring, signature, visibility, is_async,
+                 branches, loops, returns, max_nesting,
+                 unsafe_blocks, unchecked_calls, assertions,
+                 updated_at, attrs_start_line, parent_id
+             )
+             SELECT
+                 printf('n-marker-%d', i),
+                 'annotation_usage',
+                 CASE i % 4
+                     WHEN 0 THEN 'test'
+                     WHEN 1 THEN 'tokio::test'
+                     WHEN 2 THEN 'wasm_bindgen_test'
+                     ELSE 'async_std::test'
+                 END,
+                 CASE i % 4
+                     WHEN 0 THEN 'crate::test'
+                     WHEN 1 THEN 'crate::tokio::test'
+                     WHEN 2 THEN 'crate::wasm_bindgen_test'
+                     ELSE 'crate::async_std::test'
+                 END,
+                 'src/markers.rs',
+                 1, 10, 0, 1, NULL,
+                 CASE i % 4
+                     WHEN 0 THEN 'fn test()'
+                     WHEN 1 THEN 'fn tokio::test()'
+                     WHEN 2 THEN 'fn wasm_bindgen_test()'
+                     ELSE 'fn async_std::test()'
+                 END,
+                 'private',
+                 0, 0, 0, 0, 0, 0, 0, 0, 1000, 1, NULL
+             FROM seq;
+
+             WITH RECURSIVE seq(i) AS (
+                 SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i < 4999
+             )
+             INSERT OR REPLACE INTO nodes (
+                 id, kind, name, qualified_name, file_path,
+                 start_line, end_line, start_column, end_column,
+                 docstring, signature, visibility, is_async,
+                 branches, loops, returns, max_nesting,
+                 unsafe_blocks, unchecked_calls, assertions,
+                 updated_at, attrs_start_line, parent_id
+             )
+             SELECT
+                 printf('n-fn-%d', i),
+                 'function',
+                 printf('worker_%d', i),
+                 printf('crate::worker_%d', i),
+                 'src/fns.rs',
+                 1, 10, 0, 1, NULL,
+                 printf('fn worker_%d()', i),
+                 'private',
+                 0, 0, 0, 0, 0, 0, 0, 0, 1000, 1, NULL
+             FROM seq;
+
+             WITH RECURSIVE seq(i) AS (
+                 SELECT 2500 UNION ALL SELECT i + 1 FROM seq WHERE i < 4999
+             )
+             INSERT OR IGNORE INTO edges (source, target, kind, line)
+             SELECT 'n-fn-0', printf('n-fn-%d', i), 'calls', 1 FROM seq;
+
+             WITH RECURSIVE seq(i) AS (
+                 SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i < 999
+             )
+             INSERT OR IGNORE INTO edges (source, target, kind, line)
+             SELECT printf('n-marker-%d', i), printf('n-fn-%d', i), 'annotates', 1 FROM seq;
+             COMMIT;",
+        )
+        .await
+        .expect("failed to seed dead-code marker perf fixture");
+}
+
 /// Sets up a call chain: main -> process -> validate -> check.
 /// Returns the database and temp dir.
 async fn setup_call_chain() -> (Database, TempDir) {
@@ -1216,89 +1321,7 @@ async fn test_file_churn_nonexistent_dir() {
 #[tokio::test]
 async fn dead_code_marker_resolve_is_single_pass() {
     let (db, _dir) = setup_db().await;
-
-    let mut nodes: Vec<Node> = Vec::with_capacity(60_000);
-
-    // 50K noise annotation_usage nodes that should NOT match the marker
-    // patterns — these drive the LIKE scan cost.
-    for i in 0..50_000_u32 {
-        let mut n = make_node(
-            &format!("n-noise-{i}"),
-            &format!("derive_Foo_{i}"),
-            "src/noise.rs",
-            Visibility::Private,
-        );
-        n.kind = NodeKind::AnnotationUsage;
-        nodes.push(n);
-    }
-
-    // 1K real test-marker annotation_usage nodes, evenly across the 4 patterns.
-    // 250 of each pattern: bare `test`, `tokio::test`, `wasm_bindgen_test`,
-    // `async_std::test`.
-    let patterns: [&str; 4] = [
-        "test",
-        "tokio::test",
-        "wasm_bindgen_test",
-        "async_std::test",
-    ];
-    for i in 0..1_000_u32 {
-        let pat = patterns[(i as usize) % patterns.len()];
-        let mut n = make_node(
-            &format!("n-marker-{i}"),
-            pat,
-            "src/markers.rs",
-            Visibility::Private,
-        );
-        n.kind = NodeKind::AnnotationUsage;
-        nodes.push(n);
-    }
-
-    // 5K private function nodes. Naming: `fn_{i}` — `name NOT LIKE 'test%'`
-    // filter in the dead-code SQL excludes anything starting with `test`,
-    // so use a neutral prefix.
-    for i in 0..5_000_u32 {
-        nodes.push(make_node(
-            &format!("n-fn-{i}"),
-            &format!("worker_{i}"),
-            "src/fns.rs",
-            Visibility::Private,
-        ));
-    }
-
-    db.insert_nodes(&nodes)
-        .await
-        .expect("bulk insert nodes failed");
-
-    // Half the functions (i = 2500..4999) are live via a calls edge from
-    // `n-fn-0` (acting as a synthetic root). The first 1000 unreferenced
-    // functions (i = 0..999) carry a test-marker annotates edge — those
-    // must be excluded from dead-code as well. The remaining 1500
-    // (i = 1000..2499) are the genuine dead set.
-    let mut edges: Vec<Edge> = Vec::with_capacity(2_500 + 1_000);
-
-    // Live edges — `calls` from worker_0 to workers 2500..4999.
-    for i in 2_500..5_000_u32 {
-        edges.push(Edge {
-            source: "n-fn-0".to_string(),
-            target: format!("n-fn-{i}"),
-            kind: EdgeKind::Calls,
-            line: Some(1),
-        });
-    }
-
-    // Test-marker annotates — n-marker-{i} annotates n-fn-{i} for i in 0..999.
-    for i in 0..1_000_u32 {
-        edges.push(Edge {
-            source: format!("n-marker-{i}"),
-            target: format!("n-fn-{i}"),
-            kind: EdgeKind::Annotates,
-            line: Some(1),
-        });
-    }
-
-    db.insert_edges(&edges)
-        .await
-        .expect("bulk insert edges failed");
+    seed_dead_code_marker_perf_fixture(&db).await;
 
     let qm = GraphQueryManager::new(&db);
 

--- a/tests/lsp_code_diagnostics_test.rs
+++ b/tests/lsp_code_diagnostics_test.rs
@@ -4,6 +4,7 @@ use tracedecay::diagnostics::lsp;
 
 const FAKE_LANGUAGE: &str = "fake";
 const FAKE_PATH: &str = "src/lib.fake";
+const FAKE_LSP_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
 
 #[test]
 fn builtin_registry_advertises_phase_one_setup_contract() {
@@ -154,7 +155,7 @@ async fn broker_refresh_documents_populates_cached_diagnostics() {
         .refresh_documents(
             FAKE_LANGUAGE,
             vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            std::time::Duration::from_secs(3),
+            FAKE_LSP_TIMEOUT,
         )
         .await
         .unwrap();
@@ -209,7 +210,7 @@ async fn broker_keeps_diagnostics_for_multiple_languages_in_one_snapshot() {
         .refresh_documents(
             "alpha",
             vec![fake_document("alpha", "src/lib.alpha", "alpha nope")],
-            std::time::Duration::from_secs(3),
+            FAKE_LSP_TIMEOUT,
         )
         .await
         .unwrap();
@@ -217,7 +218,7 @@ async fn broker_keeps_diagnostics_for_multiple_languages_in_one_snapshot() {
         .refresh_documents(
             "beta",
             vec![fake_document("beta", "src/lib.beta", "beta nope")],
-            std::time::Duration::from_secs(3),
+            FAKE_LSP_TIMEOUT,
         )
         .await
         .unwrap();
@@ -339,15 +340,11 @@ async fn broker_reuses_warm_lsp_client_between_refreshes() {
     let document = fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope");
 
     broker
-        .refresh_documents(
-            "fake",
-            vec![document.clone()],
-            std::time::Duration::from_secs(3),
-        )
+        .refresh_documents("fake", vec![document.clone()], FAKE_LSP_TIMEOUT)
         .await
         .unwrap();
     broker
-        .refresh_documents("fake", vec![document], std::time::Duration::from_secs(3))
+        .refresh_documents("fake", vec![document], FAKE_LSP_TIMEOUT)
         .await
         .unwrap();
 
@@ -385,11 +382,11 @@ async fn broker_keys_warm_lsp_clients_by_workspace_root() {
     ];
 
     broker
-        .refresh_documents("fake", documents.clone(), std::time::Duration::from_secs(3))
+        .refresh_documents("fake", documents.clone(), FAKE_LSP_TIMEOUT)
         .await
         .unwrap();
     broker
-        .refresh_documents("fake", documents, std::time::Duration::from_secs(3))
+        .refresh_documents("fake", documents, FAKE_LSP_TIMEOUT)
         .await
         .unwrap();
 

--- a/tests/mcp_cli_serve_test.rs
+++ b/tests/mcp_cli_serve_test.rs
@@ -28,7 +28,7 @@ use tracedecay::serve;
 use tracedecay::storage::{
     default_profile_sharded_layout, write_enrollment_marker, EnrollmentMarker, StorageMode,
 };
-use tracedecay::tracedecay::TraceDecay;
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 #[cfg(unix)]
 static READ_ONLY_SERVE_ENV_LOCK: Mutex<()> = Mutex::const_new(());
@@ -37,7 +37,7 @@ async fn init_project_with_file(home: &Path, contents: &str) -> TempDir {
     let dir = TempDir::new().unwrap();
     std::fs::create_dir_all(dir.path().join("src")).unwrap();
     std::fs::write(dir.path().join("src/lib.rs"), contents).unwrap();
-    init_project_with_cli(home, dir.path());
+    init_project_direct(home, dir.path()).await;
     dir
 }
 
@@ -45,26 +45,19 @@ async fn init_project_under(home: &Path, parent: &Path, name: &str, contents: &s
     let path = parent.join(name);
     fs::create_dir_all(path.join("src")).unwrap();
     fs::write(path.join("src/lib.rs"), contents).unwrap();
-    init_project_with_cli(home, &path);
+    init_project_direct(home, &path).await;
     path
 }
 
-fn init_project_with_cli(home: &Path, project: &Path) {
-    let output = tracedecay_command_with_home(home)
-        .arg("init")
-        .current_dir(project)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("tracedecay init should run");
-    assert!(
-        output.status.success(),
-        "tracedecay init failed with status {}\nstdout:\n{}\nstderr:\n{}",
-        output.status,
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+async fn init_project_direct(home: &Path, project: &Path) {
+    let profile_root = profile_root(home);
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(profile_root.join("global.db")),
+    };
+    TraceDecay::init_with_options(project, open_options)
+        .await
+        .expect("tracedecay project should initialize");
 }
 
 async fn register_global_project(home: &Path, project: &Path) {

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -7521,7 +7521,7 @@ async fn wipe_lcm_raw_fts_for_message(cg: &TraceDecay, message_id: &str) {
 
 #[tokio::test]
 async fn lcm_doctor_clean_dry_run_reports_noise_and_filtered_sessions_without_mutating() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "cron-20260414",
@@ -7617,7 +7617,7 @@ async fn lcm_doctor_clean_dry_run_reports_noise_and_filtered_sessions_without_mu
 
 #[tokio::test]
 async fn lcm_doctor_clean_apply_is_denied_by_default() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "cron-20260414",
@@ -7656,7 +7656,7 @@ async fn lcm_doctor_clean_apply_is_denied_by_default() {
 
 #[tokio::test]
 async fn lcm_doctor_clean_apply_backs_up_and_deletes_only_safe_candidates() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "cron-20260414",
@@ -7747,7 +7747,7 @@ async fn lcm_doctor_clean_apply_backs_up_and_deletes_only_safe_candidates() {
 
 #[tokio::test]
 async fn lcm_doctor_clean_apply_deletes_all_matching_noise_beyond_diagnostic_samples() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let db = open_active_project_session_db(&cg).await;
     for idx in 0..25 {
         seed_lcm_session_message_in_db(
@@ -7810,7 +7810,7 @@ async fn lcm_doctor_clean_apply_deletes_all_matching_noise_beyond_diagnostic_sam
 
 #[tokio::test]
 async fn lcm_doctor_reports_missing_and_orphan_payloads_without_payload_bodies() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let secret = format!(
         "LCM_DOCTOR_SECRET_PAYLOAD\n{}",
         "doctor-secret ".repeat(30_000)
@@ -7860,7 +7860,7 @@ async fn lcm_doctor_reports_missing_and_orphan_payloads_without_payload_bodies()
 
 #[tokio::test]
 async fn lcm_doctor_reports_placeholder_recovery_and_gc_candidates_without_bodies() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let missing_ref = "payload_missing_placeholder_test.payload";
     let placeholder = format!(
         "[Externalized LCM ingest payload: kind=ingest_payload; role=user; field=content; chars=2048; bytes=2048; ref={missing_ref}]"
@@ -7931,7 +7931,7 @@ async fn lcm_doctor_reports_placeholder_recovery_and_gc_candidates_without_bodie
 
 #[tokio::test]
 async fn lcm_doctor_gc_mode_preview_and_apply_reports_without_body_leaks() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "gc-preview-session",
@@ -8021,7 +8021,7 @@ async fn lcm_doctor_gc_apply_is_denied_by_default() {
 
 #[tokio::test]
 async fn lcm_doctor_counts_nested_externalized_payload_refs_as_referenced() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let media_payload = format!(
         "data:image/png;base64,{}",
         "QWxhZGRpbjpvcGVuIHNlc2FtZQ==".repeat(160)
@@ -8079,7 +8079,7 @@ async fn lcm_doctor_counts_nested_externalized_payload_refs_as_referenced() {
 
 #[tokio::test]
 async fn lcm_doctor_ignores_plain_text_ref_tokens_as_placeholders() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-plain-ref",
@@ -8127,7 +8127,7 @@ async fn lcm_doctor_ignores_plain_text_ref_tokens_as_placeholders() {
 
 #[tokio::test]
 async fn lcm_doctor_scoped_payload_diagnostics_ignore_other_session_payload_files() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_tool_result_message(
         &cg,
         "lcm-doctor-payload-target",
@@ -8182,7 +8182,7 @@ async fn lcm_doctor_scoped_payload_diagnostics_ignore_other_session_payload_file
 
 #[tokio::test]
 async fn lcm_doctor_reports_scoped_fts_rebuild_when_other_session_matches_probe_term() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-fts-target",
@@ -8223,7 +8223,7 @@ async fn lcm_doctor_reports_scoped_fts_rebuild_when_other_session_matches_probe_
 
 #[tokio::test]
 async fn lcm_doctor_counts_summary_source_rows_with_missing_owner_node() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-orphan-owner",
@@ -8264,7 +8264,7 @@ async fn lcm_doctor_counts_summary_source_rows_with_missing_owner_node() {
 
 #[tokio::test]
 async fn lcm_doctor_scopes_orphan_lifecycle_debt_to_requested_session() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-debt-target",
@@ -8382,7 +8382,7 @@ async fn lcm_doctor_repair_dry_run_does_not_run_schema_migration() {
 
 #[tokio::test]
 async fn lcm_doctor_repair_dry_run_reports_fts_rebuild_without_mutating() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-dry-run",
@@ -8420,7 +8420,7 @@ async fn lcm_doctor_repair_dry_run_reports_fts_rebuild_without_mutating() {
 
 #[tokio::test]
 async fn lcm_doctor_repair_apply_rebuilds_damaged_fts() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-apply",
@@ -12639,7 +12639,7 @@ async fn mcp_server_owns_watcher_and_refreshes_token_map_on_change() {
 
 #[tokio::test]
 async fn lcm_expand_paginates_summary_sources_over_mcp() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let mut store_ids = Vec::new();
     for index in 1..=4 {
         let message_id = format!("page-msg-{index}");
@@ -12713,7 +12713,7 @@ async fn lcm_expand_paginates_summary_sources_over_mcp() {
 
 #[tokio::test]
 async fn lcm_expand_resolves_cross_session_store_ids_over_mcp() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-origin-session",
@@ -12762,7 +12762,7 @@ async fn lcm_expand_resolves_cross_session_store_ids_over_mcp() {
 
 #[tokio::test]
 async fn lcm_expand_cross_session_external_payload_supports_two_step_hydration() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let body = format!("data:image/png;base64,{}", "A".repeat(220_000));
     seed_lcm_tool_result_message(
         &cg,
@@ -12833,7 +12833,7 @@ async fn lcm_expand_cross_session_external_payload_supports_two_step_hydration()
 
 #[tokio::test]
 async fn lcm_compress_handler_honors_incremental_max_depth_override() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let mut store_ids = Vec::new();
     for index in 1..=6 {
         let message_id = format!("depth-msg-{index}");
@@ -12915,7 +12915,7 @@ async fn lcm_compress_handler_honors_incremental_max_depth_override() {
 
 #[tokio::test]
 async fn lcm_status_reports_dag_store_and_config_diagnostics_over_mcp() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-diag-session",
@@ -12977,7 +12977,7 @@ async fn lcm_status_reports_dag_store_and_config_diagnostics_over_mcp() {
 
 #[tokio::test]
 async fn lcm_status_all_provider_aggregates_provider_counts() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message_for_provider(
         &cg,
         "cursor",
@@ -13017,7 +13017,7 @@ async fn lcm_status_all_provider_aggregates_provider_counts() {
 
 #[tokio::test]
 async fn lcm_status_all_provider_counts_payload_health_once() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_tool_result_message_for_provider(
         &cg,
         "cursor",

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -1240,7 +1240,7 @@ async fn expect_missing_argument_error(
 
 #[tokio::test]
 async fn schema_required_arguments_match_representative_handler_parsers() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let tools = get_tool_definitions();
 
     // Direct `args.get(...).ok_or(...)` parser style.
@@ -3091,7 +3091,7 @@ async fn test_god_class() {
 
 #[tokio::test]
 async fn test_changelog_no_git() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     // The temp dir is not a git repo, so this should return a structured git
     // error in the tool payload rather than success-looking prose.
     let result = handle_tool_call(
@@ -3115,7 +3115,7 @@ async fn test_changelog_no_git() {
 
 #[tokio::test]
 async fn run_affected_tests_reports_git_failure_without_changed_paths() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(
         &cg,
         "tracedecay_run_affected_tests",
@@ -3137,7 +3137,7 @@ async fn run_affected_tests_reports_git_failure_without_changed_paths() {
 
 #[tokio::test]
 async fn pr_context_no_git_returns_structured_git_error() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(
         &cg,
         "tracedecay_pr_context",
@@ -3317,7 +3317,7 @@ async fn test_port_order() {
 
 #[tokio::test]
 async fn test_unknown_tool() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_unknown", json!({}), None, None).await;
     match result {
         Err(err) => {
@@ -3338,7 +3338,7 @@ async fn test_unknown_tool() {
 
 #[tokio::test]
 async fn test_missing_required_params() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_search", json!({}), None, None).await;
     let err_msg = match result {
         Err(err) => format!("{}", err),
@@ -3420,7 +3420,7 @@ async fn test_search_populates_touched_files() {
 
 #[tokio::test]
 async fn test_rename_preview_not_found() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(
         &cg,
         "tracedecay_rename_preview",
@@ -3488,35 +3488,35 @@ async fn test_rank_outgoing() {
 
 #[tokio::test]
 async fn test_context_missing_task() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_context", json!({}), None, None).await;
     assert!(result.is_err(), "context without task should error");
 }
 
 #[tokio::test]
 async fn test_callers_missing_node_id() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_callers", json!({}), None, None).await;
     assert!(result.is_err(), "callers without node_id should error");
 }
 
 #[tokio::test]
 async fn test_affected_missing_files() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_affected", json!({}), None, None).await;
     assert!(result.is_err(), "affected without files should error");
 }
 
 #[tokio::test]
 async fn test_module_api_missing_path() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_module_api", json!({}), None, None).await;
     assert!(result.is_err(), "module_api without path should error");
 }
 
 #[tokio::test]
 async fn test_rank_missing_edge_kind() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(
         &cg,
         "tracedecay_rank",
@@ -3530,28 +3530,28 @@ async fn test_rank_missing_edge_kind() {
 
 #[tokio::test]
 async fn test_similar_missing_symbol() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_similar", json!({}), None, None).await;
     assert!(result.is_err(), "similar without symbol should error");
 }
 
 #[tokio::test]
 async fn test_diff_context_missing_files() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_diff_context", json!({}), None, None).await;
     assert!(result.is_err(), "diff_context without files should error");
 }
 
 #[tokio::test]
 async fn test_changelog_missing_refs() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_changelog", json!({}), None, None).await;
     assert!(result.is_err(), "changelog without from_ref should error");
 }
 
 #[tokio::test]
 async fn test_port_status_missing_dirs() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_port_status", json!({}), None, None).await;
     assert!(
         result.is_err(),
@@ -3561,7 +3561,7 @@ async fn test_port_status_missing_dirs() {
 
 #[tokio::test]
 async fn test_port_order_missing_source_dir() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(&cg, "tracedecay_port_order", json!({}), None, None).await;
     assert!(
         result.is_err(),

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -936,7 +936,8 @@ async fn project_registry_tools_prefer_injected_registry_over_process_default() 
 
 #[tokio::test]
 async fn selected_project_read_skips_cache_write_for_read_only_store() {
-    let (cg, _project_dir) = setup_project().await;
+    let project_dir = test_temp_dir();
+    let (cg, _env) = init_test_project(project_dir.path()).await;
     let registry_dir = test_temp_dir();
     let registry_path = registry_dir.path().join("global.db");
     let _env_guard = GlobalDbEnvGuard::set(&registry_path);
@@ -955,8 +956,7 @@ async fn selected_project_read_skips_cache_write_for_read_only_store() {
         .upsert_code_project("proj_read", target_project, None, None, Some("main"))
         .await
         .unwrap();
-    let target_cg = TestTraceDecay::new(TraceDecay::init(target_project).await.unwrap());
-    index_all_retrying_sync_lock(&target_cg).await;
+    let _target_cg = TestTraceDecay::new(TraceDecay::init(target_project).await.unwrap());
 
     let read_args = json!({
         "project_id": "proj_read",
@@ -1858,30 +1858,25 @@ async fn retrieve_tool_reports_missing_and_expired_handles_actionably() {
 #[tokio::test]
 async fn fact_store_large_list_response_uses_retrieve_handle() {
     let (cg, _dir) = setup_project().await;
-    let mut last_fact_id = None;
-    for i in 0..35 {
-        let added = handle_tool_call(
-            &cg,
-            "tracedecay_fact_store",
-            json!({
-                "action": "add",
-                "content": format!(
-                    "LONG_FACT_MARKER_{i:02}: {}",
-                    "large fact-store response should remain retrievable ".repeat(80)
-                ),
-                "category": "project",
-                "trust": 0.9
-            }),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-        if i == 34 {
-            let added: Value = serde_json::from_str(extract_text(&added.value)).unwrap();
-            last_fact_id = added["fact"]["fact_id"].as_i64();
-        }
-    }
+    let added = handle_tool_call(
+        &cg,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": format!(
+                "LONG_FACT_MARKER_00: {}",
+                "large fact-store response should remain retrievable ".repeat(220)
+            ),
+            "category": "project",
+            "trust": 0.9
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let added: Value = serde_json::from_str(extract_text(&added.value)).unwrap();
+    let last_fact_id = added["fact"]["fact_id"].as_i64();
     let last_fact_id = last_fact_id.expect("tail fact id");
 
     let listed = handle_tool_call(
@@ -1943,9 +1938,9 @@ async fn fact_store_large_list_response_uses_retrieve_handle() {
         .as_str()
         .expect("retrieve response should contain original JSON text");
     let full: Value = serde_json::from_str(full_json).expect("retrieved content should be JSON");
-    assert_eq!(full["count"].as_u64(), Some(35));
+    assert_eq!(full["count"].as_u64(), Some(1));
     assert!(
-        full_json.contains("LONG_FACT_MARKER_34"),
+        full_json.contains("LONG_FACT_MARKER_00"),
         "retrieved response should include the full fact list"
     );
 }
@@ -1953,25 +1948,23 @@ async fn fact_store_large_list_response_uses_retrieve_handle() {
 #[tokio::test]
 async fn fact_store_large_list_response_reports_store_failure_actionably() {
     let (cg, _dir) = setup_project().await;
-    for i in 0..35 {
-        handle_tool_call(
-            &cg,
-            "tracedecay_fact_store",
-            json!({
-                "action": "add",
-                "content": format!(
-                    "STORE_FAILURE_MARKER_{i:02}: {}",
-                    "large fact-store response should surface cache failures ".repeat(80)
-                ),
-                "category": "project",
-                "trust": 0.9
-            }),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-    }
+    handle_tool_call(
+        &cg,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": format!(
+                "STORE_FAILURE_MARKER_00: {}",
+                "large fact-store response should surface cache failures ".repeat(220)
+            ),
+            "category": "project",
+            "trust": 0.9
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     let handle_dir = response_handle_dir(&cg);
     fs::write(&handle_dir, "not-a-directory").unwrap();
@@ -7733,9 +7726,11 @@ async fn lcm_doctor_clean_apply_backs_up_and_deletes_only_safe_candidates() {
 #[tokio::test]
 async fn lcm_doctor_clean_apply_deletes_all_matching_noise_beyond_diagnostic_samples() {
     let (cg, _dir) = setup_project().await;
+    let db = open_active_project_session_db(&cg).await;
     for idx in 0..25 {
-        seed_lcm_session_message(
-            &cg,
+        seed_lcm_session_message_in_db(
+            &db,
+            cg.project_root(),
             "normal-session",
             &format!("cron-noise-{idx}"),
             format!("Cronjob Response: noisy heartbeat {idx}"),
@@ -7743,8 +7738,9 @@ async fn lcm_doctor_clean_apply_deletes_all_matching_noise_beyond_diagnostic_sam
         )
         .await;
     }
-    seed_lcm_session_message(
-        &cg,
+    seed_lcm_session_message_in_db(
+        &db,
+        cg.project_root(),
         "normal-session",
         "normal-valuable",
         "valuable payload to preserve",
@@ -8480,7 +8476,8 @@ async fn lcm_doctor_retention_reports_candidates_without_deleting() {
 
 #[tokio::test]
 async fn lcm_doctor_uses_explicit_hermes_profile_session_db() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     seed_lcm_session_message(
         &cg,
         "lcm-doctor-profile",
@@ -8524,7 +8521,8 @@ async fn lcm_doctor_uses_explicit_hermes_profile_session_db() {
 
 #[tokio::test]
 async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     let full_text = format!("orchard dispatch {}", "external-payload-body ".repeat(400));
     seed_lcm_session_message(&cg, "lcm-session", "lcm-message", full_text, 1).await;
     let db = open_project_session_db(cg.project_root())
@@ -9666,7 +9664,8 @@ async fn lcm_grep_accepts_string_timestamp_filters() {
 
 #[tokio::test]
 async fn lcm_status_uses_explicit_hermes_profile_session_db() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     seed_lcm_session_message(
         &cg,
         "lcm-profile-status",
@@ -9949,23 +9948,8 @@ async fn lcm_hermes_profile_rejects_non_directory_home() {
 
 #[tokio::test]
 async fn lcm_grep_rejects_invalid_scope_without_searching_all_sessions() {
-    let (cg, _dir) = setup_project().await;
-    seed_lcm_session_message(
-        &cg,
-        "lcm-scope-a",
-        "lcm-scope-message-a",
-        "fail closed unique-cross-session-token alpha",
-        1,
-    )
-    .await;
-    seed_lcm_session_message(
-        &cg,
-        "lcm-scope-b",
-        "lcm-scope-message-b",
-        "fail closed unique-cross-session-token beta",
-        2,
-    )
-    .await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
 
     let err = expect_tool_error(
         handle_tool_call(
@@ -13056,7 +13040,8 @@ async fn lcm_status_all_provider_counts_payload_health_once() {
 // to LCM_SCHEMA_VERSION.
 #[tokio::test]
 async fn repeated_lcm_calls_skip_schema_reensure_per_process() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
 
     // Seed data to ensure the sessions.db exists (lcm_status is now read-only
     // and will not create the DB). The schema-ensure caching under test lives
@@ -13127,7 +13112,8 @@ async fn repeated_lcm_calls_skip_schema_reensure_per_process() {
 /// values — never silently broadened to `all`.
 #[tokio::test]
 async fn lcm_grep_rejects_invalid_scope() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     let err = expect_tool_error(
         handle_tool_call(
             &cg,
@@ -13148,7 +13134,8 @@ async fn lcm_grep_rejects_invalid_scope() {
 /// closed instead of broadening the search to every session.
 #[tokio::test]
 async fn message_search_rejects_invalid_scope() {
-    let (cg, _dir) = setup_project().await;
+    let dir = test_temp_dir();
+    let (cg, _env) = init_test_project(dir.path()).await;
     for invalid in ["everything", "", "parents"] {
         let err = expect_tool_error(
             handle_tool_call(

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -4251,7 +4251,7 @@ async fn project_selector_is_rejected_before_write_tool_parsing() {
 
 #[tokio::test]
 async fn lcm_project_root_storage_arg_is_not_rejected_as_selector() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let project_root = cg.project_root().to_string_lossy().to_string();
 
     let result = handle_tool_call(
@@ -4279,7 +4279,7 @@ async fn lcm_project_root_storage_arg_is_not_rejected_as_selector() {
 
 #[tokio::test]
 async fn lcm_project_path_selector_is_rejected_before_dispatch() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let project_path = cg.project_root().to_string_lossy().to_string();
 
     let result = handle_tool_call(
@@ -6721,7 +6721,7 @@ async fn memory_tools_validate_malformed_inputs() {
 
 #[tokio::test]
 async fn message_search_reads_project_local_session_db() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let db = open_active_project_session_db(&cg).await;
     let session = SessionRecord {
         provider: "cursor".to_string(),
@@ -6902,7 +6902,7 @@ async fn message_search_reads_project_local_session_db() {
 
 #[tokio::test]
 async fn message_search_catches_up_provider_transcripts_before_querying() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let home = cg.project_root().join("home");
     let project = cg.project_root().to_path_buf();
     let project_text = project.to_string_lossy();
@@ -7038,7 +7038,7 @@ async fn message_search_catches_up_provider_transcripts_before_querying() {
 
 #[tokio::test]
 async fn message_search_can_skip_catch_up_for_read_only_audits() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let home = cg.project_root().join("home");
     let project = cg.project_root().to_path_buf();
     let project_text = project.to_string_lossy();
@@ -8000,7 +8000,7 @@ async fn lcm_doctor_gc_mode_preview_and_apply_reports_without_body_leaks() {
 
 #[tokio::test]
 async fn lcm_doctor_gc_apply_is_denied_by_default() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let result = handle_tool_call(
         &cg,
         "tracedecay_lcm_doctor",
@@ -8306,7 +8306,7 @@ async fn lcm_doctor_scopes_orphan_lifecycle_debt_to_requested_session() {
 
 #[tokio::test]
 async fn lcm_doctor_diagnose_does_not_create_missing_project_session_db() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let db_path = project_session_db_path(&cg);
     if db_path.exists() {
         fs::remove_file(&db_path).unwrap();
@@ -9744,7 +9744,7 @@ async fn lcm_status_uses_explicit_hermes_profile_session_db() {
 
 #[tokio::test]
 async fn lcm_load_and_grep_use_explicit_hermes_profile_session_db() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-profile-read",
@@ -9843,7 +9843,7 @@ async fn lcm_load_and_grep_use_explicit_hermes_profile_session_db() {
 
 #[tokio::test]
 async fn lcm_hermes_profile_requires_explicit_valid_home_without_fallback() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-profile-missing-home",
@@ -9902,7 +9902,7 @@ async fn lcm_hermes_profile_requires_explicit_valid_home_without_fallback() {
 #[cfg(unix)]
 #[tokio::test]
 async fn lcm_hermes_profile_rejects_symlinked_tracedecay_dir_escape() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let hermes_home = test_temp_dir();
     let outside = test_temp_dir();
     unix_fs::symlink(outside.path(), hermes_home.path().join(".tracedecay")).unwrap();
@@ -9936,7 +9936,7 @@ async fn lcm_hermes_profile_rejects_symlinked_tracedecay_dir_escape() {
 
 #[tokio::test]
 async fn lcm_hermes_profile_rejects_non_directory_home() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let dir = test_temp_dir();
     let hermes_home = dir.path().join("hermes-home-file");
     fs::write(&hermes_home, "not a directory").unwrap();
@@ -9996,7 +9996,7 @@ async fn lcm_grep_rejects_invalid_scope_without_searching_all_sessions() {
 
 #[tokio::test]
 async fn lcm_load_session_rejects_fractional_negative_and_wrong_type_numeric_args() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-numeric",
@@ -10032,7 +10032,7 @@ async fn lcm_load_session_rejects_fractional_negative_and_wrong_type_numeric_arg
 
 #[tokio::test]
 async fn lcm_load_session_accepts_valid_integer_args() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-valid-integers",
@@ -10254,7 +10254,7 @@ async fn lcm_expand_query_oversized_prompt_preserves_synthesis_contract() {
 
 #[tokio::test]
 async fn message_search_preserves_provider_project_parent_scope_shape_after_lcm() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let db = open_project_session_db(cg.project_root())
         .await
         .expect("project-local session db should open");

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -418,6 +418,12 @@ async fn init_test_project(project: &Path) -> (TestTraceDecay, TestEnv) {
     )
 }
 
+async fn setup_empty_project() -> (TestTraceDecay, TestEnv, TestTempDir) {
+    let dir = test_temp_dir();
+    let (cg, env) = init_test_project(dir.path()).await;
+    (cg, env, dir)
+}
+
 async fn setup_generated_dir_project(include_dist: bool) -> (TestTraceDecay, TestEnv, TestTempDir) {
     let dir = test_temp_dir();
     let project = dir.path();
@@ -1747,7 +1753,7 @@ async fn test_search_omits_index_coverage_hint_when_generated_dir_is_included() 
 
 #[tokio::test]
 async fn retrieve_tool_returns_full_stored_response() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let original = "{\"items\":[{\"id\":1,\"name\":\"alpha\"}]}";
     let stored = tracedecay::mcp::response_handles::store_response_handle(
         cg.project_root(),
@@ -1796,7 +1802,7 @@ async fn retrieve_tool_returns_full_stored_response() {
 
 #[tokio::test]
 async fn retrieve_tool_reports_missing_and_expired_handles_actionably() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
 
     let missing = handle_tool_call(
         &cg,
@@ -1857,7 +1863,7 @@ async fn retrieve_tool_reports_missing_and_expired_handles_actionably() {
 
 #[tokio::test]
 async fn fact_store_large_list_response_uses_retrieve_handle() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let added = handle_tool_call(
         &cg,
         "tracedecay_fact_store",
@@ -1947,7 +1953,7 @@ async fn fact_store_large_list_response_uses_retrieve_handle() {
 
 #[tokio::test]
 async fn fact_store_large_list_response_reports_store_failure_actionably() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     handle_tool_call(
         &cg,
         "tracedecay_fact_store",
@@ -2007,20 +2013,26 @@ async fn fact_store_large_list_response_reports_store_failure_actionably() {
 
 #[tokio::test]
 async fn search_large_response_uses_retrievable_truncation_handle() {
-    let (cg, project) = setup_project().await;
+    const LARGE_RESPONSE_MARKER_COUNT: usize = 120;
+    const LAST_LARGE_RESPONSE_MARKER: usize = LARGE_RESPONSE_MARKER_COUNT - 1;
+
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    let (cg, _env) = init_test_project(project).await;
     let mut source = String::new();
-    for i in 0..420 {
+    for i in 0..LARGE_RESPONSE_MARKER_COUNT {
         source.push_str(&format!(
             "pub fn reversible_search_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}\n"
         ));
     }
-    fs::write(project.path().join("src/large_search.rs"), source).unwrap();
+    fs::write(project.join("src/large_search.rs"), source).unwrap();
     index_all_retrying_sync_lock(&cg).await;
 
     let result = handle_tool_call(
         &cg,
         "tracedecay_search",
-        json!({"query": "reversible_search_marker", "limit": 420}),
+        json!({"query": "reversible_search_marker", "limit": LARGE_RESPONSE_MARKER_COUNT}),
         None,
         None,
     )
@@ -2049,7 +2061,9 @@ async fn search_large_response_uses_retrievable_truncation_handle() {
         .as_str()
         .expect("retrieve response should contain full search JSON");
     assert!(
-        full_json.contains("reversible_search_marker_419"),
+        full_json.contains(&format!(
+            "reversible_search_marker_{LAST_LARGE_RESPONSE_MARKER:03}"
+        )),
         "retrieved search response should include the tail result"
     );
 }
@@ -2677,14 +2691,20 @@ async fn test_diff_context() {
 
 #[tokio::test]
 async fn diff_context_large_response_uses_retrievable_truncation_handle() {
-    let (cg, project) = setup_project().await;
+    const LARGE_RESPONSE_MARKER_COUNT: usize = 120;
+    const LAST_LARGE_RESPONSE_MARKER: usize = LARGE_RESPONSE_MARKER_COUNT - 1;
+
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    let (cg, _env) = init_test_project(project).await;
     let mut source = String::new();
-    for i in 0..420 {
+    for i in 0..LARGE_RESPONSE_MARKER_COUNT {
         source.push_str(&format!(
             "pub fn reversible_diff_context_marker_{i:03}() -> &'static str {{ \"marker-{i:03}\" }}\n"
         ));
     }
-    fs::write(project.path().join("src/large_diff.rs"), source).unwrap();
+    fs::write(project.join("src/large_diff.rs"), source).unwrap();
     index_all_retrying_sync_lock(&cg).await;
 
     let result = handle_tool_call(
@@ -2719,7 +2739,9 @@ async fn diff_context_large_response_uses_retrievable_truncation_handle() {
         .as_str()
         .expect("retrieve response should contain full diff_context JSON");
     assert!(
-        full_json.contains("reversible_diff_context_marker_419"),
+        full_json.contains(&format!(
+            "reversible_diff_context_marker_{LAST_LARGE_RESPONSE_MARKER:03}"
+        )),
         "retrieved diff_context response should include the tail result"
     );
 }

--- a/tests/memory_eval_test.rs
+++ b/tests/memory_eval_test.rs
@@ -426,9 +426,6 @@ fn initialize_fixture_project(fixture: &Fixture) {
         let cg = TraceDecay::init_with_options(&fixture.project_path, open_options)
             .await
             .unwrap_or_else(|e| panic!("initialize fixture project: {e}"));
-        cg.index_all_with_progress(|_, _, _| {})
-            .await
-            .unwrap_or_else(|e| panic!("index fixture project: {e}"));
         cg.checkpoint()
             .await
             .unwrap_or_else(|e| panic!("checkpoint fixture project: {e}"));
@@ -733,18 +730,22 @@ fn run_scenario(id: &str) {
     let scenario = load_scenario(id);
 
     // Phase A: a well-behaved agent's tool sequence must leave a compliant
-    // end-state.
-    let fixture = build_fixture(&scenario.setup);
-    let seeded_sources = fact_ids_by_source(&fixture);
+    // end-state. Scenarios with no well-behaved steps can assert their
+    // baseline on the violation fixture before any violation writes.
+    let mut fixture = build_fixture(&scenario.setup);
+    let mut seeded_sources = fact_ids_by_source(&fixture);
     let mut dry_run_report = None;
-    for step in &scenario.deterministic.well_behaved {
-        let result = execute_step(&fixture, step, &mut dry_run_report);
-        assert!(
-            result.succeeded,
-            "[{id}] well-behaved step was refused; compliant writes must be accepted"
-        );
+    let well_behaved_steps = &scenario.deterministic.well_behaved;
+    if !well_behaved_steps.is_empty() {
+        for step in well_behaved_steps {
+            let result = execute_step(&fixture, step, &mut dry_run_report);
+            assert!(
+                result.succeeded,
+                "[{id}] well-behaved step was refused; compliant writes must be accepted"
+            );
+        }
     }
-    let outcomes = evaluate_assertions(
+    let well_behaved_outcomes = evaluate_assertions(
         &scenario,
         &fixture,
         Phase::WellBehaved,
@@ -752,20 +753,25 @@ fn run_scenario(id: &str) {
         &dry_run_report,
     );
     assert!(
-        outcomes.iter().all(|o| o.passed),
+        well_behaved_outcomes.iter().all(|o| o.passed),
         "[{id}] well-behaved phase failed:\n{}",
-        format_outcomes(&outcomes)
+        format_outcomes(&well_behaved_outcomes)
     );
-    println!("[{id}] well-behaved phase:\n{}", format_outcomes(&outcomes));
+    println!(
+        "[{id}] well-behaved phase:\n{}",
+        format_outcomes(&well_behaved_outcomes)
+    );
 
     // Phase B: a misbehaving sequence must be either defended against by the
     // write path or detected by the assertion set (instrument self-check).
     let Some(violation) = &scenario.deterministic.violation else {
         return;
     };
-    let fixture = build_fixture(&scenario.setup);
-    let seeded_sources = fact_ids_by_source(&fixture);
-    let mut dry_run_report = None;
+    if !well_behaved_steps.is_empty() {
+        fixture = build_fixture(&scenario.setup);
+        seeded_sources = fact_ids_by_source(&fixture);
+    }
+    dry_run_report = None;
     let mut any_step_succeeded = false;
     for step in &violation.steps {
         let result = execute_step(&fixture, step, &mut dry_run_report);

--- a/tests/memory_eval_test.rs
+++ b/tests/memory_eval_test.rs
@@ -222,6 +222,50 @@ struct Fixture {
     _daemon: Option<common::DaemonProcess>,
 }
 
+#[cfg(windows)]
+struct FixtureSnapshot {
+    _dir: TempDir,
+    profile_path: PathBuf,
+}
+
+#[cfg(windows)]
+impl FixtureSnapshot {
+    fn capture(fixture: &Fixture) -> Self {
+        let dir = TempDir::new().expect("fixture snapshot tempdir");
+        let profile_path = dir.path().join(".tracedecay");
+        std::fs::create_dir_all(&profile_path).unwrap_or_else(|e| {
+            panic!(
+                "failed to create fixture snapshot dir {}: {e}",
+                profile_path.display()
+            )
+        });
+        copy_dir_contents(&fixture.home_path.join(".tracedecay"), &profile_path);
+        Self {
+            _dir: dir,
+            profile_path,
+        }
+    }
+
+    fn restore_into(&self, fixture: &Fixture) {
+        let profile_path = fixture.home_path.join(".tracedecay");
+        if profile_path.exists() {
+            std::fs::remove_dir_all(&profile_path).unwrap_or_else(|e| {
+                panic!(
+                    "failed to remove fixture profile {}: {e}",
+                    profile_path.display()
+                )
+            });
+        }
+        std::fs::create_dir_all(&profile_path).unwrap_or_else(|e| {
+            panic!(
+                "failed to recreate fixture profile {}: {e}",
+                profile_path.display()
+            )
+        });
+        copy_dir_contents(&self.profile_path, &profile_path);
+    }
+}
+
 impl Fixture {
     fn db_path(&self) -> PathBuf {
         tracedecay::storage::resolve_layout(&self.project_path, &self.home_path.join(".tracedecay"))
@@ -414,6 +458,37 @@ fn canonical_test_dir(path: &Path) -> PathBuf {
         .unwrap_or_else(|e| panic!("failed to create test dir {}: {e}", path.display()));
     path.canonicalize()
         .unwrap_or_else(|e| panic!("failed to canonicalize test dir {}: {e}", path.display()))
+}
+
+#[cfg(windows)]
+fn copy_dir_contents(source: &Path, destination: &Path) {
+    for entry in std::fs::read_dir(source)
+        .unwrap_or_else(|e| panic!("failed to read fixture dir {}: {e}", source.display()))
+    {
+        let entry = entry.unwrap_or_else(|e| panic!("failed to read fixture entry: {e}"));
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .unwrap_or_else(|e| panic!("failed to inspect {}: {e}", source_path.display()));
+        if file_type.is_dir() {
+            std::fs::create_dir_all(&destination_path).unwrap_or_else(|e| {
+                panic!(
+                    "failed to create fixture dir {}: {e}",
+                    destination_path.display()
+                )
+            });
+            copy_dir_contents(&source_path, &destination_path);
+        } else if file_type.is_file() {
+            std::fs::copy(&source_path, &destination_path).unwrap_or_else(|e| {
+                panic!(
+                    "failed to copy fixture file {} to {}: {e}",
+                    source_path.display(),
+                    destination_path.display()
+                )
+            });
+        }
+    }
 }
 
 fn initialize_fixture_project(fixture: &Fixture) {
@@ -728,6 +803,7 @@ fn format_outcomes(outcomes: &[AssertionOutcome]) -> String {
 
 fn run_scenario(id: &str) {
     let scenario = load_scenario(id);
+    let well_behaved_steps = &scenario.deterministic.well_behaved;
 
     // Phase A: a well-behaved agent's tool sequence must leave a compliant
     // end-state. Scenarios with no well-behaved steps can assert their
@@ -735,7 +811,13 @@ fn run_scenario(id: &str) {
     let mut fixture = build_fixture(&scenario.setup);
     let mut seeded_sources = fact_ids_by_source(&fixture);
     let mut dry_run_report = None;
-    let well_behaved_steps = &scenario.deterministic.well_behaved;
+    #[cfg(windows)]
+    let baseline_snapshot =
+        if !well_behaved_steps.is_empty() && scenario.deterministic.violation.is_some() {
+            Some(FixtureSnapshot::capture(&fixture))
+        } else {
+            None
+        };
     if !well_behaved_steps.is_empty() {
         for step in well_behaved_steps {
             let result = execute_step(&fixture, step, &mut dry_run_report);
@@ -768,7 +850,14 @@ fn run_scenario(id: &str) {
         return;
     };
     if !well_behaved_steps.is_empty() {
-        fixture = build_fixture(&scenario.setup);
+        #[cfg(windows)]
+        if let Some(snapshot) = &baseline_snapshot {
+            snapshot.restore_into(&fixture);
+        }
+        #[cfg(not(windows))]
+        {
+            fixture = build_fixture(&scenario.setup);
+        }
         seeded_sources = fact_ids_by_source(&fixture);
     }
     dry_run_report = None;

--- a/tests/migration_test.rs
+++ b/tests/migration_test.rs
@@ -18,7 +18,8 @@ async fn create_raw_db() -> (Connection, LibsqlDatabase, TempDir) {
         .expect("failed to build libsql database");
     let conn = db.connect().expect("failed to connect");
     conn.execute_batch(
-        "PRAGMA journal_mode = WAL;
+        "PRAGMA auto_vacuum = INCREMENTAL;
+         PRAGMA journal_mode = WAL;
          PRAGMA foreign_keys = ON;
          PRAGMA busy_timeout = 5000;",
     )

--- a/tests/resolution_test.rs
+++ b/tests/resolution_test.rs
@@ -1,74 +1,108 @@
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::db::Database;
 use tracedecay::resolution::ReferenceResolver;
 use tracedecay::types::*;
 
-/// Sets up a temporary database pre-populated with two nodes: a `helper`
-/// function in `src/utils.rs` and a `main` function in `src/main.rs`.
+struct ResolutionFixture {
+    _dir: TempDir,
+    db: Database,
+    nodes: Vec<Node>,
+}
+
+static RESOLUTION_FIXTURE: OnceCell<ResolutionFixture> = OnceCell::const_new();
+
+async fn resolution_fixture() -> &'static ResolutionFixture {
+    RESOLUTION_FIXTURE
+        .get_or_init(|| async {
+            let dir = TempDir::new().expect("failed to create temp dir");
+            let (db, _) = Database::initialize(&dir.path().join("test.db"))
+                .await
+                .expect("failed to init db");
+            let nodes = basic_nodes();
+
+            for node in &nodes {
+                db.insert_node(node).await.expect("failed to insert node");
+            }
+
+            ResolutionFixture {
+                _dir: dir,
+                db,
+                nodes,
+            }
+        })
+        .await
+}
+
+fn function_node(
+    file_path: &str,
+    name: &str,
+    qualified_name: &str,
+    start_line: u32,
+    end_line: u32,
+    signature: &str,
+    visibility: Visibility,
+) -> Node {
+    Node {
+        id: generate_node_id(file_path, &NodeKind::Function, name, start_line),
+        kind: NodeKind::Function,
+        name: name.to_string(),
+        qualified_name: qualified_name.to_string(),
+        file_path: file_path.to_string(),
+        start_line,
+        attrs_start_line: start_line,
+        end_line,
+        start_column: 0,
+        end_column: 1,
+        signature: Some(signature.to_string()),
+        docstring: None,
+        visibility,
+        is_async: false,
+        branches: 0,
+        loops: 0,
+        returns: 0,
+        max_nesting: 0,
+        unsafe_blocks: 0,
+        unchecked_calls: 0,
+        assertions: 0,
+        updated_at: 0,
+        parent_id: None,
+    }
+}
+
+fn basic_nodes() -> Vec<Node> {
+    vec![
+        function_node(
+            "src/utils.rs",
+            "helper",
+            "src/utils.rs::helper",
+            1,
+            5,
+            "fn helper() -> i32",
+            Visibility::Pub,
+        ),
+        function_node(
+            "src/main.rs",
+            "main",
+            "src/main.rs::main",
+            1,
+            5,
+            "fn main()",
+            Visibility::Private,
+        ),
+    ]
+}
+
 async fn setup_db_with_nodes() -> (TempDir, Database) {
     let dir = TempDir::new().expect("failed to create temp dir");
     let (db, _) = Database::initialize(&dir.path().join("test.db"))
         .await
         .expect("failed to init db");
 
-    let callee = Node {
-        id: generate_node_id("src/utils.rs", &NodeKind::Function, "helper", 1),
-        kind: NodeKind::Function,
-        name: "helper".to_string(),
-        qualified_name: "src/utils.rs::helper".to_string(),
-        file_path: "src/utils.rs".to_string(),
-        start_line: 1,
-        attrs_start_line: 1,
-        end_line: 5,
-        start_column: 0,
-        end_column: 1,
-        signature: Some("fn helper() -> i32".to_string()),
-        docstring: None,
-        visibility: Visibility::Pub,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 0,
-        parent_id: None,
-    };
+    for node in basic_nodes() {
+        db.insert_node(&node).await.expect("failed to insert node");
+    }
 
-    let caller = Node {
-        id: generate_node_id("src/main.rs", &NodeKind::Function, "main", 1),
-        kind: NodeKind::Function,
-        name: "main".to_string(),
-        qualified_name: "src/main.rs::main".to_string(),
-        file_path: "src/main.rs".to_string(),
-        start_line: 1,
-        attrs_start_line: 1,
-        end_line: 5,
-        start_column: 0,
-        end_column: 1,
-        signature: Some("fn main()".to_string()),
-        docstring: None,
-        visibility: Visibility::Private,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 0,
-        parent_id: None,
-    };
-
-    db.insert_node(&callee)
-        .await
-        .expect("failed to insert callee");
-    db.insert_node(&caller)
-        .await
-        .expect("failed to insert caller");
     (dir, db)
 }
 
@@ -102,8 +136,8 @@ async fn test_resolve_exact_name_match() {
 
 #[tokio::test]
 async fn test_resolve_qualified_name_match() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let uref = UnresolvedRef {
         from_node_id: generate_node_id("src/main.rs", &NodeKind::Function, "main", 1),
@@ -127,8 +161,8 @@ async fn test_resolve_qualified_name_match() {
 
 #[tokio::test]
 async fn test_resolve_all() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let refs = vec![UnresolvedRef {
         from_node_id: generate_node_id("src/main.rs", &NodeKind::Function, "main", 1),
@@ -148,8 +182,8 @@ async fn test_resolve_all() {
 
 #[tokio::test]
 async fn test_unresolvable_reference() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let uref = UnresolvedRef {
         from_node_id: "function:caller".to_string(),
@@ -168,8 +202,8 @@ async fn test_unresolvable_reference() {
 
 #[tokio::test]
 async fn test_unresolvable_in_resolve_all() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let refs = vec![
         UnresolvedRef {
@@ -199,8 +233,8 @@ async fn test_unresolvable_in_resolve_all() {
 
 #[tokio::test]
 async fn test_creates_edges_from_resolved() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let resolved = ResolvedRef {
         original: UnresolvedRef {
@@ -232,101 +266,37 @@ async fn test_creates_edges_from_resolved() {
 
 #[tokio::test]
 async fn test_multiple_candidates_best_match_scoring() {
-    let dir = TempDir::new().expect("failed to create temp dir");
-    let (db, _) = Database::initialize(&dir.path().join("test.db"))
-        .await
-        .expect("failed to init db");
-
     // Two nodes with the same name "process" in different files.
-    let same_file_node = Node {
-        id: generate_node_id("src/main.rs", &NodeKind::Function, "process", 10),
-        kind: NodeKind::Function,
-        name: "process".to_string(),
-        qualified_name: "src/main.rs::process".to_string(),
-        file_path: "src/main.rs".to_string(),
-        start_line: 10,
-        attrs_start_line: 10,
-        end_line: 15,
-        start_column: 0,
-        end_column: 1,
-        signature: Some("fn process()".to_string()),
-        docstring: None,
-        visibility: Visibility::Private,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 0,
-        parent_id: None,
-    };
-
-    let other_file_node = Node {
-        id: generate_node_id("src/other.rs", &NodeKind::Function, "process", 1),
-        kind: NodeKind::Function,
-        name: "process".to_string(),
-        qualified_name: "src/other.rs::process".to_string(),
-        file_path: "src/other.rs".to_string(),
-        start_line: 1,
-        attrs_start_line: 1,
-        end_line: 5,
-        start_column: 0,
-        end_column: 1,
-        signature: Some("fn process()".to_string()),
-        docstring: None,
-        visibility: Visibility::Pub,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 0,
-        parent_id: None,
-    };
-
-    let caller = Node {
-        id: generate_node_id("src/main.rs", &NodeKind::Function, "run", 1),
-        kind: NodeKind::Function,
-        name: "run".to_string(),
-        qualified_name: "src/main.rs::run".to_string(),
-        file_path: "src/main.rs".to_string(),
-        start_line: 1,
-        attrs_start_line: 1,
-        end_line: 5,
-        start_column: 0,
-        end_column: 1,
-        signature: Some("fn run()".to_string()),
-        docstring: None,
-        visibility: Visibility::Private,
-        is_async: false,
-        branches: 0,
-        loops: 0,
-        returns: 0,
-        max_nesting: 0,
-        unsafe_blocks: 0,
-        unchecked_calls: 0,
-        assertions: 0,
-        updated_at: 0,
-        parent_id: None,
-    };
-
-    db.insert_node(&same_file_node)
-        .await
-        .expect("failed to insert same_file_node");
-    db.insert_node(&other_file_node)
-        .await
-        .expect("failed to insert other_file_node");
-    db.insert_node(&caller)
-        .await
-        .expect("failed to insert caller");
-
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let same_file_node = function_node(
+        "src/main.rs",
+        "process",
+        "src/main.rs::process",
+        10,
+        15,
+        "fn process()",
+        Visibility::Private,
+    );
+    let other_file_node = function_node(
+        "src/other.rs",
+        "process",
+        "src/other.rs::process",
+        1,
+        5,
+        "fn process()",
+        Visibility::Pub,
+    );
+    let caller = function_node(
+        "src/main.rs",
+        "run",
+        "src/main.rs::run",
+        1,
+        5,
+        "fn run()",
+        Visibility::Private,
+    );
+    let nodes = vec![same_file_node.clone(), other_file_node, caller.clone()];
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &nodes);
 
     // Reference from src/main.rs should prefer the same-file candidate.
     let uref = UnresolvedRef {
@@ -354,8 +324,8 @@ async fn test_multiple_candidates_best_match_scoring() {
 
 #[tokio::test]
 async fn test_create_edges_empty_input() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let edges = resolver.create_edges(&[]);
     assert!(edges.is_empty());
@@ -363,8 +333,8 @@ async fn test_create_edges_empty_input() {
 
 #[tokio::test]
 async fn test_resolve_all_empty_input() {
-    let (_dir, db) = setup_db_with_nodes().await;
-    let resolver = ReferenceResolver::from_nodes(&db, &db.get_all_nodes().await.unwrap());
+    let fixture = resolution_fixture().await;
+    let resolver = ReferenceResolver::from_nodes(&fixture.db, &fixture.nodes);
 
     let result = resolver.resolve_all(&[]);
     assert_eq!(result.total, 0);

--- a/tests/session_lcm_compression_test.rs
+++ b/tests/session_lcm_compression_test.rs
@@ -570,15 +570,23 @@ fn summary_draft_with_times(
 }
 
 #[tokio::test]
-async fn compress_in_transaction_baseline_decision_fixture_preserves_contract() {
-    for case in [
-        CompressBaselineCase::FrontierChanged,
-        CompressBaselineCase::BelowLeafThreshold,
-        CompressBaselineCase::AuxiliarySummaryRequest,
-        CompressBaselineCase::FakeSummaryWrite,
-    ] {
-        assert_compress_baseline_case(case).await;
-    }
+async fn compress_frontier_changed_baseline_decision_fixture_preserves_contract() {
+    assert_compress_baseline_case(CompressBaselineCase::FrontierChanged).await;
+}
+
+#[tokio::test]
+async fn compress_below_leaf_threshold_baseline_decision_fixture_preserves_contract() {
+    assert_compress_baseline_case(CompressBaselineCase::BelowLeafThreshold).await;
+}
+
+#[tokio::test]
+async fn compress_auxiliary_summary_request_baseline_decision_fixture_preserves_contract() {
+    assert_compress_baseline_case(CompressBaselineCase::AuxiliarySummaryRequest).await;
+}
+
+#[tokio::test]
+async fn compress_fake_summary_write_baseline_decision_fixture_preserves_contract() {
+    assert_compress_baseline_case(CompressBaselineCase::FakeSummaryWrite).await;
 }
 
 #[tokio::test]

--- a/tests/session_lcm_payload_test.rs
+++ b/tests/session_lcm_payload_test.rs
@@ -12,42 +12,21 @@ use common::{
     lcm_payload_session as sample_session, open_lcm_db,
 };
 
-fn externalized_tool_payload(prefix: &str, fill: char) -> String {
-    fn with_filler(prefix: &str, fill: char, filler_chars: usize) -> String {
-        format!("{prefix}{}", fill.to_string().repeat(filler_chars))
-    }
+const TOOL_PAYLOAD_FIXTURE_FILLER_CHARS: usize = 260 * 1024;
 
-    let externalizes = |candidate: &str| {
+fn externalized_tool_payload(prefix: &str, fill: char) -> String {
+    let payload = format!(
+        "{prefix}{}",
+        fill.to_string().repeat(TOOL_PAYLOAD_FIXTURE_FILLER_CHARS)
+    );
+    assert!(
         tracedecay::sessions::lcm::security::should_externalize(
             "tool",
             Some("tool_result"),
-            candidate,
-        )
-    };
-
-    let mut high = 1024;
-    while !externalizes(&with_filler(prefix, fill, high)) {
-        high = high
-            .checked_mul(2)
-            .filter(|next| *next <= 2 * 1024 * 1024)
-            .expect("tool payload fixture should externalize before 2 MiB");
-    }
-
-    let mut low = 0;
-    while low < high {
-        let mid = low + (high - low) / 2;
-        if externalizes(&with_filler(prefix, fill, mid)) {
-            high = mid;
-        } else {
-            low = mid + 1;
-        }
-    }
-
-    let payload = with_filler(prefix, fill, low);
-    assert!(externalizes(&payload));
-    if low > 0 {
-        assert!(!externalizes(&with_filler(prefix, fill, low - 1)));
-    }
+            &payload,
+        ),
+        "tool payload fixture should externalize"
+    );
     payload
 }
 

--- a/tests/session_lcm_query_test.rs
+++ b/tests/session_lcm_query_test.rs
@@ -1,5 +1,5 @@
 use tempfile::TempDir;
-use tracedecay::global_db::GlobalDb;
+use tracedecay::global_db::{GlobalDb, ParseOffset};
 use tracedecay::sessions::lcm::{
     LcmContentSlice, LcmDescribeRequest, LcmDescribeTarget, LcmError, LcmExpandQueryRequest,
     LcmExpandRequest, LcmExpandTarget, LcmGcConfig, LcmGrepRequest, LcmGrepSort,
@@ -85,14 +85,28 @@ async fn insert_raw_messages(
     session_id: &str,
     contents: &[String],
 ) -> Vec<i64> {
-    insert_session(db, provider, session_id).await;
-    let mut message_ids = Vec::new();
-    for (idx, content) in contents.iter().enumerate() {
-        let message_id = format!("{session_id}-message-{:03}", idx + 1);
-        let message = raw_message(provider, &message_id, session_id, (idx + 1) as i64, content);
-        assert!(db.upsert_session_message(&message).await);
-        message_ids.push(message_id);
-    }
+    let session = sample_session(provider, session_id);
+    let messages: Vec<_> = contents
+        .iter()
+        .enumerate()
+        .map(|(idx, content)| {
+            let message_id = format!("{session_id}-message-{:03}", idx + 1);
+            raw_message(provider, &message_id, session_id, (idx + 1) as i64, content)
+        })
+        .collect();
+    assert!(
+        db.upsert_transcript_batch(
+            &session,
+            &messages,
+            &format!("session-lcm-query-{provider}-{session_id}.jsonl"),
+            ParseOffset::default(),
+        )
+        .await
+    );
+    let message_ids: Vec<_> = messages
+        .iter()
+        .map(|message| message.message_id.clone())
+        .collect();
 
     if message_ids.is_empty() {
         return Vec::new();


### PR DESCRIPTION
## Summary
- simplify the payload externalization test fixture added during the Windows timing work
- replace runtime threshold discovery with a direct 260 KiB fixture and an explicit `should_externalize` assertion
- keep this branch open for additional Windows timing optimizations from the current investigation wave

## Verification
- cargo nextest run --test session_lcm_payload_test --profile ci --locked --status-level slow --no-fail-fast
- cargo fmt --all -- --check
- cargo clippy --test session_lcm_payload_test --locked -- -D warnings

## Follow-up timing work in progress
- Latest green Windows run `28479221515` shows the next major opportunities in `mcp_handler_test`, memory eval, dashboard/project API fixtures, cursor transcript ingest, and DB/graph/global registry tests.
- Additional commits may land here as those investigations turn into low-risk fixes.
