### PR TITLE
chore: release v0.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.19](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.18...v0.0.19) - 2026-07-01
+
+### Fixed
+
+- dedupe tool descriptor hints separately
+- strengthen TraceDecay tool discovery hints
+- handle daemon hook review followups
+- resolve worktree registry context by identity
+- prefer crates.io for cargo updates
+
+### Other
+
+- daemon-owned hook event notifications
+- [codex] Fix automation retry and fact curation policy ([#161](https://github.com/ScriptedAlchemy/tracedecay/pull/161))
+- Simplify session provider ingest selection
+- scope message search catch-up
+- speed up Windows shard fixtures
+
 ## [0.0.18](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.17...v0.0.18) - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.18 -> 0.0.19

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.19](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.18...v0.0.19) - 2026-07-01

### Fixed

- dedupe tool descriptor hints separately
- strengthen TraceDecay tool discovery hints
- handle daemon hook review followups
- resolve worktree registry context by identity
- prefer crates.io for cargo updates

### Other

- daemon-owned hook event notifications
- [codex] Fix automation retry and fact curation policy ([#161](https://github.com/ScriptedAlchemy/tracedecay/pull/161))
- Simplify session provider ingest selection
- scope message search catch-up
- speed up Windows shard fixtures
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).