### PR TITLE
test: combine dashboard LCM fixture checks

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,10 +13,13 @@ use std::time::Instant;
 
 use serde_json::Value;
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::types::{Node, NodeKind, Visibility};
+
+static EMPTY_LCM_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 /// Sets (or removes) an environment variable for its lifetime, restoring the
 /// previous value on drop.
@@ -397,9 +400,51 @@ pub fn isolated_global_db_path(tmp: &TempDir) -> std::path::PathBuf {
 }
 
 pub async fn open_lcm_db(tmp: &TempDir) -> GlobalDb {
-    GlobalDb::open_at(&isolated_lcm_db_path(tmp))
+    let db_path = isolated_lcm_db_path(tmp);
+    if !db_path.exists() {
+        seed_lcm_db_from_template(&db_path).await;
+        return GlobalDb::open_at_assuming_schema(&db_path)
+            .await
+            .expect("session db open");
+    }
+    GlobalDb::open_at(&db_path).await.expect("session db open")
+}
+
+async fn seed_lcm_db_from_template(db_path: &Path) {
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!(
+                "failed to create LCM test DB directory '{}': {err}",
+                parent.display()
+            )
+        });
+    }
+    fs::write(db_path, empty_lcm_db_template().await).unwrap_or_else(|err| {
+        panic!(
+            "failed to write LCM test DB template '{}': {err}",
+            db_path.display()
+        )
+    });
+}
+
+async fn empty_lcm_db_template() -> &'static [u8] {
+    EMPTY_LCM_DB_TEMPLATE
+        .get_or_init(|| async {
+            let tmp = tempdir_or_panic();
+            let db_path = isolated_lcm_db_path(&tmp);
+            let db = GlobalDb::open_at(&db_path)
+                .await
+                .expect("template session db open");
+            db.checkpoint().await;
+            db.close();
+            fs::read(&db_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read LCM test DB template '{}': {err}",
+                    db_path.display()
+                )
+            })
+        })
         .await
-        .expect("session db open")
 }
 
 pub async fn open_global_db(tmp: &TempDir) -> GlobalDb {

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -505,7 +505,6 @@ fn basic_lcm_dashboard_errors_and_timeline_contracts() {
                 .contains("missing-node"),
             "missing node body should carry the requested id"
         );
-
     });
 }
 

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -401,7 +401,7 @@ async fn insert_undated_message(global_db_path: &Path) {
 }
 
 #[test]
-fn timeline_excludes_null_timestamps_and_reports_undated_count() {
+fn basic_lcm_dashboard_errors_and_timeline_contracts() {
     let _env_lock = GLOBAL_DB_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -457,47 +457,6 @@ fn timeline_excludes_null_timestamps_and_reports_undated_count() {
         assert_eq!(status, 200);
         assert_eq!(other["undated"]["count"], 0, "other-session: {other}");
         assert!(as_array(&other["buckets"], "other buckets").is_empty());
-    });
-}
-
-#[test]
-fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(false).await;
-        corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
-        let agent = http_agent();
-
-        let (status, overview) = get_json(
-            &agent,
-            &format!(
-                "{}/api/plugins/hermes-lcm/overview?limit=20",
-                fixture.base_url
-            ),
-        );
-        assert_eq!(status, 422);
-        assert!(
-            overview["detail"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("malformed metadata_json"),
-            "malformed summary metadata must surface a JSON error detail, got {overview}"
-        );
-    });
-}
-
-#[test]
-fn lcm_bad_params_and_missing_resources_return_json_errors() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(false).await;
-        let agent = http_agent();
 
         let (status, bad_query) = get_json(
             &agent,
@@ -545,6 +504,36 @@ fn lcm_bad_params_and_missing_resources_return_json_errors() {
                 .unwrap_or_default()
                 .contains("missing-node"),
             "missing node body should carry the requested id"
+        );
+
+    });
+}
+
+#[test]
+fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(false).await;
+        corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
+        let agent = http_agent();
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/hermes-lcm/overview?limit=20",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 422);
+        assert!(
+            overview["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("malformed metadata_json"),
+            "malformed summary metadata must surface a JSON error detail, got {overview}"
         );
     });
 }

--- a/tests/db_query_test.rs
+++ b/tests/db_query_test.rs
@@ -1,9 +1,12 @@
 use std::ops::Deref;
 
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::db::{Database, StoredFingerprint};
 use tracedecay::redundancy::Fingerprint;
 use tracedecay::types::*;
+
+static EMPTY_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 struct TestDb {
     db: Database,
@@ -21,10 +24,32 @@ impl Deref for TestDb {
 async fn setup_db() -> TestDb {
     let dir = TempDir::new().expect("failed to create temp dir");
     let db_path = dir.path().join("test.db");
-    let (db, _) = Database::initialize(&db_path)
+    std::fs::write(&db_path, empty_db_template().await).expect("failed to write template database");
+    let (db, migrated) = Database::open(&db_path)
         .await
-        .expect("failed to initialize database");
+        .expect("failed to open template database");
+    assert!(
+        !migrated,
+        "fresh test database should not require migration"
+    );
     TestDb { db, _dir: dir }
+}
+
+async fn empty_db_template() -> &'static [u8] {
+    EMPTY_DB_TEMPLATE
+        .get_or_init(|| async {
+            let dir = TempDir::new().expect("failed to create template temp dir");
+            let db_path = dir.path().join("template.db");
+            let (db, _) = Database::initialize(&db_path)
+                .await
+                .expect("failed to initialize template database");
+            db.checkpoint()
+                .await
+                .expect("failed to checkpoint template database");
+            db.close();
+            std::fs::read(&db_path).expect("failed to read template database")
+        })
+        .await
 }
 
 /// Helper: create a sample node with reasonable defaults.

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -9023,7 +9023,7 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
 
 #[tokio::test]
 async fn lcm_compress_without_summarizer_requests_auxiliary_summary() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     for (index, content) in [
         "historical planning context alpha beta gamma",
         "historical tool result delta epsilon zeta",
@@ -9270,7 +9270,7 @@ async fn lcm_preflight_structured_replay_content_is_bounded_for_mcp() {
 
 #[tokio::test]
 async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     for (index, content) in ["old-1 token", "old-2 token", "fresh-1", "fresh-2"]
         .iter()
         .enumerate()
@@ -9331,7 +9331,7 @@ async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() 
 
 #[tokio::test]
 async fn lcm_status_response_is_valid_json_and_omits_payload_secrets() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let db = open_project_session_db(cg.project_root())
         .await
         .expect("project-local session db should open");
@@ -9618,7 +9618,7 @@ async fn lcm_describe_supports_summary_node_and_external_payload_targets() {
 
 #[tokio::test]
 async fn lcm_grep_and_load_session_honor_native_filters_and_content_clamp() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message_with_role_source_timestamp(
         &cg,
         "lcm-native-filters",
@@ -10164,7 +10164,7 @@ async fn lcm_load_session_accepts_valid_integer_args() {
 
 #[tokio::test]
 async fn lcm_large_json_response_stays_parseable_after_truncation() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     for index in 0..4 {
         seed_lcm_session_message(
             &cg,
@@ -10198,7 +10198,7 @@ async fn lcm_large_json_response_stays_parseable_after_truncation() {
 
 #[tokio::test]
 async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-large-expand-query",
@@ -10262,7 +10262,7 @@ async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
 
 #[tokio::test]
 async fn lcm_expand_query_oversized_prompt_preserves_synthesis_contract() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-huge-prompt-expand-query",


### PR DESCRIPTION
## Summary
- combine dashboard LCM timeline and bad-parameter coverage into one shared-fixture test
- keep malformed metadata coverage separate while avoiding an extra fixture for the basic route/error checks

## Verification
- tracedecay diagnostics: 0 errors / 0 warnings for tests/dashboard_lcm_fixes_test.rs
- cargo fmt --all -- --check
- git diff --check -- tests/dashboard_lcm_fixes_test.rs
- CARGO_TARGET_DIR=/tmp/tracedecay-target/dashboard-lcm-combined cargo nextest run --profile ci --locked --test dashboard_lcm_fixes_test