### PR TITLE
daemon-owned hook event notifications

### DIFF
--- a/docs/BRANCHING-USER-GUIDE.md
+++ b/docs/BRANCHING-USER-GUIDE.md
@@ -4,7 +4,7 @@
 
 TraceDecay maintains a code graph in the active project store. Without multi-branch indexing, that store has one SQLite database for the project. When you switch
 git branches, the files on disk change but the graph still reflects the old branch. The
-embedded MCP watcher eventually catches up by re-indexing changed files, but there are two costs:
+MCP staleness check or daemon/server hook event path eventually catches up by re-indexing changed files, but there are two costs:
 
 1. **Stale window.** Between the checkout and the next sync, every MCP query returns results
    from the old branch. A symbol search might surface a function that doesn't exist on the
@@ -15,13 +15,13 @@ embedded MCP watcher eventually catches up by re-indexing changed files, but the
    On large projects this adds up to minutes of wasted CPU and disk I/O per day.
 
 Multi-branch indexing solves both problems by keeping a separate database per branch. Each
-branch's graph is always accurate, switching is instant, and the watcher syncs only the branch
+branch's graph is always accurate, switching is instant, and sync work targets only the branch
 you're actually working on.
 
 ## How it works
 
 Multi-branch is fully opt-in. Without it, tracedecay behaves exactly as before: one database,
-one graph, the watcher re-indexes whatever is on disk.
+one graph, sync re-indexes whatever is on disk.
 
 When you opt in, tracedecay creates a `branch-meta.json` file inside the active project store that tracks
 which branches have their own database. In repo-local mode, the storage layout looks like this:
@@ -104,18 +104,17 @@ tracedecay branch gc
 This checks each tracked branch against `.git/refs/heads/` and `packed-refs`, and deletes
 databases for branches that are gone.
 
-## How the watcher handles branches
+## How branch-aware sync handles branches
 
-The embedded MCP watcher's behavior depends on whether multi-branch is active:
+MCP staleness checks and daemon/server hook events behave differently depending on whether multi-branch is active:
 
-**Without multi-branch (default):** The watcher monitors for file changes and syncs the single
-`tracedecay.db`. Switching branches triggers a sync of all changed files.
+**Without multi-branch (default):** Sync updates the single `tracedecay.db`. Switching branches triggers a sync of all changed files.
 
-**With multi-branch:** Before each sync, the watcher checks the current branch. If that branch
+**With multi-branch:** Before each sync, TraceDecay checks the current branch. If that branch
 is tracked, it syncs that branch's database. If it's not tracked, it syncs the default
 branch's database. After syncing, it updates the `last_synced_at` timestamp in the metadata.
 
-You don't need to restart the MCP server after adding a branch. The watcher picks up metadata
+You don't need to restart the MCP server after adding a branch. Sync picks up metadata
 changes on the next sync cycle.
 
 ## How the MCP server selects a database
@@ -227,7 +226,7 @@ Yes, using `tracedecay_branch_search` and `tracedecay_branch_diff`. These open t
 branch's database directly without requiring a checkout.
 
 **What happens on detached HEAD?**
-The MCP server falls back to the default branch's database with a warning. The watcher syncs
+The MCP server falls back to the default branch's database with a warning. Sync updates
 the default branch's database.
 
 **Does this work with worktrees?**

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -278,7 +278,8 @@ Kiro setup registers tracedecay in `~/.kiro/settings/mcp.json`, writes steering 
 that steering as a resource while keeping Kiro's default prompt. The managed
 agent exposes all configured tools and pre-approves Kiro built-ins plus the
 tracedecay MCP server, then adds hooks that block research delegation until
-tracedecay MCP tools have been tried and sync the index after Kiro writes files.
+tracedecay MCP tools have been tried and notify the daemon/server after Kiro
+writes files so the server can schedule the index sync.
 If you already have a different custom default agent or a user-managed
 `tracedecay` agent, tracedecay leaves it alone and prints a warning.
 
@@ -302,13 +303,13 @@ Cursor install is plugin-based:
 - `tracedecay install --local --agent cursor` installs the same user-local plugin without writing project Cursor config files.
 - The plugin MCP config runs `tracedecay serve --path ${workspaceFolder}`, so the server resolves the active workspace's project store instead of the plugin directory.
 - Cursor install no longer writes `.cursor/mcp.json`, `.cursor/hooks.json`, `.cursor/rules/tracedecay.mdc`, or `.cursor/permissions.json`; approvals are left to Cursor approval/run-mode behavior.
-- The plugin bundles Cursor-specific, fail-open hooks (each acts only when it finds an initialized TraceDecay project store):
+- The plugin bundles Cursor-specific, fail-open hooks. File and shell hooks notify the TraceDecay daemon; if no daemon is available they return success without indexing:
   - `sessionStart` injects context steering the Agent toward tracedecay MCP tools and reports index freshness (suggests `tracedecay init` when uninitialized).
   - `postToolUse` (unmatched) injects a nonblocking `additional_context` hint after broad search/read tools (Grep, Glob, Read, semantic search, shell `rg`) so Cursor can switch to `tracedecay_context`, `tracedecay_search`, `tracedecay_outline`, or `tracedecay_files`; each hint category fires at most once per session.
   - `beforeSubmitPrompt` resets the local token counter and ingests the current Cursor transcript into the active project session store when `transcript_path` is present.
-  - `afterFileEdit` (unmatched, so every Agent edit tool counts) runs a **targeted single-file** sync of only the edited path(s) — not a full-tree scan — so it stays cheap on large codebases even when the Agent edits many files per turn.
-  - `afterShellExecution` makes branch handling automatic: Agent-run `git checkout`/`switch`/`worktree add` bootstraps/maintains tracedecay branch tracking (`branch add`), while other state-changing git commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop) trigger a coalesced incremental sync.
-  - `workspaceOpen` ensures the current branch's DB exists (branch add if missing) and runs a catch-up incremental sync.
+  - `afterFileEdit` (unmatched, so every Agent edit tool counts) sends the edited path(s) to the daemon, whose MCP server runs a **targeted single-file** sync — not a full-tree scan — so it stays cheap on large codebases even when the Agent edits many files per turn.
+  - `afterShellExecution` sends shell command effects to the daemon, whose MCP server makes branch handling automatic: Agent-run `git checkout`/`switch`/`worktree add` bootstraps/maintains tracedecay branch tracking (`branch add`), while other state-changing git commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop) trigger a coalesced incremental sync.
+  - `workspaceOpen` notifies the daemon, whose MCP server ensures the current branch's DB exists (branch add if missing) and runs a catch-up incremental sync.
 
   Blind spot: Cursor hooks only observe the Cursor Agent's own actions and IDE lifecycle. Manual or external-terminal `git checkout` and in-place branch switches are not visible to these hooks (`workspaceOpen` does not fire for an in-place checkout). Use the git post-commit hook and the on-demand MCP staleness check to keep the index fresh for those cases. The Cursor `postToolUse` hint remains nonblocking to avoid noisy denials.
 
@@ -459,7 +460,7 @@ chmod +x .git/hooks/post-commit
 
 ## MCP Staleness Checks
 
-The MCP server does not run a background file watcher. Instead, MCP tool calls perform a lightweight staleness check and run an incremental sync when indexed files are stale. Multiple MCP servers on the same project coordinate via a per-project sync lock: only one sync runs at a time.
+The MCP server does not run a background file watcher. Instead, MCP tool calls perform a lightweight staleness check and run an incremental sync when indexed files are stale. Agent file/shell hooks notify the daemon about targeted edits and branch-affecting commands, and the daemon's MCP server schedules the resulting sync/branch work. Multiple MCP servers on the same project coordinate via a per-project sync lock: only one sync runs at a time.
 
 ### CLI-Only Workflows
 
@@ -852,7 +853,7 @@ The initial full index of a large project can take a few seconds. This is normal
 
 - Subsequent syncs are incremental and much faster
 - Use `tracedecay sync` (not `--force`) for day-to-day updates
-- The post-commit hook and the embedded MCP watcher run in the background so they never block you
+- The post-commit hook and daemon hook notifications are bounded and fail open so a slow or unavailable daemon does not hold up agent work for long
 
 ### Stale install warning
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -20,7 +20,7 @@ use tokio::net::{UnixListener, UnixStream};
 #[cfg(unix)]
 use tokio::task::JoinHandle;
 #[cfg(unix)]
-use tokio::time::Duration;
+use tokio::time::{timeout, Duration};
 
 use crate::client_identity::DaemonClientIdentity;
 use crate::errors::{Result, TraceDecayError};
@@ -29,6 +29,75 @@ use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, Stdio
 
 pub const SERVICE_NAME: &str = "tracedecay.service";
 pub const SOCKET_ENV: &str = "TRACEDECAY_DAEMON_SOCKET";
+pub const HOOK_EVENT_METHOD: &str = "tracedecay/hookEvent";
+#[cfg(unix)]
+const HOOK_EVENT_NOTIFY_TIMEOUT: Duration = Duration::from_millis(750);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonHookEvent {
+    pub agent: String,
+    pub event: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rel_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<PathBuf>,
+}
+
+impl DaemonHookEvent {
+    fn new(
+        agent: &'static str,
+        event: &'static str,
+        rel_paths: Vec<String>,
+        command: Option<String>,
+        cwd: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            agent: agent.to_string(),
+            event: event.to_string(),
+            rel_paths,
+            command,
+            cwd,
+        }
+    }
+
+    pub fn cursor_after_file_edit(rel_paths: Vec<String>) -> Self {
+        Self::new("cursor", "afterFileEdit", rel_paths, None, None)
+    }
+
+    pub fn cursor_after_shell_execution(command: String, cwd: PathBuf) -> Self {
+        Self::new(
+            "cursor",
+            "afterShellExecution",
+            Vec::new(),
+            Some(command),
+            Some(cwd),
+        )
+    }
+
+    pub fn cursor_workspace_open(cwd: PathBuf) -> Self {
+        Self::new("cursor", "workspaceOpen", Vec::new(), None, Some(cwd))
+    }
+
+    pub fn codex_post_tool_use_edit(rel_paths: Vec<String>, cwd: PathBuf) -> Self {
+        Self::new("codex", "postToolUseEdit", rel_paths, None, Some(cwd))
+    }
+
+    pub fn codex_post_tool_use_shell(command: String, cwd: PathBuf) -> Self {
+        Self::new(
+            "codex",
+            "postToolUseShell",
+            Vec::new(),
+            Some(command),
+            Some(cwd),
+        )
+    }
+
+    pub fn kiro_post_tool_use(cwd: Option<PathBuf>) -> Self {
+        Self::new("kiro", "postToolUse", Vec::new(), None, cwd)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DaemonServiceSpec {
@@ -187,6 +256,192 @@ pub fn service_spec(
         tracedecay_bin: tracedecay_bin.into(),
         socket_path: socket_path_or_default(socket)?,
     })
+}
+
+#[cfg(unix)]
+pub async fn notify_hook_event(project_path: &Path, event: DaemonHookEvent) {
+    let _ = timeout(
+        HOOK_EVENT_NOTIFY_TIMEOUT,
+        notify_hook_event_inner(project_path, event),
+    )
+    .await;
+}
+
+#[cfg(unix)]
+async fn notify_hook_event_inner(project_path: &Path, event: DaemonHookEvent) {
+    let Ok(socket_path) = default_socket_path() else {
+        return;
+    };
+    if !socket_path.exists() {
+        return;
+    }
+    let Ok(handshake) =
+        DaemonHandshake::for_current_client(Some(project_path.to_path_buf()), None, false, false)
+    else {
+        return;
+    };
+    let Ok(params) = serde_json::to_value(event) else {
+        return;
+    };
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: None,
+        method: HOOK_EVENT_METHOD.to_string(),
+        params: Some(params),
+    };
+    let Ok(line) = serde_json::to_string(&request) else {
+        return;
+    };
+    let Ok(stream) = UnixStream::connect(socket_path).await else {
+        return;
+    };
+    let Ok(handshake_line) = handshake.to_line() else {
+        return;
+    };
+    let (_reader, mut writer) = stream.into_split();
+    if writer.write_all(handshake_line.as_bytes()).await.is_err() {
+        return;
+    }
+    if writer.write_all(b"\n").await.is_err() {
+        return;
+    }
+    if writer.write_all(line.as_bytes()).await.is_err() {
+        return;
+    }
+    if writer.write_all(b"\n").await.is_err() {
+        return;
+    }
+    let _ = writer.flush().await;
+    let _ = writer.shutdown().await;
+}
+
+#[cfg(not(unix))]
+pub async fn notify_hook_event(project_path: &Path, event: DaemonHookEvent) {
+    if !crate::tracedecay::TraceDecay::has_initialized_store(project_path).await {
+        return;
+    }
+    match event.event.as_str() {
+        "afterFileEdit" | "postToolUseEdit" => {
+            let rel_paths = safe_daemon_hook_rel_paths(&event.rel_paths);
+            if rel_paths.is_empty() {
+                return;
+            }
+            let Ok(cg) = crate::tracedecay::TraceDecay::open(project_path).await else {
+                return;
+            };
+            let _ = cg.sync_if_stale_silent(&rel_paths).await;
+        }
+        "afterShellExecution" | "postToolUseShell" => {
+            notify_shell_hook_event_without_daemon(project_path, event).await;
+        }
+        "workspaceOpen" => {
+            if let Some(branch) = crate::branch::current_branch(project_path) {
+                if matches!(
+                    crate::tracedecay::TraceDecay::add_branch_tracking(project_path, &branch).await,
+                    Ok(crate::branch::BranchAddOutcome::Added)
+                ) {
+                    return;
+                }
+            }
+            run_debounced_hook_sync_without_daemon(project_path, hook_marker_file(&event.agent))
+                .await;
+        }
+        "postToolUse" => {
+            run_debounced_hook_sync_without_daemon(project_path, hook_marker_file(&event.agent))
+                .await;
+        }
+        _ => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn notify_shell_hook_event_without_daemon(project_path: &Path, event: DaemonHookEvent) {
+    let Some(command) = event.command.as_deref() else {
+        return;
+    };
+    let cwd = event.cwd.as_deref().unwrap_or(project_path);
+    if !crate::hooks::cursor_shell_command_targets_project(command, cwd, project_path) {
+        return;
+    }
+    let current_branch = crate::branch::current_branch(project_path);
+    match crate::hooks::cursor_shell_sync_plan_with_current_branch(
+        command,
+        current_branch.as_deref(),
+    ) {
+        crate::hooks::CursorShellSyncPlan::BranchAdd(branch) => {
+            let _ = crate::tracedecay::TraceDecay::add_branch_tracking(project_path, &branch).await;
+        }
+        crate::hooks::CursorShellSyncPlan::CurrentBranchSync(branch) => {
+            if !matches!(
+                crate::tracedecay::TraceDecay::add_branch_tracking(project_path, &branch).await,
+                Ok(crate::branch::BranchAddOutcome::Added)
+            ) {
+                run_debounced_hook_sync_without_daemon(
+                    project_path,
+                    hook_marker_file(&event.agent),
+                )
+                .await;
+            }
+        }
+        crate::hooks::CursorShellSyncPlan::IncrementalSync => {
+            run_debounced_hook_sync_without_daemon(project_path, hook_marker_file(&event.agent))
+                .await;
+        }
+        crate::hooks::CursorShellSyncPlan::Noop => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn run_debounced_hook_sync_without_daemon(project_path: &Path, marker_file: &str) {
+    let Ok(cg) = crate::tracedecay::TraceDecay::open(project_path).await else {
+        return;
+    };
+    let marker = cg.store_layout().data_root.join(marker_file);
+    let now = crate::tracedecay::current_timestamp();
+    if !crate::hooks::cursor_should_run_sync(now, read_hook_marker_secs(&marker), 3) {
+        return;
+    }
+    match cg.sync().await {
+        Ok(_) | Err(TraceDecayError::SyncLock { .. }) => {
+            let _ = std::fs::write(marker, now.to_string());
+        }
+        Err(_) => {}
+    }
+}
+
+#[cfg(not(unix))]
+fn safe_daemon_hook_rel_paths(paths: &[String]) -> Vec<String> {
+    paths
+        .iter()
+        .filter(|path| {
+            let path_ref = Path::new(path.as_str());
+            !path.is_empty()
+                && !path_ref.is_absolute()
+                && path_ref
+                    .components()
+                    .all(|component| !matches!(component, std::path::Component::ParentDir))
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(not(unix))]
+fn hook_marker_file(agent: &str) -> &'static str {
+    match agent {
+        "codex" => ".codex_shell_sync_at",
+        "cursor" => ".cursor_shell_sync_at",
+        "kiro" => ".kiro_post_tool_sync_at",
+        _ => ".daemon_hook_shell_sync_at",
+    }
+}
+
+#[cfg(not(unix))]
+fn read_hook_marker_secs(path: &Path) -> Option<i64> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<i64>()
+        .ok()
 }
 
 pub fn install_service(spec: &DaemonServiceSpec, start: bool) -> Result<PathBuf> {
@@ -1572,6 +1827,21 @@ mod tests {
         }
     }
 
+    fn run_git(cwd: &std::path::Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     #[test]
     fn daemon_log_line_formats_stable_key_value_fields() {
         let line = super::format_daemon_log_line(
@@ -2133,6 +2403,77 @@ mod tests {
             .await
             .expect("server task")
             .expect("server result");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn socket_client_hook_event_adds_branch_tracking() {
+        let dir = TempDir::new().expect("temp dir");
+        let project = dir.path().canonicalize().expect("canonical temp dir");
+        let client_identity = test_client_identity_for(project.join("profile"));
+        std::fs::create_dir_all(project.join("src")).expect("src dir");
+        std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
+        let cg = crate::tracedecay::TraceDecay::init_with_options(
+            &project,
+            crate::tracedecay::TraceDecayOpenOptions {
+                profile_root: Some(client_identity.profile_root.clone()),
+                global_db_path: Some(client_identity.global_db_path.clone()),
+            },
+        )
+        .await
+        .expect("project init");
+        let data_root = cg.store_layout().data_root.clone();
+        run_git(&project, &["init", "-b", "main"]);
+        run_git(&project, &["switch", "-c", "feature/hook-daemon"]);
+
+        let (client, server) = tokio::net::UnixStream::pair().expect("unix stream pair");
+        let server_task = tokio::spawn(super::serve_socket_client(
+            server,
+            super::DaemonEngine::default(),
+        ));
+
+        let (_reader, mut writer) = client.into_split();
+        let handshake = DaemonHandshake {
+            project_path: Some(project.clone()),
+            scope_prefix: None,
+            timings: false,
+            allow_init: false,
+            client_identity,
+        };
+        writer
+            .write_all(handshake.to_line().expect("handshake").as_bytes())
+            .await
+            .expect("write handshake");
+        writer.write_all(b"\n").await.expect("newline");
+        writer
+            .write_all(
+                serde_json::to_string(&json!({
+                    "jsonrpc": "2.0",
+                    "method": "tracedecay/hookEvent",
+                    "params": {
+                        "agent": "cursor",
+                        "event": "afterShellExecution",
+                        "command": "git switch feature/hook-daemon",
+                        "cwd": project
+                    }
+                }))
+                .expect("hook event json")
+                .as_bytes(),
+            )
+            .await
+            .expect("write hook event");
+        writer.write_all(b"\n").await.expect("newline");
+        writer.shutdown().await.expect("shutdown writer");
+
+        server_task
+            .await
+            .expect("server task")
+            .expect("server result");
+
+        assert!(
+            data_root.join("branches/feature_hook-daemon.db").exists(),
+            "daemon hook events should add branch tracking in the active project store"
+        );
     }
 
     #[cfg(unix)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -94,8 +94,8 @@ impl DaemonHookEvent {
         )
     }
 
-    pub fn kiro_post_tool_use(cwd: Option<PathBuf>) -> Self {
-        Self::new("kiro", "postToolUse", Vec::new(), None, cwd)
+    pub fn kiro_post_tool_use(rel_paths: Vec<String>, cwd: Option<PathBuf>) -> Self {
+        Self::new("kiro", "postToolUse", rel_paths, None, cwd)
     }
 }
 
@@ -347,6 +347,14 @@ pub async fn notify_hook_event(project_path: &Path, event: DaemonHookEvent) {
                 .await;
         }
         "postToolUse" => {
+            let rel_paths = safe_daemon_hook_rel_paths(&event.rel_paths);
+            if !rel_paths.is_empty() {
+                let Ok(cg) = crate::tracedecay::TraceDecay::open(project_path).await else {
+                    return;
+                };
+                let _ = cg.sync_if_stale_silent(&rel_paths).await;
+                return;
+            }
             run_debounced_hook_sync_without_daemon(project_path, hook_marker_file(&event.agent))
                 .await;
         }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{BTreeMap, HashSet};
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -1293,6 +1293,14 @@ fn rel_under_root(root: &Path, abs: &Path) -> Option<String> {
     if stripped.as_os_str().is_empty() {
         return None;
     }
+    if stripped.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return None;
+    }
     Some(stripped.to_string_lossy().replace('\\', "/"))
 }
 
@@ -2450,11 +2458,62 @@ async fn notify_kiro_post_tool_use(event_json: &str) {
     if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
         return;
     }
+    let rel_paths = kiro_post_tool_use_rel_paths(event_json, &project_root);
     crate::daemon::notify_hook_event(
         &project_root,
-        crate::daemon::DaemonHookEvent::kiro_post_tool_use(event_cwd(event_json)),
+        crate::daemon::DaemonHookEvent::kiro_post_tool_use(rel_paths, event_cwd(event_json)),
     )
     .await;
+}
+
+pub fn kiro_post_tool_use_rel_paths(event_json: &str, project_root: &Path) -> Vec<String> {
+    let Ok(parsed) = serde_json::from_str::<Value>(event_json) else {
+        return Vec::new();
+    };
+    let cwd = event_cwd_from_parsed(&parsed).unwrap_or_else(|| project_root.to_path_buf());
+    let tool_input = parsed
+        .get("tool_input")
+        .or_else(|| parsed.get("toolInput"))
+        .or_else(|| parsed.get("input"))
+        .unwrap_or(&Value::Null);
+
+    let mut paths = Vec::new();
+    collect_event_path_fields(&parsed, &mut paths);
+    collect_event_path_fields(tool_input, &mut paths);
+
+    let mut rels = Vec::new();
+    for path in paths {
+        let path = Path::new(&path);
+        let abs = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            cwd.join(path)
+        };
+        if let Some(rel) = rel_under_root(project_root, &abs) {
+            if !rels.contains(&rel) {
+                rels.push(rel);
+            }
+        }
+    }
+    rels
+}
+
+fn collect_event_path_fields(value: &Value, out: &mut Vec<String>) {
+    for key in ["file_path", "filePath", "path", "target_file", "targetFile"] {
+        match value.get(key) {
+            Some(Value::String(path)) if !path.is_empty() => out.push(path.clone()),
+            Some(Value::Array(paths)) => {
+                out.extend(
+                    paths
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter(|path| !path.is_empty())
+                        .map(str::to_string),
+                );
+            }
+            _ => {}
+        }
+    }
 }
 
 fn cursor_tool_hint_input(parsed: &Value) -> ToolHintInput {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -565,18 +565,14 @@ async fn cursor_pre_compact_for_event_inner(
 
 /// Cursor `afterFileEdit` hook handler.
 ///
-/// Keeps the graph fresh after Cursor Agent writes files. This uses a
-/// **targeted** single-file sync (`sync_if_stale_silent`) scoped to the edited
-/// path(s) rather than a full-tree `sync()`. The agent can edit many files per
-/// turn, and a full-tree scan per edit scales with repo size, not edit size —
-/// prohibitively expensive on large codebases. The targeted path skips the
-/// scan, no-ops when not stale, and waits/gives up on the sync lock, so no
-/// time-based debounce is needed. Fail-open and silent.
+/// Keeps the graph fresh after Cursor Agent writes files by notifying the
+/// daemon about the edited path(s). The daemon owns targeted sync scheduling
+/// and the hook fails open when no daemon is available.
 pub async fn hook_cursor_after_file_edit() -> i32 {
     let event = read_hook_event!();
     let root = cursor_project_root_from_event(&event);
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "afterFileEdit", &event);
-    targeted_sync_for_cursor_after_file_edit(&event).await;
+    notify_cursor_after_file_edit(&event).await;
     0
 }
 
@@ -647,11 +643,8 @@ async fn codex_session_context_for_event(event_json: &str) -> (String, HookWorks
 
 /// Cursor `afterShellExecution` hook handler.
 ///
-/// When the executed command is a git state-changing command (checkout,
-/// switch, pull, merge, rebase, reset, cherry-pick, stash apply/pop), a
-/// broader change set is expected, so a full incremental `sync()` is
-/// acceptable. Back-to-back git commands are coalesced via a short marker-based
-/// guard (and the sync lock no-ops concurrent runs). Fail-open and silent.
+/// Notifies the daemon after Cursor shell execution. The daemon decides whether
+/// the command requires branch tracking or coalesced incremental sync.
 pub async fn hook_cursor_after_shell() -> i32 {
     let event = read_hook_event!();
     let root = cursor_project_root_from_event(&event);
@@ -661,20 +654,20 @@ pub async fn hook_cursor_after_shell() -> i32 {
         "afterShellExecution",
         &event,
     );
-    sync_after_cursor_shell_event(&event).await;
+    notify_cursor_after_shell_event(&event).await;
     0
 }
 
 /// Cursor `workspaceOpen` hook handler.
 ///
-/// Runs a one-shot catch-up incremental `sync()` when the workspace has a
-/// tracedecay index, picking up changes made while no agent was attached. We
-/// don't load plugins, so the output is an empty object. Fail-open.
+/// Notifies the daemon to run one-shot workspace catch-up when an indexed
+/// workspace opens. We don't load plugins, so the output is an empty object.
+/// Fail-open.
 pub async fn hook_cursor_workspace_open() -> i32 {
     let event = read_hook_event!();
     let root = cursor_project_root_from_event(&event);
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "workspaceOpen", &event);
-    workspace_open_for_cursor_event(&event).await;
+    notify_cursor_workspace_open(&event).await;
     println!("{}", serde_json::json!({}));
     0
 }
@@ -1255,10 +1248,9 @@ fn paths_same(a: &Path, b: &Path) -> bool {
 /// Extracts the repo-relative paths edited in a Cursor `afterFileEdit` event.
 ///
 /// Cursor sends an absolute `file_path` (plus an `edits` array). We strip the
-/// resolved `project_root` prefix and normalize to forward slashes so the set
-/// can be passed straight to [`TraceDecay::sync_if_stale_silent`], which does a
-/// targeted single-file sync instead of a full-tree scan. Paths outside the
-/// project root are skipped.
+/// resolved `project_root` prefix and normalize to forward slashes so the hook
+/// can notify the daemon about only the changed files. Paths outside the project
+/// root are skipped.
 pub fn cursor_after_file_edit_rel_paths(event_json: &str, project_root: &Path) -> Vec<String> {
     let Ok(parsed) = serde_json::from_str::<Value>(event_json) else {
         return Vec::new();
@@ -1548,12 +1540,11 @@ async fn cursor_index_signals_for_root(root: &Path) -> (Option<String>, Option<u
     (staleness, tokens_saved)
 }
 
-/// Targeted, fail-open single-file sync for Cursor `afterFileEdit`.
+/// Best-effort daemon notification for Cursor `afterFileEdit`.
 ///
-/// Resolves the edited repo-relative paths and calls `sync_if_stale_silent`,
-/// which avoids the full-tree scan that `sync()` performs. No-ops when the
-/// workspace is uninitialized or no in-project paths were edited.
-async fn targeted_sync_for_cursor_after_file_edit(event_json: &str) {
+/// Resolves the edited repo-relative paths locally, then lets the daemon own
+/// scheduling and sync execution. No-ops when no in-project paths were edited.
+async fn notify_cursor_after_file_edit(event_json: &str) {
     let Some(root) = cursor_project_root_from_event(event_json) else {
         return;
     };
@@ -1564,20 +1555,15 @@ async fn targeted_sync_for_cursor_after_file_edit(event_json: &str) {
     if rels.is_empty() {
         return;
     }
-    if let Ok(cg) = crate::tracedecay::TraceDecay::open(&root).await {
-        let _ = cg.sync_if_stale_silent(&rels).await;
-    }
+    crate::daemon::notify_hook_event(
+        &root,
+        crate::daemon::DaemonHookEvent::cursor_after_file_edit(rels),
+    )
+    .await;
 }
 
-/// Branch-aware, fail-open handler for git state-changing shell commands.
-///
-/// Branch switches (`checkout`/`switch`/`worktree add`) bootstrap/maintain
-/// tracedecay branch tracking via [`crate::tracedecay::TraceDecay::add_branch_tracking`] —
-/// which is idempotent and supersedes a plain sync. Other state-changing
-/// commands (pull/merge/rebase/reset/cherry-pick/stash apply|pop) run a full
-/// incremental `sync()`, coalesced by a short marker-based guard so back-to-back
-/// git commands don't stack. Only acts when `.tracedecay/` already exists.
-async fn sync_after_cursor_shell_event(event_json: &str) {
+/// Best-effort daemon notification for Cursor `afterShellExecution`.
+async fn notify_cursor_after_shell_event(event_json: &str) {
     let Ok(parsed) = serde_json::from_str::<Value>(event_json) else {
         return;
     };
@@ -1588,96 +1574,30 @@ async fn sync_after_cursor_shell_event(event_json: &str) {
     let Some(root) = cursor_project_root_from_event(event_json) else {
         return;
     };
-    // Never bootstrap indexing in an unindexed repo.
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
     let cwd = cursor_event_cwd(&parsed).unwrap_or_else(|| root.clone());
-    if !cursor_shell_command_targets_project(command, &cwd, &root) {
-        return;
-    }
-    let current_branch = crate::branch::current_branch(&root);
-    let plan = cursor_shell_sync_plan_with_current_branch(command, current_branch.as_deref());
-    if matches!(plan, CursorShellSyncPlan::Noop) {
-        return;
-    }
-
-    match plan {
-        CursorShellSyncPlan::BranchAdd(branch) => {
-            // Idempotent + fail-open: already-tracked branches no-op.
-            let _ = crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await;
-        }
-        CursorShellSyncPlan::IncrementalSync => {
-            run_coalesced_incremental_sync(&root, ".cursor_shell_sync_at").await;
-        }
-        CursorShellSyncPlan::CurrentBranchSync(branch) => {
-            if !matches!(
-                crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await,
-                Ok(crate::branch::BranchAddOutcome::Added)
-            ) {
-                run_coalesced_incremental_sync(&root, ".cursor_shell_sync_at").await;
-            }
-        }
-        CursorShellSyncPlan::Noop => {}
-    }
+    crate::daemon::notify_hook_event(
+        &root,
+        crate::daemon::DaemonHookEvent::cursor_after_shell_execution(command.to_string(), cwd),
+    )
+    .await;
 }
 
-/// Runs a full incremental `sync()`, coalescing back-to-back invocations via a
-/// short marker-based debounce so a burst of git commands doesn't stack syncs.
-/// `marker_file` names the per-agent marker inside the `.tracedecay/` dir. The
-/// sync lock additionally no-ops genuinely concurrent runs. Fail-open.
-async fn run_coalesced_incremental_sync(root: &Path, marker_file: &str) {
-    let marker = crate::config::get_tracedecay_dir(root).join(marker_file);
-    let now = now_unix_secs();
-    if !cursor_should_run_sync(now, read_marker_secs(&marker), 3) {
-        return;
-    }
-    write_marker_secs(&marker, now);
-
-    if let Ok(cg) = crate::tracedecay::TraceDecay::open(root).await {
-        match cg.sync().await {
-            Ok(_) | Err(crate::errors::TraceDecayError::SyncLock { .. }) => {}
-            Err(e) => eprintln!("tracedecay sync failed: {e}"),
-        }
-    }
-}
-
-/// Branch-aware workspace catch-up for Cursor `workspaceOpen`.
-///
-/// When the workspace has a tracedecay index, ensures the current branch's DB
-/// exists (branch-add if missing — which also syncs) and otherwise runs a
-/// catch-up incremental `sync()`. Idempotent and fail-open.
-async fn workspace_open_for_cursor_event(event_json: &str) {
+/// Best-effort daemon notification for Cursor `workspaceOpen`.
+async fn notify_cursor_workspace_open(event_json: &str) {
     let Some(root) = cursor_project_root_from_event(event_json) else {
         return;
     };
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
-
-    // Ensure the current branch is tracked. When a branch is freshly added,
-    // `add_branch_tracking` already runs a sync, so we can skip the catch-up.
-    if let Some(branch) = crate::branch::current_branch(&root) {
-        if let Ok(crate::branch::BranchAddOutcome::Added) =
-            crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await
-        {
-            return;
-        }
-    }
-
-    let _ = sync_for_cursor_event(event_json).await;
-}
-
-fn read_marker_secs(path: &Path) -> Option<i64> {
-    std::fs::read_to_string(path)
-        .ok()?
-        .trim()
-        .parse::<i64>()
-        .ok()
-}
-
-fn write_marker_secs(path: &Path, secs: i64) {
-    let _ = std::fs::write(path, secs.to_string());
+    crate::daemon::notify_hook_event(
+        &root,
+        crate::daemon::DaemonHookEvent::cursor_workspace_open(root.clone()),
+    )
+    .await;
 }
 
 fn now_unix_secs() -> i64 {
@@ -1771,11 +1691,8 @@ pub fn hook_codex_subagent_start() -> i32 {
 
 /// Codex `PostToolUse` hook handler used to keep the graph fresh after writes.
 ///
-/// For `apply_patch` edits this runs a **targeted** single-file sync using the
-/// paths parsed from the patch envelope (never a full-tree scan). For `Bash`
-/// commands it reuses the shared git-command classifier: branch switches
-/// bootstrap branch tracking, other state-changing commands run a coalesced
-/// incremental sync. Fail-open and silent.
+/// For edit tools and shell commands this notifies the daemon, which owns
+/// targeted sync, branch tracking, and coalescing. Fail-open and silent.
 pub async fn hook_codex_post_tool_use() -> i32 {
     let event = read_hook_event!();
     let root = codex_project_root_from_event(&event);
@@ -2067,8 +1984,8 @@ fn project_marker_exists(dir: &Path) -> bool {
 /// or `*** Move to:` lines. Patch paths are relative to the session `cwd`
 /// (which may be a subdirectory of the discovered project root), so we resolve
 /// each against `cwd` and then make it relative to `project_root`. Absolute
-/// paths outside the root are skipped. The result feeds the targeted
-/// [`TraceDecay::sync_if_stale_silent`] single-file sync.
+/// paths outside the root are skipped. The result feeds the daemon's targeted
+/// single-file sync event.
 pub fn codex_apply_patch_rel_paths(command: &str, cwd: &Path, project_root: &Path) -> Vec<String> {
     const PREFIXES: [&str; 4] = [
         "*** Add File:",
@@ -2135,7 +2052,6 @@ async fn codex_post_tool_use(event_json: &str) {
     else {
         return;
     };
-    // Never bootstrap indexing in an unindexed repo.
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         return;
     }
@@ -2145,32 +2061,17 @@ async fn codex_post_tool_use(event_json: &str) {
         if rels.is_empty() {
             return;
         }
-        if let Ok(cg) = crate::tracedecay::TraceDecay::open(&root).await {
-            let _ = cg.sync_if_stale_silent(&rels).await;
-        }
+        crate::daemon::notify_hook_event(
+            &root,
+            crate::daemon::DaemonHookEvent::codex_post_tool_use_edit(rels, cwd),
+        )
+        .await;
     } else if is_codex_bash_tool(tool_name) {
-        if !cursor_shell_command_targets_project(command, &cwd, &root) {
-            return;
-        }
-        let current_branch = crate::branch::current_branch(&root);
-        match cursor_shell_sync_plan_with_current_branch(command, current_branch.as_deref()) {
-            CursorShellSyncPlan::BranchAdd(branch) => {
-                // Idempotent + fail-open: already-tracked branches no-op.
-                let _ = crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await;
-            }
-            CursorShellSyncPlan::IncrementalSync => {
-                run_coalesced_incremental_sync(&root, ".codex_shell_sync_at").await;
-            }
-            CursorShellSyncPlan::CurrentBranchSync(branch) => {
-                if !matches!(
-                    crate::tracedecay::TraceDecay::add_branch_tracking(&root, &branch).await,
-                    Ok(crate::branch::BranchAddOutcome::Added)
-                ) {
-                    run_coalesced_incremental_sync(&root, ".codex_shell_sync_at").await;
-                }
-            }
-            CursorShellSyncPlan::Noop => {}
-        }
+        crate::daemon::notify_hook_event(
+            &root,
+            crate::daemon::DaemonHookEvent::codex_post_tool_use_shell(command.to_string(), cwd),
+        )
+        .await;
     }
 }
 
@@ -2357,18 +2258,14 @@ pub async fn hook_kiro_prompt_submit() -> i32 {
 /// Kiro `postToolUse` hook handler used to keep the graph fresh after writes.
 ///
 /// The installed Kiro agent maps this to `fs_write`. The hook discovers the
-/// nearest initialized tracedecay project from Kiro's `cwd` field and runs a
-/// silent incremental sync. Missing indexes and concurrent syncs are no-ops.
+/// nearest tracedecay project from Kiro's `cwd` field and notifies the daemon,
+/// which owns silent incremental sync scheduling. Missing daemon/index state is
+/// fail-open.
 pub async fn hook_kiro_post_tool_use() -> i32 {
     let event = read_hook_event!();
     record_hook_invoked(None, HintAgent::Kiro, "postToolUse", &event);
-    match sync_for_kiro_event(&event).await {
-        Ok(()) => 0,
-        Err(e) => {
-            eprintln!("tracedecay sync failed: {e}");
-            1
-        }
-    }
+    notify_kiro_post_tool_use(&event).await;
+    0
 }
 
 async fn reset_counter_for_kiro_event(event_json: &str) {
@@ -2546,32 +2443,18 @@ async fn ingest_cursor_transcript_for_event(
     tokio::time::timeout(budget, work).await.unwrap_or(false)
 }
 
-async fn sync_for_kiro_event(event_json: &str) -> crate::errors::Result<()> {
+async fn notify_kiro_post_tool_use(event_json: &str) {
     let Some(project_root) = kiro_project_root(event_json) else {
-        return Ok(());
+        return;
     };
     if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
-        return Ok(());
+        return;
     }
-    let cg = crate::tracedecay::TraceDecay::open(&project_root).await?;
-    match cg.sync().await {
-        Ok(_) | Err(crate::errors::TraceDecayError::SyncLock { .. }) => Ok(()),
-        Err(e) => Err(e),
-    }
-}
-
-async fn sync_for_cursor_event(event_json: &str) -> crate::errors::Result<()> {
-    let Some(project_root) = cursor_project_root_from_event(event_json) else {
-        return Ok(());
-    };
-    if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
-        return Ok(());
-    }
-    let cg = crate::tracedecay::TraceDecay::open(&project_root).await?;
-    match cg.sync().await {
-        Ok(_) | Err(crate::errors::TraceDecayError::SyncLock { .. }) => Ok(()),
-        Err(e) => Err(e),
-    }
+    crate::daemon::notify_hook_event(
+        &project_root,
+        crate::daemon::DaemonHookEvent::kiro_post_tool_use(event_cwd(event_json)),
+    )
+    .await;
 }
 
 fn cursor_tool_hint_input(parsed: &Value) -> ToolHintInput {

--- a/src/mcp/hook_events.rs
+++ b/src/mcp/hook_events.rs
@@ -102,6 +102,9 @@ pub(crate) fn plan_hook_event(
                 agent: event.agent,
             })
             .unwrap_or(HookEventPlan::DebouncedIncrementalSync(event.agent)),
+        HookEventKind::IncrementalSync if !event.rel_paths.is_empty() => {
+            HookEventPlan::SyncFiles(event.rel_paths.clone())
+        }
         HookEventKind::IncrementalSync => HookEventPlan::DebouncedIncrementalSync(event.agent),
     }
 }
@@ -251,6 +254,21 @@ mod tests {
         let params = json!({
             "agent": "cursor",
             "event": "afterFileEdit",
+            "rel_paths": ["src/lib.rs", "../outside.rs"]
+        });
+        let event = parse_or_panic(&params);
+
+        assert_eq!(
+            plan_hook_event(&event, Path::new("/tmp/project"), None),
+            HookEventPlan::SyncFiles(vec!["src/lib.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn plans_incremental_sync_with_paths_as_targeted_sync() {
+        let params = json!({
+            "agent": "kiro",
+            "event": "postToolUse",
             "rel_paths": ["src/lib.rs", "../outside.rs"]
         });
         let event = parse_or_panic(&params);

--- a/src/mcp/hook_events.rs
+++ b/src/mcp/hook_events.rs
@@ -1,0 +1,300 @@
+//! Normalizes daemon hook notifications into typed sync plans.
+//!
+//! This module owns wire-level hook semantics. The MCP server owns graph side
+//! effects such as branch tracking, sync execution, and token-map refreshes.
+
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HookAgent {
+    Codex,
+    Cursor,
+    Kiro,
+}
+
+impl HookAgent {
+    fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "codex" => Some(Self::Codex),
+            "cursor" => Some(Self::Cursor),
+            "kiro" => Some(Self::Kiro),
+            _ => None,
+        }
+    }
+
+    fn marker_file(self) -> &'static str {
+        match self {
+            Self::Codex => ".codex_shell_sync_at",
+            Self::Cursor => ".cursor_shell_sync_at",
+            Self::Kiro => ".kiro_post_tool_sync_at",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HookEventKind {
+    FileEdit,
+    Shell,
+    WorkspaceOpen,
+    IncrementalSync,
+}
+
+impl HookEventKind {
+    fn from_wire(value: &str) -> Option<Self> {
+        match value {
+            "afterFileEdit" | "postToolUseEdit" => Some(Self::FileEdit),
+            "afterShellExecution" | "postToolUseShell" => Some(Self::Shell),
+            "workspaceOpen" => Some(Self::WorkspaceOpen),
+            "postToolUse" => Some(Self::IncrementalSync),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) struct HookEvent {
+    pub(crate) agent: HookAgent,
+    pub(crate) kind: HookEventKind,
+    pub(crate) rel_paths: Vec<String>,
+    pub(crate) command: Option<String>,
+    pub(crate) cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HookEventPlan {
+    SyncFiles(Vec<String>),
+    AddBranch(String),
+    SyncCurrentBranch { branch: String, agent: HookAgent },
+    DebouncedIncrementalSync(HookAgent),
+    Noop,
+}
+
+pub(crate) fn parse_hook_event(params: Option<&Value>) -> Option<HookEvent> {
+    let event = serde_json::from_value::<crate::daemon::DaemonHookEvent>(params?.clone()).ok()?;
+    Some(HookEvent {
+        agent: HookAgent::from_wire(&event.agent)?,
+        kind: HookEventKind::from_wire(&event.event)?,
+        rel_paths: safe_hook_rel_paths(&event.rel_paths),
+        command: event.command.filter(|command| !command.is_empty()),
+        cwd: event.cwd,
+    })
+}
+
+pub(crate) fn plan_hook_event(
+    event: &HookEvent,
+    project_root: &Path,
+    current_branch: Option<&str>,
+) -> HookEventPlan {
+    match event.kind {
+        HookEventKind::FileEdit => {
+            if event.rel_paths.is_empty() {
+                HookEventPlan::Noop
+            } else {
+                HookEventPlan::SyncFiles(event.rel_paths.clone())
+            }
+        }
+        HookEventKind::Shell => plan_shell_hook_event(event, project_root, current_branch),
+        HookEventKind::WorkspaceOpen => current_branch
+            .filter(|branch| !branch.is_empty())
+            .map(|branch| HookEventPlan::SyncCurrentBranch {
+                branch: branch.to_string(),
+                agent: event.agent,
+            })
+            .unwrap_or(HookEventPlan::DebouncedIncrementalSync(event.agent)),
+        HookEventKind::IncrementalSync => HookEventPlan::DebouncedIncrementalSync(event.agent),
+    }
+}
+
+pub(crate) fn sync_marker_path(data_root: &Path, agent: HookAgent) -> PathBuf {
+    data_root.join(agent.marker_file())
+}
+
+pub(crate) fn should_run_sync(marker: &Path, now_secs: i64, debounce_secs: i64) -> bool {
+    crate::hooks::cursor_should_run_sync(now_secs, read_marker_secs(marker), debounce_secs)
+}
+
+pub(crate) fn write_sync_marker(marker: &Path, now_secs: i64) {
+    let _ = std::fs::write(marker, now_secs.to_string());
+}
+
+fn safe_hook_rel_paths(paths: &[String]) -> Vec<String> {
+    paths
+        .iter()
+        .filter(|path| {
+            let path_ref = Path::new(path.as_str());
+            !path.is_empty()
+                && !path_ref.is_absolute()
+                && path_ref.components().all(|component| {
+                    !matches!(
+                        component,
+                        Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                    )
+                })
+        })
+        .cloned()
+        .collect()
+}
+
+fn plan_shell_hook_event(
+    event: &HookEvent,
+    project_root: &Path,
+    current_branch: Option<&str>,
+) -> HookEventPlan {
+    let Some(command) = event.command.as_deref() else {
+        return HookEventPlan::Noop;
+    };
+    let cwd = event.cwd.as_deref().unwrap_or(project_root);
+    if !crate::hooks::cursor_shell_command_targets_project(command, cwd, project_root) {
+        return HookEventPlan::Noop;
+    }
+    match crate::hooks::cursor_shell_sync_plan_with_current_branch(command, current_branch) {
+        crate::hooks::CursorShellSyncPlan::BranchAdd(branch) => HookEventPlan::AddBranch(branch),
+        crate::hooks::CursorShellSyncPlan::IncrementalSync => {
+            HookEventPlan::DebouncedIncrementalSync(event.agent)
+        }
+        crate::hooks::CursorShellSyncPlan::CurrentBranchSync(branch) => {
+            HookEventPlan::SyncCurrentBranch {
+                branch,
+                agent: event.agent,
+            }
+        }
+        crate::hooks::CursorShellSyncPlan::Noop => HookEventPlan::Noop,
+    }
+}
+
+fn read_marker_secs(path: &Path) -> Option<i64> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<i64>()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use serde_json::json;
+
+    use super::{
+        parse_hook_event, plan_hook_event, HookAgent, HookEvent, HookEventKind, HookEventPlan,
+    };
+
+    fn parse_or_panic(params: &serde_json::Value) -> HookEvent {
+        match parse_hook_event(Some(params)) {
+            Some(event) => event,
+            None => panic!("hook event should parse"),
+        }
+    }
+
+    #[test]
+    fn parses_agent_and_event_kind_from_hook_notification() {
+        let params = json!({
+            "agent": "cursor",
+            "event": "afterFileEdit",
+            "rel_paths": ["src/lib.rs", "../outside.rs", "/tmp/outside.rs", ""]
+        });
+
+        let event = parse_or_panic(&params);
+
+        assert_eq!(event.agent, HookAgent::Cursor);
+        assert_eq!(event.kind, HookEventKind::FileEdit);
+        assert_eq!(event.rel_paths, ["src/lib.rs"]);
+    }
+
+    #[test]
+    fn maps_shell_and_workspace_events_to_typed_kinds() {
+        let shell = json!({
+            "agent": "codex",
+            "event": "postToolUseShell",
+            "command": "git pull --rebase",
+            "cwd": "/tmp/project"
+        });
+        let workspace = json!({
+            "agent": "kiro",
+            "event": "workspaceOpen"
+        });
+
+        let shell = parse_or_panic(&shell);
+        let workspace = parse_or_panic(&workspace);
+
+        assert_eq!(shell.agent, HookAgent::Codex);
+        assert_eq!(shell.kind, HookEventKind::Shell);
+        assert_eq!(shell.command.as_deref(), Some("git pull --rebase"));
+        assert_eq!(workspace.agent, HookAgent::Kiro);
+        assert_eq!(workspace.kind, HookEventKind::WorkspaceOpen);
+    }
+
+    #[test]
+    fn ignores_unknown_hook_event_names() {
+        let params = json!({
+            "agent": "cursor",
+            "event": "futureEvent"
+        });
+
+        assert!(parse_hook_event(Some(&params)).is_none());
+    }
+
+    #[test]
+    fn ignores_unknown_hook_agents() {
+        let params = json!({
+            "agent": "future-agent",
+            "event": "postToolUse"
+        });
+
+        assert!(parse_hook_event(Some(&params)).is_none());
+    }
+
+    #[test]
+    fn plans_file_edit_sync_with_sanitized_paths() {
+        let params = json!({
+            "agent": "cursor",
+            "event": "afterFileEdit",
+            "rel_paths": ["src/lib.rs", "../outside.rs"]
+        });
+        let event = parse_or_panic(&params);
+
+        assert_eq!(
+            plan_hook_event(&event, Path::new("/tmp/project"), None),
+            HookEventPlan::SyncFiles(vec!["src/lib.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn plans_shell_branch_add() {
+        let params = json!({
+            "agent": "codex",
+            "event": "postToolUseShell",
+            "command": "git switch feature/daemon-hooks",
+            "cwd": "/tmp/project"
+        });
+        let event = parse_or_panic(&params);
+
+        assert_eq!(
+            plan_hook_event(
+                &event,
+                Path::new("/tmp/project"),
+                Some("feature/daemon-hooks")
+            ),
+            HookEventPlan::AddBranch("feature/daemon-hooks".to_string())
+        );
+    }
+
+    #[test]
+    fn plans_workspace_open_as_current_branch_sync() {
+        let params = json!({
+            "agent": "kiro",
+            "event": "workspaceOpen"
+        });
+        let event = parse_or_panic(&params);
+
+        assert_eq!(
+            plan_hook_event(&event, Path::new("/tmp/project"), Some("main")),
+            HookEventPlan::SyncCurrentBranch {
+                branch: "main".to_string(),
+                agent: HookAgent::Kiro,
+            }
+        );
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,6 +4,7 @@
 //! query the code graph interactively. Exposes tools for searching, context
 //! building, call graph traversal, impact analysis, and more.
 
+pub(crate) mod hook_events;
 /// MCP server implementation.
 pub mod response_handles;
 pub mod server;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -6,6 +6,7 @@
 //! allowing AI assistants to query the code graph interactively.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -21,6 +22,7 @@ use crate::mcp::tool_analytics::{mcp_tool_analytics_event, McpToolAnalyticsEvent
 use crate::path_tree::format_compact_annotated_path_list;
 use crate::tracedecay::TraceDecay;
 
+use super::hook_events::{self, HookAgent, HookEventPlan};
 use super::tools::{
     explore_call_budget, get_tool_definitions_with_budget, handle_tool_call_with_registry,
 };
@@ -1295,6 +1297,11 @@ impl McpServer {
         if let Ok(mut counts) = self.method_call_counts.lock() {
             *counts.entry(request.method.clone()).or_insert(0) += 1;
         }
+        if request.method == crate::daemon::HOOK_EVENT_METHOD {
+            self.handle_hook_event_notification(request.params.as_ref())
+                .await;
+            return None;
+        }
         let id = request.id.clone()?;
 
         let result = match request.method.as_str() {
@@ -1333,6 +1340,92 @@ impl McpServer {
         }
 
         result
+    }
+
+    async fn handle_hook_event_notification(&self, params: Option<&Value>) {
+        let Some(event) = hook_events::parse_hook_event(params) else {
+            return;
+        };
+        let cg = self.reopen_if_branch_drifted().await;
+        let root = cg.project_root().to_path_buf();
+        let current_branch = crate::branch::current_branch(&root);
+        let plan = hook_events::plan_hook_event(&event, &root, current_branch.as_deref());
+        self.run_hook_event_plan(cg, &root, plan).await;
+    }
+
+    async fn run_hook_event_plan(&self, cg: Arc<TraceDecay>, root: &Path, plan: HookEventPlan) {
+        match plan {
+            HookEventPlan::SyncFiles(rel_paths) => {
+                match cg.sync_if_stale_silent(&rel_paths).await {
+                    Ok(()) | Err(TraceDecayError::SyncLock { .. }) => {
+                        self.refresh_file_token_map().await;
+                    }
+                    Err(e) => eprintln!("[tracedecay] hook file sync failed: {e}"),
+                }
+            }
+            HookEventPlan::AddBranch(branch) => {
+                match self.add_hook_branch_tracking(root, &branch, &cg).await {
+                    Ok(
+                        crate::branch::BranchAddOutcome::Added
+                        | crate::branch::BranchAddOutcome::AlreadyTracked,
+                    ) => self.refresh_file_token_map().await,
+                    Ok(
+                        crate::branch::BranchAddOutcome::Deferred
+                        | crate::branch::BranchAddOutcome::NotIndexed,
+                    ) => {}
+                    Err(e) => eprintln!("[tracedecay] hook branch tracking failed: {e}"),
+                }
+            }
+            HookEventPlan::SyncCurrentBranch { branch, agent } => {
+                match self.add_hook_branch_tracking(root, &branch, &cg).await {
+                    Ok(crate::branch::BranchAddOutcome::Added) => {
+                        self.refresh_file_token_map().await;
+                    }
+                    Ok(
+                        crate::branch::BranchAddOutcome::AlreadyTracked
+                        | crate::branch::BranchAddOutcome::Deferred,
+                    ) => self.run_hook_incremental_sync(cg, agent).await,
+                    Ok(crate::branch::BranchAddOutcome::NotIndexed) => {}
+                    Err(e) => {
+                        eprintln!("[tracedecay] hook current branch tracking failed: {e}");
+                        self.run_hook_incremental_sync(cg, agent).await;
+                    }
+                }
+            }
+            HookEventPlan::DebouncedIncrementalSync(agent) => {
+                self.run_hook_incremental_sync(cg, agent).await;
+            }
+            HookEventPlan::Noop => {}
+        }
+    }
+
+    async fn add_hook_branch_tracking(
+        &self,
+        root: &Path,
+        branch: &str,
+        cg: &TraceDecay,
+    ) -> Result<crate::branch::BranchAddOutcome> {
+        crate::tracedecay::TraceDecay::add_branch_tracking_with_options(
+            root,
+            branch,
+            cg.open_options(),
+        )
+        .await
+    }
+
+    async fn run_hook_incremental_sync(&self, cg: Arc<TraceDecay>, agent: HookAgent) {
+        let marker = hook_events::sync_marker_path(&cg.store_layout().data_root, agent);
+        let now = crate::tracedecay::current_timestamp();
+        if !hook_events::should_run_sync(&marker, now, 3) {
+            return;
+        }
+        match cg.sync().await {
+            Ok(_) | Err(TraceDecayError::SyncLock { .. }) => {
+                hook_events::write_sync_marker(&marker, now);
+                self.refresh_file_token_map().await;
+            }
+            Err(e) => eprintln!("[tracedecay] hook incremental sync failed: {e}"),
+        }
     }
 
     /// Handles the `initialize` method, returning server capabilities.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -681,6 +681,33 @@ impl McpServer {
         snapshot
     }
 
+    async fn reopen_after_branch_tracking_added(&self) {
+        let reopened = {
+            let mut guard = self.cg.write().await;
+            match guard.reopen_for_current_branch().await {
+                Ok(fresh) => {
+                    eprintln!(
+                        "[tracedecay] branch tracking added for '{}' — reopened the index for it",
+                        fresh.active_branch().unwrap_or("<detached>")
+                    );
+                    *guard = Arc::new(fresh);
+                    true
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[tracedecay] hook branch tracking added but reopen failed: {e}; \
+                         continuing to serve branch '{}'",
+                        guard.serving_branch().unwrap_or("<none>")
+                    );
+                    false
+                }
+            }
+        };
+        if reopened {
+            self.refresh_file_token_map().await;
+        }
+    }
+
     /// Estimates the raw-file token cost ("before") for the given file
     /// paths from the cached file-token map (indexed file bytes / 4).
     /// Pure lookup — persists nothing.
@@ -1365,10 +1392,12 @@ impl McpServer {
             }
             HookEventPlan::AddBranch(branch) => {
                 match self.add_hook_branch_tracking(root, &branch, &cg).await {
-                    Ok(
-                        crate::branch::BranchAddOutcome::Added
-                        | crate::branch::BranchAddOutcome::AlreadyTracked,
-                    ) => self.refresh_file_token_map().await,
+                    Ok(crate::branch::BranchAddOutcome::Added) => {
+                        self.reopen_after_branch_tracking_added().await;
+                    }
+                    Ok(crate::branch::BranchAddOutcome::AlreadyTracked) => {
+                        self.refresh_file_token_map().await;
+                    }
                     Ok(
                         crate::branch::BranchAddOutcome::Deferred
                         | crate::branch::BranchAddOutcome::NotIndexed,
@@ -1379,7 +1408,7 @@ impl McpServer {
             HookEventPlan::SyncCurrentBranch { branch, agent } => {
                 match self.add_hook_branch_tracking(root, &branch, &cg).await {
                     Ok(crate::branch::BranchAddOutcome::Added) => {
-                        self.refresh_file_token_map().await;
+                        self.reopen_after_branch_tracking_added().await;
                     }
                     Ok(
                         crate::branch::BranchAddOutcome::AlreadyTracked

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -3851,6 +3851,10 @@ impl TraceDecay {
         &self.store_layout
     }
 
+    pub(crate) fn open_options(&self) -> TraceDecayOpenOptions {
+        self.open_options.clone()
+    }
+
     pub async fn open_project_store_db(&self) -> Result<Database> {
         if self.read_only {
             return Err(TraceDecayError::Config {

--- a/tests/hooks_test.rs
+++ b/tests/hooks_test.rs
@@ -12,7 +12,8 @@ use tracedecay::hooks::{
     cursor_shell_sync_plan_with_current_branch, cursor_should_run_sync, cursor_staleness_hint,
     evaluate_codex_subagent_start, evaluate_cursor_post_tool_use, evaluate_cursor_subagent_start,
     evaluate_hook_decision, evaluate_kiro_pre_tool_use, is_git_state_changing_command,
-    record_codex_subagent_start, CursorShellSyncPlan, HookWorkspaceStatus,
+    kiro_post_tool_use_rel_paths, record_codex_subagent_start, CursorShellSyncPlan,
+    HookWorkspaceStatus,
 };
 use tracedecay::storage::{
     resolve_layout_for_current_profile, write_enrollment_marker, EnrollmentMarker, StorageMode,
@@ -736,6 +737,46 @@ fn test_cursor_after_file_edit_rel_paths_skips_paths_outside_root() {
         rels.is_empty(),
         "paths outside the project root must be ignored, got {rels:?}"
     );
+}
+
+#[test]
+fn test_kiro_post_tool_use_rel_paths_targets_written_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let input = format!(
+        r#"{{
+            "hook_event_name": "postToolUse",
+            "tool_name": "fs_write",
+            "cwd": {},
+            "tool_input": {{
+                "path": "src/lib.rs"
+            }}
+        }}"#,
+        serde_json::to_string(root.to_str().unwrap()).unwrap()
+    );
+
+    let rels = kiro_post_tool_use_rel_paths(&input, &root);
+
+    assert_eq!(rels, ["src/lib.rs"]);
+}
+
+#[test]
+fn test_kiro_post_tool_use_rel_paths_skips_paths_outside_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().canonicalize().unwrap();
+    let input = format!(
+        r#"{{
+            "hook_event_name": "postToolUse",
+            "tool_name": "fs_write",
+            "cwd": {},
+            "tool_input": {{
+                "path": "../outside.rs"
+            }}
+        }}"#,
+        serde_json::to_string(root.to_str().unwrap()).unwrap()
+    );
+
+    assert!(kiro_post_tool_use_rel_paths(&input, &root).is_empty());
 }
 
 #[test]

--- a/tests/mcp_server_test.rs
+++ b/tests/mcp_server_test.rs
@@ -94,6 +94,15 @@ fn jsonrpc_notification(method: &str) -> String {
     .unwrap()
 }
 
+fn jsonrpc_notification_with_params(method: &str, params: Value) -> String {
+    serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params
+    }))
+    .unwrap()
+}
+
 /// Parses a JSON-RPC response and returns it.
 fn parse_response(s: &str) -> Value {
     serde_json::from_str(s).unwrap()
@@ -2662,6 +2671,63 @@ async fn setup_branch_drift_fixture() -> (TempDir, PathBuf, Arc<McpServer>) {
     );
 
     (dir, project, server)
+}
+
+#[tokio::test]
+async fn hook_branch_add_reopens_server_from_single_db_mode() {
+    let _branch_lock = BRANCH_DRIFT_TEST_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().to_path_buf();
+
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/lib.rs"),
+        "pub fn main_only() -> u32 { 1 }\n",
+    )
+    .unwrap();
+    fs::write(project.join(".gitignore"), ".tracedecay/\n").unwrap();
+    git(&project, &["init"]);
+    git(&project, &["config", "user.email", "test@test.com"]);
+    git(&project, &["config", "user.name", "Test"]);
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "-m", "initial"]);
+    git(&project, &["branch", "-M", "main"]);
+
+    {
+        let cg = TraceDecay::init(&project).await.unwrap();
+        cg.index_all().await.unwrap();
+        cg.checkpoint().await.unwrap();
+    }
+
+    let cg = TraceDecay::open(&project).await.unwrap();
+    assert_eq!(cg.serving_branch(), Some("main"));
+    let server = McpServer::new(cg, None).await;
+    git(&project, &["checkout", "-b", "feature"]);
+
+    let responses = run_server_with_messages(
+        server.clone(),
+        vec![jsonrpc_notification_with_params(
+            tracedecay::daemon::HOOK_EVENT_METHOD,
+            json!({
+                "agent": "codex",
+                "event": "postToolUseShell",
+                "command": "git switch feature",
+                "cwd": project,
+            }),
+        )],
+    )
+    .await;
+    assert!(
+        responses.is_empty(),
+        "hook notification should not produce a JSON-RPC response"
+    );
+
+    let cg_now = server.cg().await;
+    assert_eq!(
+        cg_now.serving_branch(),
+        Some("feature"),
+        "adding branch tracking from a hook must swap the cached server"
+    );
 }
 
 #[tokio::test]

--- a/tests/tool_daemon_test.rs
+++ b/tests/tool_daemon_test.rs
@@ -172,9 +172,6 @@ fn spawn_sentinel_daemon_with_notification(
             .set_nonblocking(false)
             .expect("set accepted stream blocking");
         stream
-            .set_read_timeout(Some(Duration::from_secs(2)))
-            .expect("read timeout");
-        stream
             .set_write_timeout(Some(Duration::from_secs(2)))
             .expect("write timeout");
 
@@ -235,6 +232,214 @@ fn spawn_sentinel_daemon_with_notification(
         .recv_timeout(Duration::from_secs(2))
         .expect("fake daemon should become ready");
     request_rx
+}
+
+fn spawn_hook_event_daemon(socket_path: PathBuf) -> mpsc::Receiver<Value> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let (request_tx, request_rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
+        listener
+            .set_nonblocking(true)
+            .expect("set listener nonblocking");
+        ready_tx.send(()).expect("notify fake daemon readiness");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let (stream, _) = loop {
+            match listener.accept() {
+                Ok(accepted) => break accepted,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        panic!("timed out waiting for hook to connect to fake daemon");
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => panic!("accept fake daemon client: {e}"),
+            }
+        };
+        let mut reader = BufReader::new(stream);
+        let mut handshake = String::new();
+        reader
+            .read_line(&mut handshake)
+            .expect("read daemon handshake");
+        let handshake: Value = serde_json::from_str(handshake.trim()).expect("handshake JSON");
+        assert!(
+            handshake["project_path"].is_string(),
+            "hook notifications must be scoped to a project"
+        );
+        assert!(
+            !handshake
+                .get("allow_init")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+            "hook notifications must not permit daemon-side init"
+        );
+
+        let mut request = String::new();
+        reader
+            .read_line(&mut request)
+            .expect("read hook JSON-RPC notification");
+        let request: Value = serde_json::from_str(request.trim()).expect("request JSON");
+        assert_eq!(request["method"], "tracedecay/hookEvent");
+        assert!(
+            request.get("id").is_none(),
+            "hook event must be a notification, not a request"
+        );
+        request_tx
+            .send(request)
+            .expect("send observed hook event notification");
+    });
+
+    ready_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("fake daemon should become ready");
+    request_rx
+}
+
+fn assert_hook_notification(
+    command_arg: &str,
+    fail_open_label: &str,
+    expected_agent: &str,
+    expected_event: &str,
+    build_event: impl FnOnce(&Path) -> Value,
+    assert_extra_params: impl FnOnce(&Value, &Path),
+) {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let socket_dir = TempDir::new().unwrap();
+    let home_path = canonical_existing_path(home.path());
+    let project_path = canonical_existing_path(project.path());
+    init_project_with_cli(&home_path, &project_path);
+
+    let socket_path = socket_dir.path().join("tracedecay.sock");
+    let observed_request = spawn_hook_event_daemon(socket_path.clone());
+    let event = build_event(&project_path).to_string();
+
+    let output = tracedecay_command_with_home(&home_path)
+        .current_dir(&project_path)
+        .env("TRACEDECAY_DAEMON_SOCKET", &socket_path)
+        .arg(command_arg)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin should be piped")
+                .write_all(event.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("hook command should run");
+
+    assert!(
+        output.status.success(),
+        "{fail_open_label} hook should fail open\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let request = observed_request
+        .recv_timeout(Duration::from_secs(2))
+        .expect("fake daemon should receive hook event");
+    assert_eq!(request["params"]["agent"], expected_agent);
+    assert_eq!(request["params"]["event"], expected_event);
+    assert_extra_params(&request, &project_path);
+}
+
+#[test]
+fn cursor_after_file_edit_hook_notifies_daemon() {
+    assert_hook_notification(
+        "hook-cursor-after-file-edit",
+        "afterFileEdit",
+        "cursor",
+        "afterFileEdit",
+        |project_path| {
+            let edited = project_path.join("src/lib.rs");
+            std::fs::write(&edited, "pub fn answer() -> u32 { 43 }\n").unwrap();
+            json!({
+                "hook_event_name": "afterFileEdit",
+                "file_path": edited,
+                "workspace_roots": [project_path],
+            })
+        },
+        |request, _| {
+            assert_eq!(request["params"]["rel_paths"], json!(["src/lib.rs"]));
+        },
+    );
+}
+
+#[test]
+fn cursor_after_shell_hook_notifies_daemon() {
+    assert_hook_notification(
+        "hook-cursor-after-shell",
+        "afterShellExecution",
+        "cursor",
+        "afterShellExecution",
+        |project_path| {
+            json!({
+                "hook_event_name": "afterShellExecution",
+                "command": "git pull --rebase",
+                "cwd": project_path,
+                "workspace_roots": [project_path],
+            })
+        },
+        |request, project_path| {
+            assert_eq!(request["params"]["command"], "git pull --rebase");
+            assert_eq!(
+                request["params"]["cwd"],
+                project_path.to_string_lossy().to_string()
+            );
+        },
+    );
+}
+
+#[test]
+fn cursor_workspace_open_hook_notifies_daemon() {
+    assert_hook_notification(
+        "hook-cursor-workspace-open",
+        "workspaceOpen",
+        "cursor",
+        "workspaceOpen",
+        |project_path| {
+            json!({
+                "hook_event_name": "workspaceOpen",
+                "cwd": project_path,
+                "workspace_roots": [project_path],
+            })
+        },
+        |request, project_path| {
+            assert_eq!(
+                request["params"]["cwd"],
+                project_path.to_string_lossy().to_string()
+            );
+        },
+    );
+}
+
+#[test]
+fn kiro_post_tool_use_hook_notifies_daemon() {
+    assert_hook_notification(
+        "hook-kiro-post-tool-use",
+        "Kiro postToolUse",
+        "kiro",
+        "postToolUse",
+        |project_path| {
+            json!({
+                "hook_event_name": "postToolUse",
+                "cwd": project_path,
+            })
+        },
+        |request, project_path| {
+            assert_eq!(
+                request["params"]["cwd"],
+                project_path.to_string_lossy().to_string()
+            );
+        },
+    );
 }
 
 #[test]

--- a/tests/tool_daemon_test.rs
+++ b/tests/tool_daemon_test.rs
@@ -428,9 +428,15 @@ fn kiro_post_tool_use_hook_notifies_daemon() {
         "kiro",
         "postToolUse",
         |project_path| {
+            let edited = project_path.join("src/lib.rs");
+            std::fs::write(&edited, "pub fn answer() -> u32 { 44 }\n").unwrap();
             json!({
                 "hook_event_name": "postToolUse",
                 "cwd": project_path,
+                "tool_name": "fs_write",
+                "tool_input": {
+                    "path": "src/lib.rs"
+                },
             })
         },
         |request, project_path| {
@@ -438,6 +444,7 @@ fn kiro_post_tool_use_hook_notifies_daemon() {
                 request["params"]["cwd"],
                 project_path.to_string_lossy().to_string()
             );
+            assert_eq!(request["params"]["rel_paths"], json!(["src/lib.rs"]));
         },
     );
 }


### PR DESCRIPTION
## Summary
- add a daemon hook-event JSON-RPC notification path for agent hooks
- route Cursor file/shell/workspace, Codex post-tool edit/shell, and Kiro post-tool events through the daemon/server instead of hook-side sync/branch work
- handle targeted sync, branch tracking, and coalesced incremental sync inside the MCP/server with daemon profile-aware branch tracking

## Validation
- cargo fmt --all -- --check
- git diff --check
- CARGO_BUILD_JOBS=2 cargo test --test tool_daemon_test -- --nocapture
- CARGO_BUILD_JOBS=2 cargo test --lib daemon::tests::socket_client_hook_event_adds_branch_tracking -- --nocapture
- CARGO_BUILD_JOBS=2 cargo test --test hooks_test -- --nocapture
- CARGO_BUILD_JOBS=2 cargo test --test hook_branch_routing_test -- --nocapture
