### PR TITLE
agents: strengthen TraceDecay tool discovery hints

### DIFF
--- a/codex-plugin/skills/atomic-code-edits/SKILL.md
+++ b/codex-plugin/skills/atomic-code-edits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atomic-code-edits
-description: 'Use when editing source with safe anchored primitives: unique string replacement, atomic multi-replace, anchored insert, whole-symbol rewrite, structural ast-grep rewrite, or mechanical edits that should re-index the graph.'
+description: 'Use when editing source with safe anchored primitives or mechanical rewrites: tracedecay_str_replace, tracedecay_multi_str_replace, tracedecay_insert_at, tracedecay_replace_symbol, tracedecay_ast_grep_rewrite, or edits that should re-index the graph.'
 ---
 
 # Atomic code edits

--- a/codex-plugin/skills/exploring-types-and-traits/SKILL.md
+++ b/codex-plugin/skills/exploring-types-and-traits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploring-types-and-traits
-description: 'Use when answering type-level questions: trait implementors, impl blocks, type hierarchies, struct construction sites, field read/write sites, derive-generated methods, or method bodies across implementors.'
+description: 'Use when answering type-level questions: trait implementors/impls, type hierarchies, struct construction sites, field read/write sites, derive-generated methods, or method bodies; maps to tracedecay_implementations, tracedecay_impls, tracedecay_constructors, and tracedecay_field_sites.'
 ---
 
 # Exploring types & traits

--- a/codex-plugin/skills/finding-duplicate-logic/SKILL.md
+++ b/codex-plugin/skills/finding-duplicate-logic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finding-duplicate-logic
-description: 'Use before writing a new helper or utility to check whether equivalent code already exists, or when finding duplicate logic, similar symbols, repeated implementations, and consolidation candidates.'
+description: 'Use before writing a new helper or utility to check whether equivalent code already exists, or when finding duplicate logic, similar symbols, repeated implementations, and consolidation candidates with tracedecay_signature_search, tracedecay_similar, tracedecay_context, and tracedecay_redundancy.'
 ---
 
 # Finding duplicate logic

--- a/codex-plugin/skills/finding-impacted-areas/SKILL.md
+++ b/codex-plugin/skills/finding-impacted-areas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finding-impacted-areas
-description: 'Use when estimating blast radius: what depends on a symbol or file, affected tests, risk of a change, impacted areas for a refactor, or what could break if a target changes.'
+description: 'Use when estimating blast radius: what depends on a symbol/file, affected tests, test mapping, risk of a change, impacted areas for a refactor, or what could break if a target changes. Use before guessing tests or running broad suites.'
 ---
 
 # Finding impacted areas
@@ -13,7 +13,7 @@ description: 'Use when estimating blast radius: what depends on a symbol or file
 4. **Already have changed paths → `tracedecay_diff_context`** (`files`): modified symbols + dependents + affected tests in one call.
 5. **Tests to run:**
    - Reuse `tracedecay_diff_context` affected tests first.
-   - Need more detail? `tracedecay_affected` (`files`) finds affected tests; `tracedecay_test_map` (`file` / `node_id`) shows direct coverage.
+   - Need more detail? `tracedecay_affected` (`files`) finds affected tests; `tracedecay_test_map` (`file` / `node_id`) shows direct coverage. Use this before guessing a cargo/nextest filter.
    - Use `tracedecay_test_risk` for high-risk, weakly-tested dependents.
 6. **Structural fragility (optional):** `tracedecay_coupling` / `tracedecay_dependency_depth` to see if the target is a high-fan-in hub.
 

--- a/codex-plugin/skills/reading-code-cheaply/SKILL.md
+++ b/codex-plugin/skills/reading-code-cheaply/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reading-code-cheaply
-description: 'Inspect code at the cheapest sufficient depth — file outlines, cached signatures, single-symbol bodies, line slices, and module API surfaces instead of full-file reads. Use when about to read or open a source file, when a file is large, for "what''s in this file", "what''s the signature of X", or "what does this module export".'
+description: 'Inspect code at the cheapest sufficient depth with tracedecay_outline, tracedecay_signature, tracedecay_body, tracedecay_read slices, and tracedecay_module_api instead of full-file reads. Use before opening source files, large files, or MCP tool descriptor JSON.'
 ---
 
 # Reading code cheaply

--- a/codex-plugin/skills/searching-for-code/SKILL.md
+++ b/codex-plugin/skills/searching-for-code/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: searching-for-code
-description: 'Find code by concept, symbol, signature, or qualified name in this repo using the TraceDecay code graph. Use when searching the codebase, locating a function/struct/trait/class/method, exploring how a feature works, or before grep/file-search when a .tracedecay index exists.'
+description: 'Find code by concept, symbol, signature, exact name, or qualified name in this repo using the TraceDecay code graph. Use when searching the codebase, locating a function/struct/trait/class/method, exploring how a feature works, or before grep/file-search/read-file in an indexed project.'
 ---
 
 # Searching for code
 
-Use the TraceDecay code graph before Grep/Glob/file reads. Pick the cheapest tool that answers the question.
+Use the TraceDecay code graph before Grep/Glob/file reads. Pick the cheapest tool that answers the question. If the task says "trace", "find callers", "what calls X", "what depends on X", or "what does X call", switch to `tracedecay:tracing-functions` after resolving the symbol.
 
 For multi-step context gathering, use scoped read-only subagents when separate questions can run independently. Give each subagent one bounded target (symbol, path, feature, session, or branch), the TraceDecay tools it may use, and a strict "no writes / no edits / no memory mutations" instruction; the parent agent synthesizes findings and performs any follow-up actions.
 

--- a/codex-plugin/skills/tracing-functions/SKILL.md
+++ b/codex-plugin/skills/tracing-functions/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: tracing-functions
-description: 'Use when tracing call relationships: who calls a function, what it calls, shortest call paths between symbols, references for rename prep, recursion, hubs, or dynamic dispatch.'
+description: 'Use when tracing call relationships: find callers/callees, who calls a function, what it calls, what depends on a symbol or fixture/helper, shortest call paths, references for rename prep, recursion, hubs, or dynamic dispatch. Use before grep/file reads for "trace this function" tasks.'
 ---
 
 # Tracing functions
 
 ## Workflow
 
-1. **Resolve symbol(s) → node ID(s)** with `tracedecay_search` / `tracedecay_find_exact_symbol` / `tracedecay_by_qualified_name` (see `tracedecay:searching-for-code` for the full resolver ladder).
+1. **Resolve symbol(s) → node ID(s)** with `tracedecay_find_exact_symbol` for exact names, `tracedecay_search` for ranked discovery, or `tracedecay_by_qualified_name` for stable identities (see `tracedecay:searching-for-code` for the full resolver ladder).
 2. **Upstream (callers) → `tracedecay_callers`** (`node_id`, `max_depth` 1–2 first). For many symbols at once → `tracedecay_callers_for` (`node_ids[]`, one round-trip).
 3. **Downstream (callees) → `tracedecay_callees`** (resolves trait dispatch; watch for `dispatch_via_trait: true` / `dispatch_from`). Pass `resolve_dispatch: false` for direct edges only.
 4. **Path between two symbols → `tracedecay_call_chain`** (`from_id`, `to_id`, `max_depth`).
@@ -17,7 +17,7 @@ description: 'Use when tracing call relationships: who calls a function, what it
 
 ## Guardrails
 
-- Read-only and parallel-safe. Keep `max_depth` small (1–2) first; widen only when the chain is not yet clear. `tracedecay_rename_preview` only previews references — it does not rename.
+- Read-only and parallel-safe. For tasks like "find callers of setup_project", "which tests still depend on this fixture", or "trace this function", resolve the symbol and call `tracedecay_callers` / `tracedecay_callees` before running grep or opening files. Keep `max_depth` small (1–2) first; widen only when the chain is not yet clear. `tracedecay_rename_preview` only previews references — it does not rename.
 - For several independent symbols or call paths, use scoped read-only subagents per symbol, direction, or path hypothesis. Require node ids, depth/tool parameters, and dispatch notes; the parent agent owns the final trace.
 - If a trace response is truncated and includes a `handle`, narrow depth or target set first when possible; call `tracedecay_retrieve` with that `handle` when the omitted chain details are needed.
 

--- a/cursor-plugin/skills/atomic-code-edits/SKILL.md
+++ b/cursor-plugin/skills/atomic-code-edits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atomic-code-edits
-description: 'Use when editing source with safe anchored primitives: unique string replacement, atomic multi-replace, anchored insert, whole-symbol rewrite, structural ast-grep rewrite, or mechanical edits that should re-index the graph.'
+description: 'Use when editing source with safe anchored primitives or mechanical rewrites: tracedecay_str_replace, tracedecay_multi_str_replace, tracedecay_insert_at, tracedecay_replace_symbol, tracedecay_ast_grep_rewrite, or edits that should re-index the graph.'
 ---
 
 # Atomic code edits

--- a/cursor-plugin/skills/exploring-types-and-traits/SKILL.md
+++ b/cursor-plugin/skills/exploring-types-and-traits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploring-types-and-traits
-description: 'Use when answering type-level questions: trait implementors, impl blocks, type hierarchies, struct construction sites, field read/write sites, derive-generated methods, or method bodies across implementors.'
+description: 'Use when answering type-level questions: trait implementors/impls, type hierarchies, struct construction sites, field read/write sites, derive-generated methods, or method bodies; maps to tracedecay_implementations, tracedecay_impls, tracedecay_constructors, and tracedecay_field_sites.'
 ---
 
 # Exploring types & traits

--- a/cursor-plugin/skills/finding-duplicate-logic/SKILL.md
+++ b/cursor-plugin/skills/finding-duplicate-logic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finding-duplicate-logic
-description: 'Use before writing a new helper or utility to check whether equivalent code already exists, or when finding duplicate logic, similar symbols, repeated implementations, and consolidation candidates.'
+description: 'Use before writing a new helper or utility to check whether equivalent code already exists, or when finding duplicate logic, similar symbols, repeated implementations, and consolidation candidates with tracedecay_signature_search, tracedecay_similar, tracedecay_context, and tracedecay_redundancy.'
 ---
 
 # Finding duplicate logic

--- a/cursor-plugin/skills/finding-impacted-areas/SKILL.md
+++ b/cursor-plugin/skills/finding-impacted-areas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finding-impacted-areas
-description: 'Use when estimating blast radius: what depends on a symbol or file, affected tests, risk of a change, impacted areas for a refactor, or what could break if a target changes.'
+description: 'Use when estimating blast radius: what depends on a symbol/file, affected tests, test mapping, risk of a change, impacted areas for a refactor, or what could break if a target changes. Use before guessing tests or running broad suites.'
 ---
 
 # Finding impacted areas
@@ -13,7 +13,7 @@ description: 'Use when estimating blast radius: what depends on a symbol or file
 4. **Already have changed paths → `tracedecay_diff_context`** (`files`): modified symbols + dependents + affected tests in one call.
 5. **Tests to run:**
    - Reuse `tracedecay_diff_context` affected tests first.
-   - Need more detail? `tracedecay_affected` (`files`) finds affected tests; `tracedecay_test_map` (`file` / `node_id`) shows direct coverage.
+   - Need more detail? `tracedecay_affected` (`files`) finds affected tests; `tracedecay_test_map` (`file` / `node_id`) shows direct coverage. Use this before guessing a cargo/nextest filter.
    - Use `tracedecay_test_risk` for high-risk, weakly-tested dependents.
 6. **Structural fragility (optional):** `tracedecay_coupling` / `tracedecay_dependency_depth` to see if the target is a high-fan-in hub.
 

--- a/cursor-plugin/skills/reading-code-cheaply/SKILL.md
+++ b/cursor-plugin/skills/reading-code-cheaply/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reading-code-cheaply
-description: 'Inspect code at the cheapest sufficient depth — file outlines, cached signatures, single-symbol bodies, line slices, and module API surfaces instead of full-file reads. Use when about to read or open a source file, when a file is large, for "what''s in this file", "what''s the signature of X", or "what does this module export".'
+description: 'Inspect code at the cheapest sufficient depth with tracedecay_outline, tracedecay_signature, tracedecay_body, tracedecay_read slices, and tracedecay_module_api instead of full-file reads. Use before opening source files, large files, or MCP tool descriptor JSON.'
 ---
 
 # Reading code cheaply

--- a/cursor-plugin/skills/searching-for-code/SKILL.md
+++ b/cursor-plugin/skills/searching-for-code/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: searching-for-code
-description: 'Find code by concept, symbol, signature, or qualified name in this repo using the TraceDecay code graph. Use when searching the codebase, locating a function/struct/trait/class/method, exploring how a feature works, or before grep/file-search when a .tracedecay index exists.'
+description: 'Find code by concept, symbol, signature, exact name, or qualified name in this repo using the TraceDecay code graph. Use when searching the codebase, locating a function/struct/trait/class/method, exploring how a feature works, or before grep/file-search/read-file in an indexed project.'
 ---
 
 # Searching for code
 
-Use the TraceDecay code graph before Grep/Glob/file reads. Pick the cheapest tool that answers the question.
+Use the TraceDecay code graph before Grep/Glob/file reads. Pick the cheapest tool that answers the question. If the task says "trace", "find callers", "what calls X", "what depends on X", or "what does X call", switch to `tracedecay:tracing-functions` after resolving the symbol.
 
 For multi-step context gathering, use scoped read-only subagents when separate questions can run independently. Give each subagent one bounded target (symbol, path, feature, session, or branch), the TraceDecay tools it may use, and a strict "no writes / no edits / no memory mutations" instruction; the parent agent synthesizes findings and performs any follow-up actions.
 

--- a/cursor-plugin/skills/tracing-functions/SKILL.md
+++ b/cursor-plugin/skills/tracing-functions/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: tracing-functions
-description: 'Use when tracing call relationships: who calls a function, what it calls, shortest call paths between symbols, references for rename prep, recursion, hubs, or dynamic dispatch.'
+description: 'Use when tracing call relationships: find callers/callees, who calls a function, what it calls, what depends on a symbol or fixture/helper, shortest call paths, references for rename prep, recursion, hubs, or dynamic dispatch. Use before grep/file reads for "trace this function" tasks.'
 ---
 
 # Tracing functions
 
 ## Workflow
 
-1. **Resolve symbol(s) → node ID(s)** with `tracedecay_search` / `tracedecay_find_exact_symbol` / `tracedecay_by_qualified_name` (see `tracedecay:searching-for-code` for the full resolver ladder).
+1. **Resolve symbol(s) → node ID(s)** with `tracedecay_find_exact_symbol` for exact names, `tracedecay_search` for ranked discovery, or `tracedecay_by_qualified_name` for stable identities (see `tracedecay:searching-for-code` for the full resolver ladder).
 2. **Upstream (callers) → `tracedecay_callers`** (`node_id`, `max_depth` 1–2 first). For many symbols at once → `tracedecay_callers_for` (`node_ids[]`, one round-trip).
 3. **Downstream (callees) → `tracedecay_callees`** (resolves trait dispatch; watch for `dispatch_via_trait: true` / `dispatch_from`). Pass `resolve_dispatch: false` for direct edges only.
 4. **Path between two symbols → `tracedecay_call_chain`** (`from_id`, `to_id`, `max_depth`).
@@ -17,7 +17,7 @@ description: 'Use when tracing call relationships: who calls a function, what it
 
 ## Guardrails
 
-- Read-only and parallel-safe. Keep `max_depth` small (1–2) first; widen only when the chain is not yet clear. `tracedecay_rename_preview` only previews references — it does not rename.
+- Read-only and parallel-safe. For tasks like "find callers of setup_project", "which tests still depend on this fixture", or "trace this function", resolve the symbol and call `tracedecay_callers` / `tracedecay_callees` before running grep or opening files. Keep `max_depth` small (1–2) first; widen only when the chain is not yet clear. `tracedecay_rename_preview` only previews references — it does not rename.
 - For several independent symbols or call paths, use scoped read-only subagents per symbol, direction, or path hypothesis. Require node ids, depth/tool parameters, and dispatch notes; the parent agent owns the final trace.
 - If a trace response is truncated and includes a `handle`, narrow depth or target set first when possible; call `tracedecay_retrieve` with that `handle` when the omitted chain details are needed.
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -41,7 +41,11 @@ const CODEX_SUBAGENT_START_CONTEXT: &str = "tracedecay subagent context: this lo
 new/no-history subagent or code-research subagent. Use tracedecay MCP tools and the relevant TraceDecay skill/tool \
 workflow before broad file reads: `tracedecay:searching-for-code` with `tracedecay_context` \
 for code exploration, `tracedecay:reading-code-cheaply` with `tracedecay_outline` or \
-`tracedecay_body` before whole-file reads, `tracedecay:recalling-project-memory` when \
+`tracedecay_body` before whole-file reads, `tracedecay:tracing-functions` with \
+`tracedecay_find_exact_symbol`, `tracedecay_callers`, and `tracedecay_callees` when \
+asked to trace functions, find callers, or inspect setup/helper/fixture dependencies, \
+`tracedecay:finding-impacted-areas` with `tracedecay_affected` and \
+`tracedecay_test_map` before guessing affected tests, `tracedecay:recalling-project-memory` when \
 project decisions/preferences matter, and `tracedecay:recalling-session-context` with \
 `tracedecay_message_search`, `tracedecay_lcm_expand_query`, and `tracedecay_lcm_describe` \
 when prior conversation context may be missing.";

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -38,6 +38,8 @@ pub enum HintCategory {
     FileLookup,
     ProjectContext,
     SessionRecall,
+    AtomicEdit,
+    TypeOrientation,
     ExploreSubagent,
     SubagentStartContext,
 }
@@ -55,6 +57,8 @@ impl HintCategory {
             HintCategory::FileLookup => "file_lookup",
             HintCategory::ProjectContext => "project_context",
             HintCategory::SessionRecall => "session_recall",
+            HintCategory::AtomicEdit => "atomic_edit",
+            HintCategory::TypeOrientation => "type_orientation",
             HintCategory::ExploreSubagent => "explore_subagent",
             HintCategory::SubagentStartContext => "subagent_start_context",
         }
@@ -72,6 +76,8 @@ impl HintCategory {
             "file_lookup" => Some(HintCategory::FileLookup),
             "project_context" => Some(HintCategory::ProjectContext),
             "session_recall" => Some(HintCategory::SessionRecall),
+            "atomic_edit" => Some(HintCategory::AtomicEdit),
+            "type_orientation" => Some(HintCategory::TypeOrientation),
             "explore_subagent" => Some(HintCategory::ExploreSubagent),
             "subagent_start_context" => Some(HintCategory::SubagentStartContext),
             _ => None,
@@ -227,6 +233,42 @@ pub fn decide_hint(input: &ToolHintInput) -> Option<ToolHint> {
         ));
     }
 
+    if asks_for_call_graph(&text) {
+        return Some(hint(
+            HintCategory::CallGraph,
+            "For function tracing, use the indexed call graph before grep/file reads.",
+            "Resolve the symbol with tracedecay_find_exact_symbol or tracedecay_search, then use tracedecay_callers for who depends on it and tracedecay_callees for what it calls; use tracedecay_impact for broader dependents before opening files.",
+            false,
+        ));
+    }
+
+    if asks_for_impact(&text) {
+        return Some(hint(
+            HintCategory::Impact,
+            "For impact, affected-test, or blast-radius questions, use TraceDecay's dependency tools.",
+            "Start with tracedecay_diff_context when you have changed files, tracedecay_impact for a resolved symbol, tracedecay_affected for affected tests, and tracedecay_test_map when you need direct test attribution.",
+            false,
+        ));
+    }
+
+    if asks_for_atomic_edit(&text) {
+        return Some(hint(
+            HintCategory::AtomicEdit,
+            "For safe mechanical edits, use TraceDecay's anchored edit tools.",
+            "Use tracedecay_multi_str_replace for all-or-nothing anchored replacements, tracedecay_ast_grep_rewrite for structural rewrites, and tracedecay_replace_symbol when replacing one resolved symbol.",
+            false,
+        ));
+    }
+
+    if asks_for_type_orientation(&text) {
+        return Some(hint(
+            HintCategory::TypeOrientation,
+            "For type, constructor, field, trait, or duplicate-logic questions, use TraceDecay's AST orientation tools.",
+            "Use tracedecay_constructors for struct literal sites, tracedecay_field_sites for reads/writes, tracedecay_impls or tracedecay_implementations for trait methods, and tracedecay_redundancy before adding similar helpers.",
+            false,
+        ));
+    }
+
     if input
         .command
         .as_deref()
@@ -266,34 +308,21 @@ pub fn decide_hint(input: &ToolHintInput) -> Option<ToolHint> {
         ));
     }
 
+    if is_tracedecay_tool_descriptor_read(input) {
+        return Some(hint(
+            HintCategory::FileRead,
+            "This looks like a TraceDecay MCP tool descriptor; use the tool surface instead of reading schema JSON.",
+            "Call the named tracedecay_* MCP tool directly when available, or use tool discovery for its schema; for function tracing that usually means tracedecay_find_exact_symbol plus tracedecay_callers/tracedecay_callees.",
+            true,
+        ));
+    }
+
     if is_single_file_read(input) {
         return Some(hint(
             HintCategory::FileRead,
             "Before reading whole files, consider tracedecay_outline, tracedecay_body, or tracedecay_read.",
             "tracedecay_outline gives a file's table of contents, tracedecay_body returns one symbol's source, and tracedecay_read (mode: \"lines\") slices a range — usually far cheaper than a full-file read.",
             true,
-        ));
-    }
-
-    if text.is_empty() {
-        return None;
-    }
-
-    if asks_for_call_graph(&text) {
-        return Some(hint(
-            HintCategory::CallGraph,
-            "For caller or callee questions, consider using the indexed call graph.",
-            "tracedecay_callers answers who calls a symbol; tracedecay_callees answers what a symbol calls.",
-            false,
-        ));
-    }
-
-    if asks_for_impact(&text) {
-        return Some(hint(
-            HintCategory::Impact,
-            "For impact or change-risk questions, consider using tracedecay impact tools.",
-            "tracedecay_impact and tracedecay_affected can identify related code and likely affected files from the index.",
-            false,
         ));
     }
 
@@ -353,6 +382,20 @@ fn is_single_file_read(input: &ToolHintInput) -> bool {
             .as_deref()
             .unwrap_or_default()
             .is_empty()
+}
+
+fn is_tracedecay_tool_descriptor_read(input: &ToolHintInput) -> bool {
+    let is_read_tool = input
+        .tool_name
+        .as_deref()
+        .is_some_and(|name| matches_normalized(name, &["readfile", "read_file", "read"]));
+    is_read_tool
+        && input.file_path.as_deref().is_some_and(|path| {
+            (path.contains("/tools/tracedecay_") || path.contains("\\tools\\tracedecay_"))
+                && std::path::Path::new(path)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+        })
 }
 
 /// Matches Cursor's semantic/codebase-search tool names. Cursor's hooks docs do
@@ -459,7 +502,17 @@ fn asks_for_call_graph(text: &str) -> bool {
     contains_any(
         text,
         &[
+            "trace function",
+            "trace the function",
+            "trace functions",
+            "trace the functions",
+            "function trace",
+            "find callers",
+            "find caller",
+            "find callees",
+            "find callee",
             "who calls",
+            "what calls",
             "callers of",
             "caller of",
             "called by",
@@ -467,6 +520,10 @@ fn asks_for_call_graph(text: &str) -> bool {
             "call path",
             "call chain",
             "callees of",
+            "uses of",
+            "depend on",
+            "depends on",
+            "what depends",
         ],
     )
 }
@@ -476,11 +533,17 @@ fn asks_for_impact(text: &str) -> bool {
         text,
         &[
             "impact",
+            "blast radius",
             "change risk",
             "change-risk",
+            "affected tests",
             "affected files",
+            "test map",
+            "test_map",
             "what files are affected",
             "what code is affected",
+            "which tests",
+            "what tests",
         ],
     )
 }
@@ -592,6 +655,49 @@ fn asks_for_symbol_lookup(text: &str) -> bool {
     )
 }
 
+fn asks_for_atomic_edit(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "edit safely",
+            "safe edit",
+            "mechanical edit",
+            "mechanical rewrite",
+            "replace this everywhere",
+            "replace everywhere",
+            "rewrite structurally",
+            "structural rewrite",
+            "ast-grep",
+            "ast grep",
+            "multi_str_replace",
+            "ast_grep_rewrite",
+        ],
+    )
+}
+
+fn asks_for_type_orientation(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "constructor sites",
+            "constructors",
+            "struct literal",
+            "field use",
+            "field uses",
+            "field reads",
+            "field writes",
+            "trait impl",
+            "trait impls",
+            "trait implementations",
+            "implementors",
+            "impl blocks",
+            "duplicate logic",
+            "redundant",
+            "similar helper",
+        ],
+    )
+}
+
 fn asks_for_file_lookup(text: &str) -> bool {
     contains_any(
         text,
@@ -686,6 +792,96 @@ mod tests {
     }
 
     #[test]
+    fn trace_function_prompts_get_call_graph_ladder_before_generic_search() {
+        let hint = decide_hint(&ToolHintInput {
+            tool_name: Some("shell".to_string()),
+            command: Some("rg -n \"setup_project\" tests/mcp_handler_test.rs".to_string()),
+            prompt: Some(
+                "Use TraceDecay to trace the function and find callers of setup_project"
+                    .to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "call_graph");
+        assert!(hint.context.contains("tracedecay_find_exact_symbol"));
+        assert!(hint.context.contains("tracedecay_callers"));
+        assert!(hint.context.contains("tracedecay_callees"));
+    }
+
+    #[test]
+    fn dependency_fixture_prompts_get_call_graph_ladder() {
+        let hint = decide_hint(&ToolHintInput {
+            prompt: Some(
+                "Which tests still depend on setup_project instead of setup_empty_project?"
+                    .to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "call_graph");
+        assert!(hint.context.contains("tracedecay_callers"));
+        assert!(hint.context.contains("tracedecay_impact"));
+    }
+
+    #[test]
+    fn affected_test_prompts_get_test_mapping_ladder() {
+        let hint = decide_hint(&ToolHintInput {
+            prompt: Some(
+                "Find affected tests and blast radius for this refactor before running cargo"
+                    .to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "impact");
+        assert!(hint.context.contains("tracedecay_diff_context"));
+        assert!(hint.context.contains("tracedecay_affected"));
+        assert!(hint.context.contains("tracedecay_test_map"));
+    }
+
+    #[test]
+    fn mechanical_edit_prompts_get_atomic_edit_ladder() {
+        let hint = decide_hint(&ToolHintInput {
+            prompt: Some(
+                "Use ast-grep for a mechanical rewrite and replace this everywhere safely"
+                    .to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "atomic_edit");
+        assert!(hint.context.contains("tracedecay_multi_str_replace"));
+        assert!(hint.context.contains("tracedecay_ast_grep_rewrite"));
+    }
+
+    #[test]
+    fn type_orientation_prompts_get_ast_graph_ladder() {
+        let hint = decide_hint(&ToolHintInput {
+            prompt: Some(
+                "Find constructor sites, field writes, trait impls, and duplicate logic"
+                    .to_string(),
+            ),
+            session_id: Some("session-1".to_string()),
+            ..ToolHintInput::default()
+        })
+        .unwrap();
+
+        assert_eq!(hint.category.as_key(), "type_orientation");
+        assert!(hint.context.contains("tracedecay_constructors"));
+        assert!(hint.context.contains("tracedecay_field_sites"));
+        assert!(hint.context.contains("tracedecay_redundancy"));
+    }
+
+    #[test]
     fn prior_conversation_prompt_gets_session_recall_hint() {
         let hint = decide_hint(&ToolHintInput {
             prompt: Some(
@@ -709,6 +905,21 @@ mod tests {
         assert_eq!(hint.category, HintCategory::FileRead);
         assert!(hint.message.contains("tracedecay_outline"));
         assert!(hint.nonblocking, "read hints must stay soft");
+    }
+
+    #[test]
+    fn tracedecay_tool_schema_reads_get_direct_tool_hint() {
+        let mut input = input_for_tool("ReadFile");
+        input.file_path = Some(
+            "/home/zack/.cursor/projects/repo/mcps/plugin-tracedecay/tools/tracedecay_callers.json"
+                .to_string(),
+        );
+        let hint = decide_hint(&input).unwrap();
+
+        assert_eq!(hint.category, HintCategory::FileRead);
+        assert!(hint.message.contains("tool descriptor"));
+        assert!(hint.context.contains("tracedecay_callers"));
+        assert!(hint.context.contains("tracedecay_callees"));
     }
 
     #[test]

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -31,6 +31,7 @@ pub enum HintCategory {
     Search,
     SemanticSearch,
     FileRead,
+    ToolDescriptorRead,
     BroadRead,
     CallGraph,
     Impact,
@@ -50,6 +51,7 @@ impl HintCategory {
             HintCategory::Search => "search",
             HintCategory::SemanticSearch => "semantic_search",
             HintCategory::FileRead => "file_read",
+            HintCategory::ToolDescriptorRead => "tool_descriptor_read",
             HintCategory::BroadRead => "broad_read",
             HintCategory::CallGraph => "call_graph",
             HintCategory::Impact => "impact",
@@ -69,6 +71,7 @@ impl HintCategory {
             "search" => Some(HintCategory::Search),
             "semantic_search" => Some(HintCategory::SemanticSearch),
             "file_read" => Some(HintCategory::FileRead),
+            "tool_descriptor_read" => Some(HintCategory::ToolDescriptorRead),
             "broad_read" => Some(HintCategory::BroadRead),
             "call_graph" => Some(HintCategory::CallGraph),
             "impact" => Some(HintCategory::Impact),
@@ -310,7 +313,7 @@ pub fn decide_hint(input: &ToolHintInput) -> Option<ToolHint> {
 
     if is_tracedecay_tool_descriptor_read(input) {
         return Some(hint(
-            HintCategory::FileRead,
+            HintCategory::ToolDescriptorRead,
             "This looks like a TraceDecay MCP tool descriptor; use the tool surface instead of reading schema JSON.",
             "Call the named tracedecay_* MCP tool directly when available, or use tool discovery for its schema; for function tracing that usually means tracedecay_find_exact_symbol plus tracedecay_callers/tracedecay_callees.",
             true,
@@ -916,7 +919,7 @@ mod tests {
         );
         let hint = decide_hint(&input).unwrap();
 
-        assert_eq!(hint.category, HintCategory::FileRead);
+        assert_eq!(hint.category, HintCategory::ToolDescriptorRead);
         assert!(hint.message.contains("tool descriptor"));
         assert!(hint.context.contains("tracedecay_callers"));
         assert!(hint.context.contains("tracedecay_callees"));
@@ -933,7 +936,17 @@ mod tests {
         assert!(dedupe.should_emit("s1", HintCategory::Search));
         assert!(!dedupe.should_emit("s1", HintCategory::Search));
         assert!(dedupe.should_emit("s1", HintCategory::FileRead));
+        assert!(dedupe.should_emit("s1", HintCategory::ToolDescriptorRead));
         assert!(dedupe.should_emit("s2", HintCategory::Search));
+    }
+
+    #[test]
+    fn descriptor_reads_dedupe_separately_from_source_file_reads() {
+        let mut dedupe = ToolHintDedupe::default();
+        assert!(dedupe.should_emit("s1", HintCategory::FileRead));
+        assert!(dedupe.should_emit("s1", HintCategory::ToolDescriptorRead));
+        assert!(!dedupe.should_emit("s1", HintCategory::FileRead));
+        assert!(!dedupe.should_emit("s1", HintCategory::ToolDescriptorRead));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- expand TraceDecay hook hints so caller/callee, fixture dependency, affected-test, safe-edit, and type-orientation prompts surface concrete MCP tool ladders before generic grep/read guidance
- update Codex/Cursor installed skill descriptions so exact tools like tracedecay_callers, tracedecay_callees, tracedecay_affected, tracedecay_test_map, tracedecay_multi_str_replace, tracedecay_ast_grep_rewrite, tracedecay_constructors, and tracedecay_redundancy are discoverable before skill bodies load
- add a schema-descriptor read hint for Cursor-style reads of tracedecay_* MCP tool JSON files and dedupe it separately from normal file-read hints

## Evidence / RED corpus
- current-session miss: setup_project/setup_empty_project fixture optimization initially used grep/file inspection instead of resolving helpers and tracing callers/callees
- prior audit session 019f1203-e211-71f1-acaf-4f838cf367c2 showed TraceDecay was mentioned far more than used, with Shell/ReadFile/Grep usage dwarfing tracedecay_context/search/read
- Cursor transcript misses included agents asking whether to use tracedecay_read, then reading MCP schema JSON or source files directly

## Review fix
- split descriptor-read hints into a dedicated ToolDescriptorRead category so descriptor advice and ordinary file-read advice do not suppress each other within a session
- added a regression that verifies both categories emit independently and then dedupe independently

## Validation
- cargo fmt --all --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/tracedecay-target/skill-discovery-red cargo test --lib hooks::tool_hints::tests -- --nocapture (18 passed)
- CARGO_TARGET_DIR=/tmp/tracedecay-target/skill-discovery-red cargo test --lib agents::codex::tests -- --nocapture (5 passed)
- CARGO_TARGET_DIR=/tmp/tracedecay-target/skill-discovery-red cargo test --test hooks_test codex -- --nocapture (19 passed)