### PR TITLE
perf: scope message search catch-up

### DIFF
--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -2289,7 +2289,7 @@ fn def_message_search() -> ToolDefinition {
     def(
         "tracedecay_message_search",
         "Message Search",
-        "Search ingested transcript messages across all supported providers by default. Every search first catches up all supported provider adapters for the selected project unless catch_up is false; pass provider only when explicitly scoping results to one provider.",
+        "Search ingested transcript messages across all supported providers by default. Searches catch up the selected provider scope unless catch_up is false; pass provider only when intentionally scoping results to one provider.",
         json!({
             "type": "object",
             "properties": {
@@ -2299,8 +2299,8 @@ fn def_message_search() -> ToolDefinition {
                 },
                 "provider": {
                     "type": "string",
-                    "description": "Optional explicit result scope. Omit or use 'all' for unified cross-provider recall; even scoped searches still ingest all supported providers first. Use 'hermes' for Hermes agent conversation history ingested from per-profile state.db stores.",
-                    "enum": ["all", "cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "kiro", "hermes"]
+                    "description": "Optional explicit result scope. Omit or use 'all' for unified cross-provider recall; scoped searches catch up only that provider. Use 'hermes' for Hermes agent conversation history ingested from per-profile state.db stores.",
+                    "enum": crate::sessions::providers::MESSAGE_SEARCH_PROVIDER_IDS
                 },
                 "project_key": {
                     "type": "string",

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -17,7 +17,7 @@ use crate::sessions::lcm::{
     LcmGrepSort, LcmLoadSessionRequest, LcmPreflightRequest, LcmScope, LcmSessionBoundaryRequest,
     LcmSummarizerMode, LCM_EXPAND_QUERY_SYNTHESIS_SYSTEM_PROMPT,
 };
-use crate::sessions::SessionSearchScope;
+use crate::sessions::{ProviderScope, SessionSearchScope};
 use crate::tracedecay::TraceDecay;
 
 const DEFAULT_LCM_CONTENT_LIMIT: usize = 4096;
@@ -1370,6 +1370,10 @@ fn parse_message_search_scope(args: &Value) -> Result<SessionSearchScope> {
     }
 }
 
+fn parse_message_search_provider_scope(args: &Value) -> Result<ProviderScope> {
+    ProviderScope::parse_optional(string_arg(args, "provider")).map_err(argument_error)
+}
+
 pub(super) async fn handle_message_search(
     cg: &TraceDecay,
     args: Value,
@@ -1384,7 +1388,8 @@ pub(super) async fn handle_message_search(
         .ok_or_else(|| TraceDecayError::Config {
             message: "missing required parameter: query".to_string(),
         })?;
-    let requested_provider = optional_search_provider_arg(&args);
+    let provider_scope = parse_message_search_provider_scope(&args)?;
+    let requested_provider = provider_scope.provider_id();
     let project_key = args
         .get("project_key")
         .and_then(Value::as_str)
@@ -1443,8 +1448,14 @@ pub(super) async fn handle_message_search(
             }),
         ));
     };
-    if catch_up {
-        let _ = crate::sessions::ingest_global_sources(&db, &target_root).await;
+    let catch_up_performed = catch_up;
+    if catch_up_performed {
+        let _ = crate::sessions::ingest_global_sources_for_provider(
+            &db,
+            &target_root,
+            provider_scope.provider(),
+        )
+        .await;
     }
     let results = if let Some(provider) = requested_provider {
         db.search_session_messages_filtered(
@@ -1478,6 +1489,8 @@ pub(super) async fn handle_message_search(
             "parent_session_id": parent_session_id,
             "include_subagents": include_subagents,
             "catch_up": catch_up,
+            "catch_up_performed": catch_up_performed,
+            "catch_up_provider": provider_scope.response_label(),
             "scope": match scope {
                 SessionSearchScope::All => "all",
                 SessionSearchScope::ParentsOnly => "parents_only",

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -15,10 +15,23 @@ pub mod cursor_agent;
 pub mod hermes;
 pub mod kiro;
 pub mod lcm;
+pub mod providers;
 pub mod shared;
 pub mod source;
 pub(crate) mod transcript_backfill;
 pub mod vibe;
+
+pub use providers::{ProviderScope, SessionProvider};
+
+const FILE_TRANSCRIPT_PROVIDERS: &[SessionProvider] = &[
+    SessionProvider::Claude,
+    SessionProvider::Codex,
+    SessionProvider::Vibe,
+    SessionProvider::Cline,
+    SessionProvider::RooCode,
+    SessionProvider::Kilo,
+    SessionProvider::Kiro,
+];
 
 pub(crate) fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME")
@@ -36,38 +49,65 @@ pub(crate) fn home_dir() -> Option<PathBuf> {
 /// re-ingests the other's work. Fail-open and incremental (unchanged files
 /// are a no-op).
 pub async fn ingest_global_sources(db: &GlobalDb, project_root: &Path) -> TranscriptIngestStats {
+    ingest_global_sources_for_provider(db, project_root, None).await
+}
+
+pub async fn ingest_global_sources_for_provider(
+    db: &GlobalDb,
+    project_root: &Path,
+    provider: Option<SessionProvider>,
+) -> TranscriptIngestStats {
     let mut sources: Vec<Box<dyn TranscriptSource>> = Vec::new();
-    if let Some(source) = claude::ClaudeSource::new() {
-        sources.push(Box::new(source));
-    }
-    if let Some(source) = codex::CodexSource::new() {
-        sources.push(Box::new(source));
-    }
-    if let Some(source) = vibe::VibeSource::new() {
-        sources.push(Box::new(source));
-    }
-    if let Some(source) = cline_like::ClineLikeSource::cline() {
-        sources.push(Box::new(source));
-    }
-    if let Some(source) = cline_like::ClineLikeSource::roo_code() {
-        sources.push(Box::new(source));
-    }
-    if let Some(source) = cline_like::ClineLikeSource::kilo() {
-        sources.push(Box::new(source));
-    }
-    if let Some(source) = kiro::KiroSource::new() {
-        sources.push(Box::new(source));
-    }
-    // Cursor has live hook ingestion, but transcripts written before a project
-    // was indexed (or while hooks were absent) need this catch-up path; shared
-    // parse offsets make hook-ingested files no-ops here and vice versa.
-    if let Some(source) = cursor::CursorSweepSource::new() {
-        sources.push(Box::new(source));
+    match provider {
+        None => {
+            for provider in FILE_TRANSCRIPT_PROVIDERS {
+                push_file_source(&mut sources, *provider);
+            }
+        }
+        Some(provider) => push_file_source(&mut sources, provider),
     }
     let stats = ingest_sources(db, project_root, &sources).await;
-    // Hermes stores many sessions in one SQLite file per profile, so it plugs
-    // in beside the file-based sources rather than through `TranscriptSource`.
-    stats.merge(hermes::ingest_for_project(db, project_root).await)
+    let stats = if provider.is_none() || provider == Some(SessionProvider::Cursor) {
+        // Cursor has live hook ingestion, but transcripts written before a
+        // project was indexed (or while hooks were absent) need this catch-up
+        // path; shared parse offsets make hook-ingested files no-ops.
+        if let Some(source) = cursor::CursorSweepSource::new() {
+            stats.merge(ingest_source(db, &source, project_root, None).await)
+        } else {
+            stats
+        }
+    } else {
+        stats
+    };
+    if provider.is_none() || provider == Some(SessionProvider::Hermes) {
+        // Hermes stores many sessions in one SQLite file per profile, so it
+        // plugs in beside the file-based sources rather than `TranscriptSource`.
+        stats.merge(hermes::ingest_for_project(db, project_root).await)
+    } else {
+        stats
+    }
+}
+
+fn push_file_source(sources: &mut Vec<Box<dyn TranscriptSource>>, provider: SessionProvider) {
+    match provider {
+        SessionProvider::Claude => push_source(sources, claude::ClaudeSource::new()),
+        SessionProvider::Codex => push_source(sources, codex::CodexSource::new()),
+        SessionProvider::Vibe => push_source(sources, vibe::VibeSource::new()),
+        SessionProvider::Cline => push_source(sources, cline_like::ClineLikeSource::cline()),
+        SessionProvider::RooCode => push_source(sources, cline_like::ClineLikeSource::roo_code()),
+        SessionProvider::Kilo => push_source(sources, cline_like::ClineLikeSource::kilo()),
+        SessionProvider::Kiro => push_source(sources, kiro::KiroSource::new()),
+        SessionProvider::Cursor | SessionProvider::Hermes => {}
+    }
+}
+
+fn push_source<T>(sources: &mut Vec<Box<dyn TranscriptSource>>, source: Option<T>)
+where
+    T: TranscriptSource + 'static,
+{
+    if let Some(source) = source {
+        sources.push(Box::new(source));
+    }
 }
 
 /// Drive a set of sources against `db` for `project_root`. Separated from

--- a/src/sessions/providers.rs
+++ b/src/sessions/providers.rs
@@ -1,0 +1,92 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionProvider {
+    Cursor,
+    Claude,
+    Codex,
+    Vibe,
+    Cline,
+    RooCode,
+    Kilo,
+    Kiro,
+    Hermes,
+}
+
+impl SessionProvider {
+    pub const fn id(self) -> &'static str {
+        match self {
+            Self::Cursor => "cursor",
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Vibe => "vibe",
+            Self::Cline => "cline",
+            Self::RooCode => "roo-code",
+            Self::Kilo => "kilo",
+            Self::Kiro => "kiro",
+            Self::Hermes => "hermes",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "cursor" => Some(Self::Cursor),
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "vibe" => Some(Self::Vibe),
+            "cline" => Some(Self::Cline),
+            "roo-code" => Some(Self::RooCode),
+            "kilo" => Some(Self::Kilo),
+            "kiro" => Some(Self::Kiro),
+            "hermes" => Some(Self::Hermes),
+            _ => None,
+        }
+    }
+}
+
+pub const MESSAGE_SEARCH_PROVIDER_IDS: &[&str] = &[
+    "all", "cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "kiro", "hermes",
+];
+
+pub const EXPECTED_MESSAGE_SEARCH_PROVIDER: &str =
+    "all, cursor, claude, codex, vibe, cline, roo-code, kilo, kiro, or hermes";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderScope {
+    All,
+    One(SessionProvider),
+}
+
+impl ProviderScope {
+    pub fn parse_optional(value: Option<&str>) -> std::result::Result<Self, String> {
+        match value.map(str::trim).filter(|provider| !provider.is_empty()) {
+            None | Some("all") => Ok(Self::All),
+            Some(provider) => SessionProvider::parse(provider)
+                .map(Self::One)
+                .ok_or_else(|| {
+                    format!(
+                        "unknown session provider '{provider}' (expected {EXPECTED_MESSAGE_SEARCH_PROVIDER})"
+                    )
+                }),
+        }
+    }
+
+    pub const fn provider(self) -> Option<SessionProvider> {
+        match self {
+            Self::All => None,
+            Self::One(provider) => Some(provider),
+        }
+    }
+
+    pub const fn provider_id(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::One(provider) => Some(provider.id()),
+        }
+    }
+
+    pub const fn response_label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::One(provider) => provider.id(),
+        }
+    }
+}

--- a/src/sessions_cmd.rs
+++ b/src/sessions_cmd.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::{cli::SessionsAction, resolve_cli_project_root};
+use tracedecay::sessions::ProviderScope;
 
 pub(crate) async fn handle_sessions_action(
     action: SessionsAction,
@@ -20,7 +21,7 @@ pub(crate) async fn handle_sessions_action(
                         project_path.display()
                     ),
                 })?;
-            let _ = optional_session_provider_scope(provider.as_deref())?;
+            let _ = session_provider_scope(provider.as_deref())?;
             let stats = ingest_selected_session_sources(&db, &project_path).await;
             println!(
                 "ingested {} session(s), {} message(s)",
@@ -43,10 +44,15 @@ pub(crate) async fn handle_sessions_action(
                         project_path.display()
                     ),
                 })?;
-            let selected_provider = optional_session_provider_scope(provider.as_deref())?;
-            let _ = tracedecay::sessions::ingest_global_sources(&db, &project_path).await;
-            let results = if let Some(provider) = selected_provider {
-                db.search_session_messages(provider, None, &query, limit)
+            let provider_scope = session_provider_scope(provider.as_deref())?;
+            let _ = tracedecay::sessions::ingest_global_sources_for_provider(
+                &db,
+                &project_path,
+                provider_scope.provider(),
+            )
+            .await;
+            let results = if let Some(provider) = provider_scope.provider() {
+                db.search_session_messages(provider.id(), None, &query, limit)
                     .await
             } else {
                 db.search_session_messages_all_providers_filtered(
@@ -79,20 +85,7 @@ async fn ingest_selected_session_sources(
     tracedecay::sessions::ingest_global_sources(db, project_root).await
 }
 
-fn optional_session_provider_scope(
-    provider: Option<&str>,
-) -> tracedecay::errors::Result<Option<&str>> {
-    match provider.map(str::trim).filter(|provider| !provider.is_empty()) {
-        None | Some("all") => Ok(None),
-        Some(
-            provider @ ("cursor" | "claude" | "codex" | "vibe" | "cline" | "roo-code" | "kilo"
-            | "kiro" | "hermes"),
-        ) => Ok(Some(provider)),
-        other => Err(tracedecay::errors::TraceDecayError::Config {
-            message: format!(
-                "unknown session provider '{}' (expected all, cursor, claude, codex, vibe, cline, roo-code, kilo, kiro, or hermes)",
-                other.unwrap_or_default()
-            ),
-        }),
-    }
+fn session_provider_scope(provider: Option<&str>) -> tracedecay::errors::Result<ProviderScope> {
+    ProviderScope::parse_optional(provider)
+        .map_err(|message| tracedecay::errors::TraceDecayError::Config { message })
 }

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -7003,8 +7003,9 @@ async fn message_search_catches_up_provider_transcripts_before_querying() {
 
     let codex_dir = home.join(".codex/sessions/2026/01/01");
     fs::create_dir_all(&codex_dir).unwrap();
+    let codex_transcript = codex_dir.join("rollout-2026-01-01T00-00-00-codex-catchup.jsonl");
     fs::write(
-        codex_dir.join("rollout-2026-01-01T00-00-00-codex-catchup.jsonl"),
+        &codex_transcript,
         format!(
             "{}\n{}\n",
             json!({
@@ -7055,6 +7056,45 @@ async fn message_search_catches_up_provider_transcripts_before_querying() {
     assert_eq!(codex["count"], 1);
     assert_eq!(codex["results"][0]["message"]["provider"], "codex");
 
+    use std::io::Write;
+    let mut codex_append = fs::OpenOptions::new()
+        .append(true)
+        .open(&codex_transcript)
+        .unwrap();
+    writeln!(
+        codex_append,
+        "{}",
+        json!({
+            "timestamp": "2026-01-01T00:00:02.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "deterministic-provider-only-token appears in appended transcript evidence."
+            }
+        })
+    )
+    .unwrap();
+
+    let appended_codex_result = handle_tool_call(
+        &cg,
+        "tracedecay_message_search",
+        json!({
+            "query": "deterministic-provider-only-token",
+            "provider": "codex",
+            "limit": 5
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let appended_codex = extract_json(&appended_codex_result.value);
+    assert_eq!(appended_codex["status"], "ok");
+    assert_eq!(appended_codex["catch_up"], true);
+    assert_eq!(appended_codex["catch_up_performed"], true);
+    assert_eq!(appended_codex["count"], 1);
+    assert_eq!(appended_codex["results"][0]["message"]["provider"], "codex");
+
     let requested_codex_unified_result = handle_tool_call(
         &cg,
         "tracedecay_message_search",
@@ -7086,8 +7126,8 @@ async fn message_search_catches_up_provider_transcripts_before_querying() {
         .await;
     assert_eq!(
         ingested_cursor.len(),
-        1,
-        "provider-scoped search should still ingest every supported provider"
+        0,
+        "provider-scoped search should only ingest the requested provider"
     );
 
     let cursor_result = handle_tool_call(
@@ -9023,7 +9063,7 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
 
 #[tokio::test]
 async fn lcm_compress_without_summarizer_requests_auxiliary_summary() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     for (index, content) in [
         "historical planning context alpha beta gamma",
         "historical tool result delta epsilon zeta",
@@ -9270,7 +9310,7 @@ async fn lcm_preflight_structured_replay_content_is_bounded_for_mcp() {
 
 #[tokio::test]
 async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     for (index, content) in ["old-1 token", "old-2 token", "fresh-1", "fresh-2"]
         .iter()
         .enumerate()
@@ -9331,7 +9371,7 @@ async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() 
 
 #[tokio::test]
 async fn lcm_status_response_is_valid_json_and_omits_payload_secrets() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     let db = open_project_session_db(cg.project_root())
         .await
         .expect("project-local session db should open");
@@ -9618,7 +9658,7 @@ async fn lcm_describe_supports_summary_node_and_external_payload_targets() {
 
 #[tokio::test]
 async fn lcm_grep_and_load_session_honor_native_filters_and_content_clamp() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     seed_lcm_session_message_with_role_source_timestamp(
         &cg,
         "lcm-native-filters",
@@ -10164,7 +10204,7 @@ async fn lcm_load_session_accepts_valid_integer_args() {
 
 #[tokio::test]
 async fn lcm_large_json_response_stays_parseable_after_truncation() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     for index in 0..4 {
         seed_lcm_session_message(
             &cg,
@@ -10198,7 +10238,7 @@ async fn lcm_large_json_response_stays_parseable_after_truncation() {
 
 #[tokio::test]
 async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-large-expand-query",
@@ -10262,7 +10302,7 @@ async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
 
 #[tokio::test]
 async fn lcm_expand_query_oversized_prompt_preserves_synthesis_contract() {
-    let (cg, _env, _dir) = setup_empty_project().await;
+    let (cg, _dir) = setup_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-huge-prompt-expand-query",
@@ -11192,10 +11232,7 @@ fn message_search_provider_schema_matches_ingested_providers() {
 
     assert_eq!(
         message_search.input_schema["properties"]["provider"]["enum"],
-        serde_json::json!([
-            "all", "cursor", "claude", "codex", "vibe", "cline", "roo-code", "kilo", "kiro",
-            "hermes"
-        ])
+        serde_json::json!(tracedecay::sessions::providers::MESSAGE_SEARCH_PROVIDER_IDS)
     );
     assert!(
         !message_search
@@ -13268,6 +13305,21 @@ async fn message_search_rejects_invalid_scope() {
             "unexpected error for scope {invalid:?}: {err}"
         );
     }
+
+    let err = expect_tool_error(
+        handle_tool_call(
+            &cg,
+            "tracedecay_message_search",
+            json!({"query": "anything", "provider": "unknown-agent"}),
+            None,
+            None,
+        )
+        .await,
+    );
+    assert!(
+        err.contains("unknown session provider 'unknown-agent'"),
+        "unexpected provider error: {err}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- scope transcript catch-up to the requested message-search provider instead of sweeping every provider for scoped searches
- remove the time-based repeated-search debounce so message_search catch-up is deterministic and immediately sees newly appended transcript content
- centralize session provider parsing/schema labels in `sessions::providers` and reuse it from MCP definitions, handlers, CLI search, and ingest selection
- update MCP regression coverage for provider-scoped catch-up freshness, provider schema drift, invalid provider errors, and read-only catch_up=false searches

## Validation
- cargo fmt --check
- cargo test --test mcp_handler_test message_search_ -- --nocapture
- cargo check
- cargo test session_provider -- --nocapture
- cargo test ingest_global_sources -- --nocapture
- cargo test sessions_ -- --nocapture

## Notes
- Follow-up to the thermo-nuclear review: this removes the stale-result debounce behavior and replaces scattered provider string matching with a shared typed provider scope.
