### PR TITLE
[codex] Fix automation retry and fact curation policy

### DIFF
--- a/src/automation/backend.rs
+++ b/src/automation/backend.rs
@@ -130,6 +130,36 @@ impl AgentTaskFailureClass {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentTaskFailureDisposition {
+    pub classification: Option<AgentTaskFailureClass>,
+    pub retryable: Option<bool>,
+}
+
+impl AgentTaskFailureDisposition {
+    pub fn is_non_retryable(self) -> bool {
+        self.retryable == Some(false)
+    }
+}
+
+pub fn agent_task_failure_disposition(
+    recorded_classification: Option<AgentTaskFailureClass>,
+    recorded_retryable: Option<bool>,
+    error: Option<&str>,
+) -> AgentTaskFailureDisposition {
+    let classification = error
+        .map(classify_agent_task_error_message)
+        .or(recorded_classification);
+    let retryable = classification
+        .map(AgentTaskFailureClass::is_retryable)
+        .or(recorded_retryable);
+
+    AgentTaskFailureDisposition {
+        classification,
+        retryable,
+    }
+}
+
 pub fn classify_agent_task_error_message(message: &str) -> AgentTaskFailureClass {
     let normalized = message.to_ascii_lowercase();
     if normalized.contains("timed out") || normalized.contains("timeout") {
@@ -143,6 +173,7 @@ pub fn classify_agent_task_error_message(message: &str) -> AgentTaskFailureClass
         || normalized.contains("connection refused")
         || normalized.contains("connection reset")
         || normalized.contains("broken pipe")
+        || normalized.contains("closed stdout")
     {
         return AgentTaskFailureClass::Unavailable;
     }

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -650,7 +650,7 @@ async fn skipped_skill_writer_run(
 
 fn build_session_reflector_prompt(evidence: &Value) -> String {
     format!(
-        "Review these bounded TraceDecay session snippets and propose only durable memory facts. Return only JSON with a facts array. Each fact must include content, category, optional tags, optional entities, trust, source_span, and reason. Use trust, not confidence. source_span must cite one bounded evidence hit by session_id plus message_id for raw messages, by store_id for raw messages, or by node_id for summaries. Do not include secrets or ephemeral status.\n{}",
+        "Review these bounded TraceDecay session snippets and propose only durable memory facts. Return only JSON with a facts array. Each fact must include content, category, optional tags, optional entities, trust, source_span, and reason. Category must be one of general, user_pref, project, tool, decision, or code_area. Use trust, not confidence. source_span must cite one bounded evidence hit by session_id plus message_id for raw messages, by store_id for raw messages, or by node_id for summaries. Do not include secrets or ephemeral status.\n{}",
         serde_json::to_string_pretty(evidence).unwrap_or_else(|_| "{}".to_string())
     )
 }

--- a/src/automation/scheduler.rs
+++ b/src/automation/scheduler.rs
@@ -3,7 +3,7 @@ use std::time::UNIX_EPOCH;
 
 use serde::{Deserialize, Serialize};
 
-use super::backend::{task_key, AgentTaskKind};
+use super::backend::{agent_task_failure_disposition, task_key, AgentTaskKind};
 use super::config::{
     AutomationBackend, AutomationConfig, AutomationHostMode, AutomationTaskConfig,
 };
@@ -214,7 +214,12 @@ pub fn schedule_decision(
     {
         let completed_at = record.completed_at.parse::<i64>().ok().unwrap_or(0);
         if record.status == AutomationRunStatus::Failed {
-            if record.error_retryable == Some(false) {
+            let failure = agent_task_failure_disposition(
+                record.error_classification,
+                record.error_retryable,
+                record.error.as_deref(),
+            );
+            if failure.is_non_retryable() {
                 return AutomationScheduleDecision::skipped("scheduler_non_retryable_failure");
             }
             let cooldown_secs = task_config

--- a/src/automation/session_reflector.rs
+++ b/src/automation/session_reflector.rs
@@ -116,7 +116,7 @@ async fn validate_fact_proposal(
     let Some(category) = object
         .get("category")
         .and_then(Value::as_str)
-        .and_then(|value| value.parse::<MemoryCategory>().ok())
+        .and_then(|value| MemoryCategory::from_proposal_label(value).ok())
     else {
         return Ok(rejected_fact(proposal, "valid category is required"));
     };

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -26,6 +26,26 @@ impl MemoryCategory {
             Self::CodeArea => "code_area",
         }
     }
+
+    pub fn from_proposal_label(value: &str) -> Result<Self, ParseMemoryCategoryError> {
+        if let Ok(category) = value.parse::<Self>() {
+            return Ok(category);
+        }
+        let normalized = normalized_category_label(value);
+        match normalized.as_str() {
+            "tool_guidance" | "tool_use" | "tool_usage" | "tooling" => Ok(Self::Tool),
+            "workflow_preference" | "workflow_preferences" | "user_workflow_preference" => {
+                Ok(Self::UserPref)
+            }
+            "workflow_requirement" | "workflow_policy" | "project_requirement" => {
+                Ok(Self::Decision)
+            }
+            "workflow" | "process" | "procedure" | "guidance" => Ok(Self::General),
+            _ => Err(ParseMemoryCategoryError {
+                value: value.to_string(),
+            }),
+        }
+    }
 }
 
 impl fmt::Display for MemoryCategory {
@@ -51,7 +71,7 @@ impl FromStr for MemoryCategory {
     type Err = ParseMemoryCategoryError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let normalized = value.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+        let normalized = normalized_category_label(value);
         match normalized.as_str() {
             "general" => Ok(Self::General),
             "user_pref" | "user_preference" | "user_preferences" => Ok(Self::UserPref),
@@ -64,6 +84,10 @@ impl FromStr for MemoryCategory {
             }),
         }
     }
+}
+
+fn normalized_category_label(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace(['-', ' '], "_")
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/tests/automation_backend_test.rs
+++ b/tests/automation_backend_test.rs
@@ -8,9 +8,9 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use tracedecay::automation::backend::{
-    backend_availability, classify_agent_task_error_message, extract_json_object_prefix,
-    AgentTaskBackend, AgentTaskFailureClass, AgentTaskKind, AgentTaskRequest, AgentTaskResponse,
-    CodexAppServerBackend,
+    agent_task_failure_disposition, backend_availability, classify_agent_task_error_message,
+    extract_json_object_prefix, AgentTaskBackend, AgentTaskFailureClass, AgentTaskKind,
+    AgentTaskRequest, AgentTaskResponse, CodexAppServerBackend,
 };
 use tracedecay::automation::config::{AutomationBackend, AutomationConfig};
 use tracedecay::sessions::codex_app_server::{
@@ -152,6 +152,11 @@ fn classifies_backend_failures_for_retry_policy() {
             true,
         ),
         (
+            "config error: codex app-server closed stdout before completing",
+            AgentTaskFailureClass::Unavailable,
+            true,
+        ),
+        (
             "json error: expected value at line 1 column 1",
             AgentTaskFailureClass::MalformedOutput,
             false,
@@ -180,6 +185,22 @@ fn classifies_backend_failures_for_retry_policy() {
             "message: {message}"
         );
     }
+}
+
+#[test]
+fn failure_disposition_heals_stale_recorded_retryability() {
+    let disposition = agent_task_failure_disposition(
+        Some(AgentTaskFailureClass::Permanent),
+        Some(false),
+        Some("config error: codex app-server closed stdout before completing"),
+    );
+
+    assert_eq!(
+        disposition.classification,
+        Some(AgentTaskFailureClass::Unavailable)
+    );
+    assert_eq!(disposition.retryable, Some(true));
+    assert!(!disposition.is_non_retryable());
 }
 
 #[test]

--- a/tests/automation_scheduler_test.rs
+++ b/tests/automation_scheduler_test.rs
@@ -265,6 +265,28 @@ fn scheduler_does_not_retry_explicit_non_retryable_failures() {
 }
 
 #[test]
+fn scheduler_rechecks_stale_non_retryable_backend_transport_failures() {
+    let config = automation_config(Some("daily"), None);
+    let mut failed = record(
+        "run-1",
+        AgentTaskKind::MemoryCurator,
+        AutomationRunStatus::Failed,
+        1_000,
+    );
+    failed.error =
+        Some("config error: codex app-server closed stdout before completing".to_string());
+    failed.error_classification = Some(AgentTaskFailureClass::Permanent);
+    failed.error_retryable = Some(false);
+    let records = vec![failed];
+
+    assert_eq!(
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_100).skip_reason(),
+        Some("scheduler_cooldown_active")
+    );
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_400).is_due());
+}
+
+#[test]
 fn scheduler_retries_explicit_retryable_failures_after_cooldown() {
     let config = automation_config(Some("daily"), None);
     let mut failed = record(

--- a/tests/automation_session_reflector_runner_test.rs
+++ b/tests/automation_session_reflector_runner_test.rs
@@ -51,6 +51,15 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
                 "reason": "Repeated session evidence describes the required approval gate"
             },
             {
+                "content": "Use the fact-store workflow only when the user explicitly asks to memorize or remember a subject",
+                "category": "tool_guidance",
+                "tags": ["memory", "workflow"],
+                "entities": ["TraceDecay"],
+                "trust": 0.74,
+                "source_span": {"session_id": "session-reflect-1", "message_id": "session-reflect-1-message-001"},
+                "reason": "Repeated assistant guidance describes durable fact-store tool use"
+            },
+            {
                 "content": "Cache invalidation policy must be explicit",
                 "category": "project",
                 "tags": ["cache"],
@@ -143,7 +152,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(backend.calls(), 1);
     assert_eq!(run.ledger_record.task, AgentTaskKind::SessionReflector);
     assert_eq!(run.ledger_record.status, AutomationRunStatus::Succeeded);
-    assert_eq!(run.ledger_record.accepted_count, 1);
+    assert_eq!(run.ledger_record.accepted_count, 2);
     assert_eq!(run.ledger_record.rejected_count, 7);
     assert_eq!(
         run.report["accepted_facts"][0]["add_fact_request"]["source"],
@@ -160,6 +169,10 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(
         run.report["accepted_facts"][0]["add_fact_request"]["metadata"]["trust_reason"],
         json!("Repeated session evidence describes the required approval gate")
+    );
+    assert_eq!(
+        run.report["accepted_facts"][1]["add_fact_request"]["category"],
+        json!("tool")
     );
     let rejected = run.report["rejected_facts"].as_array().unwrap();
     assert!(rejected
@@ -187,11 +200,16 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     )
     .await
     .unwrap();
-    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals.len(), 2);
     assert_eq!(proposals[0].run_id, run.run_id);
     assert_eq!(
         proposals[0].add_fact_request.as_ref().unwrap().content,
         "The project requires durable session reflection facts to stay approval gated"
+    );
+    assert_eq!(proposals[1].run_id, run.run_id);
+    assert_eq!(
+        proposals[1].add_fact_request.as_ref().unwrap().category,
+        tracedecay::memory::types::MemoryCategory::Tool
     );
     assert_eq!(
         proposals[0].validation.as_ref().unwrap()["dedupe"]["near_duplicate_threshold"],
@@ -231,7 +249,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     );
     let eval_payload = read_artifact(&cg, &run.run_id, &run.ledger_record, "generated_evals").await;
     assert_eq!(eval_payload["task"], json!("session_reflector"));
-    assert_eq!(eval_payload["summary"]["eval_count"], json!(8));
+    assert_eq!(eval_payload["summary"]["eval_count"], json!(9));
     assert!(eval_payload["eval_definitions"]
         .as_array()
         .unwrap()
@@ -310,7 +328,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
         .unwrap();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].run_id, run.run_id);
-    assert_eq!(records[0].accepted_count, 1);
+    assert_eq!(records[0].accepted_count, 2);
     assert_eq!(records[0].rejected_count, 7);
     assert!(records[0].applied_ops.is_none());
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,10 +13,13 @@ use std::time::Instant;
 
 use serde_json::Value;
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::types::{Node, NodeKind, Visibility};
+
+static EMPTY_LCM_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 /// Sets (or removes) an environment variable for its lifetime, restoring the
 /// previous value on drop.
@@ -397,9 +400,51 @@ pub fn isolated_global_db_path(tmp: &TempDir) -> std::path::PathBuf {
 }
 
 pub async fn open_lcm_db(tmp: &TempDir) -> GlobalDb {
-    GlobalDb::open_at(&isolated_lcm_db_path(tmp))
+    let db_path = isolated_lcm_db_path(tmp);
+    if !db_path.exists() {
+        seed_lcm_db_from_template(&db_path).await;
+        return GlobalDb::open_at_assuming_schema(&db_path)
+            .await
+            .expect("session db open");
+    }
+    GlobalDb::open_at(&db_path).await.expect("session db open")
+}
+
+async fn seed_lcm_db_from_template(db_path: &Path) {
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!(
+                "failed to create LCM test DB directory '{}': {err}",
+                parent.display()
+            )
+        });
+    }
+    fs::write(db_path, empty_lcm_db_template().await).unwrap_or_else(|err| {
+        panic!(
+            "failed to write LCM test DB template '{}': {err}",
+            db_path.display()
+        )
+    });
+}
+
+async fn empty_lcm_db_template() -> &'static [u8] {
+    EMPTY_LCM_DB_TEMPLATE
+        .get_or_init(|| async {
+            let tmp = tempdir_or_panic();
+            let db_path = isolated_lcm_db_path(&tmp);
+            let db = GlobalDb::open_at(&db_path)
+                .await
+                .expect("template session db open");
+            db.checkpoint().await;
+            db.close();
+            fs::read(&db_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read LCM test DB template '{}': {err}",
+                    db_path.display()
+                )
+            })
+        })
         .await
-        .expect("session db open")
 }
 
 pub async fn open_global_db(tmp: &TempDir) -> GlobalDb {

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -505,7 +505,6 @@ fn basic_lcm_dashboard_errors_and_timeline_contracts() {
                 .contains("missing-node"),
             "missing node body should carry the requested id"
         );
-
     });
 }
 

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -401,7 +401,7 @@ async fn insert_undated_message(global_db_path: &Path) {
 }
 
 #[test]
-fn timeline_excludes_null_timestamps_and_reports_undated_count() {
+fn basic_lcm_dashboard_errors_and_timeline_contracts() {
     let _env_lock = GLOBAL_DB_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -457,47 +457,6 @@ fn timeline_excludes_null_timestamps_and_reports_undated_count() {
         assert_eq!(status, 200);
         assert_eq!(other["undated"]["count"], 0, "other-session: {other}");
         assert!(as_array(&other["buckets"], "other buckets").is_empty());
-    });
-}
-
-#[test]
-fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(false).await;
-        corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
-        let agent = http_agent();
-
-        let (status, overview) = get_json(
-            &agent,
-            &format!(
-                "{}/api/plugins/hermes-lcm/overview?limit=20",
-                fixture.base_url
-            ),
-        );
-        assert_eq!(status, 422);
-        assert!(
-            overview["detail"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("malformed metadata_json"),
-            "malformed summary metadata must surface a JSON error detail, got {overview}"
-        );
-    });
-}
-
-#[test]
-fn lcm_bad_params_and_missing_resources_return_json_errors() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(false).await;
-        let agent = http_agent();
 
         let (status, bad_query) = get_json(
             &agent,
@@ -545,6 +504,36 @@ fn lcm_bad_params_and_missing_resources_return_json_errors() {
                 .unwrap_or_default()
                 .contains("missing-node"),
             "missing node body should carry the requested id"
+        );
+
+    });
+}
+
+#[test]
+fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(false).await;
+        corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
+        let agent = http_agent();
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/hermes-lcm/overview?limit=20",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 422);
+        assert!(
+            overview["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("malformed metadata_json"),
+            "malformed summary metadata must surface a JSON error detail, got {overview}"
         );
     });
 }

--- a/tests/db_query_test.rs
+++ b/tests/db_query_test.rs
@@ -1,9 +1,12 @@
 use std::ops::Deref;
 
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::db::{Database, StoredFingerprint};
 use tracedecay::redundancy::Fingerprint;
 use tracedecay::types::*;
+
+static EMPTY_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 struct TestDb {
     db: Database,
@@ -21,10 +24,32 @@ impl Deref for TestDb {
 async fn setup_db() -> TestDb {
     let dir = TempDir::new().expect("failed to create temp dir");
     let db_path = dir.path().join("test.db");
-    let (db, _) = Database::initialize(&db_path)
+    std::fs::write(&db_path, empty_db_template().await).expect("failed to write template database");
+    let (db, migrated) = Database::open(&db_path)
         .await
-        .expect("failed to initialize database");
+        .expect("failed to open template database");
+    assert!(
+        !migrated,
+        "fresh test database should not require migration"
+    );
     TestDb { db, _dir: dir }
+}
+
+async fn empty_db_template() -> &'static [u8] {
+    EMPTY_DB_TEMPLATE
+        .get_or_init(|| async {
+            let dir = TempDir::new().expect("failed to create template temp dir");
+            let db_path = dir.path().join("template.db");
+            let (db, _) = Database::initialize(&db_path)
+                .await
+                .expect("failed to initialize template database");
+            db.checkpoint()
+                .await
+                .expect("failed to checkpoint template database");
+            db.close();
+            std::fs::read(&db_path).expect("failed to read template database")
+        })
+        .await
 }
 
 /// Helper: create a sample node with reasonable defaults.

--- a/tests/mcp_handler_test.rs
+++ b/tests/mcp_handler_test.rs
@@ -9023,7 +9023,7 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
 
 #[tokio::test]
 async fn lcm_compress_without_summarizer_requests_auxiliary_summary() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     for (index, content) in [
         "historical planning context alpha beta gamma",
         "historical tool result delta epsilon zeta",
@@ -9270,7 +9270,7 @@ async fn lcm_preflight_structured_replay_content_is_bounded_for_mcp() {
 
 #[tokio::test]
 async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     for (index, content) in ["old-1 token", "old-2 token", "fresh-1", "fresh-2"]
         .iter()
         .enumerate()
@@ -9331,7 +9331,7 @@ async fn lcm_session_boundary_handler_records_cooldown_for_skipped_carry_over() 
 
 #[tokio::test]
 async fn lcm_status_response_is_valid_json_and_omits_payload_secrets() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     let db = open_project_session_db(cg.project_root())
         .await
         .expect("project-local session db should open");
@@ -9618,7 +9618,7 @@ async fn lcm_describe_supports_summary_node_and_external_payload_targets() {
 
 #[tokio::test]
 async fn lcm_grep_and_load_session_honor_native_filters_and_content_clamp() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message_with_role_source_timestamp(
         &cg,
         "lcm-native-filters",
@@ -10164,7 +10164,7 @@ async fn lcm_load_session_accepts_valid_integer_args() {
 
 #[tokio::test]
 async fn lcm_large_json_response_stays_parseable_after_truncation() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     for index in 0..4 {
         seed_lcm_session_message(
             &cg,
@@ -10198,7 +10198,7 @@ async fn lcm_large_json_response_stays_parseable_after_truncation() {
 
 #[tokio::test]
 async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-large-expand-query",
@@ -10262,7 +10262,7 @@ async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
 
 #[tokio::test]
 async fn lcm_expand_query_oversized_prompt_preserves_synthesis_contract() {
-    let (cg, _dir) = setup_project().await;
+    let (cg, _env, _dir) = setup_empty_project().await;
     seed_lcm_session_message(
         &cg,
         "lcm-huge-prompt-expand-query",

--- a/tests/memory_test.rs
+++ b/tests/memory_test.rs
@@ -271,6 +271,15 @@ fn core_memory_types_use_stable_json_strings() {
         "code_area".parse::<MemoryCategory>().unwrap(),
         MemoryCategory::CodeArea
     );
+    assert!("tool_guidance".parse::<MemoryCategory>().is_err());
+    assert_eq!(
+        MemoryCategory::from_proposal_label("tool_guidance").unwrap(),
+        MemoryCategory::Tool
+    );
+    assert_eq!(
+        MemoryCategory::from_proposal_label("workflow preference").unwrap(),
+        MemoryCategory::UserPref
+    );
 
     let fact = FactRecord {
         fact_id: 42,


### PR DESCRIPTION
## Summary

- classify `codex app-server closed stdout` as a retryable backend unavailability instead of a permanent automation failure
- centralize effective automation failure disposition so stale ledger records do not permanently lock scheduler retries
- centralize permissive memory proposal category parsing in `MemoryCategory` while keeping strict direct parsing unchanged
- clarify the session-reflector prompt with canonical fact categories

## Root Cause

The automation scheduler trusted stale `error_retryable=false` ledger fields even when the underlying backend transport error is retryable under the current classifier. Separately, session reflection accepted only strict fact-store category strings, so model-produced labels such as `tool_guidance` were rejected even though they map cleanly to canonical categories.

## Verification

- `cargo fmt --check`
- `cargo test -- --test-threads=1`
- `cargo check`
- `git diff --check`

Note: a default parallel `cargo test` surfaced existing cross-test isolation races in unrelated worktree/response-handle tests. The same failing targets passed in isolation, and the full suite passed with `--test-threads=1`.
