### PR TITLE
test: restore fixture optimizations

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,10 +13,13 @@ use std::time::Instant;
 
 use serde_json::Value;
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::config::USER_DATA_DIR_ENV;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::types::{Node, NodeKind, Visibility};
+
+static EMPTY_LCM_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 /// Sets (or removes) an environment variable for its lifetime, restoring the
 /// previous value on drop.
@@ -397,9 +400,51 @@ pub fn isolated_global_db_path(tmp: &TempDir) -> std::path::PathBuf {
 }
 
 pub async fn open_lcm_db(tmp: &TempDir) -> GlobalDb {
-    GlobalDb::open_at(&isolated_lcm_db_path(tmp))
+    let db_path = isolated_lcm_db_path(tmp);
+    if !db_path.exists() {
+        seed_lcm_db_from_template(&db_path).await;
+        return GlobalDb::open_at_assuming_schema(&db_path)
+            .await
+            .expect("session db open");
+    }
+    GlobalDb::open_at(&db_path).await.expect("session db open")
+}
+
+async fn seed_lcm_db_from_template(db_path: &Path) {
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!(
+                "failed to create LCM test DB directory '{}': {err}",
+                parent.display()
+            )
+        });
+    }
+    fs::write(db_path, empty_lcm_db_template().await).unwrap_or_else(|err| {
+        panic!(
+            "failed to write LCM test DB template '{}': {err}",
+            db_path.display()
+        )
+    });
+}
+
+async fn empty_lcm_db_template() -> &'static [u8] {
+    EMPTY_LCM_DB_TEMPLATE
+        .get_or_init(|| async {
+            let tmp = tempdir_or_panic();
+            let db_path = isolated_lcm_db_path(&tmp);
+            let db = GlobalDb::open_at(&db_path)
+                .await
+                .expect("template session db open");
+            db.checkpoint().await;
+            db.close();
+            fs::read(&db_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read LCM test DB template '{}': {err}",
+                    db_path.display()
+                )
+            })
+        })
         .await
-        .expect("session db open")
 }
 
 pub async fn open_global_db(tmp: &TempDir) -> GlobalDb {

--- a/tests/dashboard_lcm_fixes_test.rs
+++ b/tests/dashboard_lcm_fixes_test.rs
@@ -401,7 +401,7 @@ async fn insert_undated_message(global_db_path: &Path) {
 }
 
 #[test]
-fn timeline_excludes_null_timestamps_and_reports_undated_count() {
+fn basic_lcm_dashboard_errors_and_timeline_contracts() {
     let _env_lock = GLOBAL_DB_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -457,47 +457,6 @@ fn timeline_excludes_null_timestamps_and_reports_undated_count() {
         assert_eq!(status, 200);
         assert_eq!(other["undated"]["count"], 0, "other-session: {other}");
         assert!(as_array(&other["buckets"], "other buckets").is_empty());
-    });
-}
-
-#[test]
-fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(false).await;
-        corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
-        let agent = http_agent();
-
-        let (status, overview) = get_json(
-            &agent,
-            &format!(
-                "{}/api/plugins/hermes-lcm/overview?limit=20",
-                fixture.base_url
-            ),
-        );
-        assert_eq!(status, 422);
-        assert!(
-            overview["detail"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("malformed metadata_json"),
-            "malformed summary metadata must surface a JSON error detail, got {overview}"
-        );
-    });
-}
-
-#[test]
-fn lcm_bad_params_and_missing_resources_return_json_errors() {
-    let _env_lock = GLOBAL_DB_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let runtime = create_runtime();
-    runtime.block_on(async {
-        let fixture = start_fixture(false).await;
-        let agent = http_agent();
 
         let (status, bad_query) = get_json(
             &agent,
@@ -545,6 +504,35 @@ fn lcm_bad_params_and_missing_resources_return_json_errors() {
                 .unwrap_or_default()
                 .contains("missing-node"),
             "missing node body should carry the requested id"
+        );
+    });
+}
+
+#[test]
+fn malformed_summary_metadata_surfaces_json_error_instead_of_empty_rows() {
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let fixture = start_fixture(false).await;
+        corrupt_summary_node_metadata(&fixture.global_db_path, &fixture.linked_node_id).await;
+        let agent = http_agent();
+
+        let (status, overview) = get_json(
+            &agent,
+            &format!(
+                "{}/api/plugins/hermes-lcm/overview?limit=20",
+                fixture.base_url
+            ),
+        );
+        assert_eq!(status, 422);
+        assert!(
+            overview["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("malformed metadata_json"),
+            "malformed summary metadata must surface a JSON error detail, got {overview}"
         );
     });
 }

--- a/tests/db_query_test.rs
+++ b/tests/db_query_test.rs
@@ -1,9 +1,12 @@
 use std::ops::Deref;
 
 use tempfile::TempDir;
+use tokio::sync::OnceCell;
 use tracedecay::db::{Database, StoredFingerprint};
 use tracedecay::redundancy::Fingerprint;
 use tracedecay::types::*;
+
+static EMPTY_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 struct TestDb {
     db: Database,
@@ -21,10 +24,32 @@ impl Deref for TestDb {
 async fn setup_db() -> TestDb {
     let dir = TempDir::new().expect("failed to create temp dir");
     let db_path = dir.path().join("test.db");
-    let (db, _) = Database::initialize(&db_path)
+    std::fs::write(&db_path, empty_db_template().await).expect("failed to write template database");
+    let (db, migrated) = Database::open(&db_path)
         .await
-        .expect("failed to initialize database");
+        .expect("failed to open template database");
+    assert!(
+        !migrated,
+        "fresh test database should not require migration"
+    );
     TestDb { db, _dir: dir }
+}
+
+async fn empty_db_template() -> &'static [u8] {
+    EMPTY_DB_TEMPLATE
+        .get_or_init(|| async {
+            let dir = TempDir::new().expect("failed to create template temp dir");
+            let db_path = dir.path().join("template.db");
+            let (db, _) = Database::initialize(&db_path)
+                .await
+                .expect("failed to initialize template database");
+            db.checkpoint()
+                .await
+                .expect("failed to checkpoint template database");
+            db.close();
+            std::fs::read(&db_path).expect("failed to read template database")
+        })
+        .await
 }
 
 /// Helper: create a sample node with reasonable defaults.


### PR DESCRIPTION
## Summary
- restore the LCM session DB template helper that was accidentally reverted by the message-search merge
- restore the db_query empty schema template fixture
- restore the combined dashboard LCM fixture test shape

## Validation
- cargo fmt --all -- --check
- git diff --check -- tests/common/mod.rs tests/dashboard_lcm_fixes_test.rs tests/db_query_test.rs
- CARGO_TARGET_DIR=/tmp/tracedecay-target/restore-fixtures cargo test --test db_query_test -- --nocapture
- CARGO_TARGET_DIR=/tmp/tracedecay-target/restore-fixtures cargo test --test dashboard_lcm_fixes_test -- --nocapture
- CARGO_TARGET_DIR=/tmp/tracedecay-target/restore-fixtures cargo test --test session_lcm_compression_test --test session_lcm_dag_test --test session_lcm_payload_test -- --nocapture