### PR TITLE
[codex] Resolve worktree project context by registry identity

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -629,6 +629,13 @@ fn repo_identity_aliases(git_common_dir: Option<&Path>) -> Vec<String> {
     aliases
 }
 
+fn project_identity_aliases(project_root: &Path, git_common_dir: Option<&Path>) -> Vec<String> {
+    let mut aliases = Vec::with_capacity(2);
+    aliases.push(GlobalDb::canonical_project_key(project_root));
+    aliases.extend(repo_identity_aliases(git_common_dir));
+    aliases
+}
+
 fn normalize_git_remote_url(remote: &str) -> Option<String> {
     let remote = remote.trim();
     if remote.is_empty() {
@@ -1153,6 +1160,16 @@ impl GlobalDb {
             .to_string()
     }
 
+    pub fn is_explicit_project_path_selector(selector: &str) -> bool {
+        let selector = selector.trim();
+        !selector.is_empty()
+            && (Path::new(selector).is_absolute()
+                || selector == "."
+                || selector == ".."
+                || selector.contains('/')
+                || selector.contains('\\'))
+    }
+
     async fn migrate_project_rows_to_canonical_keys(&self) -> Option<()> {
         let mut rows = self
             .conn
@@ -1395,15 +1412,11 @@ impl GlobalDb {
         project_root: &Path,
         git_common_dir: Option<&Path>,
     ) -> Option<ProjectStoreResolution> {
-        let mut aliases = Vec::with_capacity(2);
-        aliases.push(Self::canonical_project_key(project_root));
-        aliases.extend(repo_identity_aliases(git_common_dir));
-        for alias in aliases {
-            if let Some(resolution) = self.resolve_project_store_by_alias_key(&alias).await {
-                return Some(resolution);
-            }
-        }
-        None
+        let project_id = self
+            .project_id_by_identity(project_root, git_common_dir)
+            .await?;
+        let project = self.get_code_project(&project_id).await?;
+        self.resolve_project_store_for_project(&project).await
     }
 
     pub async fn resolve_unique_project_store_by_git_remote(
@@ -1456,39 +1469,9 @@ impl GlobalDb {
         &self,
         alias: &str,
     ) -> Option<ProjectStoreResolution> {
-        let (project, store) = {
-            let mut rows = self
-                .conn
-                .query(
-                    "SELECT
-                        cp.project_id, cp.canonical_root, cp.display_root, cp.git_common_dir,
-                        cp.git_remote_url, cp.default_branch, cp.created_at, cp.last_seen_at,
-                        si.store_id, si.project_id, si.store_kind, si.storage_mode, si.store_relpath,
-                        si.manifest_relpath, si.created_at, si.last_verified_at, si.last_write_at
-                     FROM project_aliases pa
-                     JOIN code_projects cp ON cp.project_id = pa.project_id
-                     JOIN store_instances si ON si.project_id = cp.project_id
-                     WHERE pa.alias_path = ?1
-                     ORDER BY COALESCE(si.last_verified_at, si.created_at) DESC, si.store_id
-                     LIMIT 1",
-                    params![alias],
-                )
-                .await
-                .ok()?;
-            let row = rows.next().await.ok()??;
-            (
-                row_to_code_project(&row, 0)?,
-                row_to_store_instance(&row, 8)?,
-            )
-        };
-        let graph_scopes = self.list_graph_scopes_for_store(&store.store_id).await;
-        let artifacts = self.list_store_artifacts(&store.store_id).await;
-        Some(ProjectStoreResolution {
-            project,
-            store,
-            graph_scopes,
-            artifacts,
-        })
+        let project_id = self.project_id_by_alias_key(alias).await?;
+        let project = self.get_code_project(&project_id).await?;
+        self.resolve_project_store_for_project(&project).await
     }
 
     async fn resolve_project_store_for_project(
@@ -1624,18 +1607,51 @@ impl GlobalDb {
         alias_path: &Path,
     ) -> Option<ProjectRegistryContext> {
         let alias = Self::canonical_project_key(alias_path);
-        let project_id: String = {
-            let mut rows = self
-                .conn
-                .query(
-                    "SELECT project_id FROM project_aliases WHERE alias_path = ?1",
-                    params![alias],
-                )
-                .await
-                .ok()?;
-            rows.next().await.ok()??.get(0).ok()?
-        };
+        self.project_registry_context_by_alias_key(&alias).await
+    }
+
+    pub async fn project_registry_context_by_identity(
+        &self,
+        project_root: &Path,
+        git_common_dir: Option<&Path>,
+    ) -> Option<ProjectRegistryContext> {
+        let project_id = self
+            .project_id_by_identity(project_root, git_common_dir)
+            .await?;
         self.project_registry_context_by_id(&project_id).await
+    }
+
+    async fn project_registry_context_by_alias_key(
+        &self,
+        alias: &str,
+    ) -> Option<ProjectRegistryContext> {
+        let project_id = self.project_id_by_alias_key(alias).await?;
+        self.project_registry_context_by_id(&project_id).await
+    }
+
+    async fn project_id_by_identity(
+        &self,
+        project_root: &Path,
+        git_common_dir: Option<&Path>,
+    ) -> Option<String> {
+        for alias in project_identity_aliases(project_root, git_common_dir) {
+            if let Some(project_id) = self.project_id_by_alias_key(&alias).await {
+                return Some(project_id);
+            }
+        }
+        None
+    }
+
+    async fn project_id_by_alias_key(&self, alias: &str) -> Option<String> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT project_id FROM project_aliases WHERE alias_path = ?1",
+                params![alias],
+            )
+            .await
+            .ok()?;
+        rows.next().await.ok()??.get(0).ok()
     }
 
     pub async fn get_code_project(&self, project_id: &str) -> Option<CodeProjectRecord> {
@@ -3495,6 +3511,18 @@ mod tests {
         } else {
             assert_eq!(global_db_mmap_size_guard(), None);
         }
+    }
+
+    #[test]
+    fn explicit_project_path_selector_keeps_names_and_paths_separate() {
+        assert!(!GlobalDb::is_explicit_project_path_selector("target"));
+        assert!(!GlobalDb::is_explicit_project_path_selector(" proj_123 "));
+        assert!(GlobalDb::is_explicit_project_path_selector("."));
+        assert!(GlobalDb::is_explicit_project_path_selector(".."));
+        assert!(GlobalDb::is_explicit_project_path_selector("./target"));
+        assert!(GlobalDb::is_explicit_project_path_selector("../target"));
+        assert!(GlobalDb::is_explicit_project_path_selector("/tmp/target"));
+        assert!(GlobalDb::is_explicit_project_path_selector(r"..\target"));
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,8 +498,16 @@ async fn resolve_registered_project_root(
     let context = if let Some(project_id) = project_id.as_deref() {
         db.project_registry_context_by_id(project_id).await
     } else if let Some(project_path) = project_path.as_deref() {
-        db.project_registry_context_by_alias(Path::new(project_path))
-            .await
+        let project_path_arg = Path::new(project_path);
+        if let Some(context) = db.project_registry_context_by_alias(project_path_arg).await {
+            Some(context)
+        } else if tracedecay::global_db::GlobalDb::is_explicit_project_path_selector(project_path) {
+            let git_common_dir = tracedecay::worktree::git_common_dir(project_path_arg);
+            db.project_registry_context_by_identity(project_path_arg, git_common_dir.as_deref())
+                .await
+        } else {
+            None
+        }
     } else {
         return Ok(None);
     };

--- a/src/mcp/response_handles.rs
+++ b/src/mcp/response_handles.rs
@@ -222,6 +222,7 @@ pub struct ResponseHandleRecord {
     pub created_at: i64,
     pub expires_at: i64,
     pub content: String,
+    pub response_handle_root: PathBuf,
 }
 
 impl ResponseHandleRecord {
@@ -256,15 +257,16 @@ pub fn store_response_handle(
     telemetry.store_attempts.fetch_add(1, Ordering::Relaxed);
     let handle = response_handle_for(content);
     let result = (|| {
+        let dir = response_handle_dir(project_root)?;
         let record = ResponseHandleRecord {
             handle: handle.clone(),
             created_at: now,
             expires_at: now.saturating_add(RESPONSE_HANDLE_TTL_SECS),
             content: content.to_string(),
+            response_handle_root: dir.clone(),
         };
-        let dir = response_handle_dir(project_root)?;
         fs::create_dir_all(&dir)?;
-        let path = response_handle_path(project_root, &handle)?;
+        let path = response_handle_path_in_dir(&dir, &handle)?;
         let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
         let stored = StoredResponseHandleRecord {
             created_at: record.created_at,
@@ -308,40 +310,12 @@ pub fn retrieve_response_handle(
     handle: &str,
     now: i64,
 ) -> Result<ResponseHandleLookup> {
-    enum RetrieveOutcome {
-        Hit(ResponseHandleRecord),
-        Miss,
-        Expired {
-            created_at: i64,
-            expires_at: i64,
-            removed: bool,
-        },
-    }
-
     let started = Instant::now();
     let caller = std::panic::Location::caller();
     let telemetry = telemetry();
     let result = (|| -> Result<RetrieveOutcome> {
-        let path = response_handle_path(project_root, handle)?;
-        if !path.exists() {
-            return Ok(RetrieveOutcome::Miss);
-        }
-        let payload = fs::read_to_string(&path)?;
-        let record: StoredResponseHandleRecord = serde_json::from_str(&payload)?;
-        if record.expires_at <= now {
-            let removed = fs::remove_file(&path).is_ok();
-            return Ok(RetrieveOutcome::Expired {
-                created_at: record.created_at,
-                expires_at: record.expires_at,
-                removed,
-            });
-        }
-        Ok(RetrieveOutcome::Hit(ResponseHandleRecord {
-            handle: handle.to_string(),
-            created_at: record.created_at,
-            expires_at: record.expires_at,
-            content: record.content,
-        }))
+        let dir = response_handle_dir(project_root)?;
+        read_response_handle_from_root(&dir, handle, now)
     })();
     telemetry
         .retrieve_time_us_total
@@ -456,6 +430,65 @@ pub fn cleanup_expired_response_handles(project_root: &Path, now: i64) -> Result
     result
 }
 
+#[cfg(test)]
+pub(crate) fn retrieve_response_handle_from_root(
+    response_handle_root: &Path,
+    handle: &str,
+    now: i64,
+) -> Result<ResponseHandleLookup> {
+    let outcome = read_response_handle_from_root(response_handle_root, handle, now)?;
+    Ok(match outcome {
+        RetrieveOutcome::Hit(record) => ResponseHandleLookup::Found(record),
+        RetrieveOutcome::Miss => ResponseHandleLookup::Missing,
+        RetrieveOutcome::Expired {
+            created_at,
+            expires_at,
+            ..
+        } => ResponseHandleLookup::Expired {
+            created_at,
+            expires_at,
+        },
+    })
+}
+
+enum RetrieveOutcome {
+    Hit(ResponseHandleRecord),
+    Miss,
+    Expired {
+        created_at: i64,
+        expires_at: i64,
+        removed: bool,
+    },
+}
+
+fn read_response_handle_from_root(
+    response_handle_root: &Path,
+    handle: &str,
+    now: i64,
+) -> Result<RetrieveOutcome> {
+    let path = response_handle_path_in_dir(response_handle_root, handle)?;
+    if !path.exists() {
+        return Ok(RetrieveOutcome::Miss);
+    }
+    let payload = fs::read_to_string(&path)?;
+    let record: StoredResponseHandleRecord = serde_json::from_str(&payload)?;
+    if record.expires_at <= now {
+        let removed = fs::remove_file(&path).is_ok();
+        return Ok(RetrieveOutcome::Expired {
+            created_at: record.created_at,
+            expires_at: record.expires_at,
+            removed,
+        });
+    }
+    Ok(RetrieveOutcome::Hit(ResponseHandleRecord {
+        handle: handle.to_string(),
+        created_at: record.created_at,
+        expires_at: record.expires_at,
+        content: record.content,
+        response_handle_root: response_handle_root.to_path_buf(),
+    }))
+}
+
 fn response_handle_for(content: &str) -> String {
     let digest = Sha256::digest(content.as_bytes());
     let hex = hex::encode(&digest[..(HANDLE_HEX_CHARS / 2)]);
@@ -466,9 +499,9 @@ fn response_handle_dir(project_root: &Path) -> Result<PathBuf> {
     resolve_response_handle_root(project_root)
 }
 
-fn response_handle_path(project_root: &Path, handle: &str) -> Result<PathBuf> {
+fn response_handle_path_in_dir(response_handle_root: &Path, handle: &str) -> Result<PathBuf> {
     validate_handle(handle)?;
-    Ok(response_handle_dir(project_root)?.join(format!("{handle}.json")))
+    Ok(response_handle_root.join(format!("{handle}.json")))
 }
 
 fn validate_handle(handle: &str) -> Result<()> {

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -491,15 +491,17 @@ pub(super) async fn handle_project_search(
     ))
 }
 
-fn project_context_alias_path<'a>(cg: &'a TraceDecay, args: &'a Value) -> PathBuf {
+fn project_context_alias_path<'a>(cg: &'a TraceDecay, args: &'a Value) -> (PathBuf, bool) {
     let Some(path) = args.get("path").and_then(Value::as_str) else {
-        return cg.project_root().to_path_buf();
+        return (cg.project_root().to_path_buf(), true);
     };
     let path = Path::new(path);
+    let allow_git_identity =
+        GlobalDb::is_explicit_project_path_selector(path.to_string_lossy().as_ref());
     if path.is_absolute() {
-        path.to_path_buf()
+        (path.to_path_buf(), allow_git_identity)
     } else {
-        cg.project_root().join(path)
+        (cg.project_root().join(path), allow_git_identity)
     }
 }
 
@@ -522,8 +524,17 @@ pub(super) async fn handle_project_context(
     let context = if let Some(project_id) = args.get("project_id").and_then(Value::as_str) {
         db.db().project_registry_context_by_id(project_id).await
     } else {
-        let alias_path = project_context_alias_path(cg, &args);
-        db.db().project_registry_context_by_alias(&alias_path).await
+        let (alias_path, allow_git_identity) = project_context_alias_path(cg, &args);
+        if let Some(context) = db.db().project_registry_context_by_alias(&alias_path).await {
+            Some(context)
+        } else if allow_git_identity {
+            let git_common_dir = crate::worktree::git_common_dir(&alias_path);
+            db.db()
+                .project_registry_context_by_identity(&alias_path, git_common_dir.as_deref())
+                .await
+        } else {
+            None
+        }
     };
     let Some(context) = context else {
         return Ok(project_registry_result(

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -210,11 +210,18 @@ async fn resolve_project_registry_context(
         return db.project_registry_context_by_id(project_id).await;
     }
     let project_path = project_path?;
-    if let Some(context) = db
-        .project_registry_context_by_alias(Path::new(project_path))
-        .await
-    {
+    let selector_path = Path::new(project_path);
+    if let Some(context) = db.project_registry_context_by_alias(selector_path).await {
         return Some(context);
+    }
+    if GlobalDb::is_explicit_project_path_selector(project_path) {
+        let git_common_dir = crate::worktree::git_common_dir(selector_path);
+        if let Some(context) = db
+            .project_registry_context_by_identity(selector_path, git_common_dir.as_deref())
+            .await
+        {
+            return Some(context);
+        }
     }
     let basename = bare_project_name(project_path)?;
     unique_project_basename_context(db, basename).await
@@ -280,14 +287,35 @@ fn unresolved_project_selector_error(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::process::Command;
 
     use libsql::{params, Connection};
     use serde_json::json;
     use tempfile::TempDir;
+    use tokio::sync::Mutex;
 
     use crate::global_db::GlobalDb;
 
-    use super::{require_node_id, string_array_values, unique_project_basename_context};
+    use super::{
+        require_node_id, resolve_project_registry_context, string_array_values,
+        unique_project_basename_context,
+    };
+
+    static CWD_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+    struct CurrentDirGuard(PathBuf);
+
+    impl CurrentDirGuard {
+        fn capture() -> Result<Self, std::io::Error> {
+            std::env::current_dir().map(Self)
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
 
     struct TestProjectSeed {
         project_id: String,
@@ -351,6 +379,33 @@ mod tests {
             .await?;
         }
         Ok(())
+    }
+
+    fn run_git(cwd: &std::path::Path, args: &[&str]) {
+        let mut paths: Vec<PathBuf> = std::env::var_os("PATH")
+            .map(|path| std::env::split_paths(&path).collect())
+            .unwrap_or_default();
+        #[cfg(not(windows))]
+        {
+            paths.push(PathBuf::from("/usr/bin"));
+            paths.push(PathBuf::from("/bin"));
+        }
+        let mut command = Command::new("git");
+        if let Ok(path) = std::env::join_paths(paths) {
+            command.env("PATH", path);
+        }
+        let output = command
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed in {}\nstdout:\n{}\nstderr:\n{}",
+            cwd.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]
@@ -425,6 +480,49 @@ mod tests {
                 .await
                 .is_none(),
             "duplicate exact basenames must fail closed even when one match falls outside the first search page"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn bare_project_path_selector_prefers_unique_basename_over_cwd_git_identity(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let _guard = CWD_TEST_LOCK.lock().await;
+        let _cwd_guard = CurrentDirGuard::capture()?;
+        let dir = TempDir::new()?;
+        let repo = dir.path().join("active-repo");
+        let active_root = repo.join("active");
+        let incidental_target_dir = repo.join("target");
+        let target_root = dir.path().join("registered").join("target");
+        std::fs::create_dir_all(&active_root)?;
+        std::fs::create_dir_all(&incidental_target_dir)?;
+        std::fs::create_dir_all(&target_root)?;
+        run_git(&repo, &["init", "--quiet"]);
+
+        let db = GlobalDb::open_at(&dir.path().join("global.db"))
+            .await
+            .ok_or_else(|| std::io::Error::other("failed to open test global db"))?;
+        db.upsert_code_project(
+            "proj_active",
+            &active_root,
+            Some(&repo.join(".git")),
+            None,
+            Some("main"),
+        )
+        .await
+        .ok_or_else(|| std::io::Error::other("failed to seed active project"))?;
+        db.upsert_code_project("proj_target", &target_root, None, None, Some("main"))
+            .await
+            .ok_or_else(|| std::io::Error::other("failed to seed target project"))?;
+
+        std::env::set_current_dir(&repo)?;
+        let context = resolve_project_registry_context(&db, None, Some("target"))
+            .await
+            .ok_or_else(|| std::io::Error::other("failed to resolve bare target selector"))?;
+
+        assert_eq!(
+            context.project.project_id, "proj_target",
+            "bare project_path selectors should keep basename semantics even when cwd has a git-tracked directory with the same name"
         );
         Ok(())
     }

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -499,7 +499,7 @@ fn render_object(md: &mut Md, map: &serde_json::Map<String, Value>, depth: u8) {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::mcp::response_handles::{retrieve_response_handle, ResponseHandleLookup};
+    use crate::mcp::response_handles::{retrieve_response_handle_from_root, ResponseHandleLookup};
     use crate::tracedecay::current_timestamp;
     use serde_json::json;
 
@@ -576,7 +576,15 @@ mod tests {
         let handle = parsed["handle"].as_str().unwrap();
         assert!(handle.starts_with("rh_"));
 
-        let stored = retrieve_response_handle(dir.path(), handle, current_timestamp()).unwrap();
+        let prepared = prepare_truncated_response_handle(Some(dir.path()), &long);
+        let record = prepared.record.as_ref().unwrap();
+        assert_eq!(record.handle, handle);
+        let stored = retrieve_response_handle_from_root(
+            &record.response_handle_root,
+            handle,
+            current_timestamp(),
+        )
+        .unwrap();
         match stored {
             ResponseHandleLookup::Found(record) => assert_eq!(record.content, long),
             other => panic!("stored response should be retrievable, got {other:?}"),
@@ -607,7 +615,15 @@ mod tests {
         };
         assert!(handle.starts_with("rh_"));
 
-        let stored = retrieve_response_handle(dir.path(), handle, current_timestamp()).unwrap();
+        let prepared = prepare_truncated_response_handle(Some(dir.path()), &long);
+        let record = prepared.record.as_ref().unwrap();
+        assert_eq!(record.handle, handle);
+        let stored = retrieve_response_handle_from_root(
+            &record.response_handle_root,
+            handle,
+            current_timestamp(),
+        )
+        .unwrap();
         match stored {
             ResponseHandleLookup::Found(record) => assert_eq!(record.content, long),
             other => panic!("stored markdown response should be retrievable, got {other:?}"),

--- a/src/project_cmd.rs
+++ b/src/project_cmd.rs
@@ -61,7 +61,15 @@ async fn project_context(db: &GlobalDb, selector: &str) -> Option<ProjectRegistr
     if let Some(context) = db.project_registry_context_by_id(selector).await {
         return Some(context);
     }
-    db.project_registry_context_by_alias(Path::new(selector))
+    let selector_path = Path::new(selector);
+    if let Some(context) = db.project_registry_context_by_alias(selector_path).await {
+        return Some(context);
+    }
+    if !GlobalDb::is_explicit_project_path_selector(selector) {
+        return None;
+    }
+    let git_common_dir = tracedecay::worktree::git_common_dir(selector_path);
+    db.project_registry_context_by_identity(selector_path, git_common_dir.as_deref())
         .await
 }
 

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -126,12 +126,30 @@ fn realpath(p: &Path) -> Option<PathBuf> {
     std::fs::canonicalize(p).ok()
 }
 
+#[cfg(test)]
+fn git_command() -> Command {
+    let mut command = Command::new("git");
+    let mut paths: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|path| std::env::split_paths(&path).collect())
+        .unwrap_or_default();
+    #[cfg(not(windows))]
+    {
+        paths.push(PathBuf::from("/usr/bin"));
+        paths.push(PathBuf::from("/bin"));
+    }
+    if let Ok(path) = std::env::join_paths(paths) {
+        command.env("PATH", path);
+    }
+    command
+}
+
+#[cfg(not(test))]
+fn git_command() -> Command {
+    Command::new("git")
+}
+
 fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .ok()?;
+    let output = git_command().args(args).current_dir(dir).output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -145,11 +163,10 @@ fn git_output(dir: &Path, args: &[&str]) -> Option<String> {
 mod tests {
     use super::*;
     use std::fs;
-    use std::process::Command;
     use tempfile::tempdir;
 
     fn run_git(cwd: &Path, args: &[&str]) {
-        let status = Command::new("git")
+        let status = git_command()
             .args(args)
             .current_dir(cwd)
             .status()

--- a/tests/cli_non_interactive_test.rs
+++ b/tests/cli_non_interactive_test.rs
@@ -1151,6 +1151,72 @@ async fn projects_context_resolves_project_id_and_path() {
 }
 
 #[tokio::test]
+async fn projects_context_resolves_linked_worktree_path_by_git_common_dir() {
+    let home = TempDir::new().unwrap();
+    let dir = TempDir::new().unwrap();
+    let main = canonical_temp_path(&dir.path().join("main"));
+    let linked = canonical_temp_path(&dir.path().join("linked"));
+    std::fs::create_dir_all(&main).unwrap();
+    git(&main, &["init", "-b", "main"]);
+    std::fs::write(main.join("README.md"), "linked worktree fixture\n").unwrap();
+    commit_all(&main, "initial commit");
+    git(
+        &main,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/worktree-context",
+            linked.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+
+    let db = GlobalDb::open_at(&profile_root(home.path()).join("global.db"))
+        .await
+        .unwrap();
+    db.upsert_code_project(
+        "proj_cli_worktree",
+        &main,
+        Some(&main.join(".git")),
+        None,
+        Some("main"),
+    )
+    .await
+    .expect("code project should upsert with git common-dir alias");
+    db.upsert_store_instance(StoreInstanceUpsert {
+        store_id: "store:proj_cli_worktree:profile_sharded".to_string(),
+        project_id: "proj_cli_worktree".to_string(),
+        store_kind: "code_project".to_string(),
+        storage_mode: "profile_sharded".to_string(),
+        store_relpath: "projects/proj_cli_worktree".to_string(),
+        manifest_relpath: Some(STORE_MANIFEST_FILENAME.to_string()),
+        last_verified_at: Some(1_800_000_000),
+        last_write_at: Some(1_800_000_000),
+    })
+    .await
+    .expect("store instance should upsert");
+    drop(db);
+
+    let mut command = tracedecay_command(home.path(), &linked);
+    command.args(["projects", "context", linked.to_str().unwrap(), "--json"]);
+    let output = run_with_timeout(command, cli_timeout());
+
+    assert!(
+        output.status.success(),
+        "projects context should resolve linked worktree path through git common dir\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["project"]["project_id"], "proj_cli_worktree");
+    assert_eq!(
+        payload["stores"][0]["store"]["storage_mode"],
+        "profile_sharded"
+    );
+}
+
+#[tokio::test]
 async fn wipe_all_removes_profile_sharded_store_and_global_row() {
     let home = TempDir::new().unwrap();
     let project = TempDir::new().unwrap();

--- a/tests/global_registry_test.rs
+++ b/tests/global_registry_test.rs
@@ -326,6 +326,45 @@ async fn registry_resolves_store_by_repo_identity_aliases() {
 }
 
 #[tokio::test]
+async fn registry_context_resolves_linked_worktree_by_git_common_dir_identity() {
+    let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+    let main_checkout = dir.path().join("main");
+    let linked_worktree = dir.path().join("linked");
+    let common_dir = dir.path().join("repo/.git");
+    std::fs::create_dir_all(&main_checkout).unwrap();
+    std::fs::create_dir_all(&linked_worktree).unwrap();
+    std::fs::create_dir_all(&common_dir).unwrap();
+
+    db.upsert_code_project(
+        "proj_worktree",
+        &main_checkout,
+        Some(&common_dir),
+        Some("git@github.com:ScriptedAlchemy/tracedecay.git"),
+        Some("main"),
+    )
+    .await
+    .unwrap();
+    upsert_test_store(&db, "proj_worktree", "store_worktree").await;
+
+    assert!(db
+        .project_registry_context_by_alias(&linked_worktree)
+        .await
+        .is_none());
+    let context = db
+        .project_registry_context_by_identity(&linked_worktree, Some(&common_dir))
+        .await
+        .unwrap();
+
+    assert_eq!(context.project.project_id, "proj_worktree");
+    assert_eq!(context.stores[0].store.store_id, "store_worktree");
+    close_global_db(db).await;
+}
+
+#[tokio::test]
 async fn registry_remote_resolution_is_conservative_when_ambiguous() {
     let _guard = GLOBAL_REGISTRY_TEST_LOCK.lock().await;
     let dir = TempDir::new().unwrap();

--- a/tests/lsp_code_diagnostics_test.rs
+++ b/tests/lsp_code_diagnostics_test.rs
@@ -497,6 +497,8 @@ fn fake_python_adapter(
 fn python_command() -> &'static str {
     if cfg!(windows) {
         "python"
+    } else if std::path::Path::new("/usr/bin/python3").is_file() {
+        "/usr/bin/python3"
     } else {
         "python3"
     }


### PR DESCRIPTION
## Summary
- Add identity-aware registry context lookup that falls back from a queried project path to the stored `git-common-dir:` alias, so linked worktrees resolve to the registered project/store.
- Keep bare project selectors in id/name space: exact alias first, git identity only for explicit path spellings, then unique basename fallback where supported.
- Centralize registry identity alias lookup and add CLI/MCP/user-facing coverage for linked worktree project context.
- Harden parallel tests discovered during verification by avoiding PATH/env re-resolution races in git, response-handle, and LSP helper tests.

## Root Cause
TraceDecay registered projects with repo identity aliases such as `git-common-dir:<path>`, and storage resolution already used those aliases. The project-context lookup path only checked literal path aliases. The first PR pass also let bare selectors accidentally probe cwd git identity, which could route a name like `target` to the active repo instead of the unique registered project basename.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test --lib`
- `cargo test`
- `cargo test --test global_registry_test`
- `cargo test --test session_global_db_test project_registry_path_aliases_resolve_exactly_without_active_fallback`
- `cargo test --test cli_non_interactive_test projects_context -- --nocapture`
- `cargo test --test lsp_code_diagnostics_test`
- `cargo test --lib mcp::tools::handlers::support::tests::bare_project_path_selector_prefers_unique_basename_over_cwd_git_identity -- --exact --nocapture`
- `cargo test --lib mcp::tools::render::tests::truncated_json_envelope_includes_handle -- --exact --nocapture`
- `cargo test --lib mcp::tools::render::tests::truncated_markdown_includes_readable_handle_guidance -- --exact --nocapture`