### PR TITLE
chore: release v0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.21](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.20...v0.0.21) - 2026-07-02
+
+### Fixed
+
+- ride out daemon restarts in MCP daemon clients
+
+### Other
+
+- Merge remote-tracking branch 'origin/master' into codex/self-improve-20260701
+- Merge remote-tracking branch 'origin/master' into codex/update-daemon-reconnect
+- Merge pull request #173 from ScriptedAlchemy/codex/daemon-incremental-sync
+- address plugin skill contract review findings
+- add canonical skill frontmatter parser
+- add plugin skill contract checks
+
 ### Other
 
 - isolate the test suite from the real `~/.tracedecay` profile by default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.20"
+version = "0.0.21"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.20 -> 0.0.21

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.21](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.20...v0.0.21) - 2026-07-02

### Fixed

- ride out daemon restarts in MCP daemon clients

### Other

- Merge remote-tracking branch 'origin/master' into codex/self-improve-20260701
- Merge remote-tracking branch 'origin/master' into codex/update-daemon-reconnect
- Merge pull request #173 from ScriptedAlchemy/codex/daemon-incremental-sync
- address plugin skill contract review findings
- add canonical skill frontmatter parser
- add plugin skill contract checks

### Other

- isolate the test suite from the real `~/.tracedecay` profile by default
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).