### PR TITLE
test: isolate the test suite from the real ~/.tracedecay profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,7 +20,9 @@ TRACEDECAY_DISABLE_GLOBAL_DB = { value = "1", force = false }
 # ~/.tracedecay, enrolling temp fixture repos into the real profile and
 # contending with a live daemon. Tests that need a private profile override
 # this per-test (`force = false`); the HOME-fallback tests remove the variable
-# in-process. Installed binaries run outside cargo and are unaffected.
+# in-process. Installed binaries run outside cargo and are unaffected, but the
+# profile does apply to `cargo run` — use the installed binary (or set
+# TRACEDECAY_DATA_DIR yourself) for real `daemon install-service` runs.
 # Enforced by tests/test_profile_isolation_test.rs.
 TRACEDECAY_DATA_DIR = { value = "target/test-profile/.tracedecay", force = false, relative = true }
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,6 +14,19 @@ CXXFLAGS = { value = "-DNDEBUG", force = false }
 # Installed binaries run outside cargo and are unaffected.
 TRACEDECAY_DISABLE_GLOBAL_DB = { value = "1", force = false }
 
+# Profile-storage isolation for cargo-launched processes. Without this, any
+# test (or `tracedecay` binary a test spawns) that doesn't set
+# TRACEDECAY_DATA_DIR itself resolves storage to the developer's real
+# ~/.tracedecay, enrolling every temp fixture repo into the real profile and
+# contending with a live daemon. Point everything cargo launches at a
+# workspace-local profile instead; `cargo clean` wipes it. Tests that need a
+# private profile still override this per-test (child-process `.env()` /
+# in-process EnvVarGuard win over cargo's value), and the HOME-fallback tests
+# remove the variable in-process before asserting.
+# Installed binaries run outside cargo and are unaffected.
+# Enforced by tests/test_profile_isolation_test.rs.
+TRACEDECAY_DATA_DIR = { value = "target/test-profile/.tracedecay", force = false, relative = true }
+
 [alias]
 # Local default for the full Rust test suite. Requires cargo-nextest:
 # https://nexte.st/docs/installation/pre-built-binaries/

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,16 +14,13 @@ CXXFLAGS = { value = "-DNDEBUG", force = false }
 # Installed binaries run outside cargo and are unaffected.
 TRACEDECAY_DISABLE_GLOBAL_DB = { value = "1", force = false }
 
-# Profile-storage isolation for cargo-launched processes. Without this, any
-# test (or `tracedecay` binary a test spawns) that doesn't set
+# Point cargo-launched processes at a workspace-local profile. Without this,
+# any test (or `tracedecay` binary a test spawns) that doesn't set
 # TRACEDECAY_DATA_DIR itself resolves storage to the developer's real
-# ~/.tracedecay, enrolling every temp fixture repo into the real profile and
-# contending with a live daemon. Point everything cargo launches at a
-# workspace-local profile instead; `cargo clean` wipes it. Tests that need a
-# private profile still override this per-test (child-process `.env()` /
-# in-process EnvVarGuard win over cargo's value), and the HOME-fallback tests
-# remove the variable in-process before asserting.
-# Installed binaries run outside cargo and are unaffected.
+# ~/.tracedecay, enrolling temp fixture repos into the real profile and
+# contending with a live daemon. Tests that need a private profile override
+# this per-test (`force = false`); the HOME-fallback tests remove the variable
+# in-process. Installed binaries run outside cargo and are unaffected.
 # Enforced by tests/test_profile_isolation_test.rs.
 TRACEDECAY_DATA_DIR = { value = "target/test-profile/.tracedecay", force = false, relative = true }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+
+- isolate the test suite from the real `~/.tracedecay` profile by default
+
 ## [0.0.20](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.19...v0.0.20) - 2026-07-01
 
 ### Other

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,12 @@ cargo nextest run --no-default-features --features lite
    ```bash
    cargo nextest run --workspace --no-fail-fast
    ```
+   Cargo-launched test processes are isolated from your real `~/.tracedecay`
+   profile: `.cargo/config.toml` pins `TRACEDECAY_DATA_DIR` to
+   `target/test-profile/.tracedecay` (enforced by
+   `tests/test_profile_isolation_test.rs`). Tests that need a private profile
+   should still override it per-test, e.g. via
+   `common::TraceDecayStorageEnvGuard` or `common::apply_tracedecay_home_env`.
 4. **Format your code** with the standard Rust toolchain:
    ```bash
    cargo fmt

--- a/tests/test_profile_isolation_test.rs
+++ b/tests/test_profile_isolation_test.rs
@@ -1,0 +1,49 @@
+//! Guards the suite-wide profile isolation configured in `.cargo/config.toml`.
+//!
+//! Every cargo-launched test process must resolve TraceDecay storage away
+//! from the developer's real `~/.tracedecay`; otherwise tests that index
+//! temp fixture repos enroll them into the real profile and contend with a
+//! live daemon. This binary intentionally never mutates `TRACEDECAY_DATA_DIR`,
+//! so it observes exactly what cargo's `[env]` section provided.
+
+use std::path::{Path, PathBuf};
+
+use tracedecay::config::{user_data_dir, USER_DATA_DIR_ENV};
+
+fn real_profile_root() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".tracedecay"))
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[test]
+fn cargo_env_pins_data_dir_for_tests() {
+    let value = std::env::var_os(USER_DATA_DIR_ENV).unwrap_or_default();
+    assert!(
+        !value.is_empty(),
+        "{USER_DATA_DIR_ENV} must be set for cargo-launched test processes; \
+         expected the [env] entry in .cargo/config.toml to provide it. \
+         Run tests through cargo/nextest from the workspace root."
+    );
+}
+
+#[test]
+fn resolved_data_dir_is_not_the_real_user_profile() {
+    let resolved = user_data_dir().expect("user_data_dir should resolve in tests");
+    let Some(real_profile) = real_profile_root() else {
+        return;
+    };
+
+    let resolved = canonical(&resolved);
+    let real_profile = canonical(&real_profile);
+    assert!(
+        resolved != real_profile && !resolved.starts_with(&real_profile),
+        "tests resolved TraceDecay storage to the real user profile '{}'; \
+         the suite must stay isolated (see the {USER_DATA_DIR_ENV} entry in \
+         .cargo/config.toml). If {USER_DATA_DIR_ENV} is set in your shell, \
+         unset it or point it away from ~/.tracedecay before running tests.",
+        real_profile.display()
+    );
+}

--- a/tests/test_profile_isolation_test.rs
+++ b/tests/test_profile_isolation_test.rs
@@ -10,10 +10,6 @@ use std::path::{Path, PathBuf};
 
 use tracedecay::config::{user_data_dir, USER_DATA_DIR_ENV};
 
-fn real_profile_root() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".tracedecay"))
-}
-
 fn canonical(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
@@ -32,14 +28,14 @@ fn cargo_env_pins_data_dir_for_tests() {
 #[test]
 fn resolved_data_dir_is_not_the_real_user_profile() {
     let resolved = user_data_dir().expect("user_data_dir should resolve in tests");
-    let Some(real_profile) = real_profile_root() else {
+    let Some(real_profile) = dirs::home_dir().map(|home| home.join(".tracedecay")) else {
         return;
     };
 
     let resolved = canonical(&resolved);
     let real_profile = canonical(&real_profile);
     assert!(
-        resolved != real_profile && !resolved.starts_with(&real_profile),
+        !resolved.starts_with(&real_profile),
         "tests resolved TraceDecay storage to the real user profile '{}'; \
          the suite must stay isolated (see the {USER_DATA_DIR_ENV} entry in \
          .cargo/config.toml). If {USER_DATA_DIR_ENV} is set in your shell, \


### PR DESCRIPTION
## Summary

- Pin `TRACEDECAY_DATA_DIR` for all cargo-launched processes via `.cargo/config.toml` `[env]` (`target/test-profile/.tracedecay`, `force = false`, `relative = true`), so test isolation is the default for the whole suite instead of per-test opt-in.
- Add `tests/test_profile_isolation_test.rs`, a CI-enforceable canary that fails if the env pin is missing or if `config::user_data_dir()` resolves to (or under) the real `~/.tracedecay`.
- Document the isolation contract in `CONTRIBUTING.md` and `CHANGELOG.md`.

## Motivation

Only 3 of ~138 integration test files set `TRACEDECAY_DATA_DIR` themselves. Every other test that indexes a temp fixture repo resolves storage through `config::user_data_dir()` to the developer's real `~/.tracedecay` — including `tracedecay` child binaries spawned with no env override (e.g. `branch_db_safety_test`, which writes intentionally-corrupt branch-meta fixtures into the real profile). On one dev machine this accumulated 12,800+ `/tmp/.tmpXXXX` fixture project stores, thousands of stale registry rows, a 173 MB `global.db`, and "database is locked" contention with the live daemon.

The cargo `[env]` mechanism was chosen because it covers integration tests in `tests/` (separate binaries), unit tests, doctests, and child processes those tests spawn — with no per-file changes — and both `cargo test` and `cargo nextest` honor it (same pattern as the existing `TRACEDECAY_DISABLE_GLOBAL_DB` entry). `force = false` plus process-level overrides keep existing behavior intact:

- The 3 test files that already set `TRACEDECAY_DATA_DIR` (in-process guards or child `.env()`) still win over cargo's value.
- The HOME-fallback tests (`storage_resolver_test`, `hook_branch_routing_test`, `profile_storage_migration_test`, `branch_drift_test`) `remove_var` the variable in-process before asserting, so they are unaffected.
- Installed binaries run outside cargo and are unaffected; `cargo clean` wipes the test profile.

## Changes

- `.cargo/config.toml` — new `[env]` entry pinning `TRACEDECAY_DATA_DIR` for cargo-launched processes.
- `tests/test_profile_isolation_test.rs` — canary binary (never mutates the var, so it observes exactly what cargo provided): asserts the var is set and that the resolved data dir is not the real profile.
- `CONTRIBUTING.md`, `CHANGELOG.md` — document the isolation default.

## Test plan

- [x] `cargo nextest run` over a representative subset (207 tests across 14 binaries, all passing): the previously-polluting `branch_db_safety_test`, `integration_test`, `automation_runner_test`, `automation_session_reflector_runner_test`; the opt-in files `cli_non_interactive_test`, `cursor_transcript_ingest_test`, `mcp_cli_serve_test`, `plugin_skill_contract_test`; the HOME-fallback files `storage_resolver_test`, `hook_branch_routing_test`, `profile_storage_migration_test`, `branch_drift_test`; plus `config_test` and the new canary.
- [x] Verified isolation by diffing `~/.tracedecay/projects` entries before/after the bracketed run: zero new entries in the real profile; fixture stores landed in `target/test-profile/.tracedecay/projects` instead (75 entries).
- [x] `cargo check --all-targets` passes
- [x] `cargo clippy --workspace --all-targets` has no new warnings
- [x] `cargo fmt --check` clean
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] No secrets, credentials, or `.env` files included
- [x] No breaking changes (dev/test tooling only; installed binaries unaffected)