### PR TITLE
test: consolidate transcript ingest tests into one binary

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,12 +41,12 @@ platform = { host = 'cfg(windows)' }
 test-group = 'windows-init-heavy'
 
 [[profile.ci.overrides]]
-filter = 'binary(=storage_resolver_test) | binary(=profile_storage_migration_test) | binary(=cursor_transcript_ingest_test)'
+filter = 'binary(=storage_resolver_test) | binary(=profile_storage_migration_test) | (binary(=transcript_ingest_suite) & test(~cursor::))'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-profile-storage'
 
 [[profile.ci.overrides]]
-filter = 'binary(=session_suite) | binary(=codex_transcript_ingest_test) | binary(=hermes_transcript_ingest_test) | binary(=cline_like_transcript_ingest_test) | binary(=corruption_test) | binary(=db_query_test) | binary(=mcp_handler_test) | binary(=mcp_server_test) | binary(=memory_test) | binary(=multi_mcp_coordination_test)'
+filter = 'binary(=session_suite) | (binary(=transcript_ingest_suite) & (test(~codex::) | test(~hermes::) | test(~cline_like::))) | binary(=corruption_test) | binary(=db_query_test) | binary(=mcp_handler_test) | binary(=mcp_server_test) | binary(=memory_test) | binary(=multi_mcp_coordination_test)'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-session-sqlite'
 

--- a/tests/transcript_ingest_suite/claude.rs
+++ b/tests/transcript_ingest_suite/claude.rs
@@ -5,15 +5,7 @@ use tracedecay::sessions::claude::ClaudeSource;
 use tracedecay::sessions::cursor::open_project_session_db;
 use tracedecay::sessions::source::ingest_source;
 
-/// Builds an initialized project dir and returns (home, project_root).
-fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
-    let home = tmp.path().join("home");
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
-    (home, project)
-}
+use crate::support::setup;
 
 /// Writes a Claude Code transcript (one JSON object per line) for `session` whose
 /// recorded `cwd` is `project`.

--- a/tests/transcript_ingest_suite/cline_like.rs
+++ b/tests/transcript_ingest_suite/cline_like.rs
@@ -4,14 +4,7 @@ use tracedecay::sessions::cline_like::ClineLikeSource;
 use tracedecay::sessions::cursor::{open_project_session_db, project_session_db_path};
 use tracedecay::sessions::source::ingest_source;
 
-fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
-    let home = tmp.path().join("home");
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
-    (home, project)
-}
+use crate::support::setup;
 
 fn vscode_storage_root(home: &std::path::Path, extension_id: &str) -> std::path::PathBuf {
     tracedecay::agents::vscode_data_dir(home)

--- a/tests/transcript_ingest_suite/codex.rs
+++ b/tests/transcript_ingest_suite/codex.rs
@@ -9,14 +9,7 @@ use tracedecay::sessions::lcm::{
 };
 use tracedecay::sessions::source::ingest_source;
 
-fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
-    let home = tmp.path().join("home");
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
-    (home, project)
-}
+use crate::support::setup;
 
 fn write_jsonl(path: &std::path::Path, lines: &[serde_json::Value]) {
     std::fs::write(

--- a/tests/transcript_ingest_suite/cursor.rs
+++ b/tests/transcript_ingest_suite/cursor.rs
@@ -1,8 +1,5 @@
 use std::io::Write;
 
-mod common;
-
-use common::{EnvVarGuard, GLOBAL_DB_ENV, GLOBAL_DB_ENV_LOCK};
 use tempfile::TempDir;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::hooks::cursor_pre_compact_for_event_with_config;
@@ -15,13 +12,8 @@ use tracedecay::sessions::lcm::{LcmDescribeRequest, LcmDescribeTarget};
 use tracedecay::sessions::source::ingest_source;
 use tracedecay::sessions::SessionSearchScope;
 
-fn init_project(tmp: &TempDir) -> std::path::PathBuf {
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
-    project
-}
+use crate::common::{EnvVarGuard, GLOBAL_DB_ENV, GLOBAL_DB_ENV_LOCK};
+use crate::support::{init_project, init_project_at};
 
 fn cursor_event(project: &std::path::Path, transcript: &std::path::Path) -> serde_json::Value {
     serde_json::json!({
@@ -485,10 +477,8 @@ async fn cursor_transcript_ingest_uses_cwd_root_in_multi_root_workspace() {
     let tmp = TempDir::new().unwrap();
     let root_a = tmp.path().join("root-a");
     let root_b = tmp.path().join("root-b");
-    std::fs::create_dir_all(root_a.join(".tracedecay")).unwrap();
-    std::fs::create_dir_all(root_b.join(".tracedecay")).unwrap();
-    std::fs::write(root_a.join(".tracedecay/tracedecay.db"), "").unwrap();
-    std::fs::write(root_b.join(".tracedecay/tracedecay.db"), "").unwrap();
+    init_project_at(&root_a);
+    init_project_at(&root_b);
     let cwd_b = root_b.join("workspace");
     std::fs::create_dir_all(&cwd_b).unwrap();
     let transcript = root_b.join("cursor-session.jsonl");
@@ -1086,8 +1076,7 @@ async fn cursor_sweep_skips_ambiguous_project_slug() {
     let tmp = TempDir::new().unwrap();
     let home = tmp.path().join("home");
     let project = tmp.path().join("work").join("foo-bar");
-    std::fs::create_dir_all(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
+    init_project_at(&project);
     // A second *existing* directory that encodes to the same slug as the
     // project ("…-work-foo-bar"): the sweep must skip rather than guess
     // which workspace the slug's transcripts belong to.

--- a/tests/transcript_ingest_suite/hermes.rs
+++ b/tests/transcript_ingest_suite/hermes.rs
@@ -15,12 +15,10 @@ use tracedecay::sessions::SessionRecord;
 
 const SESSION_ID: &str = "20260101_000000_abc123";
 
+/// Like [`crate::support::setup`], but returns the Hermes home
+/// (`<home>/.hermes`) instead of the plain test home.
 fn setup(tmp: &TempDir) -> (PathBuf, PathBuf) {
-    let home = tmp.path().join("home");
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
+    let (home, project) = crate::support::setup(tmp);
     (home.join(".hermes"), project)
 }
 

--- a/tests/transcript_ingest_suite/kiro.rs
+++ b/tests/transcript_ingest_suite/kiro.rs
@@ -3,14 +3,7 @@ use tracedecay::sessions::cursor::open_project_session_db;
 use tracedecay::sessions::kiro::KiroSource;
 use tracedecay::sessions::source::ingest_source;
 
-fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
-    let home = tmp.path().join("home");
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
-    (home, project)
-}
+use crate::support::setup;
 
 fn encode_workspace_path(path: &std::path::Path) -> String {
     const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/tests/transcript_ingest_suite/main.rs
+++ b/tests/transcript_ingest_suite/main.rs
@@ -1,0 +1,19 @@
+//! Consolidated transcript-ingest integration suite.
+//!
+//! One test binary for every per-agent transcript ingestion source (Claude,
+//! Codex, Cursor, Hermes, Kiro, Cline-like, Vibe) instead of seven separate
+//! binaries: each integration test binary links the full `tracedecay` crate
+//! separately, and link time dominates Windows CI.
+
+#[path = "../common/mod.rs"]
+mod common;
+
+mod support;
+
+mod claude;
+mod cline_like;
+mod codex;
+mod cursor;
+mod hermes;
+mod kiro;
+mod vibe;

--- a/tests/transcript_ingest_suite/support.rs
+++ b/tests/transcript_ingest_suite/support.rs
@@ -1,0 +1,29 @@
+//! Fixture setup shared by every provider module in this suite.
+//!
+//! Note: nextest runs each test in its own process, so per-process caches
+//! (like `common::write_empty_global_db_schema`'s DB template) do not pay
+//! off here — each test opens exactly one project session DB anyway.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+/// Initializes `project` as a tracedecay project the ingest resolvers accept
+/// (a local `.tracedecay/tracedecay.db` marker).
+pub fn init_project_at(project: &Path) {
+    std::fs::create_dir_all(project).unwrap();
+    std::fs::create_dir_all(project.join(".tracedecay")).unwrap();
+    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
+}
+
+/// Builds an initialized project dir under `tmp` and returns it.
+pub fn init_project(tmp: &TempDir) -> PathBuf {
+    let project = tmp.path().join("project");
+    init_project_at(&project);
+    project
+}
+
+/// Builds an initialized project dir and returns `(home, project)`.
+pub fn setup(tmp: &TempDir) -> (PathBuf, PathBuf) {
+    (tmp.path().join("home"), init_project(tmp))
+}

--- a/tests/transcript_ingest_suite/vibe.rs
+++ b/tests/transcript_ingest_suite/vibe.rs
@@ -5,14 +5,7 @@ use tracedecay::sessions::cursor::open_project_session_db;
 use tracedecay::sessions::source::ingest_source;
 use tracedecay::sessions::vibe::VibeSource;
 
-fn setup(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
-    let home = tmp.path().join("home");
-    let project = tmp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
-    std::fs::create_dir(project.join(".tracedecay")).unwrap();
-    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
-    (home, project)
-}
+use crate::support::setup;
 
 fn write_vibe_session(
     home: &std::path::Path,


### PR DESCRIPTION
## Summary
- Consolidates the seven transcript-ingest test binaries (claude/codex/cursor/hermes/kiro/cline_like/vibe) into a single `transcript_ingest_suite` binary (7→1 binaries, all 69 tests preserved).
- Dedupes the shared project-setup fixture across the suite.
- Updates the two `.config/nextest.toml` Windows group filter lines (windows-session-sqlite, windows-profile-storage) to module-scoped selections.

## Test plan
- [x] `cargo nextest run --profile ci --locked -E 'binary(=transcript_ingest_suite)'` — 69 passed, 0 skipped
- [x] `cargo fmt --all -- --check` — clean