### PR TITLE
refactor: deslop windows test perf changes

### DIFF
--- a/tests/automation_runner_test/scheduler.rs
+++ b/tests/automation_runner_test/scheduler.rs
@@ -12,6 +12,8 @@ use tracedecay::automation::scheduler::{
     scheduler_control_path, AutomationSchedule, AutomationSchedulerControl, AutomationTaskLock,
 };
 
+use crate::support::scheduler_record_for;
+
 fn automation_config(schedule: Option<&str>, interval_secs: Option<u64>) -> AutomationConfig {
     AutomationConfig {
         enabled: true,
@@ -50,53 +52,8 @@ fn record(
     completed_at: i64,
 ) -> AutomationRunLedgerRecord {
     AutomationRunLedgerRecord {
-        schema_version: 2,
-        run_id: run_id.to_string(),
-        trigger: AutomationTrigger::Scheduler,
-        task,
-        task_key: Some(test_task_key(task).to_string()),
-        backend: "codex_app_server".to_string(),
-        host_mode: Some("standalone".to_string()),
-        prompt_version: Some(test_prompt_version(task).to_string()),
-        response_schema: None,
-        strict_json: None,
         model: Some("test-model".to_string()),
-        status,
-        evidence_hash: None,
-        input_hash: None,
-        output_hash: None,
-        proposed_ops: None,
-        applied_ops: None,
-        rejected_ops: None,
-        validation_report: None,
-        reviewed_count: 0,
-        accepted_count: 0,
-        rejected_count: 0,
-        skipped_count: usize::from(status == AutomationRunStatus::Skipped),
-        error: None,
-        error_classification: None,
-        error_retryable: None,
-        fallback_status: None,
-        report_ref: None,
-        artifacts: Vec::new(),
-        started_at: (completed_at - 1).to_string(),
-        completed_at: completed_at.to_string(),
-    }
-}
-
-fn test_task_key(task: AgentTaskKind) -> &'static str {
-    match task {
-        AgentTaskKind::MemoryCurator => "memory_curator",
-        AgentTaskKind::SessionReflector => "session_reflector",
-        AgentTaskKind::SkillWriter => "skill_writer",
-    }
-}
-
-fn test_prompt_version(task: AgentTaskKind) -> &'static str {
-    match task {
-        AgentTaskKind::MemoryCurator => "memory_curator:v1",
-        AgentTaskKind::SessionReflector => "session_reflector:v1",
-        AgentTaskKind::SkillWriter => "skill_writer:v1",
+        ..scheduler_record_for(run_id, task, status, completed_at)
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -520,12 +520,6 @@ async fn empty_lcm_db_template() -> &'static [u8] {
         .await
 }
 
-pub async fn open_global_db(tmp: &TempDir) -> GlobalDb {
-    GlobalDb::open_at(&isolated_global_db_path(tmp))
-        .await
-        .expect("global db open")
-}
-
 pub fn session_record(
     provider: &str,
     session_id: &str,

--- a/tests/session_suite/lcm_compression.rs
+++ b/tests/session_suite/lcm_compression.rs
@@ -16,15 +16,7 @@ use tracedecay::sessions::lcm::{
 };
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 
-use crate::common;
-
-fn isolated_db_path(tmp: &TempDir) -> std::path::PathBuf {
-    common::isolated_lcm_db_path(tmp)
-}
-
-async fn open_lcm_db(tmp: &TempDir) -> GlobalDb {
-    common::open_lcm_db(tmp).await
-}
+use crate::common::{self, isolated_lcm_db_path as isolated_db_path, open_lcm_db};
 
 async fn open_lcm_conn(tmp: &TempDir) -> libsql::Connection {
     let db = libsql::Builder::new_local(isolated_db_path(tmp))

--- a/tests/session_suite/lcm_query.rs
+++ b/tests/session_suite/lcm_query.rs
@@ -8,15 +8,7 @@ use tracedecay::sessions::lcm::{
 };
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 
-use crate::common;
-
-fn isolated_db_path(tmp: &TempDir) -> std::path::PathBuf {
-    common::isolated_lcm_db_path(tmp)
-}
-
-async fn open_lcm_db(tmp: &TempDir) -> GlobalDb {
-    common::open_lcm_db(tmp).await
-}
+use crate::common::{self, isolated_lcm_db_path as isolated_db_path, open_lcm_db};
 
 fn sample_session(provider: &str, session_id: &str) -> SessionRecord {
     common::session_record(


### PR DESCRIPTION
## Summary
- Deslop/simplify pass over the merged Windows-test-optimization work (PRs #183–#187); behavior-preserving only.
- `tests/automation_runner_test/scheduler.rs`: drop local duplicates of `test_task_key` / `test_prompt_version` and the full ledger-record literal, reusing `support::scheduler_record_for` with a struct-update for the one differing field.
- `tests/common/mod.rs`: remove `open_global_db`, which lost its last caller when `session_suite/global_db.rs` switched to the schema-template fast path.
- `tests/session_suite/{lcm_compression,lcm_query}.rs`: replace pass-through `isolated_db_path` / `open_lcm_db` wrapper fns with import aliases, matching the sibling session_suite modules.
- CI workflow, nextest config, docs, and suite structure reviewed and left as-is (no slop found; consolidation structure untouched).

## Test plan
- [x] `cargo nextest run --profile ci --locked -E 'binary(=extraction_suite) | binary(=session_suite) | binary(=graph_suite) | binary(=hooks_lsp_suite) | binary(=automation_runner_test)'` — 1254 passed, 0 failed
- [x] `cargo fmt --all -- --check` clean