### PR TITLE
test: consolidate dashboard api tests into one binary

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,7 +26,7 @@ retries = 2
 flaky-result = 'pass'
 
 [[profile.ci.overrides]]
-filter = 'binary(=dashboard_api_test) | binary(=dashboard_analytics_api_test) | binary(=dashboard_automation_api_test) | binary(=dashboard_automation_config_api_test) | binary(=dashboard_automation_skills_api_test) | binary(=dashboard_code_diagnostics_api_test) | binary(=dashboard_graph_api_test) | binary(=dashboard_lcm_api_test) | binary(=dashboard_lcm_fixes_test) | binary(=dashboard_memory_curation_api_test) | binary(=dashboard_savings_api_test)'
+filter = 'binary(=dashboard_api_test)'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-dashboard-server'
 

--- a/tests/dashboard_api_test/analytics.rs
+++ b/tests/dashboard_api_test/analytics.rs
@@ -2,14 +2,11 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-mod common;
-
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
-use common::{
+use crate::common::{
     create_runtime, get_json, http_agent, message_record_at, pick_free_port, wait_for_dashboard,
-    write_empty_global_db_schema, EnvVarGuard,
+    write_empty_global_db_schema, EnvVarGuard, GLOBAL_DB_ENV_LOCK as ENV_LOCK,
 };
 use serde_json::Value;
 use tempfile::TempDir;
@@ -19,8 +16,6 @@ use tracedecay::sessions::cursor::project_session_db_path;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::storage::resolve_layout_for_current_profile;
 use tracedecay::tracedecay::TraceDecay;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 struct Fixture {
     _tmp: TempDir,

--- a/tests/dashboard_api_test/api.rs
+++ b/tests/dashboard_api_test/api.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 
 #[test]
 fn dashboard_plugin_manifest_assets_are_served() {
@@ -613,19 +610,6 @@ fn lcm_endpoints_return_empty_state_when_no_rows_exist() {
             "empty LCM store search should have zero summary-node matches"
         );
     });
-}
-
-/// Opens (creating if needed) the resolved project session store — profile
-/// sharded by default, project-local only for explicit or legacy projects.
-async fn open_project_session_store(project_root: &Path) -> GlobalDb {
-    let db_path = tracedecay::sessions::cursor::project_session_db_path(project_root);
-    match GlobalDb::open_at(&db_path).await {
-        Some(db) => db,
-        None => panic!(
-            "failed to open project session store at {}",
-            db_path.display()
-        ),
-    }
 }
 
 /// Without a `TRACEDECAY_GLOBAL_DB` override the dashboard must serve the

--- a/tests/dashboard_api_test/automation.rs
+++ b/tests/dashboard_api_test/automation.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 
 #[test]
 fn curation_agent_plan_skips_when_automation_is_disabled_and_records_history() {

--- a/tests/dashboard_api_test/automation_config.rs
+++ b/tests/dashboard_api_test/automation_config.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 
 #[test]
 fn automation_config_is_dashboard_controllable_and_persistent() {

--- a/tests/dashboard_api_test/automation_skills.rs
+++ b/tests/dashboard_api_test/automation_skills.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 
 #[test]
 fn managed_skills_are_dashboard_controllable_and_persistent() {

--- a/tests/dashboard_api_test/code_diagnostics.rs
+++ b/tests/dashboard_api_test/code_diagnostics.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 use serde_json::Value;
 
 #[test]

--- a/tests/dashboard_api_test/dashboard_api_support.rs
+++ b/tests/dashboard_api_test/dashboard_api_support.rs
@@ -105,10 +105,24 @@ pub(crate) async fn setup_project(project_root: &Path) -> TraceDecay {
         &project_root.join("src/lib.rs"),
         "pub fn seed_fixture() -> &'static str { \"dashboard\" }\n",
     );
-    match TraceDecay::init(project_root).await {
+    // Pre-create the GlobalDb-schema stores that init and the dashboard
+    // server will open, from the cached empty template: opening an existing
+    // DB is a file copy instead of a full schema creation (slow on Windows).
+    if let Some(global_db_path) = std::env::var_os(GLOBAL_DB_ENV) {
+        let global_db_path = PathBuf::from(global_db_path);
+        if !global_db_path.exists() {
+            write_empty_global_db_schema(&global_db_path).await;
+        }
+    }
+    let cg = match TraceDecay::init(project_root).await {
         Ok(cg) => cg,
         Err(err) => panic!("failed to initialize tracedecay fixture project: {err}"),
+    };
+    let sessions_db_path = &cg.store_layout().sessions_db_path;
+    if !sessions_db_path.exists() {
+        write_empty_global_db_schema(sessions_db_path).await;
     }
+    cg
 }
 
 pub(crate) fn blob_param(bytes: Vec<u8>) -> libsql::Value {
@@ -515,18 +529,16 @@ async fn start_dashboard_fixture_with_options(
         panic!("failed to enroll dashboard fixture in profile storage: {err}");
     }
 
-    // Pre-create both GlobalDb-schema stores from the cached empty template:
-    // the init-time registry write, LCM seeding, and the dashboard server's
-    // startup LCM resolve + catch-up ingest then all open existing DBs
-    // instead of each paying a full schema creation (slow on Windows).
-    write_empty_global_db_schema(&global_db_path).await;
-
+    // `setup_project` pre-creates the global and session stores from the
+    // cached empty template, so the init-time registry write, LCM seeding,
+    // and the dashboard server's startup LCM resolve + catch-up ingest all
+    // open existing DBs instead of each paying a full schema creation (slow
+    // on Windows).
     let cg = setup_project(&project_root).await;
     if seed_memory {
         seed_memory_fixture(&cg).await;
     }
 
-    write_empty_global_db_schema(&cg.store_layout().sessions_db_path).await;
     if seed_lcm {
         let session_store = open_project_session_store(&project_root).await;
         seed_lcm_fixture(&session_store, &project_root).await;
@@ -731,8 +743,13 @@ pub(crate) async fn index_all_retrying_sync_lock(cg: &TraceDecay, context: &str)
 
 /// Opens (creating if needed) the resolved project session store — profile
 /// sharded by default, project-local only for explicit or legacy projects.
+/// A missing store is written from the cached empty-schema template so the
+/// open skips full schema creation (a large fixed cost on Windows).
 pub(crate) async fn open_project_session_store(project_root: &Path) -> GlobalDb {
     let db_path = tracedecay::sessions::cursor::project_session_db_path(project_root);
+    if !db_path.exists() {
+        write_empty_global_db_schema(&db_path).await;
+    }
     match GlobalDb::open_at(&db_path).await {
         Some(db) => db,
         None => panic!(

--- a/tests/dashboard_api_test/graph.rs
+++ b/tests/dashboard_api_test/graph.rs
@@ -1,11 +1,9 @@
-mod common;
-
 use std::fs;
 use std::path::Path;
 
-use common::{
+use crate::common::{
     create_runtime, get_json, http_agent, pick_free_port, tempdir_or_panic, wait_for_dashboard,
-    EnvVarGuard, GLOBAL_DB_ENV, GLOBAL_DB_ENV_LOCK,
+    write_empty_global_db_schema, EnvVarGuard, GLOBAL_DB_ENV, GLOBAL_DB_ENV_LOCK,
 };
 use serde_json::Value;
 use tempfile::TempDir;
@@ -183,6 +181,10 @@ async fn start_dashboard_fixture_with(with_orphan: bool) -> DashboardFixture {
     let project_root = tmp.path().join("project");
     let global_db_path = tmp.path().join("global").join("global.db");
     let env_guard = EnvVarGuard::set(GLOBAL_DB_ENV, &global_db_path);
+    // Pre-create the global store from the cached empty template so init and
+    // dashboard startup open an existing DB instead of paying a full schema
+    // creation (slow on Windows).
+    write_empty_global_db_schema(&global_db_path).await;
 
     let cg = setup_project(&project_root).await;
     seed_graph_fixture(&cg).await;

--- a/tests/dashboard_api_test/lcm.rs
+++ b/tests/dashboard_api_test/lcm.rs
@@ -4,14 +4,11 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-mod common;
-
 use std::path::Path;
-use std::sync::Mutex;
 
-use common::{
+use crate::common::{
     create_runtime, get_json, http_agent, message_record_at, pick_free_port, response_to_json,
-    wait_for_dashboard, EnvVarGuard,
+    wait_for_dashboard, write_empty_global_db_schema, EnvVarGuard, GLOBAL_DB_ENV_LOCK as ENV_LOCK,
 };
 
 use serde_json::{json, Value};
@@ -22,8 +19,6 @@ use tracedecay::sessions::cursor::project_session_db_path;
 use tracedecay::sessions::lcm::{LcmCleanConfig, LcmGcConfig, LcmSourceRef, LcmSummaryNodeDraft};
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::tracedecay::TraceDecay;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 struct Fixture {
     _tmp: TempDir,
@@ -218,10 +213,15 @@ async fn start_fixture() -> Fixture {
 
     let global_db_path = tmp.path().join("global").join("global.db");
     let env_guards = vec![EnvVarGuard::set("TRACEDECAY_GLOBAL_DB", &global_db_path)];
+    // Pre-create both GlobalDb-schema stores from the cached empty template
+    // so seeding and dashboard startup open existing DBs instead of paying a
+    // full schema creation each (slow on Windows).
+    write_empty_global_db_schema(&global_db_path).await;
     let cg = TraceDecay::init(&project_root)
         .await
         .expect("tracedecay init");
     let session_db_path = project_session_db_path(&project_root);
+    write_empty_global_db_schema(&session_db_path).await;
     let (session_id, child_node_id, parent_node_id) =
         seed_lcm_store(&session_db_path, &project_root).await;
     let port = pick_free_port();

--- a/tests/dashboard_api_test/lcm_fixes.rs
+++ b/tests/dashboard_api_test/lcm_fixes.rs
@@ -3,11 +3,9 @@
 //! session pagination + ordinal ordering, accurate engine reporting, and the
 //! additive search pagination / message-enrichment fields.
 
-mod common;
-
 use std::path::Path;
 
-use common::{
+use crate::common::{
     create_runtime, get_json, http_agent, message_record_at, pick_free_port, tempdir_or_panic,
     wait_for_dashboard, write_empty_global_db_schema, EnvVarGuard, GLOBAL_DB_ENV,
     GLOBAL_DB_ENV_LOCK,

--- a/tests/dashboard_api_test/main.rs
+++ b/tests/dashboard_api_test/main.rs
@@ -1,0 +1,24 @@
+//! Consolidated dashboard API integration tests.
+//!
+//! All `dashboard_*` integration tests live in this single binary so Windows
+//! CI links one test executable instead of twelve. The binary keeps the
+//! `dashboard_api_test` name because CI invokes it directly via
+//! `cargo nextest run --test dashboard_api_test`.
+
+#[path = "../common/mod.rs"]
+mod common;
+
+mod dashboard_api_support;
+
+mod analytics;
+mod api;
+mod automation;
+mod automation_config;
+mod automation_skills;
+mod code_diagnostics;
+mod graph;
+mod lcm;
+mod lcm_fixes;
+mod memory_curation;
+mod projects;
+mod savings;

--- a/tests/dashboard_api_test/memory_curation.rs
+++ b/tests/dashboard_api_test/memory_curation.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 
 #[test]
 fn curate_hygiene_scans_unvectored_facts() {
@@ -837,14 +834,12 @@ fn curation_preview_persists_across_dashboard_restarts() {
         let _env_guard = EnvVarGuard::set(GLOBAL_DB_ENV, &global_db_path);
         let _data_dir_guard = EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root);
 
-        // Pre-create both GlobalDb-schema stores from the cached empty
-        // template so each dashboard server start opens existing DBs instead
-        // of paying a full schema creation (slow on Windows, and this test
-        // starts the server twice).
-        write_empty_global_db_schema(&global_db_path).await;
+        // `setup_project` pre-creates both GlobalDb-schema stores from the
+        // cached empty template so each dashboard server start opens
+        // existing DBs instead of paying a full schema creation (slow on
+        // Windows, and this test starts the server twice).
         let cg = setup_project(&project_root).await;
         seed_memory_fixture(&cg).await;
-        write_empty_global_db_schema(&cg.store_layout().sessions_db_path).await;
         let agent = http_agent();
         let sidecar = cg
             .store_layout()

--- a/tests/dashboard_api_test/projects.rs
+++ b/tests/dashboard_api_test/projects.rs
@@ -1,7 +1,4 @@
-mod common;
-mod dashboard_api_support;
-
-use dashboard_api_support::*;
+use crate::dashboard_api_support::*;
 use std::path::PathBuf;
 
 async fn setup_target_project(fixture: &DashboardFixture) -> (PathBuf, TraceDecay) {

--- a/tests/dashboard_api_test/savings.rs
+++ b/tests/dashboard_api_test/savings.rs
@@ -7,14 +7,11 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-mod common;
-
 use std::path::Path;
-use std::sync::Mutex;
 
-use common::{
+use crate::common::{
     create_runtime, get_json, http_agent, message_record_at, pick_free_port, wait_for_dashboard,
-    EnvVarGuard,
+    write_empty_global_db_schema, EnvVarGuard, GLOBAL_DB_ENV_LOCK as ENV_LOCK,
 };
 use serde_json::Value;
 use tempfile::TempDir;
@@ -24,9 +21,6 @@ use tracedecay::sessions::cursor::project_session_db_path;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::tracedecay::TraceDecay;
 use tracedecay::types::CostTurn;
-
-/// Serializes tests in this binary: they mutate process-wide env vars.
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 struct Fixture {
     _tmp: TempDir,
@@ -431,6 +425,11 @@ async fn start_fixture(seed: FixtureSeed) -> Fixture {
         ),
     ];
 
+    // Pre-create both GlobalDb-schema stores from the cached empty template
+    // so seeding and dashboard startup open existing DBs instead of paying a
+    // full schema creation each (slow on Windows).
+    write_empty_global_db_schema(&global_db_path).await;
+
     let now = now_unix();
     let day_start = now - (now % 86_400);
     match seed {
@@ -443,6 +442,9 @@ async fn start_fixture(seed: FixtureSeed) -> Fixture {
         .await
         .expect("tracedecay init");
     let session_db_path = project_session_db_path(&project_root);
+    if !session_db_path.exists() {
+        write_empty_global_db_schema(&session_db_path).await;
+    }
     match seed {
         FixtureSeed::Base => seed_global_db(&session_db_path, &project_root, day_start).await,
         FixtureSeed::LedgerOnly => {}


### PR DESCRIPTION
## Summary
- Consolidates all 12 dashboard test binaries into a single `dashboard_api_test` binary (name intentionally preserved because the Linux CI dashboard job runs `cargo nextest run --test dashboard_api_test`); all 49 tests preserved.
- Extends the template-DB fast path to lcm/savings/graph fixtures and replaces per-binary env locks with the shared `GLOBAL_DB_ENV_LOCK`.
- Narrows the `windows-dashboard-server` group in `.config/nextest.toml` to `binary(=dashboard_api_test)`.

## Test plan
- [x] `cargo nextest run --profile ci --locked -E 'binary(~dashboard_)'` — 61 tests passed
- [x] `cargo fmt --all -- --check` — clean