### PR TITLE
feat: run plugin refresh and health pass after upgrade

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -267,8 +267,13 @@ pub enum Commands {
         #[command(subcommand)]
         action: DaemonAction,
     },
-    /// Download and install the latest version from GitHub
-    Upgrade,
+    /// Download and install the latest version, then refresh generated
+    /// plugins, the daemon service, and run the post-update health pass
+    Upgrade {
+        /// Skip the post-update health pass (safe repairs + doctor summary)
+        #[arg(long)]
+        no_heal: bool,
+    },
     /// Refresh the tracedecay binary, generated plugins, and daemon
     Update {
         /// Skip the post-update health pass (safe repairs + doctor summary)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -267,14 +267,22 @@ pub enum Commands {
         #[command(subcommand)]
         action: DaemonAction,
     },
-    /// Download and install the latest version, then refresh generated
-    /// plugins, the daemon service, and run the post-update health pass
+    /// Install the latest version; refreshes plugins only after a real install
+    ///
+    /// Downloads and installs the newest release. When a new binary was
+    /// installed, also refreshes generated plugins and the daemon service and
+    /// runs the post-update health pass on the new version. When already up
+    /// to date it stops there — use `tracedecay update` to refresh regardless.
     Upgrade {
         /// Skip the post-update health pass (safe repairs + doctor summary)
         #[arg(long)]
         no_heal: bool,
     },
-    /// Refresh the tracedecay binary, generated plugins, and daemon
+    /// Refresh generated plugins and the daemon, even when already up to date
+    ///
+    /// Upgrades the binary first when a newer release exists, then always
+    /// refreshes generated plugins and the daemon service and runs the
+    /// post-update health pass — even when the binary was already current.
     Update {
         /// Skip the post-update health pass (safe repairs + doctor summary)
         #[arg(long)]

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -138,7 +138,10 @@ fn update_upgrade_and_update_plugin_parse_to_distinct_commands() {
         update.command,
         Some(Commands::Update { no_heal: false })
     ));
-    assert!(matches!(upgrade.command, Some(Commands::Upgrade)));
+    assert!(matches!(
+        upgrade.command,
+        Some(Commands::Upgrade { no_heal: false })
+    ));
     assert!(matches!(
         update_plugin.command,
         Some(Commands::UpdatePlugin)
@@ -169,11 +172,36 @@ fn update_and_post_update_parse_no_heal_flag() {
 }
 
 #[test]
+fn upgrade_parses_no_heal_flag() {
+    let upgrade = Cli::try_parse_from(["tracedecay", "upgrade", "--no-heal"])
+        .expect("upgrade --no-heal should parse");
+    let upgrade_default =
+        Cli::try_parse_from(["tracedecay", "upgrade"]).expect("upgrade should parse");
+
+    assert!(matches!(
+        upgrade.command,
+        Some(Commands::Upgrade { no_heal: true })
+    ));
+    assert!(matches!(
+        upgrade_default.command,
+        Some(Commands::Upgrade { no_heal: false })
+    ));
+}
+
+#[test]
 fn update_help_describes_refresh_scope() {
     let help = Cli::command().render_long_help().to_string();
 
     assert!(help.contains("update"));
     assert!(help.contains("Refresh the tracedecay binary, generated plugins, and daemon"));
+}
+
+#[test]
+fn upgrade_help_describes_post_install_refresh() {
+    let help = Cli::command().render_long_help().to_string();
+
+    assert!(help.contains("upgrade"));
+    assert!(help.contains("Download and install the latest version, then refresh generated"));
 }
 
 #[test]

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -188,20 +188,40 @@ fn upgrade_parses_no_heal_flag() {
     ));
 }
 
-#[test]
-fn update_help_describes_refresh_scope() {
-    let help = Cli::command().render_long_help().to_string();
-
-    assert!(help.contains("update"));
-    assert!(help.contains("Refresh the tracedecay binary, generated plugins, and daemon"));
+/// The full about text for one subcommand, so help assertions don't couple
+/// to exact phrasing elsewhere in the global help output.
+fn subcommand_about(name: &str) -> String {
+    let command = Cli::command();
+    let subcommand = command
+        .find_subcommand(name)
+        .unwrap_or_else(|| panic!("`{name}` subcommand should exist"));
+    let about = subcommand
+        .get_long_about()
+        .or_else(|| subcommand.get_about())
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    format!("{} {about}", subcommand.get_about().unwrap_or_default())
 }
 
 #[test]
-fn upgrade_help_describes_post_install_refresh() {
-    let help = Cli::command().render_long_help().to_string();
+fn upgrade_help_states_refresh_runs_only_after_install() {
+    let about = subcommand_about("upgrade").to_lowercase();
 
-    assert!(help.contains("upgrade"));
-    assert!(help.contains("Download and install the latest version, then refresh generated"));
+    // The distinction from `update`: install first, and no refresh (plugins,
+    // daemon, health pass) on a no-op upgrade.
+    assert!(about.contains("install"));
+    assert!(about.contains("refresh"));
+    assert!(about.contains("already up to date"));
+}
+
+#[test]
+fn update_help_states_refresh_runs_even_when_current() {
+    let about = subcommand_about("update").to_lowercase();
+
+    // The distinction from `upgrade`: the refresh runs regardless of whether
+    // a new binary was installed.
+    assert!(about.contains("refresh"));
+    assert!(about.contains("even when"));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -642,8 +642,8 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
                 print!("{}", tracedecay::daemon::service_status(&socket_path));
             }
         },
-        Commands::Upgrade => {
-            tracedecay::upgrade::run_upgrade()?;
+        Commands::Upgrade { no_heal } => {
+            update_cmd::run_upgrade_command(no_heal)?;
         }
         Commands::Update { no_heal } => {
             update_cmd::run_update_command(no_heal)?;
@@ -782,6 +782,7 @@ fn should_skip_startup_maintenance(command: &Commands) -> bool {
         Commands::Install { .. }
             | Commands::Reinstall
             | Commands::UpdatePlugin
+            | Commands::Upgrade { .. }
             | Commands::Update { .. }
             | Commands::PostUpdate { .. }
             | Commands::Uninstall { .. }
@@ -831,9 +832,11 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
     //     can blow that budget, so it must stay off `serve`.
     //   - `Install` / `Reinstall`: already perform installation — don't
     //     double-install as an implicit prelude to the explicit command.
-    //   - `UpdatePlugin` / `Update`: explicit maintenance paths that manage
-    //     plugin refresh themselves; an implicit silent reinstall beforehand
-    //     would rewrite configs and break the update-plugin contract.
+    //   - `UpdatePlugin` / `Upgrade` / `Update`: explicit maintenance paths
+    //     that manage plugin refresh themselves (upgrade/update re-exec the
+    //     new binary's `post-update`); an implicit silent reinstall beforehand
+    //     would rewrite configs with the OLD binary and break the
+    //     update-plugin contract.
     //   - `Uninstall`: about to remove agent configs — don't reinstall them
     //     first (per the original #84 intent).
     //   - `Doctor` / `Migrate`: read-only diagnostics — must not mutate agent
@@ -847,6 +850,7 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
             | Commands::Install { .. }
             | Commands::Reinstall
             | Commands::UpdatePlugin
+            | Commands::Upgrade { .. }
             | Commands::Update { .. }
             | Commands::PostUpdate { .. }
             | Commands::Uninstall { .. }

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,18 +292,32 @@ fn run_startup_preamble(command: &Commands) {
     }
 }
 
-fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::UserConfig) {
-    // Silent reinstall: re-run install for every tracked agent so permissions,
-    // hooks, and MCP config stay in sync with the new binary.
-    //
-    // Two signals can trigger this:
+/// What startup maintenance should do about the version markers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SilentReinstallAction {
+    /// Re-run install for every tracked agent.
+    Reinstall,
+    /// Patch-only bump (or nothing to reinstall): just advance the marker.
+    AdvanceMarker,
+    /// Markers already match the running version — nothing to do.
+    Nothing,
+}
+
+fn silent_reinstall_action(
+    user_config: &tracedecay::user_config::UserConfig,
+    running: &str,
+) -> SilentReinstallAction {
+    // Two signals can trigger a reinstall:
     //   (a) `previous_version` (set by `tracedecay upgrade` / `channel switch`
     //       just before replacing the binary) differs from the running version
     //       AND the transition is a minor/major bump. Patch bumps are no-ops:
     //       we just advance `previous_version` and skip reinstall.
     //   (b) Fallback for external upgrades (`brew upgrade`, `cargo install`):
     //       the running version is newer than `last_installed_version`.
-    let running = env!("CARGO_PKG_VERSION");
+    //
+    // A successful `post-update` advances both markers (see
+    // `update_cmd::mark_running_version_installed`), so the next ordinary
+    // command does not repeat the plugin refresh it just performed.
     let previous_version = if user_config.previous_version.is_empty() {
         "6.0.0".to_string()
     } else {
@@ -319,37 +333,54 @@ fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::UserCon
     let needs_reinstall = transition_needs_reinstall || external_upgrade_needs_reinstall;
 
     if !user_config.installed_agents.is_empty() && !running.is_empty() && needs_reinstall {
-        if let (Some(home), Some(bin)) = (
-            tracedecay::agents::home_dir(),
-            tracedecay::agents::which_tracedecay(),
-        ) {
-            let mut all_ok = true;
-            for id in &user_config.installed_agents {
-                if let Ok(ag) = tracedecay::agents::get_integration(id) {
-                    let ctx = tracedecay::agents::InstallContext {
-                        home: home.clone(),
-                        tracedecay_bin: bin.clone(),
-                        tool_permissions: tracedecay::agents::expected_tool_perms(),
-                        profile: None,
-                        project_root: None,
-                        dashboard: true,
-                    };
-                    if ag.install(&ctx).is_err() {
-                        all_ok = false;
-                    }
+        SilentReinstallAction::Reinstall
+    } else if upgrade_detected {
+        SilentReinstallAction::AdvanceMarker
+    } else {
+        SilentReinstallAction::Nothing
+    }
+}
+
+fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::UserConfig) {
+    // Silent reinstall: re-run install for every tracked agent so permissions,
+    // hooks, and MCP config stay in sync with the new binary.
+    let running = env!("CARGO_PKG_VERSION");
+    match silent_reinstall_action(user_config, running) {
+        SilentReinstallAction::Reinstall => run_silent_reinstall(user_config, running),
+        SilentReinstallAction::AdvanceMarker => {
+            user_config.previous_version = running.to_string();
+            user_config.save();
+        }
+        SilentReinstallAction::Nothing => {}
+    }
+}
+
+fn run_silent_reinstall(user_config: &mut tracedecay::user_config::UserConfig, running: &str) {
+    if let (Some(home), Some(bin)) = (
+        tracedecay::agents::home_dir(),
+        tracedecay::agents::which_tracedecay(),
+    ) {
+        let mut all_ok = true;
+        for id in &user_config.installed_agents {
+            if let Ok(ag) = tracedecay::agents::get_integration(id) {
+                let ctx = tracedecay::agents::InstallContext {
+                    home: home.clone(),
+                    tracedecay_bin: bin.clone(),
+                    tool_permissions: tracedecay::agents::expected_tool_perms(),
+                    profile: None,
+                    project_root: None,
+                    dashboard: true,
+                };
+                if ag.install(&ctx).is_err() {
+                    all_ok = false;
                 }
             }
-            if all_ok {
-                user_config.last_installed_version = running.to_string();
-                user_config.previous_version = running.to_string();
-                user_config.save();
-            }
         }
-    } else if upgrade_detected {
-        // Patch-only bump (or nothing to reinstall) — advance the marker so we
-        // don't keep re-checking on every subsequent startup.
-        user_config.previous_version = running.to_string();
-        user_config.save();
+        if all_ok {
+            user_config.last_installed_version = running.to_string();
+            user_config.previous_version = running.to_string();
+            user_config.save();
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,9 +315,10 @@ fn silent_reinstall_action(
     //   (b) Fallback for external upgrades (`brew upgrade`, `cargo install`):
     //       the running version is newer than `last_installed_version`.
     //
-    // A successful `post-update` advances both markers (see
-    // `update_cmd::mark_running_version_installed`), so the next ordinary
-    // command does not repeat the plugin refresh it just performed.
+    // A successful `post-update` performs the same full tracked-agent
+    // install pass and then advances both markers (see
+    // `UserConfig::mark_version_installed`), so the next ordinary command
+    // does not repeat the reinstall it just performed.
     let previous_version = if user_config.previous_version.is_empty() {
         "6.0.0".to_string()
     } else {
@@ -356,31 +357,9 @@ fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::UserCon
 }
 
 fn run_silent_reinstall(user_config: &mut tracedecay::user_config::UserConfig, running: &str) {
-    if let (Some(home), Some(bin)) = (
-        tracedecay::agents::home_dir(),
-        tracedecay::agents::which_tracedecay(),
-    ) {
-        let mut all_ok = true;
-        for id in &user_config.installed_agents {
-            if let Ok(ag) = tracedecay::agents::get_integration(id) {
-                let ctx = tracedecay::agents::InstallContext {
-                    home: home.clone(),
-                    tracedecay_bin: bin.clone(),
-                    tool_permissions: tracedecay::agents::expected_tool_perms(),
-                    profile: None,
-                    project_root: None,
-                    dashboard: true,
-                };
-                if ag.install(&ctx).is_err() {
-                    all_ok = false;
-                }
-            }
-        }
-        if all_ok {
-            user_config.last_installed_version = running.to_string();
-            user_config.previous_version = running.to_string();
-            user_config.save();
-        }
+    if update_cmd::reinstall_tracked_agents(user_config) {
+        user_config.mark_version_installed(running);
+        user_config.save();
     }
 }
 

--- a/src/startup_tests.rs
+++ b/src/startup_tests.rs
@@ -5,11 +5,12 @@ use super::{
     },
     is_local_install_command, should_skip_agent_install_maintenance,
     should_skip_startup_maintenance,
-    update_cmd::run_update_steps,
+    update_cmd::{run_update_steps, run_upgrade_steps},
     Commands,
 };
 use std::cell::RefCell;
 use tempfile::TempDir;
+use tracedecay::upgrade::UpgradeOutcome;
 
 #[test]
 fn doctor_skips_startup_maintenance() {
@@ -33,6 +34,9 @@ fn explicit_agent_config_commands_skip_startup_maintenance() {
     }));
     assert!(should_skip_startup_maintenance(&Commands::Reinstall));
     assert!(should_skip_startup_maintenance(&Commands::UpdatePlugin));
+    assert!(should_skip_startup_maintenance(&Commands::Upgrade {
+        no_heal: false
+    }));
     assert!(should_skip_startup_maintenance(&Commands::Update {
         no_heal: false
     }));
@@ -84,6 +88,9 @@ fn agent_install_maintenance_is_selective() {
     assert!(should_skip_agent_install_maintenance(
         &Commands::UpdatePlugin
     ));
+    assert!(should_skip_agent_install_maintenance(&Commands::Upgrade {
+        no_heal: false
+    }));
     assert!(should_skip_agent_install_maintenance(&Commands::Update {
         no_heal: false
     }));
@@ -151,6 +158,87 @@ fn update_steps_stop_after_upgrade_failure() {
     let calls = RefCell::new(Vec::new());
 
     let result = run_update_steps(
+        || {
+            calls.borrow_mut().push("upgrade");
+            Err(tracedecay::errors::TraceDecayError::Config {
+                message: "upgrade failed".to_string(),
+            })
+        },
+        || {
+            calls.borrow_mut().push("post-update");
+            Ok(())
+        },
+    );
+
+    assert!(result.is_err());
+    assert_eq!(calls.into_inner(), vec!["upgrade"]);
+}
+
+#[test]
+fn upgrade_steps_run_post_update_after_install() {
+    let calls = RefCell::new(Vec::new());
+
+    run_upgrade_steps(
+        || {
+            calls.borrow_mut().push("upgrade");
+            Ok(UpgradeOutcome::Installed)
+        },
+        || {
+            calls.borrow_mut().push("post-update");
+            Ok(())
+        },
+    )
+    .expect("upgrade steps should succeed");
+
+    assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+}
+
+#[test]
+fn upgrade_steps_skip_post_update_when_already_up_to_date() {
+    let calls = RefCell::new(Vec::new());
+
+    run_upgrade_steps(
+        || {
+            calls.borrow_mut().push("upgrade");
+            Ok(UpgradeOutcome::AlreadyUpToDate)
+        },
+        || {
+            calls.borrow_mut().push("post-update");
+            Ok(())
+        },
+    )
+    .expect("an up-to-date upgrade should stay a successful no-op");
+
+    assert_eq!(calls.into_inner(), vec!["upgrade"]);
+}
+
+#[test]
+fn upgrade_steps_tolerate_post_update_failure() {
+    let calls = RefCell::new(Vec::new());
+
+    let result = run_upgrade_steps(
+        || {
+            calls.borrow_mut().push("upgrade");
+            Ok(UpgradeOutcome::Installed)
+        },
+        || {
+            calls.borrow_mut().push("post-update");
+            Err(tracedecay::errors::TraceDecayError::Config {
+                message: "plugin refresh failed".to_string(),
+            })
+        },
+    );
+
+    // The binary upgrade itself succeeded — a refresh failure only warns.
+    assert!(result.is_ok());
+    assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+}
+
+#[test]
+fn upgrade_steps_stop_after_upgrade_failure() {
+    let calls = RefCell::new(Vec::new());
+
+    let result = run_upgrade_steps(
         || {
             calls.borrow_mut().push("upgrade");
             Err(tracedecay::errors::TraceDecayError::Config {

--- a/src/startup_tests.rs
+++ b/src/startup_tests.rs
@@ -4,8 +4,7 @@ use super::{
         validate_hermes_project_root_flag,
     },
     is_local_install_command, should_skip_agent_install_maintenance,
-    should_skip_startup_maintenance, silent_reinstall_action, update_cmd, Commands,
-    SilentReinstallAction,
+    should_skip_startup_maintenance, silent_reinstall_action, Commands, SilentReinstallAction,
 };
 use tempfile::TempDir;
 use tracedecay::user_config::UserConfig;
@@ -149,9 +148,13 @@ fn silent_reinstall_runs_after_minor_bump_without_post_update() {
 }
 
 #[test]
-fn post_update_marker_advancement_prevents_duplicate_silent_reinstall() {
-    // `post-update` refreshed the plugins and advanced the markers; the next
-    // ordinary command must not repeat that work via silent reinstall.
+fn post_update_full_reinstall_marker_advancement_suppresses_startup_reinstall() {
+    // `post-update` ran the full tracked-agent install pass (see
+    // `update_cmd::run_post_update_tasks`) and recorded it by advancing both
+    // markers; the next ordinary command must not repeat that work via the
+    // startup silent reinstall. The markers may only be advanced *after* the
+    // full install pass — advancing them for a plugin-artifact-only refresh
+    // would silently skip config-managed agents on minor/major bumps.
     let running = "6.1.0";
     let mut config = UserConfig {
         installed_agents: vec!["cursor".to_string()],
@@ -159,10 +162,7 @@ fn post_update_marker_advancement_prevents_duplicate_silent_reinstall() {
         ..UserConfig::default()
     };
 
-    assert!(update_cmd::mark_running_version_installed(
-        &mut config,
-        running
-    ));
+    assert!(config.mark_version_installed(running));
     assert_eq!(config.previous_version, running);
     assert_eq!(config.last_installed_version, running);
     assert_eq!(
@@ -170,10 +170,7 @@ fn post_update_marker_advancement_prevents_duplicate_silent_reinstall() {
         SilentReinstallAction::Nothing
     );
     // Idempotent: a second post-update run has nothing left to record.
-    assert!(!update_cmd::mark_running_version_installed(
-        &mut config,
-        running
-    ));
+    assert!(!config.mark_version_installed(running));
 }
 
 #[test]

--- a/src/startup_tests.rs
+++ b/src/startup_tests.rs
@@ -4,13 +4,11 @@ use super::{
         validate_hermes_project_root_flag,
     },
     is_local_install_command, should_skip_agent_install_maintenance,
-    should_skip_startup_maintenance,
-    update_cmd::{run_update_steps, run_upgrade_steps},
-    Commands,
+    should_skip_startup_maintenance, silent_reinstall_action, update_cmd, Commands,
+    SilentReinstallAction,
 };
-use std::cell::RefCell;
 use tempfile::TempDir;
-use tracedecay::upgrade::UpgradeOutcome;
+use tracedecay::user_config::UserConfig;
 
 #[test]
 fn doctor_skips_startup_maintenance() {
@@ -135,124 +133,62 @@ fn agent_install_maintenance_is_selective() {
 }
 
 #[test]
-fn update_steps_run_post_update_after_upgrade() {
-    let calls = RefCell::new(Vec::new());
+fn silent_reinstall_runs_after_minor_bump_without_post_update() {
+    // An upgraded binary whose `post-update` never ran (or predates the
+    // marker advancement) still triggers the reinstall pass.
+    let config = UserConfig {
+        installed_agents: vec!["cursor".to_string()],
+        previous_version: "6.0.0".to_string(),
+        ..UserConfig::default()
+    };
 
-    run_update_steps(
-        || {
-            calls.borrow_mut().push("upgrade");
-            Ok(())
-        },
-        || {
-            calls.borrow_mut().push("post-update");
-            Ok(())
-        },
-    )
-    .expect("update steps should succeed");
-
-    assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
-}
-
-#[test]
-fn update_steps_stop_after_upgrade_failure() {
-    let calls = RefCell::new(Vec::new());
-
-    let result = run_update_steps(
-        || {
-            calls.borrow_mut().push("upgrade");
-            Err(tracedecay::errors::TraceDecayError::Config {
-                message: "upgrade failed".to_string(),
-            })
-        },
-        || {
-            calls.borrow_mut().push("post-update");
-            Ok(())
-        },
+    assert_eq!(
+        silent_reinstall_action(&config, "6.1.0"),
+        SilentReinstallAction::Reinstall
     );
-
-    assert!(result.is_err());
-    assert_eq!(calls.into_inner(), vec!["upgrade"]);
 }
 
 #[test]
-fn upgrade_steps_run_post_update_after_install() {
-    let calls = RefCell::new(Vec::new());
+fn post_update_marker_advancement_prevents_duplicate_silent_reinstall() {
+    // `post-update` refreshed the plugins and advanced the markers; the next
+    // ordinary command must not repeat that work via silent reinstall.
+    let running = "6.1.0";
+    let mut config = UserConfig {
+        installed_agents: vec!["cursor".to_string()],
+        previous_version: "6.0.0".to_string(),
+        ..UserConfig::default()
+    };
 
-    run_upgrade_steps(
-        || {
-            calls.borrow_mut().push("upgrade");
-            Ok(UpgradeOutcome::Installed)
-        },
-        || {
-            calls.borrow_mut().push("post-update");
-            Ok(())
-        },
-    )
-    .expect("upgrade steps should succeed");
-
-    assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
-}
-
-#[test]
-fn upgrade_steps_skip_post_update_when_already_up_to_date() {
-    let calls = RefCell::new(Vec::new());
-
-    run_upgrade_steps(
-        || {
-            calls.borrow_mut().push("upgrade");
-            Ok(UpgradeOutcome::AlreadyUpToDate)
-        },
-        || {
-            calls.borrow_mut().push("post-update");
-            Ok(())
-        },
-    )
-    .expect("an up-to-date upgrade should stay a successful no-op");
-
-    assert_eq!(calls.into_inner(), vec!["upgrade"]);
-}
-
-#[test]
-fn upgrade_steps_tolerate_post_update_failure() {
-    let calls = RefCell::new(Vec::new());
-
-    let result = run_upgrade_steps(
-        || {
-            calls.borrow_mut().push("upgrade");
-            Ok(UpgradeOutcome::Installed)
-        },
-        || {
-            calls.borrow_mut().push("post-update");
-            Err(tracedecay::errors::TraceDecayError::Config {
-                message: "plugin refresh failed".to_string(),
-            })
-        },
+    assert!(update_cmd::mark_running_version_installed(
+        &mut config,
+        running
+    ));
+    assert_eq!(config.previous_version, running);
+    assert_eq!(config.last_installed_version, running);
+    assert_eq!(
+        silent_reinstall_action(&config, running),
+        SilentReinstallAction::Nothing
     );
-
-    // The binary upgrade itself succeeded — a refresh failure only warns.
-    assert!(result.is_ok());
-    assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+    // Idempotent: a second post-update run has nothing left to record.
+    assert!(!update_cmd::mark_running_version_installed(
+        &mut config,
+        running
+    ));
 }
 
 #[test]
-fn upgrade_steps_stop_after_upgrade_failure() {
-    let calls = RefCell::new(Vec::new());
+fn patch_bump_only_advances_the_marker() {
+    let config = UserConfig {
+        installed_agents: vec!["cursor".to_string()],
+        previous_version: "6.1.0".to_string(),
+        last_installed_version: "6.1.0".to_string(),
+        ..UserConfig::default()
+    };
 
-    let result = run_upgrade_steps(
-        || {
-            calls.borrow_mut().push("upgrade");
-            Err(tracedecay::errors::TraceDecayError::Config {
-                message: "upgrade failed".to_string(),
-            })
-        },
-        || {
-            calls.borrow_mut().push("post-update");
-            Ok(())
-        },
+    assert_eq!(
+        silent_reinstall_action(&config, "6.1.1"),
+        SilentReinstallAction::AdvanceMarker
     );
-
-    assert!(result.is_err());
-    assert_eq!(calls.into_inner(), vec!["upgrade"]);
 }
 
 #[test]

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -1,8 +1,10 @@
-//! The `update` / `post-update` / `update-plugin` flow: binary upgrade via
-//! subprocess re-exec, generated-plugin refresh, daemon service refresh, and
-//! the post-update health pass.
+//! The `upgrade` / `update` / `post-update` / `update-plugin` flow: binary
+//! upgrade via subprocess re-exec, generated-plugin refresh, daemon service
+//! refresh, and the post-update health pass.
 
 use std::path::PathBuf;
+
+use tracedecay::upgrade::UpgradeOutcome;
 
 pub(crate) fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
     let home = tracedecay_home_dir()?;
@@ -145,6 +147,48 @@ pub(crate) fn run_update_command(no_heal: bool) -> tracedecay::errors::Result<()
         || tracedecay::upgrade::run_upgrade().map(|_| ()),
         || run_post_update_subcommand(no_heal),
     )
+}
+
+/// The `upgrade` flow: install the new binary, then — only when something was
+/// actually installed — re-exec the NEW binary's `post-update` subcommand so
+/// the plugin refresh, daemon refresh, and health pass run on the new version.
+///
+/// Unlike `update`, a refresh failure only warns: the binary upgrade itself
+/// succeeded, so the command must not report failure (mirroring how the
+/// health pass inside `post-update` is best-effort).
+pub(crate) fn run_upgrade_steps<U, P>(
+    mut upgrade: U,
+    mut post_update: P,
+) -> tracedecay::errors::Result<()>
+where
+    U: FnMut() -> tracedecay::errors::Result<UpgradeOutcome>,
+    P: FnMut() -> tracedecay::errors::Result<()>,
+{
+    match upgrade()? {
+        UpgradeOutcome::Installed => {
+            if let Err(error) = post_update() {
+                eprintln!(
+                    "  \x1b[33mwarning:\x1b[0m post-upgrade refresh failed: {error}\n  \
+                     The new binary is installed; run `tracedecay update` to retry the \
+                     plugin refresh and health pass."
+                );
+            }
+            Ok(())
+        }
+        UpgradeOutcome::AlreadyUpToDate => {
+            eprintln!(
+                "Nothing was installed, so plugins were left untouched — \
+                 run `tracedecay update` to refresh generated plugins anyway."
+            );
+            Ok(())
+        }
+    }
+}
+
+pub(crate) fn run_upgrade_command(no_heal: bool) -> tracedecay::errors::Result<()> {
+    run_upgrade_steps(tracedecay::upgrade::run_upgrade, || {
+        run_post_update_subcommand(no_heal)
+    })
 }
 
 fn run_post_update_subcommand(no_heal: bool) -> tracedecay::errors::Result<()> {

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -1,6 +1,7 @@
 //! The `upgrade` / `update` / `post-update` / `update-plugin` flow: binary
 //! upgrade via subprocess re-exec, generated-plugin refresh, daemon service
-//! refresh, and the post-update health pass.
+//! refresh, the post-update health pass, and the full tracked-agent
+//! reinstall that keeps config-managed integrations in sync.
 
 use std::path::{Path, PathBuf};
 
@@ -146,7 +147,7 @@ pub(crate) enum RefreshPolicy {
 /// binary path, when known — so the plugin refresh, daemon refresh, and
 /// health pass run on the new version. `policy` decides whether the refresh
 /// runs on a no-op upgrade and whether a refresh failure is fatal.
-pub(crate) fn run_update_steps<U, P>(
+pub(crate) fn run_install_then_refresh<U, P>(
     policy: RefreshPolicy,
     upgrade: U,
     post_update: P,
@@ -193,7 +194,7 @@ where
 }
 
 pub(crate) fn run_update_command(no_heal: bool) -> tracedecay::errors::Result<()> {
-    run_update_steps(
+    run_install_then_refresh(
         RefreshPolicy::Always,
         tracedecay::upgrade::run_upgrade,
         |binary| run_post_update_subcommand(no_heal, binary),
@@ -201,7 +202,7 @@ pub(crate) fn run_update_command(no_heal: bool) -> tracedecay::errors::Result<()
 }
 
 pub(crate) fn run_upgrade_command(no_heal: bool) -> tracedecay::errors::Result<()> {
-    run_update_steps(
+    run_install_then_refresh(
         RefreshPolicy::AfterInstall,
         tracedecay::upgrade::run_upgrade,
         |binary| run_post_update_subcommand(no_heal, binary),
@@ -242,17 +243,35 @@ fn run_post_update_subcommand(
     })
 }
 
-/// Marks `running` as fully installed in the version markers, returning
-/// whether anything changed. Run at the end of a successful `post-update` so
-/// the next ordinary command's startup maintenance does not re-run the
-/// plugin refresh (silent reinstall) that `post-update` just performed.
-pub(crate) fn mark_running_version_installed(config: &mut UserConfig, running: &str) -> bool {
-    if config.previous_version == running && config.last_installed_version == running {
+/// Re-runs full `install()` for every tracked agent so tool permissions,
+/// hooks, and MCP config stay in sync with the running binary — a superset
+/// of `refresh_generated_plugins`, which rewrites generated artifacts only
+/// and deliberately leaves config-managed integrations untouched. Returns
+/// whether every install succeeded (an empty tracked list is a success).
+pub(crate) fn reinstall_tracked_agents(user_config: &UserConfig) -> bool {
+    let (Some(home), Some(bin)) = (
+        tracedecay::agents::home_dir(),
+        tracedecay::agents::which_tracedecay(),
+    ) else {
         return false;
+    };
+    let mut all_ok = true;
+    for id in &user_config.installed_agents {
+        if let Ok(ag) = tracedecay::agents::get_integration(id) {
+            let ctx = tracedecay::agents::InstallContext {
+                home: home.clone(),
+                tracedecay_bin: bin.clone(),
+                tool_permissions: tracedecay::agents::expected_tool_perms(),
+                profile: None,
+                project_root: None,
+                dashboard: true,
+            };
+            if ag.install(&ctx).is_err() {
+                all_ok = false;
+            }
+        }
     }
-    config.previous_version = running.to_string();
-    config.last_installed_version = running.to_string();
-    true
+    all_ok
 }
 
 pub(crate) async fn run_post_update_tasks(no_heal: bool) -> tracedecay::errors::Result<()> {
@@ -266,9 +285,29 @@ pub(crate) async fn run_post_update_tasks(no_heal: bool) -> tracedecay::errors::
         tracedecay::doctor::heal::run_post_update_health_pass().await;
     }
 
+    // The generated-artifact refresh above skips config-managed integrations
+    // (claude, copilot, …), but a version bump can change their tool
+    // permissions, hooks, or MCP config too. Run the same full tracked-agent
+    // install pass the startup silent reinstall would, then advance the
+    // version markers so that startup pass does not repeat it. On failure the
+    // markers stay put, so the next ordinary command retries via the silent
+    // reinstall.
     let mut config = UserConfig::load();
-    if mark_running_version_installed(&mut config, env!("CARGO_PKG_VERSION")) {
-        config.save();
+    if !config.installed_agents.is_empty() {
+        eprintln!(
+            "Re-running agent install for: {}",
+            config.installed_agents.join(", ")
+        );
+    }
+    if reinstall_tracked_agents(&config) {
+        if config.mark_version_installed(env!("CARGO_PKG_VERSION")) {
+            config.save();
+        }
+    } else {
+        eprintln!(
+            "  \x1b[33mwarning:\x1b[0m agent install failed for at least one integration; \
+             it will be retried on the next tracedecay command."
+        );
     }
     Ok(())
 }
@@ -278,7 +317,7 @@ mod tests {
     use std::cell::RefCell;
     use std::path::{Path, PathBuf};
 
-    use super::{post_update_binary, run_update_steps, RefreshPolicy};
+    use super::{post_update_binary, run_install_then_refresh, RefreshPolicy};
     use tracedecay::upgrade::UpgradeOutcome;
 
     fn config_err(message: &str) -> tracedecay::errors::TraceDecayError {
@@ -319,7 +358,7 @@ mod tests {
         let calls = RefCell::new(Vec::new());
         let seen_binary = RefCell::new(None);
 
-        run_update_steps(
+        run_install_then_refresh(
             RefreshPolicy::Always,
             record_upgrade(&calls, "upgrade", Ok(UpgradeOutcome::AlreadyCurrent)),
             record_post_update(&calls, "post-update", &seen_binary, Ok(())),
@@ -336,7 +375,7 @@ mod tests {
         let calls = RefCell::new(Vec::new());
         let seen_binary = RefCell::new(None);
 
-        let result = run_update_steps(
+        let result = run_install_then_refresh(
             RefreshPolicy::Always,
             record_upgrade(&calls, "upgrade", Err(config_err("upgrade failed"))),
             record_post_update(&calls, "post-update", &seen_binary, Ok(())),
@@ -351,7 +390,7 @@ mod tests {
         let calls = RefCell::new(Vec::new());
         let seen_binary = RefCell::new(None);
 
-        let result = run_update_steps(
+        let result = run_install_then_refresh(
             RefreshPolicy::Always,
             record_upgrade(&calls, "upgrade", Ok(UpgradeOutcome::AlreadyCurrent)),
             record_post_update(
@@ -372,7 +411,7 @@ mod tests {
         let seen_binary = RefCell::new(None);
         let installed = PathBuf::from("/opt/homebrew/bin/tracedecay");
 
-        run_update_steps(
+        run_install_then_refresh(
             RefreshPolicy::AfterInstall,
             record_upgrade(
                 &calls,
@@ -396,7 +435,7 @@ mod tests {
         let calls = RefCell::new(Vec::new());
         let seen_binary = RefCell::new(None);
 
-        run_update_steps(
+        run_install_then_refresh(
             RefreshPolicy::AfterInstall,
             record_upgrade(&calls, "upgrade", Ok(UpgradeOutcome::AlreadyCurrent)),
             record_post_update(&calls, "post-update", &seen_binary, Ok(())),
@@ -412,7 +451,7 @@ mod tests {
         let calls = RefCell::new(Vec::new());
         let seen_binary = RefCell::new(None);
 
-        let result = run_update_steps(
+        let result = run_install_then_refresh(
             RefreshPolicy::AfterInstall,
             record_upgrade(
                 &calls,
@@ -437,7 +476,7 @@ mod tests {
         let calls = RefCell::new(Vec::new());
         let seen_binary = RefCell::new(None);
 
-        let result = run_update_steps(
+        let result = run_install_then_refresh(
             RefreshPolicy::AfterInstall,
             record_upgrade(&calls, "upgrade", Err(config_err("upgrade failed"))),
             record_post_update(&calls, "post-update", &seen_binary, Ok(())),
@@ -464,11 +503,15 @@ mod tests {
         let missing = temp.path().join("does-not-exist/tracedecay");
 
         // A dangling path (e.g. brew cleaned the keg) must fall back to the
-        // normal resolution instead of re-execing a nonexistent file.
-        let resolved = post_update_binary(Some(&missing));
-
-        if let Ok(resolved) = resolved {
-            assert_ne!(resolved, missing.to_string_lossy());
+        // normal resolution instead of re-execing a nonexistent file. Either
+        // branch proves the dangling path was rejected — which one runs
+        // depends on whether the test environment has tracedecay on PATH.
+        match post_update_binary(Some(&missing)) {
+            Ok(resolved) => assert_ne!(resolved, missing.to_string_lossy()),
+            Err(error) => assert!(
+                error.to_string().contains("not found on PATH"),
+                "unexpected fallback error: {error}"
+            ),
         }
     }
 }

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -2,9 +2,10 @@
 //! upgrade via subprocess re-exec, generated-plugin refresh, daemon service
 //! refresh, and the post-update health pass.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tracedecay::upgrade::UpgradeOutcome;
+use tracedecay::user_config::UserConfig;
 
 pub(crate) fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
     let home = tracedecay_home_dir()?;
@@ -129,70 +130,100 @@ pub(crate) fn tracedecay_bin_on_path() -> tracedecay::errors::Result<String> {
     })
 }
 
+/// How the `post-update` re-exec reacts to the binary-upgrade outcome.
+pub(crate) enum RefreshPolicy {
+    /// `update`: refresh even when nothing was installed, and a refresh
+    /// failure fails the command.
+    Always,
+    /// `upgrade`: refresh only after a real install, and a refresh failure
+    /// only warns — the binary upgrade itself already succeeded (mirroring
+    /// how the health pass inside `post-update` is best-effort).
+    AfterInstall,
+}
+
+/// The shared `update` / `upgrade` flow: install the new binary, then re-exec
+/// the NEW binary's `post-update` subcommand — passed the freshly installed
+/// binary path, when known — so the plugin refresh, daemon refresh, and
+/// health pass run on the new version. `policy` decides whether the refresh
+/// runs on a no-op upgrade and whether a refresh failure is fatal.
 pub(crate) fn run_update_steps<U, P>(
-    mut upgrade: U,
-    mut post_update: P,
+    policy: RefreshPolicy,
+    upgrade: U,
+    post_update: P,
 ) -> tracedecay::errors::Result<()>
 where
-    U: FnMut() -> tracedecay::errors::Result<()>,
-    P: FnMut() -> tracedecay::errors::Result<()>,
+    U: FnOnce() -> tracedecay::errors::Result<UpgradeOutcome>,
+    P: FnOnce(Option<&Path>) -> tracedecay::errors::Result<()>,
 {
-    upgrade()?;
-    post_update()?;
-    Ok(())
+    let outcome = upgrade()?;
+    match policy {
+        RefreshPolicy::Always => {
+            let binary = match &outcome {
+                UpgradeOutcome::Installed { binary } => binary.as_deref(),
+                UpgradeOutcome::AlreadyCurrent => None,
+            };
+            post_update(binary)
+        }
+        RefreshPolicy::AfterInstall => match outcome {
+            UpgradeOutcome::Installed { binary } => {
+                if let Err(error) = post_update(binary.as_deref()) {
+                    // Point the retry at the installed binary when we know
+                    // where it lives — a bare `tracedecay` may not be on PATH.
+                    let retry = match &binary {
+                        Some(path) => format!("`{} update`", path.display()),
+                        None => "`tracedecay update`".to_string(),
+                    };
+                    eprintln!(
+                        "  \x1b[33mwarning:\x1b[0m post-upgrade refresh failed: {error}\n  \
+                         The new binary is installed; run {retry} to retry the \
+                         plugin refresh and health pass."
+                    );
+                }
+                Ok(())
+            }
+            UpgradeOutcome::AlreadyCurrent => {
+                eprintln!(
+                    "Nothing was installed, so plugins were left untouched — \
+                     run `tracedecay update` to refresh generated plugins anyway."
+                );
+                Ok(())
+            }
+        },
+    }
 }
 
 pub(crate) fn run_update_command(no_heal: bool) -> tracedecay::errors::Result<()> {
     run_update_steps(
-        || tracedecay::upgrade::run_upgrade().map(|_| ()),
-        || run_post_update_subcommand(no_heal),
+        RefreshPolicy::Always,
+        tracedecay::upgrade::run_upgrade,
+        |binary| run_post_update_subcommand(no_heal, binary),
     )
 }
 
-/// The `upgrade` flow: install the new binary, then — only when something was
-/// actually installed — re-exec the NEW binary's `post-update` subcommand so
-/// the plugin refresh, daemon refresh, and health pass run on the new version.
-///
-/// Unlike `update`, a refresh failure only warns: the binary upgrade itself
-/// succeeded, so the command must not report failure (mirroring how the
-/// health pass inside `post-update` is best-effort).
-pub(crate) fn run_upgrade_steps<U, P>(
-    mut upgrade: U,
-    mut post_update: P,
-) -> tracedecay::errors::Result<()>
-where
-    U: FnMut() -> tracedecay::errors::Result<UpgradeOutcome>,
-    P: FnMut() -> tracedecay::errors::Result<()>,
-{
-    match upgrade()? {
-        UpgradeOutcome::Installed => {
-            if let Err(error) = post_update() {
-                eprintln!(
-                    "  \x1b[33mwarning:\x1b[0m post-upgrade refresh failed: {error}\n  \
-                     The new binary is installed; run `tracedecay update` to retry the \
-                     plugin refresh and health pass."
-                );
-            }
-            Ok(())
-        }
-        UpgradeOutcome::AlreadyUpToDate => {
-            eprintln!(
-                "Nothing was installed, so plugins were left untouched — \
-                 run `tracedecay update` to refresh generated plugins anyway."
-            );
-            Ok(())
-        }
+pub(crate) fn run_upgrade_command(no_heal: bool) -> tracedecay::errors::Result<()> {
+    run_update_steps(
+        RefreshPolicy::AfterInstall,
+        tracedecay::upgrade::run_upgrade,
+        |binary| run_post_update_subcommand(no_heal, binary),
+    )
+}
+
+/// The binary to re-exec for `post-update`: the freshly installed one when
+/// the upgrade reported where it landed, otherwise the usual resolution.
+/// Never `which_tracedecay()` alone — its current-exe-first order can point
+/// at the OLD binary (e.g. a stale Homebrew keg) right after an upgrade.
+fn post_update_binary(installed: Option<&Path>) -> tracedecay::errors::Result<String> {
+    match installed.filter(|path| path.exists()) {
+        Some(path) => Ok(path.to_string_lossy().into_owned()),
+        None => tracedecay_bin_on_path(),
     }
 }
 
-pub(crate) fn run_upgrade_command(no_heal: bool) -> tracedecay::errors::Result<()> {
-    run_upgrade_steps(tracedecay::upgrade::run_upgrade, || {
-        run_post_update_subcommand(no_heal)
-    })
-}
-
-fn run_post_update_subcommand(no_heal: bool) -> tracedecay::errors::Result<()> {
-    let tracedecay_bin = tracedecay_bin_on_path()?;
+fn run_post_update_subcommand(
+    no_heal: bool,
+    installed: Option<&Path>,
+) -> tracedecay::errors::Result<()> {
+    let tracedecay_bin = post_update_binary(installed)?;
     let mut command = std::process::Command::new(&tracedecay_bin);
     command.arg("post-update");
     if no_heal {
@@ -211,6 +242,19 @@ fn run_post_update_subcommand(no_heal: bool) -> tracedecay::errors::Result<()> {
     })
 }
 
+/// Marks `running` as fully installed in the version markers, returning
+/// whether anything changed. Run at the end of a successful `post-update` so
+/// the next ordinary command's startup maintenance does not re-run the
+/// plugin refresh (silent reinstall) that `post-update` just performed.
+pub(crate) fn mark_running_version_installed(config: &mut UserConfig, running: &str) -> bool {
+    if config.previous_version == running && config.last_installed_version == running {
+        return false;
+    }
+    config.previous_version = running.to_string();
+    config.last_installed_version = running.to_string();
+    true
+}
+
 pub(crate) async fn run_post_update_tasks(no_heal: bool) -> tracedecay::errors::Result<()> {
     refresh_generated_plugins()?;
     if let Err(error) = refresh_daemon_service_after_update() {
@@ -221,5 +265,210 @@ pub(crate) async fn run_post_update_tasks(no_heal: bool) -> tracedecay::errors::
     } else {
         tracedecay::doctor::heal::run_post_update_health_pass().await;
     }
+
+    let mut config = UserConfig::load();
+    if mark_running_version_installed(&mut config, env!("CARGO_PKG_VERSION")) {
+        config.save();
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::path::{Path, PathBuf};
+
+    use super::{post_update_binary, run_update_steps, RefreshPolicy};
+    use tracedecay::upgrade::UpgradeOutcome;
+
+    fn config_err(message: &str) -> tracedecay::errors::TraceDecayError {
+        tracedecay::errors::TraceDecayError::Config {
+            message: message.to_string(),
+        }
+    }
+
+    /// Closure factory for the upgrade step: records `label`, returns `result`.
+    fn record_upgrade<'a>(
+        calls: &'a RefCell<Vec<&'static str>>,
+        label: &'static str,
+        result: tracedecay::errors::Result<UpgradeOutcome>,
+    ) -> impl FnOnce() -> tracedecay::errors::Result<UpgradeOutcome> + 'a {
+        move || {
+            calls.borrow_mut().push(label);
+            result
+        }
+    }
+
+    /// Closure factory for the post-update step: records `label` and the
+    /// binary path it was handed, returns `result`.
+    fn record_post_update<'a>(
+        calls: &'a RefCell<Vec<&'static str>>,
+        label: &'static str,
+        seen_binary: &'a RefCell<Option<Option<PathBuf>>>,
+        result: tracedecay::errors::Result<()>,
+    ) -> impl FnOnce(Option<&Path>) -> tracedecay::errors::Result<()> + 'a {
+        move |binary| {
+            calls.borrow_mut().push(label);
+            *seen_binary.borrow_mut() = Some(binary.map(Path::to_path_buf));
+            result
+        }
+    }
+
+    #[test]
+    fn update_policy_runs_post_update_after_upgrade() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+
+        run_update_steps(
+            RefreshPolicy::Always,
+            record_upgrade(&calls, "upgrade", Ok(UpgradeOutcome::AlreadyCurrent)),
+            record_post_update(&calls, "post-update", &seen_binary, Ok(())),
+        )
+        .expect("update steps should succeed");
+
+        assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+        // Nothing was installed, so no installed-binary path to prefer.
+        assert_eq!(seen_binary.into_inner(), Some(None));
+    }
+
+    #[test]
+    fn update_policy_stops_after_upgrade_failure() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+
+        let result = run_update_steps(
+            RefreshPolicy::Always,
+            record_upgrade(&calls, "upgrade", Err(config_err("upgrade failed"))),
+            record_post_update(&calls, "post-update", &seen_binary, Ok(())),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls.into_inner(), vec!["upgrade"]);
+    }
+
+    #[test]
+    fn update_policy_treats_post_update_failure_as_fatal() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+
+        let result = run_update_steps(
+            RefreshPolicy::Always,
+            record_upgrade(&calls, "upgrade", Ok(UpgradeOutcome::AlreadyCurrent)),
+            record_post_update(
+                &calls,
+                "post-update",
+                &seen_binary,
+                Err(config_err("plugin refresh failed")),
+            ),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+    }
+
+    #[test]
+    fn upgrade_policy_forwards_installed_binary_to_post_update() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+        let installed = PathBuf::from("/opt/homebrew/bin/tracedecay");
+
+        run_update_steps(
+            RefreshPolicy::AfterInstall,
+            record_upgrade(
+                &calls,
+                "upgrade",
+                Ok(UpgradeOutcome::Installed {
+                    binary: Some(installed.clone()),
+                }),
+            ),
+            record_post_update(&calls, "post-update", &seen_binary, Ok(())),
+        )
+        .expect("upgrade steps should succeed");
+
+        assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+        // The refresh must re-exec the binary the upgrade just installed,
+        // never a re-resolved (possibly stale) one.
+        assert_eq!(seen_binary.into_inner(), Some(Some(installed)));
+    }
+
+    #[test]
+    fn upgrade_policy_skips_post_update_when_already_current() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+
+        run_update_steps(
+            RefreshPolicy::AfterInstall,
+            record_upgrade(&calls, "upgrade", Ok(UpgradeOutcome::AlreadyCurrent)),
+            record_post_update(&calls, "post-update", &seen_binary, Ok(())),
+        )
+        .expect("an up-to-date upgrade should stay a successful no-op");
+
+        assert_eq!(calls.into_inner(), vec!["upgrade"]);
+        assert_eq!(seen_binary.into_inner(), None);
+    }
+
+    #[test]
+    fn upgrade_policy_tolerates_post_update_failure() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+
+        let result = run_update_steps(
+            RefreshPolicy::AfterInstall,
+            record_upgrade(
+                &calls,
+                "upgrade",
+                Ok(UpgradeOutcome::Installed { binary: None }),
+            ),
+            record_post_update(
+                &calls,
+                "post-update",
+                &seen_binary,
+                Err(config_err("plugin refresh failed")),
+            ),
+        );
+
+        // The binary upgrade itself succeeded — a refresh failure only warns.
+        assert!(result.is_ok());
+        assert_eq!(calls.into_inner(), vec!["upgrade", "post-update"]);
+    }
+
+    #[test]
+    fn upgrade_policy_stops_after_upgrade_failure() {
+        let calls = RefCell::new(Vec::new());
+        let seen_binary = RefCell::new(None);
+
+        let result = run_update_steps(
+            RefreshPolicy::AfterInstall,
+            record_upgrade(&calls, "upgrade", Err(config_err("upgrade failed"))),
+            record_post_update(&calls, "post-update", &seen_binary, Ok(())),
+        );
+
+        assert!(result.is_err());
+        assert_eq!(calls.into_inner(), vec!["upgrade"]);
+    }
+
+    #[test]
+    fn post_update_binary_prefers_the_freshly_installed_path() {
+        let temp = tempfile::tempdir().expect("tempdir should exist");
+        let installed = temp.path().join("tracedecay");
+        std::fs::write(&installed, b"new-binary").expect("binary should be writable");
+
+        let resolved = post_update_binary(Some(&installed)).expect("installed path should resolve");
+
+        assert_eq!(resolved, installed.to_string_lossy());
+    }
+
+    #[test]
+    fn post_update_binary_ignores_a_missing_installed_path() {
+        let temp = tempfile::tempdir().expect("tempdir should exist");
+        let missing = temp.path().join("does-not-exist/tracedecay");
+
+        // A dangling path (e.g. brew cleaned the keg) must fall back to the
+        // normal resolution instead of re-execing a nonexistent file.
+        let resolved = post_update_binary(Some(&missing));
+
+        if let Ok(resolved) = resolved {
+            assert_ne!(resolved, missing.to_string_lossy());
+        }
+    }
 }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -236,6 +236,16 @@ fn replace_default(new_exe: &Path) -> Result<()> {
     })
 }
 
+/// Outcome of an upgrade attempt that completed without error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpgradeOutcome {
+    /// A new binary was installed (or a delegated package manager reported a
+    /// successful upgrade). Post-install refresh work is warranted.
+    Installed,
+    /// Already on the latest version — the binary was not replaced.
+    AlreadyUpToDate,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UpgradeStatus<'a> {
     AlreadyCurrent,
@@ -344,13 +354,13 @@ fn run_versioned_upgrade(
     is_beta: bool,
     method: &InstallMethod,
     source: UpgradeSource,
-) -> Result<String> {
+) -> Result<UpgradeOutcome> {
     eprintln!("Checking {}...", source.check_label());
     let latest = latest_upgrade_version(source, is_beta)?;
     let latest = match classify_upgrade(current, &latest) {
         UpgradeStatus::AlreadyCurrent => {
             eprintln!("\x1b[32m✔\x1b[0m Already up to date (v{current}).");
-            return Ok(current.to_string());
+            return Ok(UpgradeOutcome::AlreadyUpToDate);
         }
         UpgradeStatus::UpgradeAvailable(latest) => latest,
     };
@@ -362,7 +372,7 @@ fn run_versioned_upgrade(
     install_upgrade_version(source, latest, is_beta, method)?;
     record_previous_version();
     eprintln!("\x1b[32m✔\x1b[0m Successfully upgraded to v{latest}!");
-    Ok(latest.to_string())
+    Ok(UpgradeOutcome::Installed)
 }
 
 /// Atomically replace a binary at `target` by copying `src` to a temp file
@@ -690,7 +700,7 @@ fn brew_upgrade_command() -> (&'static str, [&'static str; 2]) {
     ("brew", ["upgrade", "tracedecay"])
 }
 
-fn run_brew_upgrade(current: &str) -> Result<String> {
+fn run_brew_upgrade() -> Result<UpgradeOutcome> {
     eprintln!("Updating Homebrew formula cache...");
     let update_ok = std::process::Command::new("brew")
         .args(["update", "--quiet"])
@@ -713,7 +723,10 @@ fn run_brew_upgrade(current: &str) -> Result<String> {
 
     if status.success() {
         record_previous_version();
-        Ok(current.to_string())
+        // Homebrew doesn't tell us whether it actually installed a new
+        // version; treat a successful delegation as an install so the
+        // post-upgrade refresh chain keeps generated plugins in sync.
+        Ok(UpgradeOutcome::Installed)
     } else {
         Err(TraceDecayError::Config {
             message: format!("Homebrew upgrade failed with status: {status}"),
@@ -723,8 +736,8 @@ fn run_brew_upgrade(current: &str) -> Result<String> {
 
 /// Check for a newer version and perform the upgrade if one is available.
 ///
-/// Returns the new version string on success.
-pub fn run_upgrade() -> Result<String> {
+/// Returns whether a new binary was actually installed.
+pub fn run_upgrade() -> Result<UpgradeOutcome> {
     let current = env!("CARGO_PKG_VERSION");
     let is_beta = cloud::is_beta();
     let channel = if is_beta { "beta" } else { "stable" };
@@ -739,7 +752,7 @@ pub fn run_upgrade() -> Result<String> {
     eprintln!("Current version: v{current} ({channel} channel{method_suffix})");
 
     if matches!(method, InstallMethod::Brew) {
-        return run_brew_upgrade(current);
+        return run_brew_upgrade();
     }
 
     match upgrade_source_for(&method) {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -6,7 +6,7 @@
 //! Beta and stable are separate channels — a beta build only sees beta
 //! releases and vice versa.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::cloud::{self, InstallMethod};
 use crate::errors::{Result, TraceDecayError};
@@ -201,8 +201,13 @@ fn extract_zip(data: &[u8], bin_names: &[&str], dest: &Path) -> Result<()> {
 
 /// Replaces the running binary with `new_exe`, dispatching to the
 /// appropriate strategy for the detected install method. Cleans up the
-/// temp file afterwards regardless of outcome.
-fn replace_binary(new_exe: &Path, method: &InstallMethod, new_version: &str) -> Result<()> {
+/// temp file afterwards regardless of outcome. Returns the path the new
+/// binary was installed at, when known.
+fn replace_binary(
+    new_exe: &Path,
+    method: &InstallMethod,
+    new_version: &str,
+) -> Result<Option<PathBuf>> {
     let result = match method {
         InstallMethod::Brew => replace_for_brew(new_exe, new_version),
         InstallMethod::Scoop => replace_for_scoop(new_exe, new_version),
@@ -215,14 +220,19 @@ fn replace_binary(new_exe: &Path, method: &InstallMethod, new_version: &str) -> 
 /// Default replacement using `self_replace`. Falls back to a direct copy
 /// when the running binary is behind a symlink (avoids ENOENT caused by
 /// `self_replace` resolving relative symlink targets from CWD).
-fn replace_default(new_exe: &Path) -> Result<()> {
+/// Returns the path the new binary was written to, when known.
+fn replace_default(new_exe: &Path) -> Result<Option<PathBuf>> {
+    // Capture the exe path before the swap: on Linux the rename makes
+    // `/proc/self/exe` read `… (deleted)` afterwards.
+    let exe = std::env::current_exe().ok();
+
     #[cfg(unix)]
     {
-        let exe = std::env::current_exe().ok();
         let canonical = exe.as_ref().and_then(|e| e.canonicalize().ok());
-        if let (Some(exe), Some(ref canonical)) = (&exe, canonical) {
+        if let (Some(exe), Some(canonical)) = (&exe, canonical) {
             if exe.as_path() != canonical.as_path() {
-                return install_binary(new_exe, canonical);
+                install_binary(new_exe, &canonical)?;
+                return Ok(Some(canonical));
             }
         }
     }
@@ -233,17 +243,28 @@ fn replace_default(new_exe: &Path) -> Result<()> {
              The old version is still in place.\n  \
              To upgrade manually: https://github.com/{GITHUB_REPO}/releases/latest"
         ),
-    })
+    })?;
+    Ok(exe)
 }
 
 /// Outcome of an upgrade attempt that completed without error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Mirrors the pre-install classification `UpgradeStatus`:
+/// `UpgradeStatus::AlreadyCurrent` maps to `UpgradeOutcome::AlreadyCurrent`,
+/// `UpgradeStatus::UpgradeAvailable` ends in `UpgradeOutcome::Installed`.
+#[derive(Debug)]
 pub enum UpgradeOutcome {
     /// A new binary was installed (or a delegated package manager reported a
     /// successful upgrade). Post-install refresh work is warranted.
-    Installed,
+    Installed {
+        /// Where the freshly installed binary lives, when known. Callers
+        /// re-execing `post-update` must prefer this over re-resolving the
+        /// binary: `which_tracedecay()`'s current-exe-first order can point
+        /// at the OLD binary (e.g. a stale Homebrew keg) after an upgrade.
+        binary: Option<PathBuf>,
+    },
     /// Already on the latest version — the binary was not replaced.
-    AlreadyUpToDate,
+    AlreadyCurrent,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -339,9 +360,14 @@ fn install_upgrade_version(
     latest: &str,
     is_beta: bool,
     method: &InstallMethod,
-) -> Result<()> {
+) -> Result<Option<PathBuf>> {
     match source {
-        UpgradeSource::CratesIo => perform_cargo_upgrade(latest),
+        UpgradeSource::CratesIo => {
+            perform_cargo_upgrade(latest)?;
+            // Cargo replaces the binary in `$CARGO_HOME/bin` in place, so the
+            // PATH lookup in `which_tracedecay()` finds the new binary.
+            Ok(None)
+        }
         UpgradeSource::GitHubRelease => {
             let asset_url = preflight_asset_check(latest, is_beta)?;
             perform_upgrade(latest, &asset_url, method)
@@ -360,7 +386,7 @@ fn run_versioned_upgrade(
     let latest = match classify_upgrade(current, &latest) {
         UpgradeStatus::AlreadyCurrent => {
             eprintln!("\x1b[32m✔\x1b[0m Already up to date (v{current}).");
-            return Ok(UpgradeOutcome::AlreadyUpToDate);
+            return Ok(UpgradeOutcome::AlreadyCurrent);
         }
         UpgradeStatus::UpgradeAvailable(latest) => latest,
     };
@@ -369,10 +395,10 @@ fn run_versioned_upgrade(
         "Upgrading v{current} → v{latest}{}...",
         source.upgrade_suffix()
     );
-    install_upgrade_version(source, latest, is_beta, method)?;
+    let binary = install_upgrade_version(source, latest, is_beta, method)?;
     record_previous_version();
     eprintln!("\x1b[32m✔\x1b[0m Successfully upgraded to v{latest}!");
-    Ok(UpgradeOutcome::Installed)
+    Ok(UpgradeOutcome::Installed { binary })
 }
 
 /// Atomically replace a binary at `target` by copying `src` to a temp file
@@ -442,8 +468,10 @@ fn warn_best_effort(step: &str, error: &TraceDecayError) {
 
 /// Replace the binary inside the Homebrew Cellar, then rename the version
 /// directory and update the symlink so that `brew` reports the new version.
+/// Returns the stable `<prefix>/bin` symlink path when one exists, so
+/// downstream consumers never pin the keg-versioned path.
 #[cfg(unix)]
-fn replace_for_brew(new_exe: &Path, new_version: &str) -> Result<()> {
+fn replace_for_brew(new_exe: &Path, new_version: &str) -> Result<Option<PathBuf>> {
     let exe = std::env::current_exe().map_err(io_err("cannot determine current exe"))?;
     let canonical = exe
         .canonicalize()
@@ -478,6 +506,9 @@ fn replace_for_brew(new_exe: &Path, new_version: &str) -> Result<()> {
 
     // Step 1 (critical): replace the binary atomically.
     install_binary(new_exe, &canonical)?;
+    // The keg-versioned path is valid until the version-dir rename below;
+    // prefer the stable `<prefix>/bin` symlink when Homebrew manages one.
+    let mut installed_at = canonical.clone();
 
     // Steps 2-4 update Cellar metadata so `brew` sees the correct version.
     // These are best-effort — if they fail the binary itself is fine.
@@ -487,14 +518,17 @@ fn replace_for_brew(new_exe: &Path, new_version: &str) -> Result<()> {
         // Step 2: rename the version directory (e.g. 4.0.3 → 4.0.4).
         match std::fs::rename(version_dir, &new_version_dir) {
             Ok(()) => {
+                installed_at = new_version_dir.join("bin").join(bin_name);
+
                 // Step 3: update the symlink at <prefix>/bin/<binary>.
                 let symlink_path = prefix.join("bin").join(bin_name);
                 if let Ok(meta) = std::fs::symlink_metadata(&symlink_path) {
                     if meta.file_type().is_symlink() {
-                        if let Err(error) =
-                            retarget_homebrew_symlink(&symlink_path, &old_version, new_version)
-                        {
-                            warn_best_effort("could not update Homebrew symlink", &error);
+                        match retarget_homebrew_symlink(&symlink_path, &old_version, new_version) {
+                            Ok(()) => installed_at = symlink_path,
+                            Err(error) => {
+                                warn_best_effort("could not update Homebrew symlink", &error);
+                            }
                         }
                     }
                 }
@@ -518,11 +552,11 @@ fn replace_for_brew(new_exe: &Path, new_version: &str) -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(Some(installed_at))
 }
 
 #[cfg(not(unix))]
-fn replace_for_brew(new_exe: &Path, _new_version: &str) -> Result<()> {
+fn replace_for_brew(new_exe: &Path, _new_version: &str) -> Result<Option<PathBuf>> {
     replace_default(new_exe)
 }
 
@@ -532,7 +566,8 @@ fn replace_for_brew(new_exe: &Path, _new_version: &str) -> Result<()> {
 /// then update Scoop's version directory and junction so that
 /// `scoop status` reports the new version.
 #[cfg(windows)]
-fn replace_for_scoop(new_exe: &Path, new_version: &str) -> Result<()> {
+fn replace_for_scoop(new_exe: &Path, new_version: &str) -> Result<Option<PathBuf>> {
+    let exe = std::env::current_exe().ok();
     self_replace::self_replace(new_exe).map_err(|e| TraceDecayError::Config {
         message: format!(
             "binary replacement failed: {e}\n  \
@@ -544,7 +579,7 @@ fn replace_for_scoop(new_exe: &Path, new_version: &str) -> Result<()> {
     // Best-effort: update Scoop metadata for `scoop status` compatibility.
     update_scoop_metadata(new_version);
 
-    Ok(())
+    Ok(exe)
 }
 
 #[cfg(windows)]
@@ -637,7 +672,7 @@ fn find_scoop_version_dir(path: &Path) -> Option<std::path::PathBuf> {
 }
 
 #[cfg(not(windows))]
-fn replace_for_scoop(new_exe: &Path, _new_version: &str) -> Result<()> {
+fn replace_for_scoop(new_exe: &Path, _new_version: &str) -> Result<Option<PathBuf>> {
     replace_default(new_exe)
 }
 
@@ -675,7 +710,12 @@ fn record_previous_version() {
     }
 }
 
-fn perform_upgrade(version: &str, asset_url: &str, method: &InstallMethod) -> Result<()> {
+/// Returns the path the new binary was installed at, when known.
+fn perform_upgrade(
+    version: &str,
+    asset_url: &str,
+    method: &InstallMethod,
+) -> Result<Option<PathBuf>> {
     let bin_names: &[&str] = if cfg!(windows) {
         &["tracedecay.exe"]
     } else {
@@ -690,17 +730,61 @@ fn perform_upgrade(version: &str, asset_url: &str, method: &InstallMethod) -> Re
         _ => "",
     };
     eprint!("  Replacing binary{label}...");
-    replace_binary(&tmp, method, version)?;
+    let installed_at = replace_binary(&tmp, method, version)?;
     eprintln!(" Done");
 
-    Ok(())
+    Ok(installed_at)
 }
 
 fn brew_upgrade_command() -> (&'static str, [&'static str; 2]) {
     ("brew", ["upgrade", "tracedecay"])
 }
 
+/// The stable Homebrew-managed binary path: the opt symlink reported by
+/// `brew --prefix tracedecay`, which survives keg-version bumps and cleanup
+/// (unlike the keg-versioned Cellar path the running process resolves to).
+fn brew_linked_binary() -> Option<PathBuf> {
+    let output = std::process::Command::new("brew")
+        .args(["--prefix", "tracedecay"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let prefix = String::from_utf8(output.stdout).ok()?;
+    let binary = Path::new(prefix.trim()).join("bin").join("tracedecay");
+    binary.exists().then_some(binary)
+}
+
+/// Extracts the version from `tracedecay --version` output
+/// (e.g. `tracedecay 5.0.1` → `5.0.1`).
+fn parse_version_output(output: &str) -> Option<String> {
+    let version = output.split_whitespace().last()?;
+    Some(version.trim_start_matches('v').to_string())
+}
+
+/// Asks the binary at `path` for its version. `None` when it cannot be run
+/// or its output is unrecognizable.
+fn installed_binary_version(path: &Path) -> Option<String> {
+    let output = std::process::Command::new(path)
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_version_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Whether a delegated `brew upgrade` was a no-op: the linked binary still
+/// reports the version we are already running. `None` (undetectable) is
+/// treated as a real install so the refresh chain never silently skips.
+fn brew_upgrade_was_noop(current: &str, installed_version: Option<&str>) -> bool {
+    installed_version == Some(current)
+}
+
 fn run_brew_upgrade() -> Result<UpgradeOutcome> {
+    let current = env!("CARGO_PKG_VERSION");
     eprintln!("Updating Homebrew formula cache...");
     let update_ok = std::process::Command::new("brew")
         .args(["update", "--quiet"])
@@ -721,17 +805,25 @@ fn run_brew_upgrade() -> Result<UpgradeOutcome> {
         .status()
         .map_err(io_err("failed to run Homebrew upgrade"))?;
 
-    if status.success() {
-        record_previous_version();
-        // Homebrew doesn't tell us whether it actually installed a new
-        // version; treat a successful delegation as an install so the
-        // post-upgrade refresh chain keeps generated plugins in sync.
-        Ok(UpgradeOutcome::Installed)
-    } else {
-        Err(TraceDecayError::Config {
+    if !status.success() {
+        return Err(TraceDecayError::Config {
             message: format!("Homebrew upgrade failed with status: {status}"),
-        })
+        });
     }
+
+    // `brew upgrade` exits 0 even when the formula was already current, so
+    // ask the freshly linked binary for its version to tell the outcomes
+    // apart. When undetectable, assume an install so the refresh chain
+    // keeps generated plugins in sync.
+    let binary = brew_linked_binary();
+    let installed_version = binary.as_deref().and_then(installed_binary_version);
+    if brew_upgrade_was_noop(current, installed_version.as_deref()) {
+        eprintln!("\x1b[32m✔\x1b[0m Already up to date (v{current}).");
+        return Ok(UpgradeOutcome::AlreadyCurrent);
+    }
+
+    record_previous_version();
+    Ok(UpgradeOutcome::Installed { binary })
 }
 
 /// Check for a newer version and perform the upgrade if one is available.
@@ -815,7 +907,9 @@ pub fn switch_channel(target_channel: &str) -> Result<String> {
 
     let asset_url = preflight_asset_check(&latest, target_is_beta)?;
 
-    perform_upgrade(&latest, &asset_url, &method)?;
+    // Channel switches do not yet run the post-update refresh chain, so the
+    // installed path is unused here (tracked as a follow-up on PR #193).
+    let _ = perform_upgrade(&latest, &asset_url, &method)?;
     record_previous_version();
     eprintln!("\x1b[32m✔\x1b[0m Switched to {target_channel} channel: v{latest}");
     Ok(latest)
@@ -880,6 +974,33 @@ mod tests {
 
         assert_eq!(program, "brew");
         assert_eq!(args, ["upgrade", "tracedecay"]);
+    }
+
+    #[test]
+    fn parse_version_output_extracts_trailing_version() {
+        assert_eq!(
+            parse_version_output("tracedecay 5.0.1\n").as_deref(),
+            Some("5.0.1")
+        );
+        assert_eq!(
+            parse_version_output("tracedecay v5.0.1").as_deref(),
+            Some("5.0.1")
+        );
+        assert_eq!(parse_version_output(""), None);
+    }
+
+    #[test]
+    fn brew_upgrade_is_a_noop_when_linked_binary_reports_running_version() {
+        // A no-op `brew upgrade` must map to `AlreadyCurrent` so it never
+        // triggers the post-upgrade refresh chain (daemon restart included).
+        assert!(brew_upgrade_was_noop("5.0.1", Some("5.0.1")));
+    }
+
+    #[test]
+    fn brew_upgrade_with_new_or_unknown_version_counts_as_install() {
+        assert!(!brew_upgrade_was_noop("5.0.1", Some("5.0.2")));
+        // Undetectable → assume install so the refresh never silently skips.
+        assert!(!brew_upgrade_was_noop("5.0.1", None));
     }
 
     #[test]

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -6,7 +6,10 @@
 //! Beta and stable are separate channels — a beta build only sees beta
 //! releases and vice versa.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
 
 use crate::cloud::{self, InstallMethod};
 use crate::errors::{Result, TraceDecayError};
@@ -763,17 +766,35 @@ fn parse_version_output(output: &str) -> Option<String> {
     Some(version.trim_start_matches('v').to_string())
 }
 
-/// Asks the binary at `path` for its version. `None` when it cannot be run
-/// or its output is unrecognizable.
+/// Asks the binary at `path` for its version, killing it after a short
+/// deadline so a wedged binary cannot hang the upgrade. `None` when it
+/// cannot be run, times out, or its output is unrecognizable.
 fn installed_binary_version(path: &Path) -> Option<String> {
-    let output = std::process::Command::new(path)
+    let mut child = std::process::Command::new(path)
         .arg("--version")
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .ok()?;
-    if !output.status.success() {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(_) => return None,
+        }
+    };
+    if !status.success() {
         return None;
     }
-    parse_version_output(&String::from_utf8_lossy(&output.stdout))
+    let mut output = String::new();
+    child.stdout.take()?.read_to_string(&mut output).ok()?;
+    parse_version_output(&output)
 }
 
 /// Whether a delegated `brew upgrade` was a no-op: the linked binary still

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -187,6 +187,21 @@ impl UserConfig {
     pub fn exists() -> bool {
         config_path().is_some_and(|p| p.exists())
     }
+
+    /// Marks `running` as fully installed by advancing both version markers,
+    /// returning whether anything changed. This is the single home of the
+    /// marker-advancement protocol: only a completed full agent install pass
+    /// (the startup silent reinstall, or `post-update`'s reinstall step) may
+    /// record its version here, so the next startup's maintenance knows the
+    /// work does not need repeating.
+    pub fn mark_version_installed(&mut self, running: &str) -> bool {
+        if self.previous_version == running && self.last_installed_version == running {
+            return false;
+        }
+        self.previous_version = running.to_string();
+        self.last_installed_version = running.to_string();
+        true
+    }
 }
 
 /// Parse a human-readable duration string like "15s" or "1m" into a Duration.


### PR DESCRIPTION
## Summary
- `tracedecay upgrade` now runs the same post-install refresh chain as `tracedecay update`: after a successful install it re-execs the **newly installed** binary's `post-update` subcommand, so generated agent plugin artifacts (Codex plugin cache, Cursor plugin, Hermes profiles, Kiro agent, ...), the daemon service, and the post-update health pass all run on the new version. A plain `upgrade` no longer leaves stale plugins behind.
- `run_upgrade()` now returns an `UpgradeOutcome` enum (`Installed { binary }` / `AlreadyCurrent`). When the upgrade concludes "already up to date", the refresh chain is **not** run (a no-op stays a no-op) and a hint points at `tracedecay update` for refreshing plugins anyway.
- The re-exec runs the binary the upgrade actually installed, not `which_tracedecay()`'s current-exe-first resolution (which can point at the old binary right after a swap). `Installed` carries the installed path: the Homebrew delegation resolves the stable `brew --prefix tracedecay` opt symlink rather than a keg-versioned path; self-replace installs report the path they just wrote; when the path is unknown the usual PATH resolution is the fallback.
- No-op `brew upgrade` runs are detected by asking the linked binary for its version: when it still reports the running version the outcome is `AlreadyCurrent`, so an already-current Homebrew install no longer rewrites plugin files and restarts the daemon on every `tracedecay upgrade`. The version probe kills the binary after a 5 s deadline so a wedged binary cannot hang the upgrade; an undetectable version fails open to `Installed`.
- `post-update` now finishes with the **full tracked-agent `install()` pass** (the same one the startup silent reinstall runs), not just the generated-artifact refresh — config-managed integrations (claude, copilot, ...) pick up new tool permissions, hooks, and MCP config as part of the upgrade itself. Only after that pass succeeds does `post-update` advance the `previous_version` / `last_installed_version` markers (via the single `UserConfig::mark_version_installed` protocol method), so the next ordinary command's startup maintenance does not duplicate work it already did; if the install pass fails, the markers stay put and the silent reinstall retries on the next command. This also covers the external-`brew upgrade`-then-`tracedecay update` path.
- One policy-parameterized `run_install_then_refresh` seam (`RefreshPolicy::Always` for `update`, `AfterInstall` for `upgrade`) replaces the parallel step-function pair; refresh failure after a successful install warns and exits 0 (the binary upgrade itself succeeded), and the retry hint uses the installed binary's path when `tracedecay` may be off PATH.
- `upgrade` gains `--no-heal` (forwarded to `post-update`), for parity with `update`; CLI help now states the actual `upgrade`/`update` distinction (install then refresh-on-install vs. refresh regardless).
- `Upgrade` was added to both startup-maintenance skip lists: it now manages plugin refresh itself, so the implicit silent-reinstall prelude (which would rewrite configs with the OLD binary right before installing the new one) is skipped, matching `Update`/`PostUpdate`.

## Follow-up (not in this PR)
- `tracedecay channel <stable|beta>` also installs a new binary but does not yet run the post-update refresh chain, and `Commands::Channel` is not on the startup-maintenance skip lists. The same rationale as this PR applies; channel switches should adopt `UpgradeOutcome` + `run_install_then_refresh` in a follow-up.
- Brew no-op detection trusts the `brew --prefix` linked binary to represent the running install. If the linked binary ever reports an *older* version than the running one (formula lag with dual installs), the flow classifies it as `Installed` and re-execs the older binary for `post-update`. All known paths to that state are contrived (a Cellar self-replace retargets the symlink, so linked == running); noted for completeness.
- `upgrade.rs` (~1.5k lines) wants its Homebrew/Scoop strategies extracted into `upgrade/brew.rs` / `upgrade/scoop.rs` as a decomposition follow-up.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo check --all-targets`
- [x] `cargo test --bin tracedecay` (83 passed) — parse tests (`upgrade --no-heal`, per-subcommand help distinction), step-seam tests in `update_cmd` (installed → post-update runs on the installed binary path; already-current → skipped; refresh failure tolerated for `upgrade`, fatal for `update`; upgrade failure stops the chain; installed-path re-exec preference with missing-path fallback asserted in both PATH environments), and marker tests (post-update full reinstall + marker advancement → no duplicate startup reinstall; minor bump without post-update → reinstall; patch bump → marker only)
- [x] `cargo test --test cli_non_interactive_test` (32 passed)
- [x] `cargo test --test update_health_pass_test` (4 passed)
- [x] `cargo test --lib upgrade` (35 passed) — includes brew no-op classification and `--version` output parsing