### PR TITLE
fix: address review comments on windows test perf prs

### DIFF
--- a/tests/storage_suite/db_query_test.rs
+++ b/tests/storage_suite/db_query_test.rs
@@ -100,7 +100,7 @@ async fn test_empty_db_template_cache_seeds_without_migration() {
     let db_path = dir.path().join("test.db");
     support::seed_latest_graph_db(&db_path).await;
 
-    let template_path = support::template_db_path("graph-empty");
+    let template_path = support::template_db_path("graph-empty", &[]);
     assert!(template_path.exists(), "template should be cached on disk");
     assert!(
         template_path.metadata().unwrap().len() > 0,

--- a/tests/storage_suite/migration_test.rs
+++ b/tests/storage_suite/migration_test.rs
@@ -67,30 +67,36 @@ async fn create_schema_db() -> (Connection, LibsqlDatabase, TempDir) {
 /// `memory_code_areas` tables, `user_version = 10`) into a fresh temp dir
 /// and opens it raw.
 async fn create_v10_db() -> (Connection, LibsqlDatabase, TempDir) {
-    let template = support::ensure_template_db("graph-v10-legacy", |path| async move {
-        let db = Builder::new_local(&path)
-            .build()
-            .await
-            .expect("failed to build v10 template database");
-        let conn = db.connect().expect("failed to connect to v10 template");
-        conn.execute_batch(
-            "PRAGMA auto_vacuum = INCREMENTAL;
+    // The v10 fixture schema is defined by SQL in this file, so fingerprint
+    // the whole file: editing it must invalidate the cached template.
+    let template = support::ensure_template_db(
+        "graph-v10-legacy",
+        include_bytes!("migration_test.rs"),
+        |path| async move {
+            let db = Builder::new_local(&path)
+                .build()
+                .await
+                .expect("failed to build v10 template database");
+            let conn = db.connect().expect("failed to connect to v10 template");
+            conn.execute_batch(
+                "PRAGMA auto_vacuum = INCREMENTAL;
              PRAGMA journal_mode = WAL;
              PRAGMA foreign_keys = ON;
              PRAGMA busy_timeout = 5000;",
-        )
-        .await
-        .expect("failed to apply v10 template pragmas");
-        create_v10_schema_for_v11_tests(&conn).await;
-        // wal_checkpoint returns a result row, so it must go through query().
-        let mut rows = conn
-            .query("PRAGMA wal_checkpoint(TRUNCATE)", ())
+            )
             .await
-            .expect("failed to checkpoint v10 template");
-        rows.next()
-            .await
-            .expect("failed to read v10 checkpoint result");
-    })
+            .expect("failed to apply v10 template pragmas");
+            create_v10_schema_for_v11_tests(&conn).await;
+            // wal_checkpoint returns a result row, so it must go through query().
+            let mut rows = conn
+                .query("PRAGMA wal_checkpoint(TRUNCATE)", ())
+                .await
+                .expect("failed to checkpoint v10 template");
+            rows.next()
+                .await
+                .expect("failed to read v10 checkpoint result");
+        },
+    )
     .await;
     let dir = TempDir::new().expect("failed to create temp dir");
     let db_path = dir.path().join("test.db");

--- a/tests/storage_suite/support.rs
+++ b/tests/storage_suite/support.rs
@@ -20,9 +20,12 @@ use fs2::FileExt;
 pub static HOME_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// FNV-1a hash of everything that can change a template's contents: the
-/// schema-defining sources, the template name, and the unsafe-fast env
-/// toggle (it changes journal/synchronous file properties).
-fn template_hash(name: &str) -> u64 {
+/// schema-defining sources, the template name, the unsafe-fast env toggle
+/// (it changes journal/synchronous file properties), and any
+/// builder-specific fingerprint supplied by the caller (for templates whose
+/// contents also depend on sources outside src/db, such as fixture SQL
+/// defined in a test file).
+fn template_hash(name: &str, builder_fingerprint: &[u8]) -> u64 {
     let unsafe_fast = std::env::var(tracedecay::db::SQLITE_UNSAFE_FAST_ENV).unwrap_or_default();
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in include_bytes!("../../src/db/migrations.rs")
@@ -30,6 +33,7 @@ fn template_hash(name: &str) -> u64 {
         .chain(include_bytes!("../../src/db/connection.rs"))
         .chain(name.as_bytes())
         .chain(unsafe_fast.as_bytes())
+        .chain(builder_fingerprint)
     {
         hash ^= u64::from(*byte);
         hash = hash.wrapping_mul(0x100000001b3);
@@ -37,10 +41,13 @@ fn template_hash(name: &str) -> u64 {
     hash
 }
 
-pub fn template_db_path(name: &str) -> PathBuf {
+pub fn template_db_path(name: &str, builder_fingerprint: &[u8]) -> PathBuf {
     std::env::temp_dir()
         .join("tracedecay-test-fixtures")
-        .join(format!("{name}-{:016x}.db", template_hash(name)))
+        .join(format!(
+            "{name}-{:016x}.db",
+            template_hash(name, builder_fingerprint)
+        ))
 }
 
 fn template_cache_exists(path: &Path) -> bool {
@@ -50,16 +57,22 @@ fn template_cache_exists(path: &Path) -> bool {
 /// Returns the path of the cached template database named `name`, building
 /// it first if this machine has no template for the current schema revision.
 ///
+/// `builder_fingerprint` must cover every input to `build` that lives
+/// outside `src/db` — typically `include_bytes!` of the defining test file —
+/// so that editing the fixture-building code invalidates the cached
+/// template. Pass `&[]` when `build` depends only on the production schema
+/// code that `template_hash` already covers.
+///
 /// `build` must write a fully checkpointed database (no live WAL) at the
 /// path it is given. Concurrent test processes coordinate through an
 /// exclusive file lock and an atomic rename, so at most one process pays the
 /// build cost.
-pub async fn ensure_template_db<F, Fut>(name: &str, build: F) -> PathBuf
+pub async fn ensure_template_db<F, Fut>(name: &str, builder_fingerprint: &[u8], build: F) -> PathBuf
 where
     F: FnOnce(PathBuf) -> Fut,
     Fut: Future<Output = ()>,
 {
-    let template_path = template_db_path(name);
+    let template_path = template_db_path(name, builder_fingerprint);
     if template_cache_exists(&template_path) {
         return template_path;
     }
@@ -101,7 +114,7 @@ where
 /// Seeds `dest` with an empty latest-schema graph database — the exact file
 /// `Database::initialize` would produce — without paying schema creation.
 pub async fn seed_latest_graph_db(dest: &Path) {
-    let template = ensure_template_db("graph-empty", |path| async move {
+    let template = ensure_template_db("graph-empty", &[], |path| async move {
         let (db, _) = tracedecay::db::Database::initialize(&path)
             .await
             .expect("failed to initialize template database");


### PR DESCRIPTION
## Summary

Sweep of review comments on the recently merged Windows-test-perf PRs (#183–#196). One actionable comment found:

- **PR #195** (`test: consolidate storage and migration tests into one binary`) — Codex P2 comment on `tests/storage_suite/support.rs`: the template-db cache key only hashed `src/db/migrations.rs` and `src/db/connection.rs`, but the `graph-v10-legacy` template's contents are also defined by fixture SQL in `tests/storage_suite/migration_test.rs`. On machines where `/tmp/tracedecay-test-fixtures` persists, editing that fixture SQL would keep reusing a stale cached template. Fixed by adding a `builder_fingerprint` parameter to `ensure_template_db` / `template_db_path` that is mixed into the cache-key hash; `migration_test.rs` fingerprints itself with `include_bytes!`.

All other checked PRs (#183, #184, #185, #186, #187, #188, #189, #191, #192, #194, #196) had zero review threads; the only comments were changeset-bot notices (noise).

## Verification

- `cargo nextest run --profile ci --locked -E 'binary(storage_suite)'` — 255/255 passed
- `cargo fmt --all -- --check` — clean