### PR TITLE
fix: hold mcp-suite test env locks until env guards drop

### DIFF
--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -253,9 +253,13 @@ fn test_temp_dir() -> TestTempDir {
 
 struct TestProject {
     dir: Option<TestTempDir>,
-    _env_lock: MutexGuard<'static, ()>,
     _home_guard: HomeEnvGuard,
     _global_db_guard: GlobalDbEnvGuard,
+    // Field order is load-bearing: fields drop in declaration order, so the
+    // env lock must be declared last. Releasing it before the guards restore
+    // `HOME` / the global DB override would let the next waiting test install
+    // its own env, only for these guards to clobber it.
+    _env_lock: MutexGuard<'static, ()>,
 }
 
 impl std::ops::Deref for TestProject {
@@ -273,15 +277,19 @@ impl Drop for TestProject {
 }
 
 struct TestEnv {
-    _env_lock: MutexGuard<'static, ()>,
     _home_guard: HomeEnvGuard,
     _global_db_guard: GlobalDbEnvGuard,
+    // Drop order = declaration order: the env lock must outlive the guards
+    // above so their env restores happen while the lock is still held.
+    _env_lock: MutexGuard<'static, ()>,
 }
 
 struct CrossProjectMemoryEnv {
     _dir: TestTempDir,
-    _env_lock: MutexGuard<'static, ()>,
     _storage_guard: common::TraceDecayStorageEnvGuard,
+    // Drop order = declaration order: the env lock must outlive the storage
+    // guard above so its env restore happens while the lock is still held.
+    _env_lock: MutexGuard<'static, ()>,
 }
 
 struct TestTraceDecay {


### PR DESCRIPTION
## Summary
- Follow-up to the Codex bot's P2 review comment on PR #178 ("Keep the env lock until storage guards drop", https://github.com/ScriptedAlchemy/tracedecay/pull/178#discussion_r3509666797). The `IsolatedEnv` struct it flagged was already fixed on master in 822d921, but the same drop-order hazard existed in three sibling fixtures.
- Reorders fields in `TestProject`, `TestEnv`, and `CrossProjectMemoryEnv` (`tests/mcp_suite/mcp_handler_test.rs`) so `_env_lock` is declared last. Rust drops fields in declaration order, so the lock is now released only after `HomeEnvGuard` / `GlobalDbEnvGuard` / `TraceDecayStorageEnvGuard` restore `HOME`, `TRACEDECAY_DATA_DIR`, and the global DB override — a waiting test can no longer have its freshly installed env clobbered by the previous test's guard restores.
- Adds comments marking the field order as load-bearing.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --test storage_suite branch_db_safety` (5 passed)
- [x] `cargo test --test mcp_suite mcp_handler` (264 passed)