### PR TITLE
perf: hoist pricing refresh out of gain estimates and speed up unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,10 @@ tempfile = "3"
 sha2 = "0.11"
 hex = "0.4"
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+# test-util enables tokio::test(start_paused = true) so timer-driven unit
+# tests (daemon restart-grace windows) run on virtual time instead of real
+# sleeps.
+tokio = { version = "1", features = ["full", "test-util"] }
 
 [[bench]]
 name = "large_repos"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1306,9 +1306,13 @@ pub(crate) async fn init_and_index(
 /// Convert raw tokens-saved into a USD estimate using Sonnet input pricing.
 /// Sonnet is the default agent target; output-token savings are not relevant
 /// for retrieval savings.
+///
+/// Pure table lookup: callers that want up-to-date prices must run
+/// `pricing::refresh_if_stale()` once beforehand (see [`handle_gain`]).
+/// Keeping the refresh out of this function avoids a network fetch per call
+/// (it used to fire for every history row and for every unit test process).
 pub(crate) fn estimate_dollars_saved(saved_tokens: u64) -> f64 {
     use tracedecay::accounting::pricing;
-    pricing::refresh_if_stale();
     let price = pricing::lookup("claude-sonnet-4")
         .map(|p| p.input_per_mtok)
         .unwrap_or(3.0);
@@ -1321,6 +1325,7 @@ pub async fn handle_gain(
     range: &str,
     json_output: bool,
 ) -> tracedecay::errors::Result<()> {
+    tracedecay::accounting::pricing::refresh_if_stale();
     let gdb = match tracedecay::global_db::GlobalDb::open().await {
         Some(db) => db,
         None => {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1845,8 +1845,11 @@ mod tests {
         ));
     }
 
+    // start_paused: these restart-window tests only wait on tokio timers
+    // (sleep/poll intervals); paused time auto-advances them so each test
+    // finishes in milliseconds instead of real 200-300 ms waits.
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn connect_with_restart_grace_reconnects_once_daemon_rebinds() {
         let dir = TempDir::new().expect("temp dir");
         let socket = dir.path().join("daemon.sock");
@@ -1870,7 +1873,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn connect_with_restart_grace_gives_up_with_restart_hint() {
         let dir = TempDir::new().expect("temp dir");
         let socket = dir.path().join("daemon.sock");
@@ -1950,7 +1953,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn serve_waits_out_restart_window_when_service_owns_socket() {
         let dir = TempDir::new().expect("temp dir");
         let socket = dir.path().join("daemon.sock");
@@ -1978,7 +1981,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn serve_falls_back_when_installed_service_never_rebinds() {
         let dir = TempDir::new().expect("temp dir");
         let socket = dir.path().join("daemon.sock");
@@ -1996,7 +1999,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn proxied_request_survives_daemon_restart_window() {
         let dir = TempDir::new().expect("temp dir");
         let socket = dir.path().join("daemon.sock");

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -3527,9 +3527,9 @@ mod tests {
 
     #[tokio::test]
     async fn session_column_migration_tolerates_duplicate_column_race() {
-        let dir = tempfile::tempdir().unwrap();
-        let db_path = dir.path().join("sessions.db");
-        let db = Builder::new_local(&db_path).build().await.unwrap();
+        // In-memory DB: the duplicate-column race only needs one connection,
+        // so the on-disk sqlite file adds nothing but I/O.
+        let db = Builder::new_local(":memory:").build().await.unwrap();
         let conn = db.connect().unwrap();
         conn.execute_batch(
             "CREATE TABLE sessions (

--- a/src/runtime_telemetry.rs
+++ b/src/runtime_telemetry.rs
@@ -164,6 +164,10 @@ pub fn to_text_report(snap: &RuntimeSnapshot) -> String {
 // ---------------------------------------------------------------------------
 
 fn sample_process() -> ProcessSnapshot {
+    sample_process_with_window(CPU_SAMPLE_WINDOW)
+}
+
+fn sample_process_with_window(cpu_sample_window: Duration) -> ProcessSnapshot {
     let pid = Pid::from_u32(std::process::id());
 
     // Refresh only *our own* process. The previous implementation passed
@@ -185,7 +189,7 @@ fn sample_process() -> ProcessSnapshot {
     // Two reads bracketing a sleep are required: sysinfo reports
     // `cpu_usage()` as the delta between successive refreshes.
     sys.refresh_processes_specifics(sysinfo::ProcessesToUpdate::Some(&[pid]), true, refresh);
-    std::thread::sleep(CPU_SAMPLE_WINDOW);
+    std::thread::sleep(cpu_sample_window);
     sys.refresh_processes_specifics(sysinfo::ProcessesToUpdate::Some(&[pid]), true, refresh);
 
     let proc = sys.process(pid);
@@ -376,9 +380,11 @@ mod tests {
     /// inside a stack far smaller than Windows' 1 MiB main-thread default.
     #[test]
     fn sample_process_fits_in_a_small_stack() {
+        // Zero CPU sample window: the stack-footprint guard cares about the
+        // sysinfo refresh path, not the CPU delta, so skip the 200 ms sleep.
         let handle = std::thread::Builder::new()
             .stack_size(512 * 1024)
-            .spawn(sample_process)
+            .spawn(|| sample_process_with_window(Duration::ZERO))
             .expect("spawn small-stack thread");
         let snap = handle
             .join()

--- a/src/sessions/lcm/gc.rs
+++ b/src/sessions/lcm/gc.rs
@@ -895,14 +895,12 @@ mod tests {
     async fn test_store() -> Result<TestStore, String> {
         let temp = tempfile::tempdir().map_err(|err| format!("create tempdir: {err}"))?;
         let storage_root = temp.path().to_path_buf();
-        let db_path = storage_root.join("sessions.db");
-        let db = libsql::Builder::new_local(&db_path)
-            .build()
-            .await
-            .map_err(|err| format!("build test database: {err}"))?;
-        let conn = db
-            .connect()
-            .map_err(|err| format!("connect to test database: {err}"))?;
+        // In-memory DB: every test here disables backup_before_reap, so
+        // nothing reads the sessions.db file itself — only the payload files
+        // under storage_root. Skipping the on-disk DB (and its FTS5-heavy
+        // schema I/O) keeps each test's setup cheap, which matters on the
+        // Windows CI runners where per-test sqlite file churn dominated.
+        let conn = in_memory_conn().await?;
         conn.busy_timeout(Duration::from_secs(5))
             .map_err(|err| format!("set test busy timeout: {err}"))?;
         ensure_gc_test_schema(&conn).await?;

--- a/src/sessions/lcm/schema.rs
+++ b/src/sessions/lcm/schema.rs
@@ -446,16 +446,15 @@ async fn carry_forward_legacy_messages_in_transaction(conn: &Connection) -> Resu
 #[cfg(test)]
 mod tests {
     use libsql::Builder;
-    use tempfile::TempDir;
 
     use super::*;
 
     #[tokio::test]
     async fn ensure_lcm_schema_errors_and_rolls_back_failed_legacy_carry_forward(
     ) -> Result<(), String> {
-        let tmp = TempDir::new().map_err(|err| err.to_string())?;
-        let db_path = tmp.path().join("sessions.db");
-        let db = Builder::new_local(&db_path)
+        // In-memory DB: the rollback behavior under test is purely
+        // transactional, so skip the on-disk sqlite file churn.
+        let db = Builder::new_local(":memory:")
             .build()
             .await
             .map_err(|err| err.to_string())?;


### PR DESCRIPTION
## Summary
- Root cause of >1s trivial `gain` tests: `estimate_dollars_saved` downloaded LiteLLM's 1.6MB pricing JSON on every call. The pricing refresh is now hoisted to the `handle_gain` entrypoint, so estimates no longer trigger a network fetch per call (a real `src/` behavior change, not just test code).
- LCM gc/schema/global_db test fixtures now use in-memory sqlite instead of on-disk databases.
- 5 daemon restart tests switched to paused tokio time; a 200ms telemetry sleep removed.
- Unit test count unchanged by this branch; per-test time sum dropped 25.1s → 19.2s.

## Verification
- `cargo nextest run --profile ci --locked -E 'kind(lib) or kind(bin)'`: 764 passed, 0 failed (count grew from 753 via sibling PRs landed on master).
- `cargo nextest run --profile ci --locked -E 'binary(=core_cli_suite) & test(~gain)'`: 4 passed.
- `cargo fmt --all -- --check` clean; `cargo clippy --locked` clean.