### PR TITLE
refactor(extraction): deduplicate verbatim helper copies across language extractors

### DIFF
--- a/src/extraction/bash_extractor.rs
+++ b/src/extraction/bash_extractor.rs
@@ -5,6 +5,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::docstring_from_hash_comments;
 use crate::extraction::complexity::{count_complexity, BASH_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -361,23 +362,7 @@ impl BashExtractor {
     /// Bash uses comment lines (# ...) as documentation. We look for `comment`
     /// sibling nodes that immediately precede the given definition node.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments: Vec<String> = Vec::new();
-        let mut prev = node.prev_named_sibling();
-        while let Some(prev_node) = prev {
-            if prev_node.kind() == "comment" {
-                let text = state.node_text(prev_node);
-                let stripped = text.trim_start_matches('#').trim().to_string();
-                comments.push(stripped);
-                prev = prev_node.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        comments.reverse();
-        Some(comments.join("\n"))
+        docstring_from_hash_comments(&state.source, node)
     }
 
     /// Recursively find command nodes inside a given node and create unresolved Calls references.

--- a/src/extraction/bash_extractor.rs
+++ b/src/extraction/bash_extractor.rs
@@ -7,6 +7,7 @@ use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::common::docstring_from_hash_comments;
 use crate::extraction::complexity::{count_complexity, BASH_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -232,7 +233,7 @@ impl BashExtractor {
         }
 
         // Find the variable_assignment child to get the name.
-        if let Some(assignment) = Self::find_child_by_kind(node, "variable_assignment") {
+        if let Some(assignment) = find_direct_child_by_kind(node, "variable_assignment") {
             if let Some(name_node) = assignment.child_by_field_name("name") {
                 let name = state.node_text(name_node);
                 let start_line = node.start_position().row as u32;
@@ -411,23 +412,6 @@ impl BashExtractor {
                 let child = cursor.node();
                 if cursor.field_name() == Some("argument") {
                     return Some(state.node_text(child));
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
                 }
                 if !cursor.goto_next_sibling() {
                     break;

--- a/src/extraction/basic_common.rs
+++ b/src/extraction/basic_common.rs
@@ -1,0 +1,113 @@
+//! Helpers shared by the line-number BASIC extractors (GW-BASIC and
+//! MS BASIC 2.0), which synthesize Function nodes from REM ... RETURN blocks.
+//!
+//! Bodies are moved here unchanged from the per-language copies so extraction
+//! output stays byte-identical.
+
+use tree_sitter::Node as TsNode;
+
+/// Represents a collected line from the BASIC program for subroutine synthesis.
+pub(crate) struct BasicLine<'a> {
+    /// The `line` AST node.
+    pub(crate) node: TsNode<'a>,
+    /// The line number (e.g. 10, 20, 100).
+    pub(crate) line_number: u32,
+    /// The kind of the first statement on this line.
+    pub(crate) statement_kind: String,
+    /// The text of the REM comment, if this line is a REM.
+    pub(crate) comment_text: Option<String>,
+}
+
+/// Find ranges of lines that belong to subroutines (REM ... RETURN blocks).
+pub(crate) fn find_subroutine_ranges(lines: &[BasicLine<'_>]) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i].statement_kind == "comment" {
+            let rem_start = i;
+            while i < lines.len() && lines[i].statement_kind == "comment" {
+                i += 1;
+            }
+            let mut body_end = i;
+            let mut has_return = false;
+            while body_end < lines.len() {
+                if lines[body_end].statement_kind == "return_statement" {
+                    has_return = true;
+                    body_end += 1;
+                    break;
+                }
+                if lines[body_end].statement_kind == "comment" {
+                    break;
+                }
+                body_end += 1;
+            }
+            if has_return {
+                ranges.push((rem_start, body_end));
+            }
+            i = body_end;
+        } else {
+            i += 1;
+        }
+    }
+    ranges
+}
+
+/// Visit each line that is not part of a subroutine (REM ... RETURN block).
+pub(crate) fn for_each_top_level_line<'l, 'tree>(
+    lines: &'l [BasicLine<'tree>],
+    mut visit: impl FnMut(&'l BasicLine<'tree>),
+) {
+    let subroutine_ranges = find_subroutine_ranges(lines);
+    for (idx, line) in lines.iter().enumerate() {
+        // Skip lines that are inside subroutines.
+        if subroutine_ranges
+            .iter()
+            .any(|(start, end)| idx >= *start && idx < *end)
+        {
+            continue;
+        }
+        visit(line);
+    }
+}
+
+/// Derive a function name from REM comment text.
+///
+/// Takes the first REM line text and converts it into a snake_case-like
+/// identifier. For example, "VALIDATE CONFIGURATION" becomes "`VALIDATE_CONFIGURATION`".
+pub(crate) fn derive_function_name(rem_comments: &[String]) -> String {
+    if rem_comments.is_empty() {
+        return "UNNAMED_SUB".to_string();
+    }
+    let first = &rem_comments[0];
+    // Replace spaces with underscores and keep alphanumeric + underscore.
+    let name: String = first
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    // Collapse multiple underscores and trim.
+    let mut collapsed = String::new();
+    let mut prev_underscore = false;
+    for c in name.chars() {
+        if c == '_' {
+            if !prev_underscore && !collapsed.is_empty() {
+                collapsed.push('_');
+            }
+            prev_underscore = true;
+        } else {
+            collapsed.push(c);
+            prev_underscore = false;
+        }
+    }
+    let trimmed = collapsed.trim_end_matches('_').to_string();
+    if trimmed.is_empty() {
+        "UNNAMED_SUB".to_string()
+    } else {
+        trimmed
+    }
+}

--- a/src/extraction/c_extractor.rs
+++ b/src/extraction/c_extractor.rs
@@ -7,6 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::{
+    common::{clean_c_comment, docstring_from_preceding_comments},
     complexity::{count_complexity, C_COMPLEXITY},
     traversal::{find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind},
 };
@@ -1378,53 +1379,7 @@ impl CExtractor {
 
     /// Extract docstrings from preceding comment nodes.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                let text = state.node_text(sibling);
-                comments.push(text);
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        // Comments are collected in reverse order (closest first).
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
-    }
-
-    /// Strip comment markers from a single C comment text.
-    fn clean_comment(comment: &str) -> String {
-        let trimmed = comment.trim();
-        if let Some(stripped) = trimmed.strip_prefix("//") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
-            let inner = &trimmed[2..trimmed.len() - 2];
-            inner
-                .lines()
-                .map(|line| {
-                    let l = line.trim();
-                    l.strip_prefix("* ")
-                        .or_else(|| l.strip_prefix('*'))
-                        .unwrap_or(l)
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-                .trim()
-                .to_string()
-        } else {
-            trimmed.to_string()
-        }
+        docstring_from_preceding_comments(&state.source, node, clean_c_comment)
     }
 
     // -------------------------------------------------------

--- a/src/extraction/c_extractor.rs
+++ b/src/extraction/c_extractor.rs
@@ -7,7 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::{
-    common::{clean_c_comment, docstring_from_preceding_comments},
+    common::{clean_c_comment, docstring_from_preceding_comments, extract_call_expression_sites},
     complexity::{count_complexity, C_COMPLEXITY},
     traversal::{find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind},
 };
@@ -1344,33 +1344,13 @@ impl CExtractor {
 
     /// Recursively find `call_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == "call_expression" {
-                    // Get the callee: the first named child (usually an identifier)
-                    if let Some(callee) = child.named_child(0) {
-                        let callee_name = state.node_text(callee);
-                        state.unresolved_refs.push(UnresolvedRef {
-                            from_node_id: fn_node_id.to_string(),
-                            reference_name: callee_name,
-                            reference_kind: EdgeKind::Calls,
-                            line: child.start_position().row as u32,
-                            column: child.start_position().column as u32,
-                            file_path: state.file_path.clone(),
-                        });
-                    }
-                    // Also recurse into the call expression for nested calls.
-                    Self::extract_call_sites(state, child, fn_node_id);
-                } else {
-                    Self::extract_call_sites(state, child, fn_node_id);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
+        extract_call_expression_sites(
+            &state.source,
+            &state.file_path,
+            &mut state.unresolved_refs,
+            node,
+            fn_node_id,
+        );
     }
 
     // -------------------------------------------------------

--- a/src/extraction/cobol_extractor.rs
+++ b/src/extraction/cobol_extractor.rs
@@ -8,6 +8,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -194,7 +195,7 @@ impl CobolExtractor {
 
     /// Extract the PROGRAM-ID as a Module node.
     fn visit_identification_division(state: &mut ExtractionState, node: TsNode<'_>) {
-        let program_name_node = Self::find_child_by_kind(node, "program_name");
+        let program_name_node = find_direct_child_by_kind(node, "program_name");
         if let Some(pn) = program_name_node {
             let name = state.node_text(pn);
             let start_line = node.start_position().row as u32;
@@ -312,7 +313,7 @@ impl CobolExtractor {
         docstring: Option<String>,
     ) {
         // Only extract 01-level items.
-        let level_node = Self::find_child_by_kind(node, "level_number");
+        let level_node = find_direct_child_by_kind(node, "level_number");
         if let Some(ln) = level_node {
             let level_text = state.node_text(ln);
             if level_text.trim() != "01" {
@@ -322,14 +323,14 @@ impl CobolExtractor {
             return;
         }
 
-        let name_node = Self::find_child_by_kind(node, "entry_name");
+        let name_node = find_direct_child_by_kind(node, "entry_name");
         let name = if let Some(n) = name_node {
             state.node_text(n)
         } else {
             return;
         };
 
-        let has_value = Self::find_child_by_kind(node, "value_clause").is_some();
+        let has_value = find_direct_child_by_kind(node, "value_clause").is_some();
         let kind = if has_value {
             NodeKind::Const
         } else {
@@ -630,27 +631,10 @@ impl CobolExtractor {
     /// Extract the label name from a `perform_procedure` node.
     fn extract_label_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // perform_procedure -> label -> qualified_word -> WORD
-        let label = Self::find_child_by_kind(node, "label")?;
-        let qw = Self::find_child_by_kind(label, "qualified_word")?;
-        let word = Self::find_child_by_kind(qw, "WORD")?;
+        let label = find_direct_child_by_kind(node, "label")?;
+        let qw = find_direct_child_by_kind(label, "qualified_word")?;
+        let word = find_direct_child_by_kind(qw, "WORD")?;
         Some(state.node_text(word))
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/common.rs
+++ b/src/extraction/common.rs
@@ -1,0 +1,165 @@
+//! Helpers shared verbatim by multiple language extractors.
+//!
+//! Each extractor keeps its own private `ExtractionState`, so these helpers
+//! take the individual pieces of state they need (source bytes, file path,
+//! unresolved-ref sink) instead of the state struct itself. Bodies are moved
+//! here unchanged from the per-language copies so extraction output stays
+//! byte-identical.
+
+use tree_sitter::Node as TsNode;
+
+use crate::types::{EdgeKind, UnresolvedRef};
+
+/// Gets the text of a tree-sitter node from the source.
+fn node_text(source: &[u8], node: TsNode<'_>) -> String {
+    node.utf8_text(source)
+        .unwrap_or("<invalid utf8>")
+        .to_string()
+}
+
+/// Strip comment markers from a single C-style comment text
+/// (`//` line comments and `/* ... */` block comments).
+#[allow(dead_code)]
+pub(crate) fn clean_c_comment(comment: &str) -> String {
+    let trimmed = comment.trim();
+    if let Some(stripped) = trimmed.strip_prefix("//") {
+        stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
+    } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
+        let inner = &trimmed[2..trimmed.len() - 2];
+        inner
+            .lines()
+            .map(|line| {
+                let l = line.trim();
+                l.strip_prefix("* ")
+                    .or_else(|| l.strip_prefix('*'))
+                    .unwrap_or(l)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Strip comment markers from a single C-style comment text, including
+/// `///` doc comments.
+#[allow(dead_code)]
+pub(crate) fn clean_c_doc_comment(comment: &str) -> String {
+    let trimmed = comment.trim();
+    if let Some(stripped) = trimmed.strip_prefix("///") {
+        stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
+    } else if let Some(stripped) = trimmed.strip_prefix("//") {
+        stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
+    } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
+        let inner = &trimmed[2..trimmed.len() - 2];
+        inner
+            .lines()
+            .map(|line| {
+                let l = line.trim();
+                l.strip_prefix("* ")
+                    .or_else(|| l.strip_prefix('*'))
+                    .unwrap_or(l)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Extract a docstring from the run of `comment` siblings immediately
+/// preceding `node`, cleaning each comment with `clean`.
+#[allow(dead_code)]
+pub(crate) fn docstring_from_preceding_comments(
+    source: &[u8],
+    node: TsNode<'_>,
+    clean: fn(&str) -> String,
+) -> Option<String> {
+    let mut comments = Vec::new();
+    let mut current = node.prev_named_sibling();
+    while let Some(sibling) = current {
+        if sibling.kind() == "comment" {
+            comments.push(node_text(source, sibling));
+            current = sibling.prev_named_sibling();
+        } else {
+            break;
+        }
+    }
+    if comments.is_empty() {
+        return None;
+    }
+    // Comments are collected in reverse order (closest first).
+    comments.reverse();
+    let cleaned: Vec<String> = comments.iter().map(|c| clean(c)).collect();
+    let result = cleaned.join("\n").trim().to_string();
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Extract a docstring from the run of `#` comment siblings immediately
+/// preceding `node`.
+#[allow(dead_code)]
+pub(crate) fn docstring_from_hash_comments(source: &[u8], node: TsNode<'_>) -> Option<String> {
+    let mut comments: Vec<String> = Vec::new();
+    let mut prev = node.prev_named_sibling();
+    while let Some(prev_node) = prev {
+        if prev_node.kind() == "comment" {
+            let text = node_text(source, prev_node);
+            let stripped = text.trim_start_matches('#').trim().to_string();
+            comments.push(stripped);
+            prev = prev_node.prev_named_sibling();
+        } else {
+            break;
+        }
+    }
+    if comments.is_empty() {
+        return None;
+    }
+    // Comments were collected in reverse order; reverse them back.
+    comments.reverse();
+    Some(comments.join("\n"))
+}
+
+/// Recursively find `call_expression` nodes and create unresolved Calls
+/// references, taking the callee name from the first named child.
+#[allow(dead_code)]
+pub(crate) fn extract_call_expression_sites(
+    source: &[u8],
+    file_path: &str,
+    unresolved_refs: &mut Vec<UnresolvedRef>,
+    node: TsNode<'_>,
+    fn_node_id: &str,
+) {
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.kind() == "call_expression" {
+                // Get the callee: the first named child (usually an identifier)
+                if let Some(callee) = child.named_child(0) {
+                    let callee_name = node_text(source, callee);
+                    unresolved_refs.push(UnresolvedRef {
+                        from_node_id: fn_node_id.to_string(),
+                        reference_name: callee_name,
+                        reference_kind: EdgeKind::Calls,
+                        line: child.start_position().row as u32,
+                        column: child.start_position().column as u32,
+                        file_path: file_path.to_string(),
+                    });
+                }
+            }
+            // Recurse for nested calls.
+            extract_call_expression_sites(source, file_path, unresolved_refs, child, fn_node_id);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}

--- a/src/extraction/cpp_extractor.rs
+++ b/src/extraction/cpp_extractor.rs
@@ -7,7 +7,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::{
-    common::{clean_c_doc_comment, docstring_from_preceding_comments},
+    common::{
+        clean_c_doc_comment, docstring_from_preceding_comments, extract_call_expression_sites,
+    },
     complexity::{count_complexity, CPP_COMPLEXITY},
     traversal::{find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind},
 };
@@ -2083,31 +2085,13 @@ impl CppExtractor {
 
     /// Recursively find `call_expression` nodes and create unresolved Calls references.
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == "call_expression" {
-                    if let Some(callee) = child.named_child(0) {
-                        let callee_name = state.node_text(callee);
-                        state.unresolved_refs.push(UnresolvedRef {
-                            from_node_id: fn_node_id.to_string(),
-                            reference_name: callee_name,
-                            reference_kind: EdgeKind::Calls,
-                            line: child.start_position().row as u32,
-                            column: child.start_position().column as u32,
-                            file_path: state.file_path.clone(),
-                        });
-                    }
-                    Self::extract_call_sites(state, child, fn_node_id);
-                } else {
-                    Self::extract_call_sites(state, child, fn_node_id);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
+        extract_call_expression_sites(
+            &state.source,
+            &state.file_path,
+            &mut state.unresolved_refs,
+            node,
+            fn_node_id,
+        );
     }
 
     // -------------------------------------------------------

--- a/src/extraction/cpp_extractor.rs
+++ b/src/extraction/cpp_extractor.rs
@@ -7,6 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::{
+    common::{clean_c_doc_comment, docstring_from_preceding_comments},
     complexity::{count_complexity, CPP_COMPLEXITY},
     traversal::{find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind},
 };
@@ -2115,54 +2116,7 @@ impl CppExtractor {
 
     /// Extract docstrings from preceding comment nodes.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                let text = state.node_text(sibling);
-                comments.push(text);
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
-    }
-
-    /// Strip comment markers from a single C/C++ comment text.
-    fn clean_comment(comment: &str) -> String {
-        let trimmed = comment.trim();
-        if let Some(stripped) = trimmed.strip_prefix("///") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if let Some(stripped) = trimmed.strip_prefix("//") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
-            let inner = &trimmed[2..trimmed.len() - 2];
-            inner
-                .lines()
-                .map(|line| {
-                    let l = line.trim();
-                    l.strip_prefix("* ")
-                        .or_else(|| l.strip_prefix('*'))
-                        .unwrap_or(l)
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-                .trim()
-                .to_string()
-        } else {
-            trimmed.to_string()
-        }
+        docstring_from_preceding_comments(&state.source, node, clean_c_doc_comment)
     }
 
     // -------------------------------------------------------

--- a/src/extraction/dart_extractor.rs
+++ b/src/extraction/dart_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, ComplexityMetrics, DART_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -165,8 +166,8 @@ impl DartExtractor {
                 "function_declaration" => {
                     // tree-sitter-dart 0.2 wraps top-level functions in
                     // `function_declaration { function_signature, function_body }`.
-                    if let Some(sig) = Self::find_child_by_kind(child, "function_signature") {
-                        let body = Self::find_child_by_kind(child, "function_body");
+                    if let Some(sig) = find_direct_child_by_kind(child, "function_signature") {
+                        let body = find_direct_child_by_kind(child, "function_body");
                         Self::visit_top_level_function(state, sig, body);
                     }
                 }
@@ -189,23 +190,23 @@ impl DartExtractor {
     /// `top_level_variable_declaration` whose declared "type" is the
     /// `library` keyword.
     fn is_library_directive(state: &ExtractionState, node: TsNode<'_>) -> bool {
-        let Some(ty) = Self::find_child_by_kind(node, "type") else {
+        let Some(ty) = find_direct_child_by_kind(node, "type") else {
             return false;
         };
-        let Some(type_id) = Self::find_child_by_kind(ty, "type_identifier") else {
+        let Some(type_id) = find_direct_child_by_kind(ty, "type_identifier") else {
             return false;
         };
         state.node_text(type_id) == "library"
     }
 
     fn visit_library_misparse(state: &mut ExtractionState, node: TsNode<'_>) {
-        let Some(list) = Self::find_child_by_kind(node, "initialized_identifier_list") else {
+        let Some(list) = find_direct_child_by_kind(node, "initialized_identifier_list") else {
             return;
         };
-        let Some(init) = Self::find_child_by_kind(list, "initialized_identifier") else {
+        let Some(init) = find_direct_child_by_kind(list, "initialized_identifier") else {
             return;
         };
-        let Some(ident) = Self::find_child_by_kind(init, "identifier") else {
+        let Some(ident) = find_direct_child_by_kind(init, "identifier") else {
             return;
         };
         let name = state.node_text(ident);
@@ -217,7 +218,7 @@ impl DartExtractor {
     // ----------------------------------
 
     fn visit_library(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "dotted_identifier_list").map_or_else(
+        let name = find_direct_child_by_kind(node, "dotted_identifier_list").map_or_else(
             || state.node_text(node).trim().to_string(),
             |n| state.node_text(n),
         );
@@ -444,7 +445,7 @@ impl DartExtractor {
     // ----------------------------------
 
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
-        let is_abstract = Self::find_child_by_kind(node, "abstract").is_some();
+        let is_abstract = find_direct_child_by_kind(node, "abstract").is_some();
 
         let name = node
             .child_by_field_name("name")
@@ -504,7 +505,7 @@ impl DartExtractor {
 
         // Extract superclass extends reference.
         if let Some(superclass) = node.child_by_field_name("superclass") {
-            if let Some(type_id) = Self::find_child_by_kind(superclass, "type_identifier") {
+            if let Some(type_id) = find_direct_child_by_kind(superclass, "type_identifier") {
                 let type_name = state.node_text(type_id);
                 state.unresolved_refs.push(UnresolvedRef {
                     from_node_id: id.clone(),
@@ -535,7 +536,7 @@ impl DartExtractor {
     // ----------------------------------
 
     fn visit_mixin(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
@@ -588,7 +589,7 @@ impl DartExtractor {
         Self::extract_annotations_from_modifiers(state, node, &id);
 
         // Visit mixin body (it uses class_body).
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             state.node_stack.push((name, id.clone()));
             state.class_depth += 1;
             Self::visit_class_body(state, body);
@@ -602,7 +603,7 @@ impl DartExtractor {
     // ----------------------------------
 
     fn visit_extension(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
@@ -801,8 +802,8 @@ impl DartExtractor {
     // ----------------------------------
 
     fn visit_type_alias(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "type_identifier")
-            .or_else(|| Self::find_child_by_kind(node, "identifier"))
+        let name = find_direct_child_by_kind(node, "type_identifier")
+            .or_else(|| find_direct_child_by_kind(node, "identifier"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
@@ -900,7 +901,7 @@ impl DartExtractor {
     fn visit_method_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         let sig = node
             .child_by_field_name("signature")
-            .or_else(|| Self::find_child_by_kind(node, "method_signature"));
+            .or_else(|| find_direct_child_by_kind(node, "method_signature"));
         let Some(sig) = sig else {
             return;
         };
@@ -913,7 +914,7 @@ impl DartExtractor {
         }
         let body = node
             .child_by_field_name("body")
-            .or_else(|| Self::find_child_by_kind(node, "function_body"));
+            .or_else(|| find_direct_child_by_kind(node, "function_body"));
         loop {
             let child = cursor.node();
             match child.kind() {
@@ -1219,7 +1220,7 @@ impl DartExtractor {
         decl_node: TsNode<'_>,
         sig_node: TsNode<'_>,
     ) {
-        let name = Self::find_child_by_kind(sig_node, "identifier")
+        let name = find_direct_child_by_kind(sig_node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::dart_visibility(&name);
@@ -1365,7 +1366,7 @@ impl DartExtractor {
     ) {
         let name = var_def.child_by_field_name("name").map_or_else(
             || {
-                Self::find_child_by_kind(var_def, "identifier")
+                find_direct_child_by_kind(var_def, "identifier")
                     .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
             },
             |n| state.node_text(n),
@@ -1387,7 +1388,7 @@ impl DartExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "initialized_identifier" {
-                    if let Some(ident) = Self::find_child_by_kind(child, "identifier") {
+                    if let Some(ident) = find_direct_child_by_kind(child, "identifier") {
                         let name = state.node_text(ident);
                         Self::emit_field(state, decl_node, &name);
                     }
@@ -1410,7 +1411,7 @@ impl DartExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "static_final_declaration" {
-                    if let Some(ident) = Self::find_child_by_kind(child, "identifier") {
+                    if let Some(ident) = find_direct_child_by_kind(child, "identifier") {
                         let name = state.node_text(ident);
                         Self::emit_field(state, decl_node, &name);
                     }
@@ -1537,7 +1538,7 @@ impl DartExtractor {
                 // sibling pairs (still kept below for compatibility with method
                 // calls of the form `obj.method()`).
                 "call_expression" => {
-                    if let Some(ident) = Self::find_child_by_kind(child, "identifier") {
+                    if let Some(ident) = find_direct_child_by_kind(child, "identifier") {
                         state.unresolved_refs.push(UnresolvedRef {
                             from_node_id: fn_node_id.to_string(),
                             reference_name: state.node_text(ident),
@@ -1556,8 +1557,8 @@ impl DartExtractor {
                     // Check if the next sibling is a selector containing argument_part.
                     if let Some(next) = child.next_named_sibling() {
                         if next.kind() == "selector"
-                            && (Self::find_child_by_kind(next, "argument_part").is_some()
-                                || Self::find_child_by_kind(next, "arguments").is_some())
+                            && (find_direct_child_by_kind(next, "argument_part").is_some()
+                                || find_direct_child_by_kind(next, "arguments").is_some())
                         {
                             state.unresolved_refs.push(UnresolvedRef {
                                 from_node_id: fn_node_id.to_string(),
@@ -1572,14 +1573,14 @@ impl DartExtractor {
                 }
                 // A selector that contains an identifier and argument_part: method call.
                 "selector" => {
-                    if Self::find_child_by_kind(child, "argument_part").is_some()
-                        || Self::find_child_by_kind(child, "arguments").is_some()
+                    if find_direct_child_by_kind(child, "argument_part").is_some()
+                        || find_direct_child_by_kind(child, "arguments").is_some()
                     {
                         // Look for identifier inside unconditional_assignable_selector.
                         if let Some(uas) =
-                            Self::find_child_by_kind(child, "unconditional_assignable_selector")
+                            find_direct_child_by_kind(child, "unconditional_assignable_selector")
                         {
-                            if let Some(ident) = Self::find_child_by_kind(uas, "identifier") {
+                            if let Some(ident) = find_direct_child_by_kind(uas, "identifier") {
                                 let callee_name = state.node_text(ident);
                                 state.unresolved_refs.push(UnresolvedRef {
                                     from_node_id: fn_node_id.to_string(),
@@ -1711,23 +1712,6 @@ impl DartExtractor {
         }
     }
 
-    /// Find the first named child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-
     /// Walk previous siblings and children of a declaration looking for
     /// `annotation` or `marker_annotation` nodes and extract annotation usages.
     fn extract_annotations_from_modifiers(
@@ -1833,7 +1817,7 @@ impl DartExtractor {
     ///
     /// Looks for an `identifier` child, or falls back to text after `@`, before `(`.
     fn extract_annotation_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        if let Some(ident) = Self::find_child_by_kind(node, "identifier") {
+        if let Some(ident) = find_direct_child_by_kind(node, "identifier") {
             return state.node_text(ident);
         }
         // Fallback: text after '@', before '('.

--- a/src/extraction/fortran_extractor.rs
+++ b/src/extraction/fortran_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, FORTRAN_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -663,7 +664,7 @@ impl FortranExtractor {
 
     /// Extract a use statement.
     fn visit_use_statement(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "module_name")
+        let name = find_direct_child_by_kind(node, "module_name")
             .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -718,23 +719,23 @@ impl FortranExtractor {
     /// Find the module name from a module node.
     /// Structure: module -> `module_statement` -> name
     fn find_module_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        Self::find_child_by_kind(node, "module_statement")
-            .and_then(|stmt| Self::find_child_by_kind(stmt, "name"))
+        find_direct_child_by_kind(node, "module_statement")
+            .and_then(|stmt| find_direct_child_by_kind(stmt, "name"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Find the program name from a program node.
     /// Structure: program -> `program_statement` -> name
     fn find_program_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        Self::find_child_by_kind(node, "program_statement")
-            .and_then(|stmt| Self::find_child_by_kind(stmt, "name"))
+        find_direct_child_by_kind(node, "program_statement")
+            .and_then(|stmt| find_direct_child_by_kind(stmt, "name"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Find the subroutine name from a subroutine node.
     /// Structure: subroutine -> `subroutine_statement` (field name="name")
     fn find_subroutine_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        Self::find_child_by_kind(node, "subroutine_statement")
+        find_direct_child_by_kind(node, "subroutine_statement")
             .and_then(|stmt| stmt.child_by_field_name("name"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
@@ -742,7 +743,7 @@ impl FortranExtractor {
     /// Find the function name from a function node.
     /// Structure: function -> `function_statement` (field name="name")
     fn find_function_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        Self::find_child_by_kind(node, "function_statement")
+        find_direct_child_by_kind(node, "function_statement")
             .and_then(|stmt| stmt.child_by_field_name("name"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
@@ -753,14 +754,14 @@ impl FortranExtractor {
         state: &ExtractionState,
         node: TsNode<'_>,
     ) -> (String, Option<String>) {
-        let stmt = Self::find_child_by_kind(node, "derived_type_statement");
+        let stmt = find_direct_child_by_kind(node, "derived_type_statement");
         let name = stmt
-            .and_then(|s| Self::find_child_by_kind(s, "type_name"))
+            .and_then(|s| find_direct_child_by_kind(s, "type_name"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let base_type = stmt
             .and_then(|s| s.child_by_field_name("base"))
-            .and_then(|base_spec| Self::find_child_by_kind(base_spec, "identifier"))
+            .and_then(|base_spec| find_direct_child_by_kind(base_spec, "identifier"))
             .map(|n| state.node_text(n));
 
         (name, base_type)
@@ -769,8 +770,8 @@ impl FortranExtractor {
     /// Find the interface name.
     /// Structure: interface -> `interface_statement` -> name
     fn find_interface_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        Self::find_child_by_kind(node, "interface_statement")
-            .and_then(|stmt| Self::find_child_by_kind(stmt, "name"))
+        find_direct_child_by_kind(node, "interface_statement")
+            .and_then(|stmt| find_direct_child_by_kind(stmt, "name"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
@@ -886,23 +887,6 @@ impl FortranExtractor {
                 }
             }
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/glsl_extractor.rs
+++ b/src/extraction/glsl_extractor.rs
@@ -6,7 +6,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
-use crate::extraction::common::{clean_c_comment, docstring_from_preceding_comments};
+use crate::extraction::common::{
+    clean_c_comment, docstring_from_preceding_comments, extract_call_expression_sites,
+};
 use crate::extraction::complexity::{count_complexity, C_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -621,31 +623,13 @@ impl GlslExtractor {
     // -------------------------------------------------------
 
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == "call_expression" {
-                    if let Some(callee) = child.named_child(0) {
-                        let callee_name = state.node_text(callee);
-                        state.unresolved_refs.push(UnresolvedRef {
-                            from_node_id: fn_node_id.to_string(),
-                            reference_name: callee_name,
-                            reference_kind: EdgeKind::Calls,
-                            line: child.start_position().row as u32,
-                            column: child.start_position().column as u32,
-                            file_path: state.file_path.clone(),
-                        });
-                    }
-                    Self::extract_call_sites(state, child, fn_node_id);
-                } else {
-                    Self::extract_call_sites(state, child, fn_node_id);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
+        extract_call_expression_sites(
+            &state.source,
+            &state.file_path,
+            &mut state.unresolved_refs,
+            node,
+            fn_node_id,
+        );
     }
 
     // -------------------------------------------------------

--- a/src/extraction/glsl_extractor.rs
+++ b/src/extraction/glsl_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::{clean_c_comment, docstring_from_preceding_comments};
 use crate::extraction::complexity::{count_complexity, C_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -652,50 +653,7 @@ impl GlslExtractor {
     // -------------------------------------------------------
 
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                comments.push(state.node_text(sibling));
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
-    }
-
-    fn clean_comment(comment: &str) -> String {
-        let trimmed = comment.trim();
-        if let Some(stripped) = trimmed.strip_prefix("//") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
-            let inner = &trimmed[2..trimmed.len() - 2];
-            inner
-                .lines()
-                .map(|line| {
-                    let l = line.trim();
-                    l.strip_prefix("* ")
-                        .or_else(|| l.strip_prefix('*'))
-                        .unwrap_or(l)
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-                .trim()
-                .to_string()
-        } else {
-            trimmed.to_string()
-        }
+        docstring_from_preceding_comments(&state.source, node, clean_c_comment)
     }
 
     // -------------------------------------------------------

--- a/src/extraction/glsl_extractor.rs
+++ b/src/extraction/glsl_extractor.rs
@@ -10,6 +10,9 @@ use crate::extraction::common::{
     clean_c_comment, docstring_from_preceding_comments, extract_call_expression_sites,
 };
 use crate::extraction::complexity::{count_complexity, C_COMPLEXITY};
+use crate::extraction::traversal::{
+    find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind,
+};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -207,14 +210,14 @@ impl GlslExtractor {
         }
 
         // Extract call sites from the function body.
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             Self::extract_call_sites(state, body, &id);
         }
     }
 
     fn extract_function_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        if let Some(declarator) = Self::find_descendant_by_kind(node, "function_declarator") {
-            if let Some(ident) = Self::find_child_by_kind(declarator, "identifier") {
+        if let Some(declarator) = find_descendant_by_kind(node, "function_declarator") {
+            if let Some(ident) = find_direct_child_by_kind(declarator, "identifier") {
                 return Some(state.node_text(ident));
             }
         }
@@ -236,13 +239,13 @@ impl GlslExtractor {
 
     fn visit_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Function prototype
-        if Self::find_descendant_by_kind(node, "function_declarator").is_some() {
+        if find_descendant_by_kind(node, "function_declarator").is_some() {
             Self::visit_function_prototype(state, node);
             return;
         }
 
         // Struct declaration
-        if Self::has_child_kind(node, "struct_specifier") {
+        if has_direct_child_kind(node, "struct_specifier") {
             Self::visit_children(state, node);
             return;
         }
@@ -372,24 +375,24 @@ impl GlslExtractor {
 
     fn extract_variable_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // init_declarator: `int x = 0;`
-        if let Some(init_decl) = Self::find_child_by_kind(node, "init_declarator") {
-            if let Some(ident) = Self::find_child_by_kind(init_decl, "identifier") {
+        if let Some(init_decl) = find_direct_child_by_kind(node, "init_declarator") {
+            if let Some(ident) = find_direct_child_by_kind(init_decl, "identifier") {
                 return Some(state.node_text(ident));
             }
             // array declarator: `float arr[3] = ...`
-            if let Some(arr) = Self::find_child_by_kind(init_decl, "array_declarator") {
-                if let Some(ident) = Self::find_child_by_kind(arr, "identifier") {
+            if let Some(arr) = find_direct_child_by_kind(init_decl, "array_declarator") {
+                if let Some(ident) = find_direct_child_by_kind(arr, "identifier") {
                     return Some(state.node_text(ident));
                 }
             }
         }
         // Direct identifier: `uniform vec3 lightPos;`
-        if let Some(ident) = Self::find_child_by_kind(node, "identifier") {
+        if let Some(ident) = find_direct_child_by_kind(node, "identifier") {
             return Some(state.node_text(ident));
         }
         // Array declarator without init: `in vec2 texCoords[];`
-        if let Some(arr) = Self::find_child_by_kind(node, "array_declarator") {
-            if let Some(ident) = Self::find_child_by_kind(arr, "identifier") {
+        if let Some(arr) = find_direct_child_by_kind(node, "array_declarator") {
+            if let Some(ident) = find_direct_child_by_kind(arr, "identifier") {
                 return Some(state.node_text(ident));
             }
         }
@@ -401,11 +404,11 @@ impl GlslExtractor {
     // -------------------------------------------------------
 
     fn visit_standalone_struct(state: &mut ExtractionState, node: TsNode<'_>) {
-        if Self::find_child_by_kind(node, "field_declaration_list").is_none() {
+        if find_direct_child_by_kind(node, "field_declaration_list").is_none() {
             return;
         }
 
-        let name = Self::find_child_by_kind(node, "type_identifier")
+        let name = find_direct_child_by_kind(node, "type_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -454,7 +457,7 @@ impl GlslExtractor {
         }
 
         // Extract struct fields.
-        if let Some(field_list) = Self::find_child_by_kind(node, "field_declaration_list") {
+        if let Some(field_list) = find_direct_child_by_kind(node, "field_declaration_list") {
             state.node_stack.push((name, id));
             Self::visit_struct_fields(state, field_list);
             state.node_stack.pop();
@@ -527,18 +530,18 @@ impl GlslExtractor {
 
     fn find_field_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // field_identifier is used in struct field declarations
-        if let Some(fi) = Self::find_child_by_kind(node, "field_identifier") {
+        if let Some(fi) = find_direct_child_by_kind(node, "field_identifier") {
             return Some(state.node_text(fi));
         }
-        if let Some(ident) = Self::find_child_by_kind(node, "identifier") {
+        if let Some(ident) = find_direct_child_by_kind(node, "identifier") {
             return Some(state.node_text(ident));
         }
         // Array field: `float values[4];`
-        if let Some(arr) = Self::find_child_by_kind(node, "array_declarator") {
-            if let Some(fi) = Self::find_child_by_kind(arr, "field_identifier") {
+        if let Some(arr) = find_direct_child_by_kind(node, "array_declarator") {
+            if let Some(fi) = find_direct_child_by_kind(arr, "field_identifier") {
                 return Some(state.node_text(fi));
             }
-            if let Some(ident) = Self::find_child_by_kind(arr, "identifier") {
+            if let Some(ident) = find_direct_child_by_kind(arr, "identifier") {
                 return Some(state.node_text(ident));
             }
         }
@@ -550,7 +553,7 @@ impl GlslExtractor {
     // -------------------------------------------------------
 
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -599,8 +602,8 @@ impl GlslExtractor {
     }
 
     fn visit_preproc_include(state: &mut ExtractionState, node: TsNode<'_>) {
-        let include_path = Self::find_child_by_kind(node, "string_literal")
-            .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
+        let include_path = find_direct_child_by_kind(node, "string_literal")
+            .or_else(|| find_direct_child_by_kind(node, "system_lib_string"))
             .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let line = node.start_position().row as u32;
@@ -662,7 +665,7 @@ impl GlslExtractor {
                 }
                 // Wrapped in type_qualifier: `type_qualifier > const`
                 if kind == "type_qualifier" {
-                    if let Some(inner) = Self::find_child_by_kind(child, qualifier) {
+                    if let Some(inner) = find_direct_child_by_kind(child, qualifier) {
                         let _ = inner;
                         return true;
                     }
@@ -673,45 +676,6 @@ impl GlslExtractor {
             }
         }
         false
-    }
-
-    fn has_child_kind(node: TsNode<'_>, kind: &str) -> bool {
-        Self::find_child_by_kind(node, kind).is_some()
-    }
-
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-
-    fn find_descendant_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if let Some(found) = Self::find_descendant_by_kind(child, kind) {
-                    return Some(found);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {

--- a/src/extraction/go_extractor.rs
+++ b/src/extraction/go_extractor.rs
@@ -5,6 +5,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::{clean_c_comment, docstring_from_preceding_comments};
 use crate::extraction::complexity::{count_complexity, GO_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -1180,53 +1181,7 @@ impl GoExtractor {
 
     /// Extract docstrings from preceding comment nodes.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                let text = state.node_text(sibling);
-                comments.push(text);
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        // Comments are collected in reverse order (closest first).
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
-    }
-
-    /// Strip comment markers from a single Go comment text.
-    fn clean_comment(comment: &str) -> String {
-        let trimmed = comment.trim();
-        if let Some(stripped) = trimmed.strip_prefix("//") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
-            let inner = &trimmed[2..trimmed.len() - 2];
-            inner
-                .lines()
-                .map(|line| {
-                    let l = line.trim();
-                    l.strip_prefix("* ")
-                        .or_else(|| l.strip_prefix('*'))
-                        .unwrap_or(l)
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-                .trim()
-                .to_string()
-        } else {
-            trimmed.to_string()
-        }
+        docstring_from_preceding_comments(&state.source, node, clean_c_comment)
     }
 
     /// Determine Go visibility: uppercase first character means exported (Pub),

--- a/src/extraction/go_extractor.rs
+++ b/src/extraction/go_extractor.rs
@@ -7,6 +7,7 @@ use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::common::{clean_c_comment, docstring_from_preceding_comments};
 use crate::extraction::complexity::{count_complexity, GO_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -168,7 +169,7 @@ impl GoExtractor {
 
     /// Extract a package clause node.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "package_identifier")
+        let name = find_direct_child_by_kind(node, "package_identifier")
             .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -313,7 +314,7 @@ impl GoExtractor {
     /// Extract a function declaration node.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
         // In Go, function name is an `identifier` child.
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let signature = Some(Self::extract_signature(state, node));
@@ -367,7 +368,7 @@ impl GoExtractor {
         Self::extract_type_params(state, node, &id);
 
         // Extract call sites from the function body.
-        if let Some(body) = Self::find_child_by_kind(node, "block") {
+        if let Some(body) = find_direct_child_by_kind(node, "block") {
             Self::extract_call_sites(state, body, &id);
         }
     }
@@ -375,7 +376,7 @@ impl GoExtractor {
     /// Extract a method declaration node (function with receiver).
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
         // In Go, method name is a `field_identifier` child.
-        let name = Self::find_child_by_kind(node, "field_identifier")
+        let name = find_direct_child_by_kind(node, "field_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let signature = Some(Self::extract_signature(state, node));
@@ -429,7 +430,7 @@ impl GoExtractor {
         Self::extract_receiver(state, node, &id);
 
         // Extract call sites from the method body.
-        if let Some(body) = Self::find_child_by_kind(node, "block") {
+        if let Some(body) = find_direct_child_by_kind(node, "block") {
             Self::extract_call_sites(state, body, &id);
         }
     }
@@ -455,13 +456,13 @@ impl GoExtractor {
 
     /// Extract a `type_spec` node, dispatching on whether it defines a struct or interface.
     fn visit_type_spec(state: &mut ExtractionState, spec_node: TsNode<'_>, decl_node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(spec_node, "type_identifier")
+        let name = find_direct_child_by_kind(spec_node, "type_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Check what type is being defined.
-        if let Some(struct_type) = Self::find_child_by_kind(spec_node, "struct_type") {
+        if let Some(struct_type) = find_direct_child_by_kind(spec_node, "struct_type") {
             Self::visit_struct(state, &name, struct_type, decl_node);
-        } else if let Some(iface_type) = Self::find_child_by_kind(spec_node, "interface_type") {
+        } else if let Some(iface_type) = find_direct_child_by_kind(spec_node, "interface_type") {
             Self::visit_interface(state, &name, iface_type, decl_node);
         } else {
             // A plain type definition (e.g., `type Foo int`) that is not a type alias.
@@ -533,7 +534,7 @@ impl GoExtractor {
 
     /// Extract fields from a `struct_type` node.
     fn extract_struct_fields(state: &mut ExtractionState, struct_type: TsNode<'_>) {
-        if let Some(field_list) = Self::find_child_by_kind(struct_type, "field_declaration_list") {
+        if let Some(field_list) = find_direct_child_by_kind(struct_type, "field_declaration_list") {
             let mut cursor = field_list.walk();
             if cursor.goto_first_child() {
                 loop {
@@ -551,7 +552,7 @@ impl GoExtractor {
 
     /// Extract a single field from a `field_declaration` node.
     fn extract_single_field(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "field_identifier")
+        let name = find_direct_child_by_kind(node, "field_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let text = state.node_text(node);
@@ -600,7 +601,7 @@ impl GoExtractor {
         }
 
         // Extract struct tags (raw_string_literal in field_declaration).
-        if let Some(tag_node) = Self::find_child_by_kind(node, "raw_string_literal") {
+        if let Some(tag_node) = find_direct_child_by_kind(node, "raw_string_literal") {
             Self::extract_struct_tag(state, tag_node, &name, &id);
         }
     }
@@ -733,7 +734,7 @@ impl GoExtractor {
                 let child = cursor.node();
                 if child.kind() == "type_elem" {
                     // type_elem contains a type_identifier for the embedded interface.
-                    if let Some(type_id) = Self::find_child_by_kind(child, "type_identifier") {
+                    if let Some(type_id) = find_direct_child_by_kind(child, "type_identifier") {
                         let embedded_name = state.node_text(type_id);
                         let line = child.start_position().row as u32;
                         let column = child.start_position().column as u32;
@@ -760,7 +761,7 @@ impl GoExtractor {
         alias_node: TsNode<'_>,
         decl_node: TsNode<'_>,
     ) {
-        let name = Self::find_child_by_kind(alias_node, "type_identifier")
+        let name = find_direct_child_by_kind(alias_node, "type_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let docstring = Self::extract_docstring(state, decl_node);
@@ -878,7 +879,7 @@ impl GoExtractor {
 
     /// Extract a single const spec.
     fn visit_const_spec(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let text = state.node_text(node);
@@ -945,7 +946,7 @@ impl GoExtractor {
 
     /// Extract a single var spec as a Static node (Go vars are package-level state).
     fn visit_var_spec(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::go_visibility(&name);
         let text = state.node_text(node);
@@ -1008,7 +1009,7 @@ impl GoExtractor {
                 if child.kind() == "parameter_list" {
                     // This is the receiver parameter list.
                     // Extract the type name from the parameter_declaration inside.
-                    if let Some(param) = Self::find_child_by_kind(child, "parameter_declaration") {
+                    if let Some(param) = find_direct_child_by_kind(child, "parameter_declaration") {
                         let receiver_type = Self::extract_receiver_type_name(state, param);
                         if let Some(type_name) = receiver_type {
                             let line = child.start_position().row as u32;
@@ -1052,11 +1053,11 @@ impl GoExtractor {
     /// Handles both `c Circle` and `c *Circle` forms.
     fn extract_receiver_type_name(state: &ExtractionState, param: TsNode<'_>) -> Option<String> {
         // Look for type_identifier directly or inside pointer_type.
-        if let Some(type_id) = Self::find_child_by_kind(param, "type_identifier") {
+        if let Some(type_id) = find_direct_child_by_kind(param, "type_identifier") {
             return Some(state.node_text(type_id));
         }
-        if let Some(ptr_type) = Self::find_child_by_kind(param, "pointer_type") {
-            if let Some(type_id) = Self::find_child_by_kind(ptr_type, "type_identifier") {
+        if let Some(ptr_type) = find_direct_child_by_kind(param, "pointer_type") {
+            if let Some(type_id) = find_direct_child_by_kind(ptr_type, "type_identifier") {
                 return Some(state.node_text(type_id));
             }
         }
@@ -1065,14 +1066,14 @@ impl GoExtractor {
 
     /// Extract type parameters (generics) from a function or method declaration.
     fn extract_type_params(state: &mut ExtractionState, node: TsNode<'_>, parent_id: &str) {
-        if let Some(type_params) = Self::find_child_by_kind(node, "type_parameter_list") {
+        if let Some(type_params) = find_direct_child_by_kind(node, "type_parameter_list") {
             let mut cursor = type_params.walk();
             if cursor.goto_first_child() {
                 loop {
                     let child = cursor.node();
                     if child.kind() == "type_parameter_declaration" {
                         // Each type_parameter_declaration has an identifier for the param name.
-                        if let Some(ident) = Self::find_child_by_kind(child, "identifier") {
+                        if let Some(ident) = find_direct_child_by_kind(child, "identifier") {
                             let name = state.node_text(ident);
                             let start_line = child.start_position().row as u32;
                             let end_line = child.end_position().row as u32;
@@ -1192,23 +1193,6 @@ impl GoExtractor {
         } else {
             Visibility::Private
         }
-    }
-
-    /// Find the first named child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/gwbasic_extractor.rs
+++ b/src/extraction/gwbasic_extractor.rs
@@ -9,6 +9,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -183,13 +184,13 @@ impl GwBasicExtractor {
 
     /// Parse a single `line` node into a `BasicLine` struct.
     fn parse_line<'a>(state: &ExtractionState, node: TsNode<'a>) -> Option<BasicLine<'a>> {
-        let line_number_node = Self::find_child_by_kind(node, "line_number")?;
+        let line_number_node = find_direct_child_by_kind(node, "line_number")?;
         let line_number_text = state.node_text(line_number_node);
         let line_number: u32 = line_number_text.trim().parse().unwrap_or(0);
 
         // Navigate: line -> statement_list -> statement -> specific_kind
-        let statement_list = Self::find_child_by_kind(node, "statement_list")?;
-        let statement = Self::find_child_by_kind(statement_list, "statement")?;
+        let statement_list = find_direct_child_by_kind(node, "statement_list")?;
+        let statement = find_direct_child_by_kind(statement_list, "statement")?;
 
         // Get the first named child of statement (the actual statement type).
         let mut stmt_cursor = statement.walk();
@@ -229,19 +230,19 @@ impl GwBasicExtractor {
             if basic_line.statement_kind != "def_fn_statement" {
                 continue;
             }
-            let Some(statement_list) = Self::find_child_by_kind(basic_line.node, "statement_list")
+            let Some(statement_list) = find_direct_child_by_kind(basic_line.node, "statement_list")
             else {
                 continue;
             };
-            let Some(statement) = Self::find_child_by_kind(statement_list, "statement") else {
+            let Some(statement) = find_direct_child_by_kind(statement_list, "statement") else {
                 continue;
             };
-            let Some(def_fn) = Self::find_child_by_kind(statement, "def_fn_statement") else {
+            let Some(def_fn) = find_direct_child_by_kind(statement, "def_fn_statement") else {
                 continue;
             };
 
             // Extract function name from user_function child.
-            let Some(fn_name_node) = Self::find_child_by_kind(def_fn, "user_function") else {
+            let Some(fn_name_node) = find_direct_child_by_kind(def_fn, "user_function") else {
                 continue;
             };
             let fn_name = state.node_text(fn_name_node);
@@ -315,22 +316,22 @@ impl GwBasicExtractor {
 
     /// Extract a LET statement as a Const node.
     fn visit_let_statement(state: &mut ExtractionState, basic_line: &BasicLine<'_>) {
-        let Some(statement_list) = Self::find_child_by_kind(basic_line.node, "statement_list")
+        let Some(statement_list) = find_direct_child_by_kind(basic_line.node, "statement_list")
         else {
             return;
         };
-        let Some(statement) = Self::find_child_by_kind(statement_list, "statement") else {
+        let Some(statement) = find_direct_child_by_kind(statement_list, "statement") else {
             return;
         };
-        let Some(let_stmt) = Self::find_child_by_kind(statement, "let_statement") else {
+        let Some(let_stmt) = find_direct_child_by_kind(statement, "let_statement") else {
             return;
         };
 
         // Extract the variable name from: let_statement -> variable -> identifier
-        let Some(var_node) = Self::find_child_by_kind(let_stmt, "variable") else {
+        let Some(var_node) = find_direct_child_by_kind(let_stmt, "variable") else {
             return;
         };
-        let Some(id_node) = Self::find_child_by_kind(var_node, "identifier") else {
+        let Some(id_node) = find_direct_child_by_kind(var_node, "identifier") else {
             return;
         };
         let name = state.node_text(id_node);
@@ -644,7 +645,7 @@ impl GwBasicExtractor {
         match kind {
             "gosub_statement" | "goto_statement" => {
                 // Extract the target line number.
-                if let Some(ln_node) = Self::find_child_by_kind(node, "line_number") {
+                if let Some(ln_node) = find_direct_child_by_kind(node, "line_number") {
                     let target = state.node_text(ln_node);
                     state.unresolved_refs.push(UnresolvedRef {
                         from_node_id: from_node_id.to_string(),
@@ -711,23 +712,6 @@ impl GwBasicExtractor {
         } else {
             trimmed
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/gwbasic_extractor.rs
+++ b/src/extraction/gwbasic_extractor.rs
@@ -9,6 +9,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::basic_common::{
+    derive_function_name, find_subroutine_ranges, for_each_top_level_line, BasicLine,
+};
 use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -68,18 +71,6 @@ impl ExtractionState {
             .unwrap_or("<invalid utf8>")
             .to_string()
     }
-}
-
-/// Represents a collected line from the BASIC program for subroutine synthesis.
-struct BasicLine<'a> {
-    /// The `line` AST node.
-    node: TsNode<'a>,
-    /// The line number (e.g. 10, 20, 100).
-    line_number: u32,
-    /// The kind of the first statement on this line.
-    statement_kind: String,
-    /// The text of the REM comment, if this line is a REM.
-    comment_text: Option<String>,
 }
 
 impl GwBasicExtractor {
@@ -299,7 +290,7 @@ impl GwBasicExtractor {
     /// In GW-BASIC, lines like `40 MR = 3` serve as variable initialization.
     /// We treat only top-level LET assignments (those not inside subroutines) as constants.
     fn extract_top_level_lets(state: &mut ExtractionState, lines: &[BasicLine<'_>]) {
-        let subroutine_ranges = Self::find_subroutine_ranges(lines);
+        let subroutine_ranges = find_subroutine_ranges(lines);
         for (idx, basic_line) in lines.iter().enumerate() {
             // Skip lines that are inside subroutines.
             if subroutine_ranges
@@ -433,7 +424,7 @@ impl GwBasicExtractor {
 
                 if has_return && body_start < body_end {
                     // Derive a function name from the first REM comment.
-                    let fn_name = Self::derive_function_name(&rem_comments);
+                    let fn_name = derive_function_name(&rem_comments);
                     let docstring = if rem_comments.is_empty() {
                         None
                     } else {
@@ -575,59 +566,14 @@ impl GwBasicExtractor {
 
     /// Extract GOSUB/GOTO references from top-level lines (those not part of subroutines).
     fn extract_top_level_calls(state: &mut ExtractionState, lines: &[BasicLine<'_>]) {
-        // Determine which lines are part of subroutines (between first REM and RETURN).
-        let subroutine_ranges = Self::find_subroutine_ranges(lines);
-
         let file_node_id = state
             .node_stack
             .last()
             .map(|(_, id)| id.clone())
             .unwrap_or_default();
-
-        for (idx, line) in lines.iter().enumerate() {
-            // Skip lines that are inside subroutines.
-            if subroutine_ranges
-                .iter()
-                .any(|(start, end)| idx >= *start && idx < *end)
-            {
-                continue;
-            }
+        for_each_top_level_line(lines, |line| {
             Self::extract_calls_from_line(state, line, &file_node_id);
-        }
-    }
-
-    /// Find ranges of lines that belong to subroutines (REM ... RETURN blocks).
-    fn find_subroutine_ranges(lines: &[BasicLine<'_>]) -> Vec<(usize, usize)> {
-        let mut ranges = Vec::new();
-        let mut i = 0;
-        while i < lines.len() {
-            if lines[i].statement_kind == "comment" {
-                let rem_start = i;
-                while i < lines.len() && lines[i].statement_kind == "comment" {
-                    i += 1;
-                }
-                let mut body_end = i;
-                let mut has_return = false;
-                while body_end < lines.len() {
-                    if lines[body_end].statement_kind == "return_statement" {
-                        has_return = true;
-                        body_end += 1;
-                        break;
-                    }
-                    if lines[body_end].statement_kind == "comment" {
-                        break;
-                    }
-                    body_end += 1;
-                }
-                if has_return {
-                    ranges.push((rem_start, body_end));
-                }
-                i = body_end;
-            } else {
-                i += 1;
-            }
-        }
-        ranges
+        });
     }
 
     /// Extract GOSUB/GOTO call references from a single line.
@@ -669,48 +615,6 @@ impl GwBasicExtractor {
                     break;
                 }
             }
-        }
-    }
-
-    /// Derive a function name from REM comment text.
-    ///
-    /// Takes the first REM line text and converts it into a snake_case-like
-    /// identifier. For example, "VALIDATE CONFIGURATION" becomes "`VALIDATE_CONFIGURATION`".
-    fn derive_function_name(rem_comments: &[String]) -> String {
-        if rem_comments.is_empty() {
-            return "UNNAMED_SUB".to_string();
-        }
-        let first = &rem_comments[0];
-        // Replace spaces with underscores and keep alphanumeric + underscore.
-        let name: String = first
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '_' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect();
-        // Collapse multiple underscores and trim.
-        let mut collapsed = String::new();
-        let mut prev_underscore = false;
-        for c in name.chars() {
-            if c == '_' {
-                if !prev_underscore && !collapsed.is_empty() {
-                    collapsed.push('_');
-                }
-                prev_underscore = true;
-            } else {
-                collapsed.push(c);
-                prev_underscore = false;
-            }
-        }
-        let trimmed = collapsed.trim_end_matches('_').to_string();
-        if trimmed.is_empty() {
-            "UNNAMED_SUB".to_string()
-        } else {
-            trimmed
         }
     }
 

--- a/src/extraction/hlsl_extractor.rs
+++ b/src/extraction/hlsl_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::extract_call_expression_sites;
 use crate::extraction::complexity::{count_complexity, C_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -600,31 +601,13 @@ impl HlslExtractor {
     // -------------------------------------------------------
 
     fn extract_call_sites(state: &mut ExtractionState, node: TsNode<'_>, fn_node_id: &str) {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == "call_expression" {
-                    if let Some(callee) = child.named_child(0) {
-                        let callee_name = state.node_text(callee);
-                        state.unresolved_refs.push(UnresolvedRef {
-                            from_node_id: fn_node_id.to_string(),
-                            reference_name: callee_name,
-                            reference_kind: EdgeKind::Calls,
-                            line: child.start_position().row as u32,
-                            column: child.start_position().column as u32,
-                            file_path: state.file_path.clone(),
-                        });
-                    }
-                    Self::extract_call_sites(state, child, fn_node_id);
-                } else {
-                    Self::extract_call_sites(state, child, fn_node_id);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
+        extract_call_expression_sites(
+            &state.source,
+            &state.file_path,
+            &mut state.unresolved_refs,
+            node,
+            fn_node_id,
+        );
     }
 
     // -------------------------------------------------------

--- a/src/extraction/hlsl_extractor.rs
+++ b/src/extraction/hlsl_extractor.rs
@@ -8,6 +8,9 @@ use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::common::extract_call_expression_sites;
 use crate::extraction::complexity::{count_complexity, C_COMPLEXITY};
+use crate::extraction::traversal::{
+    find_descendant_by_kind, find_direct_child_by_kind, has_direct_child_kind,
+};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -210,12 +213,12 @@ impl HlslExtractor {
 
     fn extract_function_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // function_definition.declarator → function_declarator.declarator → identifier
-        if let Some(func_decl) = Self::find_descendant_by_kind(node, "function_declarator") {
-            if let Some(ident) = Self::find_child_by_kind(func_decl, "identifier") {
+        if let Some(func_decl) = find_descendant_by_kind(node, "function_declarator") {
+            if let Some(ident) = find_direct_child_by_kind(func_decl, "identifier") {
                 return Some(state.node_text(ident));
             }
             // Qualified identifier (e.g. ClassName::method)
-            if let Some(qi) = Self::find_child_by_kind(func_decl, "qualified_identifier") {
+            if let Some(qi) = find_direct_child_by_kind(func_decl, "qualified_identifier") {
                 return Some(state.node_text(qi));
             }
         }
@@ -306,8 +309,8 @@ impl HlslExtractor {
     }
 
     fn visit_field_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_descendant_by_kind(node, "field_identifier")
-            .or_else(|| Self::find_descendant_by_kind(node, "identifier"))
+        let name = find_descendant_by_kind(node, "field_identifier")
+            .or_else(|| find_descendant_by_kind(node, "identifier"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -436,12 +439,12 @@ impl HlslExtractor {
 
     fn visit_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Skip function prototypes — handled by function_definition.
-        if Self::find_descendant_by_kind(node, "function_declarator").is_some() {
+        if find_descendant_by_kind(node, "function_declarator").is_some() {
             return;
         }
         // Skip struct/cbuffer declarations (visited separately).
-        if Self::has_child_kind(node, "struct_specifier")
-            || Self::has_child_kind(node, "cbuffer_specifier")
+        if has_direct_child_kind(node, "struct_specifier")
+            || has_direct_child_kind(node, "cbuffer_specifier")
         {
             Self::visit_children(state, node);
             return;
@@ -509,18 +512,18 @@ impl HlslExtractor {
                 return Some(state.node_text(decl));
             }
             // init_declarator: identifier "=" value
-            if let Some(ident) = Self::find_child_by_kind(decl, "identifier") {
+            if let Some(ident) = find_direct_child_by_kind(decl, "identifier") {
                 return Some(state.node_text(ident));
             }
             // array_declarator: identifier "[" ... "]"
-            if let Some(arr) = Self::find_child_by_kind(decl, "array_declarator") {
-                if let Some(ident) = Self::find_child_by_kind(arr, "identifier") {
+            if let Some(arr) = find_direct_child_by_kind(decl, "array_declarator") {
+                if let Some(ident) = find_direct_child_by_kind(arr, "identifier") {
                     return Some(state.node_text(ident));
                 }
             }
         }
         // Fallback: any identifier child
-        Self::find_child_by_kind(node, "identifier").map(|n| state.node_text(n))
+        find_direct_child_by_kind(node, "identifier").map(|n| state.node_text(n))
     }
 
     // -------------------------------------------------------
@@ -528,7 +531,7 @@ impl HlslExtractor {
     // -------------------------------------------------------
 
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -577,8 +580,8 @@ impl HlslExtractor {
     }
 
     fn visit_preproc_include(state: &mut ExtractionState, node: TsNode<'_>) {
-        let include_path = Self::find_child_by_kind(node, "string_literal")
-            .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
+        let include_path = find_direct_child_by_kind(node, "string_literal")
+            .or_else(|| find_direct_child_by_kind(node, "system_lib_string"))
             .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let line = node.start_position().row as u32;
@@ -613,45 +616,6 @@ impl HlslExtractor {
     // -------------------------------------------------------
     // Utility helpers
     // -------------------------------------------------------
-
-    fn has_child_kind(node: TsNode<'_>, kind: &str) -> bool {
-        Self::find_child_by_kind(node, kind).is_some()
-    }
-
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-
-    fn find_descendant_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if let Some(found) = Self::find_descendant_by_kind(child, kind) {
-                    return Some(found);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
 
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {

--- a/src/extraction/kotlin_extractor.rs
+++ b/src/extraction/kotlin_extractor.rs
@@ -7,6 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::extraction::{
     annotations::{
         emit_annotation_usage, scan_children_for_annotation_kinds, AnnotationEmitterState,
@@ -220,7 +221,7 @@ impl KotlinExtractor {
 
     /// Extract a package header.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -301,7 +302,7 @@ impl KotlinExtractor {
 
     /// Extract a single import header as a Use node.
     fn visit_import(state: &mut ExtractionState, node: TsNode<'_>) {
-        let path = Self::find_child_by_kind(node, "identifier").map_or_else(
+        let path = find_direct_child_by_kind(node, "identifier").map_or_else(
             || {
                 let text = state.node_text(node);
                 text.trim()
@@ -453,7 +454,7 @@ impl KotlinExtractor {
 
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -514,7 +515,7 @@ impl KotlinExtractor {
 
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -574,7 +575,7 @@ impl KotlinExtractor {
 
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -636,7 +637,7 @@ impl KotlinExtractor {
         state.inside_trait = true;
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -698,7 +699,7 @@ impl KotlinExtractor {
         // Visit enum body to extract enum entries.
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "enum_class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "enum_class_body") {
             Self::visit_enum_body(state, body);
         }
         state.class_depth -= 1;
@@ -726,7 +727,7 @@ impl KotlinExtractor {
 
     /// Extract a single enum entry.
     fn visit_enum_entry(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "simple_identifier").map_or_else(
+        let name = find_direct_child_by_kind(node, "simple_identifier").map_or_else(
             || state.node_text(node).trim().to_string(),
             |n| state.node_text(n),
         );
@@ -781,7 +782,7 @@ impl KotlinExtractor {
 
     /// Extract an object declaration (Kotlin singleton).
     fn visit_object(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "type_identifier")
+        let name = find_direct_child_by_kind(node, "type_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let visibility = Self::extract_visibility(node, state);
         let docstring = Self::extract_kdoc(state, node);
@@ -833,7 +834,7 @@ impl KotlinExtractor {
 
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -847,7 +848,7 @@ impl KotlinExtractor {
     /// Extract a companion object.
     fn visit_companion_object(state: &mut ExtractionState, node: TsNode<'_>) {
         // Companion objects may have a name or be anonymous.
-        let name = Self::find_child_by_kind(node, "type_identifier")
+        let name = find_direct_child_by_kind(node, "type_identifier")
             .map_or_else(|| "Companion".to_string(), |n| state.node_text(n));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -907,7 +908,7 @@ impl KotlinExtractor {
 
         state.node_stack.push((name, id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -920,7 +921,7 @@ impl KotlinExtractor {
 
     /// Extract a function or method declaration.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "simple_identifier")
+        let name = find_direct_child_by_kind(node, "simple_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Check if this is an extension function (has a receiver type before the dot and name).
@@ -939,7 +940,7 @@ impl KotlinExtractor {
         let is_async = Self::has_modifier_keyword(node, state, "suspend");
 
         // Determine if this is a function without a body (abstract) inside an interface.
-        let has_body = Self::find_child_by_kind(node, "function_body").is_some();
+        let has_body = find_direct_child_by_kind(node, "function_body").is_some();
 
         let kind = if state.inside_trait && !has_body {
             NodeKind::AbstractMethod
@@ -1001,7 +1002,7 @@ impl KotlinExtractor {
         Self::extract_type_refs(state, node, &id);
 
         // Extract call sites from the body.
-        if let Some(body) = Self::find_child_by_kind(node, "function_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "function_body") {
             Self::extract_call_sites(state, body, &id);
         }
     }
@@ -1015,7 +1016,7 @@ impl KotlinExtractor {
         let name = Self::extract_property_name(state, node);
 
         // Determine val vs var.
-        let is_var = Self::find_child_by_kind(node, "binding_pattern_kind").is_some_and(|bpk| {
+        let is_var = find_direct_child_by_kind(node, "binding_pattern_kind").is_some_and(|bpk| {
             let text = state.node_text(bpk);
             text.trim() == "var"
         });
@@ -1154,20 +1155,20 @@ impl KotlinExtractor {
 
     /// Extract the class name from a `class_declaration` node.
     fn extract_class_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        Self::find_child_by_kind(node, "type_identifier")
+        find_direct_child_by_kind(node, "type_identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Extract the property name from a `property_declaration` node.
     fn extract_property_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // property_declaration has variable_declaration child which has simple_identifier
-        if let Some(var_decl) = Self::find_child_by_kind(node, "variable_declaration") {
-            if let Some(ident) = Self::find_child_by_kind(var_decl, "simple_identifier") {
+        if let Some(var_decl) = find_direct_child_by_kind(node, "variable_declaration") {
+            if let Some(ident) = find_direct_child_by_kind(var_decl, "simple_identifier") {
                 return state.node_text(ident);
             }
         }
         // Fallback: look for multi_variable_declaration
-        if let Some(multi) = Self::find_child_by_kind(node, "multi_variable_declaration") {
+        if let Some(multi) = find_direct_child_by_kind(node, "multi_variable_declaration") {
             return state.node_text(multi);
         }
         "<anonymous>".to_string()
@@ -1318,7 +1319,7 @@ impl KotlinExtractor {
             return text[..brace_pos].trim().to_string();
         }
         // Cut at first '=' for expression-bodied definitions.
-        if Self::find_child_by_kind(node, "function_body").is_some() {
+        if find_direct_child_by_kind(node, "function_body").is_some() {
             if let Some(eq_pos) = text.find('=') {
                 return text[..eq_pos].trim().to_string();
             }
@@ -1392,9 +1393,9 @@ impl KotlinExtractor {
     /// Extract a single delegation specifier (e.g. `: Foo()` or `: Bar`).
     fn extract_single_delegation(state: &mut ExtractionState, node: TsNode<'_>, owner_id: &str) {
         // delegation_specifier can contain constructor_invocation or user_type.
-        let type_name = Self::find_child_by_kind(node, "constructor_invocation")
-            .and_then(|ci| Self::find_child_by_kind(ci, "user_type"))
-            .or_else(|| Self::find_child_by_kind(node, "user_type"))
+        let type_name = find_direct_child_by_kind(node, "constructor_invocation")
+            .and_then(|ci| find_direct_child_by_kind(ci, "user_type"))
+            .or_else(|| find_direct_child_by_kind(node, "user_type"))
             .map_or_else(|| state.node_text(node), |ut| state.node_text(ut));
 
         let base_name = type_name
@@ -1431,16 +1432,16 @@ impl KotlinExtractor {
     /// Extract the name from an annotation node.
     fn extract_annotation_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // annotation has constructor_invocation or user_type children.
-        if let Some(ci) = Self::find_child_by_kind(node, "constructor_invocation") {
-            if let Some(ut) = Self::find_child_by_kind(ci, "user_type") {
-                if let Some(ti) = Self::find_child_by_kind(ut, "type_identifier") {
+        if let Some(ci) = find_direct_child_by_kind(node, "constructor_invocation") {
+            if let Some(ut) = find_direct_child_by_kind(ci, "user_type") {
+                if let Some(ti) = find_direct_child_by_kind(ut, "type_identifier") {
                     return state.node_text(ti);
                 }
                 return state.node_text(ut);
             }
         }
-        if let Some(ut) = Self::find_child_by_kind(node, "user_type") {
-            if let Some(ti) = Self::find_child_by_kind(ut, "type_identifier") {
+        if let Some(ut) = find_direct_child_by_kind(node, "user_type") {
+            if let Some(ti) = find_direct_child_by_kind(ut, "type_identifier") {
                 return state.node_text(ti);
             }
             return state.node_text(ut);
@@ -1582,23 +1583,6 @@ impl KotlinExtractor {
         }
         let text = state.node_text(node);
         text.split('(').next().unwrap_or(&text).trim().to_string()
-    }
-
-    /// Find the first child node of a specific kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/lua_extractor.rs
+++ b/src/extraction/lua_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, LUA_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -271,17 +272,17 @@ impl LuaExtractor {
     /// - `local CONST = <literal>` → Const node (uppercase names)
     fn visit_variable_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // variable_declaration contains an assignment_statement child.
-        let Some(assignment) = Self::find_child_by_kind(node, "assignment_statement") else {
+        let Some(assignment) = find_direct_child_by_kind(node, "assignment_statement") else {
             return;
         };
 
         // Get the variable name from the variable_list.
         let var_list = assignment
             .child_by_field_name("variable_list")
-            .or_else(|| Self::find_child_by_kind(assignment, "variable_list"));
+            .or_else(|| find_direct_child_by_kind(assignment, "variable_list"));
         let name_node = var_list.and_then(|vl| {
             // The first named child of variable_list should be the identifier.
-            Self::find_child_by_kind(vl, "identifier")
+            find_direct_child_by_kind(vl, "identifier")
         });
         let Some(n) = name_node else {
             return;
@@ -291,7 +292,7 @@ impl LuaExtractor {
         // Get the value from the expression_list.
         let expr_list = assignment
             .child_by_field_name("expression_list")
-            .or_else(|| Self::find_child_by_kind(assignment, "expression_list"));
+            .or_else(|| find_direct_child_by_kind(assignment, "expression_list"));
         let value_node = expr_list.and_then(|el| el.named_child(0));
 
         let Some(value_node) = value_node else {
@@ -432,7 +433,7 @@ impl LuaExtractor {
     fn extract_require_module(state: &ExtractionState, call_node: TsNode<'_>) -> Option<String> {
         let args = call_node
             .child_by_field_name("arguments")
-            .or_else(|| Self::find_child_by_kind(call_node, "arguments"))?;
+            .or_else(|| find_direct_child_by_kind(call_node, "arguments"))?;
         // Look for a string node inside arguments.
         let mut cursor = args.walk();
         if cursor.goto_first_child() {
@@ -440,7 +441,7 @@ impl LuaExtractor {
                 let child = cursor.node();
                 if child.kind() == "string" {
                     // The string node contains a string_content child.
-                    if let Some(content) = Self::find_child_by_kind(child, "string_content") {
+                    if let Some(content) = find_direct_child_by_kind(child, "string_content") {
                         return Some(state.node_text(content));
                     }
                     // Fall back to stripping quotes from the full text.
@@ -540,23 +541,6 @@ impl LuaExtractor {
                 }
             }
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -14,6 +14,7 @@ mod swift_extractor;
 mod typescript_extractor;
 
 pub(crate) mod annotations;
+pub(crate) mod common;
 pub mod complexity;
 pub(crate) mod traversal;
 pub mod ts_provider;

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -14,6 +14,8 @@ mod swift_extractor;
 mod typescript_extractor;
 
 pub(crate) mod annotations;
+#[cfg(any(feature = "lang-gwbasic", feature = "lang-msbasic2"))]
+pub(crate) mod basic_common;
 pub(crate) mod common;
 pub mod complexity;
 pub(crate) mod traversal;

--- a/src/extraction/msbasic2_extractor.rs
+++ b/src/extraction/msbasic2_extractor.rs
@@ -10,6 +10,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -181,13 +182,13 @@ impl MsBasic2Extractor {
 
     /// Parse a single `line` node into a `BasicLine` struct.
     fn parse_line<'a>(state: &ExtractionState, node: TsNode<'a>) -> Option<BasicLine<'a>> {
-        let line_number_node = Self::find_child_by_kind(node, "line_number")?;
+        let line_number_node = find_direct_child_by_kind(node, "line_number")?;
         let line_number_text = state.node_text(line_number_node);
         let line_number: u32 = line_number_text.trim().parse().unwrap_or(0);
 
         // Navigate: line -> statement_list -> statement -> specific_kind
-        let statement_list = Self::find_child_by_kind(node, "statement_list")?;
-        let statement = Self::find_child_by_kind(statement_list, "statement")?;
+        let statement_list = find_direct_child_by_kind(node, "statement_list")?;
+        let statement = find_direct_child_by_kind(statement_list, "statement")?;
 
         // Get the first named child of statement (the actual statement type).
         let mut stmt_cursor = statement.walk();
@@ -241,22 +242,22 @@ impl MsBasic2Extractor {
 
     /// Extract a LET statement as a Const node.
     fn visit_let_statement(state: &mut ExtractionState, basic_line: &BasicLine<'_>) {
-        let Some(statement_list) = Self::find_child_by_kind(basic_line.node, "statement_list")
+        let Some(statement_list) = find_direct_child_by_kind(basic_line.node, "statement_list")
         else {
             return;
         };
-        let Some(statement) = Self::find_child_by_kind(statement_list, "statement") else {
+        let Some(statement) = find_direct_child_by_kind(statement_list, "statement") else {
             return;
         };
-        let Some(let_stmt) = Self::find_child_by_kind(statement, "let_statement") else {
+        let Some(let_stmt) = find_direct_child_by_kind(statement, "let_statement") else {
             return;
         };
 
         // Extract the variable name from: let_statement -> variable -> identifier
-        let Some(var_node) = Self::find_child_by_kind(let_stmt, "variable") else {
+        let Some(var_node) = find_direct_child_by_kind(let_stmt, "variable") else {
             return;
         };
-        let Some(id_node) = Self::find_child_by_kind(var_node, "identifier") else {
+        let Some(id_node) = find_direct_child_by_kind(var_node, "identifier") else {
             return;
         };
         let name = state.node_text(id_node);
@@ -381,9 +382,9 @@ impl MsBasic2Extractor {
                     let mut returns: u32 = 0;
                     for line in &lines[body_start..body_end] {
                         // Try count_complexity on each line node that has children.
-                        let stmt_list = Self::find_child_by_kind(line.node, "statement_list");
+                        let stmt_list = find_direct_child_by_kind(line.node, "statement_list");
                         if let Some(sl) = stmt_list {
-                            let stmt = Self::find_child_by_kind(sl, "statement");
+                            let stmt = find_direct_child_by_kind(sl, "statement");
                             if let Some(s) = stmt {
                                 let mut sc = s.walk();
                                 if sc.goto_first_child() {
@@ -529,7 +530,7 @@ impl MsBasic2Extractor {
         match kind {
             "gosub_statement" | "goto_statement" => {
                 // Extract the target line number.
-                if let Some(ln_node) = Self::find_child_by_kind(node, "line_number") {
+                if let Some(ln_node) = find_direct_child_by_kind(node, "line_number") {
                     let target = state.node_text(ln_node);
                     state.unresolved_refs.push(UnresolvedRef {
                         from_node_id: from_node_id.to_string(),
@@ -596,23 +597,6 @@ impl MsBasic2Extractor {
         } else {
             trimmed
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/msbasic2_extractor.rs
+++ b/src/extraction/msbasic2_extractor.rs
@@ -10,6 +10,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::basic_common::{
+    derive_function_name, find_subroutine_ranges, for_each_top_level_line, BasicLine,
+};
 use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -69,18 +72,6 @@ impl ExtractionState {
             .unwrap_or("<invalid utf8>")
             .to_string()
     }
-}
-
-/// Represents a collected line from the BASIC program for subroutine synthesis.
-struct BasicLine<'a> {
-    /// The `line` AST node.
-    node: TsNode<'a>,
-    /// The line number (e.g. 10, 20, 100).
-    line_number: u32,
-    /// The kind of the first statement on this line.
-    statement_kind: String,
-    /// The text of the REM comment, if this line is a REM.
-    comment_text: Option<String>,
 }
 
 impl MsBasic2Extractor {
@@ -225,7 +216,7 @@ impl MsBasic2Extractor {
     /// In MS BASIC 2.0, lines like `30 LET MR = 3` serve as variable initialization.
     /// We treat only top-level LET assignments (those not inside subroutines) as constants.
     fn extract_top_level_lets(state: &mut ExtractionState, lines: &[BasicLine<'_>]) {
-        let subroutine_ranges = Self::find_subroutine_ranges(lines);
+        let subroutine_ranges = find_subroutine_ranges(lines);
         for (idx, basic_line) in lines.iter().enumerate() {
             // Skip lines that are inside subroutines.
             if subroutine_ranges
@@ -354,7 +345,7 @@ impl MsBasic2Extractor {
 
                 if has_return && body_start < body_end {
                     // Derive a function name from the first REM comment.
-                    let fn_name = Self::derive_function_name(&rem_comments);
+                    let fn_name = derive_function_name(&rem_comments);
                     let docstring = if rem_comments.is_empty() {
                         None
                     } else {
@@ -460,59 +451,14 @@ impl MsBasic2Extractor {
 
     /// Extract GOSUB/GOTO references from top-level lines (those not part of subroutines).
     fn extract_top_level_calls(state: &mut ExtractionState, lines: &[BasicLine<'_>]) {
-        // Determine which lines are part of subroutines (between first REM and RETURN).
-        let subroutine_ranges = Self::find_subroutine_ranges(lines);
-
         let file_node_id = state
             .node_stack
             .last()
             .map(|(_, id)| id.clone())
             .unwrap_or_default();
-
-        for (idx, line) in lines.iter().enumerate() {
-            // Skip lines that are inside subroutines.
-            if subroutine_ranges
-                .iter()
-                .any(|(start, end)| idx >= *start && idx < *end)
-            {
-                continue;
-            }
+        for_each_top_level_line(lines, |line| {
             Self::extract_calls_from_line(state, line, &file_node_id);
-        }
-    }
-
-    /// Find ranges of lines that belong to subroutines (REM ... RETURN blocks).
-    fn find_subroutine_ranges(lines: &[BasicLine<'_>]) -> Vec<(usize, usize)> {
-        let mut ranges = Vec::new();
-        let mut i = 0;
-        while i < lines.len() {
-            if lines[i].statement_kind == "comment" {
-                let rem_start = i;
-                while i < lines.len() && lines[i].statement_kind == "comment" {
-                    i += 1;
-                }
-                let mut body_end = i;
-                let mut has_return = false;
-                while body_end < lines.len() {
-                    if lines[body_end].statement_kind == "return_statement" {
-                        has_return = true;
-                        body_end += 1;
-                        break;
-                    }
-                    if lines[body_end].statement_kind == "comment" {
-                        break;
-                    }
-                    body_end += 1;
-                }
-                if has_return {
-                    ranges.push((rem_start, body_end));
-                }
-                i = body_end;
-            } else {
-                i += 1;
-            }
-        }
-        ranges
+        });
     }
 
     /// Extract GOSUB/GOTO call references from a single line.
@@ -554,48 +500,6 @@ impl MsBasic2Extractor {
                     break;
                 }
             }
-        }
-    }
-
-    /// Derive a function name from REM comment text.
-    ///
-    /// Takes the first REM line text and converts it into a snake_case-like
-    /// identifier. For example, "LOG A MESSAGE" becomes "`LOG_A_MESSAGE`".
-    fn derive_function_name(rem_comments: &[String]) -> String {
-        if rem_comments.is_empty() {
-            return "UNNAMED_SUB".to_string();
-        }
-        let first = &rem_comments[0];
-        // Replace spaces with underscores and keep alphanumeric + underscore.
-        let name: String = first
-            .chars()
-            .map(|c| {
-                if c.is_alphanumeric() || c == '_' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect();
-        // Collapse multiple underscores and trim.
-        let mut collapsed = String::new();
-        let mut prev_underscore = false;
-        for c in name.chars() {
-            if c == '_' {
-                if !prev_underscore && !collapsed.is_empty() {
-                    collapsed.push('_');
-                }
-                prev_underscore = true;
-            } else {
-                collapsed.push(c);
-                prev_underscore = false;
-            }
-        }
-        let trimmed = collapsed.trim_end_matches('_').to_string();
-        if trimmed.is_empty() {
-            "UNNAMED_SUB".to_string()
-        } else {
-            trimmed
         }
     }
 

--- a/src/extraction/objc_extractor.rs
+++ b/src/extraction/objc_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::{clean_c_doc_comment, docstring_from_preceding_comments};
 use crate::extraction::complexity::{count_complexity, OBJC_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -1019,28 +1020,7 @@ impl ObjcExtractor {
     /// Extract docstring for an `implementation_definition` by looking at preceding
     /// sibling comments within the `class_implementation`.
     fn extract_impl_method_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                let text = state.node_text(sibling);
-                comments.push(text);
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
+        docstring_from_preceding_comments(&state.source, node, clean_c_doc_comment)
     }
 
     // -------------------------------------------------------
@@ -1357,54 +1337,7 @@ impl ObjcExtractor {
 
     /// Extract docstrings from preceding comment nodes.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                let text = state.node_text(sibling);
-                comments.push(text);
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
-    }
-
-    /// Strip comment markers from a single C/ObjC comment text.
-    fn clean_comment(comment: &str) -> String {
-        let trimmed = comment.trim();
-        if let Some(stripped) = trimmed.strip_prefix("///") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if let Some(stripped) = trimmed.strip_prefix("//") {
-            stripped.strip_prefix(' ').unwrap_or(stripped).to_string()
-        } else if trimmed.starts_with("/*") && trimmed.ends_with("*/") {
-            let inner = &trimmed[2..trimmed.len() - 2];
-            inner
-                .lines()
-                .map(|line| {
-                    let l = line.trim();
-                    l.strip_prefix("* ")
-                        .or_else(|| l.strip_prefix('*'))
-                        .unwrap_or(l)
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-                .trim()
-                .to_string()
-        } else {
-            trimmed.to_string()
-        }
+        docstring_from_preceding_comments(&state.source, node, clean_c_doc_comment)
     }
 
     // -------------------------------------------------------

--- a/src/extraction/objc_extractor.rs
+++ b/src/extraction/objc_extractor.rs
@@ -8,6 +8,7 @@ use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::common::{clean_c_doc_comment, docstring_from_preceding_comments};
 use crate::extraction::complexity::{count_complexity, OBJC_COMPLEXITY};
+use crate::extraction::traversal::{find_descendant_by_kind, find_direct_child_by_kind};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -176,8 +177,8 @@ impl ObjcExtractor {
 
     /// Extract a preprocessor #import or #include.
     fn visit_preproc_include(state: &mut ExtractionState, node: TsNode<'_>) {
-        let path = Self::find_child_by_kind(node, "string_literal")
-            .or_else(|| Self::find_child_by_kind(node, "system_lib_string"))
+        let path = find_direct_child_by_kind(node, "string_literal")
+            .or_else(|| find_direct_child_by_kind(node, "system_lib_string"))
             .map_or_else(
                 || "<unknown>".to_string(),
                 |n| {
@@ -238,7 +239,7 @@ impl ObjcExtractor {
 
     /// Extract a preprocessor #define.
     fn visit_preproc_def(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let text = state.node_text(node);
@@ -302,8 +303,8 @@ impl ObjcExtractor {
     /// The enum variant names appear as `type_identifier` children with field "declarator".
     fn visit_type_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         // Check if this is an NS_ENUM pattern
-        if let Some(macro_spec) = Self::find_child_by_kind(node, "macro_type_specifier") {
-            let macro_name = Self::find_child_by_kind(macro_spec, "identifier")
+        if let Some(macro_spec) = find_direct_child_by_kind(node, "macro_type_specifier") {
+            let macro_name = find_direct_child_by_kind(macro_spec, "identifier")
                 .map(|n| state.node_text(n))
                 .unwrap_or_default();
             if macro_name == "NS_ENUM" || macro_name == "NS_OPTIONS" {
@@ -409,7 +410,7 @@ impl ObjcExtractor {
                 let child = cursor.node();
                 if child.kind() == "ERROR" {
                     // Inside ERROR, find the identifier
-                    if let Some(ident) = Self::find_child_by_kind(child, "identifier") {
+                    if let Some(ident) = find_direct_child_by_kind(child, "identifier") {
                         return Some(state.node_text(ident));
                     }
                 }
@@ -545,7 +546,7 @@ impl ObjcExtractor {
     ///
     /// Maps to Interface node kind with method declarations inside.
     fn visit_protocol(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -595,7 +596,7 @@ impl ObjcExtractor {
         }
 
         // Extract protocol inheritance from protocol_reference_list
-        if let Some(ref_list) = Self::find_child_by_kind(node, "protocol_reference_list") {
+        if let Some(ref_list) = find_direct_child_by_kind(node, "protocol_reference_list") {
             Self::extract_protocol_refs(state, ref_list, &id, start_line);
         }
 
@@ -660,7 +661,7 @@ impl ObjcExtractor {
     ///
     /// This includes properties, method declarations, superclass, and protocol conformance.
     fn visit_class_interface(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -723,7 +724,7 @@ impl ObjcExtractor {
         }
 
         // Extract protocol conformance (<Protocol1, Protocol2>)
-        if let Some(params) = Self::find_child_by_kind(node, "parameterized_arguments") {
+        if let Some(params) = find_direct_child_by_kind(node, "parameterized_arguments") {
             Self::extract_protocol_conformance(state, params, &id, start_line);
         }
 
@@ -747,7 +748,7 @@ impl ObjcExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "type_name" {
-                    if let Some(type_id) = Self::find_child_by_kind(child, "type_identifier") {
+                    if let Some(type_id) = find_direct_child_by_kind(child, "type_identifier") {
                         let name = state.node_text(type_id);
                         state.unresolved_refs.push(UnresolvedRef {
                             from_node_id: from_node_id.to_string(),
@@ -844,19 +845,19 @@ impl ObjcExtractor {
 
     /// Extract the property name from a `property_declaration` node.
     fn extract_property_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        if let Some(struct_decl) = Self::find_child_by_kind(node, "struct_declaration") {
+        if let Some(struct_decl) = find_direct_child_by_kind(node, "struct_declaration") {
             if let Some(struct_declarator) =
-                Self::find_child_by_kind(struct_decl, "struct_declarator")
+                find_direct_child_by_kind(struct_decl, "struct_declarator")
             {
                 // Direct identifier
-                if let Some(ident) = Self::find_child_by_kind(struct_declarator, "identifier") {
+                if let Some(ident) = find_direct_child_by_kind(struct_declarator, "identifier") {
                     return Some(state.node_text(ident));
                 }
                 // Pointer declarator (NSString *name)
                 if let Some(ptr_decl) =
-                    Self::find_child_by_kind(struct_declarator, "pointer_declarator")
+                    find_direct_child_by_kind(struct_declarator, "pointer_declarator")
                 {
-                    if let Some(ident) = Self::find_child_by_kind(ptr_decl, "identifier") {
+                    if let Some(ident) = find_direct_child_by_kind(ptr_decl, "identifier") {
                         return Some(state.node_text(ident));
                     }
                 }
@@ -933,7 +934,7 @@ impl ObjcExtractor {
     ///
     /// Maps to Impl node kind with method definitions inside.
     fn visit_class_implementation(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -1009,7 +1010,7 @@ impl ObjcExtractor {
     /// Visit an `implementation_definition` which wraps a `method_definition`.
     fn visit_implementation_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         // The implementation_definition contains a method_definition child
-        if let Some(method_def) = Self::find_child_by_kind(node, "method_definition") {
+        if let Some(method_def) = find_direct_child_by_kind(node, "method_definition") {
             // Check for docstring on the implementation_definition itself
             // (comments appear as siblings of implementation_definition inside class_implementation)
             let docstring = Self::extract_impl_method_docstring(state, node);
@@ -1083,7 +1084,7 @@ impl ObjcExtractor {
         }
 
         // Extract call sites from the method body
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             Self::extract_call_sites(state, body, &id);
         }
     }
@@ -1143,7 +1144,7 @@ impl ObjcExtractor {
         }
 
         // Extract call sites from the function body
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             Self::extract_call_sites(state, body, &id);
         }
     }
@@ -1151,7 +1152,7 @@ impl ObjcExtractor {
     /// Extract a C declaration (function prototype or variable).
     fn visit_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Check if this declaration contains a function_declarator (prototype)
-        if Self::find_descendant_by_kind(node, "function_declarator").is_some() {
+        if find_descendant_by_kind(node, "function_declarator").is_some() {
             Self::visit_function_prototype(state, node);
         }
     }
@@ -1313,8 +1314,8 @@ impl ObjcExtractor {
 
     /// Extract the function name from a `function_definition` or declaration node.
     fn extract_function_name(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        if let Some(declarator) = Self::find_descendant_by_kind(node, "function_declarator") {
-            if let Some(ident) = Self::find_child_by_kind(declarator, "identifier") {
+        if let Some(declarator) = find_descendant_by_kind(node, "function_declarator") {
+            if let Some(ident) = find_direct_child_by_kind(declarator, "identifier") {
                 return Some(state.node_text(ident));
             }
         }
@@ -1347,43 +1348,6 @@ impl ObjcExtractor {
     /// Extract first line of text as a signature.
     fn extract_first_line(text: &str) -> String {
         text.lines().next().unwrap_or(text).trim().to_string()
-    }
-
-    /// Find the first direct child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-
-    /// Find the first descendant of a node with a given kind (recursive search).
-    fn find_descendant_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if let Some(found) = Self::find_descendant_by_kind(child, kind) {
-                    return Some(found);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/pascal_extractor.rs
+++ b/src/extraction/pascal_extractor.rs
@@ -8,6 +8,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::docstring_from_preceding_comments;
 use crate::extraction::complexity::{count_complexity, PASCAL_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -1347,29 +1348,7 @@ impl PascalExtractor {
 
     /// Extract docstrings from preceding comment nodes.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let mut comments = Vec::new();
-        let mut current = node.prev_named_sibling();
-        while let Some(sibling) = current {
-            if sibling.kind() == "comment" {
-                let text = state.node_text(sibling);
-                comments.push(text);
-                current = sibling.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        // Comments are collected in reverse order (closest first).
-        comments.reverse();
-        let cleaned: Vec<String> = comments.iter().map(|c| Self::clean_comment(c)).collect();
-        let result = cleaned.join("\n").trim().to_string();
-        if result.is_empty() {
-            None
-        } else {
-            Some(result)
-        }
+        docstring_from_preceding_comments(&state.source, node, Self::clean_comment)
     }
 
     /// Strip comment markers from a single Pascal comment text.

--- a/src/extraction/pascal_extractor.rs
+++ b/src/extraction/pascal_extractor.rs
@@ -10,6 +10,7 @@ use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::common::docstring_from_preceding_comments;
 use crate::extraction::complexity::{count_complexity, PASCAL_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -323,7 +324,7 @@ impl PascalExtractor {
 
     /// Extract a single uses reference as a Use node.
     fn visit_single_use(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| state.node_text(node), |n| state.node_text(n));
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -399,18 +400,18 @@ impl PascalExtractor {
     /// Visit a single type declaration (declType).
     /// Dispatches based on whether it's a class, record, interface, or type alias.
     fn visit_type_decl(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Look for the type body: declClass, declIntf, or plain type.
-        if let Some(class_node) = Self::find_child_by_kind(node, "declClass") {
+        if let Some(class_node) = find_direct_child_by_kind(node, "declClass") {
             // Check if it's a record or class.
-            if Self::find_child_by_kind(class_node, "kRecord").is_some() {
+            if find_direct_child_by_kind(class_node, "kRecord").is_some() {
                 Self::visit_record_type(state, &name, class_node, node);
             } else {
                 Self::visit_class_type(state, &name, class_node, node);
             }
-        } else if let Some(intf_node) = Self::find_child_by_kind(node, "declIntf") {
+        } else if let Some(intf_node) = find_direct_child_by_kind(node, "declIntf") {
             Self::visit_interface_type(state, &name, intf_node, node);
         } else {
             // Plain type alias (e.g., TMyAlias = Integer).
@@ -441,7 +442,7 @@ impl PascalExtractor {
         // Build signature: "TMyClass = class(TObject)"
         let mut sig = format!("{name} = class");
         // Check for parent class.
-        if let Some(parent_ref) = Self::find_child_by_kind(class_node, "typeref") {
+        if let Some(parent_ref) = find_direct_child_by_kind(class_node, "typeref") {
             let parent_name = state.node_text(parent_ref);
             sig = format!("{name} = class({parent_name})");
         }
@@ -484,7 +485,7 @@ impl PascalExtractor {
         }
 
         // Extract parent class as Extends reference.
-        if let Some(parent_ref) = Self::find_child_by_kind(class_node, "typeref") {
+        if let Some(parent_ref) = find_direct_child_by_kind(class_node, "typeref") {
             let parent_name = state.node_text(parent_ref);
             state.unresolved_refs.push(UnresolvedRef {
                 from_node_id: id.clone(),
@@ -765,7 +766,7 @@ impl PascalExtractor {
 
     /// Extract a field declaration.
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -918,7 +919,7 @@ impl PascalExtractor {
 
     /// Extract a property declaration.
     fn visit_property(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -984,7 +985,7 @@ impl PascalExtractor {
 
     /// Extract a single constant declaration.
     fn visit_const(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1056,7 +1057,7 @@ impl PascalExtractor {
 
     /// Extract a single variable declaration.
     fn visit_var(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -1112,8 +1113,8 @@ impl PascalExtractor {
 
     /// Visit a function/procedure definition (defProc), which has a declProc and block.
     fn visit_def_proc(state: &mut ExtractionState, node: TsNode<'_>) {
-        let decl = Self::find_child_by_kind(node, "declProc");
-        let block = Self::find_child_by_kind(node, "block");
+        let decl = find_direct_child_by_kind(node, "declProc");
+        let block = find_direct_child_by_kind(node, "block");
 
         if let Some(decl_node) = decl {
             let (kind_str, node_kind) = Self::determine_proc_kind(decl_node);
@@ -1216,8 +1217,8 @@ impl PascalExtractor {
 
     /// Find the module name from a program or unit node.
     fn find_module_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        if let Some(mod_name) = Self::find_child_by_kind(node, "moduleName") {
-            if let Some(ident) = Self::find_child_by_kind(mod_name, "identifier") {
+        if let Some(mod_name) = find_direct_child_by_kind(node, "moduleName") {
+            if let Some(ident) = find_direct_child_by_kind(mod_name, "identifier") {
                 return state.node_text(ident);
             }
             return state.node_text(mod_name);
@@ -1228,13 +1229,13 @@ impl PascalExtractor {
     /// Determine the procedure kind from a declProc node.
     /// Returns (`kind_str`, `NodeKind`).
     fn determine_proc_kind(node: TsNode<'_>) -> (&'static str, NodeKind) {
-        if Self::find_child_by_kind(node, "kConstructor").is_some() {
+        if find_direct_child_by_kind(node, "kConstructor").is_some() {
             ("constructor", NodeKind::Constructor)
-        } else if Self::find_child_by_kind(node, "kDestructor").is_some() {
+        } else if find_direct_child_by_kind(node, "kDestructor").is_some() {
             ("destructor", NodeKind::Method)
-        } else if Self::find_child_by_kind(node, "kProcedure").is_some() {
+        } else if find_direct_child_by_kind(node, "kProcedure").is_some() {
             ("procedure", NodeKind::Procedure)
-        } else if Self::find_child_by_kind(node, "kFunction").is_some() {
+        } else if find_direct_child_by_kind(node, "kFunction").is_some() {
             ("function", NodeKind::Function)
         } else {
             ("unknown", NodeKind::Function)
@@ -1245,18 +1246,18 @@ impl PascalExtractor {
     /// Handles both simple names and dotted names (e.g., TMyClass.DoSomething).
     fn find_proc_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // Check for genericDot first (dotted name like TMyClass.DoSomething).
-        if let Some(dot_node) = Self::find_child_by_kind(node, "genericDot") {
+        if let Some(dot_node) = find_direct_child_by_kind(node, "genericDot") {
             return state.node_text(dot_node);
         }
         // Otherwise look for a simple identifier.
-        Self::find_child_by_kind(node, "identifier")
+        find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n))
     }
 
     /// Parse a dotted name from a declProc node.
     /// Returns (`is_method`, `class_name`, `method_name`).
     fn parse_dotted_name(state: &ExtractionState, decl_node: TsNode<'_>) -> (bool, String, String) {
-        if let Some(dot_node) = Self::find_child_by_kind(decl_node, "genericDot") {
+        if let Some(dot_node) = find_direct_child_by_kind(decl_node, "genericDot") {
             // genericDot has identifiers separated by kDot.
             let mut identifiers = Vec::new();
             let mut cursor = dot_node.walk();
@@ -1313,7 +1314,7 @@ impl PascalExtractor {
                             if fc.kind() == "identifier" {
                                 // Check there's no exprCall - just a bare identifier.
                                 let has_call =
-                                    Self::find_child_by_kind(child, "exprCall").is_some();
+                                    find_direct_child_by_kind(child, "exprCall").is_some();
                                 if !has_call {
                                     let callee_name = state.node_text(fc);
                                     // Skip some keywords that aren't calls.
@@ -1374,23 +1375,6 @@ impl PascalExtractor {
         } else {
             trimmed.to_string()
         }
-    }
-
-    /// Find the first named child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/perl_extractor.rs
+++ b/src/extraction/perl_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, PERL_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -237,7 +238,7 @@ impl PerlExtractor {
     /// we handle them by scanning ahead through siblings until the next
     /// `package_statement` or end of the `source_file` children.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "package_name")
+        let name = find_direct_child_by_kind(node, "package_name")
             .map_or_else(|| "<anonymous>".to_string(), |pn| state.node_text(pn));
 
         // Skip `package main;` — it just returns to the top-level scope.
@@ -398,7 +399,7 @@ impl PerlExtractor {
         let left = node.child_by_field_name("variable");
         if let Some(left_node) = left {
             if left_node.kind() == "variable_declaration" {
-                let scope_node = Self::find_child_by_kind(left_node, "scope");
+                let scope_node = find_direct_child_by_kind(left_node, "scope");
                 let is_our = scope_node.is_some_and(|s| state.node_text(s) == "our");
 
                 if is_our {
@@ -525,7 +526,7 @@ impl PerlExtractor {
                         // These contain a call_expression_with_bareword child
                         // with a function_name field.
                         let callee_name =
-                            Self::find_child_by_kind(child, "call_expression_with_bareword")
+                            find_direct_child_by_kind(child, "call_expression_with_bareword")
                                 .and_then(|ceb| ceb.child_by_field_name("function_name"))
                                 .map(|n| state.node_text(n));
 
@@ -544,7 +545,7 @@ impl PerlExtractor {
                         }
                         // Also check for qualified calls (e.g., main::log_message)
                         if let Some(ceb) =
-                            Self::find_child_by_kind(child, "call_expression_with_bareword")
+                            find_direct_child_by_kind(child, "call_expression_with_bareword")
                         {
                             if let Some(pkg) = ceb.child_by_field_name("package_name") {
                                 let pkg_name = state.node_text(pkg);
@@ -664,23 +665,6 @@ impl PerlExtractor {
                 | "ref"
                 | "bless"
         )
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/php_extractor.rs
+++ b/src/extraction/php_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, PHP_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -171,7 +172,7 @@ impl PhpExtractor {
 
     /// Extract a top-level function definition.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -225,14 +226,14 @@ impl PhpExtractor {
         Self::extract_annotations(state, node, &id);
 
         // Extract call sites from the function body.
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             Self::extract_call_sites(state, body, &id);
         }
     }
 
     /// Extract a class method declaration.
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::extract_visibility(state, node);
@@ -286,14 +287,14 @@ impl PhpExtractor {
         Self::extract_annotations(state, node, &id);
 
         // Extract call sites from the method body.
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             Self::extract_call_sites(state, body, &id);
         }
     }
 
     /// Extract a class declaration.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -352,7 +353,7 @@ impl PhpExtractor {
         // Visit class body members.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "declaration_list") {
+        if let Some(body) = find_direct_child_by_kind(node, "declaration_list") {
             Self::visit_class_body(state, body);
         }
         state.class_depth -= 1;
@@ -361,7 +362,7 @@ impl PhpExtractor {
 
     /// Extract an interface declaration.
     fn visit_interface(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -413,7 +414,7 @@ impl PhpExtractor {
         // Visit interface body.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "declaration_list") {
+        if let Some(body) = find_direct_child_by_kind(node, "declaration_list") {
             Self::visit_class_body(state, body);
         }
         state.class_depth -= 1;
@@ -422,7 +423,7 @@ impl PhpExtractor {
 
     /// Extract a trait declaration.
     fn visit_trait(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -474,7 +475,7 @@ impl PhpExtractor {
         // Visit trait body.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "declaration_list") {
+        if let Some(body) = find_direct_child_by_kind(node, "declaration_list") {
             Self::visit_class_body(state, body);
         }
         state.class_depth -= 1;
@@ -483,7 +484,7 @@ impl PhpExtractor {
 
     /// Extract an enum declaration.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -535,7 +536,7 @@ impl PhpExtractor {
         // Visit enum body for cases.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "enum_declaration_list") {
+        if let Some(body) = find_direct_child_by_kind(node, "enum_declaration_list") {
             Self::visit_enum_body(state, body);
         }
         state.class_depth -= 1;
@@ -563,7 +564,7 @@ impl PhpExtractor {
 
     /// Extract an enum case as an `EnumVariant`.
     fn visit_enum_case(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -612,7 +613,7 @@ impl PhpExtractor {
 
     /// Extract a namespace definition.
     fn visit_namespace(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "namespace_name")
+        let name = find_direct_child_by_kind(node, "namespace_name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -662,7 +663,7 @@ impl PhpExtractor {
 
         // Visit namespace body (braced namespace) or siblings (unbraced).
         state.node_stack.push((name.clone(), id));
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             Self::visit_children(state, body);
         }
         state.node_stack.pop();
@@ -697,8 +698,8 @@ impl PhpExtractor {
 
     /// Extract a single use clause (e.g., `Foo\Bar as Baz`).
     fn visit_use_clause(state: &mut ExtractionState, clause: TsNode<'_>, use_node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(clause, "qualified_name")
-            .or_else(|| Self::find_child_by_kind(clause, "name"))
+        let name = find_direct_child_by_kind(clause, "qualified_name")
+            .or_else(|| find_direct_child_by_kind(clause, "name"))
             .map_or_else(|| state.node_text(clause), |n| state.node_text(n));
         Self::create_use_node(state, &name, use_node);
     }
@@ -706,7 +707,7 @@ impl PhpExtractor {
     /// Extract a grouped use declaration (e.g., `use Foo\{Bar, Baz}`).
     fn visit_use_group(state: &mut ExtractionState, group: TsNode<'_>, use_node: TsNode<'_>) {
         // The group has a prefix and individual clauses.
-        let prefix = Self::find_child_by_kind(group, "namespace_name")
+        let prefix = find_direct_child_by_kind(group, "namespace_name")
             .map(|n| state.node_text(n))
             .unwrap_or_default();
 
@@ -715,8 +716,8 @@ impl PhpExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "namespace_use_clause" {
-                    let item = Self::find_child_by_kind(child, "name")
-                        .or_else(|| Self::find_child_by_kind(child, "qualified_name"))
+                    let item = find_direct_child_by_kind(child, "name")
+                        .or_else(|| find_direct_child_by_kind(child, "qualified_name"))
                         .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                     let full_name = if prefix.is_empty() {
                         item
@@ -808,7 +809,7 @@ impl PhpExtractor {
 
     /// Extract a single const element.
     fn visit_const_element(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "name")
+        let name = find_direct_child_by_kind(node, "name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -866,7 +867,7 @@ impl PhpExtractor {
                 let child = cursor.node();
                 if child.kind() == "property_element" || child.kind() == "variable_name" {
                     let name = if child.kind() == "property_element" {
-                        Self::find_child_by_kind(child, "variable_name")
+                        find_direct_child_by_kind(child, "variable_name")
                             .map_or_else(|| state.node_text(child), |n| state.node_text(n))
                     } else {
                         state.node_text(child)
@@ -954,7 +955,7 @@ impl PhpExtractor {
 
     /// Extract the visibility modifier from a node (looks for `visibility_modifier` child).
     fn extract_visibility(state: &ExtractionState, node: TsNode<'_>) -> Visibility {
-        if let Some(vis_node) = Self::find_child_by_kind(node, "visibility_modifier") {
+        if let Some(vis_node) = find_direct_child_by_kind(node, "visibility_modifier") {
             let text = state.node_text(vis_node);
             match text.trim() {
                 "protected" | "private" => Visibility::Private,
@@ -969,9 +970,9 @@ impl PhpExtractor {
     /// Extract base class from a class declaration (extends clause).
     fn extract_class_extends(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
         // Look for base_clause child containing a qualified_name or name.
-        if let Some(base_clause) = Self::find_child_by_kind(node, "base_clause") {
-            let base_name = Self::find_child_by_kind(base_clause, "qualified_name")
-                .or_else(|| Self::find_child_by_kind(base_clause, "name"))
+        if let Some(base_clause) = find_direct_child_by_kind(node, "base_clause") {
+            let base_name = find_direct_child_by_kind(base_clause, "qualified_name")
+                .or_else(|| find_direct_child_by_kind(base_clause, "name"))
                 .map(|n| state.node_text(n));
             if let Some(name) = base_name {
                 let line = base_clause.start_position().row as u32;
@@ -990,7 +991,7 @@ impl PhpExtractor {
 
     /// Extract implemented interfaces from a class declaration (implements clause).
     fn extract_class_implements(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
-        if let Some(impl_list) = Self::find_child_by_kind(node, "class_implements") {
+        if let Some(impl_list) = find_direct_child_by_kind(node, "class_implements") {
             let mut cursor = impl_list.walk();
             if cursor.goto_first_child() {
                 loop {
@@ -1019,7 +1020,7 @@ impl PhpExtractor {
     /// Extract the function/method signature (everything up to the body).
     fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         // Use the compound_statement body's start byte to find where the body begins.
-        if let Some(body) = Self::find_child_by_kind(node, "compound_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "compound_statement") {
             let text = state.node_text(node);
             let body_offset = body.start_byte() - node.start_byte();
             if body_offset <= text.len() {
@@ -1032,7 +1033,7 @@ impl PhpExtractor {
 
     /// Extract the class signature (class Name extends Base implements Iface).
     fn extract_class_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
-        if let Some(body) = Self::find_child_by_kind(node, "declaration_list") {
+        if let Some(body) = find_direct_child_by_kind(node, "declaration_list") {
             let text = state.node_text(node);
             let body_offset = body.start_byte() - node.start_byte();
             if body_offset <= text.len() {
@@ -1287,32 +1288,15 @@ impl PhpExtractor {
     /// Extract the name from a PHP attribute node.
     fn extract_attribute_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // PHP attributes have a "name" or "qualified_name" child.
-        if let Some(name) = Self::find_child_by_kind(node, "name") {
+        if let Some(name) = find_direct_child_by_kind(node, "name") {
             return state.node_text(name);
         }
-        if let Some(qn) = Self::find_child_by_kind(node, "qualified_name") {
+        if let Some(qn) = find_direct_child_by_kind(node, "qualified_name") {
             return state.node_text(qn);
         }
         // Fallback: full text before '('
         let text = state.node_text(node);
         text.split('(').next().unwrap_or(&text).trim().to_string()
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/powershell_extractor.rs
+++ b/src/extraction/powershell_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, POWERSHELL_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -161,10 +162,10 @@ impl PowerShellExtractor {
     /// Visit a pipeline node, which can contain assignments (consts) or commands (imports).
     fn visit_pipeline(state: &mut ExtractionState, node: TsNode<'_>) {
         // A pipeline wraps either an assignment_expression or a pipeline_chain > command.
-        if let Some(assignment) = Self::find_child_by_kind(node, "assignment_expression") {
+        if let Some(assignment) = find_direct_child_by_kind(node, "assignment_expression") {
             Self::visit_assignment(state, assignment, node);
-        } else if let Some(chain) = Self::find_child_by_kind(node, "pipeline_chain") {
-            if let Some(command) = Self::find_child_by_kind(chain, "command") {
+        } else if let Some(chain) = find_direct_child_by_kind(node, "pipeline_chain") {
+            if let Some(command) = find_direct_child_by_kind(chain, "command") {
                 Self::visit_command(state, command);
             }
         }
@@ -172,7 +173,7 @@ impl PowerShellExtractor {
 
     /// Extract a function definition.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "function_name")
+        let name = find_direct_child_by_kind(node, "function_name")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let kind = NodeKind::Function;
@@ -235,7 +236,7 @@ impl PowerShellExtractor {
     fn visit_assignment(state: &mut ExtractionState, node: TsNode<'_>, pipeline_node: TsNode<'_>) {
         // Only treat top-level typed assignments as constants.
         // We detect a cast_expression inside the left_assignment_expression.
-        let Some(left) = Self::find_child_by_kind(node, "left_assignment_expression") else {
+        let Some(left) = find_direct_child_by_kind(node, "left_assignment_expression") else {
             return;
         };
 
@@ -311,12 +312,12 @@ impl PowerShellExtractor {
         if cmd_name == "Import-Module" {
             // Extract the module name from command_elements.
             if let Some(elements) = node.child_by_field_name("command_elements") {
-                if let Some(token) = Self::find_child_by_kind(elements, "generic_token") {
+                if let Some(token) = find_direct_child_by_kind(elements, "generic_token") {
                     let module_name = state.node_text(token);
                     Self::emit_use_node(state, node, &module_name);
                 }
             }
-        } else if Self::find_child_by_kind(node, "command_invokation_operator").is_some() {
+        } else if find_direct_child_by_kind(node, "command_invokation_operator").is_some() {
             // Dot-source command: `. .\Utils.ps1`
             // The path is in command_name_expr > command_name.
             if let Some(name_expr) = node.child_by_field_name("command_name") {
@@ -456,23 +457,6 @@ impl PowerShellExtractor {
                 }
             }
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Find the first descendant of a node with a given kind (recursive DFS).

--- a/src/extraction/proto_extractor.rs
+++ b/src/extraction/proto_extractor.rs
@@ -5,6 +5,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, Visibility,
 };
@@ -157,8 +158,8 @@ impl ProtoExtractor {
     /// Extract a `package` declaration.
     fn visit_package(state: &mut ExtractionState, node: TsNode<'_>) {
         // package -> fullIdent -> ident
-        let name = Self::find_child_by_kind(node, "fullIdent")
-            .and_then(|fi| Self::find_child_by_kind(fi, "ident"))
+        let name = find_direct_child_by_kind(node, "fullIdent")
+            .and_then(|fi| find_direct_child_by_kind(fi, "ident"))
             .map_or_else(|| "<unknown>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -215,7 +216,7 @@ impl ProtoExtractor {
     /// Extract an `import` statement.
     fn visit_import(state: &mut ExtractionState, node: TsNode<'_>) {
         // import -> strLit (the quoted path)
-        let name = Self::find_child_by_kind(node, "strLit").map_or_else(
+        let name = find_direct_child_by_kind(node, "strLit").map_or_else(
             || "<unknown>".to_string(),
             |n| {
                 let text = state.node_text(n);
@@ -278,8 +279,8 @@ impl ProtoExtractor {
     /// Extract a `message` definition.
     fn visit_message(state: &mut ExtractionState, node: TsNode<'_>) {
         // message -> messageName -> ident, messageBody -> (field | message | oneof | enum | ...)
-        let name = Self::find_child_by_kind(node, "messageName")
-            .and_then(|mn| Self::find_child_by_kind(mn, "ident"))
+        let name = find_direct_child_by_kind(node, "messageName")
+            .and_then(|mn| find_direct_child_by_kind(mn, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -329,7 +330,7 @@ impl ProtoExtractor {
 
         // Visit message body for fields, nested messages, enums, oneofs.
         state.node_stack.push((name, id));
-        if let Some(body) = Self::find_child_by_kind(node, "messageBody") {
+        if let Some(body) = find_direct_child_by_kind(node, "messageBody") {
             Self::visit_message_body(state, body);
         }
         state.node_stack.pop();
@@ -358,15 +359,15 @@ impl ProtoExtractor {
     /// Extract a field declaration within a message.
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
         // field -> type, fieldName -> ident, `=`, fieldNumber -> intLit
-        let name = Self::find_child_by_kind(node, "fieldName")
-            .and_then(|fn_node| Self::find_child_by_kind(fn_node, "ident"))
+        let name = find_direct_child_by_kind(node, "fieldName")
+            .and_then(|fn_node| find_direct_child_by_kind(fn_node, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
-        let type_text = Self::find_child_by_kind(node, "type")
+        let type_text = find_direct_child_by_kind(node, "type")
             .map_or_else(|| "unknown".to_string(), |n| state.node_text(n));
 
-        let field_number = Self::find_child_by_kind(node, "fieldNumber")
-            .and_then(|fn_node| Self::find_child_by_kind(fn_node, "intLit"))
+        let field_number = find_direct_child_by_kind(node, "fieldNumber")
+            .and_then(|fn_node| find_direct_child_by_kind(fn_node, "intLit"))
             .map_or_else(|| "?".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -417,8 +418,8 @@ impl ProtoExtractor {
     /// Extract an `enum` definition.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
         // enum -> enumName -> ident, enumBody -> enumField*
-        let name = Self::find_child_by_kind(node, "enumName")
-            .and_then(|en| Self::find_child_by_kind(en, "ident"))
+        let name = find_direct_child_by_kind(node, "enumName")
+            .and_then(|en| find_direct_child_by_kind(en, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -468,7 +469,7 @@ impl ProtoExtractor {
 
         // Visit enum body for variants.
         state.node_stack.push((name, id));
-        if let Some(body) = Self::find_child_by_kind(node, "enumBody") {
+        if let Some(body) = find_direct_child_by_kind(node, "enumBody") {
             Self::visit_enum_body(state, body);
         }
         state.node_stack.pop();
@@ -493,10 +494,10 @@ impl ProtoExtractor {
     /// Extract an enum variant (enumField).
     fn visit_enum_field(state: &mut ExtractionState, node: TsNode<'_>) {
         // enumField -> ident, intLit
-        let name = Self::find_child_by_kind(node, "ident")
+        let name = find_direct_child_by_kind(node, "ident")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
-        let value = Self::find_child_by_kind(node, "intLit")
+        let value = find_direct_child_by_kind(node, "intLit")
             .map_or_else(|| "?".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -547,8 +548,8 @@ impl ProtoExtractor {
     /// Extract a `service` definition.
     fn visit_service(state: &mut ExtractionState, node: TsNode<'_>) {
         // service -> serviceName -> ident, rpc*
-        let name = Self::find_child_by_kind(node, "serviceName")
-            .and_then(|sn| Self::find_child_by_kind(sn, "ident"))
+        let name = find_direct_child_by_kind(node, "serviceName")
+            .and_then(|sn| find_direct_child_by_kind(sn, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -621,8 +622,8 @@ impl ProtoExtractor {
     /// Extract an `rpc` method definition within a service.
     fn visit_rpc(state: &mut ExtractionState, node: TsNode<'_>) {
         // rpc -> rpcName -> ident, enumMessageType (request), enumMessageType (response)
-        let name = Self::find_child_by_kind(node, "rpcName")
-            .and_then(|rn| Self::find_child_by_kind(rn, "ident"))
+        let name = find_direct_child_by_kind(node, "rpcName")
+            .and_then(|rn| find_direct_child_by_kind(rn, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let docstring = Self::extract_docstring(state, node);
@@ -699,15 +700,15 @@ impl ProtoExtractor {
     /// Extract a field within a oneof block.
     fn visit_oneof_field(state: &mut ExtractionState, node: TsNode<'_>) {
         // oneof_field -> type, fieldName -> ident, `=`, fieldNumber -> intLit.
-        let name = Self::find_child_by_kind(node, "fieldName")
-            .and_then(|fn_node| Self::find_child_by_kind(fn_node, "ident"))
+        let name = find_direct_child_by_kind(node, "fieldName")
+            .and_then(|fn_node| find_direct_child_by_kind(fn_node, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
-        let type_text = Self::find_child_by_kind(node, "type")
+        let type_text = find_direct_child_by_kind(node, "type")
             .map_or_else(|| "unknown".to_string(), |n| state.node_text(n));
 
-        let field_number = Self::find_child_by_kind(node, "fieldNumber")
-            .and_then(|fn_node| Self::find_child_by_kind(fn_node, "intLit"))
+        let field_number = find_direct_child_by_kind(node, "fieldNumber")
+            .and_then(|fn_node| find_direct_child_by_kind(fn_node, "intLit"))
             .map_or_else(|| "?".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -781,23 +782,6 @@ impl ProtoExtractor {
         }
         comments.reverse();
         Some(comments.join("\n"))
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/python_extractor.rs
+++ b/src/extraction/python_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, PYTHON_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -183,7 +184,7 @@ impl PythonExtractor {
 
     /// Extract a function definition. If inside a class (`class_depth` > 0), it becomes a Method.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>, is_async: bool) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let in_class = state.class_depth > 0;
@@ -241,14 +242,14 @@ impl PythonExtractor {
         }
 
         // Extract call sites from the function body.
-        if let Some(body) = Self::find_child_by_kind(node, "block") {
+        if let Some(body) = find_direct_child_by_kind(node, "block") {
             Self::extract_call_sites(state, body, &id);
         }
     }
 
     /// Extract a class definition.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Self::python_visibility(&name);
@@ -304,7 +305,7 @@ impl PythonExtractor {
         // Visit class body.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "block") {
+        if let Some(body) = find_direct_child_by_kind(node, "block") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -314,8 +315,8 @@ impl PythonExtractor {
     /// Extract a decorated definition (decorator + function or class).
     fn visit_decorated_definition(state: &mut ExtractionState, node: TsNode<'_>) {
         // First, find the inner definition (function_definition or class_definition).
-        let inner_def = Self::find_child_by_kind(node, "function_definition")
-            .or_else(|| Self::find_child_by_kind(node, "class_definition"));
+        let inner_def = find_direct_child_by_kind(node, "function_definition")
+            .or_else(|| find_direct_child_by_kind(node, "class_definition"));
 
         // Check if the inner def is an async function (could be wrapped in decorated_definition)
         let is_async = Self::has_async_keyword(node);
@@ -323,7 +324,7 @@ impl PythonExtractor {
         // Determine the inner definition's node ID ahead of time so we can
         // create Annotates edges from decorators to it.
         let inner_kind_and_name = if let Some(inner) = inner_def {
-            let name = Self::find_child_by_kind(inner, "identifier")
+            let name = find_direct_child_by_kind(inner, "identifier")
                 .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
             let kind = match inner.kind() {
                 "class_definition" => NodeKind::Class,
@@ -424,7 +425,7 @@ impl PythonExtractor {
                 if child.kind() == "dotted_name" || child.kind() == "aliased_import" {
                     let import_name = if child.kind() == "aliased_import" {
                         // aliased_import has a dotted_name child
-                        Self::find_child_by_kind(child, "dotted_name")
+                        find_direct_child_by_kind(child, "dotted_name")
                             .map_or_else(|| state.node_text(child), |n| state.node_text(n))
                     } else {
                         state.node_text(child)
@@ -441,8 +442,8 @@ impl PythonExtractor {
     /// Extract a from-import statement (e.g., `from os.path import join, exists`).
     fn visit_import_from(state: &mut ExtractionState, node: TsNode<'_>) {
         // Get the module being imported from.
-        let module_name = Self::find_child_by_kind(node, "dotted_name")
-            .or_else(|| Self::find_child_by_kind(node, "relative_import"))
+        let module_name = find_direct_child_by_kind(node, "dotted_name")
+            .or_else(|| find_direct_child_by_kind(node, "relative_import"))
             .map(|n| state.node_text(n))
             .unwrap_or_default();
 
@@ -451,7 +452,7 @@ impl PythonExtractor {
         let mut found_names = false;
 
         // Check for wildcard import: from X import *
-        if Self::find_child_by_kind(node, "wildcard_import").is_some() {
+        if find_direct_child_by_kind(node, "wildcard_import").is_some() {
             let full_name = format!("{module_name}.*");
             Self::create_use_node(state, &full_name, node);
             return;
@@ -464,7 +465,7 @@ impl PythonExtractor {
                 let child = cursor.node();
                 if child.kind() == "aliased_import" {
                     // aliased_import has a dotted_name child for the original name
-                    let import_name = Self::find_child_by_kind(child, "dotted_name")
+                    let import_name = find_direct_child_by_kind(child, "dotted_name")
                         .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                     let full_name = if module_name.is_empty() {
                         import_name
@@ -511,7 +512,7 @@ impl PythonExtractor {
                             Self::create_use_node(state, &full_name, node);
                         }
                         "aliased_import" => {
-                            let import_name = Self::find_child_by_kind(child, "dotted_name")
+                            let import_name = find_direct_child_by_kind(child, "dotted_name")
                                 .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                             let full_name = if module_name.is_empty() {
                                 import_name
@@ -648,7 +649,7 @@ impl PythonExtractor {
 
     /// Extract base classes from a class definition's `argument_list`.
     fn extract_base_classes(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
-        if let Some(arg_list) = Self::find_child_by_kind(node, "argument_list") {
+        if let Some(arg_list) = find_direct_child_by_kind(node, "argument_list") {
             let mut cursor = arg_list.walk();
             if cursor.goto_first_child() {
                 loop {
@@ -695,7 +696,7 @@ impl PythonExtractor {
     fn extract_function_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
         // Use the block child's start byte to find where the body begins,
         // so we don't truncate at `:` inside type annotations.
-        if let Some(block) = Self::find_child_by_kind(node, "block") {
+        if let Some(block) = find_direct_child_by_kind(node, "block") {
             let text = state.node_text(node);
             let block_offset = block.start_byte() - node.start_byte();
             let before_block = &text[..block_offset];
@@ -708,7 +709,7 @@ impl PythonExtractor {
 
     /// Extract the class signature (class Name or class Name(Base)).
     fn extract_class_signature(state: &ExtractionState, node: TsNode<'_>) -> String {
-        if let Some(block) = Self::find_child_by_kind(node, "block") {
+        if let Some(block) = find_direct_child_by_kind(node, "block") {
             let text = state.node_text(node);
             let block_offset = block.start_byte() - node.start_byte();
             let before_block = &text[..block_offset];
@@ -721,14 +722,14 @@ impl PythonExtractor {
     /// Extract docstrings from the first statement in a function/class body.
     /// Python convention: first `expression_statement` containing a string literal.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        let body = Self::find_child_by_kind(node, "block")?;
+        let body = find_direct_child_by_kind(node, "block")?;
         let mut cursor = body.walk();
         if cursor.goto_first_child() {
             loop {
                 let child = cursor.node();
                 if child.kind() == "expression_statement" {
                     // Look for a string child.
-                    if let Some(string_node) = Self::find_child_by_kind(child, "string") {
+                    if let Some(string_node) = find_direct_child_by_kind(child, "string") {
                         let text = state.node_text(string_node);
                         return Some(Self::strip_docstring_quotes(&text));
                     }
@@ -854,23 +855,6 @@ impl PythonExtractor {
         // Must not start with a digit
         let starts_ok = !name.starts_with(|c: char| c.is_ascii_digit());
         has_upper && all_valid && starts_ok
-    }
-
-    /// Find the first named child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/qbasic_extractor.rs
+++ b/src/extraction/qbasic_extractor.rs
@@ -12,6 +12,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, ComplexityMetrics, QBASIC_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -185,9 +186,9 @@ impl QBasicExtractor {
     /// Extract a comment from a line node, if the line is purely a comment.
     /// Returns the comment text (with leading ' stripped), or None if not a comment line.
     fn extract_line_comment(state: &ExtractionState, line: TsNode<'_>) -> Option<String> {
-        let stmt_list = Self::find_child_by_kind(line, "statement_list")?;
-        let stmt = Self::find_child_by_kind(stmt_list, "statement")?;
-        let comment = Self::find_child_by_kind(stmt, "apostrophe_comment")?;
+        let stmt_list = find_direct_child_by_kind(line, "statement_list")?;
+        let stmt = find_direct_child_by_kind(stmt_list, "statement")?;
+        let comment = find_direct_child_by_kind(stmt, "apostrophe_comment")?;
         let text = state.node_text(comment);
         // Strip leading ' and whitespace.
         let stripped = text.trim_start_matches('\'').trim().to_string();
@@ -196,10 +197,10 @@ impl QBasicExtractor {
 
     /// Visit a top-level `line` node, extracting CONST, DIM SHARED, CALL, etc.
     fn visit_line(state: &mut ExtractionState, line: TsNode<'_>, pending_comment: Option<&str>) {
-        let Some(stmt_list) = Self::find_child_by_kind(line, "statement_list") else {
+        let Some(stmt_list) = find_direct_child_by_kind(line, "statement_list") else {
             return;
         };
-        let Some(stmt) = Self::find_child_by_kind(stmt_list, "statement") else {
+        let Some(stmt) = find_direct_child_by_kind(stmt_list, "statement") else {
             return;
         };
 
@@ -233,7 +234,7 @@ impl QBasicExtractor {
         pending_comment: Option<&str>,
     ) {
         // Find the identifier child of const_statement.
-        let Some(id_node) = Self::find_child_by_kind(const_stmt, "identifier") else {
+        let Some(id_node) = find_direct_child_by_kind(const_stmt, "identifier") else {
             return;
         };
         let name = state.node_text(id_node);
@@ -297,10 +298,10 @@ impl QBasicExtractor {
         }
 
         // Find the dim_variable child, then get its identifier.
-        let Some(dim_var) = Self::find_child_by_kind(dim_stmt, "dim_variable") else {
+        let Some(dim_var) = find_direct_child_by_kind(dim_stmt, "dim_variable") else {
             return;
         };
-        let Some(id_node) = Self::find_child_by_kind(dim_var, "identifier") else {
+        let Some(id_node) = find_direct_child_by_kind(dim_var, "identifier") else {
             return;
         };
         let name = state.node_text(id_node);
@@ -426,7 +427,7 @@ impl QBasicExtractor {
 
     /// Visit a `type_member` inside a TYPE block and emit a Field node.
     fn visit_type_member(state: &mut ExtractionState, member: TsNode<'_>) {
-        let name = match Self::find_child_by_kind(member, "identifier") {
+        let name = match find_direct_child_by_kind(member, "identifier") {
             Some(id_node) => state.node_text(id_node),
             None => return,
         };
@@ -618,7 +619,7 @@ impl QBasicExtractor {
 
     /// Extract a call reference from a `call_statement` node.
     fn extract_call_from_call_statement(state: &mut ExtractionState, call_stmt: TsNode<'_>) {
-        let target_name = match Self::find_child_by_kind(call_stmt, "identifier") {
+        let target_name = match find_direct_child_by_kind(call_stmt, "identifier") {
             Some(id_node) => state.node_text(id_node),
             None => return,
         };
@@ -660,23 +661,6 @@ impl QBasicExtractor {
                 }
             }
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/ruby_extractor.rs
+++ b/src/extraction/ruby_extractor.rs
@@ -5,6 +5,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
+use crate::extraction::common::docstring_from_hash_comments;
 use crate::extraction::complexity::{count_complexity, RUBY_COMPLEXITY};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
@@ -587,25 +588,7 @@ impl RubyExtractor {
     /// Ruby uses comment lines (# ...) as documentation. We look for `comment`
     /// sibling nodes that immediately precede the given definition node.
     fn extract_docstring(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
-        // Look at the previous sibling nodes for consecutive comment lines.
-        let mut comments: Vec<String> = Vec::new();
-        let mut prev = node.prev_named_sibling();
-        while let Some(prev_node) = prev {
-            if prev_node.kind() == "comment" {
-                let text = state.node_text(prev_node);
-                let stripped = text.trim_start_matches('#').trim().to_string();
-                comments.push(stripped);
-                prev = prev_node.prev_named_sibling();
-            } else {
-                break;
-            }
-        }
-        if comments.is_empty() {
-            return None;
-        }
-        // Comments were collected in reverse order; reverse them back.
-        comments.reverse();
-        Some(comments.join("\n"))
+        docstring_from_hash_comments(&state.source, node)
     }
 
     /// Find the method name identifier in a singleton method.

--- a/src/extraction/ruby_extractor.rs
+++ b/src/extraction/ruby_extractor.rs
@@ -7,6 +7,7 @@ use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::common::docstring_from_hash_comments;
 use crate::extraction::complexity::{count_complexity, RUBY_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -171,7 +172,7 @@ impl RubyExtractor {
     /// `is_singleton` controls whether this becomes a Method regardless of class depth
     /// (singleton methods are always `NodeKind::Method`).
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>, is_singleton: bool) {
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let in_class = state.class_depth > 0 || is_singleton;
@@ -295,7 +296,7 @@ impl RubyExtractor {
     /// Extract a class definition.
     fn visit_class(state: &mut ExtractionState, node: TsNode<'_>) {
         // In tree-sitter-ruby, class node children include: "class", constant (name), superclass?, body
-        let name = Self::find_child_by_kind(node, "constant")
+        let name = find_direct_child_by_kind(node, "constant")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -351,7 +352,7 @@ impl RubyExtractor {
         // Visit class body.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "body_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "body_statement") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -360,7 +361,7 @@ impl RubyExtractor {
 
     /// Extract a module definition.
     fn visit_module(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "constant")
+        let name = find_direct_child_by_kind(node, "constant")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let visibility = Visibility::Pub;
@@ -420,7 +421,7 @@ impl RubyExtractor {
         // Visit module body.
         state.node_stack.push((name.clone(), id));
         state.class_depth += 1;
-        if let Some(body) = Self::find_child_by_kind(node, "body_statement") {
+        if let Some(body) = find_direct_child_by_kind(node, "body_statement") {
             Self::visit_children(state, body);
         }
         state.class_depth -= 1;
@@ -520,8 +521,8 @@ impl RubyExtractor {
                     if child.kind() == "superclass" {
                         // The superclass node contains "< ConstantName"
                         // Find the constant child inside superclass
-                        if let Some(const_node) = Self::find_child_by_kind(child, "constant")
-                            .or_else(|| Self::find_child_by_kind(child, "scope_resolution"))
+                        if let Some(const_node) = find_direct_child_by_kind(child, "constant")
+                            .or_else(|| find_direct_child_by_kind(child, "scope_resolution"))
                         {
                             let base_name = state.node_text(const_node);
                             let line = const_node.start_position().row as u32;
@@ -665,23 +666,6 @@ impl RubyExtractor {
                 }
             }
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/scala_extractor.rs
+++ b/src/extraction/scala_extractor.rs
@@ -9,6 +9,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, SCALA_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -616,7 +617,7 @@ impl ScalaExtractor {
     fn visit_enum_case(state: &mut ExtractionState, node: TsNode<'_>) {
         let name = node
             .child_by_field_name("name")
-            .or_else(|| Self::find_child_by_kind(node, "identifier"))
+            .or_else(|| find_direct_child_by_kind(node, "identifier"))
             .map_or_else(
                 || state.node_text(node).trim().to_string(),
                 |n| state.node_text(n),
@@ -1172,15 +1173,15 @@ impl ScalaExtractor {
     fn extract_type_parameters(state: &mut ExtractionState, node: TsNode<'_>, owner_id: &str) {
         let tp_node = node
             .child_by_field_name("type_parameters")
-            .or_else(|| Self::find_child_by_kind(node, "type_parameters"));
+            .or_else(|| find_direct_child_by_kind(node, "type_parameters"));
         if let Some(tp) = tp_node {
             let mut cursor = tp.walk();
             if cursor.goto_first_child() {
                 loop {
                     let child = cursor.node();
                     if child.is_named() && child.kind().contains("type_parameter") {
-                        let param_name = Self::find_child_by_kind(child, "identifier")
-                            .or_else(|| Self::find_child_by_kind(child, "type_identifier"))
+                        let param_name = find_direct_child_by_kind(child, "identifier")
+                            .or_else(|| find_direct_child_by_kind(child, "type_identifier"))
                             .map_or_else(|| state.node_text(child), |n| state.node_text(n));
                         let start_line = child.start_position().row as u32;
                         let id = generate_node_id(
@@ -1485,7 +1486,7 @@ impl ScalaExtractor {
     /// Looks for a `type_identifier` child first, then falls back to
     /// stripping `@` prefix and `(` suffix from the text.
     fn extract_annotation_name(state: &ExtractionState, node: TsNode<'_>) -> String {
-        if let Some(ti) = Self::find_child_by_kind(node, "type_identifier") {
+        if let Some(ti) = find_direct_child_by_kind(node, "type_identifier") {
             return state.node_text(ti);
         }
         // Fallback: text after '@', before '('
@@ -1498,23 +1499,6 @@ impl ScalaExtractor {
             .unwrap_or(&text)
             .trim()
             .to_string()
-    }
-
-    /// Find the first child node of a specific kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/swift_extractor.rs
+++ b/src/extraction/swift_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, SWIFT_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -171,7 +172,7 @@ impl SwiftExtractor {
 
     /// Extract an import declaration (e.g. `import Foundation`).
     fn visit_import(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "identifier").map_or_else(
+        let name = find_direct_child_by_kind(node, "identifier").map_or_else(
             || {
                 // Fallback: get everything after "import "
                 let text = state.node_text(node);
@@ -480,7 +481,7 @@ impl SwiftExtractor {
             .child_by_field_name("name")
             .map(|n| state.node_text(n))
             .or_else(|| {
-                Self::find_child_by_kind(node, "simple_identifier").map(|n| state.node_text(n))
+                find_direct_child_by_kind(node, "simple_identifier").map(|n| state.node_text(n))
             })
             .unwrap_or_else(|| {
                 // Fallback: parse text after "case "
@@ -543,7 +544,7 @@ impl SwiftExtractor {
             || "<anonymous>".to_string(),
             |n| {
                 // Could be a user_type wrapping a type_identifier.
-                Self::find_child_by_kind(n, "type_identifier")
+                find_direct_child_by_kind(n, "type_identifier")
                     .map_or_else(|| state.node_text(n), |ti| state.node_text(ti))
             },
         );
@@ -699,7 +700,7 @@ impl SwiftExtractor {
             .child_by_field_name("name")
             .map(|n| state.node_text(n))
             .or_else(|| {
-                Self::find_child_by_kind(node, "simple_identifier").map(|n| state.node_text(n))
+                find_direct_child_by_kind(node, "simple_identifier").map(|n| state.node_text(n))
             })
             .unwrap_or_else(|| "<anonymous>".to_string());
 
@@ -761,7 +762,7 @@ impl SwiftExtractor {
             .child_by_field_name("name")
             .map(|n| state.node_text(n))
             .or_else(|| {
-                Self::find_child_by_kind(node, "simple_identifier").map(|n| state.node_text(n))
+                find_direct_child_by_kind(node, "simple_identifier").map(|n| state.node_text(n))
             })
             .unwrap_or_else(|| "<anonymous>".to_string());
 
@@ -964,7 +965,7 @@ impl SwiftExtractor {
             .child_by_field_name("name")
             .map(|n| state.node_text(n))
             .or_else(|| {
-                Self::find_child_by_kind(node, "type_identifier").map(|n| state.node_text(n))
+                find_direct_child_by_kind(node, "type_identifier").map(|n| state.node_text(n))
             })
             .unwrap_or_else(|| "<anonymous>".to_string());
 
@@ -1028,7 +1029,7 @@ impl SwiftExtractor {
                 // For class/struct/enum, this is a type_identifier directly.
                 // For extension, it may be a user_type wrapping type_identifier.
                 if n.kind() == "user_type" {
-                    Self::find_child_by_kind(n, "type_identifier")
+                    find_direct_child_by_kind(n, "type_identifier")
                         .map_or_else(|| state.node_text(n), |ti| state.node_text(ti))
                 } else {
                     state.node_text(n)
@@ -1049,7 +1050,7 @@ impl SwiftExtractor {
                     // The inheritance_specifier has a child with field "inherits_from"
                     // which is a user_type containing the parent type name.
                     if let Some(inherits_from) = child.child_by_field_name("inherits_from") {
-                        let base_name = Self::find_child_by_kind(inherits_from, "type_identifier")
+                        let base_name = find_direct_child_by_kind(inherits_from, "type_identifier")
                             .map_or_else(
                                 || state.node_text(inherits_from),
                                 |ti| state.node_text(ti),
@@ -1082,14 +1083,14 @@ impl SwiftExtractor {
                 return state.node_text(ident);
             }
             // Fallback: find simple_identifier in pattern.
-            if let Some(ident) = Self::find_child_by_kind(pattern, "simple_identifier") {
+            if let Some(ident) = find_direct_child_by_kind(pattern, "simple_identifier") {
                 return state.node_text(ident);
             }
             return state.node_text(pattern);
         }
         // Fallback: find pattern child then simple_identifier.
-        if let Some(pattern) = Self::find_child_by_kind(node, "pattern") {
-            if let Some(ident) = Self::find_child_by_kind(pattern, "simple_identifier") {
+        if let Some(pattern) = find_direct_child_by_kind(node, "pattern") {
+            if let Some(ident) = find_direct_child_by_kind(pattern, "simple_identifier") {
                 return state.node_text(ident);
             }
         }
@@ -1105,7 +1106,7 @@ impl SwiftExtractor {
             loop {
                 let child = cursor.node();
                 if child.kind() == "modifiers" {
-                    if let Some(vis_mod) = Self::find_child_by_kind(child, "visibility_modifier") {
+                    if let Some(vis_mod) = find_direct_child_by_kind(child, "visibility_modifier") {
                         let text = state.node_text(vis_mod);
                         return match text.as_str() {
                             "private" | "fileprivate" => Visibility::Private,
@@ -1239,7 +1240,7 @@ impl SwiftExtractor {
                         let child = cursor.node();
                         if child.kind() == "navigation_suffix" {
                             if let Some(ident) =
-                                Self::find_child_by_kind(child, "simple_identifier")
+                                find_direct_child_by_kind(child, "simple_identifier")
                             {
                                 last_name = Some(state.node_text(ident));
                             }
@@ -1255,23 +1256,6 @@ impl SwiftExtractor {
             }
             _ => Some(state.node_text(first_child)),
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Walk previous siblings of a declaration looking for `attribute` nodes
@@ -1388,8 +1372,8 @@ impl SwiftExtractor {
     /// Looks for a `user_type` child, or falls back to text after `@`, before `(`.
     fn extract_annotation_name(state: &ExtractionState, node: TsNode<'_>) -> String {
         // Try user_type -> type_identifier path.
-        if let Some(ut) = Self::find_child_by_kind(node, "user_type") {
-            if let Some(ti) = Self::find_child_by_kind(ut, "type_identifier") {
+        if let Some(ut) = find_direct_child_by_kind(node, "user_type") {
+            if let Some(ti) = find_direct_child_by_kind(ut, "type_identifier") {
                 return state.node_text(ti);
             }
             return state.node_text(ut);

--- a/src/extraction/typescript_extractor.rs
+++ b/src/extraction/typescript_extractor.rs
@@ -7,6 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, TYPESCRIPT_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -196,7 +197,7 @@ impl TypeScriptExtractor {
             "import_statement" => Self::visit_import(state, node),
             "expression_statement" => {
                 // Namespace declarations appear as expression_statement > internal_module.
-                if let Some(internal) = Self::find_child_by_kind(node, "internal_module") {
+                if let Some(internal) = find_direct_child_by_kind(node, "internal_module") {
                     Self::visit_namespace(state, internal);
                 }
             }
@@ -287,7 +288,7 @@ impl TypeScriptExtractor {
 
     /// Extract a function declaration node.
     fn visit_function(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(node, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -345,7 +346,7 @@ impl TypeScriptExtractor {
         Self::extract_type_refs(state, node, &id);
 
         // Extract call sites from the function body.
-        if let Some(body) = Self::find_child_by_kind(node, "statement_block") {
+        if let Some(body) = find_direct_child_by_kind(node, "statement_block") {
             Self::extract_call_sites(state, body, &id);
         }
     }
@@ -361,7 +362,7 @@ impl TypeScriptExtractor {
                 let child = cursor.node();
                 if child.kind() == "variable_declarator" {
                     // Check if this is an arrow function assignment.
-                    if let Some(arrow) = Self::find_child_by_kind(child, "arrow_function") {
+                    if let Some(arrow) = find_direct_child_by_kind(child, "arrow_function") {
                         Self::visit_arrow_function(state, child, arrow);
                     } else if is_const {
                         // It's a const variable (not an arrow function).
@@ -381,7 +382,7 @@ impl TypeScriptExtractor {
         declarator: TsNode<'_>,
         arrow_node: TsNode<'_>,
     ) {
-        let name = Self::child_name(state, Self::find_child_by_kind(declarator, "identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(declarator, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -451,14 +452,14 @@ impl TypeScriptExtractor {
         Self::extract_type_refs(state, arrow_node, &id);
 
         // Extract call sites from the arrow function body.
-        if let Some(body) = Self::find_child_by_kind(arrow_node, "statement_block") {
+        if let Some(body) = find_direct_child_by_kind(arrow_node, "statement_block") {
             Self::extract_call_sites(state, body, &id);
         }
     }
 
     /// Extract a const variable declaration (not an arrow function).
     fn visit_const_variable(state: &mut ExtractionState, declarator: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(declarator, "identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(declarator, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -515,8 +516,8 @@ impl TypeScriptExtractor {
         // TS uses type_identifier, JS uses identifier for class names.
         let name = Self::child_name(
             state,
-            Self::find_child_by_kind(node, "type_identifier")
-                .or_else(|| Self::find_child_by_kind(node, "identifier")),
+            find_direct_child_by_kind(node, "type_identifier")
+                .or_else(|| find_direct_child_by_kind(node, "identifier")),
         );
         let visibility = if state.in_export {
             Visibility::Pub
@@ -576,7 +577,7 @@ impl TypeScriptExtractor {
         Self::extract_class_heritage(state, node, &id);
 
         // Recurse into class_body for methods and fields.
-        if let Some(body) = Self::find_child_by_kind(node, "class_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "class_body") {
             state.node_stack.push((name, id.clone()));
             Self::visit_class_body(state, body);
             state.node_stack.pop();
@@ -603,7 +604,10 @@ impl TypeScriptExtractor {
 
     /// Extract a `method_definition` from a class body.
     fn visit_method(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "property_identifier"));
+        let name = Self::child_name(
+            state,
+            find_direct_child_by_kind(node, "property_identifier"),
+        );
 
         let kind = if name == "constructor" {
             NodeKind::Constructor
@@ -665,14 +669,17 @@ impl TypeScriptExtractor {
         Self::extract_type_refs(state, node, &id);
 
         // Extract call sites from the method body.
-        if let Some(body) = Self::find_child_by_kind(node, "statement_block") {
+        if let Some(body) = find_direct_child_by_kind(node, "statement_block") {
             Self::extract_call_sites(state, body, &id);
         }
     }
 
     /// Extract a field from a class body (`public_field_definition`).
     fn visit_field(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "property_identifier"));
+        let name = Self::child_name(
+            state,
+            find_direct_child_by_kind(node, "property_identifier"),
+        );
         let visibility = Self::extract_ts_accessibility(state, node);
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
@@ -722,7 +729,7 @@ impl TypeScriptExtractor {
 
     /// Extract an interface declaration node.
     fn visit_interface(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "type_identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(node, "type_identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -775,7 +782,7 @@ impl TypeScriptExtractor {
         }
 
         // Extract methods from interface body.
-        if let Some(body) = Self::find_child_by_kind(node, "interface_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "interface_body") {
             state.node_stack.push((name, id.clone()));
             Self::visit_interface_body(state, body);
             state.node_stack.pop();
@@ -800,7 +807,10 @@ impl TypeScriptExtractor {
 
     /// Extract a `method_signature` from an interface body.
     fn visit_interface_method(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "property_identifier"));
+        let name = Self::child_name(
+            state,
+            find_direct_child_by_kind(node, "property_identifier"),
+        );
         let text = state.node_text(node);
         let start_line = node.start_position().row as u32;
         let end_line = node.end_position().row as u32;
@@ -849,7 +859,7 @@ impl TypeScriptExtractor {
 
     /// Extract an enum declaration node.
     fn visit_enum(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(node, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -903,7 +913,7 @@ impl TypeScriptExtractor {
         }
 
         // Extract enum members from enum_body.
-        if let Some(body) = Self::find_child_by_kind(node, "enum_body") {
+        if let Some(body) = find_direct_child_by_kind(node, "enum_body") {
             state.node_stack.push((name, id.clone()));
             Self::visit_enum_body(state, body);
             state.node_stack.pop();
@@ -976,7 +986,7 @@ impl TypeScriptExtractor {
 
     /// Extract a type alias declaration.
     fn visit_type_alias(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "type_identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(node, "type_identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -1091,7 +1101,7 @@ impl TypeScriptExtractor {
 
     /// Extract a namespace (`internal_module`) declaration.
     fn visit_namespace(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::child_name(state, Self::find_child_by_kind(node, "identifier"));
+        let name = Self::child_name(state, find_direct_child_by_kind(node, "identifier"));
         let visibility = if state.in_export {
             Visibility::Pub
         } else {
@@ -1145,7 +1155,7 @@ impl TypeScriptExtractor {
         }
 
         // Recurse into the namespace body.
-        if let Some(body) = Self::find_child_by_kind(node, "statement_block") {
+        if let Some(body) = find_direct_child_by_kind(node, "statement_block") {
             state.node_stack.push((name, id));
             Self::visit_children(state, body);
             state.node_stack.pop();
@@ -1223,7 +1233,7 @@ impl TypeScriptExtractor {
 
     /// Extract extends/implements from a class heritage clause.
     fn extract_class_heritage(state: &mut ExtractionState, node: TsNode<'_>, class_id: &str) {
-        if let Some(heritage) = Self::find_child_by_kind(node, "class_heritage") {
+        if let Some(heritage) = find_direct_child_by_kind(node, "class_heritage") {
             let mut cursor = heritage.walk();
             if cursor.goto_first_child() {
                 loop {
@@ -1231,8 +1241,8 @@ impl TypeScriptExtractor {
                     match child.kind() {
                         "extends_clause" => {
                             // Find the extended class name (identifier or type_identifier).
-                            let ext_name = Self::find_child_by_kind(child, "identifier")
-                                .or_else(|| Self::find_child_by_kind(child, "type_identifier"))
+                            let ext_name = find_direct_child_by_kind(child, "identifier")
+                                .or_else(|| find_direct_child_by_kind(child, "type_identifier"))
                                 .map(|n| state.node_text(n));
                             if let Some(name) = ext_name {
                                 state.unresolved_refs.push(UnresolvedRef {
@@ -1281,7 +1291,7 @@ impl TypeScriptExtractor {
     /// Extract the import path from an `import_statement`.
     fn extract_import_path(state: &ExtractionState, node: TsNode<'_>) -> Option<String> {
         // The string child contains the module path.
-        if let Some(string_node) = Self::find_child_by_kind(node, "string") {
+        if let Some(string_node) = find_direct_child_by_kind(node, "string") {
             let text = state.node_text(string_node);
             // Strip quotes.
             let path = text.trim().trim_matches('\'').trim_matches('"').to_string();
@@ -1476,7 +1486,7 @@ impl TypeScriptExtractor {
 
     /// Extract TypeScript accessibility modifier (public/private/protected).
     fn extract_ts_accessibility(state: &ExtractionState, node: TsNode<'_>) -> Visibility {
-        if let Some(modifier) = Self::find_child_by_kind(node, "accessibility_modifier") {
+        if let Some(modifier) = find_direct_child_by_kind(node, "accessibility_modifier") {
             let text = state.node_text(modifier);
             match text.as_str() {
                 "private" => Visibility::Private,
@@ -1503,23 +1513,6 @@ impl TypeScriptExtractor {
             }
         }
         false
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.

--- a/src/extraction/wgsl_extractor.rs
+++ b/src/extraction/wgsl_extractor.rs
@@ -7,6 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, C_COMPLEXITY};
+use crate::extraction::traversal::{find_descendant_by_kind, find_direct_child_by_kind};
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -150,10 +151,10 @@ impl WgslExtractor {
     // -------------------------------------------------------
 
     fn visit_function_decl(state: &mut ExtractionState, node: TsNode<'_>) {
-        let Some(header) = Self::find_child_by_kind(node, "function_header") else {
+        let Some(header) = find_direct_child_by_kind(node, "function_header") else {
             return;
         };
-        let name = Self::find_child_by_kind(header, "ident")
+        let name = find_direct_child_by_kind(header, "ident")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Collect stage attributes (@vertex, @fragment, @compute).
@@ -172,7 +173,7 @@ impl WgslExtractor {
         let qualified_name = format!("{}::{}", state.qualified_prefix(), name);
         let id = generate_node_id(&state.file_path, &NodeKind::Function, &name, start_line);
 
-        let body = Self::find_child_by_kind(node, "compound_statement");
+        let body = find_direct_child_by_kind(node, "compound_statement");
         let metrics = body
             .map(|b| count_complexity(b, &C_COMPLEXITY, &state.source))
             .unwrap_or_default();
@@ -235,7 +236,7 @@ impl WgslExtractor {
                 let child = cursor.node();
                 if child.kind() == "attribute" {
                     // attribute children: "@", ident, optional "(…)"
-                    if let Some(ident) = Self::find_child_by_kind(child, "ident") {
+                    if let Some(ident) = find_direct_child_by_kind(child, "ident") {
                         attrs.push(format!("@{}", state.node_text(ident)));
                     }
                 }
@@ -252,7 +253,7 @@ impl WgslExtractor {
     // -------------------------------------------------------
 
     fn visit_struct_decl(state: &mut ExtractionState, node: TsNode<'_>) {
-        let name = Self::find_child_by_kind(node, "ident")
+        let name = find_direct_child_by_kind(node, "ident")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -299,7 +300,7 @@ impl WgslExtractor {
         }
 
         // Visit struct members.
-        if let Some(body) = Self::find_child_by_kind(node, "struct_body_decl") {
+        if let Some(body) = find_direct_child_by_kind(node, "struct_body_decl") {
             state.node_stack.push((name, id));
             Self::visit_struct_members(state, body);
             state.node_stack.pop();
@@ -323,7 +324,7 @@ impl WgslExtractor {
 
     fn visit_struct_member(state: &mut ExtractionState, node: TsNode<'_>) {
         // struct_member: attribute* ident ":" type_decl
-        let Some(ident) = Self::find_child_by_kind(node, "ident") else {
+        let Some(ident) = find_direct_child_by_kind(node, "ident") else {
             return;
         };
         let name = state.node_text(ident);
@@ -380,8 +381,8 @@ impl WgslExtractor {
         // global_variable_decl: attribute* variable_decl ("=" expression)?
         // variable_decl: "var" variable_qualifier? variable_ident_decl
         // variable_ident_decl: ident (":" type_decl)?
-        let name = Self::find_descendant_by_kind(node, "variable_ident_decl")
-            .and_then(|vid| Self::find_child_by_kind(vid, "ident"))
+        let name = find_descendant_by_kind(node, "variable_ident_decl")
+            .and_then(|vid| find_direct_child_by_kind(vid, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         Self::emit_variable_node(state, node, name, NodeKind::Static);
@@ -389,9 +390,9 @@ impl WgslExtractor {
 
     fn visit_global_constant(state: &mut ExtractionState, node: TsNode<'_>) {
         // global_constant_decl: attribute* ("const"|"override") (ident | variable_ident_decl) "=" expression
-        let name = Self::find_descendant_by_kind(node, "variable_ident_decl")
-            .and_then(|vid| Self::find_child_by_kind(vid, "ident"))
-            .or_else(|| Self::find_child_by_kind(node, "ident"))
+        let name = find_descendant_by_kind(node, "variable_ident_decl")
+            .and_then(|vid| find_direct_child_by_kind(vid, "ident"))
+            .or_else(|| find_direct_child_by_kind(node, "ident"))
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         Self::emit_variable_node(state, node, name, NodeKind::Const);
@@ -454,7 +455,7 @@ impl WgslExtractor {
 
     fn visit_type_alias(state: &mut ExtractionState, node: TsNode<'_>) {
         // type_alias_decl: "type" ident "=" type_decl
-        let name = Self::find_child_by_kind(node, "ident")
+        let name = find_direct_child_by_kind(node, "ident")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -537,41 +538,6 @@ impl WgslExtractor {
     // -------------------------------------------------------
     // Utility helpers
     // -------------------------------------------------------
-
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-
-    fn find_descendant_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if let Some(found) = Self::find_descendant_by_kind(child, kind) {
-                    return Some(found);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
 
     fn build_result(state: ExtractionState, start: Instant) -> ExtractionResult {
         ExtractionResult {

--- a/src/extraction/zig_extractor.rs
+++ b/src/extraction/zig_extractor.rs
@@ -6,6 +6,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tree_sitter::{Node as TsNode, Parser, Tree};
 
 use crate::extraction::complexity::{count_complexity, ZIG_COMPLEXITY};
+use crate::extraction::traversal::find_direct_child_by_kind;
 use crate::types::{
     generate_node_id, Edge, EdgeKind, ExtractionResult, Node, NodeKind, UnresolvedRef, Visibility,
 };
@@ -172,7 +173,7 @@ impl ZigExtractor {
     /// We dispatch based on the value child.
     fn visit_variable_declaration(state: &mut ExtractionState, node: TsNode<'_>) {
         // Get the name from the first identifier child.
-        let name = Self::find_child_by_kind(node, "identifier")
+        let name = find_direct_child_by_kind(node, "identifier")
             .map_or_else(|| "<anonymous>".to_string(), |n| state.node_text(n));
 
         // Check what the value is: struct, enum, union, @import, or plain const.
@@ -238,7 +239,7 @@ impl ZigExtractor {
 
     /// Check if a `builtin_function` node is @import.
     fn is_import_call(state: &ExtractionState, node: TsNode<'_>) -> bool {
-        Self::find_child_by_kind(node, "builtin_identifier")
+        find_direct_child_by_kind(node, "builtin_identifier")
             .is_some_and(|n| state.node_text(n) == "@import")
     }
 
@@ -307,9 +308,9 @@ impl ZigExtractor {
     /// Looks for the string child inside the arguments: `@import("std")` -> `"std"`.
     fn extract_import_module(state: &ExtractionState, builtin_node: TsNode<'_>) -> Option<String> {
         // arguments -> string -> string_content
-        let args = Self::find_child_by_kind(builtin_node, "arguments")?;
-        let string_node = Self::find_child_by_kind(args, "string")?;
-        let content = Self::find_child_by_kind(string_node, "string_content")?;
+        let args = find_direct_child_by_kind(builtin_node, "arguments")?;
+        let string_node = find_direct_child_by_kind(args, "string")?;
+        let content = find_direct_child_by_kind(string_node, "string_content")?;
         let text = state.node_text(content);
         if text.is_empty() {
             None
@@ -722,8 +723,8 @@ impl ZigExtractor {
     /// Extract a test declaration: `test "name" { ... }`.
     fn visit_test(state: &mut ExtractionState, node: TsNode<'_>) {
         // The test name is in a string child.
-        let name = Self::find_child_by_kind(node, "string")
-            .and_then(|s| Self::find_child_by_kind(s, "string_content"))
+        let name = find_direct_child_by_kind(node, "string")
+            .and_then(|s| find_direct_child_by_kind(s, "string_content"))
             .map_or_else(|| "<anonymous test>".to_string(), |n| state.node_text(n));
 
         let start_line = node.start_position().row as u32;
@@ -917,28 +918,11 @@ impl ZigExtractor {
         match node.kind() {
             "builtin_function" => {
                 // @sqrt, @as, etc.
-                Self::find_child_by_kind(node, "builtin_identifier")
+                find_direct_child_by_kind(node, "builtin_identifier")
                     .map_or_else(|| state.node_text(node), |n| state.node_text(n))
             }
             _ => state.node_text(node),
         }
-    }
-
-    /// Find the first child of a node with a given kind.
-    fn find_child_by_kind<'a>(node: TsNode<'a>, kind: &str) -> Option<TsNode<'a>> {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let child = cursor.node();
-                if child.kind() == kind {
-                    return Some(child);
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
     }
 
     /// Build the final `ExtractionResult` from the accumulated state.


### PR DESCRIPTION
## Summary

Audit-driven refactor (item #2 of the latest structural health audit: the extractor duplication family). Deletes the helper functions that were copied verbatim across the ~25 `src/extraction/*_extractor.rs` modules and replaces them with shared implementations. **No behavior change** — bodies were moved unchanged, and extraction output was verified byte-identical (see test plan). Net **−747 lines** (766+/1513−) across 30 files.

One commit per helper family:

1. **Docstring/comment helpers → new `extraction::common`**
   - `clean_comment`: C-style variant (3 copies: c/go/glsl → `clean_c_comment`) and `///`-aware variant (2 copies: cpp/objc → `clean_c_doc_comment`)
   - preceding-comment docstring loop (7 copies: c/cpp/go/objc/pascal/glsl + objc's `extract_impl_method_docstring` → `docstring_from_preceding_comments`, parameterized by the cleaner)
   - `#`-comment docstring loop (2 copies: bash/ruby → `docstring_from_hash_comments`)
2. **`extract_call_sites` → `common::extract_call_expression_sites`** (4 verbatim copies: c/cpp/glsl/hlsl; per-language fns remain as thin wrappers over their private `ExtractionState`)
3. **Traversal helpers → existing `extraction::traversal`** (which was added for exactly this migration and preserves search order)
   - `find_child_by_kind` (25 verbatim copies → `find_direct_child_by_kind`)
   - `find_descendant_by_kind` (4 verbatim copies: glsl/hlsl/objc/wgsl)
   - `has_child_kind` (2 verbatim copies: glsl/hlsl → `has_direct_child_kind`)
4. **BASIC subroutine-synthesis helpers → new `extraction::basic_common`** (gwbasic/msbasic2, cfg-gated): `BasicLine`, `find_subroutine_ranges`, `derive_function_name`, and the shared top-level-line filter (`for_each_top_level_line`)

### Near-copies deliberately left unmerged

- `rust_extractor::clean_comment` — also strips `//!` inner doc comments (Rust-specific)
- `pascal_extractor::clean_comment` — handles `{ ... }` and `(* ... *)` Pascal comments; its docstring fn now passes it into the shared loop
- `powershell_extractor::find_descendant_by_kind` — iterative and, unlike the deleted copies, matches the start node itself; not a verbatim copy
- `typescript_extractor::has_child_kind` — different semantics from the glsl/hlsl copies
- the remaining per-language `extract_call_sites`/`extract_docstring` variants — each keys on language-specific node kinds/fields; unifying them would need per-language parameterization that isn't a natural abstraction
- follow-up candidate (not in this PR): the per-extractor `visit_children` dispatch loops (~38 files) could route through `traversal::visit_children`, but that's a style migration rather than deleting verbatim helper copies

Each extractor keeps its own private `ExtractionState`, so shared helpers take the pieces they need (source bytes, file path, unresolved-ref sink) rather than the state struct; unifying `ExtractionState` itself is a separate, larger refactor.

## Test plan

- [x] Byte-identical output check: dumped normalized `ExtractionResult` JSON for all `tests/fixtures/**` files plus inline go/scala/hlsl/wgsl snippets (languages without fixtures) on the merge-base and after the refactor — `diff` clean
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo check --all-targets`
- [x] `cargo nextest run -E 'binary(extraction_suite)'` — 689/689 passed
- [x] Full `cargo nextest run --profile ci` — 3341/3341 passed