### PR TITLE
fix: tolerate literal ${workspaceFolder} in serve --path

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,7 +31,7 @@ platform = { host = 'cfg(windows)' }
 test-group = 'windows-dashboard-server'
 
 [[profile.ci.overrides]]
-filter = 'binary(=agent_suite) | (binary(=storage_suite) & test(/^branch_db_safety_test::/)) | (binary(=core_cli_suite) & test(/^cli_non_interactive_test::/)) | (binary(=mcp_suite) & test(/^mcp_cli_serve_test::/))'
+filter = 'binary(=agent_suite) | (binary(=storage_suite) & test(/^branch_db_safety_test::/)) | (binary(=core_cli_suite) & test(/^cli_non_interactive_test::/)) | (binary(=mcp_suite) & test(/^(mcp_cli_serve_test|serve_template_path_test)::/))'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-tracedecay-init'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`serve` now tolerates a literal unexpanded `--path ${workspaceFolder}`** — Cursor's headless agent-session MCP scopes spawn the plugin's `tracedecay serve --path ${workspaceFolder}` command without expanding the template variable, and Cursor never retries a failed MCP scope, so the resulting `no TraceDecay index found` exit permanently surfaced as "Timed out waiting for connection". `serve` now detects an unexpanded `${...}` template value, warns on stderr, and falls back to its normal no-path project discovery (cwd walk-up, MCP initialize roots, global project registry). The plugin template keeps `--path ${workspaceFolder}` because normal Cursor windows expand it and MCP servers are spawned with cwd set to the user home, where no-path discovery cannot disambiguate multiple registered projects.
+- **`serve` now tolerates a literal unexpanded `--path ${workspaceFolder}`** — Cursor's headless agent-session MCP scopes spawn the plugin's serve command without expanding the template variable and never retry the failed scope, which surfaced as "Timed out waiting for connection" on every tool call. `serve` now discards an unexpanded `${...}` template value with a stderr warning and falls back to project discovery where possible, requiring a unique registered project when discovery reaches the global registry in this mode. Rationale and details in `cursor-plugin/README.md`.
 
 ## [0.0.22](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.21...v0.0.22) - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`serve` now tolerates a literal unexpanded `--path ${workspaceFolder}`** — Cursor's headless agent-session MCP scopes spawn the plugin's `tracedecay serve --path ${workspaceFolder}` command without expanding the template variable, and Cursor never retries a failed MCP scope, so the resulting `no TraceDecay index found` exit permanently surfaced as "Timed out waiting for connection". `serve` now detects an unexpanded `${...}` template value, warns on stderr, and falls back to its normal no-path project discovery (cwd walk-up, MCP initialize roots, global project registry). The plugin template keeps `--path ${workspaceFolder}` because normal Cursor windows expand it and MCP servers are spawned with cwd set to the user home, where no-path discovery cannot disambiguate multiple registered projects.
+
 ## [0.0.22](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.21...v0.0.22) - 2026-07-02
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ rm -rf ~/.cursor/plugins/local/tracedecay
 cp -R /path/to/tracedecay/cursor-plugin ~/.cursor/plugins/local/tracedecay
 ```
 
-Reload Cursor after installing or replacing the plugin. Manual copies use the commands in the source bundle (`tracedecay ...`), so make sure GUI-launched Cursor can resolve `tracedecay` from `PATH`; the normal `tracedecay install --agent cursor` path rewrites commands to the absolute binary path. The plugin relies on Cursor expanding `${workspaceFolder}` in MCP config; if tools do not connect, upgrade Cursor and run `tracedecay doctor --agent cursor` to inspect the generated plugin files.
+Reload Cursor after installing or replacing the plugin. Manual copies use the commands in the source bundle (`tracedecay ...`), so make sure GUI-launched Cursor can resolve `tracedecay` from `PATH`; the normal `tracedecay install --agent cursor` path rewrites commands to the absolute binary path. The plugin relies on Cursor expanding `${workspaceFolder}` in MCP config for workspace scoping; when a Cursor context passes the literal unexpanded string instead (headless agent-session MCP scopes do this), `serve` warns and falls back to its normal project discovery rather than exiting. If tools do not connect, upgrade Cursor and run `tracedecay doctor --agent cursor` to inspect the generated plugin files.
 
 ### Codex plugin installs
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ rm -rf ~/.cursor/plugins/local/tracedecay
 cp -R /path/to/tracedecay/cursor-plugin ~/.cursor/plugins/local/tracedecay
 ```
 
-Reload Cursor after installing or replacing the plugin. Manual copies use the commands in the source bundle (`tracedecay ...`), so make sure GUI-launched Cursor can resolve `tracedecay` from `PATH`; the normal `tracedecay install --agent cursor` path rewrites commands to the absolute binary path. The plugin relies on Cursor expanding `${workspaceFolder}` in MCP config for workspace scoping; when a Cursor context passes the literal unexpanded string instead (headless agent-session MCP scopes do this), `serve` warns and falls back to its normal project discovery rather than exiting. If tools do not connect, upgrade Cursor and run `tracedecay doctor --agent cursor` to inspect the generated plugin files.
+Reload Cursor after installing or replacing the plugin. Manual copies use the commands in the source bundle (`tracedecay ...`), so make sure GUI-launched Cursor can resolve `tracedecay` from `PATH`; the normal `tracedecay install --agent cursor` path rewrites commands to the absolute binary path. The plugin relies on Cursor expanding `${workspaceFolder}` in MCP config for workspace scoping; when a host passes the literal unexpanded string instead, `serve` warns and falls back to project discovery where possible (details in `cursor-plugin/README.md`). If tools do not connect, upgrade Cursor and run `tracedecay doctor --agent cursor` to inspect the generated plugin files.
 
 ### Codex plugin installs
 

--- a/cursor-plugin/README.md
+++ b/cursor-plugin/README.md
@@ -20,14 +20,26 @@ tracedecay serve --path ${workspaceFolder}
 This is intentionally workspace-scoped: each Cursor workspace uses its own
 `.tracedecay/` index instead of the legacy global Cursor MCP registration. The
 `${workspaceFolder}` variable is resolved by Cursor's MCP runner in normal
-editor windows. Some Cursor contexts (headless agent-session MCP scopes) spawn
-the server with the literal, unexpanded `${workspaceFolder}` string instead;
-`serve` detects that, warns on stderr, and falls back to its normal project
-discovery (cwd walk-up, MCP initialize roots, then the global project
-registry) rather than exiting — Cursor never retries a failed MCP scope, so an
-early exit would permanently break the connection for that session. If tools
-still do not connect, run `tracedecay doctor --agent cursor` to inspect the
-generated plugin config.
+editor windows.
+
+Some Cursor contexts (headless agent-session MCP scopes) spawn the server with
+the literal, unexpanded `${workspaceFolder}` string instead, from a working
+directory set to the user home rather than the workspace. Cursor never retries
+a failed MCP scope, so exiting on that bogus path would permanently break the
+connection for the session ("Timed out waiting for connection" on every tool
+call). `serve` therefore detects an unexpanded `${...}` template value, warns
+on stderr, and falls back to project discovery where possible: cwd walk-up,
+MCP initialize roots, then the global project registry. Because the spawn
+directory says nothing about the intended workspace in this mode, the registry
+step accepts only a unique registered project — with several projects
+registered, `serve` still exits with an actionable "multiple projects" error
+instead of guessing, and it logs which project it picked and why when
+discovery succeeds. This is also why the template keeps
+`--path ${workspaceFolder}` rather than dropping it (as was done for VS Code
+Copilot in issue #66): normal Cursor windows do expand it, and from a home-dir
+cwd no-path discovery cannot scope multi-project setups. If tools still do not
+connect, run `tracedecay doctor --agent cursor` to inspect the generated
+plugin config.
 
 Hook commands derive the active project from Cursor's event payload /
 `CURSOR_PROJECT_DIR`, not from the plugin directory.

--- a/cursor-plugin/README.md
+++ b/cursor-plugin/README.md
@@ -19,9 +19,15 @@ tracedecay serve --path ${workspaceFolder}
 
 This is intentionally workspace-scoped: each Cursor workspace uses its own
 `.tracedecay/` index instead of the legacy global Cursor MCP registration. The
-`${workspaceFolder}` variable is resolved by Cursor's MCP runner; if your Cursor
-build does not expand it, reinstall with the latest Cursor and run
-`tracedecay doctor --agent cursor` to inspect the generated plugin config.
+`${workspaceFolder}` variable is resolved by Cursor's MCP runner in normal
+editor windows. Some Cursor contexts (headless agent-session MCP scopes) spawn
+the server with the literal, unexpanded `${workspaceFolder}` string instead;
+`serve` detects that, warns on stderr, and falls back to its normal project
+discovery (cwd walk-up, MCP initialize roots, then the global project
+registry) rather than exiting — Cursor never retries a failed MCP scope, so an
+early exit would permanently break the connection for that session. If tools
+still do not connect, run `tracedecay doctor --agent cursor` to inspect the
+generated plugin config.
 
 Hook commands derive the active project from Cursor's event payload /
 `CURSOR_PROJECT_DIR`, not from the plugin directory.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -301,7 +301,7 @@ Cursor install is plugin-based:
 
 - `tracedecay install --agent cursor` installs `cursor-plugin/` into `~/.cursor/plugins/local/tracedecay`.
 - `tracedecay install --local --agent cursor` installs the same user-local plugin without writing project Cursor config files.
-- The plugin MCP config runs `tracedecay serve --path ${workspaceFolder}`, so the server resolves the active workspace's project store instead of the plugin directory.
+- The plugin MCP config runs `tracedecay serve --path ${workspaceFolder}`, so the server resolves the active workspace's project store instead of the plugin directory. If a Cursor context spawns the server without expanding `${workspaceFolder}` (headless agent-session MCP scopes do this), `serve` warns and falls back to its normal no-path project discovery instead of exiting.
 - Cursor install no longer writes `.cursor/mcp.json`, `.cursor/hooks.json`, `.cursor/rules/tracedecay.mdc`, or `.cursor/permissions.json`; approvals are left to Cursor approval/run-mode behavior.
 - The plugin bundles Cursor-specific, fail-open hooks. File and shell hooks notify the TraceDecay daemon; if no daemon is available they return success without indexing:
   - `sessionStart` injects context steering the Agent toward tracedecay MCP tools and reports index freshness (suggests `tracedecay init` when uninitialized).

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -301,7 +301,7 @@ Cursor install is plugin-based:
 
 - `tracedecay install --agent cursor` installs `cursor-plugin/` into `~/.cursor/plugins/local/tracedecay`.
 - `tracedecay install --local --agent cursor` installs the same user-local plugin without writing project Cursor config files.
-- The plugin MCP config runs `tracedecay serve --path ${workspaceFolder}`, so the server resolves the active workspace's project store instead of the plugin directory. If a Cursor context spawns the server without expanding `${workspaceFolder}` (headless agent-session MCP scopes do this), `serve` warns and falls back to its normal no-path project discovery instead of exiting.
+- The plugin MCP config runs `tracedecay serve --path ${workspaceFolder}`, so the server resolves the active workspace's project store instead of the plugin directory. If a host spawns the server without expanding `${workspaceFolder}`, `serve` warns and falls back to project discovery where possible (details in the plugin's `README.md`).
 - Cursor install no longer writes `.cursor/mcp.json`, `.cursor/hooks.json`, `.cursor/rules/tracedecay.mdc`, or `.cursor/permissions.json`; approvals are left to Cursor approval/run-mode behavior.
 - The plugin bundles Cursor-specific, fail-open hooks. File and shell hooks notify the TraceDecay daemon; if no daemon is available they return success without indexing:
   - `sessionStart` injects context steering the Agent toward tracedecay MCP tools and reports index freshness (suggests `tracedecay init` when uninitialized).

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,6 +409,14 @@ fn absolutize_path(path: PathBuf) -> PathBuf {
 /// that needs a project root should resolve it in this order — new code must
 /// converge on this chain instead of inventing its own:
 ///
+/// 0. **Template pre-filter** (`serve` only,
+///    `serve::sanitize_serve_path_arg`): an explicit path that is a literal
+///    unexpanded `${...}` host template variable (e.g. `${workspaceFolder}`
+///    from a host that failed to expand it) is discarded with a warning and
+///    resolution continues as if no path was given — except that step 4 then
+///    requires a unique registered project
+///    (`serve::ServeGlobalDbMatch::UniqueOnly`), because the host's spawn
+///    directory says nothing about the intended workspace.
 /// 1. **Explicit path** (`--path`/`-p`, tool `path` argument): used verbatim,
 ///    no discovery, and failure to open is fatal — never silently fall back.
 /// 2. **CWD walk-up** (this function via [`resolve_path_with_discovery`]):

--- a/src/main.rs
+++ b/src/main.rs
@@ -550,11 +550,26 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             // Some MCP hosts (e.g. Cursor headless agent sessions) pass config
             // template variables like `${workspaceFolder}` through literally;
             // treat such values as "no --path" and use discovery instead.
+            let had_path_arg = path.is_some();
             let path = serve::sanitize_serve_path_arg(path);
             let explicit_path = path.is_some();
+            let path_was_template = had_path_arg && !explicit_path;
+            let global_db_match = if path_was_template {
+                serve::ServeGlobalDbMatch::UniqueOnly
+            } else {
+                serve::ServeGlobalDbMatch::CwdHeuristic
+            };
             let project_path = tracedecay::config::resolve_path_with_discovery(path);
             let cg = match serve::ensure_initialized(&project_path).await {
-                Ok(cg) => cg,
+                Ok(cg) => {
+                    if path_was_template {
+                        serve::log_serve_project_choice(
+                            cg.project_root(),
+                            "discovered from the working directory",
+                        );
+                    }
+                    cg
+                }
                 Err(e) => {
                     if explicit_path {
                         return Err(e);
@@ -562,11 +577,20 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
                     // CWD-based discovery failed (e.g. VS Code launched us from ~).
                     // Next try MCP initialize roots from editor workspace context.
                     if let Some(p) = serve::resolve_serve_from_mcp_roots(&mut peeked_line).await {
+                        if path_was_template {
+                            serve::log_serve_project_choice(&p, "matched an MCP initialize root");
+                        }
                         serve::ensure_initialized(&p).await?
                     } else {
                         // Last resort: fall back to the global DB's registered projects.
-                        match serve::resolve_serve_from_global_db().await {
+                        match serve::resolve_serve_from_global_db(global_db_match).await {
                             serve::ServeGlobalDbResolution::Found(p) => {
+                                if path_was_template {
+                                    serve::log_serve_project_choice(
+                                        &p,
+                                        "resolved from the global project registry",
+                                    );
+                                }
                                 serve::ensure_initialized(&p).await?
                             }
                             serve::ServeGlobalDbResolution::Ambiguous(paths) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,6 +547,10 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             let original_cwd = std::env::current_dir().ok();
             // Track the first stdin line if we need to peek at `initialize` roots.
             let mut peeked_line: Option<String> = None;
+            // Some MCP hosts (e.g. Cursor headless agent sessions) pass config
+            // template variables like `${workspaceFolder}` through literally;
+            // treat such values as "no --path" and use discovery instead.
+            let path = serve::sanitize_serve_path_arg(path);
             let explicit_path = path.is_some();
             let project_path = tracedecay::config::resolve_path_with_discovery(path);
             let cg = match serve::ensure_initialized(&project_path).await {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::errors::{Result, TraceDecayError};
@@ -37,36 +38,73 @@ impl CwdProjectMatch {
     }
 }
 
-/// Returns the first unexpanded `${...}` template variable in a `--path`
-/// argument (e.g. `${workspaceFolder}`), or `None` when the value contains no
-/// template syntax. A bare `$` without braces is not template syntax — real
-/// directories can contain `$` in their names.
+/// Returns the first plausible unexpanded `${...}` template variable in a
+/// `--path` argument (e.g. `${workspaceFolder}`), or `None` when the value
+/// contains no template syntax. The brace contents must look like a variable
+/// name — a leading ASCII letter followed by word/`.`/`-` characters,
+/// optionally with a `:`-introduced modifier such as a default value — so
+/// degenerate forms (`${}`, `${ }`, `${a/b}`) and directories that merely
+/// contain `$` are not misclassified. A matching value is overwhelmingly more
+/// likely to be an unexpanded host template than a real directory name, so
+/// callers treat it as "no path given".
 pub fn unexpanded_template_variable(path: &str) -> Option<&str> {
-    let start = path.find("${")?;
-    let end = path[start..].find('}')?;
-    Some(&path[start..=start + end])
+    let mut search_from = 0;
+    while let Some(offset) = path[search_from..].find("${") {
+        let start = search_from + offset;
+        let inner_start = start + 2;
+        let end = inner_start + path[inner_start..].find('}')?;
+        if plausible_template_contents(&path[inner_start..end]) {
+            return Some(&path[start..=end]);
+        }
+        search_from = inner_start;
+    }
+    None
+}
+
+fn plausible_template_contents(contents: &str) -> bool {
+    // Variable name, optionally followed by a `:`-introduced modifier
+    // (e.g. `${workspaceFolder:-/tmp/fallback}`); only the name is validated.
+    let name = contents.split(':').next().unwrap_or_default();
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
 }
 
 /// Filters a `serve --path` CLI argument that the MCP host failed to expand.
 ///
-/// Some hosts pass config template variables through literally instead of
-/// expanding them — Cursor's headless agent-session scopes spawn
-/// `serve --path ${workspaceFolder}` verbatim, and Cursor never retries an
-/// MCP scope whose process exited, so a fatal config error here permanently
-/// breaks the connection. A literal `${...}` value can never name a real
-/// project, so it is discarded with a stderr warning and `serve` falls back
-/// to its normal no-path discovery chain (cwd walk-up, MCP initialize roots,
-/// global project registry).
+/// Some hosts pass config template variables like `${workspaceFolder}`
+/// through literally instead of expanding them (Cursor's headless
+/// agent-session MCP scopes do this; see `cursor-plugin/README.md`). Such a
+/// value is discarded with a stderr warning so `serve` can fall back to its
+/// no-path discovery chain where possible; callers must use
+/// [`ServeGlobalDbMatch::UniqueOnly`] for the global-registry step in that
+/// mode because the host's spawn directory says nothing about the intended
+/// workspace.
 pub fn sanitize_serve_path_arg(path: Option<String>) -> Option<String> {
     let raw = path?;
     let Some(variable) = unexpanded_template_variable(&raw) else {
         return Some(raw);
     };
-    eprintln!(
+    // The host may have spawned us with stderr closed; a failed diagnostic
+    // write must not take the server down.
+    let _ = writeln!(
+        std::io::stderr(),
         "warning: --path '{raw}' contains the unexpanded template variable '{variable}' \
          (the MCP host did not expand it); ignoring --path and falling back to project discovery"
     );
     None
+}
+
+/// Reports which project the discarded-template fallback settled on and why,
+/// so a wrong pick is diagnosable from the host's MCP logs.
+pub fn log_serve_project_choice(project: &Path, why: &str) {
+    let _ = writeln!(
+        std::io::stderr(),
+        "tracedecay serve: using project '{}' ({why})",
+        project.display()
+    );
 }
 
 pub fn global_db_ambiguity_message(paths: &[String]) -> String {
@@ -144,12 +182,33 @@ fn cwd_match_resolution(
     )))
 }
 
+/// How [`resolve_serve_from_global_db`] may pick among multiple registered
+/// projects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeGlobalDbMatch {
+    /// Disambiguate via the cwd heuristic (ancestor/descendant depth ranking).
+    /// Appropriate when the user genuinely ran `serve` without a path: cwd is
+    /// where they invoked it, so proximity is meaningful.
+    CwdHeuristic,
+    /// Require exactly one registered project; report every multi-project
+    /// registry as ambiguous. Used when an explicit `--path` was discarded as
+    /// an unexpanded host template: the host's spawn directory (typically the
+    /// user home) says nothing about the intended workspace, so a silent
+    /// depth-ranked pick risks serving the wrong project's index.
+    UniqueOnly,
+}
+
 /// Fallback for `serve`: when CWD-based discovery fails, check the global DB
-/// for registered projects. When multiple projects exist, pick the best match
-/// against cwd: prefer a project that is an ancestor of cwd (cwd is inside the
-/// project), then a project that is a descendant of cwd (project is under cwd).
-/// Ties at the winning depth are ambiguous and require an explicit path.
-pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
+/// for registered projects. With [`ServeGlobalDbMatch::CwdHeuristic`],
+/// multiple projects are ranked against cwd: prefer a project that is an
+/// ancestor of cwd (cwd is inside the project), then a project that is a
+/// descendant of cwd (project is under cwd); ties at the winning depth are
+/// ambiguous and require an explicit path. With
+/// [`ServeGlobalDbMatch::UniqueOnly`], any multi-project registry is
+/// ambiguous.
+pub async fn resolve_serve_from_global_db(
+    match_mode: ServeGlobalDbMatch,
+) -> ServeGlobalDbResolution {
     let Some(gdb) = GlobalDb::open().await else {
         return ServeGlobalDbResolution::None;
     };
@@ -160,6 +219,12 @@ pub async fn resolve_serve_from_global_db() -> ServeGlobalDbResolution {
     }
     if paths.is_empty() {
         return ServeGlobalDbResolution::None;
+    }
+    match match_mode {
+        ServeGlobalDbMatch::UniqueOnly => {
+            return ServeGlobalDbResolution::Ambiguous(paths);
+        }
+        ServeGlobalDbMatch::CwdHeuristic => {}
     }
 
     // Multiple projects — try to resolve using cwd.
@@ -379,6 +444,26 @@ mod tests {
     #[test]
     fn unterminated_template_syntax_is_not_a_template() {
         assert_eq!(unexpanded_template_variable("/tmp/${unclosed"), None);
+    }
+
+    #[test]
+    fn degenerate_brace_forms_are_not_templates() {
+        // Empty / whitespace / path-like brace contents are not plausible
+        // variable names, so a directory literally named that way stays a
+        // real path.
+        assert_eq!(unexpanded_template_variable("${}"), None);
+        assert_eq!(unexpanded_template_variable("${ }"), None);
+        assert_eq!(unexpanded_template_variable("/tmp/${a/b}/x"), None);
+        assert_eq!(unexpanded_template_variable("${1invalid}"), None);
+        assert_eq!(unexpanded_template_variable("${_underscore}"), None);
+    }
+
+    #[test]
+    fn later_plausible_template_wins_over_earlier_degenerate_braces() {
+        assert_eq!(
+            unexpanded_template_variable("/tmp/${ }/x/${workspaceFolder}"),
+            Some("${workspaceFolder}")
+        );
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -37,6 +37,38 @@ impl CwdProjectMatch {
     }
 }
 
+/// Returns the first unexpanded `${...}` template variable in a `--path`
+/// argument (e.g. `${workspaceFolder}`), or `None` when the value contains no
+/// template syntax. A bare `$` without braces is not template syntax — real
+/// directories can contain `$` in their names.
+pub fn unexpanded_template_variable(path: &str) -> Option<&str> {
+    let start = path.find("${")?;
+    let end = path[start..].find('}')?;
+    Some(&path[start..=start + end])
+}
+
+/// Filters a `serve --path` CLI argument that the MCP host failed to expand.
+///
+/// Some hosts pass config template variables through literally instead of
+/// expanding them — Cursor's headless agent-session scopes spawn
+/// `serve --path ${workspaceFolder}` verbatim, and Cursor never retries an
+/// MCP scope whose process exited, so a fatal config error here permanently
+/// breaks the connection. A literal `${...}` value can never name a real
+/// project, so it is discarded with a stderr warning and `serve` falls back
+/// to its normal no-path discovery chain (cwd walk-up, MCP initialize roots,
+/// global project registry).
+pub fn sanitize_serve_path_arg(path: Option<String>) -> Option<String> {
+    let raw = path?;
+    let Some(variable) = unexpanded_template_variable(&raw) else {
+        return Some(raw);
+    };
+    eprintln!(
+        "warning: --path '{raw}' contains the unexpanded template variable '{variable}' \
+         (the MCP host did not expand it); ignoring --path and falling back to project discovery"
+    );
+    None
+}
+
 pub fn global_db_ambiguity_message(paths: &[String]) -> String {
     let mut message =
         "Multiple tracedecay projects found — pass -p <path> to select one:".to_string();
@@ -281,5 +313,96 @@ fn hex_value(byte: u8) -> Option<u8> {
         b'a'..=b'f' => Some(byte - b'a' + 10),
         b'A'..=b'F' => Some(byte - b'A' + 10),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_literal_workspace_folder_variable() {
+        assert_eq!(
+            unexpanded_template_variable("${workspaceFolder}"),
+            Some("${workspaceFolder}")
+        );
+    }
+
+    #[test]
+    fn detects_template_variable_with_default_value_syntax() {
+        assert_eq!(
+            unexpanded_template_variable("${workspaceFolder:-/tmp/fallback}"),
+            Some("${workspaceFolder:-/tmp/fallback}")
+        );
+    }
+
+    #[test]
+    fn detects_other_host_template_variables() {
+        assert_eq!(
+            unexpanded_template_variable("${workspaceRoot}"),
+            Some("${workspaceRoot}")
+        );
+        assert_eq!(
+            unexpanded_template_variable("${userHome}"),
+            Some("${userHome}")
+        );
+    }
+
+    #[test]
+    fn detects_template_variable_embedded_in_a_longer_path() {
+        assert_eq!(
+            unexpanded_template_variable("${workspaceFolder}/packages/core"),
+            Some("${workspaceFolder}")
+        );
+        assert_eq!(
+            unexpanded_template_variable("/home/user/${workspaceFolderBasename}/src"),
+            Some("${workspaceFolderBasename}")
+        );
+    }
+
+    #[test]
+    fn plain_paths_are_not_templates() {
+        assert_eq!(unexpanded_template_variable("/home/user/project"), None);
+        assert_eq!(unexpanded_template_variable("relative/dir"), None);
+        assert_eq!(unexpanded_template_variable(""), None);
+    }
+
+    #[test]
+    fn dollar_signs_without_brace_syntax_are_not_templates() {
+        // Real directories can contain `$` — only `${...}` is template syntax.
+        assert_eq!(unexpanded_template_variable("/tmp/pri$ce/data"), None);
+        assert_eq!(unexpanded_template_variable("$workspaceFolder"), None);
+        assert_eq!(unexpanded_template_variable("/tmp/{braces}/x"), None);
+        assert_eq!(unexpanded_template_variable("/tmp/trailing$"), None);
+    }
+
+    #[test]
+    fn unterminated_template_syntax_is_not_a_template() {
+        assert_eq!(unexpanded_template_variable("/tmp/${unclosed"), None);
+    }
+
+    #[test]
+    fn sanitize_keeps_plain_paths_and_none() {
+        assert_eq!(
+            sanitize_serve_path_arg(Some("/home/user/project".to_string())),
+            Some("/home/user/project".to_string())
+        );
+        assert_eq!(
+            sanitize_serve_path_arg(Some("/tmp/pri$ce".to_string())),
+            Some("/tmp/pri$ce".to_string())
+        );
+        assert_eq!(sanitize_serve_path_arg(None), None);
+    }
+
+    #[test]
+    fn sanitize_discards_unexpanded_template_paths() {
+        assert_eq!(
+            sanitize_serve_path_arg(Some("${workspaceFolder}".to_string())),
+            None
+        );
+        assert_eq!(
+            sanitize_serve_path_arg(Some("${workspaceFolder}/nested".to_string())),
+            None
+        );
     }
 }

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -272,6 +272,16 @@ fn cursor_update_plugin_refreshes_bundle_and_preserves_user_config() {
     // Generated bundle re-baked: plugin-owned mcp.json command, hook command
     // paths, and the manifest version stamp.
     assert!(text(&plugin_dir.join("mcp.json")).contains(NEW_BIN));
+    // Template decision pin: the rebaked MCP config must keep the
+    // workspace-scoped `--path ${workspaceFolder}` args. Normal Cursor windows
+    // expand the variable; hosts that pass it literally (headless
+    // agent-session scopes) are handled by serve's unexpanded-template
+    // fallback, not by dropping the argument from the template.
+    let rebaked_mcp = read_json(&plugin_dir.join("mcp.json"));
+    assert_eq!(
+        rebaked_mcp["mcpServers"]["tracedecay"]["args"],
+        serde_json::json!(["serve", "--path", "${workspaceFolder}"])
+    );
     assert!(text(&plugin_dir.join("hooks/hooks.json")).contains(NEW_BIN));
     assert!(
         text(&plugin_dir.join(".cursor-plugin/plugin.json")).contains(env!("CARGO_PKG_VERSION"))

--- a/tests/mcp_suite/main.rs
+++ b/tests/mcp_suite/main.rs
@@ -18,3 +18,5 @@ mod mcp_handler_test;
 mod mcp_server_test;
 mod mcp_test;
 mod multi_mcp_coordination_test;
+mod serve_harness;
+mod serve_template_path_test;

--- a/tests/mcp_suite/mcp_cli_serve_test.rs
+++ b/tests/mcp_suite/mcp_cli_serve_test.rs
@@ -1042,6 +1042,253 @@ async fn initialize_roots_decode_file_uri_localhost_and_percent_escapes() {
     );
 }
 
+/// Spawns `serve --path <path_arg>` from `cwd` and drives a real MCP
+/// `initialize` + `tracedecay_runtime` tools/call over stdio. Callers assert
+/// on the returned output (success and failure paths are both exercised).
+fn run_serve_runtime_with_path_arg(home: &Path, cwd: &Path, path_arg: &str) -> Output {
+    let mut child = tracedecay_command_with_home(home)
+        .arg("serve")
+        .arg("--path")
+        .arg(path_arg)
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("tracedecay serve should start");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        // Failure-path tests exit before draining stdin; ignore broken pipes
+        // so the assertion happens on the process output instead.
+        let _ = writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            })
+        );
+        let _ = writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "tracedecay_runtime",
+                    "arguments": { "format": "json" }
+                }
+            })
+        );
+    }
+    child
+        .wait_with_output()
+        .expect("tracedecay serve should exit after stdin closes")
+}
+
+const UNEXPANDED_TEMPLATE_WARNING: &str = "unexpanded template variable";
+
+/// Exact reproduction of the Cursor headless agent-session spawn: the host
+/// launches `tracedecay serve --path ${workspaceFolder}` with the LITERAL
+/// (unexpanded) template variable and cwd set to the user home, not the
+/// workspace. `serve` must warn, discard the bogus path, and complete the MCP
+/// initialize handshake via discovery instead of exiting with a config error
+/// (Cursor never retries a failed MCP scope, so an early exit permanently
+/// breaks the connection).
+#[tokio::test]
+async fn literal_workspace_folder_path_from_home_cwd_serves_via_discovery() {
+    let home = TempDir::new().unwrap();
+    let project = init_project_with_file(home.path(), "pub fn headless_scope_marker() {}\n").await;
+    register_global_project(home.path(), project.path()).await;
+
+    let home_cwd = canonical_existing_path(home.path());
+    let output = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
+
+    assert!(
+        output.status.success(),
+        "serve must tolerate a literal ${{workspaceFolder}} --path instead of exiting\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"protocolVersion\":\"2024-11-05\""),
+        "serve should answer the MCP initialize handshake\nstdout:\n{stdout}"
+    );
+    assert_eq!(
+        canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
+        canonical_path_string(project.path()),
+        "serve should resolve the registered project via discovery"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(UNEXPANDED_TEMPLATE_WARNING)
+            && stderr.contains("${workspaceFolder}")
+            && stderr.contains("project discovery"),
+        "serve should warn that the host passed an unexpanded template variable\nstderr:\n{stderr}"
+    );
+}
+
+/// Other unexpanded `${...}` forms (different variable names, default-value
+/// syntax) must get the same tolerance as `${workspaceFolder}`.
+#[tokio::test]
+async fn literal_template_variant_paths_fall_back_to_discovery() {
+    for path_arg in ["${workspaceRoot}", "${workspaceFolder:-/tmp/never-used}"] {
+        let home = TempDir::new().unwrap();
+        let project =
+            init_project_with_file(home.path(), "pub fn template_variant_marker() {}\n").await;
+        register_global_project(home.path(), project.path()).await;
+        let cwd = TempDir::new().unwrap();
+
+        let output = run_serve_runtime_with_path_arg(home.path(), cwd.path(), path_arg);
+
+        assert!(
+            output.status.success(),
+            "serve must tolerate the literal template path {path_arg}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
+            canonical_path_string(project.path()),
+            "serve should resolve the registered project via discovery for {path_arg}"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(UNEXPANDED_TEMPLATE_WARNING) && stderr.contains(path_arg),
+            "warning should name the unexpanded variable for {path_arg}\nstderr:\n{stderr}"
+        );
+    }
+}
+
+/// A real directory whose name merely contains `$` (no `${...}` syntax) is a
+/// legitimate explicit path and must NOT be diverted through discovery.
+#[tokio::test]
+async fn explicit_path_with_dollar_sign_directory_is_not_treated_as_template() {
+    let home = TempDir::new().unwrap();
+    let parent = TempDir::new().unwrap();
+    let dollar_project = init_project_under(
+        home.path(),
+        parent.path(),
+        "pri$ce-project",
+        "pub fn dollar_dir_marker() {}\n",
+    )
+    .await;
+    // A registered decoy proves the explicit path stays authoritative: if the
+    // `$` path were misread as a template, discovery would serve the decoy.
+    let decoy = init_project_with_file(home.path(), "pub fn decoy_marker() {}\n").await;
+    register_global_project(home.path(), decoy.path()).await;
+    let cwd = TempDir::new().unwrap();
+
+    let output =
+        run_serve_runtime_with_path_arg(home.path(), cwd.path(), dollar_project.to_str().unwrap());
+
+    assert!(
+        output.status.success(),
+        "serve should accept an explicit path containing '$'\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
+        canonical_path_string(&dollar_project),
+        "the explicit '$' directory must be served, not a discovery fallback"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
+        "a real '$' directory must not trigger the template warning\nstderr:\n{stderr}"
+    );
+}
+
+/// A genuinely wrong explicit path (no template syntax) must keep failing
+/// loudly — the template tolerance must not swallow real misconfiguration.
+#[tokio::test]
+async fn explicit_nonexistent_path_still_fails_instead_of_discovery() {
+    let home = TempDir::new().unwrap();
+    let active = init_project_with_file(home.path(), "pub fn active_project_marker() {}\n").await;
+    register_global_project(home.path(), active.path()).await;
+    let scratch = TempDir::new().unwrap();
+    let missing = scratch.path().join("does-not-exist");
+
+    let output = tracedecay_command_with_home(home.path())
+        .arg("serve")
+        .arg("--path")
+        .arg(&missing)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("tracedecay serve should run");
+
+    assert!(
+        !output.status.success(),
+        "a nonexistent explicit --path must stay fatal instead of falling back to discovery\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&missing.display().to_string()),
+        "error should name the missing explicit path\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
+        "a plain nonexistent path must not be mistaken for a template\nstderr:\n{stderr}"
+    );
+}
+
+/// Pins the template decision: no-path discovery from a home-directory cwd
+/// cannot pick between multiple same-depth registered projects, which is why
+/// the Cursor plugin template keeps `--path ${workspaceFolder}` (normal
+/// windows expand it) and relies on the literal-template fallback only when
+/// the host fails to expand. When that fallback also cannot disambiguate, the
+/// actionable ambiguity error must surface rather than an arbitrary project.
+#[tokio::test]
+async fn literal_workspace_folder_with_multiple_projects_reports_ambiguity() {
+    let home = TempDir::new().unwrap();
+    let home_cwd = canonical_existing_path(home.path());
+    let projects_dir = home_cwd.join("projects");
+    fs::create_dir_all(&projects_dir).unwrap();
+    let alpha = init_project_under(
+        home.path(),
+        &projects_dir,
+        "alpha",
+        "pub fn alpha_marker() {}\n",
+    )
+    .await;
+    let beta = init_project_under(
+        home.path(),
+        &projects_dir,
+        "beta",
+        "pub fn beta_marker() {}\n",
+    )
+    .await;
+    register_global_project(home.path(), &alpha).await;
+    register_global_project(home.path(), &beta).await;
+
+    let output = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "ambiguous discovery must not silently pick a project\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr
+    );
+    assert!(
+        stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
+        "the template warning should still be emitted before the ambiguity error\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Multiple tracedecay projects found"),
+        "stderr should surface the actionable ambiguity error\nstderr:\n{stderr}"
+    );
+}
+
 #[tokio::test]
 async fn same_depth_descendant_global_fallback_is_ambiguous() {
     let home = TempDir::new().unwrap();

--- a/tests/mcp_suite/mcp_cli_serve_test.rs
+++ b/tests/mcp_suite/mcp_cli_serve_test.rs
@@ -6,6 +6,13 @@ use std::path::{Path, PathBuf};
 use std::process::{Output, Stdio};
 
 use crate::common::{canonical_existing_path, tracedecay_command_with_home};
+#[cfg(unix)]
+use crate::serve_harness::runtime_project_root;
+#[cfg(unix)]
+use crate::serve_harness::{canonical_path_string, run_serve_runtime};
+use crate::serve_harness::{
+    init_project_under, init_project_with_file, profile_root, register_global_project,
+};
 use libsql::Builder;
 use serde_json::{json, Value};
 #[cfg(unix)]
@@ -22,68 +29,15 @@ use tracedecay::automation::run_ledger::{
     AutomationRunStatus, AutomationTrigger,
 };
 use tracedecay::db::Database;
-use tracedecay::global_db::GlobalDb;
 use tracedecay::mcp::handle_tool_call;
 use tracedecay::serve;
 use tracedecay::storage::{
     default_profile_sharded_layout, write_enrollment_marker, EnrollmentMarker, StorageMode,
 };
-use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
+use tracedecay::tracedecay::TraceDecay;
 
 #[cfg(unix)]
 static READ_ONLY_SERVE_ENV_LOCK: Mutex<()> = Mutex::const_new(());
-
-async fn init_project_with_file(home: &Path, contents: &str) -> TempDir {
-    let dir = TempDir::new().unwrap();
-    std::fs::create_dir_all(dir.path().join("src")).unwrap();
-    std::fs::write(dir.path().join("src/lib.rs"), contents).unwrap();
-    init_project_direct(home, dir.path()).await;
-    dir
-}
-
-async fn init_project_under(home: &Path, parent: &Path, name: &str, contents: &str) -> PathBuf {
-    let path = parent.join(name);
-    fs::create_dir_all(path.join("src")).unwrap();
-    fs::write(path.join("src/lib.rs"), contents).unwrap();
-    init_project_direct(home, &path).await;
-    path
-}
-
-async fn init_project_direct(home: &Path, project: &Path) {
-    let profile_root = profile_root(home);
-    let open_options = TraceDecayOpenOptions {
-        profile_root: Some(profile_root.clone()),
-        global_db_path: Some(profile_root.join("global.db")),
-    };
-    crate::fixture::init_project_from_template_with_options(project, open_options)
-        .await
-        .expect("tracedecay project should initialize");
-}
-
-async fn register_global_project(home: &Path, project: &Path) {
-    let home = canonical_existing_path(home);
-    let db_path = home.join(".tracedecay/global.db");
-    let db = GlobalDb::open_at(&db_path).await.unwrap();
-    db.upsert(project, 0).await;
-    db.checkpoint().await;
-}
-
-fn runtime_project_root(stdout: &[u8], id: i64) -> String {
-    let stdout = String::from_utf8(stdout.to_vec()).unwrap();
-    let runtime_response: Value = stdout
-        .lines()
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .find(|response| response.get("id") == Some(&json!(id)))
-        .unwrap_or_else(|| panic!("missing runtime response in stdout:\n{stdout}"));
-    let text = runtime_response["result"]["content"][0]["text"]
-        .as_str()
-        .expect("runtime tool should return text content");
-    let runtime: Value = serde_json::from_str(text).unwrap();
-    runtime["database"]["project_root"]
-        .as_str()
-        .expect("runtime should include database.project_root")
-        .to_string()
-}
 
 fn json_rpc_tool_payload(stdout: &[u8], id: i64) -> Value {
     let stdout_text = String::from_utf8(stdout.to_vec()).unwrap();
@@ -142,57 +96,17 @@ fn run_serve_runtime_with_initialize_root(
     root_uri: String,
     root_name: &str,
 ) -> Output {
-    let mut command = tracedecay_command_with_home(home);
-    command.arg("serve");
-    if let Some(path) = explicit_path {
-        command.arg("--path").arg(path);
-    }
-
-    let mut child = command
-        .current_dir(cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("tracedecay serve should start");
-
-    {
-        let stdin = child.stdin.as_mut().expect("stdin should be piped");
-        writeln!(
-            stdin,
-            "{}",
-            json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "roots": [{
-                        "uri": root_uri,
-                        "name": root_name
-                    }]
-                }
-            })
-        )
-        .unwrap();
-        writeln!(
-            stdin,
-            "{}",
-            json!({
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "tools/call",
-                "params": {
-                    "name": "tracedecay_runtime",
-                    "arguments": { "format": "json" }
-                }
-            })
-        )
-        .unwrap();
-    }
-
-    let output = child
-        .wait_with_output()
-        .expect("tracedecay serve should exit after stdin closes");
+    let output = run_serve_runtime(
+        home,
+        cwd,
+        explicit_path.map(Path::as_os_str),
+        json!({
+            "roots": [{
+                "uri": root_uri,
+                "name": root_name
+            }]
+        }),
+    );
     assert!(
         output.status.success(),
         "tracedecay serve failed\nstdout:\n{}\nstderr:\n{}",
@@ -200,17 +114,6 @@ fn run_serve_runtime_with_initialize_root(
         String::from_utf8_lossy(&output.stderr)
     );
     output
-}
-
-fn canonical_path_string(path: &Path) -> String {
-    path.canonicalize()
-        .unwrap_or_else(|_| path.to_path_buf())
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn profile_root(home: &Path) -> PathBuf {
-    canonical_existing_path(home).join(".tracedecay")
 }
 
 async fn set_user_version(db_path: &Path, version: u32) {
@@ -1039,253 +942,6 @@ async fn initialize_roots_decode_file_uri_localhost_and_percent_escapes() {
         canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
         canonical_path_string(&active),
         "serve should use the decoded MCP root project"
-    );
-}
-
-/// Spawns `serve --path <path_arg>` from `cwd` and drives a real MCP
-/// `initialize` + `tracedecay_runtime` tools/call over stdio. Callers assert
-/// on the returned output (success and failure paths are both exercised).
-fn run_serve_runtime_with_path_arg(home: &Path, cwd: &Path, path_arg: &str) -> Output {
-    let mut child = tracedecay_command_with_home(home)
-        .arg("serve")
-        .arg("--path")
-        .arg(path_arg)
-        .current_dir(cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("tracedecay serve should start");
-    {
-        let stdin = child.stdin.as_mut().expect("stdin should be piped");
-        // Failure-path tests exit before draining stdin; ignore broken pipes
-        // so the assertion happens on the process output instead.
-        let _ = writeln!(
-            stdin,
-            "{}",
-            json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {}
-            })
-        );
-        let _ = writeln!(
-            stdin,
-            "{}",
-            json!({
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "tools/call",
-                "params": {
-                    "name": "tracedecay_runtime",
-                    "arguments": { "format": "json" }
-                }
-            })
-        );
-    }
-    child
-        .wait_with_output()
-        .expect("tracedecay serve should exit after stdin closes")
-}
-
-const UNEXPANDED_TEMPLATE_WARNING: &str = "unexpanded template variable";
-
-/// Exact reproduction of the Cursor headless agent-session spawn: the host
-/// launches `tracedecay serve --path ${workspaceFolder}` with the LITERAL
-/// (unexpanded) template variable and cwd set to the user home, not the
-/// workspace. `serve` must warn, discard the bogus path, and complete the MCP
-/// initialize handshake via discovery instead of exiting with a config error
-/// (Cursor never retries a failed MCP scope, so an early exit permanently
-/// breaks the connection).
-#[tokio::test]
-async fn literal_workspace_folder_path_from_home_cwd_serves_via_discovery() {
-    let home = TempDir::new().unwrap();
-    let project = init_project_with_file(home.path(), "pub fn headless_scope_marker() {}\n").await;
-    register_global_project(home.path(), project.path()).await;
-
-    let home_cwd = canonical_existing_path(home.path());
-    let output = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
-
-    assert!(
-        output.status.success(),
-        "serve must tolerate a literal ${{workspaceFolder}} --path instead of exiting\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("\"protocolVersion\":\"2024-11-05\""),
-        "serve should answer the MCP initialize handshake\nstdout:\n{stdout}"
-    );
-    assert_eq!(
-        canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
-        canonical_path_string(project.path()),
-        "serve should resolve the registered project via discovery"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(UNEXPANDED_TEMPLATE_WARNING)
-            && stderr.contains("${workspaceFolder}")
-            && stderr.contains("project discovery"),
-        "serve should warn that the host passed an unexpanded template variable\nstderr:\n{stderr}"
-    );
-}
-
-/// Other unexpanded `${...}` forms (different variable names, default-value
-/// syntax) must get the same tolerance as `${workspaceFolder}`.
-#[tokio::test]
-async fn literal_template_variant_paths_fall_back_to_discovery() {
-    for path_arg in ["${workspaceRoot}", "${workspaceFolder:-/tmp/never-used}"] {
-        let home = TempDir::new().unwrap();
-        let project =
-            init_project_with_file(home.path(), "pub fn template_variant_marker() {}\n").await;
-        register_global_project(home.path(), project.path()).await;
-        let cwd = TempDir::new().unwrap();
-
-        let output = run_serve_runtime_with_path_arg(home.path(), cwd.path(), path_arg);
-
-        assert!(
-            output.status.success(),
-            "serve must tolerate the literal template path {path_arg}\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        assert_eq!(
-            canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
-            canonical_path_string(project.path()),
-            "serve should resolve the registered project via discovery for {path_arg}"
-        );
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            stderr.contains(UNEXPANDED_TEMPLATE_WARNING) && stderr.contains(path_arg),
-            "warning should name the unexpanded variable for {path_arg}\nstderr:\n{stderr}"
-        );
-    }
-}
-
-/// A real directory whose name merely contains `$` (no `${...}` syntax) is a
-/// legitimate explicit path and must NOT be diverted through discovery.
-#[tokio::test]
-async fn explicit_path_with_dollar_sign_directory_is_not_treated_as_template() {
-    let home = TempDir::new().unwrap();
-    let parent = TempDir::new().unwrap();
-    let dollar_project = init_project_under(
-        home.path(),
-        parent.path(),
-        "pri$ce-project",
-        "pub fn dollar_dir_marker() {}\n",
-    )
-    .await;
-    // A registered decoy proves the explicit path stays authoritative: if the
-    // `$` path were misread as a template, discovery would serve the decoy.
-    let decoy = init_project_with_file(home.path(), "pub fn decoy_marker() {}\n").await;
-    register_global_project(home.path(), decoy.path()).await;
-    let cwd = TempDir::new().unwrap();
-
-    let output =
-        run_serve_runtime_with_path_arg(home.path(), cwd.path(), dollar_project.to_str().unwrap());
-
-    assert!(
-        output.status.success(),
-        "serve should accept an explicit path containing '$'\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(
-        canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
-        canonical_path_string(&dollar_project),
-        "the explicit '$' directory must be served, not a discovery fallback"
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
-        "a real '$' directory must not trigger the template warning\nstderr:\n{stderr}"
-    );
-}
-
-/// A genuinely wrong explicit path (no template syntax) must keep failing
-/// loudly — the template tolerance must not swallow real misconfiguration.
-#[tokio::test]
-async fn explicit_nonexistent_path_still_fails_instead_of_discovery() {
-    let home = TempDir::new().unwrap();
-    let active = init_project_with_file(home.path(), "pub fn active_project_marker() {}\n").await;
-    register_global_project(home.path(), active.path()).await;
-    let scratch = TempDir::new().unwrap();
-    let missing = scratch.path().join("does-not-exist");
-
-    let output = tracedecay_command_with_home(home.path())
-        .arg("serve")
-        .arg("--path")
-        .arg(&missing)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("tracedecay serve should run");
-
-    assert!(
-        !output.status.success(),
-        "a nonexistent explicit --path must stay fatal instead of falling back to discovery\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(&missing.display().to_string()),
-        "error should name the missing explicit path\nstderr:\n{stderr}"
-    );
-    assert!(
-        !stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
-        "a plain nonexistent path must not be mistaken for a template\nstderr:\n{stderr}"
-    );
-}
-
-/// Pins the template decision: no-path discovery from a home-directory cwd
-/// cannot pick between multiple same-depth registered projects, which is why
-/// the Cursor plugin template keeps `--path ${workspaceFolder}` (normal
-/// windows expand it) and relies on the literal-template fallback only when
-/// the host fails to expand. When that fallback also cannot disambiguate, the
-/// actionable ambiguity error must surface rather than an arbitrary project.
-#[tokio::test]
-async fn literal_workspace_folder_with_multiple_projects_reports_ambiguity() {
-    let home = TempDir::new().unwrap();
-    let home_cwd = canonical_existing_path(home.path());
-    let projects_dir = home_cwd.join("projects");
-    fs::create_dir_all(&projects_dir).unwrap();
-    let alpha = init_project_under(
-        home.path(),
-        &projects_dir,
-        "alpha",
-        "pub fn alpha_marker() {}\n",
-    )
-    .await;
-    let beta = init_project_under(
-        home.path(),
-        &projects_dir,
-        "beta",
-        "pub fn beta_marker() {}\n",
-    )
-    .await;
-    register_global_project(home.path(), &alpha).await;
-    register_global_project(home.path(), &beta).await;
-
-    let output = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !output.status.success(),
-        "ambiguous discovery must not silently pick a project\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        stderr
-    );
-    assert!(
-        stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
-        "the template warning should still be emitted before the ambiguity error\nstderr:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("Multiple tracedecay projects found"),
-        "stderr should surface the actionable ambiguity error\nstderr:\n{stderr}"
     );
 }
 

--- a/tests/mcp_suite/serve_harness.rs
+++ b/tests/mcp_suite/serve_harness.rs
@@ -1,0 +1,139 @@
+//! Shared helpers for `tracedecay serve` stdio integration tests
+//! (`mcp_cli_serve_test`, `serve_template_path_test`): project fixtures,
+//! a serve process spawner that drives a real MCP handshake, and output
+//! parsers.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Output, Stdio};
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tracedecay::global_db::GlobalDb;
+use tracedecay::tracedecay::TraceDecayOpenOptions;
+
+use crate::common::{canonical_existing_path, tracedecay_command_with_home};
+
+pub fn profile_root(home: &Path) -> PathBuf {
+    canonical_existing_path(home).join(".tracedecay")
+}
+
+pub async fn init_project_with_file(home: &Path, contents: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("src/lib.rs"), contents).unwrap();
+    init_project_direct(home, dir.path()).await;
+    dir
+}
+
+pub async fn init_project_under(home: &Path, parent: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = parent.join(name);
+    fs::create_dir_all(path.join("src")).unwrap();
+    fs::write(path.join("src/lib.rs"), contents).unwrap();
+    init_project_direct(home, &path).await;
+    path
+}
+
+async fn init_project_direct(home: &Path, project: &Path) {
+    let profile_root = profile_root(home);
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(profile_root.join("global.db")),
+    };
+    crate::fixture::init_project_from_template_with_options(project, open_options)
+        .await
+        .expect("tracedecay project should initialize");
+}
+
+pub async fn register_global_project(home: &Path, project: &Path) {
+    let home = canonical_existing_path(home);
+    let db_path = home.join(".tracedecay/global.db");
+    let db = GlobalDb::open_at(&db_path).await.unwrap();
+    db.upsert(project, 0).await;
+    db.checkpoint().await;
+}
+
+/// Spawns `tracedecay serve` from `cwd` (optionally with `--path`), drives an
+/// MCP `initialize` with the given params followed by a `tracedecay_runtime`
+/// tools/call (id 2) over stdio, and returns the process output once stdin
+/// closes. Stdin writes ignore broken pipes so failure-path tests can assert
+/// on the output instead of panicking when serve exits early.
+pub fn run_serve_runtime(
+    home: &Path,
+    cwd: &Path,
+    path_arg: Option<&OsStr>,
+    initialize_params: Value,
+) -> Output {
+    let mut command = tracedecay_command_with_home(home);
+    command.arg("serve");
+    if let Some(path) = path_arg {
+        command.arg("--path").arg(path);
+    }
+
+    let mut child = command
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("tracedecay serve should start");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        let _ = writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": initialize_params
+            })
+        );
+        let _ = writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "tracedecay_runtime",
+                    "arguments": { "format": "json" }
+                }
+            })
+        );
+    }
+
+    child
+        .wait_with_output()
+        .expect("tracedecay serve should exit after stdin closes")
+}
+
+/// Extracts `database.project_root` from the `tracedecay_runtime` tools/call
+/// response with the given JSON-RPC id.
+pub fn runtime_project_root(stdout: &[u8], id: i64) -> String {
+    let stdout = String::from_utf8(stdout.to_vec()).unwrap();
+    let runtime_response: Value = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .find(|response| response.get("id") == Some(&json!(id)))
+        .unwrap_or_else(|| panic!("missing runtime response in stdout:\n{stdout}"));
+    let text = runtime_response["result"]["content"][0]["text"]
+        .as_str()
+        .expect("runtime tool should return text content");
+    let runtime: Value = serde_json::from_str(text).unwrap();
+    runtime["database"]["project_root"]
+        .as_str()
+        .expect("runtime should include database.project_root")
+        .to_string()
+}
+
+pub fn canonical_path_string(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}

--- a/tests/mcp_suite/serve_template_path_test.rs
+++ b/tests/mcp_suite/serve_template_path_test.rs
@@ -1,0 +1,297 @@
+//! `serve --path` tolerance for literal unexpanded `${...}` host template
+//! variables (e.g. Cursor headless agent-session MCP scopes spawning
+//! `serve --path ${workspaceFolder}` verbatim from the user home). See
+//! `cursor-plugin/README.md` for the full rationale.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+use std::process::Stdio;
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use crate::common::{canonical_existing_path, tracedecay_command_with_home};
+use crate::serve_harness::{
+    canonical_path_string, init_project_under, init_project_with_file, register_global_project,
+    run_serve_runtime, runtime_project_root,
+};
+
+const UNEXPANDED_TEMPLATE_WARNING: &str = "unexpanded template variable";
+const PROJECT_CHOICE_LOG: &str = "tracedecay serve: using project";
+
+fn run_serve_runtime_with_path_arg(
+    home: &Path,
+    cwd: &Path,
+    path_arg: &str,
+) -> std::process::Output {
+    run_serve_runtime(home, cwd, Some(OsStr::new(path_arg)), json!({}))
+}
+
+/// Exact reproduction of the Cursor headless agent-session spawn: the host
+/// launches `tracedecay serve --path ${workspaceFolder}` with the LITERAL
+/// (unexpanded) template variable and cwd set to the user home, not the
+/// workspace. `serve` must warn, discard the bogus path, and complete the MCP
+/// initialize handshake via discovery instead of exiting with a config error
+/// (Cursor never retries a failed MCP scope, so an early exit permanently
+/// breaks the connection).
+#[tokio::test]
+async fn literal_workspace_folder_path_from_home_cwd_serves_via_discovery() {
+    let home = TempDir::new().unwrap();
+    let project = init_project_with_file(home.path(), "pub fn headless_scope_marker() {}\n").await;
+    register_global_project(home.path(), project.path()).await;
+
+    let home_cwd = canonical_existing_path(home.path());
+    let output = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
+
+    assert!(
+        output.status.success(),
+        "serve must tolerate a literal ${{workspaceFolder}} --path instead of exiting\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"protocolVersion\":\"2024-11-05\""),
+        "serve should answer the MCP initialize handshake\nstdout:\n{stdout}"
+    );
+    assert_eq!(
+        canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
+        canonical_path_string(project.path()),
+        "serve should resolve the registered project via discovery"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(UNEXPANDED_TEMPLATE_WARNING)
+            && stderr.contains("${workspaceFolder}")
+            && stderr.contains("project discovery"),
+        "serve should warn that the host passed an unexpanded template variable\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(PROJECT_CHOICE_LOG),
+        "serve should log which project the fallback picked and why\nstderr:\n{stderr}"
+    );
+}
+
+/// Other unexpanded `${...}` forms (different variable names, default-value
+/// syntax) must get the same tolerance as `${workspaceFolder}`.
+#[tokio::test]
+async fn literal_template_variant_paths_fall_back_to_discovery() {
+    for path_arg in ["${workspaceRoot}", "${workspaceFolder:-/tmp/never-used}"] {
+        let home = TempDir::new().unwrap();
+        let project =
+            init_project_with_file(home.path(), "pub fn template_variant_marker() {}\n").await;
+        register_global_project(home.path(), project.path()).await;
+        let cwd = TempDir::new().unwrap();
+
+        let output = run_serve_runtime_with_path_arg(home.path(), cwd.path(), path_arg);
+
+        assert!(
+            output.status.success(),
+            "serve must tolerate the literal template path {path_arg}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
+            canonical_path_string(project.path()),
+            "serve should resolve the registered project via discovery for {path_arg}"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(UNEXPANDED_TEMPLATE_WARNING) && stderr.contains(path_arg),
+            "warning should name the unexpanded variable for {path_arg}\nstderr:\n{stderr}"
+        );
+    }
+}
+
+/// A real directory whose name merely contains `$` (no `${...}` syntax) is a
+/// legitimate explicit path and must NOT be diverted through discovery.
+#[tokio::test]
+async fn explicit_path_with_dollar_sign_directory_is_not_treated_as_template() {
+    let home = TempDir::new().unwrap();
+    let parent = TempDir::new().unwrap();
+    let dollar_project = init_project_under(
+        home.path(),
+        parent.path(),
+        "pri$ce-project",
+        "pub fn dollar_dir_marker() {}\n",
+    )
+    .await;
+    // A registered decoy proves the explicit path stays authoritative: if the
+    // `$` path were misread as a template, discovery would serve the decoy.
+    let decoy = init_project_with_file(home.path(), "pub fn decoy_marker() {}\n").await;
+    register_global_project(home.path(), decoy.path()).await;
+    let cwd = TempDir::new().unwrap();
+
+    let output =
+        run_serve_runtime_with_path_arg(home.path(), cwd.path(), dollar_project.to_str().unwrap());
+
+    assert!(
+        output.status.success(),
+        "serve should accept an explicit path containing '$'\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        canonical_path_string(Path::new(&runtime_project_root(&output.stdout, 2))),
+        canonical_path_string(&dollar_project),
+        "the explicit '$' directory must be served, not a discovery fallback"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
+        "a real '$' directory must not trigger the template warning\nstderr:\n{stderr}"
+    );
+}
+
+/// A genuinely wrong explicit path (no template syntax) must keep failing
+/// loudly — the template tolerance must not swallow real misconfiguration.
+#[tokio::test]
+async fn explicit_nonexistent_path_still_fails_instead_of_discovery() {
+    let home = TempDir::new().unwrap();
+    let active = init_project_with_file(home.path(), "pub fn active_project_marker() {}\n").await;
+    register_global_project(home.path(), active.path()).await;
+    let scratch = TempDir::new().unwrap();
+    let missing = scratch.path().join("does-not-exist");
+
+    let output = tracedecay_command_with_home(home.path())
+        .arg("serve")
+        .arg("--path")
+        .arg(&missing)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("tracedecay serve should run");
+
+    assert!(
+        !output.status.success(),
+        "a nonexistent explicit --path must stay fatal instead of falling back to discovery\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&missing.display().to_string()),
+        "error should name the missing explicit path\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
+        "a plain nonexistent path must not be mistaken for a template\nstderr:\n{stderr}"
+    );
+}
+
+/// Pins the template decision: no-path discovery from a home-directory cwd
+/// cannot pick between multiple same-depth registered projects, which is why
+/// the Cursor plugin template keeps `--path ${workspaceFolder}` (normal
+/// windows expand it) and relies on the literal-template fallback only when
+/// the host fails to expand. When that fallback cannot find a unique project,
+/// the actionable ambiguity error must surface rather than an arbitrary
+/// project.
+#[tokio::test]
+async fn literal_workspace_folder_with_multiple_projects_reports_ambiguity() {
+    let home = TempDir::new().unwrap();
+    let home_cwd = canonical_existing_path(home.path());
+    let projects_dir = home_cwd.join("projects");
+    fs::create_dir_all(&projects_dir).unwrap();
+    let alpha = init_project_under(
+        home.path(),
+        &projects_dir,
+        "alpha",
+        "pub fn alpha_marker() {}\n",
+    )
+    .await;
+    let beta = init_project_under(
+        home.path(),
+        &projects_dir,
+        "beta",
+        "pub fn beta_marker() {}\n",
+    )
+    .await;
+    register_global_project(home.path(), &alpha).await;
+    register_global_project(home.path(), &beta).await;
+
+    let output = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "ambiguous discovery must not silently pick a project\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr
+    );
+    assert!(
+        stderr.contains(UNEXPANDED_TEMPLATE_WARNING),
+        "the template warning should still be emitted before the ambiguity error\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Multiple tracedecay projects found"),
+        "stderr should surface the actionable ambiguity error\nstderr:\n{stderr}"
+    );
+}
+
+/// The wrong-project guard: with registered projects at DIFFERENT depths
+/// (`~/proj-a` and `~/work/proj-b`), genuine no-path serve may use the cwd
+/// depth heuristic (the user ran it from that directory), but the
+/// discarded-template fallback must not — the host's spawn directory says
+/// nothing about the intended workspace, so silently serving the shallower
+/// project would attach the wrong index to the session. It must require a
+/// unique registry match and surface the ambiguity error otherwise.
+#[tokio::test]
+async fn literal_template_with_different_depth_projects_is_stricter_than_no_path() {
+    let home = TempDir::new().unwrap();
+    let home_cwd = canonical_existing_path(home.path());
+    let shallow = init_project_under(
+        home.path(),
+        &home_cwd,
+        "proj-a",
+        "pub fn shallow_marker() {}\n",
+    )
+    .await;
+    let work_dir = home_cwd.join("work");
+    fs::create_dir_all(&work_dir).unwrap();
+    let deep = init_project_under(
+        home.path(),
+        &work_dir,
+        "proj-b",
+        "pub fn deep_marker() {}\n",
+    )
+    .await;
+    register_global_project(home.path(), &shallow).await;
+    register_global_project(home.path(), &deep).await;
+
+    // Genuine no-path serve resolves via the cwd depth heuristic (shallowest
+    // registered descendant of cwd wins) — unchanged behavior.
+    let no_path = run_serve_runtime(home.path(), &home_cwd, None, json!({}));
+    assert!(
+        no_path.status.success(),
+        "genuine no-path serve should still resolve via the cwd heuristic\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&no_path.stdout),
+        String::from_utf8_lossy(&no_path.stderr)
+    );
+    assert_eq!(
+        canonical_path_string(Path::new(&runtime_project_root(&no_path.stdout, 2))),
+        canonical_path_string(&shallow),
+        "no-path serve should pick the shallowest registered descendant of cwd"
+    );
+
+    // The discarded-template fallback must be stricter: same registry, same
+    // cwd, but no unique match — so it errors instead of guessing.
+    let templated = run_serve_runtime_with_path_arg(home.path(), &home_cwd, "${workspaceFolder}");
+    let stderr = String::from_utf8_lossy(&templated.stderr);
+    assert!(
+        !templated.status.success(),
+        "the template fallback must not silently depth-rank projects\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&templated.stdout),
+        stderr
+    );
+    assert!(
+        stderr.contains("Multiple tracedecay projects found"),
+        "stderr should surface the actionable ambiguity error\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(PROJECT_CHOICE_LOG),
+        "no project-choice log should be emitted when nothing was picked\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the Cursor MCP spawn failure where every tool call surfaces as "Timed out waiting for connection".

**Root cause:** the Cursor plugin's `mcp.json` runs `tracedecay serve --path ${workspaceFolder}`. Normal editor windows expand the variable, but Cursor's headless agent-session MCP scopes pass the LITERAL string `${workspaceFolder}`. `serve` then exits within ~50ms with `config error: no TraceDecay index found at '${workspaceFolder}'`, and Cursor permanently marks the scope failed (it never retries), breaking the connection for the whole session. Same bug class as issue #66 (VS Code Copilot could not expand `${workspaceFolder}` in multi-folder workspaces).

**Fix (runtime tolerance in `serve`):** when the `--path` argument contains an unexpanded `${...}` template variable (`${workspaceFolder}`, `${workspaceRoot}`, default-value variants, etc.), `serve` warns on stderr, discards the argument, and falls through to its existing no-path discovery chain (cwd walk-up → MCP initialize roots → global project registry). This protects every already-installed plugin without a reinstall. A bare `$` without brace syntax is *not* treated as a template (real directories can contain `$`), and a genuinely wrong plain path stays fatal — no silent swallowing of real misconfiguration.

**Template decision: `--path ${workspaceFolder}` stays in the Cursor plugin template.** Unlike the Copilot case (where the host could never expand the variable and it was dropped), Cursor *does* expand it in normal editor windows — and Cursor spawns MCP servers with cwd set to the user home, not the workspace. From a home cwd, no-path discovery cannot disambiguate multiple registered projects (the global-registry fallback correctly reports ambiguity), so dropping `--path` would regress workspace scoping for every multi-project user in normal windows. The template keeps the explicit path for correct scoping, and the new serve fallback handles the headless scopes that pass it literally. This decision is pinned by regression tests (`literal_workspace_folder_with_multiple_projects_reports_ambiguity`, plus the rendered-mcp.json args pin in `update_plugin_test`). Plugin README / README / USER-GUIDE updated to document the fallback.

## Test plan

- [x] `serve::tests` unit tests (9): template detection for `${workspaceFolder}`, `${workspaceRoot}`, `${userHome}`, default-value syntax (`${workspaceFolder:-...}`), embedded-in-path forms; negatives for plain paths, bare `$`, `$var` without braces, `{braces}` without `$`, unterminated `${`.
- [x] `mcp_suite::mcp_cli_serve_test` (19, 5 new):
  - `literal_workspace_folder_path_from_home_cwd_serves_via_discovery` — exact reproduction: serve spawned with cwd = user home and `--path '${workspaceFolder}'`, real MCP `initialize` + `tools/call` over stdio; asserts the registered project is served via discovery and the stderr warning is emitted.
  - `literal_template_variant_paths_fall_back_to_discovery` — `${workspaceRoot}` and `${workspaceFolder:-...}` forms.
  - `explicit_path_with_dollar_sign_directory_is_not_treated_as_template` — a real `pri$ce-project` directory is served explicitly, decoy registered project proves discovery was not used, no warning emitted.
  - `explicit_nonexistent_path_still_fails_instead_of_discovery` — plain misconfiguration stays fatal.
  - `literal_workspace_folder_with_multiple_projects_reports_ambiguity` — pins the template decision: home-cwd discovery with multiple same-depth projects surfaces the actionable ambiguity error instead of picking arbitrarily.
- [x] `agent_suite` cursor tests (25) incl. `update_plugin_test` with the new rendered-mcp.json args pin.
- [x] `cargo check --all-targets`, `cargo clippy --all-targets` (clean; only pre-existing vendored-libsql warnings), `cargo fmt --check`.

All tests are hermetic (`TRACEDECAY_DATA_DIR` pinned to `target/test-profile` via `.cargo/config.toml`, per-test temp homes).