### PR TITLE
fix: harden utf8 bom sync test and drop windows retry mask

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,12 +20,6 @@ windows-memory-eval = { max-threads = 32 }
 windows-timing-sensitive = { max-threads = 32 }
 
 [[profile.ci.overrides]]
-filter = 'all()'
-platform = { host = 'cfg(windows)' }
-retries = 2
-flaky-result = 'pass'
-
-[[profile.ci.overrides]]
 filter = 'binary(=dashboard_api_test)'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-dashboard-server'

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -10,7 +10,7 @@ use crate::errors::Result;
 /// (detected via BOM). Returns an IO error only when the file genuinely cannot
 /// be read or decoded.
 pub fn read_source_file(path: &Path) -> std::io::Result<String> {
-    let bytes = std::fs::read(path)?;
+    let bytes = read_file_bytes(path)?;
 
     // UTF-16 LE BOM: FF FE
     if bytes.starts_with(&[0xFF, 0xFE]) {
@@ -40,6 +40,48 @@ pub fn read_source_file(path: &Path) -> std::io::Result<String> {
     };
     String::from_utf8(bytes[start..].to_vec())
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Reads a file's bytes, absorbing transient Windows file locks.
+///
+/// On Windows, antivirus scanners and the search indexer briefly open
+/// freshly written files with exclusive access; an unlucky open during that
+/// window fails with a sharing violation or "Access is denied" (os error 5)
+/// even though the file is readable milliseconds later. Callers treat read
+/// errors as "skip this file" or fail the whole sync, so a genuinely
+/// readable file must not be lost to that window — retry briefly before
+/// giving up. Other platforms read directly: `PermissionDenied` there is a
+/// real ACL problem that retrying cannot fix.
+fn read_file_bytes(path: &Path) -> std::io::Result<Vec<u8>> {
+    if !cfg!(windows) {
+        return std::fs::read(path);
+    }
+    const RETRY_DELAYS_MS: [u64; 4] = [10, 20, 40, 80];
+    let mut delays = RETRY_DELAYS_MS.iter();
+    loop {
+        match std::fs::read(path) {
+            Err(err) if is_transient_windows_file_lock(&err) => match delays.next() {
+                Some(&delay_ms) => {
+                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                }
+                None => return Err(err),
+            },
+            result => return result,
+        }
+    }
+}
+
+/// True for Windows errors that indicate another process is briefly holding
+/// the file: ERROR_SHARING_VIOLATION (32) and ERROR_LOCK_VIOLATION (33) map
+/// through as raw OS errors, while Defender-style scans surface as plain
+/// `PermissionDenied` (ERROR_ACCESS_DENIED, os error 5).
+fn is_transient_windows_file_lock(err: &std::io::Error) -> bool {
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    const ERROR_LOCK_VIOLATION: i32 = 33;
+    matches!(
+        err.raw_os_error(),
+        Some(ERROR_SHARING_VIOLATION | ERROR_LOCK_VIOLATION)
+    ) || err.kind() == std::io::ErrorKind::PermissionDenied
 }
 
 /// Get filesystem mtime (seconds since epoch) and size for pre-filter.


### PR DESCRIPTION
## Summary
- Root-caused the last retry-masked Windows flake: `core_cli_suite sync_test::test_read_source_file_utf8_bom` intermittently hit `PermissionDenied` (os error 5) reading a just-written temp file. On Windows, AV scanners / the search indexer briefly open freshly written files exclusively, so an immediate `std::fs::read` can transiently fail — a window that also hits real users during sync/indexing, where read errors skip files or fail the run.
- Fix in production code: `read_source_file` now retries transient Windows locks (sharing violation 32, lock violation 33, access denied 5) with 10/20/40/80 ms backoff before surfacing the error. Non-Windows reads are unchanged.
- With this and the libsql double-close fix (#204) landed, remove the `cfg(windows)` `retries = 2` / `flaky-result = 'pass'` nextest mask so future Windows flakes fail loudly.

## Test plan
- [x] `cargo nextest run --profile ci --locked -E 'test(~test_read_source_file_utf8_bom) | (binary(=core_cli_suite) & test(/^sync_test::/))'` — 12/12 pass, 10 consecutive runs
- [x] `cargo nextest show-config test-groups --profile ci` parses after mask removal
- [x] `cargo fmt --all -- --check` clean