### PR TITLE
chore: release v0.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.24](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.23...v0.0.24) - 2026-07-03
+
+### Added
+
+- inject fact-store memory into Codex and Cursor hook context ([#229](https://github.com/ScriptedAlchemy/tracedecay/pull/229))
+- *(automation)* combined reflector+skill scheduler pass (Hermes G9/R7)
+- *(cli)* enforce MCP tool CLI/skill parity and rich subcommand help
+
+### Fixed
+
+- *(lcm)* default transcript reads to all providers
+- *(sessions)* advance Claude cursor for filtered transcripts ([#241](https://github.com/ScriptedAlchemy/tracedecay/pull/241))
+- *(lcm)* run DB-side GC phases when the payload dir is missing
+- *(sessions)* preserve worktree routing metadata
+- *(ci)* harden cross-worktree provenance tests
+- *(sessions)* route cross-worktree provenance
+- *(sessions)* preserve transcript location metadata
+- *(codex)* preserve branch context in transcript metadata
+- *(agents)* require tracedecay local exports
+- *(lsp)* bound diagnostics refresh hangs
+- *(sessions)* normalize activity timestamps
+- satisfy clippy pedantic lints in windows read retry
+- *(sync)* retry transient Windows file locks in read_source_file
+
+### Other
+
+- *(mcp)* isolate dashboard fixture storage
+- Merge remote-tracking branch 'origin/master' into codex/export-approved-skills
+- Merge remote-tracking branch 'origin/master' into codex/hermes-parity-r9-user-jobs
+- Merge remote-tracking branch 'origin/master' into codex/skill-adoption-babysit
+- Merge remote-tracking branch 'origin/master' into codex/hermes-parity-r8-memory-digest
+- Merge remote-tracking branch 'origin/master' into codex/mcp-connection-root-routing
+- Merge remote-tracking branch 'origin/master' into codex/hook-session-route
+- *(sessions)* clarify activity timestamp units
+- Merge pull request #218 from ScriptedAlchemy/codex/activity-coupled-triggering
+- Merge pull request #226 from ScriptedAlchemy/codex/hermes-parity-r10-outcomes
+- Merge pull request #213 from ScriptedAlchemy/codex/tool-skill-cli-parity
+- *(cli)* trim tool help test commentary
+
 ### Added
 
 - Claude Code installs now register `SessionStart` and `PostToolUse` lifecycle hooks, matching the freshness/steering coverage Cursor, Codex, and Kiro already had: `SessionStart` reports index freshness and injects the LCM context-recovery hint after compaction; `PostToolUse` notifies the daemon for targeted incremental sync after edits and shell commands. Existing installs pick the hooks up via the post-upgrade backfill or `tracedecay doctor`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.23"
+version = "0.0.24"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.23 -> 0.0.24

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.24](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.23...v0.0.24) - 2026-07-03

### Added

- inject fact-store memory into Codex and Cursor hook context ([#229](https://github.com/ScriptedAlchemy/tracedecay/pull/229))
- *(automation)* combined reflector+skill scheduler pass (Hermes G9/R7)
- *(cli)* enforce MCP tool CLI/skill parity and rich subcommand help

### Fixed

- *(lcm)* default transcript reads to all providers
- *(sessions)* advance Claude cursor for filtered transcripts ([#241](https://github.com/ScriptedAlchemy/tracedecay/pull/241))
- *(lcm)* run DB-side GC phases when the payload dir is missing
- *(sessions)* preserve worktree routing metadata
- *(ci)* harden cross-worktree provenance tests
- *(sessions)* route cross-worktree provenance
- *(sessions)* preserve transcript location metadata
- *(codex)* preserve branch context in transcript metadata
- *(agents)* require tracedecay local exports
- *(lsp)* bound diagnostics refresh hangs
- *(sessions)* normalize activity timestamps
- satisfy clippy pedantic lints in windows read retry
- *(sync)* retry transient Windows file locks in read_source_file

### Other

- *(mcp)* isolate dashboard fixture storage
- Merge remote-tracking branch 'origin/master' into codex/export-approved-skills
- Merge remote-tracking branch 'origin/master' into codex/hermes-parity-r9-user-jobs
- Merge remote-tracking branch 'origin/master' into codex/skill-adoption-babysit
- Merge remote-tracking branch 'origin/master' into codex/hermes-parity-r8-memory-digest
- Merge remote-tracking branch 'origin/master' into codex/mcp-connection-root-routing
- Merge remote-tracking branch 'origin/master' into codex/hook-session-route
- *(sessions)* clarify activity timestamp units
- Merge pull request #218 from ScriptedAlchemy/codex/activity-coupled-triggering
- Merge pull request #226 from ScriptedAlchemy/codex/hermes-parity-r10-outcomes
- Merge pull request #213 from ScriptedAlchemy/codex/tool-skill-cli-parity
- *(cli)* trim tool help test commentary

### Added

- Claude Code installs now register `SessionStart` and `PostToolUse` lifecycle hooks, matching the freshness/steering coverage Cursor, Codex, and Kiro already had: `SessionStart` reports index freshness and injects the LCM context-recovery hint after compaction; `PostToolUse` notifies the daemon for targeted incremental sync after edits and shell commands. Existing installs pick the hooks up via the post-upgrade backfill or `tracedecay doctor`.
- The CLI-fallback steering ("if MCP fails, use `tracedecay tool ...`") now reaches every host with a prompt-rules surface — Claude Code, Copilot/VS Code, Gemini, OpenCode, Kimi, Vibe, and Kiro — instead of only the Cursor rule and Codex session hook.

### Fixed

- **`serve` no longer exits when project resolution fails at startup** — MCP hosts (Cursor especially) never retry a failed server spawn, so one startup exit over a recoverable config problem (uninitialized project, ambiguous global fallback, bad `--path`) turned every later tool call in the session into "Timed out waiting for connection". `serve` now stays alive in a degraded mode: it completes the MCP handshake, lists the real tools, and answers each tool call with an actionable error naming the failure, the fix, and the `tracedecay tool …` CLI fallback. It rechecks the project on every tool call and recovers in-session once `tracedecay init` (or a corrected path) makes resolution succeed — no server toggle or window reload needed.
- **`serve` now tolerates a literal unexpanded `--path ${workspaceFolder}`** — Cursor's headless agent-session MCP scopes spawn the plugin's serve command without expanding the template variable and never retry the failed scope, which surfaced as "Timed out waiting for connection" on every tool call. `serve` now discards an unexpanded `${...}` template value with a stderr warning and falls back to project discovery where possible, requiring a unique registered project when discovery reaches the global registry in this mode. Rationale and details in `cursor-plugin/README.md`.

### Added

- **`tracedecay doctor --agent cursor` now diagnoses dead Cursor MCP scopes** — best-effort scan of Cursor's recent MCP logs for tracedecay spawn failures (literal unexpanded `${workspaceFolder}` paths, `Connection failed: MCP error -32000`, degraded-mode notices) with concrete remediation ("toggle the MCP server in Cursor Settings → MCP or reload the window"), plus a plugin-bundle-version-vs-binary-version staleness check that points at `tracedecay update-plugin`.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).