### PR TITLE
fix: satisfy clippy pedantic lints in windows read retry

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -53,10 +53,10 @@ pub fn read_source_file(path: &Path) -> std::io::Result<String> {
 /// giving up. Other platforms read directly: `PermissionDenied` there is a
 /// real ACL problem that retrying cannot fix.
 fn read_file_bytes(path: &Path) -> std::io::Result<Vec<u8>> {
+    const RETRY_DELAYS_MS: [u64; 4] = [10, 20, 40, 80];
     if !cfg!(windows) {
         return std::fs::read(path);
     }
-    const RETRY_DELAYS_MS: [u64; 4] = [10, 20, 40, 80];
     let mut delays = RETRY_DELAYS_MS.iter();
     loop {
         match std::fs::read(path) {
@@ -72,9 +72,9 @@ fn read_file_bytes(path: &Path) -> std::io::Result<Vec<u8>> {
 }
 
 /// True for Windows errors that indicate another process is briefly holding
-/// the file: ERROR_SHARING_VIOLATION (32) and ERROR_LOCK_VIOLATION (33) map
-/// through as raw OS errors, while Defender-style scans surface as plain
-/// `PermissionDenied` (ERROR_ACCESS_DENIED, os error 5).
+/// the file: `ERROR_SHARING_VIOLATION` (32) and `ERROR_LOCK_VIOLATION` (33)
+/// map through as raw OS errors, while Defender-style scans surface as plain
+/// `PermissionDenied` (`ERROR_ACCESS_DENIED`, os error 5).
 fn is_transient_windows_file_lock(err: &std::io::Error) -> bool {
     const ERROR_SHARING_VIOLATION: i32 = 32;
     const ERROR_LOCK_VIOLATION: i32 = 33;


### PR DESCRIPTION
## Summary
- Fixes the master Clippy break introduced by #207 (run 28567771746): `items_after_statements` for `RETRY_DELAYS_MS` declared after a statement in `read_file_bytes`, and three `doc_markdown` missing-backticks errors on the Windows error-constant names in doc comments.
- No behavior change; hoists the const and adds backticks.

## Test plan
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean locally
- [x] `cargo fmt --check`
- [x] `cargo nextest run -E 'test(sync_test)'` — 12/12 pass