### PR TITLE
test: consolidate memory tests into one binary

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,7 +40,7 @@ platform = { host = 'cfg(windows)' }
 test-group = 'windows-profile-storage'
 
 [[profile.ci.overrides]]
-filter = 'binary(=session_suite) | (binary(=transcript_ingest_suite) & (test(~codex::) | test(~hermes::) | test(~cline_like::))) | (binary(=storage_suite) & (test(/^corruption_test::/) | test(/^db_query_test::/))) | binary(=memory_test) | (binary(=mcp_suite) & (test(/^mcp_handler_test::/) | test(/^mcp_server_test::/) | test(/^multi_mcp_coordination_test::/)))'
+filter = 'binary(=session_suite) | (binary(=transcript_ingest_suite) & (test(~codex::) | test(~hermes::) | test(~cline_like::))) | (binary(=storage_suite) & (test(/^corruption_test::/) | test(/^db_query_test::/))) | (binary(=memory_suite) & test(/^memory_test::/)) | (binary(=mcp_suite) & (test(/^mcp_handler_test::/) | test(/^mcp_server_test::/) | test(/^multi_mcp_coordination_test::/)))'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-session-sqlite'
 
@@ -55,7 +55,7 @@ platform = { host = 'cfg(windows)' }
 test-group = 'windows-subprocess'
 
 [[profile.ci.overrides]]
-filter = 'binary(=memory_eval_test)'
+filter = 'binary(=memory_suite) & test(/^memory_eval_test::/)'
 platform = { host = 'cfg(windows)' }
 test-group = 'windows-memory-eval'
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,11 +15,13 @@ use serde_json::Value;
 use tempfile::TempDir;
 use tokio::sync::OnceCell;
 use tracedecay::config::USER_DATA_DIR_ENV;
+use tracedecay::db::Database;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::types::{Node, NodeKind, Visibility};
 
 static EMPTY_LCM_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
+static EMPTY_GRAPH_DB_TEMPLATE: OnceCell<Vec<u8>> = OnceCell::const_new();
 
 /// Sets (or removes) an environment variable for its lifetime, restoring the
 /// previous value on drop.
@@ -498,6 +500,49 @@ async fn seed_lcm_db_from_template(db_path: &Path) {
             db_path.display()
         )
     });
+}
+
+/// Opens a fresh graph-schema [`Database`] at `db_path` from a cached
+/// per-process template, skipping the full `create_schema` DDL run — a large
+/// fixed cost on Windows when a suite creates one store per test. The first
+/// call in a process pays one real `Database::initialize` to build the
+/// template; every further store is a file copy plus `Database::open`.
+pub async fn open_graph_db_from_template(db_path: &Path) -> Database {
+    let bytes = EMPTY_GRAPH_DB_TEMPLATE
+        .get_or_init(|| async {
+            let tmp = tempdir_or_panic();
+            let template_path = tmp.path().join("template-graph.db");
+            let (db, _) = Database::initialize(&template_path)
+                .await
+                .expect("template graph db initialize");
+            db.checkpoint().await.expect("template graph db checkpoint");
+            db.close();
+            fs::read(&template_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read graph test DB template '{}': {err}",
+                    template_path.display()
+                )
+            })
+        })
+        .await;
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|err| {
+            panic!(
+                "failed to create graph test DB directory '{}': {err}",
+                parent.display()
+            )
+        });
+    }
+    fs::write(db_path, bytes).unwrap_or_else(|err| {
+        panic!(
+            "failed to write graph test DB template '{}': {err}",
+            db_path.display()
+        )
+    });
+    let (db, _) = Database::open(db_path)
+        .await
+        .unwrap_or_else(|err| panic!("failed to open templated graph db: {err}"));
+    db
 }
 
 async fn empty_lcm_db_template() -> &'static [u8] {

--- a/tests/memory_suite/main.rs
+++ b/tests/memory_suite/main.rs
@@ -1,0 +1,13 @@
+//! Consolidated memory test suite.
+//!
+//! Windows CI links every integration-test binary separately, and link time
+//! dominates the shard wall clock. These modules used to be the standalone
+//! `memory_test` and `memory_eval_test` binaries; merging them into one
+//! binary removes a link step while keeping every test (names gain a module
+//! prefix, e.g. `memory_test::...`, `memory_eval_test::...`).
+
+#[path = "../common/mod.rs"]
+mod common;
+
+mod memory_eval_test;
+mod memory_test;

--- a/tests/memory_suite/memory_eval_test.rs
+++ b/tests/memory_suite/memory_eval_test.rs
@@ -14,7 +14,7 @@
 //! The harness still understands `pending-sibling` for future branch-split work,
 //! but shipped hygiene contracts should be marked stable.
 
-mod common;
+use crate::common;
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};

--- a/tests/memory_suite/memory_test.rs
+++ b/tests/memory_suite/memory_test.rs
@@ -24,7 +24,10 @@ async fn make_project() -> (TempDir, TraceDecay) {
 async fn make_memory_store() -> (Database, TempDir) {
     let tmp = TempDir::new().unwrap();
     let db_path = tmp.path().join("tracedecay.db");
-    let (db, _) = Database::initialize(&db_path).await.unwrap();
+    // Template copy instead of Database::initialize: 23 tests in this module
+    // each need a fresh graph-schema store, and re-running the schema DDL per
+    // test is a large fixed cost on Windows CI.
+    let db = crate::common::open_graph_db_from_template(&db_path).await;
     (db, tmp)
 }
 


### PR DESCRIPTION
## Summary
- Merge the standalone `memory_test` and `memory_eval_test` binaries into a single `tests/memory_suite` binary (two modules), removing one Windows link step per CI shard — same pattern as the other suite consolidations (#183–#209).
- Update the two `.config/nextest.toml` filter lines so the `windows-session-sqlite` and `windows-memory-eval` groups keep identical membership via `test(/^memory_test::/)` / `test(/^memory_eval_test::/)` module-prefix filters.
- Add a cached per-process graph-DB template to `tests/common` and use it in `make_memory_store`: 23 tests re-ran the full schema DDL via `Database::initialize`; now the first store pays it once and the rest are a file copy + `Database::open`.

Test count unchanged: 45 (35 `memory_test::` + 10 `memory_eval_test::`).

## Test plan
- [x] `cargo nextest run --profile ci --locked -E 'binary(=memory_suite)'` — 45/45 pass
- [x] `cargo nextest list` before/after — 45 tests both sides
- [x] `cargo fmt --all -- --check` clean; `cargo clippy --test memory_suite` clean