### PR TITLE
feat(cli): enforce MCP tool CLI/skill parity and rich subcommand help

### DIFF
--- a/codex-plugin/skills/inspecting-managed-skills/SKILL.md
+++ b/codex-plugin/skills/inspecting-managed-skills/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: inspecting-managed-skills
+description: 'Use when listing or reading agent-managed automation skills, viewing automation run artifacts, or inspecting Hermes-owned profile skills and pending skill approvals without mutating them.'
+---
+
+# Inspecting managed skills and automation output
+
+The daemon automation loop (skill writer, memory curator, session reflector) drafts managed skills and records durable run artifacts. This skill is the read-only window into that state; every lifecycle change (approve, disable, archive, install) goes through the `tracedecay automation` CLI or the dashboard instead.
+
+## Workflow
+
+1. **List managed skills → `tracedecay_skill_list`** (`state?`: filter by lifecycle state, `include_body?`): metadata, lifecycle state, usage summary, and stale/archive/improvement evidence for every agent-managed skill in the active profile. Start here to see what automation has produced.
+2. **Read one skill → `tracedecay_skill_view`** (`id` required, `include_support_files?`): full metadata, body markdown, usage summary, and support files for a single managed skill. Use before recommending approval, edits, or archival.
+3. **Read a run artifact → `tracedecay_automation_run_artifact_view`** (`run_id`, `kind`: e.g. `traces`, `feedback`, `generated_evals`, `validation_gate`, `optimizer_diagnosis`, `codex_handoff`): the hash-verified JSON payload of one durable automation run artifact. Find run ids via `tracedecay automation runs list` when needed.
+4. **Hermes-owned profile skills → `tracedecay_hermes_skill_bridge`** (`hermes_home` absolute path required, `include_skill_bodies?`, `include_pending_payloads?`): skill summaries, pending approval records, usage telemetry, and archive counts from a Hermes profile. Hermes owns that lifecycle — report state, never promise to mutate it.
+
+## Guardrails
+
+- All four tools are read-only; none of them approve, edit, or delete anything. For lifecycle changes hand the user the matching CLI commands: `tracedecay automation skills approve|disable|archive|restore <id>` and `tracedecay automation skills install --target <host> --output <path>`.
+- Managed skills are distinct from this bundled skill set: they live in the TraceDecay profile store, not in the plugin. Do not edit bundled plugin skills based on managed-skill evidence.
+- `tracedecay_hermes_skill_bridge` requires an absolute `hermes_home`; never guess the path — ask or derive it from `tracedecay doctor` output.
+
+## Handoff
+
+- Running or configuring the automation jobs themselves → `tracedecay automation run` / `tracedecay automation config` (CLI).
+- Reviewing session-reflection fact proposals → `tracedecay automation facts list|view|apply|reject` (CLI).
+- Memory fact curation → `tracedecay:curating-project-memory`.
+
+## Output
+
+- The requested skill list, skill body, artifact payload, or Hermes bridge report, plus the exact CLI command for any lifecycle action the user should take next.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/codex-plugin/skills/using-the-cli/SKILL.md
+++ b/codex-plugin/skills/using-the-cli/SKILL.md
@@ -10,8 +10,8 @@ The `tracedecay` binary exposes every MCP tool as a shell command. MCP and CLI h
 ## Discovery
 
 1. **List every tool → `tracedecay tool`** (no name): all tools grouped by category with one-line summaries.
-2. **One tool's parameters → `tracedecay tool <name> --help`**: the tool's full description plus each parameter with its type and required/optional flag.
-3. **Everything else → `tracedecay --help`**: the non-tool subcommands (`init`, `sync`, `status`, `doctor`, `daemon`, `sessions`, `dashboard`, …).
+2. **One tool's parameters → `tracedecay tool <name> --help`**: the tool's full description, a ready-to-copy usage line with its required flags, and each parameter with its type and required/optional flag.
+3. **Everything else → `tracedecay --help`**: the non-tool subcommands (`init`, `sync`, `status`, `doctor`, `daemon`, `sessions`, `dashboard`, …) plus a quick-start trailer that restates this discovery flow. Every subcommand's own `--help` carries an `Examples:` section with real flag combinations and `Related:` cross-references — read it before improvising flags.
 
 ## Invocation
 

--- a/cursor-plugin/skills/inspecting-managed-skills/SKILL.md
+++ b/cursor-plugin/skills/inspecting-managed-skills/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: inspecting-managed-skills
+description: 'Use when listing or reading agent-managed automation skills, viewing automation run artifacts, or inspecting Hermes-owned profile skills and pending skill approvals without mutating them.'
+---
+
+# Inspecting managed skills and automation output
+
+The daemon automation loop (skill writer, memory curator, session reflector) drafts managed skills and records durable run artifacts. This skill is the read-only window into that state; every lifecycle change (approve, disable, archive, install) goes through the `tracedecay automation` CLI or the dashboard instead.
+
+## Workflow
+
+1. **List managed skills → `tracedecay_skill_list`** (`state?`: filter by lifecycle state, `include_body?`): metadata, lifecycle state, usage summary, and stale/archive/improvement evidence for every agent-managed skill in the active profile. Start here to see what automation has produced.
+2. **Read one skill → `tracedecay_skill_view`** (`id` required, `include_support_files?`): full metadata, body markdown, usage summary, and support files for a single managed skill. Use before recommending approval, edits, or archival.
+3. **Read a run artifact → `tracedecay_automation_run_artifact_view`** (`run_id`, `kind`: e.g. `traces`, `feedback`, `generated_evals`, `validation_gate`, `optimizer_diagnosis`, `codex_handoff`): the hash-verified JSON payload of one durable automation run artifact. Find run ids via `tracedecay automation runs list` when needed.
+4. **Hermes-owned profile skills → `tracedecay_hermes_skill_bridge`** (`hermes_home` absolute path required, `include_skill_bodies?`, `include_pending_payloads?`): skill summaries, pending approval records, usage telemetry, and archive counts from a Hermes profile. Hermes owns that lifecycle — report state, never promise to mutate it.
+
+## Guardrails
+
+- All four tools are read-only; none of them approve, edit, or delete anything. For lifecycle changes hand the user the matching CLI commands: `tracedecay automation skills approve|disable|archive|restore <id>` and `tracedecay automation skills install --target <host> --output <path>`.
+- Managed skills are distinct from this bundled skill set: they live in the TraceDecay profile store, not in the plugin. Do not edit bundled plugin skills based on managed-skill evidence.
+- `tracedecay_hermes_skill_bridge` requires an absolute `hermes_home`; never guess the path — ask or derive it from `tracedecay doctor` output.
+
+## Handoff
+
+- Running or configuring the automation jobs themselves → `tracedecay automation run` / `tracedecay automation config` (CLI).
+- Reviewing session-reflection fact proposals → `tracedecay automation facts list|view|apply|reject` (CLI).
+- Memory fact curation → `tracedecay:curating-project-memory`.
+
+## Output
+
+- The requested skill list, skill body, artifact payload, or Hermes bridge report, plus the exact CLI command for any lifecycle action the user should take next.
+- If any result includes a `tracedecay_metrics:` line, report the savings to the user.

--- a/cursor-plugin/skills/using-the-cli/SKILL.md
+++ b/cursor-plugin/skills/using-the-cli/SKILL.md
@@ -10,8 +10,8 @@ The `tracedecay` binary exposes every MCP tool as a shell command. MCP and CLI h
 ## Discovery
 
 1. **List every tool → `tracedecay tool`** (no name): all tools grouped by category with one-line summaries.
-2. **One tool's parameters → `tracedecay tool <name> --help`**: the tool's full description plus each parameter with its type and required/optional flag.
-3. **Everything else → `tracedecay --help`**: the non-tool subcommands (`init`, `sync`, `status`, `doctor`, `daemon`, `sessions`, `dashboard`, …).
+2. **One tool's parameters → `tracedecay tool <name> --help`**: the tool's full description, a ready-to-copy usage line with its required flags, and each parameter with its type and required/optional flag.
+3. **Everything else → `tracedecay --help`**: the non-tool subcommands (`init`, `sync`, `status`, `doctor`, `daemon`, `sessions`, `dashboard`, …) plus a quick-start trailer that restates this discovery flow. Every subcommand's own `--help` carries an `Examples:` section with real flag combinations and `Related:` cross-references — read it before improvising flags.
 
 ## Invocation
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -278,6 +278,10 @@ const CODEX_EMBEDDED_PLUGIN_FILES: &[(&str, &str)] = &[
         include_str!("../../codex-plugin/skills/fixing-build-and-type-errors/SKILL.md"),
     ),
     (
+        "skills/inspecting-managed-skills/SKILL.md",
+        include_str!("../../codex-plugin/skills/inspecting-managed-skills/SKILL.md"),
+    ),
+    (
         "skills/porting-code/SKILL.md",
         include_str!("../../codex-plugin/skills/porting-code/SKILL.md"),
     ),

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -241,6 +241,10 @@ const EMBEDDED_PLUGIN_FILES: &[(&str, &str)] = &[
         include_str!("../../cursor-plugin/skills/fixing-build-and-type-errors/SKILL.md"),
     ),
     (
+        "skills/inspecting-managed-skills/SKILL.md",
+        include_str!("../../cursor-plugin/skills/inspecting-managed-skills/SKILL.md"),
+    ),
+    (
         "skills/memorize-subject/SKILL.md",
         include_str!("../../cursor-plugin/skills/memorize-subject/SKILL.md"),
     ),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,13 @@
 use clap::{builder::PossibleValuesParser, Parser, Subcommand};
 
 mod automation;
+mod help;
 pub use automation::{
     AutomationAction, AutomationConfigAction, AutomationConfigScope, AutomationFactsAction,
     AutomationRunAction, AutomationRunsAction, AutomationSkillsAction,
     AutomationSkillsInstallTarget,
 };
+use help::*;
 
 fn agent_value_parser() -> PossibleValuesParser {
     PossibleValuesParser::new(tracedecay::agents::available_integrations())
@@ -16,6 +18,7 @@ fn agent_value_parser() -> PossibleValuesParser {
 #[command(
     name = "tracedecay",
     about = "Code intelligence for 34 languages — semantic graph queries instead of file reads",
+    after_help = TOP_LEVEL_AFTER_HELP,
     version
 )]
 pub struct Cli {
@@ -27,6 +30,7 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Initialize a new TraceDecay project (full index)
+    #[command(long_about = INIT_LONG_ABOUT, after_help = INIT_AFTER_HELP)]
     Init {
         /// Project path (default: current directory)
         path: Option<String>,
@@ -38,6 +42,7 @@ pub enum Commands {
         include_folders: Vec<String>,
     },
     /// Incremental sync (project must already be initialized with `tracedecay init`)
+    #[command(long_about = SYNC_LONG_ABOUT, after_help = SYNC_AFTER_HELP)]
     Sync {
         /// Project path (default: current directory)
         path: Option<String>,
@@ -58,6 +63,7 @@ pub enum Commands {
         verbose: bool,
     },
     /// Show project statistics
+    #[command(long_about = STATUS_LONG_ABOUT, after_help = STATUS_AFTER_HELP)]
     Status {
         /// Project path (default: current directory)
         path: Option<String>,
@@ -82,13 +88,16 @@ pub enum Commands {
         runtime: bool,
     },
     /// Invoke an MCP tool from the CLI (e.g. `tracedecay tool search foo`).
-    ///
-    /// Run `tracedecay tool` (no name) to list every available tool.
-    /// Run `tracedecay tool <name> --help` to see that tool's parameters.
     //
     // `disable_help_flag = true` lets `-h`/`--help` flow through to our parser
     // so we can print the per-tool schema instead of clap's generic help.
-    #[command(disable_help_flag = true)]
+    // `main::render_dynamic_command_help` still renders this long help for a
+    // bare `tracedecay tool --help`.
+    #[command(
+        disable_help_flag = true,
+        long_about = TOOL_LONG_ABOUT,
+        after_help = TOOL_AFTER_HELP
+    )]
     Tool {
         /// Project root to open before dispatching the tool. Defaults to the
         /// nearest initialised project walking up from cwd.
@@ -104,12 +113,18 @@ pub enum Commands {
         args: Vec<String>,
     },
     /// Inspect language-server support for dashboard code diagnostics
+    #[command(long_about = LSP_LONG_ABOUT, after_help = LSP_AFTER_HELP)]
     Lsp {
         #[command(subcommand)]
         action: LspAction,
     },
     /// Configure agent integration (MCP server, permissions, hooks, prompt rules)
-    #[command(name = "install", visible_alias = "claude-install")]
+    #[command(
+        name = "install",
+        visible_alias = "claude-install",
+        long_about = INSTALL_LONG_ABOUT,
+        after_help = INSTALL_AFTER_HELP
+    )]
     Install {
         /// Agent to configure (auto-detects if omitted)
         #[arg(long, value_parser = agent_value_parser())]
@@ -144,6 +159,7 @@ pub enum Commands {
         auto_apply: bool,
     },
     /// Refresh settings for all already-installed agents
+    #[command(long_about = REINSTALL_LONG_ABOUT, after_help = REINSTALL_AFTER_HELP)]
     Reinstall,
     /// Refresh generated plugin code/assets for detected installs without
     /// touching agent config files.
@@ -155,10 +171,19 @@ pub enum Commands {
     /// files (Hermes config.yaml and its project_root pin, mcp.json, settings,
     /// prompt rules) are left byte-for-byte intact; use `tracedecay reinstall`
     /// to refresh those.
-    #[command(name = "update-plugin", visible_alias = "update-plugins")]
+    #[command(
+        name = "update-plugin",
+        visible_alias = "update-plugins",
+        after_help = UPDATE_PLUGIN_AFTER_HELP
+    )]
     UpdatePlugin,
     /// Remove agent integration (MCP server, permissions, hooks, prompt rules)
-    #[command(name = "uninstall", visible_alias = "claude-uninstall")]
+    #[command(
+        name = "uninstall",
+        visible_alias = "claude-uninstall",
+        long_about = UNINSTALL_LONG_ABOUT,
+        after_help = UNINSTALL_AFTER_HELP
+    )]
     Uninstall {
         /// Agent to remove (removes all if omitted)
         #[arg(long, value_parser = agent_value_parser())]
@@ -237,6 +262,7 @@ pub enum Commands {
     #[command(name = "hook-codex-post-compact", hide = true)]
     HookCodexPostCompact,
     /// Serve the local dashboard UI (holographic memory + LCM + code graph explorers)
+    #[command(long_about = DASHBOARD_LONG_ABOUT, after_help = DASHBOARD_AFTER_HELP)]
     Dashboard {
         /// Project path (default: current directory, with discovery)
         #[arg(short, long)]
@@ -252,6 +278,7 @@ pub enum Commands {
         open: bool,
     },
     /// Start MCP server over stdio
+    #[command(long_about = SERVE_LONG_ABOUT, after_help = SERVE_AFTER_HELP)]
     Serve {
         /// Project path
         #[arg(short, long)]
@@ -263,6 +290,7 @@ pub enum Commands {
         timings: bool,
     },
     /// Manage the long-running TraceDecay daemon used by MCP clients
+    #[command(long_about = DAEMON_LONG_ABOUT, after_help = DAEMON_AFTER_HELP)]
     Daemon {
         #[command(subcommand)]
         action: DaemonAction,
@@ -273,6 +301,7 @@ pub enum Commands {
     /// installed, also refreshes generated plugins and the daemon service and
     /// runs the post-update health pass on the new version. When already up
     /// to date it stops there — use `tracedecay update` to refresh regardless.
+    #[command(after_help = UPGRADE_AFTER_HELP)]
     Upgrade {
         /// Skip the post-update health pass (safe repairs + doctor summary)
         #[arg(long)]
@@ -283,6 +312,7 @@ pub enum Commands {
     /// Upgrades the binary first when a newer release exists, then always
     /// refreshes generated plugins and the daemon service and runs the
     /// post-update health pass — even when the binary was already current.
+    #[command(after_help = UPDATE_AFTER_HELP)]
     Update {
         /// Skip the post-update health pass (safe repairs + doctor summary)
         #[arg(long)]
@@ -296,32 +326,53 @@ pub enum Commands {
         no_heal: bool,
     },
     /// Show or switch the update channel (stable or beta)
+    #[command(long_about = CHANNEL_LONG_ABOUT, after_help = CHANNEL_AFTER_HELP)]
     Channel {
         /// Target channel: "stable" or "beta" (omit to show current)
         channel: Option<String>,
     },
     /// Show the resettable project-local token counter
-    #[command(name = "current-counter")]
+    #[command(
+        name = "current-counter",
+        long_about = CURRENT_COUNTER_LONG_ABOUT,
+        after_help = CURRENT_COUNTER_AFTER_HELP
+    )]
     CurrentCounter {
         /// Project path (default: current directory)
         #[arg(short, long)]
         path: Option<String>,
     },
     /// Reset the project-local token counter to zero
-    #[command(name = "reset-counter")]
+    #[command(
+        name = "reset-counter",
+        long_about = RESET_COUNTER_LONG_ABOUT,
+        after_help = RESET_COUNTER_AFTER_HELP
+    )]
     ResetCounter {
         /// Project path (default: current directory)
         #[arg(short, long)]
         path: Option<String>,
     },
     /// Disable uploading token counts to the worldwide counter
-    #[command(name = "disable-upload-counter")]
+    #[command(
+        name = "disable-upload-counter",
+        long_about = DISABLE_UPLOAD_COUNTER_LONG_ABOUT,
+        after_help = DISABLE_UPLOAD_COUNTER_AFTER_HELP
+    )]
     DisableUploadCounter,
     /// Enable uploading token counts to the worldwide counter
-    #[command(name = "enable-upload-counter")]
+    #[command(
+        name = "enable-upload-counter",
+        long_about = ENABLE_UPLOAD_COUNTER_LONG_ABOUT,
+        after_help = ENABLE_UPLOAD_COUNTER_AFTER_HELP
+    )]
     EnableUploadCounter,
     /// Show or change whether .gitignore rules are respected during indexing
-    #[command(name = "gitignore")]
+    #[command(
+        name = "gitignore",
+        long_about = GITIGNORE_LONG_ABOUT,
+        after_help = GITIGNORE_AFTER_HELP
+    )]
     Gitignore {
         /// Project path (default: current directory)
         #[arg(short, long)]
@@ -330,12 +381,14 @@ pub enum Commands {
         action: Option<String>,
     },
     /// Check tracedecay installation, configuration, and agent integration
+    #[command(long_about = DOCTOR_LONG_ABOUT, after_help = DOCTOR_AFTER_HELP)]
     Doctor {
         /// Check only this agent (default: all agents)
         #[arg(long, value_parser = agent_value_parser())]
         agent: Option<String>,
     },
     /// Token cost summary from Claude Code sessions
+    #[command(long_about = COST_LONG_ABOUT, after_help = COST_AFTER_HELP)]
     Cost {
         /// Time range: "today", "7d", "30d", "month", or "all"
         #[arg(default_value = "7d")]
@@ -351,6 +404,7 @@ pub enum Commands {
         export: Option<String>,
     },
     /// Run a reproducible retrieval benchmark against the current project.
+    #[command(long_about = BENCH_LONG_ABOUT, after_help = BENCH_AFTER_HELP)]
     Bench {
         /// Path to a TOML query file (defaults to the shipped default set).
         #[arg(long)]
@@ -366,6 +420,7 @@ pub enum Commands {
         max_nodes: usize,
     },
     /// Show token savings (and dollar estimates) recorded in the global ledger.
+    #[command(long_about = GAIN_LONG_ABOUT, after_help = GAIN_AFTER_HELP)]
     Gain {
         /// Show all projects (default: only the current project).
         #[arg(short, long)]
@@ -381,44 +436,53 @@ pub enum Commands {
         json: bool,
     },
     /// Live token savings monitor (global, all projects)
+    #[command(long_about = MONITOR_LONG_ABOUT, after_help = MONITOR_AFTER_HELP)]
     Monitor,
     /// Ingest and search local agent session transcripts
+    #[command(long_about = SESSIONS_LONG_ABOUT, after_help = SESSIONS_AFTER_HELP)]
     Sessions {
         #[command(subcommand)]
         action: SessionsAction,
     },
     /// Inspect registered TraceDecay projects from the global registry
+    #[command(long_about = PROJECTS_LONG_ABOUT, after_help = PROJECTS_AFTER_HELP)]
     Projects {
         #[command(subcommand)]
         action: ProjectsAction,
     },
     /// Manage multi-branch indexing
+    #[command(long_about = BRANCH_LONG_ABOUT, after_help = BRANCH_AFTER_HELP)]
     Branch {
         #[command(subcommand)]
         action: BranchAction,
     },
     /// Holographic memory maintenance (curation without the dashboard)
+    #[command(long_about = MEMORY_LONG_ABOUT, after_help = MEMORY_AFTER_HELP)]
     Memory {
         #[command(subcommand)]
         action: MemoryAction,
     },
     /// Self-improvement automation config and manual runs
+    #[command(long_about = AUTOMATION_LONG_ABOUT, after_help = AUTOMATION_AFTER_HELP)]
     Automation {
         #[command(subcommand)]
         action: AutomationAction,
     },
     /// Inspect stores before profile-storage migration
+    #[command(long_about = MIGRATE_LONG_ABOUT, after_help = MIGRATE_AFTER_HELP)]
     Migrate {
         #[command(subcommand)]
         action: MigrateAction,
     },
     /// Wipe local tracedecay DBs (current folder, parents, and children)
+    #[command(long_about = WIPE_LONG_ABOUT, after_help = WIPE_AFTER_HELP)]
     Wipe {
         /// Wipe ALL tracked projects so the global DB ends empty
         #[arg(short, long)]
         all: bool,
     },
     /// List tracedecay projects (current folder, parents, and children)
+    #[command(long_about = LIST_LONG_ABOUT, after_help = LIST_AFTER_HELP)]
     List {
         /// List ALL tracked projects from the global DB
         #[arg(short, long)]

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,0 +1,512 @@
+//! Long help (`long_about`) and example trailers (`after_help`) for every
+//! visible CLI subcommand.
+//!
+//! The CLI is the MCP-parity surface: agents that have shell access but no
+//! MCP client must be able to discover and drive every workflow from
+//! `--help` output alone. Each subcommand therefore ships a purpose
+//! paragraph (what it does and when to reach for it) plus an `Examples:`
+//! trailer with real flag combinations and related-command pointers.
+//! `cli::parse_tests::every_visible_top_level_subcommand_ships_rich_help`
+//! pins this contract so new subcommands cannot ship bare help.
+
+pub(crate) const TOP_LEVEL_AFTER_HELP: &str = "\
+Quick start:
+  tracedecay init                       Index the current repo (once per project)
+  tracedecay sync                       Refresh the index after changes
+  tracedecay tool                       List every MCP tool callable from the CLI
+  tracedecay tool search \"parse config\" --limit 5
+  tracedecay status --json              Machine-readable project statistics
+  tracedecay doctor                     Diagnose installation + agent integration
+
+MCP tool discovery flow:
+  1. `tracedecay tool` lists every MCP tool with one-line summaries.
+  2. `tracedecay tool <name> --help` prints that tool's parameters.
+  3. `tracedecay tool <name> --key value [--json]` invokes it; use
+     --args '<json>' or --args @file.json for complex payloads.
+
+Most read commands accept --json for machine-readable output. Project-scoped
+commands resolve the nearest initialised project walking up from the current
+directory; pass a path argument or --project/--path/--project-id/--project-path
+flags to target another project.
+
+For more help on a command: tracedecay <command> --help";
+
+pub(crate) const INIT_LONG_ABOUT: &str = "\
+Walks the project tree, parses sources across the supported languages, and \
+writes the code graph plus memory/session stores under .tracedecay/. Run once \
+per repository; afterwards `tracedecay sync` keeps the index fresh \
+incrementally. Respects .gitignore by default (see `tracedecay gitignore`).";
+
+pub(crate) const INIT_AFTER_HELP: &str = "\
+Examples:
+  tracedecay init                                Index the current directory
+  tracedecay init /path/to/repo                  Index another repository
+  tracedecay init --skip-folder vendor --skip-folder dist
+  tracedecay init --include-folder dist/generated
+
+Related: tracedecay sync (incremental refresh), tracedecay status,
+tracedecay gitignore, tracedecay wipe (delete local stores).";
+
+pub(crate) const SYNC_LONG_ABOUT: &str = "\
+Re-parses only files that changed since the last index and updates the code \
+graph in place. Use after editing, switching branches, or pulling; agent \
+hooks usually run it automatically. `--force` rebuilds from scratch when the \
+index looks wrong; `--doctor`/`--verbose` explain what a sync actually did.";
+
+pub(crate) const SYNC_AFTER_HELP: &str = "\
+Examples:
+  tracedecay sync                                Incremental refresh from cwd
+  tracedecay sync --force                        Full re-index
+  tracedecay sync --doctor                       List added/modified/removed files
+  tracedecay sync --verbose                      Per-phase timings for slow syncs
+
+Related: tracedecay init (first index), tracedecay status (freshness check).";
+
+pub(crate) const STATUS_LONG_ABOUT: &str = "\
+Reports node/edge/file counts, database size, index freshness, active branch, \
+and tokens saved for the resolved project. Reach for it first when deciding \
+whether the index is stale or when an agent needs project statistics; \
+`--json` emits the same data machine-readably.";
+
+pub(crate) const STATUS_AFTER_HELP: &str = "\
+Examples:
+  tracedecay status                              Human-readable project stats
+  tracedecay status --json                       Machine-readable output
+  tracedecay status --short                      Header only (version, tokens, sync)
+  tracedecay status --details                    Node-kind breakdown
+  tracedecay status --runtime                    PID/RSS/CPU/DB-size snapshot
+  tracedecay status --project-id proj_123 --json Inspect another registered project
+
+Related: tracedecay sync (refresh a stale index), tracedecay projects
+(registry lookup), tracedecay doctor (installation health).";
+
+pub(crate) const TOOL_LONG_ABOUT: &str = "\
+Invoke any MCP tool from the shell — the full MCP surface with the same \
+arguments and the same payloads, no MCP client required. This is the fallback \
+path when an MCP transport fails and the primary path for scripts, hooks, and \
+subagents that only have shell access.
+
+Discovery flow: `tracedecay tool` (no name) lists every tool grouped by \
+category; `tracedecay tool <name> --help` prints that tool's parameters; then \
+invoke with alternating `--key value` flags.";
+
+pub(crate) const TOOL_AFTER_HELP: &str = "\
+Examples:
+  tracedecay tool                                    List every tool, grouped
+  tracedecay tool search --help                      One tool's parameters
+  tracedecay tool search \"parse config\" --limit 5    Invoke with flags
+  tracedecay tool context \"how does auth work\" --json
+  tracedecay tool find_exact_symbol --name handle_tool_call
+  tracedecay tool str_replace --path src/lib.rs --old-str @old.txt --new-str @new.txt
+  tracedecay tool multi_str_replace --args @edits.json
+
+Notes:
+  - Tool names work with or without the tracedecay_ prefix; dashes and
+    underscores are interchangeable (dead-code == dead_code).
+  - --json prints the raw JSON payload instead of the human text rendering.
+  - Any value starting with @ is read from that file. --args @file.json passes
+    an entire JSON argument object — required for array/object parameters and
+    for payloads larger than the ~128 KiB per-argument shell limit.
+  - --project <path> targets another project; the default is the nearest
+    initialised project walking up from the current directory.
+  - Exit code is non-zero on unknown tools, bad arguments, or handler errors.
+
+Related: tracedecay serve (same tools over MCP stdio), tracedecay status.";
+
+pub(crate) const LSP_LONG_ABOUT: &str = "\
+Shows which language servers the dashboard's code-diagnostics panel can use \
+on this machine: detected binaries, versions, and install hints for missing \
+ones. Purely informational — nothing is installed or started.";
+
+pub(crate) const LSP_AFTER_HELP: &str = "\
+Examples:
+  tracedecay lsp servers                         Table of supported servers
+  tracedecay lsp servers --json                  Machine-readable output
+
+Related: tracedecay dashboard (uses these servers for diagnostics).";
+
+pub(crate) const INSTALL_LONG_ABOUT: &str = "\
+Writes the MCP server registration, permissions, hooks, and prompt rules for \
+an agent host (Cursor, Codex, Claude Code, Hermes, Kiro, and others). \
+Auto-detects installed agents when --agent is omitted. Safe to re-run; use it \
+after installing a new agent or moving the tracedecay binary.";
+
+pub(crate) const INSTALL_AFTER_HELP: &str = "\
+Examples:
+  tracedecay install                             Configure every detected agent
+  tracedecay install --agent cursor              One agent only
+  tracedecay install --agent codex --automation  Also enable the automation loop
+  tracedecay install --agent hermes --profile dev
+  tracedecay install --local                     Project-local config in cwd
+
+Related: tracedecay uninstall, tracedecay reinstall (refresh settings),
+tracedecay update-plugin (refresh generated assets only), tracedecay doctor.";
+
+pub(crate) const REINSTALL_LONG_ABOUT: &str = "\
+Re-runs the installer for every agent that already has tracedecay configured, \
+rewriting MCP registrations, hooks, and prompt rules with current settings. \
+Use after upgrading the binary manually or when agent config drifted; it \
+never adds integration to agents that were not installed before.";
+
+pub(crate) const REINSTALL_AFTER_HELP: &str = "\
+Examples:
+  tracedecay reinstall                           Refresh all installed agents
+
+Related: tracedecay install (add an agent), tracedecay update-plugin
+(refresh generated plugin assets without touching config files).";
+
+pub(crate) const UPDATE_PLUGIN_AFTER_HELP: &str = "\
+Examples:
+  tracedecay update-plugin                       Refresh generated plugin assets
+
+Related: tracedecay reinstall (also rewrites agent config files),
+tracedecay update (binary + plugins + daemon + health pass).";
+
+pub(crate) const UNINSTALL_LONG_ABOUT: &str = "\
+Removes tracedecay's MCP server registration, permissions, hooks, and prompt \
+rules from agent configuration. Removes every detected agent's integration \
+when --agent is omitted. Project indexes under .tracedecay/ are left intact — \
+use `tracedecay wipe` to delete data.";
+
+pub(crate) const UNINSTALL_AFTER_HELP: &str = "\
+Examples:
+  tracedecay uninstall                           Remove from every agent
+  tracedecay uninstall --agent cursor            Remove from one agent
+  tracedecay uninstall --agent hermes --profile dev
+
+Related: tracedecay install, tracedecay wipe (delete project stores).";
+
+pub(crate) const DASHBOARD_LONG_ABOUT: &str = "\
+Starts the local web dashboard: holographic memory curation, LCM session \
+explorer, code-graph browser, analytics, and automation review UI. Binds to \
+127.0.0.1 by default and prints the URL; leave it running while you work. \
+Agents can start the same server via the tracedecay_dashboard MCP tool.";
+
+pub(crate) const DASHBOARD_AFTER_HELP: &str = "\
+Examples:
+  tracedecay dashboard                           Serve on the default port
+  tracedecay dashboard --open                    Also open it in the browser
+  tracedecay dashboard --port 8788               Fixed port (0 picks a free one)
+  tracedecay dashboard --path /path/to/repo      Serve another project
+
+Related: tracedecay memory (curation without the dashboard),
+tracedecay status --runtime (server resource snapshot).";
+
+pub(crate) const SERVE_LONG_ABOUT: &str = "\
+Runs the MCP server on stdin/stdout for a single client. This is the command \
+agent hosts execute from their MCP configuration — you rarely run it by hand \
+except to debug the protocol. For ad-hoc tool calls from a shell, use \
+`tracedecay tool` instead; both dispatch the same tool registry.";
+
+pub(crate) const SERVE_AFTER_HELP: &str = "\
+Examples:
+  tracedecay serve                               Stdio MCP server for the cwd project
+  tracedecay serve --path /path/to/repo          Pin the project explicitly
+  tracedecay serve --timings                     Annotate responses with handler time
+
+Related: tracedecay tool (same tools from the shell), tracedecay install
+(writes this command into agent MCP config), tracedecay daemon.";
+
+pub(crate) const DAEMON_LONG_ABOUT: &str = "\
+Manages the shared background daemon that MCP clients and `tracedecay tool` \
+connect to over a Unix socket, so repeated calls skip per-process startup. \
+Usually installed as a user service; check `daemon status` first when tool \
+calls hang or version-mismatch errors appear.";
+
+pub(crate) const DAEMON_AFTER_HELP: &str = "\
+Examples:
+  tracedecay daemon status                       Service and socket state
+  tracedecay daemon install-service              Install + start the user service
+  tracedecay daemon restart                      Restart after a version mismatch
+  tracedecay daemon run --socket /tmp/td.sock    Foreground run (debugging)
+
+Related: tracedecay doctor (detects daemon problems), tracedecay serve.";
+
+pub(crate) const UPGRADE_AFTER_HELP: &str = "\
+Examples:
+  tracedecay upgrade                             Install the newest release
+  tracedecay upgrade --no-heal                   Skip the post-update health pass
+
+Related: tracedecay update (refresh even when current), tracedecay channel
+(switch stable/beta).";
+
+pub(crate) const UPDATE_AFTER_HELP: &str = "\
+Examples:
+  tracedecay update                              Upgrade if needed, then refresh
+  tracedecay update --no-heal                    Skip the post-update health pass
+
+Related: tracedecay upgrade (refresh only after a real install),
+tracedecay update-plugin (plugins only), tracedecay channel.";
+
+pub(crate) const CHANNEL_LONG_ABOUT: &str = "\
+Shows the release channel used by `tracedecay upgrade`/`update`, or switches \
+between `stable` and `beta`. Beta receives releases earlier; switching back \
+to stable installs the newest stable build on the next upgrade.";
+
+pub(crate) const CHANNEL_AFTER_HELP: &str = "\
+Examples:
+  tracedecay channel                             Show the current channel
+  tracedecay channel beta                        Opt into beta releases
+  tracedecay channel stable                      Return to stable
+
+Related: tracedecay upgrade, tracedecay update.";
+
+pub(crate) const CURRENT_COUNTER_LONG_ABOUT: &str = "\
+Prints the project-local resettable token counter — tokens tracedecay saved \
+this project since the last `reset-counter`. Useful for before/after \
+comparisons of a working session; the permanent ledger lives in \
+`tracedecay gain`.";
+
+pub(crate) const CURRENT_COUNTER_AFTER_HELP: &str = "\
+Examples:
+  tracedecay current-counter                     Counter for the cwd project
+  tracedecay current-counter --path /path/to/repo
+
+Related: tracedecay reset-counter, tracedecay gain (persistent ledger),
+tracedecay monitor (live view).";
+
+pub(crate) const RESET_COUNTER_LONG_ABOUT: &str = "\
+Zeroes the project-local token counter shown by `current-counter`, marking \
+the start of a new measurement window. Does not touch the persistent global \
+savings ledger used by `tracedecay gain`.";
+
+pub(crate) const RESET_COUNTER_AFTER_HELP: &str = "\
+Examples:
+  tracedecay reset-counter                       Reset the cwd project counter
+  tracedecay reset-counter --path /path/to/repo
+
+Related: tracedecay current-counter, tracedecay gain.";
+
+pub(crate) const DISABLE_UPLOAD_COUNTER_LONG_ABOUT: &str = "\
+Opts this machine out of contributing anonymous token-savings counts to the \
+public worldwide counter. Only aggregate numbers are ever uploaded — never \
+code, paths, or queries — but uploading is entirely optional.";
+
+pub(crate) const DISABLE_UPLOAD_COUNTER_AFTER_HELP: &str = "\
+Examples:
+  tracedecay disable-upload-counter              Stop contributing counts
+
+Related: tracedecay enable-upload-counter, tracedecay gain (local ledger
+is unaffected).";
+
+pub(crate) const ENABLE_UPLOAD_COUNTER_LONG_ABOUT: &str = "\
+Re-enables contributing anonymous token-savings counts to the public \
+worldwide counter after a previous `disable-upload-counter`. Only aggregate \
+numbers are uploaded — never code, paths, or queries.";
+
+pub(crate) const ENABLE_UPLOAD_COUNTER_AFTER_HELP: &str = "\
+Examples:
+  tracedecay enable-upload-counter               Resume contributing counts
+
+Related: tracedecay disable-upload-counter, tracedecay gain.";
+
+pub(crate) const GITIGNORE_LONG_ABOUT: &str = "\
+Shows or toggles whether indexing respects .gitignore rules for this project. \
+Turning it off indexes ignored folders too (generated code, vendored deps); \
+re-run `tracedecay sync --force` afterwards so the change takes effect. \
+Prefer --include-folder on init/sync to whitelist single folders instead.";
+
+pub(crate) const GITIGNORE_AFTER_HELP: &str = "\
+Examples:
+  tracedecay gitignore                           Show the current setting
+  tracedecay gitignore off                       Index ignored files too
+  tracedecay gitignore on                        Respect .gitignore again
+
+Related: tracedecay sync --force (apply the change), tracedecay init
+--include-folder (targeted alternative).";
+
+pub(crate) const DOCTOR_LONG_ABOUT: &str = "\
+Checks the binary, PATH, daemon service, project index, and every agent \
+integration, printing actionable fixes for anything broken. Run it first \
+when MCP tools are missing from an agent, tool calls fail, or after an \
+upgrade behaves unexpectedly.";
+
+pub(crate) const DOCTOR_AFTER_HELP: &str = "\
+Examples:
+  tracedecay doctor                              Check everything
+  tracedecay doctor --agent cursor               Check one agent integration
+
+Related: tracedecay install (fix missing integration), tracedecay daemon
+status, tracedecay status (index health).";
+
+pub(crate) const COST_LONG_ABOUT: &str = "\
+Summarises token spend from local Claude Code session transcripts: totals, \
+per-model and per-task-category breakdowns, and CSV/JSON export. Reads only \
+local files; nothing is uploaded.";
+
+pub(crate) const COST_AFTER_HELP: &str = "\
+Examples:
+  tracedecay cost                                Last 7 days
+  tracedecay cost 30d --by-model                 Per-model breakdown
+  tracedecay cost month --by-task                Per-task-category breakdown
+  tracedecay cost all --export csv               Export the full history
+
+Related: tracedecay gain (savings ledger), tracedecay monitor.";
+
+pub(crate) const BENCH_LONG_ABOUT: &str = "\
+Runs a reproducible retrieval benchmark (a fixed query set against the \
+current project's index) and reports latency and result quality. Use it to \
+compare index configurations or verify a tracedecay upgrade did not regress \
+retrieval.";
+
+pub(crate) const BENCH_AFTER_HELP: &str = "\
+Examples:
+  tracedecay bench                               Shipped default query set
+  tracedecay bench --json                        Machine-readable results
+  tracedecay bench --queries my-queries.toml --max-nodes 10
+
+Related: tracedecay status (index size context).";
+
+pub(crate) const GAIN_LONG_ABOUT: &str = "\
+Reports token savings (and dollar estimates) recorded in the persistent \
+global ledger — the long-term view, unlike the resettable per-project \
+counter. Defaults to the current project over the last 30 days.";
+
+pub(crate) const GAIN_AFTER_HELP: &str = "\
+Examples:
+  tracedecay gain                                Current project, last 30 days
+  tracedecay gain --all --range all              Every project, all time
+  tracedecay gain --history --json               Per-day history, machine-readable
+
+Related: tracedecay current-counter (resettable window), tracedecay monitor
+(live view), tracedecay cost (spend from transcripts).";
+
+pub(crate) const MONITOR_LONG_ABOUT: &str = "\
+Interactive full-screen view of token savings updating live across all \
+projects as agents use tracedecay. Press Ctrl+C to exit. For scriptable \
+numbers use `tracedecay gain --json` instead.";
+
+pub(crate) const MONITOR_AFTER_HELP: &str = "\
+Examples:
+  tracedecay monitor                             Live savings across projects
+
+Related: tracedecay gain --json (scriptable equivalent).";
+
+pub(crate) const SESSIONS_LONG_ABOUT: &str = "\
+Ingests agent session transcripts (Cursor, Codex, Claude Code, and other \
+supported providers) into the project session store and searches them with \
+full-text queries. The MCP twin of search is tracedecay_message_search; \
+ingest usually runs automatically via agent hooks.";
+
+pub(crate) const SESSIONS_AFTER_HELP: &str = "\
+Examples:
+  tracedecay sessions ingest                     Sweep all supported providers
+  tracedecay sessions search \"auth refactor\"     Full-text transcript search
+  tracedecay sessions search \"bug\" --limit 5 --provider cursor
+  tracedecay sessions search \"plan\" --project-path /path/to/repo
+
+Related: tracedecay tool message_search (MCP twin), tracedecay tool
+lcm_grep (scoped/time-filtered recall), tracedecay memory.";
+
+pub(crate) const PROJECTS_LONG_ABOUT: &str = "\
+Queries the global registry of every initialised tracedecay project on this \
+machine: list, search by id/path/alias/remote/branch, or resolve one \
+project's full context. Use it to find the right --project-id/--project-path \
+value for cross-project commands.";
+
+pub(crate) const PROJECTS_AFTER_HELP: &str = "\
+Examples:
+  tracedecay projects list                       Registered projects
+  tracedecay projects search my-repo --json      Find a project id
+  tracedecay projects context proj_123           One project's registry context
+
+Related: tracedecay status --project-id, tracedecay list (path-relative
+view), tracedecay tool project_search (MCP twin).";
+
+pub(crate) const BRANCH_LONG_ABOUT: &str = "\
+Manages per-branch code-graph databases so queries reflect the branch you \
+are on. Adding a branch copies the nearest ancestor's DB and syncs \
+incrementally; gc removes DBs for branches deleted from git. Cross-branch \
+queries are served by the branch_search/branch_diff MCP tools.";
+
+pub(crate) const BRANCH_AFTER_HELP: &str = "\
+Examples:
+  tracedecay branch list                         Tracked branches and DB sizes
+  tracedecay branch add feature/login            Track a branch explicitly
+  tracedecay branch gc                           Drop DBs for deleted branches
+  tracedecay branch remove feature/login
+
+Related: tracedecay tool branch_search / branch_diff / branch_list
+(cross-branch queries without switching checkout).";
+
+pub(crate) const MEMORY_LONG_ABOUT: &str = "\
+Inspects and curates the holographic memory store from the terminal — health \
+status plus similarity-dedup curation with an explicit LLM review loop — \
+without running the dashboard. Curation defaults to a dry-run preview; \
+nothing is deleted without --apply.";
+
+pub(crate) const MEMORY_AFTER_HELP: &str = "\
+Examples:
+  tracedecay memory status --json                Memory health and counts
+  tracedecay memory curate                       Dry-run dedup preview
+  tracedecay memory curate --apply               Apply proposed deletions
+  tracedecay memory curate --llm > review.json   Emit the LLM review request
+  tracedecay memory curate --llm-ops ops.json --apply
+
+Related: tracedecay dashboard (visual curation), tracedecay tool fact_store
+(read/write individual facts), tracedecay sessions (transcript recall).";
+
+pub(crate) const AUTOMATION_LONG_ABOUT: &str = "\
+Configures and drives the self-improvement automation loop (memory curator, \
+session reflector, skill writer): sidecar config, manual dry-runs, run \
+history with durable artifacts, managed-skill lifecycle, and fact-proposal \
+review. Read-only MCP twins: tracedecay_skill_list, tracedecay_skill_view, \
+tracedecay_automation_run_artifact_view.";
+
+pub(crate) const AUTOMATION_AFTER_HELP: &str = "\
+Examples:
+  tracedecay automation config get --json        Effective config
+  tracedecay automation config enable            Turn the loop on
+  tracedecay automation run skill-writing        Manual dry-run
+  tracedecay automation runs list --json         Run history
+  tracedecay automation runs artifact run-123 codex_handoff --json
+  tracedecay automation skills list              Managed skills
+  tracedecay automation skills approve my-skill  Lifecycle changes
+  tracedecay automation facts list               Pending fact proposals
+
+Related: tracedecay install --agent codex --automation (enable at install),
+tracedecay dashboard (review UI), tracedecay memory curate.";
+
+pub(crate) const MIGRATE_LONG_ABOUT: &str = "\
+Plans and executes profile-storage migrations: inventory scans, manifest \
+plans, staged copy + cutover, verification, rollback, and registry cleanup. \
+Mutating steps require the confirmation token printed by `migrate plan`; \
+start with plan/verify, which never touch source stores.";
+
+pub(crate) const MIGRATE_AFTER_HELP: &str = "\
+Examples:
+  tracedecay migrate plan --json                 Readonly inventory of stores
+  tracedecay migrate plan --manifest plan.json   Write a manifest plan
+  tracedecay migrate verify --manifest plan.json Check without mutating
+  tracedecay migrate apply --manifest plan.json --confirm-token <token>
+  tracedecay migrate registry-gc                 Dry-run stale-registry cleanup
+
+Related: tracedecay projects (registry view), tracedecay wipe.";
+
+pub(crate) const WIPE_LONG_ABOUT: &str = "\
+Deletes .tracedecay stores (code graph, memory, sessions) for the current \
+folder, its parents, and its children — or every tracked project with --all. \
+Destructive and unrecoverable; re-create indexes with `tracedecay init`. \
+Agent integration config is untouched (see `tracedecay uninstall`).";
+
+pub(crate) const WIPE_AFTER_HELP: &str = "\
+Examples:
+  tracedecay wipe                                Wipe stores around the cwd
+  tracedecay wipe --all                          Wipe every tracked project
+
+Related: tracedecay list (see what would be affected), tracedecay init
+(re-index afterwards), tracedecay uninstall (remove agent config instead).";
+
+pub(crate) const LIST_LONG_ABOUT: &str = "\
+Lists tracedecay projects relative to the current directory (itself, \
+parents, and children) with their store locations — the quick \"what is \
+indexed around here?\" check. Use `tracedecay projects` for the global \
+registry with search.";
+
+pub(crate) const LIST_AFTER_HELP: &str = "\
+Examples:
+  tracedecay list                                Projects around the cwd
+  tracedecay list --all                          Every tracked project
+
+Related: tracedecay projects list/search (global registry), tracedecay
+status (one project's statistics).";

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,13 +1,6 @@
-//! Long help (`long_about`) and example trailers (`after_help`) for every
-//! visible CLI subcommand.
-//!
-//! The CLI is the MCP-parity surface: agents that have shell access but no
-//! MCP client must be able to discover and drive every workflow from
-//! `--help` output alone. Each subcommand therefore ships a purpose
-//! paragraph (what it does and when to reach for it) plus an `Examples:`
-//! trailer with real flag combinations and related-command pointers.
-//! `cli::parse_tests::every_visible_top_level_subcommand_ships_rich_help`
-//! pins this contract so new subcommands cannot ship bare help.
+//! Long help (`long_about`) and example trailers (`after_help`) for visible
+//! CLI subcommands. The shell CLI is the fallback surface when MCP is
+//! unavailable, so command help needs real examples and related commands.
 
 pub(crate) const TOP_LEVEL_AFTER_HELP: &str = "\
 Quick start:

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -53,11 +53,6 @@ fn visible_subcommands_accept_clap_help() {
     }
 }
 
-/// Rich-help contract: the CLI is the MCP-parity surface for agents that
-/// only have shell access, so every visible top-level subcommand must ship
-/// a when-to-use paragraph (`long_about`) and an `Examples:` trailer with
-/// real invocations (`after_help`). Constants live in `cli::help`; this
-/// test keeps future subcommands from shipping bare help.
 #[test]
 fn every_visible_top_level_subcommand_ships_rich_help() {
     let command = Cli::command();
@@ -96,9 +91,6 @@ fn every_visible_top_level_subcommand_ships_rich_help() {
     }
 }
 
-/// Nested subcommands (e.g. `daemon run`, `memory curate`) must at least
-/// carry a purpose line so `--help` on any path never prints a bare usage
-/// string.
 #[test]
 fn every_visible_nested_subcommand_has_a_purpose_line() {
     let command = Cli::command();

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -53,6 +53,98 @@ fn visible_subcommands_accept_clap_help() {
     }
 }
 
+/// Rich-help contract: the CLI is the MCP-parity surface for agents that
+/// only have shell access, so every visible top-level subcommand must ship
+/// a when-to-use paragraph (`long_about`) and an `Examples:` trailer with
+/// real invocations (`after_help`). Constants live in `cli::help`; this
+/// test keeps future subcommands from shipping bare help.
+#[test]
+fn every_visible_top_level_subcommand_ships_rich_help() {
+    let command = Cli::command();
+    for subcommand in command
+        .get_subcommands()
+        .filter(|sub| !sub.is_hide_set() && sub.get_name() != "help")
+    {
+        let name = subcommand.get_name();
+        let long_about = subcommand
+            .get_long_about()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            long_about.len() >= 80,
+            "`tracedecay {name}` needs a long_about paragraph (what it does and \
+             when to use it); got {} chars",
+            long_about.len()
+        );
+        let after_help = subcommand
+            .get_after_help()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            after_help.contains("Examples:"),
+            "`tracedecay {name}` after_help must contain an `Examples:` section"
+        );
+        assert!(
+            after_help.contains("tracedecay "),
+            "`tracedecay {name}` examples must show real `tracedecay` invocations"
+        );
+        assert!(
+            after_help.contains("Related:") || after_help.contains("Notes:"),
+            "`tracedecay {name}` after_help must cross-reference related commands \
+             or carry agent-relevant notes"
+        );
+    }
+}
+
+/// Nested subcommands (e.g. `daemon run`, `memory curate`) must at least
+/// carry a purpose line so `--help` on any path never prints a bare usage
+/// string.
+#[test]
+fn every_visible_nested_subcommand_has_a_purpose_line() {
+    let command = Cli::command();
+    for path in visible_subcommand_paths(&command) {
+        if path.len() < 2 {
+            continue;
+        }
+        let mut current = &command;
+        for name in &path {
+            current = current
+                .find_subcommand(name)
+                .unwrap_or_else(|| panic!("subcommand path {path:?} should resolve"));
+        }
+        let about = current
+            .get_about()
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            about.trim().len() >= 10,
+            "`tracedecay {}` needs a descriptive purpose line; got {about:?}",
+            path.join(" ")
+        );
+    }
+}
+
+#[test]
+fn top_level_help_teaches_the_tool_discovery_flow() {
+    let command = Cli::command();
+    let after_help = command
+        .get_after_help()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    for needle in [
+        "tracedecay tool",
+        "--help",
+        "--args",
+        "--json",
+        "Quick start:",
+    ] {
+        assert!(
+            after_help.contains(needle),
+            "top-level after_help must teach the MCP tool discovery flow; missing {needle:?}"
+        );
+    }
+}
+
 #[test]
 fn tool_command_preserves_trailing_help_and_reserved_args() {
     let cli = Cli::try_parse_from([

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1394,6 +1394,7 @@ pub const CURSOR_PLUGIN_SKILLS: &[&str] = &[
     "finding-duplicate-logic",
     "finding-impacted-areas",
     "fixing-build-and-type-errors",
+    "inspecting-managed-skills",
     "porting-code",
     "project-status",
     "reading-code-cheaply",

--- a/src/tool_command.rs
+++ b/src/tool_command.rs
@@ -586,7 +586,8 @@ fn print_tool_list(defs: &[ToolDefinition]) {
         groups.entry(group).or_default().push(def);
     }
 
-    println!("Available tools (run `tracedecay tool <name> --help` for parameters):\n");
+    println!("Available tools — run `tracedecay tool <name> --help` for parameters,");
+    println!("then invoke with `tracedecay tool <name> --key value [--json]`.\n");
 
     if !always.is_empty() {
         println!("[always-loaded]");
@@ -612,6 +613,9 @@ fn print_tool_list(defs: &[ToolDefinition]) {
         }
         println!();
     }
+
+    println!("Reserved flags: --json (raw payload), --project <path>, --args <json|@file>.");
+    println!("Values starting with @ are read from that file; see `tracedecay tool --help`.");
 }
 
 /// Display name without the `tracedecay_` prefix.
@@ -713,32 +717,39 @@ fn group_for(def: &ToolDefinition) -> &'static str {
     }
 }
 
-/// Print one tool's description and parameter table.
+/// Print one tool's description, usage line, and parameter table.
 fn print_tool_help(def: &ToolDefinition) {
-    println!("tracedecay tool {}", short_name(&def.name));
+    let short = short_name(&def.name);
+    println!("tracedecay tool {short}");
     println!();
     println!("{}", def.description);
     println!();
 
-    let Some(props) = def
+    let props = def
         .input_schema
         .get("properties")
         .and_then(Value::as_object)
-    else {
-        println!("(no parameters)");
-        return;
-    };
-    let required: std::collections::HashSet<&str> = def
+        .filter(|props| !props.is_empty());
+    let required: Vec<&str> = def
         .input_schema
         .get("required")
         .and_then(Value::as_array)
         .map(|arr| arr.iter().filter_map(Value::as_str).collect())
         .unwrap_or_default();
 
-    if props.is_empty() {
+    let Some(props) = props else {
         println!("(no parameters)");
+        println!();
+        println!("Usage: tracedecay tool {short} [--json] [--project <path>]");
         return;
-    }
+    };
+
+    let usage_params: String = required
+        .iter()
+        .map(|req| format!(" --{} <value>", req.replace('_', "-")))
+        .collect();
+    println!("Usage: tracedecay tool {short}{usage_params} [--key value]... [--json]");
+    println!();
 
     println!("Parameters:");
     let mut entries: Vec<(&String, &Value)> = props.iter().collect();
@@ -748,7 +759,7 @@ fn print_tool_help(def: &ToolDefinition) {
             .get("type")
             .and_then(Value::as_str)
             .unwrap_or("string");
-        let req = if required.contains(key.as_str()) {
+        let req = if required.contains(&key.as_str()) {
             "required"
         } else {
             "optional"
@@ -767,6 +778,7 @@ fn print_tool_help(def: &ToolDefinition) {
     }
     println!();
     println!("Reserved flags: --json, --project <path>, --args <json|@file>, -h/--help");
+    println!("Any value starting with @ is read from that file (multi-line payloads).");
 }
 
 #[cfg(test)]

--- a/tests/agent_suite/main.rs
+++ b/tests/agent_suite/main.rs
@@ -18,4 +18,5 @@ mod opencode_agent_test;
 mod plugin_skill_contract_test;
 mod skill_targets_test;
 mod skill_usage_test;
+mod tool_skill_coverage_test;
 mod update_plugin_test;

--- a/tests/agent_suite/tool_skill_coverage_test.rs
+++ b/tests/agent_suite/tool_skill_coverage_test.rs
@@ -1,14 +1,4 @@
-//! Reverse coverage contract for the MCP tool surface.
-//!
-//! The MCP server may one day be optional (or expose only a subset of
-//! tools), so the CLI must stay a fully self-sufficient interface. The
-//! forward direction — every skill-referenced tool resolving to a real MCP
-//! definition — is covered elsewhere; these tests pin the reverse:
-//!
-//! 1. every advertised MCP tool is invocable via `tracedecay tool <name>`
-//!    (end-to-end through the shipped binary), and
-//! 2. every advertised MCP tool is taught by at least one bundled skill in
-//!    each plugin bundle, so agents can discover when and how to use it.
+//! Coverage checks for the shell MCP-tool surface and bundled skill guidance.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -19,12 +9,8 @@ use crate::common::tracedecay_command_with_home;
 use tempfile::TempDir;
 use tracedecay::mcp::tools::get_tool_definitions;
 
-/// Tools intentionally exempt from the skill-coverage requirement.
-///
-/// Reserve this for genuinely internal tools (host-lifecycle plumbing an
-/// agent should never choose from a skill). Every entry needs a comment
-/// explaining why no skill should teach it. Currently every advertised tool
-/// is agent-facing and covered.
+/// MCP tools intentionally exempt from bundled-skill coverage.
+/// Keep empty unless a tool is truly internal.
 const SKILL_COVERAGE_EXCEPTIONS: &[&str] = &[];
 
 fn isolated_tracedecay_command(home: &TempDir) -> Command {

--- a/tests/agent_suite/tool_skill_coverage_test.rs
+++ b/tests/agent_suite/tool_skill_coverage_test.rs
@@ -1,0 +1,160 @@
+//! Reverse coverage contract for the MCP tool surface.
+//!
+//! The MCP server may one day be optional (or expose only a subset of
+//! tools), so the CLI must stay a fully self-sufficient interface. The
+//! forward direction — every skill-referenced tool resolving to a real MCP
+//! definition — is covered elsewhere; these tests pin the reverse:
+//!
+//! 1. every advertised MCP tool is invocable via `tracedecay tool <name>`
+//!    (end-to-end through the shipped binary), and
+//! 2. every advertised MCP tool is taught by at least one bundled skill in
+//!    each plugin bundle, so agents can discover when and how to use it.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::Path;
+use std::process::Command;
+
+use tracedecay::mcp::tools::get_tool_definitions;
+
+/// Tools intentionally exempt from the skill-coverage requirement.
+///
+/// Reserve this for genuinely internal tools (host-lifecycle plumbing an
+/// agent should never choose from a skill). Every entry needs a comment
+/// explaining why no skill should teach it. Currently every advertised tool
+/// is agent-facing and covered.
+const SKILL_COVERAGE_EXCEPTIONS: &[&str] = &[];
+
+fn tracedecay_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_tracedecay")
+}
+
+fn short_name(full: &str) -> &str {
+    full.strip_prefix("tracedecay_").unwrap_or(full)
+}
+
+#[test]
+fn every_mcp_tool_is_listed_by_the_cli_discovery_command() {
+    let output = Command::new(tracedecay_bin())
+        .arg("tool")
+        .current_dir(std::env::temp_dir())
+        .output()
+        .expect("run `tracedecay tool`");
+    assert!(
+        output.status.success(),
+        "`tracedecay tool` should list tools without needing a project:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let listing = String::from_utf8_lossy(&output.stdout);
+    for def in get_tool_definitions() {
+        let short = short_name(&def.name);
+        assert!(
+            listing.contains(short),
+            "`tracedecay tool` listing is missing `{short}` — the CLI discovery \
+             surface must cover every MCP tool"
+        );
+    }
+}
+
+#[test]
+fn every_mcp_tool_is_invocable_via_the_cli() {
+    for def in get_tool_definitions() {
+        let short = short_name(&def.name);
+        let output = Command::new(tracedecay_bin())
+            .args(["tool", short, "--help"])
+            .current_dir(std::env::temp_dir())
+            .output()
+            .unwrap_or_else(|e| panic!("run `tracedecay tool {short} --help`: {e}"));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "`tracedecay tool {short} --help` must succeed so the tool stays \
+             invocable without an MCP client:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            stdout.contains(&format!("tracedecay tool {short}")),
+            "`tracedecay tool {short} --help` should print the tool's own help, got:\n{stdout}"
+        );
+    }
+}
+
+/// True when `haystack` mentions `tool_name` as a standalone identifier
+/// (not as a prefix of a longer tool name such as `tracedecay_lcm_expand`
+/// inside `tracedecay_lcm_expand_query`).
+fn mentions_tool(haystack: &str, tool_name: &str) -> bool {
+    let mut rest = haystack;
+    while let Some(pos) = rest.find(tool_name) {
+        let after = &rest[pos + tool_name.len()..];
+        let boundary = after
+            .chars()
+            .next()
+            .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+        if boundary {
+            return true;
+        }
+        rest = after;
+    }
+    false
+}
+
+fn bundle_skill_bodies(bundle_root: &Path) -> Vec<String> {
+    let skills_root = bundle_root.join("skills");
+    let mut bodies = Vec::new();
+    for entry in std::fs::read_dir(&skills_root)
+        .unwrap_or_else(|e| panic!("read {}: {e}", skills_root.display()))
+    {
+        let skill_md = entry.expect("skill dir entry").path().join("SKILL.md");
+        if !skill_md.is_file() {
+            continue;
+        }
+        let body = std::fs::read_to_string(&skill_md)
+            .unwrap_or_else(|e| panic!("read {}: {e}", skill_md.display()));
+        bodies.push(body);
+    }
+    assert!(
+        !bodies.is_empty(),
+        "no skills under {}",
+        skills_root.display()
+    );
+    bodies
+}
+
+#[test]
+fn every_mcp_tool_is_taught_by_at_least_one_bundled_skill() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for bundle in ["cursor-plugin", "codex-plugin"] {
+        let bodies = bundle_skill_bodies(&repo_root.join(bundle));
+        let mut uncovered: Vec<String> = Vec::new();
+        for def in get_tool_definitions() {
+            if SKILL_COVERAGE_EXCEPTIONS.contains(&def.name.as_str()) {
+                continue;
+            }
+            let covered = bodies.iter().any(|body| mentions_tool(body, &def.name));
+            if !covered {
+                uncovered.push(def.name);
+            }
+        }
+        assert!(
+            uncovered.is_empty(),
+            "MCP tools not referenced by any {bundle} skill — extend an existing \
+             skill or add one so agents can discover them (or, for genuinely \
+             internal tools, document them in SKILL_COVERAGE_EXCEPTIONS): {uncovered:?}"
+        );
+    }
+}
+
+#[test]
+fn skill_coverage_exceptions_reference_real_tools() {
+    let known: Vec<String> = get_tool_definitions()
+        .into_iter()
+        .map(|def| def.name)
+        .collect();
+    for exception in SKILL_COVERAGE_EXCEPTIONS {
+        assert!(
+            known.iter().any(|name| name == exception),
+            "SKILL_COVERAGE_EXCEPTIONS entry `{exception}` does not match any \
+             registered MCP tool; remove or fix it"
+        );
+    }
+}

--- a/tests/agent_suite/tool_skill_coverage_test.rs
+++ b/tests/agent_suite/tool_skill_coverage_test.rs
@@ -15,6 +15,8 @@
 use std::path::Path;
 use std::process::Command;
 
+use crate::common::tracedecay_command_with_home;
+use tempfile::TempDir;
 use tracedecay::mcp::tools::get_tool_definitions;
 
 /// Tools intentionally exempt from the skill-coverage requirement.
@@ -25,8 +27,10 @@ use tracedecay::mcp::tools::get_tool_definitions;
 /// is agent-facing and covered.
 const SKILL_COVERAGE_EXCEPTIONS: &[&str] = &[];
 
-fn tracedecay_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_tracedecay")
+fn isolated_tracedecay_command(home: &TempDir) -> Command {
+    let mut command = tracedecay_command_with_home(home.path());
+    command.current_dir(home.path());
+    command
 }
 
 fn short_name(full: &str) -> &str {
@@ -35,9 +39,9 @@ fn short_name(full: &str) -> &str {
 
 #[test]
 fn every_mcp_tool_is_listed_by_the_cli_discovery_command() {
-    let output = Command::new(tracedecay_bin())
+    let home = TempDir::new().expect("create isolated TraceDecay home");
+    let output = isolated_tracedecay_command(&home)
         .arg("tool")
-        .current_dir(std::env::temp_dir())
         .output()
         .expect("run `tracedecay tool`");
     assert!(
@@ -58,11 +62,11 @@ fn every_mcp_tool_is_listed_by_the_cli_discovery_command() {
 
 #[test]
 fn every_mcp_tool_is_invocable_via_the_cli() {
+    let home = TempDir::new().expect("create isolated TraceDecay home");
     for def in get_tool_definitions() {
         let short = short_name(&def.name);
-        let output = Command::new(tracedecay_bin())
+        let output = isolated_tracedecay_command(&home)
             .args(["tool", short, "--help"])
-            .current_dir(std::env::temp_dir())
             .output()
             .unwrap_or_else(|e| panic!("run `tracedecay tool {short} --help`: {e}"));
         let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary

The MCP server may become optional (or expose only a subset of tools) in the future, so the CLI must be a fully self-sufficient agent interface. This PR closes the loop in both directions and brings CLI help up to an agent-navigable standard (modeled on the Hermes agent CLI: quick-start epilog, per-subcommand examples, related-command cross-references).

### Coverage parity (tools ↔ CLI ↔ skills)

- **Audit result:** all 98 advertised MCP tools were already invocable via `tracedecay tool <name>`; 4 tools were not taught by any bundled skill: `tracedecay_skill_list`, `tracedecay_skill_view`, `tracedecay_automation_run_artifact_view`, `tracedecay_hermes_skill_bridge`.
- **New skill `inspecting-managed-skills`** (both bundles, byte-identical; registered in `CURSOR_PLUGIN_SKILLS`, `EMBEDDED_PLUGIN_FILES`, `CODEX_EMBEDDED_PLUGIN_FILES`) covers that cluster — read-only inspection of automation-produced managed skills, run artifacts, and Hermes-owned skill state. Coverage is now 98/98 in both bundles.
- **New reverse coverage tests** (`tests/agent_suite/tool_skill_coverage_test.rs`), the complement of the skill-lint's forward skill→tool checks:
  - `tracedecay tool` (discovery listing) names every tool from `get_tool_definitions()`;
  - `tracedecay tool <name> --help` succeeds end-to-end through the shipped binary for every tool;
  - every tool is mentioned (word-boundary match) by at least one skill in each bundle, with a documented `SKILL_COVERAGE_EXCEPTIONS` list for genuinely internal tools (currently empty) plus a guard that exceptions reference real tools.

### Rich CLI help

- New `src/cli/help.rs`: every visible top-level subcommand now has a when-to-use `long_about` and an `Examples:`/`Related:`/`Notes:` `after_help` trailer with real flag combinations (all example flags verified against the actual tool schemas / clap args).
- Top-level `tracedecay --help` gains a quick-start epilog that teaches the MCP tool discovery flow (list → per-tool help → invoke with `--args`/`@file`) and the `--json` / project-scoping conventions.
- `tracedecay tool <name> --help` now prints a ready-to-copy `Usage:` line with the tool's required flags plus `@file` guidance; the `tracedecay tool` listing gained a reserved-flags footer.
- New parse tests pin the contract so future subcommands cannot ship bare help: `every_visible_top_level_subcommand_ships_rich_help`, `every_visible_nested_subcommand_has_a_purpose_line`, `top_level_help_teaches_the_tool_discovery_flow`.

### Skill update

- `using-the-cli` (both bundles, byte-identical) documents the improved discovery flow: per-tool usage lines, and that every subcommand's `--help` carries Examples/Related sections.

New-skill frontmatter follows the incoming plugin-validation lint rules (kebab-case name, trigger-first description ≥50 chars, no angle brackets, terminal punctuation, unique description, within the 6,000-char metadata budget).

## Test plan

- [x] `cargo check --all-targets` / `cargo clippy --all-targets` — clean (only pre-existing vendored `libsql` warnings)
- [x] `cargo fmt`
- [x] `cargo test --test agent_suite` — 356 passed (includes `plugin_skill_contract_test`, codex/cursor byte-parity tests, and the 4 new coverage tests)
- [x] `cargo test --bin tracedecay parse_tests` — 34 passed (includes 3 new help-contract tests)
- [x] `cargo test --lib hooks` (36), `--lib agents` (136), `--lib mcp::tools` (46), `--bin tracedecay tool_command` (18)
- [x] `cargo test --test core_cli_suite cli_help` — 3 passed
- [x] Smoke: `tracedecay --help`, `tracedecay tool --help`, `tracedecay tool search --help`, `tracedecay memory --help` render the new trailers; all 98 `tracedecay tool <name> --help` invocations succeed