### PR TITLE
[codex] Port Hermes editorial policy into automation prompts

### DIFF
--- a/src/automation/backend.rs
+++ b/src/automation/backend.rs
@@ -220,8 +220,8 @@ pub fn task_key(task: AgentTaskKind) -> &'static str {
 pub fn prompt_version(task: AgentTaskKind) -> &'static str {
     match task {
         AgentTaskKind::MemoryCurator => "memory_curator:v1",
-        AgentTaskKind::SessionReflector => "session_reflector:v1",
-        AgentTaskKind::SkillWriter => "skill_writer:v1",
+        AgentTaskKind::SessionReflector => "session_reflector:v2",
+        AgentTaskKind::SkillWriter => "skill_writer:v2",
     }
 }
 

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -739,15 +739,61 @@ async fn skipped_skill_writer_run(
 }
 
 fn build_session_reflector_prompt(evidence: &Value) -> String {
+    const POLICY: &str = concat!(
+        "Review these bounded TraceDecay session snippets and propose only durable memory facts.\n",
+        "\n",
+        "Signals worth capturing (any one is enough):\n",
+        "- The user revealed durable preferences, persona, expectations, or ways they want the agent to operate.\n",
+        "- The user corrected the agent's style, tone, format, verbosity, workflow, or approach. Frustration signals like 'stop doing X', 'this is too verbose', 'don't format like this', or an explicit 'remember this' are FIRST-CLASS signals: capture the correction as a durable user_pref or decision fact so the next session starts already knowing. These corrections should also end up embedded in the skill that governs that class of task, not only in memory; the skill writer handles the skill side, but the fact must still be recorded here.\n",
+        "- A durable project, tool, decision, or code-area fact emerged that a future session would need.\n",
+        "\n",
+        "Do NOT capture (these harden into stale or self-defeating rules):\n",
+        "- Environment-dependent failures: missing binaries, 'command not found', unconfigured credentials, uninstalled packages, post-migration path mismatches. The user can fix these; they are not durable facts.\n",
+        "- Negative claims about tools or features ('X is broken', 'Y does not work'). These harden into self-imposed refusals cited long after the actual problem was fixed. If a tool failed because of setup state, the durable fact is the FIX (install command, config step, env var), never 'this tool does not work'.\n",
+        "- Session-specific transient errors that resolved before the session ended. If retrying worked, the lesson is the retry pattern, not the original failure.\n",
+        "- One-off task narratives. A single 'summarize this' or 'analyze this PR' request is not a durable fact about the user or project.\n",
+        "- Secrets, credentials, tokens, or ephemeral status.\n",
+        "\n",
+        "Proposing nothing is a real option when the session ran smoothly and revealed nothing durable, but do not reach for it as a default.\n",
+        "\n",
+        "Response contract: Return only JSON with a facts array. Each fact must include content, category, optional tags, optional entities, trust, source_span, and reason. Category must be one of general, user_pref, project, tool, decision, or code_area. Use trust, not confidence; trust must be a JSON number from 0.0 to 1.0. Do not use string labels like high, medium, or low. source_span must cite one bounded evidence hit by session_id plus message_id for raw messages, by store_id for raw messages, or by node_id for summaries. Do not include secrets or ephemeral status.\n",
+    );
     format!(
-        "Review these bounded TraceDecay session snippets and propose only durable memory facts. Return only JSON with a facts array. Each fact must include content, category, optional tags, optional entities, trust, source_span, and reason. Category must be one of general, user_pref, project, tool, decision, or code_area. Use trust, not confidence; trust must be a JSON number from 0.0 to 1.0. Do not use string labels like high, medium, or low. source_span must cite one bounded evidence hit by session_id plus message_id for raw messages, by store_id for raw messages, or by node_id for summaries. Do not include secrets or ephemeral status.\n{}",
+        "{POLICY}{}",
         serde_json::to_string_pretty(evidence).unwrap_or_else(|_| "{}".to_string())
     )
 }
 
 fn build_skill_writer_prompt(evidence: &Value) -> String {
+    const POLICY: &str = concat!(
+        "Review these bounded TraceDecay session snippets and propose only reusable managed skills for repeated workflows, corrections, or tool-use patterns.\n",
+        "\n",
+        "Target shape of the skill library: CLASS-LEVEL umbrella skills, each with a rich body and support files for session-specific detail — not a long flat list of narrow one-session-one-skill entries. This shapes HOW you update, not WHETHER you update.\n",
+        "\n",
+        "Signals that warrant a skill proposal (any one is enough):\n",
+        "- The user corrected the agent's style, tone, format, verbosity, workflow, or approach. Frustration signals like 'stop doing X', 'this is too verbose', 'don't format like this', 'you always do Y and I hate it', or an explicit 'remember this' are FIRST-CLASS skill signals, not just memory signals. Embed the correction in the body of the skill that governs that class of task so the next session starts already knowing; a memory fact alone is not enough.\n",
+        "- A non-trivial technique, fix, workaround, debugging path, or tool-usage pattern emerged that a future session would benefit from.\n",
+        "- A skill that evidence shows was used or loaded this session turned out to be wrong, missing a step, or outdated. Patch it now.\n",
+        "\n",
+        "Preference order — pick the EARLIEST action that fits:\n",
+        "1. UPDATE a skill that the evidence (skill_usage_summaries, skill_improvement_recommendations, existing_managed_skills) shows was used or loaded recently. It was in play, so it is the right one to extend.\n",
+        "2. PATCH an existing umbrella skill from existing_managed_skills whose class covers the new learning. Add a subsection, a pitfall, or broaden a trigger.\n",
+        "3. ADD to an existing skill's scope via its support_files (reference notes, templates, or re-runnable snippets), with a one-line pointer in the skill body so future sessions find it.\n",
+        "4. CREATE a new skill only when nothing existing fits. The name MUST be at the class level and MUST survive the test: 'does this name only make sense for today's task?' If yes, it is wrong — no PR numbers, error strings, feature codenames, or fix-X/debug-Y session artifacts. Fall back to option 1, 2, or 3 instead.\n",
+        "\n",
+        "Do NOT capture (these become persistent self-imposed constraints that bite later when the environment changes):\n",
+        "- Environment-dependent failures: missing binaries, 'command not found', unconfigured credentials, uninstalled packages, post-migration path mismatches. The user can fix these; they are not durable rules.\n",
+        "- Negative claims about tools or features ('X is broken', 'browser tools do not work'). These harden into refusals the agent cites against itself long after the actual problem was fixed. If a tool failed because of setup state, capture the FIX (install command, config step, env var) under an existing setup or troubleshooting skill — never 'this tool does not work' as a standalone constraint.\n",
+        "- Session-specific transient errors that resolved before the session ended. If retrying worked, the lesson is the retry pattern, not the original failure.\n",
+        "- One-off task narratives. A single 'summarize this' or 'analyze this PR' request is not a class of work that warrants a skill.\n",
+        "- Secrets, credentials, or tokens in any skill body or support file.\n",
+        "\n",
+        "An empty skills array is a real option when the session ran smoothly with no corrections and produced no new technique, but do not reach for it as a default.\n",
+        "\n",
+        "Response contract: Return only JSON with a skills array of managed skill creates or updates. New skills may omit action or use action=create and must include id, title, summary, category, body_markdown, optional targets, optional support_files with text content, and reason. Targets, when present, must be an array using cursor, codex, claude, agents, opencode, kimi, or kiro; Hermes is host-owned and must not be targeted. Updates must use action=update or action=patch, include id and base_checksum, and include at least one changed field among title, summary, category, targets, body_markdown/body, support_files, or pinned. For updates, support_files is a complete replacement list, not a partial file patch. Activation is controlled only by the runner policy; do not assume activation from your response.\n",
+    );
     format!(
-        "Review these bounded TraceDecay session snippets and propose only reusable managed skills for repeated workflows, corrections, or tool-use patterns. Return only JSON with a skills array of managed skill creates or updates. New skills may omit action or use action=create and must include id, title, summary, category, body_markdown, optional targets, optional support_files with text content, and reason. Targets, when present, must be an array using cursor, codex, claude, agents, opencode, kimi, or kiro; Hermes is host-owned and must not be targeted. Updates must use action=update or action=patch, include id and base_checksum, and include at least one changed field among title, summary, category, targets, body_markdown/body, support_files, or pinned. For updates, support_files is a complete replacement list, not a partial file patch. Activation is controlled only by the runner policy; do not assume activation from your response.\n{}",
+        "{POLICY}{}",
         serde_json::to_string_pretty(evidence).unwrap_or_else(|_| "{}".to_string())
     )
 }

--- a/tests/automation_runner_test/backend.rs
+++ b/tests/automation_runner_test/backend.rs
@@ -285,7 +285,7 @@ fn codex_app_server_backend_run_task_uses_injected_config() {
     assert_eq!(backend_request["contract"]["task_key"], "skill_writer");
     assert_eq!(
         backend_request["contract"]["prompt_version"],
-        "skill_writer:v1"
+        "skill_writer:v2"
     );
     assert_eq!(backend_request["evidence_hash"], "sha256:evidence");
     assert_eq!(backend_request["prompt"], r#"{"skills":[]}"#);

--- a/tests/automation_runner_test/skill_writer.rs
+++ b/tests/automation_runner_test/skill_writer.rs
@@ -752,7 +752,7 @@ async fn skill_writer_runner_ledgers_malformed_backend_output() {
     assert_eq!(records[0].task_key.as_deref(), Some("skill_writer"));
     assert_eq!(
         records[0].prompt_version.as_deref(),
-        Some("skill_writer:v1")
+        Some("skill_writer:v2")
     );
     assert_eq!(records[0].status, AutomationRunStatus::Failed);
     assert_eq!(records[0].reviewed_count, 0);

--- a/tests/automation_runner_test/support.rs
+++ b/tests/automation_runner_test/support.rs
@@ -152,7 +152,7 @@ impl AgentTaskBackend for SkillJsonBackend {
     ) -> tracedecay::errors::Result<AgentTaskResponse> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         assert_eq!(request.task, AgentTaskKind::SkillWriter);
-        assert_request_contract(request, "skill_writer", "skill_writer:v1", "skills");
+        assert_request_contract(request, "skill_writer", "skill_writer:v2", "skills");
         assert!(request.prompt.contains("managed skill creates or updates"));
         assert_eq!(request.context["apply"], json!(false));
         assert_eq!(
@@ -221,7 +221,7 @@ impl AgentTaskBackend for InspectSkillWriterUsageBackend {
         request: &AgentTaskRequest,
     ) -> tracedecay::errors::Result<AgentTaskResponse> {
         assert_eq!(request.task, AgentTaskKind::SkillWriter);
-        assert_request_contract(request, "skill_writer", "skill_writer:v1", "skills");
+        assert_request_contract(request, "skill_writer", "skill_writer:v2", "skills");
         let summaries = request.context["skill_writer_evidence"]["skill_usage_summaries"]
             .as_array()
             .expect("skill usage summaries should be present");
@@ -262,7 +262,7 @@ impl AgentTaskBackend for InspectSkillWriterUnderusedBackend {
         request: &AgentTaskRequest,
     ) -> tracedecay::errors::Result<AgentTaskResponse> {
         assert_eq!(request.task, AgentTaskKind::SkillWriter);
-        assert_request_contract(request, "skill_writer", "skill_writer:v1", "skills");
+        assert_request_contract(request, "skill_writer", "skill_writer:v2", "skills");
         let families = request.context["skill_writer_evidence"]["underused_tool_families"]
             .as_array()
             .expect("underused tool family evidence should be present");
@@ -400,9 +400,9 @@ impl AgentTaskBackend for MalformedTextBackend {
         let (task_key, prompt_version, required_property) = match self.task {
             AgentTaskKind::MemoryCurator => ("memory_curator", "memory_curator:v1", "ops"),
             AgentTaskKind::SessionReflector => {
-                ("session_reflector", "session_reflector:v1", "facts")
+                ("session_reflector", "session_reflector:v2", "facts")
             }
-            AgentTaskKind::SkillWriter => ("skill_writer", "skill_writer:v1", "skills"),
+            AgentTaskKind::SkillWriter => ("skill_writer", "skill_writer:v2", "skills"),
         };
         assert_request_contract(request, task_key, prompt_version, required_property);
         Ok(AgentTaskResponse {
@@ -440,7 +440,7 @@ impl AgentTaskBackend for SessionJsonBackend {
         assert_request_contract(
             request,
             "session_reflector",
-            "session_reflector:v1",
+            "session_reflector:v2",
             "facts",
         );
         assert!(request.prompt.contains("durable memory facts"));
@@ -471,7 +471,7 @@ impl AgentTaskBackend for InspectSessionEvidenceBackend {
         assert_request_contract(
             request,
             "session_reflector",
-            "session_reflector:v1",
+            "session_reflector:v2",
             "facts",
         );
         let evidence = &request.context["session_reflection_evidence"];
@@ -878,7 +878,7 @@ pub(crate) fn test_task_key(task: AgentTaskKind) -> &'static str {
 pub(crate) fn test_prompt_version(task: AgentTaskKind) -> &'static str {
     match task {
         AgentTaskKind::MemoryCurator => "memory_curator:v1",
-        AgentTaskKind::SessionReflector => "session_reflector:v1",
-        AgentTaskKind::SkillWriter => "skill_writer:v1",
+        AgentTaskKind::SessionReflector => "session_reflector:v2",
+        AgentTaskKind::SkillWriter => "skill_writer:v2",
     }
 }


### PR DESCRIPTION
## Summary
- Port Hermes editorial policy into the session reflector and skill writer automation prompts.
- Keep the strict JSON response contracts unchanged while adding capture/do-not-capture policy guidance.
- Bump session_reflector and skill_writer prompt versions from v1 to v2 and update test expectations.

## Verification
- TMPDIR=/home/zack/tmp CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-targets/hermes-r2-prompts cargo test --test automation_runner_test
- TMPDIR=/home/zack/tmp CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-targets/hermes-r2-prompts cargo check

Note: /scratch is full and /scratch/tmp is missing, so verification used /home/zack/tmp for tempdirs and a home-backed Cargo target dir.