### PR TITLE
feat(automation): couple scheduler triggering to LCM session activity

### DIFF
--- a/docs/SELF-IMPROVING-LOOPS-CONTRACTS.md
+++ b/docs/SELF-IMPROVING-LOOPS-CONTRACTS.md
@@ -27,6 +27,12 @@ TraceDecay standalone automation is time-scheduled by the daemon, not by Codex n
 | `session_reflector` | Every 15 minutes, with a 5-minute cooldown | Validated accepted session facts auto-apply under the same memory auto-apply policy; otherwise they stay as dashboard fact proposals. |
 | `skill_writer` | Every 60 minutes, after a 15-minute idle window, with a 5-minute cooldown | Creates or updates managed skill drafts; skills are not auto-enabled while `auto_enable_skills=false`. |
 
+Scheduling is activity-coupled, not purely wall-clock. The scheduler reads the newest LCM session-message timestamp for the project store as its session-activity signal on every tick:
+
+- `min_idle_secs` is a true idle window: the task only runs after the project has been quiet (no LCM session ingest) for at least that long. A missing session store counts as idle.
+- `session_reflector` and `skill_writer` additionally require new session activity since their last successful run; when nothing new landed they skip with `no_new_session_activity` instead of re-reviewing the same transcripts. Because skips do not consume the interval clock, the task fires on the first tick after fresh activity lands (once the idle window is satisfied).
+- `memory_curator` reviews the fact store rather than session transcripts, so it keeps the plain interval/cooldown cadence.
+
 The daemon loop is the host for these jobs. It should not create Codex top-level chats for scheduler work, and it should not rely on Codex native recurring automations for liveness. Host backends provide the model call; TraceDecay owns evidence collection, validation, ledgers, apply policy, and scheduler state.
 
 ## Standalone And Delegated Modes

--- a/src/automation/lifecycle.rs
+++ b/src/automation/lifecycle.rs
@@ -16,7 +16,8 @@ use super::run_ledger::{
     AutomationTrigger,
 };
 use super::scheduler::{
-    schedule_decision, stale_lock_secs, AutomationScheduleDecision, AutomationTaskLock,
+    load_session_activity, schedule_decision, stale_lock_secs, AutomationScheduleDecision,
+    AutomationTaskLock,
 };
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::current_timestamp;
@@ -37,6 +38,9 @@ pub(crate) struct AgentTaskRunContext<'a> {
     pub(crate) run_id: String,
     pub(crate) trigger: AutomationTrigger,
     pub(crate) dashboard_root: PathBuf,
+    /// LCM sessions database for the project store; the scheduler gate reads
+    /// its newest message timestamp as the session-activity signal.
+    sessions_db_path: PathBuf,
     config: &'a AutomationConfig,
     task: AgentTaskKind,
     started_at: String,
@@ -50,6 +54,7 @@ pub(crate) struct AgentTaskRunContext<'a> {
 impl<'a> AgentTaskRunContext<'a> {
     pub(crate) fn new(
         dashboard_root: PathBuf,
+        sessions_db_path: PathBuf,
         run_id: Option<String>,
         run_id_prefix: &'static str,
         trigger: AutomationTrigger,
@@ -60,6 +65,7 @@ impl<'a> AgentTaskRunContext<'a> {
             run_id: run_id.unwrap_or_else(|| generated_run_id(run_id_prefix)),
             trigger,
             dashboard_root,
+            sessions_db_path,
             config,
             task,
             started_at: current_timestamp().to_string(),
@@ -72,8 +78,14 @@ impl<'a> AgentTaskRunContext<'a> {
     }
 
     pub(crate) async fn gate(&mut self) -> Result<SchedulerGate> {
-        let (gate, records) =
-            task_run_gate(self.config, &self.dashboard_root, self.task, self.trigger).await?;
+        let (gate, records) = task_run_gate(
+            self.config,
+            &self.dashboard_root,
+            &self.sessions_db_path,
+            self.task,
+            self.trigger,
+        )
+        .await?;
         self.ledger_records = records;
         Ok(gate)
     }
@@ -149,6 +161,7 @@ pub(crate) fn task_skip_reason(
 pub(crate) async fn scheduler_gate(
     config: &AutomationConfig,
     dashboard_root: &Path,
+    sessions_db_path: &Path,
     task: AgentTaskKind,
     trigger: AutomationTrigger,
 ) -> Result<(SchedulerGate, Option<Vec<AutomationRunLedgerRecord>>)> {
@@ -169,7 +182,8 @@ pub(crate) async fn scheduler_gate(
         return Ok((SchedulerGate::Skip("scheduler_lock_active"), Some(records)));
     };
 
-    let decision = schedule_decision(config, task, &records, now_secs);
+    let activity = load_session_activity(sessions_db_path).await;
+    let decision = schedule_decision(config, task, &records, activity, now_secs);
     if let Some(reason) = scheduler_skip_reason(&decision, task) {
         return Ok((SchedulerGate::Skip(reason), Some(records)));
     }
@@ -180,10 +194,12 @@ pub(crate) async fn scheduler_gate(
 pub(crate) async fn task_run_gate(
     config: &AutomationConfig,
     dashboard_root: &Path,
+    sessions_db_path: &Path,
     task: AgentTaskKind,
     trigger: AutomationTrigger,
 ) -> Result<(SchedulerGate, Option<Vec<AutomationRunLedgerRecord>>)> {
-    let (gate, records) = scheduler_gate(config, dashboard_root, task, trigger).await?;
+    let (gate, records) =
+        scheduler_gate(config, dashboard_root, sessions_db_path, task, trigger).await?;
     let gate = match gate {
         SchedulerGate::Skip(reason) => SchedulerGate::Skip(reason),
         SchedulerGate::Proceed(lock) => match task_skip_reason(config, task) {
@@ -695,6 +711,7 @@ mod tests {
         let config = AutomationConfig::default();
         let mut run = AgentTaskRunContext::new(
             dashboard_root.to_path_buf(),
+            dashboard_root.join("sessions.db"),
             Some(run_id.to_string()),
             "test",
             trigger,
@@ -825,6 +842,7 @@ mod tests {
         let config = scheduler_enabled_config();
         let mut run = AgentTaskRunContext::new(
             dashboard_root.to_path_buf(),
+            dashboard_root.join("sessions.db"),
             Some(run_id.to_string()),
             "test",
             AutomationTrigger::Scheduler,

--- a/src/automation/memory_curator.rs
+++ b/src/automation/memory_curator.rs
@@ -53,6 +53,7 @@ pub async fn run_memory_curator_with_backend(
 ) -> Result<MemoryCuratorAutomationRun> {
     let mut run = AgentTaskRunContext::new(
         cg.store_layout().dashboard_root.clone(),
+        cg.store_layout().sessions_db_path.clone(),
         options.run_id.clone(),
         "memory_curator",
         options.trigger,

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -175,6 +175,7 @@ pub async fn run_session_reflector_with_backend(
 ) -> Result<SessionReflectorAutomationRun> {
     let mut run = AgentTaskRunContext::new(
         cg.store_layout().dashboard_root.clone(),
+        cg.store_layout().sessions_db_path.clone(),
         options.run_id.clone(),
         "session_reflector",
         options.trigger,
@@ -431,6 +432,7 @@ pub async fn run_skill_writer_with_backend(
 ) -> Result<SkillWriterAutomationRun> {
     let mut run = AgentTaskRunContext::new(
         cg.store_layout().dashboard_root.clone(),
+        cg.store_layout().sessions_db_path.clone(),
         options.run_id.clone(),
         "skill_writer",
         options.trigger,

--- a/src/automation/scheduler.rs
+++ b/src/automation/scheduler.rs
@@ -9,6 +9,7 @@ use super::config::{
 };
 use super::run_ledger::{AutomationRunLedgerRecord, AutomationRunStatus, AutomationTrigger};
 use crate::errors::{Result, TraceDecayError};
+use crate::global_db::GlobalDb;
 
 const DEFAULT_FAILURE_COOLDOWN_SECS: u64 = 300;
 const DEFAULT_STALE_LOCK_SECS: u64 = 6 * 60 * 60;
@@ -25,6 +26,42 @@ pub enum AutomationSchedule {
     Manual,
     ConfiguredInterval,
     Interval { every_secs: u64 },
+}
+
+/// Most recent LCM session ingest activity for the project, in unix seconds.
+///
+/// `None` means the session store does not exist yet or holds no timestamped
+/// messages; gates that need an activity signal treat that as "no activity
+/// observed" rather than an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SessionActivity {
+    pub last_activity_secs: Option<i64>,
+}
+
+impl SessionActivity {
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    pub fn at(last_activity_secs: i64) -> Self {
+        Self {
+            last_activity_secs: Some(last_activity_secs),
+        }
+    }
+}
+
+/// Reads the session-activity signal from the LCM sessions database.
+///
+/// This is a single indexed `ORDER BY timestamp DESC LIMIT 1` lookup against
+/// the read-only store, so it is cheap and race-safe to call from every
+/// scheduler tick; concurrent ingest writers only ever move the value forward.
+pub async fn load_session_activity(sessions_db_path: &Path) -> SessionActivity {
+    let Some(db) = GlobalDb::open_read_only_at(sessions_db_path).await else {
+        return SessionActivity::none();
+    };
+    SessionActivity {
+        last_activity_secs: db.latest_session_activity_secs().await,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -170,6 +207,7 @@ pub fn schedule_decision(
     config: &AutomationConfig,
     task: AgentTaskKind,
     records: &[AutomationRunLedgerRecord],
+    activity: SessionActivity,
     now_secs: i64,
 ) -> AutomationScheduleDecision {
     if !config.enabled {
@@ -200,10 +238,12 @@ pub fn schedule_decision(
         return AutomationScheduleDecision::skipped("scheduler_schedule_manual");
     };
 
+    // `min_idle_secs` is a true idle window: the project must have been quiet
+    // (no LCM session ingest activity) for at least this long. An unknown
+    // activity signal (no session store yet) counts as idle.
     if let Some(min_idle_secs) = task_config.min_idle_secs {
-        if let Some(record) = latest_non_skipped_record(records, task, None) {
-            let completed_at = record.completed_at.parse::<i64>().ok().unwrap_or(0);
-            if elapsed_secs(completed_at, now_secs) < min_idle_secs {
+        if let Some(last_activity) = activity.last_activity_secs {
+            if elapsed_secs(last_activity, now_secs) < min_idle_secs {
                 return AutomationScheduleDecision::skipped("scheduler_idle_window_active");
             }
         }
@@ -235,7 +275,32 @@ pub fn schedule_decision(
         }
     }
 
+    // Session-evidence tasks only re-run when new session activity landed
+    // after their last successful run started; a run without fresh evidence
+    // would re-review the same transcript slices. Skips do not consume the
+    // interval clock, so the task fires on the first tick after new activity.
+    if task_consumes_session_evidence(task) {
+        if let Some(record) = latest_successful_record(records, task) {
+            let started_at = record.started_at.parse::<i64>().ok().unwrap_or(0);
+            let has_new_activity = activity
+                .last_activity_secs
+                .is_some_and(|last_activity| last_activity > started_at);
+            if !has_new_activity {
+                return AutomationScheduleDecision::skipped("no_new_session_activity");
+            }
+        }
+    }
+
     AutomationScheduleDecision::due()
+}
+
+/// Tasks whose evidence comes from the LCM session store; they are gated on
+/// new session activity since their last successful run.
+fn task_consumes_session_evidence(task: AgentTaskKind) -> bool {
+    match task {
+        AgentTaskKind::SessionReflector | AgentTaskKind::SkillWriter => true,
+        AgentTaskKind::MemoryCurator => false,
+    }
 }
 
 pub fn stale_lock_secs(config: &AutomationConfig, task: AgentTaskKind) -> Option<u64> {
@@ -301,6 +366,16 @@ fn task_config(config: &AutomationConfig, task: AgentTaskKind) -> &AutomationTas
         AgentTaskKind::SessionReflector => &config.tasks.session_reflector,
         AgentTaskKind::SkillWriter => &config.tasks.skill_writer,
     }
+}
+
+fn latest_successful_record(
+    records: &[AutomationRunLedgerRecord],
+    task: AgentTaskKind,
+) -> Option<&AutomationRunLedgerRecord> {
+    records
+        .iter()
+        .filter(|record| record.task == task && record.status == AutomationRunStatus::Succeeded)
+        .max_by_key(|record| record.completed_at.parse::<i64>().ok().unwrap_or(0))
 }
 
 fn latest_non_skipped_record(

--- a/src/dashboard/automation_scheduler_api.rs
+++ b/src/dashboard/automation_scheduler_api.rs
@@ -11,8 +11,8 @@ use crate::automation::backend::{task_key, AgentTaskKind};
 use crate::automation::config::{effective_config, load_project_config, AutomationConfig};
 use crate::automation::run_ledger::{load_run_records, AutomationRunLedgerRecord};
 use crate::automation::scheduler::{
-    load_scheduler_control, save_scheduler_control, schedule_decision, scheduler_control_path,
-    AutomationSchedulerControl,
+    load_scheduler_control, load_session_activity, save_scheduler_control, schedule_decision,
+    scheduler_control_path, AutomationSchedulerControl, SessionActivity,
 };
 use crate::tracedecay::current_timestamp;
 use crate::user_config::UserConfig;
@@ -59,12 +59,19 @@ async fn scheduler_status_payload(state: &DashboardState) -> ApiResult {
         .await
         .map_err(|err| internal_error(&err))?;
     let now = current_timestamp();
+    let activity = load_session_activity(
+        &state
+            .store_root
+            .join(crate::storage::SESSIONS_DB_FILENAME),
+    )
+    .await;
     Ok(Json(json!({
         "status": scheduler_status_label(&effective, control.paused),
         "paused": control.paused,
         "enabled": effective.enabled,
         "scheduler_tick_secs": effective.scheduler_tick_secs,
         "now": now,
+        "last_session_activity": activity.last_activity_secs,
         "project_config_path": crate::automation::config::project_config_path(&state.dashboard_root)
             .display()
             .to_string(),
@@ -72,9 +79,9 @@ async fn scheduler_status_payload(state: &DashboardState) -> ApiResult {
             .display()
             .to_string(),
         "tasks": [
-            task_status(&effective, control.paused, &records, now, AgentTaskKind::MemoryCurator),
-            task_status(&effective, control.paused, &records, now, AgentTaskKind::SessionReflector),
-            task_status(&effective, control.paused, &records, now, AgentTaskKind::SkillWriter),
+            task_status(&effective, control.paused, &records, activity, now, AgentTaskKind::MemoryCurator),
+            task_status(&effective, control.paused, &records, activity, now, AgentTaskKind::SessionReflector),
+            task_status(&effective, control.paused, &records, activity, now, AgentTaskKind::SkillWriter),
         ],
     })))
 }
@@ -83,13 +90,14 @@ fn task_status(
     config: &AutomationConfig,
     paused: bool,
     records: &[AutomationRunLedgerRecord],
+    activity: SessionActivity,
     now: i64,
     task: AgentTaskKind,
 ) -> Value {
     let decision = if paused {
         crate::automation::scheduler::AutomationScheduleDecision::skipped("scheduler_paused")
     } else {
-        schedule_decision(config, task, records, now)
+        schedule_decision(config, task, records, activity, now)
     };
     let latest_scheduler = records
         .iter()

--- a/src/dashboard/automation_scheduler_api.rs
+++ b/src/dashboard/automation_scheduler_api.rs
@@ -59,12 +59,8 @@ async fn scheduler_status_payload(state: &DashboardState) -> ApiResult {
         .await
         .map_err(|err| internal_error(&err))?;
     let now = current_timestamp();
-    let activity = load_session_activity(
-        &state
-            .store_root
-            .join(crate::storage::SESSIONS_DB_FILENAME),
-    )
-    .await;
+    let activity =
+        load_session_activity(&state.store_root.join(crate::storage::SESSIONS_DB_FILENAME)).await;
     Ok(Json(json!({
         "status": scheduler_status_label(&effective, control.paused),
         "paused": control.paused,

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -2297,6 +2297,32 @@ impl GlobalDb {
         Ok(out)
     }
 
+    /// Timestamp of the most recent ingested session message, in unix
+    /// seconds, or `None` when no timestamped messages exist. Providers store
+    /// either seconds or milliseconds; millisecond values are normalized.
+    /// Backed by `idx_session_messages_timestamp`, so this is a cheap index
+    /// seek suitable for every automation scheduler tick.
+    pub async fn latest_session_activity_secs(&self) -> Option<i64> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT timestamp FROM session_messages
+                 WHERE timestamp IS NOT NULL
+                 ORDER BY timestamp DESC
+                 LIMIT 1",
+                (),
+            )
+            .await
+            .ok()?;
+        let row = rows.next().await.ok()??;
+        let timestamp = row.get::<i64>(0).ok()?;
+        Some(if timestamp >= 1_000_000_000_000 {
+            timestamp / 1000
+        } else {
+            timestamp
+        })
+    }
+
     /// Inserts or replaces a provider message. Returns `false` on any DB error.
     pub async fn upsert_session_message(&self, message: &SessionMessageRecord) -> bool {
         if self.conn.execute("BEGIN IMMEDIATE", ()).await.is_err() {

--- a/tests/automation_runner_test/runner.rs
+++ b/tests/automation_runner_test/runner.rs
@@ -163,21 +163,13 @@ async fn scheduler_skill_writer_respects_interval_gate() {
 }
 
 #[tokio::test]
-async fn scheduler_skill_writer_respects_idle_window_after_manual_run() {
+async fn scheduler_skill_writer_respects_idle_window_after_recent_session_activity() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     let mut config = scheduler_config(Some(1), None);
     config.tasks.skill_writer.min_idle_secs = Some(3600);
-    let mut record = scheduler_record_for(
-        "recent_manual_skill_writer_run",
-        AgentTaskKind::SkillWriter,
-        AutomationRunStatus::Succeeded,
-        current_timestamp() - 60,
-    );
-    record.trigger = AutomationTrigger::ManualCli;
-    append_run_record(&cg.store_layout().dashboard_root, &record)
-        .await
-        .unwrap();
+    // A session message landed 60s ago: the project is not idle yet.
+    seed_session_activity(&cg, current_timestamp() - 60).await;
     let backend = SkillJsonBackend::new(json!({"skills": []}));
 
     let run = run_skill_writer_with_backend(
@@ -198,6 +190,64 @@ async fn scheduler_skill_writer_respects_idle_window_after_manual_run() {
         run.ledger_record.error.as_deref(),
         Some("scheduler_idle_window_active")
     );
+}
+
+#[tokio::test]
+async fn scheduler_skill_writer_skips_without_new_session_activity_since_last_success() {
+    let temp = tempdir().unwrap();
+    let cg = init_project(temp.path()).await;
+    let config = scheduler_config(Some(1), None);
+    let now = current_timestamp();
+    // Activity landed, then a successful run consumed it.
+    seed_session_activity(&cg, now - 120).await;
+    append_run_record(
+        &cg.store_layout().dashboard_root,
+        &scheduler_record_for(
+            "previous_skill_writer_run",
+            AgentTaskKind::SkillWriter,
+            AutomationRunStatus::Succeeded,
+            now - 60,
+        ),
+    )
+    .await
+    .unwrap();
+    let backend = SkillJsonBackend::new(json!({"skills": []}));
+
+    let run = run_skill_writer_with_backend(
+        &cg,
+        &config,
+        &backend,
+        SkillWriterAutomationOptions {
+            trigger: AutomationTrigger::Scheduler,
+            ..SkillWriterAutomationOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(backend.calls(), 0);
+    assert_eq!(run.ledger_record.status, AutomationRunStatus::Skipped);
+    assert_eq!(
+        run.ledger_record.error.as_deref(),
+        Some("no_new_session_activity")
+    );
+
+    // New activity after the run: the very next tick is due again.
+    seed_session_activity(&cg, now - 30).await;
+    let run = run_skill_writer_with_backend(
+        &cg,
+        &config,
+        &backend,
+        SkillWriterAutomationOptions {
+            trigger: AutomationTrigger::Scheduler,
+            ..SkillWriterAutomationOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(backend.calls(), 1);
+    assert_ne!(run.ledger_record.status, AutomationRunStatus::Skipped);
 }
 
 #[tokio::test]

--- a/tests/automation_runner_test/scheduler.rs
+++ b/tests/automation_runner_test/scheduler.rs
@@ -8,11 +8,13 @@ use tracedecay::automation::run_ledger::{
     AutomationRunLedgerRecord, AutomationRunStatus, AutomationTrigger,
 };
 use tracedecay::automation::scheduler::{
-    load_scheduler_control, parse_schedule, save_scheduler_control, schedule_decision,
-    scheduler_control_path, AutomationSchedule, AutomationSchedulerControl, AutomationTaskLock,
+    load_scheduler_control, load_session_activity, parse_schedule, save_scheduler_control,
+    schedule_decision, scheduler_control_path, AutomationSchedule, AutomationSchedulerControl,
+    AutomationTaskLock, SessionActivity,
 };
+use tracedecay::global_db::GlobalDb;
 
-use crate::support::scheduler_record_for;
+use crate::support::{scheduler_record_for, seed_session_message_in_db, SeedSessionMessage};
 
 fn automation_config(schedule: Option<&str>, interval_secs: Option<u64>) -> AutomationConfig {
     AutomationConfig {
@@ -118,13 +120,13 @@ fn scheduler_skips_disabled_and_manual_only_tasks() {
     let mut config = automation_config(Some("every 10m"), None);
     config.enabled = false;
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], 1_000).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], SessionActivity::none(), 1_000).skip_reason(),
         Some("automation_disabled")
     );
 
     let config = automation_config(Some("manual"), None);
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], 1_000).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], SessionActivity::none(), 1_000).skip_reason(),
         Some("scheduler_schedule_manual")
     );
 }
@@ -140,10 +142,10 @@ fn scheduler_uses_interval_and_latest_successful_ledger_record() {
     )];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_500).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_500).skip_reason(),
         Some("scheduler_interval_not_elapsed")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_700).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_700).is_due());
 }
 
 #[test]
@@ -164,7 +166,7 @@ fn scheduler_ignores_non_terminal_lifecycle_records_for_interval_decisions() {
         ),
     ];
 
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_700).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_700).is_due());
 }
 
 #[test]
@@ -178,10 +180,10 @@ fn scheduler_respects_configured_interval_field() {
     )];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_100).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
         Some("scheduler_interval_not_elapsed")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_700).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_700).is_due());
 }
 
 #[test]
@@ -195,10 +197,10 @@ fn scheduler_retries_failures_after_cooldown_instead_of_full_interval() {
     )];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_100).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
         Some("scheduler_cooldown_active")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_400).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).is_due());
 }
 
 #[test]
@@ -216,7 +218,7 @@ fn scheduler_does_not_retry_explicit_non_retryable_failures() {
     let records = vec![failed];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_400).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).skip_reason(),
         Some("scheduler_non_retryable_failure")
     );
 }
@@ -237,10 +239,10 @@ fn scheduler_rechecks_stale_non_retryable_backend_transport_failures() {
     let records = vec![failed];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_100).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
         Some("scheduler_cooldown_active")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_400).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).is_due());
 }
 
 #[test]
@@ -258,19 +260,19 @@ fn scheduler_retries_explicit_retryable_failures_after_cooldown() {
     let records = vec![failed];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_100).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
         Some("scheduler_cooldown_active")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, 1_400).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).is_due());
 }
 
 #[test]
 fn scheduler_supports_all_self_improvement_tasks() {
     let config = automation_config(Some("hourly"), None);
 
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], 1_000).is_due());
-    assert!(schedule_decision(&config, AgentTaskKind::SessionReflector, &[], 1_000).is_due());
-    assert!(schedule_decision(&config, AgentTaskKind::SkillWriter, &[], 1_000).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], SessionActivity::none(), 1_000).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::SessionReflector, &[], SessionActivity::none(), 1_000).is_due());
+    assert!(schedule_decision(&config, AgentTaskKind::SkillWriter, &[], SessionActivity::none(), 1_000).is_due());
 }
 
 #[test]
@@ -292,29 +294,237 @@ fn scheduler_uses_latest_record_status_before_failure_cooldown() {
     ];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::SkillWriter, &records, 1_500).skip_reason(),
+        schedule_decision(&config, AgentTaskKind::SkillWriter, &records, SessionActivity::none(), 1_500).skip_reason(),
         Some("scheduler_interval_not_elapsed")
     );
 }
 
 #[test]
-fn scheduler_respects_task_idle_window_across_manual_runs() {
+fn scheduler_idle_window_measures_time_since_session_activity() {
     let mut config = automation_config(Some("every 10m"), None);
     config.tasks.skill_writer.min_idle_secs = Some(600);
-    let mut manual_record = record(
-        "manual-skill-writer",
+    let activity = SessionActivity::at(1_000);
+
+    // Activity landed 500s ago: still inside the 600s idle window.
+    assert_eq!(
+        schedule_decision(
+            &config,
+            AgentTaskKind::SkillWriter,
+            &[],
+            activity,
+            1_500
+        )
+        .skip_reason(),
+        Some("scheduler_idle_window_active")
+    );
+    // 600s of quiet have elapsed: the project is idle, the task is due.
+    assert!(
+        schedule_decision(&config, AgentTaskKind::SkillWriter, &[], activity, 1_600).is_due()
+    );
+    // Unknown activity (no session store yet) counts as idle.
+    assert!(schedule_decision(
+        &config,
         AgentTaskKind::SkillWriter,
+        &[],
+        SessionActivity::none(),
+        1_100
+    )
+    .is_due());
+}
+
+#[test]
+fn scheduler_idle_window_ignores_task_run_history() {
+    // The idle window used to measure time since the task's own last run;
+    // it must now only observe session activity.
+    let mut config = automation_config(Some("every 10m"), None);
+    config.tasks.memory_curator.min_idle_secs = Some(600);
+    let mut manual_record = record(
+        "manual-memory-curator",
+        AgentTaskKind::MemoryCurator,
         AutomationRunStatus::Succeeded,
-        1_000,
+        1_400,
     );
     manual_record.trigger = AutomationTrigger::ManualCli;
     let records = vec![manual_record];
 
+    // A manual run 100s ago no longer arms the idle window when the last
+    // session activity is old.
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::at(100),
+        1_500
+    )
+    .is_due());
+}
+
+#[test]
+fn scheduler_skips_session_evidence_tasks_without_new_activity() {
+    let config = automation_config(Some("every 10m"), None);
+
+    for task in [AgentTaskKind::SessionReflector, AgentTaskKind::SkillWriter] {
+        // Last successful run: started_at 999, completed_at 1_000.
+        let records = vec![record("run-1", task, AutomationRunStatus::Succeeded, 1_000)];
+
+        // Interval elapsed but no session activity has ever been observed.
+        assert_eq!(
+            schedule_decision(&config, task, &records, SessionActivity::none(), 1_700)
+                .skip_reason(),
+            Some("no_new_session_activity")
+        );
+        // Interval elapsed but the newest activity predates the run.
+        assert_eq!(
+            schedule_decision(&config, task, &records, SessionActivity::at(900), 1_700)
+                .skip_reason(),
+            Some("no_new_session_activity")
+        );
+        // Activity landed after the run started: due on the next tick.
+        assert!(
+            schedule_decision(&config, task, &records, SessionActivity::at(1_650), 1_700)
+                .is_due()
+        );
+        // The interval gate still wins while it has not elapsed.
+        assert_eq!(
+            schedule_decision(&config, task, &records, SessionActivity::at(1_050), 1_100)
+                .skip_reason(),
+            Some("scheduler_interval_not_elapsed")
+        );
+    }
+}
+
+#[test]
+fn scheduler_first_session_evidence_run_is_not_gated_on_activity() {
+    // With no prior successful run there is nothing to deduplicate against;
+    // the runner's own evidence checks handle an empty session store.
+    let config = automation_config(Some("every 10m"), None);
+
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::SessionReflector,
+        &[],
+        SessionActivity::none(),
+        1_000
+    )
+    .is_due());
+}
+
+#[test]
+fn scheduler_memory_curator_is_not_gated_on_session_activity() {
+    // The memory curator reviews the fact store, not session transcripts.
+    let config = automation_config(Some("every 10m"), None);
+    let records = vec![record(
+        "run-1",
+        AgentTaskKind::MemoryCurator,
+        AutomationRunStatus::Succeeded,
+        1_000,
+    )];
+
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_700
+    )
+    .is_due());
+}
+
+#[test]
+fn scheduler_retries_failed_session_evidence_runs_without_new_activity() {
+    // The evidence gate keys off the last successful run; a failed run is
+    // retried after its cooldown with the same evidence.
+    let config = automation_config(Some("every 10m"), None);
+    let records = vec![record(
+        "run-1",
+        AgentTaskKind::SessionReflector,
+        AutomationRunStatus::Failed,
+        1_000,
+    )];
+
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::SessionReflector,
+        &records,
+        SessionActivity::none(),
+        1_400
+    )
+    .is_due());
+}
+
+#[tokio::test]
+async fn load_session_activity_reads_newest_message_timestamp() {
+    let temp = tempdir().unwrap();
+    let db_path = temp.path().join("sessions.db");
+
+    // Missing store: no activity signal.
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::SkillWriter, &records, 1_500).skip_reason(),
-        Some("scheduler_idle_window_active")
+        load_session_activity(&db_path).await,
+        SessionActivity::none()
     );
-    assert!(schedule_decision(&config, AgentTaskKind::SkillWriter, &records, 1_600).is_due());
+
+    let db = GlobalDb::open_at(&db_path).await.expect("session db open");
+    seed_session_message_in_db(
+        &db,
+        temp.path(),
+        SeedSessionMessage {
+            provider: "cursor",
+            session_id: "activity-1",
+            message_id: "activity-1-message-001",
+            role: "user",
+            timestamp: 1_715_000_100,
+            text: "older message",
+            source: None,
+        },
+    )
+    .await;
+    seed_session_message_in_db(
+        &db,
+        temp.path(),
+        SeedSessionMessage {
+            provider: "cursor",
+            session_id: "activity-2",
+            message_id: "activity-2-message-001",
+            role: "user",
+            timestamp: 1_715_000_200,
+            text: "newest message",
+            source: None,
+        },
+    )
+    .await;
+    drop(db);
+
+    assert_eq!(
+        load_session_activity(&db_path).await,
+        SessionActivity::at(1_715_000_200)
+    );
+}
+
+#[tokio::test]
+async fn load_session_activity_normalizes_millisecond_timestamps() {
+    let temp = tempdir().unwrap();
+    let db_path = temp.path().join("sessions.db");
+    let db = GlobalDb::open_at(&db_path).await.expect("session db open");
+    seed_session_message_in_db(
+        &db,
+        temp.path(),
+        SeedSessionMessage {
+            provider: "cursor",
+            session_id: "activity-ms",
+            message_id: "activity-ms-message-001",
+            role: "user",
+            timestamp: 1_715_000_300_000,
+            text: "millisecond provider timestamp",
+            source: None,
+        },
+    )
+    .await;
+    drop(db);
+
+    assert_eq!(
+        load_session_activity(&db_path).await,
+        SessionActivity::at(1_715_000_300)
+    );
 }
 
 #[test]

--- a/tests/automation_runner_test/scheduler.rs
+++ b/tests/automation_runner_test/scheduler.rs
@@ -120,13 +120,27 @@ fn scheduler_skips_disabled_and_manual_only_tasks() {
     let mut config = automation_config(Some("every 10m"), None);
     config.enabled = false;
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], SessionActivity::none(), 1_000).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &[],
+            SessionActivity::none(),
+            1_000
+        )
+        .skip_reason(),
         Some("automation_disabled")
     );
 
     let config = automation_config(Some("manual"), None);
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], SessionActivity::none(), 1_000).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &[],
+            SessionActivity::none(),
+            1_000
+        )
+        .skip_reason(),
         Some("scheduler_schedule_manual")
     );
 }
@@ -142,10 +156,24 @@ fn scheduler_uses_interval_and_latest_successful_ledger_record() {
     )];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_500).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &records,
+            SessionActivity::none(),
+            1_500
+        )
+        .skip_reason(),
         Some("scheduler_interval_not_elapsed")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_700).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_700
+    )
+    .is_due());
 }
 
 #[test]
@@ -166,7 +194,14 @@ fn scheduler_ignores_non_terminal_lifecycle_records_for_interval_decisions() {
         ),
     ];
 
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_700).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_700
+    )
+    .is_due());
 }
 
 #[test]
@@ -180,10 +215,24 @@ fn scheduler_respects_configured_interval_field() {
     )];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &records,
+            SessionActivity::none(),
+            1_100
+        )
+        .skip_reason(),
         Some("scheduler_interval_not_elapsed")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_700).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_700
+    )
+    .is_due());
 }
 
 #[test]
@@ -197,10 +246,24 @@ fn scheduler_retries_failures_after_cooldown_instead_of_full_interval() {
     )];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &records,
+            SessionActivity::none(),
+            1_100
+        )
+        .skip_reason(),
         Some("scheduler_cooldown_active")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_400
+    )
+    .is_due());
 }
 
 #[test]
@@ -218,7 +281,14 @@ fn scheduler_does_not_retry_explicit_non_retryable_failures() {
     let records = vec![failed];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &records,
+            SessionActivity::none(),
+            1_400
+        )
+        .skip_reason(),
         Some("scheduler_non_retryable_failure")
     );
 }
@@ -239,10 +309,24 @@ fn scheduler_rechecks_stale_non_retryable_backend_transport_failures() {
     let records = vec![failed];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &records,
+            SessionActivity::none(),
+            1_100
+        )
+        .skip_reason(),
         Some("scheduler_cooldown_active")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_400
+    )
+    .is_due());
 }
 
 #[test]
@@ -260,19 +344,54 @@ fn scheduler_retries_explicit_retryable_failures_after_cooldown() {
     let records = vec![failed];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_100).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::MemoryCurator,
+            &records,
+            SessionActivity::none(),
+            1_100
+        )
+        .skip_reason(),
         Some("scheduler_cooldown_active")
     );
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &records, SessionActivity::none(), 1_400).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &records,
+        SessionActivity::none(),
+        1_400
+    )
+    .is_due());
 }
 
 #[test]
 fn scheduler_supports_all_self_improvement_tasks() {
     let config = automation_config(Some("hourly"), None);
 
-    assert!(schedule_decision(&config, AgentTaskKind::MemoryCurator, &[], SessionActivity::none(), 1_000).is_due());
-    assert!(schedule_decision(&config, AgentTaskKind::SessionReflector, &[], SessionActivity::none(), 1_000).is_due());
-    assert!(schedule_decision(&config, AgentTaskKind::SkillWriter, &[], SessionActivity::none(), 1_000).is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::MemoryCurator,
+        &[],
+        SessionActivity::none(),
+        1_000
+    )
+    .is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::SessionReflector,
+        &[],
+        SessionActivity::none(),
+        1_000
+    )
+    .is_due());
+    assert!(schedule_decision(
+        &config,
+        AgentTaskKind::SkillWriter,
+        &[],
+        SessionActivity::none(),
+        1_000
+    )
+    .is_due());
 }
 
 #[test]
@@ -294,7 +413,14 @@ fn scheduler_uses_latest_record_status_before_failure_cooldown() {
     ];
 
     assert_eq!(
-        schedule_decision(&config, AgentTaskKind::SkillWriter, &records, SessionActivity::none(), 1_500).skip_reason(),
+        schedule_decision(
+            &config,
+            AgentTaskKind::SkillWriter,
+            &records,
+            SessionActivity::none(),
+            1_500
+        )
+        .skip_reason(),
         Some("scheduler_interval_not_elapsed")
     );
 }
@@ -307,20 +433,11 @@ fn scheduler_idle_window_measures_time_since_session_activity() {
 
     // Activity landed 500s ago: still inside the 600s idle window.
     assert_eq!(
-        schedule_decision(
-            &config,
-            AgentTaskKind::SkillWriter,
-            &[],
-            activity,
-            1_500
-        )
-        .skip_reason(),
+        schedule_decision(&config, AgentTaskKind::SkillWriter, &[], activity, 1_500).skip_reason(),
         Some("scheduler_idle_window_active")
     );
     // 600s of quiet have elapsed: the project is idle, the task is due.
-    assert!(
-        schedule_decision(&config, AgentTaskKind::SkillWriter, &[], activity, 1_600).is_due()
-    );
+    assert!(schedule_decision(&config, AgentTaskKind::SkillWriter, &[], activity, 1_600).is_due());
     // Unknown activity (no session store yet) counts as idle.
     assert!(schedule_decision(
         &config,
@@ -381,8 +498,7 @@ fn scheduler_skips_session_evidence_tasks_without_new_activity() {
         );
         // Activity landed after the run started: due on the next tick.
         assert!(
-            schedule_decision(&config, task, &records, SessionActivity::at(1_650), 1_700)
-                .is_due()
+            schedule_decision(&config, task, &records, SessionActivity::at(1_650), 1_700).is_due()
         );
         // The interval gate still wins while it has not elapsed.
         assert_eq!(

--- a/tests/automation_runner_test/support.rs
+++ b/tests/automation_runner_test/support.rs
@@ -629,6 +629,30 @@ pub(crate) async fn seed_search_underuse_session_evidence(cg: &TraceDecay) {
     assert!(db.upsert_session_message(&message).await);
 }
 
+/// Seeds one session message at `timestamp` so the scheduler observes LCM
+/// session activity at that instant.
+pub(crate) async fn seed_session_activity(cg: &TraceDecay, timestamp: i64) {
+    let db = GlobalDb::open_at(&cg.store_layout().sessions_db_path)
+        .await
+        .expect("session db open");
+    seed_session_message_in_db(
+        &db,
+        cg.project_root(),
+        SeedSessionMessage {
+            provider: "cursor",
+            session_id: "activity-fixture",
+            message_id: &format!("activity-fixture-message-{timestamp}"),
+            role: "user",
+            timestamp,
+            // Matches the default session_reflector and skill_writer grep
+            // queries so evidence-driven runs see this message as a hit.
+            text: "Remember this repeated workflow correction: prefer the skill tool pattern.",
+            source: None,
+        },
+    )
+    .await;
+}
+
 pub(crate) struct SeedSessionMessage<'a> {
     pub(crate) provider: &'a str,
     pub(crate) session_id: &'a str,


### PR DESCRIPTION
## Summary
- Gate scheduler `min_idle_secs` on newest LCM session-message activity instead of task run history.
- Skip `session_reflector` and `skill_writer` scheduler ticks with `no_new_session_activity` when no fresh session evidence landed since their last successful run.
- Add last-session-activity visibility through scheduler status/ledger-facing paths and document the contract.

## Test Plan
- `TMPDIR=/home/zack/.cache/tmp-r3-activity CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r3-activity cargo test --test automation_runner_test scheduler`
- `TMPDIR=/home/zack/.cache/tmp-r3-activity CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r3-activity cargo test --test automation_runner_test runner`
- `TMPDIR=/home/zack/.cache/tmp-r3-activity CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r3-activity cargo test --test dashboard_api_test automation_config_is_dashboard_controllable_and_persistent`
- `TMPDIR=/home/zack/.cache/tmp-r3-activity CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r3-activity cargo test --test dashboard_api_test dashboard_session_and_skill_runs_emit_activity_when_evidence_is_unavailable`
- `TMPDIR=/home/zack/.cache/tmp-r3-activity CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r3-activity cargo check`

Note: an earlier isolated build under `/scratch/cargo-target-r3-activity` failed before tests because `/scratch/tmp` was full while compiling bundled SQLite; reran successfully using home-backed temp and target directories.
