### PR TITLE
[codex] Combined reflector+skill scheduler pass

### DIFF
--- a/src/automation/artifact_policy.rs
+++ b/src/automation/artifact_policy.rs
@@ -69,5 +69,18 @@ pub(super) fn artifact_policy(task: AgentTaskKind) -> TaskArtifactPolicy {
             handoff_test: "cargo test --test automation_runner_test skill_writer",
             eval_replay_command: "cargo test --test automation_runner_test skill_writer_runner_creates_pending_skill_drafts_for_approval -- --nocapture",
         },
+        AgentTaskKind::CombinedReview => TaskArtifactPolicy {
+            optimizer_action: "update combined review evidence or per-task validation",
+            accepted_next_actions: &[
+                "review pending fact proposals and managed skill drafts",
+                "approve or reject each proposal from the dashboard",
+            ],
+            rejected_next_actions: &[
+                "review rejected fact and skill proposals",
+                "collect more evidence before rerunning",
+            ],
+            handoff_test: "cargo test --test automation_runner_test combined_review",
+            eval_replay_command: "cargo test --test automation_runner_test combined_review_runner_records_both_tasks_from_one_backend_call -- --nocapture",
+        },
     }
 }

--- a/src/automation/backend.rs
+++ b/src/automation/backend.rs
@@ -17,6 +17,11 @@ pub enum AgentTaskKind {
     MemoryCurator,
     SessionReflector,
     SkillWriter,
+    /// One backend call covering both the session reflector and the skill
+    /// writer when the scheduler finds both due in the same tick. The
+    /// response must carry both a `facts` and a `skills` array; each array is
+    /// validated and applied by the existing per-task pipelines.
+    CombinedReview,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -214,6 +219,7 @@ pub fn task_key(task: AgentTaskKind) -> &'static str {
         AgentTaskKind::MemoryCurator => "memory_curator",
         AgentTaskKind::SessionReflector => "session_reflector",
         AgentTaskKind::SkillWriter => "skill_writer",
+        AgentTaskKind::CombinedReview => "combined_review",
     }
 }
 
@@ -222,24 +228,33 @@ pub fn prompt_version(task: AgentTaskKind) -> &'static str {
         AgentTaskKind::MemoryCurator => "memory_curator:v1",
         AgentTaskKind::SessionReflector => "session_reflector:v2",
         AgentTaskKind::SkillWriter => "skill_writer:v2",
+        AgentTaskKind::CombinedReview => "combined_review:v1",
     }
 }
 
 fn response_schema(task: AgentTaskKind) -> Value {
     match task {
-        AgentTaskKind::MemoryCurator => json_schema_for_array_property("ops"),
-        AgentTaskKind::SessionReflector => json_schema_for_array_property("facts"),
-        AgentTaskKind::SkillWriter => json_schema_for_array_property("skills"),
+        AgentTaskKind::MemoryCurator => json_schema_for_array_properties(&["ops"]),
+        AgentTaskKind::SessionReflector => json_schema_for_array_properties(&["facts"]),
+        AgentTaskKind::SkillWriter => json_schema_for_array_properties(&["skills"]),
+        AgentTaskKind::CombinedReview => json_schema_for_array_properties(&["facts", "skills"]),
     }
 }
 
-fn json_schema_for_array_property(property: &str) -> Value {
+fn json_schema_for_array_properties(properties: &[&str]) -> Value {
+    let schema_properties: serde_json::Map<String, Value> = properties
+        .iter()
+        .map(|property| {
+            (
+                (*property).to_string(),
+                serde_json::json!({ "type": "array" }),
+            )
+        })
+        .collect();
     serde_json::json!({
         "type": "object",
-        "required": [property],
-        "properties": {
-            property: { "type": "array" }
-        },
+        "required": properties,
+        "properties": schema_properties,
         "additionalProperties": true
     })
 }
@@ -453,15 +468,15 @@ fn validate_response_schema(value: &Value, contract: &AgentTaskContract) -> Resu
         .response_schema
         .get("required")
         .and_then(Value::as_array)
-        .and_then(|required| required.first())
-        .and_then(Value::as_str)
     else {
         return Ok(());
     };
-    if value.get(required).and_then(Value::as_array).is_none() {
-        return config_error(format!(
-            "automation backend output must include a {required} array"
-        ));
+    for property in required.iter().filter_map(Value::as_str) {
+        if value.get(property).and_then(Value::as_array).is_none() {
+            return config_error(format!(
+                "automation backend output must include a {property} array"
+            ));
+        }
     }
     Ok(())
 }

--- a/src/automation/config.rs
+++ b/src/automation/config.rs
@@ -94,6 +94,11 @@ pub struct AutomationConfig {
     pub auto_apply_memory_ops: bool,
     #[serde(default)]
     pub auto_enable_skills: bool,
+    /// When true (the default), a scheduler tick that finds both the session
+    /// reflector and the skill writer due runs them as one combined backend
+    /// call with shared evidence instead of two sequential runs.
+    #[serde(default = "default_true")]
+    pub combine_due_tasks: bool,
     #[serde(default)]
     pub tasks: AutomationTaskSet,
 }
@@ -112,6 +117,7 @@ impl Default for AutomationConfig {
             require_dashboard_approval: true,
             auto_apply_memory_ops: false,
             auto_enable_skills: false,
+            combine_due_tasks: true,
             tasks: AutomationTaskSet::default(),
         }
     }
@@ -197,6 +203,8 @@ pub struct AutomationConfigPatch {
     pub auto_apply_memory_ops: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_enable_skills: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub combine_due_tasks: Option<bool>,
     #[serde(default)]
     pub memory_curator: AutomationTaskPatch,
     #[serde(default)]
@@ -390,6 +398,9 @@ fn apply_patch(config: &mut AutomationConfig, patch: &AutomationConfigPatch) {
     if let Some(auto_enable_skills) = patch.auto_enable_skills {
         config.auto_enable_skills = auto_enable_skills;
     }
+    if let Some(combine_due_tasks) = patch.combine_due_tasks {
+        config.combine_due_tasks = combine_due_tasks;
+    }
     apply_task_patch(&mut config.tasks.memory_curator, &patch.memory_curator);
     apply_task_patch(
         &mut config.tasks.session_reflector,
@@ -437,6 +448,7 @@ fn merge_patch(config: &mut AutomationConfigPatch, patch: AutomationConfigPatch)
         patch.auto_apply_memory_ops,
     );
     merge_optional_field(&mut config.auto_enable_skills, patch.auto_enable_skills);
+    merge_optional_field(&mut config.combine_due_tasks, patch.combine_due_tasks);
     merge_task_patch(&mut config.memory_curator, patch.memory_curator);
     merge_task_patch(&mut config.session_reflector, patch.session_reflector);
     merge_task_patch(&mut config.skill_writer, patch.skill_writer);

--- a/src/automation/lifecycle.rs
+++ b/src/automation/lifecycle.rs
@@ -394,6 +394,12 @@ pub(crate) struct AgentRunFinalizer<'a> {
     task: AgentTaskKind,
     started_at: &'a str,
     input_hash: Option<String>,
+    /// When set, this finalizer records one half of a combined
+    /// reflector+skill run: ledger records keep their per-task `task` and
+    /// `task_key` (so per-task last-run bookkeeping still works) but carry
+    /// the combined contract's `prompt_version`/`response_schema` plus a
+    /// `combined_run_id` correlation in `report_ref`.
+    combined_run_id: Option<String>,
 }
 
 impl<'a> AgentRunFinalizer<'a> {
@@ -414,7 +420,14 @@ impl<'a> AgentRunFinalizer<'a> {
             task,
             started_at,
             input_hash,
+            combined_run_id: None,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn for_combined_run(mut self, combined_run_id: String) -> Self {
+        self.combined_run_id = Some(combined_run_id);
+        self
     }
 
     pub(crate) async fn append_backend_fallback_record(
@@ -422,7 +435,7 @@ impl<'a> AgentRunFinalizer<'a> {
         evidence_hash: Option<String>,
         error: String,
     ) -> Result<AutomationRunLedgerRecord> {
-        let record = failed_backend_fallback_record(
+        let mut record = failed_backend_fallback_record(
             self.run_id,
             self.trigger,
             self.config,
@@ -432,6 +445,7 @@ impl<'a> AgentRunFinalizer<'a> {
             error,
             self.started_at,
         );
+        self.annotate_combined_run(&mut record);
         append_run_record(self.dashboard_root, &record).await?;
         Ok(record)
     }
@@ -576,6 +590,23 @@ impl<'a> AgentRunFinalizer<'a> {
     fn finish_record(&self, record: &mut AutomationRunLedgerRecord) {
         record.input_hash.clone_from(&self.input_hash);
         record.output_hash = record.proposed_ops.as_ref().map(sha256_json);
+        self.annotate_combined_run(record);
+    }
+
+    fn annotate_combined_run(&self, record: &mut AutomationRunLedgerRecord) {
+        let Some(combined_run_id) = &self.combined_run_id else {
+            return;
+        };
+        let contract = agent_task_contract(AgentTaskKind::CombinedReview);
+        record.prompt_version = Some(contract.prompt_version);
+        record.response_schema = Some(contract.response_schema);
+        if let Some(report_ref) = record.report_ref.as_mut().and_then(Value::as_object_mut) {
+            report_ref.insert("combined_run_id".to_string(), json!(combined_run_id));
+            report_ref.insert(
+                "combined_task_key".to_string(),
+                json!(task_key(AgentTaskKind::CombinedReview)),
+            );
+        }
     }
 }
 
@@ -584,6 +615,9 @@ fn task_disabled(config: &AutomationConfig, task: AgentTaskKind) -> bool {
         AgentTaskKind::MemoryCurator => !config.tasks.memory_curator.enabled,
         AgentTaskKind::SessionReflector => !config.tasks.session_reflector.enabled,
         AgentTaskKind::SkillWriter => !config.tasks.skill_writer.enabled,
+        AgentTaskKind::CombinedReview => {
+            !config.tasks.session_reflector.enabled || !config.tasks.skill_writer.enabled
+        }
     }
 }
 
@@ -592,6 +626,7 @@ fn task_disabled_reason(task: AgentTaskKind) -> &'static str {
         AgentTaskKind::MemoryCurator => "memory_curator_disabled",
         AgentTaskKind::SessionReflector => "session_reflector_disabled",
         AgentTaskKind::SkillWriter => "skill_writer_disabled",
+        AgentTaskKind::CombinedReview => "combined_review_disabled",
     }
 }
 
@@ -605,7 +640,7 @@ fn scheduler_skip_reason(
     }
 }
 
-fn generated_run_id(prefix: &str) -> String {
+pub(crate) fn generated_run_id(prefix: &str) -> String {
     let mut random = [0u8; 8];
     let entropy = match getrandom::getrandom(&mut random) {
         Ok(()) => hex::encode(random),
@@ -681,6 +716,7 @@ fn noop_output_for_task(task: AgentTaskKind) -> Value {
         AgentTaskKind::MemoryCurator => json!({ "ops": [] }),
         AgentTaskKind::SessionReflector => json!({ "facts": [] }),
         AgentTaskKind::SkillWriter => json!({ "skills": [] }),
+        AgentTaskKind::CombinedReview => json!({ "facts": [], "skills": [] }),
     }
 }
 

--- a/src/automation/outcomes.rs
+++ b/src/automation/outcomes.rs
@@ -358,6 +358,10 @@ fn task_outcomes(
 ) -> (Vec<&SkillOutcomeRecord>, Vec<&FactOutcomeRecord>) {
     match task {
         AgentTaskKind::SkillWriter => (snapshot.skills.iter().collect(), Vec::new()),
+        AgentTaskKind::CombinedReview => (
+            snapshot.skills.iter().collect(),
+            snapshot.facts.iter().collect(),
+        ),
         AgentTaskKind::SessionReflector | AgentTaskKind::MemoryCurator => {
             (Vec::new(), snapshot.facts.iter().collect())
         }

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -4,13 +4,17 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use super::artifacts::sha256_json;
-use super::backend::{AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse};
+use super::backend::{
+    extract_json_object_prefix, AgentTaskBackend, AgentTaskKind, AgentTaskRequest,
+    AgentTaskResponse,
+};
 use super::config::AutomationConfig;
 use super::fact_proposals::{
     apply_fact_proposal, record_session_fact_proposals, FactProposalRecord, FactProposalState,
 };
 use super::lifecycle::{
-    failed_backend_fallback_report, AgentTaskRunContext, BackendTaskRun, SchedulerGate,
+    failed_backend_fallback_report, generated_run_id, task_run_gate, AgentRunFinalizer,
+    AgentTaskRunContext, BackendTaskRun, SchedulerGate,
 };
 use super::managed_skills::list_managed_skills;
 use super::run_ledger::{AutomationRunLedgerRecord, AutomationTrigger};
@@ -162,6 +166,19 @@ enum SkillWriterEvidenceOutcome {
     },
 }
 
+struct SessionReflectorEvidenceBundle {
+    evidence: Value,
+    evidence_hash: Option<String>,
+}
+
+enum SessionReflectorEvidenceOutcome {
+    Ready(SessionReflectorEvidenceBundle),
+    Skipped {
+        reason: &'static str,
+        evidence_hash: Option<String>,
+    },
+}
+
 enum LcmAutomationStore {
     Available(PathBuf),
     NotIngested,
@@ -182,16 +199,6 @@ pub async fn run_session_reflector_with_backend(
         config,
         AgentTaskKind::SessionReflector,
     );
-    let provider = normalized_non_empty(&options.provider).unwrap_or_else(default_session_provider);
-    let query =
-        normalized_non_empty(&options.query).unwrap_or_else(default_session_reflection_query);
-    let evidence_limit = options.evidence_limit.clamp(1, 50);
-    let storage_scope =
-        normalized_non_empty(&options.storage_scope).unwrap_or_else(default_lcm_storage_scope);
-    let session_id = options.session_id.as_deref().and_then(normalized_non_empty);
-    let source = options.source.as_deref().and_then(normalized_non_empty);
-    let role = options.role.as_deref().and_then(normalized_non_empty);
-
     let _run_lock = match run.gate().await? {
         SchedulerGate::Proceed(lock) => lock,
         SchedulerGate::Skip(reason) => {
@@ -199,76 +206,16 @@ pub async fn run_session_reflector_with_backend(
         }
     };
 
-    // Refresh outcomes of previously applied fact proposals so this run's
-    // feedback artifact reports real post-apply quality. Best effort: a
-    // missing memory store must not block reflection.
-    if let Ok(project_db) = cg.open_project_store_db().await {
-        if let Err(err) = super::outcomes::refresh_fact_outcomes(
-            &run.dashboard_root,
-            project_db.conn(),
-            current_timestamp(),
-        )
-        .await
-        {
-            eprintln!("[tracedecay] warning: failed to refresh fact outcomes: {err}");
-        }
-    }
-
-    let sessions_db_path = match automation_lcm_db_path(
-        cg,
-        &storage_scope,
-        options.hermes_home.as_ref(),
-        "session_reflector",
-    )? {
-        LcmAutomationStore::Available(path) => path,
-        LcmAutomationStore::NotIngested => {
-            return skipped_session_reflector_run(&run, "lcm_not_ingested", None).await;
-        }
+    let SessionReflectorEvidenceBundle {
+        evidence,
+        evidence_hash,
+    } = match build_session_reflector_evidence(cg, &options).await? {
+        SessionReflectorEvidenceOutcome::Ready(bundle) => bundle,
+        SessionReflectorEvidenceOutcome::Skipped {
+            reason,
+            evidence_hash,
+        } => return skipped_session_reflector_run(&run, reason, evidence_hash).await,
     };
-    let Some(lcm_db) = GlobalDb::open_read_only_at(&sessions_db_path).await else {
-        return skipped_session_reflector_run(&run, "lcm_unavailable", None).await;
-    };
-    let hits = lcm_db
-        .lcm_grep(LcmGrepRequest {
-            provider: provider.clone(),
-            query: query.clone(),
-            scope: options.scope,
-            session_id: session_id.clone(),
-            include_summaries: options.include_summaries,
-            limit: evidence_limit,
-            sort: options.sort,
-            source: source.clone(),
-            role: role.clone(),
-            start_time: options.start_time,
-            end_time: options.end_time,
-        })
-        .await
-        .map_err(|e| TraceDecayError::Config {
-            message: format!("failed to build session reflection evidence: {e}"),
-        })?;
-    let evidence = json!({
-        "storage_scope": storage_scope,
-        "hermes_home": options.hermes_home.as_ref().map(|path| path.display().to_string()),
-        "provider": provider,
-        "query": query,
-        "scope": options.scope,
-        "session_id": session_id,
-        "include_summaries": options.include_summaries,
-        "sort": options.sort,
-        "source": source,
-        "role": role,
-        "start_time": options.start_time,
-        "end_time": options.end_time,
-        "hits": hits,
-    });
-    let evidence_hash = Some(sha256_json(&evidence));
-    if evidence
-        .get("hits")
-        .and_then(Value::as_array)
-        .is_none_or(Vec::is_empty)
-    {
-        return skipped_session_reflector_run(&run, "no_session_evidence", evidence_hash).await;
-    }
 
     let request = AgentTaskRequest::new(
         run.run_id.clone(),
@@ -305,13 +252,52 @@ pub async fn run_session_reflector_with_backend(
             "session reflector output must include a facts array",
         )
         .await?;
-    let (accepted_facts, rejected_facts) =
-        validate_fact_proposals(cg, &proposals, &evidence).await?;
+    let (report, record) = finalize_session_reflector_success(
+        cg,
+        config,
+        &finalizer,
+        &run.dashboard_root,
+        &run.run_id,
+        &response,
+        &evidence,
+        evidence_hash,
+        &proposed_ops,
+        &proposals,
+    )
+    .await?;
+    let record = finalizer
+        .append_success_record(&request, &response, record)
+        .await?;
+
+    Ok(SessionReflectorAutomationRun {
+        run_id: run.run_id,
+        report,
+        ledger_record: record,
+        backend_response: Some(response),
+    })
+}
+
+/// Validates and stages the `facts` half of a reflector (or combined) run,
+/// returning the report plus the not-yet-appended success ledger record.
+#[allow(clippy::too_many_arguments)]
+async fn finalize_session_reflector_success(
+    cg: &TraceDecay,
+    config: &AutomationConfig,
+    finalizer: &AgentRunFinalizer<'_>,
+    dashboard_root: &std::path::Path,
+    run_id: &str,
+    response: &AgentTaskResponse,
+    evidence: &Value,
+    evidence_hash: Option<String>,
+    proposed_ops: &Value,
+    proposals: &[Value],
+) -> Result<(Value, AutomationRunLedgerRecord)> {
+    let (accepted_facts, rejected_facts) = validate_fact_proposals(cg, proposals, evidence).await?;
     let accepted_count = accepted_facts.len();
     let rejected_count = rejected_facts.len();
     let mut proposal_records = record_session_fact_proposals(
-        &run.dashboard_root,
-        &run.run_id,
+        dashboard_root,
+        run_id,
         evidence_hash.as_deref(),
         &accepted_facts,
         &rejected_facts,
@@ -319,17 +305,13 @@ pub async fn run_session_reflector_with_backend(
     .await?;
     let auto_apply_facts = config.auto_apply_memory_ops && !config.require_dashboard_approval;
     let applied_fact_proposals = if auto_apply_facts {
-        auto_apply_session_fact_proposals(
-            cg,
-            &run.dashboard_root,
-            std::mem::take(&mut proposal_records),
-        )
-        .await?
+        auto_apply_session_fact_proposals(cg, dashboard_root, std::mem::take(&mut proposal_records))
+            .await?
     } else {
         Vec::new()
     };
     if auto_apply_facts {
-        proposal_records = applied_fact_proposals.clone();
+        proposal_records.clone_from(&applied_fact_proposals);
     }
     let proposal_ids: Vec<String> = proposal_records
         .iter()
@@ -372,7 +354,7 @@ pub async fn run_session_reflector_with_backend(
         "session_fact_apply_policy": session_fact_apply_policy,
     });
     let mut record = finalizer.success_record(
-        &response,
+        response,
         report
             .get("evidence_hash")
             .and_then(Value::as_str)
@@ -402,16 +384,7 @@ pub async fn run_session_reflector_with_backend(
             "accepted_facts": report.get("accepted_facts").cloned().unwrap_or_else(|| json!([])),
         },
     }));
-    let record = finalizer
-        .append_success_record(&request, &response, record)
-        .await?;
-
-    Ok(SessionReflectorAutomationRun {
-        run_id: run.run_id,
-        report,
-        ledger_record: record,
-        backend_response: Some(response),
-    })
+    Ok((report, record))
 }
 
 async fn auto_apply_session_fact_proposals(
@@ -524,11 +497,53 @@ pub async fn run_skill_writer_with_backend(
             "skill writer output must include a skills array",
         )
         .await?;
+    let (report, record) = finalize_skill_writer_success(
+        config,
+        &finalizer,
+        &profile_root,
+        &run.run_id,
+        &response,
+        &evidence,
+        evidence_hash,
+        activation_policy,
+        &proposed_ops,
+        &proposals,
+    )
+    .await?;
+    let record = finalizer
+        .append_success_record(&request, &response, record)
+        .await?;
+
+    Ok(SkillWriterAutomationRun {
+        run_id: run.run_id,
+        report,
+        ledger_record: record,
+        backend_response: Some(response),
+    })
+}
+
+/// Validates and stages the `skills` half of a skill-writer (or combined)
+/// run, returning the report plus the not-yet-appended success ledger record.
+/// A skill-proposal validation failure appends a failed record before
+/// bubbling the error.
+#[allow(clippy::too_many_arguments)]
+async fn finalize_skill_writer_success(
+    config: &AutomationConfig,
+    finalizer: &AgentRunFinalizer<'_>,
+    profile_root: &std::path::Path,
+    run_id: &str,
+    response: &AgentTaskResponse,
+    evidence: &Value,
+    evidence_hash: Option<String>,
+    activation_policy: &'static str,
+    proposed_ops: &Value,
+    proposals: &[Value],
+) -> Result<(Value, AutomationRunLedgerRecord)> {
     let (created_skills, updated_skills, rejected_skills) =
         match validate_and_apply_skill_proposals(
-            &profile_root,
-            &run.run_id,
-            &proposals,
+            profile_root,
+            run_id,
+            proposals,
             config.auto_enable_skills,
         )
         .await
@@ -539,7 +554,7 @@ pub async fn run_skill_writer_with_backend(
                     .append_failed_record(
                         response.model.clone(),
                         evidence_hash,
-                        Some(proposed_ops),
+                        Some(proposed_ops.clone()),
                         err.to_string(),
                     )
                     .await?;
@@ -557,13 +572,13 @@ pub async fn run_skill_writer_with_backend(
         "created_skills": created_skills,
         "updated_skills": updated_skills,
         "rejected_skills": rejected_skills,
-        "skill_improvement_recommendations": request.context
-            .pointer("/skill_writer_evidence/skill_improvement_recommendations")
+        "skill_improvement_recommendations": evidence
+            .get("skill_improvement_recommendations")
             .cloned()
             .unwrap_or_else(|| json!([])),
     });
     let mut record = finalizer.success_record(
-        &response,
+        response,
         report
             .get("evidence_hash")
             .and_then(Value::as_str)
@@ -589,16 +604,109 @@ pub async fn run_skill_writer_with_backend(
         "accepted_count": accepted_count,
         "rejected_count": rejected_count,
     }));
-    let record = finalizer
-        .append_success_record(&request, &response, record)
-        .await?;
+    Ok((report, record))
+}
 
-    Ok(SkillWriterAutomationRun {
-        run_id: run.run_id,
-        report,
-        ledger_record: record,
-        backend_response: Some(response),
-    })
+async fn build_session_reflector_evidence(
+    cg: &TraceDecay,
+    options: &SessionReflectorAutomationOptions,
+) -> Result<SessionReflectorEvidenceOutcome> {
+    // Refresh outcomes of previously applied fact proposals so this run's
+    // feedback artifact reports real post-apply quality. Best effort: a
+    // missing memory store must not block reflection.
+    if let Ok(project_db) = cg.open_project_store_db().await {
+        if let Err(err) = super::outcomes::refresh_fact_outcomes(
+            &cg.store_layout().dashboard_root,
+            project_db.conn(),
+            current_timestamp(),
+        )
+        .await
+        {
+            eprintln!("[tracedecay] warning: failed to refresh fact outcomes: {err}");
+        }
+    }
+
+    let provider = normalized_non_empty(&options.provider).unwrap_or_else(default_session_provider);
+    let query =
+        normalized_non_empty(&options.query).unwrap_or_else(default_session_reflection_query);
+    let evidence_limit = options.evidence_limit.clamp(1, 50);
+    let storage_scope =
+        normalized_non_empty(&options.storage_scope).unwrap_or_else(default_lcm_storage_scope);
+    let session_id = options.session_id.as_deref().and_then(normalized_non_empty);
+    let source = options.source.as_deref().and_then(normalized_non_empty);
+    let role = options.role.as_deref().and_then(normalized_non_empty);
+
+    let sessions_db_path = match automation_lcm_db_path(
+        cg,
+        &storage_scope,
+        options.hermes_home.as_ref(),
+        "session_reflector",
+    )? {
+        LcmAutomationStore::Available(path) => path,
+        LcmAutomationStore::NotIngested => {
+            return Ok(SessionReflectorEvidenceOutcome::Skipped {
+                reason: "lcm_not_ingested",
+                evidence_hash: None,
+            });
+        }
+    };
+    let Some(lcm_db) = GlobalDb::open_read_only_at(&sessions_db_path).await else {
+        return Ok(SessionReflectorEvidenceOutcome::Skipped {
+            reason: "lcm_unavailable",
+            evidence_hash: None,
+        });
+    };
+    let hits = lcm_db
+        .lcm_grep(LcmGrepRequest {
+            provider: provider.clone(),
+            query: query.clone(),
+            scope: options.scope,
+            session_id: session_id.clone(),
+            include_summaries: options.include_summaries,
+            limit: evidence_limit,
+            sort: options.sort,
+            source: source.clone(),
+            role: role.clone(),
+            start_time: options.start_time,
+            end_time: options.end_time,
+        })
+        .await
+        .map_err(|e| TraceDecayError::Config {
+            message: format!("failed to build session reflection evidence: {e}"),
+        })?;
+    let evidence = json!({
+        "storage_scope": storage_scope,
+        "hermes_home": options.hermes_home.as_ref().map(|path| path.display().to_string()),
+        "provider": provider,
+        "query": query,
+        "scope": options.scope,
+        "session_id": session_id,
+        "include_summaries": options.include_summaries,
+        "sort": options.sort,
+        "source": source,
+        "role": role,
+        "start_time": options.start_time,
+        "end_time": options.end_time,
+        "hits": hits,
+    });
+    let evidence_hash = Some(sha256_json(&evidence));
+    if evidence
+        .get("hits")
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty)
+    {
+        return Ok(SessionReflectorEvidenceOutcome::Skipped {
+            reason: "no_session_evidence",
+            evidence_hash,
+        });
+    }
+
+    Ok(SessionReflectorEvidenceOutcome::Ready(
+        SessionReflectorEvidenceBundle {
+            evidence,
+            evidence_hash,
+        },
+    ))
 }
 
 async fn build_skill_writer_evidence(
@@ -766,6 +874,353 @@ async fn skipped_skill_writer_run(
         ledger_record: record,
         backend_response: None,
     })
+}
+
+/// Options for the scheduler-only combined reflector+skill pass. Manual
+/// (CLI/dashboard) runs stay per-task; this path exists so one backend call
+/// can serve both tasks when they are due in the same scheduler tick.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct CombinedReviewAutomationOptions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default)]
+    pub session_reflector: SessionReflectorAutomationOptions,
+    #[serde(default)]
+    pub skill_writer: SkillWriterAutomationOptions,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CombinedReviewAutomationRun {
+    pub run_id: String,
+    pub session_reflector: SessionReflectorAutomationRun,
+    pub skill_writer: SkillWriterAutomationRun,
+}
+
+/// Outcome of attempting the combined dispatch. `NotCombined` means the
+/// caller should fall back to the normal sequential per-task runs; nothing
+/// was recorded and no locks are held.
+#[derive(Debug)]
+pub enum CombinedReviewDispatch {
+    Ran(Box<CombinedReviewAutomationRun>),
+    RecordedFailure {
+        run: Box<CombinedReviewAutomationRun>,
+        error: TraceDecayError,
+    },
+    NotCombined {
+        reason: &'static str,
+    },
+}
+
+/// Runs the session reflector and the skill writer as one combined backend
+/// call when both tasks are due in the same scheduler tick.
+///
+/// Both per-task scheduler gates must proceed (their locks are held for the
+/// whole combined run) and both evidence bundles must be available;
+/// otherwise the dispatch reports `NotCombined` and the caller runs the
+/// tasks sequentially as before. On a combined run, two ledger records are
+/// appended — one per task, so per-task last-run bookkeeping and the
+/// dashboard scheduler status stay coherent — sharing the combined request's
+/// `input_hash` and a `combined_run_id` correlation in `report_ref`, with
+/// `prompt_version` set to the combined contract's version.
+pub async fn run_combined_review_with_backend(
+    cg: &TraceDecay,
+    config: &AutomationConfig,
+    backend: &dyn AgentTaskBackend,
+    options: CombinedReviewAutomationOptions,
+) -> Result<CombinedReviewDispatch> {
+    if !config.combine_due_tasks {
+        return Ok(CombinedReviewDispatch::NotCombined {
+            reason: "combined_mode_disabled",
+        });
+    }
+    let dashboard_root = cg.store_layout().dashboard_root.clone();
+    let sessions_db_path = cg.store_layout().sessions_db_path.clone();
+    let started_at = current_timestamp().to_string();
+
+    let (reflector_gate, _) = task_run_gate(
+        config,
+        &dashboard_root,
+        &sessions_db_path,
+        AgentTaskKind::SessionReflector,
+        AutomationTrigger::Scheduler,
+    )
+    .await?;
+    let _reflector_lock = match reflector_gate {
+        SchedulerGate::Proceed(lock) => lock,
+        SchedulerGate::Skip(_) => {
+            return Ok(CombinedReviewDispatch::NotCombined {
+                reason: "session_reflector_not_due",
+            });
+        }
+    };
+    let (skill_gate, _) = task_run_gate(
+        config,
+        &dashboard_root,
+        &sessions_db_path,
+        AgentTaskKind::SkillWriter,
+        AutomationTrigger::Scheduler,
+    )
+    .await?;
+    let _skill_lock = match skill_gate {
+        SchedulerGate::Proceed(lock) => lock,
+        SchedulerGate::Skip(_) => {
+            return Ok(CombinedReviewDispatch::NotCombined {
+                reason: "skill_writer_not_due",
+            });
+        }
+    };
+
+    let reflector_bundle =
+        match build_session_reflector_evidence(cg, &options.session_reflector).await? {
+            SessionReflectorEvidenceOutcome::Ready(bundle) => bundle,
+            SessionReflectorEvidenceOutcome::Skipped { .. } => {
+                return Ok(CombinedReviewDispatch::NotCombined {
+                    reason: "session_reflector_evidence_unavailable",
+                });
+            }
+        };
+    let skill_bundle = match build_skill_writer_evidence(cg, options.skill_writer).await? {
+        SkillWriterEvidenceOutcome::Ready(bundle) => bundle,
+        SkillWriterEvidenceOutcome::Skipped { .. } => {
+            return Ok(CombinedReviewDispatch::NotCombined {
+                reason: "skill_writer_evidence_unavailable",
+            });
+        }
+    };
+
+    let run_id = options
+        .run_id
+        .unwrap_or_else(|| generated_run_id("combined_review"));
+    let reflector_run_id = format!("{run_id}_facts");
+    let skill_run_id = format!("{run_id}_skills");
+    let activation_policy = skill_writer_activation_policy(config);
+    let combined_evidence_hash = Some(sha256_json(&json!({
+        "session_reflection_evidence": reflector_bundle.evidence,
+        "skill_writer_evidence": skill_bundle.evidence,
+    })));
+    let request = AgentTaskRequest::new(
+        run_id.clone(),
+        AgentTaskKind::CombinedReview,
+        build_combined_review_prompt(&reflector_bundle.evidence, &skill_bundle.evidence),
+        combined_evidence_hash,
+        json!({
+            "session_reflection_evidence": reflector_bundle.evidence,
+            "skill_writer_evidence": skill_bundle.evidence,
+            "apply": false,
+            "activation_policy": activation_policy,
+        }),
+    );
+    let input_hash = Some(request.input_hash.clone());
+    let reflector_finalizer = AgentRunFinalizer::new(
+        &dashboard_root,
+        &reflector_run_id,
+        AutomationTrigger::Scheduler,
+        config,
+        AgentTaskKind::SessionReflector,
+        &started_at,
+        input_hash.clone(),
+    )
+    .for_combined_run(run_id.clone());
+    let skill_finalizer = AgentRunFinalizer::new(
+        &dashboard_root,
+        &skill_run_id,
+        AutomationTrigger::Scheduler,
+        config,
+        AgentTaskKind::SkillWriter,
+        &started_at,
+        input_hash,
+    )
+    .for_combined_run(run_id.clone());
+
+    let response = match backend.run_task(&request) {
+        Ok(response) => response,
+        Err(err) => {
+            let reflector_record = reflector_finalizer
+                .append_backend_fallback_record(
+                    reflector_bundle.evidence_hash.clone(),
+                    err.to_string(),
+                )
+                .await?;
+            let skill_record = skill_finalizer
+                .append_backend_fallback_record(skill_bundle.evidence_hash.clone(), err.to_string())
+                .await?;
+            return Ok(CombinedReviewDispatch::Ran(Box::new(
+                CombinedReviewAutomationRun {
+                    run_id,
+                    session_reflector: SessionReflectorAutomationRun {
+                        run_id: reflector_record.run_id.clone(),
+                        report: failed_backend_fallback_report(&reflector_record),
+                        ledger_record: reflector_record,
+                        backend_response: None,
+                    },
+                    skill_writer: SkillWriterAutomationRun {
+                        run_id: skill_record.run_id.clone(),
+                        report: failed_backend_fallback_report(&skill_record),
+                        ledger_record: skill_record,
+                        backend_response: None,
+                    },
+                },
+            )));
+        }
+    };
+
+    let output = match response
+        .output_json
+        .clone()
+        .map_or_else(|| extract_json_object_prefix(&response.output_text), Ok)
+    {
+        Ok(output) => output,
+        Err(err) => {
+            let (reflector_record, skill_record) = append_combined_failed_records(
+                &reflector_finalizer,
+                &skill_finalizer,
+                &response,
+                &reflector_bundle,
+                &skill_bundle,
+                None,
+                &err,
+            )
+            .await?;
+            return Ok(CombinedReviewDispatch::RecordedFailure {
+                run: combined_failed_run(run_id, reflector_record, skill_record, &response),
+                error: err,
+            });
+        }
+    };
+    let facts = output.get("facts").and_then(Value::as_array).cloned();
+    let skills = output.get("skills").and_then(Value::as_array).cloned();
+    let (Some(facts), Some(skills)) = (facts, skills) else {
+        let err = TraceDecayError::Config {
+            message: "combined review output must include facts and skills arrays".to_string(),
+        };
+        let (reflector_record, skill_record) = append_combined_failed_records(
+            &reflector_finalizer,
+            &skill_finalizer,
+            &response,
+            &reflector_bundle,
+            &skill_bundle,
+            Some(&output),
+            &err,
+        )
+        .await?;
+        return Ok(CombinedReviewDispatch::RecordedFailure {
+            run: combined_failed_run(run_id, reflector_record, skill_record, &response),
+            error: err,
+        });
+    };
+
+    let (reflector_report, reflector_record) = finalize_session_reflector_success(
+        cg,
+        config,
+        &reflector_finalizer,
+        &dashboard_root,
+        &reflector_run_id,
+        &response,
+        &reflector_bundle.evidence,
+        reflector_bundle.evidence_hash.clone(),
+        &output,
+        &facts,
+    )
+    .await?;
+    let reflector_record = reflector_finalizer
+        .append_success_record(&request, &response, reflector_record)
+        .await?;
+
+    let (skill_report, skill_record) = finalize_skill_writer_success(
+        config,
+        &skill_finalizer,
+        &skill_bundle.profile_root,
+        &skill_run_id,
+        &response,
+        &skill_bundle.evidence,
+        skill_bundle.evidence_hash.clone(),
+        activation_policy,
+        &output,
+        &skills,
+    )
+    .await?;
+    let skill_record = skill_finalizer
+        .append_success_record(&request, &response, skill_record)
+        .await?;
+
+    Ok(CombinedReviewDispatch::Ran(Box::new(
+        CombinedReviewAutomationRun {
+            run_id,
+            session_reflector: SessionReflectorAutomationRun {
+                run_id: reflector_run_id,
+                report: reflector_report,
+                ledger_record: reflector_record,
+                backend_response: Some(response.clone()),
+            },
+            skill_writer: SkillWriterAutomationRun {
+                run_id: skill_run_id,
+                report: skill_report,
+                ledger_record: skill_record,
+                backend_response: Some(response),
+            },
+        },
+    )))
+}
+
+fn combined_failed_run(
+    run_id: String,
+    reflector_record: AutomationRunLedgerRecord,
+    skill_record: AutomationRunLedgerRecord,
+    response: &AgentTaskResponse,
+) -> Box<CombinedReviewAutomationRun> {
+    Box::new(CombinedReviewAutomationRun {
+        run_id,
+        session_reflector: SessionReflectorAutomationRun {
+            run_id: reflector_record.run_id.clone(),
+            report: failed_backend_fallback_report(&reflector_record),
+            ledger_record: reflector_record,
+            backend_response: Some(response.clone()),
+        },
+        skill_writer: SkillWriterAutomationRun {
+            run_id: skill_record.run_id.clone(),
+            report: failed_backend_fallback_report(&skill_record),
+            ledger_record: skill_record,
+            backend_response: Some(response.clone()),
+        },
+    })
+}
+
+/// Records the same failure for both halves of a combined run so each task's
+/// cooldown/retry bookkeeping sees it.
+async fn append_combined_failed_records(
+    reflector_finalizer: &AgentRunFinalizer<'_>,
+    skill_finalizer: &AgentRunFinalizer<'_>,
+    response: &AgentTaskResponse,
+    reflector_bundle: &SessionReflectorEvidenceBundle,
+    skill_bundle: &SkillWriterEvidenceBundle,
+    proposed_ops: Option<&Value>,
+    err: &TraceDecayError,
+) -> Result<(AutomationRunLedgerRecord, AutomationRunLedgerRecord)> {
+    let reflector_record = reflector_finalizer
+        .append_failed_record(
+            response.model.clone(),
+            reflector_bundle.evidence_hash.clone(),
+            proposed_ops.cloned(),
+            err.to_string(),
+        )
+        .await?;
+    let skill_record = skill_finalizer
+        .append_failed_record(
+            response.model.clone(),
+            skill_bundle.evidence_hash.clone(),
+            proposed_ops.cloned(),
+            err.to_string(),
+        )
+        .await?;
+    Ok((reflector_record, skill_record))
+}
+
+fn build_combined_review_prompt(reflector_evidence: &Value, skill_evidence: &Value) -> String {
+    format!(
+        "This is a combined TraceDecay self-improvement review covering both session reflection and skill writing in one pass. Return only one JSON object containing both a facts array and a skills array; use an empty array for a part with nothing to propose. Follow each part's instructions exactly.\n\n## Part 1: session reflection\n{}\n\n## Part 2: skill review\n{}",
+        build_session_reflector_prompt(reflector_evidence),
+        build_skill_writer_prompt(skill_evidence)
+    )
 }
 
 fn build_session_reflector_prompt(evidence: &Value) -> String {

--- a/src/automation/scheduler.rs
+++ b/src/automation/scheduler.rs
@@ -219,7 +219,9 @@ pub fn schedule_decision(
     if config.backend == AutomationBackend::Disabled {
         return AutomationScheduleDecision::skipped("backend_disabled");
     }
-    let task_config = task_config(config, task);
+    let Some(task_config) = task_config(config, task) else {
+        return AutomationScheduleDecision::skipped("task_not_schedulable");
+    };
     if !task_config.enabled {
         return AutomationScheduleDecision::skipped("task_disabled");
     }
@@ -298,14 +300,16 @@ pub fn schedule_decision(
 /// new session activity since their last successful run.
 fn task_consumes_session_evidence(task: AgentTaskKind) -> bool {
     match task {
-        AgentTaskKind::SessionReflector | AgentTaskKind::SkillWriter => true,
+        AgentTaskKind::SessionReflector
+        | AgentTaskKind::SkillWriter
+        | AgentTaskKind::CombinedReview => true,
         AgentTaskKind::MemoryCurator => false,
     }
 }
 
 pub fn stale_lock_secs(config: &AutomationConfig, task: AgentTaskKind) -> Option<u64> {
     task_config(config, task)
-        .stale_lock_secs
+        .and_then(|task_config| task_config.stale_lock_secs)
         .or(Some(DEFAULT_STALE_LOCK_SECS))
 }
 
@@ -360,11 +364,14 @@ pub fn parse_schedule(schedule: Option<&str>) -> Result<AutomationSchedule> {
     Ok(AutomationSchedule::Interval { every_secs })
 }
 
-fn task_config(config: &AutomationConfig, task: AgentTaskKind) -> &AutomationTaskConfig {
+fn task_config(config: &AutomationConfig, task: AgentTaskKind) -> Option<&AutomationTaskConfig> {
     match task {
-        AgentTaskKind::MemoryCurator => &config.tasks.memory_curator,
-        AgentTaskKind::SessionReflector => &config.tasks.session_reflector,
-        AgentTaskKind::SkillWriter => &config.tasks.skill_writer,
+        AgentTaskKind::MemoryCurator => Some(&config.tasks.memory_curator),
+        AgentTaskKind::SessionReflector => Some(&config.tasks.session_reflector),
+        AgentTaskKind::SkillWriter => Some(&config.tasks.skill_writer),
+        // The combined review has no schedule of its own; it is dispatched
+        // when the two per-task schedules are both due in the same tick.
+        AgentTaskKind::CombinedReview => None,
     }
 }
 

--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -240,6 +240,7 @@ mod tests {
                 checksum: String::new(),
                 created_at: 1,
                 updated_at: 1,
+                approved_at: None,
                 provenance: ManagedSkillProvenance {
                     source: ManagedSkillSource::AutomationRun,
                     actor: "test".to_string(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1342,8 +1342,9 @@ async fn run_automation_scheduler_tick(
     use crate::automation::backend::{AgentTaskKind, CodexAppServerBackend};
     use crate::automation::run_ledger::AutomationTrigger;
     use crate::automation::runner::{
-        run_memory_curator_with_backend, run_session_reflector_with_backend,
-        run_skill_writer_with_backend, MemoryCuratorAutomationOptions,
+        run_combined_review_with_backend, run_memory_curator_with_backend,
+        run_session_reflector_with_backend, run_skill_writer_with_backend,
+        CombinedReviewAutomationOptions, CombinedReviewDispatch, MemoryCuratorAutomationOptions,
         SessionReflectorAutomationOptions, SkillWriterAutomationOptions,
     };
 
@@ -1400,48 +1401,101 @@ async fn run_automation_scheduler_tick(
             first_error.get_or_insert(e);
         }
     }
-    log_scheduler_task_start(project_path, AgentTaskKind::SessionReflector);
-    match run_session_reflector_with_backend(
-        &cg,
-        &config,
-        &backend,
-        SessionReflectorAutomationOptions {
-            trigger: AutomationTrigger::Scheduler,
-            ..SessionReflectorAutomationOptions::default()
-        },
-    )
-    .await
-    {
-        Ok(run) => {
-            any_succeeded |= run.ledger_record.status
-                == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
-            log_daemon_scheduler_record(project_path, &run.ledger_record);
-        }
-        Err(e) => {
-            log_scheduler_task_error(project_path, AgentTaskKind::SessionReflector, &e);
-            first_error.get_or_insert(e);
+    // When both the reflector and the skill writer are due in this tick, the
+    // combined path serves them with one backend call. Any other outcome
+    // (combined mode disabled, only one task due, missing evidence) falls
+    // back to the sequential per-task runs below.
+    let mut combined_handled = false;
+    if config.combine_due_tasks {
+        log_scheduler_task_start(project_path, AgentTaskKind::CombinedReview);
+        match run_combined_review_with_backend(
+            &cg,
+            &config,
+            &backend,
+            CombinedReviewAutomationOptions::default(),
+        )
+        .await
+        {
+            Ok(CombinedReviewDispatch::Ran(run)) => {
+                any_succeeded |= run.session_reflector.ledger_record.status
+                    == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+                any_succeeded |= run.skill_writer.ledger_record.status
+                    == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+                log_daemon_scheduler_record(project_path, &run.session_reflector.ledger_record);
+                log_daemon_scheduler_record(project_path, &run.skill_writer.ledger_record);
+                combined_handled = true;
+            }
+            Ok(CombinedReviewDispatch::RecordedFailure { run, error }) => {
+                any_succeeded |= run.session_reflector.ledger_record.status
+                    == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+                any_succeeded |= run.skill_writer.ledger_record.status
+                    == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+                log_daemon_scheduler_record(project_path, &run.session_reflector.ledger_record);
+                log_daemon_scheduler_record(project_path, &run.skill_writer.ledger_record);
+                log_scheduler_task_error(project_path, AgentTaskKind::CombinedReview, &error);
+                first_error.get_or_insert(error);
+                combined_handled = true;
+            }
+            Ok(CombinedReviewDispatch::NotCombined { reason }) => {
+                log_daemon_event(
+                    "scheduler_task",
+                    &[
+                        ("project", project_path.display().to_string()),
+                        ("task", "combined_review".to_string()),
+                        ("outcome", "not_combined".to_string()),
+                        ("reason", reason.to_string()),
+                    ],
+                );
+            }
+            Err(e) => {
+                log_scheduler_task_error(project_path, AgentTaskKind::CombinedReview, &e);
+            }
         }
     }
-    log_scheduler_task_start(project_path, AgentTaskKind::SkillWriter);
-    match run_skill_writer_with_backend(
-        &cg,
-        &config,
-        &backend,
-        SkillWriterAutomationOptions {
-            trigger: AutomationTrigger::Scheduler,
-            ..SkillWriterAutomationOptions::default()
-        },
-    )
-    .await
-    {
-        Ok(run) => {
-            any_succeeded |= run.ledger_record.status
-                == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
-            log_daemon_scheduler_record(project_path, &run.ledger_record);
+    if !combined_handled {
+        log_scheduler_task_start(project_path, AgentTaskKind::SessionReflector);
+        match run_session_reflector_with_backend(
+            &cg,
+            &config,
+            &backend,
+            SessionReflectorAutomationOptions {
+                trigger: AutomationTrigger::Scheduler,
+                ..SessionReflectorAutomationOptions::default()
+            },
+        )
+        .await
+        {
+            Ok(run) => {
+                any_succeeded |= run.ledger_record.status
+                    == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+                log_daemon_scheduler_record(project_path, &run.ledger_record);
+            }
+            Err(e) => {
+                log_scheduler_task_error(project_path, AgentTaskKind::SessionReflector, &e);
+                first_error.get_or_insert(e);
+            }
         }
-        Err(e) => {
-            log_scheduler_task_error(project_path, AgentTaskKind::SkillWriter, &e);
-            first_error.get_or_insert(e);
+        log_scheduler_task_start(project_path, AgentTaskKind::SkillWriter);
+        match run_skill_writer_with_backend(
+            &cg,
+            &config,
+            &backend,
+            SkillWriterAutomationOptions {
+                trigger: AutomationTrigger::Scheduler,
+                ..SkillWriterAutomationOptions::default()
+            },
+        )
+        .await
+        {
+            Ok(run) => {
+                any_succeeded |= run.ledger_record.status
+                    == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+                log_daemon_scheduler_record(project_path, &run.ledger_record);
+            }
+            Err(e) => {
+                log_scheduler_task_error(project_path, AgentTaskKind::SkillWriter, &e);
+                first_error.get_or_insert(e);
+            }
         }
     }
     if any_succeeded {

--- a/src/dashboard/automation_run_api.rs
+++ b/src/dashboard/automation_run_api.rs
@@ -415,16 +415,20 @@ async fn dashboard_job_skip_reason(
     if config.backend == AutomationBackend::Disabled {
         return Ok(Some("backend_disabled"));
     }
-    let task_config = match task {
-        AgentTaskKind::MemoryCurator => &config.tasks.memory_curator,
-        AgentTaskKind::SessionReflector => &config.tasks.session_reflector,
-        AgentTaskKind::SkillWriter => &config.tasks.skill_writer,
+    let task_enabled = match task {
+        AgentTaskKind::MemoryCurator => config.tasks.memory_curator.enabled,
+        AgentTaskKind::SessionReflector => config.tasks.session_reflector.enabled,
+        AgentTaskKind::SkillWriter => config.tasks.skill_writer.enabled,
+        AgentTaskKind::CombinedReview => {
+            config.tasks.session_reflector.enabled && config.tasks.skill_writer.enabled
+        }
     };
-    if !task_config.enabled {
+    if !task_enabled {
         return Ok(Some(match task {
             AgentTaskKind::MemoryCurator => "memory_curator_disabled",
             AgentTaskKind::SessionReflector => "session_reflector_disabled",
             AgentTaskKind::SkillWriter => "skill_writer_disabled",
+            AgentTaskKind::CombinedReview => "combined_review_disabled",
         }));
     }
     Ok(None)
@@ -507,6 +511,7 @@ fn dashboard_task_label(task: AgentTaskKind) -> &'static str {
         AgentTaskKind::MemoryCurator => "memory-curator",
         AgentTaskKind::SessionReflector => "session-reflector",
         AgentTaskKind::SkillWriter => "skill-writer",
+        AgentTaskKind::CombinedReview => "combined-review",
     }
 }
 

--- a/tests/automation_runner_test/backend.rs
+++ b/tests/automation_runner_test/backend.rs
@@ -83,6 +83,53 @@ fn backend_contract_round_trips_structured_task_output() {
 }
 
 #[test]
+fn combined_review_contract_requires_both_arrays_with_deterministic_input_hash() {
+    let request = AgentTaskRequest::new(
+        "run_combined".to_string(),
+        AgentTaskKind::CombinedReview,
+        "combined prompt".to_string(),
+        Some("sha256:evidence".to_string()),
+        json!({"apply": false}),
+    );
+
+    assert_eq!(request.contract.task_key, "combined_review");
+    assert_eq!(request.contract.prompt_version, "combined_review:v1");
+    assert!(request.contract.strict_json);
+    assert_eq!(
+        request.contract.response_schema["required"],
+        json!(["facts", "skills"])
+    );
+    assert_eq!(
+        request.contract.response_schema["properties"]["facts"]["type"],
+        "array"
+    );
+    assert_eq!(
+        request.contract.response_schema["properties"]["skills"]["type"],
+        "array"
+    );
+    assert!(request.input_hash.starts_with("sha256:"));
+
+    // Same inputs hash identically; run_id is not part of the input hash.
+    let same_inputs = AgentTaskRequest::new(
+        "run_combined_other".to_string(),
+        AgentTaskKind::CombinedReview,
+        "combined prompt".to_string(),
+        Some("sha256:evidence".to_string()),
+        json!({"apply": false}),
+    );
+    assert_eq!(request.input_hash, same_inputs.input_hash);
+
+    let different_evidence = AgentTaskRequest::new(
+        "run_combined".to_string(),
+        AgentTaskKind::CombinedReview,
+        "combined prompt".to_string(),
+        Some("sha256:other-evidence".to_string()),
+        json!({"apply": false}),
+    );
+    assert_ne!(request.input_hash, different_evidence.input_hash);
+}
+
+#[test]
 fn extracts_one_plain_or_fenced_json_object() {
     assert_eq!(
         extract_json_object_prefix(r#" { "ok": true } "#).unwrap()["ok"],

--- a/tests/automation_runner_test/combined_review.rs
+++ b/tests/automation_runner_test/combined_review.rs
@@ -1,0 +1,334 @@
+//! Scheduler-only combined reflector+skill pass (Hermes combined-review
+//! parity): one backend call serves both tasks when both are due in the same
+//! tick, recording one ledger entry per task so per-task bookkeeping and the
+//! dashboard scheduler status stay coherent.
+
+use crate::support::*;
+use tracedecay::automation::scheduler::{schedule_decision, SessionActivity};
+
+fn combined_options(profile_root: &Path) -> CombinedReviewAutomationOptions {
+    CombinedReviewAutomationOptions {
+        run_id: Some("combined-run-1".to_string()),
+        session_reflector: SessionReflectorAutomationOptions {
+            provider: "cursor".to_string(),
+            query: "durable session reflection".to_string(),
+            evidence_limit: 5,
+            ..SessionReflectorAutomationOptions::default()
+        },
+        skill_writer: manual_skill_writer_options(profile_root),
+    }
+}
+
+fn combined_output_fixture() -> Value {
+    json!({
+        "facts": [
+            {
+                "content": "The project requires durable session reflection facts to stay approval gated",
+                "category": "project",
+                "tags": ["automation", "memory"],
+                "entities": ["TraceDecay"],
+                "trust": 0.72,
+                "source_span": {"session_id": "session-reflect-1", "message_id": "session-reflect-1-message-001"},
+                "reason": "Repeated session evidence describes the required approval gate"
+            }
+        ],
+        "skills": [
+            {
+                "id": "automation-run-review",
+                "title": "Automation run review",
+                "summary": "Review self-improvement automation run ledgers and approval gates.",
+                "category": "workflow",
+                "body_markdown": "Use when reviewing TraceDecay self-improvement runs.",
+                "reason": "Session evidence repeats approval-gated automation workflow review."
+            }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn combined_review_runner_records_both_tasks_from_one_backend_call() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    seed_session_evidence(&cg).await;
+    let _global_db = isolate_global_db(&cg);
+    let config = scheduler_config(Some(3600), None);
+    let backend = CombinedJsonBackend::new(combined_output_fixture());
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 1, "both tasks must share one backend call");
+    let CombinedReviewDispatch::Ran(run) = dispatch else {
+        panic!("expected combined dispatch to run, got {dispatch:?}");
+    };
+    assert_eq!(run.run_id, "combined-run-1");
+
+    let reflector = &run.session_reflector.ledger_record;
+    assert_eq!(reflector.run_id, "combined-run-1_facts");
+    assert_eq!(reflector.task, AgentTaskKind::SessionReflector);
+    assert_eq!(reflector.task_key.as_deref(), Some("session_reflector"));
+    assert_eq!(reflector.trigger, AutomationTrigger::Scheduler);
+    assert_eq!(reflector.status, AutomationRunStatus::Succeeded);
+    assert_eq!(
+        reflector.prompt_version.as_deref(),
+        Some("combined_review:v1")
+    );
+    assert_eq!(reflector.accepted_count, 1);
+
+    let skill = &run.skill_writer.ledger_record;
+    assert_eq!(skill.run_id, "combined-run-1_skills");
+    assert_eq!(skill.task, AgentTaskKind::SkillWriter);
+    assert_eq!(skill.task_key.as_deref(), Some("skill_writer"));
+    assert_eq!(skill.trigger, AutomationTrigger::Scheduler);
+    assert_eq!(skill.status, AutomationRunStatus::Succeeded);
+    assert_eq!(skill.prompt_version.as_deref(), Some("combined_review:v1"));
+    assert_eq!(skill.accepted_count, 1);
+
+    // Both halves share the combined request's input hash and correlate
+    // through report_ref.combined_run_id.
+    assert!(reflector.input_hash.is_some());
+    assert_eq!(reflector.input_hash, skill.input_hash);
+    for record in [reflector, skill] {
+        let report_ref = record.report_ref.as_ref().unwrap();
+        assert_eq!(report_ref["combined_run_id"], json!("combined-run-1"));
+        assert_eq!(report_ref["combined_task_key"], json!("combined_review"));
+    }
+
+    // Approval gating is unchanged: the fact lands as a pending proposal and
+    // the skill as a pending-approval draft.
+    let proposals = list_fact_proposals(
+        &cg.store_layout().dashboard_root,
+        Some(FactProposalState::PendingApproval),
+        10,
+    )
+    .await
+    .unwrap();
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals[0].run_id, "combined-run-1_facts");
+    let draft = load_managed_skill(&profile_root, "automation-run-review")
+        .await
+        .unwrap();
+    assert_eq!(draft.metadata.state, ManagedSkillState::PendingApproval);
+
+    // Per-task last-run bookkeeping sees the combined run: both tasks are
+    // now inside their scheduler interval.
+    let records = load_run_records(&cg.store_layout().dashboard_root, 50)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 2);
+    let now = current_timestamp();
+    for task in [AgentTaskKind::SessionReflector, AgentTaskKind::SkillWriter] {
+        let decision = schedule_decision(&config, task, &records, SessionActivity::at(now), now);
+        assert_eq!(
+            decision.skip_reason(),
+            Some("scheduler_interval_not_elapsed"),
+            "{task:?} must count the combined run as its last scheduler run"
+        );
+    }
+}
+
+#[tokio::test]
+async fn combined_review_not_dispatched_when_only_one_task_is_due() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    let config = scheduler_config(Some(3600), None);
+    append_run_record(
+        &cg.store_layout().dashboard_root,
+        &scheduler_record_for(
+            "previous_session_reflector_run",
+            AgentTaskKind::SessionReflector,
+            AutomationRunStatus::Succeeded,
+            current_timestamp() - 60,
+        ),
+    )
+    .await
+    .unwrap();
+    let backend = CombinedJsonBackend::new(combined_output_fixture());
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 0);
+    let CombinedReviewDispatch::NotCombined { reason } = dispatch else {
+        panic!("expected combined dispatch to fall back, got {dispatch:?}");
+    };
+    assert_eq!(reason, "session_reflector_not_due");
+    let records = load_run_records(&cg.store_layout().dashboard_root, 50)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 1, "fallback must not append ledger records");
+}
+
+#[tokio::test]
+async fn combined_review_not_dispatched_when_skill_writer_is_not_due() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    let config = scheduler_config(Some(3600), None);
+    append_run_record(
+        &cg.store_layout().dashboard_root,
+        &scheduler_record_for(
+            "previous_skill_writer_run",
+            AgentTaskKind::SkillWriter,
+            AutomationRunStatus::Succeeded,
+            current_timestamp() - 60,
+        ),
+    )
+    .await
+    .unwrap();
+    let backend = CombinedJsonBackend::new(combined_output_fixture());
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 0);
+    let CombinedReviewDispatch::NotCombined { reason } = dispatch else {
+        panic!("expected combined dispatch to fall back, got {dispatch:?}");
+    };
+    assert_eq!(reason, "skill_writer_not_due");
+}
+
+#[tokio::test]
+async fn combined_review_respects_escape_hatch_flag() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    let mut config = scheduler_config(Some(3600), None);
+    config.combine_due_tasks = false;
+    let backend = CombinedJsonBackend::new(combined_output_fixture());
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 0);
+    let CombinedReviewDispatch::NotCombined { reason } = dispatch else {
+        panic!("expected combined dispatch to fall back, got {dispatch:?}");
+    };
+    assert_eq!(reason, "combined_mode_disabled");
+}
+
+#[tokio::test]
+async fn combined_review_falls_back_when_evidence_is_unavailable() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    // No seeded session evidence: the reflector evidence bundle is empty, so
+    // the combined path defers to the per-task runs (which record their own
+    // skips).
+    let config = scheduler_config(Some(3600), None);
+    let backend = CombinedJsonBackend::new(combined_output_fixture());
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 0);
+    let CombinedReviewDispatch::NotCombined { reason } = dispatch else {
+        panic!("expected combined dispatch to fall back, got {dispatch:?}");
+    };
+    assert_eq!(reason, "session_reflector_evidence_unavailable");
+}
+
+#[tokio::test]
+async fn combined_review_records_failures_for_both_tasks_when_an_array_is_missing() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    seed_session_evidence(&cg).await;
+    let _global_db = isolate_global_db(&cg);
+    let config = scheduler_config(Some(3600), None);
+    let backend = CombinedJsonBackend::new(json!({ "facts": [] }));
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 1);
+    let CombinedReviewDispatch::RecordedFailure { run, error } = dispatch else {
+        panic!("expected combined dispatch to record failures, got {dispatch:?}");
+    };
+    let err = error.to_string();
+    assert!(
+        err.contains("must include facts and skills arrays"),
+        "unexpected error: {err}"
+    );
+    let records = load_run_records(&cg.store_layout().dashboard_root, 50)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 2);
+    for record in &records {
+        assert_eq!(record.status, AutomationRunStatus::Failed);
+        assert_eq!(record.trigger, AutomationTrigger::Scheduler);
+        assert_eq!(record.prompt_version.as_deref(), Some("combined_review:v1"));
+        assert!(record
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("facts and skills arrays")));
+    }
+    let mut tasks: Vec<AgentTaskKind> = records.iter().map(|record| record.task).collect();
+    tasks.sort_by_key(|task| format!("{task:?}"));
+    assert_eq!(
+        tasks,
+        vec![AgentTaskKind::SessionReflector, AgentTaskKind::SkillWriter]
+    );
+    assert_eq!(
+        run.session_reflector.ledger_record.status,
+        AutomationRunStatus::Failed
+    );
+    assert_eq!(
+        run.skill_writer.ledger_record.status,
+        AutomationRunStatus::Failed
+    );
+}
+
+#[tokio::test]
+async fn combined_review_records_noop_fallbacks_for_both_tasks_when_backend_fails() {
+    let _env_lock = ENV_LOCK.lock().await;
+    let temp = tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let cg = init_project(temp.path()).await;
+    seed_session_evidence(&cg).await;
+    let _global_db = isolate_global_db(&cg);
+    let config = scheduler_config(Some(3600), None);
+    let backend = FailingBackend::new(AgentTaskKind::CombinedReview);
+
+    let dispatch =
+        run_combined_review_with_backend(&cg, &config, &backend, combined_options(&profile_root))
+            .await
+            .unwrap();
+
+    assert_eq!(backend.calls(), 1);
+    let CombinedReviewDispatch::Ran(run) = dispatch else {
+        panic!("expected combined dispatch to record fallbacks, got {dispatch:?}");
+    };
+    assert_noop_fallback_record(
+        &run.session_reflector.ledger_record,
+        AgentTaskKind::SessionReflector,
+        "session_reflector",
+        json!({ "facts": [] }),
+    );
+    assert_noop_fallback_record(
+        &run.skill_writer.ledger_record,
+        AgentTaskKind::SkillWriter,
+        "skill_writer",
+        json!({ "skills": [] }),
+    );
+}

--- a/tests/automation_runner_test/main.rs
+++ b/tests/automation_runner_test/main.rs
@@ -15,6 +15,7 @@ mod common;
 mod support;
 
 mod backend;
+mod combined_review;
 mod config;
 mod memory_curator;
 mod run_ledger;

--- a/tests/automation_runner_test/support.rs
+++ b/tests/automation_runner_test/support.rs
@@ -26,8 +26,9 @@ pub(crate) use tracedecay::automation::run_ledger::{
     AutomationRunStatus, AutomationTrigger,
 };
 pub(crate) use tracedecay::automation::runner::{
-    run_memory_curator_with_backend, run_session_reflector_with_backend,
-    run_skill_writer_with_backend, MemoryCuratorAutomationOptions,
+    run_combined_review_with_backend, run_memory_curator_with_backend,
+    run_session_reflector_with_backend, run_skill_writer_with_backend,
+    CombinedReviewAutomationOptions, CombinedReviewDispatch, MemoryCuratorAutomationOptions,
     SessionReflectorAutomationOptions, SkillWriterAutomationOptions,
 };
 pub(crate) use tracedecay::errors::TraceDecayError;
@@ -403,6 +404,7 @@ impl AgentTaskBackend for MalformedTextBackend {
                 ("session_reflector", "session_reflector:v2", "facts")
             }
             AgentTaskKind::SkillWriter => ("skill_writer", "skill_writer:v2", "skills"),
+            AgentTaskKind::CombinedReview => ("combined_review", "combined_review:v1", "facts"),
         };
         assert_request_contract(request, task_key, prompt_version, required_property);
         Ok(AgentTaskResponse {
@@ -446,6 +448,61 @@ impl AgentTaskBackend for SessionJsonBackend {
         assert!(request.prompt.contains("durable memory facts"));
         assert_eq!(request.context["apply"], json!(false));
         assert!(request.context["session_reflection_evidence"]["hits"]
+            .as_array()
+            .is_some_and(|hits| !hits.is_empty()));
+        Ok(AgentTaskResponse {
+            run_id: request.run_id.clone(),
+            task: request.task,
+            output_text: self.output.to_string(),
+            output_json: Some(self.output.clone()),
+            model: Some("fixture-model".to_string()),
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+        })
+    }
+}
+
+pub(crate) struct CombinedJsonBackend {
+    calls: AtomicUsize,
+    output: Value,
+}
+
+impl CombinedJsonBackend {
+    pub(crate) fn new(output: Value) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            output,
+        }
+    }
+
+    pub(crate) fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl AgentTaskBackend for CombinedJsonBackend {
+    fn run_task(
+        &self,
+        request: &AgentTaskRequest,
+    ) -> tracedecay::errors::Result<AgentTaskResponse> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(request.task, AgentTaskKind::CombinedReview);
+        assert_eq!(request.contract.task_key, "combined_review");
+        assert_eq!(request.contract.prompt_version, "combined_review:v1");
+        assert!(request.contract.strict_json);
+        assert_eq!(
+            request.contract.response_schema["required"],
+            json!(["facts", "skills"])
+        );
+        // The combined prompt must compose both per-task prompts.
+        assert!(request.prompt.contains("durable memory facts"));
+        assert!(request.prompt.contains("managed skill creates or updates"));
+        assert_eq!(request.context["apply"], json!(false));
+        assert!(request.context["activation_policy"].is_string());
+        assert!(request.context["session_reflection_evidence"]["hits"]
+            .as_array()
+            .is_some_and(|hits| !hits.is_empty()));
+        assert!(request.context["skill_writer_evidence"]["hits"]
             .as_array()
             .is_some_and(|hits| !hits.is_empty()));
         Ok(AgentTaskResponse {
@@ -896,6 +953,7 @@ pub(crate) fn test_task_key(task: AgentTaskKind) -> &'static str {
         AgentTaskKind::MemoryCurator => "memory_curator",
         AgentTaskKind::SessionReflector => "session_reflector",
         AgentTaskKind::SkillWriter => "skill_writer",
+        AgentTaskKind::CombinedReview => "combined_review",
     }
 }
 
@@ -904,5 +962,6 @@ pub(crate) fn test_prompt_version(task: AgentTaskKind) -> &'static str {
         AgentTaskKind::MemoryCurator => "memory_curator:v1",
         AgentTaskKind::SessionReflector => "session_reflector:v2",
         AgentTaskKind::SkillWriter => "skill_writer:v2",
+        AgentTaskKind::CombinedReview => "combined_review:v1",
     }
 }


### PR DESCRIPTION
## Summary
- Adds AgentTaskKind::CombinedReview / combined_review:v1 for one backend call when session_reflector and skill_writer are both due in the same scheduler tick.
- Validates returned facts and skills arrays through the existing per-task finalization paths and writes separate per-task ledger records with shared input_hash plus report_ref.combined_run_id.
- Keeps manual dashboard runs per-task and falls back to sequential scheduler runs when combination is disabled, one task is not due, evidence is unavailable, or a combined setup/partial-recording error occurs before both per-task outcomes are recorded.

## Validation
- cargo fmt --check
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo clippy --all-targets -- -D warnings
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo test --test automation_runner_test combined_review -- --nocapture
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo test --test automation_runner_test scheduler -- --nocapture
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo test --test automation_runner_test backend -- --nocapture --test-threads=1
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo test --test automation_runner_test run_ledger -- --nocapture
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo test --test automation_runner_test session_reflector -- --nocapture
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo test --test automation_runner_test skill_writer -- --nocapture
- TMPDIR=/tmp CARGO_TARGET_DIR=/tmp/cargo-target-r7-combined-review cargo check --workspace

Note: shared /scratch cargo target was busy and /scratch/tmp ran out of space during an isolated scratch build, so successful verification used /tmp for TMPDIR and CARGO_TARGET_DIR. Vendor libsql emitted existing warnings during tests/check/clippy. The backend filter was rerun single-threaded after two fake app-server tests passed individually; the prior parallel failure was transient process startup flakiness.