### PR TITLE
[codex] Surface staged automation output to users

### DIFF
--- a/dashboard/holographic/src/HolographicMemoryPage.tsx
+++ b/dashboard/holographic/src/HolographicMemoryPage.tsx
@@ -39,6 +39,7 @@ import SemanticMap, { type SemanticMapFocus } from "./SemanticMap";
 import SimilarityPanel from "./SimilarityPanel";
 import AssociationGraph from "./AssociationGraph";
 import CurationPanel from "./CurationPanel";
+import { usePendingAutomationCounts } from "./curation/usePendingAutomationCounts";
 import { NUM_BADGE } from "./ui";
 import { MiniBar } from "./MiniBar";
 import { Stat } from "../../lib/primitives";
@@ -901,6 +902,10 @@ function HolographicView({
     window.history.replaceState(null, "", url);
   }, []);
 
+  // Pending automation output (skill drafts + fact proposals awaiting
+  // review) surfaces as a count badge on the Curation tab (parity R5).
+  const pendingAutomationCount = usePendingAutomationCounts(api);
+
   // Cross-view navigation: a similarity pair jumps to the Semantic Map with
   // both facts selected and the first one pinned.
   const [mapFocus, setMapFocus] = useState<SemanticMapFocus | null>(null);
@@ -939,6 +944,15 @@ function HolographicView({
             >
               {tab.icon}
               {tab.label}
+              {tab.key === "curation" && pendingAutomationCount > 0 && (
+                <Badge
+                  tone="secondary"
+                  className={NUM_BADGE}
+                  aria-label={`${pendingAutomationCount} automation items awaiting review`}
+                >
+                  {pendingAutomationCount}
+                </Badge>
+              )}
             </Button>
           ))}
         </div>

--- a/dashboard/holographic/src/curation/usePendingAutomationCounts.ts
+++ b/dashboard/holographic/src/curation/usePendingAutomationCounts.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+import type { api as defaultApi } from "../api";
+
+/** Badge freshness only — no need to hammer the scheduler-status endpoint. */
+const POLL_MS = 60_000;
+
+export type PendingAutomationCountsApi = Pick<typeof defaultApi, "getAutomationSchedulerStatus">;
+
+/**
+ * Total automation output awaiting human review (pending fact proposals +
+ * pending skill drafts), sourced from the additive counts on
+ * `/api/automation/scheduler/status`. Self-contained so the Curation tab
+ * badge stays decoupled from the CurationPanel's own data plumbing.
+ */
+export function usePendingAutomationCounts(api: PendingAutomationCountsApi): number {
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const load = async () => {
+      try {
+        const status = await api.getAutomationSchedulerStatus();
+        if (!cancelled) {
+          setTotal((status.pending_fact_proposals ?? 0) + (status.pending_skills ?? 0));
+        }
+      } catch {
+        // Advisory badge: keep the last known count on transient errors.
+      }
+      if (!cancelled) timer = setTimeout(() => void load(), POLL_MS);
+    };
+    void load();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [api]);
+
+  return total;
+}

--- a/dashboard/holographic/src/types.ts
+++ b/dashboard/holographic/src/types.ts
@@ -470,6 +470,10 @@ export interface AutomationSchedulerStatusResponse {
   enabled: boolean;
   scheduler_tick_secs: number;
   now: number;
+  /** Fact proposals awaiting review (additive; older servers omit it). */
+  pending_fact_proposals?: number;
+  /** Skill drafts/updates awaiting review (additive; older servers omit it). */
+  pending_skills?: number;
   project_config_path?: string;
   control_path?: string;
   tasks: AutomationSchedulerTaskStatus[];

--- a/dashboard/test/pending-automation-counts.vitest.tsx
+++ b/dashboard/test/pending-automation-counts.vitest.tsx
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  usePendingAutomationCounts,
+  type PendingAutomationCountsApi,
+} from "../holographic/src/curation/usePendingAutomationCounts";
+
+function makeApi(
+  overrides: Partial<Record<string, unknown>> = {},
+): PendingAutomationCountsApi {
+  return {
+    getAutomationSchedulerStatus: vi.fn().mockResolvedValue({
+      status: "configured",
+      paused: false,
+      enabled: true,
+      scheduler_tick_secs: 60,
+      now: 1782283200,
+      tasks: [],
+      ...overrides,
+    }),
+  };
+}
+
+describe("usePendingAutomationCounts", () => {
+  it("sums pending fact proposals and skills from scheduler status", async () => {
+    const api = makeApi({ pending_fact_proposals: 2, pending_skills: 1 });
+    const { result } = renderHook(() => usePendingAutomationCounts(api));
+
+    await waitFor(() => expect(result.current).toBe(3));
+    expect(api.getAutomationSchedulerStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats missing counts from older servers as zero", async () => {
+    const api = makeApi();
+    const { result } = renderHook(() => usePendingAutomationCounts(api));
+
+    await waitFor(() =>
+      expect(api.getAutomationSchedulerStatus).toHaveBeenCalledTimes(1),
+    );
+    expect(result.current).toBe(0);
+  });
+
+  it("keeps the last known count when the endpoint errors", async () => {
+    const getAutomationSchedulerStatus = vi
+      .fn()
+      .mockRejectedValue(new Error("offline"));
+    const { result } = renderHook(() =>
+      usePendingAutomationCounts({ getAutomationSchedulerStatus }),
+    );
+
+    await waitFor(() =>
+      expect(getAutomationSchedulerStatus).toHaveBeenCalledTimes(1),
+    );
+    expect(result.current).toBe(0);
+  });
+});

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -26,4 +26,5 @@ pub mod skill_frontmatter;
 pub mod skill_targets;
 pub mod skill_usage;
 pub mod skill_writer;
+pub mod staged_notice;
 pub mod text;

--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -1,0 +1,378 @@
+//! Surfacing of staged automation output (R5, Hermes parity).
+//!
+//! Automation runs stage skill drafts and fact proposals for human review, but
+//! historically the approval queue was only visible in the dashboard or the
+//! run ledger. This module derives cheap pending-review counts and decides —
+//! with a persisted dedupe state — when a compact one-line notice should be
+//! surfaced to the user (via the MCP server's response nudge path and the
+//! daemon's `event=automation_staged` log line).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::fact_proposals::{load_fact_proposal_store, FactProposalState};
+use super::managed_skills::{list_managed_skills, ManagedSkillState};
+use super::run_ledger::load_run_records;
+use crate::errors::{Result, TraceDecayError};
+
+const NOTICE_STATE_FILENAME: &str = "automation_notice_seen.json";
+
+/// Counts of automation output awaiting human review.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AutomationPendingCounts {
+    /// Fact proposals in `pending_approval` state.
+    pub pending_fact_proposals: usize,
+    /// Managed skills awaiting review: drafts in `pending_approval` state
+    /// plus active skills carrying a staged `pending_update`.
+    pub pending_skills: usize,
+}
+
+impl AutomationPendingCounts {
+    pub fn total(self) -> usize {
+        self.pending_fact_proposals + self.pending_skills
+    }
+}
+
+/// Persisted marker of the last batch we notified about, so a notice fires at
+/// most once per new batch (new run id or changed pending counts).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AutomationNoticeState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run_id: Option<String>,
+    #[serde(default)]
+    pub pending_fact_proposals: usize,
+    #[serde(default)]
+    pub pending_skills: usize,
+}
+
+pub fn notice_state_path(dashboard_root: &Path) -> PathBuf {
+    dashboard_root.join(NOTICE_STATE_FILENAME)
+}
+
+pub async fn load_notice_state(dashboard_root: &Path) -> Option<AutomationNoticeState> {
+    let bytes = tokio::fs::read(notice_state_path(dashboard_root))
+        .await
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+pub async fn save_notice_state(dashboard_root: &Path, state: &AutomationNoticeState) -> Result<()> {
+    let path = notice_state_path(dashboard_root);
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            config_error(format!("failed to create automation notice directory: {e}"))
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(state).map_err(TraceDecayError::from)?;
+    tokio::fs::write(&path, bytes)
+        .await
+        .map_err(|e| config_error(format!("failed to write automation notice state: {e}")))
+}
+
+/// Counts pending fact proposals (project dashboard store) and pending
+/// managed skills (user profile store). Best-effort: unreadable or missing
+/// stores count as zero so callers never fail a request over a notice.
+pub async fn count_pending_automation_output(
+    dashboard_root: &Path,
+    profile_root: &Path,
+) -> AutomationPendingCounts {
+    let pending_fact_proposals =
+        load_fact_proposal_store(dashboard_root)
+            .await
+            .map_or(0, |store| {
+                store
+                    .proposals
+                    .iter()
+                    .filter(|proposal| proposal.state == FactProposalState::PendingApproval)
+                    .count()
+            });
+    let pending_skills = list_managed_skills(profile_root).await.map_or(0, |skills| {
+        skills
+            .iter()
+            .filter(|skill| {
+                skill.metadata.state == ManagedSkillState::PendingApproval
+                    || skill.pending_update.is_some()
+            })
+            .count()
+    });
+    AutomationPendingCounts {
+        pending_fact_proposals,
+        pending_skills,
+    }
+}
+
+/// Decides whether a notice should fire for the current pending batch.
+/// Fires only when something is pending AND the batch differs from what was
+/// last notified (different latest run id or different pending counts).
+pub fn should_notify(
+    previous: Option<&AutomationNoticeState>,
+    latest_run_id: Option<&str>,
+    counts: AutomationPendingCounts,
+) -> bool {
+    if counts.total() == 0 {
+        return false;
+    }
+    match previous {
+        None => true,
+        Some(state) => {
+            state.last_run_id.as_deref() != latest_run_id
+                || state.pending_fact_proposals != counts.pending_fact_proposals
+                || state.pending_skills != counts.pending_skills
+        }
+    }
+}
+
+/// Formats the compact one-line notice, or `None` when nothing is pending.
+pub fn staged_notice_message(counts: AutomationPendingCounts) -> Option<String> {
+    if counts.total() == 0 {
+        return None;
+    }
+    let mut parts = Vec::new();
+    if counts.pending_skills > 0 {
+        parts.push(format!(
+            "{} skill draft{}",
+            counts.pending_skills,
+            if counts.pending_skills == 1 { "" } else { "s" }
+        ));
+    }
+    if counts.pending_fact_proposals > 0 {
+        parts.push(format!(
+            "{} fact proposal{}",
+            counts.pending_fact_proposals,
+            if counts.pending_fact_proposals == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ));
+    }
+    Some(format!(
+        "TraceDecay automation: {} await{} review — dashboard Curation tab or tracedecay_fact_store.",
+        parts.join(" and "),
+        if counts.total() == 1 { "s" } else { "" },
+    ))
+}
+
+/// One-shot check used by the MCP server: derives pending counts, dedupes
+/// against the persisted notice state, and returns the notice line to surface
+/// (persisting the new state) when a new batch awaits review.
+pub async fn maybe_automation_staged_notice(
+    dashboard_root: &Path,
+    profile_root: &Path,
+) -> Option<String> {
+    let counts = count_pending_automation_output(dashboard_root, profile_root).await;
+    if counts.total() == 0 {
+        return None;
+    }
+    let latest_run_id = load_run_records(dashboard_root, 1)
+        .await
+        .ok()
+        .and_then(|records| records.into_iter().next())
+        .map(|record| record.run_id);
+    let previous = load_notice_state(dashboard_root).await;
+    if !should_notify(previous.as_ref(), latest_run_id.as_deref(), counts) {
+        return None;
+    }
+    let message = staged_notice_message(counts)?;
+    let state = AutomationNoticeState {
+        last_run_id: latest_run_id,
+        pending_fact_proposals: counts.pending_fact_proposals,
+        pending_skills: counts.pending_skills,
+    };
+    // Best-effort persistence: a failed write only risks a repeat notice.
+    let _ = save_notice_state(dashboard_root, &state).await;
+    Some(message)
+}
+
+fn config_error(message: String) -> TraceDecayError {
+    TraceDecayError::Config { message }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::automation::fact_proposals::{
+        save_fact_proposal_store, FactProposalRecord, FactProposalStore,
+    };
+    use crate::automation::managed_skill_model::{
+        ManagedSkill, ManagedSkillMetadata, ManagedSkillProvenance, ManagedSkillSource,
+    };
+    use crate::automation::managed_skills::save_managed_skill;
+
+    fn counts(facts: usize, skills: usize) -> AutomationPendingCounts {
+        AutomationPendingCounts {
+            pending_fact_proposals: facts,
+            pending_skills: skills,
+        }
+    }
+
+    fn proposal(id: &str, state: FactProposalState) -> FactProposalRecord {
+        FactProposalRecord {
+            schema_version: 1,
+            proposal_id: id.to_string(),
+            run_id: "run-1".to_string(),
+            evidence_hash: None,
+            state,
+            add_fact_request: None,
+            proposal: None,
+            validation_reason: None,
+            validation: None,
+            reviewer: None,
+            applied_fact_id: None,
+            apply_outcome: None,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    fn skill(id: &str, state: ManagedSkillState) -> ManagedSkill {
+        let mut skill = ManagedSkill {
+            metadata: ManagedSkillMetadata {
+                id: id.to_string(),
+                title: "Test skill".to_string(),
+                summary: "A test skill.".to_string(),
+                category: "testing".to_string(),
+                targets: crate::automation::managed_skills::default_managed_skill_targets(),
+                state,
+                pinned: false,
+                checksum: String::new(),
+                created_at: 1,
+                updated_at: 1,
+                provenance: ManagedSkillProvenance {
+                    source: ManagedSkillSource::AutomationRun,
+                    actor: "test".to_string(),
+                    run_id: Some("run-1".to_string()),
+                },
+            },
+            body_markdown: "# Test skill\n\nBody.".to_string(),
+            support_files: Vec::new(),
+            pending_update: None,
+        };
+        skill.refresh_checksum();
+        skill
+    }
+
+    #[test]
+    fn message_pluralizes_and_skips_empty_parts() {
+        assert_eq!(staged_notice_message(counts(0, 0)), None);
+        assert_eq!(
+            staged_notice_message(counts(2, 1)).unwrap(),
+            "TraceDecay automation: 1 skill draft and 2 fact proposals await review — dashboard Curation tab or tracedecay_fact_store."
+        );
+        assert_eq!(
+            staged_notice_message(counts(1, 0)).unwrap(),
+            "TraceDecay automation: 1 fact proposal awaits review — dashboard Curation tab or tracedecay_fact_store."
+        );
+        assert_eq!(
+            staged_notice_message(counts(0, 3)).unwrap(),
+            "TraceDecay automation: 3 skill drafts await review — dashboard Curation tab or tracedecay_fact_store."
+        );
+    }
+
+    #[test]
+    fn notify_fires_once_per_batch() {
+        // Nothing pending: never notify.
+        assert!(!should_notify(None, Some("run-1"), counts(0, 0)));
+        // First sighting of a pending batch: notify.
+        assert!(should_notify(None, Some("run-1"), counts(2, 1)));
+        let seen = AutomationNoticeState {
+            last_run_id: Some("run-1".to_string()),
+            pending_fact_proposals: 2,
+            pending_skills: 1,
+        };
+        // Same batch again: stay quiet.
+        assert!(!should_notify(Some(&seen), Some("run-1"), counts(2, 1)));
+        // New run appended: notify again.
+        assert!(should_notify(Some(&seen), Some("run-2"), counts(2, 1)));
+        // Same run but pending counts moved (e.g. a second batch staged
+        // before any run-ledger append was observed): notify.
+        assert!(should_notify(Some(&seen), Some("run-1"), counts(3, 1)));
+    }
+
+    #[tokio::test]
+    async fn counts_pending_output_across_stores() {
+        let dir = tempfile::tempdir().unwrap();
+        let dashboard_root = dir.path().join("dashboard");
+        let profile_root = dir.path().join("profile");
+
+        // Empty stores count as zero rather than erroring.
+        let empty = count_pending_automation_output(&dashboard_root, &profile_root).await;
+        assert_eq!(empty, counts(0, 0));
+
+        save_fact_proposal_store(
+            &dashboard_root,
+            &FactProposalStore {
+                schema_version: 1,
+                proposals: vec![
+                    proposal("p1", FactProposalState::PendingApproval),
+                    proposal("p2", FactProposalState::PendingApproval),
+                    proposal("p3", FactProposalState::Applied),
+                ],
+            },
+        )
+        .await
+        .unwrap();
+        save_managed_skill(
+            &profile_root,
+            &skill("draft-skill", ManagedSkillState::PendingApproval),
+        )
+        .await
+        .unwrap();
+        save_managed_skill(
+            &profile_root,
+            &skill("active-skill", ManagedSkillState::Active),
+        )
+        .await
+        .unwrap();
+
+        let counted = count_pending_automation_output(&dashboard_root, &profile_root).await;
+        assert_eq!(counted, counts(2, 1));
+    }
+
+    #[tokio::test]
+    async fn notice_fires_once_then_rearms_on_new_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let dashboard_root = dir.path().join("dashboard");
+        let profile_root = dir.path().join("profile");
+
+        save_fact_proposal_store(
+            &dashboard_root,
+            &FactProposalStore {
+                schema_version: 1,
+                proposals: vec![proposal("p1", FactProposalState::PendingApproval)],
+            },
+        )
+        .await
+        .unwrap();
+
+        let first = maybe_automation_staged_notice(&dashboard_root, &profile_root).await;
+        assert_eq!(
+            first.unwrap(),
+            "TraceDecay automation: 1 fact proposal awaits review — dashboard Curation tab or tracedecay_fact_store."
+        );
+        // Same batch: deduped.
+        assert!(
+            maybe_automation_staged_notice(&dashboard_root, &profile_root)
+                .await
+                .is_none()
+        );
+
+        // A second proposal lands: new batch, notice fires again.
+        save_fact_proposal_store(
+            &dashboard_root,
+            &FactProposalStore {
+                schema_version: 1,
+                proposals: vec![
+                    proposal("p1", FactProposalState::PendingApproval),
+                    proposal("p2", FactProposalState::PendingApproval),
+                ],
+            },
+        )
+        .await
+        .unwrap();
+        let second = maybe_automation_staged_notice(&dashboard_root, &profile_root).await;
+        assert!(second.unwrap().contains("2 fact proposals"));
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -530,6 +530,44 @@ fn log_daemon_scheduler_record(
     );
 }
 
+#[cfg(unix)]
+fn automation_staged_log_fields(
+    project_path: &Path,
+    counts: crate::automation::staged_notice::AutomationPendingCounts,
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("project", project_path.display().to_string()),
+        (
+            "pending_fact_proposals",
+            counts.pending_fact_proposals.to_string(),
+        ),
+        ("pending_skills", counts.pending_skills.to_string()),
+    ]
+}
+
+/// After a scheduler tick where at least one task completed, emit a stable
+/// `event=automation_staged` line with the pending-review counts so operators
+/// can see the approval queue growing from the daemon log alone (parity R5).
+/// Silent when nothing is pending or the profile root is unavailable.
+#[cfg(unix)]
+async fn log_automation_staged_if_pending(project_path: &Path, dashboard_root: &Path) {
+    let Ok(profile_root) = crate::storage::default_profile_root() else {
+        return;
+    };
+    let counts = crate::automation::staged_notice::count_pending_automation_output(
+        dashboard_root,
+        &profile_root,
+    )
+    .await;
+    if counts.total() == 0 {
+        return;
+    }
+    log_daemon_event(
+        "automation_staged",
+        &automation_staged_log_fields(project_path, counts),
+    );
+}
+
 pub fn unavailable_error(socket_path: &Path) -> TraceDecayError {
     TraceDecayError::Config {
         message: format!(
@@ -1338,6 +1376,7 @@ async fn run_automation_scheduler_tick(
     }
     let backend = CodexAppServerBackend::from_automation_config(&config);
     let mut first_error: Option<TraceDecayError> = None;
+    let mut any_succeeded = false;
 
     log_scheduler_task_start(project_path, AgentTaskKind::MemoryCurator);
     match run_memory_curator_with_backend(
@@ -1351,7 +1390,11 @@ async fn run_automation_scheduler_tick(
     )
     .await
     {
-        Ok(run) => log_daemon_scheduler_record(project_path, &run.ledger_record),
+        Ok(run) => {
+            any_succeeded |= run.ledger_record.status
+                == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+            log_daemon_scheduler_record(project_path, &run.ledger_record);
+        }
         Err(e) => {
             log_scheduler_task_error(project_path, AgentTaskKind::MemoryCurator, &e);
             first_error.get_or_insert(e);
@@ -1369,7 +1412,11 @@ async fn run_automation_scheduler_tick(
     )
     .await
     {
-        Ok(run) => log_daemon_scheduler_record(project_path, &run.ledger_record),
+        Ok(run) => {
+            any_succeeded |= run.ledger_record.status
+                == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+            log_daemon_scheduler_record(project_path, &run.ledger_record);
+        }
         Err(e) => {
             log_scheduler_task_error(project_path, AgentTaskKind::SessionReflector, &e);
             first_error.get_or_insert(e);
@@ -1387,11 +1434,18 @@ async fn run_automation_scheduler_tick(
     )
     .await
     {
-        Ok(run) => log_daemon_scheduler_record(project_path, &run.ledger_record),
+        Ok(run) => {
+            any_succeeded |= run.ledger_record.status
+                == crate::automation::run_ledger::AutomationRunStatus::Succeeded;
+            log_daemon_scheduler_record(project_path, &run.ledger_record);
+        }
         Err(e) => {
             log_scheduler_task_error(project_path, AgentTaskKind::SkillWriter, &e);
             first_error.get_or_insert(e);
         }
+    }
+    if any_succeeded {
+        log_automation_staged_if_pending(project_path, &cg.store_layout().dashboard_root).await;
     }
     match first_error {
         Some(err) => Err(err),
@@ -2121,6 +2175,26 @@ mod tests {
         assert_eq!(
             line,
             "[tracedecay] event=scheduler_task project=/tmp/project task=memory_curator outcome=skipped run_id=run-123 reason=scheduler_interval_not_elapsed"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn automation_staged_log_line_is_stable() {
+        let line = super::format_daemon_log_line(
+            "automation_staged",
+            &super::automation_staged_log_fields(
+                std::path::Path::new("/tmp/project"),
+                crate::automation::staged_notice::AutomationPendingCounts {
+                    pending_fact_proposals: 2,
+                    pending_skills: 1,
+                },
+            ),
+        );
+
+        assert_eq!(
+            line,
+            "[tracedecay] event=automation_staged project=/tmp/project pending_fact_proposals=2 pending_skills=1"
         );
     }
 

--- a/src/dashboard/automation_scheduler_api.rs
+++ b/src/dashboard/automation_scheduler_api.rs
@@ -14,6 +14,7 @@ use crate::automation::scheduler::{
     load_scheduler_control, save_scheduler_control, schedule_decision, scheduler_control_path,
     AutomationSchedulerControl,
 };
+use crate::automation::staged_notice::{count_pending_automation_output, AutomationPendingCounts};
 use crate::tracedecay::current_timestamp;
 use crate::user_config::UserConfig;
 
@@ -58,10 +59,21 @@ async fn scheduler_status_payload(state: &DashboardState) -> ApiResult {
     let records = load_run_records(&state.dashboard_root, 200)
         .await
         .map_err(|err| internal_error(&err))?;
+    // Pending-review badge counts (additive; Hermes parity R5). Best-effort
+    // zero when the profile root is unavailable, mirroring the count helper's
+    // treatment of missing stores.
+    let pending = match crate::storage::default_profile_root() {
+        Ok(profile_root) => {
+            count_pending_automation_output(&state.dashboard_root, &profile_root).await
+        }
+        Err(_) => AutomationPendingCounts::default(),
+    };
     let now = current_timestamp();
     Ok(Json(json!({
         "status": scheduler_status_label(&effective, control.paused),
         "paused": control.paused,
+        "pending_fact_proposals": pending.pending_fact_proposals,
+        "pending_skills": pending.pending_skills,
         "enabled": effective.enabled,
         "scheduler_tick_secs": effective.scheduler_tick_secs,
         "now": now,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -596,6 +596,12 @@ pub struct McpServer {
     /// [`maybe_sync_if_stale`](Self::maybe_sync_if_stale) so concurrent
     /// tool calls don't pile on the same walk.
     last_staleness_check_at: AtomicI64,
+    /// UNIX timestamp (secs) of the most recent staged-automation notice
+    /// check. Same `compare_exchange` cooldown pattern as
+    /// [`last_staleness_check_at`](Self::last_staleness_check_at) so the
+    /// pending-review stores are re-read at most once per window no matter
+    /// how many tool calls fire.
+    last_automation_notice_check_at: AtomicI64,
     /// Cached worktree-vs-index mismatch detection for this session. `None`
     /// when no mismatch exists (the common case) or detection was skipped
     /// (not a git repo / git missing). Computed once at startup so we
@@ -704,6 +710,7 @@ impl McpServer {
             shutdown_done: AtomicBool::new(false),
             timings_enabled: AtomicBool::new(false),
             last_staleness_check_at: AtomicI64::new(0),
+            last_automation_notice_check_at: AtomicI64::new(0),
             worktree_mismatch,
             startup_catch_up_done: AtomicBool::new(true),
             transcript_ingest_done: Arc::new(AtomicBool::new(true)),
@@ -1055,6 +1062,40 @@ impl McpServer {
         // between our cooldown windows, in which case `stale` is empty
         // here but our in-memory `file_token_map` is still pre-sync.
         self.refresh_file_token_map().await;
+    }
+
+    /// Returns a compact one-line notice when automation runs have staged
+    /// output awaiting review (skill drafts, fact proposals) that the user
+    /// hasn't been told about yet — `TraceDecay`'s equivalent of Hermes's
+    /// inline "💾 Self-improvement review" moment (parity R5).
+    ///
+    /// Cheap by construction: a 60 s `compare_exchange` cooldown gates the
+    /// check, and the underlying dedupe state
+    /// ([`crate::automation::staged_notice`]) fires at most once per new
+    /// batch (latest run id or pending-count change), so dropping this into
+    /// every `tools/call` response is safe.
+    async fn maybe_automation_staged_notice(&self, cg: &TraceDecay) -> Option<String> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+        let previous = self.last_automation_notice_check_at.load(Ordering::Acquire);
+        if now.saturating_sub(previous) < 60 {
+            return None;
+        }
+        if self
+            .last_automation_notice_check_at
+            .compare_exchange(previous, now, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return None;
+        }
+        let profile_root = crate::storage::default_profile_root().ok()?;
+        crate::automation::staged_notice::maybe_automation_staged_notice(
+            &cg.store_layout().dashboard_root,
+            &profile_root,
+        )
+        .await
     }
 
     /// Internal: snapshot of the current `file_token_map`. Exposed for
@@ -2026,6 +2067,20 @@ impl McpServer {
                                 "data": warning
                             }
                         }));
+                    }
+                }
+
+                // Staged-automation nudge (Hermes parity R5): when automation
+                // runs have queued skill drafts / fact proposals for review,
+                // append a one-line notice so the approval queue doesn't grow
+                // silently. Deduped per batch and cooldown-gated inside.
+                if let Some(notice) = self.maybe_automation_staged_notice(&cg).await {
+                    if let Some(content) = result
+                        .value
+                        .get_mut("content")
+                        .and_then(|c| c.as_array_mut())
+                    {
+                        content.push(json!({"type": "text", "text": format!("\n{notice}")}));
                     }
                 }
 

--- a/tests/dashboard_api_test/automation_config.rs
+++ b/tests/dashboard_api_test/automation_config.rs
@@ -103,6 +103,14 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
         assert_eq!(scheduler["paused"], false);
         assert_eq!(scheduler["scheduler_tick_secs"], 15);
         assert!(
+            scheduler["pending_fact_proposals"].is_u64(),
+            "scheduler status should expose the pending fact-proposal count: {scheduler}"
+        );
+        assert!(
+            scheduler["pending_skills"].is_u64(),
+            "scheduler status should expose the pending skill count: {scheduler}"
+        );
+        assert!(
             scheduler["tasks"]
                 .as_array()
                 .is_some_and(|tasks| tasks.iter().any(|task| {


### PR DESCRIPTION
## Summary

- Add a persisted, batch-deduped automation staged-output notice for MCP responses.
- Expose additive pending fact proposal / managed skill counts from the scheduler status API.
- Surface the pending automation total as a Curation tab badge and add a stable daemon `event=automation_staged` log line.

## Validation

- `CARGO_TARGET_DIR=/tmp/cargo-target-r5-nudge cargo test --lib automation::staged_notice`
- `CARGO_TARGET_DIR=/tmp/cargo-target-r5-nudge cargo test --lib daemon::tests::automation_staged_log_line_is_stable`
- `CARGO_TARGET_DIR=/tmp/cargo-target-r5-nudge cargo test --test dashboard_api_test automation_config_is_dashboard_controllable_and_persistent -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/cargo-target-r5-nudge cargo test --features test-transport --test mcp_suite mcp_server_test::test_tools_call_search -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/cargo-target-r5-nudge cargo check --workspace`
- `npm run test:dom -- pending-automation-counts.vitest.tsx`