### PR TITLE
[codex] Track automation-applied outcome feedback

### DIFF
--- a/src/automation/artifact_payloads.rs
+++ b/src/automation/artifact_payloads.rs
@@ -406,7 +406,11 @@ mod tests {
     use super::super::run_ledger::{AutomationRunStatus, AutomationTrigger};
     use super::*;
 
-    fn payload_fixture() -> (AgentTaskRequest, AgentTaskResponse, AutomationRunLedgerRecord) {
+    fn payload_fixture() -> (
+        AgentTaskRequest,
+        AgentTaskResponse,
+        AutomationRunLedgerRecord,
+    ) {
         let request = AgentTaskRequest::new(
             "run-outcomes".to_string(),
             AgentTaskKind::SkillWriter,
@@ -545,9 +549,7 @@ mod tests {
 
         let payload = feedback_payload(&ctx, &json!({"kind": "traces"}));
         assert_eq!(
-            payload
-                .pointer("/applied_change_outcomes/status")
-                .unwrap(),
+            payload.pointer("/applied_change_outcomes/status").unwrap(),
             &json!("no_outcomes_recorded")
         );
         assert!(generated_eval_payloads(&ctx).outcome_definitions.is_empty());

--- a/src/automation/artifact_payloads.rs
+++ b/src/automation/artifact_payloads.rs
@@ -14,6 +14,9 @@ use super::artifact_optimizer::{
 use super::artifact_policy::TaskArtifactPolicy;
 use super::artifact_refs::{automation_run_artifact_api, automation_run_artifacts_api};
 use super::backend::{AgentTaskKind, AgentTaskRequest, AgentTaskResponse};
+use super::outcomes::{
+    outcome_eval_definitions, outcome_feedback_section, AutomationOutcomesSnapshot,
+};
 use super::run_ledger::{AutomationRunArtifactKind, AutomationRunLedgerRecord};
 use super::text::truncate_chars_for_prompt;
 
@@ -26,6 +29,9 @@ pub(super) struct ArtifactPayloadContext<'a> {
     pub(super) request: &'a AgentTaskRequest,
     pub(super) response: &'a AgentTaskResponse,
     pub(super) record: &'a AutomationRunLedgerRecord,
+    /// Post-approval outcomes of previously applied changes, when a snapshot
+    /// has been recorded for this project.
+    pub(super) outcomes: &'a AutomationOutcomesSnapshot,
 }
 
 pub(super) struct GeneratedEvalPayloads {
@@ -35,6 +41,10 @@ pub(super) struct GeneratedEvalPayloads {
     pub(super) replay_results: Vec<Value>,
     pub(super) status: &'static str,
     pub(super) validation_decision: &'static str,
+    /// Evals derived from real post-approval outcomes; tracked separately
+    /// from the validation-replay definitions so the replay gate semantics
+    /// stay unchanged.
+    pub(super) outcome_definitions: Vec<Value>,
 }
 
 pub(super) struct ImprovementGatePayload {
@@ -87,6 +97,7 @@ pub(super) fn feedback_payload(ctx: &ArtifactPayloadContext<'_>, trace_ref: &Val
         },
         "human": [],
         "model": validation_feedback_entries(ctx.record),
+        "applied_change_outcomes": outcome_feedback_section(ctx.task, ctx.outcomes),
     })
 }
 
@@ -101,6 +112,7 @@ pub(super) fn generated_eval_payloads(ctx: &ArtifactPayloadContext<'_>) -> Gener
         replay_results,
         status: generated_evals_status(count, runner_status),
         validation_decision: validation_gate_decision(ctx.record),
+        outcome_definitions: outcome_eval_definitions(ctx.task, ctx.task_key, ctx.outcomes),
     }
 }
 
@@ -130,6 +142,7 @@ pub(super) fn generated_evals_payload(
             "eval_count": evals.count,
             "accepted_count": ctx.record.accepted_count,
             "rejected_count": ctx.record.rejected_count,
+            "outcome_eval_count": evals.outcome_definitions.len(),
         },
         "runner": {
             "type": "validation_replay",
@@ -160,6 +173,7 @@ pub(super) fn generated_evals_payload(
             "auto_apply": false,
         },
         "eval_definitions": evals.definitions.clone(),
+        "outcome_eval_definitions": evals.outcome_definitions.clone(),
         "result_refs": [{
             "kind": "validation_report",
             "hash": validation_report_hash(ctx.record.validation_report.as_ref()),
@@ -382,4 +396,160 @@ pub(super) fn codex_handoff_payload(
         "next_actions": ctx.policy.next_actions(ctx.record),
         "tests_to_run": ctx.policy.handoff_tests(),
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::artifact_policy::artifact_policy;
+    use super::super::outcomes::{SkillOutcomeRecord, SkillOutcomeVerdict};
+    use super::super::run_ledger::{AutomationRunStatus, AutomationTrigger};
+    use super::*;
+
+    fn payload_fixture() -> (AgentTaskRequest, AgentTaskResponse, AutomationRunLedgerRecord) {
+        let request = AgentTaskRequest::new(
+            "run-outcomes".to_string(),
+            AgentTaskKind::SkillWriter,
+            "propose skills".to_string(),
+            Some("sha256:evidence".to_string()),
+            json!({}),
+        );
+        let response = AgentTaskResponse {
+            run_id: "run-outcomes".to_string(),
+            task: AgentTaskKind::SkillWriter,
+            output_text: "{\"skills\":[]}".to_string(),
+            output_json: Some(json!({"skills": []})),
+            model: None,
+            input_tokens: None,
+            output_tokens: None,
+        };
+        let record = AutomationRunLedgerRecord {
+            schema_version: 2,
+            run_id: "run-outcomes".to_string(),
+            trigger: AutomationTrigger::ManualCli,
+            task: AgentTaskKind::SkillWriter,
+            task_key: Some("skill_writer".to_string()),
+            backend: "codex_app_server".to_string(),
+            host_mode: None,
+            prompt_version: None,
+            response_schema: None,
+            strict_json: None,
+            model: None,
+            status: AutomationRunStatus::Succeeded,
+            evidence_hash: Some("sha256:evidence".to_string()),
+            input_hash: None,
+            output_hash: None,
+            proposed_ops: None,
+            applied_ops: None,
+            rejected_ops: None,
+            validation_report: None,
+            reviewed_count: 0,
+            accepted_count: 0,
+            rejected_count: 0,
+            skipped_count: 0,
+            fallback_status: None,
+            error: None,
+            error_classification: None,
+            error_retryable: None,
+            report_ref: None,
+            artifacts: Vec::new(),
+            started_at: "0".to_string(),
+            completed_at: "0".to_string(),
+        };
+        (request, response, record)
+    }
+
+    fn outcomes_snapshot() -> AutomationOutcomesSnapshot {
+        AutomationOutcomesSnapshot {
+            schema_version: 1,
+            skills: vec![SkillOutcomeRecord {
+                skill_id: "ignored-skill".to_string(),
+                title: Some("Ignored skill".to_string()),
+                approved_at: 1_000,
+                days_since_approval: 30,
+                views_since_approval: 2,
+                uses_since_approval: 0,
+                verdict: SkillOutcomeVerdict::Ignored,
+            }],
+            facts: Vec::new(),
+            skills_refreshed_at: Some(2_000),
+            facts_refreshed_at: None,
+        }
+    }
+
+    #[test]
+    fn feedback_payload_includes_applied_change_outcomes() {
+        let (request, response, record) = payload_fixture();
+        let outcomes = outcomes_snapshot();
+        let ctx = ArtifactPayloadContext {
+            run_id: "run-outcomes",
+            task: AgentTaskKind::SkillWriter,
+            task_key: "skill_writer",
+            prompt_version: "skill_writer:v1",
+            policy: artifact_policy(AgentTaskKind::SkillWriter),
+            request: &request,
+            response: &response,
+            record: &record,
+            outcomes: &outcomes,
+        };
+
+        let payload = feedback_payload(&ctx, &json!({"kind": "traces"}));
+        let section = payload.get("applied_change_outcomes").unwrap();
+        assert_eq!(section.get("status").unwrap(), &json!("available"));
+        assert_eq!(
+            section.pointer("/skill_verdicts/ignored").unwrap(),
+            &json!(1)
+        );
+        assert_eq!(
+            section.pointer("/skills/0/skill_id").unwrap(),
+            &json!("ignored-skill")
+        );
+
+        let evals = generated_eval_payloads(&ctx);
+        assert_eq!(evals.outcome_definitions.len(), 1);
+        let generated = generated_evals_payload(
+            &ctx,
+            (&json!({"kind": "traces"}), &json!({"kind": "feedback"})),
+            &evals,
+        );
+        assert_eq!(
+            generated.pointer("/summary/outcome_eval_count").unwrap(),
+            &json!(1)
+        );
+        assert_eq!(
+            generated
+                .pointer("/outcome_eval_definitions/0/observed_outcome")
+                .unwrap(),
+            &json!("ignored")
+        );
+        // The validation-replay definitions must stay outcome-free so the
+        // replay gate semantics are unchanged.
+        assert_eq!(evals.count, 0);
+    }
+
+    #[test]
+    fn empty_outcomes_snapshot_reports_none_recorded() {
+        let (request, response, record) = payload_fixture();
+        let outcomes = AutomationOutcomesSnapshot::default();
+        let ctx = ArtifactPayloadContext {
+            run_id: "run-outcomes",
+            task: AgentTaskKind::SessionReflector,
+            task_key: "session_reflector",
+            prompt_version: "session_reflector:v1",
+            policy: artifact_policy(AgentTaskKind::SessionReflector),
+            request: &request,
+            response: &response,
+            record: &record,
+            outcomes: &outcomes,
+        };
+
+        let payload = feedback_payload(&ctx, &json!({"kind": "traces"}));
+        assert_eq!(
+            payload
+                .pointer("/applied_change_outcomes/status")
+                .unwrap(),
+            &json!("no_outcomes_recorded")
+        );
+        assert!(generated_eval_payloads(&ctx).outcome_definitions.is_empty());
+    }
 }

--- a/src/automation/artifacts.rs
+++ b/src/automation/artifacts.rs
@@ -12,6 +12,7 @@ use super::artifact_refs::artifact_ref;
 use super::backend::{
     prompt_version, task_key, AgentTaskKind, AgentTaskRequest, AgentTaskResponse,
 };
+use super::outcomes::load_outcomes_snapshot;
 use super::run_ledger::{
     write_run_artifact, AutomationRunArtifact, AutomationRunArtifactKind, AutomationRunLedgerRecord,
 };
@@ -74,6 +75,11 @@ pub(crate) async fn write_improvement_artifacts(
     let task_key = task_key(task);
     let prompt_version = prompt_version(task);
     let policy = artifact_policy(task);
+    // A missing or unreadable outcomes snapshot must never block the run's
+    // artifact trail; it only means no post-approval signal is available yet.
+    let outcomes = load_outcomes_snapshot(dashboard_root)
+        .await
+        .unwrap_or_default();
     let ctx = ArtifactPayloadContext {
         run_id,
         task,
@@ -83,6 +89,7 @@ pub(crate) async fn write_improvement_artifacts(
         request,
         response,
         record,
+        outcomes: &outcomes,
     };
     let mut writer = ImprovementArtifactWriter::new(dashboard_root, run_id, &created_at);
 

--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -128,6 +128,7 @@ impl ManagedSkillDraft {
                 checksum: String::new(),
                 created_at: now,
                 updated_at: now,
+                approved_at: None,
                 provenance: self.provenance,
             },
             body_markdown: self.body_markdown,
@@ -155,6 +156,11 @@ pub struct ManagedSkillMetadata {
     pub created_at: i64,
     #[serde(default)]
     pub updated_at: i64,
+    /// When the skill last transitioned into `Active` (human approval).
+    /// Anchors post-approval outcome tracking; absent for never-approved
+    /// skills and records written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<i64>,
     pub provenance: ManagedSkillProvenance,
 }
 
@@ -214,6 +220,9 @@ impl ManagedSkill {
     pub fn set_state(&mut self, state: ManagedSkillState) {
         if self.metadata.state != state {
             self.metadata.state = state;
+            if state == ManagedSkillState::Active {
+                self.metadata.approved_at = Some(current_metadata_timestamp());
+            }
             self.touch();
         }
     }

--- a/src/automation/managed_skills.rs
+++ b/src/automation/managed_skills.rs
@@ -430,17 +430,21 @@ async fn record_skill_patch(
 
 pub async fn approve_managed_skill(profile_root: &Path, id: &str) -> Result<ManagedSkill> {
     let skill = load_managed_skill(profile_root, id).await?;
-    let Some(pending) = skill.pending_update else {
-        return set_managed_skill_state(profile_root, id, ManagedSkillState::Active).await;
+    let approved = match skill.pending_update {
+        None => set_managed_skill_state(profile_root, id, ManagedSkillState::Active).await?,
+        Some(pending) => {
+            let mut promoted = pending.into_skill();
+            promoted.set_state(ManagedSkillState::Active);
+            promoted.refresh_checksum();
+            remove_pending_update(profile_root, id).await?;
+            save_managed_skill(profile_root, &promoted).await?;
+            record_skill_patch(profile_root, &promoted, "approve_staged_update".to_string())
+                .await?;
+            promoted
+        }
     };
-
-    let mut promoted = pending.into_skill();
-    promoted.set_state(ManagedSkillState::Active);
-    promoted.refresh_checksum();
-    remove_pending_update(profile_root, id).await?;
-    save_managed_skill(profile_root, &promoted).await?;
-    record_skill_patch(profile_root, &promoted, "approve_staged_update".to_string()).await?;
-    Ok(promoted)
+    super::skill_usage::record_skill_approval(profile_root, &approved).await?;
+    Ok(approved)
 }
 
 pub async fn disable_managed_skill(profile_root: &Path, id: &str) -> Result<ManagedSkill> {

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -18,6 +18,7 @@ mod managed_skill_model;
 mod managed_skill_validation;
 pub mod managed_skills;
 pub mod memory_curator;
+pub mod outcomes;
 pub mod run_ledger;
 pub mod runner;
 pub mod scheduler;

--- a/src/automation/outcomes.rs
+++ b/src/automation/outcomes.rs
@@ -1,0 +1,789 @@
+//! Post-approval outcome tracking for automation-applied changes (R10).
+//!
+//! The automation loops stage skills and facts that humans approve, but
+//! approval alone says nothing about whether the change was good. This module
+//! measures what happened *after* approval:
+//!
+//! - approved managed skills: adoption derived from the usage ledger
+//!   (`adopted` / `ignored` / `too_early`),
+//! - applied fact proposals: post-apply recall trajectory in the memory store
+//!   (`recalled_and_helpful` / `recalled` / `never_recalled` / `deleted`).
+//!
+//! Outcomes are persisted as a snapshot under the dashboard root so the next
+//! automation run for the same task can fold real-quality signal into its
+//! `feedback` and `generated_evals` artifacts, and so the dashboard can render
+//! them read-only.
+
+use std::path::{Path, PathBuf};
+
+use libsql::Connection;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use super::backend::AgentTaskKind;
+use super::fact_proposals::{load_fact_proposal_store, FactProposalRecord, FactProposalState};
+use super::managed_skills::{list_managed_skills, ManagedSkillState};
+use super::skill_usage::{summarize_skill_usage, SkillUsageSummary};
+use crate::errors::{Result, TraceDecayError};
+use crate::memory::store::MemoryStore;
+use crate::memory::types::FactRecord;
+
+const AUTOMATION_OUTCOMES_FILENAME: &str = "automation_outcomes.json";
+
+/// A skill is `too_early` to judge until this long after approval.
+pub const SKILL_ADOPTION_WINDOW_SECS: i64 = 7 * 24 * 60 * 60;
+
+const SECS_PER_DAY: i64 = 24 * 60 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillOutcomeVerdict {
+    Adopted,
+    Ignored,
+    TooEarly,
+}
+
+impl SkillOutcomeVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Adopted => "adopted",
+            Self::Ignored => "ignored",
+            Self::TooEarly => "too_early",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FactOutcomeVerdict {
+    RecalledAndHelpful,
+    Recalled,
+    NeverRecalled,
+    Deleted,
+}
+
+impl FactOutcomeVerdict {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RecalledAndHelpful => "recalled_and_helpful",
+            Self::Recalled => "recalled",
+            Self::NeverRecalled => "never_recalled",
+            Self::Deleted => "deleted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SkillOutcomeRecord {
+    pub skill_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub approved_at: i64,
+    pub days_since_approval: i64,
+    pub views_since_approval: u64,
+    pub uses_since_approval: u64,
+    pub verdict: SkillOutcomeVerdict,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FactOutcomeRecord {
+    pub proposal_id: String,
+    pub run_id: String,
+    pub fact_id: i64,
+    pub applied_at: i64,
+    pub days_since_applied: i64,
+    pub retrieval_count: i64,
+    pub access_count: i64,
+    pub helpful_count: i64,
+    pub unhelpful_count: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_recalled_at: Option<i64>,
+    pub still_exists: bool,
+    pub verdict: FactOutcomeVerdict,
+}
+
+/// Persisted, per-project snapshot of the most recently computed outcomes.
+/// Skill and fact halves are refreshed independently because they need
+/// different inputs (profile root vs memory store connection).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct AutomationOutcomesSnapshot {
+    #[serde(default)]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub skills: Vec<SkillOutcomeRecord>,
+    #[serde(default)]
+    pub facts: Vec<FactOutcomeRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills_refreshed_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub facts_refreshed_at: Option<i64>,
+}
+
+impl AutomationOutcomesSnapshot {
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty() && self.facts.is_empty()
+    }
+}
+
+/// Computes the adoption verdict for one approved skill. `None` when the
+/// skill has never been approved (no post-approval window to measure).
+pub fn skill_outcome(summary: &SkillUsageSummary, now_unix: i64) -> Option<SkillOutcomeRecord> {
+    let approved_at = summary.approved_at?;
+    let secs_since_approval = now_unix.saturating_sub(approved_at);
+    let views_since_approval = count_since_approval(
+        summary.view_count,
+        summary.view_count_at_approval,
+        summary.last_viewed_at,
+        approved_at,
+    );
+    let uses_since_approval = count_since_approval(
+        summary.use_count,
+        summary.use_count_at_approval,
+        summary.last_used_at,
+        approved_at,
+    );
+    let verdict = if uses_since_approval > 0 {
+        SkillOutcomeVerdict::Adopted
+    } else if secs_since_approval < SKILL_ADOPTION_WINDOW_SECS {
+        SkillOutcomeVerdict::TooEarly
+    } else {
+        SkillOutcomeVerdict::Ignored
+    };
+    Some(SkillOutcomeRecord {
+        skill_id: summary.skill_id.clone(),
+        title: summary.title.clone(),
+        approved_at,
+        days_since_approval: secs_since_approval / SECS_PER_DAY,
+        views_since_approval,
+        uses_since_approval,
+        verdict,
+    })
+}
+
+/// Activity since approval, preferring the exact baseline captured at
+/// approval time. Ledgers written before baselines existed fall back to the
+/// last-activity timestamp: activity at or after approval counts the full
+/// total (a conservative over-count is fine for adoption detection).
+fn count_since_approval(
+    total: u64,
+    baseline_at_approval: Option<u64>,
+    last_activity_at: Option<i64>,
+    approved_at: i64,
+) -> u64 {
+    match baseline_at_approval {
+        Some(baseline) => total.saturating_sub(baseline),
+        None if last_activity_at.is_some_and(|at| at >= approved_at) => total,
+        None => 0,
+    }
+}
+
+/// Computes the post-apply verdict for one applied fact proposal. `None`
+/// when the proposal never produced a stored fact.
+pub fn fact_outcome(
+    proposal: &FactProposalRecord,
+    fact: Option<&FactRecord>,
+    now_unix: i64,
+) -> Option<FactOutcomeRecord> {
+    if proposal.state != FactProposalState::Applied {
+        return None;
+    }
+    let fact_id = proposal.applied_fact_id?;
+    let applied_at = proposal.updated_at;
+    let mut record = FactOutcomeRecord {
+        proposal_id: proposal.proposal_id.clone(),
+        run_id: proposal.run_id.clone(),
+        fact_id,
+        applied_at,
+        days_since_applied: now_unix.saturating_sub(applied_at) / SECS_PER_DAY,
+        retrieval_count: 0,
+        access_count: 0,
+        helpful_count: 0,
+        unhelpful_count: 0,
+        last_recalled_at: None,
+        still_exists: false,
+        verdict: FactOutcomeVerdict::Deleted,
+    };
+    let Some(fact) = fact else {
+        return Some(record);
+    };
+    record.retrieval_count = fact.retrieval_count;
+    record.access_count = fact.access_count;
+    record.helpful_count = fact.helpful_count;
+    record.unhelpful_count = fact.unhelpful_count;
+    record.last_recalled_at = fact.last_recalled_at;
+    record.still_exists = true;
+    let recalled = fact.access_count > 0 || fact.last_recalled_at.is_some();
+    record.verdict = if recalled && fact.helpful_count > 0 {
+        FactOutcomeVerdict::RecalledAndHelpful
+    } else if recalled {
+        FactOutcomeVerdict::Recalled
+    } else {
+        FactOutcomeVerdict::NeverRecalled
+    };
+    Some(record)
+}
+
+pub fn automation_outcomes_path(dashboard_root: &Path) -> PathBuf {
+    dashboard_root.join(AUTOMATION_OUTCOMES_FILENAME)
+}
+
+pub async fn load_outcomes_snapshot(dashboard_root: &Path) -> Result<AutomationOutcomesSnapshot> {
+    let path = automation_outcomes_path(dashboard_root);
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(AutomationOutcomesSnapshot::default());
+        }
+        Err(e) => {
+            return Err(config_error(format!(
+                "failed to read automation outcomes snapshot '{}': {e}",
+                path.display()
+            )));
+        }
+    };
+    serde_json::from_slice(&bytes).map_err(|e| {
+        config_error(format!(
+            "failed to parse automation outcomes snapshot '{}': {e}",
+            path.display()
+        ))
+    })
+}
+
+pub async fn save_outcomes_snapshot(
+    dashboard_root: &Path,
+    snapshot: &AutomationOutcomesSnapshot,
+) -> Result<()> {
+    let path = automation_outcomes_path(dashboard_root);
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            config_error(format!(
+                "failed to create automation outcomes directory '{}': {e}",
+                parent.display()
+            ))
+        })?;
+    }
+    let bytes = serde_json::to_vec_pretty(snapshot).map_err(TraceDecayError::from)?;
+    tokio::fs::write(&path, bytes).await.map_err(|e| {
+        config_error(format!(
+            "failed to write automation outcomes snapshot '{}': {e}",
+            path.display()
+        ))
+    })
+}
+
+/// Recomputes skill outcomes from the managed-skill store plus usage ledger
+/// and persists them into the snapshot (facts half untouched).
+pub async fn refresh_skill_outcomes(
+    profile_root: &Path,
+    dashboard_root: &Path,
+    now_unix: i64,
+) -> Result<Vec<SkillOutcomeRecord>> {
+    let skills = list_managed_skills(profile_root).await?;
+    let summaries = summarize_skill_usage(profile_root, &skills).await?;
+    let outcomes = compute_skill_outcomes(&summaries, now_unix);
+    let mut snapshot = load_outcomes_snapshot(dashboard_root)
+        .await
+        .unwrap_or_default();
+    snapshot.schema_version = 1;
+    snapshot.skills = outcomes.clone();
+    snapshot.skills_refreshed_at = Some(now_unix);
+    save_outcomes_snapshot(dashboard_root, &snapshot).await?;
+    Ok(outcomes)
+}
+
+/// Recomputes fact outcomes for applied fact proposals against the memory
+/// store and persists them into the snapshot (skills half untouched).
+pub async fn refresh_fact_outcomes(
+    dashboard_root: &Path,
+    conn: &Connection,
+    now_unix: i64,
+) -> Result<Vec<FactOutcomeRecord>> {
+    let proposals = load_fact_proposal_store(dashboard_root).await?.proposals;
+    let outcomes = compute_fact_outcomes(&proposals, conn, now_unix).await?;
+    let mut snapshot = load_outcomes_snapshot(dashboard_root)
+        .await
+        .unwrap_or_default();
+    snapshot.schema_version = 1;
+    snapshot.facts = outcomes.clone();
+    snapshot.facts_refreshed_at = Some(now_unix);
+    save_outcomes_snapshot(dashboard_root, &snapshot).await?;
+    Ok(outcomes)
+}
+
+pub fn compute_skill_outcomes(
+    summaries: &[SkillUsageSummary],
+    now_unix: i64,
+) -> Vec<SkillOutcomeRecord> {
+    summaries
+        .iter()
+        // Disabled/archived skills were already acted on; their adoption
+        // outcome is no longer a pending question.
+        .filter(|summary| {
+            !matches!(
+                summary.state,
+                Some(ManagedSkillState::Disabled | ManagedSkillState::Archived)
+            )
+        })
+        .filter_map(|summary| skill_outcome(summary, now_unix))
+        .collect()
+}
+
+pub async fn compute_fact_outcomes(
+    proposals: &[FactProposalRecord],
+    conn: &Connection,
+    now_unix: i64,
+) -> Result<Vec<FactOutcomeRecord>> {
+    let store = MemoryStore::new(conn);
+    let mut outcomes = Vec::new();
+    for proposal in proposals {
+        if proposal.state != FactProposalState::Applied {
+            continue;
+        }
+        let Some(fact_id) = proposal.applied_fact_id else {
+            continue;
+        };
+        let fact = store.get_fact(fact_id).await?;
+        if let Some(outcome) = fact_outcome(proposal, fact.as_ref(), now_unix) {
+            outcomes.push(outcome);
+        }
+    }
+    Ok(outcomes)
+}
+
+/// The outcome records relevant to one automation task: the skill writer is
+/// judged by skill adoption, fact-producing tasks by fact recall.
+fn task_outcomes(
+    task: AgentTaskKind,
+    snapshot: &AutomationOutcomesSnapshot,
+) -> (Vec<&SkillOutcomeRecord>, Vec<&FactOutcomeRecord>) {
+    match task {
+        AgentTaskKind::SkillWriter => (snapshot.skills.iter().collect(), Vec::new()),
+        AgentTaskKind::SessionReflector | AgentTaskKind::MemoryCurator => {
+            (Vec::new(), snapshot.facts.iter().collect())
+        }
+    }
+}
+
+/// The "outcomes of previously applied changes" section embedded in the
+/// `feedback` artifact payload.
+pub(super) fn outcome_feedback_section(
+    task: AgentTaskKind,
+    snapshot: &AutomationOutcomesSnapshot,
+) -> Value {
+    let (skills, facts) = task_outcomes(task, snapshot);
+    let skill_verdicts = verdict_counts(skills.iter().map(|record| record.verdict.as_str()));
+    let fact_verdicts = verdict_counts(facts.iter().map(|record| record.verdict.as_str()));
+    json!({
+        "status": if skills.is_empty() && facts.is_empty() {
+            "no_outcomes_recorded"
+        } else {
+            "available"
+        },
+        "source": "post_approval_outcome_tracking",
+        "skills_refreshed_at": snapshot.skills_refreshed_at,
+        "facts_refreshed_at": snapshot.facts_refreshed_at,
+        "skill_verdicts": skill_verdicts,
+        "fact_verdicts": fact_verdicts,
+        "skills": skills,
+        "facts": facts,
+    })
+}
+
+/// Generated-eval entries derived from real post-approval outcomes rather
+/// than validation-time signals. Kept separate from the validation-replay
+/// definitions so the replay gate keeps checking only validation examples.
+pub(super) fn outcome_eval_definitions(
+    task: AgentTaskKind,
+    task_key: &str,
+    snapshot: &AutomationOutcomesSnapshot,
+) -> Vec<Value> {
+    let (skills, facts) = task_outcomes(task, snapshot);
+    let mut definitions = Vec::new();
+    for record in skills {
+        definitions.push(json!({
+            "schema_version": 1,
+            "eval_id": format!("{task_key}:outcome:skill:{}", record.skill_id),
+            "kind": "applied_change_outcome",
+            "subject": { "type": "managed_skill", "skill_id": record.skill_id },
+            "observed_outcome": record.verdict.as_str(),
+            "expected_outcome": "adopted",
+            "passed": record.verdict == SkillOutcomeVerdict::Adopted,
+            "pending": record.verdict == SkillOutcomeVerdict::TooEarly,
+            "metrics": {
+                "approved_at": record.approved_at,
+                "days_since_approval": record.days_since_approval,
+                "views_since_approval": record.views_since_approval,
+                "uses_since_approval": record.uses_since_approval,
+            },
+            "assertions": [{
+                "type": "outcome_equals",
+                "expected": "adopted",
+                "actual": record.verdict.as_str(),
+            }],
+        }));
+    }
+    for record in facts {
+        let passed = matches!(
+            record.verdict,
+            FactOutcomeVerdict::RecalledAndHelpful | FactOutcomeVerdict::Recalled
+        );
+        definitions.push(json!({
+            "schema_version": 1,
+            "eval_id": format!("{task_key}:outcome:fact:{}", record.proposal_id),
+            "kind": "applied_change_outcome",
+            "subject": {
+                "type": "applied_fact",
+                "proposal_id": record.proposal_id,
+                "fact_id": record.fact_id,
+            },
+            "observed_outcome": record.verdict.as_str(),
+            "expected_outcome": "recalled",
+            "passed": passed,
+            "pending": false,
+            "metrics": {
+                "applied_at": record.applied_at,
+                "days_since_applied": record.days_since_applied,
+                "retrieval_count": record.retrieval_count,
+                "access_count": record.access_count,
+                "helpful_count": record.helpful_count,
+                "unhelpful_count": record.unhelpful_count,
+                "still_exists": record.still_exists,
+            },
+            "assertions": [{
+                "type": "outcome_in",
+                "expected": ["recalled", "recalled_and_helpful"],
+                "actual": record.verdict.as_str(),
+            }],
+        }));
+    }
+    definitions
+}
+
+fn verdict_counts<'a>(verdicts: impl Iterator<Item = &'a str>) -> Value {
+    let mut counts = serde_json::Map::new();
+    for verdict in verdicts {
+        let entry = counts.entry(verdict.to_string()).or_insert(json!(0));
+        if let Some(count) = entry.as_u64() {
+            *entry = json!(count + 1);
+        }
+    }
+    Value::Object(counts)
+}
+
+fn config_error(message: String) -> TraceDecayError {
+    TraceDecayError::Config { message }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::skill_usage::SkillUsageRecord;
+    use super::*;
+    use crate::memory::types::MemoryCategory;
+
+    const DAY: i64 = SECS_PER_DAY;
+
+    fn summary(skill_id: &str) -> SkillUsageRecord {
+        SkillUsageRecord {
+            schema_version: 1,
+            skill_id: skill_id.to_string(),
+            title: Some(format!("{skill_id} title")),
+            category: Some("maintenance".to_string()),
+            state: None,
+            pinned: false,
+            created_by: None,
+            provenance_source: None,
+            targets: Vec::new(),
+            view_count: 0,
+            use_count: 0,
+            patch_count: 0,
+            first_seen_at: 0,
+            last_activity_at: 0,
+            last_viewed_at: None,
+            last_used_at: None,
+            last_patched_at: None,
+            approved_at: None,
+            view_count_at_approval: None,
+            use_count_at_approval: None,
+        }
+    }
+
+    fn applied_proposal(proposal_id: &str, fact_id: i64, applied_at: i64) -> FactProposalRecord {
+        FactProposalRecord {
+            schema_version: 1,
+            proposal_id: proposal_id.to_string(),
+            run_id: "run_outcomes".to_string(),
+            evidence_hash: None,
+            state: FactProposalState::Applied,
+            add_fact_request: None,
+            proposal: None,
+            validation_reason: None,
+            validation: None,
+            reviewer: Some("dashboard".to_string()),
+            applied_fact_id: Some(fact_id),
+            apply_outcome: None,
+            created_at: applied_at,
+            updated_at: applied_at,
+        }
+    }
+
+    fn fact(fact_id: i64) -> FactRecord {
+        FactRecord {
+            fact_id,
+            content: "prefers nextest for rust test runs".to_string(),
+            category: MemoryCategory::Tool,
+            tags: Vec::new(),
+            entities: Vec::new(),
+            trust_score: 0.6,
+            source: None,
+            retrieval_count: 0,
+            access_count: 0,
+            helpful_count: 0,
+            unhelpful_count: 0,
+            created_at: 0,
+            updated_at: 0,
+            last_retrieved_at: None,
+            last_recalled_at: None,
+            last_feedback_at: None,
+            metadata: json!({}),
+        }
+    }
+
+    #[test]
+    fn skill_outcome_requires_an_approval_timestamp() {
+        assert!(skill_outcome(&summary("draft-skill"), 100 * DAY).is_none());
+    }
+
+    #[test]
+    fn skill_used_after_approval_is_adopted() {
+        let mut record = summary("adopted-skill");
+        record.approved_at = Some(10 * DAY);
+        record.view_count_at_approval = Some(3);
+        record.use_count_at_approval = Some(1);
+        record.view_count = 5;
+        record.use_count = 4;
+        record.last_used_at = Some(11 * DAY);
+
+        let outcome = skill_outcome(&record, 12 * DAY).unwrap();
+        assert_eq!(outcome.verdict, SkillOutcomeVerdict::Adopted);
+        assert_eq!(outcome.views_since_approval, 2);
+        assert_eq!(outcome.uses_since_approval, 3);
+        assert_eq!(outcome.days_since_approval, 2);
+    }
+
+    #[test]
+    fn unused_skill_inside_window_is_too_early() {
+        let mut record = summary("fresh-skill");
+        record.approved_at = Some(10 * DAY);
+        record.view_count_at_approval = Some(0);
+        record.use_count_at_approval = Some(0);
+
+        let outcome = skill_outcome(&record, 10 * DAY + SKILL_ADOPTION_WINDOW_SECS - 1).unwrap();
+        assert_eq!(outcome.verdict, SkillOutcomeVerdict::TooEarly);
+        assert_eq!(outcome.uses_since_approval, 0);
+    }
+
+    #[test]
+    fn unused_skill_past_window_is_ignored() {
+        let mut record = summary("ignored-skill");
+        record.approved_at = Some(10 * DAY);
+        record.view_count_at_approval = Some(2);
+        record.use_count_at_approval = Some(0);
+        record.view_count = 4;
+        record.last_viewed_at = Some(12 * DAY);
+
+        let outcome = skill_outcome(&record, 10 * DAY + SKILL_ADOPTION_WINDOW_SECS).unwrap();
+        assert_eq!(outcome.verdict, SkillOutcomeVerdict::Ignored);
+        assert_eq!(outcome.views_since_approval, 2);
+        assert_eq!(outcome.uses_since_approval, 0);
+    }
+
+    #[test]
+    fn legacy_ledger_without_baseline_uses_last_activity_fallback() {
+        let mut record = summary("legacy-skill");
+        record.approved_at = Some(10 * DAY);
+        record.use_count = 2;
+        record.last_used_at = Some(11 * DAY);
+
+        let outcome = skill_outcome(&record, 20 * DAY).unwrap();
+        assert_eq!(outcome.verdict, SkillOutcomeVerdict::Adopted);
+        assert_eq!(outcome.uses_since_approval, 2);
+
+        record.last_used_at = Some(9 * DAY);
+        let outcome = skill_outcome(&record, 20 * DAY).unwrap();
+        assert_eq!(outcome.verdict, SkillOutcomeVerdict::Ignored);
+        assert_eq!(outcome.uses_since_approval, 0);
+    }
+
+    #[test]
+    fn deleted_fact_yields_deleted_verdict() {
+        let proposal = applied_proposal("fact_dead", 42, 5 * DAY);
+        let outcome = fact_outcome(&proposal, None, 9 * DAY).unwrap();
+        assert_eq!(outcome.verdict, FactOutcomeVerdict::Deleted);
+        assert!(!outcome.still_exists);
+        assert_eq!(outcome.days_since_applied, 4);
+    }
+
+    #[test]
+    fn never_recalled_fact_yields_never_recalled_verdict() {
+        let proposal = applied_proposal("fact_idle", 42, 5 * DAY);
+        let outcome = fact_outcome(&proposal, Some(&fact(42)), 9 * DAY).unwrap();
+        assert_eq!(outcome.verdict, FactOutcomeVerdict::NeverRecalled);
+        assert!(outcome.still_exists);
+    }
+
+    #[test]
+    fn recalled_fact_yields_recalled_verdict() {
+        let proposal = applied_proposal("fact_recalled", 42, 5 * DAY);
+        let mut record = fact(42);
+        record.access_count = 3;
+        record.last_recalled_at = Some(8 * DAY);
+        let outcome = fact_outcome(&proposal, Some(&record), 9 * DAY).unwrap();
+        assert_eq!(outcome.verdict, FactOutcomeVerdict::Recalled);
+        assert_eq!(outcome.access_count, 3);
+    }
+
+    #[test]
+    fn recalled_and_helpful_fact_yields_top_verdict() {
+        let proposal = applied_proposal("fact_helpful", 42, 5 * DAY);
+        let mut record = fact(42);
+        record.access_count = 2;
+        record.helpful_count = 1;
+        let outcome = fact_outcome(&proposal, Some(&record), 9 * DAY).unwrap();
+        assert_eq!(outcome.verdict, FactOutcomeVerdict::RecalledAndHelpful);
+    }
+
+    #[test]
+    fn helpful_feedback_without_recall_is_not_recalled_and_helpful() {
+        let proposal = applied_proposal("fact_feedback_only", 42, 5 * DAY);
+        let mut record = fact(42);
+        record.helpful_count = 1;
+        let outcome = fact_outcome(&proposal, Some(&record), 9 * DAY).unwrap();
+        assert_eq!(outcome.verdict, FactOutcomeVerdict::NeverRecalled);
+    }
+
+    #[test]
+    fn pending_and_rejected_proposals_produce_no_outcome() {
+        let mut proposal = applied_proposal("fact_pending", 42, 5 * DAY);
+        proposal.state = FactProposalState::PendingApproval;
+        assert!(fact_outcome(&proposal, None, 9 * DAY).is_none());
+
+        let mut proposal = applied_proposal("fact_no_id", 42, 5 * DAY);
+        proposal.applied_fact_id = None;
+        assert!(fact_outcome(&proposal, None, 9 * DAY).is_none());
+    }
+
+    #[test]
+    fn outcome_eval_definitions_reflect_task_scope_and_verdicts() {
+        let mut adopted = summary("adopted-skill");
+        adopted.approved_at = Some(10 * DAY);
+        adopted.use_count_at_approval = Some(0);
+        adopted.use_count = 1;
+        adopted.last_used_at = Some(11 * DAY);
+        let snapshot = AutomationOutcomesSnapshot {
+            schema_version: 1,
+            skills: compute_skill_outcomes(&[adopted], 20 * DAY),
+            facts: vec![fact_outcome(
+                &applied_proposal("fact_dead", 42, 5 * DAY),
+                None,
+                20 * DAY,
+            )
+            .unwrap()],
+            skills_refreshed_at: Some(20 * DAY),
+            facts_refreshed_at: Some(20 * DAY),
+        };
+
+        let skill_evals =
+            outcome_eval_definitions(AgentTaskKind::SkillWriter, "skill_writer", &snapshot);
+        assert_eq!(skill_evals.len(), 1);
+        assert_eq!(
+            skill_evals[0].get("observed_outcome").unwrap(),
+            &json!("adopted")
+        );
+        assert_eq!(skill_evals[0].get("passed").unwrap(), &json!(true));
+
+        let fact_evals = outcome_eval_definitions(
+            AgentTaskKind::SessionReflector,
+            "session_reflector",
+            &snapshot,
+        );
+        assert_eq!(fact_evals.len(), 1);
+        assert_eq!(
+            fact_evals[0].get("observed_outcome").unwrap(),
+            &json!("deleted")
+        );
+        assert_eq!(fact_evals[0].get("passed").unwrap(), &json!(false));
+    }
+
+    #[test]
+    fn feedback_section_counts_verdicts_per_task() {
+        let mut ignored = summary("ignored-skill");
+        ignored.approved_at = Some(0);
+        ignored.view_count_at_approval = Some(0);
+        ignored.use_count_at_approval = Some(0);
+        let snapshot = AutomationOutcomesSnapshot {
+            schema_version: 1,
+            skills: compute_skill_outcomes(&[ignored], 30 * DAY),
+            facts: Vec::new(),
+            skills_refreshed_at: Some(30 * DAY),
+            facts_refreshed_at: None,
+        };
+
+        let section = outcome_feedback_section(AgentTaskKind::SkillWriter, &snapshot);
+        assert_eq!(section.get("status").unwrap(), &json!("available"));
+        assert_eq!(
+            section.pointer("/skill_verdicts/ignored").unwrap(),
+            &json!(1)
+        );
+
+        let empty = outcome_feedback_section(AgentTaskKind::SessionReflector, &snapshot);
+        assert_eq!(empty.get("status").unwrap(), &json!("no_outcomes_recorded"));
+    }
+
+    #[tokio::test]
+    async fn refresh_skill_outcomes_persists_snapshot() {
+        use super::super::managed_skills::{
+            approve_managed_skill, create_managed_skill_draft, default_managed_skill_targets,
+            ManagedSkillDraft, ManagedSkillProvenance, ManagedSkillSource,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let profile_root = temp.path().join("profile");
+        let dashboard_root = temp.path().join("dashboard");
+        let skill = create_managed_skill_draft(
+            &profile_root,
+            ManagedSkillDraft {
+                id: "outcome-skill".to_string(),
+                title: "Outcome skill".to_string(),
+                summary: "Outcome tracking fixture.".to_string(),
+                category: "maintenance".to_string(),
+                targets: default_managed_skill_targets(),
+                body_markdown: "Use when checking outcomes.".to_string(),
+                support_files: Vec::new(),
+                provenance: ManagedSkillProvenance {
+                    source: ManagedSkillSource::AutomationRun,
+                    actor: "tracedecay".to_string(),
+                    run_id: Some("run_outcomes".to_string()),
+                },
+            },
+        )
+        .await
+        .unwrap();
+        approve_managed_skill(&profile_root, &skill.metadata.id)
+            .await
+            .unwrap();
+
+        let now = crate::tracedecay::current_timestamp();
+        let outcomes = refresh_skill_outcomes(&profile_root, &dashboard_root, now)
+            .await
+            .unwrap();
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].skill_id, "outcome-skill");
+        assert_eq!(outcomes[0].verdict, SkillOutcomeVerdict::TooEarly);
+
+        let snapshot = load_outcomes_snapshot(&dashboard_root).await.unwrap();
+        assert_eq!(snapshot.skills, outcomes);
+        assert_eq!(snapshot.skills_refreshed_at, Some(now));
+        assert!(snapshot.facts.is_empty());
+    }
+}

--- a/src/automation/outcomes.rs
+++ b/src/automation/outcomes.rs
@@ -683,12 +683,9 @@ mod tests {
         let snapshot = AutomationOutcomesSnapshot {
             schema_version: 1,
             skills: compute_skill_outcomes(&[adopted], 20 * DAY),
-            facts: vec![fact_outcome(
-                &applied_proposal("fact_dead", 42, 5 * DAY),
-                None,
-                20 * DAY,
-            )
-            .unwrap()],
+            facts: vec![
+                fact_outcome(&applied_proposal("fact_dead", 42, 5 * DAY), None, 20 * DAY).unwrap(),
+            ],
             skills_refreshed_at: Some(20 * DAY),
             facts_refreshed_at: Some(20 * DAY),
         };

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -198,6 +198,21 @@ pub async fn run_session_reflector_with_backend(
         }
     };
 
+    // Refresh outcomes of previously applied fact proposals so this run's
+    // feedback artifact reports real post-apply quality. Best effort: a
+    // missing memory store must not block reflection.
+    if let Ok(project_db) = cg.open_project_store_db().await {
+        if let Err(err) = super::outcomes::refresh_fact_outcomes(
+            &run.dashboard_root,
+            project_db.conn(),
+            current_timestamp(),
+        )
+        .await
+        {
+            eprintln!("[tracedecay] warning: failed to refresh fact outcomes: {err}");
+        }
+    }
+
     let sessions_db_path = match automation_lcm_db_path(
         cg,
         &storage_scope,
@@ -456,6 +471,19 @@ pub async fn run_skill_writer_with_backend(
         evidence,
         evidence_hash,
     } = evidence_bundle;
+
+    // Refresh adoption outcomes of previously approved skills so this run's
+    // feedback artifact reports real post-approval quality. Best effort: a
+    // stale snapshot must not block skill writing.
+    if let Err(err) = super::outcomes::refresh_skill_outcomes(
+        &profile_root,
+        &run.dashboard_root,
+        current_timestamp(),
+    )
+    .await
+    {
+        eprintln!("[tracedecay] warning: failed to refresh skill outcomes: {err}");
+    }
 
     let activation_policy = skill_writer_activation_policy(config);
     let request = AgentTaskRequest::new(

--- a/src/automation/skill_usage.rs
+++ b/src/automation/skill_usage.rs
@@ -232,10 +232,7 @@ pub async fn sync_skill_usage_metadata(profile_root: &Path, skill: &ManagedSkill
 pub async fn record_skill_approval(profile_root: &Path, skill: &ManagedSkill) -> Result<()> {
     let mut ledger = load_skill_usage_ledger(profile_root).await?;
     let skill_id = skill.metadata.id.clone();
-    let approved_at = skill
-        .metadata
-        .approved_at
-        .unwrap_or_else(current_timestamp);
+    let approved_at = skill.metadata.approved_at.unwrap_or_else(current_timestamp);
     let record = ledger
         .records
         .entry(skill_id.clone())

--- a/src/automation/skill_usage.rs
+++ b/src/automation/skill_usage.rs
@@ -53,6 +53,16 @@ pub struct SkillUsageRecord {
     pub last_viewed_at: Option<i64>,
     pub last_used_at: Option<i64>,
     pub last_patched_at: Option<i64>,
+    /// When the skill last transitioned into the active state; mirrors the
+    /// managed skill metadata so outcome scoring works from summaries alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<i64>,
+    /// View/use totals captured at approval time so activity since approval
+    /// is an exact delta rather than a heuristic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view_count_at_approval: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_count_at_approval: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -117,6 +127,9 @@ impl SkillUsageRecord {
             last_viewed_at: None,
             last_used_at: None,
             last_patched_at: None,
+            approved_at: None,
+            view_count_at_approval: None,
+            use_count_at_approval: None,
         }
     }
 
@@ -127,6 +140,9 @@ impl SkillUsageRecord {
         self.pinned = skill.metadata.pinned;
         self.created_by = Some(skill.metadata.provenance.actor.clone());
         self.provenance_source = Some(skill.metadata.provenance.source);
+        if skill.metadata.approved_at.is_some() {
+            self.approved_at = skill.metadata.approved_at;
+        }
     }
 
     fn record(&mut self, event: &SkillUsageEvent) {
@@ -207,6 +223,27 @@ pub async fn sync_skill_usage_metadata(profile_root: &Path, skill: &ManagedSkill
         .entry(skill_id.clone())
         .or_insert_with(|| SkillUsageRecord::new(skill_id, 0));
     record.merge_skill_metadata(skill);
+    save_skill_usage_ledger(profile_root, &ledger).await
+}
+
+/// Records an approval on the usage ledger: stamps `approved_at` and
+/// snapshots the current view/use totals as post-approval baselines so
+/// adoption can be measured as an exact delta.
+pub async fn record_skill_approval(profile_root: &Path, skill: &ManagedSkill) -> Result<()> {
+    let mut ledger = load_skill_usage_ledger(profile_root).await?;
+    let skill_id = skill.metadata.id.clone();
+    let approved_at = skill
+        .metadata
+        .approved_at
+        .unwrap_or_else(current_timestamp);
+    let record = ledger
+        .records
+        .entry(skill_id.clone())
+        .or_insert_with(|| SkillUsageRecord::new(skill_id, approved_at));
+    record.merge_skill_metadata(skill);
+    record.approved_at = Some(approved_at);
+    record.view_count_at_approval = Some(record.view_count);
+    record.use_count_at_approval = Some(record.use_count);
     save_skill_usage_ledger(profile_root, &ledger).await
 }
 

--- a/src/automation/skill_usage/recommendations.rs
+++ b/src/automation/skill_usage/recommendations.rs
@@ -1,4 +1,5 @@
 use super::super::managed_skills::{ManagedSkillSource, ManagedSkillState};
+use super::super::outcomes::{skill_outcome, SkillOutcomeRecord, SkillOutcomeVerdict};
 use super::{SkillImprovementRecommendation, SkillStaleRecommendation, SkillUsageSummary};
 
 pub fn stale_skill_recommendations(
@@ -15,9 +16,10 @@ pub fn stale_skill_recommendations(
 pub fn skill_improvement_recommendations(
     summaries: &[SkillUsageSummary],
 ) -> Vec<SkillImprovementRecommendation> {
+    let now_unix = crate::tracedecay::current_timestamp();
     summaries
         .iter()
-        .map(skill_improvement_recommendation)
+        .map(|summary| skill_improvement_recommendation(summary, now_unix))
         .collect()
 }
 
@@ -76,6 +78,21 @@ fn stale_skill_recommendation(
         };
     }
 
+    // Outcome feedback: an approved skill that agents never used since
+    // approval is a real-quality failure even when views keep it "active".
+    if let Some(outcome) = ignored_outcome(summary, now_unix) {
+        return SkillStaleRecommendation {
+            skill_id: summary.skill_id.clone(),
+            stale: true,
+            recommendation: "archive_review".to_string(),
+            reason: format!(
+                "skill was approved {} days ago but has not been used since approval",
+                outcome.days_since_approval
+            ),
+            evidence,
+        };
+    }
+
     keep_recommendation(
         summary,
         "recent or meaningful activity is present",
@@ -83,7 +100,18 @@ fn stale_skill_recommendation(
     )
 }
 
-fn skill_improvement_recommendation(summary: &SkillUsageSummary) -> SkillImprovementRecommendation {
+/// The post-approval outcome when it is an actionable `ignored` verdict.
+fn ignored_outcome(summary: &SkillUsageSummary, now_unix: i64) -> Option<SkillOutcomeRecord> {
+    skill_outcome(summary, now_unix).filter(|outcome| {
+        outcome.verdict == SkillOutcomeVerdict::Ignored
+            && summary.state == Some(ManagedSkillState::Active)
+    })
+}
+
+fn skill_improvement_recommendation(
+    summary: &SkillUsageSummary,
+    now_unix: i64,
+) -> SkillImprovementRecommendation {
     let evidence = usage_evidence(summary);
     if summary.pinned {
         return no_improvement_recommendation(
@@ -143,6 +171,24 @@ fn skill_improvement_recommendation(summary: &SkillUsageSummary) -> SkillImprove
         };
     }
 
+    // Outcome feedback: approval was supposed to put the skill to work, so a
+    // post-approval `ignored` verdict is a stronger review signal than raw
+    // lifetime counts.
+    if let Some(outcome) = ignored_outcome(summary, now_unix) {
+        return SkillImprovementRecommendation {
+            skill_id: summary.skill_id.clone(),
+            improvement: true,
+            recommendation: "clarify_activation".to_string(),
+            reason: format!(
+                "skill has not been used in the {} days since approval; \
+                 review whether it should be revised or archived",
+                outcome.days_since_approval
+            ),
+            priority: "medium".to_string(),
+            evidence,
+        };
+    }
+
     no_improvement_recommendation(
         summary,
         "no repeated correction or failed-use signal is present",
@@ -194,6 +240,9 @@ fn usage_evidence(summary: &SkillUsageSummary) -> Vec<String> {
     if let Some(source) = summary.provenance_source {
         evidence.push(format!("provenance_source={}", source_key(source)));
     }
+    if let Some(approved_at) = summary.approved_at {
+        evidence.push(format!("approved_at={approved_at}"));
+    }
     evidence
 }
 
@@ -212,5 +261,104 @@ fn source_key(source: ManagedSkillSource) -> &'static str {
         ManagedSkillSource::AutomationRun => "automation_run",
         ManagedSkillSource::UserDraft => "user_draft",
         ManagedSkillSource::Import => "import",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::super::outcomes::SKILL_ADOPTION_WINDOW_SECS;
+    use super::super::SkillUsageRecord;
+    use super::*;
+
+    /// An approved, active, automation-authored skill with recent views but
+    /// no uses since approval: kept by the plain activity heuristics, so any
+    /// stale recommendation must come from the outcome verdict.
+    fn ignored_since_approval_summary(now: i64) -> SkillUsageRecord {
+        SkillUsageRecord {
+            schema_version: 1,
+            skill_id: "ignored-skill".to_string(),
+            title: Some("Ignored skill".to_string()),
+            category: Some("maintenance".to_string()),
+            state: Some(ManagedSkillState::Active),
+            pinned: false,
+            created_by: Some("tracedecay".to_string()),
+            provenance_source: Some(ManagedSkillSource::AutomationRun),
+            targets: Vec::new(),
+            view_count: 2,
+            use_count: 0,
+            patch_count: 0,
+            first_seen_at: 0,
+            last_activity_at: now,
+            last_viewed_at: Some(now),
+            last_used_at: None,
+            last_patched_at: None,
+            approved_at: Some(now - SKILL_ADOPTION_WINDOW_SECS - 1),
+            view_count_at_approval: Some(0),
+            use_count_at_approval: Some(0),
+        }
+    }
+
+    #[test]
+    fn ignored_outcome_strengthens_stale_recommendation() {
+        let now = 100 * 24 * 60 * 60;
+        let summary = ignored_since_approval_summary(now);
+
+        let recommendation = stale_skill_recommendation(&summary, now, 365 * 24 * 60 * 60);
+        assert!(recommendation.stale);
+        assert_eq!(recommendation.recommendation, "archive_review");
+        assert!(recommendation.reason.contains("since approval"));
+        assert!(recommendation
+            .evidence
+            .iter()
+            .any(|entry| entry.starts_with("approved_at=")));
+    }
+
+    #[test]
+    fn adopted_outcome_keeps_skill() {
+        let now = 100 * 24 * 60 * 60;
+        let mut summary = ignored_since_approval_summary(now);
+        summary.use_count = 3;
+        summary.last_used_at = Some(now);
+
+        let recommendation = stale_skill_recommendation(&summary, now, 365 * 24 * 60 * 60);
+        assert!(!recommendation.stale);
+        assert_eq!(recommendation.recommendation, "keep");
+    }
+
+    #[test]
+    fn too_early_outcome_does_not_flag_stale() {
+        let now = 100 * 24 * 60 * 60;
+        let mut summary = ignored_since_approval_summary(now);
+        summary.approved_at = Some(now - 1);
+        summary.view_count_at_approval = Some(2);
+
+        let recommendation = stale_skill_recommendation(&summary, now, 365 * 24 * 60 * 60);
+        assert!(!recommendation.stale);
+    }
+
+    #[test]
+    fn ignored_outcome_triggers_improvement_review() {
+        let now = 100 * 24 * 60 * 60;
+        let summary = ignored_since_approval_summary(now);
+
+        let recommendation = skill_improvement_recommendation(&summary, now);
+        assert!(recommendation.improvement);
+        assert_eq!(recommendation.recommendation, "clarify_activation");
+        assert!(recommendation.reason.contains("since approval"));
+        assert_eq!(recommendation.priority, "medium");
+    }
+
+    #[test]
+    fn never_approved_skill_gets_no_outcome_driven_improvement() {
+        let now = 100 * 24 * 60 * 60;
+        let mut summary = ignored_since_approval_summary(now);
+        summary.approved_at = None;
+        summary.view_count_at_approval = None;
+        summary.use_count_at_approval = None;
+
+        let recommendation = skill_improvement_recommendation(&summary, now);
+        assert!(!recommendation.improvement);
+        assert_eq!(recommendation.recommendation, "none");
     }
 }

--- a/src/dashboard/automation_outcomes_api.rs
+++ b/src/dashboard/automation_outcomes_api.rs
@@ -1,0 +1,58 @@
+//! Read-only dashboard endpoint for post-approval automation outcomes:
+//! adoption of approved managed skills and recall trajectory of applied fact
+//! proposals.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde_json::{json, Value};
+
+use super::util::http_detail;
+use super::DashboardState;
+use crate::automation::fact_proposals::load_fact_proposal_store;
+use crate::automation::managed_skills::list_managed_skills;
+use crate::automation::outcomes::{
+    compute_fact_outcomes, compute_skill_outcomes, load_outcomes_snapshot,
+};
+use crate::automation::skill_usage::summarize_skill_usage;
+use crate::errors::Result;
+use crate::tracedecay::current_timestamp;
+
+pub(crate) async fn outcomes(State(state): State<DashboardState>) -> (StatusCode, Json<Value>) {
+    match outcomes_payload(&state).await {
+        Ok(payload) => (StatusCode::OK, Json(payload)),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(http_detail(&format!(
+                "Failed to compute automation outcomes: {err}"
+            ))),
+        ),
+    }
+}
+
+async fn outcomes_payload(state: &DashboardState) -> Result<Value> {
+    let now = current_timestamp();
+    let profile_root = crate::storage::default_profile_root()?;
+    let skills = list_managed_skills(&profile_root).await?;
+    let summaries = summarize_skill_usage(&profile_root, &skills).await?;
+    let skill_outcomes = compute_skill_outcomes(&summaries, now);
+
+    let proposals = load_fact_proposal_store(&state.dashboard_root)
+        .await?
+        .proposals;
+    let fact_outcomes = compute_fact_outcomes(&proposals, &state.mem_conn, now).await?;
+
+    let snapshot = load_outcomes_snapshot(&state.dashboard_root)
+        .await
+        .unwrap_or_default();
+    Ok(json!({
+        "generated_at": now,
+        "skills": skill_outcomes,
+        "facts": fact_outcomes,
+        "snapshot": {
+            "skills_refreshed_at": snapshot.skills_refreshed_at,
+            "facts_refreshed_at": snapshot.facts_refreshed_at,
+        },
+        "error": "",
+    }))
+}

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -25,6 +25,7 @@ mod analytics_api;
 pub(crate) mod assets;
 mod automation_config_api;
 mod automation_fact_proposals_api;
+mod automation_outcomes_api;
 mod automation_run_api;
 mod automation_run_service;
 mod automation_scheduler_api;
@@ -550,6 +551,10 @@ fn project_api_router() -> Router<DashboardState> {
         .route(
             "/api/automation/scheduler/resume",
             post(automation_scheduler_api::resume),
+        )
+        .route(
+            "/api/automation/outcomes",
+            get(automation_outcomes_api::outcomes),
         )
         .route(
             "/api/automation/runs/{run_id}/artifacts",

--- a/tests/agent_suite/managed_skills_test.rs
+++ b/tests/agent_suite/managed_skills_test.rs
@@ -940,3 +940,43 @@ async fn managed_skill_usage_ledger_records_views_uses_and_patches() {
     assert_eq!(summary.targets, vec!["codex", "cursor"]);
     assert!(summary.last_activity_at > 0);
 }
+
+#[tokio::test]
+async fn approval_stamps_approved_at_and_usage_baselines() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let skill = create_managed_skill_draft(&profile_root, draft())
+        .await
+        .unwrap();
+    assert!(skill.metadata.approved_at.is_none());
+
+    record_skill_usage(
+        &profile_root,
+        &skill,
+        SkillUsageAction::View,
+        "dashboard",
+        vec!["dashboard".to_string()],
+        Some("dashboard".to_string()),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let approved = approve_managed_skill(&profile_root, "repo-hygiene")
+        .await
+        .unwrap();
+    let approved_at = approved.metadata.approved_at.unwrap();
+    assert!(approved_at > 0);
+
+    let summary = summarize_skill_usage_for(&profile_root, &approved)
+        .await
+        .unwrap();
+    assert_eq!(summary.approved_at, Some(approved_at));
+    assert_eq!(summary.view_count_at_approval, Some(1));
+    assert_eq!(summary.use_count_at_approval, Some(0));
+
+    let reloaded = load_managed_skill(&profile_root, "repo-hygiene")
+        .await
+        .unwrap();
+    assert_eq!(reloaded.metadata.approved_at, Some(approved_at));
+}

--- a/tests/dashboard_api_test/api.rs
+++ b/tests/dashboard_api_test/api.rs
@@ -42,6 +42,110 @@ fn dashboard_plugin_manifest_assets_are_served() {
 }
 
 #[test]
+fn automation_outcomes_endpoint_returns_live_read_only_outcomes() {
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        use tracedecay::automation::fact_proposals::{
+            save_fact_proposal_store, FactProposalRecord, FactProposalState, FactProposalStore,
+        };
+        use tracedecay::automation::managed_skills::{
+            approve_managed_skill, create_managed_skill_draft, default_managed_skill_targets,
+            ManagedSkillDraft, ManagedSkillProvenance, ManagedSkillSource,
+        };
+
+        let fixture = start_dashboard_fixture(false).await;
+        let profile_root = tracedecay::storage::default_profile_root()
+            .unwrap_or_else(|err| panic!("expected dashboard fixture profile root: {err}"));
+        let skill = create_managed_skill_draft(
+            &profile_root,
+            ManagedSkillDraft {
+                id: "dashboard-outcome-skill".to_string(),
+                title: "Dashboard outcome skill".to_string(),
+                summary: "Fixture skill for outcome endpoint coverage.".to_string(),
+                category: "maintenance".to_string(),
+                targets: default_managed_skill_targets(),
+                body_markdown: "Use when validating the outcomes endpoint.".to_string(),
+                support_files: Vec::new(),
+                provenance: ManagedSkillProvenance {
+                    source: ManagedSkillSource::AutomationRun,
+                    actor: "tracedecay".to_string(),
+                    run_id: Some("run_dashboard_outcomes".to_string()),
+                },
+            },
+        )
+        .await
+        .unwrap();
+        approve_managed_skill(&profile_root, &skill.metadata.id)
+            .await
+            .unwrap();
+
+        set_fact_access_without_touching_updated_at(&fixture, 103, 2, 1_700_000_500).await;
+        let cg = TraceDecay::open(&fixture.project_root)
+            .await
+            .unwrap_or_else(|err| panic!("failed to reopen dashboard fixture project: {err}"));
+        let dashboard_root = cg.store_layout().dashboard_root.clone();
+        save_fact_proposal_store(
+            &dashboard_root,
+            &FactProposalStore {
+                schema_version: 1,
+                proposals: vec![FactProposalRecord {
+                    schema_version: 1,
+                    proposal_id: "fact_dashboard_outcome".to_string(),
+                    run_id: "run_dashboard_outcomes".to_string(),
+                    evidence_hash: None,
+                    state: FactProposalState::Applied,
+                    add_fact_request: None,
+                    proposal: None,
+                    validation_reason: None,
+                    validation: None,
+                    reviewer: Some("dashboard-test".to_string()),
+                    applied_fact_id: Some(103),
+                    apply_outcome: None,
+                    created_at: 1_700_000_400,
+                    updated_at: 1_700_000_400,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let agent = http_agent();
+        let (status, payload) = get_json(
+            &agent,
+            &format!("{}/api/automation/outcomes", fixture.base_url),
+        );
+        assert_eq!(status, 200);
+        assert!(payload["generated_at"].is_number());
+        assert_eq!(payload["error"], "");
+
+        let skills = payload["skills"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected skill outcomes array: {payload}"));
+        let skill = skills
+            .iter()
+            .find(|skill| skill["skill_id"] == "dashboard-outcome-skill")
+            .unwrap_or_else(|| panic!("expected approved skill outcome: {payload}"));
+        assert_eq!(skill["verdict"], "too_early");
+        assert!(skill["approved_at"].is_number());
+
+        let facts = payload["facts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected fact outcomes array: {payload}"));
+        let fact = facts
+            .iter()
+            .find(|fact| fact["proposal_id"] == "fact_dashboard_outcome")
+            .unwrap_or_else(|| panic!("expected applied fact outcome: {payload}"));
+        assert_eq!(fact["fact_id"], 103);
+        assert_eq!(fact["verdict"], "recalled_and_helpful");
+        assert_eq!(fact["still_exists"], true);
+        assert_eq!(fact["access_count"], 2);
+    });
+}
+
+#[test]
 fn holographic_dashboard_endpoints_return_seeded_payloads() {
     let _env_lock = GLOBAL_DB_ENV_LOCK
         .lock()

--- a/tests/dashboard_api_test/automation.rs
+++ b/tests/dashboard_api_test/automation.rs
@@ -842,3 +842,87 @@ fn automation_run_artifact_api_serves_verified_sidecar_payloads() {
         server.stop();
     });
 }
+
+#[test]
+fn automation_outcomes_endpoint_reports_applied_fact_trajectories() {
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let runtime = create_runtime();
+    runtime.block_on(async {
+        let tmp = tempdir_or_panic();
+        let tmp_root = tmp
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|err| panic!("failed to canonicalize temp root: {err}"));
+        let project_root = tmp_root.join("project");
+        let global_db_path = tmp_root.join("global").join("global.db");
+        let profile_root = tmp_root.join("profile").join(".tracedecay");
+        let _env_guard = EnvVarGuard::set(GLOBAL_DB_ENV, &global_db_path);
+        let _data_dir_guard = EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root);
+
+        let cg = setup_project(&project_root).await;
+        seed_memory_fixture(&cg).await;
+        let dashboard_root = cg.store_layout().dashboard_root.clone();
+
+        // One applied proposal whose fact still exists (seeded fact 101) and
+        // one whose fact was deleted by curation (no such fact id).
+        let applied = |proposal_id: &str, fact_id: i64| {
+            tracedecay::automation::fact_proposals::FactProposalRecord {
+                schema_version: 1,
+                proposal_id: proposal_id.to_string(),
+                run_id: "run_outcomes".to_string(),
+                evidence_hash: None,
+                state: tracedecay::automation::fact_proposals::FactProposalState::Applied,
+                add_fact_request: None,
+                proposal: None,
+                validation_reason: None,
+                validation: None,
+                reviewer: Some("dashboard".to_string()),
+                applied_fact_id: Some(fact_id),
+                apply_outcome: None,
+                created_at: 1_700_000_000,
+                updated_at: 1_700_000_050,
+            }
+        };
+        tracedecay::automation::fact_proposals::save_fact_proposal_store(
+            &dashboard_root,
+            &tracedecay::automation::fact_proposals::FactProposalStore {
+                schema_version: 1,
+                proposals: vec![applied("fact_alive", 101), applied("fact_gone", 999_999)],
+            },
+        )
+        .await
+        .unwrap();
+
+        let agent = http_agent();
+        let port = pick_free_port();
+        let base_url = format!("http://127.0.0.1:{port}");
+        let mut server = spawn_dashboard_server(cg, port);
+        wait_for_dashboard(&agent, &base_url).await;
+
+        let (status, outcomes) = get_json(&agent, &format!("{base_url}/api/automation/outcomes"));
+        assert_eq!(status, 200, "outcomes endpoint failed: {outcomes}");
+        assert_eq!(outcomes["error"], "");
+        assert_eq!(outcomes["skills"], serde_json::json!([]));
+        let facts = outcomes["facts"]
+            .as_array()
+            .unwrap_or_else(|| panic!("facts must be an array: {outcomes}"));
+        assert_eq!(facts.len(), 2);
+        let by_id = |id: &str| {
+            facts
+                .iter()
+                .find(|fact| fact["proposal_id"] == id)
+                .unwrap_or_else(|| panic!("missing proposal {id}: {outcomes}"))
+        };
+        let alive = by_id("fact_alive");
+        assert_eq!(alive["verdict"], "never_recalled");
+        assert_eq!(alive["still_exists"], true);
+        assert_eq!(alive["helpful_count"], 5);
+        let gone = by_id("fact_gone");
+        assert_eq!(gone["verdict"], "deleted");
+        assert_eq!(gone["still_exists"], false);
+
+        server.stop();
+    });
+}


### PR DESCRIPTION
## Summary
- track post-approval managed skill outcomes from usage telemetry
- track applied fact proposal recall/deletion outcomes from the memory store
- include outcome feedback in automation artifacts/generated eval payloads and expose a read-only dashboard API
- feed ignored post-approval outcomes into stale/improvement recommendations

## Validation
- cargo fmt --check
- CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r10-outcomes cargo test --lib outcomes -- --nocapture
- CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r10-outcomes cargo test --lib skill_usage::recommendations -- --nocapture
- CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r10-outcomes cargo test --test agent_suite approval_stamps_approved_at_and_usage_baselines -- --nocapture
- CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r10-outcomes cargo test --test dashboard_api_test automation_outcomes_endpoint_returns_live_read_only_outcomes -- --nocapture
- CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-r10-outcomes cargo check

## Notes
- Branch was merged with current origin/master before push.
- cargo check/test emitted existing vendor libsql warnings only.