### PR TITLE
Route MCP graph reads from hook workspace context

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -72,6 +72,11 @@ fn arguments_have_project_selector(arguments: &Value) -> bool {
         || arguments.get("project_root").is_some()
 }
 
+#[derive(Default)]
+struct ConnectionContext {
+    hook_project_path: Option<String>,
+}
+
 /// The steering instructions advertised from the `initialize` handshake of a
 /// healthy server.
 pub(crate) const SERVER_INSTRUCTIONS: &str = "tracedecay is a code-graph MCP server. \
@@ -634,10 +639,6 @@ pub struct McpServer {
     ledger_writes_started: Arc<AtomicU64>,
     ledger_writes_finished: Arc<AtomicU64>,
     ledger_write_notify: Arc<tokio::sync::Notify>,
-    /// Last project resolved from a daemon hook `cwd`. This is a connection-local
-    /// default for read-only graph tools when the caller did not pass an
-    /// explicit project selector.
-    hook_project_path: tokio::sync::RwLock<Option<String>>,
 }
 
 impl McpServer {
@@ -729,7 +730,6 @@ impl McpServer {
             ledger_writes_started: Arc::new(AtomicU64::new(0)),
             ledger_writes_finished: Arc::new(AtomicU64::new(0)),
             ledger_write_notify: Arc::new(tokio::sync::Notify::new()),
-            hook_project_path: tokio::sync::RwLock::new(None),
         });
 
         tokio::task::spawn_blocking(move || {
@@ -779,12 +779,15 @@ impl McpServer {
         self.cg.read().await.clone()
     }
 
-    async fn update_hook_workspace_route(&self, event: &hook_events::HookEvent) {
-        let route = match event.cwd.as_deref() {
+    async fn update_hook_workspace_route(
+        &self,
+        event: &hook_events::HookEvent,
+        connection: &mut ConnectionContext,
+    ) {
+        connection.hook_project_path = match event.cwd.as_deref() {
             Some(cwd) => self.registered_project_containing_path(cwd).await,
             None => None,
         };
-        *self.hook_project_path.write().await = route;
     }
 
     async fn registered_project_containing_path(&self, cwd: &Path) -> Option<String> {
@@ -800,13 +803,18 @@ impl McpServer {
         }
     }
 
-    async fn apply_hook_project_route(&self, tool_name: &str, mut arguments: Value) -> Value {
+    fn apply_hook_project_route(
+        &self,
+        tool_name: &str,
+        mut arguments: Value,
+        connection: &ConnectionContext,
+    ) -> Value {
         if !tool_dispatches_registered_project_reader(tool_name)
             || arguments_have_project_selector(&arguments)
         {
             return arguments;
         }
-        let Some(project_path) = self.hook_project_path.read().await.clone() else {
+        let Some(project_path) = connection.hook_project_path.as_deref() else {
             return arguments;
         };
         if let Some(map) = arguments.as_object_mut() {
@@ -1319,6 +1327,8 @@ impl McpServer {
         listen_for_process_signals: bool,
         timings_override: Option<bool>,
     ) -> Result<()> {
+        let mut connection_context = ConnectionContext::default();
+
         // Register the SIGTERM listener once before entering the loop so
         // there is no window between iterations where a SIGTERM is delivered
         // but no handler is installed (which would cause silent loss of the
@@ -1402,6 +1412,7 @@ impl McpServer {
                     self.handle_request_with_timings(
                         &request,
                         timings_override.unwrap_or_else(|| self.timings_enabled()),
+                        &mut connection_context,
                     )
                     .await
                 }
@@ -1524,7 +1535,8 @@ impl McpServer {
     ///
     /// Returns `None` for notifications (requests without an `id`).
     pub(crate) async fn handle_request(&self, request: &JsonRpcRequest) -> Option<JsonRpcResponse> {
-        self.handle_request_with_timings(request, self.timings_enabled())
+        let mut connection_context = ConnectionContext::default();
+        self.handle_request_with_timings(request, self.timings_enabled(), &mut connection_context)
             .await
     }
 
@@ -1532,6 +1544,7 @@ impl McpServer {
         &self,
         request: &JsonRpcRequest,
         timings_enabled: bool,
+        connection: &mut ConnectionContext,
     ) -> Option<JsonRpcResponse> {
         debug_assert!(
             !request.method.is_empty(),
@@ -1542,7 +1555,7 @@ impl McpServer {
             *counts.entry(request.method.clone()).or_insert(0) += 1;
         }
         if matches!(classify_mcp_method(&request.method), McpMethod::HookEvent) {
-            self.handle_hook_event_notification(request.params.as_ref())
+            self.handle_hook_event_notification(request.params.as_ref(), connection)
                 .await;
             return None;
         }
@@ -1557,7 +1570,7 @@ impl McpServer {
             McpMethod::InitializedAck | McpMethod::HookEvent => None,
             McpMethod::ToolsList => Some(self.handle_tools_list(id).await),
             McpMethod::ToolsCall => Some(
-                self.handle_tools_call(id, request.params.as_ref(), timings_enabled)
+                self.handle_tools_call(id, request.params.as_ref(), timings_enabled, connection)
                     .await,
             ),
             McpMethod::ResourcesList => Some(Self::handle_resources_list(id)),
@@ -1583,13 +1596,17 @@ impl McpServer {
         result
     }
 
-    async fn handle_hook_event_notification(&self, params: Option<&Value>) {
+    async fn handle_hook_event_notification(
+        &self,
+        params: Option<&Value>,
+        connection: &mut ConnectionContext,
+    ) {
         let Some(event) = hook_events::parse_hook_event(params) else {
             return;
         };
         let cg = self.reopen_if_branch_drifted().await;
         let root = cg.project_root().to_path_buf();
-        self.update_hook_workspace_route(&event).await;
+        self.update_hook_workspace_route(&event, connection).await;
         let current_branch = crate::branch::current_branch(&root);
         let plan = hook_events::plan_hook_event(&event, &root, current_branch.as_deref());
         self.run_hook_event_plan(cg, &root, plan).await;
@@ -1932,6 +1949,7 @@ impl McpServer {
         id: Value,
         params: Option<&Value>,
         timings_enabled: bool,
+        connection: &ConnectionContext,
     ) -> JsonRpcResponse {
         let Some(params) = params else {
             return JsonRpcResponse::error(
@@ -1984,7 +2002,7 @@ impl McpServer {
         } else {
             None
         };
-        let mut handler_arguments = self.apply_hook_project_route(tool_name, arguments).await;
+        let mut handler_arguments = self.apply_hook_project_route(tool_name, arguments, connection);
         if crate::analytics::is_skill_view_tool(tool_name) {
             if let Some(request_id) = json_rpc_request_id_string(&id) {
                 if let Some(map) = handler_arguments.as_object_mut() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -804,7 +804,6 @@ impl McpServer {
     }
 
     fn apply_hook_project_route(
-        &self,
         tool_name: &str,
         mut arguments: Value,
         connection: &ConnectionContext,
@@ -2002,7 +2001,8 @@ impl McpServer {
         } else {
             None
         };
-        let mut handler_arguments = self.apply_hook_project_route(tool_name, arguments, connection);
+        let mut handler_arguments =
+            Self::apply_hook_project_route(tool_name, arguments, connection);
         if crate::analytics::is_skill_view_tool(tool_name) {
             if let Some(request_id) = json_rpc_request_id_string(&id) {
                 if let Some(map) = handler_arguments.as_object_mut() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -25,6 +25,7 @@ use crate::tracedecay::TraceDecay;
 use super::hook_events::{self, HookAgent, HookEventPlan};
 use super::tools::{
     explore_call_budget, get_tool_definitions_with_budget, handle_tool_call_with_registry,
+    tool_dispatches_registered_project_reader,
 };
 use super::transport::{ErrorCode, JsonRpcRequest, JsonRpcResponse};
 
@@ -62,6 +63,13 @@ pub(crate) fn classify_mcp_method(method: &str) -> McpMethod {
         "ping" | "logging/setLevel" => McpMethod::TrivialAck,
         _ => McpMethod::Unknown,
     }
+}
+
+fn arguments_have_project_selector(arguments: &Value) -> bool {
+    arguments.get("project_selector").is_some()
+        || arguments.get("project_id").is_some()
+        || arguments.get("project_path").is_some()
+        || arguments.get("project_root").is_some()
 }
 
 /// The steering instructions advertised from the `initialize` handshake of a
@@ -626,6 +634,10 @@ pub struct McpServer {
     ledger_writes_started: Arc<AtomicU64>,
     ledger_writes_finished: Arc<AtomicU64>,
     ledger_write_notify: Arc<tokio::sync::Notify>,
+    /// Last project resolved from a daemon hook `cwd`. This is a connection-local
+    /// default for read-only graph tools when the caller did not pass an
+    /// explicit project selector.
+    hook_project_path: tokio::sync::RwLock<Option<String>>,
 }
 
 impl McpServer {
@@ -717,6 +729,7 @@ impl McpServer {
             ledger_writes_started: Arc::new(AtomicU64::new(0)),
             ledger_writes_finished: Arc::new(AtomicU64::new(0)),
             ledger_write_notify: Arc::new(tokio::sync::Notify::new()),
+            hook_project_path: tokio::sync::RwLock::new(None),
         });
 
         tokio::task::spawn_blocking(move || {
@@ -764,6 +777,45 @@ impl McpServer {
     /// held only for the clone, never across an await on the instance.
     async fn cg_snapshot(&self) -> Arc<TraceDecay> {
         self.cg.read().await.clone()
+    }
+
+    async fn update_hook_workspace_route(&self, event: &hook_events::HookEvent) {
+        let route = match event.cwd.as_deref() {
+            Some(cwd) => self.registered_project_containing_path(cwd).await,
+            None => None,
+        };
+        *self.hook_project_path.write().await = route;
+    }
+
+    async fn registered_project_containing_path(&self, cwd: &Path) -> Option<String> {
+        let registry = self.registry_db.as_deref()?;
+        let mut candidate = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+        loop {
+            if let Some(context) = registry.project_registry_context_by_alias(&candidate).await {
+                return Some(context.project.canonical_root);
+            }
+            if !candidate.pop() {
+                return None;
+            }
+        }
+    }
+
+    async fn apply_hook_project_route(&self, tool_name: &str, mut arguments: Value) -> Value {
+        if !tool_dispatches_registered_project_reader(tool_name)
+            || arguments_have_project_selector(&arguments)
+        {
+            return arguments;
+        }
+        let Some(project_path) = self.hook_project_path.read().await.clone() else {
+            return arguments;
+        };
+        if let Some(map) = arguments.as_object_mut() {
+            map.insert(
+                "project_selector".to_string(),
+                json!({ "path": project_path }),
+            );
+        }
+        arguments
     }
 
     /// Detects mid-session branch drift and reopens the served instance
@@ -1537,6 +1589,7 @@ impl McpServer {
         };
         let cg = self.reopen_if_branch_drifted().await;
         let root = cg.project_root().to_path_buf();
+        self.update_hook_workspace_route(&event).await;
         let current_branch = crate::branch::current_branch(&root);
         let plan = hook_events::plan_hook_event(&event, &root, current_branch.as_deref());
         self.run_hook_event_plan(cg, &root, plan).await;
@@ -1931,7 +1984,7 @@ impl McpServer {
         } else {
             None
         };
-        let mut handler_arguments = arguments;
+        let mut handler_arguments = self.apply_hook_project_route(tool_name, arguments).await;
         if crate::analytics::is_skill_view_tool(tool_name) {
             if let Some(request_id) = json_rpc_request_id_string(&id) {
                 if let Some(map) = handler_arguments.as_object_mut() {

--- a/src/mcp/tools/dispatch_policy.rs
+++ b/src/mcp/tools/dispatch_policy.rs
@@ -36,6 +36,6 @@ pub(super) fn tool_accepts_registered_project_selector(tool_name: &str) -> bool 
         || REGISTERED_PROJECT_SELECTOR_ONLY_TOOL_NAMES.contains(&tool_name)
 }
 
-pub(super) fn tool_dispatches_registered_project_reader(tool_name: &str) -> bool {
+pub(crate) fn tool_dispatches_registered_project_reader(tool_name: &str) -> bool {
     REGISTERED_PROJECT_READER_TOOL_NAMES.contains(&tool_name)
 }

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -17,6 +17,7 @@ pub use definitions::{
     explore_call_budget, format_capable_tool_names, get_tool_definitions,
     get_tool_definitions_with_budget,
 };
+pub(crate) use dispatch_policy::tool_dispatches_registered_project_reader;
 pub use handlers::{
     handle_profile_scoped_lcm_tool_call, handle_tool_call, handle_tool_call_with_registry,
 };

--- a/tests/mcp_suite/mcp_server_test.rs
+++ b/tests/mcp_suite/mcp_server_test.rs
@@ -18,7 +18,7 @@ use tracedecay::mcp::response_handles::{
 use tracedecay::mcp::transport::{ChannelTransport, McpTransport};
 use tracedecay::mcp::McpServer;
 use tracedecay::storage::{resolve_layout_for_current_profile, resolve_response_handle_root};
-use tracedecay::tracedecay::{current_timestamp, TraceDecay};
+use tracedecay::tracedecay::{current_timestamp, TraceDecay, TraceDecayOpenOptions};
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -2019,6 +2019,91 @@ async fn call_tool(server: Arc<McpServer>, id: i64, tool_name: &str, arguments: 
     )
     .await;
     response_for_id(&responses, id)
+}
+
+#[tokio::test]
+async fn hook_event_workspace_context_routes_followup_graph_reads() {
+    let home = TempDir::new().unwrap();
+    let profile_root = home.path().join(".tracedecay");
+    let global_db_path = profile_root.join("global.db");
+    let options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(global_db_path.clone()),
+    };
+
+    let active_dir = TempDir::new().unwrap();
+    let active_project = active_dir.path();
+    fs::create_dir_all(active_project.join("src")).unwrap();
+    fs::write(
+        active_project.join("src/active_only.rs"),
+        "fn active_only() -> i32 { 1 }\n",
+    )
+    .unwrap();
+    let active_cg = TraceDecay::init_with_options(active_project, options.clone())
+        .await
+        .unwrap();
+    active_cg.index_all().await.unwrap();
+
+    let target_dir = TempDir::new().unwrap();
+    let target_project = target_dir.path();
+    fs::create_dir_all(target_project.join("src")).unwrap();
+    fs::write(
+        target_project.join("src/target_only.rs"),
+        "fn target_only() -> i32 { 2 }\n",
+    )
+    .unwrap();
+    let target_cg = TraceDecay::init_with_options(target_project, options)
+        .await
+        .unwrap();
+    target_cg.index_all().await.unwrap();
+
+    let registry_db = tracedecay::global_db::GlobalDb::open_at(&global_db_path)
+        .await
+        .expect("registry opens");
+    registry_db
+        .upsert_code_project("proj_hook_active", active_project, None, None, Some("main"))
+        .await
+        .expect("active project registers");
+    registry_db
+        .upsert_code_project("proj_hook_target", target_project, None, None, Some("main"))
+        .await
+        .expect("target project registers");
+    let server =
+        McpServer::new_with_dbs(active_cg, None, None, Some(Arc::new(registry_db)), false).await;
+
+    let responses = run_server_with_messages(
+        server,
+        vec![
+            jsonrpc_notification_with_params(
+                "tracedecay/hookEvent",
+                json!({
+                    "agent": "codex",
+                    "event": "workspaceOpen",
+                    "cwd": target_project.join("src").to_string_lossy()
+                }),
+            ),
+            jsonrpc_request(
+                json!(1),
+                "tools/call",
+                json!({
+                    "name": "tracedecay_files",
+                    "arguments": {}
+                }),
+            ),
+        ],
+    )
+    .await;
+
+    let response = response_with_id(&responses, json!(1));
+    let text = extract_tool_text(&response["result"]);
+    assert!(
+        text.contains("target_only.rs"),
+        "hook workspace context should route graph reads to target project, got: {text}"
+    );
+    assert!(
+        !text.contains("active_only.rs"),
+        "ambient hook route should not fall back to active project when the hook cwd resolves"
+    );
 }
 
 fn analytics_metadata(event: &tracedecay::global_db::AnalyticsEventRecord) -> Value {

--- a/tests/mcp_suite/mcp_server_test.rs
+++ b/tests/mcp_suite/mcp_server_test.rs
@@ -2072,7 +2072,7 @@ async fn hook_event_workspace_context_routes_followup_graph_reads() {
         McpServer::new_with_dbs(active_cg, None, None, Some(Arc::new(registry_db)), false).await;
 
     let responses = run_server_with_messages(
-        server,
+        server.clone(),
         vec![
             jsonrpc_notification_with_params(
                 "tracedecay/hookEvent",
@@ -2103,6 +2103,30 @@ async fn hook_event_workspace_context_routes_followup_graph_reads() {
     assert!(
         !text.contains("active_only.rs"),
         "ambient hook route should not fall back to active project when the hook cwd resolves"
+    );
+
+    let responses = run_server_with_messages(
+        server,
+        vec![jsonrpc_request(
+            json!(2),
+            "tools/call",
+            json!({
+                "name": "tracedecay_files",
+                "arguments": {}
+            }),
+        )],
+    )
+    .await;
+
+    let response = response_with_id(&responses, json!(2));
+    let text = extract_tool_text(&response["result"]);
+    assert!(
+        text.contains("active_only.rs"),
+        "hook workspace context must not leak across socket clients, got: {text}"
+    );
+    assert!(
+        !text.contains("target_only.rs"),
+        "new socket client without a hook should use the active project"
     );
 }
 


### PR DESCRIPTION
## Summary
- Adds connection-local hook workspace routing on the MCP server.
- Resolves hook `cwd` to the nearest registered project ancestor and injects that project selector into follow-up registered-project graph reader calls when the caller did not provide an explicit selector.
- Reuses the existing graph-reader dispatch policy and adds an integration test for a hook from one registered project routing `tracedecay_files` away from the active project.

## Verification
- `CARGO_TARGET_DIR=/home/zack/projects/tracedecay/target cargo test --features test-transport --test mcp_suite hook_event_workspace_context_routes_followup_graph_reads -- --nocapture`
- `CARGO_TARGET_DIR=/home/zack/projects/tracedecay/target cargo test --features test-transport --test mcp_suite mcp_handler_test::always_loaded_graph_tool_schemas_advertise_project_selectors`
- `git diff --check`

## Known unrelated failures
- `CARGO_TARGET_DIR=/home/zack/projects/tracedecay/target cargo test --features test-transport --test mcp_suite mcp_server_test::` still has 2 failures unrelated to this change: `test_tools_call_plain_text_failure_sets_is_error` expects old changelog git failure text, and `test_error_tracking` expects status text to contain an errors field.