### PR TITLE
Fix mixed-unit session activity ordering

### DIFF
--- a/src/automation/scheduler.rs
+++ b/src/automation/scheduler.rs
@@ -52,9 +52,9 @@ impl SessionActivity {
 
 /// Reads the session-activity signal from the LCM sessions database.
 ///
-/// This is a single indexed `ORDER BY timestamp DESC LIMIT 1` lookup against
-/// the read-only store, so it is cheap and race-safe to call from every
-/// scheduler tick; concurrent ingest writers only ever move the value forward.
+/// This reads from the read-only store using bounded indexed timestamp lookups,
+/// so it is cheap and race-safe to call from every scheduler tick; concurrent
+/// ingest writers only ever move the value forward.
 pub async fn load_session_activity(sessions_db_path: &Path) -> SessionActivity {
     let Some(db) = GlobalDb::open_read_only_at(sessions_db_path).await else {
         return SessionActivity::none();

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -19,6 +19,8 @@ use crate::sessions::{
     SessionMessageRecord, SessionMessageSearchResult, SessionRecord, SessionSearchScope,
 };
 
+const UNIX_TIMESTAMP_MILLIS_THRESHOLD: i64 = 1_000_000_000_000;
+
 /// Total savings + call count for a project (or all projects when `project` is None).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SavingsTotal {
@@ -2309,27 +2311,27 @@ impl GlobalDb {
                 "WITH latest_seconds AS (
                     SELECT timestamp FROM session_messages
                     WHERE timestamp IS NOT NULL
-                      AND timestamp < 1000000000000
+                      AND timestamp < ?1
                     ORDER BY timestamp DESC
                     LIMIT 1
                  ),
                  latest_millis AS (
                     SELECT timestamp FROM session_messages
-                    WHERE timestamp >= 1000000000000
+                    WHERE timestamp >= ?1
                     ORDER BY timestamp DESC
                     LIMIT 1
                  )
                  SELECT timestamp FROM latest_seconds
                  UNION ALL
                  SELECT timestamp FROM latest_millis",
-                (),
+                [UNIX_TIMESTAMP_MILLIS_THRESHOLD],
             )
             .await
             .ok()?;
         let mut latest: Option<i64> = None;
         while let Some(row) = rows.next().await.ok()? {
             let timestamp = row.get::<i64>(0).ok()?;
-            let normalized = if timestamp >= 1_000_000_000_000 {
+            let normalized = if timestamp >= UNIX_TIMESTAMP_MILLIS_THRESHOLD {
                 timestamp / 1000
             } else {
                 timestamp

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -2299,28 +2299,44 @@ impl GlobalDb {
 
     /// Timestamp of the most recent ingested session message, in unix
     /// seconds, or `None` when no timestamped messages exist. Providers store
-    /// either seconds or milliseconds; millisecond values are normalized.
-    /// Backed by `idx_session_messages_timestamp`, so this is a cheap index
-    /// seek suitable for every automation scheduler tick.
+    /// either seconds or milliseconds; compare the newest value from each unit
+    /// bucket after normalization. Each bucket lookup is backed by
+    /// `idx_session_messages_timestamp`, keeping scheduler ticks bounded.
     pub async fn latest_session_activity_secs(&self) -> Option<i64> {
         let mut rows = self
             .conn
             .query(
-                "SELECT timestamp FROM session_messages
-                 WHERE timestamp IS NOT NULL
-                 ORDER BY timestamp DESC
-                 LIMIT 1",
+                "WITH latest_seconds AS (
+                    SELECT timestamp FROM session_messages
+                    WHERE timestamp IS NOT NULL
+                      AND timestamp < 1000000000000
+                    ORDER BY timestamp DESC
+                    LIMIT 1
+                 ),
+                 latest_millis AS (
+                    SELECT timestamp FROM session_messages
+                    WHERE timestamp >= 1000000000000
+                    ORDER BY timestamp DESC
+                    LIMIT 1
+                 )
+                 SELECT timestamp FROM latest_seconds
+                 UNION ALL
+                 SELECT timestamp FROM latest_millis",
                 (),
             )
             .await
             .ok()?;
-        let row = rows.next().await.ok()??;
-        let timestamp = row.get::<i64>(0).ok()?;
-        Some(if timestamp >= 1_000_000_000_000 {
-            timestamp / 1000
-        } else {
-            timestamp
-        })
+        let mut latest: Option<i64> = None;
+        while let Some(row) = rows.next().await.ok()? {
+            let timestamp = row.get::<i64>(0).ok()?;
+            let normalized = if timestamp >= 1_000_000_000_000 {
+                timestamp / 1000
+            } else {
+                timestamp
+            };
+            latest = Some(latest.map_or(normalized, |current| current.max(normalized)));
+        }
+        latest
     }
 
     /// Inserts or replaces a provider message. Returns `false` on any DB error.

--- a/tests/automation_runner_test/scheduler.rs
+++ b/tests/automation_runner_test/scheduler.rs
@@ -643,6 +643,47 @@ async fn load_session_activity_normalizes_millisecond_timestamps() {
     );
 }
 
+#[tokio::test]
+async fn load_session_activity_selects_newest_after_normalizing_mixed_timestamp_units() {
+    let temp = tempdir().unwrap();
+    let db_path = temp.path().join("sessions.db");
+    let db = GlobalDb::open_at(&db_path).await.expect("session db open");
+    seed_session_message_in_db(
+        &db,
+        temp.path(),
+        SeedSessionMessage {
+            provider: "cursor",
+            session_id: "activity-ms",
+            message_id: "activity-ms-message-001",
+            role: "user",
+            timestamp: 1_715_000_100_000,
+            text: "older millisecond provider timestamp",
+            source: None,
+        },
+    )
+    .await;
+    seed_session_message_in_db(
+        &db,
+        temp.path(),
+        SeedSessionMessage {
+            provider: "codex",
+            session_id: "activity-secs",
+            message_id: "activity-secs-message-001",
+            role: "user",
+            timestamp: 1_715_000_200,
+            text: "newer second provider timestamp",
+            source: None,
+        },
+    )
+    .await;
+    drop(db);
+
+    assert_eq!(
+        load_session_activity(&db_path).await,
+        SessionActivity::at(1_715_000_200)
+    );
+}
+
 #[test]
 fn config_requires_interval_secs_for_configured_interval_schedule() {
     let patch = AutomationConfigPatch {


### PR DESCRIPTION
## Summary
- normalize seconds and millisecond session message timestamps before choosing latest scheduler activity
- preserve bounded indexed lookups by comparing the newest raw timestamp from each unit bucket
- add a regression for mixed seconds/milliseconds where the newer seconds timestamp must win

Addresses review thread `PRRT_kwDOSzKG2s6N1M6A` from PR #218.

## Tests
- `TMPDIR=/home/zack/.cache/tmp-session-activity-normalized CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-session-activity-normalized cargo test --test automation_runner_test load_session_activity_selects_newest_after_normalizing_mixed_timestamp_units`
- `TMPDIR=/home/zack/.cache/tmp-session-activity-normalized CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-session-activity-normalized cargo test --test automation_runner_test load_session_activity`
- `TMPDIR=/home/zack/.cache/tmp-session-activity-normalized CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-session-activity-normalized cargo test --test automation_runner_test scheduler`
- `TMPDIR=/home/zack/.cache/tmp-session-activity-normalized CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-session-activity-normalized cargo check`
- `cargo fmt --all -- --check`