### PR TITLE
fix(automation): include skill approval timestamp in fixture

### DIFF
--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -240,6 +240,7 @@ mod tests {
                 checksum: String::new(),
                 created_at: 1,
                 updated_at: 1,
+                approved_at: None,
                 provenance: ManagedSkillProvenance {
                     source: ManagedSkillSource::AutomationRun,
                     actor: "test".to_string(),


### PR DESCRIPTION
## Summary\n- add the missing approved_at field to the staged-notice managed skill test fixture\n- restores compilation for branches based on current master after ManagedSkillMetadata gained approval timestamps\n\n## Verification\n- cargo fmt --check\n- TMPDIR=/tmp CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-approved-at cargo test --lib automation::staged_notice -- --nocapture\n- TMPDIR=/tmp CARGO_TARGET_DIR=/home/zack/.cache/tracedecay-target-approved-at cargo check