### PR TITLE
[codex] Bound LSP diagnostics refresh hangs

### DIFF
--- a/src/diagnostics/lsp/broker.rs
+++ b/src/diagnostics/lsp/broker.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::diagnostics::lsp::activity::adapter_workspace_root;
 use crate::diagnostics::lsp::adapters::{LspAdapterDefinition, LspInstallOption};
-use crate::diagnostics::lsp::client::{LspDocument, StdioLspClient};
+use crate::diagnostics::lsp::client::{LspDocument, LspRefreshTimeouts, StdioLspClient};
 use crate::diagnostics::lsp::settings::CodeDiagnosticsSettings;
 use crate::errors::{Result, TraceDecayError};
 
@@ -107,12 +107,14 @@ pub struct PreparedRefresh {
     project_root: PathBuf,
     command: String,
     args: Vec<String>,
+    epoch: u64,
     batches: Vec<RefreshBatch>,
 }
 
 pub struct CompletedRefresh {
     language: String,
     command: String,
+    epoch: u64,
     result: std::result::Result<Vec<CodeDiagnostic>, RefreshFailure>,
 }
 
@@ -123,40 +125,47 @@ impl CompletedRefresh {
 }
 
 impl PreparedRefresh {
-    pub async fn collect_diagnostics(self, diagnostics_timeout: Duration) -> CompletedRefresh {
+    pub async fn collect_diagnostics(
+        self,
+        diagnostics_quiet_timeout: Duration,
+    ) -> CompletedRefresh {
         let language = self.language.clone();
         let command = self.command.clone();
-        let result = self.collect(diagnostics_timeout).await;
+        let epoch = self.epoch;
+        let result = self.collect(diagnostics_quiet_timeout).await;
         CompletedRefresh {
             language,
             command,
+            epoch,
             result,
         }
     }
 
     async fn collect(
         self,
-        diagnostics_timeout: Duration,
+        diagnostics_quiet_timeout: Duration,
     ) -> std::result::Result<Vec<CodeDiagnostic>, RefreshFailure> {
         let mut diagnostics = Vec::new();
+        let timeouts = LspRefreshTimeouts::from_diagnostics_quiet_window(diagnostics_quiet_timeout);
         for batch in self.batches {
             let mut client_slot = batch.client.lock().await;
             let client = match client_slot.as_mut() {
                 Some(client) => client,
                 None => client_slot.insert(
-                    StdioLspClient::start(&self.command, &self.args, &batch.workspace_root)
-                        .await
-                        .map_err(|err| RefreshFailure::crashed(&err))?,
+                    StdioLspClient::start_with_timeouts(
+                        &self.command,
+                        &self.args,
+                        &batch.workspace_root,
+                        timeouts,
+                    )
+                    .await
+                    .map_err(|err| RefreshFailure::crashed(&err))?,
                 ),
             };
-            let result = client
-                .collect_document_diagnostics(
-                    &self.project_root,
-                    batch.documents,
-                    diagnostics_timeout,
-                )
-                .await;
-            match result {
+            match client
+                .collect_document_diagnostics(&self.project_root, batch.documents, timeouts)
+                .await
+            {
                 Ok(mut batch_diagnostics) => diagnostics.append(&mut batch_diagnostics),
                 Err(err) => {
                     *client_slot = None;
@@ -192,6 +201,7 @@ pub struct DiagnosticBroker {
     clients: BTreeMap<LspSessionKey, Arc<Mutex<Option<StdioLspClient>>>>,
     engine_overrides: BTreeMap<String, EngineState>,
     engine_errors: BTreeMap<String, String>,
+    refresh_epochs: BTreeMap<String, u64>,
     project_languages: BTreeSet<String>,
     backfill: BTreeMap<String, BackfillProgress>,
 }
@@ -210,6 +220,7 @@ impl DiagnosticBroker {
             clients: BTreeMap::new(),
             engine_overrides: BTreeMap::new(),
             engine_errors: BTreeMap::new(),
+            refresh_epochs: BTreeMap::new(),
             project_languages: BTreeSet::new(),
             backfill: BTreeMap::new(),
         }
@@ -327,6 +338,7 @@ impl DiagnosticBroker {
 
         self.engine_overrides
             .insert(language.to_string(), EngineState::Refreshing);
+        let epoch = self.next_refresh_epoch(language);
         let project_root = self.project_root.clone();
         let mut documents_by_root: BTreeMap<PathBuf, Vec<LspDocument>> = BTreeMap::new();
         for document in documents {
@@ -348,7 +360,7 @@ impl DiagnosticBroker {
                 };
                 let client = self
                     .clients
-                    .entry(session_key.clone())
+                    .entry(session_key)
                     .or_insert_with(|| Arc::new(Mutex::new(None)))
                     .clone();
                 RefreshBatch {
@@ -363,6 +375,7 @@ impl DiagnosticBroker {
             project_root,
             command,
             args: adapter.args,
+            epoch,
             batches,
         }))
     }
@@ -371,17 +384,26 @@ impl DiagnosticBroker {
         &mut self,
         language: &str,
         documents: Vec<LspDocument>,
-        diagnostics_timeout: Duration,
+        diagnostics_quiet_timeout: Duration,
     ) -> Result<()> {
         let Some(prepared) = self.prepare_refresh(language, documents)? else {
             return Ok(());
         };
-        let result = prepared.collect_diagnostics(diagnostics_timeout).await;
+        let result = prepared
+            .collect_diagnostics(diagnostics_quiet_timeout)
+            .await;
         self.finish_refresh(result)
     }
 
     pub fn finish_refresh(&mut self, completed: CompletedRefresh) -> Result<()> {
         let language = completed.language;
+        if self
+            .refresh_epochs
+            .get(&language)
+            .is_some_and(|current| completed.epoch < *current)
+        {
+            return Ok(());
+        }
         if !self.settings.language_enabled(&language) {
             self.engine_overrides
                 .insert(language.clone(), EngineState::Disabled);
@@ -466,6 +488,17 @@ impl DiagnosticBroker {
     fn remove_language_clients(&mut self, language: &str) {
         self.clients
             .retain(|key, _| key.language.as_str() != language);
+    }
+
+    fn next_refresh_epoch(&mut self, language: &str) -> u64 {
+        let next = self
+            .refresh_epochs
+            .get(language)
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(1);
+        self.refresh_epochs.insert(language.to_string(), next);
+        next
     }
 
     fn command_matches_current_settings(&self, language: &str, command: &str) -> bool {

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -14,6 +14,31 @@ use tokio::task::JoinHandle;
 use crate::diagnostics::lsp::broker::{CodeDiagnostic, DiagnosticSeverity};
 use crate::errors::{Result, TraceDecayError};
 
+const MIN_MESSAGE_IO_TIMEOUT: Duration = Duration::from_millis(250);
+const MIN_INITIALIZE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LspRefreshTimeouts {
+    refresh: Duration,
+    initialize_response: Duration,
+    message_io: Duration,
+    diagnostics_quiet: Duration,
+}
+
+impl LspRefreshTimeouts {
+    pub fn from_diagnostics_quiet_window(diagnostics_quiet: Duration) -> Self {
+        let message_io = diagnostics_quiet.max(MIN_MESSAGE_IO_TIMEOUT);
+        let initialize_response = message_io.max(MIN_INITIALIZE_RESPONSE_TIMEOUT);
+        let refresh = diagnostics_quiet.saturating_add(message_io);
+        Self {
+            refresh,
+            initialize_response,
+            message_io,
+            diagnostics_quiet,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LspDocument {
     pub language: String,
@@ -27,11 +52,13 @@ pub async fn collect_document_diagnostics(
     args: &[String],
     project_root: &Path,
     documents: Vec<LspDocument>,
-    diagnostics_timeout: Duration,
+    diagnostics_quiet_timeout: Duration,
 ) -> Result<Vec<CodeDiagnostic>> {
-    let mut client = StdioLspClient::start(command, args, project_root).await?;
+    let timeouts = LspRefreshTimeouts::from_diagnostics_quiet_window(diagnostics_quiet_timeout);
+    let mut client =
+        StdioLspClient::start_with_timeouts(command, args, project_root, timeouts).await?;
     client
-        .collect_document_diagnostics(project_root, documents, diagnostics_timeout)
+        .collect_document_diagnostics(project_root, documents, timeouts)
         .await
 }
 
@@ -45,7 +72,12 @@ pub struct StdioLspClient {
 }
 
 impl StdioLspClient {
-    pub async fn start(command: &str, args: &[String], project_root: &Path) -> Result<Self> {
+    pub async fn start_with_timeouts(
+        command: &str,
+        args: &[String],
+        project_root: &Path,
+        timeouts: LspRefreshTimeouts,
+    ) -> Result<Self> {
         let mut child = tokio::process::Command::new(command)
             .args(args)
             .current_dir(project_root)
@@ -71,7 +103,7 @@ impl StdioLspClient {
         let stderr_capture = Arc::new(Mutex::new(Vec::new()));
         let stderr_task = spawn_stderr_capture(stderr, Arc::clone(&stderr_capture));
 
-        write_message(
+        write_message_with_timeout(
             &mut stdin,
             json!({
                 "jsonrpc": "2.0",
@@ -94,22 +126,36 @@ impl StdioLspClient {
                     }]
                 }
             }),
+            timeouts.message_io,
         )
         .await?;
-        if let Err(err) = wait_for_initialize(&mut reader).await {
+        let initialize_result = tokio::time::timeout(
+            timeouts.initialize_response,
+            wait_for_initialize(&mut reader),
+        )
+        .await;
+        if let Err(err) = initialize_result.unwrap_or_else(|_| {
+            Err(TraceDecayError::Config {
+                message: format!(
+                    "LSP server '{command}' initialize timed out after {} ms",
+                    timeouts.initialize_response.as_millis()
+                ),
+            })
+        }) {
             let _ = child.start_kill();
             let _ = child.wait().await;
             let stderr = captured_stderr(&stderr_capture).await;
             stderr_task.abort();
             return Err(enrich_start_error(command, err, &stderr));
         }
-        write_message(
+        write_message_with_timeout(
             &mut stdin,
             json!({
                 "jsonrpc": "2.0",
                 "method": "initialized",
                 "params": {}
             }),
+            timeouts.message_io,
         )
         .await?;
 
@@ -127,15 +173,17 @@ impl StdioLspClient {
         &mut self,
         project_root: &Path,
         documents: Vec<LspDocument>,
-        diagnostics_timeout: Duration,
+        timeouts: LspRefreshTimeouts,
     ) -> Result<Vec<CodeDiagnostic>> {
         let mut uri_to_document = BTreeMap::new();
+        let refresh_deadline = tokio::time::Instant::now() + timeouts.refresh;
         for document in &documents {
             let uri = file_uri(&project_root.join(&document.relative_path));
             uri_to_document.insert(uri.clone(), document.clone());
             let next_version = self.document_versions.get(&uri).copied().unwrap_or(0) + 1;
             if next_version == 1 {
-                write_message(
+                let write_timeout = refresh_remaining(refresh_deadline, timeouts)?;
+                write_message_with_timeout(
                     &mut self.stdin,
                     json!({
                         "jsonrpc": "2.0",
@@ -149,11 +197,13 @@ impl StdioLspClient {
                             }
                         }
                     }),
+                    write_timeout,
                 )
                 .await?;
             }
             let change_version = next_version + 1;
-            write_message(
+            let write_timeout = refresh_remaining(refresh_deadline, timeouts)?;
+            write_message_with_timeout(
                 &mut self.stdin,
                 json!({
                     "jsonrpc": "2.0",
@@ -168,24 +218,30 @@ impl StdioLspClient {
                         }]
                     }
                 }),
+                write_timeout,
             )
             .await?;
             self.document_versions.insert(uri, change_version);
         }
 
         let mut diagnostics_by_uri: BTreeMap<String, Vec<CodeDiagnostic>> = BTreeMap::new();
-        let deadline = tokio::time::Instant::now() + diagnostics_timeout;
+        let quiet_deadline = tokio::time::Instant::now() + timeouts.diagnostics_quiet;
         loop {
             let now = tokio::time::Instant::now();
-            if now >= deadline {
+            if now >= quiet_deadline {
                 break;
             }
-            let remaining = deadline.saturating_duration_since(now);
+            if now >= refresh_deadline {
+                return Err(refresh_timed_out(timeouts));
+            }
+            let read_deadline = quiet_deadline.min(refresh_deadline);
             let message =
-                match tokio::time::timeout(remaining, read_message(&mut self.reader)).await {
-                    Ok(Ok(Some(message))) => message,
-                    Ok(Ok(None)) | Err(_) => break,
-                    Ok(Err(err)) => return Err(err),
+                match read_message_until(&mut self.reader, read_deadline, timeouts).await? {
+                    Some(message) => message,
+                    None if read_deadline == refresh_deadline => {
+                        return Err(refresh_timed_out(timeouts));
+                    }
+                    None => break,
                 };
             if message.method.as_deref() != Some("textDocument/publishDiagnostics") {
                 continue;
@@ -287,6 +343,43 @@ async fn write_message(stdin: &mut tokio::process::ChildStdin, value: Value) -> 
     })
 }
 
+async fn write_message_with_timeout(
+    stdin: &mut tokio::process::ChildStdin,
+    value: Value,
+    timeout: Duration,
+) -> Result<()> {
+    tokio::time::timeout(timeout, write_message(stdin, value))
+        .await
+        .map_err(|_| TraceDecayError::Config {
+            message: format!(
+                "LSP message write timed out after {} ms",
+                timeout.as_millis()
+            ),
+        })?
+}
+
+fn refresh_remaining(
+    refresh_deadline: tokio::time::Instant,
+    timeouts: LspRefreshTimeouts,
+) -> Result<Duration> {
+    let now = tokio::time::Instant::now();
+    if now >= refresh_deadline {
+        return Err(refresh_timed_out(timeouts));
+    }
+    Ok(timeouts
+        .message_io
+        .min(refresh_deadline.saturating_duration_since(now)))
+}
+
+fn refresh_timed_out(timeouts: LspRefreshTimeouts) -> TraceDecayError {
+    TraceDecayError::Config {
+        message: format!(
+            "LSP diagnostics collection timed out after {} ms",
+            timeouts.refresh.as_millis()
+        ),
+    }
+}
+
 async fn read_message(
     reader: &mut BufReader<tokio::process::ChildStdout>,
 ) -> Result<Option<JsonRpcMessage>> {
@@ -330,6 +423,105 @@ async fn read_message(
         .map_err(|e| TraceDecayError::Config {
             message: format!("failed to parse LSP message: {e}"),
         })
+}
+
+async fn read_message_until(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    deadline: tokio::time::Instant,
+    timeouts: LspRefreshTimeouts,
+) -> Result<Option<JsonRpcMessage>> {
+    let mut header = Vec::new();
+    while !header.ends_with(b"\r\n\r\n") && !header.ends_with(b"\n\n") {
+        let Some(byte) = read_byte_until(reader, deadline, !header.is_empty(), timeouts).await?
+        else {
+            return Ok(None);
+        };
+        header.push(byte);
+        if header.len() > 16 * 1024 {
+            return Err(TraceDecayError::Config {
+                message: "LSP message header exceeded 16 KiB".to_string(),
+            });
+        }
+    }
+
+    let header = String::from_utf8_lossy(&header);
+    let content_length = header.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("content-length")
+            .then(|| value.trim().parse::<usize>().ok())
+            .flatten()
+    });
+    let Some(length) = content_length else {
+        return Err(TraceDecayError::Config {
+            message: "LSP message missing Content-Length header".to_string(),
+        });
+    };
+
+    let mut body = vec![0_u8; length];
+    let mut read = 0;
+    while read < length {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Err(refresh_timed_out(timeouts));
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let bytes_read = match tokio::time::timeout(remaining, reader.read(&mut body[read..])).await
+        {
+            Ok(Ok(bytes_read)) => bytes_read,
+            Ok(Err(err)) => {
+                return Err(TraceDecayError::Config {
+                    message: format!("failed to read LSP body: {err}"),
+                });
+            }
+            Err(_) => return Err(refresh_timed_out(timeouts)),
+        };
+        if bytes_read == 0 {
+            return Err(TraceDecayError::Config {
+                message: "LSP server closed before completing message body".to_string(),
+            });
+        }
+        read += bytes_read;
+    }
+
+    serde_json::from_slice(&body)
+        .map(Some)
+        .map_err(|e| TraceDecayError::Config {
+            message: format!("failed to parse LSP message: {e}"),
+        })
+}
+
+async fn read_byte_until(
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    deadline: tokio::time::Instant,
+    partial_message: bool,
+    timeouts: LspRefreshTimeouts,
+) -> Result<Option<u8>> {
+    let now = tokio::time::Instant::now();
+    if now >= deadline {
+        return if partial_message {
+            Err(refresh_timed_out(timeouts))
+        } else {
+            Ok(None)
+        };
+    }
+    let mut byte = [0_u8; 1];
+    match tokio::time::timeout(
+        deadline.saturating_duration_since(now),
+        reader.read(&mut byte),
+    )
+    .await
+    {
+        Ok(Ok(0)) if partial_message => Err(TraceDecayError::Config {
+            message: "LSP server closed before completing message header".to_string(),
+        }),
+        Ok(Ok(0)) => Ok(None),
+        Ok(Ok(_)) => Ok(Some(byte[0])),
+        Ok(Err(err)) => Err(TraceDecayError::Config {
+            message: format!("failed to read LSP header: {err}"),
+        }),
+        Err(_) if partial_message => Err(refresh_timed_out(timeouts)),
+        Err(_) => Ok(None),
+    }
 }
 
 fn file_uri(path: &Path) -> String {

--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -10,6 +10,7 @@ const FAKE_PATH: &str = "src/lib.fake";
 // to cover a didOpen -> publishDiagnostics round trip against an
 // already-initialized fake server.
 const FAKE_LSP_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
+const OUTER_ASYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(4);
 
 #[test]
 fn builtin_registry_advertises_phase_one_setup_contract() {
@@ -173,15 +174,7 @@ async fn broker_refresh_documents_populates_cached_diagnostics() {
     let snapshot = broker.snapshot();
     assert_eq!(snapshot.summary.total_errors, 1);
     assert_eq!(snapshot.diagnostics[0].source, "fake-ls");
-    assert_eq!(
-        snapshot
-            .engines
-            .iter()
-            .find(|engine| engine.language == "fake")
-            .unwrap()
-            .state,
-        lsp::broker::EngineState::Ready
-    );
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Ready);
 }
 
 #[test]
@@ -195,12 +188,11 @@ fn broker_marks_active_command_available_before_first_refresh() {
     );
 
     let snapshot = broker.snapshot();
-    let status = snapshot
-        .engines
-        .iter()
-        .find(|engine| engine.language == FAKE_LANGUAGE)
-        .expect("fake engine status should be listed");
-    assert_eq!(status.state, lsp::broker::EngineState::Available);
+    assert_engine_state(
+        &snapshot,
+        FAKE_LANGUAGE,
+        lsp::broker::EngineState::Available,
+    );
 }
 
 #[tokio::test]
@@ -244,12 +236,7 @@ async fn broker_keeps_diagnostics_for_multiple_languages_in_one_snapshot() {
         .iter()
         .any(|diagnostic| diagnostic.language == "beta" && diagnostic.file == "src/lib.beta"));
     for language in ["alpha", "beta"] {
-        let status = snapshot
-            .engines
-            .iter()
-            .find(|engine| engine.language == language)
-            .unwrap_or_else(|| panic!("missing {language} status"));
-        assert_eq!(status.state, lsp::broker::EngineState::Ready);
+        assert_engine_state(&snapshot, language, lsp::broker::EngineState::Ready);
     }
 }
 
@@ -277,11 +264,7 @@ async fn broker_marks_missing_lsp_command_unavailable_after_refresh_failure() {
 
     assert!(err.to_string().contains("not available on PATH"));
     let snapshot = broker.snapshot();
-    let status = snapshot
-        .engines
-        .iter()
-        .find(|engine| engine.language == "fake")
-        .expect("fake engine status should be listed");
+    let status = engine_status(&snapshot, FAKE_LANGUAGE);
     assert_eq!(status.state, lsp::broker::EngineState::Unavailable);
     assert!(status
         .last_error
@@ -320,17 +303,260 @@ sys.stderr.flush()
 
     assert!(err.to_string().contains("unknown binary"));
     let snapshot = broker.snapshot();
-    let status = snapshot
-        .engines
-        .iter()
-        .find(|engine| engine.language == FAKE_LANGUAGE)
-        .expect("fake engine status should be listed");
+    let status = engine_status(&snapshot, FAKE_LANGUAGE);
     assert_eq!(status.state, lsp::broker::EngineState::Crashed);
     assert!(status
         .last_error
         .as_deref()
         .unwrap_or_default()
         .contains("unknown binary"));
+}
+
+#[tokio::test]
+async fn broker_bounds_lsp_initialize_hangs() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("hanging_initialize_lsp.py");
+    std::fs::write(&script_path, fake_lsp_script_that_never_initializes()).unwrap();
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        temp.path(),
+        vec![fake_python_adapter(FAKE_LANGUAGE, "fake", &script_path)],
+    );
+
+    let result = tokio::time::timeout(
+        OUTER_ASYNC_TIMEOUT,
+        broker.refresh_documents(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+            std::time::Duration::from_millis(50),
+        ),
+    )
+    .await;
+
+    let err = result
+        .expect("refresh should be bounded by the diagnostics timeout")
+        .expect_err("hung initialize should crash the engine");
+    assert!(err.to_string().contains("timed out"));
+    let snapshot = broker.snapshot();
+    let status = engine_status(&snapshot, FAKE_LANGUAGE);
+    assert_eq!(status.state, lsp::broker::EngineState::Crashed);
+    assert!(status
+        .last_error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("timed out"));
+}
+
+#[tokio::test]
+async fn broker_bounds_lsp_document_write_hangs() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("hanging_write_lsp.py");
+    std::fs::write(
+        &script_path,
+        fake_lsp_script_that_initializes_then_stops_reading(),
+    )
+    .unwrap();
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        temp.path(),
+        vec![fake_python_adapter(FAKE_LANGUAGE, "fake", &script_path)],
+    );
+
+    let result = tokio::time::timeout(
+        OUTER_ASYNC_TIMEOUT,
+        broker.refresh_documents(
+            FAKE_LANGUAGE,
+            vec![fake_document(
+                FAKE_LANGUAGE,
+                FAKE_PATH,
+                &"let nope\n".repeat(600_000),
+            )],
+            std::time::Duration::from_millis(50),
+        ),
+    )
+    .await;
+
+    let err = result
+        .expect("refresh should be bounded while writing document text")
+        .expect_err("hung document write should crash the engine");
+    assert!(err.to_string().contains("timed out"));
+    let snapshot = broker.snapshot();
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Crashed);
+
+    std::fs::write(&script_path, fake_lsp_script()).unwrap();
+    broker
+        .refresh_documents(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+            FAKE_LSP_TIMEOUT,
+        )
+        .await
+        .unwrap();
+
+    let snapshot = broker.snapshot();
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Ready);
+    assert_eq!(snapshot.summary.total_errors, 1);
+}
+
+#[tokio::test]
+async fn stdio_client_bounds_lsp_document_write_hangs() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("hanging_write_lsp.py");
+    std::fs::write(
+        &script_path,
+        fake_lsp_script_that_initializes_then_stops_reading(),
+    )
+    .unwrap();
+
+    let result = tokio::time::timeout(
+        OUTER_ASYNC_TIMEOUT,
+        lsp::client::collect_document_diagnostics(
+            python_command(),
+            &[script_path.display().to_string()],
+            temp.path(),
+            vec![fake_document(
+                FAKE_LANGUAGE,
+                FAKE_PATH,
+                &"let nope\n".repeat(600_000),
+            )],
+            std::time::Duration::from_millis(50),
+        ),
+    )
+    .await;
+
+    let err = result
+        .expect("client collection should be bounded while writing document text")
+        .expect_err("hung document write should fail the client collection");
+    assert!(err.to_string().contains("timed out"));
+}
+
+#[tokio::test]
+async fn broker_drops_lsp_client_after_partial_diagnostics_frame_timeout() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("partial_frame_lsp.py");
+    std::fs::write(&script_path, fake_lsp_script_with_partial_publish()).unwrap();
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        temp.path(),
+        vec![fake_python_adapter(FAKE_LANGUAGE, "fake", &script_path)],
+    );
+
+    let err = broker
+        .refresh_documents(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+            std::time::Duration::from_millis(50),
+        )
+        .await
+        .expect_err("partial diagnostics frame should crash the cached client");
+    assert!(err.to_string().contains("timed out"));
+    let snapshot = broker.snapshot();
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Crashed);
+
+    std::fs::write(&script_path, fake_lsp_script()).unwrap();
+    broker
+        .refresh_documents(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+            FAKE_LSP_TIMEOUT,
+        )
+        .await
+        .unwrap();
+
+    let snapshot = broker.snapshot();
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Ready);
+    assert_eq!(snapshot.summary.total_errors, 1);
+}
+
+#[tokio::test]
+async fn broker_waits_for_active_lsp_refresh_instead_of_timing_out_lock() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("fake_lsp.py");
+    let counter_path = temp.path().join("starts.txt");
+    std::fs::write(
+        &script_path,
+        fake_lsp_script_that_records_start(&counter_path),
+    )
+    .unwrap();
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        temp.path(),
+        vec![fake_python_adapter(FAKE_LANGUAGE, "fake", &script_path)],
+    );
+    let first = broker
+        .prepare_refresh(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+        )
+        .unwrap()
+        .expect("first refresh should prepare");
+    let second = broker
+        .prepare_refresh(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+        )
+        .unwrap()
+        .expect("second refresh should prepare");
+
+    let first_refresh = async move {
+        first
+            .collect_diagnostics(std::time::Duration::from_millis(500))
+            .await
+    };
+    let second_refresh = async move {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        second
+            .collect_diagnostics(std::time::Duration::from_millis(50))
+            .await
+    };
+    let (first_completed, second_completed) = tokio::join!(first_refresh, second_refresh);
+
+    assert!(first_completed.is_ok());
+    assert!(
+        second_completed.is_ok(),
+        "short second refresh should wait for the active refresh instead of timing out the client lock"
+    );
+    let starts = std::fs::read_to_string(counter_path).unwrap();
+    assert_eq!(starts.lines().count(), 1);
+}
+
+#[tokio::test]
+async fn broker_ignores_stale_refresh_completion() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("fake_lsp.py");
+    std::fs::write(&script_path, fake_lsp_script()).unwrap();
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        temp.path(),
+        vec![fake_python_adapter(FAKE_LANGUAGE, "fake", &script_path)],
+    );
+    let stale = broker
+        .prepare_refresh(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, "src/stale.fake", "let nope")],
+        )
+        .unwrap()
+        .expect("stale refresh should prepare");
+    let latest = broker
+        .prepare_refresh(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, "src/latest.fake", "let nope")],
+        )
+        .unwrap()
+        .expect("latest refresh should prepare");
+
+    let latest_completed = latest.collect_diagnostics(FAKE_LSP_TIMEOUT).await;
+    assert!(latest_completed.is_ok());
+    broker.finish_refresh(latest_completed).unwrap();
+
+    let stale_completed = stale.collect_diagnostics(FAKE_LSP_TIMEOUT).await;
+    assert!(stale_completed.is_ok());
+    broker.finish_refresh(stale_completed).unwrap();
+
+    let snapshot = broker.snapshot();
+    assert!(snapshot
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.file == "src/latest.fake"));
+    assert!(!snapshot
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.file == "src/stale.fake"));
 }
 
 #[tokio::test]
@@ -426,12 +652,7 @@ async fn broker_ignores_refresh_completion_after_language_is_disabled() {
     broker.finish_refresh(completed).unwrap();
 
     let snapshot = broker.snapshot();
-    let status = snapshot
-        .engines
-        .iter()
-        .find(|engine| engine.language == FAKE_LANGUAGE)
-        .expect("fake engine status should be listed");
-    assert_eq!(status.state, lsp::broker::EngineState::Disabled);
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Disabled);
     assert!(snapshot.diagnostics.is_empty());
 }
 
@@ -478,6 +699,25 @@ fn adapter<'a>(
         .iter()
         .find(|adapter| adapter.language == language)
         .unwrap_or_else(|| panic!("missing adapter for {language}"))
+}
+
+fn assert_engine_state(
+    snapshot: &lsp::broker::DiagnosticsSnapshot,
+    language: &str,
+    state: lsp::broker::EngineState,
+) {
+    assert_eq!(engine_status(snapshot, language).state, state);
+}
+
+fn engine_status<'a>(
+    snapshot: &'a lsp::broker::DiagnosticsSnapshot,
+    language: &str,
+) -> &'a lsp::broker::EngineStatus {
+    snapshot
+        .engines
+        .iter()
+        .find(|engine| engine.language == language)
+        .unwrap_or_else(|| panic!("{language} engine status should be listed"))
 }
 
 fn fake_document(language: &str, relative_path: &str, text: &str) -> lsp::client::LspDocument {
@@ -575,6 +815,48 @@ with open({:?}, "a", encoding="utf-8") as f:
     fake_lsp_script_with_preamble(&preamble, EMPTY_DIAGNOSTIC_PUBLISH)
 }
 
+fn fake_lsp_script_that_never_initializes() -> &'static str {
+    r#"
+import time
+
+time.sleep(60)
+"#
+}
+
+fn fake_lsp_script_that_initializes_then_stops_reading() -> &'static str {
+    r#"
+import json
+import sys
+import time
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("ascii").split(":", 1)
+        headers[name.lower()] = value.strip()
+    length = int(headers["content-length"])
+    return json.loads(sys.stdin.buffer.read(length).decode("utf-8"))
+
+def send(payload):
+    body = json.dumps(payload).encode("utf-8")
+    sys.stdout.buffer.write(b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n\r\n" + body)
+    sys.stdout.buffer.flush()
+
+message = read_message()
+send({"jsonrpc": "2.0", "id": message["id"], "result": {"capabilities": {"textDocumentSync": 1}}})
+time.sleep(60)
+"#
+}
+
+fn fake_lsp_script_with_partial_publish() -> String {
+    fake_lsp_script_with_preamble("", PARTIAL_DIAGNOSTIC_PUBLISH)
+}
+
 fn fake_lsp_script_with_preamble(preamble: &str, did_open_body: &str) -> String {
     let mut script = String::from(
         r#"
@@ -657,6 +939,12 @@ const INITIAL_EMPTY_THEN_DIAGNOSTIC_PUBLISH: &str = r#"        send({"jsonrpc": 
                 }]
             }
         })
+"#;
+
+const PARTIAL_DIAGNOSTIC_PUBLISH: &str = r#"        sys.stdout.buffer.write(b"Content-Length: 120\r\n\r\n{\"jsonrpc\":\"2.0\"")
+        sys.stdout.buffer.flush()
+        import time
+        time.sleep(60)
 "#;
 
 const EMPTY_DIAGNOSTIC_PUBLISH: &str = r#"        send({


### PR DESCRIPTION
## Summary

- move LSP refresh timeout ownership into the stdio client with explicit refresh, initialize-response, message-I/O, and diagnostics-quiet budgets
- keep same-client refreshes serialized without falsely timing out while waiting for the warm-client mutex
- add per-language refresh epochs so stale completions cannot overwrite newer diagnostics
- drop and recover poisoned LSP clients after initialize, write, partial-frame, or collection timeout failures

## Root Cause

The dashboard passed a diagnostics timeout, but the broker previously wrapped too much work in one batch timeout. A second refresh could spend its entire timeout merely waiting for an already-active refresh to release the cached-client mutex, then incorrectly mark a healthy engine as crashed. At the same time, direct stdio-client writes and partial diagnostic reads still needed their own protocol-level bounds.

## Fix

`LspRefreshTimeouts` now models the dashboard quiet-window policy once and the stdio client enforces it for initialize responses, message writes, total refresh work, and diagnostics reads. The broker waits for the per-session client lock outside that protocol timeout, clears crashed clients while still holding the slot, and records refresh epochs so older prepared refreshes are ignored if they finish after a newer one.

## Verification

- `cargo fmt --check`
- `cargo test -p tracedecay --test hooks_lsp_suite lsp_code_diagnostics_test`
- `cargo test -p tracedecay --test dashboard_api_test code_diagnostics`

Note: live smoke with the `master` dev binary was blocked because that binary did not resolve the existing profile-sharded dashboard index for `/home/zack/projects/tracedecay`; I did not run `tracedecay init` or mutate project storage just for a smoke test.
