### PR TITLE
fix(lsp): relax initialize timeout floor

### DIFF
--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -15,7 +15,7 @@ use crate::diagnostics::lsp::broker::{CodeDiagnostic, DiagnosticSeverity};
 use crate::errors::{Result, TraceDecayError};
 
 const MIN_MESSAGE_IO_TIMEOUT: Duration = Duration::from_millis(250);
-const MIN_INITIALIZE_RESPONSE_TIMEOUT: Duration = Duration::from_millis(500);
+const MIN_INITIALIZE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LspRefreshTimeouts {


### PR DESCRIPTION
## Summary
- raise the LSP initialize response floor from 500ms to 1000ms
- keep the message IO timeout floor at 250ms so document-write/partial-frame timeout tests stay bounded

## Why
- master CI on macOS failed after PR #243 because Python-backed fake LSP startup sometimes exceeded the 500ms initialize floor after timeout-heavy tests

## Tests
- cargo fmt -- --check
- cargo test -q --test hooks_lsp_suite lsp_code_diagnostics_test::broker_
- cargo test -q --test hooks_lsp_suite
- git diff --check
- scripts/check-conventional-commits.sh origin/master..HEAD