### PR TITLE
chore: release v0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.25](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.24...v0.0.25) - 2026-07-03
+
+### Added
+
+- *(plugin)* embed skill trees recursively + ship first support files
+- *(hooks)* inject adoption contract on Claude and Kiro
+- *(claude)* ship a Claude Code plugin bundle + sync skills
+
+### Fixed
+
+- *(build)* fail codegen clearly on a non-UTF-8 support file
+- *(kiro)* recognize the legacy steering marker on lifecycle ops
+- *(cursor)* sweep retired skills from the live bundle
+- *(claude)* escape hook path, settings guards, clean replace
+- *(plugin)* retarget cursor legacy-sweep test at retired skills
+- *(skills)* scope legacy-block fallback to single-host uninstall
+- *(skills)* remove staged overlay dir on failed swap
+- *(lsp)* return diagnostics for suppress-empty servers
+- *(jobs)* block IPv4-mapped/embedded IPv6 webhook SSRF targets
+- address Claude review findings
+- *(lsp)* relax initialize timeout floor
+
+### Other
+
+- dedup installer helpers and simplify marked-block splicing ([#254](https://github.com/ScriptedAlchemy/tracedecay/pull/254))
+- *(git)* resolve git binary once via cached git_program() ([#253](https://github.com/ScriptedAlchemy/tracedecay/pull/253))
+- *(hooks)* make hook_events git spawns resilient under load
+- *(cursor)* seed retired-skill sweep tests with tracedecay markers
+- *(plugin)* merge memory skills + split message_search lanes
+- *(plugin)* re-express cursor dispatchers as native slash commands
+- *(plugin)* collapse host bundles into one plugin/ tree
+- speed up slow junit cases
+
 ## [0.0.24](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.23...v0.0.24) - 2026-07-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.24"
+version = "0.0.25"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.24 -> 0.0.25

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.25](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.24...v0.0.25) - 2026-07-03

### Added

- *(plugin)* embed skill trees recursively + ship first support files
- *(hooks)* inject adoption contract on Claude and Kiro
- *(claude)* ship a Claude Code plugin bundle + sync skills

### Fixed

- *(build)* fail codegen clearly on a non-UTF-8 support file
- *(kiro)* recognize the legacy steering marker on lifecycle ops
- *(cursor)* sweep retired skills from the live bundle
- *(claude)* escape hook path, settings guards, clean replace
- *(plugin)* retarget cursor legacy-sweep test at retired skills
- *(skills)* scope legacy-block fallback to single-host uninstall
- *(skills)* remove staged overlay dir on failed swap
- *(lsp)* return diagnostics for suppress-empty servers
- *(jobs)* block IPv4-mapped/embedded IPv6 webhook SSRF targets
- address Claude review findings
- *(lsp)* relax initialize timeout floor

### Other

- dedup installer helpers and simplify marked-block splicing ([#254](https://github.com/ScriptedAlchemy/tracedecay/pull/254))
- *(git)* resolve git binary once via cached git_program() ([#253](https://github.com/ScriptedAlchemy/tracedecay/pull/253))
- *(hooks)* make hook_events git spawns resilient under load
- *(cursor)* seed retired-skill sweep tests with tracedecay markers
- *(plugin)* merge memory skills + split message_search lanes
- *(plugin)* re-express cursor dispatchers as native slash commands
- *(plugin)* collapse host bundles into one plugin/ tree
- speed up slow junit cases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).