### PR TITLE
fix: address Claude review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "open",
  "rayon",
  "regex",
+ "rustls 0.23.38",
  "self-replace",
  "serde",
  "serde_json",
@@ -4768,7 +4769,9 @@ dependencies = [
  "tree-sitter-hlsl",
  "tree-sitter-language",
  "ureq",
+ "url",
  "walkdir",
+ "webpki-roots 1.0.7",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,10 @@ clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 ureq = { version = "3", features = ["json"] }
+url = "2"
+webpki-roots = "1"
 tokio = { version = "1", features = ["full"] }
 thiserror = "2"
 tracing = "0.1"

--- a/dashboard/settings/src/SettingsPanel.tsx
+++ b/dashboard/settings/src/SettingsPanel.tsx
@@ -40,7 +40,7 @@ function textToGlobs(text: string): string[] {
     .filter(Boolean);
 }
 
-interface ProjectDraft {
+export interface ProjectDraft {
   includeText: string;
   excludeText: string;
   maxFileSize: string;
@@ -49,7 +49,7 @@ interface ProjectDraft {
   gitIgnore: boolean;
 }
 
-interface UserDraft {
+export interface UserDraft {
   uploadEnabled: boolean;
   watcherDebounce: string;
   extractionTimeoutSecs: string;
@@ -75,23 +75,57 @@ function userDraftFrom(settings: SettingsPayload): UserDraft {
   };
 }
 
-function projectPatchFrom(draft: ProjectDraft): ProjectSettingsPatch {
-  return {
-    include: textToGlobs(draft.includeText),
-    exclude: textToGlobs(draft.excludeText),
-    max_file_size: Number(draft.maxFileSize),
-    extract_docstrings: draft.extractDocstrings,
-    track_call_sites: draft.trackCallSites,
-    git_ignore: draft.gitIgnore,
-  };
+function sameStringList(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
-function userPatchFrom(draft: UserDraft): UserSettingsPatch {
-  return {
-    upload_enabled: draft.uploadEnabled,
-    watcher_debounce: draft.watcherDebounce.trim(),
-    extraction_timeout_secs: Number(draft.extractionTimeoutSecs),
-  };
+export function projectPatchFrom(
+  draft: ProjectDraft,
+  saved: ProjectDraft | null,
+): ProjectSettingsPatch {
+  const patch: ProjectSettingsPatch = {};
+  const include = textToGlobs(draft.includeText);
+  const exclude = textToGlobs(draft.excludeText);
+  const maxFileSize = Number(draft.maxFileSize);
+
+  if (!saved || !sameStringList(include, textToGlobs(saved.includeText))) {
+    patch.include = include;
+  }
+  if (!saved || !sameStringList(exclude, textToGlobs(saved.excludeText))) {
+    patch.exclude = exclude;
+  }
+  if (!saved || maxFileSize !== Number(saved.maxFileSize)) {
+    patch.max_file_size = maxFileSize;
+  }
+  if (!saved || draft.extractDocstrings !== saved.extractDocstrings) {
+    patch.extract_docstrings = draft.extractDocstrings;
+  }
+  if (!saved || draft.trackCallSites !== saved.trackCallSites) {
+    patch.track_call_sites = draft.trackCallSites;
+  }
+  if (!saved || draft.gitIgnore !== saved.gitIgnore) {
+    patch.git_ignore = draft.gitIgnore;
+  }
+
+  return patch;
+}
+
+export function userPatchFrom(draft: UserDraft, saved: UserDraft | null): UserSettingsPatch {
+  const patch: UserSettingsPatch = {};
+  const watcherDebounce = draft.watcherDebounce.trim();
+  const extractionTimeoutSecs = Number(draft.extractionTimeoutSecs);
+
+  if (!saved || draft.uploadEnabled !== saved.uploadEnabled) {
+    patch.upload_enabled = draft.uploadEnabled;
+  }
+  if (!saved || watcherDebounce !== saved.watcherDebounce.trim()) {
+    patch.watcher_debounce = watcherDebounce;
+  }
+  if (!saved || extractionTimeoutSecs !== Number(saved.extractionTimeoutSecs)) {
+    patch.extraction_timeout_secs = extractionTimeoutSecs;
+  }
+
+  return patch;
 }
 
 function sameDraft<T>(a: T | null, b: T | null): boolean {
@@ -165,7 +199,7 @@ export default function SettingsPanel() {
     setProjectError("");
     setProjectFieldErrors({});
     try {
-      const payload = await api.patchProject(projectPatchFrom(projectDraft));
+      const payload = await api.patchProject(projectPatchFrom(projectDraft, projectSaved));
       applySettings(payload);
       setResyncRecommended(Boolean(payload.resync_recommended));
     } catch (err) {
@@ -174,7 +208,7 @@ export default function SettingsPanel() {
     } finally {
       setProjectSaving(false);
     }
-  }, [applySettings, projectDraft]);
+  }, [applySettings, projectDraft, projectSaved]);
 
   const saveUser = useCallback(async () => {
     if (!userDraft) return;
@@ -182,7 +216,7 @@ export default function SettingsPanel() {
     setUserError("");
     setUserFieldErrors({});
     try {
-      const payload = await api.patchUser(userPatchFrom(userDraft));
+      const payload = await api.patchUser(userPatchFrom(userDraft, userSaved));
       applySettings(payload);
       setRestartRecommended(Boolean(payload.restart_recommended));
     } catch (err) {
@@ -191,7 +225,7 @@ export default function SettingsPanel() {
     } finally {
       setUserSaving(false);
     }
-  }, [applySettings, userDraft]);
+  }, [applySettings, userDraft, userSaved]);
 
   const discardProject = useCallback(() => {
     setProjectDraft(projectSaved);

--- a/dashboard/test/settings-panel-patches.vitest.ts
+++ b/dashboard/test/settings-panel-patches.vitest.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { projectPatchFrom, userPatchFrom } from "../settings/src/SettingsPanel";
+
+describe("settings panel patch builders", () => {
+  it("sends only changed project settings", () => {
+    const saved = {
+      includeText: "src/**\nREADME.md",
+      excludeText: "target/**",
+      maxFileSize: "1048576",
+      extractDocstrings: true,
+      trackCallSites: true,
+      gitIgnore: true,
+    };
+    const draft = {
+      ...saved,
+      includeText: "src/**\nREADME.md\nexamples/**",
+    };
+
+    expect(projectPatchFrom(draft, saved)).toEqual({
+      include: ["src/**", "README.md", "examples/**"],
+    });
+  });
+
+  it("sends only changed user settings", () => {
+    const saved = {
+      uploadEnabled: true,
+      watcherDebounce: "2s",
+      extractionTimeoutSecs: "60",
+    };
+    const draft = {
+      ...saved,
+      watcherDebounce: " 15s ",
+    };
+
+    expect(userPatchFrom(draft, saved)).toEqual({
+      watcher_debounce: "15s",
+    });
+  });
+});

--- a/dashboard/test/settings-panel.vitest.tsx
+++ b/dashboard/test/settings-panel.vitest.tsx
@@ -146,12 +146,7 @@ describe("SettingsPanel", () => {
 
     await waitFor(() => expect(apiMock.patchProject).toHaveBeenCalledTimes(1));
     expect(apiMock.patchProject).toHaveBeenCalledWith({
-      include: [".github/**"],
       exclude: ["target/**", "dist/**"],
-      max_file_size: 1048576,
-      extract_docstrings: true,
-      track_call_sites: true,
-      git_ignore: true,
     });
 
     await waitFor(() =>
@@ -205,9 +200,7 @@ describe("SettingsPanel", () => {
 
     await waitFor(() => expect(apiMock.patchUser).toHaveBeenCalledTimes(1));
     expect(apiMock.patchUser).toHaveBeenCalledWith({
-      upload_enabled: true,
       watcher_debounce: "15s",
-      extraction_timeout_secs: 60,
     });
 
     await waitFor(() =>

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -96,7 +96,11 @@ impl AgentIntegration for ClaudeIntegration {
 
         uninstall_mcp_server(&claude_json_path);
         uninstall_settings(&settings_path);
-        super::remove_managed_skill_prompt_index(&claude_md_path)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &claude_md_path,
+            crate::automation::skill_targets::SkillInstallTarget::Claude,
+        )?;
         uninstall_claude_md_rules(&claude_md_path);
         uninstall_subagents(&claude_dir);
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -149,16 +149,24 @@ impl AgentIntegration for CodexIntegration {
         if codex_plugin_manifest_path(home).exists() {
             plugin_dirs.push(codex_plugin_install_dir(home));
         }
-        plugin_dirs
-            .iter()
-            .map(|dir| {
-                crate::automation::skill_targets::install_managed_skills(
-                    profile_root,
-                    crate::automation::skill_targets::SkillInstallTarget::Codex,
-                    dir,
-                )
-            })
-            .collect()
+        let mut exports = Vec::new();
+        let mut errors = Vec::new();
+        for dir in plugin_dirs {
+            match crate::automation::skill_targets::install_managed_skills(
+                profile_root,
+                crate::automation::skill_targets::SkillInstallTarget::Codex,
+                &dir,
+            ) {
+                Ok(summary) => exports.push(summary),
+                Err(err) => errors.push(format!("{}: {err}", dir.display())),
+            }
+        }
+        if exports.is_empty() && !errors.is_empty() {
+            return Err(TraceDecayError::Config {
+                message: errors.join("; "),
+            });
+        }
+        Ok(exports)
     }
 
     fn export_managed_skills_local(
@@ -489,12 +497,15 @@ fn install_codex_plugin_bundle(
 ) -> Result<()> {
     write_codex_plugin_bundle_base(install_dir, tracedecay_bin, scope)?;
     install_codex_managed_skill_overlay(profile_home, install_dir)?;
-    let profile_root = crate::automation::skill_targets::profile_root_for_agent_home(profile_home);
-    crate::automation::memory_digest::sync_memory_digest_export(
-        &profile_root,
-        crate::automation::skill_targets::SkillInstallTarget::Codex,
-        install_dir,
-    )?;
+    if scope != InstallScope::ProjectLocal {
+        let profile_root =
+            crate::automation::skill_targets::profile_root_for_agent_home(profile_home);
+        crate::automation::memory_digest::sync_memory_digest_export(
+            &profile_root,
+            crate::automation::skill_targets::SkillInstallTarget::Codex,
+            install_dir,
+        )?;
+    }
     Ok(())
 }
 
@@ -710,10 +721,22 @@ fn install_codex_marketplace_entry(
 }
 
 fn uninstall_codex_plugin(home: &Path) -> Result<()> {
+    let profile_root = crate::automation::skill_targets::profile_root_for_agent_home(home);
     for install_dir in codex_plugin_cached_install_dirs(home) {
+        crate::automation::memory_digest::remove_memory_digest_export(
+            &profile_root,
+            crate::automation::skill_targets::SkillInstallTarget::Codex,
+            &install_dir,
+        )?;
         remove_codex_plugin_bootstrap_source(&install_dir)?;
     }
-    remove_codex_plugin_bootstrap_source(&codex_plugin_install_dir(home))?;
+    let install_dir = codex_plugin_install_dir(home);
+    crate::automation::memory_digest::remove_memory_digest_export(
+        &profile_root,
+        crate::automation::skill_targets::SkillInstallTarget::Codex,
+        &install_dir,
+    )?;
+    remove_codex_plugin_bootstrap_source(&install_dir)?;
     remove_codex_marketplace_entry(home)?;
     Ok(())
 }
@@ -723,6 +746,12 @@ fn uninstall_codex_repo_plugin_if_present(ctx: &InstallContext) -> Result<()> {
         return Ok(());
     };
     let install_dir = codex_repo_plugin_install_dir(&project_path);
+    let profile_root = crate::automation::skill_targets::profile_root_for_agent_home(&ctx.home);
+    crate::automation::memory_digest::remove_memory_digest_export(
+        &profile_root,
+        crate::automation::skill_targets::SkillInstallTarget::Codex,
+        &install_dir,
+    )?;
     if install_dir.join(".codex-plugin/plugin.json").exists()
         && codex_plugin_dir_is_tracedecay(&install_dir)
     {
@@ -835,11 +864,22 @@ fn codex_skill_dir_is_retired_managed(skill_dir: &Path, expected_name: &str) -> 
     let expected_name_line = format!("name: {expected_name}");
     skill_file.is_file()
         && std::fs::read_to_string(&skill_file).is_ok_and(|contents| {
-            contents
+            let expected_name_matches = contents
                 .lines()
                 .map(str::trim)
-                .any(|line| line == expected_name_line)
+                .any(|line| line == expected_name_line);
+            expected_name_matches && skill_contents_have_tracedecay_marker(&contents)
         })
+}
+
+fn skill_contents_have_tracedecay_marker(contents: &str) -> bool {
+    contents.lines().map(str::trim).any(|line| {
+        line.starts_with("name: tracedecay:")
+            || line.starts_with("description: TraceDecay ")
+            || line.contains("TraceDecay MCP")
+            || line.contains("tracedecay_")
+            || line.contains("`tracedecay:")
+    })
 }
 
 fn prune_empty_dirs(root: &Path) -> std::io::Result<()> {

--- a/src/agents/copilot.rs
+++ b/src/agents/copilot.rs
@@ -109,14 +109,26 @@ impl AgentIntegration for CopilotIntegration {
 
         let vscode_instructions =
             super::vscode_data_dir(&ctx.home).join("User/prompts/copilot-instructions.md");
-        super::remove_managed_skill_prompt_index(&vscode_instructions)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &vscode_instructions,
+            crate::automation::skill_targets::SkillInstallTarget::Agents,
+        )?;
         uninstall_prompt_rules(&vscode_instructions);
         let insiders_instructions =
             super::vscode_insiders_data_dir(&ctx.home).join("User/prompts/copilot-instructions.md");
-        super::remove_managed_skill_prompt_index(&insiders_instructions)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &insiders_instructions,
+            crate::automation::skill_targets::SkillInstallTarget::Agents,
+        )?;
         uninstall_prompt_rules(&insiders_instructions);
         let cli_instructions = super::copilot_cli_dir(&ctx.home).join("copilot-instructions.md");
-        super::remove_managed_skill_prompt_index(&cli_instructions)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &cli_instructions,
+            crate::automation::skill_targets::SkillInstallTarget::Agents,
+        )?;
         uninstall_prompt_rules(&cli_instructions);
 
         eprintln!();

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -103,7 +103,14 @@ impl AgentIntegration for CursorIntegration {
     }
 
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
-        remove_cursor_plugin_install(&cursor_plugin_install_dir(&ctx.home))?;
+        let install_dir = cursor_plugin_install_dir(&ctx.home);
+        let profile_root = crate::automation::skill_targets::profile_root_for_agent_home(&ctx.home);
+        crate::automation::memory_digest::remove_memory_digest_export(
+            &profile_root,
+            crate::automation::skill_targets::SkillInstallTarget::Cursor,
+            &install_dir,
+        )?;
+        remove_cursor_plugin_install(&install_dir)?;
         let mcp_path = ctx.home.join(".cursor/mcp.json");
         uninstall_mcp_server(&mcp_path);
         sweep_legacy_project_artifacts_at_cwd(&ctx.home);
@@ -511,7 +518,7 @@ fn remove_cursor_plugin_install(install_dir: &Path) -> Result<()> {
     // across upgrades.
     for legacy in LEGACY_PLUGIN_DIRS {
         let path = install_dir.join(legacy);
-        if path.is_dir() {
+        if path.is_dir() && cursor_legacy_plugin_dir_is_tracedecay_owned(legacy, &path) {
             std::fs::remove_dir_all(&path).ok();
         }
     }
@@ -530,6 +537,25 @@ fn remove_cursor_plugin_install(install_dir: &Path) -> Result<()> {
 
 fn remove_cursor_managed_skill_overlay(install_dir: &Path) {
     std::fs::remove_dir_all(install_dir.join("skills/agent-managed")).ok();
+}
+
+fn cursor_legacy_plugin_dir_is_tracedecay_owned(relative: &str, path: &Path) -> bool {
+    if !relative.starts_with("skills/") {
+        return true;
+    }
+    skill_file_has_tracedecay_marker(&path.join("SKILL.md"))
+}
+
+fn skill_file_has_tracedecay_marker(skill_file: &Path) -> bool {
+    std::fs::read_to_string(skill_file).is_ok_and(|contents| {
+        contents.lines().map(str::trim).any(|line| {
+            line.starts_with("name: tracedecay:")
+                || line.starts_with("description: TraceDecay ")
+                || line.contains("TraceDecay MCP")
+                || line.contains("tracedecay_")
+                || line.contains("`tracedecay:")
+        })
+    })
 }
 
 fn cursor_plugin_dir_is_tracedecay(install_dir: &Path) -> bool {

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -543,6 +543,9 @@ fn cursor_legacy_plugin_dir_is_tracedecay_owned(relative: &str, path: &Path) -> 
     if !relative.starts_with("skills/") {
         return true;
     }
+    if relative.starts_with("skills/tracedecay-") {
+        return true;
+    }
     skill_file_has_tracedecay_marker(&path.join("SKILL.md"))
 }
 

--- a/src/agents/kimi.rs
+++ b/src/agents/kimi.rs
@@ -77,7 +77,11 @@ impl AgentIntegration for KimiIntegration {
         uninstall_mcp_server(&mcp_path);
 
         let agents_md = kimi_dir.join("AGENTS.md");
-        super::remove_managed_skill_prompt_index(&agents_md)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &agents_md,
+            crate::automation::skill_targets::SkillInstallTarget::Kimi,
+        )?;
         uninstall_prompt_rules(&agents_md);
 
         eprintln!();

--- a/src/agents/kiro.rs
+++ b/src/agents/kiro.rs
@@ -230,7 +230,7 @@ impl AgentIntegration for KiroIntegration {
     fn uninstall(&self, ctx: &InstallContext) -> Result<()> {
         uninstall_mcp_server(&mcp_config_path(&ctx.home));
         remove_steering_rules(&steering_path(&ctx.home));
-        remove_kiro_managed_skill_index(&managed_skill_index_path(&ctx.home));
+        remove_kiro_managed_skill_index(&ctx.home, &managed_skill_index_path(&ctx.home));
         let agent_path = managed_agent_path(&ctx.home);
         let owned_agent = is_owned_agent_file(&agent_path);
         uninstall_managed_agent(&agent_path);
@@ -451,8 +451,8 @@ fn install_kiro_managed_skill_index<'a>(
     Ok((summary.exported_count > 0 || digest_exported).then_some(index_path))
 }
 
-fn remove_kiro_managed_skill_index(index_path: &Path) {
-    super::remove_managed_skill_prompt_index(index_path).ok();
+fn remove_kiro_managed_skill_index(home: &Path, index_path: &Path) {
+    super::remove_managed_skill_prompt_index(home, index_path, SkillInstallTarget::Kiro).ok();
 }
 
 fn install_default_agent(path: &Path, owns_agent: bool) -> Result<()> {

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -27,6 +27,7 @@ pub mod zed;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::Serialize;
 
@@ -66,9 +67,18 @@ pub(crate) fn install_managed_skill_prompt_index(
     Ok(())
 }
 
-pub(crate) fn remove_managed_skill_prompt_index(prompt_path: &Path) -> Result<()> {
-    crate::automation::skill_targets::remove_prompt_skill_index(prompt_path)?;
-    crate::automation::memory_digest::remove_memory_digest_prompt_block(prompt_path)
+pub(crate) fn remove_managed_skill_prompt_index(
+    profile_home: &Path,
+    prompt_path: &Path,
+    target: crate::automation::skill_targets::SkillInstallTarget,
+) -> Result<()> {
+    let profile_root = crate::automation::skill_targets::profile_root_for_agent_home(profile_home);
+    crate::automation::skill_targets::remove_prompt_skill_index_for_target(prompt_path, target)?;
+    crate::automation::memory_digest::remove_memory_digest_export(
+        &profile_root,
+        target,
+        prompt_path,
+    )
 }
 
 /// Per-agent outcome of a managed-skill export refresh, keyed by agent id.
@@ -651,13 +661,23 @@ pub fn safe_write_json_file(
 /// plain text rather than structured JSON. The target is not opened for writing
 /// until the final rename, so a failed write leaves the original untouched.
 pub fn safe_write_text_file(path: &Path, contents: &str, backup: Option<&Path>) -> Result<()> {
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| TraceDecayError::Config {
             message: format!("cannot create directory {}: {e}", parent.display()),
         })?;
     }
 
-    let new_path = PathBuf::from(format!("{}.new", path.display()));
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file");
+    let unique = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let new_name = format!(".{file_name}.{}.{}.new", std::process::id(), unique);
+    let new_path = path
+        .parent()
+        .map_or_else(|| PathBuf::from(&new_name), |parent| parent.join(&new_name));
     if let Err(e) = std::fs::write(&new_path, contents) {
         std::fs::remove_file(&new_path).ok();
         return Err(TraceDecayError::Config {

--- a/src/agents/opencode.rs
+++ b/src/agents/opencode.rs
@@ -71,7 +71,11 @@ impl AgentIntegration for OpenCodeIntegration {
         uninstall_mcp_server(&config_path);
 
         let global_prompt = opencode_prompt_path(&ctx.home);
-        super::remove_managed_skill_prompt_index(&global_prompt)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &global_prompt,
+            crate::automation::skill_targets::SkillInstallTarget::OpenCode,
+        )?;
         uninstall_prompt_rules(&global_prompt);
 
         eprintln!();

--- a/src/agents/vibe.rs
+++ b/src/agents/vibe.rs
@@ -101,7 +101,11 @@ impl AgentIntegration for VibeIntegration {
         let config_path = vibe_config_path(&ctx.home);
         uninstall_mcp_server(&config_path);
         let prompt_path = vibe_prompt_path(&ctx.home);
-        super::remove_managed_skill_prompt_index(&prompt_path)?;
+        super::remove_managed_skill_prompt_index(
+            &ctx.home,
+            &prompt_path,
+            crate::automation::skill_targets::SkillInstallTarget::Agents,
+        )?;
         uninstall_prompt_rules(&prompt_path);
 
         eprintln!();

--- a/src/automation/artifact_payloads.rs
+++ b/src/automation/artifact_payloads.rs
@@ -85,15 +85,22 @@ pub(super) fn traces_payload(ctx: &ArtifactPayloadContext<'_>) -> Value {
 /// `skill_writer_evidence`), so traces distinguish session-replay-backed runs
 /// from grep-only runs. Null for tasks without a mode label.
 fn context_evidence_mode(context: &Value) -> Value {
-    context
+    let modes = context
         .as_object()
-        .and_then(|object| {
+        .map(|object| {
             object
                 .values()
-                .find_map(|value| value.get("evidence_mode").filter(|mode| mode.is_string()))
+                .filter_map(|value| value.get("evidence_mode").and_then(Value::as_str))
+                .collect::<Vec<_>>()
         })
-        .cloned()
-        .unwrap_or(Value::Null)
+        .unwrap_or_default();
+    if modes.contains(&"session_replay_with_grep") {
+        json!("session_replay_with_grep")
+    } else if modes.contains(&"grep_only") {
+        json!("grep_only")
+    } else {
+        Value::Null
+    }
 }
 
 pub(super) fn feedback_payload(ctx: &ArtifactPayloadContext<'_>, trace_ref: &Value) -> Value {
@@ -546,6 +553,38 @@ mod tests {
         // The validation-replay definitions must stay outcome-free so the
         // replay gate semantics are unchanged.
         assert_eq!(evals.count, 0);
+    }
+
+    #[test]
+    fn traces_payload_prefers_replay_backed_evidence_mode_over_key_order() {
+        let (mut request, response, record) = payload_fixture();
+        request.context = json!({
+            "aaa_grep_only_evidence": {
+                "evidence_mode": "grep_only",
+            },
+            "zzz_replay_evidence": {
+                "evidence_mode": "session_replay_with_grep",
+            },
+        });
+        let outcomes = AutomationOutcomesSnapshot::default();
+        let ctx = ArtifactPayloadContext {
+            run_id: "run-outcomes",
+            task: AgentTaskKind::CombinedReview,
+            task_key: "combined_review",
+            prompt_version: "combined_review:v1",
+            policy: artifact_policy(AgentTaskKind::CombinedReview),
+            request: &request,
+            response: &response,
+            record: &record,
+            outcomes: &outcomes,
+        };
+
+        let payload = traces_payload(&ctx);
+
+        assert_eq!(
+            payload.pointer("/evidence_mode").unwrap(),
+            &json!("session_replay_with_grep")
+        );
     }
 
     #[test]

--- a/src/automation/job_webhook.rs
+++ b/src/automation/job_webhook.rs
@@ -1,0 +1,394 @@
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::Value;
+use url::{Host, Url};
+
+use crate::errors::{Result, TraceDecayError};
+
+pub(crate) fn validate_url(raw: &str) -> Result<()> {
+    let url = parse_url(raw)?;
+    let host = url.host().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })?;
+    validate_host(&host)
+}
+
+pub(crate) fn post_json_url(raw_url: &str, payload: &Value, timeout: Duration) -> Result<u16> {
+    let url = parse_url(raw_url)?;
+    let endpoint = resolve_endpoint(&url)?;
+    post_json(&endpoint, payload, timeout)
+}
+
+fn parse_url(raw: &str) -> Result<Url> {
+    let url = Url::parse(raw).map_err(|e| TraceDecayError::Config {
+        message: format!("invalid job webhook delivery url: {e}"),
+    })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return job_error("job webhook delivery url must use http:// or https://");
+    }
+    if url.host().is_none() {
+        return job_error("job webhook delivery url must include a host");
+    }
+    Ok(url)
+}
+
+fn validate_host(host: &Host<&str>) -> Result<()> {
+    match host {
+        Host::Domain(domain) => {
+            let normalized = domain.trim_end_matches('.').to_ascii_lowercase();
+            if is_localhost_like_domain(&normalized) {
+                return job_error("job webhook delivery url must not target localhost");
+            }
+        }
+        Host::Ipv4(ip) => validate_ip(IpAddr::V4(*ip))?,
+        Host::Ipv6(ip) => validate_ip(IpAddr::V6(*ip))?,
+    }
+    Ok(())
+}
+
+fn is_localhost_like_domain(domain: &str) -> bool {
+    matches!(domain, "localhost" | "localhost.localdomain")
+        || domain.ends_with(".localhost")
+        || domain.ends_with(".localhost.localdomain")
+}
+
+fn validate_ip(ip: IpAddr) -> Result<()> {
+    if is_disallowed_ip(ip) {
+        return job_error("job webhook delivery url must not target private or local networks");
+    }
+    Ok(())
+}
+
+fn is_disallowed_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_disallowed_ipv4(ip),
+        IpAddr::V6(ip) => is_disallowed_ipv6(ip),
+    }
+}
+
+fn is_disallowed_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, d] = ip.octets();
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 198 && matches!(b, 18 | 19))
+        || (224..=255).contains(&a)
+        || (a == 0 && (b, c, d) != (0, 0, 0))
+}
+
+fn is_disallowed_ipv6(ip: Ipv6Addr) -> bool {
+    if let Some(v4) = embedded_ipv4(ip) {
+        return is_disallowed_ipv4(v4);
+    }
+    let segments = ip.segments();
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || ((segments[0] & 0xfe00) == 0xfc00)
+        || ((segments[0] & 0xffc0) == 0xfe80)
+        || ((segments[0] & 0xff00) == 0xff00)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+}
+
+fn embedded_ipv4(ip: Ipv6Addr) -> Option<Ipv4Addr> {
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return Some(v4);
+    }
+    let segments = ip.segments();
+    if segments[0] == 0x2002 {
+        let [a, b] = segments[1].to_be_bytes();
+        let [c, d] = segments[2].to_be_bytes();
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let [a, b] = (!segments[6]).to_be_bytes();
+        let [c, d] = (!segments[7]).to_be_bytes();
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    if segments[..6].iter().all(|s| *s == 0) && !(segments[6] == 0 && segments[7] == 0) {
+        let [a, b] = segments[6].to_be_bytes();
+        let [c, d] = segments[7].to_be_bytes();
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    None
+}
+
+#[derive(Debug, Clone)]
+struct WebhookEndpoint {
+    url: Url,
+    connect_addr: SocketAddr,
+}
+
+impl WebhookEndpoint {
+    #[cfg(test)]
+    fn new_for_test(url: Url, connect_addr: SocketAddr) -> Self {
+        Self { url, connect_addr }
+    }
+}
+
+fn resolve_endpoint(url: &Url) -> Result<WebhookEndpoint> {
+    let host = url.host().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })?;
+    validate_host(&host)?;
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "job webhook delivery url must include a port for unknown schemes".to_string(),
+        })?;
+    let connect_addr = match host {
+        Host::Ipv4(ip) => SocketAddr::new(IpAddr::V4(ip), port),
+        Host::Ipv6(ip) => SocketAddr::new(IpAddr::V6(ip), port),
+        Host::Domain(host) => {
+            let addrs: Vec<SocketAddr> = (host, port)
+                .to_socket_addrs()
+                .map_err(|e| TraceDecayError::Config {
+                    message: format!("failed to resolve webhook host '{host}': {e}"),
+                })?
+                .collect();
+            if addrs.is_empty() {
+                return Err(TraceDecayError::Config {
+                    message: format!("webhook host '{host}' resolved no addresses"),
+                });
+            }
+            for addr in &addrs {
+                validate_ip(addr.ip())?;
+            }
+            addrs[0]
+        }
+    };
+    validate_ip(connect_addr.ip())?;
+    Ok(WebhookEndpoint {
+        url: url.clone(),
+        connect_addr,
+    })
+}
+
+fn post_json(endpoint: &WebhookEndpoint, payload: &Value, timeout: Duration) -> Result<u16> {
+    let body = serde_json::to_vec(payload).map_err(|e| TraceDecayError::Config {
+        message: format!("failed to encode webhook payload: {e}"),
+    })?;
+    match endpoint.url.scheme() {
+        "http" => post_json_over_http(endpoint, &body, timeout),
+        "https" => post_json_over_https(endpoint, &body, timeout),
+        _ => job_error("job webhook delivery url must use http:// or https://"),
+    }
+}
+
+fn post_json_over_http(endpoint: &WebhookEndpoint, body: &[u8], timeout: Duration) -> Result<u16> {
+    let mut stream = connect_tcp(endpoint, timeout)?;
+    write_request(&mut stream, endpoint, body)?;
+    read_status(&mut stream)
+}
+
+fn post_json_over_https(endpoint: &WebhookEndpoint, body: &[u8], timeout: Duration) -> Result<u16> {
+    let stream = connect_tcp(endpoint, timeout)?;
+    let root_store = rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let host_label = host_label(&endpoint.url)?;
+    let server_name = rustls::pki_types::ServerName::try_from(host_label).map_err(|_| {
+        TraceDecayError::Config {
+            message: "invalid webhook host for TLS verification".to_string(),
+        }
+    })?;
+    let conn = rustls::ClientConnection::new(Arc::new(config), server_name).map_err(|e| {
+        TraceDecayError::Config {
+            message: format!("failed to create webhook TLS connection: {e}"),
+        }
+    })?;
+    let mut stream = rustls::StreamOwned::new(conn, stream);
+    write_request(&mut stream, endpoint, body)?;
+    read_status(&mut stream)
+}
+
+fn connect_tcp(endpoint: &WebhookEndpoint, timeout: Duration) -> Result<TcpStream> {
+    let stream = TcpStream::connect_timeout(&endpoint.connect_addr, timeout).map_err(|e| {
+        TraceDecayError::Config {
+            message: format!(
+                "failed to connect webhook endpoint '{}': {e}",
+                endpoint.connect_addr
+            ),
+        }
+    })?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .and_then(|()| stream.set_write_timeout(Some(timeout)))
+        .map_err(|e| TraceDecayError::Config {
+            message: format!("failed to configure webhook socket timeout: {e}"),
+        })?;
+    Ok(stream)
+}
+
+fn write_request<W: Write>(writer: &mut W, endpoint: &WebhookEndpoint, body: &[u8]) -> Result<()> {
+    let path = request_target(&endpoint.url);
+    let host = host_header(&endpoint.url)?;
+    write!(
+        writer,
+        "POST {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: tracedecay-automation-jobs\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .and_then(|()| writer.write_all(body))
+    .and_then(|()| writer.flush())
+    .map_err(|e| TraceDecayError::Config {
+        message: format!("failed to write webhook request: {e}"),
+    })
+}
+
+fn read_status<R: Read>(reader: &mut R) -> Result<u16> {
+    let mut bytes = Vec::new();
+    let mut buf = [0_u8; 512];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| TraceDecayError::Config {
+            message: format!("failed to read webhook response: {e}"),
+        })?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        if bytes.windows(4).any(|window| window == b"\r\n\r\n") || bytes.len() > 8192 {
+            break;
+        }
+    }
+    let header = String::from_utf8_lossy(&bytes);
+    header
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|status| status.parse::<u16>().ok())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "webhook response did not include an HTTP status".to_string(),
+        })
+}
+
+fn request_target(url: &Url) -> String {
+    let mut target = url.path().to_string();
+    if target.is_empty() {
+        target.push('/');
+    }
+    if let Some(query) = url.query() {
+        target.push('?');
+        target.push_str(query);
+    }
+    target
+}
+
+fn host_label(url: &Url) -> Result<String> {
+    url.host_str()
+        .map(|host| host.trim_matches(['[', ']']).to_string())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "job webhook delivery url must include a host".to_string(),
+        })
+}
+
+fn host_header(url: &Url) -> Result<String> {
+    let host = url.host_str().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })?;
+    let host = match url.host().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })? {
+        Host::Ipv6(_) => format!("[{}]", host.trim_matches(['[', ']'])),
+        _ => host.to_string(),
+    };
+    let include_port = url
+        .port()
+        .is_some_and(|port| Some(port) != url.port_or_known_default());
+    if include_port {
+        let port = url.port().ok_or_else(|| TraceDecayError::Config {
+            message: "job webhook delivery url must include a port".to_string(),
+        })?;
+        Ok(format!("{host}:{port}"))
+    } else {
+        Ok(host)
+    }
+}
+
+fn job_error<T>(message: &str) -> Result<T> {
+    Err(TraceDecayError::Config {
+        message: message.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::{Read, Write};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+    use std::sync::mpsc;
+    use std::thread;
+
+    #[test]
+    fn ipv6_embedded_ipv4_targets_are_blocked() -> std::result::Result<(), std::net::AddrParseError>
+    {
+        for s in [
+            "::ffff:127.0.0.1",
+            "::ffff:169.254.169.254",
+            "::ffff:10.0.0.1",
+            "::ffff:192.168.1.1",
+            "::127.0.0.1",
+            "2002:a9fe:a9fe::",
+        ] {
+            let ip: Ipv6Addr = s.parse()?;
+            assert!(
+                is_disallowed_ipv6(ip),
+                "{s} embeds a blocked IPv4 target and must be rejected"
+            );
+        }
+        assert!(!is_disallowed_ipv6("2606:4700:4700::1111".parse()?));
+        assert!(!is_disallowed_ipv6("::ffff:93.184.216.34".parse()?));
+        Ok(())
+    }
+
+    #[test]
+    fn webhook_http_post_uses_validated_socket_addr_and_preserves_host(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let Ok((mut stream, peer)) = listener.accept() else {
+                return;
+            };
+            let mut request = Vec::new();
+            let mut buf = [0_u8; 512];
+            while let Ok(read) = stream.read(&mut buf) {
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let _ = tx.send((peer, String::from_utf8_lossy(&request).to_string()));
+            let _ = stream.write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n");
+        });
+
+        let url = Url::parse("http://webhook.example.test/hook?token=abc")?;
+        let endpoint = WebhookEndpoint::new_for_test(
+            url,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port()),
+        );
+        let status = post_json(&endpoint, &json!({"ok": true}), Duration::from_secs(10))
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        let (_peer, request) = rx.recv()?;
+
+        assert_eq!(status, 202);
+        assert!(request.starts_with("POST /hook?token=abc HTTP/1.1\r\n"));
+        assert!(request.contains("\r\nHost: webhook.example.test\r\n"));
+        assert!(request.contains("\r\nContent-Type: application/json\r\n"));
+        Ok(())
+    }
+}

--- a/src/automation/jobs.rs
+++ b/src/automation/jobs.rs
@@ -15,15 +15,11 @@
 //! pre-run command is framed as untrusted data in the prompt.
 
 use std::collections::BTreeMap;
-use std::io::{Read, Write};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use url::{Host, Url};
 
 use super::artifacts::{sha256_json, write_improvement_artifacts};
 use super::backend::{
@@ -31,6 +27,7 @@ use super::backend::{
     AgentTaskResponse,
 };
 use super::config::{AutomationBackend, AutomationConfig, AutomationHostMode};
+use super::job_webhook;
 use super::lifecycle::generated_run_id;
 use super::managed_skills::load_managed_skill;
 use super::run_ledger::{
@@ -199,297 +196,6 @@ pub async fn load_jobs(dashboard_root: &Path) -> Result<Vec<AutomationJob>> {
     }
 }
 
-fn parse_webhook_url(raw: &str) -> Result<Url> {
-    let url = Url::parse(raw).map_err(|e| TraceDecayError::Config {
-        message: format!("invalid job webhook delivery url: {e}"),
-    })?;
-    if !matches!(url.scheme(), "http" | "https") {
-        return job_error("job webhook delivery url must use http:// or https://");
-    }
-    if url.host().is_none() {
-        return job_error("job webhook delivery url must include a host");
-    }
-    Ok(url)
-}
-
-fn validate_webhook_url(raw: &str) -> Result<()> {
-    let url = parse_webhook_url(raw)?;
-    let host = url.host().ok_or_else(|| TraceDecayError::Config {
-        message: "job webhook delivery url must include a host".to_string(),
-    })?;
-    validate_webhook_host(&host)
-}
-
-fn validate_webhook_host(host: &Host<&str>) -> Result<()> {
-    match host {
-        Host::Domain(domain) => {
-            let normalized = domain.trim_end_matches('.').to_ascii_lowercase();
-            if is_localhost_like_domain(&normalized) {
-                return job_error("job webhook delivery url must not target localhost");
-            }
-        }
-        Host::Ipv4(ip) => validate_webhook_ip(IpAddr::V4(*ip))?,
-        Host::Ipv6(ip) => validate_webhook_ip(IpAddr::V6(*ip))?,
-    }
-    Ok(())
-}
-
-fn is_localhost_like_domain(domain: &str) -> bool {
-    matches!(domain, "localhost" | "localhost.localdomain")
-        || domain.ends_with(".localhost")
-        || domain.ends_with(".localhost.localdomain")
-}
-
-fn validate_webhook_ip(ip: IpAddr) -> Result<()> {
-    if is_disallowed_webhook_ip(ip) {
-        return job_error("job webhook delivery url must not target private or local networks");
-    }
-    Ok(())
-}
-
-fn is_disallowed_webhook_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ip) => is_disallowed_webhook_ipv4(ip),
-        IpAddr::V6(ip) => is_disallowed_webhook_ipv6(ip),
-    }
-}
-
-fn is_disallowed_webhook_ipv4(ip: Ipv4Addr) -> bool {
-    let [a, b, c, d] = ip.octets();
-    ip.is_loopback()
-        || ip.is_private()
-        || ip.is_link_local()
-        || ip.is_unspecified()
-        || ip.is_broadcast()
-        || ip.is_documentation()
-        || (a == 100 && (64..=127).contains(&b))
-        || (a == 192 && b == 0 && c == 0)
-        || (a == 198 && matches!(b, 18 | 19))
-        || (224..=255).contains(&a)
-        || (a == 0 && (b, c, d) != (0, 0, 0))
-}
-
-fn is_disallowed_webhook_ipv6(ip: Ipv6Addr) -> bool {
-    let segments = ip.segments();
-    ip.is_loopback()
-        || ip.is_unspecified()
-        || ((segments[0] & 0xfe00) == 0xfc00)
-        || ((segments[0] & 0xffc0) == 0xfe80)
-        || ((segments[0] & 0xff00) == 0xff00)
-        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
-}
-
-#[derive(Debug, Clone)]
-struct WebhookEndpoint {
-    url: Url,
-    connect_addr: SocketAddr,
-}
-
-impl WebhookEndpoint {
-    #[cfg(test)]
-    fn new_for_test(url: Url, connect_addr: SocketAddr) -> Self {
-        Self { url, connect_addr }
-    }
-}
-
-fn resolve_webhook_endpoint(url: &Url) -> Result<WebhookEndpoint> {
-    let host = url.host().ok_or_else(|| TraceDecayError::Config {
-        message: "job webhook delivery url must include a host".to_string(),
-    })?;
-    validate_webhook_host(&host)?;
-    let port = url
-        .port_or_known_default()
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "job webhook delivery url must include a port for unknown schemes".to_string(),
-        })?;
-    let connect_addr = match host {
-        Host::Ipv4(ip) => SocketAddr::new(IpAddr::V4(ip), port),
-        Host::Ipv6(ip) => SocketAddr::new(IpAddr::V6(ip), port),
-        Host::Domain(host) => {
-            let addrs: Vec<SocketAddr> = (host, port)
-                .to_socket_addrs()
-                .map_err(|e| TraceDecayError::Config {
-                    message: format!("failed to resolve webhook host '{host}': {e}"),
-                })?
-                .collect();
-            if addrs.is_empty() {
-                return Err(TraceDecayError::Config {
-                    message: format!("webhook host '{host}' resolved no addresses"),
-                });
-            }
-            for addr in &addrs {
-                validate_webhook_ip(addr.ip())?;
-            }
-            addrs[0]
-        }
-    };
-    validate_webhook_ip(connect_addr.ip())?;
-    Ok(WebhookEndpoint {
-        url: url.clone(),
-        connect_addr,
-    })
-}
-
-fn post_webhook_json(
-    endpoint: &WebhookEndpoint,
-    payload: &Value,
-    timeout: Duration,
-) -> Result<u16> {
-    let body = serde_json::to_vec(payload).map_err(|e| TraceDecayError::Config {
-        message: format!("failed to encode webhook payload: {e}"),
-    })?;
-    match endpoint.url.scheme() {
-        "http" => post_webhook_json_over_http(endpoint, &body, timeout),
-        "https" => post_webhook_json_over_https(endpoint, &body, timeout),
-        _ => job_error("job webhook delivery url must use http:// or https://"),
-    }
-}
-
-fn post_webhook_json_over_http(
-    endpoint: &WebhookEndpoint,
-    body: &[u8],
-    timeout: Duration,
-) -> Result<u16> {
-    let mut stream = connect_webhook_tcp(endpoint, timeout)?;
-    write_webhook_request(&mut stream, endpoint, body)?;
-    read_webhook_status(&mut stream)
-}
-
-fn post_webhook_json_over_https(
-    endpoint: &WebhookEndpoint,
-    body: &[u8],
-    timeout: Duration,
-) -> Result<u16> {
-    let stream = connect_webhook_tcp(endpoint, timeout)?;
-    let root_store = rustls::RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    };
-    let config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-    let host_label = webhook_host_label(&endpoint.url)?;
-    let server_name = rustls::pki_types::ServerName::try_from(host_label).map_err(|_| {
-        TraceDecayError::Config {
-            message: "invalid webhook host for TLS verification".to_string(),
-        }
-    })?;
-    let conn = rustls::ClientConnection::new(Arc::new(config), server_name).map_err(|e| {
-        TraceDecayError::Config {
-            message: format!("failed to create webhook TLS connection: {e}"),
-        }
-    })?;
-    let mut stream = rustls::StreamOwned::new(conn, stream);
-    write_webhook_request(&mut stream, endpoint, body)?;
-    read_webhook_status(&mut stream)
-}
-
-fn connect_webhook_tcp(endpoint: &WebhookEndpoint, timeout: Duration) -> Result<TcpStream> {
-    let stream = TcpStream::connect_timeout(&endpoint.connect_addr, timeout).map_err(|e| {
-        TraceDecayError::Config {
-            message: format!(
-                "failed to connect webhook endpoint '{}': {e}",
-                endpoint.connect_addr
-            ),
-        }
-    })?;
-    stream
-        .set_read_timeout(Some(timeout))
-        .and_then(|()| stream.set_write_timeout(Some(timeout)))
-        .map_err(|e| TraceDecayError::Config {
-            message: format!("failed to configure webhook socket timeout: {e}"),
-        })?;
-    Ok(stream)
-}
-
-fn write_webhook_request<W: Write>(
-    writer: &mut W,
-    endpoint: &WebhookEndpoint,
-    body: &[u8],
-) -> Result<()> {
-    let path = webhook_request_target(&endpoint.url);
-    let host = webhook_host_header(&endpoint.url)?;
-    write!(
-        writer,
-        "POST {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: tracedecay-automation-jobs\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n",
-        body.len()
-    )
-    .and_then(|()| writer.write_all(body))
-    .and_then(|()| writer.flush())
-    .map_err(|e| TraceDecayError::Config {
-        message: format!("failed to write webhook request: {e}"),
-    })
-}
-
-fn read_webhook_status<R: Read>(reader: &mut R) -> Result<u16> {
-    let mut bytes = Vec::new();
-    let mut buf = [0_u8; 512];
-    loop {
-        let n = reader.read(&mut buf).map_err(|e| TraceDecayError::Config {
-            message: format!("failed to read webhook response: {e}"),
-        })?;
-        if n == 0 {
-            break;
-        }
-        bytes.extend_from_slice(&buf[..n]);
-        if bytes.windows(4).any(|window| window == b"\r\n\r\n") || bytes.len() > 8192 {
-            break;
-        }
-    }
-    let header = String::from_utf8_lossy(&bytes);
-    let status = header
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .and_then(|status| status.parse::<u16>().ok())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "webhook response did not include an HTTP status".to_string(),
-        })?;
-    Ok(status)
-}
-
-fn webhook_request_target(url: &Url) -> String {
-    let mut target = url.path().to_string();
-    if target.is_empty() {
-        target.push('/');
-    }
-    if let Some(query) = url.query() {
-        target.push('?');
-        target.push_str(query);
-    }
-    target
-}
-
-fn webhook_host_label(url: &Url) -> Result<String> {
-    url.host_str()
-        .map(|host| host.trim_matches(['[', ']']).to_string())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "job webhook delivery url must include a host".to_string(),
-        })
-}
-
-fn webhook_host_header(url: &Url) -> Result<String> {
-    let host = url.host_str().ok_or_else(|| TraceDecayError::Config {
-        message: "job webhook delivery url must include a host".to_string(),
-    })?;
-    let host = match url.host().ok_or_else(|| TraceDecayError::Config {
-        message: "job webhook delivery url must include a host".to_string(),
-    })? {
-        Host::Ipv6(_) => format!("[{}]", host.trim_matches(['[', ']'])),
-        _ => host.to_string(),
-    };
-    let include_port = url
-        .port()
-        .is_some_and(|port| Some(port) != url.port_or_known_default());
-    if include_port {
-        let port = url.port().ok_or_else(|| TraceDecayError::Config {
-            message: "job webhook delivery url must include a port".to_string(),
-        })?;
-        Ok(format!("{host}:{port}"))
-    } else {
-        Ok(host)
-    }
-}
-
 pub async fn save_jobs(dashboard_root: &Path, jobs: &[AutomationJob]) -> Result<()> {
     let path = jobs_path(dashboard_root);
     if let Some(parent) = path.parent() {
@@ -557,7 +263,7 @@ pub fn validate_job(job: &AutomationJob) -> Result<()> {
         }
         JobDelivery::File { path: None } => {}
         JobDelivery::Webhook { url } => {
-            validate_webhook_url(url)?;
+            job_webhook::validate_url(url)?;
         }
     }
     Ok(())
@@ -1169,8 +875,6 @@ async fn deliver_job_output(
             }))
         }
         JobDelivery::Webhook { url } => {
-            let parsed_url = parse_webhook_url(url)?;
-            let endpoint = resolve_webhook_endpoint(&parsed_url)?;
             let payload = json!({
                 "job_id": job.id,
                 "name": job.name,
@@ -1179,9 +883,11 @@ async fn deliver_job_output(
                 "model": response.model,
                 "completed_at": current_timestamp(),
             });
+            let report_url = url.clone();
+            let post_url = url.clone();
             let status = tokio::task::spawn_blocking(move || {
-                post_webhook_json(
-                    &endpoint,
+                job_webhook::post_json_url(
+                    &post_url,
                     &payload,
                     Duration::from_secs(WEBHOOK_TIMEOUT_SECS),
                 )
@@ -1192,7 +898,7 @@ async fn deliver_job_output(
             })??;
             Ok(json!({
                 "mode": "webhook",
-                "url": url,
+                "url": report_url,
                 "status": status,
             }))
         }
@@ -1203,58 +909,4 @@ fn job_error<T>(message: &str) -> Result<T> {
     Err(TraceDecayError::Config {
         message: message.to_string(),
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::io::{Read, Write};
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
-    use std::sync::mpsc;
-    use std::thread;
-
-    #[test]
-    fn webhook_http_post_uses_validated_socket_addr_and_preserves_host(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        let addr = listener.local_addr()?;
-        let (tx, rx) = mpsc::channel();
-        thread::spawn(move || {
-            let Ok((mut stream, peer)) = listener.accept() else {
-                return;
-            };
-            let mut request = Vec::new();
-            let mut buf = [0_u8; 512];
-            while let Ok(read) = stream.read(&mut buf) {
-                if read == 0 {
-                    break;
-                }
-                request.extend_from_slice(&buf[..read]);
-                if request.windows(4).any(|window| window == b"\r\n\r\n") {
-                    break;
-                }
-            }
-            let _ = tx.send((peer, String::from_utf8_lossy(&request).to_string()));
-            let _ = stream.write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n");
-        });
-
-        let url = Url::parse("http://webhook.example.test/hook?token=abc")?;
-        let endpoint = WebhookEndpoint::new_for_test(
-            url,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port()),
-        );
-        let status = post_webhook_json(
-            &endpoint,
-            &json!({"ok": true}),
-            Duration::from_secs(WEBHOOK_TIMEOUT_SECS),
-        )
-        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
-        let (_peer, request) = rx.recv()?;
-
-        assert_eq!(status, 202);
-        assert!(request.starts_with("POST /hook?token=abc HTTP/1.1\r\n"));
-        assert!(request.contains("\r\nHost: webhook.example.test\r\n"));
-        assert!(request.contains("\r\nContent-Type: application/json\r\n"));
-        Ok(())
-    }
 }

--- a/src/automation/jobs.rs
+++ b/src/automation/jobs.rs
@@ -14,11 +14,16 @@
 //! schedule or mutate other jobs, and context gathered from skills or the
 //! pre-run command is framed as untrusted data in the prompt.
 
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream, ToSocketAddrs};
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use url::{Host, Url};
 
 use super::artifacts::{sha256_json, write_improvement_artifacts};
 use super::backend::{
@@ -103,6 +108,8 @@ pub struct AutomationJob {
     pub created_at: i64,
     #[serde(default)]
     pub updated_at: i64,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -110,6 +117,12 @@ struct AutomationJobsFile {
     schema_version: u32,
     #[serde(default)]
     jobs: Vec<AutomationJob>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AutomationJobsRawFile {
+    #[serde(default)]
+    jobs: Vec<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -161,15 +174,319 @@ fn job_lock_key(job_id: &str) -> String {
 pub async fn load_jobs(dashboard_root: &Path) -> Result<Vec<AutomationJob>> {
     let path = jobs_path(dashboard_root);
     match tokio::fs::read(&path).await {
-        Ok(bytes) => serde_json::from_slice::<AutomationJobsFile>(&bytes)
-            .map(|file| file.jobs)
-            .map_err(|e| TraceDecayError::Config {
-                message: format!("failed to parse automation jobs '{}': {e}", path.display()),
-            }),
+        Ok(bytes) => {
+            let file = serde_json::from_slice::<AutomationJobsRawFile>(&bytes).map_err(|e| {
+                TraceDecayError::Config {
+                    message: format!("failed to parse automation jobs '{}': {e}", path.display()),
+                }
+            })?;
+            let mut loaded = Vec::with_capacity(file.jobs.len());
+            for (index, entry) in file.jobs.into_iter().enumerate() {
+                match serde_json::from_value::<AutomationJob>(entry) {
+                    Ok(job) => loaded.push(job),
+                    Err(e) => eprintln!(
+                        "[tracedecay] skipped corrupt automation job entry {index} in '{}': {e}",
+                        path.display()
+                    ),
+                }
+            }
+            Ok(loaded)
+        }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
         Err(e) => Err(TraceDecayError::Config {
             message: format!("failed to read automation jobs '{}': {e}", path.display()),
         }),
+    }
+}
+
+fn parse_webhook_url(raw: &str) -> Result<Url> {
+    let url = Url::parse(raw).map_err(|e| TraceDecayError::Config {
+        message: format!("invalid job webhook delivery url: {e}"),
+    })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return job_error("job webhook delivery url must use http:// or https://");
+    }
+    if url.host().is_none() {
+        return job_error("job webhook delivery url must include a host");
+    }
+    Ok(url)
+}
+
+fn validate_webhook_url(raw: &str) -> Result<()> {
+    let url = parse_webhook_url(raw)?;
+    let host = url.host().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })?;
+    validate_webhook_host(&host)
+}
+
+fn validate_webhook_host(host: &Host<&str>) -> Result<()> {
+    match host {
+        Host::Domain(domain) => {
+            let normalized = domain.trim_end_matches('.').to_ascii_lowercase();
+            if is_localhost_like_domain(&normalized) {
+                return job_error("job webhook delivery url must not target localhost");
+            }
+        }
+        Host::Ipv4(ip) => validate_webhook_ip(IpAddr::V4(*ip))?,
+        Host::Ipv6(ip) => validate_webhook_ip(IpAddr::V6(*ip))?,
+    }
+    Ok(())
+}
+
+fn is_localhost_like_domain(domain: &str) -> bool {
+    matches!(domain, "localhost" | "localhost.localdomain")
+        || domain.ends_with(".localhost")
+        || domain.ends_with(".localhost.localdomain")
+}
+
+fn validate_webhook_ip(ip: IpAddr) -> Result<()> {
+    if is_disallowed_webhook_ip(ip) {
+        return job_error("job webhook delivery url must not target private or local networks");
+    }
+    Ok(())
+}
+
+fn is_disallowed_webhook_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => is_disallowed_webhook_ipv4(ip),
+        IpAddr::V6(ip) => is_disallowed_webhook_ipv6(ip),
+    }
+}
+
+fn is_disallowed_webhook_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, c, d] = ip.octets();
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || ip.is_broadcast()
+        || ip.is_documentation()
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 198 && matches!(b, 18 | 19))
+        || (224..=255).contains(&a)
+        || (a == 0 && (b, c, d) != (0, 0, 0))
+}
+
+fn is_disallowed_webhook_ipv6(ip: Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || ((segments[0] & 0xfe00) == 0xfc00)
+        || ((segments[0] & 0xffc0) == 0xfe80)
+        || ((segments[0] & 0xff00) == 0xff00)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8)
+}
+
+#[derive(Debug, Clone)]
+struct WebhookEndpoint {
+    url: Url,
+    connect_addr: SocketAddr,
+}
+
+impl WebhookEndpoint {
+    #[cfg(test)]
+    fn new_for_test(url: Url, connect_addr: SocketAddr) -> Self {
+        Self { url, connect_addr }
+    }
+}
+
+fn resolve_webhook_endpoint(url: &Url) -> Result<WebhookEndpoint> {
+    let host = url.host().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })?;
+    validate_webhook_host(&host)?;
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "job webhook delivery url must include a port for unknown schemes".to_string(),
+        })?;
+    let connect_addr = match host {
+        Host::Ipv4(ip) => SocketAddr::new(IpAddr::V4(ip), port),
+        Host::Ipv6(ip) => SocketAddr::new(IpAddr::V6(ip), port),
+        Host::Domain(host) => {
+            let addrs: Vec<SocketAddr> = (host, port)
+                .to_socket_addrs()
+                .map_err(|e| TraceDecayError::Config {
+                    message: format!("failed to resolve webhook host '{host}': {e}"),
+                })?
+                .collect();
+            if addrs.is_empty() {
+                return Err(TraceDecayError::Config {
+                    message: format!("webhook host '{host}' resolved no addresses"),
+                });
+            }
+            for addr in &addrs {
+                validate_webhook_ip(addr.ip())?;
+            }
+            addrs[0]
+        }
+    };
+    validate_webhook_ip(connect_addr.ip())?;
+    Ok(WebhookEndpoint {
+        url: url.clone(),
+        connect_addr,
+    })
+}
+
+fn post_webhook_json(
+    endpoint: &WebhookEndpoint,
+    payload: &Value,
+    timeout: Duration,
+) -> Result<u16> {
+    let body = serde_json::to_vec(payload).map_err(|e| TraceDecayError::Config {
+        message: format!("failed to encode webhook payload: {e}"),
+    })?;
+    match endpoint.url.scheme() {
+        "http" => post_webhook_json_over_http(endpoint, &body, timeout),
+        "https" => post_webhook_json_over_https(endpoint, &body, timeout),
+        _ => job_error("job webhook delivery url must use http:// or https://"),
+    }
+}
+
+fn post_webhook_json_over_http(
+    endpoint: &WebhookEndpoint,
+    body: &[u8],
+    timeout: Duration,
+) -> Result<u16> {
+    let mut stream = connect_webhook_tcp(endpoint, timeout)?;
+    write_webhook_request(&mut stream, endpoint, body)?;
+    read_webhook_status(&mut stream)
+}
+
+fn post_webhook_json_over_https(
+    endpoint: &WebhookEndpoint,
+    body: &[u8],
+    timeout: Duration,
+) -> Result<u16> {
+    let stream = connect_webhook_tcp(endpoint, timeout)?;
+    let root_store = rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let host_label = webhook_host_label(&endpoint.url)?;
+    let server_name = rustls::pki_types::ServerName::try_from(host_label).map_err(|_| {
+        TraceDecayError::Config {
+            message: "invalid webhook host for TLS verification".to_string(),
+        }
+    })?;
+    let conn = rustls::ClientConnection::new(Arc::new(config), server_name).map_err(|e| {
+        TraceDecayError::Config {
+            message: format!("failed to create webhook TLS connection: {e}"),
+        }
+    })?;
+    let mut stream = rustls::StreamOwned::new(conn, stream);
+    write_webhook_request(&mut stream, endpoint, body)?;
+    read_webhook_status(&mut stream)
+}
+
+fn connect_webhook_tcp(endpoint: &WebhookEndpoint, timeout: Duration) -> Result<TcpStream> {
+    let stream = TcpStream::connect_timeout(&endpoint.connect_addr, timeout).map_err(|e| {
+        TraceDecayError::Config {
+            message: format!(
+                "failed to connect webhook endpoint '{}': {e}",
+                endpoint.connect_addr
+            ),
+        }
+    })?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .and_then(|()| stream.set_write_timeout(Some(timeout)))
+        .map_err(|e| TraceDecayError::Config {
+            message: format!("failed to configure webhook socket timeout: {e}"),
+        })?;
+    Ok(stream)
+}
+
+fn write_webhook_request<W: Write>(
+    writer: &mut W,
+    endpoint: &WebhookEndpoint,
+    body: &[u8],
+) -> Result<()> {
+    let path = webhook_request_target(&endpoint.url);
+    let host = webhook_host_header(&endpoint.url)?;
+    write!(
+        writer,
+        "POST {path} HTTP/1.1\r\nHost: {host}\r\nUser-Agent: tracedecay-automation-jobs\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    )
+    .and_then(|()| writer.write_all(body))
+    .and_then(|()| writer.flush())
+    .map_err(|e| TraceDecayError::Config {
+        message: format!("failed to write webhook request: {e}"),
+    })
+}
+
+fn read_webhook_status<R: Read>(reader: &mut R) -> Result<u16> {
+    let mut bytes = Vec::new();
+    let mut buf = [0_u8; 512];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| TraceDecayError::Config {
+            message: format!("failed to read webhook response: {e}"),
+        })?;
+        if n == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        if bytes.windows(4).any(|window| window == b"\r\n\r\n") || bytes.len() > 8192 {
+            break;
+        }
+    }
+    let header = String::from_utf8_lossy(&bytes);
+    let status = header
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|status| status.parse::<u16>().ok())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "webhook response did not include an HTTP status".to_string(),
+        })?;
+    Ok(status)
+}
+
+fn webhook_request_target(url: &Url) -> String {
+    let mut target = url.path().to_string();
+    if target.is_empty() {
+        target.push('/');
+    }
+    if let Some(query) = url.query() {
+        target.push('?');
+        target.push_str(query);
+    }
+    target
+}
+
+fn webhook_host_label(url: &Url) -> Result<String> {
+    url.host_str()
+        .map(|host| host.trim_matches(['[', ']']).to_string())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "job webhook delivery url must include a host".to_string(),
+        })
+}
+
+fn webhook_host_header(url: &Url) -> Result<String> {
+    let host = url.host_str().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })?;
+    let host = match url.host().ok_or_else(|| TraceDecayError::Config {
+        message: "job webhook delivery url must include a host".to_string(),
+    })? {
+        Host::Ipv6(_) => format!("[{}]", host.trim_matches(['[', ']'])),
+        _ => host.to_string(),
+    };
+    let include_port = url
+        .port()
+        .is_some_and(|port| Some(port) != url.port_or_known_default());
+    if include_port {
+        let port = url.port().ok_or_else(|| TraceDecayError::Config {
+            message: "job webhook delivery url must include a port".to_string(),
+        })?;
+        Ok(format!("{host}:{port}"))
+    } else {
+        Ok(host)
     }
 }
 
@@ -240,9 +557,7 @@ pub fn validate_job(job: &AutomationJob) -> Result<()> {
         }
         JobDelivery::File { path: None } => {}
         JobDelivery::Webhook { url } => {
-            if !(url.starts_with("http://") || url.starts_with("https://")) {
-                return job_error("job webhook delivery url must start with http:// or https://");
-            }
+            validate_webhook_url(url)?;
         }
     }
     Ok(())
@@ -430,34 +745,41 @@ pub async fn run_user_job_with_backend(
         return ctx.skipped(reason, None).await;
     }
 
-    let mut scheduler_records = None;
-    let _lock = if trigger == AutomationTrigger::Scheduler {
-        let now_secs = current_timestamp();
-        let records = load_run_records(dashboard_root, JOB_LEDGER_LOOKBACK).await?;
-        let lock = AutomationTaskLock::try_acquire_keyed(
-            dashboard_root,
-            &job_lock_key(&job.id),
-            Some(DEFAULT_JOB_STALE_LOCK_SECS),
-            now_secs,
-        )
-        .await?;
-        let decision = job_schedule_decision(job, &records, now_secs);
-        scheduler_records = Some(records);
-        let Some(lock) = lock else {
-            return ctx
-                .skipped("scheduler_lock_active", scheduler_records.as_deref())
-                .await;
+    let scheduler_records = if trigger == AutomationTrigger::Scheduler {
+        Some(load_run_records(dashboard_root, JOB_LEDGER_LOOKBACK).await?)
+    } else {
+        None
+    };
+    let now_secs = current_timestamp();
+    let Some(_lock) = AutomationTaskLock::try_acquire_keyed(
+        dashboard_root,
+        &job_lock_key(&job.id),
+        Some(DEFAULT_JOB_STALE_LOCK_SECS),
+        now_secs,
+    )
+    .await?
+    else {
+        let reason = if trigger == AutomationTrigger::Scheduler {
+            "scheduler_lock_active"
+        } else {
+            "job_lock_active"
         };
+        return ctx.skipped(reason, scheduler_records.as_deref()).await;
+    };
+
+    if trigger == AutomationTrigger::Scheduler {
+        let now_secs = current_timestamp();
+        let decision = job_schedule_decision(
+            job,
+            scheduler_records.as_deref().unwrap_or_default(),
+            now_secs,
+        );
         if let Some(reason) = decision {
             return ctx.skipped(reason, scheduler_records.as_deref()).await;
         }
-        Some(lock)
-    } else {
-        if !job.enabled {
-            return ctx.skipped("user_job_disabled", None).await;
-        }
-        None
-    };
+    } else if !job.enabled {
+        return ctx.skipped("user_job_disabled", None).await;
+    }
 
     if job.pre_run_command.is_some() && !config.allow_job_commands {
         return ctx
@@ -847,6 +1169,8 @@ async fn deliver_job_output(
             }))
         }
         JobDelivery::Webhook { url } => {
+            let parsed_url = parse_webhook_url(url)?;
+            let endpoint = resolve_webhook_endpoint(&parsed_url)?;
             let payload = json!({
                 "job_id": job.id,
                 "name": job.name,
@@ -855,17 +1179,12 @@ async fn deliver_job_output(
                 "model": response.model,
                 "completed_at": current_timestamp(),
             });
-            let url_owned = url.clone();
             let status = tokio::task::spawn_blocking(move || {
-                let agent =
-                    crate::cloud::agent_with_timeout(Duration::from_secs(WEBHOOK_TIMEOUT_SECS));
-                agent
-                    .post(&url_owned)
-                    .send_json(&payload)
-                    .map(|response| response.status().as_u16())
-                    .map_err(|e| TraceDecayError::Config {
-                        message: format!("webhook POST failed: {e}"),
-                    })
+                post_webhook_json(
+                    &endpoint,
+                    &payload,
+                    Duration::from_secs(WEBHOOK_TIMEOUT_SECS),
+                )
             })
             .await
             .map_err(|e| TraceDecayError::Config {
@@ -884,4 +1203,58 @@ fn job_error<T>(message: &str) -> Result<T> {
     Err(TraceDecayError::Config {
         message: message.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+    use std::sync::mpsc;
+    use std::thread;
+
+    #[test]
+    fn webhook_http_post_uses_validated_socket_addr_and_preserves_host(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let Ok((mut stream, peer)) = listener.accept() else {
+                return;
+            };
+            let mut request = Vec::new();
+            let mut buf = [0_u8; 512];
+            while let Ok(read) = stream.read(&mut buf) {
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let _ = tx.send((peer, String::from_utf8_lossy(&request).to_string()));
+            let _ = stream.write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n");
+        });
+
+        let url = Url::parse("http://webhook.example.test/hook?token=abc")?;
+        let endpoint = WebhookEndpoint::new_for_test(
+            url,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port()),
+        );
+        let status = post_webhook_json(
+            &endpoint,
+            &json!({"ok": true}),
+            Duration::from_secs(WEBHOOK_TIMEOUT_SECS),
+        )
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        let (_peer, request) = rx.recv()?;
+
+        assert_eq!(status, 202);
+        assert!(request.starts_with("POST /hook?token=abc HTTP/1.1\r\n"));
+        assert!(request.contains("\r\nHost: webhook.example.test\r\n"));
+        assert!(request.contains("\r\nContent-Type: application/json\r\n"));
+        Ok(())
+    }
 }

--- a/src/automation/memory_digest.rs
+++ b/src/automation/memory_digest.rs
@@ -359,10 +359,8 @@ pub fn load_memory_digest_snapshot(profile_root: &Path) -> Result<MemoryDigestSn
 
 fn save_memory_digest_snapshot(profile_root: &Path, snapshot: &MemoryDigestSnapshot) -> Result<()> {
     let path = memory_digest_snapshot_path(profile_root);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::write(&path, serde_json::to_vec_pretty(snapshot)?)?;
+    let contents = serde_json::to_string_pretty(snapshot)?;
+    crate::agents::safe_write_text_file(&path, &contents, None)?;
     Ok(())
 }
 
@@ -410,10 +408,8 @@ fn load_digest_targets(profile_root: &Path) -> DigestTargetManifest {
 
 fn save_digest_targets(profile_root: &Path, manifest: &DigestTargetManifest) -> Result<()> {
     let path = digest_targets_path(profile_root);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::write(&path, serde_json::to_vec_pretty(manifest)?)?;
+    let contents = serde_json::to_string_pretty(manifest)?;
+    crate::agents::safe_write_text_file(&path, &contents, None)?;
     Ok(())
 }
 
@@ -434,6 +430,16 @@ fn record_digest_target(
     Ok(())
 }
 
+fn digest_target_output_matches(recorded: &Path, output: &Path) -> bool {
+    if recorded == output {
+        return true;
+    }
+    match (recorded.canonicalize(), output.canonicalize()) {
+        (Ok(recorded), Ok(output)) => recorded == output,
+        _ => false,
+    }
+}
+
 fn unrecord_digest_target(
     profile_root: &Path,
     target: SkillInstallTarget,
@@ -441,9 +447,9 @@ fn unrecord_digest_target(
 ) -> Result<()> {
     let mut manifest = load_digest_targets(profile_root);
     let before = manifest.targets.len();
-    manifest
-        .targets
-        .retain(|entry| !(entry.target == target && entry.output == output));
+    manifest.targets.retain(|entry| {
+        !(entry.target == target && digest_target_output_matches(&entry.output, output))
+    });
     if manifest.targets.len() != before {
         save_digest_targets(profile_root, &manifest)?;
     }
@@ -539,10 +545,7 @@ fn export_native_digest(
     body: &str,
 ) -> Result<PathBuf> {
     let path = plugin_root.join(native_digest_relative(target)?);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    fs::write(&path, render_native_digest_file(target, body)?)?;
+    crate::agents::safe_write_text_file(&path, &render_native_digest_file(target, body)?, None)?;
     Ok(path)
 }
 
@@ -631,10 +634,7 @@ fn export_prompt_digest(prompt_path: &Path, body: &str) -> Result<()> {
     let block = render_prompt_digest_block(body);
     let updated = replace_or_append_digest_block(&existing, &block)?;
     if updated != existing {
-        if let Some(parent) = prompt_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(prompt_path, updated)?;
+        crate::agents::safe_write_text_file(prompt_path, &updated, None)?;
     }
     Ok(())
 }
@@ -654,7 +654,7 @@ pub fn remove_memory_digest_prompt_block(prompt_path: &Path) -> Result<()> {
     if updated.trim().is_empty() {
         fs::remove_file(prompt_path)?;
     } else {
-        fs::write(prompt_path, updated)?;
+        crate::agents::safe_write_text_file(prompt_path, &updated, None)?;
     }
     Ok(())
 }
@@ -663,6 +663,19 @@ fn hermes_host_owned_error() -> TraceDecayError {
     config_error(
         "Hermes owns its MEMORY.md snapshot; TraceDecay does not export a memory digest into Hermes",
     )
+}
+
+fn native_digest_superseded_by_host_injection(target: SkillInstallTarget) -> bool {
+    matches!(
+        target,
+        SkillInstallTarget::Cursor | SkillInstallTarget::Codex
+    )
+}
+
+fn native_digest_superseded_error(target: SkillInstallTarget) -> TraceDecayError {
+    config_error(format!(
+        "{target:?} memory digest export is delivered by the host lifecycle memory injection channel; TraceDecay only cleans up the legacy native digest artifact",
+    ))
 }
 
 /// Projects the profile snapshot into one host channel, mirroring the
@@ -678,6 +691,9 @@ pub fn export_memory_digest(
 ) -> Result<MemoryDigestExportSummary> {
     if target == SkillInstallTarget::Hermes {
         return Err(hermes_host_owned_error());
+    }
+    if native_digest_superseded_by_host_injection(target) {
+        return Err(native_digest_superseded_error(target));
     }
     let snapshot = load_memory_digest_snapshot(profile_root)?;
     let body = compose_digest_body(&snapshot, DEFAULT_DIGEST_CHAR_BUDGET);
@@ -732,6 +748,10 @@ pub fn sync_memory_digest_export(
     if target == SkillInstallTarget::Hermes {
         return Ok(false);
     }
+    if native_digest_superseded_by_host_injection(target) {
+        remove_memory_digest_export(profile_root, target, output)?;
+        return Ok(false);
+    }
     if memory_digest_export_enabled(profile_root) {
         export_memory_digest(profile_root, target, output)?;
         Ok(true)
@@ -751,6 +771,10 @@ pub fn export_memory_digest_to_recorded_targets(
     let manifest = load_digest_targets(profile_root);
     let mut summaries = Vec::new();
     for entry in &manifest.targets {
+        if native_digest_superseded_by_host_injection(entry.target) {
+            remove_memory_digest_export(profile_root, entry.target, &entry.output)?;
+            continue;
+        }
         let refreshable = if entry.target.is_native_overlay() {
             entry.output.is_dir()
         } else {

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -12,6 +12,7 @@ pub mod hermes_bridge;
 mod hermes_config_projection;
 mod hermes_pending_skills;
 mod hermes_skill_inventory;
+mod job_webhook;
 pub mod jobs;
 pub mod lifecycle;
 mod managed_skill_format;

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -731,6 +731,7 @@ async fn build_session_reflector_evidence(
             &lcm_db,
             &provider,
             session_id.as_deref(),
+            options.include_summaries,
             options.recent_sessions_limit,
             "session_reflector",
         )
@@ -837,6 +838,7 @@ async fn build_skill_writer_evidence(
             &lcm_db,
             &provider,
             None,
+            true,
             options.recent_sessions_limit,
             "skill_writer",
         )
@@ -1401,6 +1403,7 @@ async fn recent_session_replay_evidence(
     lcm_db: &GlobalDb,
     provider: &str,
     explicit_session_id: Option<&str>,
+    include_summaries: bool,
     sessions_limit: usize,
     task_name: &str,
 ) -> Result<Option<Value>> {
@@ -1448,7 +1451,11 @@ async fn recent_session_replay_evidence(
                 head_limit: SESSION_REPLAY_HEAD_TURNS,
                 tail_limit: SESSION_REPLAY_TAIL_TURNS,
                 max_snippet_chars: SESSION_REPLAY_SNIPPET_CHARS,
-                summary_limit: SESSION_REPLAY_SUMMARY_NODES,
+                summary_limit: if include_summaries {
+                    SESSION_REPLAY_SUMMARY_NODES
+                } else {
+                    0
+                },
                 max_summary_chars: SESSION_REPLAY_SUMMARY_CHARS,
             })
             .await
@@ -1469,7 +1476,11 @@ async fn recent_session_replay_evidence(
             "head_turns": SESSION_REPLAY_HEAD_TURNS,
             "tail_turns": SESSION_REPLAY_TAIL_TURNS,
             "snippet_chars": SESSION_REPLAY_SNIPPET_CHARS,
-            "summary_nodes": SESSION_REPLAY_SUMMARY_NODES,
+            "summary_nodes": if include_summaries {
+                SESSION_REPLAY_SUMMARY_NODES
+            } else {
+                0
+            },
             "summary_chars": SESSION_REPLAY_SUMMARY_CHARS,
         },
         "sessions": sessions,

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -426,8 +426,18 @@ fn swap_overlay_dirs(overlay_root: &Path, stage_root: &Path) -> Result<()> {
         fs::rename(overlay_root, &backup_root)?;
     }
     if let Err(err) = fs::rename(stage_root, overlay_root) {
+        // Remove the staged directory so a failed swap does not orphan a
+        // `.tracedecay-managed.tmp-<pid>-<nonce>` sibling on every retry.
+        fs::remove_dir_all(stage_root).ok();
         if backup_root.exists() {
-            let _ = fs::rename(&backup_root, overlay_root);
+            if let Err(restore_err) = fs::rename(&backup_root, overlay_root) {
+                tracing::warn!(
+                    backup = %backup_root.display(),
+                    overlay = %overlay_root.display(),
+                    error = %restore_err,
+                    "failed to restore managed skill overlay backup; previous content remains at backup path"
+                );
+            }
         }
         return Err(err.into());
     }

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -18,6 +18,17 @@ const NATIVE_MANIFEST_FILE: &str = ".tracedecay-managed-skills.json";
 const PROMPT_INDEX_START: &str = "<!-- TRACEDECAY MANAGED SKILLS START -->";
 const PROMPT_INDEX_END: &str = "<!-- TRACEDECAY MANAGED SKILLS END -->";
 
+const ALL_SKILL_INSTALL_TARGETS: [SkillInstallTarget; 8] = [
+    SkillInstallTarget::Cursor,
+    SkillInstallTarget::Codex,
+    SkillInstallTarget::Claude,
+    SkillInstallTarget::Agents,
+    SkillInstallTarget::OpenCode,
+    SkillInstallTarget::Kimi,
+    SkillInstallTarget::Kiro,
+    SkillInstallTarget::Hermes,
+];
+
 pub use crate::automation::managed_skills::SkillInstallTarget;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -332,14 +343,31 @@ fn replace_or_append_marked_block(
 fn remove_marked_block_for_target(existing: &str, target: SkillInstallTarget) -> Result<String> {
     let (start_marker, end_marker) = prompt_index_markers(target);
     if let Some((start, end)) = marked_block_range(existing, &start_marker, &end_marker)? {
-        Ok(remove_range(existing, start, end))
-    } else if let Some((start, end)) =
-        marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?
-    {
-        Ok(remove_range(existing, start, end))
-    } else {
-        Ok(existing.to_string())
+        return Ok(remove_range(existing, start, end));
     }
+    // Legacy fallback: older installs wrote an unslugged block. Only claim it as
+    // this target's when NO other target's slugged block is present. On a shared
+    // file mid-migration (one host slugged, another still legacy-unslugged),
+    // removing the legacy block here would delete the other host's block, so
+    // leave it untouched and let the remove-all path handle it instead.
+    if !has_other_slugged_block(existing, target) {
+        if let Some((start, end)) =
+            marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?
+        {
+            return Ok(remove_range(existing, start, end));
+        }
+    }
+    Ok(existing.to_string())
+}
+
+/// True when the file contains a slugged managed-skill block belonging to a
+/// target other than `target`.
+fn has_other_slugged_block(existing: &str, target: SkillInstallTarget) -> bool {
+    ALL_SKILL_INSTALL_TARGETS
+        .iter()
+        .copied()
+        .filter(|candidate| *candidate != target)
+        .any(|candidate| existing.contains(&prompt_index_markers(candidate).0))
 }
 
 fn remove_all_marked_blocks(existing: &str) -> Result<String> {

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -75,10 +76,10 @@ pub fn export_native_skill_overlay(
 
     let skills = load_active_managed_skills_for_target(profile_root, target)?;
     let overlay_root = plugin_root.join("skills").join(NATIVE_NAMESPACE_DIR);
-    if overlay_root.exists() {
-        fs::remove_dir_all(&overlay_root)?;
-    }
     if skills.is_empty() {
+        if overlay_root.exists() {
+            fs::remove_dir_all(&overlay_root)?;
+        }
         return Ok(SkillInstallSummary {
             target,
             output: plugin_root.to_path_buf(),
@@ -86,35 +87,55 @@ pub fn export_native_skill_overlay(
             exported: Vec::new(),
         });
     }
-    fs::create_dir_all(&overlay_root)?;
-
-    let mut exported = Vec::new();
     for skill in &skills {
         validate_managed_support_files(&skill.support_files)?;
-        let package_dir = overlay_root.join(&skill.metadata.id);
-        fs::create_dir_all(&package_dir)?;
-        let skill_path = package_dir.join("SKILL.md");
-        fs::write(&skill_path, skill.render_skill_markdown())?;
-        for support in &skill.support_files {
-            write_support_file(&package_dir, support)?;
-        }
-        exported.push(SkillExportEntry {
-            id: skill.metadata.id.clone(),
-            title: skill.metadata.title.clone(),
-            checksum: skill.metadata.checksum.clone(),
-            path: skill_path,
-        });
     }
 
-    let manifest = NativeSkillManifest {
-        version: 1,
-        target,
-        exported: exported.clone(),
-    };
-    fs::write(
-        overlay_root.join(NATIVE_MANIFEST_FILE),
-        serde_json::to_vec_pretty(&manifest)?,
-    )?;
+    let stage_root = unique_overlay_sibling(&overlay_root, "tmp");
+    if stage_root.exists() {
+        fs::remove_dir_all(&stage_root)?;
+    }
+    fs::create_dir_all(&stage_root)?;
+    let mut exported = Vec::new();
+    let write_result = (|| -> Result<()> {
+        for skill in &skills {
+            let package_dir = stage_root.join(&skill.metadata.id);
+            fs::create_dir_all(&package_dir)?;
+            let skill_path = package_dir.join("SKILL.md");
+            fs::write(&skill_path, skill.render_skill_markdown())?;
+            for support in &skill.support_files {
+                write_support_file(&package_dir, support)?;
+            }
+            exported.push(SkillExportEntry {
+                id: skill.metadata.id.clone(),
+                title: skill.metadata.title.clone(),
+                checksum: skill.metadata.checksum.clone(),
+                path: skill_path,
+            });
+        }
+
+        let manifest = NativeSkillManifest {
+            version: 1,
+            target,
+            exported: exported.clone(),
+        };
+        fs::write(
+            stage_root.join(NATIVE_MANIFEST_FILE),
+            serde_json::to_vec_pretty(&manifest)?,
+        )?;
+        Ok(())
+    })();
+    if let Err(err) = write_result {
+        fs::remove_dir_all(&stage_root).ok();
+        return Err(err);
+    }
+
+    swap_overlay_dirs(&overlay_root, &stage_root)?;
+    for entry in &mut exported {
+        if let Ok(relative) = entry.path.strip_prefix(&stage_root) {
+            entry.path = overlay_root.join(relative);
+        }
+    }
 
     Ok(SkillInstallSummary {
         target,
@@ -139,10 +160,10 @@ pub fn export_prompt_skill_index(
         Err(err) => return Err(err.into()),
     };
     let updated = if skills.is_empty() {
-        remove_marked_block(&existing)?
+        remove_marked_block_for_target(&existing, target)?
     } else {
         let block = render_prompt_index_block(target, &skills);
-        replace_or_append_marked_block(&existing, &block)?
+        replace_or_append_marked_block(&existing, target, &block)?
     };
 
     if updated != existing {
@@ -171,12 +192,29 @@ pub fn export_prompt_skill_index(
 }
 
 pub fn remove_prompt_skill_index(prompt_path: &Path) -> Result<()> {
+    remove_prompt_skill_indexes(prompt_path, None)
+}
+
+pub fn remove_prompt_skill_index_for_target(
+    prompt_path: &Path,
+    target: SkillInstallTarget,
+) -> Result<()> {
+    remove_prompt_skill_indexes(prompt_path, Some(target))
+}
+
+fn remove_prompt_skill_indexes(
+    prompt_path: &Path,
+    target: Option<SkillInstallTarget>,
+) -> Result<()> {
     let existing = match fs::read_to_string(prompt_path) {
         Ok(contents) => contents,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(err) => return Err(err.into()),
     };
-    let updated = remove_marked_block(&existing)?;
+    let updated = match target {
+        Some(target) => remove_marked_block_for_target(&existing, target)?,
+        None => remove_all_marked_blocks(&existing)?,
+    };
     if updated == existing {
         return Ok(());
     }
@@ -222,7 +260,8 @@ pub fn load_active_managed_skills_for_target(
 
 fn render_prompt_index_block(target: SkillInstallTarget, skills: &[ManagedSkill]) -> String {
     let mut block = String::new();
-    block.push_str(PROMPT_INDEX_START);
+    let (start, end) = prompt_index_markers(target);
+    block.push_str(&start);
     block.push('\n');
     block.push_str("## TraceDecay managed skills\n\n");
     let _ = write!(
@@ -243,65 +282,158 @@ fn render_prompt_index_block(target: SkillInstallTarget, skills: &[ManagedSkill]
         }
     }
 
-    block.push_str(PROMPT_INDEX_END);
+    block.push_str(&end);
     block.push('\n');
     block
 }
 
-fn replace_or_append_marked_block(existing: &str, block: &str) -> Result<String> {
-    match (
-        existing.find(PROMPT_INDEX_START),
-        existing.find(PROMPT_INDEX_END),
-    ) {
-        (Some(start), Some(end)) if start <= end => {
-            let end = end + PROMPT_INDEX_END.len();
-            let mut updated = String::new();
-            updated.push_str(existing[..start].trim_end());
-            updated.push_str("\n\n");
-            updated.push_str(block.trim_end());
-            updated.push_str("\n\n");
-            updated.push_str(existing[end..].trim_start());
-            if !updated.ends_with('\n') {
-                updated.push('\n');
-            }
-            Ok(updated)
+fn replace_or_append_marked_block(
+    existing: &str,
+    target: SkillInstallTarget,
+    block: &str,
+) -> Result<String> {
+    let (start_marker, end_marker) = prompt_index_markers(target);
+    if let Some((start, end)) = marked_block_range(existing, &start_marker, &end_marker)? {
+        let mut updated = String::new();
+        updated.push_str(existing[..start].trim_end());
+        updated.push_str("\n\n");
+        updated.push_str(block.trim_end());
+        updated.push_str("\n\n");
+        updated.push_str(existing[end..].trim_start());
+        if !updated.ends_with('\n') {
+            updated.push('\n');
         }
-        (None, None) => {
-            let mut updated = String::new();
-            updated.push_str(existing.trim_end());
-            if !updated.is_empty() {
-                updated.push_str("\n\n");
-            }
-            updated.push_str(block);
-            Ok(updated)
+        Ok(updated)
+    } else if let Some((start, end)) =
+        marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?
+    {
+        let mut updated = String::new();
+        updated.push_str(existing[..start].trim_end());
+        updated.push_str("\n\n");
+        updated.push_str(block.trim_end());
+        updated.push_str("\n\n");
+        updated.push_str(existing[end..].trim_start());
+        if !updated.ends_with('\n') {
+            updated.push('\n');
         }
+        Ok(updated)
+    } else {
+        let mut updated = String::new();
+        updated.push_str(existing.trim_end());
+        if !updated.is_empty() {
+            updated.push_str("\n\n");
+        }
+        updated.push_str(block);
+        Ok(updated)
+    }
+}
+
+fn remove_marked_block_for_target(existing: &str, target: SkillInstallTarget) -> Result<String> {
+    let (start_marker, end_marker) = prompt_index_markers(target);
+    if let Some((start, end)) = marked_block_range(existing, &start_marker, &end_marker)? {
+        Ok(remove_range(existing, start, end))
+    } else if let Some((start, end)) =
+        marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?
+    {
+        Ok(remove_range(existing, start, end))
+    } else {
+        Ok(existing.to_string())
+    }
+}
+
+fn remove_all_marked_blocks(existing: &str) -> Result<String> {
+    let mut updated = existing.to_string();
+    for target in [
+        SkillInstallTarget::Claude,
+        SkillInstallTarget::Agents,
+        SkillInstallTarget::OpenCode,
+        SkillInstallTarget::Kimi,
+        SkillInstallTarget::Kiro,
+    ] {
+        updated = remove_marked_block_for_target(&updated, target)?;
+    }
+    if let Some((start, end)) = marked_block_range(&updated, PROMPT_INDEX_START, PROMPT_INDEX_END)?
+    {
+        updated = remove_range(&updated, start, end);
+    }
+    Ok(updated)
+}
+
+fn marked_block_range(
+    existing: &str,
+    start_marker: &str,
+    end_marker: &str,
+) -> Result<Option<(usize, usize)>> {
+    match (existing.find(start_marker), existing.find(end_marker)) {
+        (Some(start), Some(end)) if start <= end => Ok(Some((start, end + end_marker.len()))),
+        (None, None) => Ok(None),
         _ => Err(config_error(
             "managed skill prompt index markers are unbalanced".to_string(),
         )),
     }
 }
 
-fn remove_marked_block(existing: &str) -> Result<String> {
-    match (
-        existing.find(PROMPT_INDEX_START),
-        existing.find(PROMPT_INDEX_END),
-    ) {
-        (Some(start), Some(end)) if start <= end => {
-            let end = end + PROMPT_INDEX_END.len();
-            let mut updated = String::new();
-            updated.push_str(existing[..start].trim_end());
-            updated.push_str("\n\n");
-            updated.push_str(existing[end..].trim_start());
-            if !updated.trim().is_empty() && !updated.ends_with('\n') {
-                updated.push('\n');
-            }
-            Ok(updated)
-        }
-        (None, None) => Ok(existing.to_string()),
-        _ => Err(config_error(
-            "managed skill prompt index markers are unbalanced".to_string(),
-        )),
+fn remove_range(existing: &str, start: usize, end: usize) -> String {
+    let mut updated = String::new();
+    updated.push_str(existing[..start].trim_end());
+    updated.push_str("\n\n");
+    updated.push_str(existing[end..].trim_start());
+    if !updated.trim().is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
     }
+    updated
+}
+
+fn prompt_index_markers(target: SkillInstallTarget) -> (String, String) {
+    let slug = target_marker_slug(target);
+    (
+        format!("<!-- TRACEDECAY MANAGED SKILLS START {slug} -->"),
+        format!("<!-- TRACEDECAY MANAGED SKILLS END {slug} -->"),
+    )
+}
+
+fn target_marker_slug(target: SkillInstallTarget) -> &'static str {
+    match target {
+        SkillInstallTarget::Cursor => "cursor",
+        SkillInstallTarget::Codex => "codex",
+        SkillInstallTarget::Claude => "claude",
+        SkillInstallTarget::Agents => "agents",
+        SkillInstallTarget::OpenCode => "opencode",
+        SkillInstallTarget::Kimi => "kimi",
+        SkillInstallTarget::Kiro => "kiro",
+        SkillInstallTarget::Hermes => "hermes",
+    }
+}
+
+fn unique_overlay_sibling(overlay_root: &Path, suffix: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    overlay_root.with_file_name(format!(
+        ".{NATIVE_NAMESPACE_DIR}.{suffix}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn swap_overlay_dirs(overlay_root: &Path, stage_root: &Path) -> Result<()> {
+    let backup_root = unique_overlay_sibling(overlay_root, "previous");
+    if backup_root.exists() {
+        fs::remove_dir_all(&backup_root)?;
+    }
+    if overlay_root.exists() {
+        fs::rename(overlay_root, &backup_root)?;
+    }
+    if let Err(err) = fs::rename(stage_root, overlay_root) {
+        if backup_root.exists() {
+            let _ = fs::rename(&backup_root, overlay_root);
+        }
+        return Err(err.into());
+    }
+    if backup_root.exists() {
+        fs::remove_dir_all(backup_root)?;
+    }
+    Ok(())
 }
 
 fn write_support_file(package_dir: &Path, support: &ManagedSupportFile) -> Result<()> {

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
+use crate::agents::safe_write_text_file;
 use crate::automation::managed_skills::{
     managed_skill_root, validate_managed_support_files, ManagedSkill, ManagedSkillState,
     ManagedSupportFile,
@@ -170,7 +171,7 @@ pub fn export_prompt_skill_index(
         if let Some(parent) = prompt_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        fs::write(prompt_path, updated)?;
+        safe_write_text_file(prompt_path, &updated, None)?;
     }
 
     let exported = skills
@@ -221,7 +222,7 @@ fn remove_prompt_skill_indexes(
     if updated.trim().is_empty() {
         fs::remove_file(prompt_path)?;
     } else {
-        fs::write(prompt_path, updated)?;
+        safe_write_text_file(prompt_path, &updated, None)?;
     }
     Ok(())
 }

--- a/src/automation/skill_writer.rs
+++ b/src/automation/skill_writer.rs
@@ -64,7 +64,11 @@ pub(crate) async fn validate_and_apply_skill_proposals(
                         match create_managed_skill_draft(profile_root, draft).await {
                             Ok(skill) => {
                                 let skill = if auto_enable_skills {
-                                    approve_managed_skill(profile_root, &skill.metadata.id).await?
+                                    let approved =
+                                        approve_managed_skill(profile_root, &skill.metadata.id)
+                                            .await?;
+                                    refresh_managed_skill_exports_after_auto_enable(profile_root);
+                                    approved
                                 } else {
                                     skill
                                 };
@@ -91,7 +95,11 @@ pub(crate) async fn validate_and_apply_skill_proposals(
                         {
                             Ok(skill) => {
                                 let skill = if auto_enable_skills {
-                                    approve_managed_skill(profile_root, &skill.metadata.id).await?
+                                    let approved =
+                                        approve_managed_skill(profile_root, &skill.metadata.id)
+                                            .await?;
+                                    refresh_managed_skill_exports_after_auto_enable(profile_root);
+                                    approved
                                 } else {
                                     skill
                                 };
@@ -373,6 +381,24 @@ fn accepted_skill_proposal_record(
         }
     }
     record
+}
+
+fn refresh_managed_skill_exports_after_auto_enable(profile_root: &Path) {
+    let Some(home) = crate::agents::home_dir() else {
+        return;
+    };
+    let project_root = std::env::current_dir().unwrap_or_else(|_| home.clone());
+    for report in
+        crate::agents::export_managed_skills_to_agent_hosts(&home, &project_root, profile_root)
+    {
+        if let Some(error) = report.error {
+            tracing::warn!(
+                agent = %report.agent,
+                error = %error,
+                "failed to refresh managed skill exports after auto-enable"
+            );
+        }
+    }
 }
 
 fn accepted_skill_approval_status(

--- a/src/automation_cli.rs
+++ b/src/automation_cli.rs
@@ -252,6 +252,7 @@ async fn handle_automation_skills_command(
     };
 
     let profile_root = tracedecay::storage::default_profile_root()?;
+    let mut refresh_exports = false;
     let skill = match action {
         AutomationSkillsAction::List { json } => {
             let skills = list_managed_skills(&profile_root).await?;
@@ -341,10 +342,22 @@ async fn handle_automation_skills_command(
             )
             .await?
         }
-        AutomationSkillsAction::Approve { id } => approve_managed_skill(&profile_root, &id).await?,
-        AutomationSkillsAction::Disable { id } => disable_managed_skill(&profile_root, &id).await?,
-        AutomationSkillsAction::Archive { id } => archive_managed_skill(&profile_root, &id).await?,
-        AutomationSkillsAction::Restore { id } => restore_managed_skill(&profile_root, &id).await?,
+        AutomationSkillsAction::Approve { id } => {
+            refresh_exports = true;
+            approve_managed_skill(&profile_root, &id).await?
+        }
+        AutomationSkillsAction::Disable { id } => {
+            refresh_exports = true;
+            disable_managed_skill(&profile_root, &id).await?
+        }
+        AutomationSkillsAction::Archive { id } => {
+            refresh_exports = true;
+            archive_managed_skill(&profile_root, &id).await?
+        }
+        AutomationSkillsAction::Restore { id } => {
+            refresh_exports = true;
+            restore_managed_skill(&profile_root, &id).await?
+        }
         AutomationSkillsAction::Install {
             target,
             output,
@@ -394,8 +407,28 @@ async fn handle_automation_skills_command(
             return Ok(());
         }
     };
+    if refresh_exports {
+        refresh_managed_skill_exports_for_cli(&profile_root);
+    }
     println!("{}", serde_json::to_string_pretty(&skill)?);
     Ok(())
+}
+
+fn refresh_managed_skill_exports_for_cli(profile_root: &std::path::Path) {
+    let Some(home) = tracedecay::agents::home_dir() else {
+        return;
+    };
+    let project_root = std::env::current_dir().unwrap_or_else(|_| home.clone());
+    for report in
+        tracedecay::agents::export_managed_skills_to_agent_hosts(&home, &project_root, profile_root)
+    {
+        if let Some(error) = report.error {
+            eprintln!(
+                "warning: failed to refresh managed skill exports for {}: {}",
+                report.agent, error
+            );
+        }
+    }
 }
 
 fn print_managed_skill(skill: &tracedecay::automation::managed_skills::ManagedSkill) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1796,9 +1796,7 @@ async fn serve_socket_client(stream: tokio::net::UnixStream, engine: DaemonEngin
                 return Err(e);
             }
         };
-        server
-            .run_connection_with_timings(&mut transport, handshake.timings)
-            .await?;
+        Box::pin(server.run_connection_with_timings(&mut transport, handshake.timings)).await?;
     } else {
         serve_projectless_client(&mut transport, &handshake.client_identity).await?;
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -808,30 +808,35 @@ pub async fn proxy_transport_to_daemon(
 ) -> Result<()> {
     let mut routed_handshake = handshake.clone();
     if let Some(line) = replay_line {
-        update_proxy_handshake_from_initialize(&mut routed_handshake, &line).await;
+        update_proxy_handshake_from_initialize(handshake, &mut routed_handshake, &line).await;
         proxy_request_line_to_daemon(socket_path, &routed_handshake, &line, transport).await?;
     }
 
     while let Some(line) = transport.read_line().await? {
-        update_proxy_handshake_from_initialize(&mut routed_handshake, &line).await;
+        update_proxy_handshake_from_initialize(handshake, &mut routed_handshake, &line).await;
         proxy_request_line_to_daemon(socket_path, &routed_handshake, &line, transport).await?;
     }
     Ok(())
 }
 
 #[cfg(unix)]
-async fn update_proxy_handshake_from_initialize(handshake: &mut DaemonHandshake, line: &str) {
-    if !handshake.allow_initialize_root_routing {
-        return;
-    }
+async fn update_proxy_handshake_from_initialize(
+    base_handshake: &DaemonHandshake,
+    handshake: &mut DaemonHandshake,
+    line: &str,
+) {
     let Ok(request) = serde_json::from_str::<JsonRpcRequest>(line.trim()) else {
         return;
     };
     if request.method != "initialize" {
         return;
     }
+    *handshake = base_handshake.clone();
+    if !base_handshake.allow_initialize_root_routing {
+        return;
+    }
     let Some(registry) =
-        crate::global_db::GlobalDb::open_at(&handshake.client_identity.global_db_path).await
+        crate::global_db::GlobalDb::open_at(&base_handshake.client_identity.global_db_path).await
     else {
         return;
     };
@@ -843,7 +848,7 @@ async fn update_proxy_handshake_from_initialize(handshake: &mut DaemonHandshake,
     else {
         return;
     };
-    if handshake.project_path.as_deref() != Some(project_path.as_path()) {
+    if base_handshake.project_path.as_deref() != Some(project_path.as_path()) {
         handshake.scope_prefix = None;
     }
     handshake.project_path = Some(project_path);
@@ -2214,6 +2219,84 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn initialize_root_routing_replaces_cached_project_and_scope() {
+        let profile = TempDir::new().expect("profile temp dir");
+        let project_a = TempDir::new().expect("project a temp dir");
+        let project_b = TempDir::new().expect("project b temp dir");
+        let project_a = project_a.path().canonicalize().expect("project a path");
+        let project_b = project_b.path().canonicalize().expect("project b path");
+        let global_db_path = profile.path().join("global.db");
+        let registry = crate::global_db::GlobalDb::open_at(&global_db_path)
+            .await
+            .expect("open registry");
+        registry
+            .upsert_code_project("project-a", &project_a, None, None, None)
+            .await
+            .expect("register project a");
+        registry
+            .upsert_code_project("project-b", &project_b, None, None, None)
+            .await
+            .expect("register project b");
+        drop(registry);
+
+        let mut base_handshake = test_handshake_defaults();
+        base_handshake.project_path = Some(project_a.clone());
+        base_handshake.scope_prefix = Some("src".to_string());
+        base_handshake.allow_initialize_root_routing = true;
+        base_handshake.client_identity = test_client_identity_for(profile.path().to_path_buf());
+        base_handshake.client_identity.global_db_path = global_db_path;
+        let mut routed_handshake = base_handshake.clone();
+
+        let line = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "roots": [{
+                    "uri": project_b.to_string_lossy(),
+                    "name": "project-b"
+                }]
+            }
+        })
+        .to_string();
+
+        super::update_proxy_handshake_from_initialize(
+            &base_handshake,
+            &mut routed_handshake,
+            &line,
+        )
+        .await;
+
+        assert_eq!(
+            routed_handshake.project_path.as_deref(),
+            Some(project_b.as_path())
+        );
+        assert_eq!(routed_handshake.scope_prefix, None);
+
+        let rerun_without_roots = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "initialize",
+            "params": {}
+        })
+        .to_string();
+        super::update_proxy_handshake_from_initialize(
+            &base_handshake,
+            &mut routed_handshake,
+            &rerun_without_roots,
+        )
+        .await;
+
+        assert_eq!(
+            routed_handshake.project_path.as_deref(),
+            Some(project_a.as_path()),
+            "reinitialize without a route must not keep the previous routed project"
+        );
+        assert_eq!(routed_handshake.scope_prefix.as_deref(), Some("src"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn serve_proxies_when_socket_already_exists() {
         let dir = TempDir::new().expect("temp dir");
         let socket = dir.path().join("daemon.sock");
@@ -2377,7 +2460,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn proxy_transport_carries_initialize_root_into_followup_handshake() {
+    async fn proxy_transport_carries_initialize_root_and_resets_on_reinitialize() {
         let dir = TempDir::new().expect("temp dir");
         let temp_root = dir.path().canonicalize().expect("canonical temp dir");
         let active_root = temp_root.join("active");
@@ -2424,7 +2507,7 @@ mod tests {
         let engine = super::DaemonEngine::default();
         let accept_task = tokio::spawn(async move {
             let mut tasks = Vec::new();
-            for _ in 0..2 {
+            for _ in 0..4 {
                 let (stream, _addr) = listener.accept().await.expect("accept daemon client");
                 let engine = engine.clone();
                 tasks.push(tokio::spawn(async move {
@@ -2467,6 +2550,33 @@ mod tests {
                 .expect("tools/call json"),
             )
             .expect("send tools/call");
+        sender
+            .send(
+                serde_json::to_string(&json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "initialize",
+                    "params": {
+                        "clientInfo": {"name": "codex", "version": "test"}
+                    }
+                }))
+                .expect("reinitialize json"),
+            )
+            .expect("send reinitialize");
+        sender
+            .send(
+                serde_json::to_string(&json!({
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "tracedecay_files",
+                        "arguments": {"format": "flat"}
+                    }
+                }))
+                .expect("post-reinitialize tools/call json"),
+            )
+            .expect("send post-reinitialize tools/call");
         drop(sender);
 
         let handshake = DaemonHandshake {
@@ -2500,6 +2610,22 @@ mod tests {
         assert!(
             !text.contains("src/active.rs"),
             "daemon proxy should not keep using the original handshake project: {text}"
+        );
+        let post_reinitialize_response = responses
+            .iter()
+            .map(|line| serde_json::from_str::<Value>(line.trim()).expect("response json"))
+            .find(|response| response["id"] == json!(4))
+            .expect("post-reinitialize files response");
+        let text = post_reinitialize_response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("post-reinitialize files text");
+        assert!(
+            text.contains("src/active.rs"),
+            "reinitialize without roots should reset proxy routing to the base handshake, got {text}"
+        );
+        assert!(
+            !text.contains("src/target.rs"),
+            "stale initialize-root routing should not survive reinitialize: {text}"
         );
 
         accept_task.await.expect("daemon accept task");

--- a/src/dashboard/automation_jobs_api.rs
+++ b/src/dashboard/automation_jobs_api.rs
@@ -6,6 +6,8 @@
 //! - `GET/PATCH/DELETE /api/automation/jobs/{id}`
 //! - `POST /api/automation/jobs/{id}/run`
 
+use std::collections::BTreeMap;
+
 use axum::extract::{Path as AxumPath, State};
 use axum::http::StatusCode;
 use axum::Json;
@@ -115,6 +117,7 @@ pub(crate) async fn create(
         delivery: body.delivery.unwrap_or_default(),
         created_at: now,
         updated_at: now,
+        extra: BTreeMap::new(),
     };
     validate_job(&job).map_err(|err| bad_request(&err.to_string()))?;
     let mut jobs = load_jobs(&state.dashboard_root)

--- a/src/dashboard/automation_skills_api.rs
+++ b/src/dashboard/automation_skills_api.rs
@@ -260,7 +260,13 @@ async fn export_skills_to_agent_hosts(
         export_managed_skills_to_agent_hosts(&home, &project_root, &profile_root)
     })
     .await
-    .unwrap_or_default()
+    .unwrap_or_else(|err| {
+        vec![ManagedSkillExportReport {
+            agent: "export-task".to_string(),
+            exports: Vec::new(),
+            error: Some(format!("managed skill export task failed: {err}")),
+        }]
+    })
 }
 
 async fn skill_payload(profile_root: &std::path::Path, skill: ManagedSkill) -> ApiResult {

--- a/src/dashboard/code_diagnostics_api.rs
+++ b/src/dashboard/code_diagnostics_api.rs
@@ -162,41 +162,63 @@ async fn refresh_one_reconciled(
         .write()
         .await
         .prepare_refresh(language, documents);
+    let mut progress_recorded_in_task = false;
     let refresh_ok = match prepared {
         Ok(Some(prepared)) => {
-            let completed = prepared.collect_diagnostics(Duration::from_secs(5)).await;
-            let refresh_ok = completed.is_ok();
-            state
-                .code_diagnostics
-                .write()
-                .await
-                .finish_refresh(completed)
-                .ok();
-            refresh_ok
+            progress_recorded_in_task = true;
+            let state_for_refresh = state.clone();
+            let language_for_refresh = language.to_string();
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            tokio::spawn(async move {
+                let completed = prepared.collect_diagnostics(Duration::from_secs(5)).await;
+                let refresh_ok = completed.is_ok();
+                {
+                    let mut broker = state_for_refresh.code_diagnostics.write().await;
+                    let _ = broker.finish_refresh(completed);
+                    let snapshot = broker.snapshot();
+                    let files_with_diagnostics =
+                        files_with_diagnostics(&snapshot, &language_for_refresh);
+                    broker.record_backfill_progress(
+                        &language_for_refresh,
+                        document_count,
+                        document_count,
+                        files_with_diagnostics,
+                        refresh_ok.then(crate::tracedecay::current_timestamp),
+                    );
+                }
+                let _ = tx.send(refresh_ok);
+            });
+            rx.await.unwrap_or(false)
         }
         Ok(None) => true,
         Err(_) => false,
     };
-    let snapshot = state.code_diagnostics.read().await.snapshot();
-    let files_with_diagnostics = snapshot
+    if !progress_recorded_in_task {
+        let snapshot = state.code_diagnostics.read().await.snapshot();
+        let files_with_diagnostics = files_with_diagnostics(&snapshot, language);
+        state
+            .code_diagnostics
+            .write()
+            .await
+            .record_backfill_progress(
+                language,
+                document_count,
+                document_count,
+                files_with_diagnostics,
+                refresh_ok.then(crate::tracedecay::current_timestamp),
+            );
+    }
+    Ok(())
+}
+
+fn files_with_diagnostics(snapshot: &DiagnosticsSnapshot, language: &str) -> usize {
+    snapshot
         .diagnostics
         .iter()
         .filter(|diagnostic| diagnostic.language == language)
         .map(|diagnostic| diagnostic.file.as_str())
         .collect::<BTreeSet<_>>()
-        .len();
-    state
-        .code_diagnostics
-        .write()
-        .await
-        .record_backfill_progress(
-            language,
-            document_count,
-            document_count,
-            files_with_diagnostics,
-            refresh_ok.then(crate::tracedecay::current_timestamp),
-        );
-    Ok(())
+        .len()
 }
 
 fn maybe_spawn_idle_backfill(state: &DashboardState, snapshot: &DiagnosticsSnapshot) {

--- a/src/diagnostics/lsp/broker.rs
+++ b/src/diagnostics/lsp/broker.rs
@@ -149,24 +149,25 @@ impl PreparedRefresh {
         let timeouts = LspRefreshTimeouts::from_diagnostics_quiet_window(diagnostics_quiet_timeout);
         for batch in self.batches {
             let mut client_slot = batch.client.lock().await;
-            let client = match client_slot.as_mut() {
+            let mut client = match client_slot.take() {
                 Some(client) => client,
-                None => client_slot.insert(
-                    StdioLspClient::start_with_timeouts(
-                        &self.command,
-                        &self.args,
-                        &batch.workspace_root,
-                        timeouts,
-                    )
-                    .await
-                    .map_err(|err| RefreshFailure::crashed(&err))?,
-                ),
+                None => StdioLspClient::start_with_timeouts(
+                    &self.command,
+                    &self.args,
+                    &batch.workspace_root,
+                    timeouts,
+                )
+                .await
+                .map_err(|err| RefreshFailure::crashed(&err))?,
             };
             match client
                 .collect_document_diagnostics(&self.project_root, batch.documents, timeouts)
                 .await
             {
-                Ok(mut batch_diagnostics) => diagnostics.append(&mut batch_diagnostics),
+                Ok(mut batch_diagnostics) => {
+                    *client_slot = Some(client);
+                    diagnostics.append(&mut batch_diagnostics);
+                }
                 Err(err) => {
                     *client_slot = None;
                     return Err(RefreshFailure::crashed(&err));

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -14,8 +14,8 @@ use tokio::task::JoinHandle;
 use crate::diagnostics::lsp::broker::{CodeDiagnostic, DiagnosticSeverity};
 use crate::errors::{Result, TraceDecayError};
 
-const MIN_MESSAGE_IO_TIMEOUT: Duration = Duration::from_millis(250);
-const MIN_INITIALIZE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(1);
+const MIN_MESSAGE_IO_TIMEOUT: Duration = Duration::from_secs(2);
+const MIN_INITIALIZE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LspRefreshTimeouts {

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -176,13 +176,11 @@ impl StdioLspClient {
         timeouts: LspRefreshTimeouts,
     ) -> Result<Vec<CodeDiagnostic>> {
         let mut uri_to_document = BTreeMap::new();
-        let refresh_deadline = tokio::time::Instant::now() + timeouts.refresh;
         for document in &documents {
             let uri = file_uri(&project_root.join(&document.relative_path));
             uri_to_document.insert(uri.clone(), document.clone());
             let next_version = self.document_versions.get(&uri).copied().unwrap_or(0) + 1;
             if next_version == 1 {
-                let write_timeout = refresh_remaining(refresh_deadline, timeouts)?;
                 write_message_with_timeout(
                     &mut self.stdin,
                     json!({
@@ -197,12 +195,11 @@ impl StdioLspClient {
                             }
                         }
                     }),
-                    write_timeout,
+                    timeouts.message_io,
                 )
                 .await?;
             }
             let change_version = next_version + 1;
-            let write_timeout = refresh_remaining(refresh_deadline, timeouts)?;
             write_message_with_timeout(
                 &mut self.stdin,
                 json!({
@@ -218,7 +215,7 @@ impl StdioLspClient {
                         }]
                     }
                 }),
-                write_timeout,
+                timeouts.message_io,
             )
             .await?;
             self.document_versions.insert(uri, change_version);
@@ -231,18 +228,11 @@ impl StdioLspClient {
             if now >= quiet_deadline {
                 break;
             }
-            if now >= refresh_deadline {
-                return Err(refresh_timed_out(timeouts));
-            }
-            let read_deadline = quiet_deadline.min(refresh_deadline);
-            let message =
-                match read_message_until(&mut self.reader, read_deadline, timeouts).await? {
-                    Some(message) => message,
-                    None if read_deadline == refresh_deadline => {
-                        return Err(refresh_timed_out(timeouts));
-                    }
-                    None => break,
-                };
+            let Some(message) =
+                read_message_until(&mut self.reader, quiet_deadline, timeouts).await?
+            else {
+                break;
+            };
             if message.method.as_deref() != Some("textDocument/publishDiagnostics") {
                 continue;
             }
@@ -263,6 +253,9 @@ impl StdioLspClient {
                     .map(|diagnostic| diagnostic.into_code_diagnostic(document, &self.command))
                     .collect(),
             );
+        }
+        if diagnostics_by_uri.len() < uri_to_document.len() {
+            return Err(refresh_timed_out(timeouts));
         }
         Ok(diagnostics_by_uri.into_values().flatten().collect())
     }
@@ -356,19 +349,6 @@ async fn write_message_with_timeout(
                 timeout.as_millis()
             ),
         })?
-}
-
-fn refresh_remaining(
-    refresh_deadline: tokio::time::Instant,
-    timeouts: LspRefreshTimeouts,
-) -> Result<Duration> {
-    let now = tokio::time::Instant::now();
-    if now >= refresh_deadline {
-        return Err(refresh_timed_out(timeouts));
-    }
-    Ok(timeouts
-        .message_io
-        .min(refresh_deadline.saturating_duration_since(now)))
 }
 
 fn refresh_timed_out(timeouts: LspRefreshTimeouts) -> TraceDecayError {

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -254,7 +254,16 @@ impl StdioLspClient {
                     .collect(),
             );
         }
-        if diagnostics_by_uri.len() < uri_to_document.len() {
+        // Servers that publish empty diagnostics for clean files (rust-analyzer,
+        // tsserver) will produce one `publishDiagnostics` per requested URI, so a
+        // fully complete batch has `diagnostics_by_uri.len() == uri_to_document.len()`.
+        // Servers that suppress empty publishes (only publishing for files WITH
+        // problems) never emit for clean files, so those batches look "partial"
+        // even though every dirty file reported. To avoid dropping real results in
+        // that case, only treat the batch as a genuine timeout when NOTHING arrived
+        // (matching the #237 behavior of not recording a genuine timeout as
+        // complete); otherwise return the diagnostics that were actually published.
+        if diagnostics_by_uri.is_empty() && !uri_to_document.is_empty() {
             return Err(refresh_timed_out(timeouts));
         }
         Ok(diagnostics_by_uri.into_values().flatten().collect())

--- a/src/mcp/project_route.rs
+++ b/src/mcp/project_route.rs
@@ -90,11 +90,10 @@ impl HookProjectRouteCache {
         self.project_path.as_deref()
     }
 
-    pub(crate) fn refresh_from_shared(&mut self, mut shared: HookProjectRouteCache) {
-        if shared.project_path.is_none() {
-            shared.project_path.clone_from(&self.project_path);
-        }
-        self.clone_from(&shared);
+    pub(crate) fn refresh_from_shared(&mut self, shared: &HookProjectRouteCache) {
+        let local_project_path = self.project_path.clone();
+        self.clone_from(shared);
+        self.project_path = local_project_path;
     }
 
     fn insert_session_route(&mut self, session_id: String, project_path: String) {

--- a/src/mcp/project_route.rs
+++ b/src/mcp/project_route.rs
@@ -1,15 +1,22 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
 
 use super::hook_events;
 use super::tools::tool_dispatches_registered_project_reader;
 
-#[derive(Default)]
+const MAX_HOOK_ROUTE_CACHE_ENTRIES: usize = 256;
+
+#[derive(Clone, Default)]
 pub(crate) struct HookProjectRouteCache {
     project_path: Option<String>,
     paths_by_session: HashMap<String, String>,
     paths_by_thread: HashMap<String, String>,
+    threads_by_session: HashMap<String, String>,
+    session_by_thread: HashMap<String, String>,
+    session_order: VecDeque<String>,
+    thread_order: VecDeque<String>,
 }
 
 impl HookProjectRouteCache {
@@ -32,12 +39,21 @@ impl HookProjectRouteCache {
         };
         if let Some(route) = event.route.as_ref() {
             if let Some(session_id) = route.session_id.as_deref().filter(|id| !id.is_empty()) {
-                self.paths_by_session
-                    .insert(session_id.to_string(), project_path.clone());
+                self.insert_session_route(session_id.to_string(), project_path.clone());
+                if let Some(thread_id) = route.thread_id.as_deref().filter(|id| !id.is_empty()) {
+                    if let Some(old_thread_id) = self
+                        .threads_by_session
+                        .insert(session_id.to_string(), thread_id.to_string())
+                    {
+                        if old_thread_id != thread_id {
+                            self.remove_thread_route(&old_thread_id);
+                        }
+                    }
+                }
             }
             if let Some(thread_id) = route.thread_id.as_deref().filter(|id| !id.is_empty()) {
-                self.paths_by_thread
-                    .insert(thread_id.to_string(), project_path);
+                let session_id = route.session_id.as_deref().filter(|id| !id.is_empty());
+                self.insert_thread_route(thread_id.to_string(), project_path, session_id);
             }
         }
     }
@@ -72,6 +88,106 @@ impl HookProjectRouteCache {
             }
         }
         self.project_path.as_deref()
+    }
+
+    pub(crate) fn refresh_from_shared(&mut self, mut shared: HookProjectRouteCache) {
+        if shared.project_path.is_none() {
+            shared.project_path.clone_from(&self.project_path);
+        }
+        self.clone_from(&shared);
+    }
+
+    fn insert_session_route(&mut self, session_id: String, project_path: String) {
+        if !self.paths_by_session.contains_key(&session_id) {
+            self.session_order.push_back(session_id.clone());
+        }
+        self.paths_by_session.insert(session_id, project_path);
+        self.evict_old_session_routes();
+    }
+
+    fn insert_thread_route(
+        &mut self,
+        thread_id: String,
+        project_path: String,
+        session_id: Option<&str>,
+    ) {
+        if !self.paths_by_thread.contains_key(&thread_id) {
+            self.thread_order.push_back(thread_id.clone());
+        }
+        if let Some(session_id) = session_id {
+            if let Some(old_session_id) = self
+                .session_by_thread
+                .insert(thread_id.clone(), session_id.to_string())
+            {
+                if old_session_id != session_id
+                    && self
+                        .threads_by_session
+                        .get(&old_session_id)
+                        .is_some_and(|old_thread_id| old_thread_id == &thread_id)
+                {
+                    self.threads_by_session.remove(&old_session_id);
+                }
+            }
+        }
+        self.paths_by_thread.insert(thread_id, project_path);
+        self.evict_old_thread_routes();
+    }
+
+    fn remove_thread_route(&mut self, thread_id: &str) {
+        self.paths_by_thread.remove(thread_id);
+        if let Some(session_id) = self.session_by_thread.remove(thread_id) {
+            if self
+                .threads_by_session
+                .get(&session_id)
+                .is_some_and(|old_thread_id| old_thread_id == thread_id)
+            {
+                self.threads_by_session.remove(&session_id);
+            }
+        }
+    }
+
+    fn evict_old_session_routes(&mut self) {
+        while self.paths_by_session.len() > MAX_HOOK_ROUTE_CACHE_ENTRIES {
+            let Some(session_id) = self.session_order.pop_front() else {
+                break;
+            };
+            if self.paths_by_session.remove(&session_id).is_some() {
+                if let Some(thread_id) = self.threads_by_session.remove(&session_id) {
+                    self.remove_thread_route(&thread_id);
+                }
+            }
+        }
+    }
+
+    fn evict_old_thread_routes(&mut self) {
+        while self.paths_by_thread.len() > MAX_HOOK_ROUTE_CACHE_ENTRIES {
+            let Some(thread_id) = self.thread_order.pop_front() else {
+                break;
+            };
+            self.remove_thread_route(&thread_id);
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct SharedHookProjectRouteCache {
+    inner: Arc<Mutex<HookProjectRouteCache>>,
+}
+
+impl SharedHookProjectRouteCache {
+    pub(crate) fn snapshot(&self) -> HookProjectRouteCache {
+        self.inner
+            .lock()
+            .map(|cache| cache.clone())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn store(&self, cache: &HookProjectRouteCache) {
+        if let Ok(mut shared) = self.inner.lock() {
+            let mut cache = cache.clone();
+            cache.project_path = None;
+            shared.clone_from(&cache);
+        }
     }
 }
 
@@ -108,9 +224,13 @@ fn arguments_have_project_selector(arguments: &Value) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use serde_json::json;
 
-    use super::HookProjectRouteCache;
+    use super::{HookProjectRouteCache, SharedHookProjectRouteCache, MAX_HOOK_ROUTE_CACHE_ENTRIES};
+    use crate::daemon::{HookAgent, HookRouteMetadata};
+    use crate::mcp::hook_events::{HookEvent, HookEventKind};
 
     #[test]
     fn route_prefers_thread_then_session_then_last_hook_path() {
@@ -181,5 +301,112 @@ mod tests {
             }),
         );
         assert_eq!(explicit["project_selector"]["path"], "/repo/explicit");
+    }
+
+    #[test]
+    fn shared_route_survives_fresh_request_cache_and_invalidates_old_ids() {
+        let shared = SharedHookProjectRouteCache::default();
+        let first_event = hook_event("session-a", "thread-a", "/work/project-a");
+        let mut hook_connection_cache = shared.snapshot();
+        hook_connection_cache.observe_hook_event(&first_event, Some("/repo/a".to_string()));
+        shared.store(&hook_connection_cache);
+
+        let tool_connection_cache = shared.snapshot();
+        let routed = tool_connection_cache.apply_to_tool_arguments(
+            "tracedecay_context",
+            json!({"task": "inspect", "session_id": "session-a", "thread_id": "thread-a"}),
+        );
+        assert_eq!(routed["project_selector"]["path"], "/repo/a");
+
+        let second_event = hook_event("session-a", "thread-b", "/work/project-b");
+        let mut later_hook_connection_cache = shared.snapshot();
+        later_hook_connection_cache.observe_hook_event(&second_event, Some("/repo/b".to_string()));
+        shared.store(&later_hook_connection_cache);
+
+        let fresh_tool_connection_cache = shared.snapshot();
+        let rerouted = fresh_tool_connection_cache.apply_to_tool_arguments(
+            "tracedecay_context",
+            json!({"task": "inspect", "session_id": "session-a", "thread_id": "thread-b"}),
+        );
+        assert_eq!(rerouted["project_selector"]["path"], "/repo/b");
+
+        let stale_thread = fresh_tool_connection_cache.apply_to_tool_arguments(
+            "tracedecay_context",
+            json!({"task": "inspect", "session_id": "session-a", "thread_id": "thread-a"}),
+        );
+        assert_eq!(stale_thread["project_selector"]["path"], "/repo/b");
+    }
+
+    #[test]
+    fn shared_route_does_not_publish_last_hook_fallback() {
+        let shared = SharedHookProjectRouteCache::default();
+        let event = hook_event("session-a", "thread-a", "/work/project-a");
+        let mut hook_connection_cache = shared.snapshot();
+        hook_connection_cache.observe_hook_event(&event, Some("/repo/a".to_string()));
+        shared.store(&hook_connection_cache);
+
+        let fresh_tool_connection_cache = shared.snapshot();
+        let unrouted = fresh_tool_connection_cache
+            .apply_to_tool_arguments("tracedecay_context", json!({"task": "inspect"}));
+        assert!(
+            unrouted.get("project_selector").is_none(),
+            "daemon-wide shared state must not route identity-free calls by last hook"
+        );
+    }
+
+    #[test]
+    fn shared_route_evicts_oldest_session_and_thread_routes() {
+        let shared = SharedHookProjectRouteCache::default();
+        let mut hook_connection_cache = shared.snapshot();
+
+        for index in 0..=MAX_HOOK_ROUTE_CACHE_ENTRIES {
+            let event = hook_event(
+                &format!("session-{index}"),
+                &format!("thread-{index}"),
+                &format!("/work/project-{index}"),
+            );
+            hook_connection_cache.observe_hook_event(&event, Some(format!("/repo/{index}")));
+        }
+        shared.store(&hook_connection_cache);
+
+        let fresh_tool_connection_cache = shared.snapshot();
+        let evicted = fresh_tool_connection_cache.apply_to_tool_arguments(
+            "tracedecay_context",
+            json!({"task": "inspect", "session_id": "session-0", "thread_id": "thread-0"}),
+        );
+        assert!(
+            evicted.get("project_selector").is_none(),
+            "oldest identity routes should be evicted once the shared cache is full"
+        );
+
+        let retained = fresh_tool_connection_cache.apply_to_tool_arguments(
+            "tracedecay_context",
+            json!({
+                "task": "inspect",
+                "session_id": format!("session-{MAX_HOOK_ROUTE_CACHE_ENTRIES}"),
+                "thread_id": format!("thread-{MAX_HOOK_ROUTE_CACHE_ENTRIES}")
+            }),
+        );
+        assert_eq!(
+            retained["project_selector"]["path"],
+            format!("/repo/{MAX_HOOK_ROUTE_CACHE_ENTRIES}")
+        );
+    }
+
+    fn hook_event(session_id: &str, thread_id: &str, cwd: &str) -> HookEvent {
+        HookEvent {
+            agent: HookAgent::Claude,
+            kind: HookEventKind::FileEdit,
+            rel_paths: Vec::new(),
+            command: None,
+            cwd: Some(PathBuf::from(cwd)),
+            route: Some(HookRouteMetadata {
+                session_id: Some(session_id.to_string()),
+                thread_id: Some(thread_id.to_string()),
+                cwd: Some(PathBuf::from(cwd)),
+                worktree: None,
+                branch: None,
+            }),
+        }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -15,7 +15,9 @@ use serde_json::{json, Value};
 
 use crate::errors::{Result, TraceDecayError};
 use crate::global_db::GlobalDb;
-use crate::mcp::project_route::{mcp_analytics_session_id, HookProjectRouteCache};
+use crate::mcp::project_route::{
+    mcp_analytics_session_id, HookProjectRouteCache, SharedHookProjectRouteCache,
+};
 use crate::mcp::response_handles::{
     cleanup_expired_response_handles, response_handle_stats_json, RESPONSE_RETRIEVE_TOOL,
 };
@@ -646,6 +648,7 @@ pub struct McpServer {
     /// to the daemon process profile for selector resolution.
     registry_db: Option<Arc<GlobalDb>>,
     allow_default_registry_fallback: bool,
+    hook_project_routes: SharedHookProjectRouteCache,
     /// Cached latest-version check result.
     version_cache: std::sync::Mutex<VersionCheckState>,
     /// Pending JSON-RPC notifications to send before the next response.
@@ -772,6 +775,7 @@ impl McpServer {
             global_db,
             registry_db,
             allow_default_registry_fallback,
+            hook_project_routes: SharedHookProjectRouteCache::default(),
             version_cache: std::sync::Mutex::new(VersionCheckState {
                 latest: None,
                 checked_at: None,
@@ -848,6 +852,7 @@ impl McpServer {
             None => None,
         };
         route_cache.observe_hook_event(event, project_path);
+        self.hook_project_routes.store(route_cache);
     }
 
     async fn registered_project_containing_path(&self, cwd: &Path) -> Option<String> {
@@ -1364,7 +1369,7 @@ impl McpServer {
         listen_for_process_signals: bool,
         timings_override: Option<bool>,
     ) -> Result<()> {
-        let mut route_cache = HookProjectRouteCache::default();
+        let mut route_cache = self.hook_project_routes.snapshot();
 
         // Register the SIGTERM listener once before entering the loop so
         // there is no window between iterations where a SIGTERM is delivered
@@ -1583,7 +1588,7 @@ impl McpServer {
     ///
     /// Returns `None` for notifications (requests without an `id`).
     pub(crate) async fn handle_request(&self, request: &JsonRpcRequest) -> Option<JsonRpcResponse> {
-        let mut route_cache = HookProjectRouteCache::default();
+        let mut route_cache = self.hook_project_routes.snapshot();
         self.handle_request_with_timings(request, self.timings_enabled(), &mut route_cache)
             .await
     }
@@ -1623,6 +1628,7 @@ impl McpServer {
                 .await;
             return None;
         }
+        route_cache.refresh_from_shared(self.hook_project_routes.snapshot());
         let id = request.id.clone()?;
 
         let result = match classify_mcp_method(&request.method) {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -648,6 +648,7 @@ pub struct McpServer {
     /// to the daemon process profile for selector resolution.
     registry_db: Option<Arc<GlobalDb>>,
     allow_default_registry_fallback: bool,
+    initialize_root_routing_enabled: AtomicBool,
     hook_project_routes: SharedHookProjectRouteCache,
     /// Cached latest-version check result.
     version_cache: std::sync::Mutex<VersionCheckState>,
@@ -775,6 +776,7 @@ impl McpServer {
             global_db,
             registry_db,
             allow_default_registry_fallback,
+            initialize_root_routing_enabled: AtomicBool::new(true),
             hook_project_routes: SharedHookProjectRouteCache::default(),
             version_cache: std::sync::Mutex::new(VersionCheckState {
                 latest: None,
@@ -802,6 +804,11 @@ impl McpServer {
         });
 
         server
+    }
+
+    pub fn set_initialize_root_routing_enabled(&self, enabled: bool) {
+        self.initialize_root_routing_enabled
+            .store(enabled, Ordering::Relaxed);
     }
 
     /// Returns the active scope prefix, if the server was launched from a subdirectory.
@@ -1453,7 +1460,9 @@ impl McpServer {
 
             let response = match parsed {
                 Ok(request) => {
-                    if matches!(classify_mcp_method(&request.method), McpMethod::Initialize) {
+                    if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
+                        && self.initialize_root_routing_enabled.load(Ordering::Relaxed)
+                    {
                         connection_route
                             .observe_initialize(
                                 request.params.as_ref(),
@@ -1628,7 +1637,8 @@ impl McpServer {
                 .await;
             return None;
         }
-        route_cache.refresh_from_shared(self.hook_project_routes.snapshot());
+        let shared_routes = self.hook_project_routes.snapshot();
+        route_cache.refresh_from_shared(&shared_routes);
         let id = request.id.clone()?;
 
         let result = match classify_mcp_method(&request.method) {

--- a/src/mcp/tools/handlers/memory.rs
+++ b/src/mcp/tools/handlers/memory.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
+use crate::automation::memory_digest::refresh_memory_digest_after_memory_change;
 use crate::db::Database;
 use crate::errors::{Result, TraceDecayError};
 use crate::global_db::GlobalDb;
@@ -286,6 +287,7 @@ pub(super) async fn handle_fact_store(
         open_target_memory_db(cg, &args, global_db, allow_default_registry_fallback).await?;
     let conn = target_memory.db.conn();
     let store = MemoryStore::new(conn);
+    let mut refresh_digest = false;
     let out = match action {
         "add" => {
             let outcome = store
@@ -308,6 +310,7 @@ pub(super) async fn handle_fact_store(
             // Additive write-time diff report fields, so writers SEE
             // near-duplicates, possible conflicts, and secret rejections.
             let count = usize::from(outcome.fact.is_some());
+            refresh_digest = count > 0;
             json!({
                 "action": action,
                 "fact": outcome.fact,
@@ -450,7 +453,10 @@ pub(super) async fn handle_fact_store(
                 metadata: args.get("metadata").cloned(),
             };
             match store.update_fact(update).await {
-                Ok(fact) => json!({ "action": action, "fact": fact, "count": 1 }),
+                Ok(fact) => {
+                    refresh_digest = true;
+                    json!({ "action": action, "fact": fact, "count": 1 })
+                }
                 Err(err) => {
                     if let Some(reason) = update_rejected_secret_like(&err) {
                         json!({
@@ -469,6 +475,7 @@ pub(super) async fn handle_fact_store(
         }
         "remove" => {
             let removed = store.remove_fact(fact_id(&args)?).await?;
+            refresh_digest = removed;
             json!({ "action": action, "removed": removed, "count": usize::from(removed) })
         }
         "list" => {
@@ -483,6 +490,9 @@ pub(super) async fn handle_fact_store(
         }
         other => return Err(config_error(format!("unknown fact_store action: {other}"))),
     };
+    if refresh_digest {
+        refresh_memory_digest_after_memory_change(conn, &target_memory.project_root).await;
+    }
     Ok(tool_json(Some(&target_memory.project_root), &out))
 }
 
@@ -504,6 +514,7 @@ pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result
             note,
         })
         .await?;
+    refresh_memory_digest_after_memory_change(db.conn(), cg.project_root()).await;
     Ok(tool_json(
         Some(cg.project_root()),
         &json!({ "status": "recorded", "feedback": result }),

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -448,7 +448,7 @@ pub async fn run_serve(path_arg: Option<String>, timings: bool) -> Result<()> {
             transport.push_replay(pending_line);
             let scope_prefix = serve_scope_prefix(original_cwd.as_deref(), cg.project_root());
             let server = crate::mcp::McpServer::new(*cg, scope_prefix).await;
-            server.run(&mut transport).await
+            Box::pin(server.run(&mut transport)).await
         }
     }
 }
@@ -475,11 +475,12 @@ async fn serve_resolved_project(
         crate::daemon::proxy_stdio_to_daemon(&socket_path, &handshake, peeked_line).await
     } else {
         let server = crate::mcp::McpServer::new(cg, handshake.scope_prefix.clone()).await;
+        server.set_initialize_root_routing_enabled(allow_initialize_root_routing);
         let mut transport = ReplayTransport::new(StdioTransport::new());
         if let Some(line) = peeked_line {
             transport.push_replay(line);
         }
-        server.run(&mut transport).await
+        Box::pin(server.run(&mut transport)).await
     }
 }
 
@@ -621,10 +622,7 @@ fn allow_initialize_root_routing_for_startup(
     !explicit_path
         && matches!(
             origin,
-            ServeProjectResolutionOrigin::StartupPath
-                | ServeProjectResolutionOrigin::FreshCwd
-                | ServeProjectResolutionOrigin::InitializeRoots
-                | ServeProjectResolutionOrigin::GlobalDb
+            ServeProjectResolutionOrigin::InitializeRoots | ServeProjectResolutionOrigin::GlobalDb
         )
 }
 
@@ -922,12 +920,12 @@ mod tests {
     }
 
     #[test]
-    fn implicit_startup_discovery_still_allows_daemon_initialize_root_routing() {
-        assert!(allow_initialize_root_routing_for_startup(
+    fn initialize_root_routing_is_only_enabled_after_non_cwd_startup_resolution() {
+        assert!(!allow_initialize_root_routing_for_startup(
             false,
             ServeProjectResolutionOrigin::StartupPath
         ));
-        assert!(allow_initialize_root_routing_for_startup(
+        assert!(!allow_initialize_root_routing_for_startup(
             false,
             ServeProjectResolutionOrigin::FreshCwd
         ));

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -551,7 +551,10 @@ pub async fn resolve_serve_startup(path_arg: Option<String>) -> ServeStartup {
             return ServeStartup::Ready {
                 cg: Box::new(cg),
                 peeked_line,
-                allow_initialize_root_routing: false,
+                allow_initialize_root_routing: allow_initialize_root_routing_for_startup(
+                    resolver.explicit_path,
+                    ServeProjectResolutionOrigin::StartupPath,
+                ),
             };
         }
         Err(e) => e,
@@ -574,7 +577,10 @@ pub async fn resolve_serve_startup(path_arg: Option<String>) -> ServeStartup {
         Ok((cg, origin)) => ServeStartup::Ready {
             cg: Box::new(cg),
             peeked_line,
-            allow_initialize_root_routing: origin == ServeProjectResolutionOrigin::InitializeRoots,
+            allow_initialize_root_routing: allow_initialize_root_routing_for_startup(
+                resolver.explicit_path,
+                origin,
+            ),
         },
         Err(error) => ServeStartup::Degraded {
             resolver,
@@ -606,6 +612,20 @@ enum ServeProjectResolutionOrigin {
     FreshCwd,
     InitializeRoots,
     GlobalDb,
+}
+
+fn allow_initialize_root_routing_for_startup(
+    explicit_path: bool,
+    origin: ServeProjectResolutionOrigin,
+) -> bool {
+    !explicit_path
+        && matches!(
+            origin,
+            ServeProjectResolutionOrigin::StartupPath
+                | ServeProjectResolutionOrigin::FreshCwd
+                | ServeProjectResolutionOrigin::InitializeRoots
+                | ServeProjectResolutionOrigin::GlobalDb
+        )
 }
 
 impl ServeProjectResolver {
@@ -899,5 +919,25 @@ mod tests {
             sanitize_serve_path_arg(Some("${workspaceFolder}/nested".to_string())),
             None
         );
+    }
+
+    #[test]
+    fn implicit_startup_discovery_still_allows_daemon_initialize_root_routing() {
+        assert!(allow_initialize_root_routing_for_startup(
+            false,
+            ServeProjectResolutionOrigin::StartupPath
+        ));
+        assert!(allow_initialize_root_routing_for_startup(
+            false,
+            ServeProjectResolutionOrigin::FreshCwd
+        ));
+        assert!(allow_initialize_root_routing_for_startup(
+            false,
+            ServeProjectResolutionOrigin::InitializeRoots
+        ));
+        assert!(!allow_initialize_root_routing_for_startup(
+            true,
+            ServeProjectResolutionOrigin::StartupPath
+        ));
     }
 }

--- a/src/sessions/lcm/query.rs
+++ b/src/sessions/lcm/query.rs
@@ -158,8 +158,11 @@ pub(crate) async fn load_session(
     })
 }
 
-/// Lists sessions in the raw LCM store ordered by most recent activity
-/// (latest message timestamp, falling back to insertion order).
+/// Lists sessions in the raw LCM store ordered by most recent ingested activity.
+///
+/// `timestamp` is provider-supplied and may be absent or use a clock domain that
+/// cannot be compared with `store_id`, so recency ordering uses the raw store's
+/// insertion order.
 pub(crate) async fn recent_sessions(
     conn: &Connection,
     provider: Option<&str>,
@@ -180,7 +183,7 @@ pub(crate) async fn recent_sessions(
          FROM lcm_raw_messages
          {provider_clause}
          GROUP BY provider, session_id
-         ORDER BY COALESCE(MAX(timestamp), MAX(store_id)) DESC, MAX(store_id) DESC
+         ORDER BY MAX(store_id) DESC
          LIMIT ?"
     );
     let mut rows = conn.query(&sql, values).await?;
@@ -199,7 +202,7 @@ pub(crate) async fn recent_sessions(
 }
 
 /// Lists providers that contain raw messages for an explicit session id,
-/// ordered by most recent activity.
+/// ordered by most recent ingested activity.
 pub(crate) async fn session_providers(
     conn: &Connection,
     session_id: &str,
@@ -210,7 +213,7 @@ pub(crate) async fn session_providers(
              FROM lcm_raw_messages
              WHERE session_id = ?1
              GROUP BY provider
-             ORDER BY COALESCE(MAX(timestamp), MAX(store_id)) DESC, MAX(store_id) DESC",
+             ORDER BY MAX(store_id) DESC",
             params![session_id],
         )
         .await?;

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -1,8 +1,9 @@
 //! User-level configuration stored in the `TraceDecay` user data directory.
 //!
 //! All fields have defaults so a missing file or missing fields are handled
-//! gracefully. Unknown fields are silently ignored for forward compatibility.
+//! gracefully. Unknown fields are preserved for forward compatibility.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -99,6 +100,10 @@ pub struct UserConfig {
     /// The `TRACEDECAY_MEMORY_INJECTION` env var overrides this at runtime.
     #[serde(default = "default_true")]
     pub memory_injection_enabled: bool,
+
+    /// Unknown user config keys preserved for forward compatibility.
+    #[serde(default, flatten)]
+    pub extra: BTreeMap<String, toml::Value>,
 }
 
 fn default_true() -> bool {
@@ -135,6 +140,7 @@ impl Default for UserConfig {
             extraction_timeout_secs: default_extraction_timeout_secs(),
             automation: AutomationConfig::default(),
             memory_injection_enabled: true,
+            extra: BTreeMap::new(),
         }
     }
 }
@@ -163,6 +169,14 @@ impl UserConfig {
         let Some(path) = config_path() else {
             return false;
         };
+        if path.exists() {
+            let Ok(contents) = std::fs::read_to_string(&path) else {
+                return false;
+            };
+            if toml::from_str::<Self>(&contents).is_err() {
+                return false;
+            }
+        }
         if let Some(parent) = path.parent() {
             if std::fs::create_dir_all(parent).is_err() {
                 return false;
@@ -237,7 +251,34 @@ pub fn parse_duration(s: &str) -> Option<std::time::Duration> {
 )]
 mod tests {
     use super::*;
+    use crate::config::USER_DATA_DIR_ENV;
+    use std::ffi::OsString;
     use std::time::Duration;
+    use tempfile::TempDir;
+
+    static USER_DATA_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvRestore {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvRestore {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(previous) => std::env::set_var(self.key, previous),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn parse_duration_seconds() {
@@ -262,5 +303,49 @@ mod tests {
         assert_eq!(parse_duration("abc"), None);
         assert_eq!(parse_duration(""), None);
         assert_eq!(parse_duration("1h"), None);
+    }
+
+    #[test]
+    fn save_preserves_existing_corrupt_config_file() {
+        let _lock = USER_DATA_DIR_ENV_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let original = "installed_agents = [\"claude\"]\nautomation =";
+        std::fs::write(&path, original).unwrap();
+
+        let mut config = UserConfig::load();
+        config.upload_enabled = false;
+
+        assert!(
+            !config.save(),
+            "saving a defaulted config must fail when the existing file is corrupt"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn save_preserves_unknown_config_keys() {
+        let _lock = USER_DATA_DIR_ENV_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "upload_enabled = true\nfuture_key = \"keep-me\"\n[future_table]\nflag = true\n",
+        )
+        .unwrap();
+
+        let mut config = UserConfig::load();
+        config.upload_enabled = false;
+
+        assert!(config.save());
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("future_key = \"keep-me\""));
+        assert!(saved.contains("[future_table]"));
+        assert!(saved.contains("flag = true"));
+        assert!(saved.contains("upload_enabled = false"));
     }
 }

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -250,6 +250,26 @@ fn read_json(path: &Path) -> serde_json::Value {
     .unwrap_or_else(|e| panic!("failed to parse JSON {}: {e}", path.display()))
 }
 
+fn seed_memory_digest_target(
+    profile_root: &Path,
+    target: tracedecay::automation::skill_targets::SkillInstallTarget,
+    output: &Path,
+) {
+    let path = profile_root.join("agent_managed/memory_digest_targets.json");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "targets": [{
+                "target": target,
+                "output": output,
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
 fn expected_tracedecay_bin() -> String {
     let path_match = std::env::var_os("PATH").and_then(|path| {
         std::env::split_paths(&path).find_map(|dir| {
@@ -3203,9 +3223,10 @@ async fn test_codex_install_exports_active_managed_skills() {
 
     let digest_skill_path =
         codex_plugin_install_dir(home).join("skills/agent-managed-memory/SKILL.md");
-    let digest_skill = std::fs::read_to_string(digest_skill_path).unwrap();
-    assert!(digest_skill.contains("name: tracedecay-memory-digest"));
-    assert!(digest_skill.contains("No durable facts exported yet"));
+    assert!(
+        !digest_skill_path.exists(),
+        "Codex memory digest is delivered through hook additionalContext, not a duplicate skill"
+    );
 }
 
 #[tokio::test]
@@ -3410,6 +3431,32 @@ fn test_codex_local_install_creates_repo_plugin_bundle_and_marketplace() {
         !project.path().join("AGENTS.md").exists(),
         "local Codex install should use plugin skills, not write project AGENTS.md"
     );
+}
+
+#[test]
+fn test_codex_local_install_does_not_export_personal_memory_digest_into_repo() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    assert_local_install_success("codex", project.path(), home.path());
+
+    let digest_skill_path = codex_project_plugin_install_dir(project.path())
+        .join("skills/agent-managed-memory/SKILL.md");
+    assert!(
+        !digest_skill_path.exists(),
+        "project-local Codex install must not export the personal memory digest into the repo"
+    );
+
+    let targets_path = home
+        .path()
+        .join(".tracedecay/agent_managed/memory_digest_targets.json");
+    if targets_path.exists() {
+        let targets = std::fs::read_to_string(&targets_path).unwrap();
+        assert!(
+            !targets.contains(&project.path().display().to_string()),
+            "project-local Codex install must not record repo-tree digest targets"
+        );
+    }
 }
 
 #[test]
@@ -4045,6 +4092,37 @@ fn test_claude_install_then_uninstall() {
 }
 
 #[test]
+fn test_claude_uninstall_unrecords_memory_digest_target() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let profile_root = home.join(".tracedecay");
+    let _data_dir_guard = EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root);
+    let ctx = make_install_ctx(home);
+    let claude_md = home.join(".claude/CLAUDE.md");
+
+    ClaudeIntegration.install(&ctx).unwrap();
+    assert!(
+        std::fs::read_to_string(&claude_md)
+            .unwrap()
+            .contains(tracedecay::automation::memory_digest::MEMORY_DIGEST_START),
+        "install should seed the prompt-index memory digest block"
+    );
+
+    ClaudeIntegration.uninstall(&ctx).unwrap();
+
+    std::fs::create_dir_all(claude_md.parent().unwrap()).unwrap();
+    std::fs::write(&claude_md, "# Claude rules\n").unwrap();
+    tracedecay::automation::memory_digest::export_memory_digest_to_recorded_targets(&profile_root)
+        .unwrap();
+    assert!(
+        !std::fs::read_to_string(&claude_md)
+            .unwrap()
+            .contains(tracedecay::automation::memory_digest::MEMORY_DIGEST_START),
+        "Claude uninstall must unrecord memory digest targets so refresh cannot recreate them"
+    );
+}
+
+#[test]
 fn test_gemini_install_then_uninstall() {
     let dir = TempDir::new().unwrap();
     let home = dir.path();
@@ -4091,6 +4169,14 @@ fn test_codex_install_then_uninstall() {
     let plugin_dir = codex_plugin_install_dir(home);
     assert!(plugin_dir.exists());
     assert_codex_personal_marketplace_entry(home);
+    let legacy_digest = plugin_dir.join("skills/agent-managed-memory/SKILL.md");
+    std::fs::create_dir_all(legacy_digest.parent().unwrap()).unwrap();
+    std::fs::write(&legacy_digest, "legacy digest").unwrap();
+    seed_memory_digest_target(
+        &home.join(".tracedecay"),
+        tracedecay::automation::skill_targets::SkillInstallTarget::Codex,
+        &plugin_dir,
+    );
 
     CodexIntegration.uninstall(&ctx).unwrap();
 
@@ -4114,6 +4200,55 @@ fn test_codex_install_then_uninstall() {
             "AGENTS.md should not have tracedecay rules after uninstall"
         );
     }
+
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    tracedecay::automation::memory_digest::export_memory_digest_to_recorded_targets(
+        &home.join(".tracedecay"),
+    )
+    .unwrap();
+    assert!(
+        !plugin_dir
+            .join("skills/agent-managed-memory/SKILL.md")
+            .exists(),
+        "Codex uninstall must unrecord memory digest targets so refresh cannot recreate them"
+    );
+}
+
+#[test]
+fn test_codex_local_uninstall_unrecords_legacy_repo_memory_digest_target() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let mut ctx = make_install_ctx(home.path());
+    ctx.project_root = Some(project.path().to_path_buf());
+    let profile_root = home.path().join(".tracedecay");
+    let _data_dir_guard = EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root);
+
+    CodexIntegration
+        .install_local(&ctx, project.path())
+        .unwrap();
+
+    let plugin_dir = codex_project_plugin_install_dir(project.path());
+    let legacy_digest = plugin_dir.join("skills/agent-managed-memory/SKILL.md");
+    std::fs::create_dir_all(legacy_digest.parent().unwrap()).unwrap();
+    std::fs::write(&legacy_digest, "legacy digest").unwrap();
+    seed_memory_digest_target(
+        &profile_root,
+        tracedecay::automation::skill_targets::SkillInstallTarget::Codex,
+        &plugin_dir,
+    );
+    assert!(legacy_digest.exists());
+
+    CodexIntegration.uninstall(&ctx).unwrap();
+
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    tracedecay::automation::memory_digest::export_memory_digest_to_recorded_targets(&profile_root)
+        .unwrap();
+    assert!(
+        !plugin_dir
+            .join("skills/agent-managed-memory/SKILL.md")
+            .exists(),
+        "project-local Codex uninstall must unrecord legacy repo-tree memory digest targets"
+    );
 }
 
 #[test]
@@ -4545,12 +4680,29 @@ fn test_cursor_install_then_uninstall() {
     CursorIntegration.install(&ctx).unwrap();
     let plugin_dir = cursor_plugin_install_dir(home);
     assert!(plugin_dir.exists());
+    let legacy_digest = plugin_dir.join("rules/tracedecay-memory-digest.mdc");
+    std::fs::create_dir_all(legacy_digest.parent().unwrap()).unwrap();
+    std::fs::write(&legacy_digest, "legacy digest").unwrap();
+    seed_memory_digest_target(
+        &home.join(".tracedecay"),
+        tracedecay::automation::skill_targets::SkillInstallTarget::Cursor,
+        &plugin_dir,
+    );
 
     CursorIntegration.uninstall(&ctx).unwrap();
 
     assert!(
         !plugin_dir.exists(),
         "Cursor uninstall should remove the local plugin install"
+    );
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    tracedecay::automation::memory_digest::export_memory_digest_to_recorded_targets(
+        &home.join(".tracedecay"),
+    )
+    .unwrap();
+    assert!(
+        !legacy_digest.exists(),
+        "Cursor uninstall must unrecord legacy memory digest targets"
     );
 }
 

--- a/tests/agent_suite/memory_digest_test.rs
+++ b/tests/agent_suite/memory_digest_test.rs
@@ -155,20 +155,18 @@ fn section_render_flattens_whitespace_and_reports_omissions() {
 }
 
 #[tokio::test]
-async fn cursor_overlay_write_update_and_removal() {
+async fn prompt_index_write_update_and_removal() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");
-    let plugin_root = temp.path().join("cursor-plugin");
-    std::fs::create_dir_all(&plugin_root).unwrap();
+    let prompt_path = temp.path().join("CLAUDE.md");
 
-    // Empty snapshot exports a placeholder rule so later refreshes have a
+    // Empty snapshot exports a placeholder block so later refreshes have a
     // channel to update.
     let summary =
-        export_memory_digest(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap();
+        export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
     assert_eq!(summary.fact_count, 0);
-    let rule_path = plugin_root.join("rules/tracedecay-memory-digest.mdc");
-    let rendered = std::fs::read_to_string(&rule_path).unwrap();
-    assert!(rendered.contains("alwaysApply: true"));
+    let rendered = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(rendered.contains(MEMORY_DIGEST_START));
     assert!(rendered.contains("No durable facts exported yet"));
 
     update_project_digest_section(
@@ -181,33 +179,55 @@ async fn cursor_overlay_write_update_and_removal() {
         ),
     )
     .unwrap();
-    export_memory_digest(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap();
-    let rendered = std::fs::read_to_string(&rule_path).unwrap();
+    export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
+    let rendered = std::fs::read_to_string(&prompt_path).unwrap();
     assert!(rendered.contains("Use pnpm for installs"));
     assert!(rendered.contains("trust 0.90"));
 
-    remove_memory_digest_export(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap();
-    assert!(!rule_path.exists());
+    remove_memory_digest_export(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
+    assert!(!prompt_path.exists());
     // Removal also unrecords the target: refresh must not re-create it.
     export_memory_digest_to_recorded_targets(&profile_root).unwrap();
-    assert!(!rule_path.exists());
+    assert!(!prompt_path.exists());
 }
 
-#[tokio::test]
-async fn codex_overlay_uses_skill_package_and_prunes_on_removal() {
+#[test]
+fn native_cursor_codex_digest_channels_are_deduped_to_host_memory_injection() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");
-    let plugin_root = temp.path().join("codex-plugin");
-    std::fs::create_dir_all(&plugin_root).unwrap();
 
-    export_memory_digest(&profile_root, SkillInstallTarget::Codex, &plugin_root).unwrap();
-    let skill_path = plugin_root.join("skills/agent-managed-memory/SKILL.md");
-    let rendered = std::fs::read_to_string(&skill_path).unwrap();
-    assert!(rendered.contains("name: tracedecay-memory-digest"));
+    for (target, legacy_relative) in [
+        (
+            SkillInstallTarget::Cursor,
+            "rules/tracedecay-memory-digest.mdc",
+        ),
+        (
+            SkillInstallTarget::Codex,
+            "skills/agent-managed-memory/SKILL.md",
+        ),
+    ] {
+        let plugin_root = temp
+            .path()
+            .join(format!("plugin-{}", target.prompt_label().to_lowercase()));
+        let legacy_path = plugin_root.join(legacy_relative);
+        std::fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+        std::fs::write(&legacy_path, "legacy digest").unwrap();
 
-    remove_memory_digest_export(&profile_root, SkillInstallTarget::Codex, &plugin_root).unwrap();
-    assert!(!skill_path.exists());
-    assert!(!plugin_root.join("skills/agent-managed-memory").exists());
+        assert!(
+            !sync_memory_digest_export(&profile_root, target, &plugin_root).unwrap(),
+            "native Cursor/Codex digest export is superseded by host memory injection"
+        );
+        assert!(
+            !legacy_path.exists(),
+            "superseded native digest artifact should be removed for {target:?}"
+        );
+        std::fs::create_dir_all(&plugin_root).unwrap();
+        export_memory_digest_to_recorded_targets(&profile_root).unwrap();
+        assert!(
+            !legacy_path.exists(),
+            "superseded native digest target should not be recorded for {target:?}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -248,15 +268,13 @@ async fn config_gate_disables_export_and_strips_previous_artifacts() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");
     std::fs::create_dir_all(&profile_root).unwrap();
-    let plugin_root = temp.path().join("cursor-plugin");
-    std::fs::create_dir_all(&plugin_root).unwrap();
-    let rule_path = plugin_root.join("rules/tracedecay-memory-digest.mdc");
+    let prompt_path = temp.path().join("CLAUDE.md");
 
     assert!(memory_digest_export_enabled(&profile_root));
     assert!(
-        sync_memory_digest_export(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap()
+        sync_memory_digest_export(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap()
     );
-    assert!(rule_path.exists());
+    assert!(prompt_path.exists());
 
     std::fs::write(
         profile_root.join("config.toml"),
@@ -265,19 +283,18 @@ async fn config_gate_disables_export_and_strips_previous_artifacts() {
     .unwrap();
     assert!(!memory_digest_export_enabled(&profile_root));
     assert!(
-        !sync_memory_digest_export(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
+        !sync_memory_digest_export(&profile_root, SkillInstallTarget::Claude, &prompt_path)
             .unwrap()
     );
-    assert!(!rule_path.exists());
+    assert!(!prompt_path.exists());
 }
 
 #[tokio::test]
 async fn project_config_gate_disables_refresh_and_removes_existing_section() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");
-    let plugin_root = temp.path().join("cursor-plugin");
+    let prompt_path = temp.path().join("CLAUDE.md");
     let project_root = temp.path().join("repo");
-    std::fs::create_dir_all(&plugin_root).unwrap();
     std::fs::create_dir_all(&project_root).unwrap();
 
     let layout = default_profile_sharded_layout(&project_root, &profile_root).unwrap();
@@ -308,10 +325,9 @@ async fn project_config_gate_disables_refresh_and_removes_existing_section() {
     )
     .unwrap();
     assert!(
-        sync_memory_digest_export(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap()
+        sync_memory_digest_export(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap()
     );
-    let rule_path = plugin_root.join("rules/tracedecay-memory-digest.mdc");
-    assert!(std::fs::read_to_string(&rule_path)
+    assert!(std::fs::read_to_string(&prompt_path)
         .unwrap()
         .contains("Existing project fact"));
 
@@ -328,7 +344,7 @@ async fn project_config_gate_disables_refresh_and_removes_existing_section() {
 
     let snapshot = load_memory_digest_snapshot(&profile_root).unwrap();
     assert!(snapshot.projects.is_empty());
-    let rendered = std::fs::read_to_string(&rule_path).unwrap();
+    let rendered = std::fs::read_to_string(&prompt_path).unwrap();
     assert!(!rendered.contains("Existing project fact"));
     assert!(rendered.contains("No durable facts exported yet"));
 }
@@ -337,16 +353,14 @@ async fn project_config_gate_disables_refresh_and_removes_existing_section() {
 async fn fact_proposal_apply_then_refresh_regenerates_recorded_overlays() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");
-    let plugin_root = temp.path().join("cursor-plugin");
-    std::fs::create_dir_all(&plugin_root).unwrap();
+    let prompt_path = temp.path().join("CLAUDE.md");
     let dashboard_root = temp.path().join("dashboard");
     let project_root = temp.path().join("repo");
     std::fs::create_dir_all(&project_root).unwrap();
 
-    // Install-time export records the overlay as a refresh target.
-    sync_memory_digest_export(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap();
-    let rule_path = plugin_root.join("rules/tracedecay-memory-digest.mdc");
-    assert!(std::fs::read_to_string(&rule_path)
+    // Install-time export records the prompt index as a refresh target.
+    sync_memory_digest_export(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
+    assert!(std::fs::read_to_string(&prompt_path)
         .unwrap()
         .contains("No durable facts exported yet"));
 
@@ -394,7 +408,7 @@ async fn fact_proposal_apply_then_refresh_regenerates_recorded_overlays() {
     let snapshot = load_memory_digest_snapshot(&profile_root).unwrap();
     assert_eq!(snapshot.projects.len(), 1);
     assert_eq!(snapshot.projects[0].project_label, "repo");
-    let rendered = std::fs::read_to_string(&rule_path).unwrap();
+    let rendered = std::fs::read_to_string(&prompt_path).unwrap();
     assert!(rendered.contains("Always run cargo nextest instead of cargo test"));
     assert!(rendered.contains("## repo"));
 }

--- a/tests/agent_suite/plugin_skill_contract_test.rs
+++ b/tests/agent_suite/plugin_skill_contract_test.rs
@@ -47,7 +47,6 @@ const CURSOR_ALLOWED_FRONTMATTER: &[&str] = &[
     "name",
     "paths",
 ];
-const CODEX_GENERATED_MEMORY_SKILL: &str = "agent-managed-memory";
 
 #[test]
 fn codex_plugin_skills_match_codex_skill_creator_quick_validate_rules() {
@@ -72,22 +71,17 @@ fn generated_codex_plugin_skills_are_byte_copies_of_the_source_bundle() {
     let source_root = repo_path(CODEX_SKILL_ROOT);
     let installed_root = home.path().join("plugins/tracedecay/skills");
     assert!(
-        installed_root
-            .join(CODEX_GENERATED_MEMORY_SKILL)
-            .join("SKILL.md")
+        !installed_root
+            .join("agent-managed-memory/SKILL.md")
             .exists(),
-        "generated Codex plugin install must export the active memory digest skill"
+        "generated Codex plugin install must not add a duplicate memory digest skill"
     );
     assert_eq!(
-        skill_dir_names_except(&installed_root, &[CODEX_GENERATED_MEMORY_SKILL]),
+        skill_dir_names(&installed_root),
         skill_dir_names(&source_root),
         "generated Codex plugin bundle must ship the same bundled skills as the source bundle"
     );
-    assert_skill_trees_byte_identical_except(
-        &source_root,
-        &installed_root,
-        &[CODEX_GENERATED_MEMORY_SKILL],
-    );
+    assert_skill_trees_byte_identical(&source_root, &installed_root);
 }
 
 #[test]

--- a/tests/agent_suite/skill_targets_test.rs
+++ b/tests/agent_suite/skill_targets_test.rs
@@ -5,8 +5,8 @@ use tracedecay::agents::{export_managed_skills_to_agent_hosts, export_managed_sk
 use tracedecay::automation::hermes_bridge::{load_hermes_skill_bridge, HermesSkillBridgeOptions};
 use tracedecay::automation::managed_skills::{
     approve_managed_skill, create_managed_skill_draft, default_managed_skill_targets,
-    disable_managed_skill, ManagedSkillDraft, ManagedSkillProvenance, ManagedSkillSource,
-    ManagedSupportFile,
+    disable_managed_skill, load_managed_skill, managed_skill_dir, ManagedSkillDraft,
+    ManagedSkillProvenance, ManagedSkillSource, ManagedSupportFile,
 };
 use tracedecay::automation::skill_targets::{
     export_native_skill_overlay, export_prompt_skill_index, install_managed_skills,
@@ -281,8 +281,92 @@ async fn prompt_index_preserves_user_content_and_routes_full_body_through_mcp() 
         export_prompt_skill_index(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
     assert_eq!(second.exported_count, 1);
     let second = std::fs::read_to_string(&prompt_path).unwrap();
-    assert_eq!(second.matches("TRACEDECAY MANAGED SKILLS START").count(), 1);
+    assert_eq!(second.matches("TRACEDECAY MANAGED SKILLS START").count(), 2);
+    assert!(second.contains("TRACEDECAY MANAGED SKILLS START agents"));
+    assert!(second.contains("TRACEDECAY MANAGED SKILLS START claude"));
     assert!(second.contains("This Claude index lists"));
+}
+
+#[tokio::test]
+async fn prompt_index_keeps_separate_sections_for_shared_agents_md_hosts() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let agents_md = temp.path().join("AGENTS.md");
+
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "opencode-only",
+            "OpenCode only",
+            vec![SkillInstallTarget::OpenCode],
+        ),
+    )
+    .await
+    .unwrap();
+    approve_managed_skill(&profile_root, "opencode-only")
+        .await
+        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft("kimi-only", "Kimi only", vec![SkillInstallTarget::Kimi]),
+    )
+    .await
+    .unwrap();
+    approve_managed_skill(&profile_root, "kimi-only")
+        .await
+        .unwrap();
+
+    export_prompt_skill_index(&profile_root, SkillInstallTarget::OpenCode, &agents_md).unwrap();
+    export_prompt_skill_index(&profile_root, SkillInstallTarget::Kimi, &agents_md).unwrap();
+
+    let prompt = std::fs::read_to_string(&agents_md).unwrap();
+    assert!(prompt.contains("TRACEDECAY MANAGED SKILLS START opencode"));
+    assert!(prompt.contains("TRACEDECAY MANAGED SKILLS START kimi"));
+    assert!(prompt.contains("This OpenCode index lists"));
+    assert!(prompt.contains("This Kimi index lists"));
+    assert!(prompt.contains("`opencode-only`"));
+    assert!(prompt.contains("`kimi-only`"));
+}
+
+#[tokio::test]
+async fn native_overlay_keeps_previous_export_when_rebuild_fails() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let plugin_root = temp.path().join("cursor-plugin");
+
+    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
+        .await
+        .unwrap();
+    approve_managed_skill(&profile_root, "repo-hygiene")
+        .await
+        .unwrap();
+    export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root).unwrap();
+
+    let previous_skill = plugin_root.join("skills/agent-managed/repo-hygiene/SKILL.md");
+    assert!(previous_skill.is_file());
+
+    let mut corrupted = load_managed_skill(&profile_root, "repo-hygiene")
+        .await
+        .unwrap();
+    corrupted.support_files.push(ManagedSupportFile {
+        path: std::path::PathBuf::from("../escape.md"),
+        bytes: b"escape".to_vec(),
+    });
+    let skill_dir = managed_skill_dir(&profile_root, "repo-hygiene").unwrap();
+    std::fs::write(
+        skill_dir.join("skill.json"),
+        serde_json::to_vec_pretty(&corrupted).unwrap(),
+    )
+    .unwrap();
+
+    let err = export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unsafe support path"));
+    assert!(
+        previous_skill.is_file(),
+        "failed rebuild must preserve the last complete overlay"
+    );
 }
 
 /// Fakes a Claude Code global install under `home`: the tracedecay MCP

--- a/tests/agent_suite/skill_targets_test.rs
+++ b/tests/agent_suite/skill_targets_test.rs
@@ -10,7 +10,7 @@ use tracedecay::automation::managed_skills::{
 };
 use tracedecay::automation::skill_targets::{
     export_native_skill_overlay, export_prompt_skill_index, install_managed_skills,
-    SkillInstallTarget,
+    remove_prompt_skill_index_for_target, SkillInstallTarget,
 };
 
 fn draft(id: &str, title: &str) -> ManagedSkillDraft {
@@ -326,6 +326,96 @@ async fn prompt_index_keeps_separate_sections_for_shared_agents_md_hosts() {
     assert!(prompt.contains("This Kimi index lists"));
     assert!(prompt.contains("`opencode-only`"));
     assert!(prompt.contains("`kimi-only`"));
+}
+
+#[tokio::test]
+async fn uninstall_preserves_legacy_block_on_shared_file_mid_migration() {
+    // A shared AGENTS.md mid-migration: host A migrated to a slugged `claude`
+    // block, host B is still using the legacy unslugged block. Uninstalling a
+    // third target (`agents`, which has no slugged block here) must NOT fall
+    // back to deleting the legacy block, since another host's slugged block is
+    // present the legacy block cannot be assumed to be ours.
+    let temp = tempfile::tempdir().unwrap();
+    let agents_md = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# Shared prompt\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START claude -->\n",
+        "Claude host index.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END claude -->\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START -->\n",
+        "Legacy host B index.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END -->\n",
+    );
+    std::fs::write(&agents_md, contents).unwrap();
+
+    remove_prompt_skill_index_for_target(&agents_md, SkillInstallTarget::Agents).unwrap();
+
+    let after = std::fs::read_to_string(&agents_md).unwrap();
+    assert!(
+        after.contains("Legacy host B index."),
+        "legacy block belonging to another host must be preserved: {after}"
+    );
+    assert!(
+        after.contains("<!-- TRACEDECAY MANAGED SKILLS START -->"),
+        "legacy markers must be preserved: {after}"
+    );
+    assert!(
+        after.contains("<!-- TRACEDECAY MANAGED SKILLS START claude -->"),
+        "unrelated slugged block must be preserved: {after}"
+    );
+}
+
+#[tokio::test]
+async fn uninstall_removes_own_slugged_block_on_shared_file() {
+    // Uninstalling a target with its own slugged block removes only that block
+    // and leaves the legacy block for a still-migrating host untouched.
+    let temp = tempfile::tempdir().unwrap();
+    let agents_md = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# Shared prompt\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START claude -->\n",
+        "Claude host index.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END claude -->\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START -->\n",
+        "Legacy host B index.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END -->\n",
+    );
+    std::fs::write(&agents_md, contents).unwrap();
+
+    remove_prompt_skill_index_for_target(&agents_md, SkillInstallTarget::Claude).unwrap();
+
+    let after = std::fs::read_to_string(&agents_md).unwrap();
+    assert!(
+        !after.contains("Claude host index."),
+        "own block removed: {after}"
+    );
+    assert!(
+        after.contains("Legacy host B index."),
+        "legacy block preserved: {after}"
+    );
+}
+
+#[tokio::test]
+async fn uninstall_removes_legacy_block_when_no_slugged_blocks_remain() {
+    // When only a legacy unslugged block exists (no other host has migrated),
+    // per-target uninstall may safely reclaim it.
+    let temp = tempfile::tempdir().unwrap();
+    let agents_md = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# Shared prompt\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START -->\n",
+        "Legacy index.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END -->\n",
+    );
+    std::fs::write(&agents_md, contents).unwrap();
+
+    remove_prompt_skill_index_for_target(&agents_md, SkillInstallTarget::Agents).unwrap();
+
+    let after = std::fs::read_to_string(&agents_md).unwrap();
+    assert!(
+        !after.contains("Legacy index."),
+        "legacy block removed: {after}"
+    );
 }
 
 #[tokio::test]

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -110,7 +110,9 @@ fn write_retired_codex_skill(plugin_dir: &Path, name: &str) {
     std::fs::create_dir_all(plugin_dir.join("skills").join(name)).unwrap();
     std::fs::write(
         plugin_dir.join("skills").join(name).join("SKILL.md"),
-        format!("---\nname: {name}\ndescription: retired tracedecay skill\n---\n"),
+        format!(
+            "---\nname: {name}\ndescription: retired tracedecay skill\n---\n\nUse TraceDecay MCP tools for this workflow.\n"
+        ),
     )
     .unwrap();
 }
@@ -252,7 +254,13 @@ fn cursor_update_plugin_refreshes_bundle_and_preserves_user_config() {
     std::fs::create_dir_all(plugin_dir.join("skills/reading-code-cheaply")).unwrap();
     std::fs::write(
         plugin_dir.join("skills/reading-code-cheaply/SKILL.md"),
-        "---\nname: reading-code-cheaply\ndescription: retired tracedecay skill\n---\n",
+        "---\nname: reading-code-cheaply\ndescription: retired tracedecay skill\n---\n\nUse TraceDecay MCP tools for this workflow.\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(plugin_dir.join("skills/project-status")).unwrap();
+    std::fs::write(
+        plugin_dir.join("skills/project-status/SKILL.md"),
+        "---\nname: project-status\ndescription: My private project status workflow\n---\n",
     )
     .unwrap();
     let user_mcp_before = bytes(&user_mcp);
@@ -269,6 +277,10 @@ fn cursor_update_plugin_refreshes_bundle_and_preserves_user_config() {
     assert!(
         !plugin_dir.join("skills/reading-code-cheaply").exists(),
         "update-plugin must sweep retired Cursor skill dirs so stale workflows are not rediscovered"
+    );
+    assert!(
+        plugin_dir.join("skills/project-status/SKILL.md").exists(),
+        "same-name user-authored Cursor skills without TraceDecay markers must be preserved"
     );
 
     // Generated bundle re-baked: plugin-owned mcp.json command, hook command
@@ -317,6 +329,12 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
     )
     .unwrap();
     write_retired_codex_skill(&plugin_dir, "architecture-overview");
+    std::fs::create_dir_all(plugin_dir.join("skills/project-status")).unwrap();
+    std::fs::write(
+        plugin_dir.join("skills/project-status/SKILL.md"),
+        "---\nname: project-status\ndescription: My private project status workflow\n---\n",
+    )
+    .unwrap();
     let config_before = bytes(&codex_config);
 
     let outcome = codex
@@ -336,6 +354,10 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
     assert!(
         !plugin_dir.join("skills/architecture-overview").exists(),
         "update-plugin must remove retired bundled Codex skill dirs that lack tracedecay-prefixed names"
+    );
+    assert!(
+        plugin_dir.join("skills/project-status/SKILL.md").exists(),
+        "same-name user-authored Codex skills without TraceDecay markers must be preserved"
     );
     assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
     assert!(text(&plugin_dir.join(".codex-plugin/plugin.json")).contains(env!("CARGO_PKG_VERSION")));

--- a/tests/automation_runner_test/jobs.rs
+++ b/tests/automation_runner_test/jobs.rs
@@ -4,7 +4,9 @@
 
 use crate::support::*;
 
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use tracedecay::automation::jobs::{
     job_schedule_decision, job_task_key, load_jobs, run_user_job_with_backend, save_jobs,
@@ -26,6 +28,7 @@ fn sample_job(id: &str) -> AutomationJob {
         delivery: JobDelivery::File { path: None },
         created_at: 1_715_000_000,
         updated_at: 1_715_000_000,
+        extra: BTreeMap::new(),
     }
 }
 
@@ -107,6 +110,69 @@ async fn job_persistence_round_trips() {
         .is_empty());
 }
 
+#[tokio::test]
+async fn load_jobs_skips_corrupt_entries_without_losing_valid_jobs() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+    let valid_one = sample_job("valid-one");
+    let valid_two = sample_job("valid-two");
+    let document = json!({
+        "schema_version": 1,
+        "jobs": [
+            valid_one,
+            {
+                "id": "broken",
+                "name": "Broken",
+                "prompt": 42,
+                "enabled": true
+            },
+            valid_two
+        ]
+    });
+    fs::write(
+        root.join("automation_jobs.json"),
+        serde_json::to_vec_pretty(&document).unwrap(),
+    )
+    .unwrap();
+
+    let loaded = load_jobs(root).await.unwrap();
+    let ids: Vec<&str> = loaded.iter().map(|job| job.id.as_str()).collect();
+    assert_eq!(ids, vec!["valid-one", "valid-two"]);
+}
+
+#[tokio::test]
+async fn job_persistence_preserves_unknown_job_fields() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+    let document = json!({
+        "schema_version": 1,
+        "jobs": [
+            {
+                "id": "future-job",
+                "name": "Future job",
+                "prompt": "Preserve future fields.",
+                "enabled": true,
+                "delivery": {"mode": "file"},
+                "future_flag": true,
+                "nested_future": {"level": 2}
+            }
+        ]
+    });
+    fs::write(
+        root.join("automation_jobs.json"),
+        serde_json::to_vec_pretty(&document).unwrap(),
+    )
+    .unwrap();
+
+    let loaded = load_jobs(root).await.unwrap();
+    save_jobs(root, &loaded).await.unwrap();
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&fs::read(root.join("automation_jobs.json")).unwrap()).unwrap();
+
+    assert_eq!(persisted["jobs"][0]["future_flag"], json!(true));
+    assert_eq!(persisted["jobs"][0]["nested_future"], json!({"level": 2}));
+}
+
 #[test]
 fn job_validation_rejects_bad_definitions() {
     let mut job = sample_job("ok-job");
@@ -158,6 +224,34 @@ fn job_validation_rejects_bad_definitions() {
         url: "ftp://example.test".to_string(),
     };
     assert!(validate_job(&job).is_err());
+}
+
+#[test]
+fn job_validation_rejects_webhook_ssrf_targets() {
+    for url in [
+        "http://localhost/hook",
+        "http://localhost.localdomain/hook",
+        "http://127.0.0.1/hook",
+        "http://10.0.0.5/hook",
+        "http://172.16.0.5/hook",
+        "http://192.168.1.10/hook",
+        "http://169.254.169.254/latest/meta-data",
+        "http://[::1]/hook",
+        "http://[fe80::1]/hook",
+        "http://[fc00::1]/hook",
+    ] {
+        let mut job = sample_job("hook");
+        job.delivery = JobDelivery::Webhook {
+            url: url.to_string(),
+        };
+        assert!(validate_job(&job).is_err(), "{url} must be rejected");
+    }
+
+    let mut job = sample_job("hook");
+    job.delivery = JobDelivery::Webhook {
+        url: "https://example.test/hook".to_string(),
+    };
+    validate_job(&job).unwrap();
 }
 
 #[test]
@@ -634,4 +728,113 @@ async fn scheduler_trigger_skips_repeat_and_respects_lock_discipline() {
         "repeat scheduler skips must persist only once"
     );
     assert_eq!(records[0].run_id, "sched-run-1");
+}
+
+#[tokio::test]
+async fn manual_job_trigger_respects_existing_per_job_lock() {
+    let temp = tempdir().unwrap();
+    let dashboard_root = temp.path().join("dashboard");
+    let profile_root = temp.path().join("profile");
+    fs::create_dir_all(&profile_root).unwrap();
+    let lock_dir = dashboard_root.join("automation_locks");
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(lock_dir.join("user_job_locked-job.lock"), b"9999999999").unwrap();
+
+    let job = sample_job("locked-job");
+    let config = enabled_job_config();
+    let backend = ContentBackend::new("unused");
+    let run = run_user_job_with_backend(
+        &dashboard_root,
+        &config,
+        &backend,
+        &job,
+        UserJobRunOptions {
+            trigger: AutomationTrigger::Dashboard,
+            run_id: Some("dashboard-lock-run".to_string()),
+            profile_root: Some(profile_root),
+            project_root: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(backend.calls(), 0);
+    assert_eq!(run.report["status"], json!("skipped"));
+    assert_eq!(run.report["reason"], json!("job_lock_active"));
+    assert_eq!(run.ledger_record.status, AutomationRunStatus::Skipped);
+}
+
+#[tokio::test]
+async fn concurrent_manual_job_triggers_do_not_double_execute() {
+    struct SlowBackend {
+        calls: AtomicUsize,
+    }
+    impl AgentTaskBackend for SlowBackend {
+        fn run_task(
+            &self,
+            request: &AgentTaskRequest,
+        ) -> tracedecay::errors::Result<AgentTaskResponse> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(200));
+            Ok(AgentTaskResponse {
+                run_id: request.run_id.clone(),
+                task: request.task,
+                output_text: "done".to_string(),
+                output_json: None,
+                model: Some("fixture-model".to_string()),
+                input_tokens: None,
+                output_tokens: None,
+            })
+        }
+    }
+
+    let temp = tempdir().unwrap();
+    let dashboard_root = temp.path().join("dashboard");
+    let profile_root = temp.path().join("profile");
+    fs::create_dir_all(&profile_root).unwrap();
+    let job = sample_job("concurrent-job");
+    let config = enabled_job_config();
+    let backend = SlowBackend {
+        calls: AtomicUsize::new(0),
+    };
+
+    let (first, second) = tokio::join!(
+        run_user_job_with_backend(
+            &dashboard_root,
+            &config,
+            &backend,
+            &job,
+            UserJobRunOptions {
+                trigger: AutomationTrigger::Dashboard,
+                run_id: Some("concurrent-run-1".to_string()),
+                profile_root: Some(profile_root.clone()),
+                project_root: None,
+            },
+        ),
+        run_user_job_with_backend(
+            &dashboard_root,
+            &config,
+            &backend,
+            &job,
+            UserJobRunOptions {
+                trigger: AutomationTrigger::ManualCli,
+                run_id: Some("concurrent-run-2".to_string()),
+                profile_root: Some(profile_root),
+                project_root: None,
+            },
+        )
+    );
+    let runs = [first.unwrap(), second.unwrap()];
+    let delivered = runs
+        .iter()
+        .filter(|run| run.report["status"] == json!("delivered"))
+        .count();
+    let locked = runs
+        .iter()
+        .filter(|run| run.report["reason"] == json!("job_lock_active"))
+        .count();
+
+    assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(delivered, 1);
+    assert_eq!(locked, 1);
 }

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -812,6 +812,96 @@ async fn session_reflector_skips_when_replay_disabled_and_no_grep_hits() {
     );
 }
 
+struct NoSummaryReplayBackend;
+
+impl AgentTaskBackend for NoSummaryReplayBackend {
+    fn run_task(
+        &self,
+        request: &AgentTaskRequest,
+    ) -> tracedecay::errors::Result<AgentTaskResponse> {
+        assert_eq!(request.task, AgentTaskKind::SessionReflector);
+        let evidence = &request.context["session_reflection_evidence"];
+        assert_eq!(evidence["include_summaries"], json!(false));
+        assert_eq!(evidence["evidence_mode"], json!("session_replay_with_grep"));
+        let sessions = evidence["recent_session_slices"]["sessions"]
+            .as_array()
+            .expect("replay sessions should be present");
+        assert_eq!(sessions.len(), 1);
+        assert!(
+            sessions[0]["summary_nodes"]
+                .as_array()
+                .expect("summary nodes array")
+                .is_empty(),
+            "include_summaries=false must suppress replay summary nodes"
+        );
+        Ok(AgentTaskResponse {
+            run_id: request.run_id.clone(),
+            task: request.task,
+            output_text: json!({"facts": []}).to_string(),
+            output_json: Some(json!({"facts": []})),
+            model: Some("fixture-model".to_string()),
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+        })
+    }
+}
+
+#[tokio::test]
+async fn session_reflector_replay_respects_include_summaries_false() {
+    let temp = tempdir().unwrap();
+    let cg = init_project(temp.path()).await;
+    seed_session_evidence(&cg).await;
+    let db = GlobalDb::open_at(&cg.store_layout().sessions_db_path)
+        .await
+        .expect("session db open");
+    db.lcm_insert_summary_node(tracedecay::sessions::lcm::LcmSummaryNodeDraft {
+        provider: "cursor".to_string(),
+        conversation_id: "session-reflect-1".to_string(),
+        session_id: "session-reflect-1".to_string(),
+        depth: 1,
+        summary_text: "summary that should not be replayed when summaries are disabled".to_string(),
+        source_refs: Vec::new(),
+        source_token_count: 10,
+        summary_token_count: 5,
+        source_time_start: Some(1_715_000_001),
+        source_time_end: Some(1_715_000_001),
+        expand_hint: None,
+        metadata_json: None,
+    })
+    .await
+    .expect("summary fixture should insert");
+    let config = AutomationConfig {
+        enabled: true,
+        backend: AutomationBackend::CodexAppServer,
+        host_mode: AutomationHostMode::Standalone,
+        tasks: AutomationTaskSet {
+            session_reflector: AutomationTaskConfig {
+                enabled: true,
+                schedule: Some("manual".to_string()),
+                ..AutomationTaskConfig::default()
+            },
+            ..AutomationTaskSet::default()
+        },
+        ..AutomationConfig::default()
+    };
+
+    let run = run_session_reflector_with_backend(
+        &cg,
+        &config,
+        &NoSummaryReplayBackend,
+        SessionReflectorAutomationOptions {
+            query: "does-not-match-any-grep-hit".to_string(),
+            include_summaries: false,
+            include_recent_sessions: true,
+            ..SessionReflectorAutomationOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(run.ledger_record.status, AutomationRunStatus::Succeeded);
+}
+
 #[tokio::test]
 async fn session_reflector_runner_ledgers_malformed_backend_output() {
     let temp = tempdir().unwrap();

--- a/tests/core_cli_suite/user_config_test.rs
+++ b/tests/core_cli_suite/user_config_test.rs
@@ -33,6 +33,7 @@ fn round_trip_serialization() {
         extraction_timeout_secs: 60,
         automation: Default::default(),
         memory_injection_enabled: true,
+        extra: Default::default(),
     };
     let toml_str = toml::to_string_pretty(&config).unwrap();
     let parsed: UserConfig = toml::from_str(&toml_str).unwrap();

--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -498,12 +498,14 @@ async fn broker_drops_lsp_client_after_partial_diagnostics_frame_timeout() {
 }
 
 #[tokio::test]
-async fn stdio_client_fails_when_a_document_never_publishes_diagnostics() {
+async fn stdio_client_fails_when_no_document_publishes_diagnostics() {
+    // Preserve the #237 behavior: a genuine timeout where NOTHING arrived is
+    // still an error and must not be recorded as a complete (empty) refresh.
     let temp = tempfile::tempdir().unwrap();
-    let script_path = temp.path().join("one_document_lsp.py");
+    let script_path = temp.path().join("silent_lsp.py");
     std::fs::write(
         &script_path,
-        fake_lsp_script_with_preamble("", FIRST_URI_ONLY_DIAGNOSTIC_PUBLISH),
+        fake_lsp_script_with_preamble("", NEVER_PUBLISH),
     )
     .unwrap();
 
@@ -518,12 +520,45 @@ async fn stdio_client_fails_when_a_document_never_publishes_diagnostics() {
         std::time::Duration::from_millis(50),
     )
     .await
-    .expect_err("missing publishDiagnostics for one document should fail the refresh");
+    .expect_err("a batch with zero publishes should fail as a timeout");
 
     assert!(
         err.to_string().contains("timed out"),
         "unexpected error: {err}"
     );
+}
+
+#[tokio::test]
+async fn stdio_client_returns_diagnostics_for_suppress_empty_servers() {
+    // A server that only publishes for files WITH problems (never an empty
+    // publish for clean files) produces a "partial" batch: `first.fake` reports
+    // an error, `second.fake` (clean) never publishes. The refresh must return
+    // the real diagnostics for the file that responded rather than dropping the
+    // whole batch as a timeout.
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("one_document_lsp.py");
+    std::fs::write(
+        &script_path,
+        fake_lsp_script_with_preamble("", FIRST_URI_ONLY_DIAGNOSTIC_PUBLISH),
+    )
+    .unwrap();
+
+    let diagnostics = lsp::client::collect_document_diagnostics(
+        python_command(),
+        &[script_path.display().to_string()],
+        temp.path(),
+        vec![
+            fake_document(FAKE_LANGUAGE, "src/first.fake", "let nope"),
+            fake_document(FAKE_LANGUAGE, "src/second.fake", "let clean"),
+        ],
+        std::time::Duration::from_millis(50),
+    )
+    .await
+    .expect("diagnostics from the responding file should be returned, not dropped");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].file, "src/first.fake");
+    assert_eq!(diagnostics[0].message, "first file error");
 }
 
 #[tokio::test]
@@ -1107,6 +1142,10 @@ const PARTIAL_DIAGNOSTIC_PUBLISH: &str = r#"        sys.stdout.buffer.write(b"Co
         sys.stdout.buffer.flush()
         import time
         time.sleep(60)
+"#;
+
+const NEVER_PUBLISH: &str = r#"        _ = uri
+        pass
 "#;
 
 const FIRST_URI_ONLY_DIAGNOSTIC_PUBLISH: &str = r#"        if uri.endswith("/first.fake"):

--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -10,7 +10,7 @@ const FAKE_PATH: &str = "src/lib.fake";
 // to cover a didOpen -> publishDiagnostics round trip against an
 // already-initialized fake server.
 const FAKE_LSP_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
-const OUTER_ASYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(4);
+const OUTER_ASYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
 
 #[test]
 fn builtin_registry_advertises_phase_one_setup_contract() {
@@ -296,7 +296,7 @@ sys.stderr.flush()
         .refresh_documents(
             FAKE_LANGUAGE,
             vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            std::time::Duration::from_millis(50),
+            std::time::Duration::from_millis(500),
         )
         .await
         .unwrap_err();
@@ -449,7 +449,7 @@ async fn stdio_client_allows_slow_but_progressing_document_writes() {
                 FAKE_PATH,
                 &"let nope\n".repeat(80_000),
             )],
-            std::time::Duration::from_millis(50),
+            std::time::Duration::from_millis(500),
         ),
     )
     .await

--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -429,6 +429,38 @@ async fn stdio_client_bounds_lsp_document_write_hangs() {
 }
 
 #[tokio::test]
+async fn stdio_client_allows_slow_but_progressing_document_writes() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("slow_reader_lsp.py");
+    std::fs::write(
+        &script_path,
+        fake_lsp_script_that_reads_large_messages_slowly(),
+    )
+    .unwrap();
+
+    let diagnostics = tokio::time::timeout(
+        OUTER_ASYNC_TIMEOUT,
+        lsp::client::collect_document_diagnostics(
+            python_command(),
+            &[script_path.display().to_string()],
+            temp.path(),
+            vec![fake_document(
+                FAKE_LANGUAGE,
+                FAKE_PATH,
+                &"let nope\n".repeat(80_000),
+            )],
+            std::time::Duration::from_millis(50),
+        ),
+    )
+    .await
+    .expect("slow progressing write should stay bounded")
+    .expect("slow progressing write should not crash the client");
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message, "fake type error");
+}
+
+#[tokio::test]
 async fn broker_drops_lsp_client_after_partial_diagnostics_frame_timeout() {
     let temp = tempfile::tempdir().unwrap();
     let script_path = temp.path().join("partial_frame_lsp.py");
@@ -459,6 +491,79 @@ async fn broker_drops_lsp_client_after_partial_diagnostics_frame_timeout() {
         )
         .await
         .unwrap();
+
+    let snapshot = broker.snapshot();
+    assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Ready);
+    assert_eq!(snapshot.summary.total_errors, 1);
+}
+
+#[tokio::test]
+async fn stdio_client_fails_when_a_document_never_publishes_diagnostics() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("one_document_lsp.py");
+    std::fs::write(
+        &script_path,
+        fake_lsp_script_with_preamble("", FIRST_URI_ONLY_DIAGNOSTIC_PUBLISH),
+    )
+    .unwrap();
+
+    let err = lsp::client::collect_document_diagnostics(
+        python_command(),
+        &[script_path.display().to_string()],
+        temp.path(),
+        vec![
+            fake_document(FAKE_LANGUAGE, "src/first.fake", "let nope"),
+            fake_document(FAKE_LANGUAGE, "src/second.fake", "let clean"),
+        ],
+        std::time::Duration::from_millis(50),
+    )
+    .await
+    .expect_err("missing publishDiagnostics for one document should fail the refresh");
+
+    assert!(
+        err.to_string().contains("timed out"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn broker_cancels_partial_refresh_without_poisoning_warm_client() {
+    let temp = tempfile::tempdir().unwrap();
+    let script_path = temp.path().join("cancel_partial_lsp.py");
+    std::fs::write(&script_path, fake_lsp_script_with_partial_publish()).unwrap();
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        temp.path(),
+        vec![fake_python_adapter(FAKE_LANGUAGE, "fake", &script_path)],
+    );
+    let prepared = broker
+        .prepare_refresh(
+            FAKE_LANGUAGE,
+            vec![fake_document(
+                FAKE_LANGUAGE,
+                "src/canceled.fake",
+                "let nope",
+            )],
+        )
+        .unwrap()
+        .expect("refresh should prepare");
+    let handle = tokio::spawn(async move {
+        prepared
+            .collect_diagnostics(std::time::Duration::from_millis(500))
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    handle.abort();
+    let _ = handle.await;
+
+    std::fs::write(&script_path, fake_lsp_script()).unwrap();
+    broker
+        .refresh_documents(
+            FAKE_LANGUAGE,
+            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+            FAKE_LSP_TIMEOUT,
+        )
+        .await
+        .expect("next refresh should start a clean client and recover");
 
     let snapshot = broker.snapshot();
     assert_engine_state(&snapshot, FAKE_LANGUAGE, lsp::broker::EngineState::Ready);
@@ -853,6 +958,63 @@ time.sleep(60)
 "#
 }
 
+fn fake_lsp_script_that_reads_large_messages_slowly() -> &'static str {
+    r#"
+import json
+import sys
+import time
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, value = line.decode("ascii").split(":", 1)
+        headers[name.lower()] = value.strip()
+    length = int(headers["content-length"])
+    remaining = length
+    chunks = []
+    while remaining:
+        chunk = sys.stdin.buffer.read(min(4096, remaining))
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+        time.sleep(0.00075)
+    return json.loads(b"".join(chunks).decode("utf-8"))
+
+def send(payload):
+    body = json.dumps(payload).encode("utf-8")
+    sys.stdout.buffer.write(b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n\r\n" + body)
+    sys.stdout.buffer.flush()
+
+while True:
+    message = read_message()
+    if message is None:
+        break
+    if message.get("method") == "initialize":
+        send({"jsonrpc": "2.0", "id": message["id"], "result": {"capabilities": {"textDocumentSync": 1}}})
+    elif message.get("method") == "textDocument/didChange":
+        uri = message["params"]["textDocument"]["uri"]
+        send({
+            "jsonrpc": "2.0",
+            "method": "textDocument/publishDiagnostics",
+            "params": {
+                "uri": uri,
+                "diagnostics": [{
+                    "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 9}},
+                    "severity": 1,
+                    "source": "fake-ls",
+                    "message": "fake type error"
+                }]
+            }
+        })
+"#
+}
+
 fn fake_lsp_script_with_partial_publish() -> String {
     fake_lsp_script_with_preamble("", PARTIAL_DIAGNOSTIC_PUBLISH)
 }
@@ -945,6 +1107,22 @@ const PARTIAL_DIAGNOSTIC_PUBLISH: &str = r#"        sys.stdout.buffer.write(b"Co
         sys.stdout.buffer.flush()
         import time
         time.sleep(60)
+"#;
+
+const FIRST_URI_ONLY_DIAGNOSTIC_PUBLISH: &str = r#"        if uri.endswith("/first.fake"):
+            send({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": uri,
+                    "diagnostics": [{
+                        "range": {"start": {"line": 0, "character": 4}, "end": {"line": 0, "character": 9}},
+                        "severity": 1,
+                        "source": "fake-ls",
+                        "message": "first file error"
+                    }]
+                }
+            })
 "#;
 
 const EMPTY_DIAGNOSTIC_PUBLISH: &str = r#"        send({

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -6165,6 +6165,85 @@ async fn memory_fact_store_add_search_update_remove_and_wrappers() {
 }
 
 #[tokio::test]
+async fn memory_fact_store_mutations_refresh_recorded_digest_exports() {
+    let (cg, _env, _dir) = setup_empty_project().await;
+    let profile_root = tracedecay::storage::default_profile_root().unwrap();
+    let prompt_path = cg.project_root().join("CLAUDE.md");
+    tracedecay::automation::memory_digest::sync_memory_digest_export(
+        &profile_root,
+        tracedecay::automation::skill_targets::SkillInstallTarget::Claude,
+        &prompt_path,
+    )
+    .unwrap();
+    assert!(fs::read_to_string(&prompt_path)
+        .unwrap()
+        .contains("No durable facts exported yet"));
+
+    let added = handle_tool_call(
+        &cg,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": "Refresh exported digest after MCP fact add",
+            "category": "decision",
+            "trust": 0.9
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let added: Value = serde_json::from_str(extract_text(&added.value)).unwrap();
+    let fact_id = added["fact"]["fact_id"].as_i64().unwrap();
+    assert!(fs::read_to_string(&prompt_path)
+        .unwrap()
+        .contains("Refresh exported digest after MCP fact add"));
+
+    handle_tool_call(
+        &cg,
+        "tracedecay_fact_store",
+        json!({
+            "action": "update",
+            "fact_id": fact_id,
+            "content": "Refresh exported digest after MCP fact update"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let rendered = fs::read_to_string(&prompt_path).unwrap();
+    assert!(rendered.contains("Refresh exported digest after MCP fact update"));
+    assert!(!rendered.contains("Refresh exported digest after MCP fact add"));
+
+    handle_tool_call(
+        &cg,
+        "tracedecay_fact_feedback",
+        json!({"fact_id": fact_id, "unhelpful": true}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(fs::read_to_string(&prompt_path)
+        .unwrap()
+        .contains("trust 0.80"));
+
+    handle_tool_call(
+        &cg,
+        "tracedecay_fact_store",
+        json!({"action": "remove", "fact_id": fact_id}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let rendered = fs::read_to_string(&prompt_path).unwrap();
+    assert!(!rendered.contains("Refresh exported digest after MCP fact update"));
+    assert!(rendered.contains("No durable facts exported yet"));
+}
+
+#[tokio::test]
 async fn memory_fact_store_project_selector_targets_registered_project() {
     let (active, target, _env) = setup_cross_project_memory_projects().await;
     let target_project_id = target

--- a/tests/session_suite/lcm_query.rs
+++ b/tests/session_suite/lcm_query.rs
@@ -2298,6 +2298,49 @@ async fn recent_sessions_orders_by_last_activity_with_provider_filter() {
 }
 
 #[tokio::test]
+async fn recent_sessions_uses_store_order_for_null_timestamp_activity() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    let db_path = isolated_db_path(&tmp);
+
+    insert_raw_messages(
+        &db,
+        &db_path,
+        "cursor",
+        "timestamped-session",
+        &["has an epoch timestamp".to_string()],
+    )
+    .await;
+
+    let session = sample_session("cursor", "null-timestamp-session");
+    let mut message = raw_message(
+        "cursor",
+        "null-timestamp-message-001",
+        "null-timestamp-session",
+        1,
+        "ingested later without source timestamp",
+    );
+    message.timestamp = None;
+    assert!(
+        db.upsert_transcript_batch(
+            &session,
+            &[message],
+            "session-lcm-query-cursor-null-timestamp-session.jsonl",
+            ParseOffset::default(),
+        )
+        .await
+    );
+
+    let sessions = db
+        .lcm_recent_sessions(None, 1)
+        .await
+        .expect("recent sessions should load");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id, "null-timestamp-session");
+    assert_eq!(sessions[0].last_timestamp, None);
+}
+
+#[tokio::test]
 async fn session_providers_finds_explicit_session_beyond_recent_limit() {
     let tmp = TempDir::new().unwrap();
     let db = open_lcm_db(&tmp).await;


### PR DESCRIPTION
## Summary
- harden automation job loading, locking, webhook delivery, and forward-compatible job config round-trips
- fix daemon/project routing propagation across proxy/hook connections and stale route invalidation
- make managed skill exports, prompt cleanup, memory digest lifecycle, and host writes safer/atomic
- preserve unknown user config keys, tighten LCM recent-session evidence/replay behavior, and harden dashboard/LSP partial-refresh handling

## Claude findings covered
- #220: recent-session ordering, evidence mode, include_summaries replay
- #222/#225: skill export atomicity, prompt marker collisions, retired-skill deletion guard, archive/auto-approve export paths
- #223: webhook SSRF/DNS rebinding, manual/CLI job locking, corrupt/unknown job entries
- #227: settings panel partial saves, corrupt config handling, unknown config keys
- #228: project-local memory digest leak, uninstall cleanup, fact refreshes, atomic digest writes, duplicate injection cleanup
- #231/#232/#239: daemon route propagation, hook route cache persistence, initialize-root routing, stale route invalidation
- #237: LSP/dashboard cancellation, partial diagnostics, slow-write handling
- #242/#243 were rechecked as clean in Claude transcripts

## Extra transcript check
- Rechecked Claude transcript hits for missed findings; older #215 docs staleness/path scrub was already handled on master.

## Tests
- cargo fmt --check
- git diff --check
- scripts/check-conventional-commits.sh origin/master..HEAD
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -q --test agent_suite
- cargo test -q --test automation_runner_test jobs
- cargo test -q --test dashboard_api_test automation_jobs
- cargo test -q --test session_suite recent_sessions
- cargo test -q --test hooks_lsp_suite lsp_code_diagnostics_test
- cargo test -q --test agent_suite memory_digest_test::
- cargo test -q --test mcp_suite mcp_handler_test::memory_fact_store_mutations_refresh_recorded_digest_exports -- --exact
- cargo test -q --test agent_suite skill_targets_test
- cargo test -q --test automation_runner_test session_reflector
- cargo test -q shared_route
- cargo test -q --features test-transport --test mcp_suite hook_event_workspace_context_routes_followup_graph_reads
- cargo test -q --test core_cli_suite user_config
- (cd dashboard && npm run test:dom -- settings-panel-patches)

TraceDecay transcript recall used to validate the missed-finding sweep.