### PR TITLE
refactor: dedup installer helpers and simplify marked-block splicing

### DIFF
--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -391,17 +391,13 @@ fn substitute_command_placeholder(value: &mut serde_json::Value, tracedecay_bin:
 
 /// Stamp the plugin manifest `version` with the crate version.
 fn stamp_plugin_version(raw: &str) -> Result<String> {
-    let mut manifest: serde_json::Value = serde_json::from_str(raw)?;
-    manifest["version"] = json!(env!("CARGO_PKG_VERSION"));
-    Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
+    super::plugin_bundle::stamp_manifest_version(raw)
 }
 
 /// Set the plugin `.mcp.json` server command to the resolved absolute binary
 /// path, so the plugin does not rely on `tracedecay` being on PATH.
 fn set_mcp_command(raw: &str, tracedecay_bin: &str) -> Result<String> {
-    let mut mcp: serde_json::Value = serde_json::from_str(raw)?;
-    mcp["mcpServers"]["tracedecay"]["command"] = json!(tracedecay_bin);
-    Ok(format!("{}\n", serde_json::to_string_pretty(&mcp)?))
+    super::plugin_bundle::set_mcp_command(raw, tracedecay_bin)
 }
 
 /// Remove the deployed bundle dir (idempotent; only touches the tracedecay

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -505,15 +505,15 @@ fn write_codex_plugin_files(
 }
 
 fn codex_plugin_manifest(raw: &str) -> Result<String> {
-    let mut manifest: serde_json::Value = serde_json::from_str(raw)?;
-    manifest["version"] = json!(env!("CARGO_PKG_VERSION"));
-    Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
+    super::plugin_bundle::stamp_manifest_version(raw)
 }
 
 fn codex_plugin_mcp(raw: &str, tracedecay_bin: &str, scope: InstallScope) -> Result<String> {
-    let mut mcp: serde_json::Value = serde_json::from_str(raw)?;
+    // Reuse the shared command rewrite, then layer Codex's scope-specific
+    // args/env on top of the result.
+    let stamped = super::plugin_bundle::set_mcp_command(raw, tracedecay_bin)?;
+    let mut mcp: serde_json::Value = serde_json::from_str(&stamped)?;
     let server = &mut mcp["mcpServers"]["tracedecay"];
-    server["command"] = json!(tracedecay_bin);
     match scope {
         InstallScope::Global => {
             server["args"] = json!(["serve"]);

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -726,37 +726,16 @@ fn remove_codex_managed_skill_overlay(install_dir: &Path) {
     std::fs::remove_dir_all(install_dir.join("skills/agent-managed")).ok();
 }
 
-const RETIRED_CODEX_PLUGIN_SKILL_DIRS: &[&str] = &[
-    "architecture-overview",
-    "assessing-test-coverage",
-    "atomic-code-edits",
-    "auditing-code-safety",
-    "cleaning-up-dead-code",
-    "code-health-report",
-    "cross-branch-investigation",
-    "drafting-commit-and-pr",
-    "exploring-types-and-traits",
-    "finding-duplicate-logic",
-    "finding-impacted-areas",
-    "porting-code",
-    "project-status",
-    "reading-code-cheaply",
-    "refactoring-safely",
-    "reviewing-a-diff",
-    "running-impacted-tests",
-    "searching-for-code",
-    "tracking-session-health",
-];
-
 fn remove_codex_plugin_managed_skills(install_dir: &Path, skills_dir: &Path) -> Result<()> {
-    remove_retired_codex_plugin_skill_dirs(skills_dir)?;
+    sweep_retired_bundle_skill_dirs(skills_dir);
     let managed: HashSet<PathBuf> = codex_plugin_managed_paths(install_dir)
         .into_iter()
         .filter(|path| path.starts_with(skills_dir))
         .collect();
-    let mut files = collect_regular_files(skills_dir).map_err(|e| TraceDecayError::Config {
-        message: format!("failed to list {}: {e}", skills_dir.display()),
-    })?;
+    let mut files =
+        super::collect_regular_files(skills_dir).map_err(|e| TraceDecayError::Config {
+            message: format!("failed to list {}: {e}", skills_dir.display()),
+        })?;
     files.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
     for file in files {
         if managed.contains(&file) || codex_skill_file_is_legacy_tracedecay_managed(&file) {
@@ -781,43 +760,54 @@ fn codex_skill_file_is_legacy_tracedecay_managed(path: &Path) -> bool {
         })
 }
 
-fn remove_retired_codex_plugin_skill_dirs(skills_dir: &Path) -> Result<()> {
-    for name in RETIRED_CODEX_PLUGIN_SKILL_DIRS {
-        let skill_dir = skills_dir.join(name);
-        if !codex_skill_dir_is_retired_managed(&skill_dir, name) {
+/// Remove every `skills/<dir>` under the Codex plugin dir that the current
+/// bundle no longer ships. The keep-set is derived from the live embedded
+/// bundle (plus the agent-managed overlays deployed separately), so any retired
+/// skill is swept on upgrade without a hand-maintained legacy list.
+///
+/// Only tracedecay-owned skill dirs are swept: a same-name user-authored skill
+/// whose `SKILL.md` carries no tracedecay marker is left untouched, so an
+/// upgrade never deletes a user's private workflow that collides with a retired
+/// bundle slug.
+fn sweep_retired_bundle_skill_dirs(skills_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(skills_dir) else {
+        return;
+    };
+    let mut shipped: std::collections::BTreeSet<String> = codex_embedded_plugin_files()
+        .into_iter()
+        .filter_map(|(relative, _)| {
+            relative
+                .strip_prefix("skills/")
+                .and_then(|rest| rest.split('/').next())
+                .map(str::to_string)
+        })
+        .collect();
+    // The agent-managed overlays are deployed/removed separately; never treat
+    // them as retired.
+    shipped.insert("agent-managed".to_string());
+    shipped.insert("agent-managed-memory".to_string());
+    for entry in entries.flatten() {
+        if !entry.file_type().is_ok_and(|t| t.is_dir()) {
             continue;
         }
-        std::fs::remove_dir_all(&skill_dir).map_err(|e| TraceDecayError::Config {
-            message: format!(
-                "failed to remove retired Codex skill {}: {e}",
-                skill_dir.display()
-            ),
-        })?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if shipped.contains(&name) {
+            continue;
+        }
+        // Preserve user-authored skills that reuse a retired slug: only sweep a
+        // non-shipped dir that is demonstrably tracedecay-owned.
+        if !skill_file_has_tracedecay_marker(&entry.path().join("SKILL.md")) {
+            continue;
+        }
+        std::fs::remove_dir_all(entry.path()).ok();
     }
-    Ok(())
 }
 
-fn codex_skill_dir_is_retired_managed(skill_dir: &Path, expected_name: &str) -> bool {
-    let skill_file = skill_dir.join("SKILL.md");
-    let expected_name_line = format!("name: {expected_name}");
-    skill_file.is_file()
-        && std::fs::read_to_string(&skill_file).is_ok_and(|contents| {
-            let expected_name_matches = contents
-                .lines()
-                .map(str::trim)
-                .any(|line| line == expected_name_line);
-            expected_name_matches && skill_contents_have_tracedecay_marker(&contents)
-        })
-}
-
-fn skill_contents_have_tracedecay_marker(contents: &str) -> bool {
-    contents.lines().map(str::trim).any(|line| {
-        line.starts_with("name: tracedecay:")
-            || line.starts_with("description: TraceDecay ")
-            || line.contains("TraceDecay MCP")
-            || line.contains("tracedecay_")
-            || line.contains("`tracedecay:")
-    })
+/// True when a Codex `SKILL.md` at `skill_file` carries a tracedecay authorship
+/// marker, marking the skill dir as tracedecay-owned.
+fn skill_file_has_tracedecay_marker(skill_file: &Path) -> bool {
+    std::fs::read_to_string(skill_file)
+        .is_ok_and(|contents| super::skill_contents_have_tracedecay_marker(&contents))
 }
 
 fn prune_empty_dirs(root: &Path) -> std::io::Result<()> {
@@ -881,7 +871,7 @@ fn codex_plugin_dir_is_tracedecay(install_dir: &Path) -> bool {
 }
 
 fn codex_plugin_dir_has_only_managed_files(install_dir: &Path) -> bool {
-    let Ok(entries) = collect_regular_files(install_dir) else {
+    let Ok(entries) = super::collect_regular_files(install_dir) else {
         return false;
     };
     let managed = codex_plugin_managed_paths(install_dir);
@@ -895,25 +885,6 @@ fn codex_plugin_managed_paths(install_dir: &Path) -> Vec<PathBuf> {
         .collect();
     paths.push(install_dir.join("skills/agent-managed-memory/SKILL.md"));
     paths
-}
-
-fn collect_regular_files(root: &Path) -> std::io::Result<Vec<PathBuf>> {
-    let mut out = Vec::new();
-    collect_regular_files_inner(root, &mut out)?;
-    Ok(out)
-}
-
-fn collect_regular_files_inner(root: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(root)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        if file_type.is_dir() {
-            collect_regular_files_inner(&entry.path(), out)?;
-        } else if file_type.is_file() {
-            out.push(entry.path());
-        }
-    }
-    Ok(())
 }
 
 fn remove_codex_marketplace_entry(home: &Path) -> Result<()> {
@@ -1549,7 +1520,7 @@ mod tests {
     /// `codex_bundle_ships_exactly_the_model_invocable_cursor_skills` checks.
     /// Every file under a skills root, relative to it, forward-slashed.
     fn skill_tree_files(root: &Path) -> Vec<String> {
-        let mut files: Vec<String> = collect_regular_files(root)
+        let mut files: Vec<String> = crate::agents::collect_regular_files(root)
             .expect("skills dir readable")
             .into_iter()
             .filter_map(|path| {

--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -269,15 +269,11 @@ fn write_embedded_plugin(install_dir: &Path, tracedecay_bin: &str) -> Result<()>
 }
 
 fn cursor_plugin_manifest(raw: &str) -> Result<String> {
-    let mut manifest: serde_json::Value = serde_json::from_str(raw)?;
-    manifest["version"] = json!(env!("CARGO_PKG_VERSION"));
-    Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
+    super::plugin_bundle::stamp_manifest_version(raw)
 }
 
 fn cursor_plugin_mcp(raw: &str, tracedecay_bin: &str) -> Result<String> {
-    let mut mcp: serde_json::Value = serde_json::from_str(raw)?;
-    mcp["mcpServers"]["tracedecay"]["command"] = json!(tracedecay_bin);
-    Ok(format!("{}\n", serde_json::to_string_pretty(&mcp)?))
+    super::plugin_bundle::set_mcp_command(raw, tracedecay_bin)
 }
 
 fn cursor_plugin_hooks(raw: &str, tracedecay_bin: &str) -> Result<String> {
@@ -397,15 +393,8 @@ fn sweep_retired_bundle_skill_dirs(install_dir: &Path) {
 /// True when a Cursor `SKILL.md` carries a tracedecay authorship marker, marking
 /// the skill dir as tracedecay-owned (and therefore safe to sweep when retired).
 fn skill_file_has_tracedecay_marker(skill_file: &Path) -> bool {
-    std::fs::read_to_string(skill_file).is_ok_and(|contents| {
-        contents.lines().map(str::trim).any(|line| {
-            line.starts_with("name: tracedecay:")
-                || line.starts_with("description: TraceDecay ")
-                || line.contains("TraceDecay MCP")
-                || line.contains("tracedecay_")
-                || line.contains("`tracedecay:")
-        })
-    })
+    std::fs::read_to_string(skill_file)
+        .is_ok_and(|contents| super::skill_contents_have_tracedecay_marker(&contents))
 }
 
 fn cursor_plugin_dir_is_tracedecay(install_dir: &Path) -> bool {
@@ -417,7 +406,7 @@ fn cursor_plugin_dir_is_tracedecay(install_dir: &Path) -> bool {
 }
 
 fn cursor_plugin_dir_has_only_managed_files(install_dir: &Path) -> bool {
-    let Ok(entries) = collect_regular_files(install_dir) else {
+    let Ok(entries) = super::collect_regular_files(install_dir) else {
         return false;
     };
     let managed = cursor_plugin_managed_paths(install_dir);
@@ -431,25 +420,6 @@ fn cursor_plugin_managed_paths(install_dir: &Path) -> Vec<PathBuf> {
         .collect();
     paths.push(install_dir.join("rules/tracedecay-memory-digest.mdc"));
     paths
-}
-
-fn collect_regular_files(root: &Path) -> std::io::Result<Vec<PathBuf>> {
-    let mut out = Vec::new();
-    collect_regular_files_inner(root, &mut out)?;
-    Ok(out)
-}
-
-fn collect_regular_files_inner(root: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(root)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        if file_type.is_dir() {
-            collect_regular_files_inner(&entry.path(), out)?;
-        } else if file_type.is_file() {
-            out.push(entry.path());
-        }
-    }
-    Ok(())
 }
 
 fn legacy_mcp_has_tracedecay(mcp_path: &Path) -> bool {
@@ -943,7 +913,7 @@ mod tests {
 
     /// Every file under a single skill dir, relative to it, forward-slashed.
     fn skill_dir_tree_files(skill_dir: &Path) -> Vec<String> {
-        let mut files: Vec<String> = collect_regular_files(skill_dir)
+        let mut files: Vec<String> = crate::agents::collect_regular_files(skill_dir)
             .expect("skill dir readable")
             .into_iter()
             .filter_map(|path| {
@@ -1491,7 +1461,7 @@ mod tests {
             std::fs::read_to_string(cursor_dir.join("rules/tracedecay.mdc")).unwrap(),
             rule
         );
-        let mut files = collect_regular_files(&cursor_dir).unwrap();
+        let mut files = crate::agents::collect_regular_files(&cursor_dir).unwrap();
         files.sort();
         assert_eq!(
             files,

--- a/src/agents/kiro.rs
+++ b/src/agents/kiro.rs
@@ -336,32 +336,11 @@ fn mcp_server_entry(tracedecay_bin: &str) -> serde_json::Value {
     })
 }
 
+/// Render a path as a `file://` resource URI for Kiro's agent config. Reuses
+/// the LSP client's encoder, which additionally handles Windows drive paths and
+/// UNC (`//server/share`) prefixes; POSIX paths encode identically to before.
 fn file_resource_uri(path: &Path) -> String {
-    let path = path.to_string_lossy().replace('\\', "/");
-    let path = percent_encode_file_uri_path(&path);
-    if path.starts_with('/') {
-        format!("file://{path}")
-    } else {
-        format!("file:///{path}")
-    }
-}
-
-fn percent_encode_file_uri_path(path: &str) -> String {
-    const HEX: &[u8; 16] = b"0123456789ABCDEF";
-    let mut encoded = String::with_capacity(path.len());
-    for byte in path.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b':' | b'-' | b'.' | b'_' | b'~' => {
-                encoded.push(byte as char);
-            }
-            _ => {
-                encoded.push('%');
-                encoded.push(HEX[(byte >> 4) as usize] as char);
-                encoded.push(HEX[(byte & 0x0F) as usize] as char);
-            }
-        }
-    }
-    encoded
+    crate::diagnostics::lsp::client::file_uri_from_path_text(&path.to_string_lossy())
 }
 
 fn managed_agent_config(

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -817,6 +817,40 @@ or the server is disconnected, every tool is also available as a shell command: 
 `tracedecay tool <name> --help` shows parameters). Fall back to that CLI instead of \
 querying `.tracedecay` databases directly or abandoning tracedecay.";
 
+/// True when a `SKILL.md`'s contents carry a tracedecay authorship marker,
+/// marking the skill dir as tracedecay-owned (and therefore safe to sweep when
+/// retired). Shared by the Cursor and Codex plugin-dir sweeps.
+pub(crate) fn skill_contents_have_tracedecay_marker(contents: &str) -> bool {
+    contents.lines().map(str::trim).any(|line| {
+        line.starts_with("name: tracedecay:")
+            || line.starts_with("description: TraceDecay ")
+            || line.contains("TraceDecay MCP")
+            || line.contains("tracedecay_")
+            || line.contains("`tracedecay:")
+    })
+}
+
+/// Recursively collect every regular file under `root` (following the same
+/// hand-rolled walk both the Cursor and Codex installers rely on).
+pub(crate) fn collect_regular_files(root: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    collect_regular_files_inner(root, &mut out)?;
+    Ok(out)
+}
+
+fn collect_regular_files_inner(root: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_regular_files_inner(&entry.path(), out)?;
+        } else if file_type.is_file() {
+            out.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn hook_command(tracedecay_bin: &str, subcommand: &str) -> String {
     hook_command_for_platform(tracedecay_bin, subcommand, cfg!(windows))
 }

--- a/src/agents/plugin_bundle.rs
+++ b/src/agents/plugin_bundle.rs
@@ -36,6 +36,26 @@
 //! Composed per-host view = `GENERATED_SKILL_FILES` (recursively embedded from
 //! `plugin/skills/`, filtered per host) ∪ `<HOST>_MANIFEST_FILES` and extras.
 
+use crate::errors::Result;
+
+/// Stamp the plugin manifest `version` field with the crate version, returning
+/// pretty-printed JSON with a trailing newline. Shared by every host installer
+/// (Claude/Cursor/Codex), which all render the same manifest round-trip.
+pub(crate) fn stamp_manifest_version(raw: &str) -> Result<String> {
+    let mut manifest: serde_json::Value = serde_json::from_str(raw)?;
+    manifest["version"] = serde_json::json!(env!("CARGO_PKG_VERSION"));
+    Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
+}
+
+/// Point the MCP config's `mcpServers.tracedecay.command` at the resolved
+/// binary path, returning pretty-printed JSON with a trailing newline. Claude
+/// and Cursor use this directly; Codex layers scope-specific args/env on top.
+pub(crate) fn set_mcp_command(raw: &str, bin: &str) -> Result<String> {
+    let mut mcp: serde_json::Value = serde_json::from_str(raw)?;
+    mcp["mcpServers"]["tracedecay"]["command"] = serde_json::json!(bin);
+    Ok(format!("{}\n", serde_json::to_string_pretty(&mcp)?))
+}
+
 /// One embedded plugin file: `relative` is its deploy path (unchanged from the
 /// legacy per-host bundles), `contents` is embedded from the shared `plugin/`
 /// tree at compile time.

--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -32,6 +32,14 @@ impl SkillInstallTarget {
         matches!(self, Self::Cursor | Self::Codex)
     }
 
+    /// True for hosts that reconcile their managed-skill listing as a
+    /// marker-gated block inside a prompt file. Native-overlay hosts
+    /// (Cursor/Codex) deploy a skills directory instead, and Hermes owns its
+    /// own curation — neither writes a prompt-index block.
+    pub fn writes_prompt_index(self) -> bool {
+        !self.is_native_overlay() && self != Self::Hermes
+    }
+
     pub fn prompt_label(self) -> &'static str {
         match self {
             Self::Cursor => "Cursor",

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -15,7 +15,9 @@ use crate::errors::{Result, TraceDecayError};
 
 const NATIVE_NAMESPACE_DIR: &str = "agent-managed";
 const NATIVE_MANIFEST_FILE: &str = ".tracedecay-managed-skills.json";
-const PROMPT_INDEX_START: &str = "<!-- TRACEDECAY MANAGED SKILLS START -->";
+/// The unslugged legacy managed-skill start marker. Reuses the same literal the
+/// prompt-rules block-splicer stops at, keeping the two in sync.
+const PROMPT_INDEX_START: &str = crate::agents::prompt_rules::SKILL_INDEX_START;
 const PROMPT_INDEX_END: &str = "<!-- TRACEDECAY MANAGED SKILLS END -->";
 
 const ALL_SKILL_INSTALL_TARGETS: [SkillInstallTarget; 8] = [
@@ -305,30 +307,13 @@ fn replace_or_append_marked_block(
     block: &str,
 ) -> Result<String> {
     let (start_marker, end_marker) = prompt_index_markers(target);
-    if let Some((start, end)) = marked_block_range(existing, &start_marker, &end_marker)? {
-        let mut updated = String::new();
-        updated.push_str(existing[..start].trim_end());
-        updated.push_str("\n\n");
-        updated.push_str(block.trim_end());
-        updated.push_str("\n\n");
-        updated.push_str(existing[end..].trim_start());
-        if !updated.ends_with('\n') {
-            updated.push('\n');
-        }
-        Ok(updated)
-    } else if let Some((start, end)) =
-        marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?
-    {
-        let mut updated = String::new();
-        updated.push_str(existing[..start].trim_end());
-        updated.push_str("\n\n");
-        updated.push_str(block.trim_end());
-        updated.push_str("\n\n");
-        updated.push_str(existing[end..].trim_start());
-        if !updated.ends_with('\n') {
-            updated.push('\n');
-        }
-        Ok(updated)
+    // Prefer this target's slugged block; fall back to the legacy unslugged one.
+    let existing_range = match marked_block_range(existing, &start_marker, &end_marker)? {
+        Some(range) => Some(range),
+        None => marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?,
+    };
+    if let Some((start, end)) = existing_range {
+        Ok(splice_range(existing, start, end, block))
     } else {
         let mut updated = String::new();
         updated.push_str(existing.trim_end());
@@ -338,6 +323,21 @@ fn replace_or_append_marked_block(
         updated.push_str(block);
         Ok(updated)
     }
+}
+
+/// Replace `existing[start..end]` with `block`, normalizing surrounding blank
+/// lines and guaranteeing a trailing newline.
+fn splice_range(existing: &str, start: usize, end: usize, block: &str) -> String {
+    let mut updated = String::new();
+    updated.push_str(existing[..start].trim_end());
+    updated.push_str("\n\n");
+    updated.push_str(block.trim_end());
+    updated.push_str("\n\n");
+    updated.push_str(existing[end..].trim_start());
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated
 }
 
 fn remove_marked_block_for_target(existing: &str, target: SkillInstallTarget) -> Result<String> {
@@ -372,13 +372,10 @@ fn has_other_slugged_block(existing: &str, target: SkillInstallTarget) -> bool {
 
 fn remove_all_marked_blocks(existing: &str) -> Result<String> {
     let mut updated = existing.to_string();
-    for target in [
-        SkillInstallTarget::Claude,
-        SkillInstallTarget::Agents,
-        SkillInstallTarget::OpenCode,
-        SkillInstallTarget::Kimi,
-        SkillInstallTarget::Kiro,
-    ] {
+    for target in ALL_SKILL_INSTALL_TARGETS
+        .into_iter()
+        .filter(|target| target.writes_prompt_index())
+    {
         updated = remove_marked_block_for_target(&updated, target)?;
     }
     if let Some((start, end)) = marked_block_range(&updated, PROMPT_INDEX_START, PROMPT_INDEX_END)?

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -524,7 +524,10 @@ fn file_uri(path: &Path) -> String {
     file_uri_from_path_text(&absolute.to_string_lossy())
 }
 
-fn file_uri_from_path_text(path: &str) -> String {
+/// Build a `file://` URI from raw path text, normalizing `\` to `/` and
+/// percent-encoding. Handles POSIX paths, Windows drive paths (`C:/…`), and UNC
+/// (`//server/share`) prefixes. Shared with the Kiro installer.
+pub(crate) fn file_uri_from_path_text(path: &str) -> String {
     let normalized = path.replace('\\', "/");
     let encoded = percent_encode_file_uri_path(&normalized);
     if normalized.starts_with("//") {

--- a/src/mcp/project_route.rs
+++ b/src/mcp/project_route.rs
@@ -90,10 +90,11 @@ impl HookProjectRouteCache {
         self.project_path.as_deref()
     }
 
-    pub(crate) fn refresh_from_shared(&mut self, shared: &HookProjectRouteCache) {
-        let local_project_path = self.project_path.clone();
-        self.clone_from(shared);
-        self.project_path = local_project_path;
+    /// Overwrite every field except `project_path` from an already-cloned
+    /// shared snapshot, taking ownership so no second deep clone is needed.
+    fn refresh_from_owned(&mut self, mut shared: HookProjectRouteCache) {
+        shared.project_path = self.project_path.take();
+        *self = shared;
     }
 
     fn insert_session_route(&mut self, session_id: String, project_path: String) {
@@ -187,6 +188,17 @@ impl SharedHookProjectRouteCache {
             cache.project_path = None;
             shared.clone_from(&cache);
         }
+    }
+
+    /// Refresh `target` from the shared cache with a single deep clone taken
+    /// under the lock, preserving `target`'s local `project_path`.
+    pub(crate) fn refresh_into(&self, target: &mut HookProjectRouteCache) {
+        let cloned = self
+            .inner
+            .lock()
+            .map(|cache| cache.clone())
+            .unwrap_or_default();
+        target.refresh_from_owned(cloned);
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1637,8 +1637,7 @@ impl McpServer {
                 .await;
             return None;
         }
-        let shared_routes = self.hook_project_routes.snapshot();
-        route_cache.refresh_from_shared(&shared_routes);
+        self.hook_project_routes.refresh_into(route_cache);
         let id = request.id.clone()?;
 
         let result = match classify_mcp_method(&request.method) {


### PR DESCRIPTION
Goal: finish the Claude-deferred `/simplify` follow-ups from the plugin-bundle/installer cleanup without duplicating merged/open work, while preserving installer safety boundaries.

Detailed execution plan:
1. Start from latest `master` and verify the branch contains `origin/master`.
2. Reconcile open PRs/worktrees first; use existing active branch `simplify/dedup-installers` instead of creating a duplicate PR.
3. Apply only behavior-preserving dedupes called out by Claude/reviewer sessions:
   - clone MCP hook route cache once per refresh
   - share tracedecay marker detection and recursive file walking
   - derive Codex retired-skill sweep from the shipped bundle
   - share manifest version stamping and MCP command rewrite helpers
   - simplify marked-block splicing and derive prompt-index targets
   - reuse the LSP file-URI encoder from Kiro
4. Re-check skipped items explicitly:
   - full Cursor/Codex reconcile-primitive consolidation
   - `job_webhook` transport replacement
   - `git.rs` PATH resolver/broker reuse
   - `safe_relative_path` guard pattern
   - `remove_range` vs `prompt_rules::splice_out`
5. Verify with commit-message, fmt, clippy, build, lib, agent, hooks/LSP, and core CLI test gates.

Applied:
- `perf(mcp)`: hook route cache now clones once under the lock via `refresh_into`, removing the prior `snapshot()` plus `clone_from` double-clone.
- `agents`: `skill_contents_have_tracedecay_marker` and recursive `collect_regular_files` live in `agents::mod` instead of cursor/codex copies.
- `agents`: Codex retired-skill sweep now derives from the live bundle keep-set, matching Cursor's safer pattern and removing the stale 19-entry list.
- `agents`: manifest version stamping and MCP command rewriting moved to `plugin_bundle::{stamp_manifest_version,set_mcp_command}`.
- `skills`: `replace_or_append_marked_block` resolves the target range once via `splice_range`; `remove_all_marked_blocks` derives target files via `writes_prompt_index()` and reuses `prompt_rules::SKILL_INDEX_START`.
- `agents`: Kiro file URI handling reuses `file_uri_from_path_text`, gaining the same Windows-drive and UNC behavior as LSP diagnostics.
- `tests`: the canceled-refresh recovery test now uses the existing recovery timeout on the recovery leg, matching nearby crash-recovery tests and avoiding macOS full-suite spawn/scheduling flakes.

Deliberately deferred, after re-check:
- Full Cursor/Codex "reconcile owned plugin dir" consolidation: not simplify-safe in this PR. It is large and security-relevant; this PR removes the worst duplication around marker detection, bundle-derived sweep, manifest stamping, and command rewrite without changing ownership/deletion behavior.
- `job_webhook` to `ureq`: not safe. The hand-rolled transport connects to a pre-validated `SocketAddr` to preserve SSRF/DNS-rebind pinning.
- `git.rs` PATH resolver to broker: not applicable. Broker answers `bool`; the resolver needs the actual path.
- `safe_relative_path`: left alone as the existing codebase-wide guard pattern.
- `remove_range` to `prompt_rules::splice_out`: left alone. `remove_range` preserves trailing-newline semantics for managed skill files; `splice_out` trims final whitespace.

Validation:
- `scripts/check-conventional-commits.sh origin/master..HEAD`: pass
- `cargo fmt --all --check`: pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo build`: pass
- `cargo nextest run --lib`: 795 passed
- `cargo nextest run --test agent_suite`: 427 passed
- `cargo nextest run --test core_cli_suite`: 189 passed
- `cargo nextest run --test hooks_lsp_suite broker_cancels_partial_refresh_without_poisoning_warm_client`: pass
- `cargo nextest run --test hooks_lsp_suite`: 116 passed

Production code tests were not modified; the only test change widens an already-designated recovery path timeout.
