### PR TITLE
test(lsp): de-flake broker cancel-refresh recovery on slow CI

### DIFF
--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -598,13 +598,37 @@ async fn broker_cancels_partial_refresh_without_poisoning_warm_client() {
     let _ = handle.await;
 
     std::fs::write(&script_path, fake_lsp_script()).unwrap();
-    broker
-        .refresh_documents(
-            FAKE_LANGUAGE,
-            vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            FAKE_LSP_TIMEOUT,
-        )
-        .await
+    // The property under test is that aborting a partial refresh does not
+    // poison the broker: a *subsequent* refresh must spin up a clean client.
+    // On a loaded CI runner the recovery client's `python3` cold-start can
+    // exceed the initialize floor and surface a transient "initialize timed
+    // out" — that is a slow start, not a poisoned broker — so retry the
+    // recovery a bounded number of times before asserting.
+    let mut recovery = None;
+    for attempt in 0..5 {
+        let result = broker
+            .refresh_documents(
+                FAKE_LANGUAGE,
+                vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
+                FAKE_LSP_TIMEOUT,
+            )
+            .await;
+        match &result {
+            Ok(()) => {
+                recovery = Some(result);
+                break;
+            }
+            Err(err) if err.to_string().contains("initialize timed out") => {
+                recovery = Some(result);
+                if attempt + 1 < 5 {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+            Err(err) => panic!("recovery refresh failed unexpectedly: {err}"),
+        }
+    }
+    recovery
+        .expect("recovery refresh should have been attempted")
         .expect("next refresh should start a clean client and recover");
 
     let snapshot = broker.snapshot();


### PR DESCRIPTION
`broker_cancels_partial_refresh_without_poisoning_warm_client` (`tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs`) is a macOS CI flake. It failed on two consecutive **unrelated** PRs (#253 perf/git-resolver, #254 refactor/dedup), both with:

```
panicked at tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs:608:
next refresh should start a clean client and recover:
Config { message: "LSP server '/usr/bin/python3' initialize timed out after 3000 ms" }
```

## Root cause
The test aborts a partial refresh, then asserts the broker isn't poisoned by driving a **recovery** refresh that must spin up a clean client. That recovery spawns a fresh `python3` fake-LSP process; on a loaded runner its cold-start intermittently exceeds the 3s initialize floor (`MIN_INITIALIZE_RESPONSE_TIMEOUT`). That's a slow start, **not** a poisoned broker — but the single-shot `.expect()` treats it as a hard failure. Neither PR touches LSP runtime code.

## Fix
Retry the recovery refresh a bounded number of times (5 attempts, 50ms apart), tolerating **only** the transient `initialize timed out` error and still panicking immediately on any other error. The `EngineState::Ready` / `total_errors == 1` assertions are unchanged, so the property under test (recovery from an aborted partial refresh) is preserved. No production timeout semantics changed.

## Validation
Target test 15/15 green on repeat; full `hooks_lsp_suite` 116 passed; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)