### PR TITLE
[codex] Improve Codex plugin hook trust doctor

### DIFF
--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -126,13 +126,10 @@ impl AgentIntegration for CodexIntegration {
         // something into `refreshed`.
         let has_personal_bundle =
             !cached_dirs.is_empty() || codex_plugin_manifest_path(&ctx.home).exists();
-        if refreshed.is_empty() {
-            if !has_personal_bundle && !legacy_config_install {
-                return Ok(UpdatePluginOutcome::NotInstalled);
-            }
-            install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
-            refreshed.push(plugin_dir.clone());
-        } else if legacy_config_install && !has_personal_bundle {
+        if refreshed.is_empty() && !has_personal_bundle && !legacy_config_install {
+            return Ok(UpdatePluginOutcome::NotInstalled);
+        }
+        if refreshed.is_empty() || (legacy_config_install && !has_personal_bundle) {
             install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
             refreshed.push(plugin_dir.clone());
         }
@@ -250,7 +247,7 @@ impl AgentIntegration for CodexIntegration {
 }
 
 fn codex_legacy_config_has_tracedecay(home: &Path) -> bool {
-    let config = home.join(".codex").join("config.toml");
+    let config = codex_config_path(home);
     if !config.exists() {
         return false;
     }
@@ -304,6 +301,11 @@ fn codex_plugin_manifest_path(home: &Path) -> PathBuf {
 
 fn codex_personal_marketplace_path(home: &Path) -> PathBuf {
     home.join(".agents/plugins/marketplace.json")
+}
+
+/// The user-level Codex config that carries MCP registrations and hook trust.
+fn codex_config_path(home: &Path) -> PathBuf {
+    home.join(".codex/config.toml")
 }
 
 fn codex_repo_plugin_install_dir(project_path: &Path) -> PathBuf {
@@ -386,7 +388,7 @@ fn install_codex_repo_plugin(home: &Path, project_path: &Path, tracedecay_bin: &
 
 fn sweep_legacy_global_codex_config(home: &Path) {
     let codex_dir = home.join(".codex");
-    uninstall_tracedecay_mcp_if_present(&codex_dir.join("config.toml"));
+    uninstall_tracedecay_mcp_if_present(&codex_config_path(home));
     uninstall_hooks(&codex_dir.join("hooks.json"));
     uninstall_prompt_rules(&codex_dir.join("AGENTS.md"));
 }
@@ -479,8 +481,7 @@ impl CodexBundlePolicy {
     /// Where Codex records trust for this bundle's hooks — `None` for scopes
     /// that ship no hooks and therefore have no trust surface.
     fn hook_trust_config_path(self, home: &Path) -> Option<PathBuf> {
-        self.include_hooks()
-            .then(|| home.join(".codex/config.toml"))
+        self.include_hooks().then(|| codex_config_path(home))
     }
 
     /// The memory digest rides only the global bundle.
@@ -573,16 +574,13 @@ fn write_codex_plugin_files(
 }
 
 fn codex_plugin_manifest(raw: &str, policy: CodexBundlePolicy) -> Result<String> {
-    let stamped = super::plugin_bundle::stamp_manifest_version(raw)?;
-    if policy.include_hooks() {
-        return Ok(stamped);
-    }
-
-    let mut manifest: serde_json::Value = serde_json::from_str(&stamped)?;
-    if let Some(object) = manifest.as_object_mut() {
-        object.remove("hooks");
-    }
-    Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
+    super::plugin_bundle::stamp_manifest_version_with(raw, |manifest| {
+        if !policy.include_hooks() {
+            if let Some(object) = manifest.as_object_mut() {
+                object.remove("hooks");
+            }
+        }
+    })
 }
 
 fn codex_plugin_mcp(raw: &str, tracedecay_bin: &str, policy: CodexBundlePolicy) -> Result<String> {
@@ -669,18 +667,14 @@ fn codex_hook_state_event_key(hook: &CodexManagedHook) -> String {
 }
 
 fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
-    let Some(state) = config
+    // A missing [hooks.state] table is just "nothing trusted yet" — treat it
+    // as empty so one pipeline produces the missing list either way.
+    let empty = toml::value::Table::new();
+    let state = config
         .get("hooks")
         .and_then(|hooks| hooks.get("state"))
         .and_then(|state| state.as_table())
-    else {
-        return CodexHookTrustState::Missing(
-            CODEX_MANAGED_HOOKS
-                .iter()
-                .map(codex_hook_state_event_key)
-                .collect(),
-        );
-    };
+        .unwrap_or(&empty);
 
     let missing: Vec<String> = CODEX_MANAGED_HOOKS
         .iter()
@@ -1434,7 +1428,7 @@ fn doctor_suggest_native_memories_off(dc: &mut DoctorCounters, home: &Path) {
     if !crate::hooks::memory_inject::memory_injection_enabled() {
         return;
     }
-    let config_path = home.join(".codex/config.toml");
+    let config_path = codex_config_path(home);
     let Ok(config) = load_toml_file(&config_path) else {
         return;
     };

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -20,8 +20,8 @@ use crate::errors::{Result, TraceDecayError};
 
 use super::{
     load_json_file, load_json_file_strict, load_toml_file, safe_write_json_file,
-    safe_write_text_file, tool_names, write_toml_file, AgentIntegration, DoctorCounters,
-    HealthcheckContext, InstallContext, InstallScope, UpdatePluginOutcome,
+    safe_write_text_file, write_toml_file, AgentIntegration, DoctorCounters, HealthcheckContext,
+    InstallContext, InstallScope, UpdatePluginOutcome,
 };
 
 /// `OpenAI` Codex CLI agent.
@@ -125,10 +125,10 @@ impl AgentIntegration for CodexIntegration {
             return Ok(UpdatePluginOutcome::Refreshed(refreshed));
         }
 
-        let target = if codex_plugin_manifest_path(&ctx.home).exists() {
+        let target = if codex_plugin_manifest_path(&ctx.home).exists()
+            || codex_legacy_config_has_tracedecay(&ctx.home)
+        {
             Some(plugin_dir.clone())
-        } else if Self::has_legacy_config_install(&ctx.home) {
-            return Ok(UpdatePluginOutcome::ConfigOnly);
         } else {
             None
         };
@@ -191,10 +191,13 @@ impl AgentIntegration for CodexIntegration {
 
     fn healthcheck(&self, dc: &mut DoctorCounters, ctx: &HealthcheckContext) {
         eprintln!("\n\x1b[1mCodex CLI integration\x1b[0m");
-        let local_codex_dir = ctx.project_path.join(".codex");
         let local_plugin_dir = codex_repo_plugin_install_dir(&ctx.project_path);
         if local_plugin_dir.join(".codex-plugin/plugin.json").exists() {
-            doctor_check_plugin_dir(dc, &local_plugin_dir);
+            doctor_check_plugin_dir(
+                dc,
+                &local_plugin_dir,
+                Some(&ctx.home.join(".codex/config.toml")),
+            );
             doctor_check_marketplace_entry(
                 dc,
                 &codex_repo_marketplace_path(&ctx.project_path),
@@ -202,12 +205,6 @@ impl AgentIntegration for CodexIntegration {
                 "./plugins/tracedecay",
                 "tracedecay install --local --agent codex",
             );
-        } else if local_codex_dir.join("config.toml").exists()
-            || local_codex_dir.join("hooks.json").exists()
-        {
-            doctor_check_config(dc, &local_codex_dir.join("config.toml"));
-            doctor_check_prompt_file(dc, &ctx.project_path.join("AGENTS.md"));
-            doctor_check_hooks(dc, &local_codex_dir.join("hooks.json"));
         } else {
             doctor_check_plugin(dc, &ctx.home);
         }
@@ -228,29 +225,21 @@ impl AgentIntegration for CodexIntegration {
     }
 
     fn has_tracedecay(&self, home: &Path) -> bool {
-        if !codex_plugin_cached_install_dirs(home).is_empty()
+        !codex_plugin_cached_install_dirs(home).is_empty()
             || codex_plugin_manifest_path(home).exists()
-        {
-            return true;
-        }
-        Self::has_legacy_config_install(home)
     }
 }
 
-impl CodexIntegration {
-    fn has_legacy_config_install(home: &Path) -> bool {
-        let config = home.join(".codex").join("config.toml");
-        if !config.exists() {
-            return false;
-        }
-        // If the file is unparseable, conservatively report "not installed"
-        // so the caller treats it like a fresh install path.
-        super::load_toml_file(&config).is_ok_and(|toml| {
-            toml.get("mcp_servers")
-                .and_then(|v| v.get("tracedecay"))
-                .is_some()
-        })
+fn codex_legacy_config_has_tracedecay(home: &Path) -> bool {
+    let config = home.join(".codex").join("config.toml");
+    if !config.exists() {
+        return false;
     }
+    super::load_toml_file(&config).is_ok_and(|toml| {
+        toml.get("mcp_servers")
+            .and_then(|v| v.get("tracedecay"))
+            .is_some()
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -576,6 +565,60 @@ const CODEX_MANAGED_HOOKS: &[CodexManagedHook] = &[
 /// Subcommands from older bundles that uninstall must also strip even though
 /// the current bundle no longer registers them.
 const CODEX_LEGACY_HOOK_SUBCOMMANDS: &[&str] = &["hook-codex-pre-tool-use"];
+
+#[derive(Debug, PartialEq, Eq)]
+enum CodexHookTrustState {
+    Trusted,
+    Missing(Vec<String>),
+}
+
+fn codex_hook_state_event_key(event: &str) -> String {
+    let mut key = String::new();
+    for (index, ch) in event.chars().enumerate() {
+        if ch.is_ascii_uppercase() && index > 0 {
+            key.push('_');
+        }
+        key.push(ch.to_ascii_lowercase());
+    }
+    key
+}
+
+fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
+    let Some(state) = config
+        .get("hooks")
+        .and_then(|hooks| hooks.get("state"))
+        .and_then(|state| state.as_table())
+    else {
+        return CodexHookTrustState::Missing(
+            CODEX_MANAGED_HOOKS
+                .iter()
+                .map(|hook| codex_hook_state_event_key(hook.event))
+                .collect(),
+        );
+    };
+
+    let missing: Vec<String> = CODEX_MANAGED_HOOKS
+        .iter()
+        .map(|hook| codex_hook_state_event_key(hook.event))
+        .filter(|event_key| {
+            let suffix = format!(":hooks/hooks.json:{event_key}:0:0");
+            !state.iter().any(|(key, entry)| {
+                key.starts_with("tracedecay@")
+                    && key.ends_with(&suffix)
+                    && entry
+                        .get("trusted_hash")
+                        .and_then(|hash| hash.as_str())
+                        .is_some_and(|hash| hash.starts_with("sha256:"))
+            })
+        })
+        .collect();
+
+    if missing.is_empty() {
+        CodexHookTrustState::Trusted
+    } else {
+        CodexHookTrustState::Missing(missing)
+    }
+}
 
 fn codex_plugin_hooks(raw: &str, tracedecay_bin: &str) -> Result<String> {
     let mut hooks: serde_json::Value = serde_json::from_str(raw)?;
@@ -1121,7 +1164,7 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
     let cached_dirs = codex_plugin_cached_install_dirs(home);
     if !cached_dirs.is_empty() {
         for plugin_dir in cached_dirs {
-            doctor_check_plugin_dir(dc, &plugin_dir);
+            doctor_check_plugin_dir(dc, &plugin_dir, Some(&home.join(".codex/config.toml")));
         }
         return;
     }
@@ -1129,17 +1172,10 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
     let plugin_dir = codex_plugin_install_dir(home);
     let manifest_path = plugin_dir.join(".codex-plugin/plugin.json");
     if !manifest_path.exists() {
-        if CodexIntegration::has_legacy_config_install(home) {
-            doctor_check_config(dc, &home.join(".codex/config.toml"));
-            dc.warn(
-                "Codex uses a legacy config-managed tracedecay install — run `tracedecay install --agent codex` to install the Codex plugin bundle",
-            );
-        } else {
-            dc.warn(&format!(
-                "{} not found — run `tracedecay install --agent codex` if you use Codex CLI",
-                manifest_path.display()
-            ));
-        }
+        dc.warn(&format!(
+            "{} not found — run `tracedecay install --agent codex` or `tracedecay update-plugin` to install the Codex plugin bundle",
+            manifest_path.display()
+        ));
         return;
     }
 
@@ -1181,7 +1217,11 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
             mcp_path.display()
         ));
     }
-    doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"));
+    doctor_check_hooks(
+        dc,
+        &plugin_dir.join("hooks/hooks.json"),
+        Some(&home.join(".codex/config.toml")),
+    );
 
     doctor_check_marketplace_entry(
         dc,
@@ -1231,7 +1271,7 @@ fn doctor_check_marketplace_entry(
     }
 }
 
-fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path) {
+fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path, config_path: Option<&Path>) {
     let manifest_path = plugin_dir.join(".codex-plugin/plugin.json");
     let manifest = load_json_file(&manifest_path);
     if manifest.get("name").and_then(|value| value.as_str()) == Some("tracedecay") {
@@ -1271,95 +1311,12 @@ fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path) {
             mcp_path.display()
         ));
     }
-    doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"));
+    doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"), config_path);
 }
 
-/// Check config.toml has tracedecay registered.
-fn doctor_check_config(dc: &mut DoctorCounters, config_path: &Path) {
-    if !config_path.exists() {
-        dc.warn(&format!(
-            "{} not found — run `tracedecay install --agent codex` if you use Codex CLI",
-            config_path.display()
-        ));
-        return;
-    }
-
-    let config = match load_toml_file(config_path) {
-        Ok(c) => c,
-        Err(e) => {
-            dc.fail(&format!("{e}"));
-            return;
-        }
-    };
-    let has_server = config
-        .get("mcp_servers")
-        .and_then(|v| v.get("tracedecay"))
-        .and_then(|v| v.as_table())
-        .is_some();
-
-    if !has_server {
-        dc.fail(&format!(
-            "MCP server NOT registered in {} — run `tracedecay install --agent codex`",
-            config_path.display()
-        ));
-        return;
-    }
-    dc.pass(&format!(
-        "MCP server registered in {}",
-        config_path.display()
-    ));
-
-    // Check tool auto-approval
-    let tools = config
-        .get("mcp_servers")
-        .and_then(|v| v.get("tracedecay"))
-        .and_then(|v| v.get("tools"))
-        .and_then(|v| v.as_table());
-
-    let auto_count = tools.map_or(0, |t| {
-        t.values()
-            .filter(|v| v.get("approval_mode").and_then(|m| m.as_str()) == Some("auto"))
-            .count()
-    });
-
-    let tools = tool_names();
-    let tools_len = tools.len();
-    if auto_count >= tools_len {
-        dc.pass(&format!("All {tools_len} tools set to auto-approve"));
-    } else if auto_count > 0 {
-        dc.warn(&format!(
-            "{auto_count}/{tools_len} tools auto-approved — run `tracedecay install --agent codex` to update"
-        ));
-    } else {
-        dc.warn("No tools auto-approved — Codex will prompt for each tool call");
-    }
-}
-
-/// Check AGENTS.md contains tracedecay rules.
-fn doctor_check_prompt_file(dc: &mut DoctorCounters, agents_md: &Path) {
-    if agents_md.exists() {
-        let has_rules = std::fs::read_to_string(agents_md)
-            .unwrap_or_default()
-            .contains("tracedecay");
-        if has_rules {
-            dc.pass(&format!(
-                "AGENTS.md contains tracedecay rules in {}",
-                agents_md.display()
-            ));
-        } else {
-            dc.fail(&format!(
-                "AGENTS.md missing tracedecay rules in {} — run `tracedecay install --local --agent codex` or `tracedecay install --agent codex`",
-                agents_md.display()
-            ));
-        }
-    } else {
-        dc.warn(&format!("{} does not exist", agents_md.display()));
-    }
-}
-
-/// Check hooks.json registers the tracedecay lifecycle hooks, and remind the
-/// user that Codex requires trusting them via `/hooks` before they run.
-fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path) {
+/// Check hooks.json registers the tracedecay lifecycle hooks, and report Codex
+/// hook trust state when the user-level config is available.
+fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: Option<&Path>) {
     if !hooks_path.exists() {
         dc.warn(&format!(
             "{} not found — run `tracedecay install --agent codex` to add lifecycle hooks",
@@ -1380,9 +1337,22 @@ fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path) {
             CODEX_MANAGED_HOOKS.len(),
             hooks_path.display()
         ));
-        dc.info(
-            "Codex skips new/changed command hooks until trusted — run `/hooks` in Codex to trust the tracedecay hooks",
-        );
+        match config_path.and_then(|path| load_toml_file(path).ok().map(|config| (path, config))) {
+            Some((path, config)) => match codex_plugin_hook_trust_state(&config) {
+                CodexHookTrustState::Trusted => dc.info(&format!(
+                    "Codex hook trust entries recorded in {}",
+                    path.display()
+                )),
+                CodexHookTrustState::Missing(missing) => dc.info(&format!(
+                    "Codex skips new/changed command hooks until trusted — missing trust for {} in {}; run `/hooks` in Codex",
+                    missing.join(", "),
+                    path.display()
+                )),
+            },
+            None => dc.info(
+                "Codex skips new/changed command hooks until trusted — run `/hooks` in Codex to trust the tracedecay hooks",
+            ),
+        }
     } else {
         dc.warn(&format!(
             "tracedecay hook(s) missing for {} in {} — run `tracedecay install --local --agent codex` or `tracedecay install --agent codex`",
@@ -1476,6 +1446,57 @@ mod tests {
             "[features]\nmemories = false\n"
         )));
         assert!(!codex_native_memories_injection_enabled(&parse("")));
+    }
+
+    #[test]
+    fn codex_hook_trust_state_reports_all_trusted_entries() {
+        let config = r#"
+[hooks.state]
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:post_tool_use:0:0"]
+trusted_hash = "sha256:post"
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:session"
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:user_prompt_submit:0:0"]
+trusted_hash = "sha256:prompt"
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:subagent_start:0:0"]
+trusted_hash = "sha256:subagent"
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:post_compact:0:0"]
+trusted_hash = "sha256:compact"
+"#;
+        let config = toml::from_str::<toml::Value>(config).unwrap();
+
+        assert_eq!(
+            codex_plugin_hook_trust_state(&config),
+            CodexHookTrustState::Trusted
+        );
+    }
+
+    #[test]
+    fn codex_hook_trust_state_reports_missing_entries() {
+        let config = toml::from_str::<toml::Value>(
+            r#"
+[hooks.state]
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:post_tool_use:0:0"]
+trusted_hash = "sha256:post"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            codex_plugin_hook_trust_state(&config),
+            CodexHookTrustState::Missing(vec![
+                "session_start".to_string(),
+                "user_prompt_submit".to_string(),
+                "subagent_start".to_string(),
+                "post_compact".to_string(),
+            ])
+        );
     }
 
     #[test]

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -187,7 +187,12 @@ impl AgentIntegration for CodexIntegration {
         eprintln!("\n\x1b[1mCodex CLI integration\x1b[0m");
         let local_plugin_dir = codex_repo_plugin_install_dir(&ctx.project_path);
         if local_plugin_dir.join(".codex-plugin/plugin.json").exists() {
-            doctor_check_plugin_dir(dc, &local_plugin_dir, None);
+            doctor_check_plugin_dir(
+                dc,
+                &local_plugin_dir,
+                CodexBundlePolicy::for_scope(InstallScope::ProjectLocal),
+                &ctx.home,
+            );
             doctor_check_marketplace_entry(
                 dc,
                 &codex_repo_marketplace_path(&ctx.project_path),
@@ -406,15 +411,70 @@ fn uninstall_tracedecay_mcp_if_present(config_path: &Path) {
     }
 }
 
+/// The scope contract for a rendered Codex plugin bundle, in one place.
+///
+/// A global bundle ships lifecycle hooks (declared in the manifest and
+/// recorded as trusted in the user-level `~/.codex/config.toml`), serves with
+/// the global DB enabled, and carries the memory digest. A repo-local bundle
+/// ships no hooks, serves the project path with no env, and stays free of
+/// user-profile state. The bundle writer, manifest/MCP renderers, and doctor
+/// all consume this type instead of re-encoding the scope as ad-hoc
+/// conditionals.
+#[derive(Debug, Clone, Copy)]
+struct CodexBundlePolicy {
+    scope: InstallScope,
+}
+
+impl CodexBundlePolicy {
+    fn for_scope(scope: InstallScope) -> Self {
+        Self { scope }
+    }
+
+    /// Whether the bundle ships `hooks/hooks.json` and declares it in the
+    /// plugin manifest.
+    fn include_hooks(self) -> bool {
+        self.scope == InstallScope::Global
+    }
+
+    /// The `serve` args baked into the bundle's `.mcp.json`.
+    fn mcp_args(self) -> serde_json::Value {
+        match self.scope {
+            InstallScope::Global => json!(["serve"]),
+            InstallScope::ProjectLocal => json!(["serve", "--path", "."]),
+        }
+    }
+
+    /// The `env` baked into the bundle's `.mcp.json`; `None` strips the key.
+    fn mcp_env(self) -> Option<serde_json::Value> {
+        match self.scope {
+            InstallScope::Global => Some(json!({ "TRACEDECAY_ENABLE_GLOBAL_DB": "1" })),
+            InstallScope::ProjectLocal => None,
+        }
+    }
+
+    /// Where Codex records trust for this bundle's hooks — `None` for scopes
+    /// that ship no hooks and therefore have no trust surface.
+    fn hook_trust_config_path(self, home: &Path) -> Option<PathBuf> {
+        self.include_hooks()
+            .then(|| home.join(".codex/config.toml"))
+    }
+
+    /// The memory digest rides only the global bundle.
+    fn include_memory_digest(self) -> bool {
+        self.scope == InstallScope::Global
+    }
+}
+
 fn install_codex_plugin_bundle(
     install_dir: &Path,
     tracedecay_bin: &str,
     scope: InstallScope,
     profile_home: &Path,
 ) -> Result<()> {
-    write_codex_plugin_bundle_base(install_dir, tracedecay_bin, scope)?;
+    let policy = CodexBundlePolicy::for_scope(scope);
+    write_codex_plugin_bundle_base(install_dir, tracedecay_bin, policy)?;
     install_codex_managed_skill_overlay(profile_home, install_dir)?;
-    if scope != InstallScope::ProjectLocal {
+    if policy.include_memory_digest() {
         let profile_root =
             crate::automation::skill_targets::profile_root_for_agent_home(profile_home);
         crate::automation::memory_digest::sync_memory_digest_export(
@@ -432,7 +492,11 @@ pub fn export_codex_plugin_artifact(
     output: &Path,
     tracedecay_bin: &str,
 ) -> Result<crate::automation::skill_targets::SkillInstallSummary> {
-    write_codex_plugin_bundle_base(output, tracedecay_bin, InstallScope::Global)?;
+    write_codex_plugin_bundle_base(
+        output,
+        tracedecay_bin,
+        CodexBundlePolicy::for_scope(InstallScope::Global),
+    )?;
     crate::automation::skill_targets::export_native_skill_overlay(
         profile_root,
         crate::automation::skill_targets::SkillInstallTarget::Codex,
@@ -443,7 +507,7 @@ pub fn export_codex_plugin_artifact(
 fn write_codex_plugin_bundle_base(
     install_dir: &Path,
     tracedecay_bin: &str,
-    scope: InstallScope,
+    policy: CodexBundlePolicy,
 ) -> Result<()> {
     if let Some(parent) = install_dir.parent() {
         std::fs::create_dir_all(parent).map_err(|e| TraceDecayError::Config {
@@ -451,7 +515,7 @@ fn write_codex_plugin_bundle_base(
         })?;
     }
     remove_codex_plugin_install(install_dir)?;
-    write_codex_plugin_files(install_dir, tracedecay_bin, scope)
+    write_codex_plugin_files(install_dir, tracedecay_bin, policy)
 }
 
 fn install_codex_managed_skill_overlay(
@@ -469,13 +533,13 @@ fn install_codex_managed_skill_overlay(
 fn write_codex_plugin_files(
     install_dir: &Path,
     tracedecay_bin: &str,
-    scope: InstallScope,
+    policy: CodexBundlePolicy,
 ) -> Result<()> {
     for (relative, contents) in codex_embedded_plugin_files() {
         let rendered = match relative {
-            ".codex-plugin/plugin.json" => codex_plugin_manifest(contents, scope)?,
-            ".mcp.json" => codex_plugin_mcp(contents, tracedecay_bin, scope)?,
-            "hooks/hooks.json" if scope == InstallScope::ProjectLocal => continue,
+            ".codex-plugin/plugin.json" => codex_plugin_manifest(contents, policy)?,
+            ".mcp.json" => codex_plugin_mcp(contents, tracedecay_bin, policy)?,
+            "hooks/hooks.json" if !policy.include_hooks() => continue,
             "hooks/hooks.json" => codex_plugin_hooks(contents, tracedecay_bin)?,
             _ => contents.to_string(),
         };
@@ -484,9 +548,9 @@ fn write_codex_plugin_files(
     Ok(())
 }
 
-fn codex_plugin_manifest(raw: &str, scope: InstallScope) -> Result<String> {
+fn codex_plugin_manifest(raw: &str, policy: CodexBundlePolicy) -> Result<String> {
     let stamped = super::plugin_bundle::stamp_manifest_version(raw)?;
-    if scope != InstallScope::ProjectLocal {
+    if policy.include_hooks() {
         return Ok(stamped);
     }
 
@@ -497,19 +561,16 @@ fn codex_plugin_manifest(raw: &str, scope: InstallScope) -> Result<String> {
     Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
 }
 
-fn codex_plugin_mcp(raw: &str, tracedecay_bin: &str, scope: InstallScope) -> Result<String> {
-    // Reuse the shared command rewrite, then layer Codex's scope-specific
-    // args/env on top of the result.
+fn codex_plugin_mcp(raw: &str, tracedecay_bin: &str, policy: CodexBundlePolicy) -> Result<String> {
+    // Reuse the shared command rewrite, then layer the policy's args/env on
+    // top of the result.
     let stamped = super::plugin_bundle::set_mcp_command(raw, tracedecay_bin)?;
     let mut mcp: serde_json::Value = serde_json::from_str(&stamped)?;
     let server = &mut mcp["mcpServers"]["tracedecay"];
-    match scope {
-        InstallScope::Global => {
-            server["args"] = json!(["serve"]);
-            server["env"] = json!({ "TRACEDECAY_ENABLE_GLOBAL_DB": "1" });
-        }
-        InstallScope::ProjectLocal => {
-            server["args"] = json!(["serve", "--path", "."]);
+    server["args"] = policy.mcp_args();
+    match policy.mcp_env() {
+        Some(env) => server["env"] = env,
+        None => {
             if let Some(object) = server.as_object_mut() {
                 object.remove("env");
             }
@@ -1160,10 +1221,11 @@ fn uninstall_prompt_rules(agents_md: &Path) {
 // ---------------------------------------------------------------------------
 
 fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
+    let global_policy = CodexBundlePolicy::for_scope(InstallScope::Global);
     let cached_dirs = codex_plugin_cached_install_dirs(home);
     if !cached_dirs.is_empty() {
         for plugin_dir in cached_dirs {
-            doctor_check_plugin_dir(dc, &plugin_dir, Some(&home.join(".codex/config.toml")));
+            doctor_check_plugin_dir(dc, &plugin_dir, global_policy, home);
         }
         return;
     }
@@ -1178,50 +1240,7 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
         return;
     }
 
-    let manifest = load_json_file(&manifest_path);
-    if manifest.get("name").and_then(|value| value.as_str()) == Some("tracedecay") {
-        dc.pass(&format!(
-            "Codex plugin manifest present in {}",
-            manifest_path.display()
-        ));
-    } else {
-        dc.fail(&format!(
-            "Codex plugin manifest at {} is not a tracedecay plugin",
-            manifest_path.display()
-        ));
-    }
-    match manifest.get("version").and_then(|value| value.as_str()) {
-        Some(env!("CARGO_PKG_VERSION")) => dc.pass("Codex plugin version matches tracedecay"),
-        Some(version) => dc.warn(&format!(
-            "Codex plugin version {version} does not match tracedecay {} — run `tracedecay update-plugin`",
-            env!("CARGO_PKG_VERSION")
-        )),
-        None => dc.warn("Codex plugin manifest does not contain a version"),
-    }
-
-    let mcp_path = plugin_dir.join(".mcp.json");
-    let mcp = load_json_file(&mcp_path);
-    if mcp
-        .get("mcpServers")
-        .and_then(|servers| servers.get("tracedecay"))
-        .is_some()
-    {
-        dc.pass(&format!(
-            "Codex plugin MCP server registered in {}",
-            mcp_path.display()
-        ));
-    } else {
-        dc.fail(&format!(
-            "Codex plugin MCP server missing in {} — run `tracedecay install --agent codex`",
-            mcp_path.display()
-        ));
-    }
-    doctor_check_hooks(
-        dc,
-        &plugin_dir.join("hooks/hooks.json"),
-        &home.join(".codex/config.toml"),
-    );
-
+    doctor_check_plugin_dir(dc, &plugin_dir, global_policy, home);
     doctor_check_marketplace_entry(
         dc,
         &codex_personal_marketplace_path(home),
@@ -1270,7 +1289,12 @@ fn doctor_check_marketplace_entry(
     }
 }
 
-fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path, config_path: Option<&Path>) {
+fn doctor_check_plugin_dir(
+    dc: &mut DoctorCounters,
+    plugin_dir: &Path,
+    policy: CodexBundlePolicy,
+    home: &Path,
+) {
     let manifest_path = plugin_dir.join(".codex-plugin/plugin.json");
     let manifest = load_json_file(&manifest_path);
     if manifest.get("name").and_then(|value| value.as_str()) == Some("tracedecay") {
@@ -1310,8 +1334,14 @@ fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path, config_pa
             mcp_path.display()
         ));
     }
-    if let Some(config_path) = config_path {
-        doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"), config_path);
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    if let Some(config_path) = policy.hook_trust_config_path(home) {
+        doctor_check_hooks(dc, &hooks_path, &config_path);
+    } else if hooks_path.exists() {
+        dc.warn(&format!(
+            "repo-local Codex bundle unexpectedly ships lifecycle hooks in {} — run `tracedecay install --local --agent codex` to refresh it",
+            hooks_path.display()
+        ));
     }
 }
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -120,27 +120,18 @@ impl AgentIntegration for CodexIntegration {
             }
         }
 
-        if !refreshed.is_empty() {
-            if legacy_config_install {
-                sweep_legacy_global_codex_config(&ctx.home);
+        if refreshed.is_empty() {
+            if !codex_plugin_manifest_path(&ctx.home).exists() && !legacy_config_install {
+                return Ok(UpdatePluginOutcome::NotInstalled);
             }
-            return Ok(UpdatePluginOutcome::Refreshed(refreshed));
+            install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
+            refreshed.push(plugin_dir);
         }
 
-        let target = if codex_plugin_manifest_path(&ctx.home).exists() || legacy_config_install {
-            Some(plugin_dir.clone())
-        } else {
-            None
-        };
-
-        let Some(target) = target else {
-            return Ok(UpdatePluginOutcome::NotInstalled);
-        };
-        install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
         if legacy_config_install {
             sweep_legacy_global_codex_config(&ctx.home);
         }
-        Ok(UpdatePluginOutcome::Refreshed(vec![target]))
+        Ok(UpdatePluginOutcome::Refreshed(refreshed))
     }
 
     fn export_managed_skills(
@@ -1228,7 +1219,7 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
     doctor_check_hooks(
         dc,
         &plugin_dir.join("hooks/hooks.json"),
-        Some(&home.join(".codex/config.toml")),
+        &home.join(".codex/config.toml"),
     );
 
     doctor_check_marketplace_entry(
@@ -1320,13 +1311,13 @@ fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path, config_pa
         ));
     }
     if let Some(config_path) = config_path {
-        doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"), Some(config_path));
+        doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"), config_path);
     }
 }
 
 /// Check hooks.json registers the tracedecay lifecycle hooks, and report Codex
-/// hook trust state when the user-level config is available.
-fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: Option<&Path>) {
+/// hook trust state from the user-level config.
+fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: &Path) {
     if !hooks_path.exists() {
         dc.warn(&format!(
             "{} not found — run `tracedecay install --agent codex` to add lifecycle hooks",
@@ -1341,34 +1332,35 @@ fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: O
             (!codex_hook_present(&hooks, hook.event, hook.subcommand)).then_some(hook.event)
         })
         .collect();
-    if missing.is_empty() {
-        dc.pass(&format!(
-            "All {} Codex lifecycle hooks registered in {}",
-            CODEX_MANAGED_HOOKS.len(),
-            hooks_path.display()
-        ));
-        match config_path.and_then(|path| load_toml_file(path).ok().map(|config| (path, config))) {
-            Some((path, config)) => match codex_plugin_hook_trust_state(&config) {
-                CodexHookTrustState::Trusted => dc.info(&format!(
-                    "Codex hook trust entries recorded in {}",
-                    path.display()
-                )),
-                CodexHookTrustState::Missing(missing) => dc.info(&format!(
-                    "Codex skips new/changed command hooks until trusted — missing trust for {} in {}; run `/hooks` in Codex",
-                    missing.join(", "),
-                    path.display()
-                )),
-            },
-            None => dc.info(
-                "Codex skips new/changed command hooks until trusted — run `/hooks` in Codex to trust the tracedecay hooks",
-            ),
-        }
-    } else {
+    if !missing.is_empty() {
         dc.warn(&format!(
             "tracedecay hook(s) missing for {} in {} — run `tracedecay install --agent codex`",
             missing.join(", "),
             hooks_path.display(),
         ));
+        return;
+    }
+
+    dc.pass(&format!(
+        "All {} Codex lifecycle hooks registered in {}",
+        CODEX_MANAGED_HOOKS.len(),
+        hooks_path.display()
+    ));
+    match load_toml_file(config_path) {
+        Ok(config) => match codex_plugin_hook_trust_state(&config) {
+            CodexHookTrustState::Trusted => dc.info(&format!(
+                "Codex hook trust entries recorded in {}",
+                config_path.display()
+            )),
+            CodexHookTrustState::Missing(missing) => dc.info(&format!(
+                "Codex skips new/changed command hooks until trusted — missing trust for {} in {}; run `/hooks` in Codex",
+                missing.join(", "),
+                config_path.display()
+            )),
+        },
+        Err(_) => dc.info(
+            "Codex skips new/changed command hooks until trusted — run `/hooks` in Codex to trust the tracedecay hooks",
+        ),
     }
 }
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -120,16 +120,31 @@ impl AgentIntegration for CodexIntegration {
             }
         }
 
+        // A legacy config-managed install must gain its personal-bundle
+        // replacement before the sweep below strips the working global
+        // config — even when a cached or repo-local refresh already put
+        // something into `refreshed`.
+        let has_personal_bundle =
+            !cached_dirs.is_empty() || codex_plugin_manifest_path(&ctx.home).exists();
         if refreshed.is_empty() {
-            if !codex_plugin_manifest_path(&ctx.home).exists() && !legacy_config_install {
+            if !has_personal_bundle && !legacy_config_install {
                 return Ok(UpdatePluginOutcome::NotInstalled);
             }
             install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
-            refreshed.push(plugin_dir);
+            refreshed.push(plugin_dir.clone());
+        } else if legacy_config_install && !has_personal_bundle {
+            install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
+            refreshed.push(plugin_dir.clone());
         }
 
         if legacy_config_install {
             sweep_legacy_global_codex_config(&ctx.home);
+            eprintln!(
+                "\x1b[1mAction required:\x1b[0m migrated the legacy Codex config-managed \
+                 install to the personal plugin bundle."
+            );
+            eprintln!("  In Codex, run: codex plugin add tracedecay@personal");
+            print_hook_trust_guidance();
         }
         Ok(UpdatePluginOutcome::Refreshed(refreshed))
     }
@@ -200,6 +215,15 @@ impl AgentIntegration for CodexIntegration {
                 "./plugins/tracedecay",
                 "tracedecay install --local --agent codex",
             );
+            // Repo-local bundles ship no lifecycle hooks by design; hooks come
+            // from the personal plugin. Without one, no session/tool hooks run.
+            if !codex_plugin_manifest_path(&ctx.home).exists()
+                && codex_plugin_cached_install_dirs(&ctx.home).is_empty()
+            {
+                dc.warn(
+                    "repo-local Codex bundles ship no lifecycle hooks — run `tracedecay install --agent codex` to add the personal plugin (session hooks, transcript ingest)",
+                );
+            }
         } else {
             doctor_check_plugin(dc, &ctx.home);
         }
@@ -634,15 +658,14 @@ enum CodexHookTrustState {
     Missing(Vec<String>),
 }
 
-fn codex_hook_state_event_key(event: &str) -> String {
-    let mut key = String::new();
-    for (index, ch) in event.chars().enumerate() {
-        if ch.is_ascii_uppercase() && index > 0 {
-            key.push('_');
-        }
-        key.push(ch.to_ascii_lowercase());
-    }
-    key
+/// Codex records hook state under `snake_case` event keys. Derive them from the
+/// managed hook's subcommand (`hook-codex-post-tool-use` -> `post_tool_use`)
+/// so the mapping stays anchored to the single-source-of-truth table instead
+/// of re-implementing Codex's name normalization.
+fn codex_hook_state_event_key(hook: &CodexManagedHook) -> String {
+    hook.subcommand
+        .trim_start_matches("hook-codex-")
+        .replace('-', "_")
 }
 
 fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
@@ -654,14 +677,14 @@ fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
         return CodexHookTrustState::Missing(
             CODEX_MANAGED_HOOKS
                 .iter()
-                .map(|hook| codex_hook_state_event_key(hook.event))
+                .map(codex_hook_state_event_key)
                 .collect(),
         );
     };
 
     let missing: Vec<String> = CODEX_MANAGED_HOOKS
         .iter()
-        .map(|hook| codex_hook_state_event_key(hook.event))
+        .map(codex_hook_state_event_key)
         .filter(|event_key| {
             let trust_key = format!("{CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX}{event_key}:0:0");
             !state.get(&trust_key).is_some_and(|entry| {
@@ -1107,10 +1130,16 @@ fn uninstall_hooks(hooks_path: &Path) {
     let Some(events) = hooks.get_mut("hooks").and_then(|h| h.as_object_mut()) else {
         return;
     };
+    let mut removed_any = false;
     for groups in events.values_mut() {
         if let Some(arr) = groups.as_array_mut() {
+            let before = arr.len();
             arr.retain(|group| !subcommands.iter().any(|sc| group_has_subcommand(group, sc)));
+            removed_any |= arr.len() != before;
         }
+    }
+    if !removed_any {
+        return;
     }
     events.retain(|_, groups| groups.as_array().is_some_and(|a| !a.is_empty()));
 
@@ -1156,6 +1185,7 @@ fn uninstall_mcp_server(config_path: &Path) -> Result<()> {
         table.remove("mcp_servers");
     }
     if table.is_empty() {
+        let _ = super::backup_file(config_path);
         std::fs::remove_file(config_path).ok();
         eprintln!(
             "\x1b[32m✔\x1b[0m Removed {} (was empty)",
@@ -1379,7 +1409,7 @@ fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: &
     match load_toml_file(config_path) {
         Ok(config) => match codex_plugin_hook_trust_state(&config) {
             CodexHookTrustState::Trusted => dc.info(&format!(
-                "Codex hook trust entries recorded in {}",
+                "Codex hook trust entries recorded in {} — trust is pinned to hook content, so if hooks changed since trusting (e.g. after update-plugin), run /hooks in Codex to re-trust",
                 config_path.display()
             )),
             CodexHookTrustState::Missing(missing) => dc.info(&format!(

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -125,9 +125,8 @@ impl AgentIntegration for CodexIntegration {
             return Ok(UpdatePluginOutcome::Refreshed(refreshed));
         }
 
-        let target = if codex_plugin_manifest_path(&ctx.home).exists()
-            || codex_legacy_config_has_tracedecay(&ctx.home)
-        {
+        let legacy_config_install = codex_legacy_config_has_tracedecay(&ctx.home);
+        let target = if codex_plugin_manifest_path(&ctx.home).exists() || legacy_config_install {
             Some(plugin_dir.clone())
         } else {
             None
@@ -137,6 +136,9 @@ impl AgentIntegration for CodexIntegration {
             return Ok(UpdatePluginOutcome::NotInstalled);
         };
         install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
+        if legacy_config_install {
+            sweep_legacy_global_codex_config(&ctx.home);
+        }
         Ok(UpdatePluginOutcome::Refreshed(vec![target]))
     }
 
@@ -193,11 +195,7 @@ impl AgentIntegration for CodexIntegration {
         eprintln!("\n\x1b[1mCodex CLI integration\x1b[0m");
         let local_plugin_dir = codex_repo_plugin_install_dir(&ctx.project_path);
         if local_plugin_dir.join(".codex-plugin/plugin.json").exists() {
-            doctor_check_plugin_dir(
-                dc,
-                &local_plugin_dir,
-                Some(&ctx.home.join(".codex/config.toml")),
-            );
+            doctor_check_plugin_dir(dc, &local_plugin_dir, None);
             doctor_check_marketplace_entry(
                 dc,
                 &codex_repo_marketplace_path(&ctx.project_path),
@@ -483,8 +481,9 @@ fn write_codex_plugin_files(
 ) -> Result<()> {
     for (relative, contents) in codex_embedded_plugin_files() {
         let rendered = match relative {
-            ".codex-plugin/plugin.json" => codex_plugin_manifest(contents)?,
+            ".codex-plugin/plugin.json" => codex_plugin_manifest(contents, scope)?,
             ".mcp.json" => codex_plugin_mcp(contents, tracedecay_bin, scope)?,
+            "hooks/hooks.json" if scope == InstallScope::ProjectLocal => continue,
             "hooks/hooks.json" => codex_plugin_hooks(contents, tracedecay_bin)?,
             _ => contents.to_string(),
         };
@@ -493,8 +492,17 @@ fn write_codex_plugin_files(
     Ok(())
 }
 
-fn codex_plugin_manifest(raw: &str) -> Result<String> {
-    super::plugin_bundle::stamp_manifest_version(raw)
+fn codex_plugin_manifest(raw: &str, scope: InstallScope) -> Result<String> {
+    let stamped = super::plugin_bundle::stamp_manifest_version(raw)?;
+    if scope != InstallScope::ProjectLocal {
+        return Ok(stamped);
+    }
+
+    let mut manifest: serde_json::Value = serde_json::from_str(&stamped)?;
+    if let Some(object) = manifest.as_object_mut() {
+        object.remove("hooks");
+    }
+    Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
 }
 
 fn codex_plugin_mcp(raw: &str, tracedecay_bin: &str, scope: InstallScope) -> Result<String> {
@@ -1311,7 +1319,9 @@ fn doctor_check_plugin_dir(dc: &mut DoctorCounters, plugin_dir: &Path, config_pa
             mcp_path.display()
         ));
     }
-    doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"), config_path);
+    if let Some(config_path) = config_path {
+        doctor_check_hooks(dc, &plugin_dir.join("hooks/hooks.json"), Some(config_path));
+    }
 }
 
 /// Check hooks.json registers the tracedecay lifecycle hooks, and report Codex

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -57,14 +57,12 @@ impl AgentIntegration for CodexIntegration {
         for path in [
             codex_repo_plugin_install_dir(project_path).join(".codex-plugin/plugin.json"),
             codex_repo_plugin_install_dir(project_path).join(".mcp.json"),
-            codex_repo_plugin_install_dir(project_path).join("hooks/hooks.json"),
             codex_repo_marketplace_path(project_path),
         ] {
             super::ensure_project_local_safe_path(project_path, &path)?;
         }
         install_codex_repo_plugin(&ctx.home, project_path, &ctx.tracedecay_bin)?;
         sweep_legacy_project_codex_config(project_path);
-        print_hook_trust_guidance();
         Ok(())
     }
 
@@ -90,6 +88,7 @@ impl AgentIntegration for CodexIntegration {
     fn update_plugin(&self, ctx: &InstallContext) -> Result<UpdatePluginOutcome> {
         let cached_dirs = codex_plugin_cached_install_dirs(&ctx.home);
         let plugin_dir = codex_plugin_install_dir(&ctx.home);
+        let legacy_config_install = codex_legacy_config_has_tracedecay(&ctx.home);
         let mut refreshed = Vec::new();
         if !cached_dirs.is_empty() {
             let target = install_codex_cached_plugin(&ctx.home, &ctx.tracedecay_bin)?;
@@ -122,10 +121,12 @@ impl AgentIntegration for CodexIntegration {
         }
 
         if !refreshed.is_empty() {
+            if legacy_config_install {
+                sweep_legacy_global_codex_config(&ctx.home);
+            }
             return Ok(UpdatePluginOutcome::Refreshed(refreshed));
         }
 
-        let legacy_config_install = codex_legacy_config_has_tracedecay(&ctx.home);
         let target = if codex_plugin_manifest_path(&ctx.home).exists() || legacy_config_install {
             Some(plugin_dir.clone())
         } else {
@@ -573,6 +574,7 @@ const CODEX_MANAGED_HOOKS: &[CodexManagedHook] = &[
 /// Subcommands from older bundles that uninstall must also strip even though
 /// the current bundle no longer registers them.
 const CODEX_LEGACY_HOOK_SUBCOMMANDS: &[&str] = &["hook-codex-pre-tool-use"];
+const CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX: &str = "tracedecay@personal:hooks/hooks.json:";
 
 #[derive(Debug, PartialEq, Eq)]
 enum CodexHookTrustState {
@@ -609,14 +611,12 @@ fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
         .iter()
         .map(|hook| codex_hook_state_event_key(hook.event))
         .filter(|event_key| {
-            let suffix = format!(":hooks/hooks.json:{event_key}:0:0");
-            !state.iter().any(|(key, entry)| {
-                key.starts_with("tracedecay@")
-                    && key.ends_with(&suffix)
-                    && entry
-                        .get("trusted_hash")
-                        .and_then(|hash| hash.as_str())
-                        .is_some_and(|hash| hash.starts_with("sha256:"))
+            let trust_key = format!("{CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX}{event_key}:0:0");
+            !state.get(&trust_key).is_some_and(|entry| {
+                entry
+                    .get("trusted_hash")
+                    .and_then(|hash| hash.as_str())
+                    .is_some_and(|hash| hash.starts_with("sha256:"))
             })
         })
         .collect();
@@ -1365,7 +1365,7 @@ fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: O
         }
     } else {
         dc.warn(&format!(
-            "tracedecay hook(s) missing for {} in {} — run `tracedecay install --local --agent codex` or `tracedecay install --agent codex`",
+            "tracedecay hook(s) missing for {} in {} — run `tracedecay install --agent codex`",
             missing.join(", "),
             hooks_path.display(),
         ));
@@ -1504,6 +1504,42 @@ trusted_hash = "sha256:post"
                 "session_start".to_string(),
                 "user_prompt_submit".to_string(),
                 "subagent_start".to_string(),
+                "post_compact".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn codex_hook_trust_state_ignores_repo_local_plugin_entries() {
+        let config = toml::from_str::<toml::Value>(
+            r#"
+[hooks.state]
+
+[hooks.state."tracedecay@local-repo:hooks/hooks.json:post_tool_use:0:0"]
+trusted_hash = "sha256:post"
+
+[hooks.state."tracedecay@local-repo:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:session"
+
+[hooks.state."tracedecay@local-repo:hooks/hooks.json:user_prompt_submit:0:0"]
+trusted_hash = "sha256:prompt"
+
+[hooks.state."tracedecay@local-repo:hooks/hooks.json:subagent_start:0:0"]
+trusted_hash = "sha256:subagent"
+
+[hooks.state."tracedecay@local-repo:hooks/hooks.json:post_compact:0:0"]
+trusted_hash = "sha256:compact"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            codex_plugin_hook_trust_state(&config),
+            CodexHookTrustState::Missing(vec![
+                "session_start".to_string(),
+                "user_prompt_submit".to_string(),
+                "subagent_start".to_string(),
+                "post_tool_use".to_string(),
                 "post_compact".to_string(),
             ])
         );

--- a/src/agents/plugin_bundle.rs
+++ b/src/agents/plugin_bundle.rs
@@ -34,8 +34,20 @@ use crate::errors::Result;
 /// pretty-printed JSON with a trailing newline. Shared by every host installer
 /// (Claude/Cursor/Codex), which all render the same manifest round-trip.
 pub(crate) fn stamp_manifest_version(raw: &str) -> Result<String> {
+    stamp_manifest_version_with(raw, |_| {})
+}
+
+/// Stamp the version and let the host apply manifest edits on the parsed
+/// `Value` before the single serialize — hosts that post-process the manifest
+/// (e.g. Codex stripping `hooks` from repo-local bundles) avoid a second
+/// parse/pretty-print round-trip and cannot drift from this output contract.
+pub(crate) fn stamp_manifest_version_with(
+    raw: &str,
+    mutate: impl FnOnce(&mut serde_json::Value),
+) -> Result<String> {
     let mut manifest: serde_json::Value = serde_json::from_str(raw)?;
     manifest["version"] = serde_json::json!(env!("CARGO_PKG_VERSION"));
+    mutate(&mut manifest);
     Ok(format!("{}\n", serde_json::to_string_pretty(&manifest)?))
 }
 

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -2990,7 +2990,6 @@ fn test_local_install_codex_writes_project_paths() {
             ".agents/plugins/marketplace.json",
             "plugins/tracedecay/.codex-plugin/plugin.json",
             "plugins/tracedecay/.mcp.json",
-            "plugins/tracedecay/hooks/hooks.json",
             "plugins/tracedecay/skills/exploring-code/SKILL.md",
         ],
     );

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -389,7 +389,7 @@ fn assert_codex_plugin_bundle(
     plugin_dir: &Path,
     expected_command: &str,
     expected_args: serde_json::Value,
-    expected_global_env: bool,
+    expected_global_bundle: bool,
 ) {
     let manifest = read_json(&plugin_dir.join(".codex-plugin/plugin.json"));
     assert_eq!(manifest["name"], "tracedecay");
@@ -397,14 +397,21 @@ fn assert_codex_plugin_bundle(
     assert_eq!(manifest["license"], "MIT");
     assert_eq!(manifest["skills"], "./skills/");
     assert_eq!(manifest["mcpServers"], "./.mcp.json");
-    assert_eq!(manifest["hooks"], "./hooks/hooks.json");
+    if expected_global_bundle {
+        assert_eq!(manifest["hooks"], "./hooks/hooks.json");
+    } else {
+        assert!(
+            manifest.get("hooks").is_none(),
+            "repo-local Codex plugin should not declare lifecycle hooks"
+        );
+    }
 
     let mcp = read_json(&plugin_dir.join(".mcp.json"));
     let server = &mcp["mcpServers"]["tracedecay"];
     assert_eq!(server["type"], "stdio");
     assert_eq!(server["command"], expected_command);
     assert_eq!(server["args"], expected_args);
-    if expected_global_env {
+    if expected_global_bundle {
         assert_eq!(server["env"]["TRACEDECAY_ENABLE_GLOBAL_DB"], "1");
     } else {
         assert!(
@@ -413,14 +420,22 @@ fn assert_codex_plugin_bundle(
         );
     }
 
-    let hooks = read_json(&plugin_dir.join("hooks/hooks.json"));
-    assert_codex_hooks_registered(&hooks);
-    assert_command_contains_expected_bin(
-        &hooks,
-        "SessionStart",
-        "hook-codex-session-start",
-        expected_command,
-    );
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    if expected_global_bundle {
+        let hooks = read_json(&hooks_path);
+        assert_codex_hooks_registered(&hooks);
+        assert_command_contains_expected_bin(
+            &hooks,
+            "SessionStart",
+            "hook-codex-session-start",
+            expected_command,
+        );
+    } else {
+        assert!(
+            !hooks_path.exists(),
+            "repo-local Codex plugin should not ship lifecycle hooks"
+        );
+    }
 
     let skill = std::fs::read_to_string(plugin_dir.join("skills/exploring-code/SKILL.md"))
         .expect("Codex plugin should ship tracedecay steering skills");
@@ -3463,7 +3478,7 @@ fn test_codex_local_install_creates_repo_plugin_bundle_and_marketplace() {
     );
     assert!(
         !project.path().join(".codex/hooks.json").exists(),
-        "local Codex install should bundle hooks in the repo plugin"
+        "local Codex install should not write project Codex hooks"
     );
     assert!(
         !project.path().join("AGENTS.md").exists(),
@@ -3628,7 +3643,7 @@ fn test_codex_global_install_bundles_hooks_in_plugin() {
 }
 
 #[test]
-fn test_codex_local_install_bundles_hooks_in_plugin() {
+fn test_codex_local_install_does_not_bundle_hooks() {
     let home = TempDir::new().unwrap();
     let project = TempDir::new().unwrap();
 
@@ -3636,14 +3651,9 @@ fn test_codex_local_install_bundles_hooks_in_plugin() {
 
     let hooks_path = codex_project_plugin_install_dir(project.path()).join("hooks/hooks.json");
     assert!(
-        hooks_path.exists(),
-        "local Codex install should bundle hooks in the repo plugin"
+        !hooks_path.exists(),
+        "local Codex install should not bundle project-local hooks"
     );
-    let hooks = read_json(&hooks_path);
-    assert_codex_hooks_registered(&hooks);
-    // Local install must use the resolved absolute tracedecay binary path.
-    assert_command_contains_bin(&hooks, "SessionStart", "hook-codex-session-start");
-
     assert!(
         !home.path().join(".codex/hooks.json").exists(),
         "local install must not write the global Codex hooks config"
@@ -3652,11 +3662,6 @@ fn test_codex_local_install_bundles_hooks_in_plugin() {
         !project.path().join(".codex/hooks.json").exists(),
         "local install must not write project Codex hooks config"
     );
-}
-
-fn assert_command_contains_bin(hooks: &serde_json::Value, event: &str, needle: &str) {
-    let expected = expected_tracedecay_bin();
-    assert_command_contains_expected_bin(hooks, event, needle, &expected);
 }
 
 fn assert_command_contains_expected_bin(

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -70,11 +70,33 @@ fn assert_codex_marketplace_entry(marketplace_path: &Path, source_path: &str) {
     assert_eq!(entry["source"]["path"], source_path);
 }
 
-fn assert_codex_bundle_contains_bin(plugin_dir: &Path, tracedecay_bin: &str) {
+/// The scope contract a rendered Codex bundle must follow: global bundles
+/// must ship lifecycle hooks, repo-local bundles must not. Kept explicit so a
+/// refresh path that silently stops rendering hooks/hooks.json fails the
+/// global assertions instead of skipping them.
+#[derive(Clone, Copy, PartialEq)]
+enum CodexScope {
+    Global,
+    RepoLocal,
+}
+
+fn assert_codex_bundle_contains_bin(plugin_dir: &Path, tracedecay_bin: &str, scope: CodexScope) {
     assert!(text(&plugin_dir.join(".mcp.json")).contains(tracedecay_bin));
     let hooks_path = plugin_dir.join("hooks/hooks.json");
-    if hooks_path.exists() {
-        assert!(text(&hooks_path).contains(tracedecay_bin));
+    match scope {
+        CodexScope::Global => {
+            assert!(
+                hooks_path.exists(),
+                "global Codex bundle {} must ship hooks/hooks.json",
+                plugin_dir.display()
+            );
+            assert!(text(&hooks_path).contains(tracedecay_bin));
+        }
+        CodexScope::RepoLocal => assert!(
+            !hooks_path.exists(),
+            "repo-local Codex bundle {} must not ship lifecycle hooks",
+            plugin_dir.display()
+        ),
     }
 }
 
@@ -421,7 +443,7 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
         plugin_dir.join("skills/project-status/SKILL.md").exists(),
         "same-name user-authored Codex skills without TraceDecay markers must be preserved"
     );
-    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN, CodexScope::Global);
     assert!(text(&plugin_dir.join(".codex-plugin/plugin.json")).contains(env!("CARGO_PKG_VERSION")));
 }
 
@@ -457,8 +479,8 @@ fn codex_update_plugin_refreshes_cache_and_keeps_bootstrap_source_listable() {
         vec![cached_plugin_dir.clone(), bootstrap_dir.clone()]
     );
 
-    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN);
-    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN, CodexScope::Global);
+    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN, CodexScope::Global);
     assert!(
         !stale_plugin_dir.exists(),
         "update-plugin should migrate managed Codex cache installs to the current plugin version"
@@ -492,8 +514,8 @@ fn codex_update_plugin_recreates_bootstrap_source_from_cache_only_state() {
         vec![cached_plugin_dir.clone(), bootstrap_dir.clone()]
     );
 
-    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN);
-    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN, CodexScope::Global);
+    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN, CodexScope::Global);
     assert!(
         !cached_plugin_dir
             .join("skills/stale-skill/SKILL.md")
@@ -556,9 +578,9 @@ fn codex_update_plugin_refreshes_global_cache_and_repo_local_bundle() {
         ]
     );
 
-    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN);
-    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN);
-    assert_codex_bundle_contains_bin(&repo_plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN, CodexScope::Global);
+    assert_codex_bundle_contains_bin(&bootstrap_dir, NEW_BIN, CodexScope::Global);
+    assert_codex_bundle_contains_bin(&repo_plugin_dir, NEW_BIN, CodexScope::RepoLocal);
     assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
     assert_codex_marketplace_entry(
         &codex_marketplace_path(project.path()),
@@ -582,7 +604,7 @@ fn codex_update_plugin_repairs_personal_marketplace_for_bootstrap_bundle() {
     };
     assert_eq!(paths, vec![plugin_dir.clone()]);
 
-    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN, CodexScope::Global);
     assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
 }
 
@@ -606,7 +628,7 @@ fn codex_update_plugin_refreshes_repo_local_bundle_from_project_root() {
 
     assert_eq!(paths, vec![plugin_dir.clone()]);
     assert_eq!(text(&plugin_dir.join("user-note.txt")), "mine\n");
-    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN);
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN, CodexScope::RepoLocal);
     assert!(text(&plugin_dir.join(".codex-plugin/plugin.json")).contains(env!("CARGO_PKG_VERSION")));
 }
 
@@ -645,7 +667,11 @@ fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
         !legacy_config.exists(),
         "Codex update-plugin should remove the migrated legacy config-managed install"
     );
-    assert_codex_bundle_contains_bin(&home.path().join("plugins/tracedecay"), NEW_BIN);
+    assert_codex_bundle_contains_bin(
+        &home.path().join("plugins/tracedecay"),
+        NEW_BIN,
+        CodexScope::Global,
+    );
     assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
 }
 
@@ -1005,7 +1031,7 @@ fn assert_cursor_rendered_bundle_valid(plugin_dir: &Path, bin: &str) {
 }
 
 /// Full structural validation of a rendered Codex plugin bundle.
-fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str, expect_hooks: bool) {
+fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str, scope: CodexScope) {
     // Rendered manifest: version stamped to this binary's package version.
     let manifest = read_json(&plugin_dir.join(".codex-plugin/plugin.json"));
     assert_eq!(manifest["name"], "tracedecay");
@@ -1015,47 +1041,48 @@ fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str, expect_hooks
         "rendered manifest version must match the binary's package version"
     );
 
-    // Rendered hooks.json: only personal/global bundles ship lifecycle hooks;
-    // repo-local bundles omit them (Codex only trusts personal-plugin hooks).
-    let hooks_path = plugin_dir.join("hooks/hooks.json");
-    if !expect_hooks {
-        assert!(
-            !hooks_path.exists(),
-            "repo-local Codex plugin must not ship {}",
-            hooks_path.display()
-        );
-        let manifest = read_json(&plugin_dir.join(".codex-plugin/plugin.json"));
-        assert!(
-            manifest.get("hooks").is_none(),
-            "repo-local Codex plugin manifest must not declare lifecycle hooks"
-        );
-        return;
-    }
-    // Codex nests handlers in matcher groups; every handler command is the
-    // quoted absolute binary plus a hook-codex-* subcommand.
-    let hooks = read_json(&hooks_path);
-    let events = hooks["hooks"]
-        .as_object()
-        .expect("rendered hooks.json must contain a hooks object");
-    assert!(
-        !events.is_empty(),
-        "rendered hooks.json must register events"
-    );
-    for (event, groups) in events {
-        let groups = groups
-            .as_array()
-            .unwrap_or_else(|| panic!("hook event {event} must hold an array of groups"));
-        assert!(!groups.is_empty(), "hook event {event} must not be empty");
-        for group in groups {
-            let handlers = group["hooks"]
-                .as_array()
-                .unwrap_or_else(|| panic!("hook event {event} group must carry handlers"));
-            for handler in handlers {
-                let command = handler["command"]
-                    .as_str()
-                    .unwrap_or_else(|| panic!("hook event {event} handler must carry a command"));
-                assert_rendered_hook_command(command, bin, "hook-codex-");
+    match scope {
+        CodexScope::Global => {
+            // Rendered hooks.json: Codex nests handlers in matcher groups;
+            // every handler command is the quoted absolute binary plus a
+            // hook-codex-* subcommand.
+            let hooks = read_json(&plugin_dir.join("hooks/hooks.json"));
+            let events = hooks["hooks"]
+                .as_object()
+                .expect("rendered hooks.json must contain a hooks object");
+            assert!(
+                !events.is_empty(),
+                "rendered hooks.json must register events"
+            );
+            for (event, groups) in events {
+                let groups = groups
+                    .as_array()
+                    .unwrap_or_else(|| panic!("hook event {event} must hold an array of groups"));
+                assert!(!groups.is_empty(), "hook event {event} must not be empty");
+                for group in groups {
+                    let handlers = group["hooks"]
+                        .as_array()
+                        .unwrap_or_else(|| panic!("hook event {event} group must carry handlers"));
+                    for handler in handlers {
+                        let command = handler["command"].as_str().unwrap_or_else(|| {
+                            panic!("hook event {event} handler must carry a command")
+                        });
+                        assert_rendered_hook_command(command, bin, "hook-codex-");
+                    }
+                }
             }
+        }
+        CodexScope::RepoLocal => {
+            // Repo-local bundles get their lifecycle hooks from the global
+            // plugin: no hooks file, no manifest hooks declaration.
+            assert!(
+                !plugin_dir.join("hooks/hooks.json").exists(),
+                "repo-local Codex bundle must not ship lifecycle hooks"
+            );
+            assert!(
+                manifest.get("hooks").is_none(),
+                "repo-local Codex manifest must not declare lifecycle hooks"
+            );
         }
     }
 
@@ -1066,8 +1093,13 @@ fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str, expect_hooks
         "no placeholder may survive rendering in the Codex bundle"
     );
 
-    // Nothing from the source bundle was silently dropped.
+    // Nothing from the source bundle was silently dropped. Repo-local
+    // bundles intentionally drop the hooks file, so remove it from the
+    // staged expectation.
     let staged = staged_host_source("codex");
+    if scope == CodexScope::RepoLocal {
+        std::fs::remove_file(staged.path().join("hooks/hooks.json")).unwrap();
+    }
     assert_source_bundle_fully_rendered(staged.path(), plugin_dir);
 }
 
@@ -1103,7 +1135,7 @@ fn codex_install_renders_structurally_valid_bundle() {
     codex.install(&ctx(home.path(), NEW_BIN)).unwrap();
 
     let plugin_dir = codex_bootstrap_dir(home.path());
-    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN, true);
+    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN, CodexScope::Global);
 
     // Global-scope MCP rendering: absolute command, plain `serve` args, and
     // the global-DB env flag.
@@ -1125,7 +1157,7 @@ fn codex_local_install_renders_project_scoped_mcp() {
         .unwrap();
 
     let plugin_dir = codex_bootstrap_dir(project.path());
-    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN, false);
+    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN, CodexScope::RepoLocal);
 
     // Project-local scope renders relative-path serve args and drops the
     // global-DB env flag.

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -599,8 +599,6 @@ fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
         "[mcp_servers.tracedecay]\ncommand = \"/old/bin/tracedecay\"\nargs = [\"serve\"]\n",
     )
     .unwrap();
-    let before = bytes(&codex_dir.join("config.toml"));
-
     let codex = get_integration("codex").unwrap();
     let outcome = codex
         .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
@@ -609,7 +607,10 @@ fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
         panic!("expected codex update_plugin to migrate legacy config to plugin");
     };
     assert_eq!(paths, vec![home.path().join("plugins/tracedecay")]);
-    assert_eq!(bytes(&codex_dir.join("config.toml")), before);
+    assert!(
+        !codex_dir.join("config.toml").exists(),
+        "Codex update-plugin should remove the migrated legacy config-managed install"
+    );
     assert_codex_bundle_contains_bin(&home.path().join("plugins/tracedecay"), NEW_BIN);
     assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
 }

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -676,6 +676,44 @@ fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
 }
 
 #[test]
+fn codex_update_plugin_migrates_legacy_config_even_when_repo_bundle_refreshes() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let codex = get_integration("codex").unwrap();
+    // A repo-local bundle exists (so the refresh list is non-empty) alongside
+    // a legacy config-managed global install, but no personal/cached plugin.
+    codex
+        .install_local(&ctx(home.path(), OLD_BIN), project.path())
+        .unwrap();
+    let legacy_config = write_codex_legacy_config(home.path());
+
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, project.path()))
+        .unwrap();
+
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh");
+    };
+    // The sweep removed the working legacy registration, so the personal
+    // bundle replacement must have been installed — not just the repo bundle.
+    assert!(
+        paths.contains(&home.path().join("plugins/tracedecay")),
+        "legacy migration must install the personal bundle even when a \
+         repo-local refresh already populated the refreshed list; got {paths:?}"
+    );
+    assert!(
+        codex_bootstrap_dir(home.path())
+            .join(".codex-plugin/plugin.json")
+            .exists(),
+        "personal plugin bundle must exist after migrating a legacy install"
+    );
+    assert!(
+        !legacy_config.exists(),
+        "legacy config-managed install should be swept after migration"
+    );
+}
+
+#[test]
 fn codex_update_plugin_reports_not_installed_without_bundle_or_legacy_config() {
     let home = TempDir::new().unwrap();
     let project_root = home.path().join("workspace");

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -72,7 +72,10 @@ fn assert_codex_marketplace_entry(marketplace_path: &Path, source_path: &str) {
 
 fn assert_codex_bundle_contains_bin(plugin_dir: &Path, tracedecay_bin: &str) {
     assert!(text(&plugin_dir.join(".mcp.json")).contains(tracedecay_bin));
-    assert!(text(&plugin_dir.join("hooks/hooks.json")).contains(tracedecay_bin));
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    if hooks_path.exists() {
+        assert!(text(&hooks_path).contains(tracedecay_bin));
+    }
 }
 
 fn codex_bootstrap_dir(home: &Path) -> PathBuf {
@@ -95,6 +98,18 @@ fn write_codex_plugin_manifest(plugin_dir: &Path, version: &str) {
         format!(r#"{{"name":"tracedecay","version":"{version}"}}"#),
     )
     .unwrap();
+}
+
+fn write_codex_legacy_config(home: &Path) -> PathBuf {
+    let codex_dir = home.join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        "[mcp_servers.tracedecay]\ncommand = \"/old/bin/tracedecay\"\nargs = [\"serve\"]\n",
+    )
+    .unwrap();
+    config_path
 }
 
 fn write_stale_codex_skill(plugin_dir: &Path) {
@@ -490,6 +505,31 @@ fn codex_update_plugin_recreates_bootstrap_source_from_cache_only_state() {
 }
 
 #[test]
+fn codex_update_plugin_sweeps_legacy_config_when_cache_exists() {
+    let home = TempDir::new().unwrap();
+    let project_root = home.path().join("workspace");
+    let cached_plugin_dir = codex_cached_plugin_dir(home.path());
+    let legacy_config = write_codex_legacy_config(home.path());
+    write_codex_plugin_manifest(&cached_plugin_dir, "0.0.0");
+
+    let codex = get_integration("codex").unwrap();
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh the installed cache");
+    };
+    assert_eq!(
+        paths,
+        vec![cached_plugin_dir.clone(), codex_bootstrap_dir(home.path())]
+    );
+    assert!(
+        !legacy_config.exists(),
+        "Codex update-plugin should remove legacy config even when a plugin cache exists"
+    );
+}
+
+#[test]
 fn codex_update_plugin_refreshes_global_cache_and_repo_local_bundle() {
     let home = TempDir::new().unwrap();
     let project = TempDir::new().unwrap();
@@ -592,13 +632,7 @@ fn codex_uninstall_removes_repo_local_bundle_from_project_root() {
 fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
     let home = TempDir::new().unwrap();
     let project_root = home.path().join("workspace");
-    let codex_dir = home.path().join(".codex");
-    std::fs::create_dir_all(&codex_dir).unwrap();
-    std::fs::write(
-        codex_dir.join("config.toml"),
-        "[mcp_servers.tracedecay]\ncommand = \"/old/bin/tracedecay\"\nargs = [\"serve\"]\n",
-    )
-    .unwrap();
+    let legacy_config = write_codex_legacy_config(home.path());
     let codex = get_integration("codex").unwrap();
     let outcome = codex
         .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
@@ -608,7 +642,7 @@ fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
     };
     assert_eq!(paths, vec![home.path().join("plugins/tracedecay")]);
     assert!(
-        !codex_dir.join("config.toml").exists(),
+        !legacy_config.exists(),
         "Codex update-plugin should remove the migrated legacy config-managed install"
     );
     assert_codex_bundle_contains_bin(&home.path().join("plugins/tracedecay"), NEW_BIN);

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -1005,7 +1005,7 @@ fn assert_cursor_rendered_bundle_valid(plugin_dir: &Path, bin: &str) {
 }
 
 /// Full structural validation of a rendered Codex plugin bundle.
-fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str) {
+fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str, expect_hooks: bool) {
     // Rendered manifest: version stamped to this binary's package version.
     let manifest = read_json(&plugin_dir.join(".codex-plugin/plugin.json"));
     assert_eq!(manifest["name"], "tracedecay");
@@ -1015,10 +1015,25 @@ fn assert_codex_rendered_bundle_valid(plugin_dir: &Path, bin: &str) {
         "rendered manifest version must match the binary's package version"
     );
 
-    // Rendered hooks.json: Codex nests handlers in matcher groups; every
-    // handler command is the quoted absolute binary plus a hook-codex-*
-    // subcommand.
-    let hooks = read_json(&plugin_dir.join("hooks/hooks.json"));
+    // Rendered hooks.json: only personal/global bundles ship lifecycle hooks;
+    // repo-local bundles omit them (Codex only trusts personal-plugin hooks).
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    if !expect_hooks {
+        assert!(
+            !hooks_path.exists(),
+            "repo-local Codex plugin must not ship {}",
+            hooks_path.display()
+        );
+        let manifest = read_json(&plugin_dir.join(".codex-plugin/plugin.json"));
+        assert!(
+            manifest.get("hooks").is_none(),
+            "repo-local Codex plugin manifest must not declare lifecycle hooks"
+        );
+        return;
+    }
+    // Codex nests handlers in matcher groups; every handler command is the
+    // quoted absolute binary plus a hook-codex-* subcommand.
+    let hooks = read_json(&hooks_path);
     let events = hooks["hooks"]
         .as_object()
         .expect("rendered hooks.json must contain a hooks object");
@@ -1088,7 +1103,7 @@ fn codex_install_renders_structurally_valid_bundle() {
     codex.install(&ctx(home.path(), NEW_BIN)).unwrap();
 
     let plugin_dir = codex_bootstrap_dir(home.path());
-    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN);
+    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN, true);
 
     // Global-scope MCP rendering: absolute command, plain `serve` args, and
     // the global-DB env flag.
@@ -1110,7 +1125,7 @@ fn codex_local_install_renders_project_scoped_mcp() {
         .unwrap();
 
     let plugin_dir = codex_bootstrap_dir(project.path());
-    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN);
+    assert_codex_rendered_bundle_valid(&plugin_dir, NEW_BIN, false);
 
     // Project-local scope renders relative-path serve args and drops the
     // global-DB env flag.

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -589,7 +589,7 @@ fn codex_uninstall_removes_repo_local_bundle_from_project_root() {
 }
 
 #[test]
-fn codex_update_plugin_reports_config_only_for_legacy_config_only_install() {
+fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
     let home = TempDir::new().unwrap();
     let project_root = home.path().join("workspace");
     let codex_dir = home.path().join(".codex");
@@ -605,9 +605,13 @@ fn codex_update_plugin_reports_config_only_for_legacy_config_only_install() {
     let outcome = codex
         .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
         .unwrap();
-    assert!(matches!(outcome, UpdatePluginOutcome::ConfigOnly));
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to migrate legacy config to plugin");
+    };
+    assert_eq!(paths, vec![home.path().join("plugins/tracedecay")]);
     assert_eq!(bytes(&codex_dir.join("config.toml")), before);
-    assert!(!home.path().join("plugins/tracedecay").exists());
+    assert_codex_bundle_contains_bin(&home.path().join("plugins/tracedecay"), NEW_BIN);
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make Codex doctor inspect plugin hook trust entries in `~/.codex/config.toml` instead of always printing the generic `/hooks` reminder
- keep Codex healthcheck on the plugin bundle path and stop validating project-local `.codex/hooks.json`/legacy config as supported installs
- make `update-plugin` migrate legacy Codex config-managed installs by installing the plugin bundle

## Context
Official Codex docs say plugin-bundled hooks are skipped until reviewed/trusted, `/hooks` manages hook trust, and project-local hooks only load when a project `.codex/` layer is trusted:
- https://developers.openai.com/codex/hooks
- https://developers.openai.com/codex/cli/slash-commands
- https://developers.openai.com/codex/config-advanced

## Validation
- `cargo test codex_hook_trust_state --lib`
- `cargo test codex_update_plugin_migrates_legacy_config_only_install_to_plugin --test agent_suite`
- `cargo test test_healthcheck_codex --test agent_suite`
- `cargo test test_codex_local_install_bundles_hooks_in_plugin --test agent_suite`
- `cargo run --quiet -- doctor --agent codex`