### PR TITLE
feat(analytics): durable adoption analytics, diagnosing-analytics skill, hook replay test, Claude schema validation

### DIFF
--- a/docs/PLUGIN-VALIDATION.md
+++ b/docs/PLUGIN-VALIDATION.md
@@ -39,15 +39,22 @@ job); layer 6 covers what can't live in the Rust test harness.
 ### 1. Schema validation (cargo test)
 
 JSON artifacts in the bundles are validated against vendored JSON Schemas in
-`tests/fixtures/cursor-schemas/`:
+`tests/fixtures/cursor-schemas/` (Cursor/Codex shapes) and
+`tests/fixtures/claude-schemas/` (Claude Code shapes):
 
 | Artifact | Schema | Test |
 |---|---|---|
-| `plugin/.cursor-plugin/plugin.json` | `plugin.schema.json` | `tests/agent_suite/plugin_manifest_schema_test.rs` |
-| `plugin/.codex-plugin/plugin.json` | `plugin.schema.json` + `interface` extension | `tests/agent_suite/plugin_manifest_schema_test.rs` |
-| `plugin/.claude-plugin/marketplace.json` | `marketplace.schema.json` | vendored for refresh parity |
-| `plugin/mcp-cursor.json` (deploys as `mcp.json`) | `mcp.schema.json` | `tests/agent_suite/plugin_config_schema_test.rs` |
-| `plugin/hooks/hooks-cursor.json` and `plugin/hooks/hooks-codex.json` | `hooks.schema.json` | `tests/agent_suite/plugin_config_schema_test.rs` |
+| `plugin/.cursor-plugin/plugin.json` | `cursor-schemas/plugin.schema.json` | `tests/agent_suite/plugin_manifest_schema_test.rs` |
+| `plugin/.codex-plugin/plugin.json` | `cursor-schemas/plugin.schema.json` + `interface` extension | `tests/agent_suite/plugin_manifest_schema_test.rs` |
+| `plugin/.claude-plugin/plugin.json` | `claude-schemas/plugin.schema.json` | `tests/agent_suite/claude_plugin_schema_test.rs` |
+| `plugin/.claude-plugin/marketplace.json` | `claude-schemas/marketplace.schema.json` | `tests/agent_suite/claude_plugin_schema_test.rs` |
+| `plugin/mcp-cursor.json` (deploys as `mcp.json`) | `cursor-schemas/mcp.schema.json` | `tests/agent_suite/plugin_config_schema_test.rs` |
+| `plugin/hooks/hooks-cursor.json` and `plugin/hooks/hooks-codex.json` | `cursor-schemas/hooks.schema.json` | `tests/agent_suite/plugin_config_schema_test.rs` |
+| `plugin/hooks/hooks-claude.json` | `claude-schemas/hooks.schema.json` | `tests/agent_suite/claude_plugin_schema_test.rs` |
+
+(The Cursor `marketplace.schema.json` stays vendored for refresh parity; the
+Claude marketplace uses its own schema above because Claude entries carry
+fields — `category`, `homepage` — that Cursor's marketplace schema rejects.)
 
 The tests use the `jsonschema` crate (dev-dependency only, no network
 resolvers — the schemas are self-contained draft-07, and the shipped binary

--- a/plugin/skills/diagnosing-analytics/SKILL.md
+++ b/plugin/skills/diagnosing-analytics/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: diagnosing-analytics
+description: 'Use when checking TraceDecay adoption or telemetry health — usage analytics, silent hooks, stale hook logs, or empty analytics tables. Uses the analytics, doctor, and sessions CLI, never raw database queries.'
+---
+
+# Diagnosing TraceDecay analytics
+
+TraceDecay records three telemetry streams: durable `analytics_events` in the
+user-level global store (`mcp_tool_call` rows from the MCP server,
+`hook_route` rows from daemon routing, and `hook_<agent>` rows bridged from
+hook logs), append-only `hook_analytics.jsonl` files (one per project store
+plus a user-level fallback for hooks that could not resolve a project), and
+the per-project session store used for message-level usage. Adoption and
+health questions are answered from the durable table — never by opening
+store databases directly.
+
+## Commands
+
+1. **`tracedecay analytics diagnostics`** — the one-stop summary. Imports any
+   new hook-log rows into the durable table first, then prints event, tool,
+   and hook counts, the TraceDecay tool-call count, per-tool/per-hook rollups,
+   `hook_sources` with per-file row counts, and usage ratios. Flags:
+   `--all` (every project, not just the current one), `--no-sync` (skip the
+   import pass; read-only).
+2. **`tracedecay analytics sync`** — run only the hook-log import and report
+   how many rows each source contributed.
+3. **`tracedecay doctor`** — per-agent install health: hook registration, MCP
+   config, binary staleness. Run this first when a hook seems silent
+   (Codex hooks may exist but stay skipped until trusted in Codex's own
+   hooks approval prompt).
+4. **`tracedecay tool lcm_status --provider all --json`** and
+   **`tracedecay tool lcm_doctor --provider codex --mode diagnose --json`** —
+   session-store ingest and compression health per provider.
+5. **`tracedecay sessions search "mcp__tracedecay" --provider all`** — find
+   tool usage evidence inside ingested transcripts across providers.
+6. **`tracedecay gain`** / **`tracedecay cost`** — token savings ledger and
+   spend rollups.
+7. **Dashboard**: `tracedecay dashboard` serves the same summaries at
+   `/api/plugins/analytics/overview|diagnostics|usage|hints`.
+
+## Reading the diagnostics output
+
+- `source: "analytics_events"` means durable data answered; a
+  `session_messages_and_hook_analytics` source means no durable events matched
+  and the summary fell back to hook logs only.
+- `hook_sources` lists each hook-log file with `rows_total` vs
+  `rows_included`. A large gap means rows written before project attribution
+  existed; they are visible under `--all` but cannot be assigned to a project.
+- `project_id: null` means the command ran outside an indexed project and
+  reported globally. Run from an indexed project root for per-project scope,
+  or pass `--all` deliberately.
+- `import.imported` greater than zero means a hook-log backlog was just
+  bridged — re-read the counts, they include it.
+- A high hook-call count with a low TraceDecay tool-call count is an adoption gap:
+  hooks fire, but sessions are not using tracedecay tools. Check
+  `by_prompt_category` to see which task types miss it.
+
+## Guardrails
+
+- A zero-row `analytics_events` table inside a project store is not evidence
+  that telemetry is broken — durable events live in the user-level store. Run
+  `tracedecay analytics diagnostics` before concluding anything is dead.
+- Never query store databases with sqlite3 or scripts; schemas are internal.
+  The diagnostics JSON already merges every relevant source.
+- If the MCP transport is down, every command above still works — they are
+  plain CLI subcommands (see `tracedecay:using-the-cli`).
+
+## Output
+
+- Headline counts (events, MCP tool calls, tracedecay calls, hook calls) with
+  the exact command used, plus any gaps found: unattributed hook rows, stale
+  or missing sources, providers with hooks firing but zero tool usage.

--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -1589,7 +1589,7 @@ mod tests {
             .collect();
 
         let skills = plugin_subdir_names("skills");
-        assert_eq!(skills.len(), 29, "expected 29 shared skill dirs");
+        assert_eq!(skills.len(), 30, "expected 30 shared skill dirs");
         // Every file under plugin/skills/ (SKILL.md *and* any support files) is
         // deployed — the recursive embed leaves nothing on disk unwired.
         let skills_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin/skills");

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -1549,7 +1549,7 @@ mod tests {
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
             .collect();
         skill_dirs.sort();
-        assert_eq!(skill_dirs.len(), 29, "expected 29 shared skill dirs");
+        assert_eq!(skill_dirs.len(), 30, "expected 30 shared skill dirs");
         // Every file under plugin/skills/ (SKILL.md *and* any support files) is
         // deployed — the recursive embed leaves nothing on disk unwired.
         for relative in skill_tree_files(&skills_root) {

--- a/src/agents/plugin_bundle.rs
+++ b/src/agents/plugin_bundle.rs
@@ -5,9 +5,9 @@
 //! agent format.
 //!
 //! Layout of `plugin/`:
-//! - `plugin/skills/*/SKILL.md` — the 16 shared model-invocable skills **plus**
-//!   the 13 canonical (`claude`/`codex`) workflow dispatcher skills (29 total).
-//!   Cursor deploys only the 16 model-invocable skills (not the dispatcher
+//! - `plugin/skills/*/SKILL.md` — the 17 shared model-invocable skills **plus**
+//!   the 13 canonical (`claude`/`codex`) workflow dispatcher skills (30 total).
+//!   Cursor deploys only the 17 model-invocable skills (not the dispatcher
 //!   skills); its explicit dispatch is native commands (below).
 //! - `plugin/overlays/cursor/commands/tracedecay-*.md` — Cursor 1.6+ native
 //!   slash commands, one per workflow slug, deployed to `commands/<slug>.md`.
@@ -235,7 +235,7 @@ fn compose(
 }
 
 /// Files Claude deploys: manifest + Claude agents + Claude commands + every
-/// skill file (all 29 skills incl. dispatchers, plus any support files).
+/// skill file (all 30 skills incl. dispatchers, plus any support files).
 pub fn claude_files() -> Vec<(&'static str, &'static str)> {
     compose(
         &[
@@ -262,7 +262,7 @@ pub fn cursor_files() -> Vec<(&'static str, &'static str)> {
     )
 }
 
-/// Files Codex deploys: manifest + every skill file (all 29 skills incl.
+/// Files Codex deploys: manifest + every skill file (all 30 skills incl.
 /// dispatchers, plus any support files). Codex ships no agents/commands/rules.
 pub fn codex_files() -> Vec<(&'static str, &'static str)> {
     compose(&[CODEX_MANIFEST_FILES], all_skill_files())

--- a/src/analytics_bridge.rs
+++ b/src/analytics_bridge.rs
@@ -1,0 +1,400 @@
+//! Bridges hook telemetry into the durable `analytics_events` table.
+//!
+//! Hooks append JSONL rows to `hook_analytics.jsonl` (project store when the
+//! hook can resolve a project root, user-level profile root otherwise), while
+//! the MCP server writes `mcp_tool_call` / `hook_route` rows straight into the
+//! user-level global DB. This module imports the JSONL side into
+//! `analytics_events` so one durable table answers adoption questions, using
+//! per-file byte cursors in `parse_offsets` to stay idempotent across runs.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::global_db::{AnalyticsEventInsert, GlobalDb, ParseOffset};
+
+/// Largest batch handed to a single `append_analytics_events` transaction.
+const IMPORT_BATCH_SIZE: usize = 500;
+
+#[derive(Debug, Clone)]
+pub struct HookImportSource {
+    /// JSONL file to import.
+    pub path: PathBuf,
+    /// Project attributed to rows that carry no `project_root` field. Rows in
+    /// a project-store file all belong to that project even before writers
+    /// stamped attribution; user-level rows without it stay unattributed.
+    pub default_project_root: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HookImportSourceOutcome {
+    pub path: PathBuf,
+    pub imported: u64,
+    pub skipped: u64,
+    pub error: Option<String>,
+}
+
+impl HookImportSourceOutcome {
+    fn as_json(&self) -> Value {
+        json!({
+            "path": self.path.display().to_string(),
+            "imported": self.imported,
+            "skipped": self.skipped,
+            "error": self.error,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HookImportOutcome {
+    pub sources: Vec<HookImportSourceOutcome>,
+}
+
+impl HookImportOutcome {
+    pub fn imported(&self) -> u64 {
+        self.sources.iter().map(|source| source.imported).sum()
+    }
+
+    pub fn as_json(&self) -> Value {
+        json!({
+            "imported": self.imported(),
+            "sources": self.sources.iter().map(HookImportSourceOutcome::as_json).collect::<Vec<_>>(),
+        })
+    }
+}
+
+/// The hook JSONL files relevant to a project: its store file plus the
+/// user-level fallback file shared by every project.
+pub fn hook_import_sources(project_root: Option<&Path>) -> Vec<HookImportSource> {
+    let mut sources = Vec::new();
+    if let Some(root) = project_root {
+        if let Ok(layout) = crate::storage::resolve_layout_for_current_profile(root) {
+            sources.push(HookImportSource {
+                path: layout.data_root.join("hook_analytics.jsonl"),
+                default_project_root: Some(root.to_path_buf()),
+            });
+        }
+    }
+    if let Ok(profile_root) = crate::storage::default_profile_root() {
+        let path = profile_root.join("hook_analytics.jsonl");
+        if !sources.iter().any(|source| source.path == path) {
+            sources.push(HookImportSource {
+                path,
+                default_project_root: None,
+            });
+        }
+    }
+    sources
+}
+
+/// Imports new hook JSONL rows into `analytics_events`, advancing a byte
+/// cursor per source file so re-runs only ingest the appended tail.
+pub async fn import_hook_analytics(
+    gdb: &GlobalDb,
+    sources: &[HookImportSource],
+) -> HookImportOutcome {
+    let mut outcome = HookImportOutcome::default();
+    for source in sources {
+        outcome.sources.push(import_source(gdb, source).await);
+    }
+    outcome
+}
+
+async fn import_source(gdb: &GlobalDb, source: &HookImportSource) -> HookImportSourceOutcome {
+    let mut result = HookImportSourceOutcome {
+        path: source.path.clone(),
+        imported: 0,
+        skipped: 0,
+        error: None,
+    };
+    let Ok(metadata) = std::fs::metadata(&source.path) else {
+        return result;
+    };
+    let file_len = metadata.len();
+    let mtime = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |duration| duration.as_secs());
+
+    let cursor_key = import_cursor_key(&source.path);
+    let start = match gdb.get_parse_offset(&cursor_key).await {
+        // Truncated/rotated files restart from the top.
+        Some(cursor) if cursor.byte_offset <= file_len => cursor.byte_offset,
+        _ => 0,
+    };
+    if start == file_len {
+        return result;
+    }
+
+    let text = match read_from_offset(&source.path, start) {
+        Ok(text) => text,
+        Err(err) => {
+            result.error = Some(err);
+            return result;
+        }
+    };
+    // Only consume up to the last complete line; a concurrent writer may have
+    // an unfinished row at EOF.
+    let consumed = text.rfind('\n').map_or(0, |index| index + 1);
+    if consumed == 0 {
+        return result;
+    }
+
+    let mut batch = Vec::new();
+    for line in text[..consumed].lines() {
+        match hook_row_to_analytics_event(line, source.default_project_root.as_deref()) {
+            Some(event) => batch.push(event),
+            None => result.skipped += 1,
+        }
+    }
+    for chunk in batch.chunks(IMPORT_BATCH_SIZE) {
+        if let Err(err) = gdb.append_analytics_events(chunk).await {
+            result.error = Some(err);
+            return result;
+        }
+        result.imported += chunk.len() as u64;
+    }
+
+    gdb.set_parse_offset(
+        &cursor_key,
+        ParseOffset {
+            byte_offset: start + consumed as u64,
+            mtime,
+            file_id: 0,
+        },
+    )
+    .await;
+    result
+}
+
+/// Namespaced `parse_offsets` key so hook cursors never collide with the
+/// accounting transcript cursors that share the table.
+fn import_cursor_key(path: &Path) -> String {
+    format!("hook_analytics:{}", path.display())
+}
+
+fn read_from_offset(path: &Path, offset: u64) -> Result<String, String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file =
+        std::fs::File::open(path).map_err(|err| format!("open {}: {err}", path.display()))?;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|err| format!("seek {}: {err}", path.display()))?;
+    let mut text = String::new();
+    file.read_to_string(&mut text)
+        .map_err(|err| format!("read {}: {err}", path.display()))?;
+    Ok(text)
+}
+
+fn hook_row_to_analytics_event(
+    line: &str,
+    default_project_root: Option<&Path>,
+) -> Option<AnalyticsEventInsert> {
+    let row: Value = serde_json::from_str(line).ok()?;
+    let event_kind = row.get("event").and_then(Value::as_str)?.to_string();
+    let agent = row
+        .get("agent")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let project_id = row
+        .get("project_root")
+        .and_then(Value::as_str)
+        .map(|root| GlobalDb::canonical_project_key(Path::new(root)))
+        .or_else(|| default_project_root.map(GlobalDb::canonical_project_key))
+        .unwrap_or_default();
+    let timestamp = row
+        .get("ts_unix_ms")
+        .and_then(Value::as_i64)
+        .map_or(0, |millis| millis / 1000);
+    Some(AnalyticsEventInsert {
+        provider: format!("hook_{agent}"),
+        project_id,
+        session_id: text_field(&row, "session_id"),
+        timestamp,
+        event_kind,
+        hook_name: text_field(&row, "hook_name"),
+        tool_name: text_field(&row, "tool_name"),
+        tool_category: None,
+        skill_name: None,
+        hint_category: text_field(&row, "category"),
+        hint_id: None,
+        outcome: Some("observed".to_string()),
+        metadata_json: Some(row.to_string()),
+    })
+}
+
+fn text_field(row: &Value, key: &str) -> Option<String> {
+    row.get(key)
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .map(str::to_string)
+}
+
+// ── CLI entry points (`tracedecay analytics …`) ────────────────────────
+
+fn cli_error(message: String) -> crate::errors::TraceDecayError {
+    crate::errors::TraceDecayError::Config { message }
+}
+
+fn cli_project_root() -> Option<PathBuf> {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| crate::config::discover_project_root(&cwd))
+}
+
+async fn open_global_db() -> crate::errors::Result<GlobalDb> {
+    GlobalDb::open().await.ok_or_else(|| {
+        cli_error("user-level global DB unavailable (no writable profile root)".to_string())
+    })
+}
+
+/// `tracedecay analytics sync`: import hook JSONL rows into the durable
+/// `analytics_events` table and print what happened.
+pub async fn run_analytics_sync() -> crate::errors::Result<()> {
+    let project_root = cli_project_root();
+    let gdb = open_global_db().await?;
+    let sources = hook_import_sources(project_root.as_deref());
+    let outcome = import_hook_analytics(&gdb, &sources).await;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&outcome.as_json()).unwrap_or_default()
+    );
+    Ok(())
+}
+
+/// `tracedecay analytics diagnostics`: the CLI wrapper around the dashboard
+/// diagnostics summary — durable `analytics_events` plus merged hook JSONL.
+pub async fn run_analytics_diagnostics(
+    all_projects: bool,
+    no_sync: bool,
+) -> crate::errors::Result<()> {
+    let project_root = cli_project_root();
+    let gdb = open_global_db().await?;
+
+    let import = if no_sync {
+        Value::Null
+    } else {
+        let sources = hook_import_sources(project_root.as_deref());
+        import_hook_analytics(&gdb, &sources).await.as_json()
+    };
+
+    let project_filter = if all_projects {
+        None
+    } else {
+        project_root.as_deref().map(GlobalDb::canonical_project_key)
+    };
+    let events = gdb
+        .query_analytics_events(&crate::global_db::AnalyticsEventQuery {
+            provider: None,
+            project_id: project_filter.clone(),
+            session_id: None,
+            event_kind: None,
+            limit: 10_000,
+        })
+        .await
+        .map_err(cli_error)?;
+    let event_rows: Vec<Value> = events
+        .iter()
+        .map(crate::dashboard::analytics_api::durable_analytics_event_row)
+        .collect();
+
+    let store_root = project_root.as_deref().and_then(|root| {
+        crate::storage::resolve_layout_for_current_profile(root)
+            .ok()
+            .map(|layout| layout.data_root)
+    });
+    let hook_filter_root = if all_projects {
+        None
+    } else {
+        project_root.as_deref()
+    };
+    let hook_analytics = crate::dashboard::analytics_api::read_hook_analytics_rows_at(
+        store_root.as_deref(),
+        hook_filter_root,
+    );
+
+    let message_count = match project_root.as_deref() {
+        Some(root) => project_session_message_count(root).await,
+        None => 0,
+    };
+
+    let durable = if event_rows.is_empty() {
+        None
+    } else {
+        Some(event_rows.as_slice())
+    };
+    let mut summary = crate::dashboard::analytics_api::diagnostics_summary_from_parts(
+        message_count,
+        &hook_analytics,
+        durable,
+    );
+    if let Some(summary) = summary.as_object_mut() {
+        summary.insert(
+            "project_id".to_string(),
+            project_filter.map_or(Value::Null, Value::String),
+        );
+        summary.insert("import".to_string(), import);
+        summary.insert(
+            "global_db".to_string(),
+            crate::global_db::global_db_path()
+                .map_or(Value::Null, |path| json!(path.display().to_string())),
+        );
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&summary).unwrap_or_default()
+    );
+    Ok(())
+}
+
+async fn project_session_message_count(project_root: &Path) -> i64 {
+    let Some(db_path) =
+        crate::sessions::cursor::resolved_project_session_db_path(project_root).await
+    else {
+        return 0;
+    };
+    let Some(db) = GlobalDb::open_at(&db_path).await else {
+        return 0;
+    };
+    db.session_message_count().await.unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::hook_row_to_analytics_event;
+
+    #[test]
+    fn maps_hook_invoked_row_with_attribution() {
+        let line = r#"{"agent":"claude","event":"hook_invoked","hook_name":"preToolUse","project_root":"/repo","session_id":"s1","tool_name":"Agent","ts_unix_ms":1783000000000}"#;
+        let Some(event) = hook_row_to_analytics_event(line, None) else {
+            panic!("row should map");
+        };
+        assert_eq!(event.provider, "hook_claude");
+        assert_eq!(event.event_kind, "hook_invoked");
+        assert_eq!(event.hook_name.as_deref(), Some("preToolUse"));
+        assert_eq!(event.session_id.as_deref(), Some("s1"));
+        assert_eq!(event.timestamp, 1_783_000_000);
+        assert!(event.project_id.ends_with("repo"));
+    }
+
+    #[test]
+    fn unattributed_row_falls_back_to_default_project() {
+        let line = r#"{"agent":"cursor","event":"hook_invoked","hook_name":"postToolUse","ts_unix_ms":1783000000000}"#;
+        let Some(event) = hook_row_to_analytics_event(line, Some(Path::new("/repo"))) else {
+            panic!("row should map");
+        };
+        assert!(event.project_id.ends_with("repo"));
+        let Some(event) = hook_row_to_analytics_event(line, None) else {
+            panic!("row should map");
+        };
+        assert_eq!(event.project_id, "");
+    }
+
+    #[test]
+    fn rows_without_event_field_are_skipped() {
+        assert!(hook_row_to_analytics_event("{}", None).is_none());
+        assert!(hook_row_to_analytics_event("not json", None).is_none());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -459,6 +459,12 @@ pub enum Commands {
         #[command(subcommand)]
         action: SessionsAction,
     },
+    /// Adoption analytics: durable tool/hook events and diagnostics summary
+    #[command(long_about = ANALYTICS_LONG_ABOUT, after_help = ANALYTICS_AFTER_HELP)]
+    Analytics {
+        #[command(subcommand)]
+        action: AnalyticsAction,
+    },
     /// Inspect registered TraceDecay projects from the global registry
     #[command(long_about = PROJECTS_LONG_ABOUT, after_help = PROJECTS_AFTER_HELP)]
     Projects {
@@ -576,6 +582,22 @@ pub enum DaemonAction {
     Restart,
     /// Print daemon service/socket status
     Status,
+}
+
+#[derive(Subcommand)]
+pub enum AnalyticsAction {
+    /// Print the adoption diagnostics summary (durable analytics events plus
+    /// hook telemetry) for the current project
+    Diagnostics {
+        /// Include events for every project, not just the current one
+        #[arg(long)]
+        all: bool,
+        /// Skip the hook-JSONL import pass before summarizing
+        #[arg(long)]
+        no_sync: bool,
+    },
+    /// Import hook_analytics.jsonl rows into the durable analytics_events table
+    Sync,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -401,6 +401,23 @@ Examples:
 Related: tracedecay tool message_search (MCP twin), tracedecay tool
 lcm_grep (scoped/time-filtered recall), tracedecay memory.";
 
+pub(crate) const ANALYTICS_LONG_ABOUT: &str = "\
+Answers adoption and telemetry-health questions from the durable \
+analytics_events store: how often tracedecay MCP tools are called, which \
+hooks fire per provider, and where hook telemetry files live. `diagnostics` \
+imports any new hook-log rows first and prints the same summary the \
+dashboard serves; `sync` runs only the import.";
+
+pub(crate) const ANALYTICS_AFTER_HELP: &str = "\
+Examples:
+  tracedecay analytics diagnostics               Adoption summary (this project)
+  tracedecay analytics diagnostics --all         Every project
+  tracedecay analytics diagnostics --no-sync     Read-only, skip the import
+  tracedecay analytics sync                      Import hook logs only
+
+Related: tracedecay doctor (hook/MCP install health), tracedecay gain
+(token savings), tracedecay sessions search (transcript evidence).";
+
 pub(crate) const PROJECTS_LONG_ABOUT: &str = "\
 Queries the global registry of every initialised tracedecay project on this \
 machine: list, search by id/path/alias/remote/branch, or resolve one \

--- a/src/dashboard/analytics_api.rs
+++ b/src/dashboard/analytics_api.rs
@@ -157,7 +157,7 @@ async fn durable_analytics_rows(
     }
 }
 
-fn durable_analytics_event_row(event: &AnalyticsEventRecord) -> Value {
+pub(crate) fn durable_analytics_event_row(event: &AnalyticsEventRecord) -> Value {
     json!({
         "provider": &event.provider,
         "timestamp": event.timestamp,
@@ -441,8 +441,17 @@ async fn diagnostics_summary(state: &DashboardState, durable_events: Option<&[Va
     let message_count = session_message_rows(state.lcm_conn.as_ref())
         .await
         .map_or(0, |rows| rows.len() as i64);
-    let hook_rows = read_hook_analytics_rows(state);
-    let hook_call_count = hook_invocation_count(&hook_rows);
+    let hook_analytics = read_hook_analytics_rows(state);
+    diagnostics_summary_from_parts(message_count, &hook_analytics, durable_events)
+}
+
+pub(crate) fn diagnostics_summary_from_parts(
+    message_count: i64,
+    hook_analytics: &HookAnalyticsRows,
+    durable_events: Option<&[Value]>,
+) -> Value {
+    let hook_rows = &hook_analytics.rows;
+    let hook_call_count = hook_invocation_count(hook_rows);
 
     let Some(events) = durable_events else {
         return json!({
@@ -454,16 +463,17 @@ async fn diagnostics_summary(state: &DashboardState, durable_events: Option<&[Va
             "mcp_tool_call_count": 0,
             "tracedecay_call_count": 0,
             "hook_call_count": hook_call_count,
+            "hook_sources": hook_analytics.sources.clone(),
             "ratios": diagnostics_ratios(message_count, 0, 0, 0, hook_call_count),
             "by_event_kind": [],
             "by_tool": [],
             "by_mcp_tool": [],
             "by_tool_category": [],
             "by_outcome": [],
-            "by_hook": hook_count_rows(&hook_rows),
-            "by_prompt_category": hook_prompt_category_rows(&hook_rows),
+            "by_hook": hook_count_rows(hook_rows),
+            "by_prompt_category": hook_prompt_category_rows(hook_rows),
             "recent_events": [],
-            "recent_hooks": recent_hook_rows(&hook_rows, 20),
+            "recent_hooks": recent_hook_rows(hook_rows, 20),
         });
     };
 
@@ -522,6 +532,7 @@ async fn diagnostics_summary(state: &DashboardState, durable_events: Option<&[Va
         "mcp_tool_call_count": mcp_tool_call_count,
         "tracedecay_call_count": tracedecay_call_count,
         "hook_call_count": hook_call_count,
+        "hook_sources": hook_analytics.sources.clone(),
         "events_per_hour": events_per_hour,
         "ratios": diagnostics_ratios(
             message_count,
@@ -535,10 +546,10 @@ async fn diagnostics_summary(state: &DashboardState, durable_events: Option<&[Va
         "by_mcp_tool": count_rows("tool_name", by_mcp_tool),
         "by_tool_category": count_rows("tool_category", by_tool_category),
         "by_outcome": count_rows("outcome", by_outcome),
-        "by_hook": hook_count_rows(&hook_rows),
-        "by_prompt_category": hook_prompt_category_rows(&hook_rows),
+        "by_hook": hook_count_rows(hook_rows),
+        "by_prompt_category": hook_prompt_category_rows(hook_rows),
         "recent_events": recent_event_rows(events, 20),
-        "recent_hooks": recent_hook_rows(&hook_rows, 20),
+        "recent_hooks": recent_hook_rows(hook_rows, 20),
     })
 }
 
@@ -578,13 +589,86 @@ fn count_rows(label: &str, counts: BTreeMap<String, i64>) -> Vec<Value> {
         .collect()
 }
 
-fn read_hook_analytics_rows(state: &DashboardState) -> Vec<Value> {
-    let Ok(text) = std::fs::read_to_string(state.store_root.join("hook_analytics.jsonl")) else {
-        return Vec::new();
+pub(crate) struct HookAnalyticsRows {
+    pub(crate) rows: Vec<Value>,
+    pub(crate) sources: Vec<Value>,
+}
+
+/// Hooks write `hook_analytics.jsonl` into the project store when they can
+/// resolve a project root and into the user-level profile root otherwise, so
+/// a project's hook stream is split across both files. Read both, keeping
+/// only user-level rows whose attribution places them inside this project.
+fn read_hook_analytics_rows(state: &DashboardState) -> HookAnalyticsRows {
+    read_hook_analytics_rows_at(Some(&state.store_root), Some(&state.project_root))
+}
+
+/// Path-based variant shared with the `tracedecay analytics` CLI. Passing no
+/// `project_root` includes every user-level row instead of filtering.
+pub(crate) fn read_hook_analytics_rows_at(
+    store_root: Option<&std::path::Path>,
+    project_root: Option<&std::path::Path>,
+) -> HookAnalyticsRows {
+    let mut out = HookAnalyticsRows {
+        rows: Vec::new(),
+        sources: Vec::new(),
     };
-    text.lines()
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .collect()
+    let store_path = store_root.map(|root| root.join("hook_analytics.jsonl"));
+    if let Some(store_path) = &store_path {
+        read_hook_analytics_file(store_path, None, &mut out);
+    }
+    if let Ok(profile_root) = crate::storage::default_profile_root() {
+        let global_path = profile_root.join("hook_analytics.jsonl");
+        if store_path.as_deref() != Some(global_path.as_path()) {
+            read_hook_analytics_file(&global_path, project_root, &mut out);
+        }
+    }
+    out.rows.sort_by_key(|row| {
+        row.get("ts_unix_ms")
+            .and_then(Value::as_i64)
+            .unwrap_or_default()
+    });
+    out
+}
+
+fn read_hook_analytics_file(
+    path: &std::path::Path,
+    project_filter: Option<&std::path::Path>,
+    out: &mut HookAnalyticsRows,
+) {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let mut rows_total = 0i64;
+    let mut rows_included = 0i64;
+    for line in text.lines() {
+        let Ok(row) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        rows_total += 1;
+        let included = match project_filter {
+            None => true,
+            Some(root) => hook_row_matches_project(&row, root),
+        };
+        if included {
+            rows_included += 1;
+            out.rows.push(row);
+        }
+    }
+    out.sources.push(json!({
+        "path": path.display().to_string(),
+        "rows_total": rows_total,
+        "rows_included": rows_included,
+    }));
+}
+
+/// Rows written since project attribution landed carry `project_root` and/or
+/// `event_cwd`; earlier user-level rows carry neither and stay unattributed.
+fn hook_row_matches_project(row: &Value, project_root: &std::path::Path) -> bool {
+    ["project_root", "event_cwd"].iter().any(|key| {
+        row.get(*key)
+            .and_then(Value::as_str)
+            .is_some_and(|value| std::path::Path::new(value).starts_with(project_root))
+    })
 }
 
 fn hook_invocation_count(rows: &[Value]) -> i64 {

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -21,7 +21,7 @@
 //! `/api/capabilities` advertises which features are live so hosts (or a
 //! richer Hermes wrapper) can extend the surface without forking the UI.
 
-mod analytics_api;
+pub(crate) mod analytics_api;
 pub(crate) mod assets;
 mod automation_config_api;
 mod automation_fact_proposals_api;

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -2202,6 +2202,21 @@ impl GlobalDb {
         Ok(ids)
     }
 
+    pub async fn session_message_count(&self) -> Result<i64, String> {
+        let mut rows = self
+            .conn
+            .query("SELECT COUNT(*) FROM session_messages", ())
+            .await
+            .map_err(|e| format!("failed to count session messages: {e}"))?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read session message count: {e}"))?
+            .ok_or_else(|| "session message count returned no row".to_string())?;
+        row.get::<i64>(0)
+            .map_err(|e| format!("failed to decode session message count: {e}"))
+    }
+
     pub async fn query_analytics_events(
         &self,
         query: &AnalyticsEventQuery,

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -22,7 +22,20 @@ use super::{
 /// `PreToolUse` hook handler for Claude Code's Agent tool matcher.
 pub fn hook_pre_tool_use() {
     let tool_input = std::env::var("TOOL_INPUT").unwrap_or_default();
-    record_hook_invoked(None, HintAgent::Claude, "preToolUse", &tool_input);
+    let parsed: Value = serde_json::from_str(&tool_input).unwrap_or(Value::Null);
+    // TOOL_INPUT has no `cwd`; Claude Code runs hooks with the project as the
+    // process working directory, so fall back to it for attribution.
+    let root = codex_project_root_from_parsed_event(&parsed).or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|cwd| crate::config::discover_project_root(&cwd))
+    });
+    record_hook_invoked(
+        root.as_deref(),
+        HintAgent::Claude,
+        "preToolUse",
+        &tool_input,
+    );
     let decision = evaluate_hook_decision(&tool_input);
     if !decision.is_empty() {
         println!("{decision}");

--- a/src/hooks/kiro.rs
+++ b/src/hooks/kiro.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 
 use super::claude::is_code_research_prompt;
+use super::codex::codex_project_root_from_event;
 use super::tool_hints::{decide_hint, HintAgent, ToolHintInput};
 use super::{
     event_cwd, event_cwd_from_parsed, event_session_id, hook_route_metadata_from_event,
@@ -25,7 +26,8 @@ const KIRO_HOT_INGEST_BUDGET: std::time::Duration = std::time::Duration::from_mi
 /// Blocks with exit code 2 and stderr, per Kiro's hook contract.
 pub fn hook_kiro_pre_tool_use() -> i32 {
     let event = read_hook_event!();
-    record_hook_invoked(None, HintAgent::Kiro, "preToolUse", &event);
+    let root = codex_project_root_from_event(&event);
+    record_hook_invoked(root.as_deref(), HintAgent::Kiro, "preToolUse", &event);
     if let Some(reason) = evaluate_kiro_pre_tool_use(&event) {
         eprintln!("{reason}");
         2
@@ -127,7 +129,8 @@ fn collect_strings<'a>(value: &'a Value, out: &mut Vec<&'a str>) {
 /// Resets the per-turn counter and runs bounded Kiro transcript catch-up.
 pub async fn hook_kiro_prompt_submit() -> i32 {
     let event = read_hook_event!();
-    record_hook_invoked(None, HintAgent::Kiro, "userPromptSubmit", &event);
+    let root = codex_project_root_from_event(&event);
+    record_hook_invoked(root.as_deref(), HintAgent::Kiro, "userPromptSubmit", &event);
     reset_counter_for_kiro_event(&event).await;
     ingest_kiro_transcript_for_event(
         &event,
@@ -144,7 +147,8 @@ pub async fn hook_kiro_prompt_submit() -> i32 {
 /// fail-open.
 pub async fn hook_kiro_post_tool_use() -> i32 {
     let event = read_hook_event!();
-    record_hook_invoked(None, HintAgent::Kiro, "postToolUse", &event);
+    let root = codex_project_root_from_event(&event);
+    record_hook_invoked(root.as_deref(), HintAgent::Kiro, "postToolUse", &event);
     notify_kiro_post_tool_use(&event).await;
     0
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -101,6 +101,14 @@ fn record_hook_analytics(root: Option<&Path>, event: &str, mut fields: serde_jso
     let Some(fields) = fields.as_object_mut() else {
         return;
     };
+    // Attribute the row to its project even when it lands in the user-level
+    // fallback file, so readers can re-join the split streams per project.
+    if let Some(root) = root {
+        fields.insert(
+            "project_root".to_string(),
+            serde_json::Value::String(root.display().to_string()),
+        );
+    }
     fields.insert(
         "event".to_string(),
         serde_json::Value::String(event.to_string()),
@@ -156,6 +164,7 @@ fn record_hook_invoked(root: Option<&Path>, agent: HintAgent, hook_name: &str, e
             "tool_name": text_field(&parsed, &["tool_name", "toolName", "name"]),
             "command": text_field(&parsed, &["command", "cmd", "shell_command"]),
             "prompt_category": inferred_prompt_category(&parsed),
+            "event_cwd": event_cwd_from_parsed(&parsed).map(|cwd| cwd.display().to_string()),
         }),
     );
 }

--- a/src/hooks/steering.rs
+++ b/src/hooks/steering.rs
@@ -10,6 +10,7 @@ use super::now_unix_secs;
 pub const CURSOR_PLUGIN_SKILLS: &[&str] = &[
     "assessing-impact",
     "code-health",
+    "diagnosing-analytics",
     "editing-safely",
     "exploring-code",
     "fixing-build-and-type-errors",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod accounting;
 pub mod agents;
 mod analytics;
+pub mod analytics_bridge;
 pub mod automation;
 pub mod bench;
 pub mod branch;

--- a/src/main.rs
+++ b/src/main.rs
@@ -648,6 +648,14 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
         Commands::Sessions { action } => {
             sessions_cmd::handle_sessions_action(action).await?;
         }
+        Commands::Analytics { action } => match action {
+            AnalyticsAction::Diagnostics { all, no_sync } => {
+                tracedecay::analytics_bridge::run_analytics_diagnostics(all, no_sync).await?;
+            }
+            AnalyticsAction::Sync => {
+                tracedecay::analytics_bridge::run_analytics_sync().await?;
+            }
+        },
         Commands::Projects { action } => {
             project_cmd::handle_projects_action(action).await?;
         }
@@ -721,6 +729,7 @@ fn should_skip_startup_maintenance(command: &Commands) -> bool {
             | Commands::Uninstall { .. }
             | Commands::Lsp { .. }
             | Commands::Doctor { .. }
+            | Commands::Analytics { .. }
             | Commands::Migrate { .. }
             | Commands::Projects { .. }
             | Commands::HookPreToolUse
@@ -791,6 +800,7 @@ fn should_skip_agent_install_maintenance(command: &Commands) -> bool {
             | Commands::Uninstall { .. }
             | Commands::Lsp { .. }
             | Commands::Doctor { .. }
+            | Commands::Analytics { .. }
             | Commands::Migrate { .. }
             | Commands::Projects { .. }
             | Commands::Tool { .. }

--- a/tests/agent_suite/claude_plugin_bundle_test.rs
+++ b/tests/agent_suite/claude_plugin_bundle_test.rs
@@ -29,16 +29,17 @@ fn bundle_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin")
 }
 
-/// The 29 skills the bundle ships (also the codex skill set): the 12
+/// The 30 skills the bundle ships (also the codex skill set): the 13
 /// foundational model-invocable skills (recalling+curating-project-memory
 /// merged into `project-memory`), the 4 memory skills, plus the 13
 /// `tracedecay-*` workflow skills, kept in sync across every skill-bundling
 /// surface.
 const EXPECTED_SKILLS: &[&str] = &[
-    // 12 foundational (recalling+curating-project-memory merged into
+    // 13 foundational (recalling+curating-project-memory merged into
     // project-memory)
     "assessing-impact",
     "code-health",
+    "diagnosing-analytics",
     "editing-safely",
     "exploring-code",
     "fixing-build-and-type-errors",

--- a/tests/agent_suite/claude_plugin_schema_test.rs
+++ b/tests/agent_suite/claude_plugin_schema_test.rs
@@ -1,0 +1,108 @@
+//! Validates the Claude Code side of the plugin bundle against vendored JSON
+//! Schemas: `plugin/hooks/hooks-claude.json`, `plugin/.claude-plugin/plugin.json`,
+//! and `plugin/.claude-plugin/marketplace.json`.
+//!
+//! Anthropic does not publish standalone machine-readable schemas for these
+//! files (marketplace.json even references a schema URL that is not served),
+//! so the schemas vendored at `tests/fixtures/claude-schemas/` are derived
+//! from the Claude Code docs — see each schema's top-level `description` for
+//! provenance. This closes the gap where the Cursor/Codex configs were
+//! schema-validated (`plugin_config_schema_test.rs`) but the Claude configs
+//! only had semantic spot checks.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use jsonschema::Validator;
+use serde_json::{json, Value};
+
+use crate::plugin_validation_support::{
+    assert_schema_valid, compile_schema, read_json_file, repo_path,
+};
+
+const HOOKS_SCHEMA: &str = include_str!("../fixtures/claude-schemas/hooks.schema.json");
+const PLUGIN_SCHEMA: &str = include_str!("../fixtures/claude-schemas/plugin.schema.json");
+const MARKETPLACE_SCHEMA: &str = include_str!("../fixtures/claude-schemas/marketplace.schema.json");
+
+fn compile(schema_body: &str) -> Validator {
+    let schema: Value = serde_json::from_str(schema_body).expect("vendored schema parses");
+    compile_schema(&schema)
+}
+
+fn assert_repo_file_valid(validator: &Validator, relative: &str) {
+    let path = repo_path(relative);
+    assert!(path.exists(), "{relative} must exist");
+    assert_schema_valid(validator, &read_json_file(&path), &path);
+}
+
+#[test]
+fn claude_bundle_hooks_config_matches_the_claude_hooks_schema() {
+    assert_repo_file_valid(&compile(HOOKS_SCHEMA), "plugin/hooks/hooks-claude.json");
+}
+
+#[test]
+fn claude_plugin_manifest_matches_the_claude_plugin_schema() {
+    assert_repo_file_valid(&compile(PLUGIN_SCHEMA), "plugin/.claude-plugin/plugin.json");
+}
+
+#[test]
+fn claude_marketplace_matches_the_claude_marketplace_schema() {
+    assert_repo_file_valid(
+        &compile(MARKETPLACE_SCHEMA),
+        "plugin/.claude-plugin/marketplace.json",
+    );
+}
+
+/// Guards against the vendored schemas degenerating into accept-everything:
+/// each must reject representative malformed configs.
+#[test]
+fn vendored_claude_schemas_reject_malformed_configs() {
+    let hooks_validator = compile(HOOKS_SCHEMA);
+    let bad_hooks_configs = [
+        // typo'd event name (Claude events are PascalCase)
+        json!({ "hooks": { "preToolUse": [{ "hooks": [{ "type": "command", "command": "x" }] }] } }),
+        // matcher group missing its hooks array
+        json!({ "hooks": { "PreToolUse": [{ "matcher": "Agent" }] } }),
+        // command hook missing its command
+        json!({ "hooks": { "Stop": [{ "hooks": [{ "type": "command" }] }] } }),
+        // unsupported hook type
+        json!({ "hooks": { "Stop": [{ "hooks": [{ "type": "prompt", "command": "x" }] }] } }),
+    ];
+    for config in &bad_hooks_configs {
+        assert!(
+            !hooks_validator.is_valid(config),
+            "claude hooks schema unexpectedly accepted: {config}"
+        );
+    }
+
+    let plugin_validator = compile(PLUGIN_SCHEMA);
+    let bad_manifests = [
+        // missing required name
+        json!({ "version": "1.0.0" }),
+        // name not kebab-case
+        json!({ "name": "Trace Decay" }),
+        // unknown top-level field
+        json!({ "name": "tracedecay", "entrypoint": "main.js" }),
+    ];
+    for manifest in &bad_manifests {
+        assert!(
+            !plugin_validator.is_valid(manifest),
+            "claude plugin schema unexpectedly accepted: {manifest}"
+        );
+    }
+
+    let marketplace_validator = compile(MARKETPLACE_SCHEMA);
+    let bad_marketplaces = [
+        // plugins must be an array
+        json!({ "name": "m", "plugins": {} }),
+        // plugin entry missing its source
+        json!({ "name": "m", "plugins": [{ "name": "p" }] }),
+        // owner missing its name
+        json!({ "name": "m", "owner": {}, "plugins": [] }),
+    ];
+    for marketplace in &bad_marketplaces {
+        assert!(
+            !marketplace_validator.is_valid(marketplace),
+            "claude marketplace schema unexpectedly accepted: {marketplace}"
+        );
+    }
+}

--- a/tests/agent_suite/main.rs
+++ b/tests/agent_suite/main.rs
@@ -12,6 +12,7 @@ mod common;
 mod agent_test;
 mod claude_agent_test;
 mod claude_plugin_bundle_test;
+mod claude_plugin_schema_test;
 mod copilot_agent_test;
 mod kiro_agent_test;
 mod managed_skill_archive_test;

--- a/tests/agent_suite/skill_lint_cursor_test.rs
+++ b/tests/agent_suite/skill_lint_cursor_test.rs
@@ -1,4 +1,4 @@
-//! Cursor-specific lint for the composed Cursor skill set (the 16 shared
+//! Cursor-specific lint for the composed Cursor skill set (the 17 shared
 //! model-invocable skills from `plugin/skills/`) plus the Cursor native slash
 //! commands (`plugin/overlays/cursor/commands/`), ported from
 //! community/official skill linters so enforcement runs offline inside
@@ -46,7 +46,7 @@ use tempfile::TempDir;
 /// Cursor's native slash commands (the 13 `tracedecay-*` workflow commands).
 const CURSOR_COMMAND_ROOT: &str = "plugin/overlays/cursor/commands";
 
-/// Stages the Cursor skill *source* set into a temp dir: the 16 shared
+/// Stages the Cursor skill *source* set into a temp dir: the 17 shared
 /// model-invocable skills from `plugin/skills/` (all non-`tracedecay-*` slugs).
 /// This is exactly the skill set Cursor deploys — the `tracedecay-*` workflow
 /// slugs are native commands there (see [`command_slugs`]), not skills.

--- a/tests/agent_suite/tool_skill_coverage_test.rs
+++ b/tests/agent_suite/tool_skill_coverage_test.rs
@@ -140,10 +140,10 @@ fn skill_bodies(skills_roots: &[PathBuf]) -> Vec<String> {
 #[test]
 fn every_mcp_tool_is_taught_by_at_least_one_bundled_skill() {
     let plugin = Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin");
-    // Codex/Claude deploy the 29 canonical skills under plugin/skills. Cursor
-    // deploys the 16 shared model-invocable skills plus the 13 workflow slugs
+    // Codex/Claude deploy the 30 canonical skills under plugin/skills. Cursor
+    // deploys the 17 shared model-invocable skills plus the 13 workflow slugs
     // as native commands (`overlays/cursor/commands`). Both host views must
-    // teach every MCP tool. `plugin/skills` alone (canonical, 29) is a superset
+    // teach every MCP tool. `plugin/skills` alone (canonical, 30) is a superset
     // of the shared 17 plus the canonical dispatcher bodies, so it covers the
     // Codex/Claude view; the Cursor view is the 17 shared skills plus the 13
     // command bodies (which carry the workflow tool mentions Cursor ships).

--- a/tests/fixtures/claude-schemas/hooks.schema.json
+++ b/tests/fixtures/claude-schemas/hooks.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://anthropic.com/schemas/claude-code/hooks.json",
+  "title": "Claude Code Hooks Configuration",
+  "description": "Schema for a Claude Code hooks configuration (plugin hooks/hooks.json or the `hooks` block in settings.json). Anthropic does not publish a standalone machine-readable schema, so this is derived from the Claude Code hooks reference (https://docs.anthropic.com/en/docs/claude-code/hooks — Configuration, Hook Events) as of 2026-07-03, cross-checked against the plugin hooks files Claude Code loads. Event names are enumerated from the documented list; a Claude Code release adding new events requires re-vendoring.",
+  "type": "object",
+  "required": ["hooks"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "description": {
+      "type": "string",
+      "description": "Human-readable summary of what the hook set does. Accepted in plugin hooks.json files."
+    },
+    "hooks": {
+      "type": "object",
+      "description": "Map of hook event name to an array of matcher groups.",
+      "additionalProperties": false,
+      "properties": {
+        "PreToolUse": { "$ref": "#/$defs/matcherGroupArray" },
+        "PostToolUse": { "$ref": "#/$defs/matcherGroupArray" },
+        "Notification": { "$ref": "#/$defs/matcherGroupArray" },
+        "UserPromptSubmit": { "$ref": "#/$defs/matcherGroupArray" },
+        "Stop": { "$ref": "#/$defs/matcherGroupArray" },
+        "SubagentStop": { "$ref": "#/$defs/matcherGroupArray" },
+        "PreCompact": { "$ref": "#/$defs/matcherGroupArray" },
+        "SessionStart": { "$ref": "#/$defs/matcherGroupArray" },
+        "SessionEnd": { "$ref": "#/$defs/matcherGroupArray" }
+      }
+    }
+  },
+  "$defs": {
+    "matcherGroupArray": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/matcherGroup" }
+    },
+    "matcherGroup": {
+      "type": "object",
+      "description": "One matcher group: an optional matcher pattern plus the hook commands that run when it matches.",
+      "required": ["hooks"],
+      "additionalProperties": false,
+      "properties": {
+        "matcher": {
+          "type": "string",
+          "description": "Filter pattern; matched value depends on the event (tool name regex for PreToolUse/PostToolUse, compaction trigger for PreCompact, source for SessionStart). Omitted or empty matches everything."
+        },
+        "hooks": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/commandHook" }
+        }
+      }
+    },
+    "commandHook": {
+      "type": "object",
+      "description": "Command hook: executes a shell command that receives the event JSON on stdin.",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "command",
+          "description": "Hook execution type; only \"command\" is documented."
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Executable or shell command. Plugin hooks may reference ${CLAUDE_PLUGIN_ROOT} or a binary placeholder substituted at install time."
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Arguments passed to the command (plugin hooks form)."
+        },
+        "timeout": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Per-command timeout in seconds."
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/claude-schemas/marketplace.schema.json
+++ b/tests/fixtures/claude-schemas/marketplace.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://anthropic.com/schemas/claude-code/marketplace.json",
+  "title": "Claude Code Plugin Marketplace",
+  "description": "Schema for .claude-plugin/marketplace.json — a Claude Code plugin marketplace index. Anthropic does not publish a standalone machine-readable schema (marketplace.json files reference https://anthropic.com/claude-code/marketplace.schema.json, which is not served), so this is derived from the Claude Code plugin marketplaces reference (https://docs.anthropic.com/en/docs/claude-code/plugin-marketplaces — marketplace.json fields) as of 2026-07-03. A Claude Code release adding new fields requires re-vendoring.",
+  "type": "object",
+  "required": ["name", "plugins"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+      "description": "Marketplace identifier: lowercase kebab-case."
+    },
+    "owner": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "email": { "type": "string" },
+        "url": { "type": "string" }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Arbitrary marketplace metadata (description, version, ...)."
+    },
+    "plugins": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/pluginEntry" }
+    }
+  },
+  "$defs": {
+    "pluginEntry": {
+      "type": "object",
+      "required": ["name", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+          "description": "Plugin identifier matching the plugin's own plugin.json name."
+        },
+        "source": {
+          "description": "Where to fetch the plugin: a relative path, or a source object (git/github/url).",
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "object" }
+          ]
+        },
+        "description": { "type": "string" },
+        "version": { "type": "string" },
+        "author": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "email": { "type": "string" },
+            "url": { "type": "string" }
+          }
+        },
+        "homepage": { "type": "string" },
+        "repository": { "type": "string" },
+        "license": { "type": "string" },
+        "keywords": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "category": { "type": "string" },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "strict": { "type": "boolean" },
+        "commands": { "type": ["string", "array"], "items": { "type": "string" } },
+        "agents": { "type": ["string", "array"], "items": { "type": "string" } },
+        "skills": { "type": ["string", "array"], "items": { "type": "string" } },
+        "hooks": { "type": ["string", "object"] },
+        "mcpServers": { "type": ["string", "object"] }
+      }
+    }
+  }
+}

--- a/tests/fixtures/claude-schemas/plugin.schema.json
+++ b/tests/fixtures/claude-schemas/plugin.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://anthropic.com/schemas/claude-code/plugin.json",
+  "title": "Claude Code Plugin Manifest",
+  "description": "Schema for .claude-plugin/plugin.json — a Claude Code plugin manifest. Anthropic does not publish a standalone machine-readable schema, so this is derived from the Claude Code plugins reference (https://docs.anthropic.com/en/docs/claude-code/plugins — plugin.json fields) as of 2026-07-03. A Claude Code release adding new manifest fields requires re-vendoring.",
+  "type": "object",
+  "required": ["name"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+      "description": "Plugin identifier: lowercase kebab-case, no spaces."
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Semantic version of the plugin."
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description of what the plugin does."
+    },
+    "author": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "email": { "type": "string" },
+        "url": { "type": "string" }
+      },
+      "description": "Plugin author or organisation."
+    },
+    "homepage": { "type": "string" },
+    "repository": { "type": "string" },
+    "license": { "type": "string" },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "commands": {
+      "type": ["string", "array"],
+      "items": { "type": "string" },
+      "description": "Extra command file or directory paths beyond the default commands/ directory."
+    },
+    "agents": {
+      "type": ["string", "array"],
+      "items": { "type": "string" },
+      "description": "Extra agent file or directory paths beyond the default agents/ directory."
+    },
+    "skills": {
+      "type": ["string", "array"],
+      "items": { "type": "string" },
+      "description": "Extra skill directory paths beyond the default skills/ directory."
+    },
+    "hooks": {
+      "type": ["string", "object"],
+      "description": "Hooks config path (string) or inline hooks configuration."
+    },
+    "mcpServers": {
+      "type": ["string", "object"],
+      "description": "MCP config path (string) or inline MCP server definitions."
+    }
+  }
+}

--- a/tests/hooks_lsp_suite/hook_replay_test.rs
+++ b/tests/hooks_lsp_suite/hook_replay_test.rs
@@ -1,0 +1,338 @@
+//! End-to-end hook replay: drives every provider's hook subcommands through
+//! the real binary with representative event payloads, then asserts the full
+//! telemetry wiring — each invocation records an attributed
+//! `hook_analytics.jsonl` row in the project store, and `tracedecay analytics
+//! sync` bridges those rows into the durable `analytics_events` table.
+//!
+//! Uses only child-process env (no process-global mutation), so it does not
+//! need `GLOBAL_DB_ENV_LOCK`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use serde_json::{json, Value};
+use tracedecay::global_db::{AnalyticsEventQuery, GlobalDb};
+use tracedecay::storage::{
+    profile_sharded_data_root, write_enrollment_marker, EnrollmentMarker, StorageMode,
+};
+
+use crate::common::tracedecay_command_with_home;
+
+const REPLAY_PROJECT_ID: &str = "proj_hook_replay";
+
+struct Replay {
+    subcommand: &'static str,
+    agent: &'static str,
+    hook_name: &'static str,
+    /// JSON piped to stdin; `None` for the legacy Claude `preToolUse` contract
+    /// which reads `TOOL_INPUT` from the environment instead.
+    stdin: Option<Value>,
+    tool_input_env: Option<Value>,
+}
+
+fn replays(root: &str) -> Vec<Replay> {
+    vec![
+        Replay {
+            subcommand: "hook-claude-session-start",
+            agent: "claude",
+            hook_name: "SessionStart",
+            stdin: Some(json!({
+                "session_id": "claude-s1",
+                "cwd": root,
+                "hook_event_name": "SessionStart",
+                "source": "startup",
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-claude-post-tool-use",
+            agent: "claude",
+            hook_name: "PostToolUse",
+            stdin: Some(json!({
+                "session_id": "claude-s1",
+                "cwd": root,
+                "tool_name": "Edit",
+                "tool_input": { "file_path": format!("{root}/src/lib.rs") },
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-pre-tool-use",
+            agent: "claude",
+            hook_name: "preToolUse",
+            stdin: None,
+            tool_input_env: Some(json!({
+                "session_id": "claude-s1",
+                "subagent_type": "general-purpose",
+                "prompt": "implement the parser",
+            })),
+        },
+        Replay {
+            subcommand: "hook-codex-session-start",
+            agent: "codex",
+            hook_name: "SessionStart",
+            stdin: Some(json!({ "session_id": "codex-s1", "cwd": root })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-codex-user-prompt-submit",
+            agent: "codex",
+            hook_name: "UserPromptSubmit",
+            stdin: Some(json!({
+                "session_id": "codex-s1",
+                "cwd": root,
+                "prompt": "fix the failing test",
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-codex-post-tool-use",
+            agent: "codex",
+            hook_name: "PostToolUse",
+            stdin: Some(json!({
+                "session_id": "codex-s1",
+                "cwd": root,
+                "tool_name": "shell",
+                "command": "cargo build",
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-cursor-session-start",
+            agent: "cursor",
+            hook_name: "sessionStart",
+            stdin: Some(json!({ "conversation_id": "cursor-s1", "cwd": root })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-cursor-post-tool-use",
+            agent: "cursor",
+            hook_name: "postToolUse",
+            stdin: Some(json!({
+                "conversation_id": "cursor-s1",
+                "cwd": root,
+                "hook_event_name": "postToolUse",
+                "tool_name": "Read",
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-cursor-stop",
+            agent: "cursor",
+            hook_name: "stop",
+            stdin: Some(json!({ "conversation_id": "cursor-s1", "cwd": root })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-kiro-pre-tool-use",
+            agent: "kiro",
+            hook_name: "preToolUse",
+            stdin: Some(json!({
+                "session_id": "kiro-s1",
+                "cwd": root,
+                "tool_name": "fsWrite",
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-kiro-prompt-submit",
+            agent: "kiro",
+            hook_name: "userPromptSubmit",
+            stdin: Some(json!({
+                "session_id": "kiro-s1",
+                "cwd": root,
+                "prompt": "add a feature",
+            })),
+            tool_input_env: None,
+        },
+        Replay {
+            subcommand: "hook-kiro-post-tool-use",
+            agent: "kiro",
+            hook_name: "postToolUse",
+            stdin: Some(json!({
+                "session_id": "kiro-s1",
+                "cwd": root,
+                "tool_name": "fsWrite",
+                "file_path": format!("{root}/src/lib.rs"),
+            })),
+            tool_input_env: None,
+        },
+    ]
+}
+
+fn run_replay(home: &Path, project_root: &Path, replay: &Replay) {
+    let mut command: Command = {
+        let mut c = tracedecay_command_with_home(home);
+        c.arg(replay.subcommand)
+            .current_dir(project_root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        c
+    };
+    if let Some(tool_input) = &replay.tool_input_env {
+        command.env("TOOL_INPUT", tool_input.to_string());
+    }
+    let mut child = command
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn {}: {e}", replay.subcommand));
+    {
+        let mut stdin = child.stdin.take().expect("child stdin");
+        if let Some(event) = &replay.stdin {
+            stdin.write_all(event.to_string().as_bytes()).unwrap();
+        }
+        // Drop closes stdin so stdin-reading handlers see EOF.
+    }
+    let output = child.wait_with_output().expect("hook child output");
+    assert!(
+        output.status.success(),
+        "{} exited with {:?}\nstdout: {}\nstderr: {}",
+        replay.subcommand,
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn read_jsonl_rows(path: &Path) -> Vec<Value> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .collect()
+}
+
+fn str_field<'a>(row: &'a Value, key: &str) -> &'a str {
+    row.get(key).and_then(Value::as_str).unwrap_or_default()
+}
+
+/// Strips Windows' verbatim `\\?\` prefix: attribution resolved from a hook
+/// process's `current_dir()` is non-verbatim while `canonicalize()` yields
+/// the extended-length form, and the two must compare equal.
+fn normalize_path_text(path: &str) -> String {
+    path.strip_prefix(r"\\?\").unwrap_or(path).to_string()
+}
+
+#[tokio::test]
+async fn replayed_provider_hooks_record_attributed_rows_and_bridge_to_analytics_events() {
+    let home = tempfile::TempDir::new().expect("temp home");
+    let home_root = home.path().canonicalize().expect("canonical home");
+    let project_root = home_root.join("project");
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::write(project_root.join("Cargo.toml"), "[package]\n").unwrap();
+    write_enrollment_marker(
+        &project_root,
+        &EnrollmentMarker {
+            project_id: REPLAY_PROJECT_ID.to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let root_str = project_root.display().to_string();
+
+    let replays = replays(&root_str);
+    for replay in &replays {
+        run_replay(&home_root, &project_root, replay);
+    }
+
+    // Every replay resolved a project root, so every row must land in the
+    // project store file with `project_root` attribution (the user-level
+    // fallback file stays empty).
+    let profile_root = home_root.join(".tracedecay");
+    let store_rows = read_jsonl_rows(
+        &profile_sharded_data_root(&profile_root, REPLAY_PROJECT_ID).join("hook_analytics.jsonl"),
+    );
+    let hook_invoked: Vec<&Value> = store_rows
+        .iter()
+        .filter(|row| str_field(row, "event") == "hook_invoked")
+        .collect();
+    for replay in &replays {
+        let matched: Vec<&&Value> = hook_invoked
+            .iter()
+            .filter(|row| {
+                str_field(row, "agent") == replay.agent
+                    && str_field(row, "hook_name") == replay.hook_name
+            })
+            .collect();
+        assert_eq!(
+            matched.len(),
+            1,
+            "expected exactly one {}/{} row, got {} (all rows: {:?})",
+            replay.agent,
+            replay.hook_name,
+            matched.len(),
+            hook_invoked
+        );
+        assert_eq!(
+            normalize_path_text(str_field(matched[0], "project_root")),
+            normalize_path_text(&root_str),
+            "{}/{} row must carry project attribution",
+            replay.agent,
+            replay.hook_name
+        );
+    }
+    let fallback_rows = read_jsonl_rows(&profile_root.join("hook_analytics.jsonl"));
+    assert!(
+        fallback_rows.is_empty(),
+        "attributed hooks must not spill into the user-level fallback file: {fallback_rows:?}"
+    );
+
+    // Bridge: `analytics sync` imports the JSONL rows into the durable table.
+    let sync = tracedecay_command_with_home(&home_root)
+        .args(["analytics", "sync"])
+        .current_dir(&project_root)
+        .output()
+        .expect("analytics sync output");
+    assert!(
+        sync.status.success(),
+        "analytics sync failed: {}",
+        String::from_utf8_lossy(&sync.stderr)
+    );
+
+    let global_db = GlobalDb::open_at(&profile_root.join("global.db"))
+        .await
+        .expect("open replay global db");
+    let events = global_db
+        .query_analytics_events(&AnalyticsEventQuery {
+            provider: None,
+            project_id: None,
+            session_id: None,
+            event_kind: Some("hook_invoked".to_string()),
+            limit: 1000,
+        })
+        .await
+        .expect("query analytics events");
+    assert_eq!(
+        events.len(),
+        replays.len(),
+        "every replayed hook must bridge into analytics_events"
+    );
+    let canonical_project = GlobalDb::canonical_project_key(&project_root);
+    for replay in &replays {
+        let provider = format!("hook_{}", replay.agent);
+        let event = events
+            .iter()
+            .find(|event| {
+                event.provider == provider && event.hook_name.as_deref() == Some(replay.hook_name)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "no analytics event for {provider}/{}; got {:?}",
+                    replay.hook_name,
+                    events
+                        .iter()
+                        .map(|event| (event.provider.clone(), event.hook_name.clone()))
+                        .collect::<Vec<_>>()
+                )
+            });
+        assert_eq!(
+            event.project_id, canonical_project,
+            "{provider}/{} must be attributed to the replay project",
+            replay.hook_name
+        );
+    }
+}

--- a/tests/hooks_lsp_suite/main.rs
+++ b/tests/hooks_lsp_suite/main.rs
@@ -14,5 +14,6 @@ mod common;
 
 mod extract_worker_test;
 mod hook_branch_routing_test;
+mod hook_replay_test;
 mod hooks_test;
 mod lsp_code_diagnostics_test;

--- a/tests/session_suite/global_db.rs
+++ b/tests/session_suite/global_db.rs
@@ -918,3 +918,69 @@ async fn session_ingest_health_reports_pending_transcript_backlog() {
         "the newest recorded ingest mtime should be reported"
     );
 }
+
+#[tokio::test]
+async fn hook_analytics_import_is_incremental_and_idempotent() {
+    use tracedecay::analytics_bridge::{import_hook_analytics, HookImportSource};
+
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let jsonl = tmp.path().join("hook_analytics.jsonl");
+    std::fs::write(
+        &jsonl,
+        concat!(
+            r#"{"agent":"claude","event":"hook_invoked","hook_name":"preToolUse","session_id":"s1","ts_unix_ms":1783000000000}"#,
+            "\n",
+            r#"{"agent":"codex","event":"hint_emitted","category":"search","ts_unix_ms":1783000001000}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+    let sources = vec![HookImportSource {
+        path: jsonl.clone(),
+        default_project_root: Some(tmp.path().to_path_buf()),
+    }];
+
+    let outcome = import_hook_analytics(&db, &sources).await;
+    assert_eq!(outcome.imported(), 2);
+    assert!(outcome.sources[0].error.is_none());
+
+    // Re-running without new rows imports nothing.
+    let outcome = import_hook_analytics(&db, &sources).await;
+    assert_eq!(outcome.imported(), 0);
+
+    // Appending one complete row plus a partial trailing line imports only
+    // the complete row; the partial tail stays unconsumed for the next run.
+    let mut text = std::fs::read_to_string(&jsonl).unwrap();
+    text.push_str(
+        r#"{"agent":"cursor","event":"hook_invoked","hook_name":"postToolUse","ts_unix_ms":1783000002000}"#,
+    );
+    text.push('\n');
+    text.push_str(r#"{"agent":"kiro","event":"hook_invo"#);
+    std::fs::write(&jsonl, text).unwrap();
+    let outcome = import_hook_analytics(&db, &sources).await;
+    assert_eq!(outcome.imported(), 1);
+
+    let events = db
+        .query_analytics_events(&AnalyticsEventQuery {
+            provider: None,
+            project_id: None,
+            session_id: None,
+            event_kind: None,
+            limit: 100,
+        })
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 3);
+    let providers: Vec<&str> = events.iter().map(|event| event.provider.as_str()).collect();
+    assert!(providers.contains(&"hook_claude"));
+    assert!(providers.contains(&"hook_codex"));
+    assert!(providers.contains(&"hook_cursor"));
+    let expected_project = GlobalDb::canonical_project_key(tmp.path());
+    assert!(
+        events
+            .iter()
+            .all(|event| event.project_id == expected_project),
+        "unattributed rows should fall back to the source's default project"
+    );
+}


### PR DESCRIPTION
## Why

Investigating "is TraceDecay actually being used?" surfaced four structural problems:

1. **`analytics_events` looked dead but wasn't.** The only writer targets the user-level `global.db`; the per-project `sessions.db` carries the same schema with no writer, so anyone inspecting the project store concludes telemetry is broken.
2. **Hook telemetry splits across two JSONL files with no attribution.** Hooks write to the project store when they can resolve a project root and silently fall back to `~/.tracedecay/hook_analytics.jsonl` when they can't (Claude `preToolUse` and all Kiro hooks hardcoded `None`). Rows carried no project field, so the split streams could never be re-joined.
3. **Dashboard diagnostics read only the project-store file**, so the active user-level stream was invisible.
4. **No CLI answered adoption questions** — `tracedecay analytics …` didn't exist, and nothing taught agents which surface to use.

## What

- **Writer attribution** — hook analytics rows now carry `project_root`/`event_cwd`; Claude `preToolUse` resolves the root from the event cwd then the process cwd, and the three Kiro hooks resolve from the event cwd.
- **Merged reader** — dashboard diagnostics reads both hook files (user-level rows filtered by attribution) and reports a `hook_sources` list with per-file row counts.
- **`analytics_bridge`** — idempotent hook-JSONL → `analytics_events` import using `parse_offsets` byte cursors; partial trailing lines stay unconsumed for the next run.
- **New CLI** — `tracedecay analytics diagnostics [--all|--no-sync]` (imports, then prints the same summary the dashboard serves) and `tracedecay analytics sync`.
- **New skill** — `diagnosing-analytics` teaches agents the analytics/doctor/lcm_status/sessions surface and its guardrails (never raw sqlite); added to `CURSOR_PLUGIN_SKILLS`.
- **Hook replay E2E test** — drives all four providers' hook subcommands through the real binary with representative events, asserting attributed JSONL rows land in the project store, nothing spills to the fallback file, and `analytics sync` bridges every row into `analytics_events`.
- **Claude schema validation** — vendored draft-07 schemas for Claude Code `hooks.json`, `plugin.json`, and `marketplace.json` with positive + negative tests, closing the gap where only Cursor/Codex configs were schema-checked. `docs/PLUGIN-VALIDATION.md` table updated.

## Verification

- New tests: hook replay E2E (12 provider events, wiring end to end), bridge import integration test (incremental/idempotent/partial-line), 3 bridge unit tests, 4 Claude schema tests.
- Suites: hooks_lsp_suite 117/117, agent_suite skill/schema subset 43/43, dashboard analytics 6/6, session_suite import test — all green on this branch.
- Live run on real data imported 38,686 backlogged hook rows into `analytics_events` and the diagnostics command now answers adoption questions in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
