### PR TITLE
test(agents): lock env in uninstall memory-digest tests

### DIFF
--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -4147,6 +4147,7 @@ fn test_claude_install_then_uninstall() {
 
 #[test]
 fn test_claude_uninstall_unrecords_memory_digest_target() {
+    let _env_lock = AGENT_ENV_LOCK.blocking_lock();
     let dir = TempDir::new().unwrap();
     let home = dir.path();
     let profile_root = home.join(".tracedecay");
@@ -4270,6 +4271,7 @@ fn test_codex_install_then_uninstall() {
 
 #[test]
 fn test_codex_local_uninstall_unrecords_legacy_repo_memory_digest_target() {
+    let _env_lock = AGENT_ENV_LOCK.blocking_lock();
     let home = TempDir::new().unwrap();
     let project = TempDir::new().unwrap();
     let mut ctx = make_install_ctx(home.path());


### PR DESCRIPTION
Two sync uninstall tests (`test_claude_uninstall_unrecords_memory_digest_target`, `test_codex_local_uninstall_unrecords_legacy_repo_memory_digest_target`) set `TRACEDECAY_DATA_DIR` via `EnvVarGuard` without taking `PROCESS_ENV_LOCK`, racing every env-guarded test in the same binary under plain parallel `cargo test`. Most visible victim: `test_codex_install_exports_active_managed_skills` — its install read a foreign profile root mid-test and exported no managed skills (`cargo test --test agent_suite -- codex` failed 4/4 locally; passes solo and with `--test-threads=1`). CI uses nextest (process-per-test), so it never saw the race.

Fix: take `AGENT_ENV_LOCK.blocking_lock()` first, like every other env-mutating test in the suite. Audited the rest of the binary for unguarded `EnvVarGuard` uses — the only other hits are helpers whose callers already hold the lock.

Verified: the failing filter now passes 5/5 in parallel; full agent_suite 431/431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)