### PR TITLE
chore: release v0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.27](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.26...v0.0.27) - 2026-07-04
+
+### Other
+
+- [codex] Improve Codex plugin hook trust doctor ([#258](https://github.com/ScriptedAlchemy/tracedecay/pull/258))
+
 ## [0.0.26](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.25...v0.0.26) - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.26"
+version = "0.0.27"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.26 -> 0.0.27

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.27](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.26...v0.0.27) - 2026-07-04

### Other

- [codex] Improve Codex plugin hook trust doctor ([#258](https://github.com/ScriptedAlchemy/tracedecay/pull/258))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).