### PR TITLE
fix(agents): memory digest export lifecycle

### DIFF
--- a/src/mcp/tools/handlers/memory.rs
+++ b/src/mcp/tools/handlers/memory.rs
@@ -17,7 +17,7 @@ use crate::memory::types::{
 };
 use crate::tracedecay::TraceDecay;
 
-use super::super::render;
+use super::super::render::{self, truncated_json_envelope_with_handle};
 use super::super::ToolResult;
 use super::support::{
     profile_root_for_global_db, project_registry_context, project_selector_present,
@@ -37,6 +37,12 @@ fn text_tool_result(text: &str) -> ToolResult {
         json!({ "content": [{ "type": "text", "text": text }] }),
         vec![],
     )
+}
+
+fn tool_json(project_root: Option<&Path>, value: &Value) -> ToolResult {
+    let formatted = serde_json::to_string(value).unwrap_or_default();
+    let text = truncated_json_envelope_with_handle(project_root, &formatted);
+    text_tool_result(&text)
 }
 
 fn rendered_tool_json(project_root: Option<&Path>, args: &Value, value: &Value) -> ToolResult {
@@ -487,11 +493,7 @@ pub(super) async fn handle_fact_store(
     if refresh_digest {
         refresh_memory_digest_after_memory_change(conn, &target_memory.project_root).await;
     }
-    Ok(rendered_tool_json(
-        Some(&target_memory.project_root),
-        &args,
-        &out,
-    ))
+    Ok(tool_json(Some(&target_memory.project_root), &out))
 }
 
 pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
@@ -513,9 +515,8 @@ pub(super) async fn handle_fact_feedback(cg: &TraceDecay, args: Value) -> Result
         })
         .await?;
     refresh_memory_digest_after_memory_change(db.conn(), cg.project_root()).await;
-    Ok(rendered_tool_json(
+    Ok(tool_json(
         Some(cg.project_root()),
-        &args,
         &json!({ "status": "recorded", "feedback": result }),
     ))
 }


### PR DESCRIPTION
## Summary

The `fact_store` and `fact_feedback` memory write handlers now return **raw JSON envelopes** (`tool_json`) instead of markdown-rendered output (`rendered_tool_json`).

After the "Default TraceDecay tool output to markdown" change (#262), these write-path handlers rendered their status JSON (`{ status, feedback, count, ... }`) as markdown. That interfered with the memory digest export lifecycle, which expects the structured JSON result. A new `tool_json` helper emits the truncated JSON envelope (with project handle) directly. `handle_memory_status` intentionally keeps the rendered markdown path.

## Recovery note

This was recovered from a **stranded git worktree** that had a stale rebase in progress. The fix branch (`codex/claude-memory-digest-fixes`) had been based on an older master, so its conflicting hunks in `src/agents/claude.rs`, `src/agents/mod.rs`, and `tests/agent_suite/agent_test.rs` were **reverts of unrelated newer master work** (PR #258 codex hook trust migration, PR #260 analytics/agent tests) rather than part of the memory-digest fix. Those files were confirmed to carry no memory-digest content and were discarded; only the genuine `memory.rs` fix is carried forward, rebuilt cleanly on current `origin/master`.

## Verification

- `cargo check` — clean (only vendored libsql warnings)
- `cargo clippy --all-targets -- -D warnings` — clean for touched file
- `cargo fmt` — no changes
- `cargo test --test agent_suite -- memory_digest` — 15 passed
- `cargo test --test agent_suite -- claude` — 57 passed
- `cargo test --test mcp_suite -- fact` — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)