### PR TITLE
chore: release v0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.28](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.27...v0.0.28) - 2026-07-04
+
+### Fixed
+
+- *(agents)* memory digest export lifecycle ([#266](https://github.com/ScriptedAlchemy/tracedecay/pull/266))
+
 ## [0.0.27](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.26...v0.0.27) - 2026-07-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.27"
+version = "0.0.28"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.27 -> 0.0.28

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.28](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.27...v0.0.28) - 2026-07-04

### Fixed

- *(agents)* memory digest export lifecycle ([#266](https://github.com/ScriptedAlchemy/tracedecay/pull/266))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).