### PR TITLE
fix(claude): write schema-required marketplace registration fields

### DIFF
--- a/src/agents/claude.rs
+++ b/src/agents/claude.rs
@@ -431,11 +431,16 @@ fn register_marketplace(home: &Path, deploy_dir: &Path) -> Result<()> {
     if !known.is_object() {
         known = json!({});
     }
+    // Claude Code's marketplace schema requires `installLocation` and
+    // `lastUpdated` alongside `source`; without them `claude plugin install`
+    // rejects the record as corrupted and the plugin silently never loads.
     known[MARKETPLACE_NAME] = json!({
         "source": {
             "source": "directory",
             "path": deploy_dir.to_string_lossy(),
-        }
+        },
+        "installLocation": deploy_dir.to_string_lossy(),
+        "lastUpdated": crate::timeutil::now_iso_utc(),
     });
     write_json_file(&path, &known)?;
     eprintln!(
@@ -1180,13 +1185,24 @@ fn doctor_check_plugin(dc: &mut DoctorCounters, home: &Path) {
 
     // Marketplace registration.
     let known = load_json_file(&known_marketplaces_path(home));
-    let registered = known
-        .get(MARKETPLACE_NAME)
+    let entry = known.get(MARKETPLACE_NAME);
+    let registered = entry
         .and_then(|m| m.get("source"))
         .and_then(|s| s.get("source"))
         .and_then(|v| v.as_str())
         == Some("directory");
-    if registered {
+    let schema_complete = entry.is_some_and(|m| {
+        m.get("installLocation")
+            .is_some_and(serde_json::Value::is_string)
+            && m.get("lastUpdated")
+                .is_some_and(serde_json::Value::is_string)
+    });
+    if registered && !schema_complete {
+        dc.fail(&format!(
+            "Marketplace entry in {} is missing installLocation/lastUpdated — Claude Code treats it as corrupted; run `tracedecay install --agent claude` to rewrite it",
+            known_marketplaces_path(home).display()
+        ));
+    } else if registered {
         dc.pass(&format!(
             "Marketplace registered in {}",
             known_marketplaces_path(home).display()

--- a/tests/agent_suite/claude_agent_test.rs
+++ b/tests/agent_suite/claude_agent_test.rs
@@ -495,6 +495,23 @@ fn test_uninstall_removes_deployed_bundle_and_lone_marketplace_file() {
         known_path.exists(),
         "known_marketplaces.json should exist after install"
     );
+    // Claude Code's marketplace schema requires these fields; without them
+    // `claude plugin install` rejects the entry as corrupted and the plugin
+    // silently never loads.
+    let known: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&known_path).unwrap()).unwrap();
+    let entry = &known["tracedecay"];
+    assert_eq!(
+        entry["installLocation"].as_str(),
+        Some(deploy_dir.to_string_lossy().as_ref()),
+        "marketplace entry must carry installLocation"
+    );
+    assert!(
+        entry["lastUpdated"]
+            .as_str()
+            .is_some_and(|ts| ts.ends_with('Z')),
+        "marketplace entry must carry an ISO-8601 lastUpdated: {entry}"
+    );
 
     ClaudeIntegration.uninstall(&ctx).unwrap();
 


### PR DESCRIPTION
Found while validating the v0.0.28 Claude plugin install end to end: `tracedecay install --agent claude` wrote the `known_marketplaces.json` entry with only `source`, but Claude Code's marketplace schema also requires `installLocation` and `lastUpdated` — so `claude plugin install tracedecay@tracedecay` failed with *"Marketplace configuration file is corrupted"* and the plugin silently never loaded in any session, while `tracedecay doctor` reported all green.

- installer now writes both required fields (entries self-heal on the next install/update-plugin run)
- doctor now **fails** on a registered-but-schema-incomplete entry instead of passing on presence
- install test asserts the fields

Verified on this machine: after the fix + `claude plugin install`, a fresh headless Claude session lists the `tracedecay:*` skills, connects the MCP server, and exposes the slash commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)