### PR TITLE
fix(sessions): follow store remote fallback for renamed checkouts

### DIFF
--- a/src/sessions/cursor.rs
+++ b/src/sessions/cursor.rs
@@ -78,9 +78,31 @@ async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf
     let profile_root = crate::storage::default_profile_root().ok()?;
     let global = GlobalDb::open().await?;
     let git_common_dir = crate::worktree::git_common_dir(project_root);
-    let resolution = global
+    // Mirror the graph store's identity-then-unique-remote fallback
+    // (`resolve_store_layout_for_project` in tracedecay/lifecycle.rs) so a
+    // renamed/moved checkout keeps routing its session history to the store it
+    // was originally registered under, instead of silently forking a fresh
+    // session DB at a new default path.
+    let resolution = if let Some(resolution) = global
         .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
-        .await?;
+        .await
+    {
+        resolution
+    } else {
+        let remote = crate::tracedecay::git_remote_url(project_root)?;
+        let resolution = global
+            .resolve_unique_project_store_by_git_remote(&remote)
+            .await?;
+        // Remote uniqueness alone cannot tell a renamed checkout (whose
+        // original registered location no longer exists on disk) apart from
+        // a second, still-present clone of the same remote. Only borrow the
+        // registered store when the original checkout is gone, so a live
+        // clone never inherits another checkout's session history.
+        if registered_checkout_present(&resolution.project) {
+            return None;
+        }
+        resolution
+    };
     if resolution.store.storage_mode != "profile_sharded" {
         return None;
     }
@@ -89,6 +111,23 @@ async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf
             .join(resolution.store.store_relpath)
             .join(PROJECT_SESSION_DB_FILENAME),
     )
+}
+
+/// Returns `true` when the checkout a registered project was recorded at still
+/// exists on disk. A renamed/moved checkout leaves neither its canonical root
+/// nor its git common dir behind, whereas a separate clone of the same remote
+/// leaves the original checkout in place.
+fn registered_checkout_present(project: &crate::global_db::CodeProjectRecord) -> bool {
+    let roots = [
+        Some(project.canonical_root.as_str()),
+        Some(project.display_root.as_str()),
+        project.git_common_dir.as_deref(),
+    ];
+    roots
+        .into_iter()
+        .flatten()
+        .filter(|root| !root.is_empty())
+        .any(|root| Path::new(root).exists())
 }
 
 fn is_hermes_profile_home(path: &Path) -> bool {

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -30,6 +30,8 @@ pub use diagnostics::{BranchDiagnostics, TrackedBranchDiagnostic};
 #[doc(hidden)]
 pub use locking::{try_acquire_sync_lock, SyncLockGuard};
 
+pub(crate) use lifecycle::git_remote_url;
+
 /// Central orchestrator that coordinates all subsystems of the code graph.
 ///
 /// Provides a high-level API for initializing, indexing, querying, and

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -838,7 +838,7 @@ fn profile_store_id(project_id: &str) -> String {
     format!("store:{project_id}:profile_sharded")
 }
 
-fn git_remote_url(project_root: &Path) -> Option<String> {
+pub(crate) fn git_remote_url(project_root: &Path) -> Option<String> {
     // gix reads the same config `git config --get` would (repo-local +
     // global) without a subprocess spawn.
     if let Ok(repo) = gix::discover(project_root) {

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -783,6 +783,138 @@ async fn same_remote_clone_is_not_considered_initialized_without_local_identity(
 }
 
 #[tokio::test]
+async fn renamed_checkout_session_db_follows_registered_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let remote = dir.path().join("remote.git");
+    let original = dir.path().join("repo");
+    let renamed = dir.path().join("repo-renamed");
+    let home = test_home(&dir);
+    let _home_guard = HomeGuard::set(&home);
+
+    git(dir.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    git(
+        dir.path(),
+        &[
+            "clone",
+            remote.to_str().unwrap(),
+            original.to_str().unwrap(),
+        ],
+    );
+    fs::create_dir_all(original.join("src")).unwrap();
+    fs::write(original.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    git(&original, &["config", "user.email", "test@example.com"]);
+    git(&original, &["config", "user.name", "TraceDecay Test"]);
+    git(&original, &["add", "."]);
+    git(&original, &["commit", "-m", "initial"]);
+    git(&original, &["push", "origin", "HEAD:master"]);
+
+    let cg = TraceDecay::init(&original).await.unwrap();
+    let registered_session_db = cg.store_layout().sessions_db_path.clone();
+    drop(cg);
+
+    // Move the whole checkout on disk; both its canonical root and git common
+    // dir change, so registry identity resolution can no longer match by path.
+    fs::rename(&original, &renamed).unwrap();
+
+    let resolved = resolved_project_session_db_path(&renamed)
+        .await
+        .expect("renamed checkout should resolve a session DB path");
+    assert_path_eq(&resolved, &registered_session_db);
+    assert_ne!(
+        normalize_test_path(&resolved),
+        normalize_test_path(&project_session_db_path(&renamed)),
+        "renamed checkout must not fork a fresh default-path session DB",
+    );
+}
+
+#[tokio::test]
+async fn same_remote_clone_session_db_does_not_borrow_registered_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let remote = dir.path().join("remote.git");
+    let project = dir.path().join("repo");
+    let clone = dir.path().join("repo-clone");
+    let home = test_home(&dir);
+    let _home_guard = HomeGuard::set(&home);
+
+    git(dir.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), project.to_str().unwrap()],
+    );
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    git(&project, &["config", "user.email", "test@example.com"]);
+    git(&project, &["config", "user.name", "TraceDecay Test"]);
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "-m", "initial"]);
+    git(&project, &["push", "origin", "HEAD:master"]);
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), clone.to_str().unwrap()],
+    );
+
+    let cg = TraceDecay::init(&project).await.unwrap();
+    let registered_session_db = cg.store_layout().sessions_db_path.clone();
+    drop(cg);
+
+    // The original checkout still exists on disk, so the same-remote clone must
+    // not inherit its registered session store even though the remote is unique
+    // in the registry.
+    let resolved = resolved_project_session_db_path(&clone)
+        .await
+        .expect("clone should still resolve a default session DB path");
+    assert_ne!(
+        normalize_test_path(&resolved),
+        normalize_test_path(&registered_session_db),
+        "a separate same-remote clone must not borrow another checkout's session store",
+    );
+    assert_path_eq(&resolved, project_session_db_path(&clone));
+}
+
+#[tokio::test]
+async fn ambiguous_remote_session_db_falls_back_to_default_path() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let remote = dir.path().join("remote.git");
+    let one = dir.path().join("repo-one");
+    let two = dir.path().join("repo-two");
+    let renamed_one = dir.path().join("repo-one-renamed");
+    let home = test_home(&dir);
+    let _home_guard = HomeGuard::set(&home);
+
+    git(dir.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), one.to_str().unwrap()],
+    );
+    fs::create_dir_all(one.join("src")).unwrap();
+    fs::write(one.join("src/lib.rs"), "pub fn main_only() {}\n").unwrap();
+    git(&one, &["config", "user.email", "test@example.com"]);
+    git(&one, &["config", "user.name", "TraceDecay Test"]);
+    git(&one, &["add", "."]);
+    git(&one, &["commit", "-m", "initial"]);
+    git(&one, &["push", "origin", "HEAD:master"]);
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), two.to_str().unwrap()],
+    );
+
+    // Two registered checkouts share the same remote, so remote-based fallback
+    // is ambiguous and must be declined even after one checkout is renamed.
+    TraceDecay::init(&one).await.unwrap();
+    TraceDecay::init(&two).await.unwrap();
+
+    fs::rename(&one, &renamed_one).unwrap();
+
+    let resolved = resolved_project_session_db_path(&renamed_one)
+        .await
+        .expect("ambiguous-remote checkout should still resolve a default path");
+    assert_path_eq(&resolved, project_session_db_path(&renamed_one));
+}
+
+#[tokio::test]
 async fn nested_linked_worktree_does_not_discover_parent_checkout_marker() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
When a git checkout directory is renamed or moved on disk, both its path alias and `git_common_dir` change, so registry identity resolution no longer matches. The graph store already recovers via `resolve_store_layout_for_project`, which falls back to a unique git-remote match and reopens the originally registered store. Session-DB routing did not: `registry_profile_session_db_path` was identity-only, so after a rename the checkout reopened its graph store correctly but started a fresh session history at a new default path — silently splitting session continuity from graph continuity.

This makes the session-DB resolver mirror the same identity-then-unique-remote fallback, with the same remote-uniqueness gating.

To preserve the clone-borrow guard (a second same-remote clone must not inherit another checkout's session store), the remote fallback is accepted only when the matched project's registered checkout no longer exists on disk: a rename leaves neither the canonical root nor the git common dir behind, whereas a live clone leaves the original checkout in place. `has_initialized_store*` stays strict and untouched, per the recorded design decision.

Tests cover: renamed checkout → original registered session DB; same-remote clone → default path (no borrow); ambiguous shared remote → default path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)