### PR TITLE
fix(lsp): classify initialize-request write failures with stderr

### DIFF
--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -103,7 +103,7 @@ impl StdioLspClient {
         let stderr_capture = Arc::new(Mutex::new(Vec::new()));
         let stderr_task = spawn_stderr_capture(stderr, Arc::clone(&stderr_capture));
 
-        write_message_with_timeout(
+        let send_initialize = write_message_with_timeout(
             &mut stdin,
             json!({
                 "jsonrpc": "2.0",
@@ -128,20 +128,30 @@ impl StdioLspClient {
             }),
             timeouts.message_io,
         )
-        .await?;
-        let initialize_result = tokio::time::timeout(
-            timeouts.initialize_response,
-            wait_for_initialize(&mut reader),
-        )
         .await;
-        if let Err(err) = initialize_result.unwrap_or_else(|_| {
-            Err(TraceDecayError::Config {
-                message: format!(
-                    "LSP server '{command}' initialize timed out after {} ms",
-                    timeouts.initialize_response.as_millis()
-                ),
-            })
-        }) {
+        // A server that dies immediately can fail the initialize *request*
+        // write (broken pipe — on Windows this races the spawn under load)
+        // just as easily as the initialize *response* wait. Route both
+        // failures through the same stderr-enriched classification so the
+        // crash reason (e.g. a toolchain's "unknown binary" complaint) is
+        // never dropped.
+        let initialize_result = match send_initialize {
+            Ok(()) => tokio::time::timeout(
+                timeouts.initialize_response,
+                wait_for_initialize(&mut reader),
+            )
+            .await
+            .unwrap_or_else(|_| {
+                Err(TraceDecayError::Config {
+                    message: format!(
+                        "LSP server '{command}' initialize timed out after {} ms",
+                        timeouts.initialize_response.as_millis()
+                    ),
+                })
+            }),
+            Err(err) => Err(err),
+        };
+        if let Err(err) = initialize_result {
             let _ = child.start_kill();
             let _ = child.wait().await;
             let _ = stderr_task.await;


### PR DESCRIPTION
Fixes the Windows CI flake in `broker_marks_initialize_exit_crashed_without_message_classification` (seen on release PR #267, run 28690268431, whose diff was changelog-only).

Mechanism: a server that exits immediately can fail the initialize **request** write (broken pipe) before the initialize **response** wait begins. That write used a bare `?`, bypassing the kill + captured-stderr enrichment that the response path has — so the error lost the server's actual crash reason ("unknown binary ...") and the assertion failed. On Linux the write usually lands in the pipe buffer first, which is why only Windows-under-load flakes.

Fix at the mechanism level rather than loosening the test: the request-write failure now routes through the same stderr-enriched classification, so the crash reason is deterministic on both platforms. LSP suite 24/24 locally, strict clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)