### PR TITLE
chore: release v0.0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.29](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.28...v0.0.29) - 2026-07-04
+
+### Added
+
+- *(claude)* sync Claude Code plugin cache on install and update ([#273](https://github.com/ScriptedAlchemy/tracedecay/pull/273))
+
+### Fixed
+
+- *(sessions)* follow store remote fallback for renamed checkouts ([#269](https://github.com/ScriptedAlchemy/tracedecay/pull/269))
+- *(lsp)* classify initialize-request write failures with stderr ([#270](https://github.com/ScriptedAlchemy/tracedecay/pull/270))
+- *(claude)* write schema-required marketplace registration fields ([#268](https://github.com/ScriptedAlchemy/tracedecay/pull/268))
+
 ## [0.0.28](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.27...v0.0.28) - 2026-07-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,7 +4725,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.28"
+version = "0.0.29"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.28 -> 0.0.29

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.29](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.28...v0.0.29) - 2026-07-04

### Added

- *(claude)* sync Claude Code plugin cache on install and update ([#273](https://github.com/ScriptedAlchemy/tracedecay/pull/273))

### Fixed

- *(sessions)* follow store remote fallback for renamed checkouts ([#269](https://github.com/ScriptedAlchemy/tracedecay/pull/269))
- *(lsp)* classify initialize-request write failures with stderr ([#270](https://github.com/ScriptedAlchemy/tracedecay/pull/270))
- *(claude)* write schema-required marketplace registration fields ([#268](https://github.com/ScriptedAlchemy/tracedecay/pull/268))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).