### PR TITLE
chore(vendor): silence upstream lint noise in vendored libsql

### DIFF
--- a/vendor/libsql/Cargo.toml
+++ b/vendor/libsql/Cargo.toml
@@ -25,6 +25,14 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/tursodatabase/libsql"
 
+# Local addition to the vendored copy (see [patch.crates-io] in the workspace
+# Cargo.toml): cargo treats path dependencies as local code and prints their
+# warnings on every check/clippy run. Silence the two upstream lints so
+# workspace builds stay noise-free; drop with the vendor patch itself.
+[lints.rust]
+mismatched_lifetime_syntaxes = "allow"
+private_interfaces = "allow"
+
 [package.metadata.cargo-udeps.ignore]
 normal = ["hyper-rustls"]
 


### PR DESCRIPTION
Cargo treats path dependencies as local code, so the vendored libsql copy (patched in via `[patch.crates-io]` for the disconnect teardown fix) printed nine upstream warnings — 8× `mismatched_lifetime_syntaxes`, 1× `private_interfaces` — on every `cargo check`/`clippy` run in the workspace.

This allows those two rustc lints in the vendored crate's own `Cargo.toml` `[lints]` table, keeping the noise out of local runs and CI logs without touching upstream source files. The block is documented to be dropped together with the vendor patch once upstream makes `disconnect` idempotent.

No behavior change; `cargo clippy --workspace --all-targets --locked -- -D warnings` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)