### PR TITLE
chore: release v0.0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.30](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.29...v0.0.30) - 2026-07-05
+
+### Added
+
+- *(plugin)* add plugin-suite improvements
+- *(sessions)* add git-anchored session correlation
+- *(claude)* add plugin namespace permissions
+- *(sessions)* add date filters to recall search ([#275](https://github.com/ScriptedAlchemy/tracedecay/pull/275))
+
+### Other
+
+- split oversized merged modules ([#287](https://github.com/ScriptedAlchemy/tracedecay/pull/287))
+- configure Cargo scratch build paths
+
 ## [0.0.29](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.28...v0.0.29) - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1372,7 +1372,7 @@ impl McpServer {
             return;
         }
 
-        self.spawn_read_refresh_task(Arc::clone(cg), self.sync_config.full_sync_escalation_files);
+        self.spawn_read_refresh_task(cg, self.sync_config.full_sync_escalation_files);
     }
 
     /// Spawns the detached D4 refresh task. The task owns cheap `Arc` clones
@@ -1383,7 +1383,7 @@ impl McpServer {
     ///
     /// The caller MUST have already set `background_refresh_running` to
     /// `true`; this task clears it on completion.
-    fn spawn_read_refresh_task(&self, cg: Arc<TraceDecay>, escalation: usize) {
+    fn spawn_read_refresh_task(&self, cg: &Arc<TraceDecay>, escalation: usize) {
         let running = Arc::clone(&self.background_refresh_running);
         let done_at = Arc::clone(&self.last_background_refresh_done_at);
         let token_map = Arc::clone(&self.file_token_map);
@@ -1461,7 +1461,7 @@ impl McpServer {
         }
         self.last_background_refresh_at
             .store(now, Ordering::Release);
-        self.spawn_read_refresh_task(cg, self.sync_config.full_sync_escalation_files);
+        self.spawn_read_refresh_task(&cg, self.sync_config.full_sync_escalation_files);
     }
 
     /// Returns a compact one-line notice when automation runs have staged

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -602,7 +602,8 @@ fn assert_cursor_plugin_bundle(plugin_dir: &Path, expected_command: &str, expect
         assert!(
             hook["command"]
                 .as_str()
-                .is_some_and(|command| command.contains(expected_command)),
+                .is_some_and(|command| comparable_command_path(command)
+                    .contains(&comparable_command_path(expected_command))),
             "plugin hook commands should use the installed tracedecay binary"
         );
         assert!(

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -281,6 +281,47 @@ fn expected_tracedecay_bin() -> String {
         .replace('\\', "/")
 }
 
+fn expected_tracedecay_bin_variants() -> Vec<String> {
+    let raw = PathBuf::from(env!("CARGO_BIN_EXE_tracedecay"));
+    let canonical = std::fs::canonicalize(&raw).unwrap_or_else(|_| raw.clone());
+    let mut variants = Vec::new();
+    for path in [raw, canonical] {
+        let native = path.to_string_lossy().to_string();
+        let slash = native.replace('\\', "/");
+        if !variants.contains(&native) {
+            variants.push(native);
+        }
+        if !variants.contains(&slash) {
+            variants.push(slash);
+        }
+    }
+    variants
+}
+
+fn contains_expected_tracedecay_bin(body: &str) -> bool {
+    let slash_body = body.replace('\\', "/");
+    expected_tracedecay_bin_variants().iter().any(|expected| {
+        body.contains(expected) || slash_body.contains(&expected.replace('\\', "/"))
+    })
+}
+
+fn comparable_command_path(command: &str) -> String {
+    command
+        .strip_prefix("//?/")
+        .unwrap_or(command)
+        .replace('\\', "/")
+}
+
+fn assert_command_eq(actual: &serde_json::Value, expected: &str) {
+    let actual = actual
+        .as_str()
+        .unwrap_or_else(|| panic!("command should be a string: {actual}"));
+    assert_eq!(
+        comparable_command_path(actual),
+        comparable_command_path(expected)
+    );
+}
+
 /// Python snippet that py_compiles the generated plugin sources inside the
 /// same interpreter that runs a test's check script, instead of the separate
 /// `python3 -m py_compile` process `assert_python_compiles` spawns. On
@@ -408,7 +449,7 @@ fn assert_codex_plugin_bundle(
     let mcp = read_json(&plugin_dir.join(".mcp.json"));
     let server = &mcp["mcpServers"]["tracedecay"];
     assert_eq!(server["type"], "stdio");
-    assert_eq!(server["command"], expected_command);
+    assert_command_eq(&server["command"], expected_command);
     assert_eq!(server["args"], expected_args);
     if expected_global_bundle {
         assert_eq!(server["env"]["TRACEDECAY_ENABLE_GLOBAL_DB"], "1");
@@ -523,7 +564,7 @@ fn assert_cursor_plugin_bundle(plugin_dir: &Path, expected_command: &str, expect
     let mcp = read_json(&plugin_dir.join("mcp.json"));
     let server = &mcp["mcpServers"]["tracedecay"];
     assert_eq!(server["type"], "stdio");
-    assert_eq!(server["command"], expected_command);
+    assert_command_eq(&server["command"], expected_command);
     assert_eq!(
         server["args"],
         serde_json::json!(["serve", "--path", "${workspaceFolder}"])
@@ -1089,7 +1130,7 @@ fn test_hermes_local_install_writes_profile_plugin() {
     }));
 
     let tools_py = std::fs::read_to_string(plugin_dir.join("tools.py")).unwrap();
-    assert!(tools_py.contains(&expected_tracedecay_bin()));
+    assert!(contains_expected_tracedecay_bin(&tools_py));
     assert!(tools_py.contains("subprocess.run"));
     assert!(tools_py.contains("tracedecay tool"));
     assert!(tools_py.contains("TRACEDECAY_TIMEOUT_SECONDS = 120"));
@@ -2957,9 +2998,8 @@ fn assert_local_install_writes_project_paths(agent: &str, paths: &[&str]) {
             && (*relative == ".agents/plugins/marketplace.json"
                 || relative.ends_with(".codex-plugin/plugin.json"));
         if !is_instruction_file && !is_codex_metadata {
-            let expected = expected_tracedecay_bin();
             assert!(
-                body.contains(&expected),
+                contains_expected_tracedecay_bin(&body),
                 "{agent} local config {} should use the resolved absolute tracedecay executable",
                 path.display()
             );
@@ -3682,7 +3722,7 @@ fn assert_command_contains_expected_bin(
         })
         .expect("handler command should exist");
     assert!(
-        command.contains(expected),
+        comparable_command_path(command).contains(&comparable_command_path(expected)),
         "Codex hook command must use the resolved absolute tracedecay executable, got {command}"
     );
 }

--- a/tests/mcp_suite/git_correlation_test.rs
+++ b/tests/mcp_suite/git_correlation_test.rs
@@ -146,6 +146,9 @@ async fn sessions_for_and_scoped_search_end_to_end() {
 
     let profile_root = base.join("profile");
     std::fs::create_dir_all(&profile_root).unwrap_or_else(|e| panic!("create profile root: {e}"));
+    let profile_root = profile_root
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("canonicalize profile root: {e}"));
     let cg = TraceDecay::init_with_options(
         &project_root,
         TraceDecayOpenOptions {


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.29 -> 0.0.30

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.30](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.29...v0.0.30) - 2026-07-05

### Added

- *(plugin)* add plugin-suite improvements
- *(sessions)* add git-anchored session correlation
- *(claude)* add plugin namespace permissions
- *(sessions)* add date filters to recall search ([#275](https://github.com/ScriptedAlchemy/tracedecay/pull/275))

### Other

- split oversized merged modules ([#287](https://github.com/ScriptedAlchemy/tracedecay/pull/287))
- configure Cargo scratch build paths
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).