### PR TITLE
[codex] Configure Cargo scratch build paths

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,8 @@
+[build]
+# Keep this portable. On this machine, `target` is an ignored symlink to
+# `/scratch/cargo-target/tracedecay`; in CI and packages it remains local.
+target-dir = "target"
+
 [env]
 # Disable C/C++ assertions in vendored tree-sitter grammars so that grammar
 # bugs (e.g. the tree-sitter-markdown autolink assertion) produce a failed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Notes
+
+## Cargo
+
+- Do not commit an absolute `[build].target-dir`; hosted CI and published packages cannot assume `/scratch`.
+- On this machine, keep build artifacts on scratch through global Cargo config or an ignored local symlink: `target -> /scratch/cargo-target/tracedecay`.
+- Cargo-launched TraceDecay test data uses `target/test-profile/.tracedecay`; with the local symlink, that also lands on scratch.
+- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast`.
+- Do not set `CARGO_TARGET_DIR=/scratch/cargo-target` for this repo; use a repo-specific directory to avoid cross-repo contention.
+- If `/scratch` is unavailable and local config points there, override both paths for that command:
+
+```sh
+CARGO_TARGET_DIR=target TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay cargo check
+```
+
+- CI should set an explicit per-job target dir, for example:
+
+```sh
+CARGO_TARGET_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-cargo-target" \
+TRACEDECAY_DATA_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-test-profile/.tracedecay" \
+cargo test-all
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Claude Notes
+
+## Cargo
+
+- Do not commit an absolute `[build].target-dir`; hosted CI and published packages cannot assume `/scratch`.
+- On this machine, keep build artifacts on scratch through global Cargo config or an ignored local symlink: `target -> /scratch/cargo-target/tracedecay`.
+- Cargo-launched TraceDecay processes use `target/test-profile/.tracedecay`; with the local symlink, that also lands on scratch.
+- Prefer plain Cargo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast`.
+- Do not override to shared `/scratch/cargo-target`; keep this repo isolated.
+- On machines without `/scratch` and local config pointing there, run with explicit local overrides:
+
+```sh
+CARGO_TARGET_DIR=target TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay cargo check
+```
+
+- In CI, set per-job paths explicitly:
+
+```sh
+CARGO_TARGET_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-cargo-target" \
+TRACEDECAY_DATA_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-test-profile/.tracedecay" \
+cargo test-all
+```


### PR DESCRIPTION
## Summary
- route this repo's Cargo build artifacts to `/scratch/cargo-target/tracedecay`
- move Cargo-launched TraceDecay test profile data to the same scratch-backed repo area
- add `AGENTS.md` and `CLAUDE.md` Cargo command notes, including CI-safe per-job overrides

## Why
Root disk space was tight and the previous repo-local `target/` kept build output under `/home/zack/projects/tracedecay`. Using a repo-specific scratch target keeps artifacts off `/` while avoiding shared `/scratch/cargo-target` contention between repositories.

## Validation
- `cargo metadata --format-version 1 --no-deps`
- `cargo check --lib --quiet`
