### PR TITLE
feat(sessions): git-anchored session/LCM correlation

### DIFF
--- a/plugin/README-cursor.md
+++ b/plugin/README-cursor.md
@@ -132,6 +132,7 @@ per-call review, add the snippet below to `~/.cursor/permissions.json`
     "tracedecay:tracedecay_retrieve",
     "tracedecay:tracedecay_runtime",
     "tracedecay:tracedecay_search",
+    "tracedecay:tracedecay_sessions_for",
     "tracedecay:tracedecay_signature",
     "tracedecay:tracedecay_signature_search",
     "tracedecay:tracedecay_similar",

--- a/plugin/skills/recalling-session-context/SKILL.md
+++ b/plugin/skills/recalling-session-context/SKILL.md
@@ -16,10 +16,11 @@ This skill owns the **FTS → LCM** lane of `tracedecay_message_search`: `messag
 3. **Lossless replay → `tracedecay_lcm_load_session`** (`session_id`, `after_store_id` + `limit` for stable pagination, `roles`, `content_offset`/`content_limit`): ordered raw messages of one session; page with `next_cursor` instead of asking for everything at once.
 4. **Summary-DAG drill-down:** `tracedecay_lcm_describe` (`session_id`) for the session's raw/summary shape; `tracedecay_lcm_expand` (`target.kind`: `raw_message`|`summary_node`|`external_payload`) to open one node, paging sources via `source_offset`/`source_limit`; `tracedecay_lcm_expand_query` (`query`) to assemble bounded retrieval context for a prompt in one call.
 5. **Store inspection → `tracedecay_lcm_status`** (counts, token estimates, DAG depth/compression ratio) when you need to know what the store contains before searching it.
+6. **Git-scoped session lookup → `tracedecay_sessions_for`** (`git_ref`: `branch`|`worktree`|`commit`, `value`, optional `since`/`until`, `limit`): which sessions were active on a branch or in a worktree, or which conversations produced a commit; feed the returned session ids back into rungs 2–4.
 
 ## Guardrails
 
-- Steps 1–5 are read-only. `tracedecay_lcm_compress`, `tracedecay_lcm_preflight`, and `tracedecay_lcm_session_boundary` are **lifecycle-integration tools for host agents** — never invoke them casually during recall.
+- Steps 1–6 are read-only. `tracedecay_lcm_compress`, `tracedecay_lcm_preflight`, and `tracedecay_lcm_session_boundary` are **lifecycle-integration tools for host agents** — never invoke them casually during recall.
 - For multi-step recall, dispatch scoped read-only subagents by session id, time window, provider, role, or query variant. Subagents must not call lifecycle or repair tools; the parent agent validates cited messages/summaries and produces the final timeline.
 - If the LCM store itself looks wrong (missing sessions, broken FTS, stale counts) → `tracedecay_lcm_doctor` (`mode: "diagnose"` first; `repair`/`clean` mutate and need explicit user intent).
 - All LCM tools default to `storage_scope: "project_local"`; only pass `hermes_profile` (with an absolute `hermes_home`) when the user asks about a Hermes profile store.

--- a/src/analytics_bridge.rs
+++ b/src/analytics_bridge.rs
@@ -289,6 +289,7 @@ pub async fn run_analytics_diagnostics(
             project_id: project_filter.clone(),
             session_id: None,
             event_kind: None,
+            since: None,
             limit: 10_000,
         })
         .await

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -713,6 +713,7 @@ async fn build_session_reflector_evidence(
             role: role.clone(),
             start_time: options.start_time,
             end_time: options.end_time,
+            git_filter: crate::sessions::git_correlation::GitScopeFilter::default(),
         })
         .await
         .map_err(|e| TraceDecayError::Config {
@@ -828,6 +829,7 @@ async fn build_skill_writer_evidence(
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: crate::sessions::git_correlation::GitScopeFilter::default(),
         })
         .await
         .map_err(|e| TraceDecayError::Config {

--- a/src/automation/skill_usage/analytics.rs
+++ b/src/automation/skill_usage/analytics.rs
@@ -68,6 +68,7 @@ pub async fn ingest_project_analytics_events(
             project_id: Some(GlobalDb::canonical_project_key(project_root)),
             session_id: None,
             event_kind: None,
+            since: None,
             limit,
         })
         .await

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -636,6 +636,35 @@ pub enum SessionsAction {
         /// Registered project root path or alias whose session store should be searched
         #[arg(long, conflicts_with = "project_id")]
         project_path: Option<String>,
+        /// Only sessions correlated with this git branch
+        #[arg(long)]
+        branch: Option<String>,
+        /// Only sessions correlated with this worktree path
+        #[arg(long)]
+        worktree: Option<String>,
+        /// Only sessions that produced this commit (full or >=6-char prefix)
+        #[arg(long)]
+        commit: Option<String>,
+    },
+    /// Backfill the session↔git correlation index from historical session,
+    /// analytics, and reflog signals
+    GitBackfill {
+        /// Registered project id whose session store should be backfilled
+        #[arg(long)]
+        project_id: Option<String>,
+        /// Registered project root path or alias whose session store should be backfilled
+        #[arg(long, conflicts_with = "project_id")]
+        project_path: Option<String>,
+        /// Lower bound on session activity and commit times (ISO-8601 or unix
+        /// seconds); defaults to 90 days ago
+        #[arg(long)]
+        since: Option<String>,
+        /// Maximum number of sessions to scan
+        #[arg(long, default_value_t = 500)]
+        limit_sessions: usize,
+        /// Derive and report counts without writing to the session store
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -1552,6 +1552,9 @@ fn parses_sessions_ingest_and_search_commands() {
                     project_path,
                     since,
                     until,
+                    branch,
+                    worktree,
+                    commit,
                 },
         }) => {
             assert_eq!(query, "needle");
@@ -1561,6 +1564,9 @@ fn parses_sessions_ingest_and_search_commands() {
             assert!(project_path.is_none());
             assert!(since.is_none());
             assert!(until.is_none());
+            assert!(branch.is_none());
+            assert!(worktree.is_none());
+            assert!(commit.is_none());
         }
         _ => panic!("expected sessions search command"),
     }

--- a/src/dashboard/analytics_api.rs
+++ b/src/dashboard/analytics_api.rs
@@ -123,6 +123,7 @@ async fn durable_analytics_rows(
                 project_id: Some(project_id.to_string()),
                 session_id: None,
                 event_kind: None,
+                since: None,
                 limit: ANALYTICS_EVENT_LIMIT,
             })
             .await

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -95,6 +95,8 @@ pub struct AnalyticsEventQuery {
     pub project_id: Option<String>,
     pub session_id: Option<String>,
     pub event_kind: Option<String>,
+    /// Inclusive lower bound on `timestamp` (unix seconds). `None` = unbounded.
+    pub since: Option<i64>,
     pub limit: usize,
 }
 
@@ -1018,6 +1020,9 @@ impl GlobalDb {
         crate::sessions::lcm::schema::ensure_lcm_schema(&db.conn)
             .await
             .ok()?;
+        crate::sessions::git_correlation::ensure_git_correlation_schema(&db.conn)
+            .await
+            .ok()?;
         // One-off self-heal: re-derive timestamps and token-usage counters
         // for legacy messages ingested before extraction existed.
         // Marker-guarded (runs once per store) and fail-open, like the LCM
@@ -1880,11 +1885,9 @@ impl GlobalDb {
     /// filter by canonical project path. Returns zeros on any DB error.
     pub async fn sum_savings(&self, project: Option<&str>, since: i64) -> SavingsTotal {
         let project = project.map(|p| Self::canonical_project_key(Path::new(p)));
-        let sql_with_project =
-            "SELECT COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), COUNT(*) \
+        let sql_with_project = "SELECT COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), COUNT(*) \
              FROM savings_ledger WHERE project_path = ?1 AND ts >= ?2";
-        let sql_all =
-            "SELECT COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), COUNT(*) \
+        let sql_all = "SELECT COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), COUNT(*) \
              FROM savings_ledger WHERE ts >= ?1";
 
         let rows = match project.as_deref() {
@@ -1912,14 +1915,12 @@ impl GlobalDb {
     /// Group ledger entries by UTC calendar day. Newest-first.
     pub async fn savings_history(&self, project: Option<&str>, since: i64) -> Vec<SavingsDay> {
         let project = project.map(|p| Self::canonical_project_key(Path::new(p)));
-        let sql_with_project =
-            "SELECT (ts/86400)*86400 AS day, \
+        let sql_with_project = "SELECT (ts/86400)*86400 AS day, \
                     COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), \
                     COUNT(*) \
              FROM savings_ledger WHERE project_path = ?1 AND ts >= ?2 \
              GROUP BY day ORDER BY day DESC";
-        let sql_all =
-            "SELECT (ts/86400)*86400 AS day, \
+        let sql_all = "SELECT (ts/86400)*86400 AS day, \
                     COALESCE(SUM(CASE WHEN before_tokens > after_tokens THEN before_tokens - after_tokens ELSE 0 END), 0), \
                     COUNT(*) \
              FROM savings_ledger WHERE ts >= ?1 \
@@ -2240,6 +2241,10 @@ impl GlobalDb {
             ("event_kind", query.event_kind.as_deref()),
         ] {
             push_optional_analytics_filter(&mut clauses, &mut values, column, value);
+        }
+        if let Some(since) = query.since {
+            values.push(Value::Integer(since));
+            clauses.push(format!("timestamp >= ?{}", values.len()));
         }
         if !clauses.is_empty() {
             sql.push_str(" WHERE ");
@@ -3165,6 +3170,83 @@ impl GlobalDb {
             .await
     }
 
+    // ── Session ↔ git correlation ────────────────────────────────────
+
+    /// Folds one live/backfilled git observation into the span table.
+    /// See [`crate::sessions::git_correlation::record_span_observation`].
+    pub async fn git_record_span_observation(
+        &self,
+        observation: &crate::sessions::git_correlation::SpanObservation,
+        merge_gap_secs: i64,
+    ) -> Result<i64, crate::sessions::git_correlation::GitCorrelationError> {
+        crate::sessions::git_correlation::record_span_observation(
+            &self.conn,
+            observation,
+            merge_gap_secs,
+        )
+        .await
+    }
+
+    /// Attributes one commit to one session (idempotent).
+    /// See [`crate::sessions::git_correlation::upsert_commit_session`].
+    pub async fn git_upsert_commit_session(
+        &self,
+        record: &crate::sessions::git_correlation::CommitSessionRecord,
+    ) -> Result<bool, crate::sessions::git_correlation::GitCorrelationError> {
+        crate::sessions::git_correlation::upsert_commit_session(&self.conn, record).await
+    }
+
+    /// Runs the commit-attribution sweep, delegating branch-scoped git log
+    /// reads to `scan`. See
+    /// [`crate::sessions::git_correlation::run_commit_attribution_sweep`].
+    pub async fn git_run_commit_attribution_sweep<F>(
+        &self,
+        gap_secs: i64,
+        scan: F,
+    ) -> Result<usize, crate::sessions::git_correlation::GitCorrelationError>
+    where
+        F: FnMut(
+            &crate::sessions::git_correlation::SpanScanTarget,
+        ) -> Vec<crate::sessions::git_correlation::ScannedCommit>,
+    {
+        crate::sessions::git_correlation::run_commit_attribution_sweep(&self.conn, gap_secs, scan)
+            .await
+    }
+
+    /// Returns sessions correlated with a branch, worktree, or commit.
+    /// See [`crate::sessions::git_correlation::sessions_for`].
+    pub async fn git_sessions_for(
+        &self,
+        query: &crate::sessions::git_correlation::SessionsForQuery,
+    ) -> Result<
+        Vec<crate::sessions::git_correlation::SessionGitCorrelationHit>,
+        crate::sessions::git_correlation::GitCorrelationError,
+    > {
+        crate::sessions::git_correlation::sessions_for(&self.conn, query).await
+    }
+
+    /// Resolves the `(provider, session_id)` pairs matching a git-scope filter.
+    /// See [`crate::sessions::git_correlation::session_ids_for_scope`].
+    pub async fn git_session_ids_for_scope(
+        &self,
+        filter: &crate::sessions::git_correlation::GitScopeFilter,
+    ) -> Result<Option<Vec<(String, String)>>, crate::sessions::git_correlation::GitCorrelationError>
+    {
+        crate::sessions::git_correlation::session_ids_for_scope(&self.conn, filter).await
+    }
+
+    /// Lists per-session activity windows for the historical git-correlation
+    /// backfill: each row carries the session's declared `started_at`/`ended_at`
+    /// plus the min/max `session_messages.timestamp`, so the caller can derive
+    /// coarse activity windows without a second query per session. Ordered
+    /// newest-first (by the latest known activity), capped at `limit`.
+    pub async fn session_activity_rows(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<crate::sessions::git_correlation::SessionActivityRow>, String> {
+        crate::sessions::git_correlation::session_activity_rows(&self.conn, limit).await
+    }
+
     /// Searches message text for a provider, optionally constrained to one project.
     pub async fn search_session_messages(
         &self,
@@ -3198,6 +3280,32 @@ impl GlobalDb {
             query,
             limit,
             filters,
+            None,
+        )
+        .await
+    }
+
+    /// Like [`Self::search_session_messages_filtered`], additionally scoping
+    /// hits to sessions correlated with a git branch/worktree/commit via
+    /// EXISTS pushdown against the git-correlation tables. Pass `provider =
+    /// None` to search all providers. A git-scoped call against a store
+    /// predating the correlation schema returns no hits.
+    pub async fn search_session_messages_git_scoped(
+        &self,
+        provider: Option<&str>,
+        project_key: Option<&str>,
+        query: &str,
+        limit: usize,
+        filters: SessionSearchFilters<'_>,
+        git_filter: &crate::sessions::git_correlation::GitScopeFilter,
+    ) -> Vec<SessionMessageSearchResult> {
+        self.search_session_messages_filtered_inner(
+            provider,
+            project_key,
+            query,
+            limit,
+            filters,
+            Some(git_filter),
         )
         .await
     }
@@ -3210,7 +3318,7 @@ impl GlobalDb {
         limit: usize,
         filters: SessionSearchFilters<'_>,
     ) -> Vec<SessionMessageSearchResult> {
-        self.search_session_messages_filtered_inner(None, project_key, query, limit, filters)
+        self.search_session_messages_filtered_inner(None, project_key, query, limit, filters, None)
             .await
     }
 
@@ -3221,7 +3329,20 @@ impl GlobalDb {
         query: &str,
         limit: usize,
         filters: SessionSearchFilters<'_>,
+        git_filter: Option<&crate::sessions::git_correlation::GitScopeFilter>,
     ) -> Vec<SessionMessageSearchResult> {
+        // A git-scoped search against a store written before the correlation
+        // schema existed can never match; report empty rather than issuing a
+        // `no such table` EXISTS subquery.
+        if let Some(filter) = git_filter {
+            if !filter.is_empty()
+                && !crate::sessions::git_correlation::tables_present(&self.conn)
+                    .await
+                    .unwrap_or(false)
+            {
+                return Vec::new();
+            }
+        }
         let fts_query = session_fts_query(query);
         if fts_query.is_empty() || limit == 0 {
             return Vec::new();
@@ -3284,6 +3405,19 @@ impl GlobalDb {
             crate::sessions::SessionSearchScope::SubagentsOnly
         ) {
             sql.push_str(" AND s.is_subagent = 1");
+        }
+        // Reuse the shared scoping SQL (also used by the lcm/grep path) so the
+        // branch/worktree/commit EXISTS semantics stay in one place. Its
+        // anonymous `?` placeholders bind to the next sequential positions,
+        // which — since the predicate and its values are appended together in
+        // order — line up with the numbered placeholders that follow.
+        if let Some(filter) = git_filter {
+            if let Some((predicate, predicate_values)) =
+                crate::sessions::git_correlation::git_scope_exists_predicate(filter, "m.session_id")
+            {
+                let _ = write!(sql, " AND {predicate}");
+                query_params.extend(predicate_values);
+            }
         }
         for term in &literal_terms {
             query_params.push(Value::Text(term.clone()));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -701,6 +701,11 @@ pub struct McpServer {
     ledger_writes_started: Arc<AtomicU64>,
     ledger_writes_finished: Arc<AtomicU64>,
     ledger_write_notify: Arc<tokio::sync::Notify>,
+    /// In-process debounce for live hook-route span observations, so a burst
+    /// of tool-use events for one session/branch/worktree writes at most once
+    /// per [`crate::sessions::git_correlation::DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS`].
+    span_observation_debounce:
+        std::sync::Mutex<crate::sessions::git_correlation::SpanObservationDebounce>,
 }
 
 impl McpServer {
@@ -794,6 +799,9 @@ impl McpServer {
             ledger_writes_started: Arc::new(AtomicU64::new(0)),
             ledger_writes_finished: Arc::new(AtomicU64::new(0)),
             ledger_write_notify: Arc::new(tokio::sync::Notify::new()),
+            span_observation_debounce: std::sync::Mutex::new(
+                crate::sessions::git_correlation::SpanObservationDebounce::new(),
+            ),
         });
 
         tokio::task::spawn_blocking(move || {
@@ -873,6 +881,24 @@ impl McpServer {
                 return None;
             }
         }
+    }
+
+    /// Resolves the registered project for a hook route `cwd`, first by the
+    /// parent-directory alias walk (see
+    /// [`Self::registered_project_containing_path`]) and, when that misses,
+    /// by git-common-dir identity. A linked worktree lives at a sibling path,
+    /// so the alias walk never reaches its main checkout; identity resolution
+    /// maps it back to the registered project through the shared common dir.
+    async fn registered_project_for_route_cwd(&self, cwd: &Path) -> Option<String> {
+        if let Some(root) = self.registered_project_containing_path(cwd).await {
+            return Some(root);
+        }
+        let registry = self.registry_db.as_deref()?;
+        let git_common_dir = crate::worktree::git_common_dir(cwd);
+        let context = registry
+            .project_registry_context_by_identity(cwd, git_common_dir.as_deref())
+            .await?;
+        Some(context.project.canonical_root)
     }
 
     /// Detects mid-session branch drift and reopens the served instance
@@ -1694,6 +1720,7 @@ impl McpServer {
         self.update_hook_workspace_route(&event, route_cache).await;
         let current_branch = crate::branch::current_branch(&root);
         self.record_hook_route_analytics(&root, &event, current_branch.as_deref());
+        self.record_hook_span_observation(&event).await;
         let plan = hook_events::plan_hook_event(&event, &root, current_branch.as_deref());
         self.run_hook_event_plan(cg, &root, plan).await;
     }
@@ -2432,6 +2459,112 @@ impl McpServer {
         self.spawn_observed_ledger_write(async move {
             if let Err(e) = gdb.append_analytics_event(&event).await {
                 eprintln!("[tracedecay] hook route analytics insert failed: {e}");
+            }
+        });
+    }
+
+    /// Records a live session↔git span from one hook route notification.
+    ///
+    /// Route metadata carries `(session_id, thread_id, cwd, worktree,
+    /// branch)`; when the route names a session and resolves to a registered
+    /// project, this folds one [`SpanObservation`] into that project's
+    /// `sessions.db` span table (see [`crate::sessions::git_correlation`]).
+    /// Mid-session branch/worktree switches are handled by the span table
+    /// itself — the observation always carries the *current* branch.
+    ///
+    /// Fail-open like [`Self::update_hook_workspace_route`]: any resolution or
+    /// DB error is dropped. An in-process debounce keyed by
+    /// `(provider, session, branch, worktree)` collapses a burst of tool-use
+    /// events to one write per
+    /// [`DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS`](crate::sessions::git_correlation::DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS)
+    /// so the notification hot path never blocks on repeated writes (spans
+    /// merge regardless, so a dropped observation only widens a span slightly
+    /// less).
+    async fn record_hook_span_observation(&self, event: &hook_events::HookEvent) {
+        use crate::sessions::git_correlation::{
+            self as gc, SpanObservation, SpanSource, DEFAULT_SPAN_MERGE_GAP_SECS,
+            DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS,
+        };
+
+        let Some(route) = event.route.as_ref() else {
+            return;
+        };
+        let Some(session_id) = route
+            .session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+        // Resolve the project for this route the same way route caching does;
+        // spans belong to that project's store, not this server's checkout.
+        let route_cwd = route.cwd.as_deref().or(event.cwd.as_deref());
+        let Some(cwd) = route_cwd else {
+            return;
+        };
+        let Some(project_root) = self.registered_project_for_route_cwd(cwd).await else {
+            return;
+        };
+        let project_root = PathBuf::from(project_root);
+
+        // Worktree preference: the routed worktree, else the cwd's git
+        // worktree root, else the resolved project root. Never fabricated.
+        let worktree_raw = route
+            .worktree
+            .as_deref()
+            .map(Path::to_path_buf)
+            .or_else(|| crate::worktree::git_worktree_root(cwd))
+            .unwrap_or_else(|| project_root.clone());
+        let worktree = gc::normalize_worktree(&worktree_raw.to_string_lossy());
+
+        let branch = route
+            .branch
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let thread_id = route
+            .thread_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let ts = crate::tracedecay::current_timestamp();
+
+        // Hook routes are provider-agnostic: leave provider empty.
+        let key = gc::span_debounce_key("", session_id, branch.as_deref(), &worktree);
+        let should_record = self
+            .span_observation_debounce
+            .lock()
+            .map_or(true, |mut debounce| {
+                debounce.should_record(&key, ts, DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS)
+            });
+        if !should_record {
+            return;
+        }
+
+        let observation = SpanObservation {
+            provider: String::new(),
+            session_id: session_id.to_string(),
+            thread_id,
+            branch,
+            worktree,
+            ts,
+            source: SpanSource::HookRoute,
+        };
+        self.spawn_observed_ledger_write(async move {
+            let Ok(db_path) = crate::storage::resolve_project_session_db_path(&project_root) else {
+                return;
+            };
+            let Some(db) = GlobalDb::open_at(&db_path).await else {
+                return;
+            };
+            if let Err(e) = db
+                .git_record_span_observation(&observation, DEFAULT_SPAN_MERGE_GAP_SECS)
+                .await
+            {
+                eprintln!("[tracedecay] hook route span record failed: {e}");
             }
         });
     }

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -303,6 +303,7 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
         def_hermes_skill_bridge(),
         def_dashboard(),
         def_message_search(),
+        def_sessions_for(),
         def_lcm_status(),
         def_lcm_doctor(),
         def_lcm_load_session(),
@@ -2399,9 +2400,76 @@ fn def_message_search() -> ToolDefinition {
                 "project_path": {
                     "type": "string",
                     "description": "Optional registered project root path or alias to search instead of the active project."
-                }
+                },
+                "branch": git_scope_branch_schema(),
+                "worktree": git_scope_worktree_schema(),
+                "commit": git_scope_commit_schema()
             },
             "required": ["query"]
+        }),
+    )
+}
+
+fn git_scope_branch_schema() -> Value {
+    json!({
+        "type": "string",
+        "description": "Optional git branch filter: only messages from sessions active on this branch (via the session-git correlation index)."
+    })
+}
+
+fn git_scope_worktree_schema() -> Value {
+    json!({
+        "type": "string",
+        "description": "Optional git worktree root path filter: only messages from sessions active in this worktree (via the session-git correlation index)."
+    })
+}
+
+fn git_scope_commit_schema() -> Value {
+    json!({
+        "type": "string",
+        "description": "Optional commit sha filter (full or >=6-char hex prefix): only messages from sessions attributed to this commit (via the session-git correlation index)."
+    })
+}
+
+fn def_sessions_for() -> ToolDefinition {
+    def(
+        "tracedecay_sessions_for",
+        "Sessions For Git Ref",
+        "Find agent sessions correlated with a git artifact in the active project: all sessions active on a branch, in a worktree, or attributed to a commit (the conversations that produced it). Attribution is span-based, so mid-session branch switches are respected. Supports time-scoped queries via since/until.",
+        json!({
+            "type": "object",
+            "properties": {
+                "git_ref": {
+                    "type": "string",
+                    "enum": ["branch", "worktree", "commit"],
+                    "description": "Kind of git reference to correlate against."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The branch name, worktree root path, or commit sha (full or >=6-char hex prefix) to look up."
+                },
+                "since": {
+                    "oneOf": [
+                        { "type": "integer", "minimum": 0 },
+                        { "type": "string" }
+                    ],
+                    "description": "Optional inclusive minimum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."
+                },
+                "until": {
+                    "oneOf": [
+                        { "type": "integer", "minimum": 0 },
+                        { "type": "string" }
+                    ],
+                    "description": "Optional inclusive maximum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum sessions to return (default: 20)."
+                }
+            },
+            "required": ["git_ref", "value"]
         }),
     )
 }
@@ -2673,6 +2741,9 @@ fn def_lcm_grep() -> ToolDefinition {
                     "maximum": 100,
                     "description": "Maximum hits."
                 },
+                "branch": git_scope_branch_schema(),
+                "worktree": git_scope_worktree_schema(),
+                "commit": git_scope_commit_schema(),
                 "storage_scope": lcm_storage_scope_schema(),
                 "hermes_home": lcm_hermes_home_schema()
             },

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -429,6 +429,7 @@ pub async fn handle_tool_call_with_registry_and_implicit_project(
             )
             .await
         }
+        "tracedecay_sessions_for" => session::handle_sessions_for(cg, args).await,
         "tracedecay_lcm_status" => {
             session::handle_lcm_status(session::LcmHandlerContext::active(cg), args).await
         }
@@ -1017,7 +1018,7 @@ mod tests {
         // host CLI capabilities they need; agents should never see a tool that
         // will instantly fail. The count and per-tool checks below adapt to
         // the host's capability set.
-        let expected_total = 97 + usize::from(super::super::definitions::ast_grep_available());
+        let expected_total = 98 + usize::from(super::super::definitions::ast_grep_available());
         assert_eq!(tools.len(), expected_total);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
@@ -1099,6 +1100,7 @@ mod tests {
         assert!(tool_names.contains(&"tracedecay_memory_status"));
         assert!(tool_names.contains(&"tracedecay_dashboard"));
         assert!(tool_names.contains(&"tracedecay_message_search"));
+        assert!(tool_names.contains(&"tracedecay_sessions_for"));
         assert!(tool_names.contains(&"tracedecay_lcm_status"));
         assert!(tool_names.contains(&"tracedecay_lcm_doctor"));
         assert!(tool_names.contains(&"tracedecay_lcm_load_session"));

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -14,6 +14,7 @@ use crate::mcp::response_handles::{
 };
 use crate::mcp::tools::{ToolResult, MAX_RESPONSE_CHARS};
 use crate::sessions::cursor::HermesProfileDbReadOnly;
+use crate::sessions::git_correlation::{GitRefFilter, GitScopeFilter, SessionsForQuery};
 use crate::sessions::lcm::compression_decision::{self, AssemblyCapInput};
 use crate::sessions::lcm::{
     LcmCleanConfig, LcmCompressionRequest, LcmContentSlice, LcmDescribeRequest, LcmDescribeTarget,
@@ -76,6 +77,9 @@ fn render_message_search_md(value: &Value) -> String {
         }
     }
     md.field("count", &render::field_i64(value, "count").to_string());
+    if let Some(summary) = git_filter_summary(value) {
+        md.field("git filter", &summary);
+    }
     let results = value.get("results").and_then(Value::as_array);
     match results {
         Some(results) if !results.is_empty() => {
@@ -89,6 +93,31 @@ fn render_message_search_md(value: &Value) -> String {
         }
     }
     md.render()
+}
+
+/// One-line `branch=… worktree=… commit=…` summary of the applied git-scope
+/// filter, or `None` when no filter was applied. Reads the `git_filter` object
+/// echoed into the payload by the message-search / lcm-grep handlers.
+fn git_filter_summary(value: &Value) -> Option<String> {
+    if !value
+        .get("git_filter_applied")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let filter = value.get("git_filter")?;
+    let mut parts = Vec::new();
+    for key in ["branch", "worktree", "commit"] {
+        if let Some(field) = filter.get(key).and_then(Value::as_str) {
+            parts.push(format!("{key}={field}"));
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
 }
 
 fn append_message_search_hit(md: &mut Md, hit: &Value) {
@@ -1618,10 +1647,13 @@ async fn open_lcm_storage(
                                 LcmOpenMode::ReadOnlyOrMissing => {
                                     lcm_not_yet_ingested(args, "hermes_profile")
                                 }
-                                _ => invalid_hermes_profile_home(args, format!(
-                                    "hermes_profile LCM storage requires an existing session database: {}",
-                                    db_path.display()
-                                )),
+                                _ => invalid_hermes_profile_home(
+                                    args,
+                                    format!(
+                                        "hermes_profile LCM storage requires an existing session database: {}",
+                                        db_path.display()
+                                    ),
+                                ),
                             });
                         }
                         HermesProfileDbReadOnly::ConfigError(msg) => {
@@ -1762,6 +1794,157 @@ fn parse_message_search_provider_scope(args: &Value) -> Result<ProviderScope> {
     ProviderScope::parse_optional(string_arg(args, "provider")).map_err(argument_error)
 }
 
+/// Parses the optional `branch` / `worktree` / `commit` git-scope filter
+/// arguments shared by `tracedecay_message_search` and `tracedecay_lcm_grep`.
+fn parse_git_scope_filter(args: &Value) -> Result<GitScopeFilter> {
+    GitScopeFilter::from_args(
+        string_arg(args, "branch"),
+        string_arg(args, "worktree"),
+        string_arg(args, "commit"),
+    )
+    .map_err(|err| argument_error(err.to_string()))
+}
+
+const DEFAULT_SESSIONS_FOR_LIMIT: usize = 20;
+
+/// Renders `tracedecay_sessions_for` results as compact markdown: one bullet
+/// per correlated session with its activity window or commit attribution.
+fn render_sessions_for_md(value: &Value) -> String {
+    let mut md = Md::new();
+    md.heading(2, "Sessions For Git Ref");
+    for key in ["git_ref", "value"] {
+        let field = render::field_str(value, key);
+        if !field.is_empty() {
+            md.field(key, field);
+        }
+    }
+    md.field("count", &render::field_i64(value, "count").to_string());
+    let results = value.get("results").and_then(Value::as_array);
+    match results {
+        Some(results) if !results.is_empty() => {
+            md.blank();
+            for hit in results {
+                append_sessions_for_hit(&mut md, hit);
+            }
+        }
+        _ => {
+            md.blank()
+                .empty_note("No correlated sessions recorded for this git ref.");
+        }
+    }
+    md.render()
+}
+
+fn append_sessions_for_hit(md: &mut Md, hit: &Value) {
+    let session_id = render::field_str(hit, "session_id");
+    let provider = render::field_str(hit, "provider");
+    let mut header = format!("session `{session_id}`");
+    if !provider.is_empty() {
+        let _ = write!(header, " · {provider}");
+    }
+    md.bullet(&header);
+    let mut detail = String::new();
+    if let Some(branch) = hit.get("branch").and_then(Value::as_str) {
+        let _ = write!(detail, "branch `{branch}`");
+    }
+    if let Some(worktree) = hit.get("worktree").and_then(Value::as_str) {
+        if !detail.is_empty() {
+            detail.push_str(" · ");
+        }
+        let _ = write!(detail, "worktree `{worktree}`");
+    }
+    if let (Some(first), Some(last)) = (
+        hit.get("first_ts").and_then(Value::as_i64),
+        hit.get("last_ts").and_then(Value::as_i64),
+    ) {
+        if !detail.is_empty() {
+            detail.push_str(" · ");
+        }
+        let _ = write!(
+            detail,
+            "active {} .. {}",
+            crate::timeutil::humanize_unix_secs(first),
+            crate::timeutil::humanize_unix_secs(last)
+        );
+    }
+    if let Some(sha) = hit.get("commit_sha").and_then(Value::as_str) {
+        if !detail.is_empty() {
+            detail.push_str(" · ");
+        }
+        let short = sha.get(..12).unwrap_or(sha);
+        let _ = write!(detail, "commit `{short}`");
+        if let Some(committed_at) = hit.get("committed_at").and_then(Value::as_i64) {
+            let _ = write!(
+                detail,
+                " at {}",
+                crate::timeutil::humanize_unix_secs(committed_at)
+            );
+        }
+    }
+    if !detail.is_empty() {
+        md.line(&format!("  {detail}"));
+    }
+}
+
+pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+    let kind = required_string_arg(&args, "git_ref")?;
+    let value = required_string_arg(&args, "value")?;
+    let git_ref =
+        GitRefFilter::parse(kind, value).map_err(|err| argument_error(err.to_string()))?;
+    let since = non_negative_timestamp_arg(&args, "since", SearchTimeBound::Start)?;
+    let until = non_negative_timestamp_arg(&args, "until", SearchTimeBound::End)?;
+    let limit = bounded_usize_arg(&args, "limit", 1, MAX_LCM_RESULT_LIMIT)?
+        .unwrap_or(DEFAULT_SESSIONS_FOR_LIMIT);
+    let query = SessionsForQuery {
+        git_ref,
+        since,
+        until,
+        limit,
+    };
+
+    // Read-only lookup against the project session store; a missing store
+    // means nothing was ever recorded, which is a valid empty result (the
+    // tool never ghost-creates an empty sessions.db).
+    let db_path = cg.store_layout().sessions_db_path.clone();
+    let results = if db_path.is_file() {
+        let Some(db) = GlobalDb::open_read_only_at(&db_path).await else {
+            return Ok(tool_json(
+                Some(cg.project_root()),
+                &args,
+                &json!({
+                    "status": "unavailable",
+                    "message": "could not open project tracedecay session database",
+                    "results": [],
+                    "count": 0
+                }),
+            ));
+        };
+        db.git_sessions_for(&query)
+            .await
+            .map_err(|err| TraceDecayError::Config {
+                message: err.to_string(),
+            })?
+    } else {
+        Vec::new()
+    };
+
+    let payload = json!({
+        "status": "ok",
+        "git_ref": query.git_ref.kind(),
+        "value": query.git_ref.value(),
+        "since": since,
+        "until": until,
+        "count": results.len(),
+        "results": results,
+    });
+    Ok(tool_json_with_md(
+        Some(cg.project_root()),
+        &args,
+        &payload,
+        || render_sessions_for_md(&payload),
+    ))
+}
+
 pub(super) async fn handle_message_search(
     cg: &TraceDecay,
     args: Value,
@@ -1805,6 +1988,8 @@ pub(super) async fn handle_message_search(
         .and_then(Value::as_u64)
         .unwrap_or(10)
         .clamp(1, 50) as usize;
+    let git_filter = parse_git_scope_filter(&args)?;
+    let git_filter_applied = !git_filter.is_empty();
     let time_range = message_search_time_range(&args)?;
 
     let Some((db_path, target_root)) = selected_project_session_db_path(
@@ -1848,7 +2033,21 @@ pub(super) async fn handle_message_search(
         )
         .await;
     }
-    let results = if let Some(provider) = requested_provider {
+    let results = if git_filter_applied {
+        db.search_session_messages_git_scoped(
+            requested_provider,
+            project_key,
+            query,
+            limit,
+            SessionSearchFilters {
+                scope,
+                parent_session_id,
+                time_range,
+            },
+            &git_filter,
+        )
+        .await
+    } else if let Some(provider) = requested_provider {
         db.search_session_messages_filtered(
             provider,
             project_key,
@@ -1875,7 +2074,7 @@ pub(super) async fn handle_message_search(
         .await
     };
 
-    let payload = json!({
+    let mut payload = json!({
         "status": "ok",
         "provider": requested_provider.unwrap_or("all"),
         "requested_provider": requested_provider,
@@ -1897,6 +2096,15 @@ pub(super) async fn handle_message_search(
         "count": results.len(),
         "results": results,
     });
+    if git_filter_applied {
+        if let Some(map) = payload.as_object_mut() {
+            map.insert(
+                "git_filter".to_string(),
+                serde_json::to_value(&git_filter).unwrap_or(Value::Null),
+            );
+            map.insert("git_filter_applied".to_string(), Value::Bool(true));
+        }
+    }
     Ok(tool_json_with_md(
         Some(&target_root),
         &args,
@@ -2088,6 +2296,8 @@ pub(super) async fn handle_lcm_grep(
     // even when the sessions DB does not exist yet.
     let scope = parse_lcm_scope(&args)?;
     let provider = lcm_grep_provider_arg(&args);
+    let git_filter = parse_git_scope_filter(&args)?;
+    let git_filter_applied = !git_filter.is_empty();
     let storage = lcm_open_storage_ro!(context, &args);
     let hits = storage
         .db
@@ -2114,21 +2324,28 @@ pub(super) async fn handle_lcm_grep(
                 &["until", "end_time", "time_to"],
                 SearchTimeBound::End,
             )?,
+            git_filter: git_filter.clone(),
         })
         .await
         .map_err(lcm_error)?;
-    Ok(tool_json(
-        context.project_root,
-        &args,
-        &json!({
-            "status": "ok",
-            "provider": provider,
-            "query": query,
-            "count": hits.len(),
-            "hits": hits,
-            "sort": string_arg(&args, "sort").unwrap_or("recency"),
-        }),
-    ))
+    let mut payload = json!({
+        "status": "ok",
+        "provider": provider,
+        "query": query,
+        "count": hits.len(),
+        "hits": hits,
+        "sort": string_arg(&args, "sort").unwrap_or("recency"),
+    });
+    if git_filter_applied {
+        if let Some(map) = payload.as_object_mut() {
+            map.insert(
+                "git_filter".to_string(),
+                serde_json::to_value(&git_filter).unwrap_or(Value::Null),
+            );
+            map.insert("git_filter_applied".to_string(), Value::Bool(true));
+        }
+    }
+    Ok(tool_json(context.project_root, &args, &payload))
 }
 
 pub(super) async fn handle_lcm_describe(

--- a/src/sessions/git_correlation.rs
+++ b/src/sessions/git_correlation.rs
@@ -1,0 +1,2320 @@
+//! Session ↔ git correlation index.
+//!
+//! Correlates agent sessions (and their LCM messages) with the git artifacts
+//! they touched: branches, worktrees, and commits. The raw signals already
+//! exist — hook route metadata carries `(session_id, thread_id, cwd,
+//! worktree, branch)` per tool use, and the session store has every ingested
+//! message with timestamps — but they were never joined. This module owns the
+//! join tables and their query API.
+//!
+//! ## Where the index lives
+//!
+//! The tables live in the **per-project session store** (`sessions.db`, the
+//! same file that holds `sessions`, `session_messages`, and the LCM tables;
+//! see [`crate::global_db::GlobalDb::open_at`]). Rationale:
+//!
+//! - Every query surface joins against `sessions` / `session_messages` /
+//!   `lcm_raw_messages`, which are per-project rows. Keeping the correlation
+//!   rows in the same file makes branch/worktree/commit filters a plain SQL
+//!   join instead of a cross-database merge.
+//! - Branches, worktrees, and commits are inherently project-scoped: a
+//!   branch name is only meaningful relative to one repository.
+//! - Hook route rows in the global analytics store are a *signal source*,
+//!   not a query surface: live attribution and the backfill command resolve
+//!   each observation's project (via its worktree/cwd) and write the span
+//!   into that project's store.
+//!
+//! ## Model
+//!
+//! Sessions can switch branches (and hop worktrees) mid-session, so
+//! attribution is **span-based**: a [`SessionGitSpan`] says "session S was
+//! active on branch B in worktree W between `first_ts` and `last_ts`".
+//! Repeated observations of the same (session, branch, worktree) extend the
+//! newest matching span when they arrive within a merge gap; a branch switch
+//! (or a long silence) starts a new span, so A → B → A produces three spans.
+//!
+//! A commit is attributed to a session when its commit time falls inside a
+//! session span on the same branch/worktree (see [`SpanOverlapKind`]); the
+//! result is a [`CommitSessionRecord`] row keyed by `(commit_sha, provider,
+//! session_id)`.
+
+use std::fmt::Write as _;
+
+use libsql::{params, Connection, Value};
+use serde::{Deserialize, Serialize};
+
+/// Schema version recorded in `session_schema_migrations` under
+/// [`MIGRATION_NAME`]. Bump when the DDL below changes shape.
+///
+/// - v1: `session_git_spans` + `commit_sessions`.
+/// - v2: `git_correlation_meta` key/value table for sweep watermarks.
+pub const GIT_CORRELATION_SCHEMA_VERSION: i64 = 2;
+
+const MIGRATION_NAME: &str = "git_correlation";
+
+/// Default gap (seconds) within which a new observation extends the newest
+/// matching span instead of opening a new one. Tool-use events inside one
+/// working stretch arrive far more often than this; a longer silence most
+/// likely means the session went idle or moved elsewhere.
+pub const DEFAULT_SPAN_MERGE_GAP_SECS: i64 = 30 * 60;
+
+/// Hard cap on rows returned by [`sessions_for`].
+pub const MAX_SESSIONS_FOR_LIMIT: usize = 100;
+
+/// Errors from the git-correlation store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitCorrelationError {
+    /// Underlying database failure.
+    Db(String),
+    /// Caller-supplied argument was invalid (bad ref kind, empty value, …).
+    InvalidArgument(String),
+}
+
+impl std::fmt::Display for GitCorrelationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Db(message) => write!(f, "git correlation db error: {message}"),
+            Self::InvalidArgument(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for GitCorrelationError {}
+
+impl From<libsql::Error> for GitCorrelationError {
+    fn from(err: libsql::Error) -> Self {
+        Self::Db(err.to_string())
+    }
+}
+
+/// Where a span row came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpanSource {
+    /// Live hook route metadata observed while the session ran.
+    HookRoute,
+    /// Derived during transcript ingest/sync.
+    Ingest,
+    /// Reconstructed by the historical backfill command.
+    Backfill,
+}
+
+impl SpanSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::HookRoute => "hook_route",
+            Self::Ingest => "ingest",
+            Self::Backfill => "backfill",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "hook_route" => Some(Self::HookRoute),
+            "ingest" => Some(Self::Ingest),
+            "backfill" => Some(Self::Backfill),
+            _ => None,
+        }
+    }
+}
+
+/// How a commit's timestamp related to the session span that claimed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpanOverlapKind {
+    /// Commit time fell strictly inside `[first_ts, last_ts]` of a span on
+    /// the same branch/worktree.
+    WithinSpan,
+    /// Commit time fell inside the span extended by the merge gap (commits
+    /// often land moments after the last recorded tool use).
+    ExtendedWindow,
+    /// Attributed via `git reflog` checkout history rather than a recorded
+    /// span (backfill of sessions that predate span recording).
+    Reflog,
+}
+
+impl SpanOverlapKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WithinSpan => "within_span",
+            Self::ExtendedWindow => "extended_window",
+            Self::Reflog => "reflog",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "within_span" => Some(Self::WithinSpan),
+            "extended_window" => Some(Self::ExtendedWindow),
+            "reflog" => Some(Self::Reflog),
+            _ => None,
+        }
+    }
+}
+
+/// One recorded stretch of session activity on a branch/worktree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionGitSpan {
+    pub span_id: i64,
+    /// Session provider id (`claude`, `codex`, …). Empty when the signal
+    /// source did not identify the provider (raw hook routes are
+    /// provider-agnostic); queries treat `''` as "unknown".
+    pub provider: String,
+    pub session_id: String,
+    pub thread_id: Option<String>,
+    /// `None` = detached HEAD or branch unknown at observation time.
+    pub branch: Option<String>,
+    /// Normalized absolute worktree root path (see [`normalize_worktree`]).
+    pub worktree: String,
+    pub first_ts: i64,
+    pub last_ts: i64,
+    pub event_count: i64,
+    pub source: SpanSource,
+}
+
+/// One live observation to be folded into the span table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpanObservation {
+    pub provider: String,
+    pub session_id: String,
+    pub thread_id: Option<String>,
+    pub branch: Option<String>,
+    pub worktree: String,
+    pub ts: i64,
+    pub source: SpanSource,
+}
+
+/// One commit attributed to one session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitSessionRecord {
+    /// Full 40-hex (or 64-hex for sha256 repos) lowercase commit id.
+    pub commit_sha: String,
+    pub provider: String,
+    pub session_id: String,
+    pub branch: Option<String>,
+    pub worktree: Option<String>,
+    pub committed_at: i64,
+    pub span_overlap_kind: SpanOverlapKind,
+    /// Span row that claimed the commit, when attribution was span-based.
+    pub span_id: Option<i64>,
+}
+
+/// A parsed, validated git reference to correlate sessions against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitRefFilter {
+    Branch(String),
+    /// Normalized worktree root path.
+    Worktree(String),
+    /// Lowercase hex commit sha, possibly abbreviated (>= 6 chars).
+    Commit(String),
+}
+
+impl GitRefFilter {
+    /// Parses a `(kind, value)` pair from tool arguments. Kinds are
+    /// `branch`, `worktree`, and `commit`; values are trimmed and
+    /// normalized per kind.
+    pub fn parse(kind: &str, value: &str) -> Result<Self, GitCorrelationError> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(GitCorrelationError::InvalidArgument(
+                "value must be a non-empty string".to_string(),
+            ));
+        }
+        match kind {
+            "branch" => Ok(Self::Branch(value.to_string())),
+            "worktree" => Ok(Self::Worktree(normalize_worktree(value))),
+            "commit" => parse_commit_sha(value).map(Self::Commit),
+            other => Err(GitCorrelationError::InvalidArgument(format!(
+                "git_ref must be one of branch, worktree, commit (got `{other}`)"
+            ))),
+        }
+    }
+
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Branch(_) => "branch",
+            Self::Worktree(_) => "worktree",
+            Self::Commit(_) => "commit",
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        match self {
+            Self::Branch(value) | Self::Worktree(value) | Self::Commit(value) => value,
+        }
+    }
+}
+
+/// Optional git-scope filters shared by `tracedecay_message_search` and
+/// `tracedecay_lcm_grep` (`branch` / `worktree` / `commit` arguments).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitScopeFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+}
+
+impl GitScopeFilter {
+    /// Builds a validated filter from raw optional argument strings.
+    pub fn from_args(
+        branch: Option<&str>,
+        worktree: Option<&str>,
+        commit: Option<&str>,
+    ) -> Result<Self, GitCorrelationError> {
+        let branch = branch
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let worktree = worktree
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(normalize_worktree);
+        let commit = match commit.map(str::trim).filter(|value| !value.is_empty()) {
+            Some(value) => Some(parse_commit_sha(value)?),
+            None => None,
+        };
+        Ok(Self {
+            branch,
+            worktree,
+            commit,
+        })
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.branch.is_none() && self.worktree.is_none() && self.commit.is_none()
+    }
+}
+
+/// Query request for [`sessions_for`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionsForQuery {
+    pub git_ref: GitRefFilter,
+    /// Inclusive lower bound on span/commit activity (unix seconds).
+    pub since: Option<i64>,
+    /// Inclusive upper bound on span/commit activity (unix seconds).
+    pub until: Option<i64>,
+    pub limit: usize,
+}
+
+/// One session correlated with the queried git ref.
+///
+/// Branch/worktree queries aggregate span rows per session (`first_ts`,
+/// `last_ts`, `event_count`, `span_count`, `sources` populated); commit
+/// queries return commit attribution rows (`commit_sha`, `committed_at`,
+/// `span_overlap_kind` populated).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionGitCorrelationHit {
+    pub provider: String,
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_ts: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_ts: Option<i64>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub event_count: i64,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub span_count: i64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub committed_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span_overlap_kind: Option<SpanOverlapKind>,
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde skip_serializing_if signature
+fn is_zero(value: &i64) -> bool {
+    *value == 0
+}
+
+/// Lexically normalizes a worktree path for stable equality: trims
+/// whitespace, converts backslashes to forward slashes, and strips trailing
+/// slashes (keeping a lone `/`). Deliberately does **not** hit the
+/// filesystem — writers should pass already-resolved worktree roots (e.g.
+/// from [`crate::worktree::git_worktree_root`]); this keeps readers and
+/// writers agreeing even when the path no longer exists.
+pub fn normalize_worktree(path: &str) -> String {
+    let mut normalized = path.trim().replace('\\', "/");
+    while normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+    normalized
+}
+
+/// Validates and lowercases a (possibly abbreviated) commit sha. Requires
+/// 6–64 hex characters: shorter prefixes are too ambiguous to index-match
+/// against the attribution table.
+fn parse_commit_sha(value: &str) -> Result<String, GitCorrelationError> {
+    let ok = (6..=64).contains(&value.len()) && value.chars().all(|c| c.is_ascii_hexdigit());
+    if !ok {
+        return Err(GitCorrelationError::InvalidArgument(
+            "commit must be 6-64 hexadecimal characters".to_string(),
+        ));
+    }
+    Ok(value.to_ascii_lowercase())
+}
+
+/// True when an observation at `ts` should extend a span covering
+/// `[first_ts, last_ts]` (same session/branch/worktree assumed) instead of
+/// opening a new span: within the span or within `gap_secs` of either edge.
+pub fn observation_extends_span(first_ts: i64, last_ts: i64, ts: i64, gap_secs: i64) -> bool {
+    ts >= first_ts.saturating_sub(gap_secs) && ts <= last_ts.saturating_add(gap_secs)
+}
+
+/// In-process rate limiter for live hook-route span observations. A burst of
+/// tool-use hook events for one `(provider, session, branch, worktree)` key
+/// arrives far faster than spans need re-widening (spans merge anyway), so at
+/// most one DB write per `min_interval_secs` per key is recorded. Purely
+/// advisory: dropping an observation only widens a span slightly less, never
+/// loses attribution, so this never has to persist across restarts.
+#[derive(Debug, Default)]
+pub struct SpanObservationDebounce {
+    last_write: std::collections::HashMap<String, i64>,
+}
+
+/// Default minimum spacing between recorded hook-route observations for one
+/// key. Matches [`DEFAULT_SPAN_MERGE_GAP_SECS`] granularity: writing more
+/// often than this cannot change which spans exist.
+pub const DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS: i64 = 30;
+
+impl SpanObservationDebounce {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` (and records `ts` as the new watermark) when an
+    /// observation at `ts` for this key should be written; returns `false`
+    /// when a write for the same key happened within `min_interval_secs`.
+    /// An out-of-order (older) `ts` never suppresses a write.
+    pub fn should_record(&mut self, key: &str, ts: i64, min_interval_secs: i64) -> bool {
+        if let Some(&last) = self.last_write.get(key) {
+            if ts >= last && ts - last < min_interval_secs {
+                return false;
+            }
+        }
+        self.last_write.insert(key.to_string(), ts);
+        true
+    }
+}
+
+/// Builds the debounce key for one observation. Detached HEAD (branch `None`)
+/// gets a distinct key from any named branch so a branch switch is never
+/// debounced away.
+pub fn span_debounce_key(
+    provider: &str,
+    session_id: &str,
+    branch: Option<&str>,
+    worktree: &str,
+) -> String {
+    format!(
+        "{provider}\u{1f}{session_id}\u{1f}{}\u{1f}{worktree}",
+        branch.unwrap_or("\u{0}")
+    )
+}
+
+/// Creates the correlation tables when missing. Version-gated via
+/// `session_schema_migrations` like the LCM schema; idempotent.
+pub(crate) async fn ensure_git_correlation_schema(
+    conn: &Connection,
+) -> Result<(), GitCorrelationError> {
+    if schema_version(conn)
+        .await
+        .is_some_and(|version| version >= GIT_CORRELATION_SCHEMA_VERSION)
+    {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS session_schema_migrations (
+            name TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            applied_at INTEGER NOT NULL DEFAULT (unixepoch())
+        );
+        CREATE TABLE IF NOT EXISTS session_git_spans (
+            span_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider TEXT NOT NULL DEFAULT '',
+            session_id TEXT NOT NULL,
+            thread_id TEXT,
+            branch TEXT,
+            worktree TEXT NOT NULL,
+            first_ts INTEGER NOT NULL,
+            last_ts INTEGER NOT NULL,
+            event_count INTEGER NOT NULL DEFAULT 1,
+            source TEXT NOT NULL CHECK(source IN ('hook_route', 'ingest', 'backfill')),
+            created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            CHECK(first_ts <= last_ts)
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_git_spans_session
+            ON session_git_spans(provider, session_id, last_ts);
+        CREATE INDEX IF NOT EXISTS idx_session_git_spans_branch
+            ON session_git_spans(branch, last_ts);
+        CREATE INDEX IF NOT EXISTS idx_session_git_spans_worktree
+            ON session_git_spans(worktree, last_ts);
+        CREATE TABLE IF NOT EXISTS commit_sessions (
+            commit_sha TEXT NOT NULL,
+            provider TEXT NOT NULL DEFAULT '',
+            session_id TEXT NOT NULL,
+            branch TEXT,
+            worktree TEXT,
+            committed_at INTEGER NOT NULL,
+            span_overlap_kind TEXT NOT NULL
+                CHECK(span_overlap_kind IN ('within_span', 'extended_window', 'reflog')),
+            span_id INTEGER,
+            created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            PRIMARY KEY(commit_sha, provider, session_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_commit_sessions_session
+            ON commit_sessions(provider, session_id, committed_at);
+        CREATE INDEX IF NOT EXISTS idx_commit_sessions_branch
+            ON commit_sessions(branch, committed_at);
+        CREATE TABLE IF NOT EXISTS git_correlation_meta (
+            key TEXT PRIMARY KEY,
+            value INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+        );",
+    )
+    .await?;
+    conn.execute(
+        "INSERT INTO session_schema_migrations(name, version)
+         VALUES (?1, ?2)
+         ON CONFLICT(name) DO UPDATE SET
+            version = excluded.version,
+            applied_at = unixepoch()",
+        params![MIGRATION_NAME, GIT_CORRELATION_SCHEMA_VERSION],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn schema_version(conn: &Connection) -> Option<i64> {
+    let mut rows = conn
+        .query(
+            "SELECT version FROM session_schema_migrations WHERE name = ?1",
+            params![MIGRATION_NAME],
+        )
+        .await
+        .ok()?;
+    rows.next().await.ok()??.get(0).ok()
+}
+
+fn opt_text(value: Option<&str>) -> Value {
+    value.map_or(Value::Null, |text| Value::Text(text.to_string()))
+}
+
+/// Folds one observation into the span table: extends the newest span for
+/// the same (provider, session, branch, worktree) when the observation lands
+/// within `merge_gap_secs` of it, otherwise inserts a new span. Returns the
+/// affected `span_id`.
+///
+/// Runs in a `BEGIN IMMEDIATE` transaction so concurrent writers converge on
+/// widened spans instead of interleaved half-updates.
+pub(crate) async fn record_span_observation(
+    conn: &Connection,
+    observation: &SpanObservation,
+    merge_gap_secs: i64,
+) -> Result<i64, GitCorrelationError> {
+    conn.execute("BEGIN IMMEDIATE", ()).await?;
+    let result = record_span_observation_in_transaction(conn, observation, merge_gap_secs).await;
+    match result {
+        Ok(span_id) => {
+            if let Err(err) = conn.execute("COMMIT", ()).await {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(err.into())
+            } else {
+                Ok(span_id)
+            }
+        }
+        Err(err) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(err)
+        }
+    }
+}
+
+async fn record_span_observation_in_transaction(
+    conn: &Connection,
+    observation: &SpanObservation,
+    merge_gap_secs: i64,
+) -> Result<i64, GitCorrelationError> {
+    // `branch IS ?` is NULL-safe: a detached-HEAD observation only extends a
+    // detached-HEAD span, never a named-branch span.
+    let mut rows = conn
+        .query(
+            "SELECT span_id, first_ts, last_ts
+             FROM session_git_spans
+             WHERE provider = ?1 AND session_id = ?2
+               AND branch IS ?3 AND worktree = ?4
+             ORDER BY last_ts DESC
+             LIMIT 1",
+            params![
+                observation.provider.as_str(),
+                observation.session_id.as_str(),
+                opt_text(observation.branch.as_deref()),
+                observation.worktree.as_str(),
+            ],
+        )
+        .await?;
+    if let Some(row) = rows.next().await? {
+        let span_id: i64 = row.get(0)?;
+        let first_ts: i64 = row.get(1)?;
+        let last_ts: i64 = row.get(2)?;
+        if observation_extends_span(first_ts, last_ts, observation.ts, merge_gap_secs) {
+            conn.execute(
+                "UPDATE session_git_spans SET
+                    first_ts = MIN(first_ts, ?2),
+                    last_ts = MAX(last_ts, ?2),
+                    event_count = event_count + 1,
+                    thread_id = COALESCE(?3, thread_id),
+                    updated_at = unixepoch()
+                 WHERE span_id = ?1",
+                params![
+                    span_id,
+                    observation.ts,
+                    opt_text(observation.thread_id.as_deref()),
+                ],
+            )
+            .await?;
+            return Ok(span_id);
+        }
+    }
+    conn.execute(
+        "INSERT INTO session_git_spans (
+            provider, session_id, thread_id, branch, worktree,
+            first_ts, last_ts, event_count, source
+         )
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6, 1, ?7)",
+        params![
+            observation.provider.as_str(),
+            observation.session_id.as_str(),
+            opt_text(observation.thread_id.as_deref()),
+            opt_text(observation.branch.as_deref()),
+            observation.worktree.as_str(),
+            observation.ts,
+            observation.source.as_str(),
+        ],
+    )
+    .await?;
+    Ok(conn.last_insert_rowid())
+}
+
+/// Inserts one commit attribution row; existing rows win (idempotent for
+/// re-runs of live attribution and the backfill command). Returns `true`
+/// when a new row was inserted.
+pub(crate) async fn upsert_commit_session(
+    conn: &Connection,
+    record: &CommitSessionRecord,
+) -> Result<bool, GitCorrelationError> {
+    let inserted = conn
+        .execute(
+            "INSERT OR IGNORE INTO commit_sessions (
+                commit_sha, provider, session_id, branch, worktree,
+                committed_at, span_overlap_kind, span_id
+             )
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                record.commit_sha.as_str(),
+                record.provider.as_str(),
+                record.session_id.as_str(),
+                opt_text(record.branch.as_deref()),
+                opt_text(record.worktree.as_deref()),
+                record.committed_at,
+                record.span_overlap_kind.as_str(),
+                record.span_id.map_or(Value::Null, Value::Integer),
+            ],
+        )
+        .await?;
+    Ok(inserted > 0)
+}
+
+const COMMIT_SWEEP_WATERMARK_KEY: &str = "commit_attribution_watermark";
+
+async fn read_meta_value(conn: &Connection, key: &str) -> Result<Option<i64>, GitCorrelationError> {
+    let mut rows = conn
+        .query(
+            "SELECT value FROM git_correlation_meta WHERE key = ?1",
+            params![key],
+        )
+        .await?;
+    match rows.next().await? {
+        Some(row) => Ok(Some(row.get(0)?)),
+        None => Ok(None),
+    }
+}
+
+async fn write_meta_value(
+    conn: &Connection,
+    key: &str,
+    value: i64,
+) -> Result<(), GitCorrelationError> {
+    conn.execute(
+        "INSERT INTO git_correlation_meta(key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = unixepoch()",
+        params![key, value],
+    )
+    .await?;
+    Ok(())
+}
+
+/// A `(branch, worktree)` pair a session was observed on, with the widest span
+/// window recorded for it. Commit scans run once per pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpanScanTarget {
+    pub branch: Option<String>,
+    pub worktree: String,
+    pub window_start: i64,
+    pub window_end: i64,
+}
+
+/// One span row a candidate commit may fall inside. Kept minimal so the
+/// matching logic ([`match_commit_to_spans`]) is a pure function testable
+/// without a database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpanWindow {
+    pub span_id: i64,
+    pub provider: String,
+    pub session_id: String,
+    pub branch: Option<String>,
+    pub worktree: String,
+    pub first_ts: i64,
+    pub last_ts: i64,
+}
+
+/// Classifies a commit at `committed_at` against one span: `Some(WithinSpan)`
+/// when strictly inside `[first_ts, last_ts]`, `Some(ExtendedWindow)` when
+/// inside the span widened by `gap_secs` on either edge, `None` otherwise.
+pub fn commit_overlap_kind(
+    first_ts: i64,
+    last_ts: i64,
+    committed_at: i64,
+    gap_secs: i64,
+) -> Option<SpanOverlapKind> {
+    if committed_at >= first_ts && committed_at <= last_ts {
+        Some(SpanOverlapKind::WithinSpan)
+    } else if committed_at >= first_ts.saturating_sub(gap_secs)
+        && committed_at <= last_ts.saturating_add(gap_secs)
+    {
+        Some(SpanOverlapKind::ExtendedWindow)
+    } else {
+        None
+    }
+}
+
+/// Attributes one commit to every span whose window contains it, preferring
+/// `WithinSpan` matches. Returns one record per `(span provider, session)`
+/// pair so a commit made while several sessions were concurrently active on
+/// the same branch is attributed to all of them.
+pub fn match_commit_to_spans(
+    commit_sha: &str,
+    branch: Option<&str>,
+    worktree: &str,
+    committed_at: i64,
+    spans: &[SpanWindow],
+    gap_secs: i64,
+) -> Vec<CommitSessionRecord> {
+    let mut records = Vec::new();
+    for span in spans {
+        if span.branch.as_deref() != branch || span.worktree != worktree {
+            continue;
+        }
+        let Some(kind) = commit_overlap_kind(span.first_ts, span.last_ts, committed_at, gap_secs)
+        else {
+            continue;
+        };
+        records.push(CommitSessionRecord {
+            commit_sha: commit_sha.to_string(),
+            provider: span.provider.clone(),
+            session_id: span.session_id.clone(),
+            branch: span.branch.clone(),
+            worktree: Some(span.worktree.clone()),
+            committed_at,
+            span_overlap_kind: kind,
+            span_id: Some(span.span_id),
+        });
+    }
+    records
+}
+
+/// Loads the `(branch, worktree)` scan targets touched by spans updated at or
+/// after `since_ts` (the sweep watermark), each carrying the widest span
+/// window observed for it so the git scan can be time-bounded.
+async fn scan_targets_since(
+    conn: &Connection,
+    since_ts: i64,
+) -> Result<Vec<SpanScanTarget>, GitCorrelationError> {
+    let mut rows = conn
+        .query(
+            "SELECT branch, worktree, MIN(first_ts), MAX(last_ts)
+             FROM session_git_spans
+             WHERE last_ts >= ?1
+             GROUP BY branch, worktree",
+            params![since_ts],
+        )
+        .await?;
+    let mut targets = Vec::new();
+    while let Some(row) = rows.next().await? {
+        targets.push(SpanScanTarget {
+            branch: row.get(0)?,
+            worktree: row.get(1)?,
+            window_start: row.get(2)?,
+            window_end: row.get(3)?,
+        });
+    }
+    Ok(targets)
+}
+
+/// Loads span windows for one `(branch, worktree)` pair, used to attribute
+/// each scanned commit.
+async fn span_windows_for(
+    conn: &Connection,
+    branch: Option<&str>,
+    worktree: &str,
+) -> Result<Vec<SpanWindow>, GitCorrelationError> {
+    let mut rows = conn
+        .query(
+            "SELECT span_id, provider, session_id, branch, worktree, first_ts, last_ts
+             FROM session_git_spans
+             WHERE branch IS ?1 AND worktree = ?2",
+            params![opt_text(branch), worktree],
+        )
+        .await?;
+    let mut spans = Vec::new();
+    while let Some(row) = rows.next().await? {
+        spans.push(SpanWindow {
+            span_id: row.get(0)?,
+            provider: row.get(1)?,
+            session_id: row.get(2)?,
+            branch: row.get(3)?,
+            worktree: row.get(4)?,
+            first_ts: row.get(5)?,
+            last_ts: row.get(6)?,
+        });
+    }
+    Ok(spans)
+}
+
+/// One commit observed by the bounded git scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScannedCommit {
+    pub sha: String,
+    pub committed_at: i64,
+}
+
+/// Runs the commit-attribution sweep against the correlation store. For each
+/// `(branch, worktree)` pair touched since the last sweep, `scan` is asked for
+/// the commits on that branch in the pair's span window (widened by
+/// `gap_secs`); each commit is matched to the overlapping spans and upserted.
+/// Advances the watermark to the newest span `last_ts` seen. Returns the
+/// number of attribution rows newly inserted.
+///
+/// `scan` is injected so the git subprocess stays out of this module and unit
+/// tests can drive attribution without a real repository.
+pub(crate) async fn run_commit_attribution_sweep<F>(
+    conn: &Connection,
+    gap_secs: i64,
+    mut scan: F,
+) -> Result<usize, GitCorrelationError>
+where
+    F: FnMut(&SpanScanTarget) -> Vec<ScannedCommit>,
+{
+    if !correlation_tables_present(conn).await? {
+        return Ok(0);
+    }
+    let watermark = read_meta_value(conn, COMMIT_SWEEP_WATERMARK_KEY)
+        .await?
+        .unwrap_or(0);
+    let targets = scan_targets_since(conn, watermark).await?;
+    let mut inserted = 0usize;
+    let mut new_watermark = watermark;
+    for target in &targets {
+        new_watermark = new_watermark.max(target.window_end);
+        let spans = span_windows_for(conn, target.branch.as_deref(), &target.worktree).await?;
+        if spans.is_empty() {
+            continue;
+        }
+        for commit in scan(target) {
+            let records = match_commit_to_spans(
+                &commit.sha,
+                target.branch.as_deref(),
+                &target.worktree,
+                commit.committed_at,
+                &spans,
+                gap_secs,
+            );
+            for record in &records {
+                if upsert_commit_session(conn, record).await? {
+                    inserted += 1;
+                }
+            }
+        }
+    }
+    if new_watermark > watermark {
+        write_meta_value(conn, COMMIT_SWEEP_WATERMARK_KEY, new_watermark).await?;
+    }
+    Ok(inserted)
+}
+
+/// Returns sessions correlated with a branch, worktree, or commit, most
+/// recently active first. Branch/worktree queries aggregate span rows per
+/// session; commit queries return attribution rows (abbreviated shas match
+/// by prefix). `since`/`until` bound span overlap (branch/worktree) or
+/// commit time (commit).
+pub(crate) async fn sessions_for(
+    conn: &Connection,
+    query: &SessionsForQuery,
+) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
+    // Read-only opens never run DDL, so a store written before this schema
+    // existed simply has no correlation rows yet — report that as "no
+    // matches" rather than a hard `no such table` error.
+    if !correlation_tables_present(conn).await? {
+        return Ok(Vec::new());
+    }
+    let limit = query.limit.clamp(1, MAX_SESSIONS_FOR_LIMIT) as i64;
+    match &query.git_ref {
+        GitRefFilter::Branch(branch) => {
+            span_hits(
+                conn,
+                "branch = ?1",
+                Value::Text(branch.clone()),
+                query,
+                limit,
+            )
+            .await
+        }
+        GitRefFilter::Worktree(worktree) => {
+            span_hits(
+                conn,
+                "worktree = ?1",
+                Value::Text(worktree.clone()),
+                query,
+                limit,
+            )
+            .await
+        }
+        GitRefFilter::Commit(sha) => commit_hits(conn, sha, query, limit).await,
+    }
+}
+
+/// Resolves the set of `(provider, session_id)` pairs that satisfy a
+/// [`GitScopeFilter`], intersecting each present constraint (a session must
+/// match branch AND worktree AND commit when all three are set). Returns
+/// `None` when the filter is empty (no scoping requested) and
+/// `Some(Vec::new())` when the filter is non-empty but nothing matched (or
+/// the correlation tables do not exist yet).
+///
+/// This is a convenience for callers that want the resolved id set directly;
+/// the search paths instead push [`git_scope_exists_predicate`] EXISTS
+/// subqueries into their own statement so scoping stays index-served and
+/// single-statement.
+pub(crate) async fn session_ids_for_scope(
+    conn: &Connection,
+    filter: &GitScopeFilter,
+) -> Result<Option<Vec<(String, String)>>, GitCorrelationError> {
+    if filter.is_empty() {
+        return Ok(None);
+    }
+    if !correlation_tables_present(conn).await? {
+        return Ok(Some(Vec::new()));
+    }
+    // Intersect via a session-id key set, seeded by the first constraint and
+    // narrowed by each remaining one.
+    let mut result: Option<Vec<(String, String)>> = None;
+    if let Some(branch) = &filter.branch {
+        let ids = span_session_ids(conn, "branch = ?1", Value::Text(branch.clone())).await?;
+        result = Some(intersect_session_ids(result, ids));
+    }
+    if let Some(worktree) = &filter.worktree {
+        let ids = span_session_ids(conn, "worktree = ?1", Value::Text(worktree.clone())).await?;
+        result = Some(intersect_session_ids(result, ids));
+    }
+    if let Some(commit) = &filter.commit {
+        let ids = commit_session_ids(conn, commit).await?;
+        result = Some(intersect_session_ids(result, ids));
+    }
+    Ok(Some(result.unwrap_or_default()))
+}
+
+fn intersect_session_ids(
+    accumulated: Option<Vec<(String, String)>>,
+    next: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    match accumulated {
+        None => next,
+        Some(existing) => existing
+            .into_iter()
+            .filter(|pair| next.contains(pair))
+            .collect(),
+    }
+}
+
+async fn span_session_ids(
+    conn: &Connection,
+    ref_predicate: &str,
+    ref_value: Value,
+) -> Result<Vec<(String, String)>, GitCorrelationError> {
+    let sql = format!(
+        "SELECT DISTINCT provider, session_id FROM session_git_spans WHERE {ref_predicate}"
+    );
+    let mut rows = conn.query(&sql, vec![ref_value]).await?;
+    let mut ids = Vec::new();
+    while let Some(row) = rows.next().await? {
+        ids.push((row.get(0)?, row.get(1)?));
+    }
+    Ok(ids)
+}
+
+async fn commit_session_ids(
+    conn: &Connection,
+    sha: &str,
+) -> Result<Vec<(String, String)>, GitCorrelationError> {
+    let mut rows = conn
+        .query(
+            "SELECT DISTINCT provider, session_id FROM commit_sessions
+             WHERE commit_sha = ?1 OR commit_sha LIKE ?2",
+            params![sha, format!("{sha}%")],
+        )
+        .await?;
+    let mut ids = Vec::new();
+    while let Some(row) = rows.next().await? {
+        ids.push((row.get(0)?, row.get(1)?));
+    }
+    Ok(ids)
+}
+
+/// One EXISTS predicate string plus its bound values for a git-scope
+/// constraint, correlated to an outer message row via `session_column`
+/// (e.g. `m.session_id` or `r.session_id`). The predicate uses anonymous `?`
+/// placeholders, so callers append the returned values in order. Returns
+/// `None` when the filter is empty.
+///
+/// Span rows may carry `provider = ''` (raw hook routes are provider-agnostic),
+/// so scoping matches on `session_id` alone rather than also constraining the
+/// provider.
+pub(crate) fn git_scope_exists_predicate(
+    filter: &GitScopeFilter,
+    session_column: &str,
+) -> Option<(String, Vec<Value>)> {
+    if filter.is_empty() {
+        return None;
+    }
+    let mut clauses: Vec<String> = Vec::new();
+    let mut values: Vec<Value> = Vec::new();
+    if let Some(branch) = &filter.branch {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM session_git_spans g \
+             WHERE g.session_id = {session_column} AND g.branch = ?)"
+        ));
+        values.push(Value::Text(branch.clone()));
+    }
+    if let Some(worktree) = &filter.worktree {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM session_git_spans g \
+             WHERE g.session_id = {session_column} AND g.worktree = ?)"
+        ));
+        values.push(Value::Text(worktree.clone()));
+    }
+    if let Some(commit) = &filter.commit {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM commit_sessions c \
+             WHERE c.session_id = {session_column} \
+             AND (c.commit_sha = ? OR c.commit_sha LIKE ?))"
+        ));
+        values.push(Value::Text(commit.clone()));
+        values.push(Value::Text(format!("{commit}%")));
+    }
+    Some((clauses.join(" AND "), values))
+}
+
+/// True when the git-correlation tables exist in `conn`'s database. Search
+/// paths use this to short-circuit git-scoped queries against stores predating
+/// the git-correlation schema (returning empty rather than a `no such table`
+/// error).
+pub(crate) async fn tables_present(conn: &Connection) -> Result<bool, GitCorrelationError> {
+    correlation_tables_present(conn).await
+}
+
+async fn correlation_tables_present(conn: &Connection) -> Result<bool, GitCorrelationError> {
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'table'
+               AND name IN ('session_git_spans', 'commit_sessions')",
+            (),
+        )
+        .await?;
+    let Some(row) = rows.next().await? else {
+        return Ok(false);
+    };
+    Ok(row.get::<i64>(0)? == 2)
+}
+
+async fn span_hits(
+    conn: &Connection,
+    ref_predicate: &str,
+    ref_value: Value,
+    query: &SessionsForQuery,
+    limit: i64,
+) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
+    let mut sql = format!(
+        "SELECT provider, session_id,
+                MIN(first_ts), MAX(last_ts), SUM(event_count), COUNT(*),
+                GROUP_CONCAT(DISTINCT source),
+                GROUP_CONCAT(DISTINCT branch),
+                GROUP_CONCAT(DISTINCT worktree)
+         FROM session_git_spans
+         WHERE {ref_predicate}"
+    );
+    let mut query_params = vec![ref_value];
+    if let Some(since) = query.since {
+        query_params.push(Value::Integer(since));
+        let _ = write!(sql, " AND last_ts >= ?{}", query_params.len());
+    }
+    if let Some(until) = query.until {
+        query_params.push(Value::Integer(until));
+        let _ = write!(sql, " AND first_ts <= ?{}", query_params.len());
+    }
+    query_params.push(Value::Integer(limit));
+    let _ = write!(
+        sql,
+        " GROUP BY provider, session_id
+          ORDER BY MAX(last_ts) DESC
+          LIMIT ?{}",
+        query_params.len()
+    );
+
+    let mut rows = conn.query(&sql, query_params).await?;
+    let mut hits = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let sources: Option<String> = row.get(6)?;
+        let branches: Option<String> = row.get(7)?;
+        let worktrees: Option<String> = row.get(8)?;
+        hits.push(SessionGitCorrelationHit {
+            provider: row.get(0)?,
+            session_id: row.get(1)?,
+            branch: single_concat_value(branches.as_deref()),
+            worktree: single_concat_value(worktrees.as_deref()),
+            first_ts: row.get(2)?,
+            last_ts: row.get(3)?,
+            event_count: row.get::<Option<i64>>(4)?.unwrap_or(0),
+            span_count: row.get::<Option<i64>>(5)?.unwrap_or(0),
+            sources: sources
+                .as_deref()
+                .map(|joined| joined.split(',').map(str::to_string).collect())
+                .unwrap_or_default(),
+            commit_sha: None,
+            committed_at: None,
+            span_overlap_kind: None,
+        });
+    }
+    Ok(hits)
+}
+
+/// A `GROUP_CONCAT(DISTINCT …)` column collapses to its single value when
+/// every aggregated row agreed; report nothing when the rows disagreed
+/// (multiple branches/worktrees for one session) rather than a joined blob.
+fn single_concat_value(joined: Option<&str>) -> Option<String> {
+    joined
+        .filter(|value| !value.is_empty() && !value.contains(','))
+        .map(str::to_string)
+}
+
+async fn commit_hits(
+    conn: &Connection,
+    sha: &str,
+    query: &SessionsForQuery,
+    limit: i64,
+) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
+    let mut sql = "SELECT provider, session_id, branch, worktree,
+                commit_sha, committed_at, span_overlap_kind
+         FROM commit_sessions
+         WHERE (commit_sha = ?1 OR commit_sha LIKE ?2)"
+        .to_string();
+    // `parse_commit_sha` guarantees hex-only input, so the LIKE pattern
+    // cannot contain wildcards other than the appended one.
+    let mut query_params = vec![Value::Text(sha.to_string()), Value::Text(format!("{sha}%"))];
+    if let Some(since) = query.since {
+        query_params.push(Value::Integer(since));
+        let _ = write!(sql, " AND committed_at >= ?{}", query_params.len());
+    }
+    if let Some(until) = query.until {
+        query_params.push(Value::Integer(until));
+        let _ = write!(sql, " AND committed_at <= ?{}", query_params.len());
+    }
+    query_params.push(Value::Integer(limit));
+    let _ = write!(
+        sql,
+        " ORDER BY committed_at DESC LIMIT ?{}",
+        query_params.len()
+    );
+
+    let mut rows = conn.query(&sql, query_params).await?;
+    let mut hits = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let overlap: String = row.get(6)?;
+        hits.push(SessionGitCorrelationHit {
+            provider: row.get(0)?,
+            session_id: row.get(1)?,
+            branch: row.get(2)?,
+            worktree: row.get(3)?,
+            first_ts: None,
+            last_ts: None,
+            event_count: 0,
+            span_count: 0,
+            sources: Vec::new(),
+            commit_sha: row.get(4)?,
+            committed_at: row.get(5)?,
+            span_overlap_kind: SpanOverlapKind::from_db(&overlap),
+        });
+    }
+    Ok(hits)
+}
+
+// ── Historical backfill ─────────────────────────────────────────────────
+//
+// The live path folds observations in as sessions run, but sessions that
+// predate span recording leave only three offline signals: session-store
+// timestamps, global analytics events, and the git reflog. The backfill
+// reconstructs spans and commit attribution from those.
+
+/// One session's declared and message-derived activity bounds, read from the
+/// per-project session store. Any field may be `None` when the source row left
+/// it unset; [`SessionActivityRow::window`] collapses them into a single
+/// `[start, end]` when at least one bound is known.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionActivityRow {
+    pub provider: String,
+    pub session_id: String,
+    pub project_path: String,
+    pub started_at: Option<i64>,
+    pub ended_at: Option<i64>,
+    pub message_min_ts: Option<i64>,
+    pub message_max_ts: Option<i64>,
+}
+
+/// Millisecond/second boundary for stored session timestamps: any value at or
+/// above this is treated as unix millis and divided by 1000 (mirrors
+/// `GlobalDb::latest_session_activity_secs` and `kiro::normalize_timestamp`).
+const UNIX_TIMESTAMP_MILLIS_THRESHOLD: i64 = 1_000_000_000_000;
+
+/// Normalizes a stored session timestamp to unix seconds. Providers persist
+/// either seconds or milliseconds; a millis-scale value left un-normalized
+/// yields a span window ~1000x too wide, so commit attribution (seconds-scale
+/// `git %ct`) never overlaps it and rendered dates land in the far future.
+fn normalize_activity_ts(ts: i64) -> i64 {
+    if ts >= UNIX_TIMESTAMP_MILLIS_THRESHOLD {
+        ts / 1000
+    } else {
+        ts
+    }
+}
+
+impl SessionActivityRow {
+    /// Coarse `[start, end]` window from the widest pair of known bounds, or
+    /// `None` when the session carries no usable timestamp at all. Each bound is
+    /// normalized to unix seconds (see [`normalize_activity_ts`]) so mixed
+    /// seconds/millis rows on legacy stores produce a seconds-scale window.
+    pub fn window(&self) -> Option<(i64, i64)> {
+        let mut lo: Option<i64> = None;
+        let mut hi: Option<i64> = None;
+        for ts in [
+            self.started_at,
+            self.ended_at,
+            self.message_min_ts,
+            self.message_max_ts,
+        ]
+        .into_iter()
+        .flatten()
+        .map(normalize_activity_ts)
+        {
+            lo = Some(lo.map_or(ts, |cur| cur.min(ts)));
+            hi = Some(hi.map_or(ts, |cur| cur.max(ts)));
+        }
+        match (lo, hi) {
+            (Some(lo), Some(hi)) => Some((lo, hi)),
+            _ => None,
+        }
+    }
+}
+
+/// One `HEAD` position in a worktree's reflog timeline: the branch `HEAD`
+/// pointed at starting from `from_ts`, or `None` for a detached-HEAD checkout
+/// (the target was a raw sha, not a branch name).
+pub type BranchTimelineEntry = (i64, Option<String>);
+
+/// Reconstructs a worktree's branch timeline from `git reflog --date=unix`
+/// output on `HEAD`. Only `checkout: moving from X to Y` entries advance the
+/// timeline; each yields `(entry_ts, branch_of(Y))`, where a target that looks
+/// like a raw commit sha is treated as detached HEAD (`None`).
+///
+/// Returned oldest-first (reflog output is newest-first, so this reverses it),
+/// which is the order [`window_branch_segments`] expects. Pure: no IO.
+pub fn branch_timeline_from_reflog(reflog_text: &str) -> Vec<BranchTimelineEntry> {
+    let mut entries: Vec<BranchTimelineEntry> = Vec::new();
+    for line in reflog_text.lines() {
+        if let Some(entry) = parse_reflog_checkout_line(line) {
+            entries.push(entry);
+        }
+    }
+    entries.reverse();
+    entries
+}
+
+/// Parses one `git reflog --date=unix` line, returning `(ts, branch)` when it
+/// is a `checkout: moving from X to Y` entry (`branch` = `None` when `Y` is a
+/// detached sha). Non-checkout and unparseable lines return `None`.
+///
+/// Expected shape: `<sha> HEAD@{<unix>}: checkout: moving from <X> to <Y>`.
+fn parse_reflog_checkout_line(line: &str) -> Option<BranchTimelineEntry> {
+    let ts_open = line.find("HEAD@{")? + "HEAD@{".len();
+    let ts_close = line[ts_open..].find('}')? + ts_open;
+    let ts: i64 = line[ts_open..ts_close].trim().parse().ok()?;
+
+    let rest = line.get(ts_close + 1..)?.trim_start();
+    let message = rest.strip_prefix(':').map_or(rest, str::trim_start);
+    let moving = message.strip_prefix("checkout: moving from ")?;
+    // Split on the last ` to ` so a branch name containing ` to ` in X does
+    // not confuse the split of the target Y.
+    let (_from, to) = moving.rsplit_once(" to ")?;
+    let target = to.trim();
+    if target.is_empty() {
+        return None;
+    }
+    Some((ts, branch_from_checkout_target(target)))
+}
+
+/// Classifies a checkout target: a 7–64 char all-hex token is a detached-HEAD
+/// commit (`None`); anything else is treated as a branch name.
+fn branch_from_checkout_target(target: &str) -> Option<String> {
+    let looks_like_sha =
+        (7..=64).contains(&target.len()) && target.chars().all(|c| c.is_ascii_hexdigit());
+    if looks_like_sha {
+        None
+    } else {
+        Some(target.to_string())
+    }
+}
+
+/// One branch segment of a session's activity window: the branch `HEAD`
+/// pointed at (per the reflog timeline) over `[start, end]`, clamped to the
+/// window. `None` branch = detached HEAD during that stretch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowBranchSegment {
+    pub branch: Option<String>,
+    pub start: i64,
+    pub end: i64,
+}
+
+/// Intersects an activity window `[win_start, win_end]` with a worktree's
+/// branch `timeline` (oldest-first, from [`branch_timeline_from_reflog`]),
+/// yielding the branch segments the session overlapped. The leading stretch —
+/// before the first timeline entry that lands after `win_start` — is
+/// attributed to `initial_branch` (callers pass the branch `HEAD` currently
+/// points at as the floor).
+///
+/// Pure: no IO. Segments are clamped to the window and returned oldest-first.
+pub fn window_branch_segments(
+    win_start: i64,
+    win_end: i64,
+    timeline: &[BranchTimelineEntry],
+    initial_branch: Option<&str>,
+) -> Vec<WindowBranchSegment> {
+    if win_start > win_end {
+        return Vec::new();
+    }
+    let mut current_branch: Option<String> = initial_branch.map(str::to_string);
+    // Advance to the last timeline entry at or before win_start; that entry's
+    // target is the branch HEAD held when the window opened.
+    let mut idx = 0;
+    while idx < timeline.len() && timeline[idx].0 <= win_start {
+        current_branch.clone_from(&timeline[idx].1);
+        idx += 1;
+    }
+    let mut segments: Vec<WindowBranchSegment> = Vec::new();
+    let mut seg_start = win_start;
+    while idx < timeline.len() && timeline[idx].0 <= win_end {
+        let (change_ts, next_branch) = &timeline[idx];
+        // Only a *real* branch change ends the current segment; a checkout that
+        // lands back on the same branch (or reflog noise) must not fragment it.
+        if *next_branch != current_branch && *change_ts > seg_start {
+            segments.push(WindowBranchSegment {
+                branch: current_branch.clone(),
+                start: seg_start,
+                end: *change_ts,
+            });
+            seg_start = *change_ts;
+        }
+        current_branch.clone_from(next_branch);
+        idx += 1;
+    }
+    if seg_start <= win_end {
+        segments.push(WindowBranchSegment {
+            branch: current_branch,
+            start: seg_start,
+            end: win_end,
+        });
+    }
+    segments
+}
+
+/// Reason a session was skipped by the backfill (counted and reported).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackfillSkipReason {
+    /// Session had no usable timestamp in any signal source.
+    NoActivityWindow,
+    /// `project_path` was empty or not a resolvable git worktree.
+    NotAWorktree,
+    /// A git command for this session's repo failed; failed open.
+    GitError,
+}
+
+impl BackfillSkipReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NoActivityWindow => "no_activity_window",
+            Self::NotAWorktree => "not_a_worktree",
+            Self::GitError => "git_error",
+        }
+    }
+}
+
+/// Tunables for [`run_backfill`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackfillOptions {
+    /// Inclusive lower bound (unix seconds) on session activity and commit
+    /// times. Sessions whose activity ends before this are skipped.
+    pub since: i64,
+    /// Maximum number of sessions to scan.
+    pub limit_sessions: usize,
+    /// Span merge gap forwarded to [`record_span_observation`].
+    pub merge_gap_secs: i64,
+    /// Hard cap on commits parsed from a single `git log` invocation.
+    pub max_commits_per_repo: usize,
+    /// When true, derive and count everything but write nothing.
+    pub dry_run: bool,
+}
+
+impl Default for BackfillOptions {
+    fn default() -> Self {
+        Self {
+            since: 0,
+            limit_sessions: 500,
+            merge_gap_secs: DEFAULT_SPAN_MERGE_GAP_SECS,
+            max_commits_per_repo: 5_000,
+            dry_run: false,
+        }
+    }
+}
+
+/// Outcome counters for one backfill run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BackfillStats {
+    pub sessions_scanned: usize,
+    pub spans_written: usize,
+    pub commits_attributed: usize,
+    pub skipped_no_window: usize,
+    pub skipped_not_worktree: usize,
+    pub skipped_git_error: usize,
+}
+
+impl BackfillStats {
+    fn record_skip(&mut self, reason: BackfillSkipReason) {
+        match reason {
+            BackfillSkipReason::NoActivityWindow => self.skipped_no_window += 1,
+            BackfillSkipReason::NotAWorktree => self.skipped_not_worktree += 1,
+            BackfillSkipReason::GitError => self.skipped_git_error += 1,
+        }
+    }
+
+    pub const fn skipped_total(&self) -> usize {
+        self.skipped_no_window + self.skipped_not_worktree + self.skipped_git_error
+    }
+}
+
+/// Abstracts the git subprocess surface the backfill needs, so tests can run
+/// the core against a real repo ([`SystemGit`]) or a canned fixture.
+pub trait GitReflogSource {
+    /// `git reflog --date=unix HEAD` text for `worktree`, or `None` on error.
+    fn reflog(&self, worktree: &std::path::Path) -> Option<String>;
+    /// The branch `HEAD` currently points at in `worktree` (`None` = detached
+    /// or unknown), used as the leading-segment floor.
+    fn current_branch(&self, worktree: &std::path::Path) -> Option<String>;
+    /// `git log <branch> --pretty=%H %ct --since=<since>` text for `worktree`,
+    /// newest-first. `None` on error.
+    fn commit_log(&self, worktree: &std::path::Path, branch: &str, since: i64) -> Option<String>;
+}
+
+/// Real git-subprocess implementation of [`GitReflogSource`].
+pub struct SystemGit;
+
+impl SystemGit {
+    fn output(worktree: &std::path::Path, args: &[&str]) -> Option<String> {
+        let output = std::process::Command::new(crate::git::git_program())
+            .args(args)
+            .current_dir(worktree)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8(output.stdout).ok()
+    }
+}
+
+impl GitReflogSource for SystemGit {
+    fn reflog(&self, worktree: &std::path::Path) -> Option<String> {
+        Self::output(worktree, &["reflog", "--date=unix", "HEAD"])
+    }
+
+    fn current_branch(&self, worktree: &std::path::Path) -> Option<String> {
+        let raw = Self::output(worktree, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() || trimmed == "HEAD" {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn commit_log(&self, worktree: &std::path::Path, branch: &str, since: i64) -> Option<String> {
+        Self::output(
+            worktree,
+            &[
+                "log",
+                branch,
+                "--pretty=%H %ct",
+                &format!("--since={since}"),
+            ],
+        )
+    }
+}
+
+/// Parses `git log --pretty=%H %ct` output into `(sha, committed_at)` pairs,
+/// capping at `max`. Malformed and non-hex lines are skipped. Pure.
+pub fn parse_commit_log(log_text: &str, max: usize) -> Vec<(String, i64)> {
+    let mut commits = Vec::new();
+    for line in log_text.lines() {
+        if commits.len() >= max {
+            break;
+        }
+        let mut parts = line.split_whitespace();
+        let Some(sha) = parts.next() else { continue };
+        let Some(ts) = parts.next().and_then(|t| t.parse::<i64>().ok()) else {
+            continue;
+        };
+        if sha.len() >= 7 && sha.chars().all(|c| c.is_ascii_hexdigit()) {
+            commits.push((sha.to_ascii_lowercase(), ts));
+        }
+    }
+    commits
+}
+
+/// Runs the historical backfill against one project's session store.
+///
+/// `session_store` is the per-project `sessions.db` (already open, and — for a
+/// real run — writable). `analytics_events` are global analytics rows whose
+/// `session_id` matches a scanned session; only their timestamps are consumed
+/// (branch data is never assumed present). `git` supplies the reflog/log
+/// subprocess surface. Fail-open: a broken repo or session is counted and
+/// skipped, never aborting the run.
+///
+/// When `opts.dry_run` is set no rows are written; the returned counts reflect
+/// what *would* have been written.
+pub async fn run_backfill(
+    session_store: &crate::global_db::GlobalDb,
+    analytics_events: &[crate::global_db::AnalyticsEventRecord],
+    git: &dyn GitReflogSource,
+    opts: &BackfillOptions,
+) -> Result<BackfillStats, GitCorrelationError> {
+    let mut stats = BackfillStats::default();
+    let rows = session_store
+        .session_activity_rows(opts.limit_sessions)
+        .await
+        .map_err(GitCorrelationError::Db)?;
+
+    // Index analytics timestamps by (provider, session_id) for O(1) lookup.
+    let mut analytics_ts: std::collections::HashMap<(String, String), Vec<i64>> =
+        std::collections::HashMap::new();
+    for event in analytics_events {
+        if let Some(session_id) = event.session_id.as_deref() {
+            analytics_ts
+                .entry((event.provider.clone(), session_id.to_string()))
+                .or_default()
+                .push(event.timestamp);
+        }
+    }
+
+    for row in &rows {
+        stats.sessions_scanned += 1;
+        if let Err(reason) =
+            backfill_one_session(session_store, git, opts, row, &analytics_ts, &mut stats).await
+        {
+            stats.record_skip(reason);
+        }
+    }
+    Ok(stats)
+}
+
+async fn backfill_one_session(
+    session_store: &crate::global_db::GlobalDb,
+    git: &dyn GitReflogSource,
+    opts: &BackfillOptions,
+    row: &SessionActivityRow,
+    analytics_ts: &std::collections::HashMap<(String, String), Vec<i64>>,
+    stats: &mut BackfillStats,
+) -> Result<(), BackfillSkipReason> {
+    let (mut win_start, win_end) = row.window().ok_or(BackfillSkipReason::NoActivityWindow)?;
+    if win_end < opts.since {
+        return Err(BackfillSkipReason::NoActivityWindow);
+    }
+    win_start = win_start.max(opts.since);
+    if win_start > win_end {
+        return Err(BackfillSkipReason::NoActivityWindow);
+    }
+
+    if row.project_path.trim().is_empty() {
+        return Err(BackfillSkipReason::NotAWorktree);
+    }
+    let worktree_path = std::path::Path::new(row.project_path.trim());
+    let worktree_root = crate::worktree::git_worktree_root(worktree_path)
+        .ok_or(BackfillSkipReason::NotAWorktree)?;
+    let worktree = normalize_worktree(&worktree_root.to_string_lossy());
+
+    let reflog_text = git
+        .reflog(&worktree_root)
+        .ok_or(BackfillSkipReason::GitError)?;
+    let timeline = branch_timeline_from_reflog(&reflog_text);
+    let current_branch = git.current_branch(&worktree_root);
+
+    // Extra observation timestamps: analytics event times inside the
+    // (since-clamped) window, which refine span boundaries within a segment.
+    let mut analytics_within: Vec<i64> = Vec::new();
+    if let Some(times) = analytics_ts.get(&(row.provider.clone(), row.session_id.clone())) {
+        for &ts in times {
+            if ts >= win_start && ts <= win_end {
+                analytics_within.push(ts);
+            }
+        }
+    }
+
+    let segments = window_branch_segments(win_start, win_end, &timeline, current_branch.as_deref());
+
+    for segment in &segments {
+        // Every segment yields a span: seed it with its own clamped edges so an
+        // interior segment (e.g. a mid-session branch switch) is recorded even
+        // when the global window edges fall outside it. Analytics timestamps
+        // inside the segment refine the boundaries; record_span_observation
+        // merges observations on the same branch within the merge gap.
+        let mut segment_ts = vec![segment.start, segment.end];
+        segment_ts.extend(
+            analytics_within
+                .iter()
+                .copied()
+                .filter(|&ts| ts >= segment.start && ts <= segment.end),
+        );
+        for &ts in &segment_ts {
+            if !opts.dry_run {
+                session_store
+                    .git_record_span_observation(
+                        &SpanObservation {
+                            provider: row.provider.clone(),
+                            session_id: row.session_id.clone(),
+                            thread_id: None,
+                            branch: segment.branch.clone(),
+                            worktree: worktree.clone(),
+                            ts,
+                            source: SpanSource::Backfill,
+                        },
+                        opts.merge_gap_secs,
+                    )
+                    .await
+                    .map_err(|_| BackfillSkipReason::GitError)?;
+            }
+        }
+        stats.spans_written += 1;
+
+        // Attribute commits on this segment's branch within the segment window.
+        let Some(branch) = segment.branch.as_deref() else {
+            continue;
+        };
+        let Some(log_text) = git.commit_log(&worktree_root, branch, segment.start) else {
+            continue;
+        };
+        for (sha, committed_at) in parse_commit_log(&log_text, opts.max_commits_per_repo) {
+            if committed_at < segment.start || committed_at > segment.end {
+                continue;
+            }
+            if opts.dry_run {
+                stats.commits_attributed += 1;
+                continue;
+            }
+            let inserted = session_store
+                .git_upsert_commit_session(&CommitSessionRecord {
+                    commit_sha: sha,
+                    provider: row.provider.clone(),
+                    session_id: row.session_id.clone(),
+                    branch: Some(branch.to_string()),
+                    worktree: Some(worktree.clone()),
+                    committed_at,
+                    span_overlap_kind: SpanOverlapKind::WithinSpan,
+                    span_id: None,
+                })
+                .await
+                .map_err(|_| BackfillSkipReason::GitError)?;
+            if inserted {
+                stats.commits_attributed += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reads per-session activity windows for the backfill. See
+/// [`crate::global_db::GlobalDb::session_activity_rows`].
+pub(crate) async fn session_activity_rows(
+    conn: &Connection,
+    limit: usize,
+) -> Result<Vec<SessionActivityRow>, String> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let mut rows = conn
+        .query(
+            "SELECT s.provider, s.session_id, s.project_path,
+                    s.started_at, s.ended_at,
+                    MIN(m.timestamp), MAX(m.timestamp)
+             FROM sessions s
+             LEFT JOIN session_messages m
+                    ON m.provider = s.provider AND m.session_id = s.session_id
+             GROUP BY s.provider, s.session_id
+             ORDER BY COALESCE(MAX(m.timestamp), s.ended_at, s.started_at) DESC
+             LIMIT ?1",
+            params![i64::try_from(limit).unwrap_or(i64::MAX)],
+        )
+        .await
+        .map_err(|e| format!("failed to query session activity rows: {e}"))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("failed to read session activity row: {e}"))?
+    {
+        out.push(SessionActivityRow {
+            provider: row
+                .get(0)
+                .map_err(|e| format!("failed to decode provider: {e}"))?,
+            session_id: row
+                .get(1)
+                .map_err(|e| format!("failed to decode session_id: {e}"))?,
+            project_path: row
+                .get(2)
+                .map_err(|e| format!("failed to decode project_path: {e}"))?,
+            started_at: row
+                .get(3)
+                .map_err(|e| format!("failed to decode started_at: {e}"))?,
+            ended_at: row
+                .get(4)
+                .map_err(|e| format!("failed to decode ended_at: {e}"))?,
+            message_min_ts: row
+                .get(5)
+                .map_err(|e| format!("failed to decode message_min_ts: {e}"))?,
+            message_max_ts: row
+                .get(6)
+                .map_err(|e| format!("failed to decode message_max_ts: {e}"))?,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use libsql::Builder;
+
+    use super::*;
+
+    fn observation(
+        session_id: &str,
+        branch: Option<&str>,
+        worktree: &str,
+        ts: i64,
+    ) -> SpanObservation {
+        SpanObservation {
+            provider: "claude".to_string(),
+            session_id: session_id.to_string(),
+            thread_id: None,
+            branch: branch.map(str::to_string),
+            worktree: worktree.to_string(),
+            ts,
+            source: SpanSource::HookRoute,
+        }
+    }
+
+    async fn test_conn() -> Connection {
+        let db = Builder::new_local(":memory:")
+            .build()
+            .await
+            .expect("in-memory db");
+        let conn = db.connect().expect("connect");
+        ensure_git_correlation_schema(&conn)
+            .await
+            .expect("schema should apply");
+        conn
+    }
+
+    #[test]
+    fn normalize_worktree_strips_trailing_slashes_and_backslashes() {
+        assert_eq!(normalize_worktree("/repo/wt/"), "/repo/wt");
+        assert_eq!(normalize_worktree("  /repo/wt  "), "/repo/wt");
+        assert_eq!(normalize_worktree("/repo/wt///"), "/repo/wt");
+        assert_eq!(normalize_worktree("/"), "/");
+        assert_eq!(normalize_worktree("C:\\repo\\wt\\"), "C:/repo/wt");
+    }
+
+    #[test]
+    fn git_ref_filter_parses_and_validates_kinds() {
+        assert_eq!(
+            GitRefFilter::parse("branch", " feature/x "),
+            Ok(GitRefFilter::Branch("feature/x".to_string()))
+        );
+        assert_eq!(
+            GitRefFilter::parse("worktree", "/repo/wt/"),
+            Ok(GitRefFilter::Worktree("/repo/wt".to_string()))
+        );
+        assert_eq!(
+            GitRefFilter::parse("commit", "ABCDEF12"),
+            Ok(GitRefFilter::Commit("abcdef12".to_string()))
+        );
+        assert!(GitRefFilter::parse("commit", "abc").is_err());
+        assert!(GitRefFilter::parse("commit", "not-hex-at-all").is_err());
+        assert!(GitRefFilter::parse("tag", "v1.0").is_err());
+        assert!(GitRefFilter::parse("branch", "   ").is_err());
+    }
+
+    #[test]
+    fn observation_extends_span_only_within_gap() {
+        assert!(observation_extends_span(100, 200, 150, 60));
+        assert!(observation_extends_span(100, 200, 260, 60));
+        assert!(observation_extends_span(100, 200, 40, 60));
+        assert!(!observation_extends_span(100, 200, 261, 60));
+        assert!(!observation_extends_span(100, 200, 39, 60));
+    }
+
+    #[test]
+    fn git_scope_filter_reports_emptiness_and_validates_commit() {
+        let empty = GitScopeFilter::from_args(None, Some("  "), None).unwrap();
+        assert!(empty.is_empty());
+        let filter =
+            GitScopeFilter::from_args(Some("main"), Some("/repo/"), Some("ABC123")).unwrap();
+        assert_eq!(filter.branch.as_deref(), Some("main"));
+        assert_eq!(filter.worktree.as_deref(), Some("/repo"));
+        assert_eq!(filter.commit.as_deref(), Some("abc123"));
+        assert!(GitScopeFilter::from_args(None, None, Some("xyz")).is_err());
+    }
+
+    #[tokio::test]
+    async fn schema_is_idempotent() {
+        let conn = test_conn().await;
+        ensure_git_correlation_schema(&conn)
+            .await
+            .expect("second ensure should be a no-op");
+    }
+
+    #[tokio::test]
+    async fn observations_merge_within_gap_and_split_on_branch_switch() {
+        let conn = test_conn().await;
+        let first =
+            record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_000), 600)
+                .await
+                .unwrap();
+        let merged =
+            record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_300), 600)
+                .await
+                .unwrap();
+        assert_eq!(first, merged, "in-gap observation should extend the span");
+
+        // Branch switch mid-session opens a second span; switching back
+        // within the gap of the first span extends it again (A → B → A).
+        let switched =
+            record_span_observation(&conn, &observation("s1", Some("feat"), "/repo", 1_400), 600)
+                .await
+                .unwrap();
+        assert_ne!(first, switched);
+        let back =
+            record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_700), 600)
+                .await
+                .unwrap();
+        assert_eq!(first, back);
+
+        // Out-of-gap observation on the same branch opens a new span.
+        let idle_gap =
+            record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 9_000), 600)
+                .await
+                .unwrap();
+        assert_ne!(first, idle_gap);
+
+        // Detached HEAD (branch = NULL) never merges into a named span.
+        let detached =
+            record_span_observation(&conn, &observation("s1", None, "/repo", 1_750), 600)
+                .await
+                .unwrap();
+        assert_ne!(first, detached);
+    }
+
+    #[tokio::test]
+    async fn sessions_for_branch_worktree_and_commit_round_trip() {
+        let conn = test_conn().await;
+        record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_000), 600)
+            .await
+            .unwrap();
+        record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_200), 600)
+            .await
+            .unwrap();
+        record_span_observation(
+            &conn,
+            &observation("s2", Some("main"), "/repo/wt", 5_000),
+            600,
+        )
+        .await
+        .unwrap();
+        record_span_observation(&conn, &observation("s3", Some("feat"), "/repo", 2_000), 600)
+            .await
+            .unwrap();
+
+        let hits = sessions_for(
+            &conn,
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Branch("main".to_string()),
+                since: None,
+                until: None,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].session_id, "s2", "most recent activity first");
+        assert_eq!(hits[1].session_id, "s1");
+        assert_eq!(hits[1].event_count, 2);
+        assert_eq!(hits[1].span_count, 1);
+        assert_eq!(hits[1].first_ts, Some(1_000));
+        assert_eq!(hits[1].last_ts, Some(1_200));
+        assert_eq!(hits[1].sources, vec!["hook_route".to_string()]);
+        assert_eq!(hits[1].branch.as_deref(), Some("main"));
+        assert_eq!(hits[1].worktree.as_deref(), Some("/repo"));
+
+        // Time-scoped: only the span overlapping [4000, 6000] survives.
+        let scoped = sessions_for(
+            &conn,
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Branch("main".to_string()),
+                since: Some(4_000),
+                until: Some(6_000),
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].session_id, "s2");
+
+        let by_worktree = sessions_for(
+            &conn,
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Worktree("/repo/wt".to_string()),
+                since: None,
+                until: None,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(by_worktree.len(), 1);
+        assert_eq!(by_worktree[0].session_id, "s2");
+
+        let record = CommitSessionRecord {
+            commit_sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+            provider: "claude".to_string(),
+            session_id: "s1".to_string(),
+            branch: Some("main".to_string()),
+            worktree: Some("/repo".to_string()),
+            committed_at: 1_150,
+            span_overlap_kind: SpanOverlapKind::WithinSpan,
+            span_id: None,
+        };
+        assert!(upsert_commit_session(&conn, &record).await.unwrap());
+        assert!(
+            !upsert_commit_session(&conn, &record).await.unwrap(),
+            "second upsert should be an idempotent no-op"
+        );
+
+        let by_commit = sessions_for(
+            &conn,
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Commit("abcdef12".to_string()),
+                since: None,
+                until: None,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(by_commit.len(), 1);
+        assert_eq!(by_commit[0].session_id, "s1");
+        assert_eq!(
+            by_commit[0].commit_sha.as_deref(),
+            Some("abcdef1234567890abcdef1234567890abcdef12")
+        );
+        assert_eq!(by_commit[0].committed_at, Some(1_150));
+        assert_eq!(
+            by_commit[0].span_overlap_kind,
+            Some(SpanOverlapKind::WithinSpan)
+        );
+    }
+
+    #[test]
+    fn branch_timeline_parses_checkouts_and_detached_and_skips_noise() {
+        let reflog = concat!(
+            "def456 HEAD@{1700000300}: commit: work on feat\n",
+            "def456 HEAD@{1700000200}: checkout: moving from main to feat\n",
+            "abc123 HEAD@{1700000150}: checkout: moving from feat to a1b2c3d4e5f6\n",
+            "abc123 HEAD@{1700000100}: checkout: moving from a1b2c3d4e5f6 to main\n",
+            "abc123 HEAD@{1700000050}: clone: from origin\n",
+        );
+        let timeline = branch_timeline_from_reflog(reflog);
+        // Oldest-first, only checkout lines, detached HEAD → None.
+        assert_eq!(
+            timeline,
+            vec![
+                (1_700_000_100, Some("main".to_string())),
+                (1_700_000_150, None),
+                (1_700_000_200, Some("feat".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn branch_timeline_ignores_unparseable_lines() {
+        assert!(branch_timeline_from_reflog("").is_empty());
+        assert!(branch_timeline_from_reflog("garbage without a head marker").is_empty());
+        // Non-checkout HEAD entries do not advance the timeline.
+        assert!(
+            branch_timeline_from_reflog("abc HEAD@{1700000000}: reset: moving to HEAD").is_empty()
+        );
+    }
+
+    #[test]
+    fn window_segments_split_on_mid_window_branch_switch() {
+        // Session ran [100, 300]; HEAD switched main→feat at 200.
+        let timeline = vec![
+            (150, Some("main".to_string())),
+            (200, Some("feat".to_string())),
+        ];
+        let segments = window_branch_segments(100, 300, &timeline, Some("main"));
+        assert_eq!(
+            segments,
+            vec![
+                WindowBranchSegment {
+                    branch: Some("main".to_string()),
+                    start: 100,
+                    end: 200,
+                },
+                WindowBranchSegment {
+                    branch: Some("feat".to_string()),
+                    start: 200,
+                    end: 300,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn window_segments_use_initial_branch_before_first_entry() {
+        // No timeline entry inside the window → whole window is initial_branch.
+        let segments = window_branch_segments(100, 300, &[], Some("main"));
+        assert_eq!(
+            segments,
+            vec![WindowBranchSegment {
+                branch: Some("main".to_string()),
+                start: 100,
+                end: 300,
+            }]
+        );
+        // An entry at or before win_start sets the floor branch.
+        let timeline = vec![(50, Some("feat".to_string()))];
+        let segments = window_branch_segments(100, 300, &timeline, Some("main"));
+        assert_eq!(segments[0].branch.as_deref(), Some("feat"));
+    }
+
+    #[test]
+    fn window_segments_empty_when_start_after_end() {
+        assert!(window_branch_segments(300, 100, &[], Some("main")).is_empty());
+    }
+
+    #[test]
+    fn session_activity_row_window_spans_widest_bounds() {
+        let row = SessionActivityRow {
+            provider: "claude".to_string(),
+            session_id: "s1".to_string(),
+            project_path: "/repo".to_string(),
+            started_at: Some(200),
+            ended_at: None,
+            message_min_ts: Some(150),
+            message_max_ts: Some(400),
+        };
+        assert_eq!(row.window(), Some((150, 400)));
+        let empty = SessionActivityRow {
+            started_at: None,
+            ended_at: None,
+            message_min_ts: None,
+            message_max_ts: None,
+            ..row
+        };
+        assert_eq!(empty.window(), None);
+    }
+
+    #[test]
+    fn session_activity_row_window_normalizes_millis_bounds() {
+        // Legacy/mixed stores can hold millisecond-scale message timestamps
+        // (see `latest_session_activity_secs`). Left un-normalized the window
+        // would be ~1000x too wide, so a seconds-scale git commit time could
+        // never fall inside it. `window()` must collapse to the seconds scale.
+        let commit_ts = 1_700_000_500; // seconds-scale git %ct
+        let row = SessionActivityRow {
+            provider: "claude".to_string(),
+            session_id: "s1".to_string(),
+            project_path: "/repo".to_string(),
+            started_at: None,
+            ended_at: None,
+            message_min_ts: Some(1_700_000_000_000), // millis
+            message_max_ts: Some(1_700_001_000_000), // millis
+        };
+        let (start, end) = row.window().expect("window from millis bounds");
+        assert_eq!((start, end), (1_700_000_000, 1_700_001_000));
+        // The seconds-scale commit now lands inside the seconds-scale span,
+        // which a millis-scale window could never contain.
+        assert_eq!(
+            commit_overlap_kind(start, end, commit_ts, 600),
+            Some(SpanOverlapKind::WithinSpan)
+        );
+    }
+
+    #[test]
+    fn parse_commit_log_skips_malformed_and_caps() {
+        let log = concat!(
+            "ABCDEF1234 1700000000\n",
+            "not-a-sha 1700000100\n",
+            "deadbeef xyz\n",
+            "cafebabe 1700000200\n",
+        );
+        let commits = parse_commit_log(log, 10);
+        assert_eq!(
+            commits,
+            vec![
+                ("abcdef1234".to_string(), 1_700_000_000),
+                ("cafebabe".to_string(), 1_700_000_200),
+            ]
+        );
+        assert_eq!(parse_commit_log(log, 1).len(), 1);
+    }
+
+    #[test]
+    fn debounce_suppresses_bursts_but_admits_after_interval() {
+        let mut debounce = SpanObservationDebounce::new();
+        let key = span_debounce_key("", "s1", Some("main"), "/repo");
+        // First observation always writes; a burst inside the interval is
+        // suppressed; a later observation past the interval writes again.
+        assert!(debounce.should_record(&key, 1_000, 30));
+        assert!(!debounce.should_record(&key, 1_005, 30));
+        assert!(!debounce.should_record(&key, 1_029, 30));
+        assert!(debounce.should_record(&key, 1_030, 30));
+        assert!(!debounce.should_record(&key, 1_040, 30));
+    }
+
+    #[test]
+    fn debounce_keys_separate_branch_and_worktree_and_detached() {
+        let mut debounce = SpanObservationDebounce::new();
+        let main = span_debounce_key("", "s1", Some("main"), "/repo");
+        let feat = span_debounce_key("", "s1", Some("feat"), "/repo");
+        let other_wt = span_debounce_key("", "s1", Some("main"), "/repo/wt");
+        let detached = span_debounce_key("", "s1", None, "/repo");
+        // A branch switch is never debounced away by a prior branch's write.
+        assert!(debounce.should_record(&main, 1_000, 30));
+        assert!(debounce.should_record(&feat, 1_001, 30));
+        assert!(debounce.should_record(&other_wt, 1_002, 30));
+        assert!(debounce.should_record(&detached, 1_003, 30));
+        // Distinct keys for the four cases.
+        assert_ne!(main, feat);
+        assert_ne!(main, other_wt);
+        assert_ne!(main, detached);
+    }
+
+    #[test]
+    fn debounce_admits_out_of_order_older_observation() {
+        let mut debounce = SpanObservationDebounce::new();
+        let key = span_debounce_key("", "s1", Some("main"), "/repo");
+        assert!(debounce.should_record(&key, 1_000, 30));
+        // An out-of-order (older) timestamp is never suppressed.
+        assert!(debounce.should_record(&key, 900, 30));
+    }
+
+    #[test]
+    fn commit_overlap_kind_classifies_within_extended_and_outside() {
+        assert_eq!(
+            commit_overlap_kind(100, 200, 150, 60),
+            Some(SpanOverlapKind::WithinSpan)
+        );
+        assert_eq!(
+            commit_overlap_kind(100, 200, 100, 60),
+            Some(SpanOverlapKind::WithinSpan)
+        );
+        assert_eq!(
+            commit_overlap_kind(100, 200, 260, 60),
+            Some(SpanOverlapKind::ExtendedWindow)
+        );
+        assert_eq!(
+            commit_overlap_kind(100, 200, 40, 60),
+            Some(SpanOverlapKind::ExtendedWindow)
+        );
+        assert_eq!(commit_overlap_kind(100, 200, 261, 60), None);
+        assert_eq!(commit_overlap_kind(100, 200, 39, 60), None);
+    }
+
+    #[test]
+    fn match_commit_to_spans_filters_by_branch_worktree_and_window() {
+        let spans = vec![
+            SpanWindow {
+                span_id: 1,
+                provider: "claude".to_string(),
+                session_id: "s1".to_string(),
+                branch: Some("main".to_string()),
+                worktree: "/repo".to_string(),
+                first_ts: 100,
+                last_ts: 200,
+            },
+            // Concurrent session on the same branch/worktree.
+            SpanWindow {
+                span_id: 2,
+                provider: String::new(),
+                session_id: "s2".to_string(),
+                branch: Some("main".to_string()),
+                worktree: "/repo".to_string(),
+                first_ts: 120,
+                last_ts: 190,
+            },
+            // Different branch — must not match a main commit.
+            SpanWindow {
+                span_id: 3,
+                provider: "claude".to_string(),
+                session_id: "s3".to_string(),
+                branch: Some("feat".to_string()),
+                worktree: "/repo".to_string(),
+                first_ts: 100,
+                last_ts: 200,
+            },
+            // Different worktree — must not match.
+            SpanWindow {
+                span_id: 4,
+                provider: "claude".to_string(),
+                session_id: "s4".to_string(),
+                branch: Some("main".to_string()),
+                worktree: "/repo/wt".to_string(),
+                first_ts: 100,
+                last_ts: 200,
+            },
+        ];
+
+        // A within-window commit is attributed to both concurrent main spans.
+        let records = match_commit_to_spans("deadbeef", Some("main"), "/repo", 150, &spans, 60);
+        assert_eq!(records.len(), 2);
+        let ids: Vec<i64> = records.iter().filter_map(|r| r.span_id).collect();
+        assert_eq!(ids, vec![1, 2]);
+        assert!(records
+            .iter()
+            .all(|r| r.span_overlap_kind == SpanOverlapKind::WithinSpan));
+        assert_eq!(records[0].session_id, "s1");
+        assert_eq!(records[0].worktree.as_deref(), Some("/repo"));
+
+        // A just-past-the-edge commit lands in the extended window only.
+        let extended = match_commit_to_spans("cafef00d", Some("main"), "/repo", 250, &spans, 60);
+        assert_eq!(extended.len(), 2);
+        assert!(extended
+            .iter()
+            .all(|r| r.span_overlap_kind == SpanOverlapKind::ExtendedWindow));
+
+        // A commit outside every window attributes nothing.
+        assert!(
+            match_commit_to_spans("beefcafe", Some("main"), "/repo", 500, &spans, 60).is_empty()
+        );
+        // A commit on an unrecorded branch attributes nothing.
+        assert!(
+            match_commit_to_spans("beefcafe", Some("other"), "/repo", 150, &spans, 60).is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_attribution_sweep_attributes_and_advances_watermark() {
+        let conn = test_conn().await;
+        // One session active on main in /repo over [1000, 2000]. The 1000-wide
+        // gap between the two observations exceeds the 600 merge gap, so a third
+        // in-window observation keeps them a single contiguous span.
+        record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_000), 600)
+            .await
+            .unwrap();
+        record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 1_500), 600)
+            .await
+            .unwrap();
+        record_span_observation(&conn, &observation("s1", Some("main"), "/repo", 2_000), 600)
+            .await
+            .unwrap();
+
+        // Sweep with an injected scan returning one in-window commit.
+        let inserted = run_commit_attribution_sweep(&conn, 600, |target| {
+            assert_eq!(target.branch.as_deref(), Some("main"));
+            assert_eq!(target.worktree, "/repo");
+            vec![ScannedCommit {
+                sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+                committed_at: 1_500,
+            }]
+        })
+        .await
+        .unwrap();
+        assert_eq!(inserted, 1);
+
+        // The commit is now queryable by prefix.
+        let hits = sessions_for(
+            &conn,
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Commit("abcdef12".to_string()),
+                since: None,
+                until: None,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].session_id, "s1");
+        assert_eq!(hits[0].span_overlap_kind, Some(SpanOverlapKind::WithinSpan));
+
+        // Re-running the sweep is idempotent: even if the boundary span is
+        // re-scanned (watermark uses `>=` so nothing is ever missed), the
+        // commit is already attributed and the upsert inserts nothing more.
+        let again = run_commit_attribution_sweep(&conn, 600, |_| {
+            vec![ScannedCommit {
+                sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+                committed_at: 1_500,
+            }]
+        })
+        .await
+        .unwrap();
+        assert_eq!(again, 0, "re-attribution of the same commit is a no-op");
+    }
+}

--- a/src/sessions/git_correlation.rs
+++ b/src/sessions/git_correlation.rs
@@ -1,53 +1,18 @@
-//! Session ↔ git correlation index.
+//! Session/git correlation index.
 //!
-//! Correlates agent sessions (and their LCM messages) with the git artifacts
-//! they touched: branches, worktrees, and commits. The raw signals already
-//! exist — hook route metadata carries `(session_id, thread_id, cwd,
-//! worktree, branch)` per tool use, and the session store has every ingested
-//! message with timestamps — but they were never joined. This module owns the
-//! join tables and their query API.
-//!
-//! ## Where the index lives
-//!
-//! The tables live in the **per-project session store** (`sessions.db`, the
-//! same file that holds `sessions`, `session_messages`, and the LCM tables;
-//! see [`crate::global_db::GlobalDb::open_at`]). Rationale:
-//!
-//! - Every query surface joins against `sessions` / `session_messages` /
-//!   `lcm_raw_messages`, which are per-project rows. Keeping the correlation
-//!   rows in the same file makes branch/worktree/commit filters a plain SQL
-//!   join instead of a cross-database merge.
-//! - Branches, worktrees, and commits are inherently project-scoped: a
-//!   branch name is only meaningful relative to one repository.
-//! - Hook route rows in the global analytics store are a *signal source*,
-//!   not a query surface: live attribution and the backfill command resolve
-//!   each observation's project (via its worktree/cwd) and write the span
-//!   into that project's store.
-//!
-//! ## Model
-//!
-//! Sessions can switch branches (and hop worktrees) mid-session, so
-//! attribution is **span-based**: a [`SessionGitSpan`] says "session S was
-//! active on branch B in worktree W between `first_ts` and `last_ts`".
-//! Repeated observations of the same (session, branch, worktree) extend the
-//! newest matching span when they arrive within a merge gap; a branch switch
-//! (or a long silence) starts a new span, so A → B → A produces three spans.
-//!
-//! A commit is attributed to a session when its commit time falls inside a
-//! session span on the same branch/worktree (see [`SpanOverlapKind`]); the
-//! result is a [`CommitSessionRecord`] row keyed by `(commit_sha, provider,
-//! session_id)`.
+//! Stores branch/worktree spans and commit attribution in the per-project
+//! `sessions.db`, alongside `sessions`, `session_messages`, and LCM tables.
+//! Sessions can switch branches or worktrees, so attribution is span-based:
+//! repeated observations widen nearby spans, while branch switches or long
+//! gaps open new spans.
 
+use std::collections::HashSet;
 use std::fmt::Write as _;
 
 use libsql::{params, Connection, Value};
 use serde::{Deserialize, Serialize};
 
-/// Schema version recorded in `session_schema_migrations` under
-/// [`MIGRATION_NAME`]. Bump when the DDL below changes shape.
-///
-/// - v1: `session_git_spans` + `commit_sessions`.
-/// - v2: `git_correlation_meta` key/value table for sweep watermarks.
+/// Schema version recorded in `session_schema_migrations`.
 pub const GIT_CORRELATION_SCHEMA_VERSION: i64 = 2;
 
 const MIGRATION_NAME: &str = "git_correlation";
@@ -370,20 +335,13 @@ pub fn observation_extends_span(first_ts: i64, last_ts: i64, ts: i64, gap_secs: 
     ts >= first_ts.saturating_sub(gap_secs) && ts <= last_ts.saturating_add(gap_secs)
 }
 
-/// In-process rate limiter for live hook-route span observations. A burst of
-/// tool-use hook events for one `(provider, session, branch, worktree)` key
-/// arrives far faster than spans need re-widening (spans merge anyway), so at
-/// most one DB write per `min_interval_secs` per key is recorded. Purely
-/// advisory: dropping an observation only widens a span slightly less, never
-/// loses attribution, so this never has to persist across restarts.
+/// In-process rate limiter for live hook-route span observations.
 #[derive(Debug, Default)]
 pub struct SpanObservationDebounce {
     last_write: std::collections::HashMap<String, i64>,
 }
 
-/// Default minimum spacing between recorded hook-route observations for one
-/// key. Matches [`DEFAULT_SPAN_MERGE_GAP_SECS`] granularity: writing more
-/// often than this cannot change which spans exist.
+/// Default minimum spacing between recorded hook-route observations for one key.
 pub const DEFAULT_SPAN_OBSERVATION_DEBOUNCE_SECS: i64 = 30;
 
 impl SpanObservationDebounce {
@@ -808,15 +766,7 @@ pub struct ScannedCommit {
     pub committed_at: i64,
 }
 
-/// Runs the commit-attribution sweep against the correlation store. For each
-/// `(branch, worktree)` pair touched since the last sweep, `scan` is asked for
-/// the commits on that branch in the pair's span window (widened by
-/// `gap_secs`); each commit is matched to the overlapping spans and upserted.
-/// Advances the watermark to the newest span `last_ts` seen. Returns the
-/// number of attribution rows newly inserted.
-///
-/// `scan` is injected so the git subprocess stays out of this module and unit
-/// tests can drive attribution without a real repository.
+/// Runs commit attribution for span targets touched since the last sweep.
 pub(crate) async fn run_commit_attribution_sweep<F>(
     conn: &Connection,
     gap_secs: i64,
@@ -903,17 +853,7 @@ pub(crate) async fn sessions_for(
     }
 }
 
-/// Resolves the set of `(provider, session_id)` pairs that satisfy a
-/// [`GitScopeFilter`], intersecting each present constraint (a session must
-/// match branch AND worktree AND commit when all three are set). Returns
-/// `None` when the filter is empty (no scoping requested) and
-/// `Some(Vec::new())` when the filter is non-empty but nothing matched (or
-/// the correlation tables do not exist yet).
-///
-/// This is a convenience for callers that want the resolved id set directly;
-/// the search paths instead push [`git_scope_exists_predicate`] EXISTS
-/// subqueries into their own statement so scoping stays index-served and
-/// single-statement.
+/// Resolves the `(provider, session_id)` pairs matching all present git filters.
 pub(crate) async fn session_ids_for_scope(
     conn: &Connection,
     filter: &GitScopeFilter,
@@ -924,8 +864,6 @@ pub(crate) async fn session_ids_for_scope(
     if !correlation_tables_present(conn).await? {
         return Ok(Some(Vec::new()));
     }
-    // Intersect via a session-id key set, seeded by the first constraint and
-    // narrowed by each remaining one.
     let mut result: Option<Vec<(String, String)>> = None;
     if let Some(branch) = &filter.branch {
         let ids = span_session_ids(conn, "branch = ?1", Value::Text(branch.clone())).await?;
@@ -948,10 +886,13 @@ fn intersect_session_ids(
 ) -> Vec<(String, String)> {
     match accumulated {
         None => next,
-        Some(existing) => existing
-            .into_iter()
-            .filter(|pair| next.contains(pair))
-            .collect(),
+        Some(existing) => {
+            let next: HashSet<_> = next.into_iter().collect();
+            existing
+                .into_iter()
+                .filter(|pair| next.contains(pair))
+                .collect()
+        }
     }
 }
 
@@ -1177,12 +1118,7 @@ async fn commit_hits(
     Ok(hits)
 }
 
-// ── Historical backfill ─────────────────────────────────────────────────
-//
-// The live path folds observations in as sessions run, but sessions that
-// predate span recording leave only three offline signals: session-store
-// timestamps, global analytics events, and the git reflog. The backfill
-// reconstructs spans and commit attribution from those.
+// Historical backfill for sessions that predate live span recording.
 
 /// One session's declared and message-derived activity bounds, read from the
 /// per-project session store. Any field may be `None` when the source row left
@@ -1204,10 +1140,7 @@ pub struct SessionActivityRow {
 /// `GlobalDb::latest_session_activity_secs` and `kiro::normalize_timestamp`).
 const UNIX_TIMESTAMP_MILLIS_THRESHOLD: i64 = 1_000_000_000_000;
 
-/// Normalizes a stored session timestamp to unix seconds. Providers persist
-/// either seconds or milliseconds; a millis-scale value left un-normalized
-/// yields a span window ~1000x too wide, so commit attribution (seconds-scale
-/// `git %ct`) never overlaps it and rendered dates land in the far future.
+/// Normalizes provider timestamps to unix seconds.
 fn normalize_activity_ts(ts: i64) -> i64 {
     if ts >= UNIX_TIMESTAMP_MILLIS_THRESHOLD {
         ts / 1000

--- a/src/sessions/git_correlation.rs
+++ b/src/sessions/git_correlation.rs
@@ -309,6 +309,14 @@ fn is_zero(value: &i64) -> bool {
 /// writers agreeing even when the path no longer exists.
 pub fn normalize_worktree(path: &str) -> String {
     let mut normalized = path.trim().replace('\\', "/");
+    if let Some(stripped) = normalized.strip_prefix("//?/UNC/") {
+        normalized = format!("//{stripped}");
+    } else if let Some(stripped) = normalized.strip_prefix("//?/") {
+        normalized = stripped.to_string();
+    }
+    if let Some(stripped) = normalized.strip_prefix("/private/var/") {
+        normalized = format!("/var/{stripped}");
+    }
     while normalized.len() > 1 && normalized.ends_with('/') {
         normalized.pop();
     }
@@ -503,6 +511,7 @@ async fn record_span_observation_in_transaction(
     observation: &SpanObservation,
     merge_gap_secs: i64,
 ) -> Result<i64, GitCorrelationError> {
+    let worktree = normalize_worktree(&observation.worktree);
     // `branch IS ?` is NULL-safe: a detached-HEAD observation only extends a
     // detached-HEAD span, never a named-branch span.
     let mut rows = conn
@@ -517,7 +526,7 @@ async fn record_span_observation_in_transaction(
                 observation.provider.as_str(),
                 observation.session_id.as_str(),
                 opt_text(observation.branch.as_deref()),
-                observation.worktree.as_str(),
+                worktree.as_str(),
             ],
         )
         .await?;
@@ -555,7 +564,7 @@ async fn record_span_observation_in_transaction(
             observation.session_id.as_str(),
             opt_text(observation.thread_id.as_deref()),
             opt_text(observation.branch.as_deref()),
-            observation.worktree.as_str(),
+            worktree.as_str(),
             observation.ts,
             observation.source.as_str(),
         ],
@@ -571,6 +580,7 @@ pub(crate) async fn upsert_commit_session(
     conn: &Connection,
     record: &CommitSessionRecord,
 ) -> Result<bool, GitCorrelationError> {
+    let worktree = record.worktree.as_deref().map(normalize_worktree);
     let inserted = conn
         .execute(
             "INSERT OR IGNORE INTO commit_sessions (
@@ -583,7 +593,7 @@ pub(crate) async fn upsert_commit_session(
                 record.provider.as_str(),
                 record.session_id.as_str(),
                 opt_text(record.branch.as_deref()),
-                opt_text(record.worktree.as_deref()),
+                opt_text(worktree.as_deref()),
                 record.committed_at,
                 record.span_overlap_kind.as_str(),
                 record.span_id.map_or(Value::Null, Value::Integer),
@@ -1709,6 +1719,8 @@ mod tests {
         assert_eq!(normalize_worktree("/repo/wt///"), "/repo/wt");
         assert_eq!(normalize_worktree("/"), "/");
         assert_eq!(normalize_worktree("C:\\repo\\wt\\"), "C:/repo/wt");
+        assert_eq!(normalize_worktree("//?/C:/repo/wt/"), "C:/repo/wt");
+        assert_eq!(normalize_worktree("/private/var/tmp/repo"), "/var/tmp/repo");
     }
 
     #[test]

--- a/src/sessions/lcm/query.rs
+++ b/src/sessions/lcm/query.rs
@@ -372,6 +372,12 @@ pub(crate) async fn grep(
     if matches!(request.scope, LcmScope::Current | LcmScope::Session) && session_filter.is_none() {
         return Ok(Vec::new());
     }
+    // A git-scoped grep against a store predating the git-correlation schema
+    // can never match; short-circuit rather than issue a `no such table`
+    // EXISTS subquery.
+    if !request.git_filter.is_empty() && !lcm_table_exists(conn, "session_git_spans").await? {
+        return Ok(Vec::new());
+    }
 
     let raw_only_filters =
         request.role.is_some() || request.start_time.is_some() || request.end_time.is_some();
@@ -520,6 +526,7 @@ pub(crate) async fn expand_query(
                     role: None,
                     start_time: None,
                     end_time: None,
+                    git_filter: crate::sessions::git_correlation::GitScopeFilter::default(),
                 };
                 let summary_hits = summary_grep_hits(
                     conn,
@@ -1727,6 +1734,27 @@ fn push_raw_grep_filters(
         filters.push("r.timestamp <= ?".to_string());
         values.push(Value::Integer(end_time));
     }
+    push_grep_git_scope_filter(request, "r.session_id", filters, values);
+}
+
+/// Appends the request's git-scope constraint (branch/worktree/commit) as an
+/// EXISTS predicate correlated to the outer row via `session_column`. No-op
+/// when the filter is empty.
+fn push_grep_git_scope_filter(
+    request: &LcmGrepRequest,
+    session_column: &str,
+    filters: &mut Vec<String>,
+    values: &mut Vec<Value>,
+) {
+    if let Some((predicate, predicate_values)) =
+        crate::sessions::git_correlation::git_scope_exists_predicate(
+            &request.git_filter,
+            session_column,
+        )
+    {
+        filters.push(predicate);
+        values.extend(predicate_values);
+    }
 }
 
 fn push_summary_grep_filters(
@@ -1760,6 +1788,7 @@ fn push_summary_grep_filters(
         values.push(Value::Text(source.to_string()));
         values.push(Value::Text(format!("%\"source\":\"{source}\"%")));
     }
+    push_grep_git_scope_filter(request, "n.session_id", filters, values);
 }
 
 fn raw_hit_from_row(row: &libsql::Row, like_terms: &[String]) -> Result<LcmGrepHit, LcmError> {

--- a/src/sessions/lcm/types.rs
+++ b/src/sessions/lcm/types.rs
@@ -248,6 +248,14 @@ pub struct LcmGrepRequest {
     pub role: Option<String>,
     pub start_time: Option<i64>,
     pub end_time: Option<i64>,
+    /// Optional git-scope constraint (branch/worktree/commit). When set,
+    /// hits are limited to sessions correlated with the git ref via EXISTS
+    /// pushdown against the git-correlation tables. Defaults to `None`.
+    #[serde(
+        default,
+        skip_serializing_if = "crate::sessions::git_correlation::GitScopeFilter::is_empty"
+    )]
+    pub git_filter: crate::sessions::git_correlation::GitScopeFilter,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -12,6 +12,7 @@ pub mod codex;
 pub mod codex_app_server;
 pub mod cursor;
 pub mod cursor_agent;
+pub mod git_correlation;
 pub mod hermes;
 pub mod kiro;
 pub mod lcm;
@@ -79,13 +80,86 @@ pub async fn ingest_global_sources_for_provider(
     } else {
         stats
     };
-    if provider.is_none() || provider == Some(SessionProvider::Hermes) {
+    let stats = if provider.is_none() || provider == Some(SessionProvider::Hermes) {
         // Hermes stores many sessions in one SQLite file per profile, so it
         // plugs in beside the file-based sources rather than `TranscriptSource`.
         stats.merge(hermes::ingest_for_project(db, project_root).await)
     } else {
         stats
+    };
+    // Now that messages have landed, attribute any commits that fell inside a
+    // recorded session span. Fail-open: a git or DB hiccup never blocks ingest.
+    attribute_commits_after_ingest(db).await;
+    stats
+}
+
+/// Runs the bounded commit-attribution sweep against the correlation store.
+/// For each `(branch, worktree)` pair touched since the last sweep, scans that
+/// branch's git log inside the pair's span window (widened by the merge gap)
+/// and attributes overlapping commits to their sessions. Fail-open.
+async fn attribute_commits_after_ingest(db: &GlobalDb) {
+    let gap = git_correlation::DEFAULT_SPAN_MERGE_GAP_SECS;
+    let result = db
+        .git_run_commit_attribution_sweep(gap, |target| git_scan_commits(target, gap))
+        .await;
+    if let Err(err) = result {
+        tracing::debug!(error = %err, "commit attribution sweep skipped");
     }
+}
+
+/// Reads commits on one span target's branch within its (gap-widened) window
+/// via `git log`. Returns an empty list on any error so the sweep simply
+/// attributes nothing for that target rather than failing. The worktree value
+/// is a recorded span path; if it no longer exists on disk the scan yields
+/// nothing.
+fn git_scan_commits(
+    target: &git_correlation::SpanScanTarget,
+    gap_secs: i64,
+) -> Vec<git_correlation::ScannedCommit> {
+    let worktree = Path::new(&target.worktree);
+    if !worktree.is_dir() {
+        return Vec::new();
+    }
+    let since = target.window_start.saturating_sub(gap_secs);
+    let until = target.window_end.saturating_add(gap_secs);
+    let mut command = std::process::Command::new(crate::git::git_program());
+    command
+        .current_dir(worktree)
+        .arg("log")
+        .arg(format!("--since={since}"))
+        .arg(format!("--until={until}"))
+        .arg("--pretty=format:%H %ct");
+    // Scope to the recorded branch when known; detached-HEAD spans scan HEAD.
+    match target.branch.as_deref() {
+        Some(branch) if !branch.is_empty() => {
+            command.arg(branch);
+        }
+        _ => {}
+    }
+    let Ok(output) = command.output() else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    parse_git_log_commits(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Parses `%H %ct` lines from `git log` into scanned commits, skipping
+/// malformed rows.
+fn parse_git_log_commits(stdout: &str) -> Vec<git_correlation::ScannedCommit> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let (sha, ts) = line.trim().split_once(' ')?;
+            let committed_at: i64 = ts.trim().parse().ok()?;
+            let sha = sha.trim().to_ascii_lowercase();
+            if sha.is_empty() {
+                return None;
+            }
+            Some(git_correlation::ScannedCommit { sha, committed_at })
+        })
+        .collect()
 }
 
 fn push_file_source(sources: &mut Vec<Box<dyn TranscriptSource>>, provider: SessionProvider) {
@@ -200,4 +274,40 @@ pub enum SessionSearchScope {
     All,
     ParentsOnly,
     SubagentsOnly,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod git_scan_tests {
+    use super::*;
+
+    #[test]
+    fn parse_git_log_commits_reads_sha_and_time_skipping_malformed() {
+        let stdout = concat!(
+            "ABCDEF1234567890 1700000000\n",
+            "\n",
+            "missing-time\n",
+            "cafebabe not-a-number\n",
+            "deadbeefdeadbeef 1700000200\n",
+        );
+        let commits = parse_git_log_commits(stdout);
+        assert_eq!(
+            commits,
+            vec![
+                git_correlation::ScannedCommit {
+                    sha: "abcdef1234567890".to_string(),
+                    committed_at: 1_700_000_000,
+                },
+                git_correlation::ScannedCommit {
+                    sha: "deadbeefdeadbeef".to_string(),
+                    committed_at: 1_700_000_200,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_git_log_commits_empty_is_empty() {
+        assert!(parse_git_log_commits("").is_empty());
+    }
 }

--- a/src/sessions_cmd.rs
+++ b/src/sessions_cmd.rs
@@ -37,6 +37,9 @@ pub(crate) async fn handle_sessions_action(
             until,
             project_id,
             project_path,
+            branch,
+            worktree,
+            commit,
         } => {
             let project_path = resolve_cli_project_root(None, project_id, project_path).await?;
             let db = tracedecay::sessions::cursor::open_project_session_db(&project_path)
@@ -48,6 +51,14 @@ pub(crate) async fn handle_sessions_action(
                     ),
                 })?;
             let provider_scope = session_provider_scope(provider.as_deref())?;
+            let git_filter = tracedecay::sessions::git_correlation::GitScopeFilter::from_args(
+                branch.as_deref(),
+                worktree.as_deref(),
+                commit.as_deref(),
+            )
+            .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+                message: err.to_string(),
+            })?;
             let now = tracedecay::tracedecay::current_timestamp();
             let time_range = SessionSearchTimeRange {
                 start_time: parse_time_filter_arg(
@@ -69,7 +80,21 @@ pub(crate) async fn handle_sessions_action(
                 provider_scope.provider(),
             )
             .await;
-            let results = if let Some(provider) = provider_scope.provider() {
+            let results = if !git_filter.is_empty() {
+                db.search_session_messages_git_scoped(
+                    provider_scope.provider_id(),
+                    None,
+                    &query,
+                    limit,
+                    SessionSearchFilters {
+                        scope: tracedecay::sessions::SessionSearchScope::All,
+                        parent_session_id: None,
+                        time_range,
+                    },
+                    &git_filter,
+                )
+                .await
+            } else if let Some(provider) = provider_scope.provider() {
                 db.search_session_messages_filtered(
                     provider.id(),
                     None,
@@ -105,8 +130,127 @@ pub(crate) async fn handle_sessions_action(
                 );
             }
         }
+        SessionsAction::GitBackfill {
+            project_id,
+            project_path,
+            since,
+            limit_sessions,
+            dry_run,
+        } => {
+            run_git_backfill(project_id, project_path, since, limit_sessions, dry_run).await?;
+        }
     }
     Ok(())
+}
+
+/// Default lower bound for `git-backfill`: 90 days before now.
+const GIT_BACKFILL_DEFAULT_WINDOW_SECS: i64 = 90 * 24 * 60 * 60;
+
+/// Cap on analytics rows loaded for `git-backfill`. The query is already scoped
+/// to one project within the backfill window; this bounds the worst case rather
+/// than materializing every event ever recorded.
+const GIT_BACKFILL_ANALYTICS_LIMIT: usize = 500_000;
+
+async fn run_git_backfill(
+    project_id: Option<String>,
+    project_path: Option<String>,
+    since: Option<String>,
+    limit_sessions: usize,
+    dry_run: bool,
+) -> tracedecay::errors::Result<()> {
+    use tracedecay::sessions::git_correlation::{
+        run_backfill, BackfillOptions, SystemGit, DEFAULT_SPAN_MERGE_GAP_SECS,
+    };
+
+    let project_root = resolve_cli_project_root(None, project_id, project_path).await?;
+    let since_ts = resolve_backfill_since(since.as_deref())?;
+
+    let session_db = tracedecay::sessions::cursor::open_project_session_db(&project_root)
+        .await
+        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+            message: format!(
+                "could not open project session database for {}",
+                project_root.display()
+            ),
+        })?;
+
+    // Global analytics rows are a finer-grained timestamp signal. Missing or
+    // unreadable analytics is non-fatal: the backfill still runs on session
+    // timestamps and the reflog. Scope the query to this project and the
+    // backfill window: only rows for the target project within [since_ts, now]
+    // are ever consumed, so pulling every event from every project (these
+    // stores reach tens of GB) would be pure waste.
+    let analytics_events = match tracedecay::global_db::GlobalDb::open().await {
+        Some(global) => global
+            .query_analytics_events(&tracedecay::global_db::AnalyticsEventQuery {
+                project_id: Some(tracedecay::global_db::GlobalDb::canonical_project_key(
+                    &project_root,
+                )),
+                since: Some(since_ts),
+                limit: GIT_BACKFILL_ANALYTICS_LIMIT,
+                ..Default::default()
+            })
+            .await
+            .unwrap_or_default(),
+        None => Vec::new(),
+    };
+
+    let opts = BackfillOptions {
+        since: since_ts,
+        limit_sessions,
+        merge_gap_secs: DEFAULT_SPAN_MERGE_GAP_SECS,
+        max_commits_per_repo: 5_000,
+        dry_run,
+    };
+
+    let git = SystemGit;
+    let stats = run_backfill(&session_db, &analytics_events, &git, &opts)
+        .await
+        .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+            message: format!("git backfill failed: {err}"),
+        })?;
+
+    if dry_run {
+        println!("git-backfill (dry-run): no rows written");
+    }
+    println!("sessions scanned:    {}", stats.sessions_scanned);
+    println!("spans written:       {}", stats.spans_written);
+    println!("commits attributed:  {}", stats.commits_attributed);
+    println!(
+        "skipped:             {} (no-window {}, not-worktree {}, git-error {})",
+        stats.skipped_total(),
+        stats.skipped_no_window,
+        stats.skipped_not_worktree,
+        stats.skipped_git_error
+    );
+    Ok(())
+}
+
+/// Resolves the `--since` argument (ISO-8601 or unix seconds) to a unix-second
+/// lower bound, defaulting to 90 days before now when unset.
+fn resolve_backfill_since(since: Option<&str>) -> tracedecay::errors::Result<i64> {
+    let Some(raw) = since.map(str::trim).filter(|value| !value.is_empty()) else {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        return Ok((now - GIT_BACKFILL_DEFAULT_WINDOW_SECS).max(0));
+    };
+    if let Ok(unix) = raw.parse::<i64>() {
+        if unix >= 0 {
+            return Ok(unix);
+        }
+        return Err(tracedecay::errors::TraceDecayError::Config {
+            message: "--since must be >= 0".to_string(),
+        });
+    }
+    tracedecay::timeutil::parse_rfc3339_timestamp(raw).ok_or_else(|| {
+        tracedecay::errors::TraceDecayError::Config {
+            message: format!(
+                "--since must be a non-negative Unix timestamp or ISO/RFC3339 string (got `{raw}`)"
+            ),
+        }
+    })
 }
 
 async fn ingest_selected_session_sources(

--- a/src/timeutil.rs
+++ b/src/timeutil.rs
@@ -332,6 +332,16 @@ pub fn format_yyyy_mm_dd(days: i64) -> String {
     format!("{y:04}-{m:02}-{d:02}")
 }
 
+/// Formats a Unix-seconds instant as a human-readable UTC
+/// `YYYY-MM-DD HH:MM:SSZ` string. Used to render session activity windows
+/// and commit times as calendar timestamps instead of raw epoch seconds.
+pub fn humanize_unix_secs(secs: i64) -> String {
+    let (year, month, day) = civil_from_days(secs.div_euclid(86_400));
+    let rem = secs.rem_euclid(86_400);
+    let (hour, min, sec) = (rem / 3_600, (rem / 60) % 60, rem % 60);
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{min:02}:{sec:02}Z")
+}
+
 /// The current UTC time as an ISO 8601 `yyyy-mm-ddThh:mm:ssZ` string.
 pub fn now_iso_utc() -> String {
     let secs = std::time::SystemTime::now()
@@ -361,6 +371,13 @@ mod tests {
     #[test]
     fn parses_space_separator_and_lowercase_zone() {
         assert_eq!(parse_rfc3339_timestamp("1970-01-01 00:00:01z"), Some(1));
+    }
+
+    #[test]
+    fn humanizes_unix_seconds_as_utc_calendar_time() {
+        assert_eq!(humanize_unix_secs(0), "1970-01-01 00:00:00Z");
+        assert_eq!(humanize_unix_secs(1_767_225_600), "2026-01-01 00:00:00Z");
+        assert_eq!(humanize_unix_secs(1_767_225_661), "2026-01-01 00:01:01Z");
     }
 
     #[test]

--- a/tests/hooks_lsp_suite/hook_replay_test.rs
+++ b/tests/hooks_lsp_suite/hook_replay_test.rs
@@ -302,6 +302,7 @@ async fn replayed_provider_hooks_record_attributed_rows_and_bridge_to_analytics_
             project_id: None,
             session_id: None,
             event_kind: Some("hook_invoked".to_string()),
+            since: None,
             limit: 1000,
         })
         .await

--- a/tests/mcp_suite/git_correlation_test.rs
+++ b/tests/mcp_suite/git_correlation_test.rs
@@ -1,0 +1,457 @@
+//! End-to-end tests for the session↔git correlation query surface:
+//! `tracedecay_sessions_for` plus the git-scope filters on
+//! `tracedecay_message_search` / `tracedecay_lcm_grep`, driven through the
+//! real `handle_tool_call` dispatch against a temp project with a linked git
+//! worktree and a seeded `sessions.db`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::{json, Value};
+
+use tracedecay::global_db::GlobalDb;
+use tracedecay::sessions::git_correlation::{
+    CommitSessionRecord, SpanObservation, SpanOverlapKind, SpanSource, DEFAULT_SPAN_MERGE_GAP_SECS,
+};
+use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
+use tracedecay::tracedecay::TraceDecay;
+
+use crate::common;
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new(common::git_program())
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .unwrap_or_else(|e| panic!("git {args:?} should spawn: {e}"));
+    assert!(status.success(), "git {args:?} should succeed");
+}
+
+/// Initializes a project repo (`main`) plus a linked worktree checked out on
+/// `feature/session` under `base`. Returns `(project_root, worktree)`.
+fn setup_linked_worktree_under(base: &Path) -> (PathBuf, PathBuf) {
+    let project_root = base.join("project");
+    let worktree_root = base.join("session-worktree");
+    std::fs::create_dir_all(project_root.join("src"))
+        .unwrap_or_else(|e| panic!("project dirs: {e}"));
+    std::fs::write(project_root.join("src/lib.rs"), "pub fn marker() {}\n")
+        .unwrap_or_else(|e| panic!("source: {e}"));
+    run_git(&project_root, &["init", "-b", "main"]);
+    run_git(&project_root, &["config", "user.email", "test@test.com"]);
+    run_git(&project_root, &["config", "user.name", "Test"]);
+    run_git(&project_root, &["add", "."]);
+    run_git(&project_root, &["commit", "-m", "initial"]);
+    let worktree_arg = worktree_root.to_string_lossy();
+    run_git(
+        &project_root,
+        &[
+            "worktree",
+            "add",
+            worktree_arg.as_ref(),
+            "-b",
+            "feature/session",
+        ],
+    );
+    (project_root, worktree_root)
+}
+
+fn session(session_id: &str, project_key: &str, started_at: i64) -> SessionRecord {
+    SessionRecord {
+        provider: "claude".to_string(),
+        session_id: session_id.to_string(),
+        project_key: project_key.to_string(),
+        project_path: project_key.to_string(),
+        title: Some(format!("Session {session_id}")),
+        started_at: Some(started_at),
+        ended_at: None,
+        transcript_path: Some(format!("{session_id}.jsonl")),
+        metadata_json: None,
+        parent_session_id: None,
+        is_subagent: false,
+        agent_id: None,
+        parent_tool_use_id: None,
+    }
+}
+
+fn message(session_id: &str, message_id: &str, ts: i64, text: &str) -> SessionMessageRecord {
+    SessionMessageRecord {
+        provider: "claude".to_string(),
+        message_id: message_id.to_string(),
+        session_id: session_id.to_string(),
+        role: "assistant".to_string(),
+        timestamp: Some(ts),
+        ordinal: 1,
+        text: text.to_string(),
+        kind: Some("message".to_string()),
+        model: Some("test-model".to_string()),
+        tool_names: None,
+        source_path: Some(format!("{session_id}.jsonl")),
+        source_offset: Some(0),
+        metadata_json: None,
+    }
+}
+
+fn span(session_id: &str, branch: Option<&str>, worktree: &str, ts: i64) -> SpanObservation {
+    SpanObservation {
+        provider: "claude".to_string(),
+        session_id: session_id.to_string(),
+        thread_id: None,
+        branch: branch.map(str::to_string),
+        worktree: worktree.to_string(),
+        ts,
+        source: SpanSource::HookRoute,
+    }
+}
+
+async fn record_span(db: &GlobalDb, observation: &SpanObservation) {
+    db.git_record_span_observation(observation, DEFAULT_SPAN_MERGE_GAP_SECS)
+        .await
+        .unwrap_or_else(|e| panic!("record span: {e}"));
+}
+
+fn extract_json(result: &tracedecay::mcp::ToolResult) -> Value {
+    let text = result.value["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("tool result should carry text content: {}", result.value));
+    serde_json::from_str(text).unwrap_or_else(|e| panic!("tool result should be JSON: {e}\n{text}"))
+}
+
+async fn call(cg: &TraceDecay, tool: &str, mut args: Value) -> Value {
+    if let Some(obj) = args.as_object_mut() {
+        obj.entry("format".to_string())
+            .or_insert_with(|| json!("json"));
+    }
+    let result = tracedecay::mcp::handle_tool_call(cg, tool, args, None, None)
+        .await
+        .unwrap_or_else(|e| panic!("{tool} should succeed: {e}"));
+    extract_json(&result)
+}
+
+fn session_ids(payload: &Value) -> Vec<String> {
+    payload["results"]
+        .as_array()
+        .unwrap_or_else(|| panic!("results should be an array: {payload}"))
+        .iter()
+        .map(|hit| hit["session_id"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+/// Seeds a project store with three sessions on `main`/`feature/session` plus
+/// a mid-session branch switch, then drives the query surface end to end.
+#[tokio::test]
+async fn sessions_for_and_scoped_search_end_to_end() {
+    // Hold the shared isolated-env lock (via `IsolatedEnv`) so this test's
+    // process-wide storage env never races other env-mutating tests running in
+    // parallel under the same test binary.
+    let (_env, isolated_project) = common::IsolatedEnv::acquire().await;
+    let base = isolated_project
+        .parent()
+        .unwrap_or_else(|| panic!("isolated project has a parent"));
+    let (project_root, worktree_root) = setup_linked_worktree_under(base);
+
+    let cg = TraceDecay::init(&project_root)
+        .await
+        .unwrap_or_else(|e| panic!("init project: {e}"));
+    let project_key = cg.project_root().to_string_lossy().to_string();
+    let main_worktree = project_root.to_string_lossy().to_string();
+    let feature_worktree = worktree_root.to_string_lossy().to_string();
+
+    let db_path = cg.store_layout().sessions_db_path.clone();
+    let db = GlobalDb::open_at(&db_path)
+        .await
+        .unwrap_or_else(|| panic!("open sessions.db"));
+
+    // s1: two observations on main (one merged span). s2: on main in the
+    // linked worktree, most recent. s3: on feature/session.
+    for record in [
+        session("s1", &project_key, 1_000),
+        session("s2", &project_key, 5_000),
+        session("s3", &project_key, 2_000),
+        session("switcher", &project_key, 3_000),
+    ] {
+        assert!(db.upsert_session(&record).await);
+    }
+    for msg in [
+        message("s1", "s1-m1", 1_050, "alpha correlation evidence on main"),
+        message(
+            "s2",
+            "s2-m1",
+            5_050,
+            "beta correlation evidence in worktree",
+        ),
+        message(
+            "s3",
+            "s3-m1",
+            2_050,
+            "gamma correlation evidence on feature",
+        ),
+        message(
+            "switcher",
+            "sw-m1",
+            3_050,
+            "delta correlation evidence switching",
+        ),
+        message(
+            "switcher",
+            "sw-m2",
+            9_000,
+            "delta correlation evidence after switch",
+        ),
+    ] {
+        assert!(db.upsert_session_message(&msg).await);
+    }
+
+    record_span(&db, &span("s1", Some("main"), &main_worktree, 1_000)).await;
+    record_span(&db, &span("s1", Some("main"), &main_worktree, 1_200)).await;
+    record_span(&db, &span("s2", Some("main"), &feature_worktree, 5_000)).await;
+    record_span(
+        &db,
+        &span("s3", Some("feature/session"), &feature_worktree, 2_000),
+    )
+    .await;
+    // Mid-session branch switch: `switcher` was on main, then feature.
+    record_span(&db, &span("switcher", Some("main"), &main_worktree, 3_000)).await;
+    record_span(
+        &db,
+        &span(
+            "switcher",
+            Some("feature/session"),
+            &feature_worktree,
+            8_800,
+        ),
+    )
+    .await;
+
+    // A commit made inside the `switcher` feature span is attributed to
+    // feature/session only.
+    assert!(db
+        .git_upsert_commit_session(&CommitSessionRecord {
+            commit_sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+            provider: "claude".to_string(),
+            session_id: "switcher".to_string(),
+            branch: Some("feature/session".to_string()),
+            worktree: Some(feature_worktree.clone()),
+            committed_at: 8_850,
+            span_overlap_kind: SpanOverlapKind::WithinSpan,
+            span_id: None,
+        })
+        .await
+        .unwrap());
+
+    // (a) sessions_for by branch: main matches s1, s2, switcher, ordered by
+    // recency (most recent span first: switcher@... vs s2@5000 vs s1@1200).
+    let by_main = call(
+        &cg,
+        "tracedecay_sessions_for",
+        json!({ "git_ref": "branch", "value": "main" }),
+    )
+    .await;
+    assert_eq!(by_main["git_ref"], "branch");
+    let main_ids = session_ids(&by_main);
+    assert!(main_ids.contains(&"s1".to_string()), "{by_main}");
+    assert!(main_ids.contains(&"s2".to_string()), "{by_main}");
+    assert!(main_ids.contains(&"switcher".to_string()), "{by_main}");
+    assert!(!main_ids.contains(&"s3".to_string()), "{by_main}");
+    // Recency ordering: s2 (last_ts 5000) precedes s1 (last_ts 1200).
+    let s2_pos = main_ids.iter().position(|id| id == "s2").unwrap();
+    let s1_pos = main_ids.iter().position(|id| id == "s1").unwrap();
+    assert!(s2_pos < s1_pos, "most recent first: {main_ids:?}");
+
+    // (b) sessions_for by worktree path, trailing slash normalized.
+    let by_worktree = call(
+        &cg,
+        "tracedecay_sessions_for",
+        json!({ "git_ref": "worktree", "value": format!("{feature_worktree}/") }),
+    )
+    .await;
+    let wt_ids = session_ids(&by_worktree);
+    assert!(wt_ids.contains(&"s2".to_string()), "{by_worktree}");
+    assert!(wt_ids.contains(&"s3".to_string()), "{by_worktree}");
+    assert!(wt_ids.contains(&"switcher".to_string()), "{by_worktree}");
+    assert!(!wt_ids.contains(&"s1".to_string()), "{by_worktree}");
+
+    // (c) sessions_for by full and 8-char commit sha.
+    for sha in ["abcdef1234567890abcdef1234567890abcdef12", "abcdef12"] {
+        let by_commit = call(
+            &cg,
+            "tracedecay_sessions_for",
+            json!({ "git_ref": "commit", "value": sha }),
+        )
+        .await;
+        let commit_ids = session_ids(&by_commit);
+        assert_eq!(
+            commit_ids,
+            vec!["switcher".to_string()],
+            "sha {sha}: {by_commit}"
+        );
+        assert_eq!(
+            by_commit["results"][0]["commit_sha"],
+            "abcdef1234567890abcdef1234567890abcdef12"
+        );
+    }
+
+    // (d) mid-session branch switch: sessions_for(main) and (feature) both
+    // return `switcher`.
+    let by_feature = call(
+        &cg,
+        "tracedecay_sessions_for",
+        json!({ "git_ref": "branch", "value": "feature/session" }),
+    )
+    .await;
+    assert!(
+        session_ids(&by_feature).contains(&"switcher".to_string()),
+        "{by_feature}"
+    );
+    assert!(main_ids.contains(&"switcher".to_string()));
+
+    // message_search with branch=main and branch=feature/session both return
+    // the switcher's messages; branch=absent returns none.
+    for branch in ["main", "feature/session"] {
+        let scoped = call(
+            &cg,
+            "tracedecay_message_search",
+            json!({
+                "query": "delta correlation",
+                "provider": "claude",
+                "catch_up": false,
+                "branch": branch,
+            }),
+        )
+        .await;
+        assert_eq!(scoped["git_filter_applied"], true, "{scoped}");
+        assert_eq!(scoped["git_filter"]["branch"], branch);
+        let ids = session_ids_from_search(&scoped);
+        assert!(
+            ids.contains(&"switcher".to_string()),
+            "branch {branch}: {scoped}"
+        );
+    }
+    let unmatched = call(
+        &cg,
+        "tracedecay_message_search",
+        json!({
+            "query": "delta correlation",
+            "provider": "claude",
+            "catch_up": false,
+            "branch": "does-not-exist",
+        }),
+    )
+    .await;
+    assert_eq!(unmatched["git_filter_applied"], true, "{unmatched}");
+    assert_eq!(unmatched["count"], 0, "{unmatched}");
+
+    // (e) since/until narrowing on sessions_for(main): only s2's span
+    // ([5000,5000]) overlaps [4000, 6000].
+    let scoped_time = call(
+        &cg,
+        "tracedecay_sessions_for",
+        json!({ "git_ref": "branch", "value": "main", "since": 4_000, "until": 6_000 }),
+    )
+    .await;
+    assert_eq!(
+        session_ids(&scoped_time),
+        vec!["s2".to_string()],
+        "{scoped_time}"
+    );
+
+    // (f) commit-scoped message_search returns only the switcher.
+    let by_commit_msg = call(
+        &cg,
+        "tracedecay_message_search",
+        json!({
+            "query": "delta correlation",
+            "provider": "claude",
+            "catch_up": false,
+            "commit": "abcdef12",
+        }),
+    )
+    .await;
+    assert_eq!(by_commit_msg["git_filter_applied"], true, "{by_commit_msg}");
+    let commit_msg_sessions = unique_sorted(session_ids_from_search(&by_commit_msg));
+    assert_eq!(
+        commit_msg_sessions,
+        vec!["switcher".to_string()],
+        "{by_commit_msg}"
+    );
+
+    // worktree-scoped message_search: alpha (s1 on main worktree) excluded when
+    // scoping to the feature worktree; beta (s2) included.
+    let by_worktree_msg = call(
+        &cg,
+        "tracedecay_message_search",
+        json!({
+            "query": "correlation evidence",
+            "provider": "claude",
+            "catch_up": false,
+            "worktree": feature_worktree,
+        }),
+    )
+    .await;
+    let wt_msg_ids = session_ids_from_search(&by_worktree_msg);
+    assert!(wt_msg_ids.contains(&"s2".to_string()), "{by_worktree_msg}");
+    assert!(!wt_msg_ids.contains(&"s1".to_string()), "{by_worktree_msg}");
+
+    // (f) lcm_grep with a branch filter: the raw messages are written to
+    // lcm_raw_messages by upsert_session_message, so a feature-scoped grep
+    // surfaces only the switcher's hits.
+    let grep = call(
+        &cg,
+        "tracedecay_lcm_grep",
+        json!({
+            "query": "delta",
+            "provider": "claude",
+            "branch": "feature/session",
+        }),
+    )
+    .await;
+    assert_eq!(grep["git_filter_applied"], true, "{grep}");
+    assert_eq!(grep["git_filter"]["branch"], "feature/session");
+    let grep_sessions = grep["hits"]
+        .as_array()
+        .unwrap_or_else(|| panic!("hits should be an array: {grep}"))
+        .iter()
+        .map(|hit| hit["session_id"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        grep_sessions.iter().all(|id| id == "switcher"),
+        "feature-scoped grep should only surface the switcher: {grep}"
+    );
+    assert!(!grep_sessions.is_empty(), "{grep}");
+
+    // A grep scoped to a branch nothing ran on returns no hits.
+    let grep_none = call(
+        &cg,
+        "tracedecay_lcm_grep",
+        json!({
+            "query": "delta",
+            "provider": "claude",
+            "branch": "does-not-exist",
+        }),
+    )
+    .await;
+    assert_eq!(grep_none["git_filter_applied"], true, "{grep_none}");
+    assert_eq!(grep_none["count"], 0, "{grep_none}");
+
+    drop(db);
+    cg.close();
+}
+
+fn unique_sorted(mut ids: Vec<String>) -> Vec<String> {
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+fn session_ids_from_search(payload: &Value) -> Vec<String> {
+    payload["results"]
+        .as_array()
+        .unwrap_or_else(|| panic!("search results should be an array: {payload}"))
+        .iter()
+        .map(|hit| {
+            hit["session"]["session_id"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect()
+}

--- a/tests/mcp_suite/main.rs
+++ b/tests/mcp_suite/main.rs
@@ -11,6 +11,7 @@
 mod common;
 
 mod fixture;
+mod git_correlation_test;
 mod mcp_cli_serve_test;
 mod mcp_dashboard_tool_test;
 mod mcp_handler_test;

--- a/tests/mcp_suite/mcp_server_test.rs
+++ b/tests/mcp_suite/mcp_server_test.rs
@@ -2056,6 +2056,7 @@ async fn mcp_runtime_events(
         project_id: None,
         session_id: Some(session_id.to_string()),
         event_kind: Some("mcp_tool_call".to_string()),
+        since: None,
         limit: 100,
     })
     .await
@@ -3068,4 +3069,205 @@ async fn cross_branch_tools_keep_using_explicit_branch_dbs_after_drift_reopen() 
         !main_search_text.contains("feature_only"),
         "explicit main branch search must ignore the live feature branch DB: {main_search_text}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Live session↔git span + commit attribution
+// ---------------------------------------------------------------------------
+
+/// Captures stdout of a git command (trimmed).
+fn git_capture(project: &std::path::Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(project)
+        .output()
+        .expect("git failed to spawn");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Proves live span recording from hook route notifications and the
+/// commit-attribution sweep at ingest time:
+///  (1) a hook notification with route metadata creates a span row in the
+///      resolved project's `sessions.db`;
+///  (2) a mid-session branch switch creates a second span row;
+///  (3) a commit made inside the feature span is attributed to the session by
+///      the ingest sweep.
+#[tokio::test]
+async fn hook_route_records_spans_and_ingest_attributes_commits() {
+    use tracedecay::sessions::git_correlation::{GitRefFilter, SessionsForQuery, SpanOverlapKind};
+
+    let (_env, project) = crate::common::IsolatedEnv::acquire().await;
+    let worktree = project.with_file_name("feature-worktree");
+
+    // Real repo on `main`, plus a linked worktree checked out on `feature`.
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn marker() {}\n").unwrap();
+    fs::write(project.join(".gitignore"), ".tracedecay/\n").unwrap();
+    git(&project, &["init", "-b", "main"]);
+    git(&project, &["config", "user.email", "test@test.com"]);
+    git(&project, &["config", "user.name", "Test"]);
+    git(&project, &["add", "."]);
+    git(&project, &["commit", "-m", "initial"]);
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            worktree.to_string_lossy().as_ref(),
+            "-b",
+            "feature",
+        ],
+    );
+
+    let cg = crate::fixture::init_project_from_template(&project)
+        .await
+        .unwrap();
+    cg.index_all().await.unwrap();
+    let project_root = cg.project_root().to_path_buf();
+
+    // Register with the git common dir so the linked-worktree hook route (a
+    // sibling path the parent-alias walk never reaches) resolves back to this
+    // project by git-common-dir identity.
+    let git_common_dir = tracedecay::worktree::git_common_dir(&project_root);
+    let registry = tracedecay::global_db::GlobalDb::open().await.unwrap();
+    registry
+        .upsert_code_project(
+            "proj_live",
+            &project_root,
+            git_common_dir.as_deref(),
+            None,
+            Some("main"),
+        )
+        .await
+        .unwrap();
+    let server = McpServer::new_with_dbs(cg, None, None, Some(Arc::new(registry)), false).await;
+
+    let session_id = "sess-live";
+    let main_worktree = project_root.to_string_lossy().to_string();
+    let feature_worktree =
+        tracedecay::sessions::git_correlation::normalize_worktree(&worktree.to_string_lossy());
+
+    // (1) Hook notification on `main` in the project worktree.
+    run_server_with_messages(
+        server.clone(),
+        vec![jsonrpc_notification_with_params(
+            "tracedecay/hookEvent",
+            json!({
+                "agent": "claude",
+                "event": "postToolUse",
+                "cwd": project_root.to_string_lossy(),
+                "route": {
+                    "session_id": session_id,
+                    "cwd": project_root.to_string_lossy(),
+                    "worktree": project_root.to_string_lossy(),
+                    "branch": "main",
+                }
+            }),
+        )],
+    )
+    .await;
+    server.ledger_writes_settled().await;
+
+    // (2) Mid-session branch switch: same session, `feature` in the worktree.
+    run_server_with_messages(
+        server.clone(),
+        vec![jsonrpc_notification_with_params(
+            "tracedecay/hookEvent",
+            json!({
+                "agent": "claude",
+                "event": "postToolUse",
+                "cwd": worktree.to_string_lossy(),
+                "route": {
+                    "session_id": session_id,
+                    "cwd": worktree.to_string_lossy(),
+                    "worktree": worktree.to_string_lossy(),
+                    "branch": "feature",
+                }
+            }),
+        )],
+    )
+    .await;
+    server.ledger_writes_settled().await;
+
+    // Open the project's sessions.db the same way the live writer resolved it.
+    let db_path = tracedecay::storage::resolve_project_session_db_path(&project_root)
+        .expect("resolve sessions.db path");
+    let db = tracedecay::global_db::GlobalDb::open_at(&db_path)
+        .await
+        .expect("open sessions.db");
+
+    // Span on main exists (scenario 1).
+    let on_main = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("main".to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert!(
+        on_main.iter().any(|hit| hit.session_id == session_id),
+        "main span should exist: {on_main:?}"
+    );
+
+    // A distinct span on feature exists (scenario 2: branch switch).
+    let on_feature = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("feature".to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert!(
+        on_feature.iter().any(|hit| hit.session_id == session_id),
+        "feature span should exist after branch switch: {on_feature:?}"
+    );
+
+    // Both branches recorded distinct worktrees for the same session.
+    assert_ne!(main_worktree, feature_worktree);
+
+    // (3) Make a commit on `feature` inside the live span window, then run the
+    // ingest sweep and confirm it is attributed to the session.
+    fs::write(
+        worktree.join("src/lib.rs"),
+        "pub fn marker() { /* edit */ }\n",
+    )
+    .unwrap();
+    git(&worktree, &["add", "."]);
+    git(&worktree, &["commit", "-m", "feature change"]);
+    let sha = git_capture(&worktree, &["rev-parse", "HEAD"]);
+
+    tracedecay::sessions::ingest_global_sources(&db, &project_root).await;
+
+    let by_commit = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Commit(sha.clone()),
+            since: None,
+            until: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        by_commit.len(),
+        1,
+        "commit {sha} should be attributed once: {by_commit:?}"
+    );
+    assert_eq!(by_commit[0].session_id, session_id);
+    assert_eq!(by_commit[0].commit_sha.as_deref(), Some(sha.as_str()));
+    assert_eq!(by_commit[0].branch.as_deref(), Some("feature"));
+    assert!(matches!(
+        by_commit[0].span_overlap_kind,
+        Some(SpanOverlapKind::WithinSpan) | Some(SpanOverlapKind::ExtendedWindow)
+    ));
+
+    drop(db);
 }

--- a/tests/mcp_suite/mcp_test.rs
+++ b/tests/mcp_suite/mcp_test.rs
@@ -100,7 +100,7 @@ fn test_tool_definitions_count() {
     // is available. Outline stays registered and reports the ast-grep outline
     // requirement at runtime so plugin docs/rules can consistently reference it.
     // LCM comparison and profile-storage registry support add extra tools.
-    let expected = 97 + usize::from(tracedecay::mcp::tools::ast_grep_available());
+    let expected = 98 + usize::from(tracedecay::mcp::tools::ast_grep_available());
     assert_eq!(tools.len(), expected);
 }
 

--- a/tests/session_suite/git_backfill.rs
+++ b/tests/session_suite/git_backfill.rs
@@ -1,0 +1,395 @@
+//! Integration coverage for the historical session↔git correlation backfill
+//! (`tracedecay sessions git-backfill`).
+//!
+//! Seeds a `sessions.db` with two sessions — one spanning a mid-session branch
+//! switch — against a real git repo carrying commits on both branches, runs
+//! the backfill core directly (no binary spawn), and asserts `sessions_for`
+//! returns the expected branch/commit attribution, including the branch-switch
+//! case. A fake [`GitReflogSource`] supplies the branch timeline so the switch
+//! lands deterministically relative to each session's activity window, while
+//! commit times come from the real repo.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use tracedecay::global_db::GlobalDb;
+use tracedecay::sessions::git_correlation::{
+    normalize_worktree, run_backfill, BackfillOptions, BranchTimelineEntry, GitRefFilter,
+    GitReflogSource, SessionsForQuery,
+};
+use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
+
+use crate::common;
+
+const T_BASE: i64 = 1_780_000_000;
+
+fn run_git(dir: &Path, args: &[&str], date: Option<i64>) {
+    let mut command = Command::new(common::git_program());
+    command.args(args).current_dir(dir);
+    if let Some(ts) = date {
+        let value = format!("{ts} +0000");
+        command
+            .env("GIT_AUTHOR_DATE", &value)
+            .env("GIT_COMMITTER_DATE", &value);
+    }
+    let status = command
+        .status()
+        .unwrap_or_else(|e| panic!("git {args:?} should spawn: {e}"));
+    assert!(status.success(), "git {args:?} should succeed");
+}
+
+/// Builds a repo on `main` with one commit at `T_BASE + 100`, a `feature`
+/// branch with a commit at `T_BASE + 400`, and a second `main` commit at
+/// `T_BASE + 700`. Returns `(base, repo_root, main_shas, feature_shas)`.
+fn build_repo() -> (TempDir, PathBuf, Vec<String>, Vec<String>) {
+    let base = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+    let repo = base.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap_or_else(|e| panic!("repo dir: {e}"));
+    run_git(&repo, &["init", "-b", "main"], None);
+    run_git(&repo, &["config", "user.email", "t@t.com"], None);
+    run_git(&repo, &["config", "user.name", "Test"], None);
+
+    std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+    run_git(&repo, &["add", "."], None);
+    run_git(&repo, &["commit", "-m", "main one"], Some(T_BASE + 100));
+
+    run_git(&repo, &["checkout", "-b", "feature"], None);
+    std::fs::write(repo.join("b.txt"), "two\n").unwrap();
+    run_git(&repo, &["add", "."], None);
+    run_git(&repo, &["commit", "-m", "feature one"], Some(T_BASE + 400));
+
+    run_git(&repo, &["checkout", "main"], None);
+    std::fs::write(repo.join("a.txt"), "one-two\n").unwrap();
+    run_git(&repo, &["add", "."], None);
+    run_git(&repo, &["commit", "-m", "main two"], Some(T_BASE + 700));
+
+    let main_shas = rev_list(&repo, "main");
+    let feature_shas = rev_list(&repo, "feature");
+    (base, repo, main_shas, feature_shas)
+}
+
+fn rev_list(repo: &Path, branch: &str) -> Vec<String> {
+    let out = Command::new(common::git_program())
+        .args(["rev-list", branch])
+        .current_dir(repo)
+        .output()
+        .unwrap_or_else(|e| panic!("rev-list {branch}: {e}"));
+    assert!(out.status.success(), "rev-list {branch} should succeed");
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn session(session_id: &str, project_path: &str, started: i64, ended: i64) -> SessionRecord {
+    SessionRecord {
+        provider: "claude".to_string(),
+        session_id: session_id.to_string(),
+        project_key: project_path.to_string(),
+        project_path: project_path.to_string(),
+        title: Some(format!("Session {session_id}")),
+        started_at: Some(started),
+        ended_at: Some(ended),
+        transcript_path: Some(format!("{session_id}.jsonl")),
+        metadata_json: None,
+        parent_session_id: None,
+        is_subagent: false,
+        agent_id: None,
+        parent_tool_use_id: None,
+    }
+}
+
+fn message(session_id: &str, message_id: &str, ts: i64) -> SessionMessageRecord {
+    SessionMessageRecord {
+        provider: "claude".to_string(),
+        message_id: message_id.to_string(),
+        session_id: session_id.to_string(),
+        role: "assistant".to_string(),
+        timestamp: Some(ts),
+        ordinal: 1,
+        text: "work".to_string(),
+        kind: Some("message".to_string()),
+        model: Some("test-model".to_string()),
+        tool_names: None,
+        source_path: Some(format!("{session_id}.jsonl")),
+        source_offset: Some(0),
+        metadata_json: None,
+    }
+}
+
+/// Reflog stub: every worktree reports the same timeline and current branch.
+struct FakeGit {
+    timeline: Vec<BranchTimelineEntry>,
+    current: Option<String>,
+    real_repo: PathBuf,
+}
+
+impl GitReflogSource for FakeGit {
+    fn reflog(&self, _worktree: &Path) -> Option<String> {
+        // Rendered newest-first, the shape branch_timeline_from_reflog parses.
+        let mut lines: Vec<String> = self
+            .timeline
+            .iter()
+            .map(|(ts, branch)| {
+                let target = branch.clone().unwrap_or_else(|| "a1b2c3d4e5f6".to_string());
+                format!("abc123 HEAD@{{{ts}}}: checkout: moving from prev to {target}")
+            })
+            .collect();
+        lines.reverse();
+        Some(lines.join("\n"))
+    }
+
+    fn current_branch(&self, _worktree: &Path) -> Option<String> {
+        self.current.clone()
+    }
+
+    fn commit_log(&self, _worktree: &Path, branch: &str, since: i64) -> Option<String> {
+        // Delegate to the real repo so commit shas/times are authentic.
+        let out = Command::new(common::git_program())
+            .args([
+                "log",
+                branch,
+                "--pretty=%H %ct",
+                &format!("--since={since}"),
+            ])
+            .current_dir(&self.real_repo)
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        String::from_utf8(out.stdout).ok()
+    }
+}
+
+async fn open_seeded_db(repo: &Path) -> (TempDir, GlobalDb, String) {
+    let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("db tmpdir: {e}"));
+    let db_path = tmp.path().join("sessions.db");
+    let db = GlobalDb::open_at(&db_path)
+        .await
+        .unwrap_or_else(|| panic!("open sessions.db"));
+    let project = repo.to_string_lossy().to_string();
+
+    // s_switch spans the whole run: main → feature → main.
+    assert!(
+        db.upsert_session(&session("s_switch", &project, T_BASE, T_BASE + 900))
+            .await
+    );
+    assert!(
+        db.upsert_session_message(&message("s_switch", "m1", T_BASE + 50))
+            .await
+    );
+    assert!(
+        db.upsert_session_message(&message("s_switch", "m2", T_BASE + 850))
+            .await
+    );
+
+    // s_main only overlaps the first main stretch.
+    assert!(
+        db.upsert_session(&session("s_main", &project, T_BASE + 60, T_BASE + 250))
+            .await
+    );
+    assert!(
+        db.upsert_session_message(&message("s_main", "m3", T_BASE + 200))
+            .await
+    );
+
+    (tmp, db, project)
+}
+
+#[tokio::test]
+async fn backfill_attributes_branch_switch_and_commits() {
+    let (_base, repo, main_shas, feature_shas) = build_repo();
+    let worktree = normalize_worktree(&repo.to_string_lossy());
+    let (_db_tmp, db, _project) = open_seeded_db(&repo).await;
+
+    // HEAD held main until +300, switched to feature at +300, back to main at
+    // +600. current_branch is the floor before the first entry (main).
+    let git = FakeGit {
+        timeline: vec![
+            (T_BASE + 300, Some("feature".to_string())),
+            (T_BASE + 600, Some("main".to_string())),
+        ],
+        current: Some("main".to_string()),
+        real_repo: repo.clone(),
+    };
+    let opts = BackfillOptions {
+        since: T_BASE - 1,
+        ..Default::default()
+    };
+
+    let stats = run_backfill(&db, &[], &git, &opts)
+        .await
+        .unwrap_or_else(|e| panic!("backfill: {e}"));
+    assert_eq!(stats.sessions_scanned, 2);
+    assert_eq!(
+        stats.skipped_total(),
+        0,
+        "both sessions map to the repo worktree"
+    );
+    assert!(stats.spans_written >= 2);
+
+    // s_switch touched both branches; s_main only main.
+    let feature_hits = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("feature".to_string()),
+            since: None,
+            until: None,
+            limit: 20,
+        })
+        .await
+        .unwrap();
+    let feature_ids: Vec<&str> = feature_hits.iter().map(|h| h.session_id.as_str()).collect();
+    assert_eq!(
+        feature_ids,
+        vec!["s_switch"],
+        "only the switching session hit feature"
+    );
+    assert_eq!(feature_hits[0].worktree.as_deref(), Some(worktree.as_str()));
+
+    let main_hits = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("main".to_string()),
+            since: None,
+            until: None,
+            limit: 20,
+        })
+        .await
+        .unwrap();
+    let mut main_ids: Vec<String> = main_hits.iter().map(|h| h.session_id.clone()).collect();
+    main_ids.sort();
+    assert_eq!(main_ids, vec!["s_main".to_string(), "s_switch".to_string()]);
+
+    // The feature commit falls in s_switch's feature segment [+300, +600].
+    let feature_sha = feature_shas
+        .iter()
+        .find(|sha| !main_shas.contains(sha))
+        .expect("feature-only commit");
+    let commit_hits = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Commit(feature_sha.clone()),
+            since: None,
+            until: None,
+            limit: 20,
+        })
+        .await
+        .unwrap();
+    let commit_ids: Vec<&str> = commit_hits.iter().map(|h| h.session_id.as_str()).collect();
+    assert_eq!(
+        commit_ids,
+        vec!["s_switch"],
+        "feature commit attributed to the switching session"
+    );
+    assert_eq!(
+        commit_hits[0].commit_sha.as_deref(),
+        Some(feature_sha.as_str())
+    );
+}
+
+#[tokio::test]
+async fn backfill_is_idempotent_and_dry_run_writes_nothing() {
+    let (_base, repo, _main, _feature) = build_repo();
+    let (_db_tmp, db, _project) = open_seeded_db(&repo).await;
+    let git = FakeGit {
+        timeline: vec![
+            (T_BASE + 300, Some("feature".to_string())),
+            (T_BASE + 600, Some("main".to_string())),
+        ],
+        current: Some("main".to_string()),
+        real_repo: repo.clone(),
+    };
+    let opts = BackfillOptions {
+        since: T_BASE - 1,
+        ..Default::default()
+    };
+
+    // Dry run writes nothing: no spans, so sessions_for is empty afterward.
+    let dry = run_backfill(
+        &db,
+        &[],
+        &git,
+        &BackfillOptions {
+            dry_run: true,
+            ..opts.clone()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(dry.sessions_scanned, 2);
+    let after_dry = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("main".to_string()),
+            since: None,
+            until: None,
+            limit: 20,
+        })
+        .await
+        .unwrap();
+    assert!(after_dry.is_empty(), "dry-run must not write spans");
+
+    // First real run writes; second run writes nothing new.
+    let first = run_backfill(&db, &[], &git, &opts).await.unwrap();
+    assert!(first.commits_attributed >= 1);
+    let second = run_backfill(&db, &[], &git, &opts).await.unwrap();
+    assert_eq!(
+        second.commits_attributed, 0,
+        "re-run must not re-attribute commits (INSERT OR IGNORE)"
+    );
+
+    // Span rows also converge: the main-branch session set is unchanged.
+    let hits = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("main".to_string()),
+            since: None,
+            until: None,
+            limit: 20,
+        })
+        .await
+        .unwrap();
+    let mut ids: Vec<String> = hits.iter().map(|h| h.session_id.clone()).collect();
+    ids.sort();
+    assert_eq!(ids, vec!["s_main".to_string(), "s_switch".to_string()]);
+}
+
+#[tokio::test]
+async fn backfill_skips_non_worktree_sessions() {
+    let (_base, repo, _main, _feature) = build_repo();
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("sessions.db");
+    let db = GlobalDb::open_at(&db_path).await.unwrap();
+
+    // A session whose project_path is not a git repo.
+    let not_repo = tmp.path().join("plain-dir").to_string_lossy().to_string();
+    std::fs::create_dir_all(&not_repo).unwrap();
+    assert!(
+        db.upsert_session(&session("s_orphan", &not_repo, T_BASE, T_BASE + 100))
+            .await
+    );
+    assert!(
+        db.upsert_session_message(&message("s_orphan", "m1", T_BASE + 50))
+            .await
+    );
+
+    let git = FakeGit {
+        timeline: vec![],
+        current: Some("main".to_string()),
+        real_repo: repo.clone(),
+    };
+    let stats = run_backfill(
+        &db,
+        &[],
+        &git,
+        &BackfillOptions {
+            since: T_BASE - 1,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(stats.sessions_scanned, 1);
+    assert_eq!(stats.skipped_not_worktree, 1);
+    assert_eq!(stats.spans_written, 0);
+}

--- a/tests/session_suite/global_db.rs
+++ b/tests/session_suite/global_db.rs
@@ -151,6 +151,7 @@ fn analytics_query(
         project_id: Some("project-a".to_string()),
         session_id: session_id.map(ToOwned::to_owned),
         event_kind: event_kind.map(ToOwned::to_owned),
+        since: None,
         limit,
     }
 }
@@ -287,6 +288,39 @@ async fn analytics_events_append_and_query_by_provider_project_session_and_kind(
         events[0].metadata_json.as_deref(),
         Some(r#"{"tokens_saved":42}"#)
     );
+}
+
+#[tokio::test]
+async fn analytics_events_query_since_bounds_timestamp() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+
+    append_analytics_event(
+        &db,
+        &analytics_event(Some("session-old"), 1_715_000_100, "tool"),
+        "append old analytics event",
+    )
+    .await;
+    let recent_id = append_analytics_event(
+        &db,
+        &analytics_event(Some("session-new"), 1_715_000_200, "tool"),
+        "append recent analytics event",
+    )
+    .await;
+
+    // A `since` lower bound drops rows older than the boundary; the boundary
+    // itself is inclusive.
+    let events = db
+        .query_analytics_events(&AnalyticsEventQuery {
+            since: Some(1_715_000_200),
+            limit: 100,
+            ..Default::default()
+        })
+        .await
+        .expect("query analytics events since bound");
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].id, recent_id);
+    assert_eq!(events[0].timestamp, 1_715_000_200);
 }
 
 #[tokio::test]
@@ -742,6 +776,74 @@ async fn search_session_messages_applies_hyphen_filter_before_limit() {
 }
 
 #[tokio::test]
+async fn search_session_messages_git_scoped_by_branch_with_hyphen_term() {
+    use tracedecay::sessions::git_correlation::{GitScopeFilter, SpanObservation, SpanSource};
+
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    let session = sample_session("cursor", "cursor-scoped", "project-a");
+    db.upsert_session(&session).await;
+    db.upsert_session_message(&sample_message(
+        "cursor",
+        "scoped-msg",
+        "cursor-scoped",
+        "the literal foo-bar marker on a scoped branch",
+    ))
+    .await;
+
+    // The session was active on `feat/x`; record a span so the scoping EXISTS
+    // subquery has a row to match against.
+    db.git_record_span_observation(
+        &SpanObservation {
+            provider: "cursor".to_string(),
+            session_id: "cursor-scoped".to_string(),
+            thread_id: None,
+            branch: Some("feat/x".to_string()),
+            worktree: "/repo".to_string(),
+            ts: 1_000,
+            source: SpanSource::HookRoute,
+        },
+        600,
+    )
+    .await
+    .unwrap();
+
+    let filters = SessionSearchFilters {
+        scope: SessionSearchScope::All,
+        parent_session_id: None,
+        time_range: SessionSearchTimeRange::default(),
+    };
+
+    // A hyphenated query term appends a numbered placeholder *after* the git
+    // EXISTS predicate's anonymous placeholders; the match must still resolve.
+    let matched = db
+        .search_session_messages_git_scoped(
+            Some("cursor"),
+            Some("project-a"),
+            "foo-bar",
+            10,
+            filters,
+            &GitScopeFilter::from_args(Some("feat/x"), None, None).unwrap(),
+        )
+        .await;
+    assert_eq!(matched.len(), 1);
+    assert_eq!(matched[0].message.message_id, "scoped-msg");
+
+    // A branch the session was never on excludes the message.
+    let excluded = db
+        .search_session_messages_git_scoped(
+            Some("cursor"),
+            Some("project-a"),
+            "foo-bar",
+            10,
+            filters,
+            &GitScopeFilter::from_args(Some("other"), None, None).unwrap(),
+        )
+        .await;
+    assert!(excluded.is_empty());
+}
+
+#[tokio::test]
 async fn search_session_messages_filters_by_message_timestamp() {
     let tmp = TempDir::new().unwrap();
     let db = open_isolated_db(&tmp).await;
@@ -1030,6 +1132,7 @@ async fn hook_analytics_import_is_incremental_and_idempotent() {
             project_id: None,
             session_id: None,
             event_kind: None,
+            since: None,
             limit: 100,
         })
         .await

--- a/tests/session_suite/lcm_compression.rs
+++ b/tests/session_suite/lcm_compression.rs
@@ -1663,6 +1663,7 @@ async fn structured_active_content_replay_preserves_shape_while_grep_snippet_sta
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .unwrap();

--- a/tests/session_suite/lcm_query.rs
+++ b/tests/session_suite/lcm_query.rs
@@ -336,6 +336,7 @@ async fn grep_searches_raw_snippets_and_summary_nodes() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("grep should succeed");
@@ -377,6 +378,7 @@ async fn grep_tokenizes_punctuation_heavy_path_like_queries() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("path-like grep should not miss because punctuation was collapsed");
@@ -434,6 +436,7 @@ async fn grep_like_fallback_recalls_infix_hyphen_query_matches() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("hyphenated fallback query should keep infix matches");
@@ -471,6 +474,7 @@ async fn grep_like_fallback_recalls_infix_slash_query_matches() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("slash fallback query should keep infix matches");
@@ -507,6 +511,7 @@ async fn grep_like_fallback_handles_hash_separator_queries() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("hash separator grep should not produce an FTS syntax error");
@@ -543,6 +548,7 @@ async fn grep_quotes_reserved_operator_looking_query_text() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("reserved FTS operator text should be treated as literal text");
@@ -581,6 +587,7 @@ async fn grep_preserves_quoted_phrase_semantics() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("quoted phrase grep should preserve phrase matching");
@@ -619,6 +626,7 @@ async fn grep_preserves_boolean_or_semantics() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("OR query should preserve boolean operator semantics");
@@ -664,6 +672,7 @@ async fn grep_cjk_query_uses_like_fallback_substring_matching() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("CJK grep should fall back to LIKE substring matching");
@@ -727,6 +736,7 @@ async fn grep_filters_raw_hits_by_role_source_and_time_and_sorts() {
             role: Some("assistant".into()),
             start_time: Some(5),
             end_time: Some(25),
+            git_filter: Default::default(),
         })
         .await
         .expect("filtered grep should succeed");
@@ -1959,6 +1969,7 @@ async fn empty_session_load_grep_and_describe_return_empty_results() {
             role: None,
             start_time: None,
             end_time: None,
+            git_filter: Default::default(),
         })
         .await
         .expect("grep on empty session should succeed");
@@ -2083,6 +2094,7 @@ fn grep_request(query: &str) -> LcmGrepRequest {
         role: None,
         start_time: None,
         end_time: None,
+        git_filter: Default::default(),
     }
 }
 

--- a/tests/session_suite/main.rs
+++ b/tests/session_suite/main.rs
@@ -9,6 +9,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+mod git_backfill;
 mod global_db;
 mod lcm_compression;
 mod lcm_dag;


### PR DESCRIPTION
First-class correlation between sessions/LCM messages and git artifacts: query all sessions/messages for a **branch**, **worktree**, or **commit** ("the conversations that produced this commit").

## What's in it
- **Schema**: span-based attribution tables (`session_git_spans`, `commit_sessions`) in the per-project session store, version-gated migration
- **Live attribution**: hook-route metadata records spans per session (mid-session branch/worktree switches produce distinct spans); linked worktrees resolve via git-common-dir identity — a real defect the build's review caught: sibling-path worktrees previously dropped spans silently
- **Commit attribution**: on ingest, commits landing inside a session's active span on that branch/worktree get `commit_sessions` rows
- **Backfill**: `tracedecay sessions git-backfill` — reflog-segmented historical attribution from existing hook analytics + session timestamps; idempotent; interior branch segments seeded correctly (second review-caught defect)
- **Query surface**: new `tracedecay_sessions_for` MCP tool (git_ref: branch|worktree|commit) + `branch`/`worktree`/`commit` filter pushdown on `tracedecay_message_search` and `tracedecay_lcm_grep`

## Status: assembled onto current master, ready for review pending CI
Gates: git_correlation 21/21 · backfill 3/3 · full mcp_suite 313/313 · clean squash (zero conflicts). Built by the Fable-foundation → Opus-implement → review → fix pipeline (workflow `wf_f46d3a1c-ccb`); two review-caught product defects fixed pre-merge.

## Follow-up (designed, separate PR): layer-2 workflow indexing
Workflows attach to parent threads, agents attach to workflows, joined to these git spans (`tracedecay_workflows` tool); absorbs `codex/workflow-state-tool`. Fact 38.

## Recovery context
Session `2c51d204-3565-4a10-833d-d8fbd51620c3` · workflow `wf_f46d3a1c-ccb` · facts 20/30/38/39 (`tracedecay tool fact_store --action get --fact-id 39` = full manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)