### PR TITLE
fix: migrate Codex plugin cache to personal namespace

### DIFF
--- a/.changeset/personal-codex-plugin.md
+++ b/.changeset/personal-codex-plugin.md
@@ -1,0 +1,5 @@
+---
+"tracedecay": patch
+---
+
+Migrate legacy Codex plugin installs from the old caveman-home marketplace cache into the personal namespace and align bundled Cursor plugin metadata with current command/manifest expectations.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Codex installs are plugin-based. TraceDecay writes the plugin source bundle and 
 
 First-time global install writes `~/plugins/tracedecay`, updates the personal marketplace at `~/.agents/plugins/marketplace.json`, and prints `codex plugin add tracedecay@personal`. Run that command in Codex to copy the source into Codex's installed cache under `~/.codex/plugins/cache/personal/tracedecay/<version>`.
 
-TraceDecay does not write `~/.codex/AGENTS.md` or `~/.codex/hooks.json`. If you are working from a branch or release that adds Codex plugin refresh support, refresh the source bundle first and then rerun `codex plugin add tracedecay@personal` when you need Codex to recopy the bundle.
+TraceDecay does not write `~/.codex/AGENTS.md` or `~/.codex/hooks.json`. Re-running `tracedecay install --agent codex` refreshes the source bundle and any detected installed Codex cache, including legacy `caveman-home` cache installs, into the canonical `tracedecay@personal` namespace.
 
 Project-local Codex install writes the repository plugin bundle to `plugins/tracedecay` and the repository marketplace to `.agents/plugins/marketplace.json`. It does not write project `.codex/config.toml`, project `.codex/hooks.json`, or `AGENTS.md`.
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -335,10 +335,10 @@ writes the plugin source bundle and marketplace entry; Codex CLI installs the
 installed cache from that source. First install writes
 `~/plugins/tracedecay/`, updates `~/.agents/plugins/marketplace.json`, and prints
 `codex plugin add tracedecay@personal`. Run that command in Codex to copy the
-source into `~/.codex/plugins/cache/personal/tracedecay/<version>`. If you are
-working from a branch or release that adds Codex plugin refresh support, refresh
-the source bundle first and then rerun `codex plugin add tracedecay@personal`
-when you need Codex to recopy the bundle.
+source into `~/.codex/plugins/cache/personal/tracedecay/<version>`. Re-running
+`tracedecay install --agent codex` refreshes the source bundle and any detected
+installed Codex cache, including legacy `caveman-home` cache installs, into the
+canonical `tracedecay@personal` namespace.
 
 Skill visibility follows Codex's plugin model. `codex plugin list` and
 `codex plugin add` inspect the marketplace source bundle. Active Codex sessions

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "tracedecay",
+  "displayName": "TraceDecay",
   "version": "0.0.0",
   "description": "Cursor integration for TraceDecay semantic code intelligence: MCP server plus a `tracedecay tool` CLI fallback exposing the same tools when MCP is unavailable.",
   "author": {
@@ -16,6 +17,7 @@
     "call-graph",
     "code-health"
   ],
+  "category": "Developer Tools",
   "mcpServers": "mcp.json",
   "hooks": "hooks/hooks.json",
   "rules": [

--- a/plugin/overlays/cursor/commands/tracedecay-audit-safety.md
+++ b/plugin/overlays/cursor/commands/tracedecay-audit-safety.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-audit-safety
 description: Audit the repo or a directory for ship-blocking risk, panic sites, risk markers, dead code, and untested high-risk symbols.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-check-health.md
+++ b/plugin/overlays/cursor/commands/tracedecay-check-health.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-check-health
 description: Check code health for the repo or a directory, including worst offenders and a prioritized fix list.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-clean-dead-code.md
+++ b/plugin/overlays/cursor/commands/tracedecay-clean-dead-code.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-clean-dead-code
 description: Find and safely remove dead code, unused imports, and duplication via the TraceDecay code graph.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-compare-branches.md
+++ b/plugin/overlays/cursor/commands/tracedecay-compare-branches.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-compare-branches
 description: Compare or search another git branch's code graph without switching your checkout.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-curate-memory.md
+++ b/plugin/overlays/cursor/commands/tracedecay-curate-memory.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-curate-memory
 description: Curate, update, delete, or inspect TraceDecay memory facts and dashboard curation from an explicit slash workflow.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-draft-commit.md
+++ b/plugin/overlays/cursor/commands/tracedecay-draft-commit.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-draft-commit
 description: Draft a commit message, PR description, or changelog from semantic changes; drafts text only and never commits or pushes.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-find-impact.md
+++ b/plugin/overlays/cursor/commands/tracedecay-find-impact.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-find-impact
 description: Find the blast radius of a change, including impacted symbols, files, and the tests to run.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-fix-build.md
+++ b/plugin/overlays/cursor/commands/tracedecay-fix-build.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-fix-build
 description: Fix build and type errors by running or parsing diagnostics, mapping them to symbols with callers, then fixing.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-map-architecture.md
+++ b/plugin/overlays/cursor/commands/tracedecay-map-architecture.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-map-architecture
 description: Map repo or directory architecture, including layered modules, dependency hotspots, and structural risks.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-port-code.md
+++ b/plugin/overlays/cursor/commands/tracedecay-port-code.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-port-code
 description: Port or migrate code between directories in dependency-safe order and track progress.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-recall-memory.md
+++ b/plugin/overlays/cursor/commands/tracedecay-recall-memory.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-recall-memory
 description: Recall prior decisions, durable facts, and past session conversations for this project.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-review-diff.md
+++ b/plugin/overlays/cursor/commands/tracedecay-review-diff.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-review-diff
 description: Review the current PR or diff for impact, risk, and quality via the TraceDecay code graph.
 ---
 

--- a/plugin/overlays/cursor/commands/tracedecay-test-changes.md
+++ b/plugin/overlays/cursor/commands/tracedecay-test-changes.md
@@ -1,4 +1,5 @@
 ---
+name: tracedecay-test-changes
 description: Test current changes by running only affected tests and mapping failures back to source.
 ---
 

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -734,14 +734,34 @@ fn install_codex_marketplace_entry(
     if !marketplace.is_object() {
         marketplace = json!({});
     }
-    marketplace["name"] = json!(marketplace_name);
+    let existing_name = marketplace.get("name").and_then(|value| value.as_str());
+    let has_tracedecay_entry = marketplace
+        .get("plugins")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|plugins| {
+            plugins.iter().any(|entry| {
+                entry.get("name").and_then(|value| value.as_str()) == Some("tracedecay")
+            })
+        });
+    let should_write_identity =
+        existing_name.is_none() || (existing_name == Some("caveman-home") && has_tracedecay_entry);
+    if should_write_identity {
+        marketplace["name"] = json!(marketplace_name);
+    }
     if !marketplace
         .get("interface")
         .is_some_and(serde_json::Value::is_object)
     {
         marketplace["interface"] = json!({});
     }
-    marketplace["interface"]["displayName"] = json!(display_name);
+    if should_write_identity
+        || marketplace["interface"]
+            .get("displayName")
+            .and_then(|value| value.as_str())
+            .is_none()
+    {
+        marketplace["interface"]["displayName"] = json!(display_name);
+    }
     if !marketplace
         .get("plugins")
         .is_some_and(serde_json::Value::is_array)

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -279,19 +279,31 @@ fn codex_plugin_cached_root(home: &Path) -> PathBuf {
     home.join(".codex/plugins/cache/personal/tracedecay")
 }
 
+fn codex_plugin_legacy_cached_root(home: &Path) -> PathBuf {
+    home.join(".codex/plugins/cache/caveman-home/tracedecay")
+}
+
 fn codex_plugin_current_cached_install_dir(home: &Path) -> PathBuf {
     codex_plugin_cached_root(home).join(env!("CARGO_PKG_VERSION"))
 }
 
 fn codex_plugin_cached_install_dirs(home: &Path) -> Vec<PathBuf> {
-    let Ok(entries) = std::fs::read_dir(codex_plugin_cached_root(home)) else {
-        return Vec::new();
-    };
-    let mut dirs: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .filter(|path| path.is_dir() && codex_plugin_dir_is_tracedecay(path))
-        .collect();
+    let mut dirs = Vec::new();
+    for root in [
+        codex_plugin_cached_root(home),
+        codex_plugin_legacy_cached_root(home),
+    ] {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        dirs.extend(
+            entries
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.is_dir() && codex_plugin_dir_is_tracedecay(path)),
+        );
+    }
     dirs.sort();
+    dirs.dedup();
     dirs
 }
 
@@ -722,25 +734,14 @@ fn install_codex_marketplace_entry(
     if !marketplace.is_object() {
         marketplace = json!({});
     }
-    if marketplace
-        .get("name")
-        .and_then(|value| value.as_str())
-        .is_none()
-    {
-        marketplace["name"] = json!(marketplace_name);
-    }
+    marketplace["name"] = json!(marketplace_name);
     if !marketplace
         .get("interface")
         .is_some_and(serde_json::Value::is_object)
     {
-        marketplace["interface"] = json!({ "displayName": display_name });
-    } else if marketplace["interface"]
-        .get("displayName")
-        .and_then(|value| value.as_str())
-        .is_none()
-    {
-        marketplace["interface"]["displayName"] = json!(display_name);
+        marketplace["interface"] = json!({});
     }
+    marketplace["interface"]["displayName"] = json!(display_name);
     if !marketplace
         .get("plugins")
         .is_some_and(serde_json::Value::is_array)

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -497,12 +497,9 @@ fn assert_cursor_plugin_bundle(plugin_dir: &Path, expected_command: &str, expect
     assert_eq!(manifest["license"], "MIT");
     assert_eq!(manifest["mcpServers"], "mcp.json");
     assert_eq!(manifest["hooks"], "hooks/hooks.json");
-    // Documented manifest metadata (displayName is not a documented field and
-    // must not reappear; author/homepage/keywords are the documented ones).
-    assert!(
-        manifest.get("displayName").is_none(),
-        "displayName is not a documented plugin.json field"
-    );
+    // Documented manifest metadata shown in Cursor's plugin surfaces.
+    assert_eq!(manifest["displayName"], "TraceDecay");
+    assert_eq!(manifest["category"], "Developer Tools");
     assert!(
         manifest["author"]["name"].is_string(),
         "plugin manifest should carry a documented author object"

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -3406,6 +3406,23 @@ fn test_codex_install_migrates_legacy_caveman_home_cache_and_marketplace() {
 }
 
 #[test]
+fn test_codex_install_preserves_existing_marketplace_identity() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_install_ctx(home);
+    write_codex_personal_marketplace(home, "my-marketplace", "My Marketplace");
+
+    CodexIntegration.install(&ctx).unwrap();
+
+    assert_codex_marketplace_entry(
+        &codex_personal_marketplace_path(home),
+        "my-marketplace",
+        "My Marketplace",
+        "./plugins/tracedecay",
+    );
+}
+
+#[test]
 fn test_codex_install_refreshes_existing_cache_and_prunes_stale_skills() {
     let dir = TempDir::new().unwrap();
     let home = dir.path();

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -355,6 +355,10 @@ fn codex_stale_cached_plugin_install_dir(home: &Path) -> std::path::PathBuf {
     home.join(".codex/plugins/cache/personal/tracedecay/0.0.4")
 }
 
+fn codex_legacy_cached_plugin_install_dir(home: &Path) -> std::path::PathBuf {
+    home.join(".codex/plugins/cache/caveman-home/tracedecay/0.0.4")
+}
+
 fn codex_personal_marketplace_path(home: &Path) -> std::path::PathBuf {
     home.join(".agents/plugins/marketplace.json")
 }
@@ -3368,6 +3372,37 @@ fn test_codex_install_refreshes_existing_cache_and_keeps_bootstrap_source_listab
     assert!(
         !stale_plugin_dir.exists(),
         "global Codex install should migrate managed cache installs to the current plugin version"
+    );
+    assert_codex_personal_marketplace_entry(home);
+}
+
+#[test]
+fn test_codex_install_migrates_legacy_caveman_home_cache_and_marketplace() {
+    let dir = TempDir::new().unwrap();
+    let home = dir.path();
+    let ctx = make_install_ctx(home);
+    let legacy_plugin_dir = codex_legacy_cached_plugin_install_dir(home);
+    write_codex_plugin_manifest(&legacy_plugin_dir, "0.0.0");
+    write_stale_codex_skill(&legacy_plugin_dir);
+    std::fs::create_dir_all(home.join(".agents/plugins")).unwrap();
+    std::fs::write(
+        codex_personal_marketplace_path(home),
+        r#"{"interface":{"displayName":"Caveman Home"},"name":"caveman-home","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
+    )
+    .unwrap();
+
+    CodexIntegration.install(&ctx).unwrap();
+
+    let cached_plugin_dir = codex_cached_plugin_install_dir(home);
+    assert_codex_plugin_bundle(
+        &cached_plugin_dir,
+        &ctx.tracedecay_bin,
+        serde_json::json!(["serve"]),
+        true,
+    );
+    assert!(
+        !legacy_plugin_dir.exists(),
+        "global Codex install should migrate legacy caveman-home cache installs to personal"
     );
     assert_codex_personal_marketplace_entry(home);
 }

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -363,6 +363,17 @@ fn codex_personal_marketplace_path(home: &Path) -> std::path::PathBuf {
     home.join(".agents/plugins/marketplace.json")
 }
 
+fn write_codex_personal_marketplace(home: &Path, name: &str, display_name: &str) {
+    std::fs::create_dir_all(home.join(".agents/plugins")).unwrap();
+    std::fs::write(
+        codex_personal_marketplace_path(home),
+        format!(
+            r#"{{"interface":{{"displayName":"{display_name}"}},"name":"{name}","plugins":[{{"name":"tracedecay","source":{{"source":"local","path":"./plugins/tracedecay"}}}}]}}"#
+        ),
+    )
+    .unwrap();
+}
+
 fn codex_repo_marketplace_path(project: &Path) -> std::path::PathBuf {
     project.join(".agents/plugins/marketplace.json")
 }
@@ -3340,12 +3351,7 @@ fn test_codex_install_refreshes_existing_cache_and_keeps_bootstrap_source_listab
     let bootstrap_dir = codex_plugin_install_dir(home);
     write_codex_plugin_manifest(&bootstrap_dir, "0.0.0");
     write_stale_codex_skill(&bootstrap_dir);
-    std::fs::create_dir_all(home.join(".agents/plugins")).unwrap();
-    std::fs::write(
-        codex_personal_marketplace_path(home),
-        r#"{"interface":{"displayName":"Personal"},"name":"personal","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
-    )
-    .unwrap();
+    write_codex_personal_marketplace(home, "personal", "Personal");
 
     CodexIntegration.install(&ctx).unwrap();
 
@@ -3381,12 +3387,7 @@ fn test_codex_install_migrates_legacy_caveman_home_cache_and_marketplace() {
     let legacy_plugin_dir = codex_legacy_cached_plugin_install_dir(home);
     write_codex_plugin_manifest(&legacy_plugin_dir, "0.0.0");
     write_stale_codex_skill(&legacy_plugin_dir);
-    std::fs::create_dir_all(home.join(".agents/plugins")).unwrap();
-    std::fs::write(
-        codex_personal_marketplace_path(home),
-        r#"{"interface":{"displayName":"Caveman Home"},"name":"caveman-home","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
-    )
-    .unwrap();
+    write_codex_personal_marketplace(home, "caveman-home", "Caveman Home");
 
     CodexIntegration.install(&ctx).unwrap();
 

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -282,6 +282,23 @@ fn expected_tracedecay_bin() -> String {
     path_match.unwrap_or_else(|| env!("CARGO_BIN_EXE_tracedecay").replace('\\', "/"))
 }
 
+fn comparable_command_path(command: &str) -> String {
+    command
+        .strip_prefix("//?/")
+        .unwrap_or(command)
+        .replace('\\', "/")
+}
+
+fn assert_command_eq(actual: &serde_json::Value, expected: &str) {
+    let actual = actual
+        .as_str()
+        .unwrap_or_else(|| panic!("command should be a string: {actual}"));
+    assert_eq!(
+        comparable_command_path(actual),
+        comparable_command_path(expected)
+    );
+}
+
 /// Python snippet that py_compiles the generated plugin sources inside the
 /// same interpreter that runs a test's check script, instead of the separate
 /// `python3 -m py_compile` process `assert_python_compiles` spawns. On
@@ -424,7 +441,7 @@ fn assert_codex_plugin_bundle(
     let mcp = read_json(&plugin_dir.join(".mcp.json"));
     let server = &mcp["mcpServers"]["tracedecay"];
     assert_eq!(server["type"], "stdio");
-    assert_eq!(server["command"], expected_command);
+    assert_command_eq(&server["command"], expected_command);
     assert_eq!(server["args"], expected_args);
     if expected_global_bundle {
         assert_eq!(server["env"]["TRACEDECAY_ENABLE_GLOBAL_DB"], "1");
@@ -536,7 +553,7 @@ fn assert_cursor_plugin_bundle(plugin_dir: &Path, expected_command: &str, expect
     let mcp = read_json(&plugin_dir.join("mcp.json"));
     let server = &mcp["mcpServers"]["tracedecay"];
     assert_eq!(server["type"], "stdio");
-    assert_eq!(server["command"], expected_command);
+    assert_command_eq(&server["command"], expected_command);
     assert_eq!(
         server["args"],
         serde_json::json!(["serve", "--path", "${workspaceFolder}"])
@@ -3733,7 +3750,7 @@ fn assert_command_contains_expected_bin(
         })
         .expect("handler command should exist");
     assert!(
-        command.contains(expected),
+        comparable_command_path(command).contains(&comparable_command_path(expected)),
         "Codex hook command must use the resolved absolute tracedecay executable, got {command}"
     );
 }

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -591,7 +591,8 @@ fn assert_cursor_plugin_bundle(plugin_dir: &Path, expected_command: &str, expect
         assert!(
             hook["command"]
                 .as_str()
-                .is_some_and(|command| command.contains(expected_command)),
+                .is_some_and(|command| comparable_command_path(command)
+                    .contains(&comparable_command_path(expected_command))),
             "plugin hook commands should use the installed tracedecay binary"
         );
         assert!(

--- a/tests/agent_suite/skill_lint_cursor_test.rs
+++ b/tests/agent_suite/skill_lint_cursor_test.rs
@@ -37,7 +37,7 @@
 use std::collections::BTreeSet;
 
 use regex::Regex;
-use tracedecay::automation::skill_frontmatter::SkillFrontmatterValue;
+use tracedecay::automation::skill_frontmatter::{parse_skill_frontmatter, SkillFrontmatterValue};
 use tracedecay::mcp::get_tool_definitions;
 
 use crate::plugin_validation_support::{load_skill_docs_from, repo_path};
@@ -247,6 +247,36 @@ fn cursor_commands_are_hygienic_and_reference_resolve() {
             .expect("command file stem")
             .to_string();
         let raw = std::fs::read_to_string(&path).expect("read command");
+        let frontmatter = match parse_skill_frontmatter(&raw) {
+            Ok(frontmatter) => frontmatter,
+            Err(error) => {
+                violations.push(format!(
+                    "{at}: command file missing valid YAML frontmatter: {error}"
+                ));
+                continue;
+            }
+        };
+        match frontmatter.get("name").and_then(|value| value.as_scalar()) {
+            Some(name) if name == slug => {}
+            Some(name) => violations.push(format!(
+                "{at}: frontmatter name {name:?} must match command slug {slug:?}"
+            )),
+            None => violations.push(format!(
+                "{at}: command frontmatter must include scalar `name`"
+            )),
+        }
+        match frontmatter
+            .get("description")
+            .and_then(|value| value.as_scalar())
+        {
+            Some(description) if !description.trim().is_empty() => {}
+            Some(_) => violations.push(format!(
+                "{at}: command frontmatter `description` must not be empty"
+            )),
+            None => violations.push(format!(
+                "{at}: command frontmatter must include scalar `description`"
+            )),
+        }
 
         if raw.contains('\r') {
             violations.push(format!("{at}: contains CRLF line endings"));

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -117,6 +117,17 @@ fn codex_marketplace_path(home: &Path) -> PathBuf {
     home.join(".agents/plugins/marketplace.json")
 }
 
+fn write_codex_marketplace(home: &Path, name: &str, display_name: &str) {
+    std::fs::create_dir_all(home.join(".agents/plugins")).unwrap();
+    std::fs::write(
+        codex_marketplace_path(home),
+        format!(
+            r#"{{"interface":{{"displayName":"{display_name}"}},"name":"{name}","plugins":[{{"name":"tracedecay","source":{{"source":"local","path":"./plugins/tracedecay"}}}}]}}"#
+        ),
+    )
+    .unwrap();
+}
+
 fn write_codex_plugin_manifest(plugin_dir: &Path, version: &str) {
     std::fs::create_dir_all(plugin_dir.join(".codex-plugin")).unwrap();
     std::fs::write(
@@ -464,12 +475,7 @@ fn codex_update_plugin_refreshes_cache_and_keeps_bootstrap_source_listable() {
     let bootstrap_dir = codex_bootstrap_dir(home.path());
     write_codex_plugin_manifest(&bootstrap_dir, "0.0.0");
     write_stale_codex_skill(&bootstrap_dir);
-    std::fs::create_dir_all(home.path().join(".agents/plugins")).unwrap();
-    std::fs::write(
-        codex_marketplace_path(home.path()),
-        r#"{"interface":{"displayName":"Personal"},"name":"personal","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
-    )
-    .unwrap();
+    write_codex_marketplace(home.path(), "personal", "Personal");
 
     let codex = get_integration("codex").unwrap();
     let outcome = codex
@@ -503,12 +509,7 @@ fn codex_update_plugin_migrates_legacy_caveman_home_cache_to_personal() {
     let legacy_plugin_dir = codex_legacy_cached_plugin_dir(home.path());
     let cached_plugin_dir = codex_cached_plugin_dir(home.path());
     write_codex_plugin_manifest(&legacy_plugin_dir, "0.0.0");
-    std::fs::create_dir_all(home.path().join(".agents/plugins")).unwrap();
-    std::fs::write(
-        codex_marketplace_path(home.path()),
-        r#"{"interface":{"displayName":"Caveman Home"},"name":"caveman-home","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
-    )
-    .unwrap();
+    write_codex_marketplace(home.path(), "caveman-home", "Caveman Home");
 
     let codex = get_integration("codex").unwrap();
     let outcome = codex

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -109,6 +109,10 @@ fn codex_cached_plugin_dir(home: &Path) -> PathBuf {
         .join(env!("CARGO_PKG_VERSION"))
 }
 
+fn codex_legacy_cached_plugin_dir(home: &Path) -> PathBuf {
+    home.join(".codex/plugins/cache/caveman-home/tracedecay/0.0.4")
+}
+
 fn codex_marketplace_path(home: &Path) -> PathBuf {
     home.join(".agents/plugins/marketplace.json")
 }
@@ -488,6 +492,44 @@ fn codex_update_plugin_refreshes_cache_and_keeps_bootstrap_source_listable() {
     assert!(
         !bootstrap_dir.join("skills/stale-skill/SKILL.md").exists(),
         "update-plugin should refresh the bootstrap source so plugin list/add sees current skills"
+    );
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
+}
+
+#[test]
+fn codex_update_plugin_migrates_legacy_caveman_home_cache_to_personal() {
+    let home = TempDir::new().unwrap();
+    let project_root = home.path().join("workspace");
+    let legacy_plugin_dir = codex_legacy_cached_plugin_dir(home.path());
+    let cached_plugin_dir = codex_cached_plugin_dir(home.path());
+    write_codex_plugin_manifest(&legacy_plugin_dir, "0.0.0");
+    std::fs::create_dir_all(home.path().join(".agents/plugins")).unwrap();
+    std::fs::write(
+        codex_marketplace_path(home.path()),
+        r#"{"interface":{"displayName":"Caveman Home"},"name":"caveman-home","plugins":[{"name":"tracedecay","source":{"source":"local","path":"./plugins/tracedecay"}}]}"#,
+    )
+    .unwrap();
+
+    let codex = get_integration("codex").unwrap();
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to migrate the legacy installed cache");
+    };
+    assert_eq!(
+        paths,
+        vec![cached_plugin_dir.clone(), codex_bootstrap_dir(home.path())]
+    );
+
+    assert_codex_bundle_contains_bin(&cached_plugin_dir, NEW_BIN, CodexScope::Global);
+    assert!(
+        !legacy_plugin_dir.exists(),
+        "update-plugin should remove the legacy caveman-home cache after migrating to personal"
+    );
+    assert_eq!(
+        read_json(&codex_marketplace_path(home.path()))["name"],
+        "personal"
     );
     assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
 }

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -536,6 +536,37 @@ fn codex_update_plugin_migrates_legacy_caveman_home_cache_to_personal() {
 }
 
 #[test]
+fn codex_update_plugin_preserves_existing_marketplace_identity() {
+    let home = TempDir::new().unwrap();
+    let project_root = home.path().join("workspace");
+    let cached_plugin_dir = codex_cached_plugin_dir(home.path());
+    write_codex_plugin_manifest(&cached_plugin_dir, "0.0.0");
+    write_codex_marketplace(home.path(), "my-marketplace", "My Marketplace");
+
+    let codex = get_integration("codex").unwrap();
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh the installed cache");
+    };
+    assert_eq!(
+        paths,
+        vec![cached_plugin_dir.clone(), codex_bootstrap_dir(home.path())]
+    );
+
+    assert_eq!(
+        read_json(&codex_marketplace_path(home.path()))["name"],
+        "my-marketplace"
+    );
+    assert_eq!(
+        read_json(&codex_marketplace_path(home.path()))["interface"]["displayName"],
+        "My Marketplace"
+    );
+    assert_codex_marketplace_entry(&codex_marketplace_path(home.path()), "./plugins/tracedecay");
+}
+
+#[test]
 fn codex_update_plugin_recreates_bootstrap_source_from_cache_only_state() {
     let home = TempDir::new().unwrap();
     let project_root = home.path().join("workspace");


### PR DESCRIPTION
## Why

`tracedecay install --agent codex` could leave an existing Codex plugin install in the old `caveman-home` marketplace namespace. That made the documented command `codex plugin add tracedecay@personal` fail even though `tracedecay@caveman-home` was installed, and it also meant rerunning the TraceDecay installer did not refresh that installed Codex cache.

While checking the current Codex and Cursor plugin specs, the Cursor bundle also had a metadata gap: the Cursor command template/validator expects native command files to carry both `name` and `description` frontmatter, but our Cursor command overlays only had descriptions.

## What Changed

### Codex plugin migration
- Canonicalizes generated Codex marketplace metadata to `personal` / `Personal`, so the documented `tracedecay@personal` namespace resolves consistently.
- Teaches Codex install/update discovery to scan legacy `.codex/plugins/cache/caveman-home/tracedecay` installs as refresh candidates.
- Refreshes/migrates detected legacy caches into `.codex/plugins/cache/personal/tracedecay/<version>` while keeping the existing TraceDecay-owned directory safety checks.
- Updates the README and user guide to describe install-driven source/cache refresh behavior.

### Cursor plugin spec alignment
- Adds `displayName` and `category` to the Cursor plugin manifest, matching current Cursor template metadata guidance while staying within the official schema.
- Updates Cursor bundle assertions so install/render tests expect that documented manifest metadata.
- Adds `name` frontmatter to every Cursor native slash command.
- Extends the Cursor command lint so command frontmatter must include a slug-matching scalar `name` and a non-empty scalar `description`.

### Release note
- Adds a patch changeset for the Codex namespace migration, install/update refresh behavior, and Cursor metadata alignment.

## Spec Checks

- OpenAI Codex manual: Build plugins, Plugins, MCP, and Hooks sections.
- Cursor official `cursor/plugins` schemas: live `plugin.schema.json` and `marketplace.schema.json` match the vendored fixtures.
- Cursor `plugin-template` validator/docs: command files require `name` and `description` frontmatter.

## Validation

Previously run for the Codex migration:
- `cargo fmt`
- `cargo check`
- `cargo test --test agent_suite test_codex_install_migrates_legacy_caveman_home_cache_and_marketplace`
- `cargo test --test agent_suite codex_update_plugin_migrates_legacy_caveman_home_cache_to_personal`
- `cargo test --test agent_suite codex_install_refreshes_existing_cache`
- `cargo test --test agent_suite codex_update_plugin_refreshes_cache_and_keeps_bootstrap_source_listable`
- `cargo test --test agent_suite codex_update_plugin_recreates_bootstrap_source_from_cache_only_state`
- `cargo test --test agent_suite codex_update_plugin_repairs_personal_marketplace_for_bootstrap_bundle`
- `cargo test --test agent_suite test_codex_local_install_creates_repo_plugin_bundle_and_marketplace`

Run after the Cursor/Codex spec audit:
- `cargo fmt`
- `cargo test --test agent_suite cursor_bundle_manifest_matches_the_official_cursor_plugin_schema`
- `cargo test --test agent_suite cursor_commands_are_hygienic_and_reference_resolve`
- `cargo test --test agent_suite cursor_install_renders_structurally_valid_bundle`
- `cargo test --test agent_suite codex_bundle_manifest_matches_the_cursor_schema_plus_interface_extension`

Run after review feedback:
- `cargo fmt`
- `git diff --check`
- `cargo test --test agent_suite test_cursor_install_creates_plugin`
- `cargo test --test agent_suite cursor_install`

## Reviewer Notes

- Cursor schema fixtures did not need to change; they already match the current upstream Cursor schemas.
- The Codex cache migration still only touches directories whose plugin manifest identifies them as TraceDecay-owned.
- The review comment about `assert_cursor_plugin_bundle` is addressed by expecting the new Cursor manifest metadata.
