### PR TITLE
chore: release v0.0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.30](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.29...v0.0.30) - 2026-07-05
+
+### Added
+
+- *(sessions)* index workflow runs and agents (layer 2 of session intelligence) ([#284](https://github.com/ScriptedAlchemy/tracedecay/pull/284))
+- *(plugin)* add plugin-suite improvements
+- *(sessions)* add git-anchored session correlation
+- *(claude)* add plugin namespace permissions
+- *(sessions)* add date filters to recall search ([#275](https://github.com/ScriptedAlchemy/tracedecay/pull/275))
+
+### Fixed
+
+- migrate Codex plugin cache to personal namespace ([#282](https://github.com/ScriptedAlchemy/tracedecay/pull/282))
+
+### Other
+
+- *(git-watch)* make auto-sync watcher tests deterministic ([#285](https://github.com/ScriptedAlchemy/tracedecay/pull/285))
+- isolate install-family tests from process-global env bleed ([#283](https://github.com/ScriptedAlchemy/tracedecay/pull/283))
+- split oversized merged modules ([#287](https://github.com/ScriptedAlchemy/tracedecay/pull/287))
+- configure Cargo scratch build paths
+
 ## [0.0.29](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.28...v0.0.29) - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.29"
+version = "0.0.30"
 edition = "2021"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -322,23 +322,6 @@ fn assert_command_eq(actual: &serde_json::Value, expected: &str) {
     );
 }
 
-fn comparable_command_path(command: &str) -> String {
-    command
-        .strip_prefix("//?/")
-        .unwrap_or(command)
-        .replace('\\', "/")
-}
-
-fn assert_command_eq(actual: &serde_json::Value, expected: &str) {
-    let actual = actual
-        .as_str()
-        .unwrap_or_else(|| panic!("command should be a string: {actual}"));
-    assert_eq!(
-        comparable_command_path(actual),
-        comparable_command_path(expected)
-    );
-}
-
 /// Python snippet that py_compiles the generated plugin sources inside the
 /// same interpreter that runs a test's check script, instead of the separate
 /// `python3 -m py_compile` process `assert_python_compiles` spawns. On


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.29 -> 0.0.30

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.30](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.29...v0.0.30) - 2026-07-05

### Added

- *(sessions)* index workflow runs and agents (layer 2 of session intelligence) ([#284](https://github.com/ScriptedAlchemy/tracedecay/pull/284))
- *(plugin)* add plugin-suite improvements
- *(sessions)* add git-anchored session correlation
- *(claude)* add plugin namespace permissions
- *(sessions)* add date filters to recall search ([#275](https://github.com/ScriptedAlchemy/tracedecay/pull/275))

### Fixed

- migrate Codex plugin cache to personal namespace ([#282](https://github.com/ScriptedAlchemy/tracedecay/pull/282))

### Other

- *(git-watch)* make auto-sync watcher tests deterministic ([#285](https://github.com/ScriptedAlchemy/tracedecay/pull/285))
- isolate install-family tests from process-global env bleed ([#283](https://github.com/ScriptedAlchemy/tracedecay/pull/283))
- split oversized merged modules ([#287](https://github.com/ScriptedAlchemy/tracedecay/pull/287))
- configure Cargo scratch build paths
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).