### PR TITLE
[codex] Split session MCP tool definitions

### DIFF
--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -9,6 +9,9 @@ use serde_json::{json, Value};
 use super::dispatch_policy::REGISTERED_PROJECT_READER_TOOL_NAMES;
 use super::ToolDefinition;
 
+mod git_scope;
+mod session;
+
 /// Read-only annotations shared by every tool.
 fn read_only(title: &str) -> Value {
     json!({
@@ -307,9 +310,9 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
         def_skill_view(),
         def_hermes_skill_bridge(),
         def_dashboard(),
-        def_message_search(),
-        def_sessions_for(),
-        def_workflows(),
+        session::def_message_search(),
+        session::def_sessions_for(),
+        session::def_workflows(),
         def_lcm_status(),
         def_lcm_doctor(),
         def_lcm_load_session(),
@@ -2380,222 +2383,6 @@ fn def_hermes_skill_bridge() -> ToolDefinition {
     )
 }
 
-fn def_message_search() -> ToolDefinition {
-    def(
-        "tracedecay_message_search",
-        "Message Search",
-        "Search ingested transcript messages across all supported providers by default. Searches catch up the selected provider scope unless catch_up is false; pass provider only when intentionally scoping results to one provider.",
-        json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Full-text query to search in ingested transcript messages."
-                },
-                "provider": {
-                    "type": "string",
-                    "description": "Optional explicit result scope. Omit or use 'all' for unified cross-provider recall; scoped searches catch up only that provider. Use 'hermes' for Hermes agent conversation history ingested from per-profile state.db stores.",
-                    "enum": crate::sessions::providers::MESSAGE_SEARCH_PROVIDER_IDS
-                },
-                "project_key": {
-                    "type": "string",
-                    "description": "Optional provider-level project key/path filter within the selected session-message store. This is not a registered-project selector; use project_id or project_path to search another registered project's store."
-                },
-                "include_subagents": {
-                    "type": "boolean",
-                    "description": "Whether to include child subagent sessions in results (default: true)."
-                },
-                "catch_up": {
-                    "type": "boolean",
-                    "description": "Whether to ingest/catch up local provider transcripts before searching (default: true). Set false for strictly read-only audits of already-ingested messages."
-                },
-                "parent_session_id": {
-                    "type": "string",
-                    "description": "Optional parent session id filter. Primarily useful with scope=subagents_only."
-                },
-                "since": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "string" }
-                    ],
-                    "description": "Optional inclusive minimum message timestamp. Accepts Unix seconds, RFC3339, YYYY-MM-DD, or relative time like 'last hour'."
-                },
-                "until": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "string" }
-                    ],
-                    "description": "Optional inclusive maximum message timestamp. Accepts Unix seconds, RFC3339, YYYY-MM-DD, or relative time like 'last hour'."
-                },
-                "time_from": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "string" }
-                    ],
-                    "description": "Alias for since."
-                },
-                "time_to": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "string" }
-                    ],
-                    "description": "Alias for until."
-                },
-                "scope": {
-                    "type": "string",
-                    "description": "Relationship scope for search results (default: all).",
-                    "enum": ["all", "parents_only", "subagents_only"]
-                },
-                "limit": {
-                    "type": "number",
-                    "description": "Maximum number of messages to return (default: 10, max: 50)."
-                },
-                "project_selector": project_selector_object(
-                    "Advanced optional registered project selector. Omit to use the active project.",
-                    "search",
-                ),
-                "project_id": {
-                    "type": "string",
-                    "description": "Optional registered project id to search instead of the active project."
-                },
-                "project_path": {
-                    "type": "string",
-                    "description": "Optional registered project root path or alias to search instead of the active project."
-                },
-                "branch": git_scope_branch_schema(),
-                "worktree": git_scope_worktree_schema(),
-                "commit": git_scope_commit_schema(),
-                "workflow_run": workflow_run_scope_schema(),
-                "workflow_agent": workflow_agent_scope_schema()
-            },
-            "required": ["query"]
-        }),
-    )
-}
-
-fn git_scope_branch_schema() -> Value {
-    json!({
-        "type": "string",
-        "description": "Optional git branch filter: only messages from sessions active on this branch (via the session-git correlation index)."
-    })
-}
-
-fn git_scope_worktree_schema() -> Value {
-    json!({
-        "type": "string",
-        "description": "Optional git worktree root path filter: only messages from sessions active in this worktree (via the session-git correlation index)."
-    })
-}
-
-fn git_scope_commit_schema() -> Value {
-    json!({
-        "type": "string",
-        "description": "Optional commit sha filter (full or >=6-char hex prefix): only messages from sessions attributed to this commit (via the session-git correlation index)."
-    })
-}
-
-fn def_sessions_for() -> ToolDefinition {
-    def(
-        "tracedecay_sessions_for",
-        "Sessions For Git Ref",
-        "Find agent sessions correlated with a git artifact in the active project: all sessions active on a branch, in a worktree, or attributed to a commit (the conversations that produced it). Attribution is span-based, so mid-session branch switches are respected. Supports time-scoped queries via since/until.",
-        json!({
-            "type": "object",
-            "properties": {
-                "git_ref": {
-                    "type": "string",
-                    "enum": ["branch", "worktree", "commit"],
-                    "description": "Kind of git reference to correlate against."
-                },
-                "value": {
-                    "type": "string",
-                    "description": "The branch name, worktree root path, or commit sha (full or >=6-char hex prefix) to look up."
-                },
-                "since": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "string" }
-                    ],
-                    "description": "Optional inclusive minimum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."
-                },
-                "until": {
-                    "oneOf": [
-                        { "type": "integer", "minimum": 0 },
-                        { "type": "string" }
-                    ],
-                    "description": "Optional inclusive maximum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."
-                },
-                "limit": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 100,
-                    "description": "Maximum sessions to return (default: 20)."
-                }
-            },
-            "required": ["git_ref", "value"]
-        }),
-    )
-}
-
-fn def_workflows() -> ToolDefinition {
-    def(
-        "tracedecay_workflows",
-        "Workflow Runs",
-        "Recover Claude Code workflow runs (multi-agent `wf_*` orchestrations) and their per-phase agents from the active project. Three modes, chosen by which argument is set: (1) list runs for a parent thread via session_id, or every run on a branch/worktree/commit via branch/worktree/commit (a run inherits its parent session's git spans); (2) show one run's result summary, phases, and agent roster via run_id; (3) drill into one agent's transcript via run_id + agent_label. Read-only; runs that never ran leave no rows.",
-        json!({
-            "type": "object",
-            "properties": {
-                "session_id": {
-                    "type": "string",
-                    "description": "Parent thread/session id: list the workflow runs it spawned (newest first). Mutually exclusive with run_id and the git filters."
-                },
-                "run_id": {
-                    "type": "string",
-                    "description": "A `wf_*` run id: show that run's summary, phases, and agents. Combine with agent_label to drill into one agent."
-                },
-                "agent_label": {
-                    "type": "string",
-                    "description": "With run_id, drill into a single agent of that run by its label (e.g. 'mine:claude-transcripts')."
-                },
-                "branch": {
-                    "type": "string",
-                    "description": "List workflow runs whose parent session was active on this git branch (via the session-git correlation index)."
-                },
-                "worktree": {
-                    "type": "string",
-                    "description": "List workflow runs whose parent session was active in this git worktree root path."
-                },
-                "commit": {
-                    "type": "string",
-                    "description": "List workflow runs whose parent session was attributed to this commit sha (full or >=6-char hex prefix)."
-                },
-                "limit": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 100,
-                    "description": "Maximum runs or agents to return (default: 20)."
-                }
-            }
-        }),
-    )
-}
-
-/// Optional `workflow_run` narrowing filter shared by `tracedecay_message_search`:
-/// scopes hits to the transcripts of one workflow run's agents.
-fn workflow_run_scope_schema() -> Value {
-    json!({
-        "type": "string",
-        "description": "Optional workflow run id (`wf_*`) filter: only messages from sessions that spawned this workflow run (via the workflow-run index). Pair with agent_label to scope to one agent."
-    })
-}
-
-fn workflow_agent_scope_schema() -> Value {
-    json!({
-        "type": "string",
-        "description": "Optional workflow agent label filter, used with workflow_run to scope to a single agent of that run."
-    })
-}
-
 fn lcm_storage_scope_schema() -> Value {
     json!({
         "type": "string",
@@ -2863,9 +2650,9 @@ fn def_lcm_grep() -> ToolDefinition {
                     "maximum": 100,
                     "description": "Maximum hits."
                 },
-                "branch": git_scope_branch_schema(),
-                "worktree": git_scope_worktree_schema(),
-                "commit": git_scope_commit_schema(),
+                "branch": git_scope::branch_schema("Optional git branch filter: only LCM snippets from sessions active on this branch (via the session-git correlation index)."),
+                "worktree": git_scope::worktree_schema("Optional git worktree root path filter: only LCM snippets from sessions active in this worktree (via the session-git correlation index)."),
+                "commit": git_scope::commit_schema("Optional commit sha filter (full or >=6-char hex prefix): only LCM snippets from sessions attributed to this commit (via the session-git correlation index)."),
                 "storage_scope": lcm_storage_scope_schema(),
                 "hermes_home": lcm_hermes_home_schema()
             },

--- a/src/mcp/tools/definitions/git_scope.rs
+++ b/src/mcp/tools/definitions/git_scope.rs
@@ -1,0 +1,22 @@
+use serde_json::{json, Value};
+
+pub(super) fn branch_schema(description: &str) -> Value {
+    json!({
+        "type": "string",
+        "description": description
+    })
+}
+
+pub(super) fn worktree_schema(description: &str) -> Value {
+    json!({
+        "type": "string",
+        "description": description
+    })
+}
+
+pub(super) fn commit_schema(description: &str) -> Value {
+    json!({
+        "type": "string",
+        "description": description
+    })
+}

--- a/src/mcp/tools/definitions/session.rs
+++ b/src/mcp/tools/definitions/session.rs
@@ -1,0 +1,162 @@
+use serde_json::{json, Value};
+
+use super::{def, git_scope, project_selector_object};
+use crate::mcp::tools::ToolDefinition;
+
+pub(super) fn def_message_search() -> ToolDefinition {
+    def(
+        "tracedecay_message_search",
+        "Message Search",
+        "Search ingested transcript messages across all supported providers by default. Searches catch up the selected provider scope unless catch_up is false; pass provider only when intentionally scoping results to one provider.",
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Full-text query to search in ingested transcript messages."
+                },
+                "provider": {
+                    "type": "string",
+                    "description": "Optional explicit result scope. Omit or use 'all' for unified cross-provider recall; scoped searches catch up only that provider. Use 'hermes' for Hermes agent conversation history ingested from per-profile state.db stores.",
+                    "enum": crate::sessions::providers::MESSAGE_SEARCH_PROVIDER_IDS
+                },
+                "project_key": {
+                    "type": "string",
+                    "description": "Optional provider-level project key/path filter within the selected session-message store. This is not a registered-project selector; use project_id or project_path to search another registered project's store."
+                },
+                "include_subagents": {
+                    "type": "boolean",
+                    "description": "Whether to include child subagent sessions in results (default: true)."
+                },
+                "catch_up": {
+                    "type": "boolean",
+                    "description": "Whether to ingest/catch up local provider transcripts before searching (default: true). Set false for strictly read-only audits of already-ingested messages."
+                },
+                "parent_session_id": {
+                    "type": "string",
+                    "description": "Optional parent session id filter. Primarily useful with scope=subagents_only."
+                },
+                "since": time_filter_schema("Optional inclusive minimum message timestamp. Accepts Unix seconds, RFC3339, YYYY-MM-DD, or relative time like 'last hour'."),
+                "until": time_filter_schema("Optional inclusive maximum message timestamp. Accepts Unix seconds, RFC3339, YYYY-MM-DD, or relative time like 'last hour'."),
+                "time_from": time_filter_schema("Alias for since."),
+                "time_to": time_filter_schema("Alias for until."),
+                "scope": {
+                    "type": "string",
+                    "description": "Relationship scope for search results (default: all).",
+                    "enum": ["all", "parents_only", "subagents_only"]
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Maximum number of messages to return (default: 10, max: 50)."
+                },
+                "project_selector": project_selector_object(
+                    "Advanced optional registered project selector. Omit to use the active project.",
+                    "search",
+                ),
+                "project_id": {
+                    "type": "string",
+                    "description": "Optional registered project id to search instead of the active project."
+                },
+                "project_path": {
+                    "type": "string",
+                    "description": "Optional registered project root path or alias to search instead of the active project."
+                },
+                "branch": git_scope::branch_schema("Optional git branch filter: only messages from sessions active on this branch (via the session-git correlation index)."),
+                "worktree": git_scope::worktree_schema("Optional git worktree root path filter: only messages from sessions active in this worktree (via the session-git correlation index)."),
+                "commit": git_scope::commit_schema("Optional commit sha filter (full or >=6-char hex prefix): only messages from sessions attributed to this commit (via the session-git correlation index)."),
+                "workflow_run": workflow_run_scope_schema(),
+                "workflow_agent": workflow_agent_scope_schema()
+            },
+            "required": ["query"]
+        }),
+    )
+}
+
+pub(super) fn def_sessions_for() -> ToolDefinition {
+    def(
+        "tracedecay_sessions_for",
+        "Sessions For Git Ref",
+        "Find agent sessions correlated with a git artifact in the active project: all sessions active on a branch, in a worktree, or attributed to a commit (the conversations that produced it). Attribution is span-based, so mid-session branch switches are respected. Supports time-scoped queries via since/until.",
+        json!({
+            "type": "object",
+            "properties": {
+                "git_ref": {
+                    "type": "string",
+                    "enum": ["branch", "worktree", "commit"],
+                    "description": "Kind of git reference to correlate against."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "The branch name, worktree root path, or commit sha (full or >=6-char hex prefix) to look up."
+                },
+                "since": time_filter_schema("Optional inclusive minimum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."),
+                "until": time_filter_schema("Optional inclusive maximum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."),
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum sessions to return (default: 20)."
+                }
+            },
+            "required": ["git_ref", "value"]
+        }),
+    )
+}
+
+pub(super) fn def_workflows() -> ToolDefinition {
+    def(
+        "tracedecay_workflows",
+        "Workflow Runs",
+        "Recover Claude Code workflow runs (multi-agent `wf_*` orchestrations) and their per-phase agents from the active project. Three modes, chosen by which argument is set: (1) list runs for a parent thread via session_id, or every run on a branch/worktree/commit via branch/worktree/commit (a run inherits its parent session's git spans); (2) show one run's result summary, phases, and agent roster via run_id; (3) drill into one agent's transcript via run_id + agent_label. Read-only; runs that never ran leave no rows.",
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Parent thread/session id: list the workflow runs it spawned (newest first). Mutually exclusive with run_id and the git filters."
+                },
+                "run_id": {
+                    "type": "string",
+                    "description": "A `wf_*` run id: show that run's summary, phases, and agents. Combine with agent_label to drill into one agent."
+                },
+                "agent_label": {
+                    "type": "string",
+                    "description": "With run_id, drill into a single agent of that run by its label (e.g. 'mine:claude-transcripts')."
+                },
+                "branch": git_scope::branch_schema("List workflow runs whose parent session was active on this git branch (via the session-git correlation index)."),
+                "worktree": git_scope::worktree_schema("List workflow runs whose parent session was active in this git worktree root path."),
+                "commit": git_scope::commit_schema("List workflow runs whose parent session was attributed to this commit sha (full or >=6-char hex prefix)."),
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Maximum runs or agents to return (default: 20)."
+                }
+            }
+        }),
+    )
+}
+
+fn time_filter_schema(description: &str) -> Value {
+    json!({
+        "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string" }
+        ],
+        "description": description
+    })
+}
+
+fn workflow_run_scope_schema() -> Value {
+    json!({
+        "type": "string",
+        "description": "Optional workflow run id (`wf_*`) filter: only messages from sessions that spawned this workflow run (via the workflow-run index). Pair with agent_label to scope to one agent."
+    })
+}
+
+fn workflow_agent_scope_schema() -> Value {
+    json!({
+        "type": "string",
+        "description": "Optional workflow agent label filter, used with workflow_run to scope to a single agent of that run."
+    })
+}


### PR DESCRIPTION
## Summary
- reviewed the last 100 merged PRs (#185 through #289) as one aggregate change surface
- split message/session/workflow MCP tool schemas out of the 3.9k-line definitions module
- reused the shared git-scope schema helpers for both workflow and LCM grep definitions

## Validation
- tracedecay sync
- cargo fmt --check
- cargo check -q
- cargo test -q --lib mcp::tools::definitions::tests
- cargo test -q --lib tool_definitions_and_dispatch_handlers_stay_in_lockstep
- cargo test -q --lib profile_scoped_lcm_definitions_and_handlers_stay_in_lockstep
- cargo test -q --test mcp_suite message_search_provider_schema_matches_ingested_providers
- cargo test -q --test mcp_suite every_mcp_tool_is_invocable_via_cli_short_name
- cargo test -q --test agent_suite every_mcp_tool_renders_its_own_cli_help
- git diff --check

## Notes
- original checkout was dirty and divergent, so this was done in an isolated worktree from origin/master