### PR TITLE
feat: add repo-local TraceDecay usage skills

### DIFF
--- a/.codex/skills/inspecting-automation-cycles/SKILL.md
+++ b/.codex/skills/inspecting-automation-cycles/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: inspecting-automation-cycles
+description: 'Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, pending approvals, or run artifacts.'
+---
+
+# Inspecting Automation Cycles
+
+TraceDecay automation is a loop, not a single artifact: config schedules jobs,
+runs produce artifacts, dashboards queue approvals, and usage analytics prove
+whether generated output was adopted.
+
+## Workflow
+
+1. Start with `tracedecay automation config get` to identify enabled tasks,
+   schedules, locks, profile paths, and approval gates.
+2. List recent runs with `tracedecay automation runs list --limit 100`; group
+   by task and status before opening individual artifacts.
+3. For failures or suspicious skips, open the relevant artifact with
+   `tracedecay_automation_run_artifact_view` or
+   `tracedecay tool automation_run_artifact_view --args ...`.
+4. Inspect pending human review queues:
+   `tracedecay automation facts list`, dashboard approvals, and
+   `tracedecay_skill_list --state pending`.
+5. Check adoption evidence: `tracedecay analytics diagnostics --all --no-sync`,
+   `tracedecay sessions search "mcp__tracedecay" --provider all`, and managed
+   skill usage counts.
+
+## Reading Results
+
+| Signal | Meaning | Next step |
+|---|---|---|
+| `scheduler_interval_not_elapsed` | Healthy throttling | Count only, do not fix. |
+| `scheduler_lock_active` | Another run owns the loop | Check age before calling stale. |
+| `no_new_session_activity` | Nothing new to process | Verify transcript ingest if surprising. |
+| `validation_gate` artifact | Proposed mutation was staged | Report approval command or dashboard path. |
+| Many pending fact proposals | Queue needs curation | Use `tracedecay:project-memory`. |
+| Active managed skills with zero use | Adoption telemetry gap | Use `tracedecay:diagnosing-analytics`. |
+
+## Guardrails
+
+- Prefer read-only inspection. Do not approve, reject, delete, or apply queued
+  facts unless the user explicitly asked for mutation.
+- Do not treat skipped runs as failures until grouped by skip reason and age.
+- Avoid parallel `tracedecay_skill_view` calls against one profile while
+  automation may write usage ledgers. If a usage read reports a truncated JSON
+  or EOF parse error, retry once after `tracedecay_skill_list` succeeds.
+- Do not read `.tracedecay` databases directly; use CLI, dashboard APIs, or
+  MCP tools.
+
+## Deliverable
+
+Report task/status counts, the exact run or artifact ids inspected, pending
+approval queues, adoption gaps, and the next concrete command for any mutation
+the user should choose.

--- a/.codex/skills/inspecting-automation-cycles/SKILL.md
+++ b/.codex/skills/inspecting-automation-cycles/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: inspecting-automation-cycles
-description: 'Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, pending approvals, or run artifacts.'
+description: 'TraceDecay Dev: Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, pending approvals, or run artifacts.'
 ---
 
-# Inspecting Automation Cycles
+# TraceDecay Dev: Inspecting Automation Cycles
 
 TraceDecay automation is a loop, not a single artifact: config schedules jobs,
 runs produce artifacts, dashboards queue approvals, and usage analytics prove

--- a/.codex/skills/inspecting-automation-cycles/agents/openai.yaml
+++ b/.codex/skills/inspecting-automation-cycles/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Inspecting Automation Cycles"
+  short_description: "Audit automation runs and artifacts"
+  default_prompt: "Use $inspecting-automation-cycles to audit recent TraceDecay automation runs."

--- a/.codex/skills/inspecting-automation-cycles/agents/openai.yaml
+++ b/.codex/skills/inspecting-automation-cycles/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Inspecting Automation Cycles"
+  display_name: "TraceDecay Dev: Inspecting Automation Cycles"
   short_description: "Audit automation runs and artifacts"
   default_prompt: "Use $inspecting-automation-cycles to audit recent TraceDecay automation runs."

--- a/.codex/skills/interpreting-tracedecay-diagnostics/SKILL.md
+++ b/.codex/skills/interpreting-tracedecay-diagnostics/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: interpreting-tracedecay-diagnostics
-description: Use when interpreting TraceDecay compiler diagnostics, `tracedecay tool diagnose`, `tracedecay tool diagnostics`, mapped errors, affected symbols, or build/type failure output.
+description: 'TraceDecay Dev: Use when interpreting TraceDecay compiler diagnostics, `tracedecay tool diagnose`, `tracedecay tool diagnostics`, mapped errors, affected symbols, or build/type failure output.'
 ---
 
-# Interpreting TraceDecay Diagnostics
+# TraceDecay Dev: Interpreting TraceDecay Diagnostics
 
 TraceDecay diagnostics turn raw compiler output into mapped symbols, callers,
 and likely test scope. Use them before eyeballing cargo, clippy, tsc, or

--- a/.codex/skills/interpreting-tracedecay-diagnostics/SKILL.md
+++ b/.codex/skills/interpreting-tracedecay-diagnostics/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: interpreting-tracedecay-diagnostics
+description: Use when interpreting TraceDecay compiler diagnostics, `tracedecay tool diagnose`, `tracedecay tool diagnostics`, mapped errors, affected symbols, or build/type failure output.
+---
+
+# Interpreting TraceDecay Diagnostics
+
+TraceDecay diagnostics turn raw compiler output into mapped symbols, callers,
+and likely test scope. Use them before eyeballing cargo, clippy, tsc, or
+pyright output.
+
+## Workflow
+
+1. If raw stderr already exists, pass it to
+   `tracedecay tool diagnose --args '{"cargo_output":"..."}'`.
+2. If no stderr exists, run `tracedecay tool diagnostics` instead of a broad
+   shell build first.
+3. Read diagnostics by group:
+   - parser count: did TraceDecay recognize the compiler output?
+   - mapped node: which function, impl, type, or file owns the failure?
+   - callers/dependents: what may break after the fix?
+   - affected tests: what narrow verification should run?
+4. If parser count is zero, rerun the native command only long enough to
+   capture exact stderr, then diagnose that text. Do not manually scan pages
+   of compiler output.
+5. If output is truncated and includes a handle, retrieve or narrow before
+   rerunning broad diagnostics.
+
+## Interpretation
+
+- Unmapped diagnostics usually mean parse coverage or file mapping is missing,
+  not that the error is unimportant.
+- Many errors in one file often share one signature, enum variant, or feature
+  gate root cause. Fix the first mapped owner, then rerun diagnostics.
+- For Rust enum pattern errors, prefer `..` in matches when future fields are
+  intentionally ignored.
+- A mapped test target is a recommendation. Run it, then broaden only if the
+  changed symbol is shared or public.
+
+## Deliverable
+
+Report symptom, mapped owner, root cause, patch, and verification command. If
+diagnostics could not parse the output, include the exact command that produced
+the stderr sample.

--- a/.codex/skills/interpreting-tracedecay-diagnostics/agents/openai.yaml
+++ b/.codex/skills/interpreting-tracedecay-diagnostics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Interpreting TraceDecay Diagnostics"
+  short_description: "Map diagnostics to owners and fixes"
+  default_prompt: "Use $interpreting-tracedecay-diagnostics to interpret TraceDecay compiler diagnostics and pick verification."

--- a/.codex/skills/interpreting-tracedecay-diagnostics/agents/openai.yaml
+++ b/.codex/skills/interpreting-tracedecay-diagnostics/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Interpreting TraceDecay Diagnostics"
+  display_name: "TraceDecay Dev: Interpreting TraceDecay Diagnostics"
   short_description: "Map diagnostics to owners and fixes"
   default_prompt: "Use $interpreting-tracedecay-diagnostics to interpret TraceDecay compiler diagnostics and pick verification."

--- a/.codex/skills/introspecting-tracedecay-usage/SKILL.md
+++ b/.codex/skills/introspecting-tracedecay-usage/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: introspecting-tracedecay-usage
-description: Use when turning TraceDecay's own analytics, session history, automation runs, managed skills, memory facts, diagnostics, or code-health signals into repo improvements, evals, or bundled skill updates.
+description: "TraceDecay Dev: Use when turning TraceDecay's own analytics, session history, automation runs, managed skills, memory facts, diagnostics, or code-health signals into repo improvements, evals, or bundled skill updates."
 ---
 
-# Introspecting TraceDecay Usage
+# TraceDecay Dev: Introspecting TraceDecay Usage
 
 Use this skill for TraceDecay self-improvement driven by real agent behavior,
 not guesswork. Keep the pass evidence-first: logs and summaries identify the

--- a/.codex/skills/introspecting-tracedecay-usage/SKILL.md
+++ b/.codex/skills/introspecting-tracedecay-usage/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: introspecting-tracedecay-usage
+description: Use when turning TraceDecay's own analytics, session history, automation runs, managed skills, memory facts, diagnostics, or code-health signals into repo improvements, evals, or bundled skill updates.
+---
+
+# Introspecting TraceDecay Usage
+
+Use this skill for TraceDecay self-improvement driven by real agent behavior,
+not guesswork. Keep the pass evidence-first: logs and summaries identify the
+failure mode, then code, tests, or bundled skills encode the fix.
+
+## Required Audit Lanes
+
+1. **Adoption and telemetry:** Use `tracedecay:diagnosing-analytics`. Run
+   `tracedecay analytics diagnostics` (add `--all` when the question is
+   cross-project). Compare hook/tool volume with TraceDecay tool usage.
+2. **Past-session behavior:** Use `tracedecay:managing-session-context`.
+   Start with `tracedecay_message_search`; use `tracedecay_lcm_status` before
+   deeper LCM work, then `tracedecay_lcm_grep` or replay only as needed.
+3. **Managed skills and automation:** Use
+   `tracedecay:inspecting-managed-skills`. Start with
+   `tracedecay_skill_list`; view skills or run artifacts only when the list
+   points to a specific stale, patched, failed, or unused item.
+4. **Durable memory:** Use `tracedecay:project-memory`. Search with
+   `tracedecay_fact_store` before re-deriving project decisions. For curation,
+   run read-only inventory and dry-runs first; never remove facts without
+   explicit approval.
+5. **Code-health and implementation target:** Use `tracedecay:code-health`.
+   Let weak dimensions and hotspots decide whether the fix is code, tests,
+   docs, evals, or skill guidance.
+
+## Interpretation Rules
+
+- High hook volume with low TraceDecay tool usage is an adoption gap. Improve
+  trigger text, tool hints, or eval coverage before blaming users.
+- Managed skills with many patches and zero successful uses are validation
+  failures. Inspect their evidence and either tighten the managed-skill loop
+  or add a bundled operator skill that prevents the repeated mistake.
+- LCM depth and compression ratios are health signals, not direct quality
+  scores. Use raw/session recall to confirm what agents actually missed.
+- Memory curation candidates are proposals, not permission. Prefer merge or
+  update when provenance matters; deletion needs fresh user approval.
+- Analytics fields can be global. `project_id: null` means the run was global,
+  not broken.
+
+## Improvement Loop
+
+1. Capture counts and examples from every required audit lane.
+2. Group evidence into one failure class: discovery, fallback, diagnostics
+   interpretation, automation validation, memory curation, or code structure.
+3. Choose the smallest durable fix:
+   - bundled skill update when agents know the feature but skip the workflow;
+   - eval/test when the workflow should be enforced;
+   - code change when the data is unavailable, misleading, or too hard to
+     interpret;
+   - managed-skill action when the issue lives only in the profile store.
+4. Verify with the narrowest relevant command, then run the matching skill
+   contract or code test.
+
+## Deliverable
+
+Report the exact commands/tools used, headline counts, cited sessions or run
+ids when available, the selected failure class, the improvement made, and the
+verification result. Include any `tracedecay_metrics:` savings line.

--- a/.codex/skills/introspecting-tracedecay-usage/agents/openai.yaml
+++ b/.codex/skills/introspecting-tracedecay-usage/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Introspecting TraceDecay Usage"
+  display_name: "TraceDecay Dev: Introspecting TraceDecay Usage"
   short_description: "Turn TraceDecay evidence into fixes"
   default_prompt: "Use $introspecting-tracedecay-usage to audit TraceDecay usage evidence and choose the smallest durable improvement."

--- a/.codex/skills/introspecting-tracedecay-usage/agents/openai.yaml
+++ b/.codex/skills/introspecting-tracedecay-usage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Introspecting TraceDecay Usage"
+  short_description: "Turn TraceDecay evidence into fixes"
+  default_prompt: "Use $introspecting-tracedecay-usage to audit TraceDecay usage evidence and choose the smallest durable improvement."

--- a/.codex/skills/self-improving-from-usage-logs/SKILL.md
+++ b/.codex/skills/self-improving-from-usage-logs/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: self-improving-from-usage-logs
+description: 'Use when mining TraceDecay session logs, analytics, diagnostics, automation artifacts, or agent transcripts to improve TraceDecay code, tools, or packaged skills.'
+---
+
+# Self-Improving From Usage Logs
+
+Use real agent behavior as an eval surface: logs reveal where tools are
+confusing, silent, too hard to discover, or missing a safe command.
+
+## Workflow
+
+1. Start with adoption and health:
+   `tracedecay analytics diagnostics --all --no-sync`, `tracedecay doctor`,
+   and `tracedecay tool lcm_status --provider all --json`.
+2. Search transcripts for friction phrases, tool failures, and bypasses:
+   `tracedecay_message_search`, then narrow with `tracedecay_lcm_grep` or
+   `tracedecay_lcm_expand_query`.
+3. Inspect automation evidence with `tracedecay:inspecting-automation-cycles`
+   and managed-skill evidence with `tracedecay:writing-agent-managed-skills`.
+4. Turn patterns into the smallest durable fix: CLI affordance, clearer
+   diagnostic field, better skill trigger, missing dashboard summary, or test.
+5. Verify with the narrow command that failed in the logs plus the owning Rust
+   test or plugin validation suite.
+
+## Opportunity Ranking
+
+| Pattern | Prefer this fix |
+|---|---|
+| Repeated invalid flag or command | Accept alias or improve CLI help. |
+| Counts interpreted incorrectly | Add explicit field names and sample limits. |
+| Agents query stores directly | Add/read skill guardrail and expose CLI summary. |
+| Skill exists but is not invoked | Improve description trigger and analytics events. |
+| Automation skips look like failures | Add grouped run/status summary. |
+| Same fact proposed repeatedly | Deduplicate before approval queue. |
+
+## Guardrails
+
+- Do not store secrets, transient failures, or one-off progress as memory.
+- Do not convert a single anecdote into a broad rule without at least two
+  corroborating sessions, an automation artifact, or a failing command.
+- Keep code fixes smaller than the evidence. If logs show a CLI paper cut,
+  ship the CLI compatibility fix before redesigning the subsystem.
+
+## Deliverable
+
+Report the evidence source, repeated pattern, ranked opportunity, code or skill
+change made, verification command, and any residual adoption gap.

--- a/.codex/skills/self-improving-from-usage-logs/SKILL.md
+++ b/.codex/skills/self-improving-from-usage-logs/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: self-improving-from-usage-logs
-description: 'Use when mining TraceDecay session logs, analytics, diagnostics, automation artifacts, or agent transcripts to improve TraceDecay code, tools, or packaged skills.'
+description: 'TraceDecay Dev: Use when mining TraceDecay session logs, analytics, diagnostics, automation artifacts, or agent transcripts to improve TraceDecay code, tools, or packaged skills.'
 ---
 
-# Self-Improving From Usage Logs
+# TraceDecay Dev: Self-Improving From Usage Logs
 
 Use real agent behavior as an eval surface: logs reveal where tools are
 confusing, silent, too hard to discover, or missing a safe command.

--- a/.codex/skills/self-improving-from-usage-logs/agents/openai.yaml
+++ b/.codex/skills/self-improving-from-usage-logs/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Self-Improving From Usage Logs"
+  display_name: "TraceDecay Dev: Self-Improving From Usage Logs"
   short_description: "Turn TraceDecay logs into fixes"
   default_prompt: "Use $self-improving-from-usage-logs to find and fix TraceDecay adoption gaps."

--- a/.codex/skills/self-improving-from-usage-logs/agents/openai.yaml
+++ b/.codex/skills/self-improving-from-usage-logs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Self-Improving From Usage Logs"
+  short_description: "Turn TraceDecay logs into fixes"
+  default_prompt: "Use $self-improving-from-usage-logs to find and fix TraceDecay adoption gaps."

--- a/.codex/skills/writing-agent-managed-skills/SKILL.md
+++ b/.codex/skills/writing-agent-managed-skills/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: writing-agent-managed-skills
+description: 'Use when creating, revising, validating, approving, installing, or auditing TraceDecay agent-managed automation skills and skill-writer drafts.'
+---
+
+# Writing Agent-Managed Skills
+
+Agent-managed skills are profile-owned drafts produced by automation. Treat
+them as generated artifacts with lifecycle state, validation evidence, and
+usage telemetry; bundled `plugin/skills/` changes are a separate release path.
+
+## Workflow
+
+1. Inspect before editing: `tracedecay_skill_list` for inventory, then
+   `tracedecay_skill_view` with support files for the target draft.
+2. Read the writer run evidence:
+   `tracedecay_automation_run_artifact_view` for `generated_evals`,
+   `validation_gate`, `optimizer_diagnosis`, and `codex_handoff` artifacts.
+3. Decide the path:
+   - managed draft fix: update through `tracedecay automation skills ...`
+     commands or dashboard flow;
+   - bundled reusable guidance: edit `plugin/skills/<slug>/SKILL.md` and run
+     agent-suite validation.
+4. Validate discovery text: description starts with `Use when`, names concrete
+   triggers, avoids workflow summaries, and stays host-portable.
+5. Check adoption after install with analytics diagnostics and skill usage
+   events before declaring the skill effective.
+
+## Quality Bar
+
+| Check | Pass condition |
+|---|---|
+| Trigger | Another agent can identify when to load it from description alone. |
+| Body | Short imperative workflow, no session narrative, no stale environment facts. |
+| Evidence | Run artifact or transcript shows the failure this skill prevents. |
+| Validation | Draft has a validation gate or bundled skill passes plugin tests. |
+| Adoption | Usage telemetry or follow-up session proves it was invoked. |
+
+## Guardrails
+
+- Never approve or install a managed skill without explicit user intent.
+- Never copy managed-skill state into bundled skills unless the pattern is
+  reusable across projects.
+- Do not mutate profile stores from subagents. Subagents may inspect and
+  recommend only.
+
+## Deliverable
+
+Return the skill id or bundled path, lifecycle state, validation artifacts read,
+edits made or recommended, adoption evidence, and the exact approve/install
+command when mutation is appropriate.

--- a/.codex/skills/writing-agent-managed-skills/SKILL.md
+++ b/.codex/skills/writing-agent-managed-skills/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: writing-agent-managed-skills
-description: 'Use when creating, revising, validating, approving, installing, or auditing TraceDecay agent-managed automation skills and skill-writer drafts.'
+description: 'TraceDecay Dev: Use when creating, revising, validating, approving, installing, or auditing TraceDecay agent-managed automation skills and skill-writer drafts.'
 ---
 
-# Writing Agent-Managed Skills
+# TraceDecay Dev: Writing Agent-Managed Skills
 
 Agent-managed skills are profile-owned drafts produced by automation. Treat
 them as generated artifacts with lifecycle state, validation evidence, and

--- a/.codex/skills/writing-agent-managed-skills/agents/openai.yaml
+++ b/.codex/skills/writing-agent-managed-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Writing Agent-Managed Skills"
+  short_description: "Draft and validate managed skills"
+  default_prompt: "Use $writing-agent-managed-skills to improve a TraceDecay managed skill draft."

--- a/.codex/skills/writing-agent-managed-skills/agents/openai.yaml
+++ b/.codex/skills/writing-agent-managed-skills/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Writing Agent-Managed Skills"
+  display_name: "TraceDecay Dev: Writing Agent-Managed Skills"
   short_description: "Draft and validate managed skills"
   default_prompt: "Use $writing-agent-managed-skills to improve a TraceDecay managed skill draft."

--- a/src/analytics_bridge.rs
+++ b/src/analytics_bridge.rs
@@ -268,6 +268,8 @@ pub async fn run_analytics_diagnostics(
     all_projects: bool,
     no_sync: bool,
 ) -> crate::errors::Result<()> {
+    const EVENT_SAMPLE_LIMIT: usize = 10_000;
+
     let project_root = cli_project_root();
     let gdb = open_global_db().await?;
 
@@ -290,7 +292,7 @@ pub async fn run_analytics_diagnostics(
             session_id: None,
             event_kind: None,
             since: None,
-            limit: 10_000,
+            limit: EVENT_SAMPLE_LIMIT,
         })
         .await
         .map_err(cli_error)?;
@@ -314,9 +316,12 @@ pub async fn run_analytics_diagnostics(
         hook_filter_root,
     );
 
-    let message_count = match project_root.as_deref() {
-        Some(root) => project_session_message_count(root).await,
-        None => 0,
+    let message_count = match project_filter.as_deref() {
+        Some(project_key) => gdb
+            .session_message_count_for_project(project_key)
+            .await
+            .unwrap_or(0),
+        None => gdb.session_message_count().await.unwrap_or(0),
     };
 
     let durable = if event_rows.is_empty() {
@@ -340,24 +345,17 @@ pub async fn run_analytics_diagnostics(
             crate::global_db::global_db_path()
                 .map_or(Value::Null, |path| json!(path.display().to_string())),
         );
+        summary.insert("event_sample_limit".to_string(), json!(EVENT_SAMPLE_LIMIT));
+        summary.insert(
+            "event_count_may_be_truncated".to_string(),
+            json!(event_rows.len() >= EVENT_SAMPLE_LIMIT),
+        );
     }
     println!(
         "{}",
         serde_json::to_string_pretty(&summary).unwrap_or_default()
     );
     Ok(())
-}
-
-async fn project_session_message_count(project_root: &Path) -> i64 {
-    let Some(db_path) =
-        crate::sessions::cursor::resolved_project_session_db_path(project_root).await
-    else {
-        return 0;
-    };
-    let Some(db) = GlobalDb::open_at(&db_path).await else {
-        return 0;
-    };
-    db.session_message_count().await.unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -599,6 +599,9 @@ pub enum AnalyticsAction {
         /// Skip the hook-JSONL import pass before summarizing
         #[arg(long)]
         no_sync: bool,
+        /// Keep compatibility with JSON-capable diagnostics commands.
+        #[arg(long)]
+        json: bool,
     },
     /// Import hook_analytics.jsonl rows into the durable analytics_events table
     Sync,

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -2272,6 +2272,30 @@ impl GlobalDb {
             .map_err(|e| format!("failed to decode session message count: {e}"))
     }
 
+    pub async fn session_message_count_for_project(
+        &self,
+        project_key: &str,
+    ) -> Result<i64, String> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT COUNT(*)
+                 FROM session_messages m
+                 JOIN sessions s ON s.provider = m.provider AND s.session_id = m.session_id
+                 WHERE s.project_key = ?1",
+                libsql::params![project_key],
+            )
+            .await
+            .map_err(|e| format!("failed to count project session messages: {e}"))?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read project session message count: {e}"))?
+            .ok_or_else(|| "project session message count returned no row".to_string())?;
+        row.get::<i64>(0)
+            .map_err(|e| format!("failed to decode project session message count: {e}"))
+    }
+
     pub async fn query_analytics_events(
         &self,
         query: &AnalyticsEventQuery,

--- a/src/main.rs
+++ b/src/main.rs
@@ -650,7 +650,7 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             sessions_cmd::handle_sessions_action(action).await?;
         }
         Commands::Analytics { action } => match action {
-            AnalyticsAction::Diagnostics { all, no_sync } => {
+            AnalyticsAction::Diagnostics { all, no_sync, .. } => {
                 tracedecay::analytics_bridge::run_analytics_diagnostics(all, no_sync).await?;
             }
             AnalyticsAction::Sync => {

--- a/tests/agent_suite/plugin_skill_contract_test.rs
+++ b/tests/agent_suite/plugin_skill_contract_test.rs
@@ -13,6 +13,7 @@ use tempfile::TempDir;
 use tracedecay::agents::{expected_tool_perms, get_integration, InstallContext};
 
 const CODEX_SKILL_ROOT: &str = "plugin/skills";
+const REPO_LOCAL_SKILL_ROOT: &str = ".codex/skills";
 const MAX_BUNDLED_SKILL_METADATA_CHARS: usize = 6_000;
 const CODEX_QUICK_VALIDATE_ALLOWED_FRONTMATTER: &[&str] = &[
     "allowed-tools",
@@ -64,6 +65,55 @@ fn generated_codex_plugin_skills_are_byte_copies_of_the_source_bundle() {
         "generated Codex plugin bundle must ship the same bundled skills as the source bundle"
     );
     assert_skill_trees_byte_identical(&source_root, &installed_root);
+}
+
+#[test]
+fn repo_local_usage_introspection_skill_routes_through_all_required_audit_lanes() {
+    let skills = load_skill_docs(REPO_LOCAL_SKILL_ROOT);
+    let skill = skills
+        .iter()
+        .find(|skill| skill.name == "introspecting-tracedecay-usage")
+        .expect("repo-local skills should teach usage-driven TraceDecay self-improvement");
+    let body = &skill.body;
+    for required in [
+        "tracedecay:diagnosing-analytics",
+        "tracedecay:managing-session-context",
+        "tracedecay:inspecting-managed-skills",
+        "tracedecay:project-memory",
+        "tracedecay:code-health",
+        "tracedecay analytics diagnostics",
+        "tracedecay_skill_list",
+        "tracedecay_lcm_status",
+        "tracedecay_message_search",
+        "tracedecay_fact_store",
+    ] {
+        assert!(
+            body.contains(required),
+            "{} should mention {required}",
+            skill.path.display()
+        );
+    }
+}
+
+#[test]
+fn repo_local_usage_driven_operator_skills_are_not_template_stubs() {
+    let skills = load_skill_docs(REPO_LOCAL_SKILL_ROOT);
+    for skill_name in [
+        "inspecting-automation-cycles",
+        "interpreting-tracedecay-diagnostics",
+        "self-improving-from-usage-logs",
+        "writing-agent-managed-skills",
+    ] {
+        let skill = skills
+            .iter()
+            .find(|skill| skill.name == skill_name)
+            .unwrap_or_else(|| panic!("missing bundled operator skill {skill_name}"));
+        assert!(
+            !skill.raw.contains("[TODO"),
+            "{} should not contain skill template TODOs",
+            skill.path.display()
+        );
+    }
 }
 
 #[test]

--- a/tests/session_suite/global_db.rs
+++ b/tests/session_suite/global_db.rs
@@ -481,6 +481,43 @@ async fn upsert_session_round_trips_and_updates() {
 }
 
 #[tokio::test]
+async fn session_message_count_filters_by_project_key() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+    for (provider, session_id, project_key, message_id) in [
+        ("codex", "session-a", "project-a", "message-a"),
+        ("claude", "session-b", "project-a", "message-b"),
+        ("cursor", "session-c", "project-b", "message-c"),
+    ] {
+        db.upsert_session(&sample_session(provider, session_id, project_key))
+            .await;
+        assert!(
+            db.upsert_session_message(&sample_message(
+                provider,
+                message_id,
+                session_id,
+                "TraceDecay diagnostics fixture.",
+            ))
+            .await
+        );
+    }
+
+    assert_eq!(db.session_message_count().await.unwrap(), 3);
+    assert_eq!(
+        db.session_message_count_for_project("project-a")
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        db.session_message_count_for_project("missing-project")
+            .await
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
 async fn upsert_session_message_round_trips_and_updates() {
     let tmp = TempDir::new().unwrap();
     let db_path = isolated_db_path(&tmp);


### PR DESCRIPTION
## Summary
- Add repo-local Codex skills under .codex/skills for TraceDecay usage introspection, automation cycles, diagnostics interpretation, usage-log self-improvement, and agent-managed skill writing
- Fix analytics diagnostics JSON compatibility and project-scoped message counts
- Add focused contracts for repo-local skills and session message counting

## Verification
- quick_validate.py .codex/skills/*
- cargo test -p tracedecay --test agent_suite plugin_skill_contract_test
- cargo test -p tracedecay --test session_suite session_message_count_filters_by_project_key
- cargo fmt --check
