### PR TITLE
fix(codex): silence plugin-only MCP cleanup

### DIFF
--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -247,11 +247,14 @@ impl AgentIntegration for CodexIntegration {
 }
 
 fn codex_legacy_config_has_tracedecay(home: &Path) -> bool {
-    let config = codex_config_path(home);
-    if !config.exists() {
+    codex_config_has_tracedecay_mcp_server(&codex_config_path(home))
+}
+
+fn codex_config_has_tracedecay_mcp_server(config_path: &Path) -> bool {
+    if !config_path.exists() {
         return false;
     }
-    super::load_toml_file(&config).is_ok_and(|toml| {
+    super::load_toml_file(config_path).is_ok_and(|toml| {
         toml.get("mcp_servers")
             .and_then(|v| v.get("tracedecay"))
             .is_some()
@@ -435,10 +438,7 @@ pub fn remove_legacy_codex_native_automation(home: &Path) -> Result<bool> {
 }
 
 fn uninstall_tracedecay_mcp_if_present(config_path: &Path) {
-    let Ok(contents) = std::fs::read_to_string(config_path) else {
-        return;
-    };
-    if !contents.contains("tracedecay") {
+    if !codex_config_has_tracedecay_mcp_server(config_path) {
         return;
     }
     if let Err(err) = uninstall_mcp_server(config_path) {

--- a/src/agents/codex/tests.rs
+++ b/src/agents/codex/tests.rs
@@ -152,6 +152,47 @@ trusted_hash = "sha256:compact"
 }
 
 #[test]
+fn codex_legacy_mcp_detector_ignores_plugin_entries() {
+    let home = tempfile::tempdir().expect("tempdir should create");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("codex dir should create");
+    std::fs::write(
+        codex_dir.join("config.toml"),
+        r#"
+[plugins."tracedecay@personal"]
+enabled = true
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:post_tool_use:0:0"]
+trusted_hash = "sha256:post"
+"#,
+    )
+    .expect("config should write");
+
+    assert!(
+        !codex_legacy_config_has_tracedecay(home.path()),
+        "plugin and hook entries are not legacy direct MCP config"
+    );
+}
+
+#[test]
+fn codex_legacy_mcp_detector_finds_direct_mcp_config() {
+    let home = tempfile::tempdir().expect("tempdir should create");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).expect("codex dir should create");
+    std::fs::write(
+        codex_dir.join("config.toml"),
+        r#"
+[mcp_servers.tracedecay]
+command = "/old/bin/tracedecay"
+args = ["serve"]
+"#,
+    )
+    .expect("config should write");
+
+    assert!(codex_legacy_config_has_tracedecay(home.path()));
+}
+
+#[test]
 fn remove_legacy_codex_native_automation_deletes_stale_record() {
     let home = tempfile::tempdir().expect("tempdir should create");
     assert!(


### PR DESCRIPTION
## Summary
- detect legacy Codex direct MCP config by TOML shape instead of substring match
- avoid noisy cleanup messages for plugin/hook-only tracedecay entries
- add regression coverage for plugin-only and legacy direct-MCP config

## Tests
- CARGO_TARGET_DIR=/scratch/tracedecay-targets/codex-mcp-cleanup cargo fmt --check
- CARGO_TARGET_DIR=/tmp/tracedecay-target-codex-mcp-cleanup cargo test -q codex_legacy_mcp_detector
- CARGO_TARGET_DIR=/tmp/tracedecay-target-codex-mcp-cleanup cargo test -q --test agent_suite codex_update_plugin_sweeps_legacy_config_when_cache_exists
- CARGO_TARGET_DIR=/tmp/tracedecay-target-codex-mcp-cleanup cargo test -q --test agent_suite codex_plugin_artifact_exports_shareable_bundle_with_managed_skills
- tracedecay tool diagnostics --args '{path:/tmp/tracedecay-codex-mcp-cleanup}'
- CARGO_TARGET_DIR=/tmp/tracedecay-target-codex-mcp-cleanup cargo clippy --workspace --all-targets --locked -- -D warnings