### PR TITLE
fix: harden automation self-improvement outputs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dashboard",
+      "runtimeExecutable": "tracedecay",
+      "runtimeArgs": ["dashboard", "--path", "${workspaceFolder}", "--port", "7799"],
+      "port": 7799
+    }
+  ]
+}

--- a/.claude/skills/inspecting-automation-cycles/SKILL.md
+++ b/.claude/skills/inspecting-automation-cycles/SKILL.md
@@ -18,7 +18,7 @@ whether generated output was adopted.
 3. For failures or suspicious skips, open the relevant artifact with
    `tracedecay_automation_run_artifact_view` or
    `tracedecay tool automation_run_artifact_view --args ...`.
-4. Inspect pending human review queues:
+4. Inspect pending self-managed review/apply state:
    `tracedecay automation facts list`, dashboard approvals, and
    `tracedecay_skill_list --state pending`.
 5. Check adoption evidence: `tracedecay analytics diagnostics --all --no-sync`,
@@ -49,6 +49,6 @@ whether generated output was adopted.
 
 ## Deliverable
 
-Report task/status counts, the exact run or artifact ids inspected, pending
-approval queues, adoption gaps, and the next concrete command for any mutation
+Report task/status counts, the exact run or artifact ids inspected, staged
+fact/skill state, adoption gaps, and the next concrete command for any mutation
 the user should choose.

--- a/.claude/skills/inspecting-automation-cycles/SKILL.md
+++ b/.claude/skills/inspecting-automation-cycles/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: inspecting-automation-cycles
+description: 'TraceDecay Dev: Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, pending approvals, or run artifacts.'
+---
+
+# TraceDecay Dev: Inspecting Automation Cycles
+
+TraceDecay automation is a loop, not a single artifact: config schedules jobs,
+runs produce artifacts, dashboards queue approvals, and usage analytics prove
+whether generated output was adopted.
+
+## Workflow
+
+1. Start with `tracedecay automation config get` to identify enabled tasks,
+   schedules, locks, profile paths, and approval gates.
+2. List recent runs with `tracedecay automation runs list --limit 100`; group
+   by task and status before opening individual artifacts.
+3. For failures or suspicious skips, open the relevant artifact with
+   `tracedecay_automation_run_artifact_view` or
+   `tracedecay tool automation_run_artifact_view --args ...`.
+4. Inspect pending human review queues:
+   `tracedecay automation facts list`, dashboard approvals, and
+   `tracedecay_skill_list --state pending`.
+5. Check adoption evidence: `tracedecay analytics diagnostics --all --no-sync`,
+   `tracedecay sessions search "mcp__tracedecay" --provider all`, and managed
+   skill usage counts.
+
+## Reading Results
+
+| Signal | Meaning | Next step |
+|---|---|---|
+| `scheduler_interval_not_elapsed` | Healthy throttling | Count only, do not fix. |
+| `scheduler_lock_active` | Another run owns the loop | Check age before calling stale. |
+| `no_new_session_activity` | Nothing new to process | Verify transcript ingest if surprising. |
+| `validation_gate` artifact | Proposed mutation was staged | Report approval command or dashboard path. |
+| Many pending fact proposals | Queue needs curation | Use `tracedecay:project-memory`. |
+| Active managed skills with zero use | Adoption telemetry gap | Use `tracedecay:diagnosing-analytics`. |
+
+## Guardrails
+
+- Prefer read-only inspection. Do not approve, reject, delete, or apply queued
+  facts unless the user explicitly asked for mutation.
+- Do not treat skipped runs as failures until grouped by skip reason and age.
+- Avoid parallel `tracedecay_skill_view` calls against one profile while
+  automation may write usage ledgers. If a usage read reports a truncated JSON
+  or EOF parse error, retry once after `tracedecay_skill_list` succeeds.
+- Do not read `.tracedecay` databases directly; use CLI, dashboard APIs, or
+  MCP tools.
+
+## Deliverable
+
+Report task/status counts, the exact run or artifact ids inspected, pending
+approval queues, adoption gaps, and the next concrete command for any mutation
+the user should choose.

--- a/.claude/skills/inspecting-automation-cycles/SKILL.md
+++ b/.claude/skills/inspecting-automation-cycles/SKILL.md
@@ -1,25 +1,25 @@
 ---
 name: inspecting-automation-cycles
-description: 'TraceDecay Dev: Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, pending approvals, or run artifacts.'
+description: 'TraceDecay Dev: Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, apply policy, or run artifacts.'
 ---
 
 # TraceDecay Dev: Inspecting Automation Cycles
 
 TraceDecay automation is a loop, not a single artifact: config schedules jobs,
-runs produce artifacts, dashboards queue approvals, and usage analytics prove
-whether generated output was adopted.
+runs produce artifacts, dashboards expose outcomes/telemetry, and usage
+analytics prove whether generated output was adopted.
 
 ## Workflow
 
 1. Start with `tracedecay automation config get` to identify enabled tasks,
-   schedules, locks, profile paths, and approval gates.
+   schedules, locks, profile paths, and apply policy.
 2. List recent runs with `tracedecay automation runs list --limit 100`; group
    by task and status before opening individual artifacts.
 3. For failures or suspicious skips, open the relevant artifact with
    `tracedecay_automation_run_artifact_view` or
    `tracedecay tool automation_run_artifact_view --args ...`.
-4. Inspect pending self-managed review/apply state:
-   `tracedecay automation facts list`, dashboard approvals, and
+4. Inspect model-managed memory outcomes plus configured managed-skill review
+   queues: `tracedecay automation facts list`, dashboard telemetry, and
    `tracedecay_skill_list --state pending`.
 5. Check adoption evidence: `tracedecay analytics diagnostics --all --no-sync`,
    `tracedecay sessions search "mcp__tracedecay" --provider all`, and managed
@@ -32,14 +32,15 @@ whether generated output was adopted.
 | `scheduler_interval_not_elapsed` | Healthy throttling | Count only, do not fix. |
 | `scheduler_lock_active` | Another run owns the loop | Check age before calling stale. |
 | `no_new_session_activity` | Nothing new to process | Verify transcript ingest if surprising. |
-| `validation_gate` artifact | Proposed mutation was staged | Report approval command or dashboard path. |
-| Many pending fact proposals | Queue needs curation | Use `tracedecay:project-memory`. |
+| `validation_gate` artifact | Mutation passed validation | Inspect apply-policy state or dashboard artifact. |
+| Many fact proposal records | Inspect validation/apply telemetry | Use `tracedecay:project-memory`. |
 | Active managed skills with zero use | Adoption telemetry gap | Use `tracedecay:diagnosing-analytics`. |
 
 ## Guardrails
 
-- Prefer read-only inspection. Do not approve, reject, delete, or apply queued
-  facts unless the user explicitly asked for mutation.
+- Prefer read-only inspection. Do not mutate fact records.
+- Do not approve, reject, delete, or apply managed-skill drafts unless the user
+  explicitly asked for mutation.
 - Do not treat skipped runs as failures until grouped by skip reason and age.
 - Avoid parallel `tracedecay_skill_view` calls against one profile while
   automation may write usage ledgers. If a usage read reports a truncated JSON
@@ -49,6 +50,6 @@ whether generated output was adopted.
 
 ## Deliverable
 
-Report task/status counts, the exact run or artifact ids inspected, staged
-fact/skill state, adoption gaps, and the next concrete command for any mutation
-the user should choose.
+Report task/status counts, the exact run or artifact ids inspected, apply-policy
+state, adoption gaps, and the next concrete command for any mutation the user
+should choose.

--- a/.claude/skills/interpreting-tracedecay-diagnostics/SKILL.md
+++ b/.claude/skills/interpreting-tracedecay-diagnostics/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: interpreting-tracedecay-diagnostics
+description: 'TraceDecay Dev: Use when interpreting TraceDecay compiler diagnostics, `tracedecay tool diagnose`, `tracedecay tool diagnostics`, mapped errors, affected symbols, or build/type failure output.'
+---
+
+# TraceDecay Dev: Interpreting TraceDecay Diagnostics
+
+TraceDecay diagnostics turn raw compiler output into mapped symbols, callers,
+and likely test scope. Use them before eyeballing cargo, clippy, tsc, or
+pyright output.
+
+## Workflow
+
+1. If raw stderr already exists, pass it to
+   `tracedecay tool diagnose --args '{"cargo_output":"..."}'`.
+2. If no stderr exists, run `tracedecay tool diagnostics` instead of a broad
+   shell build first.
+3. Read diagnostics by group:
+   - parser count: did TraceDecay recognize the compiler output?
+   - mapped node: which function, impl, type, or file owns the failure?
+   - callers/dependents: what may break after the fix?
+   - affected tests: what narrow verification should run?
+4. If parser count is zero, rerun the native command only long enough to
+   capture exact stderr, then diagnose that text. Do not manually scan pages
+   of compiler output.
+5. If output is truncated and includes a handle, retrieve or narrow before
+   rerunning broad diagnostics.
+
+## Interpretation
+
+- Unmapped diagnostics usually mean parse coverage or file mapping is missing,
+  not that the error is unimportant.
+- Many errors in one file often share one signature, enum variant, or feature
+  gate root cause. Fix the first mapped owner, then rerun diagnostics.
+- For Rust enum pattern errors, prefer `..` in matches when future fields are
+  intentionally ignored.
+- A mapped test target is a recommendation. Run it, then broaden only if the
+  changed symbol is shared or public.
+
+## Deliverable
+
+Report symptom, mapped owner, root cause, patch, and verification command. If
+diagnostics could not parse the output, include the exact command that produced
+the stderr sample.

--- a/.claude/skills/introspecting-tracedecay-usage/SKILL.md
+++ b/.claude/skills/introspecting-tracedecay-usage/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: introspecting-tracedecay-usage
+description: "TraceDecay Dev: Use when turning TraceDecay's own analytics, session history, automation runs, managed skills, memory facts, diagnostics, or code-health signals into repo improvements, evals, or bundled skill updates."
+---
+
+# TraceDecay Dev: Introspecting TraceDecay Usage
+
+Use this skill for TraceDecay self-improvement driven by real agent behavior,
+not guesswork. Keep the pass evidence-first: logs and summaries identify the
+failure mode, then code, tests, or bundled skills encode the fix.
+
+## Required Audit Lanes
+
+1. **Adoption and telemetry:** Use `tracedecay:diagnosing-analytics`. Run
+   `tracedecay analytics diagnostics` (add `--all` when the question is
+   cross-project). Compare hook/tool volume with TraceDecay tool usage.
+2. **Past-session behavior:** Use `tracedecay:managing-session-context`.
+   Start with `tracedecay_message_search`; use `tracedecay_lcm_status` before
+   deeper LCM work, then `tracedecay_lcm_grep` or replay only as needed.
+3. **Managed skills and automation:** Use
+   `tracedecay:inspecting-managed-skills`. Start with
+   `tracedecay_skill_list`; view skills or run artifacts only when the list
+   points to a specific stale, patched, failed, or unused item.
+4. **Durable memory:** Use `tracedecay:project-memory`. Search with
+   `tracedecay_fact_store` before re-deriving project decisions. For curation,
+   run read-only inventory and dry-runs first; never remove facts without
+   explicit approval.
+5. **Code-health and implementation target:** Use `tracedecay:code-health`.
+   Let weak dimensions and hotspots decide whether the fix is code, tests,
+   docs, evals, or skill guidance.
+
+## Interpretation Rules
+
+- High hook volume with low TraceDecay tool usage is an adoption gap. Improve
+  trigger text, tool hints, or eval coverage before blaming users.
+- Managed skills with many patches and zero successful uses are validation
+  failures. Inspect their evidence and either tighten the managed-skill loop
+  or add a bundled operator skill that prevents the repeated mistake.
+- LCM depth and compression ratios are health signals, not direct quality
+  scores. Use raw/session recall to confirm what agents actually missed.
+- Memory curation candidates are proposals, not permission. Prefer merge or
+  update when provenance matters; deletion needs fresh user approval.
+- Analytics fields can be global. `project_id: null` means the run was global,
+  not broken.
+
+## Improvement Loop
+
+1. Capture counts and examples from every required audit lane.
+2. Group evidence into one failure class: discovery, fallback, diagnostics
+   interpretation, automation validation, memory curation, or code structure.
+3. Choose the smallest durable fix:
+   - bundled skill update when agents know the feature but skip the workflow;
+   - eval/test when the workflow should be enforced;
+   - code change when the data is unavailable, misleading, or too hard to
+     interpret;
+   - managed-skill action when the issue lives only in the profile store.
+4. Verify with the narrowest relevant command, then run the matching skill
+   contract or code test.
+
+## Deliverable
+
+Report the exact commands/tools used, headline counts, cited sessions or run
+ids when available, the selected failure class, the improvement made, and the
+verification result. Include any `tracedecay_metrics:` savings line.

--- a/.claude/skills/self-improving-from-usage-logs/SKILL.md
+++ b/.claude/skills/self-improving-from-usage-logs/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: self-improving-from-usage-logs
+description: 'TraceDecay Dev: Use when mining TraceDecay session logs, analytics, diagnostics, automation artifacts, or agent transcripts to improve TraceDecay code, tools, or packaged skills.'
+---
+
+# TraceDecay Dev: Self-Improving From Usage Logs
+
+Use real agent behavior as an eval surface: logs reveal where tools are
+confusing, silent, too hard to discover, or missing a safe command.
+
+## Workflow
+
+1. Start with adoption and health:
+   `tracedecay analytics diagnostics --all --no-sync`, `tracedecay doctor`,
+   and `tracedecay tool lcm_status --provider all --json`.
+2. Search transcripts for friction phrases, tool failures, and bypasses:
+   `tracedecay_message_search`, then narrow with `tracedecay_lcm_grep` or
+   `tracedecay_lcm_expand_query`.
+3. Inspect automation evidence with `tracedecay:inspecting-automation-cycles`
+   and managed-skill evidence with `tracedecay:writing-agent-managed-skills`.
+4. Turn patterns into the smallest durable fix: CLI affordance, clearer
+   diagnostic field, better skill trigger, missing dashboard summary, or test.
+5. Verify with the narrow command that failed in the logs plus the owning Rust
+   test or plugin validation suite.
+
+## Opportunity Ranking
+
+| Pattern | Prefer this fix |
+|---|---|
+| Repeated invalid flag or command | Accept alias or improve CLI help. |
+| Counts interpreted incorrectly | Add explicit field names and sample limits. |
+| Agents query stores directly | Add/read skill guardrail and expose CLI summary. |
+| Skill exists but is not invoked | Improve description trigger and analytics events. |
+| Automation skips look like failures | Add grouped run/status summary. |
+| Same fact proposed repeatedly | Deduplicate before approval queue. |
+
+## Guardrails
+
+- Do not store secrets, transient failures, or one-off progress as memory.
+- Do not convert a single anecdote into a broad rule without at least two
+  corroborating sessions, an automation artifact, or a failing command.
+- Keep code fixes smaller than the evidence. If logs show a CLI paper cut,
+  ship the CLI compatibility fix before redesigning the subsystem.
+
+## Deliverable
+
+Report the evidence source, repeated pattern, ranked opportunity, code or skill
+change made, verification command, and any residual adoption gap.

--- a/.claude/skills/self-improving-from-usage-logs/SKILL.md
+++ b/.claude/skills/self-improving-from-usage-logs/SKILL.md
@@ -32,7 +32,7 @@ confusing, silent, too hard to discover, or missing a safe command.
 | Agents query stores directly | Add/read skill guardrail and expose CLI summary. |
 | Skill exists but is not invoked | Improve description trigger and analytics events. |
 | Automation skips look like failures | Add grouped run/status summary. |
-| Same fact proposed repeatedly | Deduplicate before approval queue. |
+| Same fact proposed repeatedly | Deduplicate before validation/apply. |
 
 ## Guardrails
 

--- a/.claude/skills/writing-agent-managed-skills/SKILL.md
+++ b/.claude/skills/writing-agent-managed-skills/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: writing-agent-managed-skills
+description: 'TraceDecay Dev: Use when creating, revising, validating, approving, installing, or auditing TraceDecay agent-managed automation skills and skill-writer drafts.'
+---
+
+# TraceDecay Dev: Writing Agent-Managed Skills
+
+Agent-managed skills are profile-owned drafts produced by automation. Treat
+them as generated artifacts with lifecycle state, validation evidence, and
+usage telemetry; bundled `plugin/skills/` changes are a separate release path.
+
+## Workflow
+
+1. Inspect before editing: `tracedecay_skill_list` for inventory, then
+   `tracedecay_skill_view` with support files for the target draft.
+2. Read the writer run evidence:
+   `tracedecay_automation_run_artifact_view` for `generated_evals`,
+   `validation_gate`, `optimizer_diagnosis`, and `codex_handoff` artifacts.
+3. Decide the path:
+   - managed draft fix: update through `tracedecay automation skills ...`
+     commands or dashboard flow;
+   - bundled reusable guidance: edit `plugin/skills/<slug>/SKILL.md` and run
+     agent-suite validation.
+4. Validate discovery text: description starts with `Use when`, names concrete
+   triggers, avoids workflow summaries, and stays host-portable.
+5. Check adoption after install with analytics diagnostics and skill usage
+   events before declaring the skill effective.
+
+## Quality Bar
+
+| Check | Pass condition |
+|---|---|
+| Trigger | Another agent can identify when to load it from description alone. |
+| Body | Short imperative workflow, no session narrative, no stale environment facts. |
+| Evidence | Run artifact or transcript shows the failure this skill prevents. |
+| Validation | Draft has a validation gate or bundled skill passes plugin tests. |
+| Adoption | Usage telemetry or follow-up session proves it was invoked. |
+
+## Guardrails
+
+- Never approve or install a managed skill without explicit user intent.
+- Never copy managed-skill state into bundled skills unless the pattern is
+  reusable across projects.
+- Do not mutate profile stores from subagents. Subagents may inspect and
+  recommend only.
+
+## Deliverable
+
+Return the skill id or bundled path, lifecycle state, validation artifacts read,
+edits made or recommended, adoption evidence, and the exact approve/install
+command when mutation is appropriate.

--- a/.codex/skills/inspecting-automation-cycles/SKILL.md
+++ b/.codex/skills/inspecting-automation-cycles/SKILL.md
@@ -1,25 +1,25 @@
 ---
 name: inspecting-automation-cycles
-description: 'TraceDecay Dev: Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, pending approvals, or run artifacts.'
+description: 'TraceDecay Dev: Use when auditing TraceDecay automation loops, skipped runs, memory-curator/session-reflector/skill-writer output, apply policy, or run artifacts.'
 ---
 
 # TraceDecay Dev: Inspecting Automation Cycles
 
 TraceDecay automation is a loop, not a single artifact: config schedules jobs,
-runs produce artifacts, dashboards queue approvals, and usage analytics prove
-whether generated output was adopted.
+runs produce artifacts, dashboards expose outcomes/telemetry, and usage
+analytics prove whether generated output was adopted.
 
 ## Workflow
 
 1. Start with `tracedecay automation config get` to identify enabled tasks,
-   schedules, locks, profile paths, and approval gates.
+   schedules, locks, profile paths, and apply policy.
 2. List recent runs with `tracedecay automation runs list --limit 100`; group
    by task and status before opening individual artifacts.
 3. For failures or suspicious skips, open the relevant artifact with
    `tracedecay_automation_run_artifact_view` or
    `tracedecay tool automation_run_artifact_view --args ...`.
-4. Inspect pending human review queues:
-   `tracedecay automation facts list`, dashboard approvals, and
+4. Inspect model-managed memory outcomes plus configured managed-skill review
+   queues: `tracedecay automation facts list`, dashboard telemetry, and
    `tracedecay_skill_list --state pending`.
 5. Check adoption evidence: `tracedecay analytics diagnostics --all --no-sync`,
    `tracedecay sessions search "mcp__tracedecay" --provider all`, and managed
@@ -32,14 +32,15 @@ whether generated output was adopted.
 | `scheduler_interval_not_elapsed` | Healthy throttling | Count only, do not fix. |
 | `scheduler_lock_active` | Another run owns the loop | Check age before calling stale. |
 | `no_new_session_activity` | Nothing new to process | Verify transcript ingest if surprising. |
-| `validation_gate` artifact | Proposed mutation was staged | Report approval command or dashboard path. |
-| Many pending fact proposals | Queue needs curation | Use `tracedecay:project-memory`. |
+| `validation_gate` artifact | Mutation passed validation | Inspect apply-policy state or dashboard artifact. |
+| Many fact proposal records | Inspect validation/apply telemetry | Use `tracedecay:project-memory`. |
 | Active managed skills with zero use | Adoption telemetry gap | Use `tracedecay:diagnosing-analytics`. |
 
 ## Guardrails
 
-- Prefer read-only inspection. Do not approve, reject, delete, or apply queued
-  facts unless the user explicitly asked for mutation.
+- Prefer read-only inspection. Do not mutate fact records.
+- Do not approve, reject, delete, or apply managed-skill drafts unless the user
+  explicitly asked for mutation.
 - Do not treat skipped runs as failures until grouped by skip reason and age.
 - Avoid parallel `tracedecay_skill_view` calls against one profile while
   automation may write usage ledgers. If a usage read reports a truncated JSON
@@ -49,6 +50,6 @@ whether generated output was adopted.
 
 ## Deliverable
 
-Report task/status counts, the exact run or artifact ids inspected, pending
-approval queues, adoption gaps, and the next concrete command for any mutation
-the user should choose.
+Report task/status counts, the exact run or artifact ids inspected, apply-policy
+state, adoption gaps, and the next concrete command for any mutation the user
+should choose.

--- a/.codex/skills/self-improving-from-usage-logs/SKILL.md
+++ b/.codex/skills/self-improving-from-usage-logs/SKILL.md
@@ -32,7 +32,7 @@ confusing, silent, too hard to discover, or missing a safe command.
 | Agents query stores directly | Add/read skill guardrail and expose CLI summary. |
 | Skill exists but is not invoked | Improve description trigger and analytics events. |
 | Automation skips look like failures | Add grouped run/status summary. |
-| Same fact proposed repeatedly | Deduplicate before approval queue. |
+| Same fact proposed repeatedly | Deduplicate before validation/apply. |
 
 ## Guardrails
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 .tracedecay
 .mcp.json
 !plugin/.mcp.json
-.claude/*
-!.claude/skills/
+.claude/settings.local.json
 .cursor/
 docs/superpowers
 /local-only

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 .tracedecay
 .mcp.json
 !plugin/.mcp.json
-.claude/
+.claude/*
+!.claude/skills/
 .cursor/
 docs/superpowers
 /local-only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,16 @@ CARGO_TARGET_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-cargo-target" \
 TRACEDECAY_DATA_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-test-profile/.tracedecay" \
 cargo test-all
 ```
+
+## Learned User Preferences
+
+- Do not merge a batch of PRs until aggregate verification is stable; a single flaky pass is not enough.
+- Delegate code edits to execution-focused subagents; use planning/review-focused agents for planning, review, and thinking.
+- When orchestrating parallel agents, the lead dictates exact scoped edits, subagents execute, and the lead reviews diffs before any push.
+- Subagents should not invent scope beyond what the lead dictated.
+
+## Learned Workspace Facts
+
+- Parallel branch work uses git worktrees under `.worktrees/` in the repo root (for example `.worktrees/codex-cli-args-stdin`).
+- Integration/default branch is `master`, not `main` (GitHub: ScriptedAlchemy/tracedecay).
+- Multi-PR merge verification: build a detached scratch worktree on `origin/master`, merge all target branches, then run tests with isolated `CARGO_TARGET_DIR` and `TRACEDECAY_DATA_DIR` paths.

--- a/dashboard/code-diagnostics/src/styles.css
+++ b/dashboard/code-diagnostics/src/styles.css
@@ -87,6 +87,17 @@
   font-size: 0.76rem;
 }
 
+/* Engine ids are single tokens (e.g. `rust-analyzer`); in a squeezed grid
+   column `overflow-wrap: anywhere` stacks them one character per line. Truncate
+   with an ellipsis instead. Long file paths in file-group/diagnostic code keep
+   the anywhere-wrap above. */
+.tdcd-engine-row > code {
+  overflow: hidden;
+  overflow-wrap: normal;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .tdcd-toggle {
   display: inline-flex;
   align-items: center;

--- a/dashboard/holographic/src/CurationPanel.tsx
+++ b/dashboard/holographic/src/CurationPanel.tsx
@@ -206,9 +206,9 @@ export default function CurationPanel({
     : null;
   // Same server-side count the outer Curation tab badge uses, so the two
   // badges can't disagree and no proposal/skill lists need loading up front.
-  const pendingProposalCount = usePendingAutomationCounts(api);
-  const proposalsLabel = pendingProposalCount
-    ? `Proposals ${pendingProposalCount}`
+  const pendingReviewCount = usePendingAutomationCounts(api);
+  const proposalsLabel = pendingReviewCount
+    ? `Proposals ${pendingReviewCount}`
     : "Proposals";
   const tabs: Array<{ id: CurationTab; label: string; Icon: typeof Wand2 }> = [
     { id: "plan", label: planLabel, Icon: ListChecks },

--- a/dashboard/holographic/src/HolographicMemoryPage.tsx
+++ b/dashboard/holographic/src/HolographicMemoryPage.tsx
@@ -902,8 +902,7 @@ function HolographicView({
     window.history.replaceState(null, "", url);
   }, []);
 
-  // Pending automation output (skill drafts + fact proposals awaiting
-  // review) surfaces as a count badge on the Curation tab (parity R5).
+  // Managed-skill drafts awaiting review surface as a Curation badge.
   const pendingAutomationCount = usePendingAutomationCounts(api);
 
   // Cross-view navigation: a similarity pair jumps to the Semantic Map with
@@ -948,7 +947,7 @@ function HolographicView({
                 <Badge
                   tone="secondary"
                   className={NUM_BADGE}
-                  aria-label={`${pendingAutomationCount} automation items awaiting review`}
+                  aria-label={`${pendingAutomationCount} managed skill drafts awaiting review`}
                 >
                   {pendingAutomationCount}
                 </Badge>

--- a/dashboard/holographic/src/api.ts
+++ b/dashboard/holographic/src/api.ts
@@ -260,7 +260,7 @@ export const api = {
   /** Restore an archived/disabled skill to pending approval. */
   restoreManagedSkill: (id: string) => postManagedSkillAction(id, "restore"),
 
-  /** Durable session-reflection fact proposals awaiting approval. */
+  /** Durable session-reflection fact proposal telemetry. */
   getFactProposals: (params: { state?: string; limit?: number } = {}) => {
     const qs = new URLSearchParams();
     if (params.state) qs.set("state", params.state);
@@ -271,13 +271,13 @@ export const api = {
     );
   },
 
-  /** Apply an approved fact proposal to the memory store. */
+  /** Apply a pending fact proposal to the memory store. */
   applyFactProposal: (id: string) =>
     fetchJSON<FactProposalResponse>(factProposalPath(id, "apply"), {
       method: "POST",
     }),
 
-  /** Reject a pending fact proposal without mutating memory. */
+  /** Mark a pending fact proposal rejected without mutating memory. */
   rejectFactProposal: (id: string, reason?: string) =>
     fetchJSON<FactProposalResponse>(factProposalPath(id, "reject"), {
       method: "POST",

--- a/dashboard/holographic/src/curation/AutomationConfigSection.tsx
+++ b/dashboard/holographic/src/curation/AutomationConfigSection.tsx
@@ -127,8 +127,8 @@ export function AutomationConfigSection({
               onCheckedChange={(enabled) => updateConfigDraft({ enabled })}
             />
             <ConfigCheckbox
-              label="Require approval"
-              ariaLabel="Require dashboard approval"
+              label="Require manual apply"
+              ariaLabel="Require manual dashboard apply"
               checked={configDraft.require_dashboard_approval}
               error={configFieldErrors.require_dashboard_approval}
               onCheckedChange={(require_dashboard_approval) =>

--- a/dashboard/holographic/src/curation/AutomationTaskConfigRow.tsx
+++ b/dashboard/holographic/src/curation/AutomationTaskConfigRow.tsx
@@ -79,6 +79,7 @@ export function AutomationTaskConfigRow({
         <Button
           size="xs"
           outlined
+          aria-label={`Run ${descriptor.runAriaLabel}`}
           disabled={!canRun || !config.enabled}
           title={runTitle}
           onClick={() => onRun(task)}

--- a/dashboard/holographic/src/curation/CurationProposalsPanel.tsx
+++ b/dashboard/holographic/src/curation/CurationProposalsPanel.tsx
@@ -60,7 +60,7 @@ export function CurationProposalsPanel({
     <CurationTabPanel
       tab="proposals"
       title="Proposals"
-      subtitle="Facts and skills the automation loops staged for your approval."
+      subtitle="Memory fact outcomes and managed skill drafts staged by automation loops."
     >
       <FactProposalsSection
         proposals={factProposals}

--- a/dashboard/holographic/src/curation/FactProposalsSection.tsx
+++ b/dashboard/holographic/src/curation/FactProposalsSection.tsx
@@ -83,7 +83,7 @@ export function FactProposalsSection({
             ) : null}
           </div>
           <div className="mt-0.5 text-[11px] text-text-tertiary">
-            Session-reflection facts staged for dashboard approval.
+            Session-reflection facts retained as automation telemetry.
           </div>
         </div>
         <Button
@@ -146,8 +146,8 @@ export function FactProposalsSection({
         {pendingProposals.length === 0 ? (
           <div className="text-xs text-text-tertiary">
             {proposals.length === 0
-              ? "No fact proposals are waiting in this profile."
-              : "No proposals are waiting for review."}
+              ? "No fact proposals recorded in this profile."
+              : "No pending fact proposals in this profile."}
           </div>
         ) : null}
         {resolvedProposals.length ? (

--- a/dashboard/holographic/src/curation/usePendingAutomationCounts.ts
+++ b/dashboard/holographic/src/curation/usePendingAutomationCounts.ts
@@ -8,10 +8,9 @@ const POLL_MS = 60_000;
 export type PendingAutomationCountsApi = Pick<typeof defaultApi, "getAutomationSchedulerStatus">;
 
 /**
- * Total automation output awaiting human review (pending fact proposals +
- * pending skill drafts), sourced from the additive counts on
- * `/api/automation/scheduler/status`. Self-contained so the Curation tab
- * badge stays decoupled from the CurationPanel's own data plumbing.
+ * Managed-skill drafts awaiting human review, sourced from the additive counts
+ * on `/api/automation/scheduler/status`. Fact proposal counts remain telemetry
+ * and do not drive review badges.
  */
 export function usePendingAutomationCounts(api: PendingAutomationCountsApi): number {
   const [total, setTotal] = useState(0);
@@ -24,7 +23,7 @@ export function usePendingAutomationCounts(api: PendingAutomationCountsApi): num
       try {
         const status = await api.getAutomationSchedulerStatus();
         if (!cancelled) {
-          setTotal((status.pending_fact_proposals ?? 0) + (status.pending_skills ?? 0));
+          setTotal(status.pending_skills ?? 0);
         }
       } catch {
         // Advisory badge: keep the last known count on transient errors.

--- a/dashboard/holographic/src/types.ts
+++ b/dashboard/holographic/src/types.ts
@@ -470,7 +470,7 @@ export interface AutomationSchedulerStatusResponse {
   enabled: boolean;
   scheduler_tick_secs: number;
   now: number;
-  /** Fact proposals awaiting review (additive; older servers omit it). */
+  /** Pending fact proposal telemetry (additive; older servers omit it). */
   pending_fact_proposals?: number;
   /** Skill drafts/updates awaiting review (additive; older servers omit it). */
   pending_skills?: number;

--- a/dashboard/smoke.mjs
+++ b/dashboard/smoke.mjs
@@ -132,6 +132,25 @@ async function runViewportSmoke(browser, baseUrl, profile, expectLcmMode) {
     ...profile.contextOptions,
   });
   const page = await context.newPage();
+
+  // Fail the smoke on any uncaught JS error, console.error, or 5xx response —
+  // a tab that renders visually but throws in the console is still broken.
+  const runtimeErrors = [];
+  page.on("pageerror", (err) => {
+    runtimeErrors.push(`pageerror: ${err.message}`);
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      runtimeErrors.push(`console.error: ${msg.text()}`);
+    }
+  });
+  const serverErrors = [];
+  page.on("response", (response) => {
+    if (response.status() >= 500) {
+      serverErrors.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
   await page.goto(baseUrl, { waitUntil: "networkidle" });
 
   // Shell tabs render with role="tab" (older shells used buttons).
@@ -222,7 +241,82 @@ async function runViewportSmoke(browser, baseUrl, profile, expectLcmMode) {
     await waitForAny(page, [recentSessionsHeader, emptyStateHeader], 8000);
   }
 
+  // The Savings, Code Diagnostics, and Settings shells are full tabs the smoke
+  // previously never opened. Walk them once (content is viewport-independent, so
+  // the desktop pass is enough) and assert each resolves past its loading/empty
+  // state rather than rendering a blank or spinner-stuck panel.
+  if (profile.name === "desktop") {
+    await runSecondaryTabsSmoke(page);
+  }
+
+  if (runtimeErrors.length > 0) {
+    throw new Error(
+      `dashboard raised ${runtimeErrors.length} runtime error(s):\n  ${runtimeErrors.join("\n  ")}`,
+    );
+  }
+  if (serverErrors.length > 0) {
+    throw new Error(
+      `dashboard returned ${serverErrors.length} server error response(s):\n  ${serverErrors.join("\n  ")}`,
+    );
+  }
+
   await context.close();
+}
+
+// Opens the Savings & Cost, Code Diagnostics, and Settings tabs and asserts each
+// renders real content. These are the shells the memory/graph/LCM smoke skipped.
+async function runSecondaryTabsSmoke(page) {
+  const tab = (name) =>
+    page
+      .getByRole("tab", { name, exact: true })
+      .or(page.getByRole("button", { name, exact: true }));
+
+  // --- Savings & Cost: must resolve past the "Loading savings analytics…"
+  // placeholder into real analytics, and expose its sub-tabs.
+  await tab("Savings & Cost").click();
+  await page.waitForFunction(
+    () => {
+      const text = document.body.innerText;
+      return !text.includes("Loading savings analytics") && /saved/i.test(text);
+    },
+    undefined,
+    { timeout: 12000 },
+  );
+  for (const subTab of ["Sessions", "Models & Pricing"]) {
+    await tab(subTab).click();
+    await page.waitForTimeout(200);
+  }
+
+  // --- Code Graph (already covered above) — jump straight to Code Diagnostics.
+  await tab("Code Diagnostics").click();
+  await page.getByText("ENGINES", { exact: false }).first().waitFor({ state: "visible", timeout: 8000 });
+  await assertEngineIdsDoNotCharStack(page);
+
+  // --- Settings: the config panel must render its project-config path and the
+  // Save/Discard controls.
+  await tab("Settings").click();
+  await page.getByText("Project config", { exact: false }).first().waitFor({ state: "visible", timeout: 8000 });
+  // Settings renders a Save per section (Indexing, User & Uploads); assert at
+  // least one is present.
+  await page.getByRole("button", { name: "Save", exact: true }).first().waitFor({ state: "visible", timeout: 8000 });
+}
+
+// Regression guard: engine ids (e.g. `rust-analyzer`) live in a squeezable grid
+// column. With `overflow-wrap: anywhere` they collapse to one character per line
+// when the column is tight. The fix pins them to `white-space: nowrap` (truncate
+// with an ellipsis instead), so assert that computed style is applied.
+async function assertEngineIdsDoNotCharStack(page) {
+  const whiteSpaces = await page.$$eval(".tdcd-engine-row > code", (nodes) =>
+    nodes.map((node) => getComputedStyle(node).whiteSpace),
+  );
+  // No engine rows in a hermetic workspace is acceptable; only assert when present.
+  for (const whiteSpace of whiteSpaces) {
+    if (whiteSpace !== "nowrap") {
+      throw new Error(
+        `engine id <code> must not per-character wrap; expected white-space: nowrap, got "${whiteSpace}"`,
+      );
+    }
+  }
 }
 
 async function assertNoHorizontalOverflow(page) {

--- a/dashboard/smoke.mjs
+++ b/dashboard/smoke.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import readline from "node:readline";
+import { fileURLToPath } from "node:url";
 import { chromium, devices } from "playwright";
 
 const VIEWPORT_PROFILES = {
@@ -32,7 +33,7 @@ const VIEWPORT_PROFILES = {
 const DASHBOARD_URL_RE = /(http:\/\/127\.0\.0\.1:\d+\/)/;
 
 function workspaceRoot() {
-  return new URL("..", import.meta.url).pathname;
+  return fileURLToPath(new URL("..", import.meta.url));
 }
 
 function withTrailingSlash(url) {
@@ -118,13 +119,16 @@ async function startDashboardServer(projectPath) {
 }
 
 async function waitForAny(page, locators, timeoutMs) {
-  const timeout = new Promise((_, reject) => {
-    setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
-  });
-  const checks = locators.map((locator) =>
-    locator.waitFor({ state: "visible", timeout: timeoutMs }).then(() => locator),
-  );
-  return Promise.race([timeout, ...checks]);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const locator of locators) {
+      if (await locator.isVisible().catch(() => false)) {
+        return locator;
+      }
+    }
+    await page.waitForTimeout(Math.min(100, Math.max(0, deadline - Date.now())));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms`);
 }
 
 async function runViewportSmoke(browser, baseUrl, profile, expectLcmMode) {
@@ -133,8 +137,6 @@ async function runViewportSmoke(browser, baseUrl, profile, expectLcmMode) {
   });
   const page = await context.newPage();
 
-  // Fail the smoke on any uncaught JS error, console.error, or 5xx response —
-  // a tab that renders visually but throws in the console is still broken.
   const runtimeErrors = [];
   page.on("pageerror", (err) => {
     runtimeErrors.push(`pageerror: ${err.message}`);
@@ -241,10 +243,6 @@ async function runViewportSmoke(browser, baseUrl, profile, expectLcmMode) {
     await waitForAny(page, [recentSessionsHeader, emptyStateHeader], 8000);
   }
 
-  // The Savings, Code Diagnostics, and Settings shells are full tabs the smoke
-  // previously never opened. Walk them once (content is viewport-independent, so
-  // the desktop pass is enough) and assert each resolves past its loading/empty
-  // state rather than rendering a blank or spinner-stuck panel.
   if (profile.name === "desktop") {
     await runSecondaryTabsSmoke(page);
   }
@@ -263,16 +261,12 @@ async function runViewportSmoke(browser, baseUrl, profile, expectLcmMode) {
   await context.close();
 }
 
-// Opens the Savings & Cost, Code Diagnostics, and Settings tabs and asserts each
-// renders real content. These are the shells the memory/graph/LCM smoke skipped.
 async function runSecondaryTabsSmoke(page) {
   const tab = (name) =>
     page
       .getByRole("tab", { name, exact: true })
       .or(page.getByRole("button", { name, exact: true }));
 
-  // --- Savings & Cost: must resolve past the "Loading savings analytics…"
-  // placeholder into real analytics, and expose its sub-tabs.
   await tab("Savings & Cost").click();
   await page.waitForFunction(
     () => {
@@ -287,29 +281,19 @@ async function runSecondaryTabsSmoke(page) {
     await page.waitForTimeout(200);
   }
 
-  // --- Code Graph (already covered above) — jump straight to Code Diagnostics.
   await tab("Code Diagnostics").click();
   await page.getByText("ENGINES", { exact: false }).first().waitFor({ state: "visible", timeout: 8000 });
   await assertEngineIdsDoNotCharStack(page);
 
-  // --- Settings: the config panel must render its project-config path and the
-  // Save/Discard controls.
   await tab("Settings").click();
   await page.getByText("Project config", { exact: false }).first().waitFor({ state: "visible", timeout: 8000 });
-  // Settings renders a Save per section (Indexing, User & Uploads); assert at
-  // least one is present.
   await page.getByRole("button", { name: "Save", exact: true }).first().waitFor({ state: "visible", timeout: 8000 });
 }
 
-// Regression guard: engine ids (e.g. `rust-analyzer`) live in a squeezable grid
-// column. With `overflow-wrap: anywhere` they collapse to one character per line
-// when the column is tight. The fix pins them to `white-space: nowrap` (truncate
-// with an ellipsis instead), so assert that computed style is applied.
 async function assertEngineIdsDoNotCharStack(page) {
   const whiteSpaces = await page.$$eval(".tdcd-engine-row > code", (nodes) =>
     nodes.map((node) => getComputedStyle(node).whiteSpace),
   );
-  // No engine rows in a hermetic workspace is acceptable; only assert when present.
   for (const whiteSpace of whiteSpaces) {
     if (whiteSpace !== "nowrap") {
       throw new Error(

--- a/dashboard/test/curation-panel.vitest.tsx
+++ b/dashboard/test/curation-panel.vitest.tsx
@@ -590,9 +590,9 @@ describe("CurationPanel", () => {
     renderAutomationPanel();
 
     expect(await screen.findByText(/was not found/i)).toBeTruthy();
-    const runButtons = await screen.findAllByRole("button", { name: /^run$/i });
-    expect((runButtons[0] as HTMLButtonElement).disabled).toBe(true);
-    expect(runButtons[0].getAttribute("title")).toContain("was not found");
+    const runButton = await screen.findByRole("button", { name: "Run Memory curator" });
+    expect((runButton as HTMLButtonElement).disabled).toBe(true);
+    expect(runButton.getAttribute("title")).toContain("was not found");
   });
 
   it("renders automation config validation errors inline", async () => {
@@ -713,9 +713,8 @@ describe("CurationPanel", () => {
     renderAutomationPanel();
 
     await screen.findByLabelText("Session reflector schedule");
-    const runButtons = screen.getAllByRole("button", { name: /^run$/i });
 
-    fireEvent.click(runButtons[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Run Session reflector" }));
 
     await waitFor(() => {
       expect(apiMock.postAutomationRunSessionReflection).toHaveBeenCalledWith({
@@ -723,7 +722,7 @@ describe("CurationPanel", () => {
       });
     });
 
-    fireEvent.click(runButtons[2]);
+    fireEvent.click(screen.getByRole("button", { name: "Run Skill writer" }));
 
     await waitFor(() => {
       expect(apiMock.postAutomationRunSkillWriting).toHaveBeenCalledWith({
@@ -731,7 +730,7 @@ describe("CurationPanel", () => {
       });
     });
 
-    fireEvent.click(runButtons[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Run Memory curator" }));
 
     await waitFor(() => {
       expect(apiMock.postAutomationRunMemoryCurator).toHaveBeenCalledWith({

--- a/dashboard/test/pending-automation-counts.vitest.tsx
+++ b/dashboard/test/pending-automation-counts.vitest.tsx
@@ -23,11 +23,11 @@ function makeApi(
 }
 
 describe("usePendingAutomationCounts", () => {
-  it("sums pending fact proposals and skills from scheduler status", async () => {
+  it("counts only pending skills from scheduler status", async () => {
     const api = makeApi({ pending_fact_proposals: 2, pending_skills: 1 });
     const { result } = renderHook(() => usePendingAutomationCounts(api));
 
-    await waitFor(() => expect(result.current).toBe(3));
+    await waitFor(() => expect(result.current).toBe(1));
     expect(api.getAutomationSchedulerStatus).toHaveBeenCalledTimes(1);
   });
 

--- a/docs/AGENT-MEMORY-INTERCEPTION.md
+++ b/docs/AGENT-MEMORY-INTERCEPTION.md
@@ -243,7 +243,7 @@ transcripts"), so Codex sessions also feed reflection.
   from the hook binary** (the hooks are the same `tracedecay` binary; no MCP
   round-trip needed).
 
-### 3.4 Storage loop: session_reflector (exists, gated off by default)
+### 3.4 Storage loop: session_reflector (exists, automation disabled by default)
 
 `src/automation/{runner,session_reflector,fact_proposals}.rs`:
 
@@ -253,14 +253,13 @@ transcripts"), so Codex sessions also feed reflection.
   returned **fact proposals** against evidence citations
   (`validate_fact_proposals` — each proposal must cite raw messages / store
   ids / summary nodes; trust bounded by `proposal_trust_value`).
-- Accepted proposals are recorded to the dashboard proposal store
-  (`fact_proposals.rs::record_session_fact_proposals`) for human approval in
-  the curation UI, or auto-applied when
-  `auto_apply_memory_ops && !require_dashboard_approval`.
-- **Defaults are conservative:** `AutomationConfig::default()` has
-  `enabled: false`, `backend: Disabled`, `require_dashboard_approval: true`,
-  `auto_apply_memory_ops: false` (`src/automation/config.rs:101-113`). So the
-  write path from transcripts → facts exists but is off unless the user
+- Accepted proposals flow through the automation apply policy
+  (`fact_proposals.rs::record_session_fact_proposals`): self-managed memory
+  apply is the normal model-managed path, while the dashboard exposes outcomes,
+  telemetry, and explicit apply/reject controls for configured review modes.
+- **Defaults are conservative:** automation starts disabled
+  (`enabled: false`, `backend: Disabled`; `src/automation/config.rs:101-113`).
+  The write path from transcripts → facts exists but is off unless the user
   enables automation.
 
 ### 3.5 hermes_skill_bridge / skill deployment
@@ -373,13 +372,13 @@ half pointed at TraceDecay.
 ### D. Enable the reflection loop (sidecar-equivalent storage)
 
 session_reflector is the background sidecar analog: transcripts (both agents,
-already ingested by the hooks) → evidence-cited fact proposals → dashboard
-approval → store. The work is activation, not construction:
+already ingested by the hooks) → evidence-cited fact operations → model-managed
+apply policy → store, with dashboard inspection/telemetry. The work is
+activation, not construction:
 
 - Surface a one-command enable (`tracedecay automation enable
-  session-reflector`) that picks a backend and leaves
-  `require_dashboard_approval: true`; document the graduation path to
-  `auto_apply_memory_ops` once proposal quality is trusted.
+  session-reflector`) that picks a backend and uses model-managed memory apply
+  defaults; document the explicit dashboard-review mode for high-risk rollout.
 - Wire a nudge into `doctor`/`memory_status` when transcripts accumulate but
   automation is disabled ("N sessions ingested, 0 reflected").
 
@@ -404,7 +403,7 @@ With `features.memories = true`, Codex builds a parallel memory in
 3. **Harvest:** one-way import of `~/.codex/memories/raw_memories.md` +
    `rollout_summaries/*.md` into fact proposals (they're clean markdown with
    cwd/thread metadata — easy to parse into `AddFactRequest`s routed through
-   the same proposal/approval path as D). Gives the fact store Codex's
+   the same validation/apply path as D). Gives the fact store Codex's
    already-consolidated knowledge on day one.
 
 For Cursor: native Memories can't be intercepted or exported; the only lever

--- a/docs/HERMES-LOOPS-PARITY-AUDIT.md
+++ b/docs/HERMES-LOOPS-PARITY-AUDIT.md
@@ -220,7 +220,7 @@ Every backend-validated run writes six chained artifacts, each hash-linked to
 its predecessors: **traces → feedback → generated_evals → validation_gate →
 optimizer_diagnosis → codex_handoff**. These are inspectable via
 `/api/automation/runs/{run_id}/artifacts[/{kind}]`. The handoff is the durable
-output for broader improvement work and preserves the approval gates.
+output for broader improvement work and preserves the configured apply policy.
 
 ### 2.5 Managed skills and distribution (`managed_skills.rs`, `skill_targets.rs`)
 
@@ -275,13 +275,13 @@ in `delegated_host` mode TraceDecay does no backend calls of its own.
 
 | # | Strength | TraceDecay | Hermes |
 |---|----------|-----------|--------|
-| S1 | **Approval gating by default** | `require_dashboard_approval=true`, fact proposals and skill drafts staged as `pending_approval`; destructive memory ops manual-approval-only | `write_approval` default **off**; background review writes memory and skills freely (the source of the "wrong assumptions" complaints its own docstring admits) |
+| S1 | **Model-managed memory with safety policy** | Fact automation is self-managed by the model/automation loop, with explicit dashboard review only when configured; destructive memory ops remain policy-gated | `write_approval` default **off**; background review writes memory and skills freely (the source of the "wrong assumptions" complaints its own docstring admits) |
 | S2 | **Deterministic validation gate** | LLM output re-validated against recomputed evidence (allowed fact ids, confidence floor, mandatory source spans, checksum-guarded skill updates) | Trusts the review fork's writes; only optional post-hoc security scan |
 | S3 | **Artifact/evidence chain** | traces → feedback → generated evals → validation gate → optimizer diagnosis → codex handoff, hash-linked, per run, API-inspectable | Cron output archives and a curator report file; no structured chain |
 | S4 | **Run ledger and failure discipline** | Trigger provenance, input/evidence hashes, error classification, non-retryable circuit breaker, cooldowns, skip dedup, stale locks | Best-effort daemon thread; failures log a warning and vanish |
 | S5 | **Structured memory** | HRR/FHRR-encoded fact store with trust scores, categories, entities, contradiction checks, FTS, oplog | Two flat §-delimited markdown files with char budgets (plus optional external providers) |
 | S6 | **Multi-host skill distribution** | One managed store exported to Cursor, Codex, Claude Code, OpenCode, Kimi, Kiro (overlay or prompt-index + MCP body serving), plus shareable Codex plugin artifacts | Single-host `~/.hermes/skills` |
-| S7 | **Dashboard review surface** | Full CRUD + lifecycle UI/API for skills, fact proposals, scheduler pause/resume, run artifacts | CLI slash-commands and a thinner web dashboard for pending writes |
+| S7 | **Dashboard observability surface** | Full CRUD + lifecycle UI/API for skills, fact automation outcomes/proposals, scheduler pause/resume, run artifacts | CLI slash-commands and a thinner web dashboard for pending writes |
 | S8 | **Standalone/delegated host split** | Clean contract for owning vs bridging the loops (incl. read-only Hermes bridge) | N/A — Hermes is always the host |
 
 ### 3.3 Verdict
@@ -291,7 +291,7 @@ missing the **signal layer** that makes Hermes's loops actually learn
 (G1–G4): Hermes reviews the right context at the right moment with a smart
 prompt and an agentic loop; TraceDecay reviews a keyword-filtered sample on a
 timer with a thin prompt. Closing G1–G5 keeps every TraceDecay safety
-property intact — they are orthogonal to approval gating.
+property intact — they are orthogonal to manual approval modes.
 
 ---
 
@@ -303,7 +303,7 @@ property intact — they are orthogonal to approval gating.
 | **P0** | **R2. Port the Hermes editorial policy into the prompts** | Rewrite `build_skill_writer_prompt` / `build_session_reflector_prompt` with: patch-over-create preference ladder, class-level naming rule, frustration-as-first-class-signal, and the do-NOT-capture list (env failures, negative tool claims, transients, one-off narratives). Bump `prompt_version` to `:v2` so ledger/input hashes distinguish eras. | `src/automation/runner.rs:741-753`, `src/automation/backend.rs:220-226`; source text to adapt: `hermes-agent/agent/background_review.py:45-233` |
 | **P1** | **R3. Activity-coupled triggering** | Add `AutomationTrigger::SessionActivity`: have session-ingestion (hooks / LCM ingest) mark "new evidence since last run" per task, and let the scheduler tick run reflector/skill_writer when new sessions landed — instead of (or in addition to) the blind interval. Redefine `min_idle_secs` to measure time since the **last LCM ingestion/session activity** (true idle, matching the contracts doc's wording), not time since the task's own last run. | `src/automation/scheduler.rs:203-208` (`schedule_decision`), `src/automation/run_ledger.rs` (`AutomationTrigger`), `src/daemon.rs:1228` (`run_automation_scheduler_loop`); activity timestamps available from the LCM sessions DB used in `runner.rs::automation_lcm_db_path` |
 | **P1** | **R4. Session-replay evidence, not just keyword grep** | For the reflector and skill writer, add a "recent completed sessions" evidence mode: pull the last N sessions' turn-ordered slices (or LCM summary DAG nodes) rather than only grep hits on fixed queries. Keep the grep as a secondary recall channel. The `session_id` option already exists on `SessionReflectorAutomationOptions` — drive it from recently-completed sessions. | `src/automation/runner.rs:170-260` and `:574-700` (evidence builders), `src/sessions/lcm` replay/summary APIs; keep `evidence_hash` semantics intact |
-| **P1** | **R5. Surface loop results to the user in-session** | Emit a compact result line ("skill draft 'x' staged for approval; 2 fact proposals pending") through channels agents already see: an MCP notification / next-tool-response nudge (the hint infrastructure exists), plus a dashboard badge count. This is Hermes's "💾 Self-improvement review" moment and drives the approval queue getting drained. | `src/daemon.rs:431-530` (scheduler task logging), MCP server hint/nudge path in `src/mcp/server.rs`; dashboard: pending counts already derivable from `fact_proposals.rs` + `managed_skills.rs::list_managed_skills` |
+| **P1** | **R5. Surface loop results to the user in-session** | Emit a compact result line ("skill draft 'x' staged; 2 fact updates applied; 1 validation warning") through channels agents already see: an MCP notification / next-tool-response nudge (the hint infrastructure exists), plus a dashboard badge count. This is Hermes's "💾 Self-improvement review" moment and drives inspection of outcomes and telemetry. | `src/daemon.rs:431-530` (scheduler task logging), MCP server hint/nudge path in `src/mcp/server.rs`; dashboard: fact automation counts already derivable from `fact_proposals.rs` + `managed_skills.rs::list_managed_skills` |
 | **P2** | **R6. Managed-skill consolidation pass (curator parity)** | Add an overlap/consolidation review to skill_writer evidence (pairwise similarity of managed skill bodies/titles) and allow an explicit `merge`/`archive` recommendation kind that stages — never auto-applies — consolidations. Honor pinned exactly as Hermes curator does; keep "archive not delete". | New logic beside `src/automation/skill_usage/recommendations.rs`; proposal handling in `src/automation/skill_writer.rs::validate_and_apply_skill_proposals`; similarity helpers exist in the memory/dedup stack |
 | **P2** | **R7. Combined reflector+skill pass option** | When both tasks are due in the same tick, run one combined backend call with shared evidence (Hermes `_COMBINED_REVIEW_PROMPT` pattern) returning `{facts:[], skills:[]}`. Halves backend cost and gives the model cross-signal (a correction often yields both a fact and a skill patch). | `src/automation/runner.rs` (new entry point), `src/automation/backend.rs` (new `AgentTaskKind::CombinedReview` contract), scheduler dispatch in `src/daemon.rs` |
 | **P2** | **R8. Deliver curated memory into host prompts** | Close the loop's consumption side: export a bounded, trust-ranked "durable facts" snapshot (Hermes MEMORY.md analogue) into the same overlay/prompt-index channel skills already use, so approved facts inform sessions without an MCP recall call. Char-budgeted and injection-scanned like Hermes's frozen snapshot. | New exporter beside `src/automation/skill_targets.rs`; fact selection from `src/memory/store.rs` (trust + category filters); wire into `src/agents/{cursor,codex}.rs` install paths |
@@ -312,7 +312,7 @@ property intact — they are orthogonal to approval gating.
 
 Deliberately **not** recommended: copying Hermes's write-freely default
 (`write_approval=false`) or its flat-file memory. TraceDecay's
-approval-first posture and structured fact store are the differentiators;
+policy-guarded apply posture and structured fact store are the differentiators;
 the fixes above raise signal quality and loop latency without weakening
 either.
 
@@ -337,7 +337,7 @@ TraceDecay (`~/projects/tracedecay`):
 - `src/automation/backend.rs` — codex_app_server backend, contracts, error classes
 - `src/automation/{artifacts,artifact_payloads,artifact_policy}.rs` — artifact chain
 - `src/automation/{managed_skills,managed_skill_model,skill_targets,skill_usage}.rs` — skill store + export
-- `src/automation/fact_proposals.rs` — fact approval staging
+- `src/automation/fact_proposals.rs` — fact apply-policy staging
 - `src/automation/hermes_*.rs` — read-only Hermes bridge
 - `src/daemon.rs:1055-1300` — per-project scheduler loops
 - `src/dashboard/automation_*_api.rs`, `src/dashboard/mod.rs:417-559` — `/api/automation/*`

--- a/docs/MEMORY-CURATION-AUTONOMY.md
+++ b/docs/MEMORY-CURATION-AUTONOMY.md
@@ -170,14 +170,14 @@ details carry hashes rather than deleted content.
    transient, stale-but-uncertain, and ambiguous same-topic findings. Do not
    lower trust solely because a fact is old.
 7. **Produce a dry-run curation report.** Include every proposed operation,
-   every skipped candidate, and the approval state for any destructive action.
-8. **Gate mutation by risk tier.** Add/update/merge require review-first
-   approval. Delete requires manual approval immediately before apply, showing
-   fact id, content/source summary, reason, and permanent-delete warning.
+   every skipped candidate, and the apply-policy state for any destructive action.
+8. **Gate mutation by risk tier.** Add/update/merge follow the configured apply
+   policy. Delete requires an explicit user request immediately before apply,
+   showing fact id, content/source summary, reason, and permanent-delete warning.
 9. **Apply narrowly.** Use fact-store add/update only for directly supported
-   facts. Use `--llm-ops <file> --apply` or `/curate/apply` only for reviewed
+   facts. Use `--llm-ops <file> --apply` or `/curate/apply` only for validated
    ops. Avoid `POST /curate {"dry_run": false}` unless the operator explicitly
-   approved the deterministic duplicate-deletion plan.
+   requested the deterministic duplicate-deletion plan.
 10. **Verify read-only.** Re-run targeted get/search/list/contradict checks and
     inspect apply results/oplog. Report changed, skipped, rejected, and still
     ambiguous facts.
@@ -197,7 +197,7 @@ Before any mutation, produce this compact report:
 - `merges`: winner id, loser ids, similarity evidence, retained provenance,
   optional `merged_content`, and why separate facts are redundant.
 - `deletes`: fact ids, content/source summary, permanent-delete reason, risk,
-  surviving fact if any, and explicit approval status.
+  surviving fact if any, and apply-policy status.
 - `skipped`: rejected transient, secret-like, unsupported, stale-but-uncertain,
   same-topic-not-duplicate, out-of-scope, or duplicate candidates.
 - `verification_plan`: exact read-only checks to run after apply.
@@ -208,9 +208,9 @@ Before any mutation, produce this compact report:
 | --- | --- | --- |
 | Read-mostly | MCP context/search, fact get/contradict/search/list/probe/related/reason, dry-run preview | allowed |
 | Draft | propose add, update, merge, delete, retag-like notes, LLM review request | allowed |
-| Low-risk apply | add clearly durable facts with source links | review-first |
-| Medium-risk apply | update or merge facts with retained source evidence | review-first |
-| High-risk apply | hard-delete facts or merge losers | manual approval only |
+| Low-risk apply | add clearly durable facts with source links | auto-apply when `auto_apply_memory_ops=true` |
+| Medium-risk apply | update or merge facts with retained source evidence | policy-gated |
+| High-risk apply | hard-delete facts or merge losers | explicit user request only |
 
 Deletion and merge loser removal remain high risk because they remove rows from
 `memory_facts`; entity links cascade and FTS rows drop. There is no recovery
@@ -232,7 +232,7 @@ When subagents participate, give each one an explicit project selector and a non
 - **Telemetry Analyst**: measures hint uptake, accepted/rejected candidates,
   false positives, and audited net token deltas from real transcript data.
 - **Apply Operator**: the parent/operator role only. It invokes mutating APIs
-  after policy and approval gates pass.
+  after policy checks pass and any required explicit user request is present.
 
 For multi-agent runs, each role owns separate notes or database rows. Writers
 do not share editable artifacts. The apply role consumes finalized plans only.

--- a/docs/SELF-IMPROVING-LOOPS-CONTRACTS.md
+++ b/docs/SELF-IMPROVING-LOOPS-CONTRACTS.md
@@ -23,8 +23,8 @@ TraceDecay standalone automation is time-scheduled by the daemon, not by Codex n
 
 | Task | Default cadence | Default mutation behavior |
 | --- | --- | --- |
-| `memory_curator` | Every 15 minutes, with a 5-minute cooldown | Validated accepted curation ops auto-apply when `auto_apply_memory_ops=true` and dashboard approval is disabled. |
-| `session_reflector` | Every 15 minutes, with a 5-minute cooldown | Validated accepted session facts auto-apply under the same memory auto-apply policy; otherwise they stay as dashboard fact proposals. |
+| `memory_curator` | Every 15 minutes, with a 5-minute cooldown | Validated accepted curation ops auto-apply when `auto_apply_memory_ops=true`; destructive ops remain policy-gated. |
+| `session_reflector` | Every 15 minutes, with a 5-minute cooldown | Validated accepted session facts auto-apply under the same memory auto-apply policy; otherwise they remain pending automation fact records. |
 | `skill_writer` | Every 60 minutes, after a 15-minute idle window, with a 5-minute cooldown | Creates or updates managed skill drafts; skills are not auto-enabled while `auto_enable_skills=false`. |
 
 Scheduling is activity-coupled, not purely wall-clock. The scheduler reads the newest LCM session-message timestamp for the project store as its session-activity signal on every tick:
@@ -37,7 +37,7 @@ The daemon loop is the host for these jobs. It should not create Codex top-level
 
 ## Standalone And Delegated Modes
 
-`standalone` means TraceDecay owns backend calls, evidence collection, validation, run ledger writes, approval staging, dashboard review payloads, and optional scheduler execution. Backend output can propose changes, but TraceDecay validates every proposed mutation before it can be applied.
+`standalone` means TraceDecay owns backend calls, evidence collection, validation, run ledger writes, apply-policy staging, dashboard telemetry payloads, and optional scheduler execution. Backend output can propose changes, but TraceDecay validates every proposed mutation before it can be applied.
 
 `delegated_host` means the host owns intelligence and mutation decisions. TraceDecay exposes contracts and storage views, validates proposed operations when asked, and records bridge-visible evidence. It must not call its own backend for memory curation, session reflection, or skill writing in this mode. Legacy `hermes_hosted` config is only an alias for `delegated_host`.
 
@@ -84,4 +84,4 @@ Every automation run that reaches backend validation should be able to produce a
 - optimizer diagnosis
 - Codex handoff
 
-The handoff is the durable output for broader code or behavior changes. It must preserve approval gates and list validation requirements before any generated recommendation is applied.
+The handoff is the durable output for broader code or behavior changes. It must preserve apply-policy gates and list validation requirements before any generated recommendation is applied.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -239,8 +239,8 @@ The Curation panel is organized into five sub-tabs:
   per-task **Run** buttons for the memory curator / session reflector /
   skill writer loops, and the automation run ledger with hash-verified
   artifact drill-down.
-- **Proposals**: Session-reflection fact proposals awaiting approval
-  (pending first; resolved proposals are collapsed) and managed-skill
+- **Proposals**: Session-reflection fact automation outcomes and proposals
+  for inspection (recent first; resolved proposals are collapsed) and managed-skill
   drafts with approve/disable/archive/restore actions. The tab label shows
   the pending count.
 - **History**: Curator run history, recent snapshots, the memory operation

--- a/plugin/skills/inspecting-managed-skills/SKILL.md
+++ b/plugin/skills/inspecting-managed-skills/SKILL.md
@@ -23,7 +23,7 @@ The daemon automation loop (skill writer, memory curator, session reflector) dra
 ## Handoff
 
 - Running or configuring the automation jobs themselves → `tracedecay automation run` / `tracedecay automation config` (CLI).
-- Reviewing session-reflection fact proposals → `tracedecay automation facts list|view|apply|reject` (CLI).
+- Inspecting session-reflection fact automation outcomes → `tracedecay automation facts list|view|apply|reject` (CLI; mutate only on explicit request).
 - Memory fact curation → `tracedecay:project-memory`.
 
 ## If tools are deferred or MCP fails

--- a/plugin/skills/project-memory/references/curation.md
+++ b/plugin/skills/project-memory/references/curation.md
@@ -6,7 +6,7 @@ Full curation and memorize-a-subject protocol for `tracedecay:project-memory`.
 - Curation guardrails (deletion, subagents, dashboard)
 - Memorize a subject on explicit request
 
-## Curate (mutation, requires approval)
+## Curate (explicit destructive mutation)
 
 Destructive curation is a parent-agent responsibility. Use subagents only for
 scoped inspection or recommendation work, with explicit project selectors and

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -88,7 +88,7 @@ impl AgentIntegration for CodexIntegration {
     fn update_plugin(&self, ctx: &InstallContext) -> Result<UpdatePluginOutcome> {
         let cached_dirs = codex_plugin_cached_install_dirs(&ctx.home);
         let plugin_dir = codex_plugin_install_dir(&ctx.home);
-        let legacy_config_install = codex_legacy_config_has_tracedecay(&ctx.home)?;
+        let legacy_config_install = codex_legacy_config_has_tracedecay_for_update(&ctx.home);
         let mut refreshed = Vec::new();
         if !cached_dirs.is_empty() {
             let target = install_codex_cached_plugin(&ctx.home, &ctx.tracedecay_bin)?;
@@ -248,6 +248,10 @@ impl AgentIntegration for CodexIntegration {
 
 fn codex_legacy_config_has_tracedecay(home: &Path) -> Result<bool> {
     codex_config_has_tracedecay_mcp_server(&codex_config_path(home))
+}
+
+fn codex_legacy_config_has_tracedecay_for_update(home: &Path) -> bool {
+    codex_legacy_config_has_tracedecay(home).unwrap_or(false)
 }
 
 fn codex_config_has_tracedecay_mcp_server(config_path: &Path) -> Result<bool> {

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -124,12 +124,15 @@ impl AgentIntegration for CodexIntegration {
         // replacement before the sweep below strips the working global
         // config — even when a cached or repo-local refresh already put
         // something into `refreshed`.
-        let has_personal_bundle =
-            !cached_dirs.is_empty() || codex_plugin_manifest_path(&ctx.home).exists();
+        let personal_bundle_exists = codex_plugin_manifest_path(&ctx.home).exists();
+        let has_personal_bundle = !cached_dirs.is_empty() || personal_bundle_exists;
         if refreshed.is_empty() && !has_personal_bundle && !legacy_config_install {
             return Ok(UpdatePluginOutcome::NotInstalled);
         }
-        if refreshed.is_empty() || (legacy_config_install && !has_personal_bundle) {
+        if (cached_dirs.is_empty() && personal_bundle_exists)
+            || refreshed.is_empty()
+            || (legacy_config_install && !has_personal_bundle)
+        {
             install_codex_personal_bootstrap(&ctx.home, &ctx.tracedecay_bin)?;
             refreshed.push(plugin_dir.clone());
         }
@@ -251,7 +254,16 @@ fn codex_legacy_config_has_tracedecay(home: &Path) -> Result<bool> {
 }
 
 fn codex_legacy_config_has_tracedecay_for_update(home: &Path) -> bool {
-    codex_legacy_config_has_tracedecay(home).unwrap_or(false)
+    match codex_legacy_config_has_tracedecay(home) {
+        Ok(has_tracedecay) => has_tracedecay,
+        Err(err) => {
+            eprintln!(
+                "  Could not inspect legacy Codex MCP config at {}: {err}",
+                codex_config_path(home).display()
+            );
+            false
+        }
+    }
 }
 
 fn codex_config_has_tracedecay_mcp_server(config_path: &Path) -> Result<bool> {

--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -88,7 +88,7 @@ impl AgentIntegration for CodexIntegration {
     fn update_plugin(&self, ctx: &InstallContext) -> Result<UpdatePluginOutcome> {
         let cached_dirs = codex_plugin_cached_install_dirs(&ctx.home);
         let plugin_dir = codex_plugin_install_dir(&ctx.home);
-        let legacy_config_install = codex_legacy_config_has_tracedecay(&ctx.home);
+        let legacy_config_install = codex_legacy_config_has_tracedecay(&ctx.home)?;
         let mut refreshed = Vec::new();
         if !cached_dirs.is_empty() {
             let target = install_codex_cached_plugin(&ctx.home, &ctx.tracedecay_bin)?;
@@ -246,19 +246,19 @@ impl AgentIntegration for CodexIntegration {
     }
 }
 
-fn codex_legacy_config_has_tracedecay(home: &Path) -> bool {
+fn codex_legacy_config_has_tracedecay(home: &Path) -> Result<bool> {
     codex_config_has_tracedecay_mcp_server(&codex_config_path(home))
 }
 
-fn codex_config_has_tracedecay_mcp_server(config_path: &Path) -> bool {
+fn codex_config_has_tracedecay_mcp_server(config_path: &Path) -> Result<bool> {
     if !config_path.exists() {
-        return false;
+        return Ok(false);
     }
-    super::load_toml_file(config_path).is_ok_and(|toml| {
-        toml.get("mcp_servers")
-            .and_then(|v| v.get("tracedecay"))
-            .is_some()
-    })
+    let toml = super::load_toml_file(config_path)?;
+    Ok(toml
+        .get("mcp_servers")
+        .and_then(|v| v.get("tracedecay"))
+        .is_some())
 }
 
 // ---------------------------------------------------------------------------
@@ -438,8 +438,16 @@ pub fn remove_legacy_codex_native_automation(home: &Path) -> Result<bool> {
 }
 
 fn uninstall_tracedecay_mcp_if_present(config_path: &Path) {
-    if !codex_config_has_tracedecay_mcp_server(config_path) {
-        return;
+    match codex_config_has_tracedecay_mcp_server(config_path) {
+        Ok(true) => {}
+        Ok(false) => return,
+        Err(err) => {
+            eprintln!(
+                "  Could not inspect project-local Codex MCP config at {}: {err}",
+                config_path.display()
+            );
+            return;
+        }
     }
     if let Err(err) = uninstall_mcp_server(config_path) {
         eprintln!(

--- a/src/agents/codex/tests.rs
+++ b/src/agents/codex/tests.rs
@@ -169,7 +169,7 @@ trusted_hash = "sha256:post"
     .expect("config should write");
 
     assert!(
-        !codex_legacy_config_has_tracedecay(home.path()),
+        !codex_legacy_config_has_tracedecay(home.path()).expect("config should parse"),
         "plugin and hook entries are not legacy direct MCP config"
     );
 }
@@ -189,7 +189,7 @@ args = ["serve"]
     )
     .expect("config should write");
 
-    assert!(codex_legacy_config_has_tracedecay(home.path()));
+    assert!(codex_legacy_config_has_tracedecay(home.path()).expect("config should parse"));
 }
 
 #[test]

--- a/src/automation/apply_policy.rs
+++ b/src/automation/apply_policy.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::backend::AgentTaskKind;
 use super::config::AutomationConfig;
@@ -61,12 +61,27 @@ pub(crate) struct MemoryApplyPolicy {
 
 impl MemoryApplyPolicy {
     pub(crate) fn curation_ops(config: &AutomationConfig, accepted_count: usize) -> Self {
+        let should_apply = should_auto_apply_memory_ops(config, accepted_count);
         Self::new(
             MemoryApplySubject::CurationOps,
             config,
             accepted_count,
-            should_auto_apply_memory_ops(config, accepted_count),
-            should_auto_apply_memory_ops(config, accepted_count),
+            should_apply,
+            should_apply,
+        )
+    }
+
+    pub(crate) fn applied_curation_ops(
+        config: &AutomationConfig,
+        accepted_count: usize,
+        applied_count: usize,
+    ) -> Self {
+        Self::new(
+            MemoryApplySubject::CurationOps,
+            config,
+            accepted_count,
+            applied_count > 0,
+            accepted_count > 0 && applied_count >= accepted_count,
         )
     }
 

--- a/src/automation/apply_policy.rs
+++ b/src/automation/apply_policy.rs
@@ -1,4 +1,4 @@
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::backend::AgentTaskKind;
 use super::config::AutomationConfig;
@@ -89,14 +89,16 @@ impl MemoryApplyPolicy {
         config: &AutomationConfig,
         accepted_count: usize,
         applied_count: usize,
+        auto_managed: bool,
     ) -> Self {
-        Self::new(
-            MemoryApplySubject::SessionFacts,
-            config,
+        Self {
+            subject: MemoryApplySubject::SessionFacts,
             accepted_count,
-            applied_count > 0,
-            accepted_count > 0 && applied_count >= accepted_count,
-        )
+            auto_apply_memory_ops: should_auto_apply_session_facts(config, accepted_count),
+            require_dashboard_approval: session_facts_require_dashboard_approval(config),
+            mutates_store: auto_managed,
+            fully_applied: accepted_count > 0 && applied_count >= accepted_count,
+        }
     }
 
     fn new(
@@ -117,13 +119,15 @@ impl MemoryApplyPolicy {
     }
 
     pub(crate) fn should_apply(config: &AutomationConfig, accepted_count: usize) -> bool {
-        should_auto_apply_memory_ops(config, accepted_count)
+        should_auto_apply_session_facts(config, accepted_count)
     }
 
     pub(crate) fn decision(self) -> MemoryApplyDecision {
         if self.accepted_count == 0 {
             self.subject.no_valid_decision()
-        } else if self.fully_applied {
+        } else if self.fully_applied
+            || (self.subject == MemoryApplySubject::SessionFacts && self.mutates_store)
+        {
             MemoryApplyDecision::AutoApplyAllowed
         } else if self.require_dashboard_approval {
             MemoryApplyDecision::RequiresDashboardApproval
@@ -137,7 +141,8 @@ impl MemoryApplyPolicy {
             "decision": self.decision().as_str(),
             "auto_apply_memory_ops": self.auto_apply_memory_ops,
             "require_dashboard_approval": self.require_dashboard_approval,
-            "approval_required": self.accepted_count > 0 && !self.fully_applied,
+            "approval_required": self.accepted_count > 0
+                && self.decision() != MemoryApplyDecision::AutoApplyAllowed,
             "autonomous_memory_apply": self.mutates_store,
             "mutates_store": self.mutates_store,
         })
@@ -193,7 +198,22 @@ fn session_fact_record_fully_applied(record: &AutomationRunLedgerRecord) -> bool
     if record.accepted_count == 0 {
         return false;
     }
+    if record
+        .validation_report
+        .as_ref()
+        .is_some_and(session_fact_record_self_managed)
+    {
+        return true;
+    }
     session_fact_applied_count(record) >= record.accepted_count
+}
+
+fn session_fact_record_self_managed(report: &Value) -> bool {
+    report.get("dry_run").and_then(Value::as_bool) == Some(false)
+        && report
+            .pointer("/session_fact_apply_policy/decision")
+            .and_then(Value::as_str)
+            == Some(MemoryApplyDecision::AutoApplyAllowed.as_str())
 }
 
 fn session_fact_applied_count(record: &AutomationRunLedgerRecord) -> usize {
@@ -229,4 +249,12 @@ fn value_as_usize(value: &Value) -> Option<usize> {
 
 fn should_auto_apply_memory_ops(config: &AutomationConfig, accepted_count: usize) -> bool {
     accepted_count > 0 && config.auto_apply_memory_ops && !config.require_dashboard_approval
+}
+
+fn should_auto_apply_session_facts(config: &AutomationConfig, accepted_count: usize) -> bool {
+    accepted_count > 0 && !session_facts_require_dashboard_approval(config)
+}
+
+fn session_facts_require_dashboard_approval(config: &AutomationConfig) -> bool {
+    config.require_dashboard_approval && config.auto_apply_memory_ops
 }

--- a/src/automation/apply_policy.rs
+++ b/src/automation/apply_policy.rs
@@ -1,0 +1,217 @@
+use serde_json::{json, Value};
+
+use super::backend::AgentTaskKind;
+use super::config::AutomationConfig;
+use super::run_ledger::AutomationRunLedgerRecord;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemoryApplySubject {
+    CurationOps,
+    SessionFacts,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemoryApplyDecision {
+    AutoApplyAllowed,
+    RequiresDashboardApproval,
+    DryRunOnly,
+    ProposalOnly,
+    NoValidOps,
+    NoValidFacts,
+}
+
+impl MemoryApplyDecision {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::AutoApplyAllowed => "auto_apply_allowed",
+            Self::RequiresDashboardApproval => "requires_dashboard_approval",
+            Self::DryRunOnly => "dry_run_only",
+            Self::ProposalOnly => "proposal_only",
+            Self::NoValidOps => "no_valid_ops",
+            Self::NoValidFacts => "no_valid_facts",
+        }
+    }
+}
+
+impl MemoryApplySubject {
+    fn no_valid_decision(self) -> MemoryApplyDecision {
+        match self {
+            Self::CurationOps => MemoryApplyDecision::NoValidOps,
+            Self::SessionFacts => MemoryApplyDecision::NoValidFacts,
+        }
+    }
+
+    fn dry_run_decision(self) -> MemoryApplyDecision {
+        match self {
+            Self::CurationOps => MemoryApplyDecision::DryRunOnly,
+            Self::SessionFacts => MemoryApplyDecision::ProposalOnly,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MemoryApplyPolicy {
+    subject: MemoryApplySubject,
+    accepted_count: usize,
+    auto_apply_memory_ops: bool,
+    require_dashboard_approval: bool,
+    mutates_store: bool,
+    fully_applied: bool,
+}
+
+impl MemoryApplyPolicy {
+    pub(crate) fn curation_ops(config: &AutomationConfig, accepted_count: usize) -> Self {
+        Self::new(
+            MemoryApplySubject::CurationOps,
+            config,
+            accepted_count,
+            should_auto_apply_memory_ops(config, accepted_count),
+            should_auto_apply_memory_ops(config, accepted_count),
+        )
+    }
+
+    pub(crate) fn session_facts(
+        config: &AutomationConfig,
+        accepted_count: usize,
+        applied_count: usize,
+    ) -> Self {
+        Self::new(
+            MemoryApplySubject::SessionFacts,
+            config,
+            accepted_count,
+            applied_count > 0,
+            accepted_count > 0 && applied_count >= accepted_count,
+        )
+    }
+
+    fn new(
+        subject: MemoryApplySubject,
+        config: &AutomationConfig,
+        accepted_count: usize,
+        mutates_store: bool,
+        fully_applied: bool,
+    ) -> Self {
+        Self {
+            subject,
+            accepted_count,
+            auto_apply_memory_ops: config.auto_apply_memory_ops,
+            require_dashboard_approval: config.require_dashboard_approval,
+            mutates_store,
+            fully_applied,
+        }
+    }
+
+    pub(crate) fn should_apply(config: &AutomationConfig, accepted_count: usize) -> bool {
+        should_auto_apply_memory_ops(config, accepted_count)
+    }
+
+    pub(crate) fn decision(self) -> MemoryApplyDecision {
+        if self.accepted_count == 0 {
+            self.subject.no_valid_decision()
+        } else if self.fully_applied {
+            MemoryApplyDecision::AutoApplyAllowed
+        } else if self.require_dashboard_approval {
+            MemoryApplyDecision::RequiresDashboardApproval
+        } else {
+            self.subject.dry_run_decision()
+        }
+    }
+
+    pub(crate) fn to_json(self) -> Value {
+        json!({
+            "decision": self.decision().as_str(),
+            "auto_apply_memory_ops": self.auto_apply_memory_ops,
+            "require_dashboard_approval": self.require_dashboard_approval,
+            "approval_required": self.accepted_count > 0 && !self.fully_applied,
+            "autonomous_memory_apply": self.mutates_store,
+            "mutates_store": self.mutates_store,
+        })
+    }
+}
+
+pub(crate) fn record_has_auto_applied_memory_ops(
+    task: AgentTaskKind,
+    record: &AutomationRunLedgerRecord,
+) -> bool {
+    match task {
+        AgentTaskKind::MemoryCurator => memory_curator_record_fully_applied(record),
+        AgentTaskKind::SessionReflector => session_fact_record_fully_applied(record),
+        _ => false,
+    }
+}
+
+fn memory_curator_record_fully_applied(record: &AutomationRunLedgerRecord) -> bool {
+    if record.accepted_count == 0 {
+        return false;
+    }
+    let applied_count = record
+        .validation_report
+        .as_ref()
+        .map_or(0, memory_curator_applied_count);
+    applied_count >= record.accepted_count
+}
+
+fn memory_curator_applied_count(report: &Value) -> usize {
+    report
+        .get("applied")
+        .and_then(value_as_usize)
+        .or_else(|| {
+            report
+                .get("results")
+                .and_then(Value::as_array)
+                .map(|results| {
+                    results
+                        .iter()
+                        .filter(|result| {
+                            matches!(
+                                result.get("status").and_then(Value::as_str),
+                                Some("deleted" | "merged")
+                            )
+                        })
+                        .count()
+                })
+        })
+        .unwrap_or(0)
+}
+
+fn session_fact_record_fully_applied(record: &AutomationRunLedgerRecord) -> bool {
+    if record.accepted_count == 0 {
+        return false;
+    }
+    session_fact_applied_count(record) >= record.accepted_count
+}
+
+fn session_fact_applied_count(record: &AutomationRunLedgerRecord) -> usize {
+    let report = record.validation_report.as_ref();
+    [
+        record.applied_ops.as_ref().and_then(array_len),
+        report.and_then(|report| {
+            report
+                .pointer("/session_fact_apply_policy/applied_proposal_ids")
+                .and_then(array_len)
+        }),
+        report.and_then(|report| {
+            report
+                .pointer("/session_fact_apply_policy/applied_fact_ids")
+                .and_then(array_len)
+        }),
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or(0)
+}
+
+fn array_len(value: &Value) -> Option<usize> {
+    value.as_array().map(Vec::len)
+}
+
+fn value_as_usize(value: &Value) -> Option<usize> {
+    value
+        .as_u64()
+        .and_then(|number| usize::try_from(number).ok())
+}
+
+fn should_auto_apply_memory_ops(config: &AutomationConfig, accepted_count: usize) -> bool {
+    accepted_count > 0 && config.auto_apply_memory_ops && !config.require_dashboard_approval
+}

--- a/src/automation/artifact_feedback.rs
+++ b/src/automation/artifact_feedback.rs
@@ -27,11 +27,13 @@ fn accepted_feedback_items(record: &AutomationRunLedgerRecord) -> Vec<Value> {
     if !applied.is_empty() {
         return applied;
     }
+    let report = record.validation_report.as_ref();
     artifact_items(
-        record
-            .validation_report
-            .as_ref()
-            .and_then(|report| report.pointer("/pending_proposals/accepted_facts")),
+        report
+            .and_then(|report| report.pointer("/applied_proposals/accepted_facts"))
+            .or_else(|| {
+                report.and_then(|report| report.pointer("/pending_proposals/accepted_facts"))
+            }),
     )
 }
 

--- a/src/automation/artifact_payloads.rs
+++ b/src/automation/artifact_payloads.rs
@@ -225,6 +225,7 @@ pub(super) fn validation_gate_payload(
     gate: &ImprovementGatePayload,
 ) -> Value {
     let (trace_ref, feedback_ref, generated_evals_ref) = refs;
+    let auto_applied = record_has_auto_applied_memory_ops(ctx.task, ctx.record);
     json!({
         "schema_version": 1,
         "run_id": ctx.run_id,
@@ -235,7 +236,7 @@ pub(super) fn validation_gate_payload(
             "accepted_count": ctx.record.accepted_count,
             "rejected_count": ctx.record.rejected_count,
             "reviewed_count": ctx.record.reviewed_count,
-            "approval_required": ctx.record.accepted_count > 0,
+            "approval_required": ctx.record.accepted_count > 0 && !auto_applied,
             "report": ctx.record.validation_report,
         },
         "improvement_gate": {
@@ -260,8 +261,8 @@ pub(super) fn validation_gate_payload(
                 "has_feedback": ctx.record.reviewed_count > 0,
                 "has_generated_evals": evals.count > 0,
                 "validation_report_hash": validation_report_hash(ctx.record.validation_report.as_ref()),
-                "approval_required": ctx.record.accepted_count > 0,
-                "auto_apply_allowed": false,
+                "approval_required": ctx.record.accepted_count > 0 && !auto_applied,
+                "auto_apply_allowed": auto_applied,
             },
             "source_refs": [
                 trace_ref.clone(),
@@ -329,6 +330,7 @@ pub(super) fn codex_handoff_payload(
     evals: &GeneratedEvalPayloads,
     gate: &ImprovementGatePayload,
 ) -> Value {
+    let auto_applied = record_has_auto_applied_memory_ops(ctx.task, ctx.record);
     json!({
         "schema_version": 1,
         "run_id": ctx.run_id,
@@ -358,8 +360,8 @@ pub(super) fn codex_handoff_payload(
             "validation_gate_decision": gate.decision,
             "eval_count": evals.count,
             "blockers": gate.blockers.clone(),
-            "approval_required": ctx.record.accepted_count > 0,
-            "auto_apply_allowed": false,
+            "approval_required": ctx.record.accepted_count > 0 && !auto_applied,
+            "auto_apply_allowed": auto_applied,
         },
         "source_refs": [
             refs.validation_gate.clone(),
@@ -390,8 +392,8 @@ pub(super) fn codex_handoff_payload(
         "validation_requirements": {
             "must_review_artifact_refs": true,
             "must_run_tests": ctx.policy.handoff_tests(),
-            "must_preserve_approval_gate": true,
-            "must_not_auto_apply": true,
+            "must_preserve_approval_gate": !auto_applied,
+            "must_not_auto_apply": !auto_applied,
         },
         "artifact_manifest": {
             "api_list": automation_run_artifacts_api(ctx.run_id),
@@ -420,6 +422,28 @@ pub(super) fn codex_handoff_payload(
         "next_actions": ctx.policy.next_actions(ctx.record),
         "tests_to_run": ctx.policy.handoff_tests(),
     })
+}
+
+fn record_has_auto_applied_memory_ops(
+    task: AgentTaskKind,
+    record: &AutomationRunLedgerRecord,
+) -> bool {
+    if !matches!(
+        task,
+        AgentTaskKind::MemoryCurator | AgentTaskKind::SessionReflector
+    ) {
+        return false;
+    }
+    record
+        .validation_report
+        .as_ref()
+        .and_then(|report| {
+            report
+                .pointer("/apply_policy/mutates_store")
+                .or_else(|| report.pointer("/session_fact_apply_policy/mutates_store"))
+        })
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -609,5 +633,128 @@ mod tests {
             &json!("no_outcomes_recorded")
         );
         assert!(generated_eval_payloads(&ctx).outcome_definitions.is_empty());
+    }
+
+    #[test]
+    fn codex_handoff_reports_auto_applied_records_without_approval_gate() {
+        let (request, response, mut record) = payload_fixture();
+        record.accepted_count = 1;
+        record.reviewed_count = 1;
+        record.applied_ops = Some(json!(["proposal-1"]));
+        record.validation_report = Some(json!({
+            "session_fact_apply_policy": {
+                "mutates_store": true,
+            }
+        }));
+        let outcomes = AutomationOutcomesSnapshot::default();
+        let ctx = ArtifactPayloadContext {
+            run_id: "run-outcomes",
+            task: AgentTaskKind::SessionReflector,
+            task_key: "session_reflector",
+            prompt_version: "session_reflector:v1",
+            policy: artifact_policy(AgentTaskKind::SessionReflector),
+            request: &request,
+            response: &response,
+            record: &record,
+            outcomes: &outcomes,
+        };
+        let refs = ArtifactRefs {
+            trace: json!({"kind": "traces"}),
+            feedback: json!({"kind": "feedback"}),
+            generated_evals: json!({"kind": "generated_evals"}),
+            validation_gate: json!({"kind": "validation_gate"}),
+            optimizer_diagnosis: json!({"kind": "optimizer_diagnosis"}),
+        };
+        let evals = generated_eval_payloads(&ctx);
+        let gate = improvement_gate_payload(&ctx, &evals);
+        let validation_payload = validation_gate_payload(
+            &ctx,
+            (&refs.trace, &refs.feedback, &refs.generated_evals),
+            &evals,
+            &gate,
+        );
+
+        let payload = codex_handoff_payload(&ctx, &refs, &evals, &gate);
+
+        assert_eq!(
+            validation_payload
+                .pointer("/task_validation/approval_required")
+                .unwrap(),
+            &json!(false)
+        );
+        assert_eq!(
+            validation_payload
+                .pointer("/improvement_gate/criteria/auto_apply_allowed")
+                .unwrap(),
+            &json!(true)
+        );
+        assert_eq!(
+            payload.pointer("/readiness/approval_required").unwrap(),
+            &json!(false)
+        );
+        assert_eq!(
+            payload.pointer("/readiness/auto_apply_allowed").unwrap(),
+            &json!(true)
+        );
+        assert_eq!(
+            payload
+                .pointer("/validation_requirements/must_not_auto_apply")
+                .unwrap(),
+            &json!(false)
+        );
+    }
+
+    #[test]
+    fn codex_handoff_does_not_treat_skill_writer_applied_ops_as_memory_auto_apply() {
+        let (request, response, mut record) = payload_fixture();
+        record.accepted_count = 1;
+        record.reviewed_count = 1;
+        record.applied_ops = Some(json!({
+            "created_skills": [],
+            "updated_skills": [],
+            "staged_consolidations": [],
+        }));
+        record.validation_report = Some(json!({
+            "status": "needs_approval",
+            "dry_run": true,
+        }));
+        let outcomes = AutomationOutcomesSnapshot::default();
+        let ctx = ArtifactPayloadContext {
+            run_id: "run-outcomes",
+            task: AgentTaskKind::SkillWriter,
+            task_key: "skill_writer",
+            prompt_version: "skill_writer:v1",
+            policy: artifact_policy(AgentTaskKind::SkillWriter),
+            request: &request,
+            response: &response,
+            record: &record,
+            outcomes: &outcomes,
+        };
+        let refs = ArtifactRefs {
+            trace: json!({"kind": "traces"}),
+            feedback: json!({"kind": "feedback"}),
+            generated_evals: json!({"kind": "generated_evals"}),
+            validation_gate: json!({"kind": "validation_gate"}),
+            optimizer_diagnosis: json!({"kind": "optimizer_diagnosis"}),
+        };
+        let evals = generated_eval_payloads(&ctx);
+        let gate = improvement_gate_payload(&ctx, &evals);
+
+        let payload = codex_handoff_payload(&ctx, &refs, &evals, &gate);
+
+        assert_eq!(
+            payload.pointer("/readiness/approval_required").unwrap(),
+            &json!(true)
+        );
+        assert_eq!(
+            payload.pointer("/readiness/auto_apply_allowed").unwrap(),
+            &json!(false)
+        );
+        assert_eq!(
+            payload
+                .pointer("/validation_requirements/must_not_auto_apply")
+                .unwrap(),
+            &json!(true)
+        );
     }
 }

--- a/src/automation/artifact_payloads.rs
+++ b/src/automation/artifact_payloads.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
 
+use super::apply_policy::record_has_auto_applied_memory_ops;
 use super::artifact_feedback::{
     validation_feedback_entries, validation_gate_decision, validation_report_hash,
 };
@@ -424,28 +425,6 @@ pub(super) fn codex_handoff_payload(
     })
 }
 
-fn record_has_auto_applied_memory_ops(
-    task: AgentTaskKind,
-    record: &AutomationRunLedgerRecord,
-) -> bool {
-    if !matches!(
-        task,
-        AgentTaskKind::MemoryCurator | AgentTaskKind::SessionReflector
-    ) {
-        return false;
-    }
-    record
-        .validation_report
-        .as_ref()
-        .and_then(|report| {
-            report
-                .pointer("/apply_policy/mutates_store")
-                .or_else(|| report.pointer("/session_fact_apply_policy/mutates_store"))
-        })
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -700,6 +679,78 @@ mod tests {
             payload
                 .pointer("/validation_requirements/must_not_auto_apply")
                 .unwrap(),
+            &json!(false)
+        );
+    }
+
+    #[test]
+    fn codex_handoff_preserves_approval_gate_for_partial_memory_apply() {
+        let (request, response, mut record) = payload_fixture();
+        record.accepted_count = 2;
+        record.reviewed_count = 2;
+        record.applied_ops = Some(json!([
+            { "op": "delete", "fact_id": 102 },
+            { "op": "delete", "fact_id": 102 }
+        ]));
+        record.validation_report = Some(json!({
+            "applied": 1,
+            "results": [
+                { "op": "delete", "fact_id": 102, "status": "deleted" },
+                { "op": "delete", "fact_id": 102, "status": "error" }
+            ],
+            "apply_policy": {
+                "accepted_count": 2,
+                "mutates_store": true,
+            }
+        }));
+        let outcomes = AutomationOutcomesSnapshot::default();
+        let ctx = ArtifactPayloadContext {
+            run_id: "run-outcomes",
+            task: AgentTaskKind::MemoryCurator,
+            task_key: "memory_curator",
+            prompt_version: "memory_curator:v1",
+            policy: artifact_policy(AgentTaskKind::MemoryCurator),
+            request: &request,
+            response: &response,
+            record: &record,
+            outcomes: &outcomes,
+        };
+        let refs = ArtifactRefs {
+            trace: json!({"kind": "traces"}),
+            feedback: json!({"kind": "feedback"}),
+            generated_evals: json!({"kind": "generated_evals"}),
+            validation_gate: json!({"kind": "validation_gate"}),
+            optimizer_diagnosis: json!({"kind": "optimizer_diagnosis"}),
+        };
+        let evals = generated_eval_payloads(&ctx);
+        let gate = improvement_gate_payload(&ctx, &evals);
+        let validation_payload = validation_gate_payload(
+            &ctx,
+            (&refs.trace, &refs.feedback, &refs.generated_evals),
+            &evals,
+            &gate,
+        );
+
+        let payload = codex_handoff_payload(&ctx, &refs, &evals, &gate);
+
+        assert_eq!(
+            validation_payload
+                .pointer("/task_validation/approval_required")
+                .unwrap(),
+            &json!(true)
+        );
+        assert_eq!(
+            validation_payload
+                .pointer("/improvement_gate/criteria/auto_apply_allowed")
+                .unwrap(),
+            &json!(false)
+        );
+        assert_eq!(
+            payload.pointer("/readiness/approval_required").unwrap(),
+            &json!(true)
+        );
+        assert_eq!(
+            payload.pointer("/readiness/auto_apply_allowed").unwrap(),
             &json!(false)
         );
     }

--- a/src/automation/artifact_policy.rs
+++ b/src/automation/artifact_policy.rs
@@ -46,15 +46,15 @@ pub(super) fn artifact_policy(task: AgentTaskKind) -> TaskArtifactPolicy {
         AgentTaskKind::SessionReflector => TaskArtifactPolicy {
             optimizer_action: "update fact proposal evidence or dedupe policy",
             accepted_next_actions: &[
-                "review pending fact proposals",
-                "approve or reject fact proposals from the dashboard",
+                "inspect fact automation outcomes",
+                "apply or reject fact records only when explicitly reviewing",
             ],
             rejected_next_actions: &[
                 "review rejected fact proposals",
                 "adjust evidence query before rerunning",
             ],
             handoff_test: "cargo test --test automation_runner_test session_reflector",
-            eval_replay_command: "cargo test --test automation_runner_test session_reflector_runner_validates_fact_proposals_without_applying -- --nocapture",
+            eval_replay_command: "cargo test --test automation_runner_test session_reflector_runner_auto_applies_valid_fact_proposals_by_default -- --nocapture",
         },
         AgentTaskKind::SkillWriter => TaskArtifactPolicy {
             optimizer_action: "update skill writer evidence or draft validation",
@@ -72,8 +72,8 @@ pub(super) fn artifact_policy(task: AgentTaskKind) -> TaskArtifactPolicy {
         AgentTaskKind::CombinedReview => TaskArtifactPolicy {
             optimizer_action: "update combined review evidence or per-task validation",
             accepted_next_actions: &[
-                "review pending fact proposals and managed skill drafts",
-                "approve or reject each proposal from the dashboard",
+                "inspect fact automation outcomes and managed skill drafts",
+                "apply or reject fact records only when explicitly reviewing",
             ],
             rejected_next_actions: &[
                 "review rejected fact and skill proposals",

--- a/src/automation/fact_proposals.rs
+++ b/src/automation/fact_proposals.rs
@@ -166,7 +166,7 @@ pub async fn record_session_fact_proposals(
             .ok_or_else(|| config_error("accepted fact proposal missing add_fact_request"))?;
         let add_fact_request = serde_json::from_value::<AddFactRequest>(add_fact_request)
             .map_err(|e| config_error(format!("invalid accepted fact add_fact_request: {e}")))?;
-        if pending_add_fact_request_exists(&store, &add_fact_request) {
+        if active_add_fact_request_exists(&store, &add_fact_request) {
             continue;
         }
         let proposal = value.get("proposal").cloned();
@@ -217,10 +217,10 @@ pub async fn record_session_fact_proposals(
     Ok(records)
 }
 
-fn pending_add_fact_request_exists(store: &FactProposalStore, request: &AddFactRequest) -> bool {
+fn active_add_fact_request_exists(store: &FactProposalStore, request: &AddFactRequest) -> bool {
     let content = normalize_fact_content(&request.content);
     store.proposals.iter().any(|proposal| {
-        proposal.state == FactProposalState::PendingApproval
+        proposal.state != FactProposalState::Rejected
             && proposal.add_fact_request.as_ref().is_some_and(|existing| {
                 existing.category == request.category
                     && normalize_fact_content(&existing.content) == content

--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -56,7 +56,6 @@ impl SkillInstallTarget {
 
 pub fn default_managed_skill_targets() -> Vec<SkillInstallTarget> {
     vec![
-        SkillInstallTarget::Cursor,
         SkillInstallTarget::Codex,
         SkillInstallTarget::Claude,
         SkillInstallTarget::Agents,
@@ -64,6 +63,21 @@ pub fn default_managed_skill_targets() -> Vec<SkillInstallTarget> {
         SkillInstallTarget::Kimi,
         SkillInstallTarget::Kiro,
     ]
+}
+
+fn managed_skill_description(summary: &str) -> String {
+    let trimmed = summary.trim();
+    if trimmed
+        .get(..8)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("use when"))
+        || trimmed
+            .get(..19)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("use this skill when"))
+    {
+        trimmed.to_string()
+    } else {
+        format!("Use when {trimmed}")
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -283,6 +297,12 @@ impl ManagedSkill {
     pub fn render_skill_markdown(&self) -> String {
         let mut output = String::new();
         output.push_str("---\n");
+        let _ = writeln!(output, "name: {}", self.metadata.id);
+        let _ = writeln!(
+            output,
+            "description: {}",
+            frontmatter_string(&managed_skill_description(&self.metadata.summary))
+        );
         let _ = writeln!(output, "id: {}", self.metadata.id);
         let _ = writeln!(
             output,

--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -9,6 +9,7 @@ use crate::errors::Result;
 use super::managed_skill_format::{frontmatter_string, source_key, state_key, target_key};
 use super::managed_skill_validation::{
     validate_managed_skill, validate_native_skill_markdown, validate_support_file,
+    MAX_NATIVE_SKILL_DESCRIPTION_CHARS, MAX_NATIVE_SKILL_NAME_CHARS,
 };
 
 pub const MAX_MANAGED_SUPPORT_FILES: usize = 20;
@@ -70,7 +71,7 @@ pub fn default_managed_skill_targets() -> Vec<SkillInstallTarget> {
 
 fn managed_skill_description(summary: &str) -> String {
     let trimmed = summary.trim();
-    if trimmed
+    let description = if trimmed
         .get(..8)
         .is_some_and(|prefix| prefix.eq_ignore_ascii_case("use when"))
         || trimmed
@@ -80,7 +81,41 @@ fn managed_skill_description(summary: &str) -> String {
         trimmed.to_string()
     } else {
         format!("Use when {trimmed}")
+    };
+    truncate_frontmatter_chars(&description, MAX_NATIVE_SKILL_DESCRIPTION_CHARS)
+}
+
+fn native_skill_name(id: &str) -> String {
+    let mut normalized = String::with_capacity(id.len().min(MAX_NATIVE_SKILL_NAME_CHARS));
+    for byte in id.bytes() {
+        match byte {
+            b'a'..=b'z' | b'0'..=b'9' => normalized.push(byte as char),
+            b'-' | b'_' if !normalized.ends_with('-') => normalized.push('-'),
+            _ => {}
+        }
     }
+
+    let trimmed = normalized.trim_matches('-');
+    let truncated = truncate_frontmatter_chars(trimmed, MAX_NATIVE_SKILL_NAME_CHARS);
+    let name = truncated.trim_end_matches('-');
+    if name.is_empty() {
+        "skill".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+fn truncate_frontmatter_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    value
+        .chars()
+        .take(max_chars)
+        .collect::<String>()
+        .trim_end()
+        .to_string()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -347,7 +382,7 @@ impl ManagedSkill {
     pub fn render_native_skill_markdown(&self) -> Result<String> {
         let mut output = String::new();
         output.push_str("---\n");
-        let _ = writeln!(output, "name: {}", self.metadata.id);
+        let _ = writeln!(output, "name: {}", native_skill_name(&self.metadata.id));
         let _ = writeln!(
             output,
             "description: {}",

--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -7,7 +7,9 @@ use sha2::{Digest, Sha256};
 use crate::errors::Result;
 
 use super::managed_skill_format::{frontmatter_string, source_key, state_key, target_key};
-use super::managed_skill_validation::{validate_managed_skill, validate_support_file};
+use super::managed_skill_validation::{
+    validate_managed_skill, validate_native_skill_markdown, validate_support_file,
+};
 
 pub const MAX_MANAGED_SUPPORT_FILES: usize = 20;
 pub const MAX_MANAGED_SUPPORT_FILE_BYTES: usize = 64 * 1024;
@@ -56,6 +58,7 @@ impl SkillInstallTarget {
 
 pub fn default_managed_skill_targets() -> Vec<SkillInstallTarget> {
     vec![
+        SkillInstallTarget::Cursor,
         SkillInstallTarget::Codex,
         SkillInstallTarget::Claude,
         SkillInstallTarget::Agents,
@@ -297,12 +300,6 @@ impl ManagedSkill {
     pub fn render_skill_markdown(&self) -> String {
         let mut output = String::new();
         output.push_str("---\n");
-        let _ = writeln!(output, "name: {}", self.metadata.id);
-        let _ = writeln!(
-            output,
-            "description: {}",
-            frontmatter_string(&managed_skill_description(&self.metadata.summary))
-        );
         let _ = writeln!(output, "id: {}", self.metadata.id);
         let _ = writeln!(
             output,
@@ -347,6 +344,22 @@ impl ManagedSkill {
         output
     }
 
+    pub fn render_native_skill_markdown(&self) -> Result<String> {
+        let mut output = String::new();
+        output.push_str("---\n");
+        let _ = writeln!(output, "name: {}", self.metadata.id);
+        let _ = writeln!(
+            output,
+            "description: {}",
+            frontmatter_string(&managed_skill_description(&self.metadata.summary))
+        );
+        output.push_str("---\n\n");
+        output.push_str(&self.body_markdown);
+        output.push('\n');
+        validate_native_skill_markdown(&output)?;
+        Ok(output)
+    }
+
     fn content_checksum(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.metadata.id.as_bytes());
@@ -375,4 +388,39 @@ impl ManagedSkill {
 
 pub(super) fn current_metadata_timestamp() -> i64 {
     crate::tracedecay::current_timestamp()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::automation::skill_frontmatter::parse_skill_frontmatter;
+
+    #[test]
+    fn native_skill_markdown_round_trips_escaped_description() {
+        let skill = ManagedSkillDraft {
+            id: "native-escape".to_string(),
+            title: "Native escape".to_string(),
+            summary: r#"Use when checking "quoted" paths like C:\tmp"#.to_string(),
+            category: "testing".to_string(),
+            targets: vec![SkillInstallTarget::Codex],
+            body_markdown: "# Native escape\n".to_string(),
+            support_files: Vec::new(),
+            provenance: ManagedSkillProvenance {
+                source: ManagedSkillSource::UserDraft,
+                actor: "tester".to_string(),
+                run_id: None,
+            },
+        }
+        .materialize()
+        .unwrap();
+
+        let markdown = skill.render_native_skill_markdown().unwrap();
+        let frontmatter = parse_skill_frontmatter(&markdown).unwrap();
+
+        assert_eq!(
+            frontmatter["description"].as_scalar(),
+            Some(r#"Use when checking "quoted" paths like C:\tmp"#)
+        );
+    }
 }

--- a/src/automation/managed_skill_validation.rs
+++ b/src/automation/managed_skill_validation.rs
@@ -12,8 +12,8 @@ use super::managed_skill_model::{
 use super::skill_frontmatter::{parse_skill_frontmatter, SkillFrontmatterValue};
 
 const ALLOWED_SUPPORT_ROOTS: &[&str] = &["references", "templates", "scripts", "assets"];
-const MAX_NATIVE_SKILL_NAME_CHARS: usize = 64;
-const MAX_NATIVE_SKILL_DESCRIPTION_CHARS: usize = 1024;
+pub(crate) const MAX_NATIVE_SKILL_NAME_CHARS: usize = 64;
+pub(crate) const MAX_NATIVE_SKILL_DESCRIPTION_CHARS: usize = 1024;
 
 pub(crate) fn validate_skill_id(id: &str) -> Result<()> {
     if id.is_empty()

--- a/src/automation/managed_skill_validation.rs
+++ b/src/automation/managed_skill_validation.rs
@@ -9,8 +9,11 @@ use super::managed_skill_model::{
     ManagedSupportFile, SkillInstallTarget, MAX_MANAGED_SKILL_BODY_BYTES,
     MAX_MANAGED_SUPPORT_FILES, MAX_MANAGED_SUPPORT_FILE_BYTES,
 };
+use super::skill_frontmatter::{parse_skill_frontmatter, SkillFrontmatterValue};
 
 const ALLOWED_SUPPORT_ROOTS: &[&str] = &["references", "templates", "scripts", "assets"];
+const MAX_NATIVE_SKILL_NAME_CHARS: usize = 64;
+const MAX_NATIVE_SKILL_DESCRIPTION_CHARS: usize = 1024;
 
 pub(crate) fn validate_skill_id(id: &str) -> Result<()> {
     if id.is_empty()
@@ -21,6 +24,63 @@ pub(crate) fn validate_skill_id(id: &str) -> Result<()> {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
     {
         return Err(config_error(format!("unsafe managed skill id '{id}'")));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_native_skill_markdown(markdown: &str) -> Result<()> {
+    let frontmatter = parse_skill_frontmatter(markdown)?;
+    for key in frontmatter.keys() {
+        if key != "name" && key != "description" {
+            return Err(config_error(format!(
+                "native skill frontmatter cannot include '{key}'"
+            )));
+        }
+    }
+    let name = frontmatter
+        .get("name")
+        .and_then(SkillFrontmatterValue::as_scalar)
+        .ok_or_else(|| config_error("native skill frontmatter requires scalar name".to_string()))?;
+    let description = frontmatter
+        .get("description")
+        .and_then(SkillFrontmatterValue::as_scalar)
+        .ok_or_else(|| {
+            config_error("native skill frontmatter requires scalar description".to_string())
+        })?;
+    validate_native_skill_name(name)?;
+    validate_native_skill_description(description)
+}
+
+fn validate_native_skill_name(name: &str) -> Result<()> {
+    validate_frontmatter_scalar("native name", name)?;
+    if name.chars().count() > MAX_NATIVE_SKILL_NAME_CHARS {
+        return Err(config_error(format!(
+            "native skill name cannot exceed {MAX_NATIVE_SKILL_NAME_CHARS} characters"
+        )));
+    }
+    if name.starts_with('-') || name.ends_with('-') || name.contains("--") {
+        return Err(config_error(
+            "native skill name must use kebab-case lowercase letters, numbers, or '-'".to_string(),
+        ));
+    }
+    if name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        Ok(())
+    } else {
+        Err(config_error(
+            "native skill name must use kebab-case lowercase letters, numbers, or '-'".to_string(),
+        ))
+    }
+}
+
+fn validate_native_skill_description(description: &str) -> Result<()> {
+    validate_frontmatter_scalar("native description", description)?;
+    if description.chars().count() > MAX_NATIVE_SKILL_DESCRIPTION_CHARS {
+        return Err(config_error(format!(
+            "native skill description cannot exceed {MAX_NATIVE_SKILL_DESCRIPTION_CHARS} characters"
+        )));
     }
     Ok(())
 }

--- a/src/automation/memory_curator.rs
+++ b/src/automation/memory_curator.rs
@@ -262,26 +262,20 @@ fn memory_curation_apply_policy(config: &AutomationConfig, accepted_ops: Option<
         .map_or_else(|| &[] as &[Value], Vec::as_slice);
     let destructive = memory_destructive_op_counts(ops);
     let accepted_count = ops.len();
-    let mutates_store =
-        accepted_count > 0 && config.auto_apply_memory_ops && !config.require_dashboard_approval;
+    let mutates_store = accepted_count > 0 && config.auto_apply_memory_ops;
     let decision = if accepted_count == 0 {
         "no_valid_ops"
     } else if mutates_store {
         "auto_apply_allowed"
-    } else if config.require_dashboard_approval {
-        "requires_dashboard_approval"
     } else {
-        "dry_run_only"
+        "memory_auto_apply_disabled"
     };
     let apply_instructions = match decision {
         "auto_apply_allowed" => {
-            "Accepted memory curation ops were applied because auto-apply is enabled and dashboard approval is not required."
+            "Accepted memory curation ops were applied because memory auto-apply is enabled."
         }
-        "requires_dashboard_approval" => {
-            "Review accepted memory curation ops in the dashboard before applying permanent deletes or merge losers."
-        }
-        "dry_run_only" => {
-            "Re-run with an explicit apply policy before mutating the memory store."
+        "memory_auto_apply_disabled" => {
+            "Enable memory auto-apply before mutating the memory store."
         }
         _ => "No accepted memory curation ops require apply.",
     };
@@ -290,8 +284,7 @@ fn memory_curation_apply_policy(config: &AutomationConfig, accepted_ops: Option<
         "dry_run_first": true,
         "mutates_store": mutates_store,
         "auto_apply_memory_ops": config.auto_apply_memory_ops,
-        "require_dashboard_approval": config.require_dashboard_approval,
-        "approval_required": accepted_count > 0 && !mutates_store,
+        "autonomous_memory_apply": mutates_store,
         "accepted_count": accepted_count,
         "permanent_delete_count": destructive.permanent_delete_count,
         "merge_loser_count": destructive.merge_loser_count,

--- a/src/automation/memory_curator.rs
+++ b/src/automation/memory_curator.rs
@@ -1,15 +1,15 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::apply_policy::{MemoryApplyDecision, MemoryApplyPolicy};
 use super::artifacts::sha256_json;
 use super::backend::{AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse};
 use super::config::AutomationConfig;
-use super::lifecycle::{failed_backend_fallback_report, AgentTaskRunContext, SchedulerGate};
+use super::lifecycle::{AgentTaskRunContext, SchedulerGate, failed_backend_fallback_report};
 use super::run_ledger::{AutomationRunLedgerRecord, AutomationTrigger};
 use crate::dashboard::memory_curate::{
-    run_memory_curate, MemoryCurateOptions, CURATION_DEFAULT_MAX_CLUSTERS,
-    CURATION_DEFAULT_MIN_CONFIDENCE,
+    CURATION_DEFAULT_MAX_CLUSTERS, CURATION_DEFAULT_MIN_CONFIDENCE, MemoryCurateOptions,
+    run_memory_curate,
 };
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
@@ -276,7 +276,12 @@ fn memory_curation_apply_policy(
         .map_or_else(|| &[] as &[Value], Vec::as_slice);
     let destructive = memory_destructive_op_counts(ops);
     let accepted_count = ops.len();
-    let policy = MemoryApplyPolicy::curation_ops(config, accepted_count);
+    let policy = applied_count.map_or_else(
+        || MemoryApplyPolicy::curation_ops(config, accepted_count),
+        |applied_count| {
+            MemoryApplyPolicy::applied_curation_ops(config, accepted_count, applied_count)
+        },
+    );
     let apply_instructions = match policy.decision() {
         MemoryApplyDecision::AutoApplyAllowed => {
             "Accepted memory curation ops were applied because auto-apply is enabled and dashboard approval is not required."
@@ -299,16 +304,7 @@ fn memory_curation_apply_policy(
             object.insert("applied_count".to_string(), json!(applied_count));
             object.insert(
                 "fully_applied".to_string(),
-                json!(accepted_count > 0 && applied_count == accepted_count),
-            );
-            object.insert(
-                "approval_required".to_string(),
-                json!(accepted_count > 0 && applied_count < accepted_count),
-            );
-            object.insert("mutates_store".to_string(), json!(applied_count > 0));
-            object.insert(
-                "autonomous_memory_apply".to_string(),
-                json!(applied_count > 0),
+                json!(accepted_count > 0 && applied_count >= accepted_count),
             );
         }
         object.insert(

--- a/src/automation/memory_curator.rs
+++ b/src/automation/memory_curator.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::apply_policy::{MemoryApplyDecision, MemoryApplyPolicy};
 use super::artifacts::sha256_json;
 use super::backend::{AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse};
 use super::config::AutomationConfig;
@@ -152,8 +153,8 @@ pub async fn run_memory_curator_with_backend(
     };
 
     let accepted_ops = dry_run_report.pointer("/llm_apply/ops").cloned();
-    let apply_policy = memory_curation_apply_policy(config, accepted_ops.as_ref());
-    let should_apply = apply_policy
+    let dry_run_apply_policy = memory_curation_apply_policy(config, accepted_ops.as_ref(), None);
+    let should_apply = dry_run_apply_policy
         .get("mutates_store")
         .and_then(Value::as_bool)
         .unwrap_or(false);
@@ -183,18 +184,27 @@ pub async fn run_memory_curator_with_backend(
                 return Err(err);
             }
         };
+        let applied_ops = applied_report.pointer("/llm_apply/ops").cloned();
+        let applied_count = applied_report
+            .pointer("/llm_apply/applied")
+            .and_then(value_as_usize)
+            .unwrap_or(0);
+        let apply_policy =
+            memory_curation_apply_policy(config, applied_ops.as_ref(), Some(applied_count));
         annotate_memory_curation_report(&mut applied_report, apply_policy.clone());
-        if let Ok(project_db) = cg.open_project_store_db().await {
-            crate::automation::memory_digest::refresh_memory_digest_after_memory_change(
-                project_db.conn(),
-                &cg.store_layout().project_root,
-            )
-            .await;
+        if applied_count > 0 {
+            if let Ok(project_db) = cg.open_project_store_db().await {
+                crate::automation::memory_digest::refresh_memory_digest_after_memory_change(
+                    project_db.conn(),
+                    &cg.store_layout().project_root,
+                )
+                .await;
+            }
         }
         applied_report
     } else {
         let mut report = dry_run_report;
-        annotate_memory_curation_report(&mut report, apply_policy.clone());
+        annotate_memory_curation_report(&mut report, dry_run_apply_policy.clone());
         report
     };
 
@@ -256,41 +266,72 @@ fn build_memory_curator_prompt(llm_review: &Value) -> String {
     )
 }
 
-fn memory_curation_apply_policy(config: &AutomationConfig, accepted_ops: Option<&Value>) -> Value {
+fn memory_curation_apply_policy(
+    config: &AutomationConfig,
+    accepted_ops: Option<&Value>,
+    applied_count: Option<usize>,
+) -> Value {
     let ops = accepted_ops
         .and_then(Value::as_array)
         .map_or_else(|| &[] as &[Value], Vec::as_slice);
     let destructive = memory_destructive_op_counts(ops);
     let accepted_count = ops.len();
-    let mutates_store = accepted_count > 0 && config.auto_apply_memory_ops;
-    let decision = if accepted_count == 0 {
-        "no_valid_ops"
-    } else if mutates_store {
-        "auto_apply_allowed"
-    } else {
-        "memory_auto_apply_disabled"
-    };
-    let apply_instructions = match decision {
-        "auto_apply_allowed" => {
-            "Accepted memory curation ops were applied because memory auto-apply is enabled."
+    let policy = MemoryApplyPolicy::curation_ops(config, accepted_count);
+    let apply_instructions = match policy.decision() {
+        MemoryApplyDecision::AutoApplyAllowed => {
+            "Accepted memory curation ops were applied because auto-apply is enabled and dashboard approval is not required."
         }
-        "memory_auto_apply_disabled" => {
-            "Enable memory auto-apply before mutating the memory store."
+        MemoryApplyDecision::RequiresDashboardApproval => {
+            "Review accepted memory curation ops in the dashboard before applying permanent deletes or merge losers."
         }
-        _ => "No accepted memory curation ops require apply.",
+        MemoryApplyDecision::DryRunOnly | MemoryApplyDecision::ProposalOnly => {
+            "Re-run with an explicit apply policy before mutating the memory store."
+        }
+        MemoryApplyDecision::NoValidOps | MemoryApplyDecision::NoValidFacts => {
+            "No accepted memory curation ops require apply."
+        }
     };
-    json!({
-        "decision": decision,
-        "dry_run_first": true,
-        "mutates_store": mutates_store,
-        "auto_apply_memory_ops": config.auto_apply_memory_ops,
-        "autonomous_memory_apply": mutates_store,
-        "accepted_count": accepted_count,
-        "permanent_delete_count": destructive.permanent_delete_count,
-        "merge_loser_count": destructive.merge_loser_count,
-        "destructive_target_count": destructive.permanent_delete_count + destructive.merge_loser_count,
-        "apply_instructions": apply_instructions,
-    })
+    let mut payload = policy.to_json();
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("dry_run_first".to_string(), json!(true));
+        object.insert("accepted_count".to_string(), json!(accepted_count));
+        if let Some(applied_count) = applied_count {
+            object.insert("applied_count".to_string(), json!(applied_count));
+            object.insert(
+                "fully_applied".to_string(),
+                json!(accepted_count > 0 && applied_count == accepted_count),
+            );
+            object.insert(
+                "approval_required".to_string(),
+                json!(accepted_count > 0 && applied_count < accepted_count),
+            );
+            object.insert("mutates_store".to_string(), json!(applied_count > 0));
+            object.insert(
+                "autonomous_memory_apply".to_string(),
+                json!(applied_count > 0),
+            );
+        }
+        object.insert(
+            "permanent_delete_count".to_string(),
+            json!(destructive.permanent_delete_count),
+        );
+        object.insert(
+            "merge_loser_count".to_string(),
+            json!(destructive.merge_loser_count),
+        );
+        object.insert(
+            "destructive_target_count".to_string(),
+            json!(destructive.permanent_delete_count + destructive.merge_loser_count),
+        );
+        object.insert("apply_instructions".to_string(), json!(apply_instructions));
+    }
+    payload
+}
+
+fn value_as_usize(value: &Value) -> Option<usize> {
+    value
+        .as_u64()
+        .and_then(|number| usize::try_from(number).ok())
 }
 
 #[derive(Debug, Default)]

--- a/src/automation/memory_curator.rs
+++ b/src/automation/memory_curator.rs
@@ -1,15 +1,15 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use super::apply_policy::{MemoryApplyDecision, MemoryApplyPolicy};
 use super::artifacts::sha256_json;
 use super::backend::{AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse};
 use super::config::AutomationConfig;
-use super::lifecycle::{AgentTaskRunContext, SchedulerGate, failed_backend_fallback_report};
+use super::lifecycle::{failed_backend_fallback_report, AgentTaskRunContext, SchedulerGate};
 use super::run_ledger::{AutomationRunLedgerRecord, AutomationTrigger};
 use crate::dashboard::memory_curate::{
-    CURATION_DEFAULT_MAX_CLUSTERS, CURATION_DEFAULT_MIN_CONFIDENCE, MemoryCurateOptions,
-    run_memory_curate,
+    run_memory_curate, MemoryCurateOptions, CURATION_DEFAULT_MAX_CLUSTERS,
+    CURATION_DEFAULT_MIN_CONFIDENCE,
 };
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -1,3 +1,4 @@
+mod apply_policy;
 mod artifact_feedback;
 mod artifact_generated_evals;
 mod artifact_optimizer;

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::apply_policy::MemoryApplyPolicy;
 use super::artifacts::sha256_json;
 use super::backend::{
     extract_json_object_prefix, AgentTaskBackend, AgentTaskKind, AgentTaskRequest,
@@ -333,7 +334,7 @@ async fn finalize_session_reflector_success(
         &rejected_facts,
     )
     .await?;
-    let auto_apply_facts = config.auto_apply_memory_ops;
+    let auto_apply_facts = MemoryApplyPolicy::should_apply(config, accepted_count);
     let applied_fact_proposals = if auto_apply_facts {
         auto_apply_session_fact_proposals(cg, dashboard_root, std::mem::take(&mut proposal_records))
             .await?
@@ -356,23 +357,22 @@ async fn finalize_session_reflector_success(
         .iter()
         .filter_map(|record| record.applied_fact_id)
         .collect();
-    let session_fact_apply_policy = json!({
-        "decision": if auto_apply_facts && accepted_count > 0 {
-            "auto_apply_allowed"
-        } else if accepted_count > 0 {
-            "memory_auto_apply_disabled"
-        } else {
-            "no_valid_facts"
-        },
-        "auto_apply_memory_ops": config.auto_apply_memory_ops,
-        "autonomous_memory_apply": !applied_proposal_ids.is_empty(),
-        "mutates_store": !applied_proposal_ids.is_empty(),
-        "applied_proposal_ids": applied_proposal_ids,
-        "applied_fact_ids": applied_fact_ids,
-    });
+    let applied_count = applied_proposal_ids.len();
+    let fully_applied = accepted_count > 0 && applied_count == accepted_count;
+    let mut session_fact_apply_policy =
+        MemoryApplyPolicy::session_facts(config, accepted_count, applied_count).to_json();
+    if let Some(object) = session_fact_apply_policy.as_object_mut() {
+        object.insert(
+            "applied_proposal_ids".to_string(),
+            json!(applied_proposal_ids),
+        );
+        object.insert("applied_fact_ids".to_string(), json!(applied_fact_ids));
+        object.insert("applied_count".to_string(), json!(applied_count));
+        object.insert("fully_applied".to_string(), json!(fully_applied));
+    }
     let report = json!({
-        "status": if auto_apply_facts && accepted_count > 0 { "auto_applied" } else { "needs_approval" },
-        "dry_run": !(auto_apply_facts && accepted_count > 0),
+        "status": if fully_applied { "auto_applied" } else { "needs_approval" },
+        "dry_run": !fully_applied,
         "task": "session_reflector",
         "evidence_hash": evidence_hash,
         "accepted_facts": accepted_facts,

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -360,7 +360,8 @@ async fn finalize_session_reflector_success(
     let applied_count = applied_proposal_ids.len();
     let fully_applied = accepted_count > 0 && applied_count == accepted_count;
     let mut session_fact_apply_policy =
-        MemoryApplyPolicy::session_facts(config, accepted_count, applied_count).to_json();
+        MemoryApplyPolicy::session_facts(config, accepted_count, applied_count, auto_apply_facts)
+            .to_json();
     if let Some(object) = session_fact_apply_policy.as_object_mut() {
         object.insert(
             "applied_proposal_ids".to_string(),
@@ -371,8 +372,8 @@ async fn finalize_session_reflector_success(
         object.insert("fully_applied".to_string(), json!(fully_applied));
     }
     let report = json!({
-        "status": if fully_applied { "auto_applied" } else { "needs_approval" },
-        "dry_run": !fully_applied,
+        "status": if auto_apply_facts { "auto_applied" } else { "needs_approval" },
+        "dry_run": !auto_apply_facts,
         "task": "session_reflector",
         "evidence_hash": evidence_hash,
         "accepted_facts": accepted_facts,
@@ -401,17 +402,36 @@ async fn finalize_session_reflector_success(
         .filter(|value| value.as_array().is_some_and(|items| !items.is_empty()))
         .cloned();
     record.rejected_ops = report.get("rejected_facts").cloned();
-    record.validation_report = Some(json!({
+    let proposal_review_key = if auto_apply_facts {
+        "applied_proposals"
+    } else {
+        "pending_proposals"
+    };
+    let proposal_review_ids = if auto_apply_facts {
+        report
+            .pointer("/session_fact_apply_policy/applied_proposal_ids")
+            .cloned()
+    } else {
+        report.get("proposal_ids").cloned()
+    }
+    .unwrap_or_else(|| json!([]));
+    let mut validation_report = json!({
         "status": report.get("status").cloned().unwrap_or_else(|| json!("needs_approval")),
         "dry_run": report.get("dry_run").cloned().unwrap_or(json!(true)),
         "accepted_count": accepted_count,
         "rejected_count": rejected_count,
         "session_fact_apply_policy": report.get("session_fact_apply_policy").cloned().unwrap_or_else(|| json!({})),
-        "pending_proposals": {
-            "proposal_ids": report.get("proposal_ids").cloned().unwrap_or_else(|| json!([])),
+    });
+    if let Some(object) = validation_report.as_object_mut() {
+        object.insert(
+            proposal_review_key.to_string(),
+            json!({
+            "proposal_ids": proposal_review_ids,
             "accepted_facts": report.get("accepted_facts").cloned().unwrap_or_else(|| json!([])),
-        },
-    }));
+            }),
+        );
+    }
+    record.validation_report = Some(validation_report);
     Ok((report, record))
 }
 

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -333,7 +333,7 @@ async fn finalize_session_reflector_success(
         &rejected_facts,
     )
     .await?;
-    let auto_apply_facts = config.auto_apply_memory_ops && !config.require_dashboard_approval;
+    let auto_apply_facts = config.auto_apply_memory_ops;
     let applied_fact_proposals = if auto_apply_facts {
         auto_apply_session_fact_proposals(cg, dashboard_root, std::mem::take(&mut proposal_records))
             .await?
@@ -359,15 +359,13 @@ async fn finalize_session_reflector_success(
     let session_fact_apply_policy = json!({
         "decision": if auto_apply_facts && accepted_count > 0 {
             "auto_apply_allowed"
-        } else if config.require_dashboard_approval && accepted_count > 0 {
-            "requires_dashboard_approval"
         } else if accepted_count > 0 {
-            "proposal_only"
+            "memory_auto_apply_disabled"
         } else {
             "no_valid_facts"
         },
         "auto_apply_memory_ops": config.auto_apply_memory_ops,
-        "require_dashboard_approval": config.require_dashboard_approval,
+        "autonomous_memory_apply": !applied_proposal_ids.is_empty(),
         "mutates_store": !applied_proposal_ids.is_empty(),
         "applied_proposal_ids": applied_proposal_ids,
         "applied_fact_ids": applied_fact_ids,

--- a/src/automation/skill_frontmatter.rs
+++ b/src/automation/skill_frontmatter.rs
@@ -106,12 +106,11 @@ pub fn parse_skill_frontmatter(contents: &str) -> Result<BTreeMap<String, SkillF
     Ok(fields)
 }
 
-/// Strips one level of YAML quoting, including YAML `''` single-quote escaping.
 fn unquote_scalar(value: &str) -> String {
     if let Some(inner) = value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')) {
         inner.replace("''", "'")
     } else if let Some(inner) = value.strip_prefix('"').and_then(|v| v.strip_suffix('"')) {
-        inner.to_string()
+        serde_json::from_str(value).unwrap_or_else(|_| inner.to_string())
     } else {
         value.to_string()
     }
@@ -150,6 +149,28 @@ mod tests {
         assert_eq!(
             fields["paths"].as_list_items(),
             Some(vec!["**/*.rs".to_string(), "**/Cargo.toml".to_string()])
+        );
+    }
+
+    #[test]
+    fn parses_json_escaped_double_quoted_scalars() {
+        let doc = concat!(
+            "---\n",
+            "name: my-skill\n",
+            "description: \"Use \\\"quoted\\\" paths like C:\\\\tmp\"\n",
+            "paths:\n",
+            "  - \"C:\\\\tmp\"\n",
+            "---\n",
+            "\n# Body\n"
+        );
+        let fields = parse_skill_frontmatter(doc).unwrap();
+        assert_eq!(
+            fields["description"].as_scalar(),
+            Some(r#"Use "quoted" paths like C:\tmp"#)
+        );
+        assert_eq!(
+            fields["paths"].as_list_items(),
+            Some(vec![r"C:\tmp".to_string()])
         );
     }
 

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -128,10 +128,20 @@ pub fn export_native_skill_overlay(
             });
         }
 
+        let manifest_exported = exported
+            .iter()
+            .cloned()
+            .map(|mut entry| {
+                if let Ok(relative) = entry.path.strip_prefix(&stage_root) {
+                    entry.path = overlay_root.join(relative);
+                }
+                entry
+            })
+            .collect();
         let manifest = NativeSkillManifest {
             version: 1,
             target,
-            exported: exported.clone(),
+            exported: manifest_exported,
         };
         fs::write(
             stage_root.join(NATIVE_MANIFEST_FILE),

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -101,8 +101,10 @@ pub fn export_native_skill_overlay(
             exported: Vec::new(),
         });
     }
+    let mut native_markdown = Vec::with_capacity(skills.len());
     for skill in &skills {
         validate_managed_support_files(&skill.support_files)?;
+        native_markdown.push(skill.render_native_skill_markdown()?);
     }
 
     let stage_root = unique_overlay_sibling(&overlay_root, "tmp");
@@ -111,44 +113,49 @@ pub fn export_native_skill_overlay(
     }
     fs::create_dir_all(&stage_root)?;
     let mut exported = Vec::new();
-    let write_result = (|| -> Result<()> {
-        for skill in &skills {
-            let package_dir = stage_root.join(&skill.metadata.id);
-            fs::create_dir_all(&package_dir)?;
-            let skill_path = package_dir.join("SKILL.md");
-            fs::write(&skill_path, skill.render_skill_markdown())?;
-            for support in &skill.support_files {
-                write_support_file(&package_dir, support)?;
-            }
-            exported.push(SkillExportEntry {
-                id: skill.metadata.id.clone(),
-                title: skill.metadata.title.clone(),
-                checksum: skill.metadata.checksum.clone(),
-                path: skill_path,
-            });
-        }
-
-        let manifest_exported = exported
-            .iter()
-            .cloned()
-            .map(|mut entry| {
-                if let Ok(relative) = entry.path.strip_prefix(&stage_root) {
-                    entry.path = overlay_root.join(relative);
+    let write_result =
+        (|| -> Result<()> {
+            for (skill, skill_markdown) in skills.iter().zip(native_markdown.iter()) {
+                let package_dir = stage_root.join(&skill.metadata.id);
+                fs::create_dir_all(&package_dir)?;
+                let skill_path = package_dir.join("SKILL.md");
+                fs::write(&skill_path, skill_markdown)?;
+                for support in &skill.support_files {
+                    write_support_file(&package_dir, support)?;
                 }
-                entry
-            })
-            .collect();
-        let manifest = NativeSkillManifest {
-            version: 1,
-            target,
-            exported: manifest_exported,
-        };
-        fs::write(
-            stage_root.join(NATIVE_MANIFEST_FILE),
-            serde_json::to_vec_pretty(&manifest)?,
-        )?;
-        Ok(())
-    })();
+                exported.push(SkillExportEntry {
+                    id: skill.metadata.id.clone(),
+                    title: skill.metadata.title.clone(),
+                    checksum: skill.metadata.checksum.clone(),
+                    path: skill_path,
+                });
+            }
+
+            let mut manifest_exported = Vec::with_capacity(exported.len());
+            for mut entry in exported.iter().cloned() {
+                let relative_path = entry.path.strip_prefix(&stage_root).map_err(|err| {
+                    TraceDecayError::Config {
+                        message: format!(
+                            "native skill export path '{}' escaped stage root '{}': {err}",
+                            entry.path.display(),
+                            stage_root.display()
+                        ),
+                    }
+                })?;
+                entry.path = overlay_root.join(relative_path);
+                manifest_exported.push(entry);
+            }
+            let manifest = NativeSkillManifest {
+                version: 1,
+                target,
+                exported: manifest_exported,
+            };
+            fs::write(
+                stage_root.join(NATIVE_MANIFEST_FILE),
+                serde_json::to_vec_pretty(&manifest)?,
+            )?;
+            Ok(())
+        })();
     if let Err(err) = write_result {
         fs::remove_dir_all(&stage_root).ok();
         return Err(err);

--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -1,11 +1,8 @@
 //! Surfacing of staged automation output (R5, Hermes parity).
 //!
-//! Automation runs stage skill drafts and fact proposals for human review, but
-//! historically the approval queue was only visible in the dashboard or the
-//! run ledger. This module derives cheap pending-review counts and decides —
-//! with a persisted dedupe state — when a compact one-line notice should be
-//! surfaced to the user (via the MCP server's response nudge path and the
-//! daemon's `event=automation_staged` log line).
+//! Automation runs may stage skill drafts for review. Fact proposals are
+//! tracked as automation telemetry/backcompat, but memory management is
+//! self-managed and does not surface a human review queue by default.
 
 use std::path::{Path, PathBuf};
 
@@ -18,10 +15,10 @@ use crate::errors::{Result, TraceDecayError};
 
 const NOTICE_STATE_FILENAME: &str = "automation_notice_seen.json";
 
-/// Counts of automation output awaiting human review.
+/// Counts of staged automation output.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct AutomationPendingCounts {
-    /// Fact proposals in `pending_approval` state.
+    /// Fact proposals in `pending_approval` state, retained as telemetry.
     pub pending_fact_proposals: usize,
     /// Managed skills awaiting review: drafts in `pending_approval` state
     /// plus active skills carrying a staged `pending_update`.
@@ -30,7 +27,7 @@ pub struct AutomationPendingCounts {
 
 impl AutomationPendingCounts {
     pub fn total(self) -> usize {
-        self.pending_fact_proposals + self.pending_skills
+        self.pending_skills
     }
 }
 
@@ -70,7 +67,7 @@ pub async fn save_notice_state(dashboard_root: &Path, state: &AutomationNoticeSt
         .map_err(|e| config_error(format!("failed to write automation notice state: {e}")))
 }
 
-/// Counts pending fact proposals (project dashboard store) and pending
+/// Counts pending fact proposal telemetry (project dashboard store) and pending
 /// managed skills (user profile store). Best-effort: unreadable or missing
 /// stores count as zero so callers never fail a request over a notice.
 pub async fn count_pending_automation_output(
@@ -104,7 +101,7 @@ pub async fn count_pending_automation_output(
 
 /// Decides whether a notice should fire for the current pending batch.
 /// Fires only when something is pending AND the batch differs from what was
-/// last notified (different latest run id or different pending counts).
+/// last notified (different latest run id or different pending skill counts).
 pub fn should_notify(
     previous: Option<&AutomationNoticeState>,
     latest_run_id: Option<&str>,
@@ -117,7 +114,6 @@ pub fn should_notify(
         None => true,
         Some(state) => {
             state.last_run_id.as_deref() != latest_run_id
-                || state.pending_fact_proposals != counts.pending_fact_proposals
                 || state.pending_skills != counts.pending_skills
         }
     }
@@ -137,18 +133,11 @@ pub fn staged_notice_message(counts: AutomationPendingCounts) -> Option<String> 
         ));
     }
     if counts.pending_fact_proposals > 0 {
-        parts.push(format!(
-            "{} fact proposal{}",
-            counts.pending_fact_proposals,
-            if counts.pending_fact_proposals == 1 {
-                ""
-            } else {
-                "s"
-            }
-        ));
+        // Fact proposals are self-managed automation state. Keep counting them
+        // for APIs, but never surface them here.
     }
     Some(format!(
-        "TraceDecay automation: {} await{} review — dashboard Curation tab or tracedecay_fact_store.",
+        "TraceDecay automation: {} await{} review — dashboard Skills tab.",
         parts.join(" and "),
         if counts.total() == 1 { "s" } else { "" },
     ))
@@ -156,7 +145,7 @@ pub fn staged_notice_message(counts: AutomationPendingCounts) -> Option<String> 
 
 /// One-shot check used by the MCP server: derives pending counts, dedupes
 /// against the persisted notice state, and returns the notice line to surface
-/// (persisting the new state) when a new batch awaits review.
+/// (persisting the new state) when a new managed-skill batch awaits review.
 pub async fn maybe_automation_staged_notice(
     dashboard_root: &Path,
     profile_root: &Path,
@@ -260,15 +249,12 @@ mod tests {
         assert_eq!(staged_notice_message(counts(0, 0)), None);
         assert_eq!(
             staged_notice_message(counts(2, 1)).unwrap(),
-            "TraceDecay automation: 1 skill draft and 2 fact proposals await review — dashboard Curation tab or tracedecay_fact_store."
+            "TraceDecay automation: 1 skill draft awaits review — dashboard Skills tab."
         );
-        assert_eq!(
-            staged_notice_message(counts(1, 0)).unwrap(),
-            "TraceDecay automation: 1 fact proposal awaits review — dashboard Curation tab or tracedecay_fact_store."
-        );
+        assert_eq!(staged_notice_message(counts(1, 0)), None);
         assert_eq!(
             staged_notice_message(counts(0, 3)).unwrap(),
-            "TraceDecay automation: 3 skill drafts await review — dashboard Curation tab or tracedecay_fact_store."
+            "TraceDecay automation: 3 skill drafts await review — dashboard Skills tab."
         );
     }
 
@@ -278,6 +264,7 @@ mod tests {
         assert!(!should_notify(None, Some("run-1"), counts(0, 0)));
         // First sighting of a pending batch: notify.
         assert!(should_notify(None, Some("run-1"), counts(2, 1)));
+        assert!(!should_notify(None, Some("run-1"), counts(2, 0)));
         let seen = AutomationNoticeState {
             last_run_id: Some("run-1".to_string()),
             pending_fact_proposals: 2,
@@ -287,9 +274,11 @@ mod tests {
         assert!(!should_notify(Some(&seen), Some("run-1"), counts(2, 1)));
         // New run appended: notify again.
         assert!(should_notify(Some(&seen), Some("run-2"), counts(2, 1)));
-        // Same run but pending counts moved (e.g. a second batch staged
-        // before any run-ledger append was observed): notify.
-        assert!(should_notify(Some(&seen), Some("run-1"), counts(3, 1)));
+        // Fact proposal count changes alone are telemetry and do not rearm
+        // user-facing notices.
+        assert!(!should_notify(Some(&seen), Some("run-1"), counts(3, 1)));
+        // Skill count changes still rearm.
+        assert!(should_notify(Some(&seen), Some("run-1"), counts(2, 2)));
     }
 
     #[tokio::test]
@@ -348,19 +337,13 @@ mod tests {
         .await
         .unwrap();
 
-        let first = maybe_automation_staged_notice(&dashboard_root, &profile_root).await;
-        assert_eq!(
-            first.unwrap(),
-            "TraceDecay automation: 1 fact proposal awaits review — dashboard Curation tab or tracedecay_fact_store."
-        );
-        // Same batch: deduped.
         assert!(
             maybe_automation_staged_notice(&dashboard_root, &profile_root)
                 .await
                 .is_none()
         );
 
-        // A second proposal lands: new batch, notice fires again.
+        // More fact proposals land: still no user-facing notice.
         save_fact_proposal_store(
             &dashboard_root,
             &FactProposalStore {
@@ -373,7 +356,22 @@ mod tests {
         )
         .await
         .unwrap();
-        let second = maybe_automation_staged_notice(&dashboard_root, &profile_root).await;
-        assert!(second.unwrap().contains("2 fact proposals"));
+        assert!(
+            maybe_automation_staged_notice(&dashboard_root, &profile_root)
+                .await
+                .is_none()
+        );
+
+        save_managed_skill(
+            &profile_root,
+            &skill("draft-skill", ManagedSkillState::PendingApproval),
+        )
+        .await
+        .unwrap();
+        let skill_notice = maybe_automation_staged_notice(&dashboard_root, &profile_root).await;
+        assert_eq!(
+            skill_notice.unwrap(),
+            "TraceDecay automation: 1 skill draft awaits review — dashboard Skills tab."
+        );
     }
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1125,22 +1125,22 @@ pub(crate) fn handle_upload_counter(enable: bool) {
     }
 }
 
-pub(crate) fn handle_gitignore(
+pub(crate) async fn handle_gitignore(
     path: Option<String>,
     action: Option<String>,
 ) -> tracedecay::errors::Result<()> {
     let project_path = tracedecay::config::resolve_path(path);
-    let mut config = tracedecay::config::load_config(&project_path)?;
+    let mut config = tracedecay::config::load_config_with_identity(&project_path).await?;
     match action.as_deref() {
         Some("on") => {
             config.git_ignore = true;
-            tracedecay::config::save_config(&project_path, &config)?;
+            tracedecay::config::save_config_with_identity(&project_path, &config).await?;
             eprintln!("gitignore enabled — .gitignore rules will be respected during indexing.");
             eprintln!("Run `tracedecay sync` to re-index with the new setting.");
         }
         Some("off") => {
             config.git_ignore = false;
-            tracedecay::config::save_config(&project_path, &config)?;
+            tracedecay::config::save_config_with_identity(&project_path, &config).await?;
             eprintln!("gitignore disabled — .gitignore rules will be ignored during indexing.");
             eprintln!("Run `tracedecay sync` to re-index with the new setting.");
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -402,12 +402,26 @@ pub fn get_config_path(project_root: &Path) -> PathBuf {
     get_tracedecay_dir(project_root).join(CONFIG_FILENAME)
 }
 
+pub async fn get_config_path_with_identity(project_root: &Path) -> PathBuf {
+    if let Ok(layout) =
+        crate::tracedecay::TraceDecay::resolve_store_layout_for_identity(project_root).await
+    {
+        return layout.config_path;
+    }
+    get_config_path(project_root)
+}
+
 /// Loads the configuration from disk.
 ///
 /// If the configuration file does not exist, returns a default configuration
 /// with `root_dir` set to the given project root.
 pub fn load_config(project_root: &Path) -> Result<TraceDecayConfig> {
     let config_path = get_config_path(project_root);
+    load_config_from_path(project_root, &config_path)
+}
+
+pub async fn load_config_with_identity(project_root: &Path) -> Result<TraceDecayConfig> {
+    let config_path = get_config_path_with_identity(project_root).await;
     load_config_from_path(project_root, &config_path)
 }
 
@@ -447,6 +461,14 @@ pub fn load_config_from_path(project_root: &Path, config_path: &Path) -> Result<
 /// ensuring that a partial write never corrupts the configuration.
 pub fn save_config(project_root: &Path, config: &TraceDecayConfig) -> Result<()> {
     let config_path = get_config_path(project_root);
+    save_config_to_path(&config_path, config)
+}
+
+pub async fn save_config_with_identity(
+    project_root: &Path,
+    config: &TraceDecayConfig,
+) -> Result<()> {
+    let config_path = get_config_path_with_identity(project_root).await;
     save_config_to_path(&config_path, config)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,25 +696,9 @@ pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Identity-aware async companion to [`discover_project_root`].
-///
-/// The sync [`discover_project_root`] only recognises a project through
-/// path-hash signals: a repo-local database, an enrollment marker, or a
-/// profile-sharded store discoverable from the path itself. A project whose
-/// store is global-only — no repo-local `.tracedecay/`, e.g. after the repo
-/// directory was renamed on disk — is invisible to that walk even though the
-/// git-identity/`GlobalDb` layer binds it to a store just fine.
-///
-/// This wrapper keeps the fast sync path unchanged (so all existing callers of
-/// [`discover_project_root`] and its sync signature are untouched), and on a
-/// sync miss walks the same ancestor chain — with the identical
-/// worktree-root stop condition — but gates each candidate on the async
-/// identity resolver [`crate::tracedecay::TraceDecay::has_initialized_store`]
-/// (which routes through `resolve_store_layout_for_local_identity` ->
-/// `GlobalDb::resolve_project_store_by_identity`, requiring a real graph db on
-/// disk). Async hook SessionStart/context surfaces route through this so
-/// renamed / global-only repos resolve instead of falsely nudging "no project
-/// index found".
+/// Like [`discover_project_root`], but on a sync miss walks ancestors with
+/// [`crate::tracedecay::TraceDecay::has_initialized_store`] so renamed or
+/// global-only repos still resolve.
 pub async fn discover_project_root_with_identity(start: &Path) -> Option<PathBuf> {
     if let Some(root) = discover_project_root(start) {
         return Some(root);

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,6 +696,47 @@ pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Identity-aware async companion to [`discover_project_root`].
+///
+/// The sync [`discover_project_root`] only recognises a project through
+/// path-hash signals: a repo-local database, an enrollment marker, or a
+/// profile-sharded store discoverable from the path itself. A project whose
+/// store is global-only — no repo-local `.tracedecay/`, e.g. after the repo
+/// directory was renamed on disk — is invisible to that walk even though the
+/// git-identity/`GlobalDb` layer binds it to a store just fine.
+///
+/// This wrapper keeps the fast sync path unchanged (so all existing callers of
+/// [`discover_project_root`] and its sync signature are untouched), and on a
+/// sync miss walks the same ancestor chain — with the identical
+/// worktree-root stop condition — but gates each candidate on the async
+/// identity resolver [`crate::tracedecay::TraceDecay::has_initialized_store`]
+/// (which routes through `resolve_store_layout_for_local_identity` ->
+/// `GlobalDb::resolve_project_store_by_identity`, requiring a real graph db on
+/// disk). Async hook SessionStart/context surfaces route through this so
+/// renamed / global-only repos resolve instead of falsely nudging "no project
+/// index found".
+pub async fn discover_project_root_with_identity(start: &Path) -> Option<PathBuf> {
+    if let Some(root) = discover_project_root(start) {
+        return Some(root);
+    }
+    let mut dir = start.to_path_buf();
+    let worktree_root = crate::worktree::git_worktree_root(start);
+    loop {
+        if crate::tracedecay::TraceDecay::has_initialized_store(&dir).await {
+            return Some(dir);
+        }
+        if worktree_root
+            .as_ref()
+            .is_some_and(|root| paths_same(&dir, root))
+        {
+            return None;
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
 /// Like [`resolve_path`], but when `path` is `None` it walks up from `cwd`
 /// to find the nearest initialised `TraceDecay` project before falling back to
 /// `cwd` itself.

--- a/src/config.rs
+++ b/src/config.rs
@@ -696,28 +696,19 @@ pub fn discover_project_root(start: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Like [`discover_project_root`], but on a sync miss walks ancestors with
-/// [`crate::tracedecay::TraceDecay::has_initialized_store`] so renamed or
-/// global-only repos still resolve.
+/// Like [`discover_project_root`], but on a sync miss checks the git worktree
+/// root with [`crate::tracedecay::TraceDecay::has_initialized_store`] so renamed
+/// or global-only repos still resolve without probing unrelated ancestors.
 pub async fn discover_project_root_with_identity(start: &Path) -> Option<PathBuf> {
     if let Some(root) = discover_project_root(start) {
         return Some(root);
     }
-    let mut dir = start.to_path_buf();
-    let worktree_root = crate::worktree::git_worktree_root(start);
-    loop {
-        if crate::tracedecay::TraceDecay::has_initialized_store(&dir).await {
-            return Some(dir);
-        }
-        if worktree_root
-            .as_ref()
-            .is_some_and(|root| paths_same(&dir, root))
-        {
-            return None;
-        }
-        if !dir.pop() {
-            return None;
-        }
+    let candidate =
+        crate::worktree::git_worktree_root(start).unwrap_or_else(|| start.to_path_buf());
+    if crate::tracedecay::TraceDecay::has_initialized_store(&candidate).await {
+        Some(candidate)
+    } else {
+        None
     }
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -307,26 +307,17 @@ fn sync_config_env_overrides_bool_and_int() {
     );
 }
 
-/// The identity-aware wrapper must resolve a project whose store is reachable
-/// ONLY through the git-identity/`GlobalDb` layer (registered by canonical path,
-/// no repo-local enrollment marker, no path-hash store) — the exact renamed /
-/// global-only repo scenario. It must also leave the sync fast path unchanged
-/// and return `None` for a bare directory with no store at all.
+/// Resolves a global-only registered store that sync discovery cannot see.
 #[tokio::test]
 async fn discover_project_root_with_identity_resolves_global_only_store() {
     let _profile = super::PinnedUserDataDir::new();
     let profile_root = crate::storage::default_profile_root().unwrap();
 
-    // Point the process at a real (pinned-profile) global DB so the default
-    // TraceDecayOpenOptions used by has_initialized_store opens it.
     let gdb = crate::global_db::GlobalDb::open().await.unwrap();
 
     let project_dir = TempDir::new().unwrap();
     let project_root = project_dir.path().canonicalize().unwrap();
 
-    // Register the project by canonical path only (no enrollment marker), so
-    // resolution must go through the GlobalDb identity branch, not the marker
-    // short-circuit.
     let project_id = "proj_identity_only";
     gdb.upsert_code_project(project_id, &project_root, None, None, None)
         .await
@@ -344,9 +335,6 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
     .await
     .unwrap();
 
-    // Create the REAL graph db the identity resolver will look for. The layout
-    // is deterministic in the project_id, so this matches whatever
-    // has_initialized_store computes for the GlobalDb-resolved project.
     let layout = crate::storage::profile_sharded_layout(
         &project_root,
         &profile_root,
@@ -359,15 +347,11 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
     fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
     fs::write(&layout.graph_db_path, b"").unwrap();
 
-    // Sanity: the sync path-hash resolver cannot see this store (no marker, no
-    // repo-local db, and the default path-hash store id differs from the
-    // registered project_id).
     assert!(
         super::discover_project_root(&project_root).is_none(),
         "sync discover_project_root must not see a global-only store"
     );
 
-    // The identity wrapper resolves it, from the root and from a nested cwd.
     assert_eq!(
         super::discover_project_root_with_identity(&project_root).await,
         Some(project_root.clone()),
@@ -383,7 +367,6 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
         "identity wrapper must walk up from a nested cwd to the registered root"
     );
 
-    // A bare directory with no store resolves to nothing.
     let bare = TempDir::new().unwrap();
     let bare_root = bare.path().canonicalize().unwrap();
     assert!(
@@ -394,16 +377,13 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
     );
 }
 
-/// The identity wrapper's fast path must be byte-identical to the sync
-/// `discover_project_root` for a dir that the sync resolver already recognizes
-/// (repo-local db present), so the two cannot diverge.
+/// Sync fast path stays identical when repo-local discovery already works.
 #[tokio::test]
 async fn discover_project_root_with_identity_preserves_sync_fast_path() {
     let _profile = super::PinnedUserDataDir::new();
     let project_dir = TempDir::new().unwrap();
     let project_root = project_dir.path().canonicalize().unwrap();
 
-    // A repo-local project db makes the sync resolver return the dir directly.
     let db_dir = super::get_tracedecay_dir(&project_root);
     fs::create_dir_all(&db_dir).unwrap();
     fs::write(super::get_project_db_path(&project_root), b"").unwrap();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -306,3 +306,113 @@ fn sync_config_env_overrides_bool_and_int() {
         super::SyncConfig::default().max_concurrent_syncs
     );
 }
+
+/// The identity-aware wrapper must resolve a project whose store is reachable
+/// ONLY through the git-identity/`GlobalDb` layer (registered by canonical path,
+/// no repo-local enrollment marker, no path-hash store) — the exact renamed /
+/// global-only repo scenario. It must also leave the sync fast path unchanged
+/// and return `None` for a bare directory with no store at all.
+#[tokio::test]
+async fn discover_project_root_with_identity_resolves_global_only_store() {
+    let _profile = super::PinnedUserDataDir::new();
+    let profile_root = crate::storage::default_profile_root().unwrap();
+
+    // Point the process at a real (pinned-profile) global DB so the default
+    // TraceDecayOpenOptions used by has_initialized_store opens it.
+    let gdb = crate::global_db::GlobalDb::open().await.unwrap();
+
+    let project_dir = TempDir::new().unwrap();
+    let project_root = project_dir.path().canonicalize().unwrap();
+
+    // Register the project by canonical path only (no enrollment marker), so
+    // resolution must go through the GlobalDb identity branch, not the marker
+    // short-circuit.
+    let project_id = "proj_identity_only";
+    gdb.upsert_code_project(project_id, &project_root, None, None, None)
+        .await
+        .unwrap();
+    gdb.upsert_store_instance(crate::global_db::StoreInstanceUpsert {
+        store_id: "store_identity_only".to_string(),
+        project_id: project_id.to_string(),
+        store_kind: "code_project".to_string(),
+        storage_mode: "profile_sharded".to_string(),
+        store_relpath: format!("projects/{project_id}"),
+        manifest_relpath: Some(format!("projects/{project_id}/store_manifest.json")),
+        last_verified_at: Some(100),
+        last_write_at: Some(101),
+    })
+    .await
+    .unwrap();
+
+    // Create the REAL graph db the identity resolver will look for. The layout
+    // is deterministic in the project_id, so this matches whatever
+    // has_initialized_store computes for the GlobalDb-resolved project.
+    let layout = crate::storage::profile_sharded_layout(
+        &project_root,
+        &profile_root,
+        &crate::storage::EnrollmentMarker {
+            project_id: project_id.to_string(),
+            storage_mode: crate::storage::StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
+    fs::write(&layout.graph_db_path, b"").unwrap();
+
+    // Sanity: the sync path-hash resolver cannot see this store (no marker, no
+    // repo-local db, and the default path-hash store id differs from the
+    // registered project_id).
+    assert!(
+        super::discover_project_root(&project_root).is_none(),
+        "sync discover_project_root must not see a global-only store"
+    );
+
+    // The identity wrapper resolves it, from the root and from a nested cwd.
+    assert_eq!(
+        super::discover_project_root_with_identity(&project_root).await,
+        Some(project_root.clone()),
+        "identity wrapper must resolve a global-only registered store"
+    );
+    let nested = project_root.join("crates/inner");
+    fs::create_dir_all(&nested).unwrap();
+    assert_eq!(
+        super::discover_project_root_with_identity(&nested)
+            .await
+            .map(|p| p.canonicalize().unwrap()),
+        Some(project_root.clone()),
+        "identity wrapper must walk up from a nested cwd to the registered root"
+    );
+
+    // A bare directory with no store resolves to nothing.
+    let bare = TempDir::new().unwrap();
+    let bare_root = bare.path().canonicalize().unwrap();
+    assert!(
+        super::discover_project_root_with_identity(&bare_root)
+            .await
+            .is_none(),
+        "a directory with no store must not resolve"
+    );
+}
+
+/// The identity wrapper's fast path must be byte-identical to the sync
+/// `discover_project_root` for a dir that the sync resolver already recognizes
+/// (repo-local db present), so the two cannot diverge.
+#[tokio::test]
+async fn discover_project_root_with_identity_preserves_sync_fast_path() {
+    let _profile = super::PinnedUserDataDir::new();
+    let project_dir = TempDir::new().unwrap();
+    let project_root = project_dir.path().canonicalize().unwrap();
+
+    // A repo-local project db makes the sync resolver return the dir directly.
+    let db_dir = super::get_tracedecay_dir(&project_root);
+    fs::create_dir_all(&db_dir).unwrap();
+    fs::write(super::get_project_db_path(&project_root), b"").unwrap();
+
+    let sync = super::discover_project_root(&project_root);
+    assert!(sync.is_some(), "sync resolver must see a repo-local db");
+    assert_eq!(
+        super::discover_project_root_with_identity(&project_root).await,
+        sync,
+        "identity wrapper fast path must equal the sync result"
+    );
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    TraceDecayConfig, USER_DATA_DIR_ENV, db_filename, get_project_db_path, get_tracedecay_dir,
-    is_excluded, is_excluded_dir, is_ignored_by_explicit_global_excludes, is_ignored_by_git,
-    is_included, lock_user_data_dir_test_env, user_data_dir,
+    db_filename, get_project_db_path, get_tracedecay_dir, is_excluded, is_excluded_dir,
+    is_ignored_by_explicit_global_excludes, is_ignored_by_git, is_included,
+    lock_user_data_dir_test_env, user_data_dir, TraceDecayConfig, USER_DATA_DIR_ENV,
 };
 use std::ffi::OsString;
 use std::fs;
@@ -380,6 +380,75 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
             .await
             .is_none(),
         "a directory with no store must not resolve"
+    );
+}
+
+#[tokio::test]
+async fn config_path_with_identity_uses_registered_store_without_enrollment() {
+    let _profile = super::PinnedUserDataDir::new();
+    let profile_root = crate::storage::default_profile_root().unwrap();
+    let gdb = crate::global_db::GlobalDb::open().await.unwrap();
+
+    let project_dir = TempDir::new().unwrap();
+    let project_root = project_dir.path().canonicalize().unwrap();
+    let status = Command::new("git")
+        .arg("init")
+        .arg(&project_root)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git init failed");
+
+    let project_id = "proj_config_identity";
+    let git_common_dir = crate::worktree::git_common_dir(&project_root);
+    gdb.upsert_code_project(
+        project_id,
+        &project_root,
+        git_common_dir.as_deref(),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    gdb.upsert_store_instance(crate::global_db::StoreInstanceUpsert {
+        store_id: "store_config_identity".to_string(),
+        project_id: project_id.to_string(),
+        store_kind: "code_project".to_string(),
+        storage_mode: "profile_sharded".to_string(),
+        store_relpath: format!("projects/{project_id}"),
+        manifest_relpath: Some(format!("projects/{project_id}/store_manifest.json")),
+        last_verified_at: Some(100),
+        last_write_at: Some(101),
+    })
+    .await
+    .unwrap();
+    let identity_layout = crate::storage::profile_sharded_layout(
+        &project_root,
+        &profile_root,
+        &crate::storage::EnrollmentMarker {
+            project_id: project_id.to_string(),
+            storage_mode: crate::storage::StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    super::save_config_to_path(
+        &identity_layout.config_path,
+        &TraceDecayConfig {
+            root_dir: "identity-config".to_string(),
+            ..TraceDecayConfig::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        super::get_config_path_with_identity(&project_root).await,
+        identity_layout.config_path
+    );
+    assert_eq!(
+        super::load_config_with_identity(&project_root)
+            .await
+            .unwrap()
+            .root_dir,
+        "identity-config"
     );
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    db_filename, get_project_db_path, get_tracedecay_dir, is_excluded, is_excluded_dir,
-    is_ignored_by_explicit_global_excludes, is_ignored_by_git, is_included,
-    lock_user_data_dir_test_env, user_data_dir, TraceDecayConfig, USER_DATA_DIR_ENV,
+    TraceDecayConfig, USER_DATA_DIR_ENV, db_filename, get_project_db_path, get_tracedecay_dir,
+    is_excluded, is_excluded_dir, is_ignored_by_explicit_global_excludes, is_ignored_by_git,
+    is_included, lock_user_data_dir_test_env, user_data_dir,
 };
 use std::ffi::OsString;
 use std::fs;
@@ -307,7 +307,6 @@ fn sync_config_env_overrides_bool_and_int() {
     );
 }
 
-/// Resolves a global-only registered store that sync discovery cannot see.
 #[tokio::test]
 async fn discover_project_root_with_identity_resolves_global_only_store() {
     let _profile = super::PinnedUserDataDir::new();
@@ -347,6 +346,13 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
     fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
     fs::write(&layout.graph_db_path, b"").unwrap();
 
+    let status = Command::new("git")
+        .arg("init")
+        .arg(&project_root)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git init failed");
+
     assert!(
         super::discover_project_root(&project_root).is_none(),
         "sync discover_project_root must not see a global-only store"
@@ -377,7 +383,52 @@ async fn discover_project_root_with_identity_resolves_global_only_store() {
     );
 }
 
-/// Sync fast path stays identical when repo-local discovery already works.
+#[tokio::test]
+async fn discover_project_root_with_identity_does_not_bind_non_git_child_to_parent_store() {
+    let _profile = super::PinnedUserDataDir::new();
+    let profile_root = crate::storage::default_profile_root().unwrap();
+    let gdb = crate::global_db::GlobalDb::open().await.unwrap();
+
+    let parent_dir = TempDir::new().unwrap();
+    let parent_root = parent_dir.path().canonicalize().unwrap();
+    let project_id = "proj_parent_identity_only";
+    gdb.upsert_code_project(project_id, &parent_root, None, None, None)
+        .await
+        .unwrap();
+    gdb.upsert_store_instance(crate::global_db::StoreInstanceUpsert {
+        store_id: "store_parent_identity_only".to_string(),
+        project_id: project_id.to_string(),
+        store_kind: "code_project".to_string(),
+        storage_mode: "profile_sharded".to_string(),
+        store_relpath: format!("projects/{project_id}"),
+        manifest_relpath: Some(format!("projects/{project_id}/store_manifest.json")),
+        last_verified_at: Some(100),
+        last_write_at: Some(101),
+    })
+    .await
+    .unwrap();
+    let layout = crate::storage::profile_sharded_layout(
+        &parent_root,
+        &profile_root,
+        &crate::storage::EnrollmentMarker {
+            project_id: project_id.to_string(),
+            storage_mode: crate::storage::StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
+    fs::write(&layout.graph_db_path, b"").unwrap();
+
+    let child = parent_root.join("scratch/deep");
+    fs::create_dir_all(&child).unwrap();
+
+    assert_eq!(
+        super::discover_project_root_with_identity(&child).await,
+        None,
+        "non-git scratch directories must not inherit initialized parent stores"
+    );
+}
+
 #[tokio::test]
 async fn discover_project_root_with_identity_preserves_sync_fast_path() {
     let _profile = super::PinnedUserDataDir::new();

--- a/src/context/builder.rs
+++ b/src/context/builder.rs
@@ -62,7 +62,13 @@ impl<'a> ContextBuilder<'a> {
         // Build summary
         let summary = Self::build_summary(query, &entry_points, &subgraph);
 
-        let seen_node_ids: Vec<String> = entry_points.iter().map(|n| n.id.clone()).collect();
+        let mut seen = HashSet::new();
+        let mut seen_node_ids = Vec::new();
+        for id in entry_points.iter().chain(&subgraph.nodes).map(|n| &n.id) {
+            if seen.insert(id.as_str()) {
+                seen_node_ids.push(id.clone());
+            }
+        }
 
         Ok(TaskContext {
             query: query.to_string(),

--- a/src/context/formatter.rs
+++ b/src/context/formatter.rs
@@ -3,6 +3,26 @@ use std::fmt::Write as _;
 
 use crate::types::TaskContext;
 
+pub(crate) const CODE_CONTEXT_HEADING: &str = "## Code Context";
+pub(crate) const CONTEXT_MEMORY_MATCHES_HEADING: &str = "### Memory Matches";
+pub(crate) const CONTEXT_ENTRY_POINTS_HEADING: &str = "### Entry Points";
+pub(crate) const CONTEXT_RELATED_SYMBOLS_HEADING: &str = "### Related Symbols";
+pub(crate) const CONTEXT_CODE_HEADING: &str = "### Code";
+pub(crate) const CONTEXT_INDEX_COVERAGE_HINT_HEADING: &str = "### Index Coverage Hint";
+pub(crate) const CONTEXT_EXTENSION_POINTS_HEADING: &str = "### Extension Points";
+pub(crate) const CONTEXT_TEST_COVERAGE_HEADING: &str = "### Test Coverage";
+pub(crate) const CONTEXT_SEEN_NODE_IDS_LABEL: &str = "seen_node_ids:";
+pub(crate) const CONTEXT_PRIORITY_HEADINGS: &[&str] = &[
+    CONTEXT_MEMORY_MATCHES_HEADING,
+    CONTEXT_ENTRY_POINTS_HEADING,
+    CONTEXT_RELATED_SYMBOLS_HEADING,
+    CONTEXT_INDEX_COVERAGE_HINT_HEADING,
+    CONTEXT_EXTENSION_POINTS_HEADING,
+    CONTEXT_TEST_COVERAGE_HEADING,
+    CONTEXT_SEEN_NODE_IDS_LABEL,
+    CONTEXT_CODE_HEADING,
+];
+
 /// Formats a `TaskContext` as a Markdown document suitable for LLM consumption.
 ///
 /// The output includes sections for the query, entry points, related symbols
@@ -18,11 +38,13 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
     );
     let mut out = String::new();
 
-    out.push_str("## Code Context\n");
+    out.push_str(CODE_CONTEXT_HEADING);
+    out.push('\n');
     let _ = write!(out, "**Query:** {}\n\n", context.query);
 
     // Entry Points
-    out.push_str("### Entry Points\n");
+    out.push_str(CONTEXT_ENTRY_POINTS_HEADING);
+    out.push('\n');
     if context.entry_points.is_empty() {
         out.push_str("_No entry points found._\n\n");
     } else {
@@ -43,7 +65,8 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
     }
 
     // Related Symbols grouped by file
-    out.push_str("### Related Symbols\n");
+    out.push_str(CONTEXT_RELATED_SYMBOLS_HEADING);
+    out.push('\n');
     if context.subgraph.nodes.is_empty() {
         out.push_str("_No related symbols._\n\n");
     } else {
@@ -71,7 +94,8 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
     }
 
     // Code blocks
-    out.push_str("### Code\n");
+    out.push_str(CONTEXT_CODE_HEADING);
+    out.push('\n');
     if context.code_blocks.is_empty() {
         out.push_str("_No code blocks extracted._\n");
     } else {
@@ -107,7 +131,7 @@ pub fn format_context_as_markdown(context: &TaskContext) -> String {
         "format_context_as_markdown produced empty output"
     );
     debug_assert!(
-        out.contains("## Code Context"),
+        out.contains(CODE_CONTEXT_HEADING),
         "output missing required header"
     );
     out

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -15,3 +15,8 @@ pub mod read_modes;
 
 pub use builder::{extract_symbols_from_query, ContextBuilder};
 pub use formatter::{format_context_as_json, format_context_as_markdown};
+pub(crate) use formatter::{
+    CONTEXT_CODE_HEADING, CONTEXT_ENTRY_POINTS_HEADING, CONTEXT_EXTENSION_POINTS_HEADING,
+    CONTEXT_INDEX_COVERAGE_HINT_HEADING, CONTEXT_MEMORY_MATCHES_HEADING, CONTEXT_PRIORITY_HEADINGS,
+    CONTEXT_RELATED_SYMBOLS_HEADING, CONTEXT_SEEN_NODE_IDS_LABEL, CONTEXT_TEST_COVERAGE_HEADING,
+};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -771,8 +771,8 @@ fn automation_staged_log_fields(
 }
 
 /// After a scheduler tick where at least one task completed, emit a stable
-/// `event=automation_staged` line with the pending-review counts so operators
-/// can see the approval queue growing from the daemon log alone (parity R5).
+/// `event=automation_staged` line with managed-skill review counts plus fact
+/// proposal telemetry.
 /// Silent when nothing is pending or the profile root is unavailable.
 #[cfg(unix)]
 async fn log_automation_staged_if_pending(project_path: &Path, dashboard_root: &Path) {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1466,12 +1466,18 @@ impl DaemonEngine {
         .await?;
         let accounting_db = accounting_db_for_handshake(handshake).await;
         let registry_db = registry_db_for_handshake(handshake).await;
-        let server = crate::mcp::McpServer::new_with_dbs(
+        let reconciler = self.automation_scheduler_reconciler(
+            key.clone(),
+            canonical_project_path.clone(),
+            handshake.clone(),
+        );
+        let server = crate::mcp::McpServer::new_with_dbs_and_automation_reconciler(
             cg,
             handshake.scope_prefix.clone(),
             accounting_db,
             registry_db,
             false,
+            Some(reconciler),
         )
         .await;
         servers.insert(key.clone(), Arc::clone(&server));
@@ -1497,7 +1503,7 @@ impl DaemonEngine {
             }
         }
 
-        let scheduler_configured = match Box::pin(automation_scheduler_configured_for_project(
+        let configured = match Box::pin(automation_scheduler_has_work_for_project(
             &project_path,
             &handshake,
         ))
@@ -1516,10 +1522,40 @@ impl DaemonEngine {
                 false
             }
         };
-        if scheduler_configured {
-            self.start_automation_scheduler(key, project_path, handshake)
-                .await;
+        if !configured {
+            log_daemon_event(
+                "scheduler_config",
+                &[
+                    ("project", project_path.display().to_string()),
+                    ("outcome", "skipped".to_string()),
+                    ("reason", "not_configured".to_string()),
+                ],
+            );
+            return;
         }
+
+        self.start_automation_scheduler(key, project_path, handshake)
+            .await;
+    }
+
+    fn automation_scheduler_reconciler(
+        &self,
+        key: ProjectServerKey,
+        project_path: PathBuf,
+        handshake: DaemonHandshake,
+    ) -> crate::dashboard::AutomationSchedulerReconciler {
+        let engine = self.clone();
+        std::sync::Arc::new(move || {
+            let engine = engine.clone();
+            let key = key.clone();
+            let project_path = project_path.clone();
+            let handshake = handshake.clone();
+            tokio::spawn(async move {
+                engine
+                    .ensure_automation_scheduler(key, project_path, handshake)
+                    .await;
+            });
+        })
     }
 
     async fn start_automation_scheduler(
@@ -1561,6 +1597,35 @@ impl DaemonEngine {
 #[cfg(unix)]
 async fn run_automation_scheduler_loop(project_path: PathBuf, handshake: DaemonHandshake) {
     loop {
+        match Box::pin(automation_scheduler_has_work_for_project(
+            &project_path,
+            &handshake,
+        ))
+        .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                log_daemon_event(
+                    "scheduler_exit",
+                    &[
+                        ("project", project_path.display().to_string()),
+                        ("reason", "not_configured".to_string()),
+                    ],
+                );
+                break;
+            }
+            Err(e) => {
+                log_daemon_event(
+                    "scheduler_project_open",
+                    &[
+                        ("project", project_path.display().to_string()),
+                        ("outcome", "error".to_string()),
+                        ("error", e.to_string()),
+                    ],
+                );
+                break;
+            }
+        }
         log_daemon_event(
             "scheduler_tick",
             &[
@@ -1592,6 +1657,16 @@ async fn run_automation_scheduler_loop(project_path: PathBuf, handshake: DaemonH
         );
         tokio::time::sleep(Duration::from_secs(tick_secs)).await;
     }
+}
+
+#[cfg(unix)]
+async fn automation_scheduler_has_work_for_project(
+    project_path: &Path,
+    handshake: &DaemonHandshake,
+) -> Result<bool> {
+    let cg = open_existing_project_with_options(project_path, handshake.open_options()).await?;
+    let config = effective_automation_config_for_project(&cg, &handshake.client_identity).await?;
+    Ok(automation_scheduler_has_work(&cg, &config).await)
 }
 
 #[cfg(unix)]
@@ -1822,16 +1897,6 @@ async fn effective_automation_config_for_project(
     let global = user_config_for_client(client_identity).automation;
     let project = load_project_config(&cg.store_layout().dashboard_root).await?;
     effective_config(&global, project.as_ref())
-}
-
-#[cfg(unix)]
-async fn automation_scheduler_configured_for_project(
-    project_path: &Path,
-    handshake: &DaemonHandshake,
-) -> Result<bool> {
-    let cg = open_existing_project_with_options(project_path, handshake.open_options()).await?;
-    let config = effective_automation_config_for_project(&cg, &handshake.client_identity).await?;
-    Ok(automation_scheduler_has_work(&cg, &config).await)
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -945,6 +945,90 @@ async fn automation_scheduler_tick_secs_loads_dashboard_project_config() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn daemon_ensure_scheduler_skips_before_project_has_configured_work() {
+    let dir = TempDir::new().expect("temp dir");
+    let project = dir.path().canonicalize().expect("canonical temp dir");
+    let client_identity = test_client_identity_for(project.join("profile"));
+    std::fs::create_dir_all(project.join("src")).expect("src dir");
+    std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
+    let handshake = DaemonHandshake {
+        project_path: Some(project.clone()),
+        client_identity,
+        ..test_handshake_defaults()
+    };
+    let engine = super::DaemonEngine::default();
+    let key = super::ProjectServerKey::from_handshake(project.clone(), &handshake);
+
+    engine
+        .ensure_automation_scheduler(key.clone(), project, handshake)
+        .await;
+
+    let schedulers = engine.automation_schedulers.lock().await;
+    assert!(!schedulers.contains_key(&key));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
+    use crate::automation::config::{
+        save_project_config, AutomationBackend, AutomationConfigPatch, AutomationTaskPatch,
+    };
+
+    let dir = TempDir::new().expect("temp dir");
+    let project = dir.path().canonicalize().expect("canonical temp dir");
+    let client_identity = test_client_identity_for(project.join("profile"));
+    std::fs::create_dir_all(project.join("src")).expect("src dir");
+    std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
+    let cg = crate::tracedecay::TraceDecay::init_with_options(
+        &project,
+        crate::tracedecay::TraceDecayOpenOptions {
+            profile_root: Some(client_identity.profile_root.clone()),
+            global_db_path: Some(client_identity.global_db_path.clone()),
+        },
+    )
+    .await
+    .expect("project init");
+    let handshake = DaemonHandshake {
+        project_path: Some(project.clone()),
+        client_identity,
+        ..test_handshake_defaults()
+    };
+    let engine = super::DaemonEngine::default();
+    let key = super::ProjectServerKey::from_handshake(project.clone(), &handshake);
+
+    engine
+        .ensure_automation_scheduler(key.clone(), project.clone(), handshake.clone())
+        .await;
+    assert!(!engine.automation_schedulers.lock().await.contains_key(&key));
+
+    save_project_config(
+        &cg.store_layout().dashboard_root,
+        &AutomationConfigPatch {
+            enabled: Some(true),
+            backend: Some(AutomationBackend::CodexAppServer),
+            memory_curator: AutomationTaskPatch {
+                enabled: Some(true),
+                schedule: Some(Some("every:5m".to_string())),
+                ..AutomationTaskPatch::default()
+            },
+            ..AutomationConfigPatch::default()
+        },
+    )
+    .await
+    .expect("save automation config");
+
+    engine
+        .ensure_automation_scheduler(key.clone(), project, handshake)
+        .await;
+
+    let schedulers = engine.automation_schedulers.lock().await;
+    assert!(schedulers.contains_key(&key));
+    drop(schedulers);
+    engine.shutdown_all().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn automation_scheduler_tick_respects_pause_control_without_backend_call() {
     use crate::automation::config::{
         save_project_config, AutomationBackend, AutomationConfigPatch, AutomationTaskPatch,

--- a/src/dashboard/automation_config_api.rs
+++ b/src/dashboard/automation_config_api.rs
@@ -36,6 +36,7 @@ pub(crate) async fn patch_config(
     save_project_config(&state.dashboard_root, &project)
         .await
         .map_err(|err| internal_error(&err))?;
+    state.reconcile_automation_scheduler();
     Ok(Json(config_payload_value(
         &state,
         &global,
@@ -49,6 +50,7 @@ pub(crate) async fn reset_config(State(state): State<DashboardState>) -> ApiResu
     clear_project_config(&state.dashboard_root)
         .await
         .map_err(|err| internal_error(&err))?;
+    state.reconcile_automation_scheduler();
     config_payload(&state, &global, None)
 }
 

--- a/src/dashboard/automation_jobs_api.rs
+++ b/src/dashboard/automation_jobs_api.rs
@@ -130,6 +130,7 @@ pub(crate) async fn create(
     save_jobs(&state.dashboard_root, &jobs)
         .await
         .map_err(|err| internal_error(&err))?;
+    state.reconcile_automation_scheduler();
     Ok(Json(json!({ "job": job })))
 }
 
@@ -187,6 +188,7 @@ pub(crate) async fn update(
     save_jobs(&state.dashboard_root, &jobs)
         .await
         .map_err(|err| internal_error(&err))?;
+    state.reconcile_automation_scheduler();
     Ok(Json(json!({ "job": updated })))
 }
 
@@ -205,6 +207,7 @@ pub(crate) async fn delete(
     save_jobs(&state.dashboard_root, &jobs)
         .await
         .map_err(|err| internal_error(&err))?;
+    state.reconcile_automation_scheduler();
     Ok(Json(json!({ "deleted": job_id })))
 }
 

--- a/src/dashboard/automation_scheduler_api.rs
+++ b/src/dashboard/automation_scheduler_api.rs
@@ -59,9 +59,8 @@ async fn scheduler_status_payload(state: &DashboardState) -> ApiResult {
     let records = load_run_records(&state.dashboard_root, 200)
         .await
         .map_err(|err| internal_error(&err))?;
-    // Pending-review badge counts (additive; Hermes parity R5). Best-effort
-    // zero when the profile root is unavailable, mirroring the count helper's
-    // treatment of missing stores.
+    // Additive pending-output counts. Fact proposals stay telemetry/backcompat;
+    // pending skills are the only human-review badge input.
     let pending = match crate::storage::default_profile_root() {
         Ok(profile_root) => {
             count_pending_automation_output(&state.dashboard_root, &profile_root).await

--- a/src/dashboard/memory_api.rs
+++ b/src/dashboard/memory_api.rs
@@ -421,7 +421,7 @@ pub(crate) async fn curation_runs(
 }
 
 /// `GET /api/plugins/holographic/fact-proposals` — session-reflector fact
-/// proposals awaiting approval, plus historical applied/rejected decisions.
+/// proposal telemetry, plus historical applied/rejected decisions.
 pub(crate) async fn fact_proposals(
     State(state): State<DashboardState>,
     JsonQuery(params): JsonQuery<FactProposalParams>,
@@ -455,7 +455,7 @@ pub(crate) async fn fact_proposals(
 }
 
 /// `POST /api/plugins/holographic/fact-proposals/{proposal_id}/apply` —
-/// approval-gated session-reflector fact write.
+/// applies a stored session-reflector fact proposal.
 pub(crate) async fn fact_proposal_apply(
     State(state): State<DashboardState>,
     Path(proposal_id): Path<String>,

--- a/src/dashboard/memory_curate.rs
+++ b/src/dashboard/memory_curate.rs
@@ -143,6 +143,7 @@ async fn cli_state(cg: &TraceDecay) -> DashboardState {
             crate::diagnostics::lsp::settings::CodeDiagnosticsSettings::default(),
         ))),
         code_diagnostics_backfill_started: Arc::new(AtomicBool::new(false)),
+        automation_scheduler_reconciler: None,
     }
 }
 

--- a/src/dashboard/memory_curate.rs
+++ b/src/dashboard/memory_curate.rs
@@ -133,6 +133,7 @@ async fn cli_state(cg: &TraceDecay) -> DashboardState {
         project_root: cg.project_root().to_path_buf(),
         storage_mode: storage_mode_label(&store_layout.storage_mode).to_string(),
         store_root: store_layout.data_root.clone(),
+        config_path: store_layout.config_path.clone(),
         dashboard_root: store_layout.dashboard_root.clone(),
         curate_preview: Arc::new(RwLock::new(None)),
         curation_activity: Arc::new(RwLock::new(Vec::new())),

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -77,6 +77,7 @@ use crate::tracedecay::TraceDecay;
 /// Default port for `tracedecay dashboard` (chosen to avoid common dev-server
 /// defaults; override with `--port`).
 pub const DEFAULT_PORT: u16 = 7341;
+pub(crate) type AutomationSchedulerReconciler = Arc<dyn Fn() + Send + Sync + 'static>;
 
 pub(crate) type CuratePreviewFingerprint = (i64, i64, i64, i64);
 
@@ -121,10 +122,7 @@ pub(crate) struct DashboardState {
     pub(crate) storage_mode: String,
     /// Resolved active project store root.
     pub(crate) store_root: PathBuf,
-    /// Identity-resolved `config.json` path for this project's store. Derived
-    /// from the resolved store layout (not the path-hash `get_config_path`), so
-    /// settings read/write hit the store the dashboard actually serves — e.g.
-    /// after the repo directory was renamed on disk.
+    /// Resolved `config.json` path for the active project store.
     pub(crate) config_path: PathBuf,
     /// Resolved dashboard sidecar root inside the active project store.
     pub(crate) dashboard_root: PathBuf,
@@ -141,6 +139,15 @@ pub(crate) struct DashboardState {
     /// Ensures the dashboard-opened idle backfill pass is scheduled once per
     /// dashboard server lifetime.
     pub(crate) code_diagnostics_backfill_started: Arc<AtomicBool>,
+    pub(crate) automation_scheduler_reconciler: Option<AutomationSchedulerReconciler>,
+}
+
+impl DashboardState {
+    pub(crate) fn reconcile_automation_scheduler(&self) {
+        if let Some(reconcile) = &self.automation_scheduler_reconciler {
+            reconcile();
+        }
+    }
 }
 
 /// The LCM session store the dashboard will serve.
@@ -249,6 +256,7 @@ async fn build_state_inner(
     cg: &TraceDecay,
     repair_memory_on_startup: bool,
     warm_token_counts: bool,
+    automation_scheduler_reconciler: Option<AutomationSchedulerReconciler>,
 ) -> DashboardState {
     let (mem_conn, mem_db_path) = resolve_project_memory_store(cg).await;
     let lcm = resolve_lcm_store(cg).await;
@@ -289,6 +297,7 @@ async fn build_state_inner(
         token_counts: Arc::new(token_count::TokenCountCache::new()),
         code_diagnostics: Arc::new(RwLock::new(code_diagnostics)),
         code_diagnostics_backfill_started: Arc::new(AtomicBool::new(false)),
+        automation_scheduler_reconciler,
     };
     if repair_memory_on_startup {
         if let Err(err) = memory_api::repair_derived_memory(&state).await {
@@ -305,14 +314,22 @@ async fn build_state_inner(
 
 /// Builds the dashboard state shared by the CLI `run` path and the
 /// `tracedecay_dashboard` MCP tool.
+#[allow(dead_code)]
 pub(crate) async fn build_state(cg: &TraceDecay) -> DashboardState {
-    build_state_inner(cg, true, true).await
+    build_state_inner(cg, true, true, None).await
+}
+
+pub(crate) async fn build_state_with_automation_reconciler(
+    cg: &TraceDecay,
+    automation_scheduler_reconciler: Option<AutomationSchedulerReconciler>,
+) -> DashboardState {
+    build_state_inner(cg, true, true, automation_scheduler_reconciler).await
 }
 
 /// Builds a lightweight cached state for a non-active project selected from the
 /// dashboard project picker.
 pub(crate) async fn build_selected_project_state(cg: &TraceDecay) -> DashboardState {
-    build_state_inner(cg, false, false).await
+    build_state_inner(cg, false, false, None).await
 }
 
 /// Detached catch-up ingest for transcript sources (Claude, Codex, Vibe,
@@ -421,6 +438,7 @@ where
         cg,
         options.repair_memory_on_startup,
         options.warm_token_counts,
+        None,
     )
     .await;
     if options.start_session_catch_up && state.lcm_scope != "global" {

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -121,6 +121,11 @@ pub(crate) struct DashboardState {
     pub(crate) storage_mode: String,
     /// Resolved active project store root.
     pub(crate) store_root: PathBuf,
+    /// Identity-resolved `config.json` path for this project's store. Derived
+    /// from the resolved store layout (not the path-hash `get_config_path`), so
+    /// settings read/write hit the store the dashboard actually serves — e.g.
+    /// after the repo directory was renamed on disk.
+    pub(crate) config_path: PathBuf,
     /// Resolved dashboard sidecar root inside the active project store.
     pub(crate) dashboard_root: PathBuf,
     /// Last saved dry-run curation preview (shared across all clones of the state).
@@ -251,6 +256,7 @@ async fn build_state_inner(
     // survives server restarts (staleness is recomputed on read anyway).
     let dashboard_root = cg.store_layout().dashboard_root.clone();
     let store_root = cg.store_layout().data_root.clone();
+    let config_path = cg.store_layout().config_path.clone();
     let storage_mode = storage_mode_label(&cg.store_layout().storage_mode).to_string();
     let persisted_preview = curate_preview_store::load(&dashboard_root).await;
     let code_diagnostics_settings = lsp::settings::load_settings(&dashboard_root)
@@ -276,6 +282,7 @@ async fn build_state_inner(
         project_root: cg.project_root().to_path_buf(),
         storage_mode,
         store_root,
+        config_path,
         dashboard_root,
         curate_preview: Arc::new(RwLock::new(persisted_preview)),
         curation_activity: Arc::new(RwLock::new(Vec::new())),

--- a/src/dashboard/settings_api.rs
+++ b/src/dashboard/settings_api.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use super::util::{http_detail, JsonError};
 use super::DashboardState;
 use crate::automation::config as automation_config;
-use crate::config::{load_config, save_config, TraceDecayConfig};
+use crate::config::{load_config_from_path, save_config_to_path, TraceDecayConfig};
 use crate::user_config::{self, UserConfig};
 
 type ApiResult = std::result::Result<Json<Value>, JsonError>;
@@ -72,7 +72,8 @@ pub(crate) async fn patch_project_settings(
         return Err(validation_failed(&errors));
     }
 
-    let current = load_config(&state.project_root).map_err(|err| internal_error(&err))?;
+    let current = load_config_from_path(&state.project_root, &state.config_path)
+        .map_err(|err| internal_error(&err))?;
     let updated = TraceDecayConfig {
         include: patch.include.unwrap_or_else(|| current.include.clone()),
         exclude: patch.exclude.unwrap_or_else(|| current.exclude.clone()),
@@ -86,7 +87,7 @@ pub(crate) async fn patch_project_settings(
     };
     let resync_recommended = updated != current;
     if resync_recommended {
-        save_config(&state.project_root, &updated).map_err(|err| internal_error(&err))?;
+        save_config_to_path(&state.config_path, &updated).map_err(|err| internal_error(&err))?;
     }
 
     let mut payload = settings_payload(&state).await?;
@@ -147,8 +148,9 @@ pub(crate) async fn patch_user_settings(
 }
 
 async fn settings_payload(state: &DashboardState) -> std::result::Result<Value, JsonError> {
-    let project_config = load_config(&state.project_root).map_err(|err| internal_error(&err))?;
-    let project_config_path = crate::config::get_config_path(&state.project_root);
+    let project_config = load_config_from_path(&state.project_root, &state.config_path)
+        .map_err(|err| internal_error(&err))?;
+    let project_config_path = state.config_path.clone();
     let user = UserConfig::load();
     let user_config_path = user_config::config_path()
         .map(|path| path.display().to_string())

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -12,7 +12,7 @@ use crate::storage::StoreLayout;
 use crate::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 pub mod heal;
-mod registry_drift;
+pub(crate) mod registry_drift;
 
 /// Runs a comprehensive health check of the tracedecay installation.
 pub async fn run_doctor(agent_filter: Option<&str>) {

--- a/src/doctor/heal.rs
+++ b/src/doctor/heal.rs
@@ -44,6 +44,9 @@ pub struct HealthPassReport {
     pub quarantined_branch_meta: Vec<BranchMetaQuarantine>,
     /// `None` when the global DB could not be opened, so the GC never ran.
     pub purged_temp_registry_rows: Option<usize>,
+    /// Stale store manifests (and sibling configs) whose project root was
+    /// reconciled to the registry canonical path after a project rename.
+    pub reconciled_store_roots: Vec<super::registry_drift::ReconciledStoreRoot>,
     pub remaining_findings: Vec<String>,
     pub warnings: Vec<String>,
 }
@@ -93,6 +96,15 @@ async fn compute_health_pass_report(profile_root: &Path) -> HealthPassReport {
     let (purged, purged_ids) = gc_stale_temp_registry_rows(&global_db, &projects).await;
     report.purged_temp_registry_rows = Some(purged);
 
+    // Reconcile stale store manifest / config roots to the registry canonical
+    // path (durable half of the project-rename self-heal). Runs before
+    // collect_remaining_findings so any healed drift drops out of the
+    // report-only remaining-findings count.
+    let (reconciled, reconcile_warnings) =
+        super::registry_drift::reconcile_drifted_store_roots(&global_db, profile_root).await;
+    report.reconciled_store_roots = reconciled;
+    report.warnings.extend(reconcile_warnings);
+
     let (findings, warnings) =
         collect_remaining_findings(&global_db, profile_root, &projects, &purged_ids).await;
     report.remaining_findings = findings;
@@ -120,6 +132,21 @@ fn render_health_pass_report(report: &HealthPassReport) {
             eprintln!("  \x1b[32m✔\x1b[0m Purged {purged} stale temp-root registry row(s)");
         }
         None => {}
+    }
+
+    if report.reconciled_store_roots.is_empty() {
+        eprintln!("  \x1b[32m✔\x1b[0m No stale store manifest roots to reconcile");
+    } else {
+        eprintln!(
+            "  \x1b[32m✔\x1b[0m Reconciled {} stale store manifest root(s):",
+            report.reconciled_store_roots.len()
+        );
+        for reconciled in &report.reconciled_store_roots {
+            eprintln!("      • {}", reconciled.manifest_path.display());
+            if let Some(config_path) = &reconciled.config_path {
+                eprintln!("        (config: {})", config_path.display());
+            }
+        }
     }
 
     if report.remaining_findings.is_empty() {

--- a/src/doctor/heal.rs
+++ b/src/doctor/heal.rs
@@ -44,8 +44,7 @@ pub struct HealthPassReport {
     pub quarantined_branch_meta: Vec<BranchMetaQuarantine>,
     /// `None` when the global DB could not be opened, so the GC never ran.
     pub purged_temp_registry_rows: Option<usize>,
-    /// Stale store manifests (and sibling configs) whose project root was
-    /// reconciled to the registry canonical path after a project rename.
+    /// Stale store manifests reconciled to the registry canonical path.
     pub reconciled_store_roots: Vec<super::registry_drift::ReconciledStoreRoot>,
     pub remaining_findings: Vec<String>,
     pub warnings: Vec<String>,
@@ -96,17 +95,23 @@ async fn compute_health_pass_report(profile_root: &Path) -> HealthPassReport {
     let (purged, purged_ids) = gc_stale_temp_registry_rows(&global_db, &projects).await;
     report.purged_temp_registry_rows = Some(purged);
 
-    // Reconcile stale store manifest / config roots to the registry canonical
-    // path (durable half of the project-rename self-heal). Runs before
-    // collect_remaining_findings so any healed drift drops out of the
-    // report-only remaining-findings count.
+    let registry_drift =
+        super::registry_drift::registry_drift_findings(&global_db, profile_root).await;
     let (reconciled, reconcile_warnings) =
-        super::registry_drift::reconcile_drifted_store_roots(&global_db, profile_root).await;
+        super::registry_drift::reconcile_drifted_store_roots_from_findings(&registry_drift);
+    let remaining_registry_drift_count =
+        count_remaining_registry_drift(&registry_drift, &reconciled);
     report.reconciled_store_roots = reconciled;
     report.warnings.extend(reconcile_warnings);
 
-    let (findings, warnings) =
-        collect_remaining_findings(&global_db, profile_root, &projects, &purged_ids).await;
+    let (findings, warnings) = collect_remaining_findings(
+        &global_db,
+        profile_root,
+        &projects,
+        &purged_ids,
+        remaining_registry_drift_count,
+    )
+    .await;
     report.remaining_findings = findings;
     report.warnings.extend(warnings);
     report
@@ -263,6 +268,7 @@ async fn collect_remaining_findings(
     profile_root: &Path,
     projects: &[CodeProjectRecord],
     purged_ids: &[String],
+    remaining_registry_drift_count: usize,
 ) -> (Vec<String>, Vec<String>) {
     let mut findings = Vec::new();
     let project_paths = global_db.list_project_paths().await;
@@ -285,14 +291,28 @@ async fn collect_remaining_findings(
         ));
     }
 
-    let drift = super::registry_drift::registry_drift_findings(global_db, profile_root).await;
-    if !drift.is_empty() {
+    if remaining_registry_drift_count > 0 {
         findings.push(format!(
-            "{} registry/store manifest identity drift finding(s)",
-            drift.len()
+            "{remaining_registry_drift_count} registry/store manifest identity drift finding(s)"
         ));
     }
     (findings, warnings)
+}
+
+fn count_remaining_registry_drift(
+    drift: &[super::registry_drift::RegistryDriftFinding],
+    reconciled: &[super::registry_drift::ReconciledStoreRoot],
+) -> usize {
+    drift
+        .iter()
+        .filter(|finding| {
+            finding.field != "project_root"
+                || !reconciled.iter().any(|entry| {
+                    entry.store_id == finding.store_id
+                        && entry.manifest_path == finding.manifest_path
+                })
+        })
+        .count()
 }
 
 #[cfg(test)]

--- a/src/doctor/registry_drift.rs
+++ b/src/doctor/registry_drift.rs
@@ -326,6 +326,13 @@ mod tests {
             .root_dir
     }
 
+    fn comparable_path(path: &Path) -> String {
+        let text = path.to_string_lossy();
+        text.strip_prefix(r"\\?\")
+            .unwrap_or(&text)
+            .replace('\\', "/")
+    }
+
     #[tokio::test]
     async fn detection_does_not_mutate() {
         let fx = build_fixture().await;
@@ -402,8 +409,8 @@ mod tests {
         );
         assert_eq!(reconciled[0].store_id, STORE_ID);
         assert_eq!(
-            reconciled[0].manifest_path,
-            fx.manifest_path.canonicalize().unwrap()
+            comparable_path(&reconciled[0].manifest_path),
+            comparable_path(&fx.manifest_path.canonicalize().unwrap())
         );
         assert_eq!(
             reconciled[0].config_path, None,

--- a/src/doctor/registry_drift.rs
+++ b/src/doctor/registry_drift.rs
@@ -8,6 +8,7 @@ pub(super) struct RegistryDriftFinding {
     pub(super) registry_value: String,
     pub(super) manifest_value: String,
     pub(super) manifest_path: PathBuf,
+    registry_path: Option<PathBuf>,
 }
 
 pub(super) async fn registry_drift_findings(
@@ -43,19 +44,21 @@ pub(super) async fn registry_drift_findings(
                     registry_value: store.project_id.clone(),
                     manifest_value: manifest_project_id,
                     manifest_path: manifest_path.clone(),
+                    registry_path: None,
                 });
             }
 
-            let registry_project_root = comparable_path(Path::new(&project.canonical_root));
-            let manifest_project_root = comparable_path(&manifest.project_root);
+            let registry_project_root = PathBuf::from(&project.canonical_root);
+            let manifest_project_root = manifest.project_root.clone();
             if registry_project_root != manifest_project_root {
                 findings.push(RegistryDriftFinding {
                     project_id: project.project_id.clone(),
                     store_id: store.store_id.clone(),
                     field: "project_root",
-                    registry_value: registry_project_root,
-                    manifest_value: manifest_project_root,
+                    registry_value: project.canonical_root.clone(),
+                    manifest_value: manifest_project_root.display().to_string(),
                     manifest_path,
+                    registry_path: Some(registry_project_root),
                 });
             }
         }
@@ -63,60 +66,49 @@ pub(super) async fn registry_drift_findings(
     findings
 }
 
-/// One reconciled store: the stale roots that were rewritten to the registry
-/// canonical path during the heal pass.
+/// One reconciled store root rewritten during the heal pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReconciledStoreRoot {
     pub store_id: String,
-    /// The `store_manifest.json` whose `project_root` was rewritten.
     pub manifest_path: PathBuf,
-    /// The sibling `config.json` whose `root_dir` was rewritten, when it was
-    /// also stale.
     pub config_path: Option<PathBuf>,
 }
 
-/// Reconciles stale `store_manifest.json` `project_root` (and the sibling
-/// `config.json` `root_dir`, when stale) to the registry canonical path.
-///
-/// This is the durable half of the project-rename self-heal: the `GlobalDb`
-/// registry already self-heals `canonical_root`/`display_root` to the current
-/// path on every open, but the on-disk store artifacts keep the old path. This
-/// runs ONLY in the on-demand doctor heal pass — never from resolution or
-/// registration — so it stays off the hot path.
-///
-/// Safety: a drift is healed only when the registry canonical root
-/// (`finding.registry_value`, already `comparable_path(canonical_root)`) still
-/// resolves to a path that exists on disk. That is precisely the "registry
-/// already binds the current path" precondition — after a rename the stale
-/// manifest path no longer exists while the registry canonical path does, so
-/// the existence check both proves the registry is authoritative and prevents
-/// inventing a path. Every I/O failure becomes a warning; nothing aborts.
-///
-/// Idempotent: once a manifest's `project_root` equals the canonical value the
-/// drift finding disappears, so a second pass finds nothing to do.
-pub(super) async fn reconcile_drifted_store_roots(
+#[cfg(test)]
+async fn reconcile_drifted_store_roots(
     global_db: &crate::global_db::GlobalDb,
     profile_root: &Path,
+) -> (Vec<ReconciledStoreRoot>, Vec<String>) {
+    let findings = registry_drift_findings(global_db, profile_root).await;
+    reconcile_drifted_store_roots_from_findings(&findings)
+}
+
+pub(super) fn reconcile_drifted_store_roots_from_findings(
+    findings: &[RegistryDriftFinding],
 ) -> (Vec<ReconciledStoreRoot>, Vec<String>) {
     let mut reconciled = Vec::new();
     let mut warnings = Vec::new();
 
-    for finding in registry_drift_findings(global_db, profile_root).await {
+    for finding in findings {
         if finding.field != "project_root" {
             continue;
         }
-        // SAFETY GATE: only heal when the registry canonical root exists on
-        // disk (the registry already binds the current path). Never invent a
-        // path; leave drift whose canonical root is missing as a report-only
-        // finding.
-        let canonical = Path::new(&finding.registry_value);
+        let Some(canonical) = finding.registry_path.as_deref() else {
+            continue;
+        };
         if !canonical.exists() {
             continue;
         }
 
-        match reconcile_one_store_root(&finding, canonical) {
-            Ok(Some(entry)) => reconciled.push(entry),
-            Ok(None) => {}
+        match reconcile_one_store_root(finding, canonical) {
+            Ok((entry, warning)) => {
+                if let Some(entry) = entry {
+                    reconciled.push(entry);
+                }
+                if let Some(warning) = warning {
+                    warnings.push(warning);
+                }
+            }
             Err(message) => warnings.push(message),
         }
     }
@@ -124,13 +116,10 @@ pub(super) async fn reconcile_drifted_store_roots(
     (reconciled, warnings)
 }
 
-/// Rewrites the manifest `project_root` (and sibling config `root_dir` if
-/// stale) for one drift finding. Returns `Ok(None)` when nothing needed
-/// rewriting (idempotent no-op).
 fn reconcile_one_store_root(
     finding: &RegistryDriftFinding,
     canonical: &Path,
-) -> std::result::Result<Option<ReconciledStoreRoot>, String> {
+) -> std::result::Result<(Option<ReconciledStoreRoot>, Option<String>), String> {
     let mut manifest =
         crate::storage::read_store_manifest(&finding.manifest_path).map_err(|e| {
             format!(
@@ -140,7 +129,7 @@ fn reconcile_one_store_root(
         })?;
 
     let mut manifest_rewritten = false;
-    if comparable_path(&manifest.project_root) != finding.registry_value {
+    if manifest.project_root != canonical {
         manifest.project_root = canonical.to_path_buf();
         crate::storage::write_store_manifest_to_path(&finding.manifest_path, &manifest).map_err(
             |e| {
@@ -153,51 +142,52 @@ fn reconcile_one_store_root(
         manifest_rewritten = true;
     }
 
-    // config.json is a sibling of store_manifest.json in the data_root. Heal
-    // its root_dir opportunistically when it is also stale — registry_drift
-    // does not emit a separate finding for it.
     let config_path = finding
         .manifest_path
         .parent()
         .map(|parent| parent.join(crate::config::CONFIG_FILENAME));
     let mut config_rewritten = None;
+    let mut warning = None;
     if let Some(config_path) = config_path {
         if config_path.is_file() {
-            match reconcile_config_root_dir(&config_path, canonical, &finding.registry_value) {
+            match reconcile_config_root_dir(&config_path, canonical) {
                 Ok(true) => config_rewritten = Some(config_path),
                 Ok(false) => {}
-                Err(message) => return Err(message),
+                Err(message) => {
+                    if manifest_rewritten {
+                        warning = Some(message);
+                    } else {
+                        return Err(message);
+                    }
+                }
             }
         }
     }
 
     if !manifest_rewritten && config_rewritten.is_none() {
-        return Ok(None);
+        return Ok((None, warning));
     }
 
-    Ok(Some(ReconciledStoreRoot {
-        store_id: finding.store_id.clone(),
-        manifest_path: finding.manifest_path.clone(),
-        config_path: config_rewritten,
-    }))
+    Ok((
+        Some(ReconciledStoreRoot {
+            store_id: finding.store_id.clone(),
+            manifest_path: finding.manifest_path.clone(),
+            config_path: config_rewritten,
+        }),
+        warning,
+    ))
 }
 
-/// Rewrites `config.json`'s `root_dir` to the canonical path when stale.
-/// Returns `Ok(true)` when it wrote, `Ok(false)` when already current.
 fn reconcile_config_root_dir(
     config_path: &Path,
     canonical: &Path,
-    canonical_spelling: &str,
 ) -> std::result::Result<bool, String> {
-    // `root_dir` is a free-form String; normalize both sides through
-    // comparable_path so an already-canonical (but differently spelled) value
-    // is treated as current and not needlessly rewritten.
     let mut config = crate::config::load_config_from_path(canonical, config_path)
         .map_err(|e| format!("could not read config '{}': {e}", config_path.display()))?;
-    if comparable_path(Path::new(&config.root_dir)) == canonical_spelling {
+    if Path::new(&config.root_dir) == canonical {
         return Ok(false);
     }
-    config.root_dir = canonical.to_string_lossy().to_string();
+    config.root_dir = canonical.display().to_string();
     crate::config::save_config_to_path(config_path, &config)
         .map_err(|e| format!("could not rewrite config '{}': {e}", config_path.display()))?;
     Ok(true)
@@ -242,13 +232,6 @@ fn resolve_registry_manifest_path(
     None
 }
 
-fn comparable_path(path: &Path) -> String {
-    path.canonicalize()
-        .unwrap_or_else(|_| path.to_path_buf())
-        .to_string_lossy()
-        .to_string()
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -269,18 +252,12 @@ mod tests {
         global_db: GlobalDb,
     }
 
-    /// Builds a profile with one profile-sharded store whose on-disk manifest
-    /// (and config) still point at a stale `stale_root`, while the registry
-    /// canonical root is `current_root` (a real directory that exists).
     async fn build_fixture() -> Fixture {
         let tmp = tempfile::TempDir::new().unwrap();
         let profile_root = tmp.path().join("profile");
         let current_root = tmp.path().join("current-name");
         let stale_root = tmp.path().join("old-name");
         std::fs::create_dir_all(&current_root).unwrap();
-        // stale_root is intentionally NOT created — after a rename the old
-        // path no longer exists on disk.
-
         let data_root = profile_root.join("stores").join(STORE_ID);
         std::fs::create_dir_all(&data_root).unwrap();
         let manifest_path = data_root.join(crate::storage::STORE_MANIFEST_FILENAME);
@@ -312,7 +289,6 @@ mod tests {
         let global_db = GlobalDb::open_at(&profile_root.join("global.db"))
             .await
             .unwrap();
-        // Registry already self-healed canonical_root to the current path.
         global_db
             .upsert_code_project(PROJECT_ID, &current_root, None, None, None)
             .await
@@ -354,9 +330,6 @@ mod tests {
             .root_dir
     }
 
-    // (a) Detection alone (the report-only path) never mutates the on-disk
-    //     files — the "dry-run" analog, since the heal pass has no separate
-    //     apply flag and running reconcile IS the apply.
     #[tokio::test]
     async fn detection_does_not_mutate() {
         let fx = build_fixture().await;
@@ -368,7 +341,6 @@ mod tests {
             .collect();
         assert_eq!(root_drift.len(), 1, "should detect project_root drift");
 
-        // No write happened: the manifest and config still hold the stale root.
         assert_eq!(manifest_root(&fx.manifest_path), fx.stale_root);
         assert_eq!(
             config_root_dir(&fx.config_path),
@@ -376,8 +348,6 @@ mod tests {
         );
     }
 
-    // (c) Applying the reconcile rewrites the manifest and config to the
-    //     registry canonical (current) path; (d) a second run is a no-op.
     #[tokio::test]
     async fn reconcile_rewrites_then_is_idempotent() {
         let fx = build_fixture().await;
@@ -393,14 +363,12 @@ mod tests {
             "stale config should be reconciled too"
         );
 
-        // Manifest + config now hold the canonical current path.
         assert_eq!(manifest_root(&fx.manifest_path), canonical);
         assert_eq!(
             config_root_dir(&fx.config_path),
             canonical.to_string_lossy()
         );
 
-        // Every other manifest field survived the surgical rewrite.
         let healed = crate::storage::read_store_manifest(&fx.manifest_path).unwrap();
         assert_eq!(healed.project_id.as_deref(), Some(PROJECT_ID));
         assert_eq!(
@@ -408,14 +376,12 @@ mod tests {
             PathBuf::from(crate::config::DB_FILENAME)
         );
 
-        // The drift finding is gone now that the manifest matches the registry.
         let post = registry_drift_findings(&fx.global_db, &fx.profile_root).await;
         assert!(
             post.iter().all(|f| f.field != "project_root"),
             "project_root drift should be resolved: {post:?}"
         );
 
-        // Second run: nothing left to heal.
         let (again, warnings) =
             reconcile_drifted_store_roots(&fx.global_db, &fx.profile_root).await;
         assert!(again.is_empty(), "second run must be a no-op: {again:?}");
@@ -425,13 +391,36 @@ mod tests {
         );
     }
 
-    // (b)/safety: when the registry canonical root does NOT exist on disk the
-    //     drift is left untouched — never invent a path.
+    #[tokio::test]
+    async fn manifest_reconcile_is_reported_when_config_rewrite_fails() {
+        let fx = build_fixture().await;
+        let canonical = fx.current_root.canonicalize().unwrap();
+        std::fs::write(&fx.config_path, "{ not json").unwrap();
+
+        let (reconciled, warnings) =
+            reconcile_drifted_store_roots(&fx.global_db, &fx.profile_root).await;
+        assert_eq!(
+            reconciled.len(),
+            1,
+            "manifest rewrite should still be reported"
+        );
+        assert_eq!(reconciled[0].store_id, STORE_ID);
+        assert_eq!(reconciled[0].manifest_path, fx.manifest_path);
+        assert_eq!(
+            reconciled[0].config_path, None,
+            "failed config rewrite must not be reported as reconciled"
+        );
+        assert_eq!(manifest_root(&fx.manifest_path), canonical);
+        assert_eq!(warnings.len(), 1, "config failure should still be surfaced");
+        assert!(
+            warnings[0].contains("could not read config"),
+            "unexpected warning: {warnings:?}"
+        );
+    }
+
     #[tokio::test]
     async fn missing_canonical_root_is_not_healed() {
         let fx = build_fixture().await;
-        // Remove the current root so the registry canonical path no longer
-        // exists; the safety gate must refuse to heal.
         std::fs::remove_dir_all(&fx.current_root).unwrap();
 
         let (reconciled, warnings) =
@@ -441,7 +430,6 @@ mod tests {
             warnings.is_empty(),
             "gate is silent, not a warning: {warnings:?}"
         );
-        // Manifest untouched.
         assert_eq!(manifest_root(&fx.manifest_path), fx.stale_root);
     }
 }

--- a/src/doctor/registry_drift.rs
+++ b/src/doctor/registry_drift.rs
@@ -8,6 +8,7 @@ pub(super) struct RegistryDriftFinding {
     pub(super) registry_value: String,
     pub(super) manifest_value: String,
     pub(super) manifest_path: PathBuf,
+    manifest: crate::storage::StoreManifest,
     registry_path: Option<PathBuf>,
 }
 
@@ -44,6 +45,7 @@ pub(super) async fn registry_drift_findings(
                     registry_value: store.project_id.clone(),
                     manifest_value: manifest_project_id,
                     manifest_path: manifest_path.clone(),
+                    manifest: manifest.clone(),
                     registry_path: None,
                 });
             }
@@ -58,6 +60,7 @@ pub(super) async fn registry_drift_findings(
                     registry_value: project.canonical_root.clone(),
                     manifest_value: manifest_project_root.display().to_string(),
                     manifest_path,
+                    manifest,
                     registry_path: Some(registry_project_root),
                 });
             }
@@ -119,13 +122,7 @@ fn reconcile_one_store_root(
     finding: &RegistryDriftFinding,
     canonical: &Path,
 ) -> std::result::Result<(Option<ReconciledStoreRoot>, Option<String>), String> {
-    let mut manifest =
-        crate::storage::read_store_manifest(&finding.manifest_path).map_err(|e| {
-            format!(
-                "could not read store manifest '{}': {e}",
-                finding.manifest_path.display()
-            )
-        })?;
+    let mut manifest = finding.manifest.clone();
 
     let mut manifest_rewritten = false;
     if manifest.project_root != canonical {
@@ -236,7 +233,7 @@ fn resolve_registry_manifest_path(
 mod tests {
     use super::*;
     use crate::global_db::{GlobalDb, StoreInstanceUpsert};
-    use crate::storage::{STORE_MANIFEST_SCHEMA_VERSION, StorageMode, StoreKind, StoreManifest};
+    use crate::storage::{StorageMode, StoreKind, StoreManifest, STORE_MANIFEST_SCHEMA_VERSION};
 
     const STORE_ID: &str = "store_reconcile_test";
     const PROJECT_ID: &str = "proj_reconcile_test";

--- a/src/doctor/registry_drift.rs
+++ b/src/doctor/registry_drift.rs
@@ -66,7 +66,6 @@ pub(super) async fn registry_drift_findings(
     findings
 }
 
-/// One reconciled store root rewritten during the heal pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReconciledStoreRoot {
     pub store_id: String,
@@ -237,7 +236,7 @@ fn resolve_registry_manifest_path(
 mod tests {
     use super::*;
     use crate::global_db::{GlobalDb, StoreInstanceUpsert};
-    use crate::storage::{StorageMode, StoreKind, StoreManifest, STORE_MANIFEST_SCHEMA_VERSION};
+    use crate::storage::{STORE_MANIFEST_SCHEMA_VERSION, StorageMode, StoreKind, StoreManifest};
 
     const STORE_ID: &str = "store_reconcile_test";
     const PROJECT_ID: &str = "proj_reconcile_test";
@@ -405,7 +404,10 @@ mod tests {
             "manifest rewrite should still be reported"
         );
         assert_eq!(reconciled[0].store_id, STORE_ID);
-        assert_eq!(reconciled[0].manifest_path, fx.manifest_path);
+        assert_eq!(
+            reconciled[0].manifest_path,
+            fx.manifest_path.canonicalize().unwrap()
+        );
         assert_eq!(
             reconciled[0].config_path, None,
             "failed config rewrite must not be reported as reconciled"

--- a/src/doctor/registry_drift.rs
+++ b/src/doctor/registry_drift.rs
@@ -63,6 +63,146 @@ pub(super) async fn registry_drift_findings(
     findings
 }
 
+/// One reconciled store: the stale roots that were rewritten to the registry
+/// canonical path during the heal pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconciledStoreRoot {
+    pub store_id: String,
+    /// The `store_manifest.json` whose `project_root` was rewritten.
+    pub manifest_path: PathBuf,
+    /// The sibling `config.json` whose `root_dir` was rewritten, when it was
+    /// also stale.
+    pub config_path: Option<PathBuf>,
+}
+
+/// Reconciles stale `store_manifest.json` `project_root` (and the sibling
+/// `config.json` `root_dir`, when stale) to the registry canonical path.
+///
+/// This is the durable half of the project-rename self-heal: the `GlobalDb`
+/// registry already self-heals `canonical_root`/`display_root` to the current
+/// path on every open, but the on-disk store artifacts keep the old path. This
+/// runs ONLY in the on-demand doctor heal pass — never from resolution or
+/// registration — so it stays off the hot path.
+///
+/// Safety: a drift is healed only when the registry canonical root
+/// (`finding.registry_value`, already `comparable_path(canonical_root)`) still
+/// resolves to a path that exists on disk. That is precisely the "registry
+/// already binds the current path" precondition — after a rename the stale
+/// manifest path no longer exists while the registry canonical path does, so
+/// the existence check both proves the registry is authoritative and prevents
+/// inventing a path. Every I/O failure becomes a warning; nothing aborts.
+///
+/// Idempotent: once a manifest's `project_root` equals the canonical value the
+/// drift finding disappears, so a second pass finds nothing to do.
+pub(super) async fn reconcile_drifted_store_roots(
+    global_db: &crate::global_db::GlobalDb,
+    profile_root: &Path,
+) -> (Vec<ReconciledStoreRoot>, Vec<String>) {
+    let mut reconciled = Vec::new();
+    let mut warnings = Vec::new();
+
+    for finding in registry_drift_findings(global_db, profile_root).await {
+        if finding.field != "project_root" {
+            continue;
+        }
+        // SAFETY GATE: only heal when the registry canonical root exists on
+        // disk (the registry already binds the current path). Never invent a
+        // path; leave drift whose canonical root is missing as a report-only
+        // finding.
+        let canonical = Path::new(&finding.registry_value);
+        if !canonical.exists() {
+            continue;
+        }
+
+        match reconcile_one_store_root(&finding, canonical) {
+            Ok(Some(entry)) => reconciled.push(entry),
+            Ok(None) => {}
+            Err(message) => warnings.push(message),
+        }
+    }
+
+    (reconciled, warnings)
+}
+
+/// Rewrites the manifest `project_root` (and sibling config `root_dir` if
+/// stale) for one drift finding. Returns `Ok(None)` when nothing needed
+/// rewriting (idempotent no-op).
+fn reconcile_one_store_root(
+    finding: &RegistryDriftFinding,
+    canonical: &Path,
+) -> std::result::Result<Option<ReconciledStoreRoot>, String> {
+    let mut manifest =
+        crate::storage::read_store_manifest(&finding.manifest_path).map_err(|e| {
+            format!(
+                "could not read store manifest '{}': {e}",
+                finding.manifest_path.display()
+            )
+        })?;
+
+    let mut manifest_rewritten = false;
+    if comparable_path(&manifest.project_root) != finding.registry_value {
+        manifest.project_root = canonical.to_path_buf();
+        crate::storage::write_store_manifest_to_path(&finding.manifest_path, &manifest).map_err(
+            |e| {
+                format!(
+                    "could not rewrite store manifest '{}': {e}",
+                    finding.manifest_path.display()
+                )
+            },
+        )?;
+        manifest_rewritten = true;
+    }
+
+    // config.json is a sibling of store_manifest.json in the data_root. Heal
+    // its root_dir opportunistically when it is also stale — registry_drift
+    // does not emit a separate finding for it.
+    let config_path = finding
+        .manifest_path
+        .parent()
+        .map(|parent| parent.join(crate::config::CONFIG_FILENAME));
+    let mut config_rewritten = None;
+    if let Some(config_path) = config_path {
+        if config_path.is_file() {
+            match reconcile_config_root_dir(&config_path, canonical, &finding.registry_value) {
+                Ok(true) => config_rewritten = Some(config_path),
+                Ok(false) => {}
+                Err(message) => return Err(message),
+            }
+        }
+    }
+
+    if !manifest_rewritten && config_rewritten.is_none() {
+        return Ok(None);
+    }
+
+    Ok(Some(ReconciledStoreRoot {
+        store_id: finding.store_id.clone(),
+        manifest_path: finding.manifest_path.clone(),
+        config_path: config_rewritten,
+    }))
+}
+
+/// Rewrites `config.json`'s `root_dir` to the canonical path when stale.
+/// Returns `Ok(true)` when it wrote, `Ok(false)` when already current.
+fn reconcile_config_root_dir(
+    config_path: &Path,
+    canonical: &Path,
+    canonical_spelling: &str,
+) -> std::result::Result<bool, String> {
+    // `root_dir` is a free-form String; normalize both sides through
+    // comparable_path so an already-canonical (but differently spelled) value
+    // is treated as current and not needlessly rewritten.
+    let mut config = crate::config::load_config_from_path(canonical, config_path)
+        .map_err(|e| format!("could not read config '{}': {e}", config_path.display()))?;
+    if comparable_path(Path::new(&config.root_dir)) == canonical_spelling {
+        return Ok(false);
+    }
+    config.root_dir = canonical.to_string_lossy().to_string();
+    crate::config::save_config_to_path(config_path, &config)
+        .map_err(|e| format!("could not rewrite config '{}': {e}", config_path.display()))?;
+    Ok(true)
+}
+
 fn resolve_registry_manifest_path(
     profile_root: &Path,
     store: &crate::global_db::StoreInstanceRecord,
@@ -107,4 +247,201 @@ fn comparable_path(path: &Path) -> String {
         .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()
         .to_string()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::global_db::{GlobalDb, StoreInstanceUpsert};
+    use crate::storage::{StorageMode, StoreKind, StoreManifest, STORE_MANIFEST_SCHEMA_VERSION};
+
+    const STORE_ID: &str = "store_reconcile_test";
+    const PROJECT_ID: &str = "proj_reconcile_test";
+
+    struct Fixture {
+        _tmp: tempfile::TempDir,
+        profile_root: PathBuf,
+        current_root: PathBuf,
+        stale_root: PathBuf,
+        manifest_path: PathBuf,
+        config_path: PathBuf,
+        global_db: GlobalDb,
+    }
+
+    /// Builds a profile with one profile-sharded store whose on-disk manifest
+    /// (and config) still point at a stale `stale_root`, while the registry
+    /// canonical root is `current_root` (a real directory that exists).
+    async fn build_fixture() -> Fixture {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let profile_root = tmp.path().join("profile");
+        let current_root = tmp.path().join("current-name");
+        let stale_root = tmp.path().join("old-name");
+        std::fs::create_dir_all(&current_root).unwrap();
+        // stale_root is intentionally NOT created — after a rename the old
+        // path no longer exists on disk.
+
+        let data_root = profile_root.join("stores").join(STORE_ID);
+        std::fs::create_dir_all(&data_root).unwrap();
+        let manifest_path = data_root.join(crate::storage::STORE_MANIFEST_FILENAME);
+        let config_path = data_root.join(crate::config::CONFIG_FILENAME);
+
+        let manifest = StoreManifest {
+            schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+            project_id: Some(PROJECT_ID.to_string()),
+            store_kind: StoreKind::CodeProject,
+            storage_mode: StorageMode::ProfileSharded,
+            project_root: stale_root.clone(),
+            data_root: data_root.clone(),
+            graph_db_relpath: PathBuf::from(crate::config::DB_FILENAME),
+            sessions_db_relpath: PathBuf::from("sessions.db"),
+            branch_meta_relpath: PathBuf::from(crate::storage::BRANCH_META_FILENAME),
+        };
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let config = crate::config::TraceDecayConfig {
+            root_dir: stale_root.to_string_lossy().to_string(),
+            ..crate::config::TraceDecayConfig::default()
+        };
+        std::fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+        let global_db = GlobalDb::open_at(&profile_root.join("global.db"))
+            .await
+            .unwrap();
+        // Registry already self-healed canonical_root to the current path.
+        global_db
+            .upsert_code_project(PROJECT_ID, &current_root, None, None, None)
+            .await
+            .unwrap();
+        global_db
+            .upsert_store_instance(StoreInstanceUpsert {
+                store_id: STORE_ID.to_string(),
+                project_id: PROJECT_ID.to_string(),
+                store_kind: "project".to_string(),
+                storage_mode: "profile_sharded".to_string(),
+                store_relpath: format!("stores/{STORE_ID}"),
+                manifest_relpath: None,
+                last_verified_at: None,
+                last_write_at: None,
+            })
+            .await
+            .unwrap();
+
+        Fixture {
+            _tmp: tmp,
+            profile_root,
+            current_root,
+            stale_root,
+            manifest_path,
+            config_path,
+            global_db,
+        }
+    }
+
+    fn manifest_root(path: &Path) -> PathBuf {
+        crate::storage::read_store_manifest(path)
+            .unwrap()
+            .project_root
+    }
+
+    fn config_root_dir(path: &Path) -> String {
+        crate::config::load_config_from_path(Path::new("/"), path)
+            .unwrap()
+            .root_dir
+    }
+
+    // (a) Detection alone (the report-only path) never mutates the on-disk
+    //     files — the "dry-run" analog, since the heal pass has no separate
+    //     apply flag and running reconcile IS the apply.
+    #[tokio::test]
+    async fn detection_does_not_mutate() {
+        let fx = build_fixture().await;
+
+        let findings = registry_drift_findings(&fx.global_db, &fx.profile_root).await;
+        let root_drift: Vec<_> = findings
+            .iter()
+            .filter(|f| f.field == "project_root")
+            .collect();
+        assert_eq!(root_drift.len(), 1, "should detect project_root drift");
+
+        // No write happened: the manifest and config still hold the stale root.
+        assert_eq!(manifest_root(&fx.manifest_path), fx.stale_root);
+        assert_eq!(
+            config_root_dir(&fx.config_path),
+            fx.stale_root.to_string_lossy()
+        );
+    }
+
+    // (c) Applying the reconcile rewrites the manifest and config to the
+    //     registry canonical (current) path; (d) a second run is a no-op.
+    #[tokio::test]
+    async fn reconcile_rewrites_then_is_idempotent() {
+        let fx = build_fixture().await;
+        let canonical = fx.current_root.canonicalize().unwrap();
+
+        let (reconciled, warnings) =
+            reconcile_drifted_store_roots(&fx.global_db, &fx.profile_root).await;
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+        assert_eq!(reconciled.len(), 1, "one store should be reconciled");
+        assert_eq!(reconciled[0].store_id, STORE_ID);
+        assert!(
+            reconciled[0].config_path.is_some(),
+            "stale config should be reconciled too"
+        );
+
+        // Manifest + config now hold the canonical current path.
+        assert_eq!(manifest_root(&fx.manifest_path), canonical);
+        assert_eq!(
+            config_root_dir(&fx.config_path),
+            canonical.to_string_lossy()
+        );
+
+        // Every other manifest field survived the surgical rewrite.
+        let healed = crate::storage::read_store_manifest(&fx.manifest_path).unwrap();
+        assert_eq!(healed.project_id.as_deref(), Some(PROJECT_ID));
+        assert_eq!(
+            healed.graph_db_relpath,
+            PathBuf::from(crate::config::DB_FILENAME)
+        );
+
+        // The drift finding is gone now that the manifest matches the registry.
+        let post = registry_drift_findings(&fx.global_db, &fx.profile_root).await;
+        assert!(
+            post.iter().all(|f| f.field != "project_root"),
+            "project_root drift should be resolved: {post:?}"
+        );
+
+        // Second run: nothing left to heal.
+        let (again, warnings) =
+            reconcile_drifted_store_roots(&fx.global_db, &fx.profile_root).await;
+        assert!(again.is_empty(), "second run must be a no-op: {again:?}");
+        assert!(
+            warnings.is_empty(),
+            "no warnings on no-op run: {warnings:?}"
+        );
+    }
+
+    // (b)/safety: when the registry canonical root does NOT exist on disk the
+    //     drift is left untouched — never invent a path.
+    #[tokio::test]
+    async fn missing_canonical_root_is_not_healed() {
+        let fx = build_fixture().await;
+        // Remove the current root so the registry canonical path no longer
+        // exists; the safety gate must refuse to heal.
+        std::fs::remove_dir_all(&fx.current_root).unwrap();
+
+        let (reconciled, warnings) =
+            reconcile_drifted_store_roots(&fx.global_db, &fx.profile_root).await;
+        assert!(reconciled.is_empty(), "must not heal a nonexistent root");
+        assert!(
+            warnings.is_empty(),
+            "gate is silent, not a warning: {warnings:?}"
+        );
+        // Manifest untouched.
+        assert_eq!(manifest_root(&fx.manifest_path), fx.stale_root);
+    }
 }

--- a/src/hook_cmd.rs
+++ b/src/hook_cmd.rs
@@ -30,7 +30,7 @@ pub(crate) async fn handle_hook_command(command: Commands) -> tracedecay::errors
             exit_if_nonzero(tracedecay::hooks::hook_kiro_post_tool_use().await);
         }
         Commands::HookCursorSubagentStart => {
-            exit_if_nonzero(tracedecay::hooks::hook_cursor_subagent_start());
+            exit_if_nonzero(tracedecay::hooks::hook_cursor_subagent_start().await);
         }
         Commands::HookCursorPostToolUse => {
             exit_if_nonzero(tracedecay::hooks::hook_cursor_post_tool_use().await);

--- a/src/hook_cmd.rs
+++ b/src/hook_cmd.rs
@@ -33,7 +33,7 @@ pub(crate) async fn handle_hook_command(command: Commands) -> tracedecay::errors
             exit_if_nonzero(tracedecay::hooks::hook_cursor_subagent_start());
         }
         Commands::HookCursorPostToolUse => {
-            exit_if_nonzero(tracedecay::hooks::hook_cursor_post_tool_use());
+            exit_if_nonzero(tracedecay::hooks::hook_cursor_post_tool_use().await);
         }
         Commands::HookCursorBeforeSubmitPrompt => {
             exit_if_nonzero(tracedecay::hooks::hook_cursor_before_submit_prompt().await);

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -4,10 +4,7 @@
 
 use serde_json::Value;
 
-use super::codex::{
-    codex_additional_context_json, codex_project_root_from_event,
-    codex_project_root_from_parsed_event,
-};
+use super::codex::{codex_additional_context_json, codex_project_root_from_parsed_event};
 use super::post_tool_use::{
     is_claude_edit_tool, is_claude_hint_tool, notify_post_tool_use, tool_input_command_str,
     tool_input_file_path_str, CLAUDE_POST_TOOL_USE_SHELL_TOOLS, CLAUDE_POST_TOOL_USE_SPEC,
@@ -144,12 +141,8 @@ pub(super) fn is_code_research_prompt(prompt: &str) -> bool {
 pub async fn hook_claude_session_start() -> i32 {
     let event = read_hook_event!();
     let parsed = serde_json::from_str::<Value>(&event).unwrap_or(Value::Null);
-    // Resolve the project root the same registry-aware way the printed context
-    // does: the walk-up-only `codex_project_root_from_event` returns `None` for
-    // exactly this feature's targets — global-only-store projects (e.g. the
-    // tracedecay repo, which has no repo-local `.tracedecay/`) and fresh
-    // harness-created linked worktrees — so gating the notify on it would skip
-    // the AddBranchAt path in its primary scenario.
+    // Resolve the project root the same identity-aware way the printed context
+    // does, including global-only stores and fresh harness-created worktrees.
     let root = claude_session_project_root(&parsed).await;
     record_hook_invoked(root.as_deref(), HintAgent::Claude, "SessionStart", &event);
     let mut context = claude_session_context_for_event(&event).await;
@@ -196,7 +189,7 @@ symbol->search, concept->context";
 /// nothing to steer toward). Analytics are fire-and-forget like `SessionStart`.
 pub async fn hook_claude_subagent_start() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = claude_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Claude, "SubagentStart", &event);
     if let Some(context) = claude_subagent_start_context(&event).await {
         println!(
@@ -262,61 +255,18 @@ pub async fn claude_session_context_for_event(event_json: &str) -> String {
 
 /// Resolves the tracedecay project root for a Claude session event.
 ///
-/// The cwd walk-up ([`codex_project_root_from_parsed_event`], which calls
-/// `discover_project_root`) only finds projects with a repo-local store, an
-/// enrollment marker, or a profile-sharded store on disk under the session
-/// tree. Projects whose store is global-only — no repo-local `.tracedecay/`,
-/// e.g. the tracedecay repo itself — are invisible to that walk even though the
-/// MCP server serves them via the global-DB registry (see
-/// `serve::resolve_serve_from_global_db`). Without this fallback the
-/// `SessionStart` hook wrongly prints the "no project index found" init nudge
-/// for a project the server indexes fine. Mirror the server's registry step:
-/// prefer a registered, initialized project that contains (or equals) the
-/// session cwd, deepest match first.
+/// Uses the same identity-aware cwd resolver as Codex and Cursor so global-only
+/// git worktrees do not get a false "no project index found" init nudge.
 async fn claude_session_project_root(parsed: &Value) -> Option<std::path::PathBuf> {
-    if let Some(root) = codex_project_root_from_parsed_event(parsed) {
-        return Some(root);
-    }
     let cwd = event_cwd_from_parsed(parsed)?;
-    claude_session_root_from_global_registry(&cwd).await
+    crate::config::discover_project_root_with_identity(&cwd).await
 }
 
-/// Global-DB registry fallback for [`claude_session_project_root`]: returns the
-/// deepest registered, initialized project whose path is an ancestor of (or
-/// equal to) `cwd`. Returns `None` when the global DB is unavailable or no
-/// registered project contains the session cwd.
-async fn claude_session_root_from_global_registry(
-    cwd: &std::path::Path,
+async fn claude_project_root_from_event_with_identity(
+    event_json: &str,
 ) -> Option<std::path::PathBuf> {
-    let gdb = crate::global_db::GlobalDb::open().await?;
-    claude_session_root_from_global_registry_db(cwd, &gdb).await
-}
-
-async fn claude_session_root_from_global_registry_db(
-    cwd: &std::path::Path,
-    gdb: &crate::global_db::GlobalDb,
-) -> Option<std::path::PathBuf> {
-    let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
-    let mut best: Option<std::path::PathBuf> = None;
-    for path in gdb.list_project_paths().await {
-        let project_path = std::path::PathBuf::from(&path);
-        let canonical_project =
-            std::fs::canonicalize(&project_path).unwrap_or_else(|_| project_path.clone());
-        if !canonical_cwd.starts_with(&canonical_project) {
-            continue;
-        }
-        if !crate::tracedecay::TraceDecay::has_initialized_store(&canonical_project).await {
-            continue;
-        }
-        // Deepest ancestor wins (most specific registered project).
-        let is_deeper = best.as_ref().is_none_or(|current| {
-            canonical_project.components().count() > current.components().count()
-        });
-        if is_deeper {
-            best = Some(canonical_project);
-        }
-    }
-    best
+    let parsed = serde_json::from_str::<Value>(event_json).ok()?;
+    claude_session_project_root(&parsed).await
 }
 
 /// Claude Code `PostToolUse` hook handler used to keep the graph fresh and to
@@ -329,7 +279,7 @@ async fn claude_session_root_from_global_registry_db(
 /// not interfere. Fail-open: no surviving hint leaves prior behavior unchanged.
 pub async fn hook_claude_post_tool_use() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = claude_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Claude, "PostToolUse", &event);
     if let Some(context) = claude_post_tool_use_hint_context(&event) {
         println!("{}", codex_additional_context_json("PostToolUse", &context));
@@ -624,23 +574,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn session_root_falls_back_to_global_registry_for_global_only_project() {
+    async fn session_root_uses_shared_identity_resolver_for_global_only_project() {
         let _profile = crate::config::PinnedUserDataDir::new();
-
-        let gdb_dir = tempfile::tempdir().unwrap();
-        let gdb_path = gdb_dir.path().join("global.db");
-        let gdb = crate::global_db::GlobalDb::open_at(&gdb_path)
-            .await
-            .unwrap();
+        let profile_root = crate::storage::default_profile_root().unwrap();
+        let gdb = crate::global_db::GlobalDb::open().await.unwrap();
 
         let project_dir = tempfile::tempdir().unwrap();
         let project_root = project_dir.path().canonicalize().unwrap();
-        gdb.upsert(&project_root, 0).await;
-        let graph_db_path = touch_marker_graph_db(&project_root);
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(&project_root)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git init failed");
+
+        let project_id = "proj_claude_identity";
+        gdb.upsert_code_project(project_id, &project_root, None, None, None)
+            .await
+            .unwrap();
+        gdb.upsert_store_instance(crate::global_db::StoreInstanceUpsert {
+            store_id: "store_claude_identity".to_string(),
+            project_id: project_id.to_string(),
+            store_kind: "code_project".to_string(),
+            storage_mode: "profile_sharded".to_string(),
+            store_relpath: format!("projects/{project_id}"),
+            manifest_relpath: Some(format!("projects/{project_id}/store_manifest.json")),
+            last_verified_at: Some(100),
+            last_write_at: Some(101),
+        })
+        .await
+        .unwrap();
+        let layout = crate::storage::profile_sharded_layout(
+            &project_root,
+            &profile_root,
+            &crate::storage::EnrollmentMarker {
+                project_id: project_id.to_string(),
+                storage_mode: crate::storage::StorageMode::ProfileSharded,
+            },
+        )
+        .unwrap();
+        std::fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
+        std::fs::write(&layout.graph_db_path, b"").unwrap();
 
         let nested = project_root.join("crates/inner");
         std::fs::create_dir_all(&nested).unwrap();
-        let resolved = claude_session_root_from_global_registry_db(&nested, &gdb).await;
+        let event = serde_json::json!({ "cwd": nested.to_string_lossy() });
+        let resolved = claude_session_project_root(&event).await;
         assert_eq!(
             resolved
                 .as_deref()
@@ -652,17 +631,17 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         let outside_root = outside.path().canonicalize().unwrap();
         assert!(
-            claude_session_root_from_global_registry_db(&outside_root, &gdb)
-                .await
-                .is_none(),
+            claude_session_project_root(
+                &serde_json::json!({ "cwd": outside_root.to_string_lossy() })
+            )
+            .await
+            .is_none(),
             "a cwd outside every registered project must not resolve"
         );
 
-        std::fs::remove_file(&graph_db_path).unwrap();
+        std::fs::remove_file(&layout.graph_db_path).unwrap();
         assert!(
-            claude_session_root_from_global_registry_db(&nested, &gdb)
-                .await
-                .is_none(),
+            claude_session_project_root(&event).await.is_none(),
             "a registered project without a real graph db must not resolve"
         );
     }

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -305,7 +305,7 @@ async fn claude_session_root_from_global_registry_db(
         if !canonical_cwd.starts_with(&canonical_project) {
             continue;
         }
-        if !crate::tracedecay::TraceDecay::is_initialized(&canonical_project) {
+        if !crate::tracedecay::TraceDecay::has_initialized_store(&canonical_project).await {
             continue;
         }
         // Deepest ancestor wins (most specific registered project).
@@ -614,8 +614,33 @@ mod tests {
     /// registered and initialized in the global DB, so the registry fallback must
     /// resolve it — otherwise `SessionStart`/`SubagentStart` wrongly print the
     /// init nudge for a project the MCP server serves fine.
+    /// Touches a real profile-sharded graph db for `project_root` under the
+    /// current (pinned) profile so `has_initialized_store` — which requires
+    /// `graph_db_path.is_file()`, not just an enrollment marker — returns true.
+    /// Returns the graph db path so callers can later delete it to drive the
+    /// negative path.
+    fn touch_marker_graph_db(project_root: &std::path::Path) -> std::path::PathBuf {
+        crate::storage::write_enrollment_marker(
+            project_root,
+            &crate::storage::EnrollmentMarker {
+                project_id: "proj_global_only".to_string(),
+                storage_mode: crate::storage::StorageMode::ProfileSharded,
+            },
+        )
+        .unwrap();
+        let layout = crate::storage::resolve_layout_for_current_profile(project_root).unwrap();
+        std::fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
+        std::fs::write(&layout.graph_db_path, b"").unwrap();
+        layout.graph_db_path
+    }
+
     #[tokio::test]
     async fn session_root_falls_back_to_global_registry_for_global_only_project() {
+        // Pin the profile so `has_initialized_store` resolves the same graph db
+        // path we touch below, and so parallel lib tests cannot race the
+        // process-global USER_DATA_DIR env.
+        let _profile = crate::config::PinnedUserDataDir::new();
+
         let gdb_dir = tempfile::tempdir().unwrap();
         let gdb_path = gdb_dir.path().join("global.db");
         let gdb = crate::global_db::GlobalDb::open_at(&gdb_path)
@@ -624,17 +649,12 @@ mod tests {
 
         let project_dir = tempfile::tempdir().unwrap();
         let project_root = project_dir.path().canonicalize().unwrap();
-        // Register + initialize the project in the global DB only. An enrollment
-        // marker makes `is_initialized` true without a repo-local project db.
+        // Register the project in the global DB and create a REAL profile-sharded
+        // graph db (enrollment marker + touched graph_db_path) so
+        // `has_initialized_store` — not just the old path-hash `is_initialized`
+        // — reports the project initialized.
         gdb.upsert(&project_root, 0).await;
-        crate::storage::write_enrollment_marker(
-            &project_root,
-            &crate::storage::EnrollmentMarker {
-                project_id: "proj_global_only".to_string(),
-                storage_mode: crate::storage::StorageMode::ProfileSharded,
-            },
-        )
-        .unwrap();
+        let graph_db_path = touch_marker_graph_db(&project_root);
 
         // cwd inside the registered project resolves back to its root.
         let nested = project_root.join("crates/inner");
@@ -656,6 +676,65 @@ mod tests {
                 .await
                 .is_none(),
             "a cwd outside every registered project must not resolve"
+        );
+
+        // Removing the graph db drops the candidate: the guard now keys on
+        // has_initialized_store (real db on disk), not the path-hash marker.
+        std::fs::remove_file(&graph_db_path).unwrap();
+        assert!(
+            claude_session_root_from_global_registry_db(&nested, &gdb)
+                .await
+                .is_none(),
+            "a registered project without a real graph db must not resolve"
+        );
+    }
+
+    /// The observable SessionStart symptom: for a registered, graph-db-backed
+    /// project the context must report the initialized status and NOT print the
+    /// false "no project index found" nudge; for a project-like cwd with no
+    /// store the real nudge must still appear (the fix must not mask it).
+    #[tokio::test]
+    async fn session_context_reports_initialized_and_preserves_nudge() {
+        let _profile = crate::config::PinnedUserDataDir::new();
+
+        // The global registry fallback opens the real (pinned-profile) global
+        // DB, so register the project there too.
+        let gdb = crate::global_db::GlobalDb::open().await.unwrap();
+        let project_dir = tempfile::tempdir().unwrap();
+        let project_root = project_dir.path().canonicalize().unwrap();
+        gdb.upsert(&project_root, 0).await;
+        touch_marker_graph_db(&project_root);
+
+        let event = serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "cwd": project_root.to_string_lossy(),
+            "source": "startup",
+        })
+        .to_string();
+        let context = claude_session_context_for_event(&event).await;
+        assert!(
+            !context.contains("no project index found"),
+            "a registered, graph-db-backed project must not emit the init nudge: {context}"
+        );
+        assert!(
+            context.contains("tracedecay index status:"),
+            "context must report the index status line: {context}"
+        );
+
+        // A project-like cwd with no store on disk must still nudge.
+        let unindexed = tempfile::tempdir().unwrap();
+        let unindexed_root = unindexed.path().canonicalize().unwrap();
+        std::fs::write(unindexed_root.join("Cargo.toml"), b"[package]\n").unwrap();
+        let bogus_event = serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "cwd": unindexed_root.to_string_lossy(),
+            "source": "startup",
+        })
+        .to_string();
+        let bogus_context = claude_session_context_for_event(&bogus_event).await;
+        assert!(
+            bogus_context.contains("no project index found"),
+            "an unindexed project-like cwd must still emit the real nudge: {bogus_context}"
         );
     }
 }

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -689,7 +689,7 @@ mod tests {
         );
     }
 
-    /// The observable SessionStart symptom: for a registered, graph-db-backed
+    /// The observable `SessionStart` symptom: for a registered, graph-db-backed
     /// project the context must report the initialized status and NOT print the
     /// false "no project index found" nudge; for a project-like cwd with no
     /// store the real nudge must still appear (the fix must not mask it).

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -608,17 +608,6 @@ mod tests {
         assert!(CLAUDE_SUBAGENT_START_CONTEXT.contains("concept->context"));
     }
 
-    /// Regression for a global-store-only project (no repo-local `.tracedecay/`,
-    /// like the tracedecay repo itself): the cwd walk-up
-    /// (`codex_project_root_from_parsed_event`) finds nothing, but the project is
-    /// registered and initialized in the global DB, so the registry fallback must
-    /// resolve it — otherwise `SessionStart`/`SubagentStart` wrongly print the
-    /// init nudge for a project the MCP server serves fine.
-    /// Touches a real profile-sharded graph db for `project_root` under the
-    /// current (pinned) profile so `has_initialized_store` — which requires
-    /// `graph_db_path.is_file()`, not just an enrollment marker — returns true.
-    /// Returns the graph db path so callers can later delete it to drive the
-    /// negative path.
     fn touch_marker_graph_db(project_root: &std::path::Path) -> std::path::PathBuf {
         crate::storage::write_enrollment_marker(
             project_root,
@@ -636,9 +625,6 @@ mod tests {
 
     #[tokio::test]
     async fn session_root_falls_back_to_global_registry_for_global_only_project() {
-        // Pin the profile so `has_initialized_store` resolves the same graph db
-        // path we touch below, and so parallel lib tests cannot race the
-        // process-global USER_DATA_DIR env.
         let _profile = crate::config::PinnedUserDataDir::new();
 
         let gdb_dir = tempfile::tempdir().unwrap();
@@ -649,14 +635,9 @@ mod tests {
 
         let project_dir = tempfile::tempdir().unwrap();
         let project_root = project_dir.path().canonicalize().unwrap();
-        // Register the project in the global DB and create a REAL profile-sharded
-        // graph db (enrollment marker + touched graph_db_path) so
-        // `has_initialized_store` — not just the old path-hash `is_initialized`
-        // — reports the project initialized.
         gdb.upsert(&project_root, 0).await;
         let graph_db_path = touch_marker_graph_db(&project_root);
 
-        // cwd inside the registered project resolves back to its root.
         let nested = project_root.join("crates/inner");
         std::fs::create_dir_all(&nested).unwrap();
         let resolved = claude_session_root_from_global_registry_db(&nested, &gdb).await;
@@ -668,7 +649,6 @@ mod tests {
             "a registered, initialized project must resolve for a cwd inside it"
         );
 
-        // A cwd outside every registered project resolves to nothing.
         let outside = tempfile::tempdir().unwrap();
         let outside_root = outside.path().canonicalize().unwrap();
         assert!(
@@ -678,8 +658,6 @@ mod tests {
             "a cwd outside every registered project must not resolve"
         );
 
-        // Removing the graph db drops the candidate: the guard now keys on
-        // has_initialized_store (real db on disk), not the path-hash marker.
         std::fs::remove_file(&graph_db_path).unwrap();
         assert!(
             claude_session_root_from_global_registry_db(&nested, &gdb)
@@ -689,16 +667,10 @@ mod tests {
         );
     }
 
-    /// The observable `SessionStart` symptom: for a registered, graph-db-backed
-    /// project the context must report the initialized status and NOT print the
-    /// false "no project index found" nudge; for a project-like cwd with no
-    /// store the real nudge must still appear (the fix must not mask it).
     #[tokio::test]
     async fn session_context_reports_initialized_and_preserves_nudge() {
         let _profile = crate::config::PinnedUserDataDir::new();
 
-        // The global registry fallback opens the real (pinned-profile) global
-        // DB, so register the project there too.
         let gdb = crate::global_db::GlobalDb::open().await.unwrap();
         let project_dir = tempfile::tempdir().unwrap();
         let project_root = project_dir.path().canonicalize().unwrap();
@@ -721,7 +693,6 @@ mod tests {
             "context must report the index status line: {context}"
         );
 
-        // A project-like cwd with no store on disk must still nudge.
         let unindexed = tempfile::tempdir().unwrap();
         let unindexed_root = unindexed.path().canonicalize().unwrap();
         std::fs::write(unindexed_root.join("Cargo.toml"), b"[package]\n").unwrap();

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -115,9 +115,6 @@ async fn codex_prompt_memory_recall(event_json: &str) -> Option<String> {
 async fn codex_session_context_for_event(event_json: &str) -> (String, HookWorkspaceStatus) {
     let parsed = serde_json::from_str::<Value>(event_json).unwrap_or(Value::Null);
     let cwd = event_cwd_from_parsed(&parsed);
-    // On a sync miss, fall back to the git-identity resolver so a renamed /
-    // global-only repo (registered store, no repo-local marker) still resolves
-    // its root and reports Initialized instead of the UnindexedProject nudge.
     let root = match codex_project_root_from_parsed_event(&parsed) {
         Some(r) => Some(r),
         None => match cwd.as_deref() {
@@ -685,11 +682,6 @@ mod tests {
         );
     }
 
-    /// A renamed / global-only repo (registered store, no repo-local marker or
-    /// path-hash store) must resolve via the identity fallback in
-    /// `codex_session_context_for_event` and report Initialized, NOT the
-    /// `UnindexedProject` nudge. A project-like cwd with no store must still nudge
-    /// (the fix must not mask the real `UnindexedProject` status).
     #[tokio::test]
     async fn codex_session_context_resolves_global_only_and_preserves_nudge() {
         let _profile = crate::config::PinnedUserDataDir::new();
@@ -699,8 +691,6 @@ mod tests {
         let project_dir = tempfile::tempdir().unwrap();
         let project_root = project_dir.path().canonicalize().unwrap();
 
-        // Register by canonical path only (no enrollment marker) so resolution
-        // must use the GlobalDb identity branch.
         let project_id = "proj_codex_identity";
         gdb.upsert_code_project(project_id, &project_root, None, None, None)
             .await
@@ -737,7 +727,6 @@ mod tests {
             "a registered, graph-db-backed global-only repo must report Initialized"
         );
 
-        // A project-like cwd with no store on disk must still report Unindexed.
         let unindexed = tempfile::tempdir().unwrap();
         let unindexed_root = unindexed.path().canonicalize().unwrap();
         std::fs::write(unindexed_root.join("Cargo.toml"), b"[package]\n").unwrap();

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -688,8 +688,8 @@ mod tests {
     /// A renamed / global-only repo (registered store, no repo-local marker or
     /// path-hash store) must resolve via the identity fallback in
     /// `codex_session_context_for_event` and report Initialized, NOT the
-    /// UnindexedProject nudge. A project-like cwd with no store must still nudge
-    /// (the fix must not mask the real UnindexedProject status).
+    /// `UnindexedProject` nudge. A project-like cwd with no store must still nudge
+    /// (the fix must not mask the real `UnindexedProject` status).
     #[tokio::test]
     async fn codex_session_context_resolves_global_only_and_preserves_nudge() {
         let _profile = crate::config::PinnedUserDataDir::new();

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -45,7 +45,7 @@ const CODEX_POST_COMPACT_BUDGET: Duration = Duration::from_secs(115);
 /// Codex `SessionStart` hook handler.
 pub async fn hook_codex_session_start() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = codex_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Codex, "SessionStart", &event);
     let (mut context, _) = codex_session_context_for_event(&event).await;
     if let Some(root) = root.as_deref() {
@@ -74,7 +74,7 @@ pub async fn hook_codex_session_start() -> i32 {
 /// Resets the local counter and injects steering context for the new turn.
 pub async fn hook_codex_user_prompt_submit() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = codex_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(
         root.as_deref(),
         HintAgent::Codex,
@@ -105,7 +105,7 @@ pub async fn codex_user_prompt_submit_context_for_event(event: &str) -> String {
 
 async fn codex_prompt_memory_recall(event_json: &str) -> Option<String> {
     let parsed = serde_json::from_str::<Value>(event_json).ok()?;
-    let root = codex_project_root_from_parsed_event(&parsed)?;
+    let root = codex_project_root_from_parsed_event_with_identity(&parsed).await?;
     let prompt = prompt_like_text(&parsed)?;
     let session_id = event_session_id(&parsed);
     memory_inject::prompt_memory_recall(&root, session_id.as_deref(), &prompt).await
@@ -115,13 +115,7 @@ async fn codex_prompt_memory_recall(event_json: &str) -> Option<String> {
 async fn codex_session_context_for_event(event_json: &str) -> (String, HookWorkspaceStatus) {
     let parsed = serde_json::from_str::<Value>(event_json).unwrap_or(Value::Null);
     let cwd = event_cwd_from_parsed(&parsed);
-    let root = match codex_project_root_from_parsed_event(&parsed) {
-        Some(r) => Some(r),
-        None => match cwd.as_deref() {
-            Some(cwd) => crate::config::discover_project_root_with_identity(cwd).await,
-            None => None,
-        },
-    };
+    let root = codex_project_root_from_parsed_event_with_identity(&parsed).await;
     let session_id = event_session_id(&parsed);
     let status = codex_workspace_status(root.as_deref(), cwd.as_deref());
     record_workspace_status_analytics(root.as_deref(), status, session_id.as_deref());
@@ -141,9 +135,9 @@ async fn codex_session_context_for_event(event_json: &str) -> (String, HookWorks
 /// Codex `SubagentStart` hook handler.
 pub async fn hook_codex_subagent_start() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = codex_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Codex, "SubagentStart", &event);
-    let count = record_codex_subagent_start(&event);
+    let count = record_codex_subagent_start(&event).await;
     let output = evaluate_codex_subagent_start(&event);
     let digest = match root.as_deref() {
         Some(root) => memory_inject::session_memory_digest(root, None).await,
@@ -185,7 +179,7 @@ fn merge_codex_subagent_output(output: Option<String>, digest: Option<String>) -
 /// Codex `PostToolUse` hook handler used to keep the graph fresh.
 pub async fn hook_codex_post_tool_use() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = codex_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Codex, "PostToolUse", &event);
     notify_post_tool_use(&CODEX_POST_TOOL_USE_SPEC, &event).await;
     0
@@ -196,7 +190,7 @@ pub async fn hook_codex_post_tool_use() -> i32 {
 /// Replaces temporary compaction summaries from visible LCM source messages.
 pub async fn hook_codex_post_compact() -> i32 {
     let event = read_hook_event!();
-    let root = codex_project_root_from_event(&event);
+    let root = codex_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Codex, "PostCompact", &event);
     if std::env::var_os(crate::sessions::codex_app_server::CODEX_SUMMARY_CHILD_ENV).is_none() {
         codex_post_compact(&event).await;
@@ -274,10 +268,12 @@ pub fn evaluate_codex_subagent_start(event_json: &str) -> Option<String> {
 }
 
 /// Records a Codex `SubagentStart` and returns the session-local count.
-pub fn record_codex_subagent_start(event_json: &str) -> Option<u64> {
+pub async fn record_codex_subagent_start(event_json: &str) -> Option<u64> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
-    let root = codex_project_root_from_parsed_event(&parsed)?;
-    let layout = crate::storage::resolve_layout_for_current_profile(&root).ok()?;
+    let root = codex_project_root_from_parsed_event_with_identity(&parsed).await?;
+    let layout = crate::tracedecay::TraceDecay::resolve_store_layout_for_identity(&root)
+        .await
+        .ok()?;
     let path = layout.data_root.join("codex_subagent_starts.json");
     let analytics_session_id = event_session_id(&parsed);
     let session_id = analytics_session_id
@@ -418,6 +414,16 @@ pub(super) fn codex_project_root_from_parsed_event(parsed: &Value) -> Option<Pat
     crate::config::discover_project_root(&cwd)
 }
 
+async fn codex_project_root_from_event_with_identity(event_json: &str) -> Option<PathBuf> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    codex_project_root_from_parsed_event_with_identity(&parsed).await
+}
+
+async fn codex_project_root_from_parsed_event_with_identity(parsed: &Value) -> Option<PathBuf> {
+    let cwd = event_cwd_from_parsed(parsed)?;
+    crate::config::discover_project_root_with_identity(&cwd).await
+}
+
 fn codex_workspace_status(root: Option<&Path>, cwd: Option<&Path>) -> HookWorkspaceStatus {
     if root.is_some() {
         return HookWorkspaceStatus::Initialized;
@@ -472,7 +478,8 @@ pub fn codex_apply_patch_rel_paths(command: &str, cwd: &Path, project_root: &Pat
 
 async fn codex_post_compact(event_json: &str) {
     let work = async {
-        let Some(project_root) = codex_project_root_from_event(event_json) else {
+        let Some(project_root) = codex_project_root_from_event_with_identity(event_json).await
+        else {
             return;
         };
         if !crate::tracedecay::TraceDecay::has_initialized_store(&project_root).await {
@@ -523,7 +530,7 @@ async fn codex_post_compact(event_json: &str) {
 }
 
 async fn reset_counter_for_codex_event(event_json: &str) {
-    let Some(project_root) = codex_project_root_from_event(event_json) else {
+    let Some(project_root) = codex_project_root_from_event_with_identity(event_json).await else {
         return;
     };
     if let Ok(cg) = crate::tracedecay::TraceDecay::open(&project_root).await {

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -114,8 +114,17 @@ async fn codex_prompt_memory_recall(event_json: &str) -> Option<String> {
 /// Builds Codex session/prompt context.
 async fn codex_session_context_for_event(event_json: &str) -> (String, HookWorkspaceStatus) {
     let parsed = serde_json::from_str::<Value>(event_json).unwrap_or(Value::Null);
-    let root = codex_project_root_from_parsed_event(&parsed);
     let cwd = event_cwd_from_parsed(&parsed);
+    // On a sync miss, fall back to the git-identity resolver so a renamed /
+    // global-only repo (registered store, no repo-local marker) still resolves
+    // its root and reports Initialized instead of the UnindexedProject nudge.
+    let root = match codex_project_root_from_parsed_event(&parsed) {
+        Some(r) => Some(r),
+        None => match cwd.as_deref() {
+            Some(cwd) => crate::config::discover_project_root_with_identity(cwd).await,
+            None => None,
+        },
+    };
     let session_id = event_session_id(&parsed);
     let status = codex_workspace_status(root.as_deref(), cwd.as_deref());
     record_workspace_status_analytics(root.as_deref(), status, session_id.as_deref());
@@ -673,6 +682,71 @@ mod tests {
         assert!(
             codex_prompt_hint(&event).is_none(),
             "Codex should use shared per-session hint dedupe for prompt hints"
+        );
+    }
+
+    /// A renamed / global-only repo (registered store, no repo-local marker or
+    /// path-hash store) must resolve via the identity fallback in
+    /// `codex_session_context_for_event` and report Initialized, NOT the
+    /// UnindexedProject nudge. A project-like cwd with no store must still nudge
+    /// (the fix must not mask the real UnindexedProject status).
+    #[tokio::test]
+    async fn codex_session_context_resolves_global_only_and_preserves_nudge() {
+        let _profile = crate::config::PinnedUserDataDir::new();
+        let profile_root = crate::storage::default_profile_root().unwrap();
+        let gdb = crate::global_db::GlobalDb::open().await.unwrap();
+
+        let project_dir = tempfile::tempdir().unwrap();
+        let project_root = project_dir.path().canonicalize().unwrap();
+
+        // Register by canonical path only (no enrollment marker) so resolution
+        // must use the GlobalDb identity branch.
+        let project_id = "proj_codex_identity";
+        gdb.upsert_code_project(project_id, &project_root, None, None, None)
+            .await
+            .unwrap();
+        gdb.upsert_store_instance(crate::global_db::StoreInstanceUpsert {
+            store_id: "store_codex_identity".to_string(),
+            project_id: project_id.to_string(),
+            store_kind: "code_project".to_string(),
+            storage_mode: "profile_sharded".to_string(),
+            store_relpath: format!("projects/{project_id}"),
+            manifest_relpath: Some(format!("projects/{project_id}/store_manifest.json")),
+            last_verified_at: Some(100),
+            last_write_at: Some(101),
+        })
+        .await
+        .unwrap();
+        let layout = crate::storage::profile_sharded_layout(
+            &project_root,
+            &profile_root,
+            &crate::storage::EnrollmentMarker {
+                project_id: project_id.to_string(),
+                storage_mode: crate::storage::StorageMode::ProfileSharded,
+            },
+        )
+        .unwrap();
+        std::fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
+        std::fs::write(&layout.graph_db_path, b"").unwrap();
+
+        let event = serde_json::json!({ "cwd": project_root.to_string_lossy() }).to_string();
+        let (_context, status) = codex_session_context_for_event(&event).await;
+        assert_eq!(
+            status,
+            HookWorkspaceStatus::Initialized,
+            "a registered, graph-db-backed global-only repo must report Initialized"
+        );
+
+        // A project-like cwd with no store on disk must still report Unindexed.
+        let unindexed = tempfile::tempdir().unwrap();
+        let unindexed_root = unindexed.path().canonicalize().unwrap();
+        std::fs::write(unindexed_root.join("Cargo.toml"), b"[package]\n").unwrap();
+        let bogus = serde_json::json!({ "cwd": unindexed_root.to_string_lossy() }).to_string();
+        let (_bogus_context, bogus_status) = codex_session_context_for_event(&bogus).await;
+        assert_eq!(
+            bogus_status,
+            HookWorkspaceStatus::UnindexedProject,
+            "an unindexed project-like cwd must still report UnindexedProject"
         );
     }
 }

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 use super::cursor_compact::{
-    cursor_pre_compact_for_event_with_config, CURSOR_PRE_COMPACT_SUMMARY_BUDGET,
+    CURSOR_PRE_COMPACT_SUMMARY_BUDGET, cursor_pre_compact_for_event_with_config,
 };
 use super::cursor_shell::paths_same;
 use super::memory_inject;
@@ -18,7 +18,7 @@ use super::steering::{
     append_context_block, append_context_recovery_hint, build_cursor_session_context,
     cursor_index_signals_for_root, session_start_from_compaction,
 };
-use super::tool_hints::{decide_hint, HintAgent, ToolHint, ToolHintInput};
+use super::tool_hints::{HintAgent, ToolHint, ToolHintInput, decide_hint};
 use super::{
     append_tool_hint, deduped_project_hint_with_id, event_session_id, format_tool_hint,
     hook_route_metadata_from_event, mint_hint_id, nearest_project_like_root, prompt_like_text,
@@ -367,12 +367,7 @@ pub fn evaluate_cursor_subagent_start(event_json: &str) -> Option<String> {
 pub fn evaluate_cursor_post_tool_use(event_json: &str) -> Option<String> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let hint = decide_hint(&cursor_tool_hint_input(&parsed))?;
-    Some(
-        serde_json::json!({
-            "additional_context": format_tool_hint(&hint),
-        })
-        .to_string(),
-    )
+    Some(format_cursor_post_tool_use_decision(&hint))
 }
 
 fn format_cursor_post_tool_use_decision(hint: &ToolHint) -> String {

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -259,7 +259,18 @@ pub async fn hook_cursor_after_file_edit() -> i32 {
 /// for the resolved workspace. Never blocks session creation.
 pub async fn hook_cursor_session_start() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let mut root = cursor_project_root_from_event(&event);
+    // On a sync miss, fall back to the git-identity resolver so a renamed /
+    // global-only repo (registered store, no repo-local marker) still resolves
+    // its root; cursor_session_context_for_root already gates on
+    // has_initialized_store, so the Initialized line is emitted once root binds.
+    if root.is_none() {
+        if let Ok(parsed) = serde_json::from_str::<Value>(&event) {
+            if let Some(cwd) = cursor_event_cwd(&parsed) {
+                root = crate::config::discover_project_root_with_identity(&cwd).await;
+            }
+        }
+    }
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "sessionStart", &event);
     ingest_cursor_transcript_for_event(
         &event,

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 use super::cursor_compact::{
-    CURSOR_PRE_COMPACT_SUMMARY_BUDGET, cursor_pre_compact_for_event_with_config,
+    cursor_pre_compact_for_event_with_config, CURSOR_PRE_COMPACT_SUMMARY_BUDGET,
 };
 use super::cursor_shell::paths_same;
 use super::memory_inject;
@@ -18,7 +18,7 @@ use super::steering::{
     append_context_block, append_context_recovery_hint, build_cursor_session_context,
     cursor_index_signals_for_root, session_start_from_compaction,
 };
-use super::tool_hints::{HintAgent, ToolHint, ToolHintInput, decide_hint};
+use super::tool_hints::{decide_hint, HintAgent, ToolHint, ToolHintInput};
 use super::{
     append_tool_hint, deduped_project_hint_with_id, event_session_id, format_tool_hint,
     hook_route_metadata_from_event, mint_hint_id, nearest_project_like_root, prompt_like_text,
@@ -44,9 +44,9 @@ const CURSOR_STOP_INGEST_BUDGET: Duration = Duration::from_secs(25);
 /// Cursor `subagentStart` hook handler.
 ///
 /// Allows Cursor subagents while preserving legacy hook compatibility.
-pub fn hook_cursor_subagent_start() -> i32 {
+pub async fn hook_cursor_subagent_start() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "subagentStart", &event);
     if let Some(decision) = evaluate_cursor_subagent_start(&event) {
         println!("{decision}");
@@ -67,7 +67,7 @@ pub fn hook_cursor_subagent_start() -> i32 {
 /// [`super::tool_hints::ToolHintDedupe`] persisted under `.tracedecay/`.
 pub async fn hook_cursor_post_tool_use() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "postToolUse", &event);
     if let Some(decision) = cursor_post_tool_use_decision_for_hook(&event).await {
         println!("{decision}");
@@ -89,7 +89,7 @@ pub async fn hook_cursor_post_tool_use() -> i32 {
 /// blocks submission, even if the tail ingest or hint injection times out.
 pub async fn hook_cursor_before_submit_prompt() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(
         root.as_deref(),
         HintAgent::Cursor,
@@ -166,7 +166,7 @@ fn cursor_prompt_hint(event_json: &str) -> Option<ToolHint> {
 
 async fn cursor_prompt_memory_recall(event_json: &str) -> Option<String> {
     let parsed = serde_json::from_str::<Value>(event_json).ok()?;
-    let root = cursor_project_root_from_parsed_event(&parsed)?;
+    let root = cursor_project_root_from_parsed_event_with_identity(&parsed).await?;
     let prompt = prompt_like_text(&parsed)?;
     let session_id = event_session_id(&parsed);
     memory_inject::prompt_memory_recall(&root, session_id.as_deref(), &prompt).await
@@ -181,7 +181,7 @@ async fn cursor_prompt_memory_recall(event_json: &str) -> Option<String> {
 /// so an empty object is emitted. Fail-open.
 pub async fn hook_cursor_session_end() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "sessionEnd", &event);
     ingest_cursor_transcript_for_event(
         &event,
@@ -201,7 +201,7 @@ pub async fn hook_cursor_session_end() -> i32 {
 /// we emit an empty object and never ask the agent to continue. Fail-open.
 pub async fn hook_cursor_stop() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "stop", &event);
     ingest_cursor_transcript_for_event(
         &event,
@@ -222,7 +222,7 @@ pub async fn hook_cursor_stop() -> i32 {
 /// summary node. The hook is fail-open and emits Cursor's empty object shape.
 pub async fn hook_cursor_pre_compact() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "preCompact", &event);
     if std::env::var(crate::sessions::cursor_agent::CURSOR_SUMMARY_CHILD_ENV).is_err() {
         let mut config = crate::sessions::cursor_agent::CursorAgentSummaryConfig::from_env();
@@ -246,7 +246,7 @@ pub async fn hook_cursor_pre_compact() -> i32 {
 /// and the hook fails open when no daemon is available.
 pub async fn hook_cursor_after_file_edit() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "afterFileEdit", &event);
     notify_cursor_after_file_edit(&event).await;
     0
@@ -259,16 +259,7 @@ pub async fn hook_cursor_after_file_edit() -> i32 {
 /// for the resolved workspace. Never blocks session creation.
 pub async fn hook_cursor_session_start() -> i32 {
     let event = read_hook_event!();
-    let mut root = cursor_project_root_from_event(&event);
-    if root.is_none() {
-        root = match serde_json::from_str::<Value>(&event) {
-            Ok(parsed) => match cursor_event_cwd(&parsed) {
-                Some(cwd) => crate::config::discover_project_root_with_identity(&cwd).await,
-                None => None,
-            },
-            Err(_) => None,
-        };
-    }
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "sessionStart", &event);
     ingest_cursor_transcript_for_event(
         &event,
@@ -317,7 +308,7 @@ async fn cursor_session_context_for_root(root: Option<&Path>) -> String {
 /// the command requires branch tracking or coalesced incremental sync.
 pub async fn hook_cursor_after_shell() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(
         root.as_deref(),
         HintAgent::Cursor,
@@ -333,7 +324,7 @@ pub async fn hook_cursor_after_shell() -> i32 {
 /// Notifies the daemon to run one-shot workspace catch-up. Fail-open.
 pub async fn hook_cursor_workspace_open() -> i32 {
     let event = read_hook_event!();
-    let root = cursor_project_root_from_event(&event);
+    let root = cursor_project_root_from_event_with_identity(&event).await;
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "workspaceOpen", &event);
     notify_cursor_workspace_open(&event).await;
     if let Some(root) = root.as_deref() {
@@ -512,6 +503,30 @@ pub(super) fn cursor_project_root_from_parsed_event(parsed: &Value) -> Option<Pa
     }
 }
 
+async fn cursor_project_root_from_event_with_identity(event_json: &str) -> Option<PathBuf> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    cursor_project_root_from_parsed_event_with_identity(&parsed).await
+}
+
+async fn cursor_project_root_from_parsed_event_with_identity(parsed: &Value) -> Option<PathBuf> {
+    let mut resolved = None;
+    for candidate in cursor_event_candidates(parsed) {
+        if let Some(root) = crate::config::discover_project_root_with_identity(&candidate).await {
+            resolved = Some(root);
+            break;
+        }
+    }
+    let cwd_root = match cursor_event_cwd(parsed) {
+        Some(cwd) => crate::config::discover_project_root_with_identity(&cwd).await,
+        None => None,
+    };
+    match (cwd_root, resolved) {
+        (Some(cwd_root), Some(resolved)) if !paths_same(&cwd_root, &resolved) => Some(cwd_root),
+        (Some(cwd_root), None) => Some(cwd_root),
+        (_, other) => other,
+    }
+}
+
 fn cursor_event_candidates(event: &Value) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     let mut push_unique = |candidate: PathBuf| {
@@ -634,7 +649,7 @@ pub fn cursor_session_start_json(project_root: Option<&Path>, additional_context
 /// Resolves the edited repo-relative paths locally, then lets the daemon own
 /// scheduling and sync execution. No-ops when no in-project paths were edited.
 async fn notify_cursor_after_file_edit(event_json: &str) {
-    let Some(root) = cursor_project_root_from_event(event_json) else {
+    let Some(root) = cursor_project_root_from_event_with_identity(event_json).await else {
         return;
     };
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
@@ -661,7 +676,7 @@ async fn notify_cursor_after_shell_event(event_json: &str) {
         .get("command")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let Some(root) = cursor_project_root_from_event(event_json) else {
+    let Some(root) = cursor_project_root_from_event_with_identity(event_json).await else {
         return;
     };
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
@@ -678,7 +693,7 @@ async fn notify_cursor_after_shell_event(event_json: &str) {
 
 /// Best-effort daemon notification for Cursor `workspaceOpen`.
 async fn notify_cursor_workspace_open(event_json: &str) {
-    let Some(root) = cursor_project_root_from_event(event_json) else {
+    let Some(root) = cursor_project_root_from_event_with_identity(event_json).await else {
         return;
     };
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
@@ -693,7 +708,7 @@ async fn notify_cursor_workspace_open(event_json: &str) {
 }
 
 async fn reset_counter_for_cursor_event(event_json: &str) {
-    let Some(project_root) = cursor_project_root_from_event(event_json) else {
+    let Some(project_root) = cursor_project_root_from_event_with_identity(event_json).await else {
         return;
     };
     if let Ok(cg) = crate::tracedecay::TraceDecay::open(&project_root).await {
@@ -714,7 +729,8 @@ pub(super) async fn ingest_cursor_transcript_for_event(
         let Ok(parsed) = serde_json::from_str::<Value>(event_json) else {
             return false;
         };
-        let Some(project_root) = cursor_project_root_from_parsed_event(&parsed) else {
+        let Some(project_root) = cursor_project_root_from_parsed_event_with_identity(&parsed).await
+        else {
             return false;
         };
         if let Some(cwd_root) = cursor_event_cwd(&parsed)
@@ -863,6 +879,70 @@ mod tests {
         assert!(
             cursor_prompt_hint(&event).is_none(),
             "Cursor prompt hints must reuse the shared per-session hint dedupe"
+        );
+    }
+
+    #[tokio::test]
+    async fn cursor_root_uses_identity_resolver_for_global_only_store() {
+        let _profile = crate::config::PinnedUserDataDir::new();
+        let profile_root = crate::storage::default_profile_root().unwrap();
+        let gdb = crate::global_db::GlobalDb::open().await.unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        let project_root = project.path().canonicalize().unwrap();
+        let status = std::process::Command::new("git")
+            .arg("init")
+            .arg(&project_root)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git init failed");
+
+        let project_id = "proj_cursor_identity";
+        let git_common_dir = crate::worktree::git_common_dir(&project_root);
+        gdb.upsert_code_project(
+            project_id,
+            &project_root,
+            git_common_dir.as_deref(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        gdb.upsert_store_instance(crate::global_db::StoreInstanceUpsert {
+            store_id: "store_cursor_identity".to_string(),
+            project_id: project_id.to_string(),
+            store_kind: "code_project".to_string(),
+            storage_mode: "profile_sharded".to_string(),
+            store_relpath: format!("projects/{project_id}"),
+            manifest_relpath: Some(format!("projects/{project_id}/store_manifest.json")),
+            last_verified_at: Some(100),
+            last_write_at: Some(101),
+        })
+        .await
+        .unwrap();
+        let layout = crate::storage::profile_sharded_layout(
+            &project_root,
+            &profile_root,
+            &crate::storage::EnrollmentMarker {
+                project_id: project_id.to_string(),
+                storage_mode: crate::storage::StorageMode::ProfileSharded,
+            },
+        )
+        .unwrap();
+        std::fs::create_dir_all(layout.graph_db_path.parent().unwrap()).unwrap();
+        std::fs::write(&layout.graph_db_path, b"").unwrap();
+
+        let nested = project_root.join("src/deep");
+        std::fs::create_dir_all(&nested).unwrap();
+        let parsed = serde_json::json!({
+            "cwd": nested,
+            "workspace_roots": [project_root.clone()],
+        });
+
+        assert!(cursor_project_root_from_parsed_event(&parsed).is_none());
+        assert_eq!(
+            cursor_project_root_from_parsed_event_with_identity(&parsed).await,
+            Some(project_root)
         );
     }
 }

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -65,11 +65,11 @@ pub fn hook_cursor_subagent_start() -> i32 {
 /// search tool) and irrelevant tools fail open with no output. Each hint
 /// category is emitted at most once per session via
 /// [`super::tool_hints::ToolHintDedupe`] persisted under `.tracedecay/`.
-pub fn hook_cursor_post_tool_use() -> i32 {
+pub async fn hook_cursor_post_tool_use() -> i32 {
     let event = read_hook_event!();
     let root = cursor_project_root_from_event(&event);
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "postToolUse", &event);
-    if let Some(decision) = cursor_post_tool_use_decision(&event) {
+    if let Some(decision) = cursor_post_tool_use_decision_for_hook(&event).await {
         println!("{decision}");
     }
     0
@@ -260,16 +260,14 @@ pub async fn hook_cursor_after_file_edit() -> i32 {
 pub async fn hook_cursor_session_start() -> i32 {
     let event = read_hook_event!();
     let mut root = cursor_project_root_from_event(&event);
-    // On a sync miss, fall back to the git-identity resolver so a renamed /
-    // global-only repo (registered store, no repo-local marker) still resolves
-    // its root; cursor_session_context_for_root already gates on
-    // has_initialized_store, so the Initialized line is emitted once root binds.
     if root.is_none() {
-        if let Ok(parsed) = serde_json::from_str::<Value>(&event) {
-            if let Some(cwd) = cursor_event_cwd(&parsed) {
-                root = crate::config::discover_project_root_with_identity(&cwd).await;
-            }
-        }
+        root = match serde_json::from_str::<Value>(&event) {
+            Ok(parsed) => match cursor_event_cwd(&parsed) {
+                Some(cwd) => crate::config::discover_project_root_with_identity(&cwd).await,
+                None => None,
+            },
+            Err(_) => None,
+        };
     }
     record_hook_invoked(root.as_deref(), HintAgent::Cursor, "sessionStart", &event);
     ingest_cursor_transcript_for_event(
@@ -377,9 +375,14 @@ pub fn evaluate_cursor_post_tool_use(event_json: &str) -> Option<String> {
     )
 }
 
-/// Impure `postToolUse` path: [`evaluate_cursor_post_tool_use`] plus
-/// per-session hint dedupe persisted under the project's `.tracedecay/` dir.
-pub fn cursor_post_tool_use_decision(event_json: &str) -> Option<String> {
+fn format_cursor_post_tool_use_decision(hint: &ToolHint) -> String {
+    serde_json::json!({
+        "additional_context": format_tool_hint(hint),
+    })
+    .to_string()
+}
+
+fn prepare_cursor_post_tool_use_hint(event_json: &str) -> Option<(String, ToolHint)> {
     let parsed: Value = serde_json::from_str(event_json).ok()?;
     let hint = decide_hint(&cursor_tool_hint_input(&parsed))?;
     let root = cursor_project_root_candidate_from_parsed_event(&parsed);
@@ -392,13 +395,21 @@ pub fn cursor_post_tool_use_decision(event_json: &str) -> Option<String> {
         &hint_id,
         &hint,
     );
+    Some((hint_id, hint))
+}
+
+/// Impure `postToolUse` path: [`evaluate_cursor_post_tool_use`] plus
+/// per-session hint dedupe persisted under the project's `.tracedecay/` dir.
+pub fn cursor_post_tool_use_decision(event_json: &str) -> Option<String> {
+    let (hint_id, hint) = prepare_cursor_post_tool_use_hint(event_json)?;
     let hint = deduped_cursor_hint(event_json, &hint_id, hint)?;
-    Some(
-        serde_json::json!({
-            "additional_context": format_tool_hint(&hint),
-        })
-        .to_string(),
-    )
+    Some(format_cursor_post_tool_use_decision(&hint))
+}
+
+async fn cursor_post_tool_use_decision_for_hook(event_json: &str) -> Option<String> {
+    let (hint_id, hint) = prepare_cursor_post_tool_use_hint(event_json)?;
+    let hint = deduped_cursor_hint_for_initialized_store(event_json, &hint_id, hint).await?;
+    Some(format_cursor_post_tool_use_decision(&hint))
 }
 
 /// Suppresses hints that were already emitted for this session.
@@ -410,17 +421,19 @@ pub fn cursor_post_tool_use_decision(event_json: &str) -> Option<String> {
 /// tracedecay tools there would be misleading). When no session id is present
 /// the hint is emitted as-is — dedupe is impossible but the hint is still
 /// useful (fail-open).
-fn deduped_cursor_hint(event_json: &str, hint_id: &str, hint: ToolHint) -> Option<ToolHint> {
+fn cursor_hint_root(
+    event_json: &str,
+    hint_id: &str,
+    hint: &ToolHint,
+) -> Option<(PathBuf, Option<String>)> {
     let Ok(parsed) = serde_json::from_str::<Value>(event_json) else {
-        // The candidate was already recorded against `hint_id`; close its outcome
-        // with a terminal event instead of dropping it silently.
         record_hint_analytics(
             None,
             "dropped_no_root",
             HintAgent::Cursor,
             None,
             hint_id,
-            &hint,
+            hint,
         );
         return None;
     };
@@ -432,11 +445,36 @@ fn deduped_cursor_hint(event_json: &str, hint_id: &str, hint: ToolHint) -> Optio
             HintAgent::Cursor,
             session_id.as_deref(),
             hint_id,
-            &hint,
+            hint,
         );
         return None;
     };
+    Some((root, session_id))
+}
+
+fn deduped_cursor_hint(event_json: &str, hint_id: &str, hint: ToolHint) -> Option<ToolHint> {
+    let (root, session_id) = cursor_hint_root(event_json, hint_id, &hint)?;
     if !crate::tracedecay::TraceDecay::is_initialized(&root) {
+        record_hint_analytics(
+            Some(&root),
+            "suppressed_uninitialized",
+            HintAgent::Cursor,
+            session_id.as_deref(),
+            hint_id,
+            &hint,
+        );
+        return None;
+    }
+    deduped_project_hint_with_id(Some(root), HintAgent::Cursor, session_id, hint_id, hint)
+}
+
+async fn deduped_cursor_hint_for_initialized_store(
+    event_json: &str,
+    hint_id: &str,
+    hint: ToolHint,
+) -> Option<ToolHint> {
+    let (root, session_id) = cursor_hint_root(event_json, hint_id, &hint)?;
+    if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {
         record_hint_analytics(
             Some(&root),
             "suppressed_uninitialized",

--- a/src/hooks/post_tool_use.rs
+++ b/src/hooks/post_tool_use.rs
@@ -81,9 +81,7 @@ pub(crate) async fn notify_post_tool_use(spec: &PostToolUseSpec, event_json: &st
     let Some(cwd) = event_cwd_from_parsed(&parsed) else {
         return;
     };
-    let Some(root) = crate::config::discover_project_root(&cwd)
-        .or_else(|| crate::worktree::git_worktree_root(&cwd))
-    else {
+    let Some(root) = crate::config::discover_project_root_with_identity(&cwd).await else {
         return;
     };
     if !crate::tracedecay::TraceDecay::has_initialized_store(&root).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -611,7 +611,7 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             commands::handle_upload_counter(true);
         }
         Commands::Gitignore { path, action } => {
-            commands::handle_gitignore(path, action)?;
+            commands::handle_gitignore(path, action).await?;
         }
         Commands::Doctor { agent } => {
             tracedecay::doctor::run_doctor(agent.as_deref()).await;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -715,6 +715,7 @@ pub struct McpServer {
     /// to the daemon process profile for selector resolution.
     registry_db: Option<Arc<GlobalDb>>,
     allow_default_registry_fallback: bool,
+    automation_scheduler_reconciler: Option<crate::dashboard::AutomationSchedulerReconciler>,
     initialize_root_routing_enabled: AtomicBool,
     hook_project_routes: SharedHookProjectRouteCache,
     /// Cached latest-version check result.
@@ -842,6 +843,25 @@ impl McpServer {
         registry_db: Option<Arc<GlobalDb>>,
         allow_default_registry_fallback: bool,
     ) -> Arc<Self> {
+        Self::new_with_dbs_and_automation_reconciler(
+            cg,
+            scope_prefix,
+            global_db,
+            registry_db,
+            allow_default_registry_fallback,
+            None,
+        )
+        .await
+    }
+
+    pub(crate) async fn new_with_dbs_and_automation_reconciler(
+        cg: TraceDecay,
+        scope_prefix: Option<String>,
+        global_db: Option<Arc<GlobalDb>>,
+        registry_db: Option<Arc<GlobalDb>>,
+        allow_default_registry_fallback: bool,
+        automation_scheduler_reconciler: Option<crate::dashboard::AutomationSchedulerReconciler>,
+    ) -> Arc<Self> {
         let file_token_map = cg.get_file_token_map().await.unwrap_or_default();
         let persisted = cg.get_tokens_saved().await.unwrap_or(0);
         let response_handle_project_root = cg.project_root().to_path_buf();
@@ -882,6 +902,7 @@ impl McpServer {
             global_db,
             registry_db,
             allow_default_registry_fallback,
+            automation_scheduler_reconciler,
             initialize_root_routing_enabled: AtomicBool::new(true),
             hook_project_routes: SharedHookProjectRouteCache::default(),
             version_cache: std::sync::Mutex::new(VersionCheckState {
@@ -2426,6 +2447,7 @@ impl McpServer {
                 global_db: self.registry_db.as_deref(),
                 allow_default_registry_fallback: self.allow_default_registry_fallback,
                 implicit_project_path,
+                automation_scheduler_reconciler: self.automation_scheduler_reconciler.clone(),
             },
         )
         .await;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1489,9 +1489,8 @@ impl McpServer {
     }
 
     /// Returns a compact one-line notice when automation runs have staged
-    /// output awaiting review (skill drafts, fact proposals) that the user
-    /// hasn't been told about yet — `TraceDecay`'s equivalent of Hermes's
-    /// inline "💾 Self-improvement review" moment (parity R5).
+    /// managed-skill output awaiting review that the user hasn't been told
+    /// about yet. Fact proposal counts remain telemetry-only.
     ///
     /// Cheap by construction: a 60 s `compare_exchange` cooldown gates the
     /// check, and the underlying dedupe state
@@ -2572,9 +2571,9 @@ impl McpServer {
                 }
 
                 // Staged-automation nudge (Hermes parity R5): when automation
-                // runs have queued skill drafts / fact proposals for review,
-                // append a one-line notice so the approval queue doesn't grow
-                // silently. Deduped per batch and cooldown-gated inside.
+                // runs have queued skill drafts for review, append a one-line
+                // notice so the approval queue doesn't grow silently. Fact
+                // proposal counts stay telemetry-only in `staged_notice`.
                 if let Some(notice) = self.maybe_automation_staged_notice(&cg).await {
                     if let Some(content) = result
                         .value

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -1506,7 +1506,7 @@ pub(super) async fn handle_unsafe_patterns(
         "matches": matches,
     });
     let text = render::finalize(Some(cg.project_root()), &args, &payload, || {
-        render::generic_md(&payload)
+        render::diagnostics_md(&payload)
     });
     Ok(ToolResult::new(
         json!({

--- a/src/mcp/tools/handlers/dashboard.rs
+++ b/src/mcp/tools/handlers/dashboard.rs
@@ -13,7 +13,10 @@ use crate::tracedecay::TraceDecay;
 use super::super::render;
 use super::super::ToolResult;
 
-use crate::dashboard::{bind_dashboard, build_state, router, DEFAULT_PORT};
+use crate::dashboard::{
+    bind_dashboard, build_state_with_automation_reconciler, router, AutomationSchedulerReconciler,
+    DEFAULT_PORT,
+};
 
 /// Internal handle for a managed dashboard instance.
 struct RunningDashboard {
@@ -56,7 +59,11 @@ fn dashboard_tool_result(cg: &TraceDecay, args: &Value, payload: &Value) -> Tool
 }
 
 /// Handles `tracedecay_dashboard` tool calls.
-pub(super) async fn handle_dashboard(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+pub(super) async fn handle_dashboard(
+    cg: &TraceDecay,
+    args: Value,
+    automation_scheduler_reconciler: Option<AutomationSchedulerReconciler>,
+) -> Result<ToolResult> {
     let action = args
         .get("action")
         .and_then(|v| v.as_str())
@@ -106,7 +113,8 @@ pub(super) async fn handle_dashboard(cg: &TraceDecay, args: Value) -> Result<Too
             // Shared construction with the CLI path: resolved LCM/session store
             // selection included. No catch-up ingest spawn here — the host
             // MCP server already swept hookless transcripts at startup.
-            let state = build_state(cg).await;
+            let state =
+                build_state_with_automation_reconciler(cg, automation_scheduler_reconciler).await;
 
             let app = router(state);
             let (listener, addr) = bind_dashboard(&host, port).await?;

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -7,7 +7,12 @@ use std::fmt::Write as _;
 
 use serde_json::{json, Value};
 
-use crate::context::format_context_as_markdown;
+use crate::context::{
+    format_context_as_markdown, CONTEXT_CODE_HEADING, CONTEXT_ENTRY_POINTS_HEADING,
+    CONTEXT_EXTENSION_POINTS_HEADING, CONTEXT_INDEX_COVERAGE_HINT_HEADING,
+    CONTEXT_MEMORY_MATCHES_HEADING, CONTEXT_RELATED_SYMBOLS_HEADING, CONTEXT_SEEN_NODE_IDS_LABEL,
+    CONTEXT_TEST_COVERAGE_HEADING,
+};
 use crate::errors::{Result, TraceDecayError};
 use crate::memory::types::{FactSearchResult, SearchFactsRequest};
 use crate::path_tree::format_compact_path_list;
@@ -43,40 +48,25 @@ where
     F: FnOnce() -> String,
 {
     let internal_analytics = value.get(CONTEXT_MEMORY_ANALYTICS_KEY).cloned();
-    let public_value;
-    let value = if internal_analytics.is_some() {
-        public_value = strip_internal_context_memory_analytics(value);
-        &public_value
-    } else {
-        value
-    };
+    let public_value = internal_analytics
+        .as_ref()
+        .and_then(|_| public_value_without_internal_context_memory_analytics(value));
+    let value = public_value.as_ref().unwrap_or(value);
     let text = render::finalize(Some(cg.project_root()), args, value, md);
-    let result = text_tool_result(&text, touched_files);
-    if let Some(internal_analytics) = internal_analytics {
-        result.with_internal_analytics(internal_analytics)
-    } else {
-        result
-    }
+    text_tool_result_with_analytics(&text, touched_files, internal_analytics)
 }
 
 fn rendered_context_tool_result(
     cg: &TraceDecay,
     args: &Value,
-    value: &Value,
+    mut value: Value,
     touched_files: Vec<String>,
     full_markdown: String,
     preview_markdown: Option<&str>,
 ) -> ToolResult {
-    let internal_analytics = value.get(CONTEXT_MEMORY_ANALYTICS_KEY).cloned();
-    let public_value;
-    let value = if internal_analytics.is_some() {
-        public_value = strip_internal_context_memory_analytics(value);
-        &public_value
-    } else {
-        value
-    };
+    let internal_analytics = take_internal_context_memory_analytics(&mut value);
     let text = if render::wants_json(args) {
-        render::finalize(Some(cg.project_root()), args, value, || full_markdown)
+        render::finalize(Some(cg.project_root()), args, &value, || full_markdown)
     } else {
         render::markdown_preview_with_handle(
             Some(cg.project_root()),
@@ -84,20 +74,29 @@ fn rendered_context_tool_result(
             preview_markdown.unwrap_or(&full_markdown),
         )
     };
-    let result = text_tool_result(&text, touched_files);
+    text_tool_result_with_analytics(&text, touched_files, internal_analytics)
+}
+
+fn public_value_without_internal_context_memory_analytics(value: &Value) -> Option<Value> {
+    let mut value = value.clone();
+    take_internal_context_memory_analytics(&mut value).map(|_| value)
+}
+
+fn take_internal_context_memory_analytics(value: &mut Value) -> Option<Value> {
+    value.as_object_mut()?.remove(CONTEXT_MEMORY_ANALYTICS_KEY)
+}
+
+fn text_tool_result_with_analytics(
+    text: &str,
+    touched_files: Vec<String>,
+    internal_analytics: Option<Value>,
+) -> ToolResult {
+    let result = text_tool_result(text, touched_files);
     if let Some(internal_analytics) = internal_analytics {
         result.with_internal_analytics(internal_analytics)
     } else {
         result
     }
-}
-
-fn strip_internal_context_memory_analytics(value: &Value) -> Value {
-    let mut value = value.clone();
-    if let Some(object) = value.as_object_mut() {
-        object.remove(CONTEXT_MEMORY_ANALYTICS_KEY);
-    }
-    value
 }
 
 fn text_tool_result(text: &str, touched_files: Vec<String>) -> ToolResult {
@@ -269,7 +268,8 @@ pub(super) async fn handle_context(
     if let Some(hint) = cg.index_coverage_hint(context.subgraph.nodes.len()) {
         let _ = writeln!(
             output,
-            "\n### Index Coverage Hint\n{}\nSkipped trees seen: {}\nTo opt in, run: `{}`\n",
+            "\n{}\n{}\nSkipped trees seen: {}\nTo opt in, run: `{}`\n",
+            CONTEXT_INDEX_COVERAGE_HINT_HEADING,
             hint.message,
             hint.skipped_dirs.join(", "),
             hint.suggested_command,
@@ -284,7 +284,8 @@ pub(super) async fn handle_context(
     if !context.seen_node_ids.is_empty() {
         let _ = write!(
             output,
-            "\nseen_node_ids: {}\n",
+            "\n{} {}\n",
+            CONTEXT_SEEN_NODE_IDS_LABEL,
             serde_json::to_string(&context.seen_node_ids).unwrap_or_default()
         );
     }
@@ -313,7 +314,7 @@ pub(super) async fn handle_context(
     Ok(rendered_context_tool_result(
         cg,
         &args,
-        &value,
+        value,
         touched_files,
         output,
         preview.as_deref(),
@@ -344,7 +345,7 @@ fn context_markdown_lane_preview(markdown: &str) -> String {
 }
 
 fn context_lane_key(line: &str) -> Option<&str> {
-    if line.starts_with("### ") || line.starts_with("seen_node_ids:") {
+    if line.starts_with("### ") || line.starts_with(CONTEXT_SEEN_NODE_IDS_LABEL) {
         Some(line.trim_end())
     } else {
         None
@@ -369,19 +370,21 @@ fn push_context_lane_preview(preview: &mut String, lane_key: &str, lane: &str) {
 }
 
 fn context_lane_budget(lane_key: &str) -> usize {
-    if lane_key.starts_with("### Code") {
+    if lane_key.starts_with(CONTEXT_SEEN_NODE_IDS_LABEL) {
+        usize::MAX
+    } else if lane_key.starts_with(CONTEXT_CODE_HEADING) {
         8_500
-    } else if lane_key.starts_with("### Related Symbols") {
+    } else if lane_key.starts_with(CONTEXT_RELATED_SYMBOLS_HEADING) {
         3_500
-    } else if lane_key.starts_with("### Entry Points") || lane_key.starts_with("### Test Coverage")
+    } else if lane_key.starts_with(CONTEXT_ENTRY_POINTS_HEADING)
+        || lane_key.starts_with(CONTEXT_TEST_COVERAGE_HEADING)
     {
         3_000
-    } else if lane_key.starts_with("### Memory Matches") {
+    } else if lane_key.starts_with(CONTEXT_MEMORY_MATCHES_HEADING) {
         2_500
-    } else if lane_key.starts_with("### Extension Points") || lane_key.starts_with("seen_node_ids:")
-    {
+    } else if lane_key.starts_with(CONTEXT_EXTENSION_POINTS_HEADING) {
         1_500
-    } else if lane_key.starts_with("### Index Coverage Hint") {
+    } else if lane_key.starts_with(CONTEXT_INDEX_COVERAGE_HINT_HEADING) {
         1_000
     } else {
         2_000
@@ -405,7 +408,7 @@ fn insert_context_memory_section(
     let Some(section) = context_memory_section(memory_matches, memory_matches_error) else {
         return;
     };
-    if let Some(idx) = output.find("\n### Entry Points") {
+    if let Some(idx) = output.find(&format!("\n{CONTEXT_ENTRY_POINTS_HEADING}")) {
         output.insert_str(idx, &section);
     } else {
         output.push_str(&section);
@@ -418,7 +421,9 @@ fn context_memory_section(
 ) -> Option<String> {
     let mut section = String::new();
     if !memory_matches.is_empty() {
-        section.push_str("\n### Memory Matches\n");
+        section.push('\n');
+        section.push_str(CONTEXT_MEMORY_MATCHES_HEADING);
+        section.push('\n');
         for hit in memory_matches {
             let fact = &hit.fact;
             let _ = writeln!(
@@ -434,7 +439,10 @@ fn context_memory_section(
         return Some(section);
     }
     if let Some(err) = memory_matches_error {
-        let _ = writeln!(section, "\n### Memory Matches\nUnavailable: {err}");
+        let _ = writeln!(
+            section,
+            "\n{CONTEXT_MEMORY_MATCHES_HEADING}\nUnavailable: {err}"
+        );
         return Some(section);
     }
     None
@@ -1668,6 +1676,26 @@ mod tests {
         assert!(preview.len() < full.len());
         assert!(preview.contains("lane truncated"));
         assert!(preview.is_char_boundary(preview.len()));
+    }
+
+    #[test]
+    fn context_lane_preview_keeps_seen_node_ids_parseable() {
+        let ids: Vec<String> = (0..100).map(|i| format!("function:{i:032x}")).collect();
+        let markdown = format!(
+            "{} {}\n",
+            CONTEXT_SEEN_NODE_IDS_LABEL,
+            serde_json::to_string(&ids).unwrap()
+        );
+
+        let preview = context_markdown_lane_preview(&markdown);
+        let json = preview
+            .strip_prefix(CONTEXT_SEEN_NODE_IDS_LABEL)
+            .expect("preview should keep seen_node_ids label")
+            .trim();
+        let parsed: Vec<String> = serde_json::from_str(json).unwrap();
+
+        assert_eq!(parsed, ids);
+        assert!(!preview.contains("lane truncated"));
     }
 
     #[test]

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -11,13 +11,15 @@ use crate::context::format_context_as_markdown;
 use crate::errors::{Result, TraceDecayError};
 use crate::memory::types::{FactSearchResult, SearchFactsRequest};
 use crate::path_tree::format_compact_path_list;
+use crate::text::utf8_prefix_at_or_before;
 use crate::tracedecay::TraceDecay;
 use crate::types::{BuildContextOptions, EdgeKind, Node, NodeKind, TaskContext, Visibility};
 
 const CONTEXT_MEMORY_MATCH_LIMIT: usize = 3;
 const CONTEXT_MEMORY_MATCH_LIMIT_MAX: usize = 10;
-const CONTEXT_MEMORY_SNIPPET_CHARS: usize = 240;
 const CONTEXT_MEMORY_ANALYTICS_KEY: &str = "context_memory_analytics";
+const CONTEXT_LANE_TRUNCATED_NOTE: &str =
+    "\n... lane truncated; retrieve the full response handle for omitted details.\n";
 
 use super::super::render::{self, Md};
 use super::super::ToolResult;
@@ -49,6 +51,39 @@ where
         value
     };
     let text = render::finalize(Some(cg.project_root()), args, value, md);
+    let result = text_tool_result(&text, touched_files);
+    if let Some(internal_analytics) = internal_analytics {
+        result.with_internal_analytics(internal_analytics)
+    } else {
+        result
+    }
+}
+
+fn rendered_context_tool_result(
+    cg: &TraceDecay,
+    args: &Value,
+    value: &Value,
+    touched_files: Vec<String>,
+    full_markdown: String,
+    preview_markdown: Option<&str>,
+) -> ToolResult {
+    let internal_analytics = value.get(CONTEXT_MEMORY_ANALYTICS_KEY).cloned();
+    let public_value;
+    let value = if internal_analytics.is_some() {
+        public_value = strip_internal_context_memory_analytics(value);
+        &public_value
+    } else {
+        value
+    };
+    let text = if render::wants_json(args) {
+        render::finalize(Some(cg.project_root()), args, value, || full_markdown)
+    } else {
+        render::markdown_preview_with_handle(
+            Some(cg.project_root()),
+            &full_markdown,
+            preview_markdown.unwrap_or(&full_markdown),
+        )
+    };
     let result = text_tool_result(&text, touched_files);
     if let Some(internal_analytics) = internal_analytics {
         result.with_internal_analytics(internal_analytics)
@@ -226,23 +261,11 @@ pub(super) async fn handle_context(
             ),
     );
     let mut output = format_context_as_markdown(&context);
-    if !memory_matches.is_empty() {
-        let _ = writeln!(output, "\n### Memory Matches");
-        for hit in &memory_matches {
-            let fact = &hit.fact;
-            let _ = writeln!(
-                output,
-                "- fact_id={} category={} trust={:.2} score={:.3}: {}",
-                fact.fact_id,
-                fact.category,
-                fact.trust_score,
-                hit.score,
-                compact_memory_content(&fact.content)
-            );
-        }
-    } else if let Some(err) = &memory_matches_error {
-        let _ = writeln!(output, "\n### Memory Matches\nUnavailable: {err}");
-    }
+    insert_context_memory_section(
+        &mut output,
+        &memory_matches,
+        memory_matches_error.as_deref(),
+    );
     if let Some(hint) = cg.index_coverage_hint(context.subgraph.nodes.len()) {
         let _ = writeln!(
             output,
@@ -286,13 +309,139 @@ pub(super) async fn handle_context(
             object.insert("memory_matches_error".to_string(), json!(err));
         }
     }
-    Ok(rendered_tool_result(
+    let preview = (!render::wants_json(&args)).then(|| context_markdown_lane_preview(&output));
+    Ok(rendered_context_tool_result(
         cg,
         &args,
         &value,
         touched_files,
-        || output,
+        output,
+        preview.as_deref(),
     ))
+}
+
+fn context_markdown_lane_preview(markdown: &str) -> String {
+    let mut preview = String::with_capacity(markdown.len().min(24_000));
+    let mut lane = String::new();
+    let mut lane_key = String::new();
+    let mut in_fence = false;
+
+    for line in markdown.split_inclusive('\n') {
+        if !in_fence {
+            if let Some(key) = context_lane_key(line) {
+                push_context_lane_preview(&mut preview, &lane_key, &lane);
+                lane.clear();
+                lane_key = key.to_string();
+            }
+        }
+        lane.push_str(line);
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+        }
+    }
+    push_context_lane_preview(&mut preview, &lane_key, &lane);
+    preview
+}
+
+fn context_lane_key(line: &str) -> Option<&str> {
+    if line.starts_with("### ") || line.starts_with("seen_node_ids:") {
+        Some(line.trim_end())
+    } else {
+        None
+    }
+}
+
+fn push_context_lane_preview(preview: &mut String, lane_key: &str, lane: &str) {
+    if lane.is_empty() {
+        return;
+    }
+    let budget = context_lane_budget(lane_key);
+    if lane.len() <= budget {
+        preview.push_str(lane);
+        return;
+    }
+    let prefix = utf8_prefix_at_or_before(lane, budget);
+    preview.push_str(prefix);
+    if has_open_markdown_fence(prefix) {
+        preview.push_str("\n```\n");
+    }
+    preview.push_str(CONTEXT_LANE_TRUNCATED_NOTE);
+}
+
+fn context_lane_budget(lane_key: &str) -> usize {
+    if lane_key.starts_with("### Code") {
+        8_500
+    } else if lane_key.starts_with("### Related Symbols") {
+        3_500
+    } else if lane_key.starts_with("### Entry Points") || lane_key.starts_with("### Test Coverage")
+    {
+        3_000
+    } else if lane_key.starts_with("### Memory Matches") {
+        2_500
+    } else if lane_key.starts_with("### Extension Points") || lane_key.starts_with("seen_node_ids:")
+    {
+        1_500
+    } else if lane_key.starts_with("### Index Coverage Hint") {
+        1_000
+    } else {
+        2_000
+    }
+}
+
+fn has_open_markdown_fence(markdown: &str) -> bool {
+    markdown
+        .lines()
+        .filter(|line| line.trim_start().starts_with("```"))
+        .count()
+        % 2
+        == 1
+}
+
+fn insert_context_memory_section(
+    output: &mut String,
+    memory_matches: &[FactSearchResult],
+    memory_matches_error: Option<&str>,
+) {
+    let Some(section) = context_memory_section(memory_matches, memory_matches_error) else {
+        return;
+    };
+    if let Some(idx) = output.find("\n### Entry Points") {
+        output.insert_str(idx, &section);
+    } else {
+        output.push_str(&section);
+    }
+}
+
+fn context_memory_section(
+    memory_matches: &[FactSearchResult],
+    memory_matches_error: Option<&str>,
+) -> Option<String> {
+    let mut section = String::new();
+    if !memory_matches.is_empty() {
+        section.push_str("\n### Memory Matches\n");
+        for hit in memory_matches {
+            let fact = &hit.fact;
+            let _ = writeln!(
+                section,
+                "- fact_id={} category={} trust={:.2} score={:.3}: {}",
+                fact.fact_id,
+                fact.category,
+                fact.trust_score,
+                hit.score,
+                compact_memory_content(&fact.content)
+            );
+        }
+        return Some(section);
+    }
+    if let Some(err) = memory_matches_error {
+        let _ = writeln!(section, "\n### Memory Matches\nUnavailable: {err}");
+        return Some(section);
+    }
+    None
+}
+
+fn compact_memory_content(content: &str) -> String {
+    content.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 struct ContextMemoryOptions {
@@ -355,22 +504,6 @@ async fn context_memory_matches(
         include_why: false,
     })
     .await
-}
-
-fn compact_memory_content(content: &str) -> String {
-    let mut snippet = String::new();
-    let mut truncated = false;
-    for (idx, ch) in content.chars().enumerate() {
-        if idx >= CONTEXT_MEMORY_SNIPPET_CHARS {
-            truncated = true;
-            break;
-        }
-        snippet.push(ch);
-    }
-    if truncated {
-        snippet.push_str("...");
-    }
-    snippet
 }
 
 fn build_context_options(args: &Value, scope_prefix: Option<&str>) -> BuildContextOptions {
@@ -1496,4 +1629,146 @@ async fn collect_method_bodies(
         }));
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::types::{FactRecord, FactSearchResult, MemoryCategory};
+
+    #[test]
+    fn context_markdown_lane_preview_keeps_all_lanes_visible() {
+        let full = format!(
+            "## Code Context\n**Query:** q\n\n### Memory Matches\n{}\n### Entry Points\n{}\n### Related Symbols\n{}\n### Code\n{}\n### Index Coverage Hint\n{}\n### Extension Points\n{}\n### Test Coverage\n{}\nseen_node_ids: [{}]\n",
+            "memory fact with unicode caf\u{e9}\n".repeat(300),
+            "- **entry** src/lib.rs:1\n".repeat(300),
+            "- related\n".repeat(500),
+            "```rust\nfn demo() {}\n```\n".repeat(500),
+            "hint\n".repeat(500),
+            "- trait\n".repeat(400),
+            "- tests/context_test.rs\n".repeat(400),
+            "\"node-id\",".repeat(400)
+        );
+
+        let preview = context_markdown_lane_preview(&full);
+
+        for heading in [
+            "## Code Context",
+            "### Memory Matches",
+            "### Entry Points",
+            "### Related Symbols",
+            "### Code",
+            "### Index Coverage Hint",
+            "### Extension Points",
+            "### Test Coverage",
+            "seen_node_ids:",
+        ] {
+            assert!(preview.contains(heading), "missing {heading}: {preview}");
+        }
+        assert!(preview.len() < full.len());
+        assert!(preview.contains("lane truncated"));
+        assert!(preview.is_char_boundary(preview.len()));
+    }
+
+    #[test]
+    fn context_memory_section_keeps_full_content_for_retrieval_handle() {
+        let content = format!("{}tail-marker", "long memory body ".repeat(100));
+        let hit = FactSearchResult {
+            fact: FactRecord {
+                fact_id: 7,
+                content: content.clone(),
+                category: MemoryCategory::Project,
+                trust_score: 0.9,
+                source: Some("test".to_string()),
+                entities: vec![],
+                tags: vec![],
+                metadata: serde_json::Value::Null,
+                created_at: 0,
+                updated_at: 0,
+                access_count: 0,
+                last_retrieved_at: None,
+                retrieval_count: 0,
+                helpful_count: 0,
+                unhelpful_count: 0,
+                last_feedback_at: None,
+                last_recalled_at: None,
+            },
+            score: 0.5,
+            fts_score: 0.25,
+            jaccard_score: 0.25,
+            holographic_score: 0.0,
+            trust_score: 0.9,
+            why: None,
+        };
+
+        let Some(section) = context_memory_section(&[hit], None) else {
+            panic!("memory hit should render");
+        };
+
+        assert!(section.contains(&content));
+        assert!(section.contains("tail-marker"));
+        assert!(!section.contains("..."));
+    }
+
+    #[test]
+    fn context_memory_section_compacts_multiline_content() {
+        let hit = FactSearchResult {
+            fact: FactRecord {
+                fact_id: 7,
+                content: "first line\n# heading\n- item".to_string(),
+                category: MemoryCategory::Project,
+                trust_score: 0.9,
+                source: Some("test".to_string()),
+                entities: vec![],
+                tags: vec![],
+                metadata: serde_json::Value::Null,
+                created_at: 0,
+                updated_at: 0,
+                access_count: 0,
+                last_retrieved_at: None,
+                retrieval_count: 0,
+                helpful_count: 0,
+                unhelpful_count: 0,
+                last_feedback_at: None,
+                last_recalled_at: None,
+            },
+            score: 0.5,
+            fts_score: 0.25,
+            jaccard_score: 0.25,
+            holographic_score: 0.0,
+            trust_score: 0.9,
+            why: None,
+        };
+
+        let Some(section) = context_memory_section(&[hit], None) else {
+            panic!("memory hit should render");
+        };
+
+        assert!(section.contains("first line # heading - item"));
+        assert!(!section.contains("\n# heading"));
+        assert!(!section.contains("\n- item"));
+    }
+
+    #[test]
+    fn context_lane_preview_closes_open_code_fence_before_truncation_note() {
+        let markdown = format!("### Code\n```rust\n{}\n", "fn demo() {}\n".repeat(1_000));
+
+        let preview = context_markdown_lane_preview(&markdown);
+
+        assert!(preview.contains("```\n\n... lane truncated"));
+    }
+
+    #[test]
+    fn context_lane_preview_ignores_heading_markers_inside_code_fences() {
+        let markdown = format!(
+            "### Code\n```markdown\n{}\n```\n### Test Coverage\n- real lane\n",
+            "### not a lane\n".repeat(1_000)
+        );
+
+        let preview = context_markdown_lane_preview(&markdown);
+
+        assert!(preview.contains("### Code"));
+        assert!(preview.contains("### Test Coverage"));
+        assert_eq!(preview.matches("lane truncated").count(), 1);
+    }
 }

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -1684,15 +1684,17 @@ mod tests {
         let markdown = format!(
             "{} {}\n",
             CONTEXT_SEEN_NODE_IDS_LABEL,
-            serde_json::to_string(&ids).unwrap()
+            serde_json::to_string(&ids)
+                .unwrap_or_else(|err| panic!("failed to serialize seen node ids: {err}"))
         );
 
         let preview = context_markdown_lane_preview(&markdown);
-        let json = preview
-            .strip_prefix(CONTEXT_SEEN_NODE_IDS_LABEL)
-            .expect("preview should keep seen_node_ids label")
-            .trim();
-        let parsed: Vec<String> = serde_json::from_str(json).unwrap();
+        let json = match preview.strip_prefix(CONTEXT_SEEN_NODE_IDS_LABEL) {
+            Some(json) => json.trim(),
+            None => panic!("preview should keep seen_node_ids label: {preview}"),
+        };
+        let parsed: Vec<String> = serde_json::from_str(json)
+            .unwrap_or_else(|err| panic!("failed to parse seen node ids: {err}: {json}"));
 
         assert_eq!(parsed, ids);
         assert!(!preview.contains("lane truncated"));

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -149,7 +149,6 @@ fn render_status_md(value: &Value) -> String {
     let mut md = Md::new();
     md.heading(2, "Project Status");
     if let Some(obj) = value.as_object() {
-        let mut rows: Vec<Vec<String>> = Vec::new();
         let mut warnings: Vec<String> = Vec::new();
         let mut keys: Vec<&String> = obj.keys().collect();
         keys.sort();
@@ -162,15 +161,24 @@ fn render_status_md(value: &Value) -> String {
                 }
             }
             match v {
-                Value::String(s) => rows.push(vec![k.clone(), s.clone()]),
-                Value::Number(n) => rows.push(vec![k.clone(), n.to_string()]),
-                Value::Bool(b) => rows.push(vec![k.clone(), b.to_string()]),
-                Value::Array(a) => rows.push(vec![k.clone(), format!("{} item(s)", a.len())]),
-                Value::Object(o) => rows.push(vec![k.clone(), format!("{{{} field(s)}}", o.len())]),
+                Value::String(s) => {
+                    md.field(k, s);
+                }
+                Value::Number(n) => {
+                    md.field(k, &n.to_string());
+                }
+                Value::Bool(b) => {
+                    md.field(k, &b.to_string());
+                }
+                Value::Array(a) => {
+                    md.field(k, &format!("{} item(s)", a.len()));
+                }
+                Value::Object(o) => {
+                    md.field(k, &format!("{{{} field(s)}}", o.len()));
+                }
                 Value::Null => {}
             }
         }
-        md.table(&["field", "value"], &rows);
         if !warnings.is_empty() {
             md.blank().heading(3, "Warnings");
             for w in &warnings {
@@ -1404,79 +1412,74 @@ fn render_simplify_scan_markdown(output: &Value) -> String {
 }
 
 fn render_simplify_duplications(md: &mut Md, items: &[Value]) {
-    if items.is_empty() {
-        return;
-    }
-    md.heading(2, "Possible Duplications");
-    let rows = items
-        .iter()
-        .map(|item| {
-            vec![
-                render::field_str(item, "symbol").to_string(),
-                finding_location(item),
-                summarize_similar_symbols(item),
-            ]
-        })
-        .collect::<Vec<_>>();
-    md.table(&["Symbol", "Location", "Similar Symbols"], &rows)
-        .blank();
+    render_simplify_section(md, "Possible Duplications", items, "symbol", |md, item| {
+        md.line(&format!("  **Location:** {}", finding_location(item)));
+        let similar = summarize_similar_symbols(item);
+        if !similar.is_empty() {
+            md.line(&format!("  **Similar symbols:** {similar}"));
+        }
+    });
 }
 
 fn render_simplify_dead_code(md: &mut Md, items: &[Value]) {
-    if items.is_empty() {
-        return;
-    }
-    md.heading(2, "Potential Dead Code");
-    let rows = items
-        .iter()
-        .map(|item| {
-            vec![
-                render::field_str(item, "symbol").to_string(),
-                finding_location(item),
-                render::field_str(item, "reason").to_string(),
-            ]
-        })
-        .collect::<Vec<_>>();
-    md.table(&["Symbol", "Location", "Reason"], &rows).blank();
+    render_simplify_section(md, "Potential Dead Code", items, "symbol", |md, item| {
+        md.line(&format!("  **Location:** {}", finding_location(item)));
+        md.line(&format!(
+            "  **Reason:** {}",
+            render::field_str(item, "reason")
+        ));
+    });
 }
 
 fn render_simplify_complexity(md: &mut Md, items: &[Value]) {
-    if items.is_empty() {
-        return;
-    }
-    md.heading(2, "Complexity Warnings");
-    let rows = items
-        .iter()
-        .map(|item| {
-            vec![
-                render::field_str(item, "symbol").to_string(),
-                finding_location(item),
-                render::field_i64(item, "lines").to_string(),
-                render::field_i64(item, "fan_out").to_string(),
-                render::field_i64(item, "score").to_string(),
-            ]
-        })
-        .collect::<Vec<_>>();
-    md.table(&["Symbol", "Location", "Lines", "Fan-out", "Score"], &rows)
-        .blank();
+    render_simplify_section(md, "Complexity Warnings", items, "symbol", |md, item| {
+        md.line(&format!("  **Location:** {}", finding_location(item)));
+        md.line(&format!(
+            "  **Lines:** {}",
+            render::field_i64(item, "lines")
+        ));
+        md.line(&format!(
+            "  **Fan-out:** {}",
+            render::field_i64(item, "fan_out")
+        ));
+        md.line(&format!(
+            "  **Score:** {}",
+            render::field_i64(item, "score")
+        ));
+    });
 }
 
 fn render_simplify_coupling(md: &mut Md, items: &[Value]) {
+    render_simplify_section(md, "Coupling Warnings", items, "file", |md, item| {
+        md.line(&format!(
+            "  **Fan-in:** {}",
+            render::field_i64(item, "fan_in")
+        ));
+        md.line(&format!(
+            "  **Warning:** {}",
+            render::field_str(item, "warning")
+        ));
+    });
+}
+
+fn render_simplify_section<FDetails>(
+    md: &mut Md,
+    title: &str,
+    items: &[Value],
+    label_field: &str,
+    details: FDetails,
+) where
+    FDetails: Fn(&mut Md, &Value),
+{
     if items.is_empty() {
         return;
     }
-    md.heading(2, "Coupling Warnings");
-    let rows = items
-        .iter()
-        .map(|item| {
-            vec![
-                render::field_str(item, "file").to_string(),
-                render::field_i64(item, "fan_in").to_string(),
-                render::field_str(item, "warning").to_string(),
-            ]
-        })
-        .collect::<Vec<_>>();
-    md.table(&["File", "Fan-in", "Warning"], &rows).blank();
+    md.heading(2, title);
+    for item in items {
+        md.bullet(&format!("**{}**", render::field_str(item, label_field)));
+        details(md, item);
+    }
+    md.blank();
 }
 
 fn finding_location(item: &Value) -> String {
@@ -2297,25 +2300,25 @@ fn render_outline_md(value: &Value) -> String {
     md.blank();
     match value.get("symbols").and_then(Value::as_array) {
         Some(symbols) if !symbols.is_empty() => {
-            let rows: Vec<Vec<String>> = symbols
-                .iter()
-                .map(|s| {
-                    let line = render::field_i64(s, "line");
-                    let end = render::field_i64(s, "end_line");
-                    let span = if end > line {
-                        format!("{line}-{end}")
-                    } else {
-                        line.to_string()
-                    };
-                    vec![
-                        render::field_str(s, "name").to_string(),
-                        render::field_str(s, "kind").to_string(),
-                        span,
-                        render::field_str(s, "visibility").to_string(),
-                    ]
-                })
-                .collect();
-            md.table(&["symbol", "kind", "lines", "visibility"], &rows);
+            for symbol in symbols {
+                let name = render::field_str(symbol, "name");
+                let kind = render::field_str(symbol, "kind");
+                let visibility = render::field_str(symbol, "visibility");
+                let line = render::field_i64(symbol, "line");
+                let end = render::field_i64(symbol, "end_line");
+                let span = if end > line {
+                    format!("{line}-{end}")
+                } else {
+                    line.to_string()
+                };
+                let signature = render::field_str(symbol, "signature");
+                md.bullet(&format!(
+                    "**{name}** ({kind}) - lines {span} - {visibility}"
+                ));
+                if !signature.is_empty() {
+                    md.line(&format!("  `{signature}`"));
+                }
+            }
         }
         _ => {
             md.empty_note("No symbols.");

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -213,16 +213,18 @@ pub async fn handle_tool_call_with_registry(
             global_db,
             allow_default_registry_fallback,
             implicit_project_path: None,
+            automation_scheduler_reconciler: None,
         },
     )
     .await
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct ToolCallRegistryOptions<'a> {
     pub global_db: Option<&'a GlobalDb>,
     pub allow_default_registry_fallback: bool,
     pub implicit_project_path: Option<&'a Path>,
+    pub automation_scheduler_reconciler: Option<crate::dashboard::AutomationSchedulerReconciler>,
 }
 
 pub async fn handle_tool_call_with_registry_and_implicit_project(
@@ -422,7 +424,10 @@ pub async fn handle_tool_call_with_registry_and_implicit_project(
         "tracedecay_skill_list" => skills::handle_skill_list(cg, args).await,
         "tracedecay_skill_view" => skills::handle_skill_view(cg, args).await,
         "tracedecay_hermes_skill_bridge" => skills::handle_hermes_skill_bridge(cg, &args),
-        "tracedecay_dashboard" => dashboard::handle_dashboard(cg, args).await,
+        "tracedecay_dashboard" => {
+            dashboard::handle_dashboard(cg, args, options.automation_scheduler_reconciler.clone())
+                .await
+        }
         "tracedecay_message_search" => {
             session::handle_message_search(
                 cg,
@@ -913,7 +918,7 @@ mod tests {
 
     #[tokio::test]
     async fn selected_project_retrieve_finds_selected_project_response_handle() {
-        const LARGE_RESPONSE_MARKER_COUNT: usize = 120;
+        const LARGE_RESPONSE_MARKER_COUNT: usize = 260;
         const LAST_LARGE_RESPONSE_MARKER: usize = LARGE_RESPONSE_MARKER_COUNT - 1;
 
         let _env_lock = lock_user_data_dir_test_env();

--- a/src/mcp/tools/handlers/workflow.rs
+++ b/src/mcp/tools/handlers/workflow.rs
@@ -202,7 +202,7 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
         "diagnostics": items,
     });
     let text = render::finalize(Some(cg.project_root()), &args, &body, || {
-        render::generic_md(&body)
+        render::diagnostics_md(&body)
     });
     Ok(ToolResult::new(
         json!({
@@ -430,17 +430,21 @@ fn select_test_targets(
 fn cargo_test_command(project_root: &Path, profile: &str, test_names: &[String]) -> Command {
     let mut cmd = Command::new("cargo");
     cmd.current_dir(project_root)
-        .arg("test")
-        .arg("--no-fail-fast");
-    if profile == "release" {
-        cmd.arg("--release");
-    }
-    cmd.arg("--");
-    for name in test_names {
-        cmd.arg(name);
-    }
+        .args(cargo_test_args(profile, test_names));
     cmd.kill_on_drop(true);
     cmd
+}
+
+fn cargo_test_args(profile: &str, test_names: &[String]) -> Vec<String> {
+    let mut args = vec!["test".to_string(), "--no-fail-fast".to_string()];
+    if profile == "release" {
+        args.push("--release".to_string());
+    }
+    args.push("--".to_string());
+    for name in test_names {
+        args.push(name.clone());
+    }
+    args
 }
 
 fn run_affected_tests_body(
@@ -605,6 +609,23 @@ test result: FAILED. 1 passed; 1 failed; 1 ignored
 ";
         let results = parse_libtest_output(stdout);
         assert_eq!(results, vec![("foo".into(), true), ("bar".into(), false)]);
+    }
+
+    #[test]
+    fn cargo_test_args_put_multiple_filters_after_libtest_separator() {
+        let args = cargo_test_args("debug", &["alpha".to_string(), "beta".to_string()]);
+
+        assert_eq!(args, ["test", "--no-fail-fast", "--", "alpha", "beta"]);
+    }
+
+    #[test]
+    fn cargo_test_args_keep_release_before_libtest_separator() {
+        let args = cargo_test_args("release", &["alpha".to_string(), "beta".to_string()]);
+
+        assert_eq!(
+            args,
+            ["test", "--no-fail-fast", "--release", "--", "alpha", "beta"]
+        );
     }
 
     #[test]

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use serde_json::Value;
 
+use crate::context::CONTEXT_PRIORITY_HEADINGS;
 use crate::display::format_relative_time;
 use crate::mcp::response_handles::{
     note_response_handle_store_skipped_no_project_root, observe_response_truncation,
@@ -17,12 +18,6 @@ use crate::tracedecay::current_timestamp;
 use super::MAX_RESPONSE_CHARS;
 
 const MARKDOWN_TRUNCATION_RESERVED_CHARS: usize = 2_048;
-const MARKDOWN_PRIORITY_HEADINGS: &[&str] = &[
-    "### Memory Matches",
-    "### Entry Points",
-    "### Extension Points",
-    "### Test Coverage",
-];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OutputFormat {
@@ -178,12 +173,14 @@ pub(super) fn truncate_text_with_handle(project_root: Option<&Path>, text: &str)
     truncated_markdown_with_handle(project_root, text)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn markdown_preview_with_handle(
     project_root: Option<&Path>,
     full_text: &str,
     preview: &str,
 ) -> String {
+    if full_text.len() <= MAX_RESPONSE_CHARS {
+        return full_text.to_string();
+    }
     if full_text == preview {
         return truncated_markdown_with_handle(project_root, full_text);
     }
@@ -194,21 +191,10 @@ fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> St
     if text.len() <= MAX_RESPONSE_CHARS {
         return text.to_string();
     }
-    let started = std::time::Instant::now();
-    let now = current_timestamp();
-    let handle = prepare_truncated_response_handle(project_root, text);
-    let end = text
-        .len()
-        .min(MAX_RESPONSE_CHARS.saturating_sub(MARKDOWN_TRUNCATION_RESERVED_CHARS));
-    render_markdown_with_shrinking_preview(
-        &MarkdownPreviewRender {
-            project_root,
-            full_len: text.len(),
-            handle: &handle,
-            started,
-            now,
-        },
-        end,
+    render_markdown_truncation_with_handle(
+        project_root,
+        text,
+        text.len(),
         |end| markdown_truncation_preview(text, end),
         |preview| {
             format!(
@@ -220,27 +206,15 @@ fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> St
     )
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 fn markdown_preview_truncation_with_handle(
     project_root: Option<&Path>,
     full_text: &str,
     preview: &str,
 ) -> String {
-    let started = std::time::Instant::now();
-    let now = current_timestamp();
-    let handle = prepare_truncated_response_handle(project_root, full_text);
-    let end = preview
-        .len()
-        .min(MAX_RESPONSE_CHARS.saturating_sub(MARKDOWN_TRUNCATION_RESERVED_CHARS));
-    render_markdown_with_shrinking_preview(
-        &MarkdownPreviewRender {
-            project_root,
-            full_len: full_text.len(),
-            handle: &handle,
-            started,
-            now,
-        },
-        end,
+    render_markdown_truncation_with_handle(
+        project_root,
+        full_text,
+        preview.len(),
         |end| {
             if preview.len() <= end {
                 preview.to_string()
@@ -258,32 +232,28 @@ fn markdown_preview_truncation_with_handle(
     )
 }
 
-struct MarkdownPreviewRender<'a> {
-    project_root: Option<&'a Path>,
-    full_len: usize,
-    handle: &'a TruncatedResponseHandle,
-    started: std::time::Instant,
-    now: i64,
-}
-
-fn render_markdown_with_shrinking_preview(
-    context: &MarkdownPreviewRender<'_>,
+fn render_markdown_truncation_with_handle(
+    project_root: Option<&Path>,
+    full_text: &str,
     mut end: usize,
     mut preview_for_end: impl FnMut(usize) -> String,
     preview_note: impl Fn(&str) -> String,
 ) -> String {
+    let started = std::time::Instant::now();
+    let now = current_timestamp();
+    let handle = prepare_truncated_response_handle(project_root, full_text);
+    end = end.min(MAX_RESPONSE_CHARS.saturating_sub(MARKDOWN_TRUNCATION_RESERVED_CHARS));
     loop {
         let preview = preview_for_end(end);
-        let rendered =
-            render_markdown_truncation(&preview, context.handle, &preview_note(&preview));
+        let rendered = render_markdown_truncation(&preview, &handle, &preview_note(&preview));
         if rendered.len() <= MAX_RESPONSE_CHARS || end == 0 {
             observe_response_truncation(
-                context.full_len,
+                full_text.len(),
                 rendered.len(),
-                context.handle.record.is_some(),
-                context.now,
-                truncation_handle_status(context.project_root, context.handle),
-                context.started.elapsed(),
+                handle.record.is_some(),
+                now,
+                truncation_handle_status(project_root, &handle),
+                started.elapsed(),
             );
             return rendered;
         }
@@ -295,7 +265,7 @@ fn markdown_truncation_preview(text: &str, budget: usize) -> String {
     if text.len() <= budget {
         return text.to_string();
     }
-    let has_late_priority = MARKDOWN_PRIORITY_HEADINGS
+    let has_late_priority = CONTEXT_PRIORITY_HEADINGS
         .iter()
         .any(|heading| text.find(heading).is_some_and(|idx| idx > budget));
     if !has_late_priority {
@@ -310,7 +280,7 @@ fn markdown_truncation_preview(text: &str, budget: usize) -> String {
     let mut remaining = budget.saturating_sub(preview.len());
     let mut preserved = String::new();
 
-    for heading in MARKDOWN_PRIORITY_HEADINGS {
+    for heading in CONTEXT_PRIORITY_HEADINGS {
         let Some(start) = text.find(heading) else {
             continue;
         };
@@ -447,8 +417,7 @@ fn render_markdown_truncation(
         let _ = writeln!(
             rendered,
             "Full response stored locally. Retrieve it with `{RESPONSE_RETRIEVE_TOOL}` using handle `{}` before {}.",
-            record.handle,
-            record.expires_at
+            record.handle, record.expires_at
         );
     } else if let Some(status) = &handle.unavailable {
         let message = status

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -611,6 +611,9 @@ fn render_object_array_table(md: &mut Md, arr: &[Value]) {
     }
 
     if keep.is_empty() {
+        if hoisted.is_empty() {
+            md.empty_note("No visible fields.");
+        }
         return;
     }
     let headers: Vec<&str> = keep.iter().map(|&ci| cols[ci].as_str()).collect();

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -11,9 +11,18 @@ use crate::mcp::response_handles::{
     store_response_handle, ResponseHandleRecord, RESPONSE_HANDLE_TTL_SECS, RESPONSE_RETRIEVE_TOOL,
 };
 use crate::path_tree::format_compact_path_list;
+use crate::text::utf8_prefix_at_or_before;
 use crate::tracedecay::current_timestamp;
 
 use super::MAX_RESPONSE_CHARS;
+
+const MARKDOWN_TRUNCATION_RESERVED_CHARS: usize = 2_048;
+const MARKDOWN_PRIORITY_HEADINGS: &[&str] = &[
+    "### Memory Matches",
+    "### Entry Points",
+    "### Extension Points",
+    "### Test Coverage",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OutputFormat {
@@ -169,6 +178,18 @@ pub(super) fn truncate_text_with_handle(project_root: Option<&Path>, text: &str)
     truncated_markdown_with_handle(project_root, text)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn markdown_preview_with_handle(
+    project_root: Option<&Path>,
+    full_text: &str,
+    preview: &str,
+) -> String {
+    if full_text == preview {
+        return truncated_markdown_with_handle(project_root, full_text);
+    }
+    markdown_preview_truncation_with_handle(project_root, full_text, preview)
+}
+
 fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> String {
     if text.len() <= MAX_RESPONSE_CHARS {
         return text.to_string();
@@ -176,26 +197,188 @@ fn truncated_markdown_with_handle(project_root: Option<&Path>, text: &str) -> St
     let started = std::time::Instant::now();
     let now = current_timestamp();
     let handle = prepare_truncated_response_handle(project_root, text);
-    let mut end = text.len().min(MAX_RESPONSE_CHARS.saturating_sub(2048));
+    let end = text
+        .len()
+        .min(MAX_RESPONSE_CHARS.saturating_sub(MARKDOWN_TRUNCATION_RESERVED_CHARS));
+    render_markdown_with_shrinking_preview(
+        &MarkdownPreviewRender {
+            project_root,
+            full_len: text.len(),
+            handle: &handle,
+            started,
+            now,
+        },
+        end,
+        |end| markdown_truncation_preview(text, end),
+        |preview| {
+            format!(
+                "Showing the first {} of {} characters.",
+                preview.len(),
+                text.len()
+            )
+        },
+    )
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn markdown_preview_truncation_with_handle(
+    project_root: Option<&Path>,
+    full_text: &str,
+    preview: &str,
+) -> String {
+    let started = std::time::Instant::now();
+    let now = current_timestamp();
+    let handle = prepare_truncated_response_handle(project_root, full_text);
+    let end = preview
+        .len()
+        .min(MAX_RESPONSE_CHARS.saturating_sub(MARKDOWN_TRUNCATION_RESERVED_CHARS));
+    render_markdown_with_shrinking_preview(
+        &MarkdownPreviewRender {
+            project_root,
+            full_len: full_text.len(),
+            handle: &handle,
+            started,
+            now,
+        },
+        end,
+        |end| {
+            if preview.len() <= end {
+                preview.to_string()
+            } else {
+                markdown_truncation_preview(preview, end)
+            }
+        },
+        |compact_preview| {
+            format!(
+                "Showing a lane-budgeted preview of {} characters from {} original characters.",
+                compact_preview.len(),
+                full_text.len()
+            )
+        },
+    )
+}
+
+struct MarkdownPreviewRender<'a> {
+    project_root: Option<&'a Path>,
+    full_len: usize,
+    handle: &'a TruncatedResponseHandle,
+    started: std::time::Instant,
+    now: i64,
+}
+
+fn render_markdown_with_shrinking_preview(
+    context: &MarkdownPreviewRender<'_>,
+    mut end: usize,
+    mut preview_for_end: impl FnMut(usize) -> String,
+    preview_note: impl Fn(&str) -> String,
+) -> String {
     loop {
-        while end > 0 && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-        let preview = &text[..end];
-        let rendered = render_markdown_truncation(preview, text.len(), &handle);
+        let preview = preview_for_end(end);
+        let rendered =
+            render_markdown_truncation(&preview, context.handle, &preview_note(&preview));
         if rendered.len() <= MAX_RESPONSE_CHARS || end == 0 {
             observe_response_truncation(
-                text.len(),
+                context.full_len,
                 rendered.len(),
-                handle.record.is_some(),
-                now,
-                truncation_handle_status(project_root, &handle),
-                started.elapsed(),
+                context.handle.record.is_some(),
+                context.now,
+                truncation_handle_status(context.project_root, context.handle),
+                context.started.elapsed(),
             );
             return rendered;
         }
         end = end.saturating_sub(1024);
     }
+}
+
+fn markdown_truncation_preview(text: &str, budget: usize) -> String {
+    if text.len() <= budget {
+        return text.to_string();
+    }
+    let has_late_priority = MARKDOWN_PRIORITY_HEADINGS
+        .iter()
+        .any(|heading| text.find(heading).is_some_and(|idx| idx > budget));
+    if !has_late_priority {
+        return markdown_prefix_preview(text, budget);
+    }
+
+    let prefix_budget = budget.saturating_mul(2) / 3;
+    let prefix = utf8_prefix_at_or_before(text, prefix_budget);
+    let prefix_len = prefix.len();
+    let mut preview = prefix.to_string();
+    close_open_markdown_fence(&mut preview);
+    let mut remaining = budget.saturating_sub(preview.len());
+    let mut preserved = String::new();
+
+    for heading in MARKDOWN_PRIORITY_HEADINGS {
+        let Some(start) = text.find(heading) else {
+            continue;
+        };
+        if start < prefix_len {
+            continue;
+        }
+        let section_header = if preserved.is_empty() {
+            "\n\n## Preserved Priority Sections\n\n"
+        } else {
+            "\n"
+        };
+        if remaining <= section_header.len() + 96 {
+            break;
+        }
+        preserved.push_str(section_header);
+        remaining -= section_header.len();
+
+        let section = markdown_section_at(text, start);
+        let section_preview = utf8_prefix_at_or_before(section, remaining);
+        preserved.push_str(section_preview);
+        let section_truncated = section_preview.len() < section.len();
+        close_open_markdown_fence(&mut preserved);
+        remaining = budget.saturating_sub(preview.len() + preserved.len());
+        if section_truncated && remaining >= 5 {
+            preserved.push_str("\n...");
+            remaining -= 5;
+        }
+    }
+
+    if preserved.is_empty() {
+        return markdown_prefix_preview(text, budget);
+    }
+    preview.push_str(&preserved);
+    preview
+}
+
+fn markdown_prefix_preview(text: &str, budget: usize) -> String {
+    let mut preview = utf8_prefix_at_or_before(text, budget).to_string();
+    close_open_markdown_fence(&mut preview);
+    preview
+}
+
+fn markdown_section_at(text: &str, start: usize) -> &str {
+    let rest = &text[start..];
+    let end = ["\n## ", "\n### "]
+        .into_iter()
+        .filter_map(|marker| rest[1..].find(marker).map(|idx| idx + 1))
+        .min()
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+fn close_open_markdown_fence(markdown: &mut String) {
+    if has_open_markdown_fence(markdown) {
+        if !markdown.ends_with('\n') {
+            markdown.push('\n');
+        }
+        markdown.push_str("```");
+    }
+}
+
+fn has_open_markdown_fence(markdown: &str) -> bool {
+    markdown
+        .lines()
+        .filter(|line| line.trim_start().starts_with("```"))
+        .count()
+        % 2
+        == 1
 }
 
 struct TruncatedResponseHandle {
@@ -254,16 +437,12 @@ fn prepare_truncated_response_handle(
 
 fn render_markdown_truncation(
     preview: &str,
-    original_chars: usize,
     handle: &TruncatedResponseHandle,
+    preview_note: &str,
 ) -> String {
     let mut rendered = String::new();
     rendered.push_str("# Truncated Response\n\n");
-    let _ = writeln!(
-        rendered,
-        "Showing the first {} of {original_chars} characters.",
-        preview.len()
-    );
+    let _ = writeln!(rendered, "{preview_note}");
     if let Some(record) = &handle.record {
         let _ = writeln!(
             rendered,
@@ -284,10 +463,6 @@ fn render_markdown_truncation(
         rendered.push('\n');
     }
     rendered
-}
-
-fn esc_cell(s: &str) -> String {
-    s.replace('|', "\\|").replace(['\n', '\r'], " ")
 }
 
 pub(super) fn field_str<'a>(v: &'a Value, key: &str) -> &'a str {
@@ -339,20 +514,6 @@ impl Md {
         self
     }
 
-    pub(super) fn table(&mut self, headers: &[&str], rows: &[Vec<String>]) -> &mut Self {
-        if headers.is_empty() {
-            return self;
-        }
-        let _ = writeln!(self.buf, "| {} |", headers.join(" | "));
-        let sep: Vec<&str> = headers.iter().map(|_| "---").collect();
-        let _ = writeln!(self.buf, "| {} |", sep.join(" | "));
-        for row in rows {
-            let cells: Vec<String> = row.iter().map(|c| esc_cell(c)).collect();
-            let _ = writeln!(self.buf, "| {} |", cells.join(" | "));
-        }
-        self
-    }
-
     pub(super) fn code(&mut self, lang: &str, body: &str) -> &mut Self {
         let _ = writeln!(self.buf, "```{lang}");
         self.buf.push_str(body);
@@ -379,6 +540,143 @@ pub(super) fn generic_md(value: &Value) -> String {
     } else {
         out
     }
+}
+
+pub(super) fn diagnostics_md(value: &Value) -> String {
+    let mut md = Md::new();
+    md.heading(2, "Diagnostics");
+    for key in [
+        "status",
+        "scope",
+        "diagnostics_parsed",
+        "diagnostics_returned",
+        "diagnostic_count",
+        "error_count",
+        "warning_count",
+        "mapped_to_node",
+        "unmapped",
+        "truncated",
+        "target_dir",
+    ] {
+        if let Some(v) = value.get(key).filter(|v| is_scalar(v)) {
+            md.field(title_label(key), &cell_str(key, v));
+        }
+    }
+    if let Some(message) = value.get("message").and_then(Value::as_str) {
+        md.field("Message", &indent_multiline_value(message));
+    }
+    md.blank();
+
+    let diagnostics = value
+        .get("diagnostics")
+        .and_then(Value::as_array)
+        .map_or(&[][..], Vec::as_slice);
+    if diagnostics.is_empty() {
+        md.empty_note("No diagnostics.");
+        return md.render();
+    }
+
+    md.heading(3, "Findings");
+    for diagnostic in diagnostics {
+        render_diagnostic_record(&mut md, diagnostic);
+    }
+    md.render()
+}
+
+fn render_diagnostic_record(md: &mut Md, diagnostic: &Value) {
+    let level = diagnostic
+        .get("level")
+        .or_else(|| diagnostic.get("severity"))
+        .and_then(Value::as_str)
+        .unwrap_or("diagnostic");
+    let location = diagnostic_location(diagnostic);
+    let code = diagnostic.get("code").and_then(Value::as_str).unwrap_or("");
+    let title = if code.is_empty() {
+        format!("{} at {location}", level.to_uppercase())
+    } else {
+        format!("{} {code} at {location}", level.to_uppercase())
+    };
+    md.bullet(&format!("**{title}**"));
+    if let Some(message) = diagnostic.get("message").and_then(Value::as_str) {
+        md.line(&format!(
+            "  **Message:** {}",
+            indent_multiline_value(message)
+        ));
+    }
+    if let Some(driver) = diagnostic.get("driver").and_then(Value::as_str) {
+        md.line(&format!("  **Driver:** {driver}"));
+    }
+    if let Some(enclosing) = diagnostic.get("enclosing").and_then(Value::as_str) {
+        if !enclosing.is_empty() {
+            md.line(&format!("  **Enclosing:** {enclosing}"));
+        }
+    }
+    if let Some(node) = diagnostic.get("node").filter(|v| !v.is_null()) {
+        let name = node
+            .get("qualified_name")
+            .or_else(|| node.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !name.is_empty() {
+            md.line(&format!("  **Node:** {name}"));
+        }
+    }
+    if let Some(callers) = diagnostic.get("callers").and_then(Value::as_array) {
+        let callers = callers
+            .iter()
+            .filter_map(|caller| {
+                let name = caller.get("name").and_then(Value::as_str)?;
+                let file = caller.get("file").and_then(Value::as_str).unwrap_or("");
+                let line = caller.get("line").and_then(Value::as_u64).unwrap_or(0);
+                Some(if file.is_empty() {
+                    name.to_string()
+                } else {
+                    format!("{name} ({file}:{line})")
+                })
+            })
+            .collect::<Vec<_>>();
+        if !callers.is_empty() {
+            md.line(&format!("  **Callers:** {}", callers.join(", ")));
+        }
+    }
+}
+
+fn diagnostic_location(diagnostic: &Value) -> String {
+    let file = diagnostic
+        .get("file")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let line = diagnostic
+        .get("line_start")
+        .or_else(|| diagnostic.get("line"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let column = diagnostic.get("column").and_then(Value::as_u64);
+    match column {
+        Some(column) if column > 0 => format!("{file}:{line}:{column}"),
+        _ => format!("{file}:{line}"),
+    }
+}
+
+fn title_label(key: &str) -> &str {
+    match key {
+        "diagnostics_parsed" => "Diagnostics parsed",
+        "diagnostics_returned" => "Diagnostics returned",
+        "diagnostic_count" => "Diagnostic count",
+        "error_count" => "Error count",
+        "warning_count" => "Warning count",
+        "mapped_to_node" => "Mapped to node",
+        "target_dir" => "Target dir",
+        "status" => "Status",
+        "scope" => "Scope",
+        "unmapped" => "Unmapped",
+        "truncated" => "Truncated",
+        _ => key,
+    }
+}
+
+fn indent_multiline_value(value: &str) -> String {
+    value.replace('\n', "\n    ")
 }
 
 fn is_id_key(k: &str) -> bool {
@@ -437,9 +735,6 @@ fn scalar_str_keyed(key: &str, v: &Value) -> String {
     scalar_str(v)
 }
 
-/// Renders a nested JSON value into a single table cell without dumping raw
-/// JSON. Arrays of objects become `name (file:line)`-style summaries; plain
-/// objects become compact `k=v` strings; arrays of scalars are comma-joined.
 fn nested_cell_str(v: &Value) -> String {
     const MAX_ITEMS: usize = 3;
 
@@ -472,8 +767,6 @@ fn nested_cell_str(v: &Value) -> String {
     }
 }
 
-/// Compact one-line summary of an object for a table cell. Prefers a
-/// `name (file:line)` shape when those keys exist, else `k=v` pairs.
 fn summarize_object(obj: &serde_json::Map<String, Value>) -> String {
     let name = obj
         .get("name")
@@ -533,7 +826,7 @@ fn render_array(md: &mut Md, arr: &[Value], depth: u8) {
         return;
     }
     if arr.iter().all(Value::is_object) {
-        render_object_array_table(md, arr);
+        render_object_array_records(md, arr);
     } else {
         for e in arr {
             if is_scalar(e) {
@@ -557,12 +850,7 @@ fn column_rank(col: &str) -> (usize, &str) {
     }
 }
 
-/// Renders an array of objects as a markdown table with three refinements:
-/// columns are ordered (preferred keys first, rest alphabetical), columns that
-/// are empty in every row are dropped, and columns whose value is constant
-/// across every row are hoisted into a header line (`edge_kind: calls`) rather
-/// than repeated in each cell.
-fn render_object_array_table(md: &mut Md, arr: &[Value]) {
+fn render_object_array_records(md: &mut Md, arr: &[Value]) {
     // Collect the union of keys.
     let mut cols: Vec<String> = Vec::new();
     for e in arr {
@@ -588,10 +876,12 @@ fn render_object_array_table(md: &mut Md, arr: &[Value]) {
 
     // Drop columns empty in every row; hoist columns constant across all rows.
     let mut hoisted: Vec<(String, String)> = Vec::new();
+    let mut dropped_empty: Vec<String> = Vec::new();
     let mut keep: Vec<usize> = Vec::new();
     for (ci, col) in cols.iter().enumerate() {
         let all_empty = rendered.iter().all(|row| row[ci].is_empty());
         if all_empty {
+            dropped_empty.push(col.clone());
             continue;
         }
         let first = &rendered[0][ci];
@@ -612,16 +902,38 @@ fn render_object_array_table(md: &mut Md, arr: &[Value]) {
 
     if keep.is_empty() {
         if hoisted.is_empty() {
-            md.empty_note("No visible fields.");
+            let dropped = if dropped_empty.is_empty() {
+                "none".to_string()
+            } else {
+                dropped_empty.join(", ")
+            };
+            md.empty_note(&format!(
+                "No visible fields across {} rows; dropped empty keys: {dropped}.",
+                arr.len()
+            ));
         }
         return;
     }
-    let headers: Vec<&str> = keep.iter().map(|&ci| cols[ci].as_str()).collect();
-    let rows: Vec<Vec<String>> = rendered
+    let title_ci = keep
         .iter()
-        .map(|row| keep.iter().map(|&ci| row[ci].clone()).collect())
-        .collect();
-    md.table(&headers, &rows);
+        .copied()
+        .find(|ci| matches!(cols[*ci].as_str(), "name" | "symbol" | "file" | "path"))
+        .unwrap_or(keep[0]);
+    for (idx, row) in rendered.iter().enumerate() {
+        let title = if row[title_ci].is_empty() {
+            format!("Item {}", idx + 1)
+        } else {
+            row[title_ci].clone()
+        };
+        md.bullet(&format!("**{title}**"));
+        for &ci in &keep {
+            if ci == title_ci || row[ci].is_empty() {
+                continue;
+            }
+            let value = row[ci].replace('\n', "\n    ");
+            md.line(&format!("  **{}:** {}", cols[ci], value));
+        }
+    }
 }
 
 fn compact_path_array(arr: &[Value]) -> Option<String> {

--- a/src/mcp/tools/render/tests.rs
+++ b/src/mcp/tools/render/tests.rs
@@ -358,6 +358,12 @@ fn table_drops_all_empty_columns() {
 }
 
 #[test]
+fn table_with_no_visible_columns_is_not_blank() {
+    let out = generic_md(&json!([{ "id": null }, { "id": null }]));
+    assert!(out.contains("No visible fields."), "got: {out}");
+}
+
+#[test]
 fn table_hoists_constant_columns() {
     let v = json!([
         { "name": "foo", "edge_kind": "calls" },

--- a/src/mcp/tools/render/tests.rs
+++ b/src/mcp/tools/render/tests.rs
@@ -189,10 +189,13 @@ fn markdown_truncation_preview_closes_prefix_fence_before_preserved_sections() {
 fn markdown_preview_with_handle_stores_full_text_when_preview_differs() {
     let _store_guard = lock_response_handle_store();
     let dir = tempfile::TempDir::new().unwrap();
-    let full = "# Full\n\nsmall visible preview\n\n## Details\nfull-only detail";
+    let full = format!(
+        "# Full\n\nsmall visible preview\n\n{}## Details\nfull-only detail",
+        "full-only body\n".repeat(MAX_RESPONSE_CHARS)
+    );
     let preview = "# Full\n\nsmall visible preview";
 
-    let result = markdown_preview_with_handle(Some(dir.path()), full, preview);
+    let result = markdown_preview_with_handle(Some(dir.path()), &full, preview);
 
     assert!(result.starts_with("# Truncated Response"));
     assert!(result.contains("lane-budgeted preview"));
@@ -206,7 +209,7 @@ fn markdown_preview_with_handle_stores_full_text_when_preview_differs() {
         panic!("markdown preview envelope should include handle");
     };
 
-    let prepared = prepare_truncated_response_handle(Some(dir.path()), full);
+    let prepared = prepare_truncated_response_handle(Some(dir.path()), &full);
     let record = prepared.record.as_ref().unwrap();
     assert_eq!(record.handle, handle);
     let stored = retrieve_response_handle_from_root(
@@ -226,6 +229,14 @@ fn markdown_preview_with_handle_keeps_matching_short_text_plain() {
     let text = "# Full\n\nalready complete";
 
     assert_eq!(markdown_preview_with_handle(None, text, text), text);
+}
+
+#[test]
+fn markdown_preview_with_handle_keeps_different_short_full_text_plain() {
+    let full = "# Full\n\nsmall visible preview\n\n## Details\nfull-only detail";
+    let preview = "# Full\n\nsmall visible preview";
+
+    assert_eq!(markdown_preview_with_handle(None, full, preview), full);
 }
 
 #[test]

--- a/src/mcp/tools/render/tests.rs
+++ b/src/mcp/tools/render/tests.rs
@@ -52,10 +52,14 @@ fn truncate_short_response() {
 
 #[test]
 fn truncate_long_response() {
-    let long = "x".repeat(20_000);
+    let long = "x".repeat(MAX_RESPONSE_CHARS - 1);
     let result = truncate_response(&long);
-    assert!(result.len() < 20_000);
-    assert!(result.contains("[... truncated at 15000 chars]"));
+    assert_eq!(result, long);
+
+    let longer = "x".repeat(MAX_RESPONSE_CHARS + 5_000);
+    let result = truncate_response(&longer);
+    assert!(result.len() < longer.len());
+    assert!(result.contains(&format!("[... truncated at {MAX_RESPONSE_CHARS} chars]")));
 }
 
 #[test]
@@ -135,6 +139,96 @@ fn truncated_markdown_includes_readable_handle_guidance() {
 }
 
 #[test]
+fn truncated_markdown_preserves_late_priority_sections() {
+    let _store_guard = lock_response_handle_store();
+    let dir = tempfile::TempDir::new().unwrap();
+    let long = format!(
+        "## Code Context\n{}\n### Memory Matches\n- fact_id=42 category=project trust=0.90 score=0.500: remembered context\n\n### Entry Points\n- **late_symbol** (function) - src/lib.rs:10\n",
+        "padding\n".repeat(5_000)
+    );
+
+    let result = truncated_markdown_with_handle(Some(dir.path()), &long);
+
+    assert!(result.len() <= MAX_RESPONSE_CHARS);
+    assert!(result.contains("## Preserved Priority Sections"));
+    assert!(result.contains("### Memory Matches"));
+    assert!(result.contains("fact_id=42"));
+    assert!(result.contains("### Entry Points"));
+    assert!(result.contains("late_symbol"));
+}
+
+#[test]
+fn markdown_truncation_preview_closes_open_code_fence() {
+    let markdown = format!("### Code\n```rust\n{}\n", "fn demo() {}\n".repeat(1_000));
+
+    let preview = markdown_truncation_preview(&markdown, 1_024);
+
+    assert!(!has_open_markdown_fence(&preview));
+}
+
+#[test]
+fn markdown_truncation_preview_closes_prefix_fence_before_preserved_sections() {
+    let markdown = format!(
+        "## Code Context\n```rust\n{}\n### Memory Matches\n- fact_id=42 category=project trust=0.90 score=0.500: remembered context\n",
+        "fn demo() {}\n".repeat(5_000)
+    );
+
+    let preview = markdown_truncation_preview(&markdown, 12_000);
+    let preserved_start = preview
+        .find("## Preserved Priority Sections")
+        .unwrap_or(preview.len());
+    assert!(
+        preserved_start < preview.len(),
+        "late priority section should be preserved: {preview}"
+    );
+
+    assert!(!has_open_markdown_fence(&preview[..preserved_start]));
+}
+
+#[test]
+fn markdown_preview_with_handle_stores_full_text_when_preview_differs() {
+    let _store_guard = lock_response_handle_store();
+    let dir = tempfile::TempDir::new().unwrap();
+    let full = "# Full\n\nsmall visible preview\n\n## Details\nfull-only detail";
+    let preview = "# Full\n\nsmall visible preview";
+
+    let result = markdown_preview_with_handle(Some(dir.path()), full, preview);
+
+    assert!(result.starts_with("# Truncated Response"));
+    assert!(result.contains("lane-budgeted preview"));
+    assert!(result.contains(preview));
+    assert!(!result.contains("full-only detail"));
+    let Some(handle) = result
+        .split("handle `")
+        .nth(1)
+        .and_then(|tail| tail.split('`').next())
+    else {
+        panic!("markdown preview envelope should include handle");
+    };
+
+    let prepared = prepare_truncated_response_handle(Some(dir.path()), full);
+    let record = prepared.record.as_ref().unwrap();
+    assert_eq!(record.handle, handle);
+    let stored = retrieve_response_handle_from_root(
+        &record.response_handle_root,
+        handle,
+        current_timestamp(),
+    )
+    .unwrap();
+    match stored {
+        ResponseHandleLookup::Found(record) => assert_eq!(record.content, full),
+        other => panic!("stored markdown preview should be retrievable, got {other:?}"),
+    }
+}
+
+#[test]
+fn markdown_preview_with_handle_keeps_matching_short_text_plain() {
+    let text = "# Full\n\nalready complete";
+
+    assert_eq!(markdown_preview_with_handle(None, text, text), text);
+}
+
+#[test]
 fn truncate_text_with_handle_returns_short_text_unchanged() {
     let short = "hello world";
     assert_eq!(truncate_text_with_handle(None, short), short);
@@ -197,17 +291,17 @@ fn truncated_json_envelope_reports_store_failure() {
 }
 
 #[test]
-fn generic_md_renders_array_of_objects_as_table() {
+fn generic_md_renders_array_of_objects_as_bullets() {
     let v = json!([
         {"id": "function:abc", "name": "foo", "line": 10},
         {"id": "function:def", "name": "bar", "line": 20}
     ]);
     let out = generic_md(&v);
-    // Preferred column order follows PREFERRED_COLUMNS
-    // (name, kind, file, line, id, ...), so `line` sorts ahead of `id`.
-    assert!(out.contains("| name | line | id |"), "got: {out}");
+    assert!(out.contains("- **foo**"), "got: {out}");
+    assert!(out.contains("- **bar**"), "got: {out}");
+    assert!(out.contains("**line:** 10"), "got: {out}");
     assert!(out.contains("`function:abc`"), "id should be backticked");
-    assert!(out.contains("foo"));
+    assert!(!out.contains("| name | line | id |"), "got: {out}");
 }
 
 #[test]
@@ -221,8 +315,40 @@ fn generic_md_renders_object_fields_and_sections() {
     assert!(out.contains("**total:** 3"));
     assert!(out.contains("**name:** demo"));
     assert!(out.contains("## items"));
-    // `file` is a preferred column so it sorts ahead of `count`.
-    assert!(out.contains("| file | count |"), "got: {out}");
+    assert!(out.contains("- **a.rs**"), "got: {out}");
+    assert!(out.contains("**count:** 1"), "got: {out}");
+    assert!(!out.contains("| file | count |"), "got: {out}");
+}
+
+#[test]
+fn diagnostics_md_renders_bullets_not_tables() {
+    let v = json!({
+        "scope": "workspace",
+        "diagnostic_count": 1,
+        "error_count": 1,
+        "warning_count": 0,
+        "diagnostics": [{
+            "level": "error",
+            "code": "E0425",
+            "message": "cannot find value\nsecond line",
+            "file": "src/lib.rs",
+            "line_start": 42,
+            "driver": "cargo",
+            "enclosing": "crate::demo"
+        }]
+    });
+
+    let out = diagnostics_md(&v);
+
+    assert!(out.contains("## Diagnostics"), "got: {out}");
+    assert!(out.contains("**Diagnostic count:** 1"), "got: {out}");
+    assert!(
+        out.contains("- **ERROR E0425 at src/lib.rs:42**"),
+        "got: {out}"
+    );
+    assert!(out.contains("  **Message:** cannot find value\n    second line"));
+    assert!(!out.contains("| file |"), "got: {out}");
+    assert!(!out.contains("| --- |"), "got: {out}");
 }
 
 #[test]
@@ -332,19 +458,20 @@ fn nested_object_becomes_kv_cell() {
 }
 
 #[test]
-fn table_columns_use_preferred_order() {
+fn object_array_fields_use_preferred_order() {
     let v = json!([{ "line": 5, "name": "foo", "file": "a.rs", "extra": "z", "kind": "fn" }]);
     let out = generic_md(&v);
-    let header = out.lines().find(|l| l.starts_with("| name")).unwrap();
-    // name, kind, file, line come first; unknown `extra` sorts after.
-    assert_eq!(
-        header, "| name | kind | file | line | extra |",
-        "got: {out}"
-    );
+    let kind_idx = out.find("**kind:** fn").unwrap();
+    let file_idx = out.find("**file:** a.rs").unwrap();
+    let line_idx = out.find("**line:** 5").unwrap();
+    let extra_idx = out.find("**extra:** z").unwrap();
+    assert!(kind_idx < file_idx, "got: {out}");
+    assert!(file_idx < line_idx, "got: {out}");
+    assert!(line_idx < extra_idx, "got: {out}");
 }
 
 #[test]
-fn table_drops_all_empty_columns() {
+fn object_array_drops_all_empty_fields() {
     let v = json!([
         { "name": "foo", "doc": "", "line": 1 },
         { "name": "bar", "doc": "", "line": 2 }
@@ -354,17 +481,22 @@ fn table_drops_all_empty_columns() {
         !out.contains("doc"),
         "empty column should be dropped: {out}"
     );
-    assert!(out.contains("| name | line |"), "got: {out}");
+    assert!(out.contains("- **foo**"), "got: {out}");
+    assert!(out.contains("**line:** 1"), "got: {out}");
+    assert!(!out.contains("| name | line |"), "got: {out}");
 }
 
 #[test]
 fn table_with_no_visible_columns_is_not_blank() {
     let out = generic_md(&json!([{ "id": null }, { "id": null }]));
-    assert!(out.contains("No visible fields."), "got: {out}");
+    assert!(
+        out.contains("No visible fields across 2 rows; dropped empty keys: id."),
+        "got: {out}"
+    );
 }
 
 #[test]
-fn table_hoists_constant_columns() {
+fn object_array_hoists_constant_fields() {
     let v = json!([
         { "name": "foo", "edge_kind": "calls" },
         { "name": "bar", "edge_kind": "calls" }
@@ -377,9 +509,22 @@ fn table_hoists_constant_columns() {
     // It should not also appear as a table column.
     assert!(
         !out.contains("| edge_kind"),
-        "constant leaked into table: {out}"
+        "constant leaked into table output: {out}"
     );
-    assert!(out.contains("| name |"), "got: {out}");
+    assert!(out.contains("- **foo**"), "got: {out}");
+    assert!(out.contains("- **bar**"), "got: {out}");
+}
+
+#[test]
+fn object_array_indents_multiline_field_values() {
+    let v = json!([{ "name": "foo", "doc": "first\n# heading\n- item" }]);
+    let out = generic_md(&v);
+    assert!(
+        out.contains("  **doc:** first\n    # heading\n    - item"),
+        "got: {out}"
+    );
+    assert!(!out.contains("\n# heading"), "got: {out}");
+    assert!(!out.contains("\n- item"), "got: {out}");
 }
 
 #[test]
@@ -401,16 +546,4 @@ fn object_collapses_empty_collections_to_one_line() {
     assert!(out.contains("meta: none"), "got: {out}");
     // No bare heading for the empty collection.
     assert!(!out.contains("## callers"), "got: {out}");
-}
-
-#[test]
-fn table_escapes_pipes() {
-    let mut md = Md::new();
-    md.table(
-        &["name", "sig"],
-        &[vec!["foo".to_string(), "fn foo(a|b)".to_string()]],
-    );
-    let out = md.render();
-    assert!(out.contains("fn foo(a\\|b)"));
-    assert!(out.contains("| name | sig |"));
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -151,9 +151,14 @@ pub async fn ensure_initialized_with_options(
     })
 }
 
-fn initialized_project_paths(mut paths: Vec<String>) -> Vec<String> {
-    paths.retain(|path| TraceDecay::is_initialized(Path::new(path)));
-    paths
+async fn initialized_project_paths(paths: Vec<String>) -> Vec<String> {
+    let mut initialized = Vec::new();
+    for path in paths {
+        if TraceDecay::has_initialized_store(Path::new(&path)).await {
+            initialized.push(path);
+        }
+    }
+    initialized
 }
 
 fn cwd_match_resolution(
@@ -213,7 +218,7 @@ pub async fn resolve_serve_from_global_db(
     let Some(gdb) = GlobalDb::open().await else {
         return ServeGlobalDbResolution::None;
     };
-    let mut paths = initialized_project_paths(gdb.list_project_paths().await);
+    let mut paths = initialized_project_paths(gdb.list_project_paths().await).await;
     paths.sort();
     if paths.len() == 1 {
         return ServeGlobalDbResolution::Found(PathBuf::from(paths.remove(0)));
@@ -285,7 +290,7 @@ async fn resolve_project_from_roots(roots: &[std::path::PathBuf]) -> Option<std:
         return None;
     }
     let registered = match GlobalDb::open().await {
-        Some(gdb) => initialized_project_paths(gdb.list_project_paths().await),
+        Some(gdb) => initialized_project_paths(gdb.list_project_paths().await).await,
         None => Vec::new(),
     };
     for root_path in roots {

--- a/src/sessions/codex_app_server.rs
+++ b/src/sessions/codex_app_server.rs
@@ -1,7 +1,7 @@
 //! Codex app-server adapter used to generate auxiliary compaction summaries.
 
 use std::fmt::Write as _;
-use std::io::{BufRead, BufReader, Write as IoWrite};
+use std::io::{BufRead, BufReader, ErrorKind, Write as IoWrite};
 #[cfg(windows)]
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
@@ -14,6 +14,8 @@ use crate::errors::{Result, TraceDecayError};
 use crate::sessions::lcm::LcmSummaryRequest;
 
 pub const CODEX_SUMMARY_CHILD_ENV: &str = "TRACEDECAY_CODEX_SUMMARY_CHILD";
+const CODEX_APP_SERVER_SPAWN_RETRY_WINDOW: Duration = Duration::from_millis(250);
+const CODEX_APP_SERVER_SPAWN_RETRY_SLEEP: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone)]
 pub struct CodexAppServerSummaryConfig {
@@ -105,15 +107,12 @@ pub fn run_prompt_with_codex_app_server(
 ) -> Result<CodexAppServerSummary> {
     let model = configured_model(config);
     let mut command = codex_app_server_command(&config.codex_bin);
-    let child = command
+    command
         .env(CODEX_SUMMARY_CHILD_ENV, "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|err| TraceDecayError::Config {
-            message: format!("failed to start `{}` app-server: {err}", config.codex_bin),
-        })?;
+        .stderr(Stdio::null());
+    let child = spawn_codex_app_server(&mut command, &config.codex_bin)?;
     let mut child = ChildGuard { child };
 
     let stdout = child
@@ -209,6 +208,25 @@ pub fn run_prompt_with_codex_app_server(
     }
     summary.text = text.to_string();
     Ok(summary)
+}
+
+fn spawn_codex_app_server(command: &mut Command, codex_bin: &str) -> Result<Child> {
+    let deadline = Instant::now() + CODEX_APP_SERVER_SPAWN_RETRY_WINDOW;
+    loop {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(err)
+                if err.kind() == ErrorKind::ExecutableFileBusy && Instant::now() < deadline =>
+            {
+                std::thread::sleep(CODEX_APP_SERVER_SPAWN_RETRY_SLEEP);
+            }
+            Err(err) => {
+                return Err(TraceDecayError::Config {
+                    message: format!("failed to start `{codex_bin}` app-server: {err}"),
+                });
+            }
+        }
+    }
 }
 
 fn codex_app_server_command(codex_bin: &str) -> Command {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -325,6 +325,28 @@ pub fn write_store_manifest(layout: &StoreLayout) -> Result<StoreManifest> {
     Ok(manifest)
 }
 
+/// Writes a [`StoreManifest`] to an explicit path with an atomic temp+rename,
+/// preserving every field as given.
+///
+/// Unlike [`write_store_manifest`], this does not rebuild the manifest from a
+/// [`StoreLayout`]; it serializes the manifest exactly as passed, so callers
+/// (e.g. the doctor heal pass) can surgically rewrite a single field on an
+/// already-parsed manifest without a layout in hand.
+pub fn write_store_manifest_to_path(path: &Path, manifest: &StoreManifest) -> Result<()> {
+    let text = serde_json::to_string_pretty(manifest).map_err(|e| TraceDecayError::Config {
+        message: format!(
+            "failed to serialize store manifest '{}': {e}",
+            path.display()
+        ),
+    })?;
+    let temp_path = path.with_extension("json.tmp");
+    PrivateStoreIo::write_file_atomically(path, &temp_path, text.as_bytes()).map_err(|e| {
+        TraceDecayError::Config {
+            message: format!("failed to write store manifest '{}': {e}", path.display()),
+        }
+    })
+}
+
 pub fn read_store_manifest(path: &Path) -> Result<StoreManifest> {
     let text = fs::read_to_string(path).map_err(|e| TraceDecayError::Config {
         message: format!("failed to read store manifest '{}': {e}", path.display()),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -304,34 +304,12 @@ pub fn write_store_manifest(layout: &StoreLayout) -> Result<StoreManifest> {
                 layout.storage_mode
             ),
         })?;
-    if let Some(parent) = path.parent() {
-        PrivateStoreIo::create_dir_all(parent).map_err(|e| TraceDecayError::Config {
-            message: format!(
-                "failed to create store manifest directory '{}': {e}",
-                parent.display()
-            ),
-        })?;
-    }
     let manifest = StoreManifest::from_layout(layout);
-    let text = serde_json::to_string_pretty(&manifest).map_err(|e| TraceDecayError::Config {
-        message: format!(
-            "failed to serialize store manifest '{}': {e}",
-            path.display()
-        ),
-    })?;
-    PrivateStoreIo::write_file(path, text.as_bytes()).map_err(|e| TraceDecayError::Config {
-        message: format!("failed to write store manifest '{}': {e}", path.display()),
-    })?;
+    write_store_manifest_to_path(path, &manifest)?;
     Ok(manifest)
 }
 
-/// Writes a [`StoreManifest`] to an explicit path with an atomic temp+rename,
-/// preserving every field as given.
-///
-/// Unlike [`write_store_manifest`], this does not rebuild the manifest from a
-/// [`StoreLayout`]; it serializes the manifest exactly as passed, so callers
-/// (e.g. the doctor heal pass) can surgically rewrite a single field on an
-/// already-parsed manifest without a layout in hand.
+/// Writes `manifest` to `path` without rebuilding it from a [`StoreLayout`].
 pub fn write_store_manifest_to_path(path: &Path, manifest: &StoreManifest) -> Result<()> {
     let text = serde_json::to_string_pretty(manifest).map_err(|e| TraceDecayError::Config {
         message: format!(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -305,12 +305,16 @@ pub fn write_store_manifest(layout: &StoreLayout) -> Result<StoreManifest> {
             ),
         })?;
     let manifest = StoreManifest::from_layout(layout);
-    write_store_manifest_to_path(path, &manifest)?;
+    write_store_manifest_payload(path, &manifest)?;
     Ok(manifest)
 }
 
 /// Writes `manifest` to `path` without rebuilding it from a [`StoreLayout`].
 pub fn write_store_manifest_to_path(path: &Path, manifest: &StoreManifest) -> Result<()> {
+    write_store_manifest_payload(path, manifest)
+}
+
+fn write_store_manifest_payload(path: &Path, manifest: &StoreManifest) -> Result<()> {
     let text = serde_json::to_string_pretty(manifest).map_err(|e| TraceDecayError::Config {
         message: format!(
             "failed to serialize store manifest '{}': {e}",

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -794,6 +794,23 @@ impl TraceDecay {
             .filter(|layout| layout.graph_db_path.is_file())
     }
 
+    /// Resolves the profile store layout for a local path using enrollment
+    /// markers first, then the global registry aliases for the git identity.
+    pub async fn resolve_store_layout_for_identity(project_root: &Path) -> Result<StoreLayout> {
+        Self::resolve_store_layout_for_identity_with_options(
+            project_root,
+            &TraceDecayOpenOptions::default(),
+        )
+        .await
+    }
+
+    pub async fn resolve_store_layout_for_identity_with_options(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> Result<StoreLayout> {
+        Self::resolve_store_layout_for_local_identity(project_root, open_options).await
+    }
+
     async fn resolve_store_layout_for_local_identity(
         project_root: &Path,
         open_options: &TraceDecayOpenOptions,

--- a/src/types.rs
+++ b/src/types.rs
@@ -587,7 +587,7 @@ pub struct TaskContext {
     pub entry_points: Vec<Node>,
     pub code_blocks: Vec<CodeBlock>,
     pub related_files: Vec<String>,
-    /// IDs of all nodes returned as entry points (pass to next call's `exclude_node_ids` for dedup).
+    /// IDs of all returned nodes (pass to next call's `exclude_node_ids` for dedup).
     pub seen_node_ids: Vec<String>,
 }
 

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -15,7 +15,7 @@ use tracedecay::user_config::UserConfig;
 
 pub(crate) fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
     let home = tracedecay_home_dir()?;
-    let tracedecay_bin = tracedecay_bin_on_path()?;
+    let tracedecay_bin = tracedecay_bin_for_generated_artifacts()?;
     eprintln!("Refreshing tracedecay-generated plugin artifacts (agent configs are not touched)");
 
     // Detection-driven, not `installed_agents`-driven: each integration
@@ -126,6 +126,25 @@ pub(crate) fn tracedecay_bin_on_path() -> tracedecay::errors::Result<String> {
             message: "tracedecay not found on PATH".to_string(),
         }
     })
+}
+
+fn tracedecay_bin_for_generated_artifacts() -> tracedecay::errors::Result<String> {
+    current_tracedecay_exe().map_or_else(tracedecay_bin_on_path, Ok)
+}
+
+fn current_tracedecay_exe() -> Option<String> {
+    let current = std::env::current_exe().ok()?;
+    current_tracedecay_exe_from(Some(&current))
+}
+
+fn current_tracedecay_exe_from(current: Option<&Path>) -> Option<String> {
+    let current = current?;
+    let stem = current.file_stem()?.to_str()?;
+    (stem == "tracedecay").then(|| normalize_bin_path(current))
+}
+
+fn normalize_bin_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 /// How the `post-update` re-exec reacts to the binary-upgrade outcome.
@@ -392,8 +411,8 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use super::{
-        partition_reinstall_results, post_update_binary, run_install_then_refresh, RefreshPolicy,
-        ReinstallOutcome,
+        current_tracedecay_exe_from, partition_reinstall_results, post_update_binary,
+        run_install_then_refresh, RefreshPolicy, ReinstallOutcome,
     };
     use tempfile::TempDir;
     use tracedecay::upgrade::UpgradeOutcome;
@@ -411,6 +430,23 @@ mod tests {
 
     fn err(id: &str) -> (String, tracedecay::errors::Result<()>) {
         (id.to_string(), Err(config_err("install failed")))
+    }
+
+    #[test]
+    fn generated_artifact_bin_accepts_cargo_target_tracedecay_exe() {
+        let current = Path::new("/repo/target/debug/tracedecay");
+
+        assert_eq!(
+            current_tracedecay_exe_from(Some(current)).as_deref(),
+            Some("/repo/target/debug/tracedecay")
+        );
+    }
+
+    #[test]
+    fn generated_artifact_bin_ignores_non_tracedecay_test_exe() {
+        let current = Path::new("/repo/target/debug/deps/agent_suite-abc123");
+
+        assert_eq!(current_tracedecay_exe_from(Some(current)), None);
     }
 
     #[test]

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -3339,7 +3339,9 @@ async fn test_codex_install_exports_active_managed_skills() {
     let skill_path =
         codex_plugin_install_dir(home).join("skills/agent-managed/repo-hygiene/SKILL.md");
     let skill = std::fs::read_to_string(skill_path).unwrap();
-    assert!(skill.contains("id: repo-hygiene"));
+    assert!(skill.contains("name: repo-hygiene"));
+    assert!(skill.contains("description:"));
+    assert!(!skill.contains("id: repo-hygiene"));
     assert!(skill.contains("Use Repo Hygiene for repeated workflows."));
 
     let digest_skill_path =
@@ -3386,7 +3388,9 @@ async fn test_codex_shareable_plugin_artifact_exports_bundle_and_managed_skills(
         .output
         .join("skills/agent-managed/repo-hygiene/SKILL.md");
     let skill = std::fs::read_to_string(skill_path).unwrap();
-    assert!(skill.contains("id: repo-hygiene"));
+    assert!(skill.contains("name: repo-hygiene"));
+    assert!(skill.contains("description:"));
+    assert!(!skill.contains("id: repo-hygiene"));
     assert!(skill.contains("Use Repo Hygiene for repeated workflows."));
     assert!(
         !summary
@@ -3963,7 +3967,9 @@ async fn test_cursor_install_exports_active_managed_skills() {
     let skill_path =
         cursor_plugin_install_dir(home).join("skills/agent-managed/repo-hygiene/SKILL.md");
     let skill = std::fs::read_to_string(skill_path).unwrap();
-    assert!(skill.contains("id: repo-hygiene"));
+    assert!(skill.contains("name: repo-hygiene"));
+    assert!(skill.contains("description:"));
+    assert!(!skill.contains("id: repo-hygiene"));
     assert!(skill.contains("Use Repo Hygiene for repeated workflows."));
 }
 

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use tracedecay::agents::*;
 use tracedecay::automation::managed_skills::{
     approve_managed_skill, create_managed_skill_draft, ManagedSkillDraft, ManagedSkillProvenance,
-    ManagedSkillSource,
+    ManagedSkillSource, SkillInstallTarget,
 };
 use tracedecay::branch_meta;
 use tracedecay::config::USER_DATA_DIR_ENV;
@@ -3948,12 +3948,11 @@ async fn test_cursor_install_exports_active_managed_skills() {
     let home = dir.path();
     let profile_root = home.join(".tracedecay");
     let _data_dir_guard = EnvVarGuard::set(USER_DATA_DIR_ENV, &profile_root);
-    create_managed_skill_draft(
-        &profile_root,
-        managed_skill_draft("repo-hygiene", "Repo Hygiene"),
-    )
-    .await
-    .unwrap();
+    let mut draft = managed_skill_draft("repo-hygiene", "Repo Hygiene");
+    draft.targets = vec![SkillInstallTarget::Cursor];
+    create_managed_skill_draft(&profile_root, draft)
+        .await
+        .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();

--- a/tests/agent_suite/managed_skills_test.rs
+++ b/tests/agent_suite/managed_skills_test.rs
@@ -108,8 +108,6 @@ fn validates_minimum_metadata_and_renders_frontmatter() {
     let skill = draft().materialize().unwrap();
     let markdown = skill.render_skill_markdown();
     for key in [
-        "name: repo-hygiene",
-        r#"description: "Use when Keep repository maintenance guidance current.""#,
         "id: repo-hygiene",
         r#"title: "Repository hygiene""#,
         r#"summary: "Keep repository maintenance guidance current.""#,
@@ -125,6 +123,12 @@ fn validates_minimum_metadata_and_renders_frontmatter() {
         r#"provenance_run_id: "run_123""#,
     ] {
         assert!(markdown.contains(key), "missing frontmatter key {key}");
+    }
+    for key in ["name:", "description:"] {
+        assert!(
+            !markdown.contains(key),
+            "managed markdown must not include native frontmatter key {key}"
+        );
     }
 
     let mut punctuated = draft();

--- a/tests/agent_suite/managed_skills_test.rs
+++ b/tests/agent_suite/managed_skills_test.rs
@@ -108,6 +108,8 @@ fn validates_minimum_metadata_and_renders_frontmatter() {
     let skill = draft().materialize().unwrap();
     let markdown = skill.render_skill_markdown();
     for key in [
+        "name: repo-hygiene",
+        r#"description: "Use when Keep repository maintenance guidance current.""#,
         "id: repo-hygiene",
         r#"title: "Repository hygiene""#,
         r#"summary: "Keep repository maintenance guidance current.""#,

--- a/tests/agent_suite/skill_targets_test.rs
+++ b/tests/agent_suite/skill_targets_test.rs
@@ -236,16 +236,17 @@ async fn codex_plugin_artifact_exports_shareable_bundle_with_managed_skills() {
 }
 
 #[tokio::test]
-async fn native_overlay_rejects_invalid_skill_names_without_clobbering_export() {
-    for (index, invalid_name) in [
-        "repo_hygiene",
-        "-repo-hygiene",
-        "repo-hygiene-",
-        "repo--hygiene",
-    ]
-    .into_iter()
-    .enumerate()
-    {
+async fn native_overlay_sanitizes_legacy_native_frontmatter_without_blocking_peers() {
+    for (legacy_id, expected_name) in [
+        ("repo_hygiene", "repo-hygiene"),
+        ("-repo-hygiene", "repo-hygiene"),
+        ("repo-hygiene-", "repo-hygiene"),
+        ("repo--hygiene", "repo-hygiene"),
+        (
+            "repo-hygiene-with-an-excessively-long-name-that-used-to-be-valid-for-managed-skills",
+            "repo-hygiene-with-an-excessively-long-name-that-used-to-be-valid",
+        ),
+    ] {
         let temp = tempfile::tempdir().unwrap();
         let profile_root = temp.path().join("profile");
         let plugin_root = temp.path().join("cursor-plugin");
@@ -264,35 +265,42 @@ async fn native_overlay_rejects_invalid_skill_names_without_clobbering_export() 
             .await
             .unwrap();
 
-        let previous_skill = plugin_root.join("skills/agent-managed/repo-hygiene/SKILL.md");
-        if index == 0 {
-            export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
-                .unwrap();
-            assert!(previous_skill.is_file());
-        }
-
-        let mut invalid = load_managed_skill(&profile_root, "repo-hygiene")
+        let mut legacy = targeted_draft(
+            legacy_id,
+            "Legacy native compatibility",
+            vec![SkillInstallTarget::Cursor],
+        );
+        legacy.summary = "a".repeat(1020);
+        create_managed_skill_draft(&profile_root, legacy)
             .await
             .unwrap();
-        invalid.metadata.id = invalid_name.to_string();
-        let skill_dir = managed_skill_dir(&profile_root, "repo-hygiene").unwrap();
-        std::fs::write(
-            skill_dir.join("skill.json"),
-            serde_json::to_vec_pretty(&invalid).unwrap(),
+        approve_managed_skill(&profile_root, legacy_id)
+            .await
+            .unwrap();
+
+        let summary =
+            export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
+                .unwrap();
+        assert_eq!(summary.exported_count, 2);
+        assert!(plugin_root
+            .join("skills/agent-managed/repo-hygiene/SKILL.md")
+            .is_file());
+
+        let legacy_skill = std::fs::read_to_string(
+            plugin_root
+                .join("skills/agent-managed")
+                .join(legacy_id)
+                .join("SKILL.md"),
         )
         .unwrap();
-
-        let err =
-            export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
-                .unwrap_err()
-                .to_string();
-        assert!(
-            err.contains("native skill name must use kebab-case"),
-            "accepted invalid native skill name {invalid_name}: {err}"
-        );
-        if index == 0 {
-            assert!(previous_skill.is_file());
-        }
+        assert!(legacy_skill.contains(&format!("name: {expected_name}\n")));
+        let description = legacy_skill
+            .lines()
+            .find_map(|line| line.strip_prefix("description: \""))
+            .and_then(|line| line.strip_suffix('"'))
+            .unwrap();
+        assert_eq!(description.chars().count(), 1024);
+        assert!(description.starts_with("Use when "));
     }
 }
 

--- a/tests/agent_suite/skill_targets_test.rs
+++ b/tests/agent_suite/skill_targets_test.rs
@@ -42,11 +42,12 @@ fn targeted_draft(id: &str, title: &str, targets: Vec<SkillInstallTarget>) -> Ma
 }
 
 #[test]
-fn managed_skill_defaults_do_not_target_cursor() {
+fn managed_skill_defaults_target_supported_hosts() {
     let targets = default_managed_skill_targets();
     assert_eq!(
         targets,
         vec![
+            SkillInstallTarget::Cursor,
             SkillInstallTarget::Codex,
             SkillInstallTarget::Claude,
             SkillInstallTarget::Agents,
@@ -55,7 +56,6 @@ fn managed_skill_defaults_do_not_target_cursor() {
             SkillInstallTarget::Kiro,
         ]
     );
-    assert!(!targets.contains(&SkillInstallTarget::Cursor));
 }
 
 #[tokio::test]
@@ -226,10 +226,74 @@ async fn codex_plugin_artifact_exports_shareable_bundle_with_managed_skills() {
             .unwrap();
     assert!(codex_skill.contains("name: codex-only"));
     assert!(codex_skill.contains(r#"description: "Use when Codex only summary""#));
+    assert!(!codex_skill.contains("id: codex-only"));
+    assert!(!codex_skill.contains("targets:"));
+    assert!(!codex_skill.contains("checksum:"));
 
     let mcp = std::fs::read_to_string(plugin_root.join(".mcp.json")).unwrap();
     assert!(mcp.contains("\"command\": \"tracedecay-bin\""));
     assert!(mcp.contains("\"TRACEDECAY_ENABLE_GLOBAL_DB\": \"1\""));
+}
+
+#[tokio::test]
+async fn native_overlay_rejects_invalid_skill_names_without_clobbering_export() {
+    for (index, invalid_name) in [
+        "repo_hygiene",
+        "-repo-hygiene",
+        "repo-hygiene-",
+        "repo--hygiene",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let temp = tempfile::tempdir().unwrap();
+        let profile_root = temp.path().join("profile");
+        let plugin_root = temp.path().join("cursor-plugin");
+
+        create_managed_skill_draft(
+            &profile_root,
+            targeted_draft(
+                "repo-hygiene",
+                "Repository hygiene",
+                vec![SkillInstallTarget::Cursor],
+            ),
+        )
+        .await
+        .unwrap();
+        approve_managed_skill(&profile_root, "repo-hygiene")
+            .await
+            .unwrap();
+
+        let previous_skill = plugin_root.join("skills/agent-managed/repo-hygiene/SKILL.md");
+        if index == 0 {
+            export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
+                .unwrap();
+            assert!(previous_skill.is_file());
+        }
+
+        let mut invalid = load_managed_skill(&profile_root, "repo-hygiene")
+            .await
+            .unwrap();
+        invalid.metadata.id = invalid_name.to_string();
+        let skill_dir = managed_skill_dir(&profile_root, "repo-hygiene").unwrap();
+        std::fs::write(
+            skill_dir.join("skill.json"),
+            serde_json::to_vec_pretty(&invalid).unwrap(),
+        )
+        .unwrap();
+
+        let err =
+            export_native_skill_overlay(&profile_root, SkillInstallTarget::Cursor, &plugin_root)
+                .unwrap_err()
+                .to_string();
+        assert!(
+            err.contains("native skill name must use kebab-case"),
+            "accepted invalid native skill name {invalid_name}: {err}"
+        );
+        if index == 0 {
+            assert!(previous_skill.is_file());
+        }
+    }
 }
 
 #[tokio::test]

--- a/tests/agent_suite/skill_targets_test.rs
+++ b/tests/agent_suite/skill_targets_test.rs
@@ -41,21 +41,52 @@ fn targeted_draft(id: &str, title: &str, targets: Vec<SkillInstallTarget>) -> Ma
     }
 }
 
+#[test]
+fn managed_skill_defaults_do_not_target_cursor() {
+    let targets = default_managed_skill_targets();
+    assert_eq!(
+        targets,
+        vec![
+            SkillInstallTarget::Codex,
+            SkillInstallTarget::Claude,
+            SkillInstallTarget::Agents,
+            SkillInstallTarget::OpenCode,
+            SkillInstallTarget::Kimi,
+            SkillInstallTarget::Kiro,
+        ]
+    );
+    assert!(!targets.contains(&SkillInstallTarget::Cursor));
+}
+
 #[tokio::test]
 async fn native_overlay_exports_only_active_skills_and_prunes_generated_namespace() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");
     let plugin_root = temp.path().join("cursor-plugin");
 
-    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Cursor],
+        ),
+    )
+    .await
+    .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();
-    create_managed_skill_draft(&profile_root, draft("pending-flow", "Pending flow"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "pending-flow",
+            "Pending flow",
+            vec![SkillInstallTarget::Cursor],
+        ),
+    )
+    .await
+    .unwrap();
 
     std::fs::create_dir_all(plugin_root.join("skills/static-skill")).unwrap();
     std::fs::write(
@@ -91,6 +122,18 @@ async fn native_overlay_exports_only_active_skills_and_prunes_generated_namespac
     assert!(plugin_root
         .join("skills/agent-managed/.tracedecay-managed-skills.json")
         .is_file());
+    let manifest = std::fs::read_to_string(
+        plugin_root.join("skills/agent-managed/.tracedecay-managed-skills.json"),
+    )
+    .unwrap();
+    let manifest: serde_json::Value = serde_json::from_str(&manifest).unwrap();
+    let exported_path = manifest["exported"][0]["path"].as_str().unwrap();
+    let exported_path_normalized = exported_path.replace('\\', "/");
+    assert!(exported_path_normalized.ends_with("skills/agent-managed/repo-hygiene/SKILL.md"));
+    assert!(
+        !exported_path.contains(".agent-managed.tmp"),
+        "manifest must expose final overlay paths: {exported_path}"
+    );
 
     disable_managed_skill(&profile_root, "repo-hygiene")
         .await
@@ -111,9 +154,16 @@ async fn codex_native_overlay_uses_agent_managed_namespace() {
     let profile_root = temp.path().join("profile");
     let plugin_root = temp.path().join("codex-plugin");
 
-    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Codex],
+        ),
+    )
+    .await
+    .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();
@@ -171,6 +221,11 @@ async fn codex_plugin_artifact_exports_shareable_bundle_with_managed_skills() {
     assert!(!plugin_root
         .join("skills/agent-managed/cursor-only/SKILL.md")
         .exists());
+    let codex_skill =
+        std::fs::read_to_string(plugin_root.join("skills/agent-managed/codex-only/SKILL.md"))
+            .unwrap();
+    assert!(codex_skill.contains("name: codex-only"));
+    assert!(codex_skill.contains(r#"description: "Use when Codex only summary""#));
 
     let mcp = std::fs::read_to_string(plugin_root.join(".mcp.json")).unwrap();
     assert!(mcp.contains("\"command\": \"tracedecay-bin\""));
@@ -254,15 +309,29 @@ async fn prompt_index_preserves_user_content_and_routes_full_body_through_mcp() 
     let profile_root = temp.path().join("profile");
     let prompt_path = temp.path().join("AGENTS.md");
 
-    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Agents, SkillInstallTarget::Claude],
+        ),
+    )
+    .await
+    .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();
-    create_managed_skill_draft(&profile_root, draft("pending-flow", "Pending flow"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "pending-flow",
+            "Pending flow",
+            vec![SkillInstallTarget::Agents],
+        ),
+    )
+    .await
+    .unwrap();
 
     std::fs::write(&prompt_path, "# User rules\n\nKeep this line.\n").unwrap();
     let summary =
@@ -424,9 +493,16 @@ async fn native_overlay_keeps_previous_export_when_rebuild_fails() {
     let profile_root = temp.path().join("profile");
     let plugin_root = temp.path().join("cursor-plugin");
 
-    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Claude, SkillInstallTarget::Cursor],
+        ),
+    )
+    .await
+    .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();
@@ -495,9 +571,16 @@ async fn lifecycle_export_sweep_deploys_and_retracts_across_detected_agents() {
     let claude_md = install_fake_claude(&home);
     let cursor_plugin = install_fake_cursor_plugin(&home);
 
-    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Claude, SkillInstallTarget::Cursor],
+        ),
+    )
+    .await
+    .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();
@@ -546,9 +629,16 @@ async fn lifecycle_export_sweep_isolates_per_agent_failures() {
     std::fs::remove_file(&claude_md).unwrap();
     std::fs::create_dir_all(&claude_md).unwrap();
 
-    create_managed_skill_draft(&profile_root, draft("repo-hygiene", "Repository hygiene"))
-        .await
-        .unwrap();
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Claude, SkillInstallTarget::Cursor],
+        ),
+    )
+    .await
+    .unwrap();
     approve_managed_skill(&profile_root, "repo-hygiene")
         .await
         .unwrap();

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -884,6 +884,63 @@ fn codex_update_plugin_reports_not_installed_without_bundle_or_legacy_config() {
     assert!(!home.path().join("plugins").exists());
 }
 
+#[test]
+fn codex_update_plugin_ignores_plugin_only_config_without_legacy_mcp() {
+    let home = TempDir::new().unwrap();
+    let _agent_env = AgentEnvLock::pin(&home);
+    let project_root = home.path().join("workspace");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config = codex_dir.join("config.toml");
+    std::fs::write(
+        &config,
+        r#"
+[plugins."tracedecay@personal"]
+enabled = true
+
+[hooks.state."tracedecay@personal:hooks/hooks.json:post_tool_use:0:0"]
+trusted_hash = "sha256:post"
+"#,
+    )
+    .unwrap();
+    let before = bytes(&config);
+    let codex = get_integration("codex").unwrap();
+
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+
+    assert!(matches!(outcome, UpdatePluginOutcome::NotInstalled));
+    assert_eq!(bytes(&config), before);
+    assert!(!home.path().join("plugins/tracedecay").exists());
+}
+
+#[test]
+fn codex_update_plugin_errors_on_malformed_legacy_mcp_config() {
+    let home = TempDir::new().unwrap();
+    let _agent_env = AgentEnvLock::pin(&home);
+    let project_root = home.path().join("workspace");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        codex_dir.join("config.toml"),
+        "[mcp_servers.tracedecay\ncommand = \"/old/bin/tracedecay\"\n",
+    )
+    .unwrap();
+    let codex = get_integration("codex").unwrap();
+
+    let err = match codex.update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root)) {
+        Ok(_) => panic!("malformed legacy MCP config must not be treated as absent"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("config.toml"),
+        "error should identify the malformed Codex config: {err}"
+    );
+    assert!(!home.path().join("plugins/tracedecay").exists());
+}
+
 // ---------------------------------------------------------------------------
 // Kiro
 // ---------------------------------------------------------------------------

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -927,14 +927,19 @@ fn codex_update_plugin_refreshes_bundle_with_malformed_unrelated_legacy_config()
     let codex_dir = home.path().join(".codex");
     std::fs::create_dir_all(&codex_dir).unwrap();
     let config = codex_dir.join("config.toml");
-    std::fs::write(&config, "[mcp_servers.tracedecay\ncommand = \"/old/bin/tracedecay\"\n")
-        .unwrap();
+    std::fs::write(
+        &config,
+        "[mcp_servers.tracedecay\ncommand = \"/old/bin/tracedecay\"\n",
+    )
+    .unwrap();
     let before = bytes(&config);
 
     let outcome = codex
         .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
         .unwrap();
-    assert!(matches!(outcome, UpdatePluginOutcome::Refreshed(paths) if paths == vec![plugin_dir.clone()]));
+    assert!(
+        matches!(outcome, UpdatePluginOutcome::Refreshed(paths) if paths == vec![plugin_dir.clone()])
+    );
     assert_eq!(bytes(&config), before);
     assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN, CodexScope::Global);
 }

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use tempfile::TempDir;
 use tracedecay::agents::{get_integration, InstallContext, UpdatePluginOutcome};
 
-use crate::common::{AgentEnvLock, EnvVarGuard};
+use crate::common::{tracedecay_command_with_home, AgentEnvLock, EnvVarGuard};
 use crate::plugin_validation_support::{assert_schema_valid, compile_schema, relative_files_under};
 
 const OLD_BIN: &str = "/old/bin/tracedecay";
@@ -919,7 +919,6 @@ trusted_hash = "sha256:post"
 fn codex_update_plugin_refreshes_bundle_with_malformed_unrelated_legacy_config() {
     let home = TempDir::new().unwrap();
     let _agent_env = AgentEnvLock::pin(&home);
-    let project_root = home.path().join("workspace");
     let codex = get_integration("codex").unwrap();
     codex.install(&ctx(home.path(), OLD_BIN)).unwrap();
 
@@ -934,14 +933,20 @@ fn codex_update_plugin_refreshes_bundle_with_malformed_unrelated_legacy_config()
     .unwrap();
     let before = bytes(&config);
 
-    let outcome = codex
-        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
-        .unwrap();
-    assert!(
-        matches!(outcome, UpdatePluginOutcome::Refreshed(paths) if paths == vec![plugin_dir.clone()])
-    );
+    let output = tracedecay_command_with_home(home.path())
+        .arg("update-plugin")
+        .output()
+        .expect("run tracedecay update-plugin");
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Could not inspect legacy Codex MCP config at"));
+    assert!(stderr.contains("failed to parse"));
     assert_eq!(bytes(&config), before);
-    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN, CodexScope::Global);
+    assert_codex_bundle_contains_bin(
+        &plugin_dir,
+        env!("CARGO_BIN_EXE_tracedecay"),
+        CodexScope::Global,
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -75,7 +75,8 @@ enum CodexScope {
 }
 
 fn assert_codex_bundle_contains_bin(plugin_dir: &Path, tracedecay_bin: &str, scope: CodexScope) {
-    assert!(text(&plugin_dir.join(".mcp.json")).contains(tracedecay_bin));
+    let tracedecay_bin = tracedecay_bin.replace('\\', "/");
+    assert!(text(&plugin_dir.join(".mcp.json")).contains(&tracedecay_bin));
     let hooks_path = plugin_dir.join("hooks/hooks.json");
     match scope {
         CodexScope::Global => {
@@ -84,7 +85,7 @@ fn assert_codex_bundle_contains_bin(plugin_dir: &Path, tracedecay_bin: &str, sco
                 "global Codex bundle {} must ship hooks/hooks.json",
                 plugin_dir.display()
             );
-            assert!(text(&hooks_path).contains(tracedecay_bin));
+            assert!(text(&hooks_path).contains(&tracedecay_bin));
         }
         CodexScope::RepoLocal => assert!(
             !hooks_path.exists(),

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -916,29 +916,27 @@ trusted_hash = "sha256:post"
 }
 
 #[test]
-fn codex_update_plugin_errors_on_malformed_legacy_mcp_config() {
+fn codex_update_plugin_refreshes_bundle_with_malformed_unrelated_legacy_config() {
     let home = TempDir::new().unwrap();
     let _agent_env = AgentEnvLock::pin(&home);
     let project_root = home.path().join("workspace");
+    let codex = get_integration("codex").unwrap();
+    codex.install(&ctx(home.path(), OLD_BIN)).unwrap();
+
+    let plugin_dir = codex_bootstrap_dir(home.path());
     let codex_dir = home.path().join(".codex");
     std::fs::create_dir_all(&codex_dir).unwrap();
-    std::fs::write(
-        codex_dir.join("config.toml"),
-        "[mcp_servers.tracedecay\ncommand = \"/old/bin/tracedecay\"\n",
-    )
-    .unwrap();
-    let codex = get_integration("codex").unwrap();
+    let config = codex_dir.join("config.toml");
+    std::fs::write(&config, "[mcp_servers.tracedecay\ncommand = \"/old/bin/tracedecay\"\n")
+        .unwrap();
+    let before = bytes(&config);
 
-    let err = match codex.update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root)) {
-        Ok(_) => panic!("malformed legacy MCP config must not be treated as absent"),
-        Err(err) => err,
-    };
-
-    assert!(
-        err.to_string().contains("config.toml"),
-        "error should identify the malformed Codex config: {err}"
-    );
-    assert!(!home.path().join("plugins/tracedecay").exists());
+    let outcome = codex
+        .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
+        .unwrap();
+    assert!(matches!(outcome, UpdatePluginOutcome::Refreshed(paths) if paths == vec![plugin_dir.clone()]));
+    assert_eq!(bytes(&config), before);
+    assert_codex_bundle_contains_bin(&plugin_dir, NEW_BIN, CodexScope::Global);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/automation_runner_test/combined_review.rs
+++ b/tests/automation_runner_test/combined_review.rs
@@ -23,23 +23,23 @@ fn combined_output_fixture() -> Value {
     json!({
         "facts": [
             {
-                "content": "The project requires durable session reflection facts to stay approval gated",
+                "content": "TraceDecay automation should manage durable session reflection facts directly",
                 "category": "project",
                 "tags": ["automation", "memory"],
                 "entities": ["TraceDecay"],
                 "trust": 0.72,
                 "source_span": {"session_id": "session-reflect-1", "message_id": "session-reflect-1-message-001"},
-                "reason": "Repeated session evidence describes the required approval gate"
+                "reason": "Repeated session evidence supports self-managed durable fact automation"
             }
         ],
         "skills": [
             {
                 "id": "automation-run-review",
                 "title": "Automation run review",
-                "summary": "Review self-improvement automation run ledgers and approval gates.",
+                "summary": "Review self-improvement automation run ledgers and apply policies.",
                 "category": "workflow",
                 "body_markdown": "Use when reviewing TraceDecay self-improvement runs.",
-                "reason": "Session evidence repeats approval-gated automation workflow review."
+                "reason": "Session evidence repeats automation workflow outcome review."
             }
         ]
     })
@@ -98,11 +98,18 @@ async fn combined_review_runner_records_both_tasks_from_one_backend_call() {
         assert_eq!(report_ref["combined_task_key"], json!("combined_review"));
     }
 
-    // Approval gating is unchanged: the fact lands as a pending proposal and
-    // the skill as a pending-approval draft.
-    let proposals = list_fact_proposals(
+    // Session facts are self-managed by default; managed skills still stage drafts.
+    let pending = list_fact_proposals(
         &cg.store_layout().dashboard_root,
         Some(FactProposalState::PendingApproval),
+        10,
+    )
+    .await
+    .unwrap();
+    assert!(pending.is_empty());
+    let proposals = list_fact_proposals(
+        &cg.store_layout().dashboard_root,
+        Some(FactProposalState::Applied),
         10,
     )
     .await

--- a/tests/automation_runner_test/memory_curator.rs
+++ b/tests/automation_runner_test/memory_curator.rs
@@ -99,24 +99,21 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
     assert_eq!(run.ledger_record.backend, "codex_app_server");
     assert_eq!(run.ledger_record.host_mode.as_deref(), Some("standalone"));
     assert_eq!(run.ledger_record.model.as_deref(), Some("fixture-model"));
-    assert!(
-        run.ledger_record
-            .evidence_hash
-            .as_deref()
-            .is_some_and(|hash| hash.starts_with("sha256:"))
-    );
-    assert!(
-        run.ledger_record
-            .input_hash
-            .as_deref()
-            .is_some_and(|hash| hash.starts_with("sha256:"))
-    );
-    assert!(
-        run.ledger_record
-            .output_hash
-            .as_deref()
-            .is_some_and(|hash| hash.starts_with("sha256:"))
-    );
+    assert!(run
+        .ledger_record
+        .evidence_hash
+        .as_deref()
+        .is_some_and(|hash| hash.starts_with("sha256:")));
+    assert!(run
+        .ledger_record
+        .input_hash
+        .as_deref()
+        .is_some_and(|hash| hash.starts_with("sha256:")));
+    assert!(run
+        .ledger_record
+        .output_hash
+        .as_deref()
+        .is_some_and(|hash| hash.starts_with("sha256:")));
     assert_eq!(
         run.ledger_record.applied_ops.as_ref().unwrap()[0]["fact_id"],
         json!(102)
@@ -134,7 +131,8 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         json!("requires_dashboard_approval")
     );
     assert_eq!(
-        run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]["permanent_delete_count"],
+        run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]
+            ["permanent_delete_count"],
         json!(1)
     );
     assert_eq!(
@@ -227,16 +225,14 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         validation_payload["improvement_gate"]["optimizer_status"],
         json!("ready_for_optimizer_review")
     );
-    assert!(
-        validation_payload["improvement_gate"]["artifact_refs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reference| reference["kind"] == json!("generated_evals")
-                && reference["sha256"]
-                    .as_str()
-                    .is_some_and(|hash| hash.starts_with("sha256:")))
-    );
+    assert!(validation_payload["improvement_gate"]["artifact_refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reference| reference["kind"] == json!("generated_evals")
+            && reference["sha256"]
+                .as_str()
+                .is_some_and(|hash| hash.starts_with("sha256:"))));
     let feedback_artifact = run
         .ledger_record
         .artifacts
@@ -257,32 +253,26 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
     assert_eq!(feedback_payload["summary"]["rejected_count"], json!(1));
     assert_eq!(feedback_payload["summary"]["reviewed_count"], json!(2));
     assert_eq!(feedback_payload["human"], json!([]));
-    assert!(
-        feedback_payload["artifact_refs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reference| reference["kind"] == json!("traces")
-                && reference["sha256"]
-                    .as_str()
-                    .is_some_and(|hash| hash.starts_with("sha256:")))
-    );
+    assert!(feedback_payload["artifact_refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reference| reference["kind"] == json!("traces")
+            && reference["sha256"]
+                .as_str()
+                .is_some_and(|hash| hash.starts_with("sha256:"))));
     assert_eq!(feedback_payload["model"].as_array().unwrap().len(), 2);
-    assert!(
-        feedback_payload["model"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|entry| entry["outcome"] == json!("accepted"))
-    );
-    assert!(
-        feedback_payload["model"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|entry| entry["outcome"] == json!("rejected")
-                && entry["reason"] == json!("fact_id 999 was not in reviewed evidence"))
-    );
+    assert!(feedback_payload["model"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry["outcome"] == json!("accepted")));
+    assert!(feedback_payload["model"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry["outcome"] == json!("rejected")
+            && entry["reason"] == json!("fact_id 999 was not in reviewed evidence")));
 
     let eval_artifact = run
         .ledger_record
@@ -332,11 +322,9 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         eval_payload["runner"]["inputs"]["expected_eval_count"],
         json!(2)
     );
-    assert!(
-        eval_payload["runner"]["inputs"]["validation_report_hash"]
-            .as_str()
-            .is_some_and(|hash| hash.starts_with("sha256:"))
-    );
+    assert!(eval_payload["runner"]["inputs"]["validation_report_hash"]
+        .as_str()
+        .is_some_and(|hash| hash.starts_with("sha256:")));
     assert_eq!(
         eval_payload["runner"]["checks"].as_array().unwrap().len(),
         3
@@ -355,48 +343,41 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         eval_payload["promotion"]["requires_human_review"],
         json!(true)
     );
-    assert!(
-        eval_payload["artifact_refs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reference| reference["kind"] == json!("feedback")
-                && reference["sha256"]
-                    .as_str()
-                    .is_some_and(|hash| hash.starts_with("sha256:")))
-    );
-    assert!(
-        eval_payload["eval_definitions"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|entry| entry["expected_outcome"] == json!("accepted")
-                && entry["eval_id"] == json!("memory_curator:accepted:0")
-                && entry["source_feedback_ref"] == json!("accepted:0")
-                && entry["schema_version"] == json!(1)
-                && entry["kind"] == json!("automation_validation_regression")
-                && entry["harness"]["type"] == json!("cargo_test_filter")
-                && entry["harness"]["commands"][0]
-                    == json!("cargo test --test automation_runner_test memory_curator")
-                && entry["fixture"]["candidate"].is_object()
-                && entry["source_feedback"]["artifact_kind"] == json!("feedback")
-                && entry["source_feedback"]["feedback_id"] == json!("accepted:0")
-                && entry["assertions"][0]["type"] == json!("outcome_equals"))
-    );
-    assert!(
-        eval_payload["eval_definitions"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|entry| entry["expected_outcome"] == json!("rejected")
-                && entry["eval_id"] == json!("memory_curator:rejected:0")
-                && entry["source_feedback_ref"] == json!("rejected:0")
-                && entry["source_feedback"]["outcome"] == json!("rejected")
-                && entry["expected"]["reason"]
-                    == json!("fact_id 999 was not in reviewed evidence")
-                && entry["input"]["evidence_hash"] == json!(run.ledger_record.evidence_hash)
-                && entry["input"]["input_hash"] == json!(run.ledger_record.input_hash))
-    );
+    assert!(eval_payload["artifact_refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reference| reference["kind"] == json!("feedback")
+            && reference["sha256"]
+                .as_str()
+                .is_some_and(|hash| hash.starts_with("sha256:"))));
+    assert!(eval_payload["eval_definitions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry["expected_outcome"] == json!("accepted")
+            && entry["eval_id"] == json!("memory_curator:accepted:0")
+            && entry["source_feedback_ref"] == json!("accepted:0")
+            && entry["schema_version"] == json!(1)
+            && entry["kind"] == json!("automation_validation_regression")
+            && entry["harness"]["type"] == json!("cargo_test_filter")
+            && entry["harness"]["commands"][0]
+                == json!("cargo test --test automation_runner_test memory_curator")
+            && entry["fixture"]["candidate"].is_object()
+            && entry["source_feedback"]["artifact_kind"] == json!("feedback")
+            && entry["source_feedback"]["feedback_id"] == json!("accepted:0")
+            && entry["assertions"][0]["type"] == json!("outcome_equals")));
+    assert!(eval_payload["eval_definitions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry["expected_outcome"] == json!("rejected")
+            && entry["eval_id"] == json!("memory_curator:rejected:0")
+            && entry["source_feedback_ref"] == json!("rejected:0")
+            && entry["source_feedback"]["outcome"] == json!("rejected")
+            && entry["expected"]["reason"] == json!("fact_id 999 was not in reviewed evidence")
+            && entry["input"]["evidence_hash"] == json!(run.ledger_record.evidence_hash)
+            && entry["input"]["input_hash"] == json!(run.ledger_record.input_hash)));
     assert_eq!(
         eval_payload["result_refs"][0]["kind"],
         json!("validation_report")
@@ -427,23 +408,19 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         optimizer_payload["signals"]["validation_gate_decision"],
         json!("ready_for_optimizer_review")
     );
-    assert!(
-        optimizer_payload["artifact_refs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reference| reference["kind"] == json!("traces"))
-    );
-    assert!(
-        optimizer_payload["diagnostic_inputs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reference| reference["kind"] == json!("generated_evals")
-                && reference["sha256"]
-                    .as_str()
-                    .is_some_and(|hash| hash.starts_with("sha256:")))
-    );
+    assert!(optimizer_payload["artifact_refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reference| reference["kind"] == json!("traces")));
+    assert!(optimizer_payload["diagnostic_inputs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reference| reference["kind"] == json!("generated_evals")
+            && reference["sha256"]
+                .as_str()
+                .is_some_and(|hash| hash.starts_with("sha256:"))));
     assert_eq!(optimizer_payload["blockers"], json!([]));
     assert_eq!(
         optimizer_payload["recommendations"][0]["id"],
@@ -494,13 +471,11 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         handoff_payload["source_refs"][0]["kind"],
         json!("validation_gate")
     );
-    assert!(
-        handoff_payload["artifact_manifest"]["refs"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|reference| reference["kind"] == json!("optimizer_diagnosis"))
-    );
+    assert!(handoff_payload["artifact_manifest"]["refs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|reference| reference["kind"] == json!("optimizer_diagnosis")));
     assert_eq!(
         handoff_payload["artifact_manifest"]["api_list"],
         json!(format!("/api/automation/runs/{}/artifacts", run.run_id))
@@ -525,11 +500,9 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
             "cargo test --test automation_runner_test memory_curator_runner_validates_backend_ops_and_records_ledger -- --nocapture"
         )
     );
-    assert!(
-        handoff_payload["request"]["evidence_hash"]
-            .as_str()
-            .is_some_and(|hash| hash.starts_with("sha256:"))
-    );
+    assert!(handoff_payload["request"]["evidence_hash"]
+        .as_str()
+        .is_some_and(|hash| hash.starts_with("sha256:")));
     assert_eq!(run.report["llm_apply"]["ops"][0]["fact_id"], json!(102));
     assert_eq!(
         run.report["llm_apply"]["rejected_ops"][0]["rejected_reason"],
@@ -1080,12 +1053,11 @@ async fn memory_curator_runner_records_noop_fallback_when_backend_run_task_fails
         "memory_curator",
         json!({ "ops": [] }),
     );
-    assert!(
-        run.ledger_record
-            .error
-            .as_deref()
-            .is_some_and(|error| error.contains("executable"))
-    );
+    assert!(run
+        .ledger_record
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("executable")));
     let records = load_run_records(&cg.store_layout().dashboard_root, 10)
         .await
         .unwrap();

--- a/tests/automation_runner_test/memory_curator.rs
+++ b/tests/automation_runner_test/memory_curator.rs
@@ -128,7 +128,7 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
     );
     assert_eq!(
         run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]["decision"],
-        json!("memory_auto_apply_disabled")
+        json!("requires_dashboard_approval")
     );
     assert_eq!(
         run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]
@@ -143,11 +143,13 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         run.report["automation_apply_policy"]["autonomous_memory_apply"],
         json!(false)
     );
-    assert!(
-        run.report["automation_apply_policy"]
-            .get("approval_required")
-            .is_none(),
-        "memory apply policy should not expose approval terminology"
+    assert_eq!(
+        run.report["automation_apply_policy"]["require_dashboard_approval"],
+        json!(true)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["approval_required"],
+        json!(true)
     );
     assert_eq!(
         run.ledger_record.report_ref.as_ref().unwrap()["run_id"],
@@ -698,7 +700,7 @@ async fn memory_curator_runner_artifacts_mark_handoff_ready_for_accepted_only_ex
 }
 
 #[tokio::test]
-async fn memory_curator_runner_auto_applies_even_when_dashboard_approval_is_required() {
+async fn memory_curator_runner_auto_apply_is_blocked_by_dashboard_approval() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     seed_duplicate_facts(&cg).await;
@@ -745,7 +747,7 @@ async fn memory_curator_runner_auto_applies_even_when_dashboard_approval_is_requ
     assert_eq!(backend.calls(), 1);
     assert_eq!(
         run.report["automation_apply_policy"]["decision"],
-        json!("auto_apply_allowed")
+        json!("requires_dashboard_approval")
     );
     assert_eq!(
         run.report["automation_apply_policy"]["auto_apply_memory_ops"],
@@ -753,26 +755,125 @@ async fn memory_curator_runner_auto_applies_even_when_dashboard_approval_is_requ
     );
     assert_eq!(
         run.report["automation_apply_policy"]["mutates_store"],
-        json!(true)
+        json!(false)
     );
     assert_eq!(
         run.report["automation_apply_policy"]["autonomous_memory_apply"],
+        json!(false)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["require_dashboard_approval"],
         json!(true)
     );
-    assert!(
-        run.report["automation_apply_policy"]
-            .get("require_dashboard_approval")
-            .is_none(),
-        "memory apply policy should not expose stale dashboard approval terminology"
+    assert_eq!(
+        run.report["automation_apply_policy"]["approval_required"],
+        json!(true)
     );
-    assert_eq!(run.report["llm_apply"]["applied"], json!(1));
+    assert_eq!(run.report["llm_apply"]["applied"], Value::Null);
+    assert!(
+        fact_exists(&cg, 102).await,
+        "dashboard approval must block permanent delete auto-apply"
+    );
+}
+
+#[tokio::test]
+async fn memory_curator_runner_preserves_review_gate_when_auto_apply_applies_zero_ops() {
+    let temp = tempdir().unwrap();
+    let cg = init_project(temp.path()).await;
+    seed_duplicate_facts(&cg).await;
+    let backend = JsonBackend::new(json!({
+        "ops": [
+            {
+                "cluster_id": "cluster-0000",
+                "op": "merge",
+                "winner_id": 101,
+                "loser_ids": [102, 102],
+                "confidence": 0.98,
+                "reason": "valid dry-run ids but invalid duplicate loser ids at apply"
+            }
+        ]
+    }));
+    let config = AutomationConfig {
+        enabled: true,
+        backend: AutomationBackend::CodexAppServer,
+        host_mode: AutomationHostMode::Standalone,
+        auto_apply_memory_ops: true,
+        require_dashboard_approval: false,
+        tasks: AutomationTaskSet {
+            memory_curator: AutomationTaskConfig {
+                enabled: true,
+                schedule: Some("manual".to_string()),
+                ..AutomationTaskConfig::default()
+            },
+            ..AutomationTaskSet::default()
+        },
+        ..AutomationConfig::default()
+    };
+
+    let run = run_memory_curator_with_backend(
+        &cg,
+        &config,
+        &backend,
+        MemoryCuratorAutomationOptions {
+            trigger: AutomationTrigger::ManualCli,
+            max_clusters: 4,
+            min_confidence: 0.5,
+            run_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(run.report["llm_apply"]["applied"], json!(0));
     assert_eq!(
         run.report["llm_apply"]["results"][0]["status"],
-        json!("deleted")
+        json!("error")
     );
-    assert!(
-        !fact_exists(&cg, 102).await,
-        "memory curation auto-apply should not be blocked by dashboard approval"
+    assert_eq!(
+        run.report["automation_apply_policy"]["accepted_count"],
+        json!(1)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["applied_count"],
+        json!(0)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["fully_applied"],
+        json!(false)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["mutates_store"],
+        json!(false)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["approval_required"],
+        json!(true)
+    );
+
+    let validation_payload =
+        read_artifact(&cg, &run.run_id, &run.ledger_record, "validation_gate").await;
+    assert_eq!(
+        validation_payload["task_validation"]["approval_required"],
+        json!(true)
+    );
+    assert_eq!(
+        validation_payload["improvement_gate"]["criteria"]["auto_apply_allowed"],
+        json!(false)
+    );
+
+    let handoff_payload =
+        read_artifact(&cg, &run.run_id, &run.ledger_record, "codex_handoff").await;
+    assert_eq!(
+        handoff_payload["readiness"]["approval_required"],
+        json!(true)
+    );
+    assert_eq!(
+        handoff_payload["readiness"]["auto_apply_allowed"],
+        json!(false)
+    );
+    assert_eq!(
+        handoff_payload["validation_requirements"]["must_not_auto_apply"],
+        json!(true)
     );
 }
 

--- a/tests/automation_runner_test/memory_curator.rs
+++ b/tests/automation_runner_test/memory_curator.rs
@@ -128,7 +128,7 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
     );
     assert_eq!(
         run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]["decision"],
-        json!("requires_dashboard_approval")
+        json!("memory_auto_apply_disabled")
     );
     assert_eq!(
         run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]
@@ -140,8 +140,14 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         json!(false)
     );
     assert_eq!(
-        run.report["automation_apply_policy"]["approval_required"],
-        json!(true)
+        run.report["automation_apply_policy"]["autonomous_memory_apply"],
+        json!(false)
+    );
+    assert!(
+        run.report["automation_apply_policy"]
+            .get("approval_required")
+            .is_none(),
+        "memory apply policy should not expose approval terminology"
     );
     assert_eq!(
         run.ledger_record.report_ref.as_ref().unwrap()["run_id"],
@@ -692,7 +698,7 @@ async fn memory_curator_runner_artifacts_mark_handoff_ready_for_accepted_only_ex
 }
 
 #[tokio::test]
-async fn memory_curator_runner_auto_apply_is_blocked_by_dashboard_approval() {
+async fn memory_curator_runner_auto_applies_even_when_dashboard_approval_is_required() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     seed_duplicate_facts(&cg).await;
@@ -739,7 +745,7 @@ async fn memory_curator_runner_auto_apply_is_blocked_by_dashboard_approval() {
     assert_eq!(backend.calls(), 1);
     assert_eq!(
         run.report["automation_apply_policy"]["decision"],
-        json!("requires_dashboard_approval")
+        json!("auto_apply_allowed")
     );
     assert_eq!(
         run.report["automation_apply_policy"]["auto_apply_memory_ops"],
@@ -747,12 +753,26 @@ async fn memory_curator_runner_auto_apply_is_blocked_by_dashboard_approval() {
     );
     assert_eq!(
         run.report["automation_apply_policy"]["mutates_store"],
-        json!(false)
+        json!(true)
     );
-    assert_eq!(run.report["llm_apply"]["applied"], Value::Null);
+    assert_eq!(
+        run.report["automation_apply_policy"]["autonomous_memory_apply"],
+        json!(true)
+    );
     assert!(
-        fact_exists(&cg, 102).await,
-        "dashboard approval must block permanent delete auto-apply"
+        run.report["automation_apply_policy"]
+            .get("require_dashboard_approval")
+            .is_none(),
+        "memory apply policy should not expose stale dashboard approval terminology"
+    );
+    assert_eq!(run.report["llm_apply"]["applied"], json!(1));
+    assert_eq!(
+        run.report["llm_apply"]["results"][0]["status"],
+        json!("deleted")
+    );
+    assert!(
+        !fact_exists(&cg, 102).await,
+        "memory curation auto-apply should not be blocked by dashboard approval"
     );
 }
 

--- a/tests/automation_runner_test/memory_curator.rs
+++ b/tests/automation_runner_test/memory_curator.rs
@@ -99,21 +99,24 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
     assert_eq!(run.ledger_record.backend, "codex_app_server");
     assert_eq!(run.ledger_record.host_mode.as_deref(), Some("standalone"));
     assert_eq!(run.ledger_record.model.as_deref(), Some("fixture-model"));
-    assert!(run
-        .ledger_record
-        .evidence_hash
-        .as_deref()
-        .is_some_and(|hash| hash.starts_with("sha256:")));
-    assert!(run
-        .ledger_record
-        .input_hash
-        .as_deref()
-        .is_some_and(|hash| hash.starts_with("sha256:")));
-    assert!(run
-        .ledger_record
-        .output_hash
-        .as_deref()
-        .is_some_and(|hash| hash.starts_with("sha256:")));
+    assert!(
+        run.ledger_record
+            .evidence_hash
+            .as_deref()
+            .is_some_and(|hash| hash.starts_with("sha256:"))
+    );
+    assert!(
+        run.ledger_record
+            .input_hash
+            .as_deref()
+            .is_some_and(|hash| hash.starts_with("sha256:"))
+    );
+    assert!(
+        run.ledger_record
+            .output_hash
+            .as_deref()
+            .is_some_and(|hash| hash.starts_with("sha256:"))
+    );
     assert_eq!(
         run.ledger_record.applied_ops.as_ref().unwrap()[0]["fact_id"],
         json!(102)
@@ -131,8 +134,7 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         json!("requires_dashboard_approval")
     );
     assert_eq!(
-        run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]
-            ["permanent_delete_count"],
+        run.ledger_record.validation_report.as_ref().unwrap()["apply_policy"]["permanent_delete_count"],
         json!(1)
     );
     assert_eq!(
@@ -225,14 +227,16 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         validation_payload["improvement_gate"]["optimizer_status"],
         json!("ready_for_optimizer_review")
     );
-    assert!(validation_payload["improvement_gate"]["artifact_refs"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|reference| reference["kind"] == json!("generated_evals")
-            && reference["sha256"]
-                .as_str()
-                .is_some_and(|hash| hash.starts_with("sha256:"))));
+    assert!(
+        validation_payload["improvement_gate"]["artifact_refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference["kind"] == json!("generated_evals")
+                && reference["sha256"]
+                    .as_str()
+                    .is_some_and(|hash| hash.starts_with("sha256:")))
+    );
     let feedback_artifact = run
         .ledger_record
         .artifacts
@@ -253,26 +257,32 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
     assert_eq!(feedback_payload["summary"]["rejected_count"], json!(1));
     assert_eq!(feedback_payload["summary"]["reviewed_count"], json!(2));
     assert_eq!(feedback_payload["human"], json!([]));
-    assert!(feedback_payload["artifact_refs"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|reference| reference["kind"] == json!("traces")
-            && reference["sha256"]
-                .as_str()
-                .is_some_and(|hash| hash.starts_with("sha256:"))));
+    assert!(
+        feedback_payload["artifact_refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference["kind"] == json!("traces")
+                && reference["sha256"]
+                    .as_str()
+                    .is_some_and(|hash| hash.starts_with("sha256:")))
+    );
     assert_eq!(feedback_payload["model"].as_array().unwrap().len(), 2);
-    assert!(feedback_payload["model"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|entry| entry["outcome"] == json!("accepted")));
-    assert!(feedback_payload["model"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|entry| entry["outcome"] == json!("rejected")
-            && entry["reason"] == json!("fact_id 999 was not in reviewed evidence")));
+    assert!(
+        feedback_payload["model"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["outcome"] == json!("accepted"))
+    );
+    assert!(
+        feedback_payload["model"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["outcome"] == json!("rejected")
+                && entry["reason"] == json!("fact_id 999 was not in reviewed evidence"))
+    );
 
     let eval_artifact = run
         .ledger_record
@@ -322,9 +332,11 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         eval_payload["runner"]["inputs"]["expected_eval_count"],
         json!(2)
     );
-    assert!(eval_payload["runner"]["inputs"]["validation_report_hash"]
-        .as_str()
-        .is_some_and(|hash| hash.starts_with("sha256:")));
+    assert!(
+        eval_payload["runner"]["inputs"]["validation_report_hash"]
+            .as_str()
+            .is_some_and(|hash| hash.starts_with("sha256:"))
+    );
     assert_eq!(
         eval_payload["runner"]["checks"].as_array().unwrap().len(),
         3
@@ -343,41 +355,48 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         eval_payload["promotion"]["requires_human_review"],
         json!(true)
     );
-    assert!(eval_payload["artifact_refs"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|reference| reference["kind"] == json!("feedback")
-            && reference["sha256"]
-                .as_str()
-                .is_some_and(|hash| hash.starts_with("sha256:"))));
-    assert!(eval_payload["eval_definitions"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|entry| entry["expected_outcome"] == json!("accepted")
-            && entry["eval_id"] == json!("memory_curator:accepted:0")
-            && entry["source_feedback_ref"] == json!("accepted:0")
-            && entry["schema_version"] == json!(1)
-            && entry["kind"] == json!("automation_validation_regression")
-            && entry["harness"]["type"] == json!("cargo_test_filter")
-            && entry["harness"]["commands"][0]
-                == json!("cargo test --test automation_runner_test memory_curator")
-            && entry["fixture"]["candidate"].is_object()
-            && entry["source_feedback"]["artifact_kind"] == json!("feedback")
-            && entry["source_feedback"]["feedback_id"] == json!("accepted:0")
-            && entry["assertions"][0]["type"] == json!("outcome_equals")));
-    assert!(eval_payload["eval_definitions"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|entry| entry["expected_outcome"] == json!("rejected")
-            && entry["eval_id"] == json!("memory_curator:rejected:0")
-            && entry["source_feedback_ref"] == json!("rejected:0")
-            && entry["source_feedback"]["outcome"] == json!("rejected")
-            && entry["expected"]["reason"] == json!("fact_id 999 was not in reviewed evidence")
-            && entry["input"]["evidence_hash"] == json!(run.ledger_record.evidence_hash)
-            && entry["input"]["input_hash"] == json!(run.ledger_record.input_hash)));
+    assert!(
+        eval_payload["artifact_refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference["kind"] == json!("feedback")
+                && reference["sha256"]
+                    .as_str()
+                    .is_some_and(|hash| hash.starts_with("sha256:")))
+    );
+    assert!(
+        eval_payload["eval_definitions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["expected_outcome"] == json!("accepted")
+                && entry["eval_id"] == json!("memory_curator:accepted:0")
+                && entry["source_feedback_ref"] == json!("accepted:0")
+                && entry["schema_version"] == json!(1)
+                && entry["kind"] == json!("automation_validation_regression")
+                && entry["harness"]["type"] == json!("cargo_test_filter")
+                && entry["harness"]["commands"][0]
+                    == json!("cargo test --test automation_runner_test memory_curator")
+                && entry["fixture"]["candidate"].is_object()
+                && entry["source_feedback"]["artifact_kind"] == json!("feedback")
+                && entry["source_feedback"]["feedback_id"] == json!("accepted:0")
+                && entry["assertions"][0]["type"] == json!("outcome_equals"))
+    );
+    assert!(
+        eval_payload["eval_definitions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["expected_outcome"] == json!("rejected")
+                && entry["eval_id"] == json!("memory_curator:rejected:0")
+                && entry["source_feedback_ref"] == json!("rejected:0")
+                && entry["source_feedback"]["outcome"] == json!("rejected")
+                && entry["expected"]["reason"]
+                    == json!("fact_id 999 was not in reviewed evidence")
+                && entry["input"]["evidence_hash"] == json!(run.ledger_record.evidence_hash)
+                && entry["input"]["input_hash"] == json!(run.ledger_record.input_hash))
+    );
     assert_eq!(
         eval_payload["result_refs"][0]["kind"],
         json!("validation_report")
@@ -408,19 +427,23 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         optimizer_payload["signals"]["validation_gate_decision"],
         json!("ready_for_optimizer_review")
     );
-    assert!(optimizer_payload["artifact_refs"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|reference| reference["kind"] == json!("traces")));
-    assert!(optimizer_payload["diagnostic_inputs"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|reference| reference["kind"] == json!("generated_evals")
-            && reference["sha256"]
-                .as_str()
-                .is_some_and(|hash| hash.starts_with("sha256:"))));
+    assert!(
+        optimizer_payload["artifact_refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference["kind"] == json!("traces"))
+    );
+    assert!(
+        optimizer_payload["diagnostic_inputs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference["kind"] == json!("generated_evals")
+                && reference["sha256"]
+                    .as_str()
+                    .is_some_and(|hash| hash.starts_with("sha256:")))
+    );
     assert_eq!(optimizer_payload["blockers"], json!([]));
     assert_eq!(
         optimizer_payload["recommendations"][0]["id"],
@@ -471,11 +494,13 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
         handoff_payload["source_refs"][0]["kind"],
         json!("validation_gate")
     );
-    assert!(handoff_payload["artifact_manifest"]["refs"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|reference| reference["kind"] == json!("optimizer_diagnosis")));
+    assert!(
+        handoff_payload["artifact_manifest"]["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reference| reference["kind"] == json!("optimizer_diagnosis"))
+    );
     assert_eq!(
         handoff_payload["artifact_manifest"]["api_list"],
         json!(format!("/api/automation/runs/{}/artifacts", run.run_id))
@@ -500,9 +525,11 @@ async fn memory_curator_runner_validates_backend_ops_and_records_ledger() {
             "cargo test --test automation_runner_test memory_curator_runner_validates_backend_ops_and_records_ledger -- --nocapture"
         )
     );
-    assert!(handoff_payload["request"]["evidence_hash"]
-        .as_str()
-        .is_some_and(|hash| hash.starts_with("sha256:")));
+    assert!(
+        handoff_payload["request"]["evidence_hash"]
+            .as_str()
+            .is_some_and(|hash| hash.starts_with("sha256:"))
+    );
     assert_eq!(run.report["llm_apply"]["ops"][0]["fact_id"], json!(102));
     assert_eq!(
         run.report["llm_apply"]["rejected_ops"][0]["rejected_reason"],
@@ -842,7 +869,15 @@ async fn memory_curator_runner_preserves_review_gate_when_auto_apply_applies_zer
         json!(false)
     );
     assert_eq!(
+        run.report["automation_apply_policy"]["decision"],
+        json!("dry_run_only")
+    );
+    assert_eq!(
         run.report["automation_apply_policy"]["mutates_store"],
+        json!(false)
+    );
+    assert_eq!(
+        run.report["automation_apply_policy"]["autonomous_memory_apply"],
         json!(false)
     );
     assert_eq!(
@@ -1045,11 +1080,12 @@ async fn memory_curator_runner_records_noop_fallback_when_backend_run_task_fails
         "memory_curator",
         json!({ "ops": [] }),
     );
-    assert!(run
-        .ledger_record
-        .error
-        .as_deref()
-        .is_some_and(|error| error.contains("executable")));
+    assert!(
+        run.ledger_record
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("executable"))
+    );
     let records = load_run_records(&cg.store_layout().dashboard_root, 10)
         .await
         .unwrap();

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -357,7 +357,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
 }
 
 #[tokio::test]
-async fn session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_required() {
+async fn session_reflector_runner_auto_apply_is_blocked_by_dashboard_approval() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     seed_session_evidence(&cg).await;
@@ -409,39 +409,32 @@ async fn session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_
     .unwrap();
 
     assert_eq!(backend.calls(), 1);
-    assert_eq!(run.report["status"], json!("auto_applied"));
-    assert_eq!(run.report["dry_run"], json!(false));
+    assert_eq!(run.report["status"], json!("needs_approval"));
+    assert_eq!(run.report["dry_run"], json!(true));
     assert_eq!(
         run.report["session_fact_apply_policy"]["decision"],
-        json!("auto_apply_allowed")
+        json!("requires_dashboard_approval")
     );
     assert_eq!(
         run.report["session_fact_apply_policy"]["mutates_store"],
-        json!(true)
+        json!(false)
     );
     assert_eq!(
         run.report["session_fact_apply_policy"]["autonomous_memory_apply"],
+        json!(false)
+    );
+    assert_eq!(
+        run.report["session_fact_apply_policy"]["require_dashboard_approval"],
         json!(true)
     );
-    assert!(
-        run.report["session_fact_apply_policy"]
-            .get("require_dashboard_approval")
-            .is_none(),
-        "memory apply policy should not expose stale dashboard approval terminology"
-    );
     assert_eq!(
-        run.ledger_record
-            .applied_ops
-            .as_ref()
-            .unwrap()
-            .as_array()
-            .unwrap()
-            .len(),
-        1
+        run.report["session_fact_apply_policy"]["approval_required"],
+        json!(true)
     );
+    assert!(run.ledger_record.applied_ops.is_none());
     assert_eq!(
         run.ledger_record.validation_report.as_ref().unwrap()["status"],
-        json!("auto_applied")
+        json!("needs_approval")
     );
 
     let pending = list_fact_proposals(
@@ -451,7 +444,7 @@ async fn session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_
     )
     .await
     .unwrap();
-    assert!(pending.is_empty());
+    assert_eq!(pending.len(), 1);
     let applied = list_fact_proposals(
         &cg.store_layout().dashboard_root,
         Some(FactProposalState::Applied),
@@ -459,11 +452,7 @@ async fn session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_
     )
     .await
     .unwrap();
-    assert_eq!(applied.len(), 1);
-    assert_eq!(
-        applied[0].reviewer.as_deref(),
-        Some("session_reflector:auto_apply")
-    );
+    assert!(applied.is_empty());
 
     let facts = cg
         .search_facts(tracedecay::memory::types::SearchFactsRequest {
@@ -478,8 +467,99 @@ async fn session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_
     assert!(
         facts
             .iter()
-            .any(|hit| hit.fact.source.as_deref() == Some("session_reflector")),
-        "auto-applied accepted session facts should be written to the fact store"
+            .all(|hit| hit.fact.source.as_deref() != Some("session_reflector")),
+        "dashboard approval should block accepted session facts from being auto-applied"
+    );
+}
+
+#[tokio::test]
+async fn session_reflector_runner_preserves_review_gate_when_auto_apply_partially_noops() {
+    let temp = tempdir().unwrap();
+    let cg = init_project(temp.path()).await;
+    seed_session_evidence(&cg).await;
+    let backend = SessionJsonBackend::new(json!({
+        "facts": [
+            {
+                "content": "TraceDecay automation should keep partial session memory applies review gated",
+                "category": "project",
+                "tags": ["automation", "memory"],
+                "entities": ["TraceDecay"],
+                "trust": 0.76,
+                "source_span": {"session_id": "session-reflect-1", "message_id": "session-reflect-1-message-001"},
+                "reason": "Repeated session evidence supports a partial apply regression"
+            },
+            {
+                "content": "TraceDecay automation should keep partial session memory applies review gated",
+                "category": "project",
+                "tags": ["automation", "memory"],
+                "entities": ["TraceDecay"],
+                "trust": 0.76,
+                "source_span": {"session_id": "session-reflect-1", "message_id": "session-reflect-1-message-001"},
+                "reason": "Repeated session evidence supports a duplicate proposal no-op"
+            }
+        ]
+    }));
+    let config = AutomationConfig {
+        enabled: true,
+        backend: AutomationBackend::CodexAppServer,
+        host_mode: AutomationHostMode::Standalone,
+        model: Some("configured-model".to_string()),
+        auto_apply_memory_ops: true,
+        require_dashboard_approval: false,
+        tasks: AutomationTaskSet {
+            session_reflector: AutomationTaskConfig {
+                enabled: true,
+                schedule: Some("manual".to_string()),
+                ..AutomationTaskConfig::default()
+            },
+            ..AutomationTaskSet::default()
+        },
+        ..AutomationConfig::default()
+    };
+
+    let run = run_session_reflector_with_backend(
+        &cg,
+        &config,
+        &backend,
+        SessionReflectorAutomationOptions {
+            trigger: AutomationTrigger::ManualCli,
+            provider: "cursor".to_string(),
+            query: "durable session reflection".to_string(),
+            evidence_limit: 5,
+            run_id: None,
+            ..SessionReflectorAutomationOptions::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(run.report["status"], json!("needs_approval"));
+    assert_eq!(
+        run.report["session_fact_apply_policy"]["applied_count"],
+        json!(1)
+    );
+    assert_eq!(
+        run.report["session_fact_apply_policy"]["fully_applied"],
+        json!(false)
+    );
+    assert_eq!(
+        run.report["session_fact_apply_policy"]["approval_required"],
+        json!(true)
+    );
+    assert_eq!(
+        run.ledger_record.validation_report.as_ref().unwrap()["status"],
+        json!("needs_approval")
+    );
+
+    let handoff_payload =
+        read_artifact(&cg, &run.run_id, &run.ledger_record, "codex_handoff").await;
+    assert_eq!(
+        handoff_payload["readiness"]["approval_required"],
+        json!(true)
+    );
+    assert_eq!(
+        handoff_payload["readiness"]["auto_apply_allowed"],
+        json!(false)
     );
 }
 

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -357,7 +357,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
 }
 
 #[tokio::test]
-async fn session_reflector_runner_auto_applies_facts_when_memory_auto_apply_is_enabled() {
+async fn session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_required() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     seed_session_evidence(&cg).await;
@@ -379,7 +379,7 @@ async fn session_reflector_runner_auto_applies_facts_when_memory_auto_apply_is_e
         backend: AutomationBackend::CodexAppServer,
         host_mode: AutomationHostMode::Standalone,
         model: Some("configured-model".to_string()),
-        require_dashboard_approval: false,
+        require_dashboard_approval: true,
         auto_apply_memory_ops: true,
         tasks: AutomationTaskSet {
             session_reflector: AutomationTaskConfig {
@@ -418,6 +418,16 @@ async fn session_reflector_runner_auto_applies_facts_when_memory_auto_apply_is_e
     assert_eq!(
         run.report["session_fact_apply_policy"]["mutates_store"],
         json!(true)
+    );
+    assert_eq!(
+        run.report["session_fact_apply_policy"]["autonomous_memory_apply"],
+        json!(true)
+    );
+    assert!(
+        run.report["session_fact_apply_policy"]
+            .get("require_dashboard_approval")
+            .is_none(),
+        "memory apply policy should not expose stale dashboard approval terminology"
     );
     assert_eq!(
         run.ledger_record

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -32,7 +32,7 @@ async fn session_reflector_runner_skips_when_task_is_disabled() {
 }
 
 #[tokio::test]
-async fn session_reflector_runner_validates_fact_proposals_without_applying() {
+async fn session_reflector_runner_auto_applies_valid_fact_proposals_by_default() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     seed_session_evidence(&cg).await;
@@ -40,13 +40,13 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     let backend = SessionJsonBackend::new(json!({
         "facts": [
             {
-                "content": "The project requires durable session reflection facts to stay approval gated",
+                "content": "TraceDecay automation should manage durable session reflection facts directly",
                 "category": "project",
                 "tags": ["automation", "memory"],
                 "entities": ["TraceDecay"],
                 "trust": 0.72,
                 "source_span": {"session_id": "session-reflect-1", "message_id": "session-reflect-1-message-001"},
-                "reason": "Repeated session evidence describes the required approval gate"
+                "reason": "Repeated session evidence supports self-managed durable fact automation"
             },
             {
                 "content": "Use the fact-store workflow only when the user explicitly asks to memorize or remember a subject",
@@ -184,7 +184,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     );
     assert_eq!(
         run.report["accepted_facts"][0]["add_fact_request"]["metadata"]["trust_reason"],
-        json!("Repeated session evidence describes the required approval gate")
+        json!("Repeated session evidence supports self-managed durable fact automation")
     );
     assert_eq!(
         run.report["accepted_facts"][1]["add_fact_request"]["category"],
@@ -216,9 +216,17 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
         run.report["accepted_facts"][2]["add_fact_request"]["trust"],
         json!(0.85)
     );
-    let proposals = list_fact_proposals(
+    let pending = list_fact_proposals(
         &cg.store_layout().dashboard_root,
         Some(FactProposalState::PendingApproval),
+        10,
+    )
+    .await
+    .unwrap();
+    assert!(pending.is_empty());
+    let proposals = list_fact_proposals(
+        &cg.store_layout().dashboard_root,
+        Some(FactProposalState::Applied),
         10,
     )
     .await
@@ -227,7 +235,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(proposals[0].run_id, run.run_id);
     assert_eq!(
         proposals[0].add_fact_request.as_ref().unwrap().content,
-        "The project requires durable session reflection facts to stay approval gated"
+        "TraceDecay automation should manage durable session reflection facts directly"
     );
     assert_eq!(proposals[1].run_id, run.run_id);
     assert_eq!(
@@ -242,16 +250,22 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
         run.report["proposal_ids"][0],
         json!(proposals[0].proposal_id)
     );
-    assert!(run.ledger_record.applied_ops.is_none());
+    assert_eq!(run.report["status"], json!("auto_applied"));
+    assert_eq!(run.report["dry_run"], json!(false));
     assert_eq!(
-        run.ledger_record.validation_report.as_ref().unwrap()["pending_proposals"]["proposal_ids"]
+        run.report["session_fact_apply_policy"]["decision"],
+        json!("auto_apply_allowed")
+    );
+    assert!(run.ledger_record.applied_ops.is_some());
+    assert_eq!(
+        run.ledger_record.validation_report.as_ref().unwrap()["applied_proposals"]["proposal_ids"]
             [0],
         json!(proposals[0].proposal_id)
     );
     assert_eq!(
-        run.ledger_record.validation_report.as_ref().unwrap()["pending_proposals"]
+        run.ledger_record.validation_report.as_ref().unwrap()["applied_proposals"]
             ["accepted_facts"][0]["add_fact_request"]["content"],
-        json!("The project requires durable session reflection facts to stay approval gated")
+        json!("TraceDecay automation should manage durable session reflection facts directly")
     );
     let artifact_kinds: Vec<&str> = run
         .ledger_record
@@ -285,7 +299,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(
         eval_payload["runner"]["commands"][0],
         json!(
-            "cargo test --test automation_runner_test session_reflector_runner_validates_fact_proposals_without_applying -- --nocapture"
+            "cargo test --test automation_runner_test session_reflector_runner_auto_applies_valid_fact_proposals_by_default -- --nocapture"
         )
     );
     let handoff_payload =
@@ -293,45 +307,17 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(handoff_payload["task"], json!("session_reflector"));
     assert_eq!(
         handoff_payload["next_actions"][0],
-        json!("review pending fact proposals")
+        json!("inspect fact automation outcomes")
     );
     assert_eq!(
         handoff_payload["eval_replay"]["commands"][0],
         json!(
-            "cargo test --test automation_runner_test session_reflector_runner_validates_fact_proposals_without_applying -- --nocapture"
+            "cargo test --test automation_runner_test session_reflector_runner_auto_applies_valid_fact_proposals_by_default -- --nocapture"
         )
     );
-    let before_apply = cg
-        .search_facts(tracedecay::memory::types::SearchFactsRequest {
-            query: "durable session reflection facts approval gated".to_string(),
-            category: Some(tracedecay::memory::types::MemoryCategory::Project),
-            limit: Some(10),
-            min_trust: Some(0.1),
-            include_why: false,
-        })
-        .await
-        .unwrap();
-    assert!(
-        before_apply
-            .iter()
-            .all(|hit| hit.fact.source.as_deref() != Some("session_reflector")),
-        "session reflector should not write accepted facts before proposal approval"
-    );
-
-    let project_db = cg.open_project_store_db().await.unwrap();
-    let applied = apply_fact_proposal(
-        &cg.store_layout().dashboard_root,
-        project_db.conn(),
-        &proposals[0].proposal_id,
-        Some("test".to_string()),
-    )
-    .await
-    .unwrap();
-    assert_eq!(applied.state, FactProposalState::Applied);
-    assert!(applied.apply_outcome.is_some());
     let after_apply = cg
         .search_facts(tracedecay::memory::types::SearchFactsRequest {
-            query: "durable session reflection facts approval gated".to_string(),
+            query: "TraceDecay automation durable session reflection facts".to_string(),
             category: Some(tracedecay::memory::types::MemoryCategory::Project),
             limit: Some(10),
             min_trust: Some(0.1),
@@ -343,7 +329,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
         after_apply
             .iter()
             .any(|hit| hit.fact.source.as_deref() == Some("session_reflector")),
-        "approving the proposal should apply it to the fact store"
+        "session reflector should auto-apply accepted facts"
     );
 
     let records = load_run_records(&cg.store_layout().dashboard_root, 10)
@@ -353,7 +339,7 @@ async fn session_reflector_runner_validates_fact_proposals_without_applying() {
     assert_eq!(records[0].run_id, run.run_id);
     assert_eq!(records[0].accepted_count, 3);
     assert_eq!(records[0].rejected_count, 8);
-    assert!(records[0].applied_ops.is_none());
+    assert!(records[0].applied_ops.is_some());
 }
 
 #[tokio::test]
@@ -473,7 +459,7 @@ async fn session_reflector_runner_auto_apply_is_blocked_by_dashboard_approval() 
 }
 
 #[tokio::test]
-async fn session_reflector_runner_preserves_review_gate_when_auto_apply_partially_noops() {
+async fn session_reflector_runner_self_manages_partial_noops_without_review_gate() {
     let temp = tempdir().unwrap();
     let cg = init_project(temp.path()).await;
     seed_session_evidence(&cg).await;
@@ -533,7 +519,8 @@ async fn session_reflector_runner_preserves_review_gate_when_auto_apply_partiall
     .await
     .unwrap();
 
-    assert_eq!(run.report["status"], json!("needs_approval"));
+    assert_eq!(run.report["status"], json!("auto_applied"));
+    assert_eq!(run.report["dry_run"], json!(false));
     assert_eq!(
         run.report["session_fact_apply_policy"]["applied_count"],
         json!(1)
@@ -544,22 +531,22 @@ async fn session_reflector_runner_preserves_review_gate_when_auto_apply_partiall
     );
     assert_eq!(
         run.report["session_fact_apply_policy"]["approval_required"],
-        json!(true)
+        json!(false)
     );
     assert_eq!(
         run.ledger_record.validation_report.as_ref().unwrap()["status"],
-        json!("needs_approval")
+        json!("auto_applied")
     );
 
     let handoff_payload =
         read_artifact(&cg, &run.run_id, &run.ledger_record, "codex_handoff").await;
     assert_eq!(
         handoff_payload["readiness"]["approval_required"],
-        json!(true)
+        json!(false)
     );
     assert_eq!(
         handoff_payload["readiness"]["auto_apply_allowed"],
-        json!(false)
+        json!(true)
     );
 }
 
@@ -569,7 +556,7 @@ async fn session_fact_proposals_dedupe_repeated_pending_facts_across_runs() {
     let dashboard_root = temp.path().join("dashboard");
     let accepted = json!({
         "add_fact_request": {
-            "content": "Repeated session evidence should produce one pending fact proposal",
+            "content": "Repeated session evidence should produce one durable fact action",
             "category": "project",
             "source": "session_reflector",
             "tags": ["session-reflector"],
@@ -584,7 +571,7 @@ async fn session_fact_proposals_dedupe_repeated_pending_facts_across_runs() {
             }
         },
         "proposal": {
-            "content": "Repeated session evidence should produce one pending fact proposal"
+            "content": "Repeated session evidence should produce one durable fact action"
         },
         "validation": {
             "dedupe": {

--- a/tests/automation_runner_test/skill_writer.rs
+++ b/tests/automation_runner_test/skill_writer.rs
@@ -243,7 +243,7 @@ async fn skill_writer_runner_creates_pending_skill_drafts_for_approval() {
                         "text": "- Check ledger counts\n- Check pending approval state\n"
                     }
                 ],
-                "reason": "Session evidence repeats approval-gated automation workflow review."
+                "reason": "Session evidence repeats automation workflow outcome review."
             },
             {
                 "id": "automation-run-review",
@@ -295,11 +295,11 @@ async fn skill_writer_runner_creates_pending_skill_drafts_for_approval() {
     assert_eq!(run.report["created_skills"][0]["action"], json!("create"));
     assert_eq!(
         run.report["created_skills"][0]["proposal_reason"],
-        json!("Session evidence repeats approval-gated automation workflow review.")
+        json!("Session evidence repeats automation workflow outcome review.")
     );
     assert_eq!(
         run.report["created_skills"][0]["reason"],
-        json!("Session evidence repeats approval-gated automation workflow review.")
+        json!("Session evidence repeats automation workflow outcome review.")
     );
     assert_eq!(
         run.report["created_skills"][0]["approval_status"],
@@ -560,7 +560,7 @@ async fn skill_writer_runner_auto_enables_when_config_explicitly_allows() {
                     "base_checksum": base_checksum,
                     "summary": "Review self-improvement automation runs and activation policy.",
                     "body_markdown": "Check the run ledger, activation policy, and approval state before applying changes.",
-                    "reason": "Session evidence repeats approval-gated automation workflow review."
+                    "reason": "Session evidence repeats automation workflow outcome review."
                 }
             ]
         }),
@@ -687,7 +687,7 @@ async fn skill_writer_runner_updates_existing_skills_with_checksum_precondition(
                         "text": "- Check ledger counts\n- Check rejected proposals\n"
                     }
                 ],
-                "reason": "Session evidence repeats approval-gated automation workflow review."
+                "reason": "Session evidence repeats automation workflow outcome review."
             },
             {
                 "action": "patch",
@@ -734,11 +734,11 @@ async fn skill_writer_runner_updates_existing_skills_with_checksum_precondition(
     assert_eq!(run.report["updated_skills"][0]["action"], json!("update"));
     assert_eq!(
         run.report["updated_skills"][0]["proposal_reason"],
-        json!("Session evidence repeats approval-gated automation workflow review.")
+        json!("Session evidence repeats automation workflow outcome review.")
     );
     assert_eq!(
         run.report["updated_skills"][0]["reason"],
-        json!("Session evidence repeats approval-gated automation workflow review.")
+        json!("Session evidence repeats automation workflow outcome review.")
     );
     assert_eq!(
         run.report["updated_skills"][0]["approval_status"],

--- a/tests/automation_runner_test/support.rs
+++ b/tests/automation_runner_test/support.rs
@@ -758,7 +758,7 @@ pub(crate) async fn seed_session_evidence(cg: &TraceDecay) {
             message_id: "session-reflect-1-message-001",
             role: "user",
             timestamp: 1_715_000_001,
-            text: "Remember durable session reflection facts must remain approval gated for automation workflows.",
+            text: "Remember TraceDecay automation should manage durable session reflection facts directly.",
             source: None,
         },
     )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,6 +2,10 @@
 
 use std::ffi::{OsStr, OsString};
 use std::fs;
+#[cfg(not(windows))]
+use std::fs::File;
+#[cfg(not(windows))]
+use std::io::Write;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -12,6 +16,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use serde_json::Value;
+#[cfg(not(windows))]
+use tempfile::NamedTempFile;
 use tempfile::TempDir;
 use tokio::sync::OnceCell;
 use tracedecay::config::USER_DATA_DIR_ENV;
@@ -293,38 +299,42 @@ pub fn install_fake_codex_launcher(script: &Path, bin: &Path) {
          SCRIPT_DIR=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n\
          exec python3 \"$SCRIPT_DIR/{script_name}\" \"$@\"\n"
     );
-    let tmp = bin.with_extension(format!("tmp.{}", std::process::id()));
-    fs::write(&tmp, launcher).unwrap_or_else(|err| {
+    write_executable_atomically(bin, launcher.as_bytes()).unwrap_or_else(|err| {
         panic!(
-            "failed to write fake codex launcher {} for {}: {err}",
-            tmp.display(),
+            "failed to install fake codex launcher {} for {}: {err}",
+            bin.display(),
             script.display()
         )
     });
-    make_executable(&tmp);
-    fs::rename(&tmp, bin).unwrap_or_else(|err| {
-        panic!(
-            "failed to install fake codex launcher {} from {}: {err}",
-            bin.display(),
-            tmp.display()
-        )
-    });
+}
+
+#[cfg(not(windows))]
+fn write_executable_atomically(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = NamedTempFile::new_in(parent)?;
+    tmp.write_all(contents)?;
+    make_executable_file(tmp.as_file())?;
+    tmp.as_file_mut().sync_all()?;
+    tmp.persist(path).map_err(|err| err.error)?;
+    Ok(())
 }
 
 #[cfg(unix)]
-fn make_executable(path: &Path) {
+fn make_executable_file(file: &File) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    let mut permissions = fs::metadata(path)
-        .unwrap_or_else(|err| panic!("failed to stat {}: {err}", path.display()))
-        .permissions();
+    let mut permissions = file.metadata()?.permissions();
     permissions.set_mode(0o755);
-    fs::set_permissions(path, permissions)
-        .unwrap_or_else(|err| panic!("failed to chmod {}: {err}", path.display()));
+    file.set_permissions(permissions)
 }
 
 #[cfg(not(unix))]
-fn make_executable(_path: &Path) {}
+fn make_executable_file(_file: &File) -> std::io::Result<()> {
+    Ok(())
+}
 
 pub fn windows_python_launcher(script_name: &str) -> String {
     format!(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,7 @@
 #![allow(dead_code)]
 
 use std::ffi::{OsStr, OsString};
-use std::fs;
-#[cfg(not(windows))]
-use std::fs::File;
+use std::fs::{self, File};
 #[cfg(not(windows))]
 use std::io::Write;
 use std::net::TcpListener;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -279,14 +279,36 @@ pub fn install_fake_codex_launcher(_script: &Path, bin: &Path) {
 
 #[cfg(not(windows))]
 pub fn install_fake_codex_launcher(script: &Path, bin: &Path) {
-    fs::copy(script, bin).unwrap_or_else(|err| {
+    let script_name = script
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "fake codex script has no valid file name: {}",
+                script.display()
+            )
+        });
+    let launcher = format!(
+        "#!/bin/sh\n\
+         SCRIPT_DIR=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n\
+         exec python3 \"$SCRIPT_DIR/{script_name}\" \"$@\"\n"
+    );
+    let tmp = bin.with_extension(format!("tmp.{}", std::process::id()));
+    fs::write(&tmp, launcher).unwrap_or_else(|err| {
         panic!(
-            "failed to install fake codex launcher {} from {}: {err}",
-            bin.display(),
+            "failed to write fake codex launcher {} for {}: {err}",
+            tmp.display(),
             script.display()
         )
     });
-    make_executable(bin);
+    make_executable(&tmp);
+    fs::rename(&tmp, bin).unwrap_or_else(|err| {
+        panic!(
+            "failed to install fake codex launcher {} from {}: {err}",
+            bin.display(),
+            tmp.display()
+        )
+    });
 }
 
 #[cfg(unix)]

--- a/tests/dashboard_api_test/automation_config.rs
+++ b/tests/dashboard_api_test/automation_config.rs
@@ -57,6 +57,7 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
         );
 
         let patch = serde_json::json!({
+            "backend": "codex_app_server",
             "model": "project-model",
             "timeout_secs": 90,
             "scheduler_tick_secs": 15,
@@ -64,6 +65,8 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
         });
         let (status, saved) = patch_json_body(&agent, &config_url, &patch);
         assert_eq!(status, 200);
+        assert_eq!(saved["project"]["backend"], "codex_app_server");
+        assert_eq!(saved["effective"]["backend"], "codex_app_server");
         assert_eq!(saved["project"]["model"], "project-model");
         assert_eq!(saved["effective"]["model"], "project-model");
         assert_eq!(saved["effective"]["timeout_secs"], 90);
@@ -208,7 +211,7 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
             &agent,
             &config_url,
             &serde_json::json!({
-                "require_dashboard_approval": false,
+                "require_dashboard_approval": true,
                 "auto_apply_memory_ops": true,
                 "export_memory_digest": false
             }),
@@ -219,7 +222,7 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
         );
         assert_eq!(
             saved_auto_apply["effective"]["require_dashboard_approval"],
-            false
+            true
         );
         assert_eq!(saved_auto_apply["effective"]["auto_apply_memory_ops"], true);
         assert_eq!(saved_auto_apply["effective"]["export_memory_digest"], false);
@@ -269,6 +272,8 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
             &format!("{base_url}/api/plugins/holographic/curation/config"),
         );
         assert_eq!(status, 200);
+        assert_eq!(restored["project"]["backend"], "codex_app_server");
+        assert_eq!(restored["effective"]["backend"], "codex_app_server");
         assert_eq!(restored["project"]["model"], "project-model");
         assert_eq!(restored["effective"]["model"], "project-model");
         assert_eq!(

--- a/tests/hooks_lsp_suite/hooks_test.rs
+++ b/tests/hooks_lsp_suite/hooks_test.rs
@@ -1408,8 +1408,8 @@ fn test_codex_subagent_start_no_history_does_not_suppress_later_research_context
     assert!(context.contains("tracedecay hint:"));
 }
 
-#[test]
-fn test_codex_subagent_start_counts_and_formats_log_line() {
+#[tokio::test]
+async fn test_codex_subagent_start_counts_and_formats_log_line() {
     let _lock = lock_global_db_env();
     let project = tempfile::tempdir().unwrap();
     let profile = tempfile::tempdir().unwrap();
@@ -1425,8 +1425,8 @@ fn test_codex_subagent_start_counts_and_formats_log_line() {
     })
     .to_string();
 
-    assert_eq!(record_codex_subagent_start(&input), Some(1));
-    assert_eq!(record_codex_subagent_start(&input), Some(2));
+    assert_eq!(record_codex_subagent_start(&input).await, Some(1));
+    assert_eq!(record_codex_subagent_start(&input).await, Some(2));
 
     let line = codex_subagent_start_log_line(&input, Some(2), true);
     assert!(line.contains("Codex SubagentStart #2"));

--- a/tests/hooks_lsp_suite/hooks_test.rs
+++ b/tests/hooks_lsp_suite/hooks_test.rs
@@ -1408,8 +1408,8 @@ fn test_codex_subagent_start_no_history_does_not_suppress_later_research_context
     assert!(context.contains("tracedecay hint:"));
 }
 
-#[tokio::test]
-async fn test_codex_subagent_start_counts_and_formats_log_line() {
+#[test]
+fn test_codex_subagent_start_counts_and_formats_log_line() {
     let _lock = lock_global_db_env();
     let project = tempfile::tempdir().unwrap();
     let profile = tempfile::tempdir().unwrap();
@@ -1425,8 +1425,18 @@ async fn test_codex_subagent_start_counts_and_formats_log_line() {
     })
     .to_string();
 
-    assert_eq!(record_codex_subagent_start(&input).await, Some(1));
-    assert_eq!(record_codex_subagent_start(&input).await, Some(2));
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|err| panic!("failed to build tokio runtime: {err}"));
+    assert_eq!(
+        runtime.block_on(record_codex_subagent_start(&input)),
+        Some(1)
+    );
+    assert_eq!(
+        runtime.block_on(record_codex_subagent_start(&input)),
+        Some(2)
+    );
 
     let line = codex_subagent_start_log_line(&input, Some(2), true);
     assert!(line.contains("Codex SubagentStart #2"));

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -2770,7 +2770,7 @@ async fn context_memory_controls_filter_disable_and_preserve_markdown() {
 async fn context_memory_large_markdown_uses_reversible_lane_preview() {
     let (cg, _dir) = setup_project().await;
     let tail = "MEMORY_TAIL_MARKER";
-    let long_content = format!("Large reversible memory fact {}{tail}", "x".repeat(4_000));
+    let long_content = format!("Large reversible memory fact {}{tail}", "x".repeat(20_000));
     handle_tool_call(
         &cg,
         "tracedecay_fact_store",

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -44,7 +44,8 @@ use tracedecay::storage::{
 };
 use tracedecay::tracedecay::TraceDecay;
 
-static GLOBAL_DB_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+pub(crate) static GLOBAL_DB_ENV_LOCK: Mutex<()> = Mutex::const_new(());
+const MCP_TEST_RESPONSE_CHAR_LIMIT: usize = 15_000;
 
 struct TestDbConnection {
     _db: libsql::Database,
@@ -2368,25 +2369,28 @@ async fn retrieve_tool_reports_missing_and_expired_handles_actionably() {
 #[tokio::test]
 async fn fact_store_large_list_response_uses_retrieve_handle() {
     let (cg, _env, _dir) = setup_empty_project().await;
-    let added = handle_tool_call(
-        &cg,
-        "tracedecay_fact_store",
-        json!({
-            "action": "add",
-            "content": format!(
-                "LONG_FACT_MARKER_00: {}",
-                "large fact-store response should remain retrievable ".repeat(220)
-            ),
-            "category": "project",
-            "trust": 0.9
-        }),
-        None,
-        None,
-    )
-    .await
-    .unwrap();
-    let added: Value = serde_json::from_str(extract_text(&added.value)).unwrap();
-    let last_fact_id = added["fact"]["fact_id"].as_i64();
+    let mut last_fact_id = None;
+    for index in 0..4 {
+        let added = handle_tool_call(
+            &cg,
+            "tracedecay_fact_store",
+            json!({
+                "action": "add",
+                "content": format!(
+                    "LONG_FACT_MARKER_{index:02}: {}",
+                    "large fact-store response should remain retrievable ".repeat(180)
+                ),
+                "category": "project",
+                "trust": 0.9
+            }),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let added: Value = serde_json::from_str(extract_text(&added.value)).unwrap();
+        last_fact_id = added["fact"]["fact_id"].as_i64();
+    }
     let last_fact_id = last_fact_id.expect("tail fact id");
 
     let listed = handle_tool_call(
@@ -2448,7 +2452,7 @@ async fn fact_store_large_list_response_uses_retrieve_handle() {
         .as_str()
         .expect("retrieve response should contain original JSON text");
     let full: Value = serde_json::from_str(full_json).expect("retrieved content should be JSON");
-    assert_eq!(full["count"].as_u64(), Some(1));
+    assert_eq!(full["count"].as_u64(), Some(4));
     assert!(
         full_json.contains("LONG_FACT_MARKER_00"),
         "retrieved response should include the full fact list"
@@ -2458,23 +2462,25 @@ async fn fact_store_large_list_response_uses_retrieve_handle() {
 #[tokio::test]
 async fn fact_store_large_list_response_reports_store_failure_actionably() {
     let (cg, _env, _dir) = setup_empty_project().await;
-    handle_tool_call(
-        &cg,
-        "tracedecay_fact_store",
-        json!({
-            "action": "add",
-            "content": format!(
-                "STORE_FAILURE_MARKER_00: {}",
-                "large fact-store response should surface cache failures ".repeat(220)
-            ),
-            "category": "project",
-            "trust": 0.9
-        }),
-        None,
-        None,
-    )
-    .await
-    .unwrap();
+    for index in 0..4 {
+        handle_tool_call(
+            &cg,
+            "tracedecay_fact_store",
+            json!({
+                "action": "add",
+                "content": format!(
+                    "STORE_FAILURE_MARKER_{index:02}: {}",
+                    "large fact-store response should surface cache failures ".repeat(180)
+                ),
+                "category": "project",
+                "trust": 0.9
+            }),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
 
     let handle_dir = response_handle_dir(&cg);
     fs::write(&handle_dir, "not-a-directory").unwrap();
@@ -2517,7 +2523,7 @@ async fn fact_store_large_list_response_reports_store_failure_actionably() {
 
 #[tokio::test]
 async fn search_large_response_uses_retrievable_truncation_handle() {
-    const LARGE_RESPONSE_MARKER_COUNT: usize = 120;
+    const LARGE_RESPONSE_MARKER_COUNT: usize = 260;
     const LAST_LARGE_RESPONSE_MARKER: usize = LARGE_RESPONSE_MARKER_COUNT - 1;
 
     let dir = test_temp_dir();
@@ -2666,7 +2672,7 @@ async fn context_includes_matching_memory_facts() {
 }
 
 #[tokio::test]
-async fn context_memory_controls_filter_disable_and_compact_markdown() {
+async fn context_memory_controls_filter_disable_and_preserve_markdown() {
     let (cg, _dir) = setup_project().await;
     let long_content = format!("Long memory control fact {}", "x".repeat(320));
     handle_tool_call(
@@ -2756,8 +2762,50 @@ async fn context_memory_controls_filter_disable_and_compact_markdown() {
     .unwrap();
     let text = extract_text(&markdown.value);
     assert!(text.contains("Long memory control fact"));
-    assert!(text.contains("..."));
-    assert!(!text.contains(&"x".repeat(300)));
+    assert!(text.contains(&"x".repeat(300)));
+    assert!(!text.contains("..."));
+}
+
+#[tokio::test]
+async fn context_memory_large_markdown_uses_reversible_lane_preview() {
+    let (cg, _dir) = setup_project().await;
+    let tail = "MEMORY_TAIL_MARKER";
+    let long_content = format!("Large reversible memory fact {}{tail}", "x".repeat(4_000));
+    handle_tool_call(
+        &cg,
+        "tracedecay_fact_store",
+        json!({
+            "action": "add",
+            "content": long_content,
+            "category": "decision",
+            "entity": "large reversible memory fact",
+            "tags": ["context-memory-lane-preview"],
+            "trust": 0.95,
+            "source": "mcp-context-test"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let markdown = handle_tool_call(
+        &cg,
+        "tracedecay_context",
+        json!({"task": "large reversible memory fact", "memory_limit": 1}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&markdown.value);
+    assert!(text.starts_with("# Truncated Response"), "got: {text}");
+    assert!(text.contains("lane-budgeted preview"), "got: {text}");
+    assert!(text.contains("### Memory Matches"), "got: {text}");
+    assert!(text.contains("lane truncated"), "got: {text}");
+    assert!(text.contains("tracedecay_retrieve"), "got: {text}");
+    assert!(!text.contains(tail), "preview should omit tail: {text}");
 }
 
 #[tokio::test]
@@ -3203,7 +3251,7 @@ async fn test_diff_context() {
 
 #[tokio::test]
 async fn diff_context_large_response_uses_retrievable_truncation_handle() {
-    const LARGE_RESPONSE_MARKER_COUNT: usize = 120;
+    const LARGE_RESPONSE_MARKER_COUNT: usize = 260;
     const LAST_LARGE_RESPONSE_MARKER: usize = LARGE_RESPONSE_MARKER_COUNT - 1;
 
     let dir = test_temp_dir();
@@ -4705,6 +4753,29 @@ async fn outline_preserves_db_payload_and_adds_ast_grep_outline_when_available()
                 .is_some_and(|items| items.iter().any(|item| item["name"] == "helper")))),
         "ast-grep outline should be attached under ast_grep_outline: {payload}"
     );
+}
+
+#[tokio::test]
+async fn outline_markdown_uses_context_style_bullets_not_table() {
+    if !tracedecay::mcp::tools::ast_grep_outline_available() {
+        return;
+    }
+
+    let (cg, _dir) = setup_project().await;
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_outline",
+        json!({"file": "src/utils.rs", "format": "markdown"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    assert!(text.contains("## Outline"));
+    assert!(text.contains("- **helper**"));
+    assert!(!text.contains("| symbol | kind |"));
 }
 
 #[cfg(unix)]
@@ -9672,7 +9743,7 @@ async fn lcm_session_handlers_expose_bounded_read_apis_and_placeholders() {
         .as_str()
         .unwrap()
         .contains("EXPANDED CONTEXT"));
-    assert!(extract_text(&result.value).len() <= 15_000);
+    assert!(extract_text(&result.value).len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
 
     let preflight = handle_tool_call(
         &cg,
@@ -9938,7 +10009,7 @@ async fn lcm_compress_oversized_needs_summary_uses_retrievable_full_payload() {
     assert_eq!(payload["retrieve_tool"], "tracedecay_retrieve");
     assert!(payload.get("contract_truncated").is_none());
     assert!(payload.get("replay_messages_truncated_for_mcp").is_none());
-    assert!(text.len() <= 15_000);
+    assert!(text.len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
     let retrieved = handle_tool_call(
         &cg,
         "tracedecay_retrieve",
@@ -10018,7 +10089,7 @@ async fn lcm_preflight_oversized_replay_preserves_bridge_contract() {
     assert_eq!(payload["mcp_response_truncated"], true);
     assert_eq!(payload["contract_truncated"], true);
     assert!(payload.get("truncated").is_none());
-    assert!(text.len() <= 15_000);
+    assert!(text.len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
     assert!(payload["replay_messages_compacted_for_mcp"]
         .as_bool()
         .unwrap_or(false));
@@ -10063,7 +10134,7 @@ async fn lcm_preflight_structured_replay_content_is_bounded_for_mcp() {
     let payload: Value = serde_json::from_str(text).unwrap();
     assert_eq!(payload["status"], "ok");
     assert!(payload.get("truncated").is_none());
-    assert!(text.len() <= 15_000);
+    assert!(text.len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
     let compacted_content = payload["replay_messages"][0]["content"]
         .as_str()
         .expect("structured replay content should be serialized to bounded text");
@@ -11134,7 +11205,7 @@ async fn lcm_large_json_response_stays_parseable_after_truncation() {
     let payload: Value = serde_json::from_str(extract_text(&result.value))
         .expect("truncated LCM tool text should remain valid JSON");
     assert_eq!(payload["truncated"], true);
-    assert!(payload["preview"].as_str().unwrap().len() <= 15_000);
+    assert!(payload["preview"].as_str().unwrap().len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
 }
 
 #[tokio::test]
@@ -11197,7 +11268,7 @@ async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
         payload["context_blocks"].as_array().unwrap().len() <= 3,
         "MCP expand-query context should stay compact"
     );
-    assert!(text.len() <= 15_000);
+    assert!(text.len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
     close_test_graph(cg).await;
 }
 
@@ -11284,7 +11355,7 @@ async fn lcm_expand_query_oversized_prompt_preserves_synthesis_contract() {
         .as_str()
         .unwrap()
         .contains("QUESTION:"));
-    assert!(text.len() <= 15_000);
+    assert!(text.len() <= MCP_TEST_RESPONSE_CHAR_LIMIT);
 }
 
 #[tokio::test]

--- a/tests/mcp_suite/multi_mcp_coordination_test.rs
+++ b/tests/mcp_suite/multi_mcp_coordination_test.rs
@@ -1,9 +1,59 @@
-use std::time::Duration;
+use std::{ffi::OsString, path::Path, time::Duration};
 use tempfile::tempdir;
 use tracedecay::mcp::McpServer;
 use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 use crate::common::canonical_existing_path;
+
+struct TranscriptHomeEnvGuard {
+    previous_home: Option<OsString>,
+    previous_userprofile: Option<OsString>,
+    previous_data_dir: Option<OsString>,
+    previous_hermes_home: Option<OsString>,
+}
+
+impl TranscriptHomeEnvGuard {
+    fn set(home: &Path) -> Self {
+        let previous_home = std::env::var_os("HOME");
+        let previous_userprofile = std::env::var_os("USERPROFILE");
+        let previous_data_dir = std::env::var_os(tracedecay::config::USER_DATA_DIR_ENV);
+        let previous_hermes_home = std::env::var_os("HERMES_HOME");
+        std::env::set_var("HOME", home);
+        std::env::set_var("USERPROFILE", home);
+        std::env::set_var(
+            tracedecay::config::USER_DATA_DIR_ENV,
+            home.join(tracedecay::config::TRACEDECAY_DIR),
+        );
+        std::env::set_var("HERMES_HOME", home.join(".hermes"));
+        Self {
+            previous_home,
+            previous_userprofile,
+            previous_data_dir,
+            previous_hermes_home,
+        }
+    }
+}
+
+impl Drop for TranscriptHomeEnvGuard {
+    fn drop(&mut self) {
+        match self.previous_home.take() {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match self.previous_userprofile.take() {
+            Some(value) => std::env::set_var("USERPROFILE", value),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        match self.previous_data_dir.take() {
+            Some(value) => std::env::set_var(tracedecay::config::USER_DATA_DIR_ENV, value),
+            None => std::env::remove_var(tracedecay::config::USER_DATA_DIR_ENV),
+        }
+        match self.previous_hermes_home.take() {
+            Some(value) => std::env::set_var("HERMES_HOME", value),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+    }
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_mcps_on_same_project_coordinate_via_sync_lock() {
@@ -11,6 +61,7 @@ async fn two_mcps_on_same_project_coordinate_via_sync_lock() {
     let tmp = tempdir().unwrap();
     let project = tmp.path().to_path_buf();
     let profile_root = canonical_existing_path(home.path()).join(".tracedecay");
+    let _transcript_home_env = TranscriptHomeEnvGuard::set(home.path());
     let open_options = TraceDecayOpenOptions {
         profile_root: Some(profile_root.clone()),
         global_db_path: Some(profile_root.join("global.db")),

--- a/tests/mcp_suite/workflow_query_test.rs
+++ b/tests/mcp_suite/workflow_query_test.rs
@@ -301,6 +301,7 @@ fn search_session_ids(payload: &Value) -> Vec<String> {
 /// modes plus the git-scope list end to end.
 #[tokio::test]
 async fn workflows_query_surface_end_to_end() {
+    let _env_lock = crate::mcp_handler_test::GLOBAL_DB_ENV_LOCK.lock().await;
     let (env, project_root) = common::IsolatedEnv::acquire().await;
     let home = env.home().to_path_buf();
 
@@ -432,6 +433,7 @@ async fn workflows_query_surface_end_to_end() {
 /// `tracedecay_message_search`.
 #[tokio::test]
 async fn message_search_workflow_scope_narrows_to_run_agents() {
+    let _env_lock = crate::mcp_handler_test::GLOBAL_DB_ENV_LOCK.lock().await;
     let (env, project_root) = common::IsolatedEnv::acquire().await;
     let home = env.home().to_path_buf();
 
@@ -585,6 +587,7 @@ async fn message_search_workflow_scope_narrows_to_run_agents() {
 /// schema returns empty rather than erroring on a missing table.
 #[tokio::test]
 async fn message_search_workflow_scope_empty_without_workflow_tables() {
+    let _env_lock = crate::mcp_handler_test::GLOBAL_DB_ENV_LOCK.lock().await;
     let (_env, project_root) = common::IsolatedEnv::acquire().await;
 
     let cg = TraceDecay::init(&project_root)

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -291,6 +291,30 @@ fn store_manifest_roundtrips_from_profile_sharded_layout() {
 
 #[cfg(unix)]
 #[test]
+fn store_manifest_write_rejects_symlinked_atomic_temp_path() {
+    let dir = TempDir::new().unwrap();
+    let temp_root = canonical_temp_path(dir.path());
+    let project = temp_root.join("repo");
+    let profile = temp_root.join("profile");
+    let outside = temp_root.join("outside.tmp");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(&outside, b"outside").unwrap();
+    write_enrollment(&project);
+    let marker = read_enrollment_marker(&project).unwrap().unwrap();
+    let layout = profile_sharded_layout(&project, &profile, &marker).unwrap();
+    let manifest_path = layout.manifest_path.as_ref().unwrap();
+    PrivateStoreIo::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    symlink(&outside, manifest_path.with_extension("json.tmp")).unwrap();
+
+    let err = write_store_manifest(&layout).unwrap_err();
+
+    assert!(err.to_string().contains("symlink"));
+    assert!(!manifest_path.exists());
+    assert_eq!(fs::read(&outside).unwrap(), b"outside");
+}
+
+#[cfg(unix)]
+#[test]
 fn store_manifest_write_rejects_symlinked_parent_components() {
     let dir = TempDir::new().unwrap();
     let project = dir.path().join("repo");


### PR DESCRIPTION
## Summary
- harden TraceDecay automation self-improvement outputs and managed-skill exports
- make memory curator and session reflector auto-apply honor `auto_apply_memory_ops` even when dashboard approval remains enabled
- export managed skills with Codex-loadable `name`/`description` frontmatter and stop defaulting generated skills to Cursor
- fix native skill overlay manifests to record final paths, not temp staging paths
- make generic markdown tables report empty visible fields instead of rendering blank
- update codex handoff readiness for auto-applied records and dashboard backend persistence coverage

## Renderer audit notes
`tracedecay_context` is the good markdown baseline. Remaining renderer opportunities: custom renderers for run artifacts, skill list/view, project/fact/LCM outputs, and callers/impact instead of generic JSON-ish markdown.

## Thermo review status
Subagents are reviewing current branch structure, automation policy, managed-skill exports, renderer behavior, tests, and CI/base shape. Early high-conviction finding: native managed-skill export should split host SKILL frontmatter from TraceDecay storage metadata instead of emitting both through one renderer.

## Tests
- cargo fmt --check
- cargo test -p tracedecay codex_handoff_reports_auto_applied_records_without_approval_gate -- --nocapture
- cargo test -p tracedecay table_with_no_visible_columns_is_not_blank -- --nocapture
- cargo test -p tracedecay --test automation_runner_test session_reflector_runner_auto_applies_facts_when_dashboard_approval_is_required -- --nocapture
- cargo test -p tracedecay --test automation_runner_test memory_curator_runner_auto_applies -- --nocapture
- cargo test -p tracedecay --test agent_suite skill_targets_test -- --nocapture
- cargo test -p tracedecay --test agent_suite test_cursor_install_exports_active_managed_skills -- --nocapture

Note: ran `cargo clean` as requested; it removed the repo target symlink, then I restored `target -> /scratch/cargo-target/tracedecay` per AGENTS.md.