### PR TITLE
[codex] Add lazy ignored dependency indexing

### DIFF
--- a/src/mcp/tools/handlers/dependency_hints.rs
+++ b/src/mcp/tools/handlers/dependency_hints.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeSet;
+use std::path::Path;
 
 use serde_json::{json, Value};
 
-use crate::dependency_imports::candidates_from_type_only_import;
+use crate::dependency_imports::{candidates_from_type_only_import, DependencyImportCandidate};
 use crate::errors::Result;
 use crate::mcp::tools::render::{self, Md};
 use crate::tracedecay::TraceDecay;
@@ -17,9 +18,57 @@ pub(super) async fn ignored_dependency_hint(
     limit: usize,
     scope_prefix: Option<&str>,
 ) -> Result<Option<Value>> {
+    let candidates = ignored_dependency_candidates(cg, query, limit, scope_prefix).await?;
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(json!({
+        "message": "No indexed symbol matched, but project imports reference matching symbols from an ignored dependency. Keep node_modules ignored for normal sync; use bounded lazy dependency indexing for the listed module if this symbol is needed.",
+        "candidates": candidates.into_iter().map(|candidate| json!({
+            "module": candidate.module,
+            "symbol": candidate.symbol,
+            "import_file": candidate.import_file,
+            "line": user_line(candidate.line),
+        })).collect::<Vec<_>>(),
+        "suggested_action": "lazy_index_ignored_dependency",
+    })))
+}
+
+pub(super) async fn lazy_index_ignored_dependency_candidates(
+    cg: &TraceDecay,
+    query: &str,
+    limit: usize,
+    scope_prefix: Option<&str>,
+) -> Result<Vec<String>> {
+    if cg.is_read_only() {
+        return Ok(Vec::new());
+    }
+
+    let candidates = ignored_dependency_candidates(cg, query, limit, scope_prefix).await?;
+    let mut seen = BTreeSet::new();
+    let mut paths = Vec::new();
+    for candidate in candidates {
+        if let Some(path) = candidate_entry_paths(cg.project_root(), &candidate.module)
+            .into_iter()
+            .next()
+        {
+            if seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+    }
+    cg.lazy_index_ignored_dependency_files(&paths).await
+}
+
+async fn ignored_dependency_candidates(
+    cg: &TraceDecay,
+    query: &str,
+    limit: usize,
+    scope_prefix: Option<&str>,
+) -> Result<Vec<DependencyImportCandidate>> {
     let query = query.trim();
     if query.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
     let candidate_limit = limit.clamp(1, 20);
     let db = if cg.is_read_only() {
@@ -53,24 +102,43 @@ pub(super) async fn ignored_dependency_hint(
         )) {
             continue;
         }
-        candidates.push(json!({
-            "module": candidate.module,
-            "symbol": candidate.symbol,
-            "import_file": candidate.import_file,
-            "line": user_line(candidate.line),
-        }));
+        candidates.push(candidate);
         if candidates.len() >= candidate_limit {
             break;
         }
     }
-    if candidates.is_empty() {
-        return Ok(None);
+    Ok(candidates)
+}
+
+fn candidate_entry_paths(project_root: &Path, module: &str) -> Vec<String> {
+    if !safe_module_path(module) {
+        return Vec::new();
     }
-    Ok(Some(json!({
-        "message": "No indexed symbol matched, but project imports reference matching symbols from an ignored dependency. Keep node_modules ignored for normal sync; use bounded lazy dependency indexing for the listed module if this symbol is needed.",
-        "candidates": candidates,
-        "suggested_action": "lazy_index_ignored_dependency",
-    })))
+    let base = format!("node_modules/{module}");
+    [
+        format!("{base}.d.ts"),
+        format!("{base}.ts"),
+        format!("{base}.tsx"),
+        format!("{base}.js"),
+        format!("{base}.jsx"),
+        format!("{base}/index.d.ts"),
+        format!("{base}/index.ts"),
+        format!("{base}/index.tsx"),
+        format!("{base}/index.js"),
+        format!("{base}/index.jsx"),
+    ]
+    .into_iter()
+    .filter(|path| project_root.join(path).is_file())
+    .collect()
+}
+
+fn safe_module_path(module: &str) -> bool {
+    !module.is_empty()
+        && !module.starts_with('/')
+        && !module.contains('\\')
+        && !module
+            .split('/')
+            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
 }
 
 pub(super) fn append_ignored_dependency_hint_md(md: &mut Md, value: &Value) {

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -127,16 +127,40 @@ pub(super) async fn handle_search(
         .map_or(10, |v| v.min(500) as usize);
 
     let results = cg.search(query, limit).await?;
-    let results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
+    let mut results = filter_by_scope(results, scope_prefix, |r| &r.node.file_path);
+    let mut lazy_indexed_files = Vec::new();
+    if dependency_hints::should_check_ignored_dependency_hint(results.len(), limit) {
+        lazy_indexed_files = dependency_hints::lazy_index_ignored_dependency_candidates(
+            cg,
+            query,
+            limit,
+            scope_prefix,
+        )
+        .await?;
+        if !lazy_indexed_files.is_empty() {
+            results = filter_by_scope(cg.search(query, limit).await?, scope_prefix, |r| {
+                &r.node.file_path
+            });
+        }
+    }
     let coverage_hint = cg.index_coverage_hint(results.len());
-    let ignored_dependency_hint =
-        if dependency_hints::should_check_ignored_dependency_hint(results.len(), limit) {
-            dependency_hints::ignored_dependency_hint(cg, query, limit, scope_prefix).await?
-        } else {
-            None
-        };
+    let lazy_match_visible = results
+        .iter()
+        .any(|result| lazy_indexed_files.contains(&result.node.file_path));
+    let ignored_dependency_hint = if !lazy_match_visible
+        && dependency_hints::should_check_ignored_dependency_hint(results.len(), limit)
+    {
+        dependency_hints::ignored_dependency_hint(cg, query, limit, scope_prefix).await?
+    } else {
+        None
+    };
 
-    let touched_files = unique_file_paths(results.iter().map(|r| r.node.file_path.as_str()));
+    let touched_files = unique_file_paths(
+        results
+            .iter()
+            .map(|r| r.node.file_path.as_str())
+            .chain(lazy_indexed_files.iter().map(String::as_str)),
+    );
 
     let items: Vec<Value> = results
         .iter()
@@ -155,6 +179,9 @@ pub(super) async fn handle_search(
 
     let output_value = if coverage_hint.is_some() || ignored_dependency_hint.is_some() {
         let mut value = json!({ "results": items });
+        if !lazy_indexed_files.is_empty() {
+            value["lazy_indexed_ignored_dependency_files"] = json!(lazy_indexed_files);
+        }
         if let Some(hint) = coverage_hint {
             value["index_coverage_hint"] = json!(hint);
         }
@@ -162,6 +189,11 @@ pub(super) async fn handle_search(
             value["ignored_dependency_hint"] = hint;
         }
         value
+    } else if !lazy_indexed_files.is_empty() {
+        json!({
+            "results": items,
+            "lazy_indexed_ignored_dependency_files": lazy_indexed_files,
+        })
     } else {
         json!(items)
     };
@@ -773,11 +805,31 @@ pub(super) async fn handle_find_exact_symbol(
 
     let mut nodes = cg.get_nodes_by_name(name).await?;
     nodes = filter_by_scope(nodes, scope_prefix, |n| &n.file_path);
+    let mut lazy_indexed_files = Vec::new();
+    if nodes.is_empty() {
+        lazy_indexed_files = dependency_hints::lazy_index_ignored_dependency_candidates(
+            cg,
+            name,
+            limit,
+            scope_prefix,
+        )
+        .await?;
+        if !lazy_indexed_files.is_empty() {
+            nodes = filter_by_scope(cg.get_nodes_by_name(name).await?, scope_prefix, |n| {
+                &n.file_path
+            });
+        }
+    }
     if nodes.len() > limit {
         nodes.truncate(limit);
     }
 
-    let touched_files = unique_file_paths(nodes.iter().map(|n| n.file_path.as_str()));
+    let touched_files = unique_file_paths(
+        nodes
+            .iter()
+            .map(|n| n.file_path.as_str())
+            .chain(lazy_indexed_files.iter().map(String::as_str)),
+    );
 
     let items: Vec<Value> = nodes
         .iter()
@@ -798,6 +850,7 @@ pub(super) async fn handle_find_exact_symbol(
         "name": name,
         "count": items.len(),
         "matches": items,
+        "lazy_indexed_ignored_dependency_files": lazy_indexed_files,
     });
     Ok(rendered_tool_result(
         cg,

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -15,6 +15,7 @@ use crate::types::{NodeKind, Visibility};
 
 use super::super::render::{self, Md};
 use super::super::ToolResult;
+use super::dependency_hints;
 use super::support::{effective_path, filter_by_scope, require_node_id, unique_file_paths};
 
 /// Handles `tracedecay_status` tool calls.
@@ -1720,7 +1721,23 @@ async fn body_candidates(
     // struct field). Falls back to suffix / name match inside
     // `get_nodes_by_qualified_name`.
     let exact_nodes = cg.get_nodes_by_qualified_name(symbol).await?;
-    let exact_nodes = filter_by_scope(exact_nodes, scope_prefix, |n| &n.file_path);
+    let mut exact_nodes = filter_by_scope(exact_nodes, scope_prefix, |n| &n.file_path);
+    if exact_nodes.is_empty() {
+        let indexed = dependency_hints::lazy_index_ignored_dependency_candidates(
+            cg,
+            symbol,
+            limit,
+            scope_prefix,
+        )
+        .await?;
+        if !indexed.is_empty() {
+            exact_nodes = filter_by_scope(
+                cg.get_nodes_by_qualified_name(symbol).await?,
+                scope_prefix,
+                |n| &n.file_path,
+            );
+        }
+    }
 
     // Wrap as SearchResult so the existing scoring/rendering path works.
     let mut candidates: Vec<crate::types::SearchResult> = exact_nodes

--- a/src/tracedecay/indexing.rs
+++ b/src/tracedecay/indexing.rs
@@ -2,7 +2,7 @@
 //! detection for the active project store.
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Component, Path};
 use std::time::{Duration, Instant};
 
 use rayon::prelude::*;
@@ -37,6 +37,15 @@ fn normalize_rel_path(path: &str) -> String {
 /// the caller's existing `Vec`.
 fn normalize_rel_paths(paths: &[String]) -> Vec<String> {
     paths.iter().map(|p| normalize_rel_path(p)).collect()
+}
+
+fn is_safe_lazy_dependency_path(path: &str) -> bool {
+    if !path.starts_with("node_modules/") || path.contains('\\') {
+        return false;
+    }
+    Path::new(path)
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
 }
 
 /// Metadata flag recording that the *complete* extracted reference set has
@@ -587,6 +596,43 @@ impl TraceDecay {
 
         clear_dirty_sentinel_at(&self.store_layout.dirty_path);
         Ok(())
+    }
+
+    /// Lazily index explicitly requested dependency files that normal sync
+    /// skips, keeping the operation bounded and inside `node_modules`.
+    pub async fn lazy_index_ignored_dependency_files(
+        &self,
+        file_paths: &[String],
+    ) -> Result<Vec<String>> {
+        self.ensure_branch_writable("lazy index ignored dependency files")?;
+
+        let mut accepted = Vec::new();
+        let mut seen = HashSet::new();
+        for path in file_paths {
+            let normalized = normalize_rel_path(path.trim());
+            if !is_safe_lazy_dependency_path(&normalized) || !seen.insert(normalized.clone()) {
+                continue;
+            }
+            let abs_path = self.project_root.join(&normalized);
+            let Ok(metadata) = std::fs::metadata(&abs_path) else {
+                continue;
+            };
+            if !metadata.is_file()
+                || metadata.len() > self.config.max_file_size
+                || self.registry.extractor_for_file(&normalized).is_none()
+            {
+                continue;
+            }
+            accepted.push(normalized);
+            if accepted.len() >= 20 {
+                break;
+            }
+        }
+
+        if !accepted.is_empty() {
+            self.sync_single_files(&accepted).await?;
+        }
+        Ok(accepted)
     }
 
     /// Re-resolves only the references whose edge can appear or disappear when

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -2079,7 +2079,7 @@ async fn test_search_returns_index_coverage_hint_for_skipped_generated_dirs() {
 }
 
 #[tokio::test]
-async fn test_search_hints_at_ignored_dependency_candidates() {
+async fn test_search_lazy_indexes_ignored_dependency_candidates() {
     let dir = test_temp_dir();
     let project = dir.path();
     fs::create_dir_all(project.join("src")).unwrap();
@@ -2111,17 +2111,75 @@ export const value = 1;
     .unwrap();
     let payload: Value = serde_json::from_str(extract_text(&result.value)).unwrap();
     assert_eq!(
-        payload["ignored_dependency_hint"]["candidates"][0]["module"].as_str(),
-        Some("pkg")
+        payload["lazy_indexed_ignored_dependency_files"][0].as_str(),
+        Some("node_modules/pkg/index.d.ts")
     );
+    assert!(payload["results"].as_array().is_some_and(|results| results
+        .iter()
+        .any(|result| result["name"].as_str() == Some("Foo")
+            && result["file"].as_str() == Some("node_modules/pkg/index.d.ts"))));
+}
+
+#[tokio::test]
+async fn test_find_exact_symbol_lazy_indexes_ignored_dependency_candidate() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::create_dir_all(project.join("node_modules/pkg")).unwrap();
+    fs::write(
+        project.join("src/app.ts"),
+        r#"import type { Foo } from "pkg";
+export const value = 1;
+"#,
+    )
+    .unwrap();
+    fs::write(
+        project.join("node_modules/pkg/index.d.ts"),
+        "export interface Foo { value: string }\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let lookup = handle_tool_call(
+        &cg,
+        "tracedecay_find_exact_symbol",
+        json!({"name": "Foo", "limit": 5, "format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&lookup.value)).unwrap();
+    let db = cg.open_project_store_db().await.unwrap();
+    let indexed_file = db
+        .get_file("node_modules/pkg/index.d.ts")
+        .await
+        .unwrap()
+        .is_some();
+    assert!(indexed_file, "{payload}");
+    assert_eq!(payload["count"].as_u64(), Some(1), "{payload}");
     assert_eq!(
-        payload["ignored_dependency_hint"]["candidates"][0]["symbol"].as_str(),
-        Some("Foo")
+        payload["matches"][0]["file"].as_str(),
+        Some("node_modules/pkg/index.d.ts")
     );
-    assert!(payload["ignored_dependency_hint"]["message"]
-        .as_str()
-        .unwrap_or_default()
-        .contains("ignored dependency"));
+
+    let body = handle_tool_call(
+        &cg,
+        "tracedecay_body",
+        json!({"symbol": "Foo", "limit": 5, "format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&body.value)).unwrap();
+    assert_eq!(payload["match_count"].as_u64(), Some(1));
+    assert_eq!(
+        payload["matches"][0]["body"].as_str(),
+        Some("export interface Foo { value: string }")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add bounded lazy indexing for ignored dependency candidates found from type-only imports
- retry `tracedecay_search`, `tracedecay_find_exact_symbol`, and `tracedecay_body` after lazy indexing
- keep lazy indexing writable-only and constrained to safe `node_modules` entry files

## Validation
- `cargo fmt && cargo test -q --test mcp_suite ignored_dependency && cargo test -q --test mcp_suite body`
- `git diff --check`
