### PR TITLE
chore: release v0.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.34](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.33...v0.0.34) - 2026-07-07
+
+### Added
+
+- install codex managed agents
+- *(codex)* install proactive memory prompt rules
+- *(memory)* document proactive fact-store guidance
+- *(mcp)* improve tool output rendering
+- *(memory)* reinforce recalled fact ranking
+- add memory feedback trust scenario
+- capture default timing telemetry
+- make the worldwide token-savings counter opt-in
+
+### Fixed
+
+- refresh Codex managed agent overlays
+- address automation cleanup review findings
+- satisfy renderer clippy lint
+- restore skill renderer module
+- stabilize automation cleanup CI
+- *(diagnostics)* improve freshness handling
+- satisfy clippy large-future lints
+- route init to worktree-local index
+
+### Other
+
+- simplify diagnostics and renderer fixes
+- split MCP render and diagnostics boundaries
+- Merge remote-tracking branch 'origin/codex/lazy-ignored-dependency-indexing' into simplify/automation-mcp-cleanup
+- split mcp renderer tests
+- *(evals)* document the fact-store triggering/adoption scorecard
+- behavior-preserving cleanups from the merged #295 changes
+
 ## [0.0.33](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.32...v0.0.33) - 2026-07-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.33"
+version = "0.0.34"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.33 -> 0.0.34

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.34](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.33...v0.0.34) - 2026-07-07

### Added

- install codex managed agents
- *(codex)* install proactive memory prompt rules
- *(memory)* document proactive fact-store guidance
- *(mcp)* improve tool output rendering
- *(memory)* reinforce recalled fact ranking
- add memory feedback trust scenario
- capture default timing telemetry
- make the worldwide token-savings counter opt-in

### Fixed

- refresh Codex managed agent overlays
- address automation cleanup review findings
- satisfy renderer clippy lint
- restore skill renderer module
- stabilize automation cleanup CI
- *(diagnostics)* improve freshness handling
- satisfy clippy large-future lints
- route init to worktree-local index

### Other

- simplify diagnostics and renderer fixes
- split MCP render and diagnostics boundaries
- Merge remote-tracking branch 'origin/codex/lazy-ignored-dependency-indexing' into simplify/automation-mcp-cleanup
- split mcp renderer tests
- *(evals)* document the fact-store triggering/adoption scorecard
- behavior-preserving cleanups from the merged #295 changes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).