### PR TITLE
Validate Claude marketplace metadata

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -67,6 +67,21 @@ jobs:
               echo "ok: $f"
             done
 
+  claude-native-validation:
+    name: Claude native plugin validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Validate Claude plugin bundle
+        run: claude plugin validate plugin --strict
+
   # Uses MCP Inspector's TypeScript SDK client to cover stdio handshake and
   # schema compatibility beyond the in-repo Rust MCP tests.
   mcp-conformance-smoke:

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "tracedecay",
+  "description": "TraceDecay tools for Claude Code: semantic code search, code graph navigation, diagnostics, and durable project memory.",
   "owner": {
     "name": "ScriptedAlchemy"
   },

--- a/tests/agent_suite/claude_plugin_schema_test.rs
+++ b/tests/agent_suite/claude_plugin_schema_test.rs
@@ -52,6 +52,22 @@ fn claude_marketplace_matches_the_claude_marketplace_schema() {
     );
 }
 
+#[test]
+fn claude_marketplace_includes_strict_validator_metadata() {
+    let path = repo_path("plugin/.claude-plugin/marketplace.json");
+    let marketplace = read_json_file(&path);
+    let description = marketplace
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    assert!(
+        !description.is_empty(),
+        "{} must include a top-level description so `claude plugin validate --strict` stays clean",
+        path.display()
+    );
+}
+
 /// Guards against the vendored schemas degenerating into accept-everything:
 /// each must reject representative malformed configs.
 #[test]

--- a/tests/fixtures/claude-schemas/marketplace.schema.json
+++ b/tests/fixtures/claude-schemas/marketplace.schema.json
@@ -14,6 +14,8 @@
       "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
       "description": "Marketplace identifier: lowercase kebab-case."
     },
+    "description": { "type": "string", "minLength": 1 },
+    "version": { "type": "string" },
     "owner": {
       "type": "object",
       "required": ["name"],


### PR DESCRIPTION
## Summary
- Add top-level Claude marketplace description so native strict validation is clean.
- Extend the vendored marketplace schema for top-level metadata.
- Add an agent-suite guard for strict Claude marketplace metadata.

## Validation
- claude plugin validate plugin --strict
- claude plugin validate /home/zack/.claude/plugins/marketplaces/tracedecay --strict
- cargo test --test agent_suite claude_marketplace
- cargo nextest run -E 'binary(=agent_suite)'\n- TRACEDECAY_BIN=target/debug/tracedecay scripts/mcp-conformance-smoke.sh\n- codex doctor --summary --ascii with TERM=xterm\n- target/debug/tracedecay doctor --agent claude\n- target/debug/tracedecay doctor --agent codex\n\n## Notes\n- Claude Code `claude doctor` itself hung under a 90s timeout even in /tmp; plugin validation and plugin listing were healthy.