### PR TITLE
[codex] Fix Codex hook manifest schema

### DIFF
--- a/plugin/README-codex.md
+++ b/plugin/README-codex.md
@@ -21,9 +21,9 @@ Codex.
   encrypted Codex compaction placeholders with auxiliary app-server summaries
   backed by the visible source messages in TraceDecay's LCM DAG.
 
-The source `hooks/hooks-codex.json` is an empty, self-documenting seed for
-repo-local bundles. Global Codex installs populate `hooks/hooks.json` from the
-managed hook table at install time.
+The source `hooks/hooks-codex.json` is an empty seed for repo-local bundles.
+Global Codex installs populate `hooks/hooks.json` from the managed hook table
+at install time.
 
 Codex skips newly installed or changed command hooks until they are trusted —
 run `/hooks` in Codex to review and trust the tracedecay hooks.

--- a/plugin/hooks/hooks-codex.json
+++ b/plugin/hooks/hooks-codex.json
@@ -1,4 +1,3 @@
 {
-  "description": "Seed template for the Codex hooks bundle. The `hooks` object is intentionally empty here: repo-local Codex bundles ship no lifecycle hooks (those come from the global personal plugin), and the global bundle populates this object at install time from the CODEX_MANAGED_HOOKS table in src/agents/codex.rs. Codex's hook loader reads only `hooks.*` and ignores this field.",
   "hooks": {}
 }

--- a/src/agents/codex/tests.rs
+++ b/src/agents/codex/tests.rs
@@ -1,11 +1,10 @@
 use super::*;
 
-/// The repo-local `hooks-codex.json` ships an empty `hooks` object plus a
-/// self-documenting `description`. Rendering the global bundle must fill the
-/// object from `CODEX_MANAGED_HOOKS` while leaving the description intact,
-/// and must never invent hooks the managed table does not declare.
+/// The repo-local `hooks-codex.json` ships only an empty `hooks` object.
+/// Rendering the global bundle must fill the object from `CODEX_MANAGED_HOOKS`
+/// while keeping Codex's strict top-level schema clean.
 #[test]
-fn codex_plugin_hooks_fills_empty_seed_and_preserves_description() {
+fn codex_plugin_hooks_fills_empty_seed_and_preserves_strict_schema() {
     let raw = codex_embedded_plugin_files()
         .into_iter()
         .find_map(|(relative, contents)| (relative == "hooks/hooks.json").then_some(contents))
@@ -15,18 +14,20 @@ fn codex_plugin_hooks_fills_empty_seed_and_preserves_description() {
     // base the renderer mutates in place).
     let seed: serde_json::Value = serde_json::from_str(raw).unwrap();
     assert_eq!(seed["hooks"], json!({}));
-    assert!(
-        seed["description"]
-            .as_str()
-            .unwrap()
-            .contains("no lifecycle hooks"),
-        "empty seed must carry a self-documenting description"
+    assert_eq!(
+        seed.as_object().unwrap().keys().collect::<Vec<_>>(),
+        vec!["hooks"],
+        "Codex rejects unknown top-level hook fields"
     );
 
     let rendered = codex_plugin_hooks(raw, "/usr/local/bin/tracedecay").unwrap();
     let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
-    // The description survives rendering (Codex's loader ignores it).
-    assert_eq!(value["description"], seed["description"]);
+    let top_level_keys = value.as_object().unwrap().keys().collect::<Vec<_>>();
+    assert_eq!(
+        top_level_keys,
+        vec!["hooks"],
+        "rendered hooks bundle must stay within Codex's strict schema"
+    );
     let hooks = value["hooks"].as_object().unwrap();
     for managed in CODEX_MANAGED_HOOKS {
         assert!(


### PR DESCRIPTION
## Summary
- remove unsupported top-level `description` from the Codex hooks seed
- update the renderer regression test to enforce Codex strict top-level hook schema
- refresh Codex README wording for the hook seed

## Root cause
Codex v0.142.5 rejects plugin hook manifests with unknown top-level fields. TraceDecay rendered `hooks/hooks.json` with `description`, so Codex failed before `/hooks` could manage trust.

## Validation
- `cargo test --lib codex_plugin_hooks`
- `cargo test --test agent_suite codex_plugin`
- `cargo build --bin tracedecay`
- `/home/zack/.local/bin/tracedecay update`
- `codex plugin add tracedecay@personal --json`
