### PR TITLE
Improve tracedecay_read line context

### DIFF
--- a/src/context/read_modes.rs
+++ b/src/context/read_modes.rs
@@ -4,7 +4,7 @@
 //! Four modes are implemented in 5.0:
 //!
 //! - `full` — verbatim file content (parity with the raw `Read` tool)
-//! - `lines` — explicit byte-range slice (`A-B`, 1-based, inclusive)
+//! - `lines` — explicit line slice (`A-B`, 1-based, inclusive)
 //! - `map` — flat list of every top-level symbol in the file, sourced from
 //!   the code graph (cheap; no source bytes touched)
 //! - `signatures` — `map` filtered to function/type kinds, with the cached
@@ -18,6 +18,8 @@ use serde_json::{Value, json};
 use crate::db::Database;
 use crate::errors::{Result, TraceDecayError};
 use crate::types::{Node, NodeKind};
+
+const MAX_CONTEXT_SYMBOLS: usize = 12;
 
 /// Mode selector for `tracedecay_read`. Parsed from the JSON `mode` argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,7 +51,7 @@ impl ReadMode {
     }
 }
 
-/// Inclusive 1-based byte-line range parsed from `"A-B"` (or just `"A"` for a
+/// Inclusive 1-based line range parsed from `"A-B"` (or just `"A"` for a
 /// single line). Out-of-range values are clamped at render time.
 #[derive(Debug, Clone, Copy)]
 pub struct LineRange {
@@ -142,6 +144,41 @@ pub async fn render_signatures(db: &Database, file_path: &str) -> Result<Value> 
     }))
 }
 
+/// Renders graph context for source reads. For full-file reads, this is a
+/// compact signature overview; for line reads, it is the overlapping symbols.
+pub async fn render_symbol_context(
+    db: &Database,
+    file_path: &str,
+    range: Option<LineRange>,
+) -> Result<Value> {
+    let nodes = fetch_nodes(db, file_path).await?;
+    let mut entries = Vec::new();
+    let mut symbol_count = 0usize;
+
+    for node in nodes
+        .iter()
+        .filter(|node| is_signature_kind(&node.kind))
+        .filter(|node| range.is_none_or(|range| symbol_overlaps_range(node, range)))
+        .filter_map(context_symbol_entry)
+    {
+        symbol_count += 1;
+        if entries.len() < MAX_CONTEXT_SYMBOLS {
+            entries.push(node);
+        }
+    }
+
+    Ok(json!({
+        "file": file_path,
+        "range": range.map(|range| json!({
+            "start": range.start,
+            "end": range.end,
+        })),
+        "symbol_count": symbol_count,
+        "truncated": symbol_count > entries.len(),
+        "symbols": entries,
+    }))
+}
+
 async fn fetch_nodes(db: &Database, file_path: &str) -> Result<Vec<Node>> {
     db.get_nodes_by_file(file_path)
         .await
@@ -181,6 +218,33 @@ fn signature_symbol_entry(node: &Node) -> Option<Value> {
         "signature": signature,
         "is_async": node.is_async,
     }))
+}
+
+fn context_symbol_entry(node: &Node) -> Option<Value> {
+    let signature = node.signature.as_deref()?;
+    let (line, end_line) = node_user_line_span(node);
+    Some(json!({
+        "kind": node.kind.as_str(),
+        "name": node.name,
+        "qualified_name": node.qualified_name,
+        "line": line,
+        "end_line": end_line,
+        "visibility": node.visibility.as_str(),
+        "signature": signature,
+        "is_async": node.is_async,
+    }))
+}
+
+fn symbol_overlaps_range(node: &Node, range: LineRange) -> bool {
+    let (start, end) = node_user_line_span(node);
+    start <= range.end && end >= range.start
+}
+
+fn node_user_line_span(node: &Node) -> (u32, u32) {
+    (
+        node.start_line.saturating_add(1),
+        node.end_line.saturating_add(1),
+    )
 }
 
 /// Kinds whose `signature` column carries useful information for the
@@ -347,5 +411,70 @@ mod tests {
         let node = node_fixture(NodeKind::Function, None);
 
         assert_eq!(signature_symbol_entry(&node), None);
+    }
+
+    #[test]
+    fn context_symbol_entry_uses_user_facing_line_numbers() {
+        let node = node_fixture(NodeKind::Function, Some("pub async fn sample()"));
+
+        assert_eq!(
+            context_symbol_entry(&node),
+            Some(json!({
+                "kind": "function",
+                "name": "sample",
+                "qualified_name": "crate::sample",
+                "line": 13,
+                "end_line": 19,
+                "visibility": "public",
+                "signature": "pub async fn sample()",
+                "is_async": true,
+            }))
+        );
+    }
+
+    #[test]
+    fn symbol_overlap_detects_enclosing_ranges() {
+        let node = node_fixture(NodeKind::Function, Some("pub async fn sample()"));
+
+        assert!(symbol_overlaps_range(
+            &node,
+            LineRange { start: 14, end: 16 }
+        ));
+        assert!(symbol_overlaps_range(
+            &node,
+            LineRange { start: 1, end: 13 }
+        ));
+        assert!(symbol_overlaps_range(
+            &node,
+            LineRange { start: 19, end: 30 }
+        ));
+        assert!(!symbol_overlaps_range(
+            &node,
+            LineRange { start: 1, end: 12 }
+        ));
+        assert!(!symbol_overlaps_range(
+            &node,
+            LineRange { start: 20, end: 30 }
+        ));
+    }
+
+    #[test]
+    fn symbol_overlap_handles_single_line_boundaries() {
+        let mut node = node_fixture(NodeKind::Function, Some("pub fn sample()"));
+        node.start_line = 12;
+        node.end_line = 12;
+
+        assert!(symbol_overlaps_range(
+            &node,
+            LineRange { start: 13, end: 13 }
+        ));
+        assert!(!symbol_overlaps_range(
+            &node,
+            LineRange { start: 12, end: 12 }
+        ));
+        assert!(!symbol_overlaps_range(
+            &node,
+            LineRange { start: 14, end: 14 }
+        ));
     }
 }

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -3491,11 +3491,12 @@ fn def_read() -> ToolDefinition {
         "tracedecay_read",
         "Read File (mode-aware)",
         "Read a file or its symbol map. Modes: 'full' (entire file), 'lines' \
-         (1-based inclusive byte-range slice via the 'lines' arg, e.g. '120-180'), \
+         (1-based inclusive line slice via the 'lines' arg, e.g. '120-180'), \
          'map' (flat list of every top-level symbol from the graph — no source \
          bytes touched), 'signatures' (functions and types with their cached \
-         signature). Cross-session cached: a re-call on an unchanged file returns \
-         a tiny stub with 'unchanged: true'.",
+         signature). Line reads include overlapping symbol signatures by default; \
+         full reads can opt in with include_symbols. Cross-session cached: a re-call \
+         on an unchanged file returns a tiny stub with 'unchanged: true'.",
         json!({
             "type": "object",
             "properties": {
@@ -3511,6 +3512,10 @@ fn def_read() -> ToolDefinition {
                 "lines": {
                     "type": "string",
                     "description": "Required when mode='lines'. Format 'A-B' or single 'A' (1-based, inclusive). E.g. '120-180' or '42'."
+                },
+                "include_symbols": {
+                    "type": "boolean",
+                    "description": "Include graph symbol context for source reads. Defaults to true for mode='lines' and false for mode='full'."
                 }
             },
             "required": ["file"]

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -7,6 +7,7 @@ use std::path::{Component, Path, PathBuf};
 
 use serde_json::{Value, json};
 
+use crate::context::read_modes::{LineRange, ReadMode, render_symbol_context};
 use crate::errors::{Result, TraceDecayError};
 use crate::global_db::{GlobalDb, global_db_path};
 use crate::path_tree::format_compact_annotated_path_list;
@@ -2134,6 +2135,10 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
     let mode = ReadMode::parse(mode_str).ok_or_else(|| TraceDecayError::Config {
         message: format!("unknown mode '{mode_str}'; expected one of full, lines, map, signatures"),
     })?;
+    let include_symbols = args
+        .get("include_symbols")
+        .and_then(Value::as_bool)
+        .unwrap_or(mode == ReadMode::Lines);
 
     let line_range = if mode == ReadMode::Lines {
         let raw =
@@ -2185,7 +2190,7 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
     )
     .await?
     {
-        let stub = json!({
+        let mut stub = json!({
             "unchanged": true,
             "file": display_file,
             "mode": mode.as_str(),
@@ -2193,6 +2198,11 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
             "digest": cached.digest,
             "token_count": cached.token_count,
         });
+        if let Some(context) =
+            read_symbol_context(cg.db(), &display_file, mode, line_range, include_symbols).await?
+        {
+            stub["context"] = context;
+        }
         let text = render::finalize(Some(cg.project_root()), &args, &stub, || {
             render_read_md(&stub)
         });
@@ -2232,6 +2242,8 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
         }
     };
 
+    let context =
+        read_symbol_context(cg.db(), &display_file, mode, line_range, include_symbols).await?;
     let token_count = read_modes::estimate_tokens(&body_text);
     let digest = read_cache::digest_bytes(body_text.as_bytes());
 
@@ -2251,7 +2263,7 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
         .await?;
     }
 
-    let payload = json!({
+    let mut payload = json!({
         "file": display_file,
         "mode": mode.as_str(),
         "mtime_ns": mtime_ns,
@@ -2259,6 +2271,9 @@ pub(super) async fn handle_read(cg: &TraceDecay, args: Value) -> Result<ToolResu
         "token_count": token_count,
         "body": body_text,
     });
+    if let Some(context) = context {
+        payload["context"] = context;
+    }
     let text = render::finalize(Some(cg.project_root()), &args, &payload, || {
         render_read_md(&payload)
     });
@@ -2290,6 +2305,7 @@ fn render_read_md(value: &Value) -> String {
         "tokens",
         &render::field_i64(value, "token_count").to_string(),
     );
+    render_read_context_md(&mut md, value.get("context"));
     if value.get("body").is_none() {
         return md.render();
     }
@@ -2297,6 +2313,65 @@ fn render_read_md(value: &Value) -> String {
     let lang = file.rsplit_once('.').map_or("", |(_, ext)| ext);
     md.code(lang, render::field_str(value, "body"));
     md.render()
+}
+
+async fn read_symbol_context(
+    db: &crate::db::Database,
+    display_file: &str,
+    mode: ReadMode,
+    line_range: Option<LineRange>,
+    include_symbols: bool,
+) -> Result<Option<Value>> {
+    if !include_symbols || !matches!(mode, ReadMode::Full | ReadMode::Lines) {
+        return Ok(None);
+    }
+    Ok(Some(
+        render_symbol_context(db, display_file, line_range).await?,
+    ))
+}
+
+fn render_read_context_md(md: &mut Md, context: Option<&Value>) {
+    let Some(context) = context else {
+        return;
+    };
+    let Some(symbols) = context.get("symbols").and_then(Value::as_array) else {
+        return;
+    };
+    if symbols.is_empty() {
+        return;
+    }
+
+    md.blank();
+    md.heading(3, "Context");
+    let symbol_count = context
+        .get("symbol_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(symbols.len() as u64);
+    md.field("symbols", &symbol_count.to_string());
+    for symbol in symbols {
+        let kind = render::field_str(symbol, "kind");
+        let name = render::field_str(symbol, "name");
+        let line = render::field_i64(symbol, "line");
+        let end_line = render::field_i64(symbol, "end_line");
+        let signature = render::field_str(symbol, "signature");
+        let span = if end_line > line {
+            format!("{line}-{end_line}")
+        } else {
+            line.to_string()
+        };
+        if signature.is_empty() {
+            md.bullet(&format!("{kind} {name} {span}"));
+        } else {
+            md.bullet(&format!("{kind} {name} {span}: `{signature}`"));
+        }
+    }
+    if context
+        .get("truncated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        md.empty_note("symbol list truncated");
+    }
 }
 
 /// Handles `tracedecay_outline` — flat symbol map for a file with optional

--- a/tests/mcp_suite/mcp_rendering_test.rs
+++ b/tests/mcp_suite/mcp_rendering_test.rs
@@ -41,6 +41,63 @@ async fn read_cache_default_response_stays_markdown() {
 }
 
 #[tokio::test]
+async fn read_lines_includes_overlapping_symbol_context() {
+    let (cg, _dir) = setup_project().await;
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_read",
+        json!({"file": "src/main.rs", "mode": "lines", "lines": "5-7"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+
+    assert!(text.contains("### Context"), "got: {text}");
+    assert!(text.contains("fn main()"), "got: {text}");
+    assert!(text.contains("main 5-8"), "got: {text}");
+    assert!(text.contains("let result = helper();"), "got: {text}");
+
+    let json_result = handle_tool_call(
+        &cg,
+        "tracedecay_read",
+        json!({
+            "file": "src/main.rs",
+            "mode": "lines",
+            "lines": "5-7",
+            "format": "json"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let parsed = extract_json(&json_result.value);
+    assert_eq!(parsed["context"]["symbol_count"], 1);
+    assert_eq!(parsed["context"]["symbols"][0]["name"], "main");
+    assert_eq!(parsed["context"]["symbols"][0]["signature"], "fn main()");
+
+    let cached = handle_tool_call(
+        &cg,
+        "tracedecay_read",
+        json!({"file": "src/main.rs", "mode": "lines", "lines": "5-7"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let cached_text = extract_text(&cached.value);
+    assert!(
+        cached_text.contains("**unchanged:** true"),
+        "got: {cached_text}"
+    );
+    assert!(cached_text.contains("### Context"), "got: {cached_text}");
+    assert!(cached_text.contains("fn main()"), "got: {cached_text}");
+}
+
+#[tokio::test]
 async fn simplify_scan_markdown_visible_output_is_not_escaped_blob() {
     let (cg, _env, dir) = setup_empty_project().await;
     fs::create_dir_all(dir.path().join("src")).unwrap();


### PR DESCRIPTION
## Summary
- Add graph-backed symbol context to `tracedecay_read` source reads.
- Default `mode=lines` to include overlapping symbol signatures; allow `mode=full` opt-in with `include_symbols`.
- Render context in Markdown and JSON, including cached line-read stubs.

## Research
- Usage analytics showed `tracedecay_read` is heavily used but mostly competes with raw file reads.
- LCM evidence pointed to payload usefulness and cache/rendering friction, not a strong case for running diagnostics inside read.
- Diagnostics stay in `tracedecay_diagnostics`; read now provides nearby graph context so agents can decide the next tool.

## Tests
- `cargo test -p tracedecay --test mcp_suite mcp_rendering_test`
- `cargo test -p tracedecay context::read_modes`
- `cargo test -p tracedecay --test mcp_suite test_tool_definitions_have_input_schemas`
- `git diff --check`