### PR TITLE
[codex] Fix provider-neutral ingest guidance

### DIFF
--- a/src/agents/cursor.rs
+++ b/src/agents/cursor.rs
@@ -819,7 +819,7 @@ fn doctor_check_session_ingest(dc: &mut DoctorCounters, project_path: &Path) {
                     dc.info(&format!("  - {path}"));
                 }
             }
-            Some(db.session_ingest_health().await)
+            Some(db.session_ingest_health_for_provider(Some("cursor")).await)
         })
     });
     let Some(health) = health else {
@@ -834,11 +834,13 @@ fn doctor_check_session_ingest(dc: &mut DoctorCounters, project_path: &Path) {
             "Cursor transcript ingest looks stalled: a transcript has {} un-ingested \
              byte(s) ({} byte(s) total across {} transcript(s)), exceeding the {} byte \
              per-transcript hook catch-up cap — it will not drain automatically and \
-             session recall is missing those turns",
+             session recall is missing those turns. Run `tracedecay sessions ingest \
+             --project-path {}` to drain the backlog manually",
             health.max_transcript_pending_bytes,
             health.pending_bytes,
             health.pending_transcripts,
             crate::hooks::CURSOR_CATCH_UP_INGEST_MAX_BYTES,
+            project_path.display(),
         ));
     } else {
         dc.pass(&format!(

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -1089,22 +1089,40 @@ impl GlobalDb {
     /// For every session with a known transcript path, compares the on-disk
     /// transcript size against the persisted parse offset. `pending_bytes` is
     /// the total un-ingested tail across transcripts; `last_ingest_unix` is
-    /// the newest transcript mtime recorded at ingest time. Surfaced by
-    /// `tracedecay_status` and `tracedecay doctor --agent cursor` so a stalled
-    /// ingest (e.g. a backlog larger than the hook ingest caps) is visible
-    /// instead of silently eroding trust in session recall.
+    /// the newest transcript mtime recorded at ingest time. Surfaced by status
+    /// and doctor checks so a stalled ingest is visible instead of silently
+    /// eroding trust in session recall.
     pub async fn session_ingest_health(&self) -> SessionIngestHealth {
+        self.session_ingest_health_for_provider(None).await
+    }
+
+    pub async fn session_ingest_health_for_provider(
+        &self,
+        provider: Option<&str>,
+    ) -> SessionIngestHealth {
         let mut health = SessionIngestHealth::default();
-        let Ok(mut rows) = self
-            .conn
-            .query(
-                "SELECT DISTINCT transcript_path FROM sessions
+        let rows = if let Some(provider) = provider {
+            self.conn
+                .query(
+                    "SELECT DISTINCT transcript_path FROM sessions
+                     WHERE provider = ?1
+                       AND transcript_path IS NOT NULL
+                       AND transcript_path != ''
+                     LIMIT 1000",
+                    params![provider],
+                )
+                .await
+        } else {
+            self.conn
+                .query(
+                    "SELECT DISTINCT transcript_path FROM sessions
                  WHERE transcript_path IS NOT NULL AND transcript_path != ''
                  LIMIT 1000",
-                (),
-            )
-            .await
-        else {
+                    (),
+                )
+                .await
+        };
+        let Ok(mut rows) = rows else {
             return health;
         };
         let mut paths = Vec::new();

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -29,10 +29,9 @@ use super::{
 /// backlogs are left for the `sessionStart` / `stop` catch-up ingests.
 const CURSOR_HOT_INGEST_MAX_BYTES: u64 = 256 * 1024;
 /// Largest transcript tail a low-priority Cursor catch-up hook will read.
-/// Oversized backlogs stay queued instead of blocking hook execution. Public
-/// so ingest-health reporting (`tracedecay_status`, doctor) can flag a backlog
-/// the hooks will never drain on their own.
-pub const CURSOR_CATCH_UP_INGEST_MAX_BYTES: u64 = 2 * 1024 * 1024;
+/// Oversized backlogs stay queued instead of blocking hook execution.
+pub const CURSOR_CATCH_UP_INGEST_MAX_BYTES: u64 =
+    crate::sessions::SESSION_TRANSCRIPT_STALLED_INGEST_WARNING_BYTES;
 /// Hard wall-clock budget for the `beforeSubmitPrompt` tail ingest. Well under
 /// Cursor's 5s hook timeout; on expiry we fail open and let heavier hooks catch up.
 const CURSOR_HOT_INGEST_BUDGET: Duration = Duration::from_millis(1_500);

--- a/src/mcp/tools/handlers/info.rs
+++ b/src/mcp/tools/handlers/info.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 
 use crate::context::read_modes::{LineRange, ReadMode, render_symbol_context};
 use crate::errors::{Result, TraceDecayError};
-use crate::global_db::{GlobalDb, global_db_path};
+use crate::global_db::{GlobalDb, SessionIngestHealth, global_db_path};
 use crate::path_tree::format_compact_annotated_path_list;
 use crate::storage::{ProjectPath, StorageMode, StoreKind};
 use crate::tracedecay::{BranchDiagnostics, TraceDecay};
@@ -96,17 +96,10 @@ pub(super) async fn handle_status(
                 let ingest = db.session_ingest_health().await;
                 output["session_ingest"] = serde_json::to_value(&ingest).unwrap_or(json!({}));
                 if ingest.max_transcript_pending_bytes
-                    > crate::hooks::CURSOR_CATCH_UP_INGEST_MAX_BYTES
+                    > crate::sessions::SESSION_TRANSCRIPT_STALLED_INGEST_WARNING_BYTES
                 {
-                    output["session_ingest_warning"] = json!(format!(
-                        "session transcript ingest looks stalled: a transcript has {} \
-                         un-ingested bytes ({} total across {} transcript(s)), exceeding \
-                         the per-transcript hook catch-up cap — session recall is missing \
-                         those turns. See `tracedecay doctor --agent cursor`.",
-                        ingest.max_transcript_pending_bytes,
-                        ingest.pending_bytes,
-                        ingest.pending_transcripts
-                    ));
+                    output["session_ingest_warning"] =
+                        json!(session_ingest_warning(&ingest, cg.project_root()));
                 }
             }
         }
@@ -146,6 +139,20 @@ pub(super) async fn handle_status(
         }),
         vec![],
     ))
+}
+
+fn session_ingest_warning(ingest: &SessionIngestHealth, project_root: &Path) -> String {
+    format!(
+        "session transcript ingest looks stalled: a transcript has {} \
+         un-ingested bytes ({} total across {} transcript(s)), exceeding \
+         the automatic catch-up warning threshold — session recall is missing \
+         those turns. Run `tracedecay sessions ingest --project-path {}` \
+         to drain the backlog manually.",
+        ingest.max_transcript_pending_bytes,
+        ingest.pending_bytes,
+        ingest.pending_transcripts,
+        project_root.display()
+    )
 }
 
 fn render_status_md(value: &Value) -> String {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -835,11 +835,12 @@ pub fn degraded_serve_notice(project_path: &Path, startup_error: &TraceDecayErro
          project via `tracedecay serve --path <project>`).\n\
          2. Retry the tool call — this server rechecks the project on every call and recovers \
          automatically once resolution succeeds.\n\
-         3. If the MCP client shows connection errors instead of this message, toggle the \
-         tracedecay MCP server in Cursor Settings → MCP or reload the window; Cursor does not \
-         retry a failed MCP server on its own.\n\
+         3. If the MCP client shows connection errors instead of this message, restart or toggle \
+         the tracedecay MCP server in your MCP host; some hosts do not retry a failed server \
+         process on their own.\n\
          \n\
-         Diagnose with `tracedecay doctor --agent cursor`. Every tool is also available from \
+         Diagnose agent-specific install/config issues with `tracedecay doctor --agent <agent>`. \
+         Every tool is also available from \
          the shell: {args} (run `tracedecay tool` to list tools) from inside an initialized \
          project.",
         args = crate::agents::CLI_FALLBACK_ARGS_INVOCATION,

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -26,6 +26,7 @@ pub mod workflow_ingest;
 pub mod workflow_state;
 
 pub use providers::{ProviderScope, SessionProvider};
+pub use shared::SESSION_TRANSCRIPT_STALLED_INGEST_WARNING_BYTES;
 
 const FILE_TRANSCRIPT_PROVIDERS: &[SessionProvider] = &[
     SessionProvider::Claude,

--- a/src/sessions/shared.rs
+++ b/src/sessions/shared.rs
@@ -10,6 +10,10 @@ use serde_json::Value;
 
 use crate::sessions::SessionMessageRecord;
 
+/// Generic per-transcript backlog threshold for warning that automatic
+/// session transcript catch-up may not drain recall transcripts quickly enough.
+pub const SESSION_TRANSCRIPT_STALLED_INGEST_WARNING_BYTES: u64 = 2 * 1024 * 1024;
+
 /// Counters returned by an ingestion pass.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TranscriptIngestStats {

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -3206,6 +3206,44 @@ async fn test_status() {
 }
 
 #[tokio::test]
+async fn status_stalled_session_ingest_warning_points_to_manual_ingest() {
+    let (cg, _env, dir) = setup_empty_project().await;
+    let db = open_active_project_session_db(&cg).await;
+    let transcript = dir.path().join("claude-backlog.jsonl");
+    let file = fs::File::create(&transcript).unwrap();
+    file.set_len(tracedecay::sessions::SESSION_TRANSCRIPT_STALLED_INGEST_WARNING_BYTES + 1)
+        .unwrap();
+    assert!(
+        db.upsert_session(&SessionRecord {
+            provider: "claude".to_string(),
+            session_id: "claude-backlog".to_string(),
+            project_key: cg.project_root().to_string_lossy().to_string(),
+            project_path: cg.project_root().to_string_lossy().to_string(),
+            title: Some("Claude backlog".to_string()),
+            started_at: Some(1),
+            ended_at: None,
+            transcript_path: Some(transcript.to_string_lossy().to_string()),
+            metadata_json: None,
+            parent_session_id: None,
+            is_subagent: false,
+            agent_id: None,
+            parent_tool_use_id: None,
+        })
+        .await
+    );
+
+    let result = handle_tool_call(&cg, "tracedecay_status", json!({}), None, None)
+        .await
+        .unwrap();
+    let text = extract_text(&result.value);
+    assert!(text.contains("session transcript ingest looks stalled"));
+    assert!(text.contains("automatic catch-up warning threshold"));
+    assert!(text.contains("tracedecay sessions ingest --project-path"));
+    assert!(!text.contains("hook catch-up cap"));
+    assert!(!text.contains("tracedecay doctor --agent cursor"));
+}
+
+#[tokio::test]
 async fn test_branch_list_reports_live_vs_serving_drift_state() {
     fn git(project: &Path, args: &[&str]) {
         let status = Command::new("git")

--- a/tests/mcp_suite/serve_degraded_mode_test.rs
+++ b/tests/mcp_suite/serve_degraded_mode_test.rs
@@ -79,13 +79,17 @@ async fn explicit_uninitialized_path_serves_degraded_error_instead_of_global_fal
         explicit_display.as_str(),
         "tracedecay init",
         "tracedecay tool",
-        "Cursor Settings → MCP",
+        "restart or toggle the tracedecay MCP server in your MCP host",
     ] {
         assert!(
             text.contains(needle),
             "degraded tool error should mention '{needle}':\n{text}"
         );
     }
+    assert!(
+        !text.contains("Cursor Settings → MCP") && !text.contains("doctor --agent cursor"),
+        "generic degraded serve guidance should not assume Cursor:\n{text}"
+    );
     assert!(
         !text.contains(&active.path().display().to_string()),
         "degraded serve must not leak or serve the global-fallback project:\n{text}"

--- a/tests/session_suite/global_db.rs
+++ b/tests/session_suite/global_db.rs
@@ -1136,6 +1136,49 @@ async fn session_ingest_health_reports_pending_transcript_backlog() {
 }
 
 #[tokio::test]
+async fn session_ingest_health_can_filter_by_provider() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_isolated_db(&tmp).await;
+
+    let cursor_transcript = tmp.path().join("cursor.jsonl");
+    std::fs::write(&cursor_transcript, "x".repeat(100)).unwrap();
+    let claude_transcript = tmp.path().join("claude.jsonl");
+    std::fs::write(&claude_transcript, "y".repeat(500)).unwrap();
+
+    for (provider, session_id, path) in [
+        ("cursor", "cursor-session", &cursor_transcript),
+        ("claude", "claude-session", &claude_transcript),
+    ] {
+        let mut session = sample_session(provider, session_id, "proj");
+        session.transcript_path = Some(path.to_string_lossy().to_string());
+        db.upsert_session(&session).await;
+    }
+
+    let cursor = |byte_offset, mtime| tracedecay::global_db::ParseOffset {
+        byte_offset,
+        mtime,
+        file_id: 0,
+    };
+    db.set_parse_offset(&cursor_transcript.to_string_lossy(), cursor(100, 1_000))
+        .await;
+    db.set_parse_offset(&claude_transcript.to_string_lossy(), cursor(200, 2_000))
+        .await;
+
+    let all_health = db.session_ingest_health().await;
+    assert_eq!(all_health.pending_transcripts, 1);
+    assert_eq!(all_health.pending_bytes, 300);
+
+    let cursor_health = db.session_ingest_health_for_provider(Some("cursor")).await;
+    assert_eq!(cursor_health.tracked_transcripts, 1);
+    assert_eq!(cursor_health.pending_transcripts, 0);
+
+    let claude_health = db.session_ingest_health_for_provider(Some("claude")).await;
+    assert_eq!(claude_health.tracked_transcripts, 1);
+    assert_eq!(claude_health.pending_transcripts, 1);
+    assert_eq!(claude_health.pending_bytes, 300);
+}
+
+#[tokio::test]
 async fn hook_analytics_import_is_incremental_and_idempotent() {
     use tracedecay::analytics_bridge::{HookImportSource, import_hook_analytics};
 


### PR DESCRIPTION
## Summary
- make stalled session-ingest status guidance provider-neutral and point to `tracedecay sessions ingest --project-path ...`
- add provider-filtered session ingest health so Cursor doctor only reports Cursor transcript backlog
- make generic degraded MCP serve guidance host-neutral instead of assuming Cursor

## Root cause
Shared session/status paths reused Cursor-era wording and the Cursor hook cap symbol even when the backlog came from Claude transcripts in another project. That made `tracedecay_status` recommend `tracedecay doctor --agent cursor` for a provider-agnostic backlog that manual session ingest can drain.

## Validation
- `cargo check -q`
- `cargo test -q --test mcp_suite status`
- `cargo test -q --test session_suite session_ingest_health`
- `cargo test -q --test mcp_suite explicit_uninitialized_path_serves_degraded_error_instead_of_global_fallback`
- `cargo test -q --test transcript_ingest_suite cursor_transcript_ingest_cap_defers_large_backlog`
