### PR TITLE
[codex] improve plugin skill discoverability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,11 +111,11 @@ section so the contributor command and blocking/advisory split still match CI.
 
 ## Validating Plugins and Skills
 
-Changes under `cursor-plugin/`, `codex-plugin/`, or `src/agents/` are covered
+Changes under `plugin/` or `src/agents/` are covered
 by a layered validation system: vendored JSON-schema checks, per-host skill
 frontmatter contracts, cross-bundle sync/parity tests, and a CI
-schema-validation workflow. `cursor-plugin/` is the source of truth — never
-hand-edit mirrored Codex skills. Before submitting, run:
+schema-validation workflow. `plugin/skills/` is the shared source of truth for
+bundled skills — do not fork host-specific copies. Before submitting, run:
 
 ```bash
 cargo nextest run -E 'binary(=agent_suite)'

--- a/plugin/skills/code-health/SKILL.md
+++ b/plugin/skills/code-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-health
-description: 'Use when producing a code-health scorecard or tech-debt ranking, mapping repo/module architecture and dependency layers, bracketing a refactor with a before/after health delta, or checking project identity, index freshness, config values, TODO markers, or server runtime.'
+description: 'Use when producing code-health scorecards, architecture maps, project identity/index status, registered project lookup, cross-project or cross-repo context gathering, TODO/config/runtime checks, or before/after refactor health deltas.'
 ---
 
 # Code health, architecture & status
@@ -60,9 +60,13 @@ and the specific scans the user asked for — don't run every tool by reflex.
 2. **Storage status → `tracedecay_storage_status`** (no args): resolved
    active project store health, graph DB path, writability, branch-fallback
    warnings — instead of probing `.tracedecay` or direct SQLite checks.
-3. **Project registry → `tracedecay_project_list` /
+3. **Project registry / cross-project context → `tracedecay_project_list` /
    `tracedecay_project_search` / `tracedecay_project_context`** when the user
-   asks about another project or workspace.
+   asks about another project, sibling workspace, cross-repo context, or
+   cross-project context gathering. Confirm the target store first, then pass
+   `project_id`, `project_path`, or `project_selector` to
+   `tracedecay_context`, `tracedecay_search`, or `tracedecay_message_search`
+   instead of scanning parent directories.
 4. **Index status → `tracedecay_status`**: node/edge/file counts, DB size,
    active branch + fallback warning, tokens saved.
 5. **Config lookups → `tracedecay_config`** (`key` required, plus `path` or
@@ -92,7 +96,7 @@ and the specific scans the user asked for — don't run every tool by reflex.
 ## If tools are deferred or MCP fails
 
 - Deferred (names listed without schemas): load once with ToolSearch —
-  `select:tracedecay_health,tracedecay_gini,tracedecay_dsm,tracedecay_status,tracedecay_active_project`
+  `select:tracedecay_health,tracedecay_gini,tracedecay_dsm,tracedecay_status,tracedecay_active_project,tracedecay_project_list,tracedecay_project_search,tracedecay_project_context`
   (one batched call, add others needed) — then call normally.
 - MCP error/timeout/disconnect: same tool, same args, via shell:
   `tracedecay tool <name>` (see `tracedecay:using-the-cli`). Never

--- a/plugin/skills/managing-session-context/SKILL.md
+++ b/plugin/skills/managing-session-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: managing-session-context
-description: 'Use the moment you need anything from a PAST agent session — transcript recall, scoped/time grep, lossless replay, summary-DAG drill-down, or compaction recovery — and when driving the host LCM lifecycle (preflight, compression, boundary, or repair). Reach here before trusting a compacted summary.'
+description: 'Use when you need LCM, session search, transcript search, raw past-session replay, scoped/time grep, summary-DAG drill-down, branch/worktree/commit history, workflow recovery, or compaction recovery; and when driving host LCM lifecycle preflight/compress/boundary/repair.'
 ---
 
 # Managing session context
@@ -18,12 +18,17 @@ For durable *decisions and facts* (rather than raw conversation), start with
 
 ## Retrieval ladder (read-only, start here)
 
-Climb cheapest-first; stop as soon as the question is answered.
+Climb cheapest-first; stop as soon as the question is answered. For
+cross-project or sibling-repo session search, first resolve the target project
+with `tracedecay_project_search`/`tracedecay_project_context`, then pass
+`project_id`, `project_path`, or `project_selector` to
+`tracedecay_message_search` instead of searching the active project by accident.
 
 1. **Fast full-text recall → `tracedecay_message_search`** (`query`, optional
-   `provider`, `scope`: `all`|`parents_only`|`subagents_only`, `limit`): FTS
-   over ingested transcripts; returns messages with their session ids — the
-   entry point into the ladder below.
+   `provider`, `scope`: `all`|`parents_only`|`subagents_only`, `limit`;
+   optional `project_id`/`project_path`/`project_selector` for registered
+   projects): FTS over ingested transcripts; returns messages with their
+   session ids — the entry point into the ladder below.
 2. **Scoped/filtered grep → `tracedecay_lcm_grep`** (`query`, `scope`:
    `current`|`session`|`all` — `current`/`session` require `session_id`; `role`,
    `source`, `start_time`/`end_time`, `sort`: `recency`|`relevance`|`hybrid`):
@@ -119,7 +124,7 @@ on explicit user intent.
 ## If tools are deferred or MCP fails
 
 - Deferred (names listed without schemas): load once with ToolSearch —
-  `select:tracedecay_message_search,tracedecay_lcm_grep,tracedecay_lcm_load_session,tracedecay_lcm_status,tracedecay_lcm_compress,tracedecay_sessions_for`
+  `select:tracedecay_message_search,tracedecay_lcm_grep,tracedecay_lcm_load_session,tracedecay_lcm_status,tracedecay_lcm_compress,tracedecay_sessions_for,tracedecay_workflows,tracedecay_project_search,tracedecay_project_context`
   (one batched call, add others needed) — then call normally.
 - MCP error/timeout/disconnect: same tool, same args, via shell:
   `tracedecay tool <name>` (see `tracedecay:using-the-cli`). Never

--- a/plugin/skills/using-tracedecay/SKILL.md
+++ b/plugin/skills/using-tracedecay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-tracedecay
-description: 'Use when starting any code task in a TraceDecay-indexed project, before the first Grep, Glob, cat, Read, "gh pr diff", test run, or memory-file write, including in subagents. Maps moments to tools; rebuts native-search fallback. Do NOT use for a scoped subagent handed exact files.'
+description: 'Use when starting any code or repo-context task in a TraceDecay-indexed project, before Grep/Glob/cat/Read/gh pr diff/tests/memory writes, including cross-project or sibling workspace context via project registry. Skip only for scoped subagents handed exact files.'
 ---
 
 # Using TraceDecay
@@ -33,8 +33,10 @@ of this rule is violating its spirit.
 tracedecay tools may be **deferred** — listed by name only, uncallable until
 their schemas load. First need → ONE batched ToolSearch call:
 `select:tracedecay_context,tracedecay_search,tracedecay_grep,tracedecay_outline,tracedecay_body`
-(add others per the skill you enter). If any MCP call errors or times out, the
-same tool runs as `tracedecay tool <name> --args '<json>'` — see
+(add project/session tools such as `tracedecay_project_list`,
+`tracedecay_project_search`, `tracedecay_project_context`, or
+`tracedecay_message_search` when the moment needs them). If any MCP call
+errors or times out, the same tool runs as `tracedecay tool <name> --args '<json>'` — see
 `tracedecay:using-the-cli`. Transport failure never justifies grep.
 
 ## Moment to mandatory action
@@ -43,6 +45,7 @@ same tool runs as `tracedecay tool <name> --args '<json>'` — see
 |---|---|
 | About to grep/rg a literal string, regex, or config key | `tracedecay_grep` — skill: `tracedecay:exploring-code` |
 | About to search for a symbol or concept, or open/Read a source file | `tracedecay_search` / `tracedecay_context`; read via outline→body→read slices — `tracedecay:exploring-code` |
+| User names another repo/project/workspace, sibling checkout, or cross-repo/cross-project context | `tracedecay_project_list` / `tracedecay_project_search` → `tracedecay_project_context`; pass `project_id`, `project_path`, or `project_selector` to `tracedecay_context`, `tracedecay_search`, and `tracedecay_message_search` |
 | "Who calls X" / "what does X call" / "trace this" | `tracedecay:tracing-functions` |
 | Wondering what breaks or which tests to run | `tracedecay:assessing-impact` |
 | About to run `gh pr diff` / read a raw diff to review | `tracedecay_pr_context` / `tracedecay_diff_context` (offline, no gh needed) — `tracedecay:reviewing-changes` |

--- a/src/diagnostics/lsp/broker.rs
+++ b/src/diagnostics/lsp/broker.rs
@@ -129,10 +129,20 @@ impl PreparedRefresh {
         self,
         diagnostics_quiet_timeout: Duration,
     ) -> CompletedRefresh {
+        self.collect_diagnostics_with_timeouts(LspRefreshTimeouts::from_diagnostics_quiet_window(
+            diagnostics_quiet_timeout,
+        ))
+        .await
+    }
+
+    pub async fn collect_diagnostics_with_timeouts(
+        self,
+        timeouts: LspRefreshTimeouts,
+    ) -> CompletedRefresh {
         let language = self.language.clone();
         let command = self.command.clone();
         let epoch = self.epoch;
-        let result = self.collect(diagnostics_quiet_timeout).await;
+        let result = self.collect(timeouts).await;
         CompletedRefresh {
             language,
             command,
@@ -143,10 +153,9 @@ impl PreparedRefresh {
 
     async fn collect(
         self,
-        diagnostics_quiet_timeout: Duration,
+        timeouts: LspRefreshTimeouts,
     ) -> std::result::Result<Vec<CodeDiagnostic>, RefreshFailure> {
         let mut diagnostics = Vec::new();
-        let timeouts = LspRefreshTimeouts::from_diagnostics_quiet_window(diagnostics_quiet_timeout);
         for batch in self.batches {
             let mut client_slot = batch.client.lock().await;
             let mut client = match client_slot.take() {
@@ -387,12 +396,24 @@ impl DiagnosticBroker {
         documents: Vec<LspDocument>,
         diagnostics_quiet_timeout: Duration,
     ) -> Result<()> {
+        self.refresh_documents_with_timeouts(
+            language,
+            documents,
+            LspRefreshTimeouts::from_diagnostics_quiet_window(diagnostics_quiet_timeout),
+        )
+        .await
+    }
+
+    pub async fn refresh_documents_with_timeouts(
+        &mut self,
+        language: &str,
+        documents: Vec<LspDocument>,
+        timeouts: LspRefreshTimeouts,
+    ) -> Result<()> {
         let Some(prepared) = self.prepare_refresh(language, documents)? else {
             return Ok(());
         };
-        let result = prepared
-            .collect_diagnostics(diagnostics_quiet_timeout)
-            .await;
+        let result = prepared.collect_diagnostics_with_timeouts(timeouts).await;
         self.finish_refresh(result)
     }
 

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -26,6 +26,20 @@ pub struct LspRefreshTimeouts {
 }
 
 impl LspRefreshTimeouts {
+    pub fn new(
+        refresh: Duration,
+        initialize_response: Duration,
+        message_io: Duration,
+        diagnostics_quiet: Duration,
+    ) -> Self {
+        Self {
+            refresh,
+            initialize_response,
+            message_io,
+            diagnostics_quiet,
+        }
+    }
+
     pub fn from_diagnostics_quiet_window(diagnostics_quiet: Duration) -> Self {
         let message_io = diagnostics_quiet.max(MIN_MESSAGE_IO_TIMEOUT);
         let initialize_response = message_io.max(MIN_INITIALIZE_RESPONSE_TIMEOUT);
@@ -55,6 +69,17 @@ pub async fn collect_document_diagnostics(
     diagnostics_quiet_timeout: Duration,
 ) -> Result<Vec<CodeDiagnostic>> {
     let timeouts = LspRefreshTimeouts::from_diagnostics_quiet_window(diagnostics_quiet_timeout);
+    collect_document_diagnostics_with_timeouts(command, args, project_root, documents, timeouts)
+        .await
+}
+
+pub async fn collect_document_diagnostics_with_timeouts(
+    command: &str,
+    args: &[String],
+    project_root: &Path,
+    documents: Vec<LspDocument>,
+    timeouts: LspRefreshTimeouts,
+) -> Result<Vec<CodeDiagnostic>> {
     let mut client =
         StdioLspClient::start_with_timeouts(command, args, project_root, timeouts).await?;
     client

--- a/tests/agent_suite/plugin_skill_contract_test.rs
+++ b/tests/agent_suite/plugin_skill_contract_test.rs
@@ -120,34 +120,27 @@ fn repo_local_usage_driven_operator_skills_are_not_template_stubs() {
 fn bundled_session_context_skill_exposes_lcm_session_search_routes() {
     let skills = load_skill_docs(CODEX_SKILL_ROOT);
     let skill = skill_named(&skills, "managing-session-context");
-    let searchable = format!(
-        "{}\n{}",
-        required_scalar_field(skill, "description"),
-        skill.body
-    );
 
-    for required in [
-        "LCM",
-        "session search",
-        "transcript search",
-        "compaction recovery",
-        "tracedecay_message_search",
-        "tracedecay_lcm_grep",
-        "tracedecay_lcm_status",
-        "tracedecay_sessions_for",
-        "tracedecay_workflows",
-        "branch",
-        "worktree",
-        "commit",
-        "project_path",
-        "project_selector",
-    ] {
-        assert!(
-            searchable.contains(required),
-            "{} should expose {required:?} for discovery and routing",
-            skill.path.display()
-        );
-    }
+    assert_skill_contains_all(
+        skill,
+        &[
+            "LCM",
+            "session search",
+            "transcript search",
+            "compaction recovery",
+            "tracedecay_message_search",
+            "tracedecay_lcm_grep",
+            "tracedecay_lcm_status",
+            "tracedecay_sessions_for",
+            "tracedecay_workflows",
+            "branch",
+            "worktree",
+            "commit",
+            "project_path",
+            "project_selector",
+        ],
+        "expose session search and LCM routes for discovery",
+    );
 }
 
 #[test]
@@ -155,34 +148,45 @@ fn bundled_skills_route_cross_project_context_through_registry() {
     let skills = load_skill_docs(CODEX_SKILL_ROOT);
     let using_tracedecay = skill_named(&skills, "using-tracedecay");
     let code_health = skill_named(&skills, "code-health");
-    let searchable = format!(
-        "{}\n{}\n{}\n{}",
-        required_scalar_field(using_tracedecay, "description"),
-        using_tracedecay.body,
-        required_scalar_field(code_health, "description"),
-        code_health.body
-    );
 
-    for required in [
-        "cross-project",
-        "cross-repo",
-        "sibling",
-        "registered project",
-        "tracedecay_project_list",
-        "tracedecay_project_search",
-        "tracedecay_project_context",
-        "project_id",
-        "project_path",
-        "project_selector",
-        "tracedecay_context",
-        "tracedecay_search",
-        "tracedecay_message_search",
-    ] {
-        assert!(
-            searchable.contains(required),
-            "shared plugin skills should route cross-project context through {required:?}"
-        );
-    }
+    assert_skill_contains_all(
+        using_tracedecay,
+        &[
+            "cross-project",
+            "cross-repo",
+            "sibling",
+            "project registry",
+            "tracedecay_project_list",
+            "tracedecay_project_search",
+            "tracedecay_project_context",
+            "project_id",
+            "project_path",
+            "project_selector",
+            "tracedecay_context",
+            "tracedecay_search",
+            "tracedecay_message_search",
+        ],
+        "route cross-project code and session context through the project registry",
+    );
+    assert_skill_contains_all(
+        code_health,
+        &[
+            "cross-project",
+            "cross-repo",
+            "sibling",
+            "registered project",
+            "tracedecay_project_list",
+            "tracedecay_project_search",
+            "tracedecay_project_context",
+            "project_id",
+            "project_path",
+            "project_selector",
+            "tracedecay_context",
+            "tracedecay_search",
+            "tracedecay_message_search",
+        ],
+        "route project status and cross-project context through the project registry",
+    );
 }
 
 #[test]
@@ -436,6 +440,22 @@ fn skill_named<'a>(skills: &'a [SkillDoc], name: &str) -> &'a SkillDoc {
         .iter()
         .find(|skill| skill.name == name)
         .unwrap_or_else(|| panic!("missing bundled skill {name}"))
+}
+
+fn assert_skill_contains_all(skill: &SkillDoc, required_terms: &[&str], purpose: &str) {
+    let searchable = format!(
+        "{}\n{}",
+        required_scalar_field(skill, "description"),
+        skill.body
+    );
+
+    for &required in required_terms {
+        assert!(
+            searchable.contains(required),
+            "{} should {purpose}; missing {required:?}",
+            skill.path.display()
+        );
+    }
 }
 
 fn required_scalar_field<'a>(skill: &'a SkillDoc, field: &str) -> &'a str {

--- a/tests/agent_suite/plugin_skill_contract_test.rs
+++ b/tests/agent_suite/plugin_skill_contract_test.rs
@@ -117,6 +117,75 @@ fn repo_local_usage_driven_operator_skills_are_not_template_stubs() {
 }
 
 #[test]
+fn bundled_session_context_skill_exposes_lcm_session_search_routes() {
+    let skills = load_skill_docs(CODEX_SKILL_ROOT);
+    let skill = skill_named(&skills, "managing-session-context");
+    let searchable = format!(
+        "{}\n{}",
+        required_scalar_field(skill, "description"),
+        skill.body
+    );
+
+    for required in [
+        "LCM",
+        "session search",
+        "transcript search",
+        "compaction recovery",
+        "tracedecay_message_search",
+        "tracedecay_lcm_grep",
+        "tracedecay_lcm_status",
+        "tracedecay_sessions_for",
+        "tracedecay_workflows",
+        "branch",
+        "worktree",
+        "commit",
+        "project_path",
+        "project_selector",
+    ] {
+        assert!(
+            searchable.contains(required),
+            "{} should expose {required:?} for discovery and routing",
+            skill.path.display()
+        );
+    }
+}
+
+#[test]
+fn bundled_skills_route_cross_project_context_through_registry() {
+    let skills = load_skill_docs(CODEX_SKILL_ROOT);
+    let using_tracedecay = skill_named(&skills, "using-tracedecay");
+    let code_health = skill_named(&skills, "code-health");
+    let searchable = format!(
+        "{}\n{}\n{}\n{}",
+        required_scalar_field(using_tracedecay, "description"),
+        using_tracedecay.body,
+        required_scalar_field(code_health, "description"),
+        code_health.body
+    );
+
+    for required in [
+        "cross-project",
+        "cross-repo",
+        "sibling",
+        "registered project",
+        "tracedecay_project_list",
+        "tracedecay_project_search",
+        "tracedecay_project_context",
+        "project_id",
+        "project_path",
+        "project_selector",
+        "tracedecay_context",
+        "tracedecay_search",
+        "tracedecay_message_search",
+    ] {
+        assert!(
+            searchable.contains(required),
+            "shared plugin skills should route cross-project context through {required:?}"
+        );
+    }
+}
+
+#[test]
 fn cursor_plugin_skills_match_cursor_skill_contract() {
     let staged = staged_cursor_skill_source();
     let skills = load_skill_docs_from(staged.path());
@@ -360,6 +429,13 @@ fn scalar_field<'a>(skill: &'a SkillDoc, field: &str) -> Option<&'a str> {
             )
         })
     })
+}
+
+fn skill_named<'a>(skills: &'a [SkillDoc], name: &str) -> &'a SkillDoc {
+    skills
+        .iter()
+        .find(|skill| skill.name == name)
+        .unwrap_or_else(|| panic!("missing bundled skill {name}"))
 }
 
 fn required_scalar_field<'a>(skill: &'a SkillDoc, field: &str) -> &'a str {

--- a/tests/daemon_suite/git_watch_test.rs
+++ b/tests/daemon_suite/git_watch_test.rs
@@ -276,7 +276,7 @@ async fn fifty_commit_rebase_needs_one_sync() {
     // One coalesced diff covers all 50 commits (under the escalation limit).
     let files = cg
         .stale_files_since_commit(&base, 500)
-        .expect("50 files is within the escalation limit → one bounded diff");
+        .expect("50 files is within the escalation limit -> one bounded diff");
     assert_eq!(files.len(), 50, "one diff should surface all 50 new files");
     cg.sync_if_stale_silent(&files).await.unwrap();
     drop(cg);

--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -11,13 +11,31 @@ const FAKE_PATH: &str = "src/lib.fake";
 // already-initialized fake server.
 const FAKE_LSP_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
 // Recovery collections (re-run a healthy server after forcing a crash) must
-// complete a real python spawn + didOpen -> publishDiagnostics round trip. The
-// client early-returns as soon as every requested URI has published, so this
-// generous bound costs no extra wall time on success — it only prevents a
-// false timeout when a loaded runner is slow to spawn/schedule the child. It
-// stays well under `OUTER_ASYNC_TIMEOUT`, so a genuine hang is still caught.
+// complete a real python spawn + didOpen -> publishDiagnostics round trip. This
+// generous spawn/write bound prevents false timeouts on loaded runners; the
+// recovery helper keeps the diagnostics quiet window small so success stays
+// cheap.
 const FAKE_LSP_RECOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 const OUTER_ASYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+const HANGING_WRITE_LINE_COUNT: usize = 64_000;
+
+fn bounded_fake_lsp_timeouts() -> lsp::client::LspRefreshTimeouts {
+    lsp::client::LspRefreshTimeouts::new(
+        std::time::Duration::from_millis(350),
+        std::time::Duration::from_millis(350),
+        std::time::Duration::from_millis(350),
+        std::time::Duration::from_millis(50),
+    )
+}
+
+fn recovery_fake_lsp_timeouts() -> lsp::client::LspRefreshTimeouts {
+    lsp::client::LspRefreshTimeouts::new(
+        FAKE_LSP_RECOVERY_TIMEOUT + FAKE_LSP_TIMEOUT,
+        FAKE_LSP_RECOVERY_TIMEOUT,
+        FAKE_LSP_RECOVERY_TIMEOUT,
+        FAKE_LSP_TIMEOUT,
+    )
+}
 
 #[test]
 fn builtin_registry_advertises_phase_one_setup_contract() {
@@ -343,10 +361,10 @@ async fn broker_bounds_lsp_initialize_hangs() {
 
     let result = tokio::time::timeout(
         OUTER_ASYNC_TIMEOUT,
-        broker.refresh_documents(
+        broker.refresh_documents_with_timeouts(
             FAKE_LANGUAGE,
             vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            std::time::Duration::from_millis(50),
+            bounded_fake_lsp_timeouts(),
         ),
     )
     .await;
@@ -383,14 +401,14 @@ async fn broker_bounds_lsp_document_write_hangs() {
 
     let result = tokio::time::timeout(
         OUTER_ASYNC_TIMEOUT,
-        broker.refresh_documents(
+        broker.refresh_documents_with_timeouts(
             FAKE_LANGUAGE,
             vec![fake_document(
                 FAKE_LANGUAGE,
                 FAKE_PATH,
-                &"let nope\n".repeat(600_000),
+                &"let nope\n".repeat(HANGING_WRITE_LINE_COUNT),
             )],
-            std::time::Duration::from_millis(50),
+            bounded_fake_lsp_timeouts(),
         ),
     )
     .await;
@@ -404,10 +422,10 @@ async fn broker_bounds_lsp_document_write_hangs() {
 
     std::fs::write(&script_path, fake_lsp_script()).unwrap();
     broker
-        .refresh_documents(
+        .refresh_documents_with_timeouts(
             FAKE_LANGUAGE,
             vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            FAKE_LSP_RECOVERY_TIMEOUT,
+            recovery_fake_lsp_timeouts(),
         )
         .await
         .unwrap();
@@ -429,16 +447,16 @@ async fn stdio_client_bounds_lsp_document_write_hangs() {
 
     let result = tokio::time::timeout(
         OUTER_ASYNC_TIMEOUT,
-        lsp::client::collect_document_diagnostics(
+        lsp::client::collect_document_diagnostics_with_timeouts(
             python_command(),
             &[script_path.display().to_string()],
             temp.path(),
             vec![fake_document(
                 FAKE_LANGUAGE,
                 FAKE_PATH,
-                &"let nope\n".repeat(600_000),
+                &"let nope\n".repeat(HANGING_WRITE_LINE_COUNT),
             )],
-            std::time::Duration::from_millis(50),
+            bounded_fake_lsp_timeouts(),
         ),
     )
     .await;
@@ -492,10 +510,10 @@ async fn broker_drops_lsp_client_after_partial_diagnostics_frame_timeout() {
     );
 
     let err = broker
-        .refresh_documents(
+        .refresh_documents_with_timeouts(
             FAKE_LANGUAGE,
             vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            std::time::Duration::from_millis(50),
+            bounded_fake_lsp_timeouts(),
         )
         .await
         .expect_err("partial diagnostics frame should crash the cached client");
@@ -505,10 +523,10 @@ async fn broker_drops_lsp_client_after_partial_diagnostics_frame_timeout() {
 
     std::fs::write(&script_path, fake_lsp_script()).unwrap();
     broker
-        .refresh_documents(
+        .refresh_documents_with_timeouts(
             FAKE_LANGUAGE,
             vec![fake_document(FAKE_LANGUAGE, FAKE_PATH, "let nope")],
-            FAKE_LSP_RECOVERY_TIMEOUT,
+            recovery_fake_lsp_timeouts(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- expand bundled TraceDecay skill descriptions so LCM/session search and transcript search trigger reliably
- add registry-first cross-project/cross-repo context routing through `tracedecay_project_list`, `tracedecay_project_search`, and `tracedecay_project_context`
- add per-skill agent-suite contracts that protect the LCM/session and cross-project discoverability terms without letting sibling skills satisfy each other by accident
- trim slow LSP/git watcher test paths by giving hanging-LSP tests explicit bounded timeouts and reducing oversized fake write payloads
- update CONTRIBUTING to name `plugin/skills/` as the shared bundled skill source of truth

## Impact
Agents should now discover the right bundled skill for LCM, session search, transcript search, compaction recovery, sibling workspaces, and cross-project context gathering instead of falling back to broad filesystem scans or the active project by accident. The refreshed LSP test helpers keep timeout semantics explicit while cutting avoidable wall time in slow/hanging fake-server cases.

## Tests
- `cargo fmt --check`
- `cargo test --test agent_suite plugin_skill_contract_test::bundled_session_context_skill_exposes_lcm_session_search_routes -- --exact`
- `cargo test --test agent_suite plugin_skill_contract_test::bundled_skills_route_cross_project_context_through_registry -- --exact`
- `cargo nextest run -E 'binary(=agent_suite)'`
- `git diff --check`
- `codex debug prompt-input | rg -n "tracedecay:(using-tracedecay|managing-session-context|code-health)|cross-project|session search|transcript search|tracedecay_project_context|tracedecay_project_search"`
- GitHub CI on `6379218addc2e52769592e7860a360271f307633`: all checks passed
