### PR TITLE
fix(release): guard against unpublished version drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,23 @@ jobs:
           fi
           scripts/check-conventional-commits.sh "$RANGE"
 
+  release-version-drift:
+    name: Release Version Drift
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-plz-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Test release version drift guard
+        run: bash tests/release_drift_check_test.sh
+
+      - name: Check release version drift
+        run: scripts/check-release-drift.sh
+
   test:
     name: Test ${{ matrix.name }}
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,11 +58,31 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Run release-plz release
+        id: release
         uses: release-plz/action@v0.5
+        continue-on-error: true
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retry release-plz release after transient GitHub API failure
+        id: release_retry
+        if: steps.release.outcome == 'failure'
+        uses: release-plz/action@v0.5
+        continue-on-error: true
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail when release-plz release still fails
+        if: steps.release.outcome == 'failure' && steps.release_retry.outcome == 'failure'
+        run: exit 1
+
+      - name: Check release version drift
+        if: always()
+        run: scripts/check-release-drift.sh
 
   release-plz-pr:
     name: Open or update release PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,39 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.34](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.33...v0.0.34) - 2026-07-07
-
-### Added
-
-- install codex managed agents
-- *(codex)* install proactive memory prompt rules
-- *(memory)* document proactive fact-store guidance
-- *(mcp)* improve tool output rendering
-- *(memory)* reinforce recalled fact ranking
-- add memory feedback trust scenario
-- capture default timing telemetry
-- make the worldwide token-savings counter opt-in
-
-### Fixed
-
-- refresh Codex managed agent overlays
-- address automation cleanup review findings
-- satisfy renderer clippy lint
-- restore skill renderer module
-- stabilize automation cleanup CI
-- *(diagnostics)* improve freshness handling
-- satisfy clippy large-future lints
-- route init to worktree-local index
-
-### Other
-
-- simplify diagnostics and renderer fixes
-- split MCP render and diagnostics boundaries
-- Merge remote-tracking branch 'origin/codex/lazy-ignored-dependency-indexing' into simplify/automation-mcp-cleanup
-- split mcp renderer tests
-- *(evals)* document the fact-store triggering/adoption scorecard
-- behavior-preserving cleanups from the merged #295 changes
-
 ## [0.0.33](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.32...v0.0.33) - 2026-07-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.34"
+version = "0.0.33"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.34"
+version = "0.0.33"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"

--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-release-drift.sh [--repo PATH] [--registry-version VERSION]
+
+Fails when Cargo.toml is ahead of crates.io. That state means a release-plz
+version bump reached master without the crate publish/tag/release completing.
+EOF
+}
+
+repo="."
+registry_version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:?missing value for --repo}"
+      shift 2
+      ;;
+    --registry-version)
+      registry_version="${2:?missing value for --registry-version}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+cargo_toml="$repo/Cargo.toml"
+local_version="$(python3 - "$cargo_toml" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as handle:
+    manifest = tomllib.load(handle)
+print(manifest["package"]["version"])
+PY
+)"
+
+if [[ -z "$registry_version" ]]; then
+  registry_version="$(curl -fsSL \
+    -A "tracedecay-release-drift-check" \
+    https://crates.io/api/v1/crates/tracedecay \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin)["crate"]["max_version"])')"
+fi
+
+comparison="$(python3 - "$local_version" "$registry_version" <<'PY'
+import sys
+
+def parse(version: str):
+    main, sep, pre = version.partition("-")
+    parts = tuple(int(part) for part in main.split("."))
+    return parts + ((1, "") if not sep else (0, pre))
+
+local = parse(sys.argv[1])
+registry = parse(sys.argv[2])
+if local > registry:
+    print("ahead")
+elif local < registry:
+    print("behind")
+else:
+    print("equal")
+PY
+)"
+
+case "$comparison" in
+  equal)
+    echo "release versions are aligned: $local_version"
+    ;;
+  ahead)
+    echo "release drift detected: local Cargo.toml version $local_version is ahead of crates.io $registry_version" >&2
+    echo "Reset the unpublished release bump so release-plz can recreate it, or publish $local_version manually before merging more release changes." >&2
+    exit 1
+    ;;
+  behind)
+    echo "release drift detected: local Cargo.toml version $local_version is behind crates.io $registry_version" >&2
+    echo "Update the checkout from master before running release automation." >&2
+    exit 1
+    ;;
+esac

--- a/tests/release_drift_check_test.sh
+++ b/tests/release_drift_check_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/check-release-drift.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+write_repo() {
+  local version="$1"
+  local path="$tmpdir/repo"
+  rm -rf "$path"
+  mkdir -p "$path"
+  cat >"$path/Cargo.toml" <<TOML
+[package]
+name = "tracedecay"
+version = "$version"
+TOML
+  printf '%s\n' "$path"
+}
+
+same_repo="$(write_repo 0.0.33)"
+same_output="$("$SCRIPT" --repo "$same_repo" --registry-version 0.0.33)"
+[[ "$same_output" == *"release versions are aligned: 0.0.33"* ]]
+
+ahead_repo="$(write_repo 0.0.34)"
+set +e
+ahead_output="$("$SCRIPT" --repo "$ahead_repo" --registry-version 0.0.33 2>&1)"
+ahead_status=$?
+set -e
+
+[[ "$ahead_status" -eq 1 ]]
+[[ "$ahead_output" == *"release drift detected: local Cargo.toml version 0.0.34 is ahead of crates.io 0.0.33"* ]]
+[[ "$ahead_output" == *"Reset the unpublished release bump so release-plz can recreate it, or publish 0.0.34 manually before merging more release changes."* ]]


### PR DESCRIPTION
## Summary
- add a release drift guard that fails when Cargo.toml is ahead of crates.io
- run the guard in PR CI, skipping release-plz branches
- retry release-plz publish with the built-in GitHub token and fail on drift after release attempts
- reset the unpublished 0.0.34 bump so release-plz can recreate the release PR from 0.0.33

## Why
The v0.0.34 release PR merged, but publish failed on a transient GitHub API rate limit. Later release-plz runs then skipped both publish and release-pr because Cargo.toml was already 0.0.34 while crates.io was still 0.0.33.

## Verification
- bash -n scripts/check-release-drift.sh tests/release_drift_check_test.sh
- bash tests/release_drift_check_test.sh
- scripts/check-release-drift.sh
- cargo metadata --format-version 1 --no-deps
- python3 YAML parse for .github/workflows/ci.yml and .github/workflows/release-plz.yml