### PR TITLE
fix(release): preserve release workflow trigger token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Test release version drift guard
         run: bash tests/release_drift_check_test.sh
 
+      - name: Test release workflow contract
+        run: bash tests/release_workflow_contract_test.sh
+
       - name: Check release version drift
         run: scripts/check-release-drift.sh
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Retry release-plz release after transient GitHub API failure
         id: release_retry
@@ -74,7 +74,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Fail when release-plz release still fails
         if: steps.release.outcome == 'failure' && steps.release_retry.outcome == 'failure'

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_plz=".github/workflows/release-plz.yml"
+release_workflow=".github/workflows/release.yml"
+
+if grep -q 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}' "$release_plz"; then
+  echo "release-plz must not publish releases with GITHUB_TOKEN" >&2
+  echo "GitHub suppresses downstream on: release workflows from GITHUB_TOKEN-created releases." >&2
+  exit 1
+fi
+
+python3 - "$release_plz" <<'PY'
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+release_step = text.split("- name: Run release-plz release", 1)[1].split("- name:", 1)[0]
+retry_step = text.split("- name: Retry release-plz release after transient GitHub API failure", 1)[1].split("- name:", 1)[0]
+release_pr_step = text.split("- name: Run release-plz release-pr", 1)[1]
+
+for name, step in [
+    ("release", release_step),
+    ("release retry", retry_step),
+    ("release-pr", release_pr_step),
+]:
+    expected = "GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}"
+    if expected not in step:
+        raise SystemExit(f"{name} step must use RELEASE_PLZ_TOKEN")
+PY
+
+grep -q 'release:' "$release_workflow"
+grep -q 'types: \[published\]' "$release_workflow"


### PR DESCRIPTION
## Summary
- restore RELEASE_PLZ_TOKEN for release-plz publish and retry steps
- add CI contract test blocking GITHUB_TOKEN for release-plz release creation
- run the contract in Release Version Drift CI

## Diagnosis
Last good automatic binary release was v0.0.33 on 2026-07-06: Release workflow run 28816585124 was triggered by a release event and uploaded six assets.

v0.0.34 was published by release-plz on 2026-07-07, but release-plz had been changed to use secrets.GITHUB_TOKEN. GitHub suppresses downstream workflows from GITHUB_TOKEN-created release events, so .github/workflows/release.yml never fired automatically and the release had zero assets.

## Tests
- bash tests/release_workflow_contract_test.sh
- bash tests/release_drift_check_test.sh
- scripts/check-release-drift.sh
- python3 YAML parse for ci.yml, release-plz.yml, release.yml
- git diff --check