### PR TITLE
Route Hermes profile storage through global TraceDecay stores

### DIFF
--- a/scripts/hermes_plugin_unit_check.py
+++ b/scripts/hermes_plugin_unit_check.py
@@ -357,8 +357,7 @@ def run_checks(work: Path):
     storage = plugin._storage_args("/some/pin", str(hermes_home))
     assert storage["project_root"] == "/some/pin", storage
     fallback_storage = plugin._storage_args(None, str(hermes_home))
-    assert fallback_storage["storage_scope"] == "hermes_profile", fallback_storage
-    assert fallback_storage["hermes_home"] == str(hermes_home), fallback_storage
+    assert fallback_storage["project_root"] == str(hermes_home), fallback_storage
     ok("LCM/memory storage routes through resolved project roots")
 
     # ── 4. provider hooks call the right verbs ───────────────────────────
@@ -380,10 +379,8 @@ def run_checks(work: Path):
         assert name == "tracedecay_lcm_preflight", calls
         assert args["session_id"] == "other-session"
         assert args["messages"] == messages
-        assert args["storage_scope"] == "hermes_profile", args
-        assert args["hermes_home"] == str(hermes_home), args
-        assert kwargs["storage_scope"] == "hermes_profile", kwargs
-        assert kwargs["hermes_home"] == str(hermes_home), kwargs
+        assert args["project_root"] == str(hermes_home), args
+        assert kwargs["project_root"] == str(hermes_home), kwargs
         ok("sync_turn ingests via tracedecay_lcm_preflight")
 
         provider.sync_turn("only user", "and assistant", session_id="s2", messages=None)
@@ -391,10 +388,8 @@ def run_checks(work: Path):
         assert name == "tracedecay_lcm_preflight", calls
         assert args["messages"][0]["content"] == "only user"
         assert args["messages"][1]["content"] == "and assistant"
-        assert args["storage_scope"] == "hermes_profile", args
-        assert args["hermes_home"] == str(hermes_home), args
-        assert kwargs["storage_scope"] == "hermes_profile", kwargs
-        assert kwargs["hermes_home"] == str(hermes_home), kwargs
+        assert args["project_root"] == str(hermes_home), args
+        assert kwargs["project_root"] == str(hermes_home), kwargs
         ok("sync_turn synthesizes a turn when messages are missing")
 
         provider.on_memory_write("add", "user", "likes rust", {"session_id": "s"})
@@ -402,10 +397,8 @@ def run_checks(work: Path):
         assert name == "tracedecay_fact_store", calls
         assert args["action"] == "add" and args["category"] == "user_pref"
         assert args["metadata"]["hermes_action"] == "add"
-        assert args["storage_scope"] == "hermes_profile", args
-        assert args["hermes_home"] == str(hermes_home), args
-        assert kwargs["storage_scope"] == "hermes_profile", kwargs
-        assert kwargs["hermes_home"] == str(hermes_home), kwargs
+        assert args["project_root"] == str(hermes_home), args
+        assert kwargs["project_root"] == str(hermes_home), kwargs
         before = len(calls)
         provider.on_memory_write("remove", "memory", "anything")
         assert len(calls) == before

--- a/src/agents/hermes/templates.rs
+++ b/src/agents/hermes/templates.rs
@@ -251,8 +251,6 @@ def call_tracedecay_tool(name: str, args: dict, **kwargs) -> str:
         #      profile-sharded tracedecay store. Explicit hermes_profile
         #      storage remains supported as a legacy escape hatch.
         project_root = kwargs.get("project_root") or tool_args.get("project_root")
-        if not project_root and tool_args.get("storage_scope") == "hermes_profile":
-            project_root = None
         if not project_root and tool_args.get("storage_scope") != "hermes_profile":
             project_root = code_project_root(cwd=kwargs.get("cwd") or tool_args.get("cwd"))
             if not project_root and name in PROFILE_STORE_TOOLS:

--- a/src/agents/hermes/templates.rs
+++ b/src/agents/hermes/templates.rs
@@ -246,8 +246,10 @@ def call_tracedecay_tool(name: str, args: dict, **kwargs) -> str:
         #   2. Hermes state tools use the active code project when one is
         #      pinned/resolved, so LCM and memory share the unified
         #      user-level tracedecay store for that project.
-        #   3. Unpinned Hermes profile-store calls use the hermes_profile
-        #      storage scope instead of synthesizing a project root.
+        #   3. Unpinned Hermes profile-store calls use the Hermes home as
+        #      project identity, which routes through the user-level
+        #      profile-sharded tracedecay store. Explicit hermes_profile
+        #      storage remains supported as a legacy escape hatch.
         project_root = kwargs.get("project_root") or tool_args.get("project_root")
         if not project_root and tool_args.get("storage_scope") == "hermes_profile":
             project_root = None
@@ -255,9 +257,9 @@ def call_tracedecay_tool(name: str, args: dict, **kwargs) -> str:
             project_root = code_project_root(cwd=kwargs.get("cwd") or tool_args.get("cwd"))
             if not project_root and name in PROFILE_STORE_TOOLS:
                 tool_args = dict(tool_args)
-                tool_args.setdefault("storage_scope", "hermes_profile")
-                tool_args.setdefault("hermes_home", hermes_home_dir())
-                project_root = None
+                home = tool_args.get("hermes_home") or hermes_home_dir()
+                tool_args.setdefault("project_root", str(home))
+                project_root = tool_args["project_root"]
         payload = json.dumps(tool_args)
         argv = [TRACEDECAY_BIN, "tool"]
         if project_root:

--- a/src/agents/hermes/templates/plugin_init.py
+++ b/src/agents/hermes/templates/plugin_init.py
@@ -646,7 +646,7 @@ def _storage_args(project_root=None, hermes_home=None):
         return {"project_root": str(project_root)}
     home = hermes_home or _resolve_hermes_home()
     if home:
-        return {"storage_scope": "hermes_profile", "hermes_home": str(home)}
+        return {"project_root": str(home)}
     return {}
 
 # Conventional config home: a `plugins.tracedecay` block in the profile
@@ -2393,7 +2393,8 @@ class TraceDecayContextEngine(ContextEngine):
             "lcm_session_db_path": None,
             "storage_note": (
                 "Hermes LCM conversation state is stored in the unified "
-                "user-level tracedecay store; unpinned profiles use hermes_profile storage."
+                "user-level tracedecay store; unpinned profiles use the Hermes home "
+                "as a profile-sharded project identity."
             ),
             "project_root": self.project_root,
             "tracedecay_binary_path": tools.TRACEDECAY_BIN,

--- a/src/tool_command.rs
+++ b/src/tool_command.rs
@@ -80,6 +80,16 @@ const FIRST_TOUCH_STORE_TOOLS: &[&str] = &[
     "tracedecay_fact_feedback",
     "tracedecay_memory_status",
     "tracedecay_message_search",
+    "tracedecay_lcm_status",
+    "tracedecay_lcm_grep",
+    "tracedecay_lcm_load_session",
+    "tracedecay_lcm_doctor",
+    "tracedecay_lcm_describe",
+    "tracedecay_lcm_expand",
+    "tracedecay_lcm_expand_query",
+    "tracedecay_lcm_preflight",
+    "tracedecay_lcm_compress",
+    "tracedecay_lcm_session_boundary",
 ];
 
 /// Entry point for `tracedecay tool ...`.

--- a/src/tool_command/tests.rs
+++ b/src/tool_command/tests.rs
@@ -269,6 +269,17 @@ fn profile_scoped_lcm_dispatch_rejects_non_profile_or_non_lcm_calls() {
     ));
 }
 
+#[test]
+fn explicit_project_lcm_dispatch_allows_first_touch_init() {
+    let dispatch = DaemonToolDispatch::project_scoped(
+        Some("/tmp/hermes-profile".to_string()),
+        "tracedecay_lcm_status",
+    );
+
+    assert!(dispatch.allow_init);
+    assert!(!dispatch.allow_profile_scoped_fallback);
+}
+
 // Registry integrity guardrail (companion to the handler lockstep tests in
 // `mcp::tools::handlers`): the CLI routes profile-scoped LCM calls through
 // `is_profile_scoped_lcm_dispatch`, which consults the hand-maintained

--- a/src/tool_command/tests.rs
+++ b/src/tool_command/tests.rs
@@ -695,3 +695,13 @@ fn join_content_text_empty_when_no_content() {
     assert_eq!(join_content_text(&json!({})), "");
     assert_eq!(join_content_text(&json!({ "content": [] })), "");
 }
+
+#[test]
+fn first_touch_store_tools_superset_of_profile_scoped_lcm_tools() {
+    for tool in PROFILE_SCOPED_LCM_TOOLS {
+        assert!(
+            FIRST_TOUCH_STORE_TOOLS.contains(tool),
+            "profile-scoped LCM tool {tool} must also be a first-touch store tool; keep the two allowlists in lockstep",
+        );
+    }
+}

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -1283,7 +1283,7 @@ fn test_hermes_plugin_init_snapshot_matches_embedded_asset() {
     hasher.update(body.as_bytes());
     assert_eq!(
         hex::encode(hasher.finalize()),
-        "30608faf4faf37d78e23826031f7b5422ad81ef5030b8c8bc1a7d3381e1ba85a",
+        "167f7a24ab448980e063f09c1581d81cc69f3e1605223e538616ebda5062f976",
         "templates/plugin_init.py payload hash changed — verify the edit is intentional and update this snapshot"
     );
 }

--- a/tests/hermes_suite/lcm_bridge.rs
+++ b/tests/hermes_suite/lcm_bridge.rs
@@ -615,7 +615,7 @@ assert engine.hermes_home == "/tmp/hermes-from-env"
 status = engine.get_status()
 assert status["storage_scope"] == "profile_sharded"
 assert status["hermes_home"] == "/tmp/hermes-from-env"
-assert status["lcm_project_root"] is None
+assert status["lcm_project_root"] == "/tmp/hermes-from-env"
 
 engine.handle_tool_call(
     "lcm_grep",
@@ -624,14 +624,12 @@ engine.handle_tool_call(
 )
 
 assert calls[0][0] == "tracedecay_lcm_preflight"
-assert calls[0][1]["storage_scope"] == "hermes_profile"
-assert calls[0][1]["hermes_home"] == "/tmp/hermes-from-env"
+assert calls[0][1]["project_root"] == "/tmp/hermes-from-env"
 assert calls[0][1]["messages"] == [{"role": "user", "content": "profile current turn"}]
 assert calls[1][0] == "tracedecay_lcm_grep"
-assert calls[1][1]["storage_scope"] == "hermes_profile"
-assert calls[1][1]["hermes_home"] == "/tmp/hermes-from-env"
+assert calls[1][1]["project_root"] == "/tmp/hermes-from-env"
 "#,
-        "generated context engine should use HERMES_HOME as the unpinned profile store",
+        "generated context engine should use HERMES_HOME as the unpinned profile-sharded project identity",
     );
 }
 
@@ -897,7 +895,7 @@ with tempfile.TemporaryDirectory() as tmp:
     status = engine.get_status()
     assert status["storage_scope"] == "profile_sharded"
     assert normalized(status["hermes_home"]) == normalized(expected), status
-    assert status["lcm_project_root"] is None, status
+    assert normalized(status["lcm_project_root"]) == normalized(expected), status
 "#,
         "generated context engine should default to ~/.hermes even if missing",
     );
@@ -1070,23 +1068,19 @@ assert engine.hermes_home == "/tmp/hermes-profile"
 assert engine.project_root == "/tmp/project"
 
 # LCM/session storage routes through the unified user-level tracedecay store
-# for the active project, falling back to the Hermes profile home only when
-# no project is pinned/resolved.
+# for the active project, using the Hermes profile home as the project
+# identity only when no project is pinned/resolved.
 local_args = plugin._storage_args(project_root="/tmp/project", hermes_home="/tmp/hermes-profile")
 assert local_args == {"project_root": "/tmp/project"}
 
 profile_args = plugin._storage_args(hermes_home="/tmp/hermes-profile")
-assert profile_args == {
-    "storage_scope": "hermes_profile",
-    "hermes_home": "/tmp/hermes-profile",
-}
+assert profile_args == {"project_root": "/tmp/hermes-profile"}
 
 fallback_args = plugin._storage_args()
 # Match the plugin's expanduser fallback byte-for-byte: pathlib normalizes
 # separators on Windows while expanduser("~/.hermes") emits mixed ones.
 assert fallback_args == {
-    "storage_scope": "hermes_profile",
-    "hermes_home": os.path.expanduser("~/.hermes"),
+    "project_root": os.path.expanduser("~/.hermes"),
 }
 
 calls = []
@@ -1103,8 +1097,7 @@ profile_engine.should_compress_preflight(messages=[], current_tokens=123)
 name, args, kwargs = calls.pop()
 assert name == "tracedecay_lcm_preflight"
 assert args["session_id"] == "session-1"
-assert args["storage_scope"] == "hermes_profile"
-assert args["hermes_home"] == "/tmp/hermes"
+assert args["project_root"] == "/tmp/hermes"
 
 project_engine = plugin.TraceDecayContextEngine()
 project_engine.on_session_start(
@@ -1134,8 +1127,7 @@ profile_engine.should_compress_preflight(messages=[], current_tokens=321)
 name, args, kwargs = calls.pop()
 assert name == "tracedecay_lcm_preflight"
 assert args["session_id"] == "next"
-assert args["storage_scope"] == "hermes_profile"
-assert args["hermes_home"] == "/tmp/hermes"
+assert args["project_root"] == "/tmp/hermes"
 
 class LegacyCtx:
     def register_tool(self, *args, **kwargs):
@@ -1621,10 +1613,9 @@ assert profile_result["status"] == "ok"
 assert profile_engine.should_compress_preflight([], current_tokens=100) is False
 profile_argv = calls.pop()
 assert profile_argv[0] == plugin.tools.TRACEDECAY_BIN
-assert profile_argv[1:4] == ["tool", "tracedecay_lcm_preflight", "--json"]
+assert profile_argv[1:6] == ["tool", "--project", "/tmp/hermes-profile", "tracedecay_lcm_preflight", "--json"]
 profile_args = json.loads(profile_argv[profile_argv.index("--args") + 1])
-assert profile_args["storage_scope"] == "hermes_profile"
-assert profile_args["hermes_home"] == "/tmp/hermes-profile"
+assert profile_args["project_root"] == "/tmp/hermes-profile"
 
 explicit = plugin.tools.call_tracedecay_tool(
     "tracedecay_lcm_status",
@@ -2195,10 +2186,8 @@ fallback = plugin.TracedecayMemoryProvider()
 fallback.initialize(session_id="session-2", hermes_home="/tmp/hermes")
 fallback.sync_turn("user", "assistant", session_id="session-2")
 assert fallback.project_root is None
-assert calls[-1][1]["storage_scope"] == "hermes_profile"
-assert calls[-1][1]["hermes_home"] == "/tmp/hermes"
-assert calls[-1][2]["storage_scope"] == "hermes_profile"
-assert calls[-1][2]["hermes_home"] == "/tmp/hermes"
+assert calls[-1][1]["project_root"] == "/tmp/hermes"
+assert calls[-1][2]["project_root"] == "/tmp/hermes"
 "#,
         "sync_turn fallback messages should not collapse repeated identical turns",
     );


### PR DESCRIPTION
## Summary
- route unpinned Hermes profile storage through profile-sharded TraceDecay project roots instead of hermes_profile local stores
- keep explicit hermes_profile calls as the backward-compatible escape hatch
- update generated plugin tests for HERMES_HOME/default-home routing

## Tests
- cargo fmt --check
- cargo test -p tracedecay --test hermes_suite lcm_bridge -- --nocapture

## Local verification
- installed fixed Hermes plugin with cargo run -p tracedecay -- install --agent hermes --all-profiles
- hermes doctor exits 0; remaining reported issue is missing optional API keys
- default hermes gateway active