### PR TITLE
chore: release v0.0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.36](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.35...v0.0.36) - 2026-07-07
+
+### Fixed
+
+- *(cursor)* ignore stale degraded MCP ambiguity logs
+
 ## [0.0.35](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.34...v0.0.35) - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.35"
+version = "0.0.36"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.35"
+version = "0.0.36"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"

--- a/src/agents/cursor_diagnostics.rs
+++ b/src/agents/cursor_diagnostics.rs
@@ -120,8 +120,9 @@ fn stale_degraded_ambiguity(contents: &str) -> bool {
             break;
         }
         let trimmed = line.trim();
-        if trimmed.starts_with('/') {
-            paths.push(Path::new(trimmed));
+        let path = Path::new(trimmed);
+        if path.is_absolute() {
+            paths.push(path);
         }
     }
     !paths.is_empty() && paths.iter().any(|path| !path.exists())


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.35 -> 0.0.36

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.36](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.35...v0.0.36) - 2026-07-07

### Fixed

- *(cursor)* ignore stale degraded MCP ambiguity logs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).