### PR TITLE
chore: release v0.0.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.38](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.37...v0.0.38) - 2026-07-08
+
+### Fixed
+
+- *(hooks)* broaden hint eval coverage
+- *(hooks)* compact TraceDecay hook steering
+
+### Other
+
+- Merge pull request #318 from ScriptedAlchemy/release-plz-2026-07-08T00-48-50Z
+- *(hooks)* make hint eval coverage explicit
+- *(hooks)* table-drive hint eval cleanup
+- *(hooks)* centralize hint category metadata
+- simplify hook eval helpers
+- *(hooks)* deslop hint classifier changes
+- *(hooks)* share shell command parsing
+- *(hooks)* deslop hint eval coverage
+- *(hooks)* expand hint scenario evals
+
 ## [0.0.37](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.36...v0.0.37) - 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.37"
+version = "0.0.38"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.37"
+version = "0.0.38"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.37 -> 0.0.38

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.38](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.37...v0.0.38) - 2026-07-08

### Fixed

- *(hooks)* broaden hint eval coverage
- *(hooks)* compact TraceDecay hook steering

### Other

- Merge pull request #318 from ScriptedAlchemy/release-plz-2026-07-08T00-48-50Z
- *(hooks)* make hint eval coverage explicit
- *(hooks)* table-drive hint eval cleanup
- *(hooks)* centralize hint category metadata
- simplify hook eval helpers
- *(hooks)* deslop hint classifier changes
- *(hooks)* share shell command parsing
- *(hooks)* deslop hint eval coverage
- *(hooks)* expand hint scenario evals
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).