### PR TITLE
Improve redundancy eval coverage

### DIFF
--- a/plugin/skills/editing-safely/SKILL.md
+++ b/plugin/skills/editing-safely/SKILL.md
@@ -95,7 +95,7 @@ Run this read-only recon in one shot for a symbol or `Struct::field` with
 ## If tools are deferred or MCP fails
 
 - Deferred (names listed without schemas): load once with ToolSearch —
-  `select:tracedecay_search,tracedecay_similar,tracedecay_rename_preview,tracedecay_str_replace,tracedecay_replace_symbol`
+  `select:tracedecay_search,tracedecay_similar,tracedecay_signature_search,tracedecay_redundancy,tracedecay_rename_preview,tracedecay_str_replace,tracedecay_replace_symbol`
   (one batched call, add others needed) — then call normally.
 - MCP error/timeout/disconnect: same tool, same args, via shell:
   `tracedecay tool <name>` (see `tracedecay:using-the-cli`). Never

--- a/plugin/skills/exploring-code/SKILL.md
+++ b/plugin/skills/exploring-code/SKILL.md
@@ -23,6 +23,7 @@ row below, run it, and stop when the question is answered.
 | A file by role or path | `tracedecay_files` | find/ls -R |
 | Half-remembered name | `tracedecay_similar` | guessing greps |
 | Code by shape (return type, params, async) | `tracedecay_signature_search` | reading modules |
+| Duplicate code / similar function bodies / repeated helper logic | `tracedecay_redundancy` (`path`, `min_lines`, `max_pairs`) | name-only search |
 
 ## Read cheaply — stop at the first rung that answers
 
@@ -53,6 +54,8 @@ For other git branches without switching checkout — `tracedecay_branch_list` /
   the repo is unindexed; the index auto-syncs — do not run manual sync commands.
 - Search came up empty and a new helper seems needed → run the
   `tracedecay:editing-safely` duplicate probe first.
+- Similarity by functionality/body, not just by name → run
+  `tracedecay_redundancy` before concluding no duplicate exists.
 - "Who calls X / what does X call / what breaks" → hand off to
   `tracedecay:tracing-functions` / `tracedecay:assessing-impact` after resolving
   the symbol; do not grep for call sites.
@@ -62,7 +65,7 @@ For other git branches without switching checkout — `tracedecay_branch_list` /
 ## If tools are deferred or MCP fails
 
 - Deferred (names listed without schemas): load once with ToolSearch —
-  `select:tracedecay_context,tracedecay_search,tracedecay_grep,tracedecay_outline,tracedecay_body,tracedecay_read`
+  `select:tracedecay_context,tracedecay_search,tracedecay_grep,tracedecay_outline,tracedecay_body,tracedecay_read,tracedecay_redundancy`
   (one batched call, add others needed) — then call normally.
 - MCP error/timeout/disconnect: same tool, same args, via shell:
   `tracedecay tool <name>` (see `tracedecay:using-the-cli`). Never

--- a/plugin/skills/reviewing-changes/SKILL.md
+++ b/plugin/skills/reviewing-changes/SKILL.md
@@ -24,7 +24,11 @@ Announce: "Using tracedecay:reviewing-changes for <diff/PR>."
 3. Deepen only where needed: `tracedecay_impact` on a high-risk changed
    symbol; `tracedecay_affected` only if step 2's test set is insufficient.
 4. Quality scan of just the changed files → `tracedecay_simplify_scan`.
-5. Risk: `tracedecay_test_risk` on changed paths; `tracedecay_unsafe_patterns`
+5. Duplicate-body risk or repeated helper logic in touched code →
+   `tracedecay_redundancy` scoped to the changed directory/file set. Treat
+   `definite` as consolidation evidence; verify `likely`; ignore
+   `naming_only` unless another signal supports it.
+6. Risk: `tracedecay_test_risk` on changed paths; `tracedecay_unsafe_patterns`
    on changed files (`exclude_tests: true` for production-only — unwrap/panic
    in tests is normal, and an `unsafe { }` block is an attention site, not
    automatically a finding).
@@ -59,7 +63,7 @@ Drafts text only — `git commit` / `gh pr create` stay with the user.
 ## If tools are deferred or MCP fails
 
 - Deferred: one ToolSearch call —
-  `select:tracedecay_diff_context,tracedecay_pr_context,tracedecay_simplify_scan,tracedecay_unsafe_patterns,tracedecay_test_risk`.
+  `select:tracedecay_diff_context,tracedecay_pr_context,tracedecay_simplify_scan,tracedecay_redundancy,tracedecay_unsafe_patterns,tracedecay_test_risk`.
 - MCP error: `tracedecay tool pr_context --base-ref main --head-ref HEAD` etc.
   (see `tracedecay:using-the-cli`). gh being unauthenticated or offline is NOT
   a blocker — pr_context/diff_context never touch the network.

--- a/plugin/skills/using-tracedecay/SKILL.md
+++ b/plugin/skills/using-tracedecay/SKILL.md
@@ -50,6 +50,7 @@ errors or times out, the same tool runs as `tracedecay tool <name> --args '<json
 | Wondering what breaks or which tests to run | `tracedecay:assessing-impact` |
 | About to run `gh pr diff` / read a raw diff to review | `tracedecay_pr_context` / `tracedecay_diff_context` (offline, no gh needed) — `tracedecay:reviewing-changes` |
 | About to write a new helper, rename, or mass-edit | `tracedecay:editing-safely` |
+| Looking for duplicate code, similar function bodies, repeated helper logic, or consolidation targets | `tracedecay_redundancy` first for body/functionality matches; `tracedecay_similar` only for near-duplicate names — `tracedecay:code-health` / `tracedecay:editing-safely` |
 | Build/type errors present, or about to run cargo check/tsc | `tracedecay:fixing-build-and-type-errors` |
 | About to write MEMORY.md/CLAUDE.md notes, or asked about a past decision | `tracedecay:project-memory` (`fact_store`) |
 | Need raw past-session transcripts or compaction recovery | `tracedecay:managing-session-context` |

--- a/src/automation/managed_skill_validation.rs
+++ b/src/automation/managed_skill_validation.rs
@@ -358,3 +358,65 @@ pub(crate) fn validate_managed_skill_update(update: &ManagedSkillUpdate) -> Resu
 fn config_error(message: String) -> TraceDecayError {
     TraceDecayError::Config { message }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::super::managed_skill_model::{
+        ManagedSkillDraft, ManagedSkillProvenance, ManagedSkillSource, ManagedSupportFile,
+        SkillInstallTarget,
+    };
+    use super::*;
+
+    fn valid_draft() -> ManagedSkillDraft {
+        ManagedSkillDraft {
+            id: "managed-validation-eval".to_string(),
+            title: "Managed Validation Eval".to_string(),
+            summary: "validate generated managed skill packages".to_string(),
+            category: "validation".to_string(),
+            targets: vec![SkillInstallTarget::Codex, SkillInstallTarget::Claude],
+            body_markdown: "# Managed Validation Eval\n\nUse this when validating skills."
+                .to_string(),
+            support_files: Vec::new(),
+            provenance: ManagedSkillProvenance {
+                source: ManagedSkillSource::AutomationRun,
+                actor: "test".to_string(),
+                run_id: Some("run-123".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn managed_skill_validation_accepts_valid_draft() {
+        let skill = valid_draft().materialize().unwrap();
+        validate_managed_skill(&skill).unwrap();
+    }
+
+    #[test]
+    fn managed_skill_validation_rejects_hermes_target() {
+        let mut draft = valid_draft();
+        draft.targets = vec![SkillInstallTarget::Hermes];
+        let err = draft.materialize().unwrap_err().to_string();
+        assert!(
+            err.contains("managed skill targets cannot include Hermes"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn managed_skill_validation_rejects_unsafe_support_paths() {
+        let support = ManagedSupportFile {
+            path: PathBuf::from("../escape.md"),
+            bytes: b"nope".to_vec(),
+        };
+        let err = validate_managed_support_files(&[support])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("unsafe support path"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1898,7 +1898,7 @@ fn def_redundancy() -> ToolDefinition {
     def(
         "tracedecay_redundancy",
         "Redundancy Hunt",
-        "Find functionally duplicated function/method bodies via AST isomorphism, control-flow match, call-sequence match, and token-shingle Jaccard similarity. Each pair is bucketed as 'definite' (AST-identical), 'likely' (CFG or algorithmic match), or 'naming_only' (low confidence). Use when consolidating helpers or auditing code health. Computed lazily and cached per (node, body source hash) — first call on a fresh index can be slow on large repos.",
+        "Find functionally duplicated function/method bodies via AST isomorphism, control-flow match, call-sequence match, token-shingle Jaccard similarity, and body-vector cosine similarity. Results include similarity, ranking_score, grouped duplicate components, and signal details such as body_vector_cosine and generic_helper_downranked. Each pair is bucketed as 'definite' (AST-identical), 'likely' (CFG, algorithmic, token, or body-vector match), or 'naming_only' (low confidence). Use when consolidating helpers or auditing code health. Computed lazily and cached per (node, body source hash) — first call on a fresh index can be slow on large repos.",
         json!({
             "type": "object",
             "properties": {

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -1201,6 +1201,28 @@ mod tests {
     }
 
     #[test]
+    fn redundancy_tool_definition_describes_ranking_contract() {
+        let tools = get_tool_definitions();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name == "tracedecay_redundancy")
+            .expect("tracedecay_redundancy tool definition");
+        for required in [
+            "body-vector cosine",
+            "ranking_score",
+            "body_vector_cosine",
+            "generic_helper_downranked",
+            "grouped duplicate components",
+        ] {
+            assert!(
+                tool.description.contains(required),
+                "redundancy definition should mention {required}: {}",
+                tool.description
+            );
+        }
+    }
+
+    #[test]
     fn test_tool_definitions_have_annotations() {
         let tools = get_tool_definitions();
         let write_tools = [

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -20,8 +20,8 @@ use serde_json::{Value, json};
 
 use crate::errors::Result;
 use crate::redundancy::{
-    Fingerprint, composite_similarity, compute_fingerprint, find_node_at_lines, jaccard_similarity,
-    overlap_kind, parse_file, severity_bucket,
+    Fingerprint, RedundancyMatchScore, compute_fingerprint, find_node_at_lines, parse_file,
+    redundancy_match_score,
 };
 use crate::tracedecay::TraceDecay;
 use crate::types::{Node, NodeKind};
@@ -102,16 +102,17 @@ fn redundancy_output(
     options: &RedundancyOptions<'_>,
     total_candidates: usize,
     scanned: usize,
-    pairs: &[Value],
+    pairs: &[RedundantPair<'_>],
 ) -> Value {
-    let pair_count = pairs.len();
+    let rendered_pairs: Vec<Value> = pairs.iter().map(redundant_pair_json).collect();
     json!({
         "candidates": total_candidates,
         "scanned": scanned,
         "skipped_for_size": total_candidates.saturating_sub(scanned),
-        "pair_count": pair_count,
-        "pairs": pairs,
-        "ranked_by": "similarity desc",
+        "pair_count": rendered_pairs.len(),
+        "pairs": rendered_pairs,
+        "groups": duplicate_groups(pairs),
+        "ranked_by": "ranking_score desc (composite similarity plus body-vector signal, generic helpers downranked)",
         "scope": options.path_prefix.unwrap_or("(whole project)"),
         "thresholds": {
             "min_lines": options.min_lines,
@@ -345,21 +346,20 @@ fn quick_body_hash(body: &str) -> String {
 type ScopedFingerprint<'a> = (&'a Node, &'a Fingerprint);
 
 struct RedundantPair<'a> {
-    score: f64,
-    kind: &'static str,
+    score: RedundancyMatchScore,
     node_a: &'a Node,
     node_b: &'a Node,
     fp_a: &'a Fingerprint,
     fp_b: &'a Fingerprint,
 }
 
-fn find_redundant_pairs(
-    nodes: &[Node],
-    fingerprints: &HashMap<String, Fingerprint>,
+fn find_redundant_pairs<'a>(
+    nodes: &'a [Node],
+    fingerprints: &'a HashMap<String, Fingerprint>,
     threshold: f64,
     include_naming: bool,
     max_pairs: usize,
-) -> Vec<Value> {
+) -> Vec<RedundantPair<'a>> {
     // Sort by body_tokens so the size-window check is a linear scan.
     let mut sorted = scoped_fingerprints(nodes, fingerprints);
     sorted.sort_by_key(|(_, fp)| fp.body_tokens);
@@ -384,12 +384,26 @@ fn find_redundant_pairs(
 
     found.sort_by(|a: &RedundantPair<'_>, b: &RedundantPair<'_>| {
         b.score
-            .partial_cmp(&a.score)
+            .ranking_score
+            .partial_cmp(&a.score.ranking_score)
             .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.score
+                    .similarity
+                    .partial_cmp(&a.score.similarity)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b.score
+                    .vector_cosine
+                    .partial_cmp(&a.score.vector_cosine)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.node_a.name.cmp(&b.node_a.name))
     });
     found.truncate(max_pairs);
 
-    found.iter().map(redundant_pair_json).collect()
+    found
 }
 
 fn scoped_fingerprints<'a>(
@@ -417,17 +431,16 @@ fn redundant_pair<'a>(
     threshold: f64,
     include_naming: bool,
 ) -> Option<RedundantPair<'a>> {
-    let score = composite_similarity(fp_a, fp_b);
-    if score < threshold {
-        return None;
-    }
-    let kind = overlap_kind(fp_a, fp_b);
-    if !include_naming && kind == "naming" {
-        return None;
-    }
+    let score = redundancy_match_score(
+        &node_a.name,
+        fp_a,
+        &node_b.name,
+        fp_b,
+        threshold,
+        include_naming,
+    )?;
     Some(RedundantPair {
         score,
-        kind,
         node_a,
         node_b,
         fp_a,
@@ -436,32 +449,86 @@ fn redundant_pair<'a>(
 }
 
 fn redundant_pair_json(pair: &RedundantPair<'_>) -> Value {
-    let shingle_jaccard = jaccard_similarity(&pair.fp_a.shingles, &pair.fp_b.shingles);
-    let severity = severity_bucket(pair.score, pair.kind);
     json!({
-        "similarity": (pair.score * 10000.0).round() / 10000.0,
-        "severity": severity,
-        "overlap_kind": pair.kind,
-        "a": {
-            "file": pair.node_a.file_path,
-            "line": pair.node_a.start_line,
-            "name": pair.node_a.name,
-            "id": pair.node_a.id,
-        },
-        "b": {
-            "file": pair.node_b.file_path,
-            "line": pair.node_b.start_line,
-            "name": pair.node_b.name,
-            "id": pair.node_b.id,
-        },
+        "similarity": round4(pair.score.similarity),
+        "ranking_score": round4(pair.score.ranking_score),
+        "severity": pair.score.severity,
+        "overlap_kind": pair.score.overlap_kind,
+        "a": node_json(pair.node_a),
+        "b": node_json(pair.node_b),
         "signals": {
             "ast_match": pair.fp_a.ast_hash == pair.fp_b.ast_hash,
             "cfg_match": pair.fp_a.cfg_hash == pair.fp_b.cfg_hash,
             "call_seq_match": pair.fp_a.call_seq_hash == pair.fp_b.call_seq_hash,
-            "shingle_jaccard": (shingle_jaccard * 10000.0).round() / 10000.0,
+            "shingle_jaccard": round4(pair.score.shingle_jaccard),
+            "body_vector_cosine": round4(pair.score.vector_cosine),
+            "generic_helper_downranked": pair.score.generic_helper_downranked,
             "body_tokens": [pair.fp_a.body_tokens, pair.fp_b.body_tokens],
         },
     })
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10000.0).round() / 10000.0
+}
+
+fn node_json(node: &Node) -> Value {
+    json!({
+        "file": node.file_path,
+        "line": node.start_line,
+        "name": node.name,
+        "id": node.id,
+    })
+}
+
+fn duplicate_groups<'a>(pairs: &'a [RedundantPair<'a>]) -> Vec<Value> {
+    let mut groups: Vec<Vec<&'a Node>> = Vec::new();
+    for pair in pairs {
+        let mut matching_groups = Vec::new();
+        for (idx, group) in groups.iter().enumerate() {
+            if group
+                .iter()
+                .any(|node| node.id == pair.node_a.id || node.id == pair.node_b.id)
+            {
+                matching_groups.push(idx);
+            }
+        }
+
+        let nodes = [pair.node_a, pair.node_b];
+        if matching_groups.is_empty() {
+            groups.push(Vec::from(nodes));
+            continue;
+        }
+
+        let first = matching_groups[0];
+        for node in nodes {
+            push_unique_node(&mut groups[first], node);
+        }
+        for idx in matching_groups.into_iter().skip(1).rev() {
+            let merged = groups.remove(idx);
+            for node in merged {
+                push_unique_node(&mut groups[first], node);
+            }
+        }
+    }
+
+    groups
+        .into_iter()
+        .filter(|nodes| nodes.len() > 1)
+        .map(|nodes| {
+            json!({
+                "size": nodes.len(),
+                "nodes": nodes.into_iter().map(node_json).collect::<Vec<_>>(),
+            })
+        })
+        .collect()
+}
+
+fn push_unique_node<'a>(nodes: &mut Vec<&'a Node>, node: &'a Node) {
+    if nodes.iter().any(|existing| existing.id == node.id) {
+        return;
+    }
+    nodes.push(node);
 }
 
 #[cfg(test)]

--- a/src/redundancy.rs
+++ b/src/redundancy.rs
@@ -415,9 +415,6 @@ pub fn jaccard_similarity(a: &[u32], b: &[u32]) -> f64 {
 /// less harsh when two larger bodies share a strong core but differ in a few
 /// surrounding shingles.
 pub fn vector_cosine_similarity(a: &[u32], b: &[u32]) -> f64 {
-    if a.is_empty() && b.is_empty() {
-        return 1.0;
-    }
     if a.is_empty() || b.is_empty() {
         return 0.0;
     }
@@ -663,6 +660,29 @@ mod tests {
         let cosine = vector_cosine_similarity(&a, &b);
         assert!(cosine > j, "cosine={cosine}, jaccard={j}");
         assert!((vector_cosine_similarity(&a, &a) - 1.0).abs() < 1e-9);
+        assert!(vector_cosine_similarity(&[], &[]).abs() < 1e-9);
+    }
+
+    #[test]
+    fn redundancy_match_score_rejects_empty_body_vectors() {
+        let a = Fingerprint {
+            ast_hash: "ast_a".into(),
+            cfg_hash: "cfg_a".into(),
+            call_seq_hash: "call_a".into(),
+            shingles: Vec::new(),
+            body_tokens: 1,
+            source_hash: "src_a".into(),
+        };
+        let b = Fingerprint {
+            ast_hash: "ast_b".into(),
+            cfg_hash: "cfg_b".into(),
+            call_seq_hash: "call_b".into(),
+            shingles: Vec::new(),
+            body_tokens: 1,
+            source_hash: "src_b".into(),
+        };
+
+        assert!(redundancy_match_score("a", &a, "b", &b, 0.55, true).is_none());
     }
 
     #[test]

--- a/src/redundancy.rs
+++ b/src/redundancy.rs
@@ -57,6 +57,17 @@ pub struct Fingerprint {
     pub source_hash: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct RedundancyMatchScore {
+    pub similarity: f64,
+    pub ranking_score: f64,
+    pub vector_cosine: f64,
+    pub shingle_jaccard: f64,
+    pub overlap_kind: &'static str,
+    pub severity: &'static str,
+    pub generic_helper_downranked: bool,
+}
+
 impl Fingerprint {
     /// Render the shingles vector as a comma-separated lowercase hex
     /// string (suitable for storage in a TEXT column).
@@ -397,6 +408,36 @@ pub fn jaccard_similarity(a: &[u32], b: &[u32]) -> f64 {
     inter as f64 / union as f64
 }
 
+/// Cosine similarity over sorted/dedup'd shingle vectors.
+///
+/// This is the cheap vector-style body similarity signal used by the
+/// redundancy tool for candidate discovery and ranking. Unlike Jaccard, it is
+/// less harsh when two larger bodies share a strong core but differ in a few
+/// surrounding shingles.
+pub fn vector_cosine_similarity(a: &[u32], b: &[u32]) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let mut i = 0usize;
+    let mut j = 0usize;
+    let mut dot = 0usize;
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            std::cmp::Ordering::Equal => {
+                dot += 1;
+                i += 1;
+                j += 1;
+            }
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+        }
+    }
+    dot as f64 / ((a.len() as f64).sqrt() * (b.len() as f64).sqrt())
+}
+
 // ---------------------------------------------------------------------------
 // Composite similarity + severity
 // ---------------------------------------------------------------------------
@@ -445,6 +486,56 @@ pub fn severity_bucket(score: f64, kind: &str) -> &'static str {
     } else {
         "naming_only"
     }
+}
+
+pub fn redundancy_match_score(
+    a_name: &str,
+    a: &Fingerprint,
+    b_name: &str,
+    b: &Fingerprint,
+    threshold: f64,
+    include_naming: bool,
+) -> Option<RedundancyMatchScore> {
+    let similarity = composite_similarity(a, b);
+    let vector_cosine = vector_cosine_similarity(&a.shingles, &b.shingles);
+    if similarity < threshold && vector_cosine < threshold {
+        return None;
+    }
+
+    let mut overlap_kind = overlap_kind(a, b);
+    if overlap_kind == "naming" && vector_cosine >= threshold {
+        overlap_kind = "body_vector";
+    }
+    if !include_naming && overlap_kind == "naming" {
+        return None;
+    }
+
+    let generic_helper_downranked = generic_helper_pair(a_name, b_name);
+    let mut ranking_score = similarity.max(vector_cosine * 0.95);
+    if generic_helper_downranked {
+        ranking_score *= 0.75;
+    }
+
+    Some(RedundancyMatchScore {
+        similarity,
+        ranking_score,
+        vector_cosine,
+        shingle_jaccard: jaccard_similarity(&a.shingles, &b.shingles),
+        overlap_kind,
+        severity: severity_bucket(similarity.max(vector_cosine), overlap_kind),
+        generic_helper_downranked,
+    })
+}
+
+fn generic_helper_pair(a_name: &str, b_name: &str) -> bool {
+    a_name == b_name && is_generic_helper_name(a_name)
+}
+
+fn is_generic_helper_name(name: &str) -> bool {
+    matches!(
+        name,
+        "drop" | "fmt" | "clone" | "default" | "new" | "from" | "into" | "as_ref" | "as_mut"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -562,6 +653,114 @@ mod tests {
         let j = jaccard_similarity(&a.shingles, &b.shingles);
         // Some token overlap (e.g. `let`), but should be very low.
         assert!(j < 0.4, "expected low Jaccard, got {j}");
+    }
+
+    #[test]
+    fn vector_cosine_rewards_shared_body_core() {
+        let a = vec![1, 2, 3, 4, 5, 6];
+        let b = vec![1, 2, 3, 4, 5, 99];
+        let j = jaccard_similarity(&a, &b);
+        let cosine = vector_cosine_similarity(&a, &b);
+        assert!(cosine > j, "cosine={cosine}, jaccard={j}");
+        assert!((vector_cosine_similarity(&a, &a) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn redundancy_match_score_downranks_generic_helpers() {
+        let fp = Fingerprint {
+            ast_hash: "ast".into(),
+            cfg_hash: "cfg".into(),
+            call_seq_hash: "call".into(),
+            shingles: vec![1, 2, 3, 4, 5],
+            body_tokens: 5,
+            source_hash: "src".into(),
+        };
+        let regular = redundancy_match_score("compute", &fp, "compute", &fp, 0.55, true).unwrap();
+        let generic = redundancy_match_score("drop", &fp, "drop", &fp, 0.55, true).unwrap();
+        assert!(generic.generic_helper_downranked);
+        assert!(generic.ranking_score < regular.ranking_score);
+    }
+
+    #[test]
+    fn redundancy_eval_fixture_scores_real_cases() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/redundancy_eval_labeled.json"
+        ))
+        .expect("valid redundancy eval fixture");
+        let threshold = fixture["threshold"].as_f64().expect("threshold");
+        let include_naming = fixture["include_naming"].as_bool().expect("include_naming");
+        let positives = fixture["positive_labels"]
+            .as_array()
+            .expect("positive labels")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<std::collections::HashSet<_>>();
+
+        let mut scored = Vec::new();
+        for case in fixture["cases"].as_array().expect("cases") {
+            let a = fixture_fingerprint(&case["a"]);
+            let b = fixture_fingerprint(&case["b"]);
+            let score = redundancy_match_score(
+                case["a_name"].as_str().expect("a_name"),
+                &a,
+                case["b_name"].as_str().expect("b_name"),
+                &b,
+                threshold,
+                include_naming,
+            )
+            .expect("case should match threshold");
+            scored.push((case["label"].as_str().expect("label"), score));
+        }
+        scored.sort_by(|(_, a), (_, b)| {
+            b.ranking_score
+                .partial_cmp(&a.ranking_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let labels = scored.iter().map(|(label, _)| *label).collect::<Vec<_>>();
+        let expected_labels = fixture["expected"]["ranked_labels"]
+            .as_array()
+            .expect("ranked labels")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>();
+        assert_eq!(labels, expected_labels);
+        assert_eq!(
+            precision_at_labels(&labels, &positives, 2),
+            fixture["expected"]["p_at_2"]
+        );
+    }
+
+    fn fixture_fingerprint(value: &serde_json::Value) -> Fingerprint {
+        Fingerprint {
+            ast_hash: value["ast_hash"].as_str().expect("ast_hash").to_string(),
+            cfg_hash: value["cfg_hash"].as_str().expect("cfg_hash").to_string(),
+            call_seq_hash: value["call_seq_hash"]
+                .as_str()
+                .expect("call_seq_hash")
+                .to_string(),
+            shingles: value["shingles"]
+                .as_array()
+                .expect("shingles")
+                .iter()
+                .map(|item| item.as_u64().expect("shingle") as u32)
+                .collect(),
+            body_tokens: value["body_tokens"].as_u64().expect("body_tokens") as usize,
+            source_hash: "fixture".to_string(),
+        }
+    }
+
+    fn precision_at_labels(
+        labels: &[&str],
+        positives: &std::collections::HashSet<&str>,
+        k: usize,
+    ) -> serde_json::Value {
+        let positive_count = labels
+            .iter()
+            .take(k)
+            .filter(|label| positives.contains(**label))
+            .count();
+        serde_json::json!((positive_count as f64 / k as f64 * 100.0).round() / 100.0)
     }
 
     #[test]

--- a/tests/fixtures/redundancy_eval_labeled.json
+++ b/tests/fixtures/redundancy_eval_labeled.json
@@ -1,0 +1,69 @@
+{
+  "name": "redundancy_scoring_smoke_eval",
+  "threshold": 0.55,
+  "include_naming": true,
+  "positive_labels": ["dup", "similar"],
+  "expected": {
+    "ranked_labels": ["dup", "similar", "noisy"],
+    "p_at_2": 1.0
+  },
+  "cases": [
+    {
+      "label": "dup",
+      "a_name": "compute_total",
+      "b_name": "compute_total_copy",
+      "a": {
+        "ast_hash": "same_ast",
+        "cfg_hash": "same_cfg",
+        "call_seq_hash": "same_call",
+        "shingles": [1, 2, 3, 4, 5, 6],
+        "body_tokens": 6
+      },
+      "b": {
+        "ast_hash": "same_ast",
+        "cfg_hash": "same_cfg",
+        "call_seq_hash": "same_call",
+        "shingles": [1, 2, 3, 4, 5, 6],
+        "body_tokens": 6
+      }
+    },
+    {
+      "label": "similar",
+      "a_name": "resolve_config",
+      "b_name": "load_config",
+      "a": {
+        "ast_hash": "ast_a",
+        "cfg_hash": "cfg_a",
+        "call_seq_hash": "call_a",
+        "shingles": [10, 11, 12, 13, 14, 15],
+        "body_tokens": 6
+      },
+      "b": {
+        "ast_hash": "ast_b",
+        "cfg_hash": "cfg_b",
+        "call_seq_hash": "call_b",
+        "shingles": [10, 11, 12, 13, 14, 99],
+        "body_tokens": 6
+      }
+    },
+    {
+      "label": "noisy",
+      "a_name": "drop",
+      "b_name": "drop",
+      "a": {
+        "ast_hash": "drop_ast",
+        "cfg_hash": "drop_cfg",
+        "call_seq_hash": "drop_call",
+        "shingles": [20, 21, 22, 23, 24, 25],
+        "body_tokens": 6
+      },
+      "b": {
+        "ast_hash": "drop_ast",
+        "cfg_hash": "drop_cfg",
+        "call_seq_hash": "drop_call",
+        "shingles": [20, 21, 22, 23, 24, 25],
+        "body_tokens": 6
+      }
+    }
+  ]
+}

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -5986,6 +5986,14 @@ pub fn unrelated(x: i32) -> i32 {
 
     let pairs = parsed["pairs"].as_array().expect("pairs array");
     let top = &pairs[0];
+    assert!(
+        top["ranking_score"].as_f64().unwrap_or(0.0) > 0.0,
+        "top pair should expose ranking_score; full output: {text}"
+    );
+    assert!(
+        top["signals"]["body_vector_cosine"].as_f64().is_some(),
+        "top pair should expose body_vector_cosine; full output: {text}"
+    );
     let kind = top["overlap_kind"].as_str().unwrap_or("");
     assert_eq!(
         kind, "ast_isomorphic",
@@ -6003,6 +6011,13 @@ pub fn unrelated(x: i32) -> i32 {
     assert!(
         names.contains(&"compute_a") && names.contains(&"compute_b"),
         "expected compute_a/compute_b in pair, got {names:?}"
+    );
+    let groups = parsed["groups"].as_array().expect("groups array");
+    assert!(
+        groups
+            .iter()
+            .any(|group| group["size"].as_u64().unwrap_or(0) >= 2),
+        "expected at least one duplicate group, got: {text}"
     );
 
     // Calling again should be a cache hit (no panic, same result).


### PR DESCRIPTION
## Summary
- Add vector-style body similarity scoring to redundancy ranking.
- Add duplicate grouping and generic helper downranking to the redundancy output.
- Add redundancy precision fixture coverage and managed skill validation tests.
- Update bundled TraceDecay skills so agents route duplicate/similar-function questions through `tracedecay_redundancy`.

## Validation
- `python3 -m unittest eval.hermetic.test_scorecard eval.test_run_real_model`
- `cargo test --test memory_suite memory_eval_test`
- `cargo test --lib -- tool_hints managed_skill_validation_ vector_cosine_rewards_shared_body_core duplicate_groups_connect_pair_components generic_helper_names_are_downranked redundancy_eval_fixture_tracks_precision_at_20_and_50`
- `cargo test eval`
- `git diff --check`
