### PR TITLE
fix: lock private jsonl appends

### DIFF
--- a/plugin/skills/diagnosing-analytics/SKILL.md
+++ b/plugin/skills/diagnosing-analytics/SKILL.md
@@ -46,6 +46,8 @@ store databases directly.
 - `hook_sources` lists each hook-log file with `rows_total` vs
   `rows_included`. A large gap means rows written before project attribution
   existed; they are visible under `--all` but cannot be assigned to a project.
+  `rows_malformed` / `first_malformed_line` show JSONL corruption that the
+  reader skipped and should usually be investigated as a concurrent append bug.
 - `project_id: null` means the command ran outside an indexed project and
   reported globally. Run from an indexed project root for per-project scope,
   or pass `--all` deliberately.

--- a/src/automation/run_ledger.rs
+++ b/src/automation/run_ledger.rs
@@ -1,9 +1,10 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use tokio::io::AsyncWriteExt;
 
 use super::backend::{AgentTaskFailureClass, AgentTaskKind};
 use crate::errors::{Result, TraceDecayError};
@@ -243,39 +244,34 @@ pub async fn append_run_record(
             .await
             .map_err(|e| config_error(format!("failed to create run ledger directory: {e}")))?;
     }
-    // The record and its trailing newline must land in a single append.
-    // Concurrent runs (e.g. two dashboard automation jobs finishing at the
-    // same time) each append to this file; O_APPEND keeps one write atomic,
-    // but splitting the line across two writes let them interleave into
-    // `{recA}{recB}\n\n`, silently destroying both records at read time
-    // (load_run_records skips unparseable lines) and leaving the runs stuck
-    // at their previous status forever.
-    let mut line = serde_json::to_string(record).map_err(TraceDecayError::from)?;
-    line.push('\n');
-    let mut file = tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
+    let line = serde_json::to_string(record).map_err(TraceDecayError::from)?;
+    let write_path = path.clone();
+    tokio::task::spawn_blocking(move || append_jsonl_line_locked(&write_path, &line))
         .await
+        .map_err(|e| config_error(format!("failed to join automation run ledger write: {e}")))?
         .map_err(|e| {
             config_error(format!(
-                "failed to open automation run ledger '{}': {e}",
+                "failed to write automation run ledger '{}': {e}",
                 path.display()
             ))
         })?;
-    file.write_all(line.as_bytes()).await.map_err(|e| {
-        config_error(format!(
-            "failed to write automation run ledger '{}': {e}",
-            path.display()
-        ))
-    })?;
-    file.flush().await.map_err(|e| {
-        config_error(format!(
-            "failed to finish automation run ledger '{}': {e}",
-            path.display()
-        ))
-    })?;
     Ok(())
+}
+
+fn append_jsonl_line_locked(path: &Path, line: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    file.lock_exclusive()?;
+    let write_result = file.write_all(format!("{line}\n").as_bytes());
+    let flush_result = write_result.and_then(|()| file.flush());
+    let unlock_result = file.unlock();
+    flush_result?;
+    unlock_result
 }
 
 pub async fn load_run_records(
@@ -295,7 +291,8 @@ pub async fn load_run_records(
     };
     let mut records = Vec::new();
     let mut seen_run_ids = std::collections::BTreeSet::new();
-    for line in contents.lines().rev() {
+    let lines = contents.lines().collect::<Vec<_>>();
+    for (index, line) in lines.iter().enumerate().rev() {
         if records.len() >= limit {
             break;
         }
@@ -303,11 +300,21 @@ pub async fn load_run_records(
         if trimmed.is_empty() {
             continue;
         }
-        if let Ok(record) = serde_json::from_str::<AutomationRunLedgerRecord>(trimmed) {
-            if !seen_run_ids.insert(record.run_id.clone()) {
-                continue;
+        match serde_json::from_str::<AutomationRunLedgerRecord>(trimmed) {
+            Ok(record) => {
+                if !seen_run_ids.insert(record.run_id.clone()) {
+                    continue;
+                }
+                records.push(record);
             }
-            records.push(record);
+            Err(err) => {
+                tracing::warn!(
+                    automation_run_ledger = %path.display(),
+                    line_number = index + 1,
+                    error = %err,
+                    "skipping malformed automation run ledger jsonl row"
+                );
+            }
         }
     }
     Ok(records)

--- a/src/dashboard/analytics_api.rs
+++ b/src/dashboard/analytics_api.rs
@@ -694,9 +694,26 @@ fn read_hook_analytics_file(
     };
     let mut rows_total = 0i64;
     let mut rows_included = 0i64;
-    for line in text.lines() {
-        let Ok(row) = serde_json::from_str::<Value>(line) else {
-            continue;
+    let mut rows_malformed = 0i64;
+    let mut first_malformed_line = None;
+    let mut first_malformed_error = None;
+    for (index, line) in text.lines().enumerate() {
+        let row = match serde_json::from_str::<Value>(line) {
+            Ok(row) => row,
+            Err(err) => {
+                rows_malformed += 1;
+                if first_malformed_line.is_none() {
+                    first_malformed_line = Some(index + 1);
+                    first_malformed_error = Some(err.to_string());
+                }
+                tracing::warn!(
+                    hook_analytics_path = %path.display(),
+                    line_number = index + 1,
+                    error = %err,
+                    "skipping malformed hook analytics jsonl row"
+                );
+                continue;
+            }
         };
         rows_total += 1;
         let included = match project_filter {
@@ -712,6 +729,9 @@ fn read_hook_analytics_file(
         "path": path.display().to_string(),
         "rows_total": rows_total,
         "rows_included": rows_included,
+        "rows_malformed": rows_malformed,
+        "first_malformed_line": first_malformed_line,
+        "first_malformed_error": first_malformed_error,
     }));
 }
 
@@ -803,4 +823,43 @@ async fn underused_tool_families(conn: Option<&libsql::Connection>) -> Value {
 
 fn normalize(value: &str) -> String {
     value.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HookAnalyticsRows, read_hook_analytics_file};
+
+    #[test]
+    fn hook_analytics_sources_report_malformed_jsonl_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let store_root = dir.path().join("store");
+        std::fs::create_dir_all(&store_root).unwrap();
+        std::fs::write(
+            store_root.join("hook_analytics.jsonl"),
+            concat!(
+                "{\"event\":\"hook_invoked\",\"ts_unix_ms\":1}\n",
+                "{\"event\":\"hook_invoked\"\n",
+                "{\"event\":\"hook_completed\",\"ts_unix_ms\":2}\n",
+            ),
+        )
+        .unwrap();
+
+        let mut rows = HookAnalyticsRows {
+            rows: Vec::new(),
+            sources: Vec::new(),
+        };
+        read_hook_analytics_file(&store_root.join("hook_analytics.jsonl"), None, &mut rows);
+
+        assert_eq!(rows.rows.len(), 2);
+        assert_eq!(rows.sources.len(), 1);
+        assert_eq!(rows.sources[0]["rows_total"], 2);
+        assert_eq!(rows.sources[0]["rows_included"], 2);
+        assert_eq!(rows.sources[0]["rows_malformed"], 1);
+        assert_eq!(rows.sources[0]["first_malformed_line"], 2);
+        assert!(
+            rows.sources[0]["first_malformed_error"]
+                .as_str()
+                .is_some_and(|error| error.contains("EOF"))
+        );
+    }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Component, Path, PathBuf};
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -471,16 +472,19 @@ impl PrivateStoreIo {
         set_private_file_permissions(path)
     }
 
-    /// Appends one line via a single `O_APPEND` write so concurrent hook
-    /// processes never interleave partial lines or lose each other's entries
-    /// the way read-modify-rewrite appends do.
+    /// Appends one line while holding an advisory file lock so concurrent hook
+    /// processes never interleave partial lines.
     pub fn append_line(path: &Path, line: &str) -> io::Result<()> {
         if let Some(parent) = path.parent() {
             Self::create_dir_all(parent)?;
         }
         reject_symlink_components(path, "private store file")?;
-        Self::open_private(path, fs::OpenOptions::new().append(true))?
-            .write_all(format!("{line}\n").as_bytes())?;
+        let mut file = Self::open_private(path, fs::OpenOptions::new().append(true))?;
+        file.lock_exclusive()?;
+        let write_result = file.write_all(format!("{line}\n").as_bytes());
+        let unlock_result = file.unlock();
+        write_result?;
+        unlock_result?;
         set_private_file_permissions(path)
     }
 
@@ -747,4 +751,54 @@ fn apply_private_create_mode(_options: &mut fs::OpenOptions) {}
 #[cfg(not(unix))]
 fn set_private_file_permissions(_path: &Path) -> std::io::Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PrivateStoreIo;
+    use serde_json::Value;
+    use std::sync::{Arc, Barrier};
+
+    #[test]
+    fn append_line_keeps_concurrent_jsonl_writes_intact() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(
+            dir.path()
+                .canonicalize()
+                .unwrap()
+                .join("hook_analytics.jsonl"),
+        );
+        let writers = 8;
+        let lines_per_writer = 100;
+        let barrier = Arc::new(Barrier::new(writers));
+        let mut handles = Vec::new();
+
+        for writer in 0..writers {
+            let path = Arc::clone(&path);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for line in 0..lines_per_writer {
+                    let payload = serde_json::json!({
+                        "event": "hook_invoked",
+                        "writer": writer,
+                        "line": line,
+                        "padding": "x".repeat(4096),
+                    });
+                    PrivateStoreIo::append_line(&path, &payload.to_string()).unwrap();
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let contents = std::fs::read_to_string(&*path).unwrap();
+        let rows = contents.lines().collect::<Vec<_>>();
+        assert_eq!(rows.len(), writers * lines_per_writer);
+        for row in rows {
+            serde_json::from_str::<Value>(row).unwrap();
+        }
+    }
 }

--- a/src/tracedecay/facts.rs
+++ b/src/tracedecay/facts.rs
@@ -69,7 +69,7 @@ impl TraceDecay {
         &self,
         request: SearchFactsRequest,
     ) -> Result<Vec<FactSearchResult>> {
-        let db = self.open_project_store_db().await?;
+        let db = self.open_project_store_db_read_only().await?;
         let mut results = FactRetriever::new(db.conn())
             .search_untracked(
                 &request.query,

--- a/tests/automation_runner_test/run_ledger.rs
+++ b/tests/automation_runner_test/run_ledger.rs
@@ -1,4 +1,5 @@
 use tempfile::tempdir;
+use tokio::sync::Barrier;
 
 use tracedecay::automation::backend::AgentTaskKind;
 use tracedecay::automation::run_ledger::{
@@ -75,6 +76,46 @@ async fn run_ledger_appends_jsonl_under_dashboard_root() {
     assert_eq!(loaded[0].host_mode.as_deref(), Some("standalone"));
     assert_eq!(loaded[0].input_hash.as_deref(), Some("sha256:input"));
     assert_eq!(loaded[0].output_hash.as_deref(), Some("sha256:output"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn run_ledger_keeps_concurrent_jsonl_writes_intact() {
+    let temp = tempdir().unwrap();
+    let dashboard_root = std::sync::Arc::new(temp.path().join("dashboard"));
+    let writers = 8;
+    let lines_per_writer = 50;
+    let barrier = std::sync::Arc::new(Barrier::new(writers));
+    let mut handles = Vec::new();
+
+    for writer in 0..writers {
+        let dashboard_root = std::sync::Arc::clone(&dashboard_root);
+        let barrier = std::sync::Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for line in 0..lines_per_writer {
+                let run_id = format!("run-{writer}-{line}");
+                append_run_record(
+                    &dashboard_root,
+                    &record(&run_id, AutomationRunStatus::Succeeded),
+                )
+                .await
+                .unwrap();
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    let raw = tokio::fs::read_to_string(run_ledger_path(&dashboard_root))
+        .await
+        .unwrap();
+    let lines = raw.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), writers * lines_per_writer);
+    for line in lines {
+        serde_json::from_str::<AutomationRunLedgerRecord>(line).unwrap();
+    }
 }
 
 #[tokio::test]

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -3031,8 +3031,16 @@ async fn context_memory_matches_use_project_store_when_serving_branch_db() {
         .as_i64()
         .expect("fact_store add should return numeric id");
 
+    let read_only_cg = TestTraceDecay::new(TraceDecay::open_read_only(&project).await.unwrap());
+    assert!(read_only_cg.is_read_only());
+    assert_ne!(
+        read_only_cg.db_path(),
+        read_only_cg.store_layout().graph_db_path,
+        "test must serve a read-only branch DB distinct from the shared project store"
+    );
+
     let result = handle_tool_call(
-        &cg,
+        &read_only_cg,
         "tracedecay_context",
         json!({"task": "branch context recall project-scoped memory", "format": "json"}),
         None,
@@ -14161,7 +14169,14 @@ async fn mcp_server_owns_watcher_and_refreshes_token_map_on_change() {
     // `maybe_sync_if_stale`.
     std::fs::write(project.join("b.rs"), "fn b() {}").unwrap();
     let server_cg = server.cg().await;
-    let stale = server_cg.find_stale_files().await;
+    let mut stale = Vec::new();
+    for _ in 0..20 {
+        stale = server_cg.find_stale_files().await;
+        if !stale.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
     assert!(
         !stale.is_empty(),
         "find_stale_files should detect newly written b.rs"


### PR DESCRIPTION
## Summary
- lock shared private JSONL appends used by hook analytics
- lock automation run-ledger appends and warn when corrupt ledger rows are skipped
- make untracked context memory search use the read-only project-store opener
- report malformed hook analytics rows in diagnostics (`rows_malformed`, first line/error)
- add regressions for concurrent appends, read-only MCP memory matches, and malformed-row diagnostics

## Root cause
Live TraceDecay logs showed malformed JSONL in multiple `hook_analytics.jsonl` files and one `dashboard/automation_runs.jsonl`. Both append paths relied on append mode/write_all without an advisory lock, so split writes from concurrent processes/tasks could interleave and corrupt rows. Separately, `tracedecay_context` memory enrichment called a project-store opener that requires write access, causing read-only MCP serving to render `Memory Matches` unavailable.

## Live log scan
- `/home/zack/.tracedecay/hook_analytics.jsonl`: 1 malformed row, first line 256
- `/home/zack/.tracedecay/projects/proj_b4a8bbe4953823c4/hook_analytics.jsonl`: 0 malformed rows
- all `/home/zack/.tracedecay/**/*.jsonl`: 5 files with malformed rows, all hook analytics or automation run ledger files

## Validation
- `cargo fmt --all -- --check`
- `tracedecay_diagnostics` workspace: 0 diagnostics
- `git diff --check`
- `cargo test storage::tests::append_line_keeps_concurrent_jsonl_writes_intact`
- `cargo test context_memory_matches_use_project_store_when_serving_branch_db`
- `cargo test hook_analytics_sources_report_malformed_jsonl_rows`
- `cargo test run_ledger`
- `cargo test --lib`