### PR TITLE
feat: compact tool telemetry ingestion across Codex, Claude Code, and Cursor

### DIFF
--- a/src/dashboard/token_count.rs
+++ b/src/dashboard/token_count.rs
@@ -62,7 +62,7 @@ pub(super) const MESSAGE_TOKENS_CTE: &str = "
                CAST(json_extract(metadata_json, '$.usage.cache_creation_input_tokens') AS INTEGER)
            END AS usage_cache_write
     FROM session_messages
-    WHERE kind IS NULL OR kind <> 'summary'";
+    WHERE kind IS NULL OR kind NOT IN ('summary', 'tool_event', 'hook_event', 'reasoning')";
 
 /// Which BPE vocabulary a model id maps to, and whether the resulting count
 /// is exact (the model's real tokenizer) or a labeled approximation.
@@ -619,5 +619,45 @@ mod tests {
             first_backfill, second_backfill,
             "same-length metadata edits must invalidate overlay"
         );
+    }
+
+    #[tokio::test]
+    async fn derived_kinds_are_excluded_from_token_cte() {
+        let db = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .expect("build in-memory database");
+        let conn = db.connect().expect("connect in-memory database");
+        conn.execute_batch(
+            "CREATE TABLE session_messages (
+                provider TEXT NOT NULL,
+                message_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                timestamp INTEGER,
+                ordinal INTEGER NOT NULL,
+                text TEXT NOT NULL,
+                kind TEXT,
+                model TEXT,
+                metadata_json TEXT,
+                PRIMARY KEY(provider, message_id)
+            );
+            INSERT INTO session_messages
+                (provider, message_id, session_id, role, timestamp, ordinal, text, kind, model, metadata_json)
+            VALUES
+                ('codex', 'm1', 's1', 'assistant', 1, 1, 'kept', NULL, 'gpt-5', NULL),
+                ('codex', 'm2', 's1', 'assistant', 2, 2, 'sum', 'summary', 'gpt-5', NULL),
+                ('codex', 'm3', 's1', 'tool', 3, 3, 'te', 'tool_event', 'gpt-5', NULL),
+                ('codex', 'm4', 's1', 'tool', 4, 4, 'he', 'hook_event', 'gpt-5', NULL),
+                ('codex', 'm5', 's1', 'assistant', 5, 5, 're', 'reasoning', 'gpt-5', NULL);",
+        )
+        .await
+        .expect("seed session_messages");
+
+        let sql = format!("SELECT COUNT(*) FROM ({MESSAGE_TOKENS_CTE})");
+        let mut rows = conn.query(&sql, ()).await.expect("run token CTE count");
+        let row = rows.next().await.expect("read row").expect("one row");
+        let count: i64 = row.get(0).expect("count column");
+        assert_eq!(count, 1, "only the non-derived message must be counted");
     }
 }

--- a/src/sessions/claude.rs
+++ b/src/sessions/claude.rs
@@ -20,7 +20,8 @@ use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
     StoredCursor, TranscriptLocation, TranscriptLocationMetadataKeys, append_location_metadata,
     append_tool_calls_metadata, append_tool_event_metadata, append_usage_metadata,
-    content_storage_text_and_tools, path_belongs_to_project, title_from_messages,
+    content_storage_text_and_tools, path_belongs_to_project, preview_truncated,
+    title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, stream_new_jsonl,
@@ -338,12 +339,7 @@ fn system_hook_message_from_line(
         lines.push(format!("hook_errors: {joined}"));
     }
     let joined = lines.join("\n");
-    let prefix = crate::text::utf8_prefix_at_or_before(&joined, 2000);
-    let text = if prefix.len() == joined.len() {
-        prefix.to_string()
-    } else {
-        format!("{prefix}…")
-    };
+    let text = preview_truncated(&joined, 2000);
 
     let message_id = record
         .get("uuid")
@@ -382,7 +378,8 @@ fn system_hook_message_from_line(
         provider: PROVIDER.to_string(),
         message_id,
         session_id: session_id.to_string(),
-        role: "system".to_string(),
+        // role "tool" keeps transient hook telemetry out of LCM policy anchors, which pin role system/developer.
+        role: "tool".to_string(),
         timestamp,
         ordinal: offset,
         text,

--- a/src/sessions/claude.rs
+++ b/src/sessions/claude.rs
@@ -19,8 +19,8 @@ use crate::accounting::parser::parse_timestamp;
 use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
     StoredCursor, TranscriptLocation, TranscriptLocationMetadataKeys, append_location_metadata,
-    append_tool_calls_metadata, append_usage_metadata, content_storage_text_and_tools,
-    path_belongs_to_project, title_from_messages,
+    append_tool_calls_metadata, append_tool_event_metadata, append_usage_metadata,
+    content_storage_text_and_tools, path_belongs_to_project, title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, stream_new_jsonl,
@@ -122,7 +122,16 @@ impl TranscriptSource for ClaudeSource {
                 path,
                 line.offset,
                 session_cwd.as_deref(),
-            ) {
+            )
+            .or_else(|| {
+                system_hook_message_from_line(
+                    &line.value,
+                    &session_id,
+                    path,
+                    line.offset,
+                    session_cwd.as_deref(),
+                )
+            }) {
                 messages.push(message);
             }
         }
@@ -261,8 +270,128 @@ fn message_from_line(
         tool_names: (!tool_names.is_empty()).then(|| tool_names.join(",")),
         source_path: Some(path.to_string_lossy().to_string()),
         source_offset: Some(offset),
-        metadata_json: serde_json::to_string(&message_metadata(kind, record, message, session_cwd))
-            .ok(),
+        metadata_json: serde_json::to_string(&message_metadata(
+            kind,
+            record,
+            message,
+            content,
+            session_cwd,
+        ))
+        .ok(),
+    })
+}
+
+/// Map a `type=="system"` hook-summary record to a compact, signal-only
+/// `hook_event` row, or `None` for non-system records and routine hook
+/// summaries that carry no error/interruption signal.
+fn system_hook_message_from_line(
+    record: &Value,
+    session_id: &str,
+    path: &Path,
+    offset: i64,
+    _session_cwd: Option<&Path>,
+) -> Option<SessionMessageRecord> {
+    if record.get("type").and_then(Value::as_str) != Some("system") {
+        return None;
+    }
+
+    let hook_errors: Vec<&Value> = record
+        .get("hookErrors")
+        .and_then(Value::as_array)
+        .map(|errors| errors.iter().collect())
+        .unwrap_or_default();
+    let stop_reason = record
+        .get("stopReason")
+        .and_then(Value::as_str)
+        .filter(|reason| !reason.is_empty());
+    let prevented_continuation = record
+        .get("preventedContinuation")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if hook_errors.is_empty() && stop_reason.is_none() && !prevented_continuation {
+        return None;
+    }
+
+    let subtype = record.get("subtype").and_then(Value::as_str).unwrap_or("");
+    let tool_use_id = record.get("toolUseID").and_then(Value::as_str);
+
+    let mut lines = vec![format!("Claude hook event: {subtype}")];
+    if let Some(tool_use_id) = tool_use_id {
+        lines.push(format!("tool_use_id: {tool_use_id}"));
+    }
+    if let Some(stop_reason) = stop_reason {
+        lines.push(format!("stop_reason: {stop_reason}"));
+    }
+    if prevented_continuation {
+        lines.push("prevented_continuation: true".to_string());
+    }
+    if !hook_errors.is_empty() {
+        let joined = hook_errors
+            .iter()
+            .map(|error| {
+                error
+                    .as_str()
+                    .map_or_else(|| error.to_string(), str::to_string)
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        lines.push(format!("hook_errors: {joined}"));
+    }
+    let joined = lines.join("\n");
+    let prefix = crate::text::utf8_prefix_at_or_before(&joined, 2000);
+    let text = if prefix.len() == joined.len() {
+        prefix.to_string()
+    } else {
+        format!("{prefix}…")
+    };
+
+    let message_id = record
+        .get("uuid")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map_or_else(|| format!("{session_id}:{offset}"), ToString::to_string);
+    let timestamp = record
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp)
+        .map(|secs| secs as i64);
+
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        "source".to_string(),
+        Value::String("claude_system_record".to_string()),
+    );
+    metadata.insert("subtype".to_string(), Value::String(subtype.to_string()));
+    if let Some(tool_use_id) = tool_use_id {
+        metadata.insert(
+            "tool_use_id".to_string(),
+            Value::String(tool_use_id.to_string()),
+        );
+    }
+    if let Some(hook_count) = record.get("hookCount") {
+        metadata.insert("hook_count".to_string(), hook_count.clone());
+    }
+    if let Some(level) = record.get("level").and_then(Value::as_str) {
+        metadata.insert("level".to_string(), Value::String(level.to_string()));
+    }
+    if prevented_continuation {
+        metadata.insert("prevented_continuation".to_string(), Value::Bool(true));
+    }
+
+    Some(SessionMessageRecord {
+        provider: PROVIDER.to_string(),
+        message_id,
+        session_id: session_id.to_string(),
+        role: "system".to_string(),
+        timestamp,
+        ordinal: offset,
+        text,
+        kind: Some("hook_event".to_string()),
+        model: None,
+        tool_names: None,
+        source_path: Some(path.to_string_lossy().to_string()),
+        source_offset: Some(offset),
+        metadata_json: serde_json::to_string(&Value::Object(metadata)).ok(),
     })
 }
 
@@ -284,6 +413,7 @@ fn message_metadata(
     kind: &str,
     record: &Value,
     message: &Value,
+    content: &Value,
     session_cwd: Option<&Path>,
 ) -> Value {
     let mut metadata = serde_json::Map::new();
@@ -304,6 +434,7 @@ fn message_metadata(
         TranscriptLocation::new(location_cwd, location_provenance),
     );
     append_tool_calls_metadata(&mut metadata, message);
+    append_tool_event_metadata(&mut metadata, content);
     // Anthropic-style per-message counters: `message.usage.{input_tokens,
     // output_tokens, cache_creation_input_tokens, cache_read_input_tokens}`.
     append_usage_metadata(&mut metadata, &[message]);

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -47,21 +47,20 @@ use crate::accounting::parser::parse_timestamp;
 use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
     StoredCursor, append_tool_calls_metadata, content_storage_text_and_tools,
-    path_belongs_to_project, title_from_messages,
+    path_belongs_to_project, preview_truncated, title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, stream_new_jsonl,
 };
-use crate::text::utf8_prefix_at_or_before;
 use context::CodexContextState;
 
 const PROVIDER: &str = "codex";
 /// `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` → date dirs add depth.
 const MAX_SCAN_DEPTH: u8 = 6;
 /// Response-item tool call/output/reasoning previews are truncated to this
-/// many chars so large tool outputs are searchable without duplicating the
+/// many bytes so large tool outputs are searchable without duplicating the
 /// full body (Codex already stores that in the rollout itself).
-const TOOL_EVENT_PREVIEW_CHARS: usize = 2000;
+const TOOL_EVENT_PREVIEW_BYTES: usize = 2000;
 
 /// Session metadata read from a rollout's leading `session_meta` line.
 struct CodexMeta {
@@ -483,6 +482,8 @@ fn response_item_tool_event_from_line(
     }
     let payload = record.get("payload")?;
     let response_item_type = payload.get("type").and_then(Value::as_str)?;
+    // Serialize the output payload once and share it with both helpers below.
+    let output = payload.get("output").map(compact_response_item_value);
     let (role, text, metadata) = match response_item_type {
         "function_call" | "custom_tool_call" | "tool_search_call" | "web_search_call" => {
             let tool_name = response_item_tool_name(payload, response_item_type);
@@ -491,15 +492,20 @@ fn response_item_tool_event_from_line(
             (
                 "tool",
                 text,
-                response_item_tool_metadata(response_item_type, payload, tool_name),
+                response_item_tool_metadata(
+                    response_item_type,
+                    payload,
+                    tool_name,
+                    output.as_deref(),
+                ),
             )
         }
         "function_call_output" | "custom_tool_call_output" => {
-            let text = response_item_tool_output_text(payload)?;
+            let text = response_item_tool_output_text(payload, output.as_deref())?;
             (
                 "tool",
                 text,
-                response_item_tool_metadata(response_item_type, payload, None),
+                response_item_tool_metadata(response_item_type, payload, None, output.as_deref()),
             )
         }
         "reasoning" => {
@@ -507,7 +513,7 @@ fn response_item_tool_event_from_line(
             (
                 "assistant",
                 text,
-                response_item_tool_metadata(response_item_type, payload, None),
+                response_item_tool_metadata(response_item_type, payload, None, output.as_deref()),
             )
         }
         _ => return None,
@@ -564,21 +570,25 @@ fn response_item_tool_call_text(
     if let Some(arguments) = payload
         .get("arguments")
         .or_else(|| payload.get("input"))
+        .or_else(|| payload.get("action"))
         .map(compact_response_item_value)
     {
-        parts.push(format!("arguments: {}", preview_text(&arguments)));
+        parts.push(format!(
+            "arguments: {}",
+            preview_truncated(&arguments, TOOL_EVENT_PREVIEW_BYTES)
+        ));
     }
     parts.join("\n")
 }
 
-fn response_item_tool_output_text(payload: &Value) -> Option<String> {
+fn response_item_tool_output_text(payload: &Value, output: Option<&str>) -> Option<String> {
     let call_id = payload
         .get("call_id")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
-    let output = payload.get("output").map(compact_response_item_value)?;
+    let output = output?;
     let output_bytes = output.len();
-    let preview = preview_text(&output);
+    let preview = preview_truncated(output, TOOL_EVENT_PREVIEW_BYTES);
     Some(format!(
         "Codex tool output: {call_id}\noutput_bytes: {output_bytes}\npreview: {preview}"
     ))
@@ -597,19 +607,11 @@ fn compact_response_item_value(value: &Value) -> String {
         .unwrap_or_else(|| serde_json::to_string(value).unwrap_or_else(|_| value.to_string()))
 }
 
-fn preview_text(text: &str) -> String {
-    let prefix = utf8_prefix_at_or_before(text, TOOL_EVENT_PREVIEW_CHARS);
-    if prefix.len() == text.len() {
-        prefix.to_string()
-    } else {
-        format!("{prefix}…")
-    }
-}
-
 fn response_item_tool_metadata(
     response_item_type: &str,
     payload: &Value,
     tool_name: Option<String>,
+    output: Option<&str>,
 ) -> Value {
     let mut metadata = serde_json::Map::new();
     metadata.insert(
@@ -628,11 +630,11 @@ fn response_item_tool_metadata(
     if let Some(tool_name) = tool_name {
         metadata.insert("tool_name".to_string(), Value::String(tool_name));
     }
-    if let Some(output) = payload.get("output").map(compact_response_item_value) {
+    if let Some(output) = output {
         metadata.insert("output_bytes".to_string(), Value::from(output.len() as i64));
         metadata.insert(
             "output_truncated".to_string(),
-            Value::Bool(output.len() > TOOL_EVENT_PREVIEW_CHARS),
+            Value::Bool(output.len() > TOOL_EVENT_PREVIEW_BYTES),
         );
     }
     Value::Object(metadata)

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -52,11 +52,16 @@ use crate::sessions::shared::{
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, stream_new_jsonl,
 };
+use crate::text::utf8_prefix_at_or_before;
 use context::CodexContextState;
 
 const PROVIDER: &str = "codex";
 /// `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` → date dirs add depth.
 const MAX_SCAN_DEPTH: u8 = 6;
+/// Response-item tool call/output/reasoning previews are truncated to this
+/// many chars so large tool outputs are searchable without duplicating the
+/// full body (Codex already stores that in the rollout itself).
+const TOOL_EVENT_PREVIEW_CHARS: usize = 2000;
 
 /// Session metadata read from a rollout's leading `session_meta` line.
 struct CodexMeta {
@@ -145,6 +150,21 @@ impl TranscriptSource for CodexSource {
                 continue;
             }
             if let Some(mut message) = response_item_goal_context_from_line(
+                &line.value,
+                &meta,
+                context_state.model.as_deref(),
+                path,
+                line.offset,
+            ) {
+                context::annotate_message(
+                    &mut message,
+                    context_state.cwd.as_deref(),
+                    context_state.git.as_ref(),
+                );
+                messages.push(message);
+                continue;
+            }
+            if let Some(mut message) = response_item_tool_event_from_line(
                 &line.value,
                 &meta,
                 context_state.model.as_deref(),
@@ -449,6 +469,173 @@ fn response_item_goal_context_from_line(
         &goal_context,
         &metadata,
     ))
+}
+
+fn response_item_tool_event_from_line(
+    record: &Value,
+    meta: &CodexMeta,
+    model: Option<&str>,
+    path: &Path,
+    offset: i64,
+) -> Option<SessionMessageRecord> {
+    if record.get("type").and_then(Value::as_str) != Some("response_item") {
+        return None;
+    }
+    let payload = record.get("payload")?;
+    let response_item_type = payload.get("type").and_then(Value::as_str)?;
+    let (role, text, metadata) = match response_item_type {
+        "function_call" | "custom_tool_call" | "tool_search_call" | "web_search_call" => {
+            let tool_name = response_item_tool_name(payload, response_item_type);
+            let text =
+                response_item_tool_call_text(response_item_type, tool_name.as_deref(), payload);
+            (
+                "tool",
+                text,
+                response_item_tool_metadata(response_item_type, payload, tool_name),
+            )
+        }
+        "function_call_output" | "custom_tool_call_output" => {
+            let text = response_item_tool_output_text(payload)?;
+            (
+                "tool",
+                text,
+                response_item_tool_metadata(response_item_type, payload, None),
+            )
+        }
+        "reasoning" => {
+            let text = response_item_reasoning_summary_text(payload)?;
+            (
+                "assistant",
+                text,
+                response_item_tool_metadata(response_item_type, payload, None),
+            )
+        }
+        _ => return None,
+    };
+    if text.trim().is_empty() {
+        return None;
+    }
+    Some(SessionMessageRecord {
+        provider: PROVIDER.to_string(),
+        message_id: format!("{}:{offset}", meta.session_id),
+        session_id: meta.session_id.clone(),
+        role: role.to_string(),
+        timestamp: timestamp_from_record(record),
+        ordinal: offset,
+        text,
+        kind: Some(if response_item_type == "reasoning" {
+            "reasoning".to_string()
+        } else {
+            "tool_event".to_string()
+        }),
+        model: model.map(str::to_string),
+        tool_names: response_item_tool_name(payload, response_item_type),
+        source_path: Some(path.to_string_lossy().to_string()),
+        source_offset: Some(offset),
+        metadata_json: serde_json::to_string(&metadata).ok(),
+    })
+}
+
+fn response_item_tool_name(payload: &Value, response_item_type: &str) -> Option<String> {
+    payload
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| match response_item_type {
+            "tool_search_call" => Some("tool_search".to_string()),
+            "web_search_call" => Some("web_search".to_string()),
+            _ => None,
+        })
+}
+
+fn response_item_tool_call_text(
+    response_item_type: &str,
+    tool_name: Option<&str>,
+    payload: &Value,
+) -> String {
+    let label = tool_name.unwrap_or(response_item_type);
+    let mut parts = vec![format!("Codex tool call: {label}")];
+    if let Some(namespace) = payload.get("namespace").and_then(Value::as_str) {
+        parts.push(format!("namespace: {namespace}"));
+    }
+    if let Some(call_id) = payload.get("call_id").and_then(Value::as_str) {
+        parts.push(format!("call_id: {call_id}"));
+    }
+    if let Some(arguments) = payload
+        .get("arguments")
+        .or_else(|| payload.get("input"))
+        .map(compact_response_item_value)
+    {
+        parts.push(format!("arguments: {}", preview_text(&arguments)));
+    }
+    parts.join("\n")
+}
+
+fn response_item_tool_output_text(payload: &Value) -> Option<String> {
+    let call_id = payload
+        .get("call_id")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let output = payload.get("output").map(compact_response_item_value)?;
+    let output_bytes = output.len();
+    let preview = preview_text(&output);
+    Some(format!(
+        "Codex tool output: {call_id}\noutput_bytes: {output_bytes}\npreview: {preview}"
+    ))
+}
+
+fn response_item_reasoning_summary_text(payload: &Value) -> Option<String> {
+    let summary = payload.get("summary")?;
+    let text = collect_response_item_text(summary);
+    (!text.trim().is_empty()).then(|| format!("Codex reasoning summary:\n{text}"))
+}
+
+fn compact_response_item_value(value: &Value) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| serde_json::to_string(value).unwrap_or_else(|_| value.to_string()))
+}
+
+fn preview_text(text: &str) -> String {
+    let prefix = utf8_prefix_at_or_before(text, TOOL_EVENT_PREVIEW_CHARS);
+    if prefix.len() == text.len() {
+        prefix.to_string()
+    } else {
+        format!("{prefix}…")
+    }
+}
+
+fn response_item_tool_metadata(
+    response_item_type: &str,
+    payload: &Value,
+    tool_name: Option<String>,
+) -> Value {
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        "source".to_string(),
+        Value::String("codex_response_item".to_string()),
+    );
+    metadata.insert(
+        "response_item_type".to_string(),
+        Value::String(response_item_type.to_string()),
+    );
+    for key in ["call_id", "id", "status", "namespace"] {
+        if let Some(value) = payload.get(key) {
+            metadata.insert(key.to_string(), value.clone());
+        }
+    }
+    if let Some(tool_name) = tool_name {
+        metadata.insert("tool_name".to_string(), Value::String(tool_name));
+    }
+    if let Some(output) = payload.get("output").map(compact_response_item_value) {
+        metadata.insert("output_bytes".to_string(), Value::from(output.len() as i64));
+        metadata.insert(
+            "output_truncated".to_string(),
+            Value::Bool(output.len() > TOOL_EVENT_PREVIEW_CHARS),
+        );
+    }
+    Value::Object(metadata)
 }
 
 fn goal_context_message(

--- a/src/sessions/cursor.rs
+++ b/src/sessions/cursor.rs
@@ -6,8 +6,8 @@ use crate::global_db::GlobalDb;
 use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
     StoredCursor, TranscriptLocation, TranscriptLocationMetadataKeys, append_location_metadata,
-    append_tool_calls_metadata, append_usage_metadata, content_storage_text_and_tools, paths_equal,
-    title_from_messages,
+    append_tool_calls_metadata, append_tool_event_metadata, append_usage_metadata,
+    content_storage_text_and_tools, paths_equal, title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, ingest_source,
@@ -860,6 +860,7 @@ fn event_message(
         metadata_json: serde_json::to_string(&message_metadata(
             record,
             message,
+            content,
             context.event_cwd,
             context.event_location_provenance,
         ))
@@ -1155,6 +1156,7 @@ fn session_metadata(event: &Value, event_cwd: Option<&Path>, location_provenance
 fn message_metadata(
     record: &Value,
     message: &Value,
+    content: &Value,
     event_cwd: Option<&Path>,
     location_provenance: &str,
 ) -> Value {
@@ -1173,6 +1175,7 @@ fn message_metadata(
         TranscriptLocation::new(event_cwd, location_provenance),
     );
     append_tool_calls_metadata(&mut metadata, message);
+    append_tool_event_metadata(&mut metadata, content);
     // Cursor transcripts carry no token counters today (verified across
     // 100k+ real lines); this probe is future-proofing for when they do.
     append_usage_metadata(&mut metadata, &[record, message]);

--- a/src/sessions/shared.rs
+++ b/src/sessions/shared.rs
@@ -4,6 +4,7 @@
 //! file-backed [`crate::sessions::source`] drivers and the Hermes `SQLite` sweep
 //! both depend on them so they do not need to import from each other.
 
+use std::io;
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
@@ -214,6 +215,18 @@ pub(crate) fn one_line_truncated(text: &str, max: usize) -> String {
     format!("{truncated}…")
 }
 
+/// Clip `text` to at most `max_bytes` on a UTF-8 boundary, appending a single
+/// `…` only when truncation occurred. Unlike [`one_line_truncated`] this keeps
+/// internal newlines, so multi-line derived-row previews retain their structure.
+pub(crate) fn preview_truncated(text: &str, max_bytes: usize) -> String {
+    let prefix = crate::text::utf8_prefix_at_or_before(text, max_bytes);
+    if prefix.len() == text.len() {
+        prefix.to_string()
+    } else {
+        format!("{prefix}…")
+    }
+}
+
 /// Collapse whitespace and clip to a short preview suitable for a session title.
 pub(crate) fn preview_title(text: &str) -> String {
     const MAX_TITLE_CHARS: usize = 80;
@@ -262,9 +275,33 @@ pub(crate) fn append_tool_calls_metadata(
 
 /// Byte length of `serde_json::to_string(value)`, or 0 when `value` is absent.
 fn json_byte_len(value: Option<&Value>) -> u64 {
-    value
-        .and_then(|value| serde_json::to_string(value).ok())
-        .map_or(0, |text| text.len() as u64)
+    let Some(value) = value else {
+        return 0;
+    };
+    let mut sink = ByteCountSink::default();
+    if serde_json::to_writer(&mut sink, value).is_ok() {
+        sink.count
+    } else {
+        0
+    }
+}
+
+/// `io::Write` sink that counts bytes without retaining them, so JSON byte
+/// lengths can be measured without allocating an intermediate `String`.
+#[derive(Default)]
+struct ByteCountSink {
+    count: u64,
+}
+
+impl io::Write for ByteCountSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.count += buf.len() as u64;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 /// Records bounded per-call tool metadata (byte counts and identifiers only,

--- a/src/sessions/shared.rs
+++ b/src/sessions/shared.rs
@@ -260,6 +260,64 @@ pub(crate) fn append_tool_calls_metadata(
     }
 }
 
+/// Byte length of `serde_json::to_string(value)`, or 0 when `value` is absent.
+fn json_byte_len(value: Option<&Value>) -> u64 {
+    value
+        .and_then(|value| serde_json::to_string(value).ok())
+        .map_or(0, |text| text.len() as u64)
+}
+
+/// Records bounded per-call tool metadata (byte counts and identifiers only,
+/// never content) for `tool_use`/`tool_result` blocks found in `content`.
+/// Inserts the `tool_events` key only when at least one entry was collected.
+pub(crate) fn append_tool_event_metadata(
+    map: &mut serde_json::Map<String, Value>,
+    content: &Value,
+) {
+    let Some(items) = content.as_array() else {
+        return;
+    };
+    let mut events = Vec::new();
+    for item in items {
+        let Some(item_type) = item.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+        match item_type {
+            "tool_use" => {
+                let mut event = serde_json::Map::new();
+                event.insert("type".to_string(), Value::String("tool_use".to_string()));
+                if let Some(name) = item.get("name").and_then(Value::as_str) {
+                    event.insert("tool_name".to_string(), Value::String(name.to_string()));
+                }
+                if let Some(id) = item.get("id").and_then(Value::as_str) {
+                    event.insert("call_id".to_string(), Value::String(id.to_string()));
+                }
+                event.insert(
+                    "input_bytes".to_string(),
+                    Value::from(json_byte_len(item.get("input"))),
+                );
+                events.push(Value::Object(event));
+            }
+            "tool_result" => {
+                let mut event = serde_json::Map::new();
+                event.insert("type".to_string(), Value::String("tool_result".to_string()));
+                if let Some(id) = item.get("tool_use_id").and_then(Value::as_str) {
+                    event.insert("call_id".to_string(), Value::String(id.to_string()));
+                }
+                event.insert(
+                    "output_bytes".to_string(),
+                    Value::from(json_byte_len(item.get("content"))),
+                );
+                events.push(Value::Object(event));
+            }
+            _ => {}
+        }
+    }
+    if !events.is_empty() {
+        map.insert("tool_events".to_string(), Value::Array(events));
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct TranscriptLocation<'a> {
     pub(crate) cwd: Option<&'a Path>,

--- a/tests/transcript_ingest_suite/claude.rs
+++ b/tests/transcript_ingest_suite/claude.rs
@@ -354,6 +354,200 @@ async fn claude_missing_projects_dir_is_silent_noop() {
     assert_eq!(stats.messages_upserted, 0);
 }
 
+/// Writes a Claude Code transcript with an assistant `tool_use` line and a
+/// paired user `tool_result` line, both with recorded `cwd` matching `project`.
+fn write_claude_tool_event_transcript(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".claude/projects/-some-slug");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{session}.jsonl"));
+    let cwd = project.to_string_lossy();
+    let contents = format!(
+        "{}\n{}\n",
+        serde_json::json!({
+            "type": "assistant",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "tool-a1",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Running a shell command to list files."},
+                    {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls"}}
+                ]
+            }
+        }),
+        serde_json::json!({
+            "type": "user",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "tool-a2",
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": "file listing output"}
+                ]
+            }
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn claude_tool_use_and_results_populate_tool_event_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_claude_tool_event_transcript(&home, &project, "claude-tool-sess");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClaudeSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    // No new rows beyond the normal two message rows: tool events are metadata
+    // on the existing assistant/user rows, not separate rows.
+    assert_eq!(stats.messages_upserted, 2);
+    assert_eq!(stats.sessions_upserted, 1);
+
+    let results = db
+        .search_session_messages("claude", None, "shell command", 10)
+        .await;
+    assert_eq!(results.len(), 1);
+    let assistant = &results[0];
+    assert_eq!(assistant.message.kind.as_deref(), Some("message"));
+    assert_eq!(assistant.message.tool_names.as_deref(), Some("Bash"));
+    assert!(assistant.message.text.contains("tool_use"));
+    let assistant_metadata: serde_json::Value =
+        serde_json::from_str(assistant.message.metadata_json.as_deref().unwrap()).unwrap();
+    let tool_events = assistant_metadata["tool_events"]
+        .as_array()
+        .expect("assistant row should carry tool_events metadata");
+    assert_eq!(tool_events.len(), 1);
+    assert_eq!(tool_events[0]["type"], "tool_use");
+    assert_eq!(tool_events[0]["tool_name"], "Bash");
+    assert_eq!(tool_events[0]["call_id"], "toolu_1");
+    assert!(tool_events[0]["input_bytes"].as_u64().unwrap() > 0);
+
+    let user_results = db
+        .search_session_messages("claude", None, "listing output", 10)
+        .await;
+    assert_eq!(user_results.len(), 1);
+    let user = &user_results[0];
+    assert_eq!(user.message.kind.as_deref(), Some("message"));
+    let user_metadata: serde_json::Value =
+        serde_json::from_str(user.message.metadata_json.as_deref().unwrap()).unwrap();
+    let user_tool_events = user_metadata["tool_events"]
+        .as_array()
+        .expect("user row should carry tool_events metadata");
+    assert_eq!(user_tool_events.len(), 1);
+    assert_eq!(user_tool_events[0]["type"], "tool_result");
+    assert_eq!(user_tool_events[0]["call_id"], "toolu_1");
+    assert!(user_tool_events[0]["output_bytes"].as_u64().unwrap() > 0);
+}
+
+/// Writes a Claude Code transcript with a `type=="system"` hook record that
+/// carries `hookErrors`, a routine `type=="system"` record with no signal, and
+/// one normal user message.
+fn write_claude_system_hook_transcript(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".claude/projects/-some-slug");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{session}.jsonl"));
+    let cwd = project.to_string_lossy();
+    let contents = format!(
+        "{}\n{}\n{}\n",
+        serde_json::json!({
+            "type": "system",
+            "cwd": cwd,
+            "sessionId": session,
+            "subtype": "stop_hook_summary",
+            "uuid": "hook-1",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "toolUseID": "tu-1",
+            "hookCount": 2,
+            "hookInfos": [{"command": "lint.sh", "durationMs": 12}],
+            "hookErrors": ["hook boom failed"],
+            "hookAdditionalContext": [],
+            "preventedContinuation": false,
+            "stopReason": "",
+            "level": "error"
+        }),
+        serde_json::json!({
+            "type": "system",
+            "cwd": cwd,
+            "sessionId": session,
+            "subtype": "stop_hook_summary",
+            "uuid": "hook-2",
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "toolUseID": "tu-2",
+            "hookCount": 1,
+            "hookInfos": [{"command": "routine-marker-command"}],
+            "hookErrors": [],
+            "hookAdditionalContext": [],
+            "preventedContinuation": false,
+            "stopReason": "",
+            "level": "info"
+        }),
+        serde_json::json!({
+            "type": "user",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "hook-3",
+            "timestamp": "2026-01-01T00:00:02.000Z",
+            "message": {"role": "user", "content": "Continue the billing investigation"}
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn claude_system_hook_errors_become_searchable_hook_events() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_claude_system_hook_transcript(&home, &project, "claude-hook-sess");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClaudeSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    // The routine system record produces no row; only the user message and
+    // one hook-event row are ingested.
+    assert_eq!(stats.messages_upserted, 2);
+
+    let results = db.search_session_messages("claude", None, "boom", 10).await;
+    assert_eq!(results.len(), 1);
+    let hit = &results[0];
+    assert_eq!(hit.message.role, "system");
+    assert_eq!(hit.message.kind.as_deref(), Some("hook_event"));
+    assert!(
+        hit.message
+            .text
+            .contains("Claude hook event: stop_hook_summary")
+    );
+    assert!(hit.message.text.contains("tool_use_id: tu-1"));
+    let metadata: serde_json::Value =
+        serde_json::from_str(hit.message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["source"], "claude_system_record");
+    assert!(metadata.get("hook_count").is_some());
+
+    let routine = db
+        .search_session_messages("claude", None, "routine-marker-command", 10)
+        .await;
+    assert!(
+        routine.is_empty(),
+        "routine system record without signal must not produce a row"
+    );
+}
+
 #[tokio::test]
 async fn claude_subagent_layout_uses_parent_link_and_parent_cwd_fallback() {
     let tmp = TempDir::new().unwrap();

--- a/tests/transcript_ingest_suite/claude.rs
+++ b/tests/transcript_ingest_suite/claude.rs
@@ -526,7 +526,7 @@ async fn claude_system_hook_errors_become_searchable_hook_events() {
     let results = db.search_session_messages("claude", None, "boom", 10).await;
     assert_eq!(results.len(), 1);
     let hit = &results[0];
-    assert_eq!(hit.message.role, "system");
+    assert_eq!(hit.message.role, "tool");
     assert_eq!(hit.message.kind.as_deref(), Some("hook_event"));
     assert!(
         hit.message
@@ -538,6 +538,16 @@ async fn claude_system_hook_errors_become_searchable_hook_events() {
         serde_json::from_str(hit.message.metadata_json.as_deref().unwrap()).unwrap();
     assert_eq!(metadata["source"], "claude_system_record");
     assert!(metadata.get("hook_count").is_some());
+
+    // The capped hook preview stays reversible: the row points back at the exact
+    // transcript JSONL line so full fidelity is recoverable from the source.
+    assert!(
+        hit.message
+            .source_path
+            .as_deref()
+            .is_some_and(|path| path.ends_with("claude-hook-sess.jsonl"))
+    );
+    assert!(hit.message.source_offset.is_some());
 
     let routine = db
         .search_session_messages("claude", None, "routine-marker-command", 10)

--- a/tests/transcript_ingest_suite/codex.rs
+++ b/tests/transcript_ingest_suite/codex.rs
@@ -326,6 +326,20 @@ fn write_codex_rollout_with_response_item_tools(
                     "status": "completed"
                 }
             }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.600Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "web_search_call",
+                    "call_id": "call-tool-4",
+                    "action": {
+                        "type": "search",
+                        "query": "zxqvunicorntoken rust async runtime",
+                        "queries": ["zxqvunicorntoken rust async runtime"]
+                    },
+                    "status": "completed"
+                }
+            }),
         ],
     );
     path
@@ -396,7 +410,7 @@ async fn codex_response_item_tool_events_are_cataloged_compactly() {
     let source = CodexSource::with_home(&home);
 
     let stats = ingest_source(&db, &source, &project, None).await;
-    assert_eq!(stats.messages_upserted, 5);
+    assert_eq!(stats.messages_upserted, 6);
 
     let results = db
         .search_session_messages(
@@ -420,6 +434,18 @@ async fn codex_response_item_tool_events_are_cataloged_compactly() {
     assert_eq!(metadata["tool_name"], "exec_command");
     assert_eq!(metadata["call_id"], "call-tool-1");
 
+    // The capped preview stays reversible: the row points back at the exact
+    // rollout JSONL line so full fidelity is recoverable from the source.
+    let rollout_name = "rollout-2026-01-01T00-00-18-codex-response-item-tools.jsonl";
+    assert!(
+        call.source_path
+            .as_deref()
+            .is_some_and(|path| path.ends_with(rollout_name))
+    );
+    let call_offset = call
+        .source_offset
+        .expect("tool_event carries source_offset");
+
     let output_results = db
         .search_session_messages(
             "codex",
@@ -434,6 +460,36 @@ async fn codex_response_item_tool_events_are_cataloged_compactly() {
     assert!(output.text.contains("output_bytes: 2427"));
     assert!(!output.text.contains("error: exact failure line"));
     assert!(output.text.len() < 2200);
+
+    let web_search_results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "zxqvunicorntoken",
+            10,
+        )
+        .await;
+    assert_eq!(web_search_results.len(), 1);
+    let web_search = &web_search_results[0].message;
+    assert_eq!(web_search.kind.as_deref(), Some("tool_event"));
+    assert_eq!(web_search.tool_names.as_deref(), Some("web_search"));
+    assert!(
+        web_search
+            .text
+            .contains("zxqvunicorntoken rust async runtime")
+    );
+    assert!(
+        web_search
+            .source_path
+            .as_deref()
+            .is_some_and(|path| path.ends_with(rollout_name))
+    );
+    // web_search_call is a later JSONL line than the exec_command call, so its
+    // byte offset into the rollout is strictly greater.
+    let web_search_offset = web_search
+        .source_offset
+        .expect("web_search row carries source_offset");
+    assert!(web_search_offset > call_offset);
 }
 
 #[tokio::test]

--- a/tests/transcript_ingest_suite/codex.rs
+++ b/tests/transcript_ingest_suite/codex.rs
@@ -262,6 +262,75 @@ fn write_codex_rollout_with_compaction(
     path
 }
 
+fn write_codex_rollout_with_response_item_tools(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("rollout-2026-01-01T00-00-18-{session}.jsonl"));
+    let long_output = format!("{}{}", "A".repeat(2400), "\nerror: exact failure line\n");
+    write_jsonl(
+        &path,
+        &[
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.000Z",
+                "type": "session_meta",
+                "payload": {"id": session, "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.100Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "Inspect response item telemetry"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.200Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"rg -n MEMORY.md ~/.codex/memories\",\"workdir\":\"/home/zack/projects/tracedecay\"}",
+                    "call_id": "call-tool-1",
+                    "status": "completed"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.300Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-tool-1",
+                    "output": long_output,
+                    "status": "completed"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.400Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call",
+                    "name": "apply_patch",
+                    "input": "*** Begin Patch\n*** Update File: src/lib.rs\n@@\n-old\n+new\n*** End Patch\n",
+                    "call_id": "call-tool-2",
+                    "status": "completed"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:18.500Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "tool_search_call",
+                    "call_id": "call-tool-3",
+                    "arguments": {"query": "tracedecay context", "limit": 8},
+                    "status": "completed"
+                }
+            }),
+        ],
+    );
+    path
+}
+
 #[tokio::test]
 async fn codex_goal_response_item_is_cataloged_as_context() {
     let tmp = TempDir::new().unwrap();
@@ -315,6 +384,144 @@ async fn codex_regular_response_item_goal_words_are_not_cataloged() {
         )
         .await;
     assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn codex_response_item_tool_events_are_cataloged_compactly() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_codex_rollout_with_response_item_tools(&home, &project, "codex-response-item-tools");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 5);
+
+    let results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "exec_command MEMORY.md",
+            10,
+        )
+        .await;
+    assert_eq!(results.len(), 1);
+    let call = &results[0].message;
+    assert_eq!(call.role, "tool");
+    assert_eq!(call.kind.as_deref(), Some("tool_event"));
+    assert!(call.text.contains("Codex tool call: exec_command"));
+    assert!(call.text.contains("rg -n MEMORY.md"));
+
+    let metadata: serde_json::Value =
+        serde_json::from_str(call.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["source"], "codex_response_item");
+    assert_eq!(metadata["response_item_type"], "function_call");
+    assert_eq!(metadata["tool_name"], "exec_command");
+    assert_eq!(metadata["call_id"], "call-tool-1");
+
+    let output_results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "output_bytes",
+            10,
+        )
+        .await;
+    assert_eq!(output_results.len(), 1);
+    let output = &output_results[0].message;
+    assert!(output.text.contains("Codex tool output: call-tool-1"));
+    assert!(output.text.contains("output_bytes: 2427"));
+    assert!(!output.text.contains("error: exact failure line"));
+    assert!(output.text.len() < 2200);
+}
+
+#[tokio::test]
+async fn codex_response_item_skips_developer_messages_and_keeps_reasoning_summaries() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    let session = "codex-response-item-reasoning";
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("rollout-2026-01-01T00-00-19-{session}.jsonl"));
+    write_jsonl(
+        &path,
+        &[
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:19.000Z",
+                "type": "session_meta",
+                "payload": {"id": session, "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:19.100Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "SECRET_DEVELOPER_CONTEXT_SHOULD_NOT_INDEX"}]
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:19.200Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "summary": [],
+                    "encrypted_content": "ENCRYPTED_REASONING_SHOULD_NOT_INDEX"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-01T00:00:19.300Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Reasoned that compact tool telemetry is useful."}],
+                    "encrypted_content": "ENCRYPTED_REASONING_SHOULD_NOT_INDEX"
+                }
+            }),
+        ],
+    );
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 1);
+
+    let developer_results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "SECRET_DEVELOPER_CONTEXT_SHOULD_NOT_INDEX",
+            10,
+        )
+        .await;
+    assert!(developer_results.is_empty());
+
+    let encrypted_results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "ENCRYPTED_REASONING_SHOULD_NOT_INDEX",
+            10,
+        )
+        .await;
+    assert!(encrypted_results.is_empty());
+
+    let reasoning_results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "compact tool telemetry",
+            10,
+        )
+        .await;
+    assert_eq!(reasoning_results.len(), 1);
+    assert_eq!(reasoning_results[0].message.role, "assistant");
+    assert_eq!(
+        reasoning_results[0].message.kind.as_deref(),
+        Some("reasoning")
+    );
 }
 
 #[tokio::test]
@@ -386,6 +593,16 @@ async fn codex_rollout_populates_user_and_agent_messages_only() {
     let user_metadata: serde_json::Value =
         serde_json::from_str(user.message.metadata_json.as_deref().unwrap()).unwrap();
     assert!(user_metadata.get("usage").is_none());
+
+    let duplicate_results = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "duplicate",
+            10,
+        )
+        .await;
+    assert!(duplicate_results.is_empty());
 }
 
 #[tokio::test]

--- a/tests/transcript_ingest_suite/cursor.rs
+++ b/tests/transcript_ingest_suite/cursor.rs
@@ -391,6 +391,51 @@ async fn cursor_transcript_ingest_preserves_structured_content_in_raw_lcm() {
 }
 
 #[tokio::test]
+async fn cursor_tool_use_blocks_populate_tool_event_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let project = init_project(&tmp);
+
+    let transcript = tmp.path().join("cursor-session.jsonl");
+    std::fs::write(
+        &transcript,
+        r#"{"role":"assistant","message":{"content":[{"type":"text","text":"Running a shell command to list files."},{"type":"tool_use","id":"call_1","name":"Shell","input":{"command":"echo hi"}}]}}
+"#,
+    )
+    .unwrap();
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let event = serde_json::json!({
+        "session_id": "cursor-session",
+        "transcript_path": transcript,
+        "workspace_roots": [project]
+    });
+
+    let stats = ingest_cursor_transcript_event(&event.to_string(), &db).await;
+    // No additional rows beyond the single assistant row: tool events are
+    // metadata on the existing row, not separate rows.
+    assert_eq!(stats.messages_upserted, 1);
+
+    let results = db
+        .search_session_messages("cursor", None, "shell command", 10)
+        .await;
+    assert_eq!(results.len(), 1);
+    let assistant = &results[0];
+    assert_eq!(assistant.message.tool_names.as_deref(), Some("Shell"));
+    assert!(assistant.message.text.contains("tool_use"));
+
+    let metadata: serde_json::Value =
+        serde_json::from_str(assistant.message.metadata_json.as_deref().unwrap()).unwrap();
+    let tool_events = metadata["tool_events"]
+        .as_array()
+        .expect("assistant row should carry tool_events metadata");
+    assert_eq!(tool_events.len(), 1);
+    assert_eq!(tool_events[0]["type"], "tool_use");
+    assert_eq!(tool_events[0]["tool_name"], "Shell");
+    assert_eq!(tool_events[0]["call_id"], "call_1");
+    assert!(tool_events[0]["input_bytes"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
 async fn cursor_transcript_ingest_is_idempotent() {
     let tmp = TempDir::new().unwrap();
     let project = init_project(&tmp);


### PR DESCRIPTION
## Summary

Compact, search-friendly tool telemetry across all three transcript providers, scoped per provider to what each format actually needs — verified against real on-disk data before implementation.

### Codex — new `tool_event` rows
Codex `response_item` tool telemetry was previously skipped entirely. Now cataloged as `role="tool"`, `kind="tool_event"` rows:
- `function_call` / `custom_tool_call` / `tool_search_call` / `web_search_call` → compact call text with a capped preview of `arguments`/`input`/`action` (web-search queries live under `payload.action` in real rollouts and are now indexed)
- `function_call_output` / `custom_tool_call_output` → capped preview + `output_bytes` / `output_truncated` metadata, never the full blob
- `reasoning` with a non-empty `summary` → `kind="reasoning"` rows; encrypted reasoning bodies are never indexed

Ordinary `response_item.message` entries stay skipped (they duplicate `event_msg` / developer context) — guarded by a strengthened regression test.

### Claude Code — hook events + bounded per-call metadata
- Previously-dropped `type=="system"` hook records become compact `kind="hook_event"` rows, **signal-only**: ingested when `hookErrors` / `stopReason` / `preventedContinuation` carry signal; routine stop-hook summaries produce no row. Rows use `role="tool"` so transient hook telemetry is never pinned as an LCM policy anchor (LCM pins `system`/`developer` roles into every compacted replay).
- Existing message rows gain a bounded `tool_events` metadata array for `tool_use` / `tool_result` content blocks: `tool_name`, `call_id`, input/output **byte counts only** — never content.

### Cursor — bounded per-call metadata
- The same `tool_events` metadata for `tool_use` blocks (`tool_name`, `call_id`, `input_bytes`).
- **No output handling by design**: sampling 4,085 real Cursor transcripts found zero tool-output payloads — Cursor's format structurally omits them. Documented asymmetry, not an oversight.
- The existing `Task`/`Subagent` `tool_dispatch` path is untouched.

### Reversibility contract
Previews are capped (2000 bytes, UTF-8-safe, via shared `preview_truncated`) but retrieval is reversible: every derived row carries `source_path` + `source_offset` pointing at the exact transcript JSONL line, pinned by tests. Full fidelity is always recoverable from the original rollout and the LCM raw store.

### Deep-review round (multi-agent, adversarially verified)
A 57-agent review produced 7 confirmed findings; 4 fixed here (LCM anchor pinning via role, missing web-search queries, dashboard token/cost inflation from derived kinds, double serialization on the ingest path), 1 hardening (reversibility pinned in tests), 1 consolidation (shared preview helper + `_BYTES` rename). Two findings accepted as designed and documented:
- **LCM raw-store growth**: derived rows do enter `lcm_raw_messages`; previews are capped and `role="tool"` rows are non-anchor and budget-droppable.
- **FTS index growth**: derived rows are intentionally searchable — that is the feature's purpose; index cost is bounded by the preview cap.

## Validation
- `cargo test -q --test transcript_ingest_suite` — 77/77, stable across 9 consecutive runs (includes 8 new/strengthened tests)
- `token_count` unit tests 6/6 (new CTE-exclusion test), `sessions::shared` 3/3
- `cargo fmt --check` / `cargo check -q` clean
- All slices developed TDD (verified RED before implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)