### PR TITLE
fix(tests): isolate env for flaky cursor mid-batch retry test

### DIFF
--- a/tests/transcript_ingest_suite/cursor.rs
+++ b/tests/transcript_ingest_suite/cursor.rs
@@ -425,8 +425,23 @@ async fn cursor_transcript_ingest_is_idempotent() {
 }
 
 #[tokio::test]
+// Intentional: this test resolves the profile session DB path twice (capturing
+// db_path, then opening the store), so it pins process-wide profile env under
+// GLOBAL_DB_ENV_LOCK to exclude the env-mutating siblings and keep both
+// resolutions identical.
+#[allow(clippy::await_holding_lock)]
 async fn cursor_transcript_ingest_retries_after_mid_batch_db_failure() {
     let tmp = TempDir::new().unwrap();
+    let _env_lock = GLOBAL_DB_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    let profile = tmp.path().join("profile");
+    let _env_guards = [
+        EnvVarGuard::set("TRACEDECAY_DATA_DIR", &profile),
+        EnvVarGuard::set(GLOBAL_DB_ENV, profile.join("global.db")),
+        EnvVarGuard::set("HOME", tmp.path().join("home")),
+        EnvVarGuard::set("USERPROFILE", tmp.path().join("home")),
+    ];
     let project = init_project(&tmp);
     let transcript = tmp.path().join("cursor-session.jsonl");
     std::fs::write(


### PR DESCRIPTION
## Summary
- Fixes the flaky `cursor_transcript_ingest_retries_after_mid_batch_db_failure` (`SQLITE_CANTOPEN(14)` / `ConnectionFailed` on `target/test-profile/.tracedecay/projects/proj_<hash>/sessions.db`).
- Root cause: the test resolves the env-dependent profile DB path **twice** (captured `db_path`, then `open_project_session_db`) while holding no lock and pinning no env. Sibling tests in the same binary legally mutate `TRACEDECAY_DATA_DIR`/`HOME` under `GLOBAL_DB_ENV_LOCK`; a flip between the two resolutions splits the captured path from the created store, so the final `connect()` targets a parent directory that was never created. A process-global env writer cannot be made safe by a lock its readers don't also hold — this test simply never took the lock.
- Fix: test-isolation only (production is sound — no production path resolves the data dir twice across an external env mutation). The test now uses the suite's existing blessed pattern: acquire `GLOBAL_DB_ENV_LOCK` (poison-tolerant) and pin `TRACEDECAY_DATA_DIR` / `TRACEDECAY_GLOBAL_DB` / `HOME` / `USERPROFILE` to a per-test tempdir profile.

## Validation
- Reproduced pre-fix: 2/15 plain suite runs; deterministic-ish targeted harness failed at iteration 13/40.
- Post-fix: 40/40 under the identical targeted harness; 20/20 full-suite runs (default threads) + 10/10 at `RUST_TEST_THREADS=32` + 30/30 targeted runs — zero failures, no `SQLITE_CANTOPEN` recurrence.
- `cargo fmt --check` / `cargo check -q` clean.

## Notes
- Other unguarded storage-resolving tests in this binary remain latently exposed to the same writer pattern but have never been observed to flake; standardizing the whole binary onto one isolation idiom is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)