### PR TITLE
chore: release v0.0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.40](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.39...v0.0.40) - 2026-07-09
+
+### Added
+
+- compact tool telemetry ingestion across Codex, Claude Code, and Cursor ([#325](https://github.com/ScriptedAlchemy/tracedecay/pull/325))
+
+### Fixed
+
+- *(config)* atomic user-config saves with honest errors and recovery
+- eliminate three CI test flakes at their roots
+
+### Other
+
+- Merge pull request #322 from ScriptedAlchemy/codex/project-discovery-rendering
+- Merge remote-tracking branch 'origin/master' into codex/project-discovery-rendering-fixes
+- Merge pull request #338 from ScriptedAlchemy/codex/automation-resilience
+
 ## [0.0.39](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.38...v0.0.39) - 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.39"
+version = "0.0.40"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.39 -> 0.0.40

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.40](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.39...v0.0.40) - 2026-07-09

### Added

- compact tool telemetry ingestion across Codex, Claude Code, and Cursor ([#325](https://github.com/ScriptedAlchemy/tracedecay/pull/325))

### Fixed

- *(config)* atomic user-config saves with honest errors and recovery
- eliminate three CI test flakes at their roots

### Other

- Merge pull request #322 from ScriptedAlchemy/codex/project-discovery-rendering
- Merge remote-tracking branch 'origin/master' into codex/project-discovery-rendering-fixes
- Merge pull request #338 from ScriptedAlchemy/codex/automation-resilience
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).