### PR TITLE
fix(storage): stop locking append-only handles on Windows ledger writes

### DIFF
--- a/src/automation/run_ledger.rs
+++ b/src/automation/run_ledger.rs
@@ -262,16 +262,37 @@ fn append_jsonl_line_locked(path: &Path, line: &str) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    crate::storage::retry_transient_file_op(|| append_jsonl_line_once(path, line))
+}
+
+fn append_jsonl_line_once(path: &Path, line: &str) -> std::io::Result<()> {
+    // Serialize on a dedicated read+write `<path>.lock` sidecar handle rather
+    // than on the append-only data handle. Locking an append-only handle fails
+    // on Windows `LockFileEx` with `ERROR_ACCESS_DENIED` (os error 5) because
+    // Rust opens such handles without `FILE_READ_DATA`/`FILE_WRITE_DATA`, which
+    // `LockFileEx` requires.
+    let lock_path = crate::storage::append_lock_path(path);
+    let lock_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    lock_file.lock_exclusive()?;
+
+    let write_result = append_jsonl_line_data(path, line);
+    let unlock_result = lock_file.unlock();
+    write_result?;
+    unlock_result
+}
+
+fn append_jsonl_line_data(path: &Path, line: &str) -> std::io::Result<()> {
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)?;
-    file.lock_exclusive()?;
-    let write_result = file.write_all(format!("{line}\n").as_bytes());
-    let flush_result = write_result.and_then(|()| file.flush());
-    let unlock_result = file.unlock();
-    flush_result?;
-    unlock_result
+    file.write_all(format!("{line}\n").as_bytes())?;
+    file.flush()
 }
 
 pub async fn load_run_records(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Component, Path, PathBuf};
@@ -472,19 +473,48 @@ impl PrivateStoreIo {
         set_private_file_permissions(path)
     }
 
-    /// Appends one line while holding an advisory file lock so concurrent hook
-    /// processes never interleave partial lines.
+    /// Appends one line while holding an advisory lock on a dedicated sidecar
+    /// lock file so concurrent threads and processes never interleave partial
+    /// lines.
+    ///
+    /// The lock is taken on a separate `<path>.lock` handle opened for
+    /// read+write, never on the append-only data handle. This is deliberate:
+    /// Windows `LockFileEx` requires the handle to carry `FILE_READ_DATA` or
+    /// `FILE_WRITE_DATA`, but Rust opens append-only handles with
+    /// `FILE_GENERIC_WRITE & !FILE_WRITE_DATA` (no read-data, no write-data),
+    /// so locking such a handle fails with `ERROR_ACCESS_DENIED` (os error 5).
+    /// Locking the r/w sidecar sidesteps that and also avoids locking the data
+    /// region being appended.
     pub fn append_line(path: &Path, line: &str) -> io::Result<()> {
         if let Some(parent) = path.parent() {
             Self::create_dir_all(parent)?;
         }
-        reject_symlink_components(path, "private store file")?;
-        let mut file = Self::open_private(path, fs::OpenOptions::new().append(true))?;
-        file.lock_exclusive()?;
-        let write_result = file.write_all(format!("{line}\n").as_bytes());
-        let unlock_result = file.unlock();
-        write_result?;
+        retry_transient_file_op(|| Self::append_line_once(path, line))
+    }
+
+    fn append_line_once(path: &Path, line: &str) -> io::Result<()> {
+        let lock_path = append_lock_path(path);
+        reject_symlink_components(&lock_path, "private store lock file")?;
+        let mut lock_options = fs::OpenOptions::new();
+        lock_options.read(true).write(true);
+        let lock_file = Self::open_private(&lock_path, &mut lock_options)?;
+        lock_file.lock_exclusive()?;
+
+        let append_result = Self::append_line_locked(path, line);
+        let unlock_result = lock_file.unlock();
+        append_result?;
         unlock_result?;
+        Ok(())
+    }
+
+    fn append_line_locked(path: &Path, line: &str) -> io::Result<()> {
+        reject_symlink_components(path, "private store file")?;
+        let mut options = fs::OpenOptions::new();
+        options.append(true);
+        let mut file = Self::open_private(path, &mut options)?;
+        file.write_all(format!("{line}\n").as_bytes())?;
+        file.flush()?;
+        drop(file);
         set_private_file_permissions(path)
     }
 
@@ -603,6 +633,65 @@ fn invalid_input(message: impl Into<String>) -> io::Error {
 
 fn path_parent(path: &Path) -> &Path {
     path.parent().unwrap_or_else(|| Path::new(""))
+}
+
+/// Sibling `<file>.lock` path used to serialize appends without locking the
+/// data file's own handle. Shared with the automation run ledger writer.
+pub(crate) fn append_lock_path(path: &Path) -> PathBuf {
+    let mut lock_name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_else(|| OsString::from("append"));
+    lock_name.push(".lock");
+    path.with_file_name(lock_name)
+}
+
+/// Runs `op`, retrying a bounded number of times on Windows for the transient
+/// file-access error codes that antivirus scanners and delete-pending handle
+/// states briefly produce: `ERROR_ACCESS_DENIED` (5), `ERROR_SHARING_VIOLATION`
+/// (32), and `ERROR_LOCK_VIOLATION` (33). The retries total well under ~250ms
+/// and the final error is always propagated. On non-Windows platforms `op`
+/// runs exactly once.
+pub(crate) fn retry_transient_file_op<F>(mut op: F) -> io::Result<()>
+where
+    F: FnMut() -> io::Result<()>,
+{
+    #[cfg(windows)]
+    {
+        const MAX_ATTEMPTS: u32 = 5;
+        let mut attempt: u32 = 1;
+        loop {
+            match op() {
+                Ok(()) => return Ok(()),
+                Err(err) if attempt < MAX_ATTEMPTS && is_transient_windows_file_error(&err) => {
+                    std::thread::sleep(transient_file_backoff(attempt));
+                    attempt += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        op()
+    }
+}
+
+#[cfg(windows)]
+fn is_transient_windows_file_error(err: &io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(5 | 32 | 33))
+}
+
+#[cfg(windows)]
+fn transient_file_backoff(attempt: u32) -> std::time::Duration {
+    // Base 10, 20, 40, 80 ms (sum 150 ms across the 4 retries) plus a small
+    // jitter derived from the wall clock to de-correlate contending writers.
+    let base = 10u64 << (attempt - 1);
+    let jitter = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::from(d.subsec_nanos()) % u64::from(attempt + 1))
+        .unwrap_or(0);
+    std::time::Duration::from_millis(base + jitter)
 }
 
 fn relative_to_data_root(path: &Path, data_root: &Path) -> PathBuf {
@@ -755,7 +844,7 @@ fn set_private_file_permissions(_path: &Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::PrivateStoreIo;
+    use super::{append_lock_path, PrivateStoreIo};
     use serde_json::Value;
     use std::sync::{Arc, Barrier};
 
@@ -800,5 +889,56 @@ mod tests {
         for row in rows {
             serde_json::from_str::<Value>(row).unwrap();
         }
+    }
+
+    #[test]
+    fn append_line_uses_a_reusable_sidecar_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ledger.jsonl");
+        let lock_path = append_lock_path(&path);
+        assert_eq!(lock_path.file_name().unwrap(), "ledger.jsonl.lock");
+
+        PrivateStoreIo::append_line(&path, "{\"n\":1}").unwrap();
+        assert!(lock_path.is_file(), "sidecar lock file should be created");
+
+        // A second append reuses the same sidecar and never locks the data
+        // handle, so it must succeed and leave both entries intact.
+        PrivateStoreIo::append_line(&path, "{\"n\":2}").unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents.lines().count(), 2);
+        assert!(lock_path.is_file());
+        // The lock file is metadata only; it must not accumulate ledger bytes.
+        assert_eq!(std::fs::metadata(&lock_path).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn append_line_leaves_data_file_writable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("perms.jsonl");
+
+        PrivateStoreIo::append_line(&path, "{\"a\":1}").unwrap();
+        PrivateStoreIo::append_line(&path, "{\"a\":2}").unwrap();
+
+        let meta = std::fs::metadata(&path).unwrap();
+        // Guards against any Windows FILE_ATTRIBUTE_READONLY regression and any
+        // Unix mode regression that would strip the owner write bit.
+        assert!(
+            !meta.permissions().readonly(),
+            "appended data file must stay writable"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                meta.permissions().mode() & 0o777,
+                0o600,
+                "private data file must retain owner-only 0o600 permissions"
+            );
+        }
+
+        // The file must still be openable for a further append after the cycle.
+        PrivateStoreIo::append_line(&path, "{\"a\":3}").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap().lines().count(), 3);
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -894,7 +894,9 @@ mod tests {
     #[test]
     fn append_line_uses_a_reusable_sidecar_lock_file() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("ledger.jsonl");
+        // Canonicalize: on macOS the tempdir lives under /var -> /private/var,
+        // which the symlink guard would otherwise reject.
+        let path = dir.path().canonicalize().unwrap().join("ledger.jsonl");
         let lock_path = append_lock_path(&path);
         assert_eq!(lock_path.file_name().unwrap(), "ledger.jsonl.lock");
 
@@ -914,7 +916,9 @@ mod tests {
     #[test]
     fn append_line_leaves_data_file_writable() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("perms.jsonl");
+        // Canonicalize: on macOS the tempdir lives under /var -> /private/var,
+        // which the symlink guard would otherwise reject.
+        let path = dir.path().canonicalize().unwrap().join("perms.jsonl");
 
         PrivateStoreIo::append_line(&path, "{\"a\":1}").unwrap();
         PrivateStoreIo::append_line(&path, "{\"a\":2}").unwrap();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -844,7 +844,7 @@ fn set_private_file_permissions(_path: &Path) -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{append_lock_path, PrivateStoreIo};
+    use super::{PrivateStoreIo, append_lock_path};
     use serde_json::Value;
     use std::sync::{Arc, Barrier};
 


### PR DESCRIPTION
Root-causes and fixes the Windows CI regression present on every master run since #323 (~80 tests failing with `Access is denied (os error 5)` on `automation_runs.jsonl` appends).

**Root cause**: `LockFileEx` requires the handle to hold `FILE_READ_DATA` or `FILE_WRITE_DATA`; Rust's `append(true)` handles carry only `FILE_APPEND_DATA`, so `lock_exclusive()` on the data file fails deterministically with os error 5 — on every call, no contention needed. Two sites did this: `PrivateStoreIo::append_line` (src/storage.rs) and the automation run ledger's `append_jsonl_line_locked` (src/automation/run_ledger.rs). The sidecar attempt on `codex/redundancy-evals` fixed only the former, which is why its CI still failed identically. The repo's two working `lock_exclusive` sites (monitor.rs, branch.rs) open read/write handles — the proof by contrast.

**Fix**: both sites now serialize on a dedicated read+write `<path>.lock` sidecar handle and never lock the append-only data handle; shared audited helpers in storage.rs; Windows-only bounded retry (≤5 attempts, ~150 ms) for transient os errors 5/32/33 as defense-in-depth; Unix 0o600 behavior unchanged.

**Victory condition**: the Windows shards go green and the `failed to write automation run ledger ... os error 5` signature disappears from `automation_runner_test/*`, `automation::lifecycle`, `hint_analytics`, and the mcp artifact-view smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)