### PR TITLE
feat(redundancy): harden scoring, expand evals, integrate across surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ include = [
     "/src/**",
     "/benches/**",
     "/examples/**",
+    "/tests/fixtures/redundancy_eval_labeled.json",
     "/benchmarks/queries/default.toml",
     "/plugin/**",
     "/vendor/**",

--- a/TEST-QUERIES.md
+++ b/TEST-QUERIES.md
@@ -583,7 +583,7 @@ Test with defaults:
 ```
 tracedecay_redundancy()
 ```
-Expected: Returns `{candidates, scanned, skipped_for_size, pair_count, pairs: [...], ranked_by, scope, thresholds}`. Each pair has `similarity` (0.0-1.0), `severity` (`definite` / `likely` / `naming_only`), `overlap_kind` (`ast_isomorphic` / `control_flow` / `algorithmic` / `token_overlap` / `naming`), `a` / `b` symbol info (`file`, `line`, `name`, `id`), and a `signals` block with `ast_match`, `cfg_match`, `call_seq_match`, `shingle_jaccard`, and `body_tokens`. Pairs are sorted by similarity descending. Default thresholds: `min_lines=8`, `max_pairs=20`, `similarity_threshold=0.6`, `include_naming_only=false`.
+Expected: Returns `{candidates, scanned, skipped_for_size, pair_count, pairs: [...], groups, groups_scope, ranked_by, scope, thresholds}`. Each pair has `similarity` (0.0-1.0), `ranking_score` (rank key: composite blended with discounted body-vector cosine, generic helpers downranked — may sit below the threshold), `severity` (`definite` / `likely` / `naming_only`), `overlap_kind` (`ast_isomorphic` / `control_flow` / `algorithmic` / `token_overlap` / `body_vector` / `naming`), `a` / `b` symbol info (`file`, `line`, `name`, `id`), and a `signals` block with `ast_match`, `cfg_match`, `call_seq_match`, `shingle_jaccard`, `body_vector_cosine`, `generic_helper_downranked`, and `body_tokens`. `groups` lists connected duplicate components over the returned pairs only. Pairs are sorted by `ranking_score` descending (deterministic total order). Default thresholds: `min_lines=8`, `max_pairs=20`, `similarity_threshold=0.6`, `include_naming_only=false`.
 
 Test path scope:
 ```
@@ -595,13 +595,13 @@ Test tightened threshold (only "definite" duplicates):
 ```
 tracedecay_redundancy(similarity_threshold=0.85)
 ```
-Expected: Only AST-isomorphic pairs survive — the AST signal alone contributes 0.40 to the composite score, so anything ≥ 0.85 with `severity: "definite"` is a strong consolidation candidate.
+Expected: Pairs survive when either the composite similarity or the body-vector cosine reaches 0.85. AST-isomorphic composite matches come back with `severity: "definite"` (strong consolidation candidates); high-cosine matches without an AST match come back as `severity: "likely"` with a non-`ast_isomorphic` overlap kind.
 
 Test surface naming-only candidates:
 ```
 tracedecay_redundancy(include_naming_only=true, similarity_threshold=0.1)
 ```
-Expected: Long-tail matches where only names look similar but bodies diverge. Most are false positives — useful for naming-convention audits, not for refactoring.
+Expected: Long-tail matches. At very low thresholds most former `naming` pairs are relabeled `body_vector` (cosine ≥ 0.55 rescues them) and are returned even without this flag; `include_naming_only` controls only pairs that stay `overlap_kind: "naming"` (cosine below 0.55). Most are false positives — useful for naming-convention audits, not for refactoring.
 
 Test minimum function size:
 ```

--- a/plugin/skills/exploring-code/SKILL.md
+++ b/plugin/skills/exploring-code/SKILL.md
@@ -55,7 +55,10 @@ For other git branches without switching checkout — `tracedecay_branch_list` /
 - Search came up empty and a new helper seems needed → run the
   `tracedecay:editing-safely` duplicate probe first.
 - Similarity by functionality/body, not just by name → run
-  `tracedecay_redundancy` before concluding no duplicate exists.
+  `tracedecay_redundancy` before concluding no duplicate exists. Scoped hunt
+  recipe: `path` to the suspect directory, `min_lines: 6`,
+  `similarity_threshold: 0.55` — whole-repo scans at defaults favor precision
+  and can miss real duplicates.
 - "Who calls X / what does X call / what breaks" → hand off to
   `tracedecay:tracing-functions` / `tracedecay:assessing-impact` after resolving
   the symbol; do not grep for call sites.

--- a/plugin/skills/reviewing-changes/SKILL.md
+++ b/plugin/skills/reviewing-changes/SKILL.md
@@ -26,8 +26,9 @@ Announce: "Using tracedecay:reviewing-changes for <diff/PR>."
 4. Quality scan of just the changed files → `tracedecay_simplify_scan`.
 5. Duplicate-body risk or repeated helper logic in touched code →
    `tracedecay_redundancy` scoped to the changed directory/file set. Treat
-   `definite` as consolidation evidence; verify `likely`; ignore
-   `naming_only` unless another signal supports it.
+   `definite` as consolidation evidence; verify `likely` — especially pairs
+   whose `overlap_kind` is `body_vector` (vector-only signal); `naming_only`
+   appears only with `include_naming_only: true` and needs another signal.
 6. Risk: `tracedecay_test_risk` on changed paths; `tracedecay_unsafe_patterns`
    on changed files (`exclude_tests: true` for production-only — unwrap/panic
    in tests is normal, and an `unsafe { }` block is an attention site, not

--- a/src/accounting/classifier.rs
+++ b/src/accounting/classifier.rs
@@ -1,6 +1,6 @@
 //! Deterministic task classification for Claude Code turns.
 //!
-//! Classifies each API turn into one of 13 categories based on tool usage
+//! Classifies each API turn into one of 14 categories based on tool usage
 //! patterns and keyword matching. Adapted from AgentSeal/codeburn (MIT).
 
 use std::fmt;
@@ -23,6 +23,7 @@ pub enum TaskCategory {
     Brainstorming,
     Conversation,
     General,
+    Redundancy,
 }
 
 impl fmt::Display for TaskCategory {
@@ -47,6 +48,7 @@ impl TaskCategory {
             Self::Brainstorming => ("brainstorming", "Brainstorming"),
             Self::Conversation => ("conversation", "Conversation"),
             Self::General => ("general", "General"),
+            Self::Redundancy => ("redundancy", "Redundancy"),
         }
     }
 
@@ -76,6 +78,12 @@ pub fn classify(tool_names: &[&str], bash_commands: &[&str]) -> TaskCategory {
     // Planning tools
     if tool_names.contains(&"EnterPlanMode") || tool_names.contains(&"TaskCreate") {
         return TaskCategory::Planning;
+    }
+
+    // Redundancy analysis tool → dedicated bucket so dashboards can track
+    // tracedecay_redundancy adoption separately from generic MCP tool calls.
+    if tool_names.contains(&"tracedecay_redundancy") {
+        return TaskCategory::Redundancy;
     }
 
     let has_edit = tool_names.contains(&"Edit") || tool_names.contains(&"Write");
@@ -266,5 +274,19 @@ mod tests {
     fn test_category_display() {
         assert_eq!(TaskCategory::GitOps.as_str(), "git_ops");
         assert_eq!(TaskCategory::GitOps.label(), "Git Ops");
+    }
+
+    #[test]
+    fn test_redundancy_tool_is_redundancy() {
+        assert_eq!(
+            classify(&["tracedecay_redundancy"], &[]),
+            TaskCategory::Redundancy
+        );
+    }
+
+    #[test]
+    fn test_redundancy_category_display() {
+        assert_eq!(TaskCategory::Redundancy.as_str(), "redundancy");
+        assert_eq!(TaskCategory::Redundancy.label(), "Redundancy");
     }
 }

--- a/src/dashboard/code_diagnostics_api.rs
+++ b/src/dashboard/code_diagnostics_api.rs
@@ -12,7 +12,7 @@ use super::DashboardState;
 use super::util::{JsonError, http_detail};
 use crate::diagnostics::lsp::activity::{active_languages_for_files, documents_for_adapter};
 use crate::diagnostics::lsp::adapters::LspAdapterDefinition;
-use crate::diagnostics::lsp::broker::{DiagnosticsSnapshot, EngineState};
+use crate::diagnostics::lsp::broker::{DiagnosticsSnapshot, EngineState, NodeSpan};
 use crate::diagnostics::lsp::settings::{IdleBackfillMode, save_settings};
 
 type ApiResult = std::result::Result<Json<Value>, JsonError>;
@@ -175,6 +175,13 @@ async fn refresh_one_reconciled(
                 {
                     let mut broker = state_for_refresh.code_diagnostics.write().await;
                     let _ = broker.finish_refresh(completed);
+                    let graph_conn = state_for_refresh.graph_conn.clone();
+                    broker
+                        .resolve_enclosing_nodes(move |file| {
+                            let graph_conn = graph_conn.clone();
+                            async move { node_spans_for_file(&graph_conn, &file).await }
+                        })
+                        .await;
                     let snapshot = broker.snapshot();
                     let files_with_diagnostics =
                         files_with_diagnostics(&snapshot, &language_for_refresh);
@@ -296,6 +303,36 @@ async fn reconcile_project_language_activity(
         .await
         .update_project_languages(active_languages);
     Ok(())
+}
+
+/// Loads the indexed symbol spans for a file so a diagnostic can be attributed
+/// to its smallest enclosing node. Returns an empty vec (leaving the diagnostic
+/// unattributed) when the file isn't indexed or the query fails — the enclosing
+/// node is a best-effort annotation, never a hard dependency of a refresh.
+async fn node_spans_for_file(conn: &libsql::Connection, file: &str) -> Vec<NodeSpan> {
+    let mut spans = Vec::new();
+    let Ok(mut rows) = conn
+        .query(
+            "SELECT start_line, end_line, qualified_name FROM nodes WHERE file_path = ?1",
+            libsql::params![file],
+        )
+        .await
+    else {
+        return spans;
+    };
+    while let Ok(Some(row)) = rows.next().await {
+        let (Ok(start_line), Ok(end_line), Ok(qualified_name)) =
+            (row.get::<i64>(0), row.get::<i64>(1), row.get::<String>(2))
+        else {
+            continue;
+        };
+        spans.push(NodeSpan {
+            start_line: start_line.max(0) as u32,
+            end_line: end_line.max(0) as u32,
+            qualified_name,
+        });
+    }
+    spans
 }
 
 async fn indexed_files(conn: &libsql::Connection) -> crate::errors::Result<Vec<String>> {

--- a/src/db/fingerprints.rs
+++ b/src/db/fingerprints.rs
@@ -73,26 +73,42 @@ impl Database {
         }
     }
 
-    /// Fetch every fingerprint row. The caller (the redundancy handler)
-    /// filters by `body_tokens` window before pairwise comparison so the
-    /// full table scan is acceptable.
-    pub async fn get_all_fingerprints(&self) -> Result<Vec<StoredFingerprint>> {
+    /// Fetch cached fingerprint rows whose `body_tokens` fall inside the
+    /// inclusive `[lo, hi]` window, capped at `limit` rows.
+    ///
+    /// The `body_tokens` range is filtered in SQL so a large cache never
+    /// materializes fully in memory — callers pass a bounded `limit` (the
+    /// diagnose near-duplicate lookup caps it) so a huge cache cannot blow up
+    /// the call. Each row carries its `node_id`, so results map back to graph
+    /// nodes; row order is unspecified.
+    pub async fn fingerprints_in_token_window(
+        &self,
+        lo: u32,
+        hi: u32,
+        limit: usize,
+    ) -> Result<Vec<StoredFingerprint>> {
         let mut rows = self
             .conn()
             .query(
                 "SELECT node_id, ast_hash, cfg_hash, call_seq_hash, shingles, body_tokens, source_hash
-                   FROM node_fingerprints",
-                (),
+                   FROM node_fingerprints
+                  WHERE body_tokens >= ?1 AND body_tokens <= ?2
+                  LIMIT ?3",
+                params![
+                    i64::from(lo),
+                    i64::from(hi),
+                    i64::try_from(limit).unwrap_or(i64::MAX),
+                ],
             )
             .await
             .map_err(|e| TraceDecayError::Database {
-                message: format!("failed to query fingerprints: {e}"),
-                operation: "get_all_fingerprints".to_string(),
+                message: format!("failed to query fingerprint window: {e}"),
+                operation: "fingerprints_in_token_window".to_string(),
             })?;
-        let mut out: Vec<StoredFingerprint> = Vec::new();
+        let mut out = Vec::new();
         while let Some(row) = rows.next().await.map_err(|e| TraceDecayError::Database {
-            message: format!("failed to read fingerprint row: {e}"),
-            operation: "get_all_fingerprints".to_string(),
+            message: format!("failed to read fingerprint window row: {e}"),
+            operation: "fingerprints_in_token_window".to_string(),
         })? {
             out.push(row_to_fingerprint(&row)?);
         }

--- a/src/db/fingerprints.rs
+++ b/src/db/fingerprints.rs
@@ -20,6 +20,21 @@ pub struct StoredFingerprint {
     pub source_hash: String,
 }
 
+impl From<StoredFingerprint> for crate::redundancy::Fingerprint {
+    /// Rehydrate a stored row into the in-memory scoring shape, dropping the
+    /// `node_id` (which the fingerprint itself does not carry).
+    fn from(stored: StoredFingerprint) -> Self {
+        Self {
+            ast_hash: stored.ast_hash,
+            cfg_hash: stored.cfg_hash,
+            call_seq_hash: stored.call_seq_hash,
+            shingles: stored.shingles,
+            body_tokens: stored.body_tokens as usize,
+            source_hash: stored.source_hash,
+        }
+    }
+}
+
 impl Database {
     /// Upsert a fingerprint for a node. Replaces any existing row.
     pub async fn upsert_fingerprint(

--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -16,7 +16,7 @@ use crate::memory::store::MemoryStore;
 
 /// The highest migration version defined in this file. Bump this and add a
 /// new entry to `run_migration` whenever the schema changes.
-const LATEST_VERSION: u32 = 15;
+const LATEST_VERSION: u32 = 16;
 
 /// Reads the current schema version from `PRAGMA user_version`.
 async fn get_version(conn: &Connection) -> Result<u32> {
@@ -273,6 +273,13 @@ pub async fn create_schema(conn: &Connection) -> Result<()> {
         operation: "create_schema".to_string(),
     })?;
 
+    conn.execute_batch(REDUNDANCY_PAIRS_SCHEMA)
+        .await
+        .map_err(|e| TraceDecayError::Database {
+            message: format!("failed to create redundancy_pairs schema: {e}"),
+            operation: "create_schema".to_string(),
+        })?;
+
     create_holographic_memory_schema(conn, "create_schema").await?;
     set_version(conn, LATEST_VERSION).await?;
     Ok(())
@@ -362,6 +369,7 @@ async fn run_migration(conn: &Connection, version: u32) -> Result<()> {
         13 => migrate_v13(conn).await,
         14 => migrate_v14(conn).await,
         15 => migrate_v15(conn).await,
+        16 => migrate_v16(conn).await,
         _ => Err(TraceDecayError::Database {
             message: format!("unknown migration version: {version}"),
             operation: "run_migration".to_string(),
@@ -558,6 +566,50 @@ async fn migrate_v15(conn: &Connection) -> Result<()> {
     backfill_holographic_memory_vectors_and_banks(conn).await?;
     Ok(())
 }
+
+/// v16: `redundancy_pairs` — a freshness-validated cache of the duplicate pairs
+/// computed by `tracedecay_redundancy`.
+///
+/// Lets other surfaces (diagnose near-duplicate enrichment, the dashboard,
+/// future tools) read the last-known duplicates by an indexed lookup instead
+/// of re-running the token-window scan. Rows are keyed on the canonical
+/// `(node_a_id, node_b_id)` orientation the scan already emits (a < b by
+/// `(file_path, start_line, id)`), and carry the `source_hash` of each side so
+/// a reader can join against `node_fingerprints` and discard any row whose
+/// stored hash no longer matches the current cached fingerprint. `ON DELETE
+/// CASCADE` reclaims rows when either node is deleted, so orphan cleanup is
+/// automatic and no explicit sweep is needed. Idempotent via `IF NOT EXISTS`.
+async fn migrate_v16(conn: &Connection) -> Result<()> {
+    conn.execute_batch(REDUNDANCY_PAIRS_SCHEMA)
+        .await
+        .map_err(|e| TraceDecayError::Database {
+            message: format!("v16: failed to create redundancy_pairs table: {e}"),
+            operation: "migrate_v16".to_string(),
+        })?;
+    Ok(())
+}
+
+/// Freshness-validated cache of `tracedecay_redundancy` duplicate pairs. Shared
+/// verbatim by the fresh-schema path (`create_schema`) and the v16 migration so
+/// the two cannot drift. See [`migrate_v16`] for the column contract.
+const REDUNDANCY_PAIRS_SCHEMA: &str = "CREATE TABLE IF NOT EXISTS redundancy_pairs (
+        node_a_id TEXT NOT NULL,
+        node_b_id TEXT NOT NULL,
+        source_hash_a TEXT NOT NULL,
+        source_hash_b TEXT NOT NULL,
+        ranking_score REAL NOT NULL,
+        similarity REAL NOT NULL,
+        vector_cosine REAL NOT NULL,
+        overlap_kind TEXT NOT NULL,
+        severity TEXT NOT NULL,
+        generic_helper_downranked INTEGER NOT NULL,
+        computed_at INTEGER NOT NULL,
+        PRIMARY KEY (node_a_id, node_b_id),
+        FOREIGN KEY (node_a_id) REFERENCES nodes(id) ON DELETE CASCADE,
+        FOREIGN KEY (node_b_id) REFERENCES nodes(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_redundancy_pairs_node_b ON redundancy_pairs(node_b_id);";
 
 /// Append-only audit log of memory mutations (add/update/remove/feedback and
 /// curation applies). `detail_json` never carries fact content beyond what

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -8,6 +8,7 @@ mod maintenance;
 mod metadata;
 pub mod migrations;
 mod nodes;
+mod redundancy_pairs;
 mod rows;
 mod search;
 mod sql;
@@ -20,4 +21,5 @@ pub(crate) use connection::{
     platform_safe_journal_mode, platform_safe_mmap_size, platform_safe_synchronous_mode,
 };
 pub use fingerprints::StoredFingerprint;
+pub use redundancy_pairs::{RedundancyPairRow, RedundancyPairWrite};
 pub use search::DependencyImportUse;

--- a/src/db/redundancy_pairs.rs
+++ b/src/db/redundancy_pairs.rs
@@ -77,36 +77,53 @@ impl Database {
         &self,
         pairs: &[RedundancyPairWrite<'_>],
     ) -> Result<usize> {
+        if pairs.is_empty() {
+            return Ok(0);
+        }
+
+        let tx = self
+            .conn()
+            .transaction()
+            .await
+            .map_err(|e| TraceDecayError::Database {
+                message: format!("failed to begin transaction: {e}"),
+                operation: "upsert_redundancy_pairs".to_string(),
+            })?;
+
         let mut written = 0usize;
         for pair in pairs {
-            self.conn()
-                .execute(
-                    "INSERT OR REPLACE INTO redundancy_pairs
+            tx.execute(
+                "INSERT OR REPLACE INTO redundancy_pairs
                      (node_a_id, node_b_id, source_hash_a, source_hash_b,
                       ranking_score, similarity, vector_cosine, overlap_kind,
                       severity, generic_helper_downranked, computed_at)
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-                    params![
-                        pair.node_a_id,
-                        pair.node_b_id,
-                        pair.source_hash_a,
-                        pair.source_hash_b,
-                        pair.ranking_score,
-                        pair.similarity,
-                        pair.vector_cosine,
-                        pair.overlap_kind,
-                        pair.severity,
-                        i64::from(pair.generic_helper_downranked),
-                        pair.computed_at,
-                    ],
-                )
-                .await
-                .map_err(|e| TraceDecayError::Database {
-                    message: format!("failed to upsert redundancy pair: {e}"),
-                    operation: "upsert_redundancy_pairs".to_string(),
-                })?;
+                params![
+                    pair.node_a_id,
+                    pair.node_b_id,
+                    pair.source_hash_a,
+                    pair.source_hash_b,
+                    pair.ranking_score,
+                    pair.similarity,
+                    pair.vector_cosine,
+                    pair.overlap_kind,
+                    pair.severity,
+                    i64::from(pair.generic_helper_downranked),
+                    pair.computed_at,
+                ],
+            )
+            .await
+            .map_err(|e| TraceDecayError::Database {
+                message: format!("failed to upsert redundancy pair: {e}"),
+                operation: "upsert_redundancy_pairs".to_string(),
+            })?;
             written += 1;
         }
+
+        tx.commit().await.map_err(|e| TraceDecayError::Database {
+            message: format!("failed to commit transaction: {e}"),
+            operation: "upsert_redundancy_pairs".to_string(),
+        })?;
         Ok(written)
     }
 
@@ -165,7 +182,9 @@ fn row_to_pair(row: &libsql::Row) -> Result<RedundancyPairRow> {
         message: format!("failed to read redundancy pair {field}: {e}"),
         operation: "row_to_pair".to_string(),
     };
-    let downranked: i64 = row.get(7).map_err(|e| get_err("generic_helper_downranked", e))?;
+    let downranked: i64 = row
+        .get(7)
+        .map_err(|e| get_err("generic_helper_downranked", e))?;
     Ok(RedundancyPairRow {
         node_a_id: row.get(0).map_err(|e| get_err("node_a_id", e))?,
         node_b_id: row.get(1).map_err(|e| get_err("node_b_id", e))?,

--- a/src/db/redundancy_pairs.rs
+++ b/src/db/redundancy_pairs.rs
@@ -1,0 +1,180 @@
+// Rust guideline compliant 2026-07-09
+//! Freshness-validated cache of `tracedecay_redundancy` duplicate pairs.
+//!
+//! The redundancy handler computes duplicate function/method pairs on demand.
+//! Persisting the ranked pairs here lets other surfaces — the diagnose
+//! near-duplicate enrichment, the dashboard, future tools — read the
+//! last-known duplicates by an indexed lookup instead of re-running the
+//! token-window scan.
+//!
+//! Rows are stored in the canonical `(node_a_id, node_b_id)` orientation the
+//! scan already emits (`a < b` by `(file_path, start_line, id)`) and carry the
+//! `source_hash` of each side. A row is only *served* when both stored hashes
+//! still match the current `node_fingerprints.source_hash` for their nodes —
+//! see [`Database::fresh_redundancy_pairs_for_node`] for the staleness
+//! contract. `ON DELETE CASCADE` on the schema reclaims rows when either node
+//! is deleted, so orphaned rows never need an explicit sweep.
+
+use libsql::params;
+
+use super::connection::Database;
+use crate::errors::{Result, TraceDecayError};
+
+/// A duplicate pair to persist. Borrows from the caller's `RedundantPair`
+/// slice so the writer stays decoupled from `crate::redundancy`.
+#[derive(Debug, Clone, Copy)]
+pub struct RedundancyPairWrite<'a> {
+    pub node_a_id: &'a str,
+    pub node_b_id: &'a str,
+    pub source_hash_a: &'a str,
+    pub source_hash_b: &'a str,
+    pub ranking_score: f64,
+    pub similarity: f64,
+    pub vector_cosine: f64,
+    pub overlap_kind: &'a str,
+    pub severity: &'a str,
+    pub generic_helper_downranked: bool,
+    /// UNIX seconds the pair was computed; stamped by the caller.
+    pub computed_at: i64,
+}
+
+/// A stored duplicate pair row served by the reader. `node_a_id` / `node_b_id`
+/// keep the canonical orientation; callers pick the partner relative to the
+/// node they queried.
+#[derive(Debug, Clone)]
+pub struct RedundancyPairRow {
+    pub node_a_id: String,
+    pub node_b_id: String,
+    pub ranking_score: f64,
+    pub similarity: f64,
+    pub vector_cosine: f64,
+    pub overlap_kind: String,
+    pub severity: String,
+    pub generic_helper_downranked: bool,
+    pub computed_at: i64,
+}
+
+impl RedundancyPairRow {
+    /// The id of the pair member that is *not* `node_id`. Assumes `node_id`
+    /// is one of the two members (the reader only returns such rows).
+    #[must_use]
+    pub fn partner_of(&self, node_id: &str) -> &str {
+        if self.node_a_id == node_id {
+            &self.node_b_id
+        } else {
+            &self.node_a_id
+        }
+    }
+}
+
+impl Database {
+    /// Upsert computed duplicate pairs, replacing any existing row for the
+    /// same `(node_a_id, node_b_id)` key. Returns the number of rows written.
+    ///
+    /// Callers pass pairs in canonical orientation (`a < b`); the primary key
+    /// makes a re-run idempotent. Empty input is a no-op.
+    pub async fn upsert_redundancy_pairs(
+        &self,
+        pairs: &[RedundancyPairWrite<'_>],
+    ) -> Result<usize> {
+        let mut written = 0usize;
+        for pair in pairs {
+            self.conn()
+                .execute(
+                    "INSERT OR REPLACE INTO redundancy_pairs
+                     (node_a_id, node_b_id, source_hash_a, source_hash_b,
+                      ranking_score, similarity, vector_cosine, overlap_kind,
+                      severity, generic_helper_downranked, computed_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    params![
+                        pair.node_a_id,
+                        pair.node_b_id,
+                        pair.source_hash_a,
+                        pair.source_hash_b,
+                        pair.ranking_score,
+                        pair.similarity,
+                        pair.vector_cosine,
+                        pair.overlap_kind,
+                        pair.severity,
+                        i64::from(pair.generic_helper_downranked),
+                        pair.computed_at,
+                    ],
+                )
+                .await
+                .map_err(|e| TraceDecayError::Database {
+                    message: format!("failed to upsert redundancy pair: {e}"),
+                    operation: "upsert_redundancy_pairs".to_string(),
+                })?;
+            written += 1;
+        }
+        Ok(written)
+    }
+
+    /// Return the cached duplicate pairs that mention `node_id`, filtered to
+    /// only the **fresh** rows.
+    ///
+    /// Staleness contract: a row is served only when the stored `source_hash`
+    /// of *both* its members still equals the current
+    /// `node_fingerprints.source_hash` for that node. Any row whose either
+    /// side's fingerprint is missing or has a different hash (the node's body
+    /// changed, or its fingerprint was never recomputed) is filtered out — the
+    /// inner join to `node_fingerprints` on `(node_id, source_hash)` enforces
+    /// this. Deleted nodes drop out via `ON DELETE CASCADE` on the table, so
+    /// this reader never returns a pair pointing at a vanished node.
+    ///
+    /// Rows are ordered by `ranking_score` descending, then by ids for a
+    /// deterministic tie-break independent of storage order.
+    pub async fn fresh_redundancy_pairs_for_node(
+        &self,
+        node_id: &str,
+    ) -> Result<Vec<RedundancyPairRow>> {
+        let mut rows = self
+            .conn()
+            .query(
+                "SELECT rp.node_a_id, rp.node_b_id, rp.ranking_score, rp.similarity,
+                        rp.vector_cosine, rp.overlap_kind, rp.severity,
+                        rp.generic_helper_downranked, rp.computed_at
+                   FROM redundancy_pairs rp
+                   JOIN node_fingerprints fa
+                     ON fa.node_id = rp.node_a_id AND fa.source_hash = rp.source_hash_a
+                   JOIN node_fingerprints fb
+                     ON fb.node_id = rp.node_b_id AND fb.source_hash = rp.source_hash_b
+                  WHERE rp.node_a_id = ?1 OR rp.node_b_id = ?1
+                  ORDER BY rp.ranking_score DESC, rp.node_a_id ASC, rp.node_b_id ASC",
+                params![node_id],
+            )
+            .await
+            .map_err(|e| TraceDecayError::Database {
+                message: format!("failed to query fresh redundancy pairs: {e}"),
+                operation: "fresh_redundancy_pairs_for_node".to_string(),
+            })?;
+
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| TraceDecayError::Database {
+            message: format!("failed to read redundancy pair row: {e}"),
+            operation: "fresh_redundancy_pairs_for_node".to_string(),
+        })? {
+            out.push(row_to_pair(&row)?);
+        }
+        Ok(out)
+    }
+}
+
+fn row_to_pair(row: &libsql::Row) -> Result<RedundancyPairRow> {
+    let get_err = |field: &str, e: libsql::Error| TraceDecayError::Database {
+        message: format!("failed to read redundancy pair {field}: {e}"),
+        operation: "row_to_pair".to_string(),
+    };
+    let downranked: i64 = row.get(7).map_err(|e| get_err("generic_helper_downranked", e))?;
+    Ok(RedundancyPairRow {
+        node_a_id: row.get(0).map_err(|e| get_err("node_a_id", e))?,
+        node_b_id: row.get(1).map_err(|e| get_err("node_b_id", e))?,
+        ranking_score: row.get(2).map_err(|e| get_err("ranking_score", e))?,
+        similarity: row.get(3).map_err(|e| get_err("similarity", e))?,
+        vector_cosine: row.get(4).map_err(|e| get_err("vector_cosine", e))?,
+        overlap_kind: row.get(5).map_err(|e| get_err("overlap_kind", e))?,
+        severity: row.get(6).map_err(|e| get_err("severity", e))?,
+        generic_helper_downranked: downranked != 0,
+        computed_at: row.get(8).map_err(|e| get_err("computed_at", e))?,
+    })
+}

--- a/src/diagnostics/lsp/broker.rs
+++ b/src/diagnostics/lsp/broker.rs
@@ -29,6 +29,32 @@ pub struct CodeDiagnostic {
     pub updated_at: i64,
 }
 
+/// Minimal indexed-symbol span used to attribute a diagnostic to the smallest
+/// enclosing code-graph node. Line numbers are 0-based, matching
+/// [`crate::types::Node`]; they are compared against a diagnostic's 1-based line
+/// inside [`enclosing_node_for_line`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeSpan {
+    pub start_line: u32,
+    pub end_line: u32,
+    pub qualified_name: String,
+}
+
+/// Returns the qualified name of the smallest span that encloses `line_1based`,
+/// or `None` when no span covers it. Shared by the LSP broker and the
+/// `tracedecay_diagnostics` handler so both attribute diagnostics identically.
+pub fn enclosing_node_for_line(spans: &[NodeSpan], line_1based: u32) -> Option<String> {
+    if line_1based == 0 {
+        return None;
+    }
+    let node_line = line_1based - 1;
+    spans
+        .iter()
+        .filter(|span| span.start_line <= node_line && node_line <= span.end_line)
+        .min_by_key(|span| span.end_line.saturating_sub(span.start_line))
+        .map(|span| span.qualified_name.clone())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticSeverity {
@@ -476,6 +502,31 @@ impl DiagnosticBroker {
 
     pub fn cache_diagnostic(&mut self, diagnostic: CodeDiagnostic) {
         self.diagnostics.push(diagnostic);
+    }
+
+    /// Fills `enclosing_node` for cached diagnostics that don't yet have it,
+    /// calling `fetch_spans` once per file to load its indexed symbols.
+    /// Diagnostics whose file has no covering span leave `enclosing_node` as
+    /// `None`. The broker holds no code-graph handle of its own, so callers
+    /// inject the lookup (the dashboard backs it with its graph connection).
+    pub async fn resolve_enclosing_nodes<F, Fut>(&mut self, mut fetch_spans: F)
+    where
+        F: FnMut(String) -> Fut,
+        Fut: std::future::Future<Output = Vec<NodeSpan>>,
+    {
+        let mut spans_by_file: BTreeMap<String, Vec<NodeSpan>> = BTreeMap::new();
+        for diagnostic in &mut self.diagnostics {
+            if diagnostic.enclosing_node.is_some() {
+                continue;
+            }
+            if !spans_by_file.contains_key(&diagnostic.file) {
+                let fetched = fetch_spans(diagnostic.file.clone()).await;
+                spans_by_file.insert(diagnostic.file.clone(), fetched);
+            }
+            if let Some(spans) = spans_by_file.get(&diagnostic.file) {
+                diagnostic.enclosing_node = enclosing_node_for_line(spans, diagnostic.line_start);
+            }
+        }
     }
 
     pub fn record_backfill_progress(

--- a/src/diagnostics/lsp/client.rs
+++ b/src/diagnostics/lsp/client.rs
@@ -640,6 +640,9 @@ impl LspDiagnostic {
             },
             code: self.code.and_then(code_to_string),
             message: self.message,
+            // The LSP client has no code-graph handle; the enclosing symbol is
+            // resolved later via `DiagnosticBroker::resolve_enclosing_nodes`,
+            // which has access to the indexed nodes for the file.
             enclosing_node: None,
             updated_at: now_unix(),
         }

--- a/src/hooks/claude.rs
+++ b/src/hooks/claude.rs
@@ -7,7 +7,8 @@ use serde_json::Value;
 use super::codex::{codex_additional_context_json, codex_project_root_from_parsed_event};
 use super::post_tool_use::{
     CLAUDE_POST_TOOL_USE_SHELL_TOOLS, CLAUDE_POST_TOOL_USE_SPEC, is_claude_edit_tool,
-    is_claude_hint_tool, notify_post_tool_use, tool_input_command_str, tool_input_file_path_str,
+    is_claude_hint_tool, notify_post_tool_use, tool_input_command_str, tool_input_edit_text,
+    tool_input_file_path_str,
 };
 use super::steering::{
     append_context_recovery_hint, append_tracedecay_bootstrap_context,
@@ -87,6 +88,7 @@ pub fn evaluate_hook_decision(tool_input: &str) -> String {
             .and_then(Value::as_str)
             .map(str::to_string),
         file_path: None,
+        edit_text: None,
         hints_enabled: true,
     });
     let block_reason = research_block_reason(hint);
@@ -316,16 +318,24 @@ fn claude_post_tool_use_hint_context(event_json: &str) -> Option<String> {
 fn decide_post_tool_use_hint(parsed: &Value) -> Option<ToolHint> {
     let tool_name = parsed.get("tool_name").and_then(Value::as_str)?;
     let file_path = tool_input_file_path_str(parsed);
-    // Candidates: the native hint tools (Grep/Glob/Read), Bash, and the
-    // edit/write tools *only* when they target a harness-memory file (so the
-    // memory_store hint can route durable facts to tracedecay_fact_store).
-    // Every other edit/write drives daemon sync only and gets no hint.
+    // Candidates: the native hint tools (Grep/Glob/Read), Bash, edit/write tools
+    // targeting a harness-memory file (so the memory_store hint can route
+    // durable facts to tracedecay_fact_store), and edit/write tools that add a
+    // new function-sized body (so the edit_redundancy hint can nudge a
+    // duplicate-logic probe). `edit_text` is read only for edit tools and only
+    // to feed those two edit branches; every other edit/write drives daemon sync
+    // only and gets no hint.
     let is_shell = CLAUDE_POST_TOOL_USE_SHELL_TOOLS
         .iter()
         .any(|tool| tool.eq_ignore_ascii_case(tool_name));
-    let is_memory_edit =
-        is_claude_edit_tool(tool_name) && file_path.as_deref().is_some_and(is_harness_memory_path);
-    if !is_claude_hint_tool(tool_name) && !is_shell && !is_memory_edit {
+    let is_edit = is_claude_edit_tool(tool_name);
+    let is_memory_edit = is_edit && file_path.as_deref().is_some_and(is_harness_memory_path);
+    // Only pay the string scan for non-memory edits (memory edits route to their
+    // own branch and never carry a code body worth probing).
+    let edit_text = (is_edit && !is_memory_edit)
+        .then(|| tool_input_edit_text(parsed))
+        .flatten();
+    if !is_claude_hint_tool(tool_name) && !is_shell && !is_memory_edit && edit_text.is_none() {
         return None;
     }
     decide_hint(&ToolHintInput {
@@ -336,6 +346,7 @@ fn decide_post_tool_use_hint(parsed: &Value) -> Option<ToolHint> {
         prompt: None,
         subagent_type: None,
         file_path,
+        edit_text,
         hints_enabled: true,
     })
 }
@@ -471,6 +482,47 @@ mod tests {
                 "{tool} on a source file drives daemon sync only and must not emit a hint"
             );
         }
+    }
+
+    #[test]
+    fn write_adding_a_function_body_decides_an_edit_redundancy_hint() {
+        // A Write whose content is a new function-sized Rust body nudges toward
+        // the duplicate-logic probe.
+        let content = "fn summarize(items: &[Item]) -> u64 {\n    let mut total = 0;\n    for item in items {\n        if item.active {\n            total += item.count;\n        }\n    }\n    total\n}\n";
+        let event = post_event(
+            "Write",
+            &serde_json::json!({ "file_path": "src/widgets.rs", "content": content }),
+        );
+        let hint = decide_post_tool_use_hint(&event)
+            .expect("a new function-sized Write must produce an edit-redundancy hint");
+        let context = format_tool_hint(&hint);
+        assert!(
+            context.contains("tracedecay_redundancy"),
+            "edit-redundancy hint must point at tracedecay_redundancy: {context}"
+        );
+
+        // A MultiEdit whose joined new_strings form a function body also nudges.
+        let multi = post_event(
+            "MultiEdit",
+            &serde_json::json!({
+                "file_path": "src/widgets.rs",
+                "edits": [ { "old_string": "", "new_string": content } ],
+            }),
+        );
+        assert!(
+            decide_post_tool_use_hint(&multi).is_some(),
+            "a MultiEdit adding a function body must produce a hint"
+        );
+
+        // A small, non-function edit stays silent.
+        let tiny = post_event(
+            "Edit",
+            &serde_json::json!({ "file_path": "src/widgets.rs", "new_string": "let x = 1;" }),
+        );
+        assert!(
+            decide_post_tool_use_hint(&tiny).is_none(),
+            "a small non-function edit must not produce a hint"
+        );
     }
 
     #[test]

--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -558,6 +558,7 @@ fn codex_prompt_hint(event_json: &str) -> Option<ToolHint> {
         prompt: prompt_like_text(&parsed),
         subagent_type: None,
         file_path: None,
+        edit_text: None,
         hints_enabled: true,
     })?;
     let root = codex_project_root_from_event(event_json);

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -160,6 +160,7 @@ fn cursor_prompt_hint(event_json: &str) -> Option<ToolHint> {
         prompt: prompt_like_text(&parsed),
         subagent_type: None,
         file_path: None,
+        edit_text: None,
         hints_enabled: true,
     })?;
     let root = cursor_project_root_candidate_from_parsed_event(&parsed);
@@ -798,6 +799,9 @@ fn cursor_tool_hint_input(parsed: &Value) -> ToolHintInput {
         subagent_type: text_field(parsed, &["subagent_type", "subagentType", "agent_type"]),
         file_path: text_field(tool_input, CURSOR_FILE_PATH_FIELDS)
             .or_else(|| text_field(parsed, CURSOR_FILE_PATH_FIELDS)),
+        // Cursor's prompt/pre-tool surface does not carry edit bodies; the
+        // edit-redundancy nudge is a Claude post-tool-use surface only.
+        edit_text: None,
         hints_enabled: true,
     }
 }

--- a/src/hooks/kiro.rs
+++ b/src/hooks/kiro.rs
@@ -59,6 +59,7 @@ pub fn evaluate_kiro_pre_tool_use(event_json: &str) -> Option<String> {
             prompt: Some(prompt),
             subagent_type: Some(tool_name.to_string()),
             file_path: None,
+            edit_text: None,
             hints_enabled: true,
         });
         Some(research_block_reason(hint))

--- a/src/hooks/post_tool_use.rs
+++ b/src/hooks/post_tool_use.rs
@@ -141,7 +141,11 @@ pub(super) fn tool_input_command_str(parsed: &Value) -> Option<String> {
 pub(super) fn tool_input_edit_text(parsed: &Value) -> Option<String> {
     let ti = parsed.get("tool_input")?;
     for key in ["content", "new_string", "new_source"] {
-        if let Some(text) = ti.get(key).and_then(Value::as_str).filter(|s| !s.is_empty()) {
+        if let Some(text) = ti
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        {
             return Some(text.to_string());
         }
     }

--- a/src/hooks/post_tool_use.rs
+++ b/src/hooks/post_tool_use.rs
@@ -133,6 +133,34 @@ pub(super) fn tool_input_command_str(parsed: &Value) -> Option<String> {
     (!command.is_empty()).then(|| command.to_string())
 }
 
+/// The text an edit tool adds, if any: `Write`'s `content`, `Edit`'s
+/// `new_string`, the joined `MultiEdit` `edits[].new_string`s, or
+/// `NotebookEdit`'s `new_source`. Used only by the Claude hint surface to detect
+/// a newly added function body; it never drives daemon sync. O(len): reads or
+/// concatenates existing JSON string fields without parsing code.
+pub(super) fn tool_input_edit_text(parsed: &Value) -> Option<String> {
+    let ti = parsed.get("tool_input")?;
+    for key in ["content", "new_string", "new_source"] {
+        if let Some(text) = ti.get(key).and_then(Value::as_str).filter(|s| !s.is_empty()) {
+            return Some(text.to_string());
+        }
+    }
+    // MultiEdit: join each replacement's new text so a body split across edits
+    // still reaches the line/keyword heuristic.
+    let joined = ti
+        .get("edits")
+        .and_then(Value::as_array)
+        .map(|edits| {
+            edits
+                .iter()
+                .filter_map(|edit| edit.get("new_string").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .filter(|joined| !joined.is_empty())?;
+    Some(joined)
+}
+
 /// The `tool_input.file_path` string, if any (Grep/Glob/Read/Edit targets).
 /// Empty when absent.
 pub(super) fn tool_input_file_path_str(parsed: &Value) -> Option<String> {

--- a/src/hooks/steering.rs
+++ b/src/hooks/steering.rs
@@ -131,6 +131,12 @@ pub fn build_codex_session_context_for_workspace(
                  paste captured output into tracedecay_diagnose, or run tracedecay_diagnostics \
                  for fresh structured errors mapped to the enclosing symbols and callers.\n",
             );
+            s.push_str(
+                "Managed subagents installed: tracedecay-code-explorer (scoped code \
+                 exploration), tracedecay-code-health-auditor (health audits), \
+                 tracedecay-session-historian (past-session recall) — prefer them over \
+                 generic subagents for those jobs.\n",
+            );
             s.push_str(crate::agents::CLI_FALLBACK_PROMPT_RULES);
             s.push('\n');
             append_codex_recall_and_registry_guidance(&mut s);
@@ -293,6 +299,38 @@ mod tests {
                 "missing compile-moment cue for {status:?}"
             );
         }
+    }
+
+    #[test]
+    fn codex_session_context_advertises_managed_subagents() {
+        // Codex sessions have no other discovery surface for the managed
+        // tracedecay-* subagents besides this steering line, so it must
+        // survive on both the initialized and unindexed code-workspace
+        // surfaces, and stay off the generic (non-code-workspace) surface.
+        for status in [
+            HookWorkspaceStatus::Initialized,
+            HookWorkspaceStatus::UnindexedProject,
+        ] {
+            let context = build_codex_session_context_for_workspace(status, None);
+            assert!(
+                context.contains("tracedecay-code-explorer"),
+                "missing tracedecay-code-explorer mention for {status:?}"
+            );
+            assert!(
+                context.contains("tracedecay-code-health-auditor"),
+                "missing tracedecay-code-health-auditor mention for {status:?}"
+            );
+            assert!(
+                context.contains("tracedecay-session-historian"),
+                "missing tracedecay-session-historian mention for {status:?}"
+            );
+        }
+
+        let generic = build_codex_session_context_for_workspace(HookWorkspaceStatus::Generic, None);
+        assert!(
+            !generic.contains("tracedecay-code-explorer"),
+            "generic (non-code-workspace) surface should stay compact"
+        );
     }
 
     #[test]

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -46,6 +46,7 @@ pub enum HintCategory {
     BuildDiagnostics,
     ReviewChanges,
     MemoryStore,
+    EditRedundancy,
 }
 
 impl HintCategory {
@@ -247,6 +248,15 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         context: "tracedecay_fact_store persists a trust-ranked project/user fact that survives across sessions and is recalled by tracedecay_context and tracedecay_recall; a memory markdown edit is only visible to the current harness. Keep secrets and unnecessary PII out of stored facts.",
         nonblocking: false,
     },
+    HintCategorySpec {
+        category: HintCategory::EditRedundancy,
+        key: "edit_redundancy",
+        label: "new-function edit",
+        skill: "editing-safely",
+        message: "You just added a new function-sized block; before moving on, confirm it does not duplicate logic that already exists.",
+        context: "tracedecay_redundancy surfaces near-duplicate function bodies and tracedecay_similar finds structurally similar code; if a match exists, reuse or refactor the existing helper instead of keeping a second copy.",
+        nonblocking: true,
+    },
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -258,6 +268,11 @@ pub struct ToolHintInput {
     pub prompt: Option<String>,
     pub subagent_type: Option<String>,
     pub file_path: Option<String>,
+    /// Text an edit tool adds (Write `content`, Edit `new_string`, the joined
+    /// `MultiEdit` `new_string`s). Used only to detect a newly added
+    /// function-sized body for the [`HintCategory::EditRedundancy`] nudge; other
+    /// surfaces leave it `None`.
+    pub edit_text: Option<String>,
     pub hints_enabled: bool,
 }
 
@@ -271,6 +286,7 @@ impl Default for ToolHintInput {
             prompt: None,
             subagent_type: None,
             file_path: None,
+            edit_text: None,
             hints_enabled: true,
         }
     }
@@ -683,6 +699,10 @@ const CLASSIFICATION_RULES: &[ClassificationRule] = &[
         matches: |facts| is_memory_store_edit(facts.input),
     },
     ClassificationRule {
+        category: HintCategory::EditRedundancy,
+        matches: |facts| is_redundancy_candidate_edit(facts.input),
+    },
+    ClassificationRule {
         category: HintCategory::FileLookup,
         matches: |facts| {
             facts
@@ -752,10 +772,10 @@ use classifiers::{
     asks_for_session_recall, asks_for_symbol_lookup, asks_for_text_search,
     asks_for_type_orientation, combined_text, is_build_diagnostics_command, is_diff_review_command,
     is_explore_subagent, is_file_lookup_command, is_memory_store_edit,
-    is_project_discovery_command, is_semantic_search_tool, is_shell_file_read_command,
-    is_shell_search_command, is_shell_text_search_command, is_single_file_read,
-    is_subagent_context_handoff, is_tracedecay_tool_descriptor_read, looks_like_pasted_diagnostic,
-    matches_normalized,
+    is_project_discovery_command, is_redundancy_candidate_edit, is_semantic_search_tool,
+    is_shell_file_read_command, is_shell_search_command, is_shell_text_search_command,
+    is_single_file_read, is_subagent_context_handoff, is_tracedecay_tool_descriptor_read,
+    looks_like_pasted_diagnostic, matches_normalized,
 };
 
 #[cfg(test)]

--- a/src/hooks/tool_hints/classifiers.rs
+++ b/src/hooks/tool_hints/classifiers.rs
@@ -291,7 +291,9 @@ pub(super) fn is_redundancy_candidate_edit(input: &ToolHintInput) -> bool {
 /// only.
 fn added_text_adds_function_body(path: &str, text: &str) -> bool {
     // A small edit is never a duplicate-logic risk worth interrupting for.
-    if text.lines().count() < REDUNDANCY_EDIT_MIN_LINES {
+    // Stop after MIN_LINES lines instead of counting the whole (possibly huge)
+    // Write payload: if there is no MIN_LINES-th line, the edit is too small.
+    if text.lines().nth(REDUNDANCY_EDIT_MIN_LINES - 1).is_none() {
         return false;
     }
     let Some(ext) = source_extension(path) else {
@@ -923,7 +925,9 @@ mod tests {
         let body = rust_fn_body();
         // Non-edit tool.
         assert!(!is_redundancy_candidate_edit(&edit(
-            "Read", "src/widgets.rs", &body
+            "Read",
+            "src/widgets.rs",
+            &body
         )));
         // Missing file_path.
         assert!(!is_redundancy_candidate_edit(&ToolHintInput {
@@ -942,10 +946,22 @@ mod tests {
     #[test]
     fn language_keywords_are_recognized() {
         let cases = [
-            ("mod.py", "def build_report(rows):\n    total = 0\n    for r in rows:\n        if r.ok:\n            total += r.n\n        else:\n            total -= 1\n    return total\n"),
-            ("server.go", "func Handle(w Writer, r Request) {\n    a := 1\n    b := 2\n    c := a + b\n    d := c * 2\n    e := d - 1\n    f := e + 3\n    _ = f\n}\n"),
-            ("app.ts", "export function render(state: State) {\n    const a = 1;\n    const b = 2;\n    const c = a + b;\n    const d = c * 2;\n    const e = d - 1;\n    const f = e + 3;\n    return f;\n}\n"),
-            ("view.jsx", "const handler = (event) => {\n    const a = 1;\n    const b = 2;\n    const c = a + b;\n    const d = c * 2;\n    const e = d - 1;\n    const f = e + 3;\n    return f;\n};\n"),
+            (
+                "mod.py",
+                "def build_report(rows):\n    total = 0\n    for r in rows:\n        if r.ok:\n            total += r.n\n        else:\n            total -= 1\n    return total\n",
+            ),
+            (
+                "server.go",
+                "func Handle(w Writer, r Request) {\n    a := 1\n    b := 2\n    c := a + b\n    d := c * 2\n    e := d - 1\n    f := e + 3\n    _ = f\n}\n",
+            ),
+            (
+                "app.ts",
+                "export function render(state: State) {\n    const a = 1;\n    const b = 2;\n    const c = a + b;\n    const d = c * 2;\n    const e = d - 1;\n    const f = e + 3;\n    return f;\n}\n",
+            ),
+            (
+                "view.jsx",
+                "const handler = (event) => {\n    const a = 1;\n    const b = 2;\n    const c = a + b;\n    const d = c * 2;\n    const e = d - 1;\n    const f = e + 3;\n    return f;\n};\n",
+            ),
         ];
         for (path, body) in cases {
             assert!(
@@ -971,7 +987,9 @@ mod tests {
         ]
         .join("\n");
         assert!(is_redundancy_candidate_edit(&edit(
-            "Write", "Totals.java", &method
+            "Write",
+            "Totals.java",
+            &method
         )));
         // A block of only control-flow (no signature) does not qualify.
         let control_only = [
@@ -999,11 +1017,11 @@ mod tests {
     fn unknown_extension_never_matches() {
         let body = rust_fn_body();
         assert!(!is_redundancy_candidate_edit(&edit(
-            "Write",
-            "notes.md",
-            &body
+            "Write", "notes.md", &body
         )));
         // No extension at all.
-        assert!(!is_redundancy_candidate_edit(&edit("Write", "Makefile", &body)));
+        assert!(!is_redundancy_candidate_edit(&edit(
+            "Write", "Makefile", &body
+        )));
     }
 }

--- a/src/hooks/tool_hints/classifiers.rs
+++ b/src/hooks/tool_hints/classifiers.rs
@@ -262,6 +262,105 @@ pub(in crate::hooks) fn is_harness_memory_path(path: &str) -> bool {
         .any(|segment| segment.eq_ignore_ascii_case(".claude"))
 }
 
+/// Minimum number of added lines for an edit to count as a "meaningful" new
+/// body worth a redundancy nudge. Matches the redundancy tool's default
+/// `min_lines`, so a one-line rename or a tiny tweak never trips the hint.
+const REDUNDANCY_EDIT_MIN_LINES: usize = 8;
+
+/// True when a Write/Edit/MultiEdit event adds a new function-shaped body of
+/// meaningful size — the case where the model may be re-implementing logic that
+/// already exists. Conservative by design (prefers missing a hint over
+/// spamming), and `O(len(edit_text))`: pure string scanning over the added text
+/// already in hand, with no AST parsing and no file I/O.
+pub(super) fn is_redundancy_candidate_edit(input: &ToolHintInput) -> bool {
+    let is_edit_tool = input.tool_name.as_deref().is_some_and(|name| {
+        matches_normalized(name, &["write", "edit", "multiedit", "notebookedit"])
+    });
+    if !is_edit_tool {
+        return false;
+    }
+    let (Some(path), Some(text)) = (input.file_path.as_deref(), input.edit_text.as_deref()) else {
+        return false;
+    };
+    added_text_adds_function_body(path, text)
+}
+
+/// Core heuristic for [`is_redundancy_candidate_edit`]: does `text` (the text an
+/// edit adds) look like it introduces a new function/method body of at least
+/// [`REDUNDANCY_EDIT_MIN_LINES`] lines for `path`'s language? String scanning
+/// only.
+fn added_text_adds_function_body(path: &str, text: &str) -> bool {
+    // A small edit is never a duplicate-logic risk worth interrupting for.
+    if text.lines().count() < REDUNDANCY_EDIT_MIN_LINES {
+        return false;
+    }
+    let Some(ext) = source_extension(path) else {
+        return false;
+    };
+    text_contains_function_definition(&ext, text)
+}
+
+/// Lowercased file extension for `path`, if it has one.
+fn source_extension(path: &str) -> Option<String> {
+    std::path::Path::new(path)
+        .extension()
+        .map(|ext| ext.to_ascii_lowercase().to_string_lossy().into_owned())
+}
+
+/// Whether `text` contains a function-definition shape for the language family
+/// keyed by `ext`. Clear-keyword languages match on a definition keyword; the
+/// C-family/Java match on a conservative brace-signature shape. Unknown
+/// extensions never match, so a data/markdown edit is silent.
+fn text_contains_function_definition(ext: &str, text: &str) -> bool {
+    match ext {
+        "rs" => text.contains("fn "),
+        "py" | "pyi" | "rb" => text.contains("def "),
+        "go" | "swift" => text.contains("func "),
+        "kt" | "kts" => text.contains("fun "),
+        "php" => text.contains("function "),
+        "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => {
+            text.contains("function ") || text.contains("=> {")
+        }
+        "java" | "cs" | "c" | "cc" | "cpp" | "cxx" | "h" | "hpp" | "hh" => {
+            contains_brace_method_signature(text)
+        }
+        _ => false,
+    }
+}
+
+/// Conservative detector for a brace-language method signature line: a line that
+/// opens a block (`{`) after a parameter list `(...)` whose leading token is not
+/// a control-flow keyword (so `if (...) {`, `for (...) {`, etc. are excluded)
+/// and whose name sits directly before the `(`. Deliberately misses more than
+/// it matches to avoid false positives.
+fn contains_brace_method_signature(text: &str) -> bool {
+    text.lines().any(|line| {
+        let trimmed = line.trim();
+        if !trimmed.ends_with('{') || !trimmed.contains(')') {
+            return false;
+        }
+        let Some(open) = trimmed.find('(') else {
+            return false;
+        };
+        let before = trimmed[..open].trim_end();
+        // The name must sit immediately before `(` (a signature, not a bare
+        // block), and the first token must not be a control-flow keyword.
+        let ends_in_name = before
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+        let first_token = before
+            .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .find(|token| !token.is_empty())
+            .unwrap_or_default();
+        let is_control = matches!(
+            first_token,
+            "if" | "for" | "while" | "switch" | "catch" | "do" | "else" | "return" | "using"
+        );
+        ends_in_name && !is_control && !first_token.is_empty()
+    })
+}
+
 pub(super) fn is_project_discovery_command(command: &str) -> bool {
     shell_invocations(command).into_iter().any(|invocation| {
         matches!(
@@ -748,4 +847,163 @@ pub(super) fn matches_normalized(value: &str, expected: &[&str]) -> bool {
         .collect::<String>()
         .to_ascii_lowercase();
     expected.iter().any(|candidate| normalized == *candidate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edit(tool: &str, path: &str, text: &str) -> ToolHintInput {
+        ToolHintInput {
+            tool_name: Some(tool.to_string()),
+            file_path: Some(path.to_string()),
+            edit_text: Some(text.to_string()),
+            ..ToolHintInput::default()
+        }
+    }
+
+    fn rust_fn_body() -> String {
+        // A new function-sized Rust body (>= REDUNDANCY_EDIT_MIN_LINES lines).
+        [
+            "fn compute_widget_total(items: &[Item]) -> u64 {",
+            "    let mut total = 0;",
+            "    for item in items {",
+            "        if item.active {",
+            "            total += item.count;",
+            "        }",
+            "    }",
+            "    total",
+            "}",
+        ]
+        .join("\n")
+    }
+
+    #[test]
+    fn new_rust_function_body_is_a_redundancy_candidate() {
+        assert!(is_redundancy_candidate_edit(&edit(
+            "Write",
+            "src/widgets.rs",
+            &rust_fn_body(),
+        )));
+        // Edit and MultiEdit tools qualify too.
+        assert!(is_redundancy_candidate_edit(&edit(
+            "Edit",
+            "src/widgets.rs",
+            &rust_fn_body(),
+        )));
+        assert!(is_redundancy_candidate_edit(&edit(
+            "MultiEdit",
+            "src/widgets.rs",
+            &rust_fn_body(),
+        )));
+    }
+
+    #[test]
+    fn short_or_non_function_edits_are_not_candidates() {
+        // Under the line threshold, even with a `fn`.
+        assert!(!is_redundancy_candidate_edit(&edit(
+            "Write",
+            "src/widgets.rs",
+            "fn tiny() -> u8 { 1 }",
+        )));
+        // Long enough, but no function definition shape (a data/const block).
+        let data = (0..12)
+            .map(|i| format!("    const VALUE_{i}: u32 = {i};"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!is_redundancy_candidate_edit(&edit(
+            "Write",
+            "src/widgets.rs",
+            &data,
+        )));
+    }
+
+    #[test]
+    fn requires_edit_tool_path_and_text() {
+        let body = rust_fn_body();
+        // Non-edit tool.
+        assert!(!is_redundancy_candidate_edit(&edit(
+            "Read", "src/widgets.rs", &body
+        )));
+        // Missing file_path.
+        assert!(!is_redundancy_candidate_edit(&ToolHintInput {
+            tool_name: Some("Write".to_string()),
+            edit_text: Some(body.clone()),
+            ..ToolHintInput::default()
+        }));
+        // Missing edit_text.
+        assert!(!is_redundancy_candidate_edit(&ToolHintInput {
+            tool_name: Some("Write".to_string()),
+            file_path: Some("src/widgets.rs".to_string()),
+            ..ToolHintInput::default()
+        }));
+    }
+
+    #[test]
+    fn language_keywords_are_recognized() {
+        let cases = [
+            ("mod.py", "def build_report(rows):\n    total = 0\n    for r in rows:\n        if r.ok:\n            total += r.n\n        else:\n            total -= 1\n    return total\n"),
+            ("server.go", "func Handle(w Writer, r Request) {\n    a := 1\n    b := 2\n    c := a + b\n    d := c * 2\n    e := d - 1\n    f := e + 3\n    _ = f\n}\n"),
+            ("app.ts", "export function render(state: State) {\n    const a = 1;\n    const b = 2;\n    const c = a + b;\n    const d = c * 2;\n    const e = d - 1;\n    const f = e + 3;\n    return f;\n}\n"),
+            ("view.jsx", "const handler = (event) => {\n    const a = 1;\n    const b = 2;\n    const c = a + b;\n    const d = c * 2;\n    const e = d - 1;\n    const f = e + 3;\n    return f;\n};\n"),
+        ];
+        for (path, body) in cases {
+            assert!(
+                is_redundancy_candidate_edit(&edit("Write", path, body)),
+                "{path} body should be recognized as a new function"
+            );
+        }
+    }
+
+    #[test]
+    fn brace_method_signature_excludes_control_flow() {
+        // A Java method signature qualifies.
+        let method = [
+            "public int total(List<Item> items) {",
+            "    int total = 0;",
+            "    for (Item i : items) {",
+            "        if (i.active) {",
+            "            total += i.count;",
+            "        }",
+            "    }",
+            "    return total;",
+            "}",
+        ]
+        .join("\n");
+        assert!(is_redundancy_candidate_edit(&edit(
+            "Write", "Totals.java", &method
+        )));
+        // A block of only control-flow (no signature) does not qualify.
+        let control_only = [
+            "if (ready) {",
+            "    step();",
+            "} else if (waiting) {",
+            "    wait();",
+            "}",
+            "while (running) {",
+            "    tick();",
+            "}",
+            "for (int i = 0; i < 3; i++) {",
+            "    poll();",
+            "}",
+        ]
+        .join("\n");
+        assert!(!is_redundancy_candidate_edit(&edit(
+            "Write",
+            "Totals.java",
+            &control_only,
+        )));
+    }
+
+    #[test]
+    fn unknown_extension_never_matches() {
+        let body = rust_fn_body();
+        assert!(!is_redundancy_candidate_edit(&edit(
+            "Write",
+            "notes.md",
+            &body
+        )));
+        // No extension at all.
+        assert!(!is_redundancy_candidate_edit(&edit("Write", "Makefile", &body)));
+    }
 }

--- a/src/hooks/tool_hints/evals/mod.rs
+++ b/src/hooks/tool_hints/evals/mod.rs
@@ -277,7 +277,9 @@ fn default_families(
         }
         Some(HintCategory::BuildDiagnostics) => families.push(ScenarioFamily::BuildDiagnostics),
         Some(HintCategory::MemoryStore) => families.push(ScenarioFamily::MemoryStore),
-        None => {}
+        // The edit-redundancy nudge is an edit-tool surface; it rides the
+        // AdapterShape family already added for tool_name/file_path inputs.
+        Some(HintCategory::EditRedundancy) | None => {}
     }
 
     families
@@ -565,6 +567,38 @@ fn dynamic_action_context_cases() -> Vec<HintEval> {
                 tool_name: Some("Edit".to_string()),
                 file_path: Some("src/hooks/steering.rs".to_string()),
                 prompt: Some("tighten this string".to_string()),
+                ..ToolHintInput::default()
+            },
+            None,
+            &[],
+        ),
+        input_eval(
+            "new-function-write-nudges-redundancy",
+            ToolHintInput {
+                tool_name: Some("Write".to_string()),
+                file_path: Some("src/hooks/steering.rs".to_string()),
+                edit_text: Some(
+                    "fn summarize_hits(hits: &[Hit]) -> Summary {\n    \
+                     let mut total = 0;\n    \
+                     for hit in hits {\n        \
+                     if hit.active {\n            \
+                     total += hit.count;\n        \
+                     }\n    \
+                     }\n    \
+                     Summary { total }\n}\n"
+                        .to_string(),
+                ),
+                ..ToolHintInput::default()
+            },
+            Some(HintCategory::EditRedundancy),
+            &["tracedecay_redundancy", "tracedecay_similar"],
+        ),
+        input_eval(
+            "small-edit-does-not-nudge-redundancy",
+            ToolHintInput {
+                tool_name: Some("Edit".to_string()),
+                file_path: Some("src/hooks/steering.rs".to_string()),
+                edit_text: Some("fn one_liner() -> u8 { 1 }".to_string()),
                 ..ToolHintInput::default()
             },
             None,
@@ -893,6 +927,7 @@ fn scenario_coverage_reaches_high_value_target() {
         HintCategory::BuildDiagnostics,
         HintCategory::ReviewChanges,
         HintCategory::MemoryStore,
+        HintCategory::EditRedundancy,
     ]
     .into_iter()
     .collect();

--- a/src/hooks/tool_hints/tests.rs
+++ b/src/hooks/tool_hints/tests.rs
@@ -293,6 +293,7 @@ fn every_category_has_compact_skill_backed_rendering() {
         HintCategory::BuildDiagnostics,
         HintCategory::ReviewChanges,
         HintCategory::MemoryStore,
+        HintCategory::EditRedundancy,
     ];
 
     for category in categories {

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1898,7 +1898,7 @@ fn def_redundancy() -> ToolDefinition {
     def(
         "tracedecay_redundancy",
         "Redundancy Hunt",
-        "Find functionally duplicated function/method bodies via AST isomorphism, control-flow match, call-sequence match, token-shingle Jaccard similarity, and body-vector cosine similarity. Results include similarity, ranking_score, grouped duplicate components, and signal details such as body_vector_cosine and generic_helper_downranked. Each pair is bucketed as 'definite' (AST-identical), 'likely' (CFG, algorithmic, token, or body-vector match), or 'naming_only' (low confidence). Use when consolidating helpers or auditing code health. Computed lazily and cached per (node, body source hash) — first call on a fresh index can be slow on large repos.",
+        "Find functionally duplicated function/method bodies via AST isomorphism, control-flow match, call-sequence match, token-shingle Jaccard similarity, and body-vector cosine similarity. Results include similarity, ranking_score (a rank key, not a thresholded quantity), grouped duplicate components (connected components over the returned pairs only), and signal details such as body_vector_cosine and generic_helper_downranked. Each pair is bucketed as 'definite' (AST-identical with score >= 0.8), 'likely' (CFG, algorithmic, token, body-vector, or lower-scoring AST match at score >= 0.55), or 'naming_only' (weaker signals). Use when consolidating helpers or auditing code health. Computed lazily and cached per (node, body source hash) — first call on a fresh index can be slow on large repos.",
         json!({
             "type": "object",
             "properties": {
@@ -1916,11 +1916,15 @@ fn def_redundancy() -> ToolDefinition {
                 },
                 "similarity_threshold": {
                     "type": "number",
-                    "description": "Drop pairs scoring below this composite similarity (default: 0.6, range 0.0-1.0)"
+                    "description": "Drop pairs only when both the composite similarity and the body-vector cosine fall below this value (default: 0.6, range 0.0-1.0). A naming-only pair whose cosine clears this and 0.55 is reclassified as 'body_vector'"
                 },
                 "include_naming_only": {
                     "type": "boolean",
-                    "description": "If true, include 'naming_only' / low-confidence matches in the output (default: false)"
+                    "description": "If true, include pairs whose only signal is name similarity (overlap_kind 'naming'), including identical-non-generic-name pairs rescued below the score gate. Cosine-rescued 'body_vector' pairs are always included regardless of this flag (default: false)"
+                },
+                "include_generated_paths": {
+                    "type": "boolean",
+                    "description": "If true, also scan build outputs, vendored code, and worktree mirrors (dist/, build/, out/, node_modules/, vendor/, target/, .worktrees/, *.min.js). Excluded by default because generated mirrors duplicate real sources byte-for-byte (default: false)"
                 }
             }
         }),
@@ -2014,6 +2018,8 @@ fn def_diagnose() -> ToolDefinition {
          diagnostic to the smallest containing graph node, with callers \
          pre-attached so you can see what the failing code is reachable \
          from. Diagnostics without a `--> file:line:col` span are dropped. \
+         Each mapped node also carries up to 3 `near_duplicates` — cached \
+         functional-duplicate matches from the redundancy index, when present. \
          Pass the full stderr capture; you do not need to pre-filter.",
         json!({
             "type": "object",

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -1547,23 +1547,28 @@ fn required_diagnostics_scope_value(args: &Value, scope: &str, name: &str) -> Re
 
 async fn enclosing_diagnostic_node(
     cg: &TraceDecay,
-    nodes_by_file: &mut HashMap<String, Vec<crate::types::Node>>,
+    spans_by_file: &mut HashMap<String, Vec<crate::diagnostics::lsp::broker::NodeSpan>>,
     file: &str,
     line_start: u32,
 ) -> Result<Option<String>> {
-    if !nodes_by_file.contains_key(file) {
-        let fetched = cg.get_nodes_by_file(file).await?;
-        nodes_by_file.insert(file.to_string(), fetched);
+    use crate::diagnostics::lsp::broker::{NodeSpan, enclosing_node_for_line};
+    if !spans_by_file.contains_key(file) {
+        let spans = cg
+            .get_nodes_by_file(file)
+            .await?
+            .into_iter()
+            .map(|n| NodeSpan {
+                start_line: n.start_line,
+                end_line: n.end_line,
+                qualified_name: n.qualified_name,
+            })
+            .collect();
+        spans_by_file.insert(file.to_string(), spans);
     }
 
-    let node_line = line_start.saturating_sub(1);
-    Ok(nodes_by_file.get(file).and_then(|nodes| {
-        nodes
-            .iter()
-            .filter(|n| n.start_line <= node_line && node_line <= n.end_line)
-            .min_by_key(|n| n.end_line.saturating_sub(n.start_line))
-            .map(|n| n.qualified_name.clone())
-    }))
+    Ok(spans_by_file
+        .get(file)
+        .and_then(|spans| enclosing_node_for_line(spans, line_start)))
 }
 
 /// Whether the diagnostics prewarm behaviour is enabled. Off by default: the
@@ -1647,7 +1652,8 @@ pub(super) async fn handle_diagnostics(
     let mut entries: Vec<Value> = Vec::with_capacity(diagnostics.len());
     let mut error_count = 0u64;
     let mut warning_count = 0u64;
-    let mut nodes_by_file: HashMap<String, Vec<crate::types::Node>> = HashMap::new();
+    let mut spans_by_file: HashMap<String, Vec<crate::diagnostics::lsp::broker::NodeSpan>> =
+        HashMap::new();
 
     for diag in &diagnostics {
         match diag.level.as_str() {
@@ -1657,7 +1663,7 @@ pub(super) async fn handle_diagnostics(
         }
 
         let enclosing =
-            enclosing_diagnostic_node(cg, &mut nodes_by_file, &diag.file, diag.line_start).await?;
+            enclosing_diagnostic_node(cg, &mut spans_by_file, &diag.file, diag.line_start).await?;
 
         entries.push(json!({
             "file": diag.file,

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -1207,12 +1207,12 @@ mod tests {
             .iter()
             .find(|tool| tool.name == "tracedecay_redundancy")
             .expect("tracedecay_redundancy tool definition");
+        // Assert only literal output keys — free prose in the description may
+        // be reworded without breaking the ranking contract.
         for required in [
-            "body-vector cosine",
             "ranking_score",
             "body_vector_cosine",
             "generic_helper_downranked",
-            "grouped duplicate components",
         ] {
             assert!(
                 tool.description.contains(required),

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -26,7 +26,7 @@ use serde_json::{Value, json};
 use crate::errors::Result;
 use crate::redundancy::{
     Fingerprint, RedundantPair, compute_fingerprint, connected_node_groups, find_node_at_lines,
-    find_redundant_pairs, parse_file,
+    find_redundant_pairs, parse_file, round4,
 };
 use crate::tracedecay::TraceDecay;
 use crate::types::{Node, NodeKind};
@@ -72,9 +72,14 @@ pub(super) async fn handle_redundancy(
     // effort: a write failure never fails the query.
     persist_redundancy_pairs(cg, &pairs).await;
 
-    let output = redundancy_output(&options, total_candidates, scanned, &pairs);
+    // Connected components are the shared source of truth for the JSON `groups`
+    // array and the markdown Groups section; compute them once and thread the
+    // result into both so the two views can never diverge and the O(pairs²)
+    // grouping runs a single time per call.
+    let groups = connected_node_groups(&pairs);
+    let output = redundancy_output(&options, total_candidates, scanned, &pairs, &groups);
     let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        redundancy_md(&options, total_candidates, scanned, &pairs)
+        redundancy_md(&options, total_candidates, scanned, &pairs, &groups)
     });
     Ok(ToolResult::new(
         json!({
@@ -125,6 +130,7 @@ fn redundancy_output(
     total_candidates: usize,
     scanned: usize,
     pairs: &[RedundantPair<'_>],
+    groups: &[Vec<&Node>],
 ) -> Value {
     let rendered_pairs: Vec<Value> = pairs.iter().map(redundant_pair_json).collect();
     json!({
@@ -133,7 +139,7 @@ fn redundancy_output(
         "skipped_for_size": total_candidates.saturating_sub(scanned),
         "pair_count": rendered_pairs.len(),
         "pairs": rendered_pairs,
-        "groups": duplicate_groups(pairs),
+        "groups": duplicate_groups(groups),
         "groups_scope": "connected components over the returned pairs only; raise max_pairs to see full clusters",
         "ranked_by": "ranking_score desc (composite similarity plus body-vector signal, generic helpers downranked)",
         "scope": options.path_prefix.unwrap_or("(whole project)"),
@@ -155,6 +161,7 @@ fn redundancy_md(
     total_candidates: usize,
     scanned: usize,
     pairs: &[RedundantPair<'_>],
+    groups: &[Vec<&Node>],
 ) -> String {
     let mut md = Md::new();
     md.heading(2, "Redundancy");
@@ -190,11 +197,10 @@ fn redundancy_md(
     }
 
     md.blank().heading(3, "Groups");
-    let groups = connected_node_groups(pairs);
     if groups.is_empty() {
         md.empty_note("No duplicate groups.");
     } else {
-        for group in &groups {
+        for group in groups {
             append_group_md(&mut md, group);
         }
     }
@@ -332,17 +338,7 @@ async fn ensure_fingerprints(
             let expected_hash = quick_body_hash(body);
             match cg.db().get_fingerprint(&node.id).await? {
                 Some(stored) if stored.source_hash == expected_hash => {
-                    cached.insert(
-                        node.id.as_str(),
-                        Fingerprint {
-                            ast_hash: stored.ast_hash,
-                            cfg_hash: stored.cfg_hash,
-                            call_seq_hash: stored.call_seq_hash,
-                            shingles: stored.shingles,
-                            body_tokens: stored.body_tokens as usize,
-                            source_hash: stored.source_hash,
-                        },
-                    );
+                    cached.insert(node.id.as_str(), stored.into());
                 }
                 _ => {
                     needs_parse = true;
@@ -543,10 +539,6 @@ fn redundant_pair_json(pair: &RedundantPair<'_>) -> Value {
     })
 }
 
-fn round4(value: f64) -> f64 {
-    (value * 10000.0).round() / 10000.0
-}
-
 fn node_json(node: &Node) -> Value {
     json!({
         "file": node.file_path,
@@ -556,13 +548,13 @@ fn node_json(node: &Node) -> Value {
     })
 }
 
-fn duplicate_groups<'a>(pairs: &'a [RedundantPair<'a>]) -> Vec<Value> {
-    connected_node_groups(pairs)
-        .into_iter()
+fn duplicate_groups(groups: &[Vec<&Node>]) -> Vec<Value> {
+    groups
+        .iter()
         .map(|nodes| {
             json!({
                 "size": nodes.len(),
-                "nodes": nodes.into_iter().map(node_json).collect::<Vec<_>>(),
+                "nodes": nodes.iter().map(|n| node_json(n)).collect::<Vec<_>>(),
             })
         })
         .collect()
@@ -572,7 +564,9 @@ fn duplicate_groups<'a>(pairs: &'a [RedundantPair<'a>]) -> Vec<Value> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::{RedundancyOptions, body_slice, is_generated_path, redundancy_md};
-    use crate::redundancy::{Fingerprint, RedundancyMatchScore, RedundantPair};
+    use crate::redundancy::{
+        Fingerprint, RedundancyMatchScore, RedundantPair, connected_node_groups,
+    };
     use crate::types::{Node, NodeKind, Visibility};
 
     #[test]
@@ -692,7 +686,8 @@ mod tests {
             include_generated: false,
         };
 
-        let md = redundancy_md(&options, 4, 4, &pairs);
+        let groups = connected_node_groups(&pairs);
+        let md = redundancy_md(&options, 4, 4, &pairs, &groups);
 
         // Ranked pair line carries the ranking_score.
         assert!(md.contains("ranking_score 0.95"), "{md}");

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -10,9 +10,14 @@
 //!    the result keyed on `(node_id, body source hash)` so we don't pay
 //!    re-parse cost on subsequent calls when the file hasn't changed.
 //! 3. Bucket the resulting fingerprints by `body_tokens` (±25 % window).
-//!    Within each bucket, compare every pair via
-//!    [`composite_similarity`](crate::redundancy::composite_similarity).
-//! 4. Filter by threshold, sort by score desc, return the top N pairs.
+//!    Within each bucket, score every pair via
+//!    [`redundancy_match_score`](crate::redundancy::redundancy_match_score),
+//!    which blends the composite similarity with the body-vector cosine,
+//!    relabels cosine-rescued `naming` pairs as `body_vector`, and downranks
+//!    generic helper names.
+//! 4. Filter by threshold, sort by `ranking_score` desc (total order — ties
+//!    fall through similarity, cosine, then names and node ids), and return
+//!    the top N pairs plus their connected duplicate groups.
 
 use std::collections::HashMap;
 
@@ -20,14 +25,14 @@ use serde_json::{Value, json};
 
 use crate::errors::Result;
 use crate::redundancy::{
-    Fingerprint, RedundancyMatchScore, compute_fingerprint, find_node_at_lines, parse_file,
-    redundancy_match_score,
+    Fingerprint, RedundantPair, compute_fingerprint, connected_node_groups, find_node_at_lines,
+    find_redundant_pairs, parse_file,
 };
 use crate::tracedecay::TraceDecay;
 use crate::types::{Node, NodeKind};
 
 use super::super::ToolResult;
-use super::super::render;
+use super::super::render::{self, Md};
 use super::support::effective_path;
 
 /// `tracedecay_redundancy` handler.
@@ -39,7 +44,13 @@ pub(super) async fn handle_redundancy(
     let options = redundancy_options(&args, scope_prefix);
 
     // 1. Collect candidate function nodes.
-    let nodes = collect_candidates(cg, options.path_prefix, options.min_lines).await?;
+    let nodes = collect_candidates(
+        cg,
+        options.path_prefix,
+        options.min_lines,
+        options.include_generated,
+    )
+    .await?;
     let total_candidates = nodes.len();
 
     // 2. Ensure each has a fresh fingerprint (cache by source hash).
@@ -47,17 +58,23 @@ pub(super) async fn handle_redundancy(
     let scanned = fingerprints.len();
 
     // 3. Bucket by token count to keep pairwise comparison sub-quadratic.
+    let scoped = scoped_fingerprints(&nodes, &fingerprints);
     let pairs = find_redundant_pairs(
-        &nodes,
-        &fingerprints,
+        scoped,
         options.threshold,
         options.include_naming,
         options.max_pairs,
     );
 
+    // Persist the ranked pairs as a freshness-validated cache so other
+    // surfaces (diagnose near-duplicate enrichment, the dashboard, future
+    // tools) can read the last-known duplicates without recomputing. Best
+    // effort: a write failure never fails the query.
+    persist_redundancy_pairs(cg, &pairs).await;
+
     let output = redundancy_output(&options, total_candidates, scanned, &pairs);
     let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
+        redundancy_md(&options, total_candidates, scanned, &pairs)
     });
     Ok(ToolResult::new(
         json!({
@@ -73,6 +90,7 @@ struct RedundancyOptions<'a> {
     max_pairs: usize,
     threshold: f64,
     include_naming: bool,
+    include_generated: bool,
 }
 
 fn redundancy_options<'a>(args: &'a Value, scope_prefix: Option<&'a str>) -> RedundancyOptions<'a> {
@@ -95,6 +113,10 @@ fn redundancy_options<'a>(args: &'a Value, scope_prefix: Option<&'a str>) -> Red
             .get("include_naming_only")
             .and_then(Value::as_bool)
             .unwrap_or(false),
+        include_generated: args
+            .get("include_generated_paths")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
     }
 }
 
@@ -112,14 +134,106 @@ fn redundancy_output(
         "pair_count": rendered_pairs.len(),
         "pairs": rendered_pairs,
         "groups": duplicate_groups(pairs),
+        "groups_scope": "connected components over the returned pairs only; raise max_pairs to see full clusters",
         "ranked_by": "ranking_score desc (composite similarity plus body-vector signal, generic helpers downranked)",
         "scope": options.path_prefix.unwrap_or("(whole project)"),
         "thresholds": {
             "min_lines": options.min_lines,
             "similarity_threshold": options.threshold,
             "include_naming_only": options.include_naming,
+            "include_generated_paths": options.include_generated,
         },
     })
+}
+
+/// Typed markdown view over the same data the JSON output is built from (the
+/// `RedundantPair` slice plus the scan counts and options), so the two formats
+/// cannot silently drift. Bounded and compact per the repo convention: no
+/// tables, the full ranked pair list, and the full member list per group.
+fn redundancy_md(
+    options: &RedundancyOptions<'_>,
+    total_candidates: usize,
+    scanned: usize,
+    pairs: &[RedundantPair<'_>],
+) -> String {
+    let mut md = Md::new();
+    md.heading(2, "Redundancy");
+    md.field("candidates", &total_candidates.to_string());
+    md.field("scanned", &scanned.to_string());
+    md.field(
+        "skipped_for_size",
+        &total_candidates.saturating_sub(scanned).to_string(),
+    );
+    md.field("pair_count", &pairs.len().to_string());
+    md.field("scope", options.path_prefix.unwrap_or("(whole project)"));
+    md.field(
+        "thresholds",
+        &format!(
+            "min_lines {}, similarity_threshold {}, include_naming_only {}, include_generated_paths {}",
+            options.min_lines,
+            round4(options.threshold),
+            options.include_naming,
+            options.include_generated
+        ),
+    );
+    md.line(
+        "groups_scope: connected components over the returned pairs only; raise max_pairs to see full clusters",
+    );
+
+    md.blank().heading(3, "Pairs");
+    if pairs.is_empty() {
+        md.empty_note("No redundant pairs above threshold.");
+    } else {
+        for pair in pairs {
+            append_pair_md(&mut md, pair);
+        }
+    }
+
+    md.blank().heading(3, "Groups");
+    let groups = connected_node_groups(pairs);
+    if groups.is_empty() {
+        md.empty_note("No duplicate groups.");
+    } else {
+        for group in &groups {
+            append_group_md(&mut md, group);
+        }
+    }
+
+    md.render()
+}
+
+/// `name (file:line)` locator that chains into `tracedecay_body` / `_callers`.
+fn node_label(node: &Node) -> String {
+    format!("{} ({}:{})", node.name, node.file_path, node.start_line)
+}
+
+fn append_pair_md(md: &mut Md, pair: &RedundantPair<'_>) {
+    let downranked = if pair.score.generic_helper_downranked {
+        ", generic-helper downranked"
+    } else {
+        ""
+    };
+    md.bullet(&format!(
+        "**{} <-> {}** — {}/{}, ranking_score {}, similarity {}, cosine {}{downranked}",
+        node_label(pair.node_a),
+        node_label(pair.node_b),
+        pair.score.severity,
+        pair.score.overlap_kind,
+        round4(pair.score.ranking_score),
+        round4(pair.score.similarity),
+        round4(pair.score.vector_cosine),
+    ));
+    md.line(&format!(
+        "  body_tokens [{}, {}]; ids `{}`, `{}`",
+        pair.fp_a.body_tokens, pair.fp_b.body_tokens, pair.node_a.id, pair.node_b.id
+    ));
+}
+
+fn append_group_md(md: &mut Md, group: &[&Node]) {
+    md.bullet(&format!("**Group of {}**", group.len()));
+    for node in group {
+        md.line(&format!("  {}", node_label(node)));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,12 +244,14 @@ async fn collect_candidates(
     cg: &TraceDecay,
     path_prefix: Option<&str>,
     min_lines: u32,
+    include_generated: bool,
 ) -> Result<Vec<Node>> {
     let all = cg.get_all_nodes().await?;
     Ok(all
         .into_iter()
         .filter(|n| matches!(n.kind, NodeKind::Function | NodeKind::Method))
         .filter(|n| n.end_line.saturating_sub(n.start_line) + 1 >= min_lines)
+        .filter(|n| include_generated || !is_generated_path(&n.file_path))
         .filter(|n| {
             path_prefix.is_none_or(|pfx| {
                 let prefix = if pfx.ends_with('/') {
@@ -147,6 +263,24 @@ async fn collect_candidates(
             })
         })
         .collect())
+}
+
+/// Build outputs, vendored code, and worktree mirrors duplicate real sources
+/// byte-for-byte, so their pairs are indistinguishable from true duplicates
+/// at the scoring layer — they have to be excluded during candidate
+/// collection (a recurring noise source in real scans: dist mirrors, package
+/// twins, and `.worktrees` self-duplicates). Opt back in with
+/// `include_generated_paths: true`.
+fn is_generated_path(path: &str) -> bool {
+    if path.ends_with(".min.js") {
+        return true;
+    }
+    path.split('/').any(|segment| {
+        matches!(
+            segment,
+            "dist" | "build" | "out" | "node_modules" | "vendor" | "target" | ".worktrees"
+        )
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -345,67 +479,6 @@ fn quick_body_hash(body: &str) -> String {
 
 type ScopedFingerprint<'a> = (&'a Node, &'a Fingerprint);
 
-struct RedundantPair<'a> {
-    score: RedundancyMatchScore,
-    node_a: &'a Node,
-    node_b: &'a Node,
-    fp_a: &'a Fingerprint,
-    fp_b: &'a Fingerprint,
-}
-
-fn find_redundant_pairs<'a>(
-    nodes: &'a [Node],
-    fingerprints: &'a HashMap<String, Fingerprint>,
-    threshold: f64,
-    include_naming: bool,
-    max_pairs: usize,
-) -> Vec<RedundantPair<'a>> {
-    // Sort by body_tokens so the size-window check is a linear scan.
-    let mut sorted = scoped_fingerprints(nodes, fingerprints);
-    sorted.sort_by_key(|(_, fp)| fp.body_tokens);
-
-    let mut found = Vec::new();
-    for (i, (node_a, fp_a)) in sorted.iter().enumerate() {
-        let (lo, hi) = body_token_window(fp_a.body_tokens);
-        for (node_b, fp_b) in sorted.iter().skip(i + 1) {
-            if fp_b.body_tokens > hi {
-                break; // sorted, no need to scan further
-            }
-            if fp_b.body_tokens < lo {
-                continue;
-            }
-            if let Some(pair) =
-                redundant_pair(node_a, fp_a, node_b, fp_b, threshold, include_naming)
-            {
-                found.push(pair);
-            }
-        }
-    }
-
-    found.sort_by(|a: &RedundantPair<'_>, b: &RedundantPair<'_>| {
-        b.score
-            .ranking_score
-            .partial_cmp(&a.score.ranking_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| {
-                b.score
-                    .similarity
-                    .partial_cmp(&a.score.similarity)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .then_with(|| {
-                b.score
-                    .vector_cosine
-                    .partial_cmp(&a.score.vector_cosine)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .then_with(|| a.node_a.name.cmp(&b.node_a.name))
-    });
-    found.truncate(max_pairs);
-
-    found
-}
-
 fn scoped_fingerprints<'a>(
     nodes: &'a [Node],
     fingerprints: &'a HashMap<String, Fingerprint>,
@@ -416,36 +489,38 @@ fn scoped_fingerprints<'a>(
         .collect()
 }
 
-fn body_token_window(body_tokens: usize) -> (usize, usize) {
-    (
-        (body_tokens as f64 * 0.75).floor() as usize,
-        (body_tokens as f64 * 1.25).ceil() as usize,
-    )
-}
-
-fn redundant_pair<'a>(
-    node_a: &'a Node,
-    fp_a: &'a Fingerprint,
-    node_b: &'a Node,
-    fp_b: &'a Fingerprint,
-    threshold: f64,
-    include_naming: bool,
-) -> Option<RedundantPair<'a>> {
-    let score = redundancy_match_score(
-        &node_a.name,
-        fp_a,
-        &node_b.name,
-        fp_b,
-        threshold,
-        include_naming,
-    )?;
-    Some(RedundantPair {
-        score,
-        node_a,
-        node_b,
-        fp_a,
-        fp_b,
-    })
+/// Upsert the returned duplicate pairs into the `redundancy_pairs` cache.
+///
+/// Each pair is stored in its canonical `(node_a, node_b)` orientation with
+/// both `source_hash`es so a reader can validate freshness against the live
+/// fingerprint cache. Errors are logged but never fatal — the redundancy query
+/// still returns results even if the cache write fails. Node-id orphan cleanup
+/// is handled by the table's `ON DELETE CASCADE`, so full-project runs need no
+/// explicit deletion pass here.
+async fn persist_redundancy_pairs(cg: &TraceDecay, pairs: &[RedundantPair<'_>]) {
+    if pairs.is_empty() {
+        return;
+    }
+    let computed_at = crate::tracedecay::current_timestamp();
+    let rows: Vec<crate::db::RedundancyPairWrite<'_>> = pairs
+        .iter()
+        .map(|pair| crate::db::RedundancyPairWrite {
+            node_a_id: pair.node_a.id.as_str(),
+            node_b_id: pair.node_b.id.as_str(),
+            source_hash_a: pair.fp_a.source_hash.as_str(),
+            source_hash_b: pair.fp_b.source_hash.as_str(),
+            ranking_score: pair.score.ranking_score,
+            similarity: pair.score.similarity,
+            vector_cosine: pair.score.vector_cosine,
+            overlap_kind: pair.score.overlap_kind,
+            severity: pair.score.severity,
+            generic_helper_downranked: pair.score.generic_helper_downranked,
+            computed_at,
+        })
+        .collect();
+    if let Err(e) = cg.db().upsert_redundancy_pairs(&rows).await {
+        eprintln!("[tracedecay] redundancy: upsert_redundancy_pairs failed: {e}");
+    }
 }
 
 fn redundant_pair_json(pair: &RedundantPair<'_>) -> Value {
@@ -482,39 +557,8 @@ fn node_json(node: &Node) -> Value {
 }
 
 fn duplicate_groups<'a>(pairs: &'a [RedundantPair<'a>]) -> Vec<Value> {
-    let mut groups: Vec<Vec<&'a Node>> = Vec::new();
-    for pair in pairs {
-        let mut matching_groups = Vec::new();
-        for (idx, group) in groups.iter().enumerate() {
-            if group
-                .iter()
-                .any(|node| node.id == pair.node_a.id || node.id == pair.node_b.id)
-            {
-                matching_groups.push(idx);
-            }
-        }
-
-        let nodes = [pair.node_a, pair.node_b];
-        if matching_groups.is_empty() {
-            groups.push(Vec::from(nodes));
-            continue;
-        }
-
-        let first = matching_groups[0];
-        for node in nodes {
-            push_unique_node(&mut groups[first], node);
-        }
-        for idx in matching_groups.into_iter().skip(1).rev() {
-            let merged = groups.remove(idx);
-            for node in merged {
-                push_unique_node(&mut groups[first], node);
-            }
-        }
-    }
-
-    groups
+    connected_node_groups(pairs)
         .into_iter()
-        .filter(|nodes| nodes.len() > 1)
         .map(|nodes| {
             json!({
                 "size": nodes.len(),
@@ -524,17 +568,152 @@ fn duplicate_groups<'a>(pairs: &'a [RedundantPair<'a>]) -> Vec<Value> {
         .collect()
 }
 
-fn push_unique_node<'a>(nodes: &mut Vec<&'a Node>, node: &'a Node) {
-    if nodes.iter().any(|existing| existing.id == node.id) {
-        return;
-    }
-    nodes.push(node);
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::body_slice;
+    use super::{RedundancyOptions, body_slice, is_generated_path, redundancy_md};
+    use crate::redundancy::{Fingerprint, RedundancyMatchScore, RedundantPair};
+    use crate::types::{Node, NodeKind, Visibility};
+
+    #[test]
+    fn generated_paths_are_excluded_from_candidates_by_default() {
+        for path in [
+            "dashboard/lcm/dist/index.js",
+            "node_modules/lib/index.js",
+            ".worktrees/feature/src/lib.rs",
+            "vendor/libsql/src/lib.rs",
+            "assets/app.min.js",
+        ] {
+            assert!(is_generated_path(path), "{path} should count as generated");
+        }
+        // Segment matching must not catch prefixes of real source dirs.
+        for path in [
+            "src/redundancy.rs",
+            "src/distributed/mod.rs",
+            "builder/mod.rs",
+        ] {
+            assert!(!is_generated_path(path), "{path} is real source");
+        }
+    }
+
+    fn test_node(id: &str, name: &str, line: u32) -> Node {
+        Node {
+            id: id.to_string(),
+            kind: NodeKind::Function,
+            name: name.to_string(),
+            qualified_name: name.to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: line,
+            attrs_start_line: line,
+            end_line: line + 10,
+            start_column: 0,
+            end_column: 0,
+            signature: None,
+            docstring: None,
+            visibility: Visibility::default(),
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: 0,
+            parent_id: None,
+        }
+    }
+
+    fn test_fingerprint(body_tokens: usize) -> Fingerprint {
+        Fingerprint {
+            ast_hash: "ast".into(),
+            cfg_hash: "cfg".into(),
+            call_seq_hash: "call".into(),
+            shingles: vec![1, 2, 3],
+            body_tokens,
+            source_hash: "src".into(),
+        }
+    }
+
+    fn test_score(ranking_score: f64) -> RedundancyMatchScore {
+        RedundancyMatchScore {
+            similarity: 0.9,
+            ranking_score,
+            vector_cosine: 0.8,
+            shingle_jaccard: 0.7,
+            overlap_kind: "body_vector",
+            severity: "high",
+            generic_helper_downranked: false,
+        }
+    }
+
+    #[test]
+    fn redundancy_md_renders_ranked_pairs_and_full_groups() {
+        // Chain a->b->c->d so the connected component has more than 3 members.
+        let a = test_node("id_a", "alpha", 10);
+        let b = test_node("id_b", "beta", 20);
+        let c = test_node("id_c", "gamma", 30);
+        let d = test_node("id_d", "delta", 40);
+        let fa = test_fingerprint(50);
+        let fb = test_fingerprint(52);
+        let fc = test_fingerprint(54);
+        let fd = test_fingerprint(56);
+
+        let pairs = vec![
+            RedundantPair {
+                score: test_score(0.95),
+                node_a: &a,
+                node_b: &b,
+                fp_a: &fa,
+                fp_b: &fb,
+            },
+            RedundantPair {
+                score: test_score(0.9),
+                node_a: &b,
+                node_b: &c,
+                fp_a: &fb,
+                fp_b: &fc,
+            },
+            RedundantPair {
+                score: test_score(0.85),
+                node_a: &c,
+                node_b: &d,
+                fp_a: &fc,
+                fp_b: &fd,
+            },
+        ];
+
+        let options = RedundancyOptions {
+            path_prefix: None,
+            min_lines: 8,
+            max_pairs: 20,
+            threshold: 0.6,
+            include_naming: false,
+            include_generated: false,
+        };
+
+        let md = redundancy_md(&options, 4, 4, &pairs);
+
+        // Ranked pair line carries the ranking_score.
+        assert!(md.contains("ranking_score 0.95"), "{md}");
+        // Per-pair body_tokens survive (dropped by the generic walker).
+        assert!(md.contains("body_tokens [50, 52]"), "{md}");
+        assert!(md.contains("`id_a`, `id_b`"), "{md}");
+        // The 4-member group lists every member without truncation.
+        assert!(md.contains("**Group of 4**"), "{md}");
+        for name in ["alpha", "beta", "gamma", "delta"] {
+            assert!(md.contains(name), "missing group member {name}: {md}");
+        }
+        assert!(!md.contains("(+"), "group was truncated: {md}");
+        assert!(!md.contains("more)"), "group was truncated: {md}");
+        // The groups_scope caveat is present.
+        assert!(
+            md.contains(
+                "groups_scope: connected components over the returned pairs only; raise max_pairs to see full clusters"
+            ),
+            "{md}"
+        );
+    }
 
     #[test]
     fn body_slice_extracts_single_line_zero_indexed() {

--- a/src/mcp/tools/handlers/workflow.rs
+++ b/src/mcp/tools/handlers/workflow.rs
@@ -15,6 +15,9 @@ use tokio::time::timeout;
 
 use crate::diagnose::{Severity, parse_cargo_output};
 use crate::errors::{Result, TraceDecayError};
+use crate::redundancy::{
+    Fingerprint, RedundancyMatchScore, body_token_window, redundancy_match_score,
+};
 use crate::tracedecay::{TraceDecay, is_test_file};
 use crate::types::Node;
 
@@ -26,6 +29,19 @@ use super::support::unique_file_paths;
 /// cap — libtest filters are passed as positional args so very long lists
 /// can blow past OS argv limits on some platforms.
 const MAX_TESTS_HARD_CAP: usize = 500;
+
+/// Cap on cached fingerprint rows the near-duplicate lookup pulls per
+/// diagnostic. A single diagnose call can resolve many diagnostics, so we
+/// bound the candidate window query — a huge fingerprint cache must not be
+/// able to blow up a diagnose call.
+const MAX_NEAR_DUP_CANDIDATES: usize = 200;
+
+/// Similarity threshold for near-duplicate cross-referencing in `diagnose`.
+/// Mirrors the `tracedecay_redundancy` tool default.
+const NEAR_DUP_THRESHOLD: f64 = 0.6;
+
+/// Maximum near-duplicate matches attached per diagnostic.
+const NEAR_DUP_MAX: usize = 3;
 
 #[derive(Debug, Clone)]
 struct TestTarget {
@@ -147,6 +163,19 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
         touched.insert(d.file.clone());
 
         let node = cg.node_at_location(&d.file, d.line).await?;
+        // Cross-reference the redundancy index: if the enclosing node has a
+        // cached fingerprint, surface near-duplicate functions so a
+        // diagnostic points at code it may share logic with. Purely reads the
+        // cache — never parses/warms files inside diagnose.
+        let near_duplicates = match &node {
+            Some(n) => near_duplicates_for_node(cg, n).await?,
+            None => Vec::new(),
+        };
+        for dupe in &near_duplicates {
+            if let Some(file) = dupe.get("file").and_then(Value::as_str) {
+                touched.insert(file.to_string());
+            }
+        }
         let callers_json = if include_callers {
             match &node {
                 Some(n) => {
@@ -189,6 +218,7 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
                 "end_line": n.end_line,
             })),
             "callers": callers_json,
+            "near_duplicates": near_duplicates,
         }));
     }
 
@@ -210,6 +240,169 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
         }),
         touched.into_iter().collect(),
     ))
+}
+
+/// Look up cached near-duplicate matches for a diagnostic's enclosing
+/// `node`, ranked and capped at [`NEAR_DUP_MAX`].
+///
+/// Consults the `redundancy_pairs` cache first (a cheap indexed lookup that
+/// returns only pairs still fresh against the current fingerprints); if a
+/// prior `tracedecay_redundancy` run left fresh pairs for this node they are
+/// served directly. Otherwise falls back to the live token-window scan: reads
+/// the fingerprint cache, pulls candidates from the ±25 % `body_tokens` window
+/// (see [`body_token_window`]) capped at [`MAX_NEAR_DUP_CANDIDATES`], scores
+/// with [`redundancy_match_score`] at [`NEAR_DUP_THRESHOLD`], and excludes the
+/// node itself. Either path reads only cached data — no files are parsed or
+/// warmed inside diagnose.
+async fn near_duplicates_for_node(cg: &TraceDecay, node: &Node) -> Result<Vec<Value>> {
+    // Fast path: fresh cached duplicate pairs from a prior redundancy run.
+    let cached_pairs = cg.db().fresh_redundancy_pairs_for_node(&node.id).await?;
+    if !cached_pairs.is_empty() {
+        return near_duplicates_from_cached_pairs(cg, node, cached_pairs).await;
+    }
+
+    let Some(stored) = cg.db().get_fingerprint(&node.id).await? else {
+        return Ok(Vec::new());
+    };
+    let self_fp = stored_to_fingerprint(stored);
+    let (lo, hi) = body_token_window(self_fp.body_tokens);
+    let lo = u32::try_from(lo).unwrap_or(u32::MAX);
+    let hi = u32::try_from(hi).unwrap_or(u32::MAX);
+    let candidates = cg
+        .db()
+        .fingerprints_in_token_window(lo, hi, MAX_NEAR_DUP_CANDIDATES)
+        .await?;
+
+    let cand_ids: Vec<String> = candidates
+        .iter()
+        .filter(|row| row.node_id != node.id)
+        .map(|row| row.node_id.clone())
+        .collect();
+    if cand_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let cand_nodes = cg.db().get_nodes_by_ids(&cand_ids).await?;
+    let nodes_by_id: HashMap<&str, &Node> =
+        cand_nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+    let mut scored: Vec<(RedundancyMatchScore, &Node)> = Vec::new();
+    for row in &candidates {
+        if row.node_id == node.id {
+            continue;
+        }
+        let Some(cand_node) = nodes_by_id.get(row.node_id.as_str()) else {
+            continue;
+        };
+        let cand_fp = stored_to_fingerprint(row.clone());
+        if let Some(score) = redundancy_match_score(
+            &node.name,
+            &self_fp,
+            &cand_node.name,
+            &cand_fp,
+            NEAR_DUP_THRESHOLD,
+            false,
+        ) {
+            scored.push((score, cand_node));
+        }
+    }
+
+    // Rank by ranking_score desc; break ties on name then id so the output is
+    // deterministic regardless of DB row order.
+    scored.sort_by(|(a_score, a_node), (b_score, b_node)| {
+        b_score
+            .ranking_score
+            .partial_cmp(&a_score.ranking_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a_node.name.cmp(&b_node.name))
+            .then_with(|| a_node.id.cmp(&b_node.id))
+    });
+
+    Ok(scored
+        .into_iter()
+        .take(NEAR_DUP_MAX)
+        .map(|(score, matched)| {
+            json!({
+                "name": matched.name,
+                "file": matched.file_path,
+                "line": matched.start_line,
+                "id": matched.id,
+                "ranking_score": round4(score.ranking_score),
+                "severity": score.severity,
+                "overlap_kind": score.overlap_kind,
+            })
+        })
+        .collect())
+}
+
+/// Resolve fresh cached duplicate pairs into the diagnose near-duplicate JSON
+/// shape, ranked and capped at [`NEAR_DUP_MAX`].
+///
+/// The pairs are already freshness-validated by the reader; this only resolves
+/// each partner node's metadata and re-applies the same rank-then-tie-break
+/// (`ranking_score` desc, then name, then id) the live scan uses, so the fast
+/// path and the fallback produce identically ordered output.
+async fn near_duplicates_from_cached_pairs(
+    cg: &TraceDecay,
+    node: &Node,
+    pairs: Vec<crate::db::RedundancyPairRow>,
+) -> Result<Vec<Value>> {
+    let partner_ids: Vec<String> = pairs
+        .iter()
+        .map(|p| p.partner_of(&node.id).to_string())
+        .collect();
+    let partner_nodes = cg.db().get_nodes_by_ids(&partner_ids).await?;
+    let nodes_by_id: HashMap<&str, &Node> =
+        partner_nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+    let mut resolved: Vec<(&crate::db::RedundancyPairRow, &Node)> = Vec::new();
+    for pair in &pairs {
+        if let Some(partner) = nodes_by_id.get(pair.partner_of(&node.id)) {
+            resolved.push((pair, partner));
+        }
+    }
+
+    resolved.sort_by(|(a_pair, a_node), (b_pair, b_node)| {
+        b_pair
+            .ranking_score
+            .partial_cmp(&a_pair.ranking_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a_node.name.cmp(&b_node.name))
+            .then_with(|| a_node.id.cmp(&b_node.id))
+    });
+
+    Ok(resolved
+        .into_iter()
+        .take(NEAR_DUP_MAX)
+        .map(|(pair, matched)| {
+            json!({
+                "name": matched.name,
+                "file": matched.file_path,
+                "line": matched.start_line,
+                "id": matched.id,
+                "ranking_score": round4(pair.ranking_score),
+                "severity": pair.severity,
+                "overlap_kind": pair.overlap_kind,
+            })
+        })
+        .collect())
+}
+
+/// Rehydrate a stored fingerprint row into the in-memory [`Fingerprint`]
+/// scoring shape (the same field-for-field mapping the redundancy handler
+/// uses for cache hits).
+fn stored_to_fingerprint(stored: crate::db::StoredFingerprint) -> Fingerprint {
+    Fingerprint {
+        ast_hash: stored.ast_hash,
+        cfg_hash: stored.cfg_hash,
+        call_seq_hash: stored.call_seq_hash,
+        shingles: stored.shingles,
+        body_tokens: stored.body_tokens as usize,
+        source_hash: stored.source_hash,
+    }
+}
+
+fn round4(value: f64) -> f64 {
+    (value * 10000.0).round() / 10000.0
 }
 
 fn severity_string(s: Severity) -> &'static str {

--- a/src/mcp/tools/handlers/workflow.rs
+++ b/src/mcp/tools/handlers/workflow.rs
@@ -15,9 +15,7 @@ use tokio::time::timeout;
 
 use crate::diagnose::{Severity, parse_cargo_output};
 use crate::errors::{Result, TraceDecayError};
-use crate::redundancy::{
-    Fingerprint, RedundancyMatchScore, body_token_window, redundancy_match_score,
-};
+use crate::redundancy::{Fingerprint, body_token_window, redundancy_match_score, round4};
 use crate::tracedecay::{TraceDecay, is_test_file};
 use crate::types::Node;
 
@@ -158,6 +156,10 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
 
     let mut items: Vec<Value> = Vec::with_capacity(diagnostics.len());
     let mut touched: HashSet<String> = HashSet::new();
+    // Several diagnostics commonly share one enclosing function, so memoize the
+    // near-duplicate lookup per node id across the loop — each node's cache read
+    // (or fallback scan) then runs at most once per diagnose call.
+    let mut near_dup_cache: HashMap<String, Vec<Value>> = HashMap::new();
 
     for d in &diagnostics {
         touched.insert(d.file.clone());
@@ -168,7 +170,13 @@ pub(super) async fn handle_diagnose(cg: &TraceDecay, args: Value) -> Result<Tool
         // diagnostic points at code it may share logic with. Purely reads the
         // cache — never parses/warms files inside diagnose.
         let near_duplicates = match &node {
-            Some(n) => near_duplicates_for_node(cg, n).await?,
+            Some(n) => {
+                if !near_dup_cache.contains_key(&n.id) {
+                    let dupes = near_duplicates_for_node(cg, n).await?;
+                    near_dup_cache.insert(n.id.clone(), dupes);
+                }
+                near_dup_cache.get(&n.id).cloned().unwrap_or_default()
+            }
             None => Vec::new(),
         };
         for dupe in &near_duplicates {
@@ -264,7 +272,7 @@ async fn near_duplicates_for_node(cg: &TraceDecay, node: &Node) -> Result<Vec<Va
     let Some(stored) = cg.db().get_fingerprint(&node.id).await? else {
         return Ok(Vec::new());
     };
-    let self_fp = stored_to_fingerprint(stored);
+    let self_fp: Fingerprint = stored.into();
     let (lo, hi) = body_token_window(self_fp.body_tokens);
     let lo = u32::try_from(lo).unwrap_or(u32::MAX);
     let hi = u32::try_from(hi).unwrap_or(u32::MAX);
@@ -282,10 +290,9 @@ async fn near_duplicates_for_node(cg: &TraceDecay, node: &Node) -> Result<Vec<Va
         return Ok(Vec::new());
     }
     let cand_nodes = cg.db().get_nodes_by_ids(&cand_ids).await?;
-    let nodes_by_id: HashMap<&str, &Node> =
-        cand_nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+    let nodes_by_id: HashMap<&str, &Node> = cand_nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
-    let mut scored: Vec<(RedundancyMatchScore, &Node)> = Vec::new();
+    let mut matches: Vec<NearDupCandidate<'_>> = Vec::new();
     for row in &candidates {
         if row.node_id == node.id {
             continue;
@@ -293,7 +300,7 @@ async fn near_duplicates_for_node(cg: &TraceDecay, node: &Node) -> Result<Vec<Va
         let Some(cand_node) = nodes_by_id.get(row.node_id.as_str()) else {
             continue;
         };
-        let cand_fp = stored_to_fingerprint(row.clone());
+        let cand_fp: Fingerprint = row.clone().into();
         if let Some(score) = redundancy_match_score(
             &node.name,
             &self_fp,
@@ -302,45 +309,27 @@ async fn near_duplicates_for_node(cg: &TraceDecay, node: &Node) -> Result<Vec<Va
             NEAR_DUP_THRESHOLD,
             false,
         ) {
-            scored.push((score, cand_node));
+            matches.push(NearDupCandidate {
+                ranking_score: score.ranking_score,
+                similarity: score.similarity,
+                vector_cosine: score.vector_cosine,
+                severity: score.severity,
+                overlap_kind: score.overlap_kind,
+                node: cand_node,
+            });
         }
     }
 
-    // Rank by ranking_score desc; break ties on name then id so the output is
-    // deterministic regardless of DB row order.
-    scored.sort_by(|(a_score, a_node), (b_score, b_node)| {
-        b_score
-            .ranking_score
-            .partial_cmp(&a_score.ranking_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a_node.name.cmp(&b_node.name))
-            .then_with(|| a_node.id.cmp(&b_node.id))
-    });
-
-    Ok(scored
-        .into_iter()
-        .take(NEAR_DUP_MAX)
-        .map(|(score, matched)| {
-            json!({
-                "name": matched.name,
-                "file": matched.file_path,
-                "line": matched.start_line,
-                "id": matched.id,
-                "ranking_score": round4(score.ranking_score),
-                "severity": score.severity,
-                "overlap_kind": score.overlap_kind,
-            })
-        })
-        .collect())
+    Ok(rank_and_emit(matches))
 }
 
 /// Resolve fresh cached duplicate pairs into the diagnose near-duplicate JSON
 /// shape, ranked and capped at [`NEAR_DUP_MAX`].
 ///
 /// The pairs are already freshness-validated by the reader; this only resolves
-/// each partner node's metadata and re-applies the same rank-then-tie-break
-/// (`ranking_score` desc, then name, then id) the live scan uses, so the fast
-/// path and the fallback produce identically ordered output.
+/// each partner node's metadata and feeds them through [`rank_and_emit`], the
+/// same rank-and-render path the live scan uses, so the fast path and the
+/// fallback produce identically ordered and shaped output.
 async fn near_duplicates_from_cached_pairs(
     cg: &TraceDecay,
     node: &Node,
@@ -354,55 +343,75 @@ async fn near_duplicates_from_cached_pairs(
     let nodes_by_id: HashMap<&str, &Node> =
         partner_nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
-    let mut resolved: Vec<(&crate::db::RedundancyPairRow, &Node)> = Vec::new();
+    let mut matches: Vec<NearDupCandidate<'_>> = Vec::new();
     for pair in &pairs {
         if let Some(partner) = nodes_by_id.get(pair.partner_of(&node.id)) {
-            resolved.push((pair, partner));
+            matches.push(NearDupCandidate {
+                ranking_score: pair.ranking_score,
+                similarity: pair.similarity,
+                vector_cosine: pair.vector_cosine,
+                severity: &pair.severity,
+                overlap_kind: &pair.overlap_kind,
+                node: partner,
+            });
         }
     }
 
-    resolved.sort_by(|(a_pair, a_node), (b_pair, b_node)| {
-        b_pair
-            .ranking_score
-            .partial_cmp(&a_pair.ranking_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a_node.name.cmp(&b_node.name))
-            .then_with(|| a_node.id.cmp(&b_node.id))
-    });
+    Ok(rank_and_emit(matches))
+}
 
-    Ok(resolved
+/// One near-duplicate candidate, unified across the cached-pair fast path and
+/// the live token-window scan so both rank and emit through one code path. The
+/// cached `RedundancyPairRow` and the live `RedundancyMatchScore` both carry
+/// every field below.
+struct NearDupCandidate<'a> {
+    ranking_score: f64,
+    similarity: f64,
+    vector_cosine: f64,
+    severity: &'a str,
+    overlap_kind: &'a str,
+    node: &'a Node,
+}
+
+/// Rank unified near-duplicate candidates by the full canonical key
+/// (`ranking_score` desc, `similarity` desc, `vector_cosine` desc, then name,
+/// then id — the same total order [`find_redundant_pairs`] applies), cap at
+/// [`NEAR_DUP_MAX`], and render the diagnose JSON shape. Shared so the cached
+/// fast path and the live scan produce identically ordered, identically shaped
+/// output.
+fn rank_and_emit(mut candidates: Vec<NearDupCandidate<'_>>) -> Vec<Value> {
+    candidates.sort_by(|a, b| {
+        b.ranking_score
+            .partial_cmp(&a.ranking_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.similarity
+                    .partial_cmp(&a.similarity)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b.vector_cosine
+                    .partial_cmp(&a.vector_cosine)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.node.name.cmp(&b.node.name))
+            .then_with(|| a.node.id.cmp(&b.node.id))
+    });
+    candidates
         .into_iter()
         .take(NEAR_DUP_MAX)
-        .map(|(pair, matched)| {
+        .map(|c| {
             json!({
-                "name": matched.name,
-                "file": matched.file_path,
-                "line": matched.start_line,
-                "id": matched.id,
-                "ranking_score": round4(pair.ranking_score),
-                "severity": pair.severity,
-                "overlap_kind": pair.overlap_kind,
+                "name": c.node.name,
+                "file": c.node.file_path,
+                "line": c.node.start_line,
+                "id": c.node.id,
+                "ranking_score": round4(c.ranking_score),
+                "severity": c.severity,
+                "overlap_kind": c.overlap_kind,
             })
         })
-        .collect())
-}
-
-/// Rehydrate a stored fingerprint row into the in-memory [`Fingerprint`]
-/// scoring shape (the same field-for-field mapping the redundancy handler
-/// uses for cache hits).
-fn stored_to_fingerprint(stored: crate::db::StoredFingerprint) -> Fingerprint {
-    Fingerprint {
-        ast_hash: stored.ast_hash,
-        cfg_hash: stored.cfg_hash,
-        call_seq_hash: stored.call_seq_hash,
-        shingles: stored.shingles,
-        body_tokens: stored.body_tokens as usize,
-        source_hash: stored.source_hash,
-    }
-}
-
-fn round4(value: f64) -> f64 {
-    (value * 10000.0).round() / 10000.0
+        .collect()
 }
 
 fn severity_string(s: Severity) -> &'static str {

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -610,6 +610,28 @@ fn render_diagnostic_record(md: &mut Md, diagnostic: &Value) {
             md.line(&format!("  **Callers:** {}", callers.join(", ")));
         }
     }
+    if let Some(dupes) = diagnostic.get("near_duplicates").and_then(Value::as_array) {
+        let dupes = dupes
+            .iter()
+            .filter_map(|dupe| {
+                let name = dupe.get("name").and_then(Value::as_str)?;
+                let file = dupe.get("file").and_then(Value::as_str).unwrap_or("");
+                let line = dupe.get("line").and_then(Value::as_u64).unwrap_or(0);
+                let kind = dupe
+                    .get("overlap_kind")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                Some(if file.is_empty() {
+                    format!("{name} [{kind}]")
+                } else {
+                    format!("{name} ({file}:{line}) [{kind}]")
+                })
+            })
+            .collect::<Vec<_>>();
+        if !dupes.is_empty() {
+            md.line(&format!("  **Near-duplicates:** {}", dupes.join(", ")));
+        }
+    }
 }
 
 fn diagnostic_location(diagnostic: &Value) -> String {

--- a/src/mcp/tools/render/tests.rs
+++ b/src/mcp/tools/render/tests.rs
@@ -347,7 +347,16 @@ fn diagnostics_md_renders_bullets_not_tables() {
             "file": "src/lib.rs",
             "line_start": 42,
             "driver": "cargo",
-            "enclosing": "crate::demo"
+            "enclosing": "crate::demo",
+            "near_duplicates": [{
+                "name": "compute_b",
+                "file": "src/other.rs",
+                "line": 7,
+                "id": "function:abc",
+                "ranking_score": 0.85,
+                "severity": "definite",
+                "overlap_kind": "ast_isomorphic"
+            }]
         }]
     });
 
@@ -360,6 +369,10 @@ fn diagnostics_md_renders_bullets_not_tables() {
         "got: {out}"
     );
     assert!(out.contains("  **Message:** cannot find value\n    second line"));
+    assert!(
+        out.contains("  **Near-duplicates:** compute_b (src/other.rs:7) [ast_isomorphic]"),
+        "got: {out}"
+    );
     assert!(!out.contains("| file |"), "got: {out}");
     assert!(!out.contains("| --- |"), "got: {out}");
 }

--- a/src/redundancy.rs
+++ b/src/redundancy.rs
@@ -446,6 +446,12 @@ pub fn vector_cosine_similarity(a: &[u32], b: &[u32]) -> f64 {
 
 /// Blend the four signals into a single \[0,1\] similarity score.
 pub fn composite_similarity(a: &Fingerprint, b: &Fingerprint) -> f64 {
+    composite_similarity_with_jaccard(a, b, jaccard_similarity(&a.shingles, &b.shingles))
+}
+
+/// [`composite_similarity`] with the shingle Jaccard already computed, so a
+/// caller scoring a pair pays the merge cost once.
+fn composite_similarity_with_jaccard(a: &Fingerprint, b: &Fingerprint, jaccard: f64) -> f64 {
     let ast = if a.ast_hash == b.ast_hash { 1.0 } else { 0.0 };
     let cfg = if a.cfg_hash == b.cfg_hash { 1.0 } else { 0.0 };
     let call = if a.call_seq_hash == b.call_seq_hash {
@@ -453,20 +459,25 @@ pub fn composite_similarity(a: &Fingerprint, b: &Fingerprint) -> f64 {
     } else {
         0.0
     };
-    let shingle = jaccard_similarity(&a.shingles, &b.shingles);
-    W_AST * ast + W_CFG * cfg + W_CALL_SEQ * call + W_SHINGLE * shingle
+    W_AST * ast + W_CFG * cfg + W_CALL_SEQ * call + W_SHINGLE * jaccard
 }
 
 /// Determine the "kind" of overlap two functions share. Returned alongside
 /// the composite score so callers can filter (e.g. drop `naming` matches).
 pub fn overlap_kind(a: &Fingerprint, b: &Fingerprint) -> &'static str {
+    overlap_kind_with_jaccard(a, b, jaccard_similarity(&a.shingles, &b.shingles))
+}
+
+/// [`overlap_kind`] with the shingle Jaccard already computed, so a caller
+/// scoring a pair pays the merge cost once.
+fn overlap_kind_with_jaccard(a: &Fingerprint, b: &Fingerprint, jaccard: f64) -> &'static str {
     if a.ast_hash == b.ast_hash {
         "ast_isomorphic"
     } else if a.cfg_hash == b.cfg_hash {
         "control_flow"
     } else if a.call_seq_hash == b.call_seq_hash {
         "algorithmic"
-    } else if jaccard_similarity(&a.shingles, &b.shingles) >= 0.5 {
+    } else if jaccard >= 0.5 {
         "token_overlap"
     } else {
         "naming"
@@ -519,7 +530,8 @@ pub fn redundancy_match_score(
         return None;
     }
 
-    let similarity = composite_similarity(a, b);
+    let shingle_jaccard = jaccard_similarity(&a.shingles, &b.shingles);
+    let similarity = composite_similarity_with_jaccard(a, b, shingle_jaccard);
     let vector_cosine = vector_cosine_similarity(&a.shingles, &b.shingles);
     if similarity < threshold
         && vector_cosine < threshold
@@ -528,7 +540,7 @@ pub fn redundancy_match_score(
         return None;
     }
 
-    let mut overlap_kind = overlap_kind(a, b);
+    let mut overlap_kind = overlap_kind_with_jaccard(a, b, shingle_jaccard);
     if overlap_kind == "naming"
         && vector_cosine >= threshold
         && vector_cosine >= LIKELY_SEVERITY_FLOOR
@@ -552,7 +564,7 @@ pub fn redundancy_match_score(
         similarity,
         ranking_score,
         vector_cosine,
-        shingle_jaccard: jaccard_similarity(&a.shingles, &b.shingles),
+        shingle_jaccard,
         overlap_kind,
         severity: severity_bucket(similarity.max(vector_cosine), overlap_kind),
         generic_helper_downranked,
@@ -630,6 +642,11 @@ fn short_hex(bytes: &[u8]) -> String {
         let _ = write!(s, "{b:02x}");
     }
     s
+}
+
+/// Round a score to 4 decimal places for stable JSON/markdown output.
+pub fn round4(value: f64) -> f64 {
+    (value * 10000.0).round() / 10000.0
 }
 
 fn short_sha256(s: &str) -> String {
@@ -811,10 +828,7 @@ pub fn connected_node_groups<'a>(
     groups
 }
 
-fn push_unique_node<'a>(
-    nodes: &mut Vec<&'a crate::types::Node>,
-    node: &'a crate::types::Node,
-) {
+fn push_unique_node<'a>(nodes: &mut Vec<&'a crate::types::Node>, node: &'a crate::types::Node) {
     if nodes.iter().any(|existing| existing.id == node.id) {
         return;
     }
@@ -1054,8 +1068,7 @@ mod tests {
 
         // Filtered without include_naming; inert for different or generic names.
         assert!(
-            redundancy_match_score("clean_comment", &a, "clean_comment", &b, 0.55, false)
-                .is_none()
+            redundancy_match_score("clean_comment", &a, "clean_comment", &b, 0.55, false).is_none()
         );
         assert!(
             redundancy_match_score("clean_comment", &a, "strip_comment", &b, 0.55, true).is_none()
@@ -1198,7 +1211,10 @@ mod tests {
                 .map(|item| item.as_u64().expect("shingle") as u32)
                 .collect(),
             body_tokens: value["body_tokens"].as_u64().expect("body_tokens") as usize,
-            source_hash: value["source_hash"].as_str().unwrap_or("fixture").to_string(),
+            source_hash: value["source_hash"]
+                .as_str()
+                .unwrap_or("fixture")
+                .to_string(),
         }
     }
 

--- a/src/redundancy.rs
+++ b/src/redundancy.rs
@@ -57,6 +57,11 @@ pub struct Fingerprint {
     pub source_hash: String,
 }
 
+/// Full scoring verdict for one candidate pair.
+///
+/// `ranking_score` orders results (composite blended with the discounted
+/// cosine, generic helpers downranked); `severity` is derived from the raw
+/// signals only — the generic-helper downrank never changes severity.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RedundancyMatchScore {
     pub similarity: f64,
@@ -468,6 +473,11 @@ pub fn overlap_kind(a: &Fingerprint, b: &Fingerprint) -> &'static str {
     }
 }
 
+/// Minimum score for a non-AST match to be bucketed `likely`. Shared with the
+/// `naming` -> `body_vector` relabel in [`redundancy_match_score`] so a pair
+/// can never carry the `body_vector` kind with a `naming_only` severity.
+pub const LIKELY_SEVERITY_FLOOR: f64 = 0.55;
+
 /// Severity bucket for a `(score, overlap_kind)` pair.
 ///
 /// `definite` requires AST isomorphism — anything less can still be a
@@ -478,13 +488,22 @@ pub fn severity_bucket(score: f64, kind: &str) -> &'static str {
         "definite"
     } else if kind == "naming" {
         "naming_only"
-    } else if score >= 0.55 {
+    } else if score >= LIKELY_SEVERITY_FLOOR {
         "likely"
     } else {
         "naming_only"
     }
 }
 
+/// Score a candidate pair, or `None` when it should not be reported.
+///
+/// A pair passes the gate when either the composite similarity or the
+/// body-vector cosine clears `threshold`. A `naming` pair whose cosine clears
+/// both `threshold` and [`LIKELY_SEVERITY_FLOOR`] is reclassified as
+/// `body_vector` (the body evidence, not the name, is what matched); weaker
+/// `naming` pairs stay `naming` and honor `include_naming`. Pairs sharing an
+/// identical non-generic name are retained as `naming_only` leads even below
+/// the gate (see [`same_name_rescue`]).
 pub fn redundancy_match_score(
     a_name: &str,
     a: &Fingerprint,
@@ -493,14 +512,27 @@ pub fn redundancy_match_score(
     threshold: f64,
     include_naming: bool,
 ) -> Option<RedundancyMatchScore> {
+    // Bodies below SHINGLE_N tokens have no shingle evidence at all; their
+    // ast/cfg/call hashes are near-constant (kinds only, no identifiers), so
+    // without token evidence only textually identical bodies are trustworthy.
+    if a.shingles.is_empty() && b.shingles.is_empty() && a.source_hash != b.source_hash {
+        return None;
+    }
+
     let similarity = composite_similarity(a, b);
     let vector_cosine = vector_cosine_similarity(&a.shingles, &b.shingles);
-    if similarity < threshold && vector_cosine < threshold {
+    if similarity < threshold
+        && vector_cosine < threshold
+        && !same_name_rescue(a_name, b_name, vector_cosine, include_naming)
+    {
         return None;
     }
 
     let mut overlap_kind = overlap_kind(a, b);
-    if overlap_kind == "naming" && vector_cosine >= threshold {
+    if overlap_kind == "naming"
+        && vector_cosine >= threshold
+        && vector_cosine >= LIKELY_SEVERITY_FLOOR
+    {
         overlap_kind = "body_vector";
     }
     if !include_naming && overlap_kind == "naming" {
@@ -508,6 +540,9 @@ pub fn redundancy_match_score(
     }
 
     let generic_helper_downranked = generic_helper_pair(a_name, b_name);
+    // The cosine-only signal is trusted slightly less than the composite, so
+    // rank it at a 0.95 discount. ranking_score is a rank key, not a
+    // thresholded quantity — it can legitimately sit below `threshold`.
     let mut ranking_score = similarity.max(vector_cosine * 0.95);
     if generic_helper_downranked {
         ranking_score *= 0.75;
@@ -524,14 +559,62 @@ pub fn redundancy_match_score(
     })
 }
 
+/// Minimum body-vector cosine for the same-name rescue: identical non-generic
+/// names with less shared body than this are treated as coincidence.
+const SAME_NAME_COSINE_FLOOR: f64 = 0.3;
+
+/// Identical non-generic names across two bodies with modest vector overlap
+/// are real duplicate leads even when both score limbs miss the gate
+/// (verified live: `clean_comment` duplicated across extractor modules was
+/// invisible at every practical threshold). Rescued pairs keep their natural
+/// overlap kind — usually `naming` — and therefore surface only with
+/// `include_naming`, making that flag a genuine recall lever.
+fn same_name_rescue(a_name: &str, b_name: &str, vector_cosine: f64, include_naming: bool) -> bool {
+    include_naming
+        && a_name == b_name
+        && !is_generic_helper_name(a_name)
+        && vector_cosine >= SAME_NAME_COSINE_FLOOR
+}
+
 fn generic_helper_pair(a_name: &str, b_name: &str) -> bool {
     a_name == b_name && is_generic_helper_name(a_name)
 }
 
+/// Method names whose bodies are structurally near-identical across unrelated
+/// types (trait impls and ubiquitous idioms), in Rust and the other indexed
+/// languages. Pairs of these are downranked, never dropped, and only the
+/// ranking is affected — severity is intentionally left untouched.
 fn is_generic_helper_name(name: &str) -> bool {
     matches!(
         name,
-        "drop" | "fmt" | "clone" | "default" | "new" | "from" | "into" | "as_ref" | "as_mut"
+        "drop"
+            | "fmt"
+            | "clone"
+            | "default"
+            | "new"
+            | "from"
+            | "into"
+            | "as_ref"
+            | "as_mut"
+            | "eq"
+            | "ne"
+            | "hash"
+            | "cmp"
+            | "partial_cmp"
+            | "deref"
+            | "deref_mut"
+            | "index"
+            | "next"
+            | "len"
+            | "is_empty"
+            | "to_string"
+            | "try_from"
+            | "constructor"
+            | "toString"
+            | "__init__"
+            | "__str__"
+            | "__repr__"
+            | "__eq__"
     )
 }
 
@@ -553,6 +636,189 @@ fn short_sha256(s: &str) -> String {
     let mut h = Sha256::new();
     h.update(s.as_bytes());
     short_hex(h.finalize().as_slice())
+}
+
+// ---------------------------------------------------------------------------
+// Pairwise redundancy scan
+// ---------------------------------------------------------------------------
+
+/// One scored redundant pair: the [`RedundancyMatchScore`] verdict plus
+/// borrows of the two graph nodes and their fingerprints. Orientation is
+/// canonicalized by [`redundant_pair`] so the same logical pair always
+/// presents the same `a`/`b` sides regardless of input order.
+pub struct RedundantPair<'a> {
+    pub score: RedundancyMatchScore,
+    pub node_a: &'a crate::types::Node,
+    pub node_b: &'a crate::types::Node,
+    pub fp_a: &'a Fingerprint,
+    pub fp_b: &'a Fingerprint,
+}
+
+/// Scan a set of `(node, fingerprint)` candidates for redundant pairs.
+///
+/// Candidates are sorted by `body_tokens` (ties broken on node id so the
+/// enumeration order never depends on DB row order), then each is compared
+/// only against the following candidates whose token count falls inside its
+/// ±25 % [`body_token_window`] — a linear window over the sorted slice that
+/// keeps the pairwise comparison sub-quadratic. Surviving pairs are ranked by
+/// `ranking_score` (a total order: ties fall through similarity, cosine, then
+/// names and node ids) and truncated to `max_pairs`.
+pub fn find_redundant_pairs<'a>(
+    mut scoped: Vec<(&'a crate::types::Node, &'a Fingerprint)>,
+    threshold: f64,
+    include_naming: bool,
+    max_pairs: usize,
+) -> Vec<RedundantPair<'a>> {
+    // Sort by body_tokens so the size-window check is a linear scan; break
+    // ties on node id so candidate enumeration never depends on DB row order.
+    scoped.sort_by(|(na, fa), (nb, fb)| {
+        fa.body_tokens
+            .cmp(&fb.body_tokens)
+            .then_with(|| na.id.cmp(&nb.id))
+    });
+
+    let mut found = Vec::new();
+    for (i, (node_a, fp_a)) in scoped.iter().enumerate() {
+        let (lo, hi) = body_token_window(fp_a.body_tokens);
+        for (node_b, fp_b) in scoped.iter().skip(i + 1) {
+            if fp_b.body_tokens > hi {
+                break; // sorted, no need to scan further
+            }
+            if fp_b.body_tokens < lo {
+                continue;
+            }
+            if let Some(pair) =
+                redundant_pair(node_a, fp_a, node_b, fp_b, threshold, include_naming)
+            {
+                found.push(pair);
+            }
+        }
+    }
+
+    found.sort_by(|a: &RedundantPair<'_>, b: &RedundantPair<'_>| {
+        b.score
+            .ranking_score
+            .partial_cmp(&a.score.ranking_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.score
+                    .similarity
+                    .partial_cmp(&a.score.similarity)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
+                b.score
+                    .vector_cosine
+                    .partial_cmp(&a.score.vector_cosine)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.node_a.name.cmp(&b.node_a.name))
+            .then_with(|| a.node_b.name.cmp(&b.node_b.name))
+            .then_with(|| a.node_a.id.cmp(&b.node_a.id))
+            .then_with(|| a.node_b.id.cmp(&b.node_b.id))
+    });
+    found.truncate(max_pairs);
+
+    found
+}
+
+/// The ±25 % `body_tokens` window used to bucket candidates before scoring.
+/// Returns the inclusive `(low, high)` token bounds for a body of the given
+/// size.
+pub fn body_token_window(body_tokens: usize) -> (usize, usize) {
+    (
+        (body_tokens as f64 * 0.75).floor() as usize,
+        (body_tokens as f64 * 1.25).ceil() as usize,
+    )
+}
+
+/// Score one candidate pair, returning a canonically-oriented
+/// [`RedundantPair`] or `None` when [`redundancy_match_score`] rejects it.
+///
+/// Orientation is fixed by `(file_path, start_line, id)` so the same logical
+/// pair always presents the same `a`/`b` sides regardless of input order
+/// (scoring is symmetric).
+pub fn redundant_pair<'a>(
+    node_a: &'a crate::types::Node,
+    fp_a: &'a Fingerprint,
+    node_b: &'a crate::types::Node,
+    fp_b: &'a Fingerprint,
+    threshold: f64,
+    include_naming: bool,
+) -> Option<RedundantPair<'a>> {
+    let score = redundancy_match_score(
+        &node_a.name,
+        fp_a,
+        &node_b.name,
+        fp_b,
+        threshold,
+        include_naming,
+    )?;
+    // Canonicalize orientation so the same logical pair always presents the
+    // same a/b sides regardless of DB row order (scoring is symmetric).
+    let a_key = (&node_a.file_path, node_a.start_line, &node_a.id);
+    let b_key = (&node_b.file_path, node_b.start_line, &node_b.id);
+    let (node_a, fp_a, node_b, fp_b) = if a_key <= b_key {
+        (node_a, fp_a, node_b, fp_b)
+    } else {
+        (node_b, fp_b, node_a, fp_a)
+    };
+    Some(RedundantPair {
+        score,
+        node_a,
+        node_b,
+        fp_a,
+        fp_b,
+    })
+}
+
+/// Connected components over the returned pairs — the shared source of truth
+/// for both the JSON `groups` array and the markdown Groups section, so the
+/// two views cannot drift on membership.
+pub fn connected_node_groups<'a>(
+    pairs: &'a [RedundantPair<'a>],
+) -> Vec<Vec<&'a crate::types::Node>> {
+    let mut groups: Vec<Vec<&'a crate::types::Node>> = Vec::new();
+    for pair in pairs {
+        let mut matching_groups = Vec::new();
+        for (idx, group) in groups.iter().enumerate() {
+            if group
+                .iter()
+                .any(|node| node.id == pair.node_a.id || node.id == pair.node_b.id)
+            {
+                matching_groups.push(idx);
+            }
+        }
+
+        let nodes = [pair.node_a, pair.node_b];
+        if matching_groups.is_empty() {
+            groups.push(Vec::from(nodes));
+            continue;
+        }
+
+        let first = matching_groups[0];
+        for node in nodes {
+            push_unique_node(&mut groups[first], node);
+        }
+        for idx in matching_groups.into_iter().skip(1).rev() {
+            let merged = groups.remove(idx);
+            for node in merged {
+                push_unique_node(&mut groups[first], node);
+            }
+        }
+    }
+
+    groups
+}
+
+fn push_unique_node<'a>(
+    nodes: &mut Vec<&'a crate::types::Node>,
+    node: &'a crate::types::Node,
+) {
+    if nodes.iter().any(|existing| existing.id == node.id) {
+        return;
+    }
+    nodes.push(node);
 }
 
 // ---------------------------------------------------------------------------
@@ -701,6 +967,102 @@ mod tests {
         assert!(generic.ranking_score < regular.ranking_score);
     }
 
+    fn tiny_body_fingerprint(source_hash: &str) -> Fingerprint {
+        Fingerprint {
+            ast_hash: "tiny_ast".into(),
+            cfg_hash: "tiny_cfg".into(),
+            call_seq_hash: "tiny_call".into(),
+            shingles: Vec::new(),
+            body_tokens: 2,
+            source_hash: source_hash.into(),
+        }
+    }
+
+    #[test]
+    fn empty_shingles_with_identical_hashes_require_identical_source() {
+        // Tiny bodies (< SHINGLE_N tokens) hash identically on ast/cfg/call
+        // even when textually different — without token evidence, only a
+        // source_hash match is trustworthy.
+        let a = tiny_body_fingerprint("src_a");
+        let b = tiny_body_fingerprint("src_b");
+        assert!(redundancy_match_score("width", &a, "height", &b, 0.55, true).is_none());
+
+        let twin = tiny_body_fingerprint("src_a");
+        let matched = redundancy_match_score("width", &a, "width_copy", &twin, 0.55, true)
+            .expect("textually identical tiny bodies should match");
+        assert_eq!(matched.overlap_kind, "ast_isomorphic");
+        assert_eq!(matched.severity, "definite");
+    }
+
+    fn shingle_fingerprint(tag: &str, shingles: Vec<u32>) -> Fingerprint {
+        Fingerprint {
+            ast_hash: format!("{tag}_ast"),
+            cfg_hash: format!("{tag}_cfg"),
+            call_seq_hash: format!("{tag}_call"),
+            body_tokens: shingles.len(),
+            source_hash: format!("{tag}_src"),
+            shingles,
+        }
+    }
+
+    #[test]
+    fn sub_floor_cosine_pairs_stay_naming_and_honor_include_naming() {
+        // cosine 9/20 = 0.45 clears a 0.4 threshold but not the 0.55
+        // severity floor: the pair keeps kind "naming" (no body_vector
+        // relabel), gets severity "naming_only", and include_naming filters
+        // it — kind, severity, and filter stay mutually consistent.
+        let a = shingle_fingerprint("na", (1..=20).collect());
+        let b_shingles: Vec<u32> = (1..=9).chain(101..=111).collect();
+        let b = shingle_fingerprint("nb", b_shingles);
+
+        assert!(redundancy_match_score("alpha", &a, "beta", &b, 0.4, false).is_none());
+        let kept = redundancy_match_score("alpha", &a, "beta", &b, 0.4, true)
+            .expect("include_naming=true keeps the pair");
+        assert_eq!(kept.overlap_kind, "naming");
+        assert_eq!(kept.severity, "naming_only");
+    }
+
+    #[test]
+    fn cosine_rescue_relabels_naming_to_body_vector_as_likely() {
+        // cosine 6/10 = 0.6 with jaccard 6/14 < 0.5 and all hashes distinct:
+        // the naming pair is rescued by body-vector evidence, and rescued
+        // pairs are reported even with include_naming=false.
+        let a = shingle_fingerprint("va", (1..=10).collect());
+        let b_shingles: Vec<u32> = (1..=6).chain(101..=104).collect();
+        let b = shingle_fingerprint("vb", b_shingles);
+
+        let rescued = redundancy_match_score("merge_spans", &a, "merge_ranges", &b, 0.55, false)
+            .expect("cosine >= floor rescues the pair");
+        assert_eq!(rescued.overlap_kind, "body_vector");
+        assert_eq!(rescued.severity, "likely");
+        assert!(!rescued.generic_helper_downranked);
+    }
+
+    #[test]
+    fn same_name_non_generic_pairs_survive_the_gate_as_naming_only() {
+        // clean_comment shape: identical helper name duplicated across
+        // extractor modules, cosine 10/sqrt(24*18) ~= 0.48 — below every
+        // practical threshold, invisible without the same-name rescue.
+        let a = shingle_fingerprint("sna", (1..=24).collect());
+        let b_shingles: Vec<u32> = (1..=10).chain(101..=108).collect();
+        let b = shingle_fingerprint("snb", b_shingles);
+
+        let rescued = redundancy_match_score("clean_comment", &a, "clean_comment", &b, 0.55, true)
+            .expect("identical non-generic names with shared body must be retained");
+        assert_eq!(rescued.overlap_kind, "naming");
+        assert_eq!(rescued.severity, "naming_only");
+
+        // Filtered without include_naming; inert for different or generic names.
+        assert!(
+            redundancy_match_score("clean_comment", &a, "clean_comment", &b, 0.55, false)
+                .is_none()
+        );
+        assert!(
+            redundancy_match_score("clean_comment", &a, "strip_comment", &b, 0.55, true).is_none()
+        );
+        assert!(redundancy_match_score("new", &a, "new", &b, 0.55, true).is_none());
+    }
+
     #[test]
     fn redundancy_eval_fixture_scores_real_cases() {
         let fixture: serde_json::Value = serde_json::from_str(include_str!(
@@ -709,15 +1071,16 @@ mod tests {
         .expect("valid redundancy eval fixture");
         let threshold = fixture["threshold"].as_f64().expect("threshold");
         let include_naming = fixture["include_naming"].as_bool().expect("include_naming");
-        let positives = fixture["positive_labels"]
-            .as_array()
-            .expect("positive labels")
-            .iter()
-            .filter_map(serde_json::Value::as_str)
-            .collect::<std::collections::HashSet<_>>();
 
-        let mut scored = Vec::new();
+        let mut scored: Vec<(&str, RedundancyMatchScore)> = Vec::new();
+        let mut rejected: Vec<&str> = Vec::new();
+        let mut positives: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut seen_labels: std::collections::HashSet<&str> = std::collections::HashSet::new();
+
         for case in fixture["cases"].as_array().expect("cases") {
+            let label = case["label"].as_str().expect("label");
+            assert!(seen_labels.insert(label), "duplicate fixture label {label}");
+            let expect = &case["expect"];
             let a = fixture_fingerprint(&case["a"]);
             let b = fixture_fingerprint(&case["b"]);
             let score = redundancy_match_score(
@@ -727,27 +1090,96 @@ mod tests {
                 &b,
                 threshold,
                 include_naming,
-            )
-            .expect("case should match threshold");
-            scored.push((case["label"].as_str().expect("label"), score));
+            );
+            match expect["outcome"].as_str().expect("outcome") {
+                "reject" => {
+                    assert!(
+                        score.is_none(),
+                        "case {label} should be rejected, got {score:?}"
+                    );
+                    rejected.push(label);
+                }
+                "match" => {
+                    let score =
+                        score.unwrap_or_else(|| panic!("case {label} should match threshold"));
+                    assert_eq!(
+                        score.overlap_kind,
+                        expect["overlap_kind"].as_str().expect("overlap_kind"),
+                        "case {label} overlap_kind"
+                    );
+                    assert_eq!(
+                        score.severity,
+                        expect["severity"].as_str().expect("severity"),
+                        "case {label} severity"
+                    );
+                    assert_eq!(
+                        score.generic_helper_downranked,
+                        expect["generic_helper_downranked"]
+                            .as_bool()
+                            .expect("generic_helper_downranked"),
+                        "case {label} generic_helper_downranked"
+                    );
+                    if expect["positive"].as_bool().expect("positive") {
+                        positives.insert(label);
+                    }
+                    scored.push((label, score));
+                }
+                other => panic!("unknown outcome '{other}' for case {label}"),
+            }
         }
+
         scored.sort_by(|(_, a), (_, b)| {
             b.ranking_score
                 .partial_cmp(&a.ranking_score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
+        // A ranking tie would make the expected order an accident of sort
+        // stability rather than scoring behavior — keep the fixture tie-free.
+        for window in scored.windows(2) {
+            assert!(
+                window[0].1.ranking_score > window[1].1.ranking_score,
+                "ranking tie between '{}' and '{}' — fixture must stay tie-free",
+                window[0].0,
+                window[1].0
+            );
+        }
 
         let labels = scored.iter().map(|(label, _)| *label).collect::<Vec<_>>();
-        let expected_labels = fixture["expected"]["ranked_labels"]
+        let expected = &fixture["expected"];
+        let expected_labels = expected["ranked_labels"]
             .as_array()
             .expect("ranked labels")
             .iter()
             .filter_map(serde_json::Value::as_str)
             .collect::<Vec<_>>();
         assert_eq!(labels, expected_labels);
-        assert_eq!(
-            precision_at_labels(&labels, &positives, 2),
-            fixture["expected"]["p_at_2"]
+        let expected_rejected = expected["rejected_labels"]
+            .as_array()
+            .expect("rejected labels")
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .collect::<Vec<_>>();
+        assert_eq!(rejected, expected_rejected);
+
+        // Metrics are recomputed from the ranking, so a fixture whose
+        // expected.metrics disagree with its own ranked_labels fails loudly.
+        let metrics = &expected["metrics"];
+        for k in 1..=3 {
+            let key = format!("p_at_{k}");
+            let actual = round2(precision_at_k(&labels, &positives, k));
+            let expected_metric = metrics[key.as_str()].as_f64().expect("p_at_k");
+            assert!(
+                (actual - expected_metric).abs() < 1e-9,
+                "{key}: computed {actual}, fixture expects {expected_metric}"
+            );
+        }
+        let actual_ap = round2(average_precision(&labels, &positives));
+        let expected_ap = metrics["average_precision"]
+            .as_f64()
+            .expect("average_precision");
+        assert!(
+            (actual_ap - expected_ap).abs() < 1e-9,
+            "average_precision: computed {actual_ap}, fixture expects {expected_ap}"
         );
     }
 
@@ -766,21 +1198,41 @@ mod tests {
                 .map(|item| item.as_u64().expect("shingle") as u32)
                 .collect(),
             body_tokens: value["body_tokens"].as_u64().expect("body_tokens") as usize,
-            source_hash: "fixture".to_string(),
+            source_hash: value["source_hash"].as_str().unwrap_or("fixture").to_string(),
         }
     }
 
-    fn precision_at_labels(
+    fn round2(value: f64) -> f64 {
+        (value * 100.0).round() / 100.0
+    }
+
+    fn precision_at_k(
         labels: &[&str],
         positives: &std::collections::HashSet<&str>,
         k: usize,
-    ) -> serde_json::Value {
-        let positive_count = labels
+    ) -> f64 {
+        let hits = labels
             .iter()
             .take(k)
             .filter(|label| positives.contains(**label))
             .count();
-        serde_json::json!((positive_count as f64 / k as f64 * 100.0).round() / 100.0)
+        hits as f64 / k as f64
+    }
+
+    fn average_precision(labels: &[&str], positives: &std::collections::HashSet<&str>) -> f64 {
+        let mut hits = 0usize;
+        let mut sum = 0.0;
+        for (idx, label) in labels.iter().enumerate() {
+            if positives.contains(*label) {
+                hits += 1;
+                sum += hits as f64 / (idx + 1) as f64;
+            }
+        }
+        if positives.is_empty() {
+            0.0
+        } else {
+            sum / positives.len() as f64
+        }
     }
 
     #[test]

--- a/tests/fixtures/redundancy_eval_labeled.json
+++ b/tests/fixtures/redundancy_eval_labeled.json
@@ -1,17 +1,44 @@
 {
-  "name": "redundancy_scoring_smoke_eval",
+  "name": "redundancy_scoring_labeled_eval",
+  "description": "Labeled scoring eval for redundancy_match_score: matched cases assert kind/severity/downrank and a tie-free ranking; reject cases pin the accept/reject gate. Metrics are recomputed from the ranking by the test.",
   "threshold": 0.55,
   "include_naming": true,
-  "positive_labels": ["dup", "similar"],
   "expected": {
-    "ranked_labels": ["dup", "similar", "noisy"],
-    "p_at_2": 1.0
+    "ranked_labels": [
+      "dup",
+      "superset_variant_adapter",
+      "similar",
+      "noisy_generic_clone",
+      "generic_high_score_demoted",
+      "shared_boilerplate_distinct_logic",
+      "vector_rescue_renamed",
+      "containment_false_positive",
+      "same_name_domain_helper"
+    ],
+    "rejected_labels": [
+      "reject_disjoint",
+      "reject_below_gate",
+      "reject_empty_tiny_bodies"
+    ],
+    "metrics": {
+      "p_at_1": 1.0,
+      "p_at_2": 1.0,
+      "p_at_3": 1.0,
+      "average_precision": 0.83
+    }
   },
   "cases": [
     {
       "label": "dup",
       "a_name": "compute_total",
       "b_name": "compute_total_copy",
+      "expect": {
+        "outcome": "match",
+        "positive": true,
+        "overlap_kind": "ast_isomorphic",
+        "severity": "definite",
+        "generic_helper_downranked": false
+      },
       "a": {
         "ast_hash": "same_ast",
         "cfg_hash": "same_cfg",
@@ -31,6 +58,13 @@
       "label": "similar",
       "a_name": "resolve_config",
       "b_name": "load_config",
+      "expect": {
+        "outcome": "match",
+        "positive": true,
+        "overlap_kind": "token_overlap",
+        "severity": "likely",
+        "generic_helper_downranked": false
+      },
       "a": {
         "ast_hash": "ast_a",
         "cfg_hash": "cfg_a",
@@ -47,9 +81,16 @@
       }
     },
     {
-      "label": "noisy",
+      "label": "noisy_generic_clone",
       "a_name": "drop",
       "b_name": "drop",
+      "expect": {
+        "outcome": "match",
+        "positive": false,
+        "overlap_kind": "ast_isomorphic",
+        "severity": "definite",
+        "generic_helper_downranked": true
+      },
       "a": {
         "ast_hash": "drop_ast",
         "cfg_hash": "drop_cfg",
@@ -63,6 +104,230 @@
         "call_seq_hash": "drop_call",
         "shingles": [20, 21, 22, 23, 24, 25],
         "body_tokens": 6
+      }
+    },
+    {
+      "label": "generic_high_score_demoted",
+      "a_name": "new",
+      "b_name": "new",
+      "expect": {
+        "outcome": "match",
+        "positive": false,
+        "overlap_kind": "ast_isomorphic",
+        "severity": "definite",
+        "generic_helper_downranked": true
+      },
+      "a": {
+        "ast_hash": "gen_ast",
+        "cfg_hash": "gen_cfg_a",
+        "call_seq_hash": "gen_call_a",
+        "shingles": [810, 811, 812, 813, 814, 815, 816, 817, 818, 819],
+        "body_tokens": 10
+      },
+      "b": {
+        "ast_hash": "gen_ast",
+        "cfg_hash": "gen_cfg_b",
+        "call_seq_hash": "gen_call_b",
+        "shingles": [810, 811, 812, 813, 814, 815, 816, 817, 818, 901],
+        "body_tokens": 10
+      }
+    },
+    {
+      "label": "vector_rescue_renamed",
+      "a_name": "merge_spans",
+      "b_name": "merge_ranges",
+      "expect": {
+        "outcome": "match",
+        "positive": true,
+        "overlap_kind": "body_vector",
+        "severity": "likely",
+        "generic_helper_downranked": false
+      },
+      "a": {
+        "ast_hash": "rescue_ast_a",
+        "cfg_hash": "rescue_cfg_a",
+        "call_seq_hash": "rescue_call_a",
+        "shingles": [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49],
+        "body_tokens": 20
+      },
+      "b": {
+        "ast_hash": "rescue_ast_b",
+        "cfg_hash": "rescue_cfg_b",
+        "call_seq_hash": "rescue_call_b",
+        "shingles": [30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 130, 131, 132, 133, 134, 135, 136, 137],
+        "body_tokens": 20
+      }
+    },
+    {
+      "label": "containment_false_positive",
+      "a_name": "read_u32",
+      "b_name": "decode_packet",
+      "expect": {
+        "outcome": "match",
+        "positive": false,
+        "overlap_kind": "body_vector",
+        "severity": "likely",
+        "generic_helper_downranked": false
+      },
+      "a": {
+        "ast_hash": "contain_ast_a",
+        "cfg_hash": "contain_cfg_a",
+        "call_seq_hash": "contain_call_a",
+        "shingles": [600, 601, 602, 603, 604, 605, 606, 607],
+        "body_tokens": 8
+      },
+      "b": {
+        "ast_hash": "contain_ast_b",
+        "cfg_hash": "contain_cfg_b",
+        "call_seq_hash": "contain_call_b",
+        "shingles": [600, 601, 602, 603, 604, 605, 606, 607, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715],
+        "body_tokens": 24
+      }
+    },
+    {
+      "label": "superset_variant_adapter",
+      "a_name": "set_mcp_command",
+      "b_name": "set_mcp_command_codex",
+      "expect": {
+        "outcome": "match",
+        "positive": true,
+        "overlap_kind": "token_overlap",
+        "severity": "likely",
+        "generic_helper_downranked": false
+      },
+      "a": {
+        "ast_hash": "stamp_ast_a",
+        "cfg_hash": "stamp_cfg_a",
+        "call_seq_hash": "stamp_call_a",
+        "shingles": [900, 901, 902, 903, 904, 905, 906, 907, 908, 909],
+        "body_tokens": 14
+      },
+      "b": {
+        "ast_hash": "stamp_ast_b",
+        "cfg_hash": "stamp_cfg_b",
+        "call_seq_hash": "stamp_call_b",
+        "shingles": [900, 901, 902, 903, 904, 905, 906, 907, 908, 909, 910, 911, 912],
+        "body_tokens": 18
+      }
+    },
+    {
+      "label": "shared_boilerplate_distinct_logic",
+      "a_name": "render_growth_sparkline",
+      "b_name": "render_memory_panel",
+      "expect": {
+        "outcome": "match",
+        "positive": false,
+        "overlap_kind": "token_overlap",
+        "severity": "likely",
+        "generic_helper_downranked": false
+      },
+      "a": {
+        "ast_hash": "boil_ast_a",
+        "cfg_hash": "boil_cfg_a",
+        "call_seq_hash": "boil_call_a",
+        "shingles": [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1020, 1021, 1022, 1023],
+        "body_tokens": 12
+      },
+      "b": {
+        "ast_hash": "boil_ast_b",
+        "cfg_hash": "boil_cfg_b",
+        "call_seq_hash": "boil_call_b",
+        "shingles": [1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1030, 1031, 1032, 1033],
+        "body_tokens": 12
+      }
+    },
+    {
+      "label": "same_name_domain_helper",
+      "a_name": "clean_comment",
+      "b_name": "clean_comment",
+      "expect": {
+        "outcome": "match",
+        "positive": true,
+        "overlap_kind": "naming",
+        "severity": "naming_only",
+        "generic_helper_downranked": false
+      },
+      "a": {
+        "ast_hash": "cc_ast_rust",
+        "cfg_hash": "cc_cfg_rust",
+        "call_seq_hash": "cc_call_rust",
+        "shingles": [1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113, 1114, 1115, 1116, 1117, 1118, 1119, 1120, 1121, 1122, 1123],
+        "body_tokens": 24
+      },
+      "b": {
+        "ast_hash": "cc_ast_pascal",
+        "cfg_hash": "cc_cfg_pascal",
+        "call_seq_hash": "cc_call_pascal",
+        "shingles": [1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207],
+        "body_tokens": 18
+      }
+    },
+    {
+      "label": "reject_disjoint",
+      "a_name": "parse_header",
+      "b_name": "render_footer",
+      "expect": {
+        "outcome": "reject"
+      },
+      "a": {
+        "ast_hash": "dis_ast_a",
+        "cfg_hash": "dis_cfg_a",
+        "call_seq_hash": "dis_call_a",
+        "shingles": [200, 201, 202, 203, 204, 205],
+        "body_tokens": 6
+      },
+      "b": {
+        "ast_hash": "dis_ast_b",
+        "cfg_hash": "dis_cfg_b",
+        "call_seq_hash": "dis_call_b",
+        "shingles": [300, 301, 302, 303, 304, 305],
+        "body_tokens": 6
+      }
+    },
+    {
+      "label": "reject_below_gate",
+      "a_name": "sum_evens",
+      "b_name": "sum_odds",
+      "expect": {
+        "outcome": "reject"
+      },
+      "a": {
+        "ast_hash": "gate_ast_a",
+        "cfg_hash": "gate_cfg_a",
+        "call_seq_hash": "gate_call_a",
+        "shingles": [400, 401, 402, 403, 404, 405, 406, 407, 408, 409],
+        "body_tokens": 10
+      },
+      "b": {
+        "ast_hash": "gate_ast_b",
+        "cfg_hash": "gate_cfg_b",
+        "call_seq_hash": "gate_call_b",
+        "shingles": [400, 401, 402, 403, 404, 500, 501, 502, 503, 504],
+        "body_tokens": 10
+      }
+    },
+    {
+      "label": "reject_empty_tiny_bodies",
+      "a_name": "width",
+      "b_name": "height",
+      "expect": {
+        "outcome": "reject"
+      },
+      "a": {
+        "ast_hash": "tiny_ast",
+        "cfg_hash": "tiny_cfg",
+        "call_seq_hash": "tiny_call",
+        "shingles": [],
+        "body_tokens": 2,
+        "source_hash": "tiny_src_a"
+      },
+      "b": {
+        "ast_hash": "tiny_ast",
+        "cfg_hash": "tiny_cfg",
+        "call_seq_hash": "tiny_call",
+        "shingles": [],
+        "body_tokens": 2,
+        "source_hash": "tiny_src_b"
       }
     }
   ]

--- a/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
+++ b/tests/hooks_lsp_suite/lsp_code_diagnostics_test.rs
@@ -898,6 +898,85 @@ fn broker_clears_language_diagnostics_when_disabled() {
     assert_eq!(snapshot.summary.total_errors, 0);
 }
 
+#[tokio::test]
+async fn broker_resolve_enclosing_nodes_attributes_diagnostic_to_smallest_span() {
+    let mut broker = lsp::broker::DiagnosticBroker::new_for_test(
+        "/tmp/tracedecay-lsp-test",
+        vec![fake_adapter("rust", "rs", "rust-analyzer", Vec::new())],
+    );
+    // Diagnostic inside a known function (1-based line 5 -> 0-based line 4).
+    broker.cache_diagnostic(lsp::broker::CodeDiagnostic {
+        language: "rust".to_string(),
+        source: "rust-analyzer".to_string(),
+        file: "src/lib.rs".to_string(),
+        line_start: 5,
+        line_end: 5,
+        character_start: Some(4),
+        character_end: Some(8),
+        severity: lsp::broker::DiagnosticSeverity::Error,
+        code: Some("E0308".to_string()),
+        message: "mismatched types".to_string(),
+        enclosing_node: None,
+        updated_at: 1,
+    });
+    // Diagnostic on a line no indexed span covers stays unattributed.
+    broker.cache_diagnostic(lsp::broker::CodeDiagnostic {
+        language: "rust".to_string(),
+        source: "rust-analyzer".to_string(),
+        file: "src/lib.rs".to_string(),
+        line_start: 40,
+        line_end: 40,
+        character_start: None,
+        character_end: None,
+        severity: lsp::broker::DiagnosticSeverity::Warning,
+        code: None,
+        message: "unused variable".to_string(),
+        enclosing_node: None,
+        updated_at: 1,
+    });
+
+    broker
+        .resolve_enclosing_nodes(|file| async move {
+            assert_eq!(file, "src/lib.rs");
+            vec![
+                // Outer impl block spanning the whole region.
+                lsp::broker::NodeSpan {
+                    start_line: 0,
+                    end_line: 20,
+                    qualified_name: "crate::Widget".to_string(),
+                },
+                // Inner method: the smallest span covering line 4.
+                lsp::broker::NodeSpan {
+                    start_line: 3,
+                    end_line: 9,
+                    qualified_name: "crate::Widget::render".to_string(),
+                },
+            ]
+        })
+        .await;
+
+    let snapshot = broker.snapshot();
+    let attributed = snapshot
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.line_start == 5)
+        .expect("diagnostic at line 5 should be present");
+    assert_eq!(
+        attributed.enclosing_node.as_deref(),
+        Some("crate::Widget::render"),
+        "diagnostic should attribute to the smallest enclosing indexed node"
+    );
+    let unattributed = snapshot
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.line_start == 40)
+        .expect("diagnostic at line 40 should be present");
+    assert_eq!(
+        unattributed.enclosing_node, None,
+        "diagnostic outside every indexed span stays unattributed"
+    );
+}
+
 fn adapter<'a>(
     adapters: &'a [lsp::adapters::LspAdapterDefinition],
     language: &str,

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -6055,13 +6055,15 @@ pub fn unrelated(x: i32) -> i32 {
         let mut rows = cg
             .db()
             .conn()
-            .query(
-                "SELECT id FROM nodes WHERE name = 'compute_a'",
-                (),
-            )
+            .query("SELECT id FROM nodes WHERE name = 'compute_a'", ())
             .await
             .unwrap();
-        rows.next().await.unwrap().unwrap().get::<String>(0).unwrap()
+        rows.next()
+            .await
+            .unwrap()
+            .unwrap()
+            .get::<String>(0)
+            .unwrap()
     };
 
     // The reader serves the planted pair while both source hashes are fresh.

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -6032,6 +6032,68 @@ pub fn unrelated(x: i32) -> i32 {
     .unwrap();
     let parsed2: serde_json::Value = serde_json::from_str(extract_text(&result2.value)).unwrap();
     assert_eq!(parsed2["pair_count"], parsed["pair_count"]);
+
+    // The redundancy run persists its ranked pairs into the freshness-validated
+    // `redundancy_pairs` cache so other surfaces can read them without
+    // recomputing. At least the planted compute_a/compute_b pair lands.
+    let cached_count = {
+        let mut rows = cg
+            .db()
+            .conn()
+            .query("SELECT COUNT(*) FROM redundancy_pairs", ())
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+    };
+    assert!(
+        cached_count >= 1,
+        "redundancy run should populate the redundancy_pairs cache, got {cached_count}"
+    );
+
+    // Resolve compute_a's node id to exercise the fresh-pairs reader.
+    let compute_a_id = {
+        let mut rows = cg
+            .db()
+            .conn()
+            .query(
+                "SELECT id FROM nodes WHERE name = 'compute_a'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get::<String>(0).unwrap()
+    };
+
+    // The reader serves the planted pair while both source hashes are fresh.
+    let fresh = cg
+        .db()
+        .fresh_redundancy_pairs_for_node(&compute_a_id)
+        .await
+        .unwrap();
+    assert!(
+        !fresh.is_empty(),
+        "fresh-pairs reader should return the planted duplicate for compute_a"
+    );
+
+    // Changing compute_a's cached fingerprint source_hash makes every pair it
+    // participates in stale — the reader's freshness join must drop them.
+    cg.db()
+        .conn()
+        .execute(
+            "UPDATE node_fingerprints SET source_hash = 'stale-hash' WHERE node_id = ?1",
+            libsql::params![compute_a_id.clone()],
+        )
+        .await
+        .unwrap();
+    let stale = cg
+        .db()
+        .fresh_redundancy_pairs_for_node(&compute_a_id)
+        .await
+        .unwrap();
+    assert!(
+        stale.is_empty(),
+        "reader must filter rows whose stored source_hash no longer matches the fingerprint"
+    );
 }
 
 /// Issue #80: `tracedecay_runtime` must surface process + DB telemetry so
@@ -13318,6 +13380,163 @@ async fn diagnose_normalizes_absolute_and_backslash_paths() {
     assert_eq!(
         mapped, 2,
         "both diagnostics should map to nodes after path normalization; got mapped={mapped} full={output:#}"
+    );
+}
+
+/// `tracedecay_diagnose` cross-references the redundancy index: when the
+/// enclosing node of a diagnostic has a cached fingerprint, near-duplicate
+/// functions surface under `near_duplicates`. Plant two AST-isomorphic
+/// functions, warm the fingerprint cache via `tracedecay_redundancy`, then
+/// diagnose a synthetic error on one and assert the other is reported.
+#[tokio::test]
+async fn diagnose_surfaces_near_duplicates_from_redundancy_cache() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/lib.rs"),
+        r#"
+pub fn compute_a(value: i32) -> i32 {
+    let mut acc = 0;
+    for i in 0..value {
+        if i % 2 == 0 {
+            acc += i;
+        } else {
+            acc -= i;
+        }
+    }
+    acc
+}
+
+pub fn compute_b(input: i32) -> i32 {
+    let mut total = 0;
+    for j in 0..input {
+        if j % 2 == 0 {
+            total += j;
+        } else {
+            total -= j;
+        }
+    }
+    total
+}
+"#,
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    // Warm the fingerprint cache so diagnose has something to read.
+    handle_tool_call(
+        &cg,
+        "tracedecay_redundancy",
+        json!({ "min_lines": 5, "similarity_threshold": 0.5 }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Craft a diagnostic whose span lands inside compute_a.
+    let a_id = find_node_id(&cg, "compute_a").await;
+    let a_node = cg.get_node(&a_id).await.unwrap().expect("compute_a node");
+    let diag_line = a_node.start_line + 1; // 0-based start -> 1-based span line
+    let cargo_output =
+        format!("error[E0001]: synthetic error\n  --> src/lib.rs:{diag_line}:5\n   |\n");
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_diagnose",
+        json!({"cargo_output": cargo_output, "include_callers": false}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let output: Value = serde_json::from_str(text).unwrap();
+
+    let diagnostics = output["diagnostics"].as_array().expect("diagnostics");
+    let diag = diagnostics
+        .iter()
+        .find(|d| d["node"]["name"].as_str() == Some("compute_a"))
+        .unwrap_or_else(|| panic!("diagnostic did not map to compute_a: {output:#}"));
+    let dupes = diag["near_duplicates"]
+        .as_array()
+        .unwrap_or_else(|| panic!("near_duplicates missing: {output:#}"));
+    assert!(
+        dupes
+            .iter()
+            .any(|d| d["name"].as_str() == Some("compute_b")),
+        "expected compute_b in near_duplicates, got: {output:#}"
+    );
+    let top = &dupes[0];
+    assert_eq!(top["name"].as_str(), Some("compute_b"));
+    assert_eq!(top["overlap_kind"].as_str(), Some("ast_isomorphic"));
+    assert_eq!(top["severity"].as_str(), Some("definite"));
+    assert!(top["ranking_score"].as_f64().unwrap_or(0.0) > 0.0);
+}
+
+/// When no fingerprint is cached for the enclosing node, `diagnose` must not
+/// parse or warm files — it silently reports an empty `near_duplicates` list.
+#[tokio::test]
+async fn diagnose_near_duplicates_absent_without_cached_fingerprint() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/lib.rs"),
+        r#"
+pub fn compute_a(value: i32) -> i32 {
+    let mut acc = 0;
+    for i in 0..value {
+        acc += i;
+    }
+    acc
+}
+
+pub fn compute_b(input: i32) -> i32 {
+    let mut total = 0;
+    for j in 0..input {
+        total += j;
+    }
+    total
+}
+"#,
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+    // Deliberately do NOT run tracedecay_redundancy — no fingerprints cached.
+
+    let a_id = find_node_id(&cg, "compute_a").await;
+    let a_node = cg.get_node(&a_id).await.unwrap().expect("compute_a node");
+    let diag_line = a_node.start_line + 1;
+    let cargo_output =
+        format!("error[E0001]: synthetic error\n  --> src/lib.rs:{diag_line}:5\n   |\n");
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_diagnose",
+        json!({"cargo_output": cargo_output, "include_callers": false}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&result.value);
+    let output: Value = serde_json::from_str(text).unwrap();
+
+    let diagnostics = output["diagnostics"].as_array().expect("diagnostics");
+    let diag = diagnostics
+        .iter()
+        .find(|d| d["node"]["name"].as_str() == Some("compute_a"))
+        .unwrap_or_else(|| panic!("diagnostic did not map to compute_a: {output:#}"));
+    let dupes = diag["near_duplicates"]
+        .as_array()
+        .unwrap_or_else(|| panic!("near_duplicates missing: {output:#}"));
+    assert!(
+        dupes.is_empty(),
+        "expected no near_duplicates without cached fingerprints, got: {output:#}"
     );
 }
 

--- a/tests/storage_suite/db_test.rs
+++ b/tests/storage_suite/db_test.rs
@@ -496,14 +496,14 @@ async fn test_migrate_v7_adds_and_backfills_attrs_start_line() {
         .expect("migrate failed");
     assert!(migrated, "expected v7 migration to run");
 
-    // user_version is now LATEST (= 15).
+    // user_version is now LATEST (= 16).
     let mut rows = conn
         .query("PRAGMA user_version", ())
         .await
         .expect("read version");
     let row = rows.next().await.expect("row").expect("some row");
     let version: i64 = row.get(0).expect("version");
-    assert_eq!(version, 15);
+    assert_eq!(version, 16);
 
     // attrs_start_line is backfilled from start_line for both rows.
     // Row a: start_line=42 -> attrs_start_line=42.

--- a/tests/storage_suite/migration_test.rs
+++ b/tests/storage_suite/migration_test.rs
@@ -486,7 +486,7 @@ async fn test_create_schema_fresh_db() {
         .await
         .expect("create_schema should succeed");
 
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         2,
@@ -508,6 +508,8 @@ async fn test_create_schema_fresh_db() {
     assert!(table_exists(&conn, "memory_bank_dirty").await);
     assert!(table_exists(&conn, "memory_feedback_events").await);
     assert!(table_exists(&conn, "memory_facts_fts").await);
+    assert!(table_exists(&conn, "redundancy_pairs").await);
+    assert!(index_exists(&conn, "idx_redundancy_pairs_node_b").await);
 }
 
 /// create_schema is idempotent — calling it twice does not error.
@@ -522,7 +524,7 @@ async fn test_create_schema_idempotent() {
         .await
         .expect("second create_schema should succeed");
 
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 }
 
 /// migrate returns false when already at the latest version.
@@ -536,7 +538,7 @@ async fn test_migrate_already_latest_returns_false() {
         !migrated,
         "migrate should return false when already at latest"
     );
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 }
 
 /// migrate from v0 (completely empty database) applies all migrations to latest.
@@ -555,7 +557,7 @@ async fn test_migrate_from_v0() {
         migrated,
         "migrate should return true when migrations were applied"
     );
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     // All expected tables should exist
     assert!(table_exists(&conn, "nodes").await);
@@ -596,7 +598,7 @@ async fn test_migrate_from_v1() {
         .expect("migrate from v1 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     // V2: metadata table
     assert!(table_exists(&conn, "metadata").await);
@@ -632,7 +634,7 @@ async fn test_migrate_from_v2() {
         .expect("migrate from v2 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     // V3 columns
     assert!(column_exists(&conn, "nodes", "branches").await);
@@ -662,7 +664,7 @@ async fn test_migrate_from_v3() {
         .expect("migrate from v3 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     // V4 columns
     assert!(column_exists(&conn, "nodes", "unsafe_blocks").await);
@@ -690,7 +692,7 @@ async fn test_migrate_from_v4() {
         .expect("migrate from v4 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     assert!(index_exists(&conn, "idx_edges_unique").await);
 }
@@ -820,7 +822,7 @@ async fn test_database_initialize_creates_latest_version() {
         .await
         .expect("Database::initialize should succeed");
 
-    assert_eq!(get_user_version(db.conn()).await, 15);
+    assert_eq!(get_user_version(db.conn()).await, 16);
 }
 
 /// Database::open on an already-current database does not re-migrate.
@@ -872,7 +874,7 @@ async fn test_database_open_migrates_v1_to_latest() {
 
     assert!(migrated, "opening a v1 database should trigger migration");
 
-    assert_eq!(get_user_version(db.conn()).await, 15);
+    assert_eq!(get_user_version(db.conn()).await, 16);
 }
 
 /// After create_schema, all v5 columns on nodes exist.
@@ -1015,7 +1017,7 @@ async fn test_v7_to_latest_upgrade_path() {
     let did_migrate = migrate(&conn).await.unwrap();
     assert!(did_migrate, "expected migrate() to return true");
 
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     let mut rows = conn
         .query(
@@ -1045,6 +1047,40 @@ async fn test_migrate_v9_adds_read_cache() {
     assert!(
         index_exists(&conn, "idx_read_cache_session").await,
         "v9 migration should create idx_read_cache_session"
+    );
+}
+
+/// V16 adds the `redundancy_pairs` cache table on a database that predates it.
+#[tokio::test]
+async fn test_migrate_v16_adds_redundancy_pairs() {
+    let (conn, _db, _dir) = create_schema_db().await;
+
+    // Rewind past v16: drop the table and step the version back to v15.
+    conn.execute("DROP TABLE IF EXISTS redundancy_pairs", ())
+        .await
+        .expect("failed to drop redundancy_pairs for rewind");
+    set_user_version(&conn, 15).await;
+    assert!(!table_exists(&conn, "redundancy_pairs").await);
+
+    let migrated = migrate(&conn).await.expect("v16 migration should apply");
+
+    assert!(migrated, "expected migrate() to run the v16 addition");
+    assert_eq!(get_user_version(&conn).await, 16);
+    assert!(
+        table_exists(&conn, "redundancy_pairs").await,
+        "v16 migration should create the redundancy_pairs table"
+    );
+    assert!(
+        index_exists(&conn, "idx_redundancy_pairs_node_b").await,
+        "v16 migration should create idx_redundancy_pairs_node_b"
+    );
+    assert_eq!(
+        column_type_and_pk(&conn, "redundancy_pairs", "node_a_id").await,
+        ("TEXT".to_string(), 1)
+    );
+    assert_eq!(
+        column_type_and_pk(&conn, "redundancy_pairs", "node_b_id").await,
+        ("TEXT".to_string(), 2)
     );
 }
 
@@ -1185,7 +1221,7 @@ async fn test_v10_to_v11_backfills_and_drops_legacy_memory_tables() {
     let did_migrate = migrate(&conn).await.expect("v10 to v11 should migrate");
 
     assert!(did_migrate);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
     assert!(!table_exists(&conn, "memory_decisions").await);
     assert!(!table_exists(&conn, "memory_code_areas").await);
     assert!(table_exists(&conn, "memory_facts").await);
@@ -1205,7 +1241,7 @@ async fn test_v11_database_migrates_to_monotonic_v12() {
     let did_migrate = migrate(&conn).await.expect("v11 to v12 should migrate");
 
     assert!(did_migrate);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
     assert!(table_exists(&conn, "memory_bank_dirty").await);
 }
 
@@ -1628,7 +1664,7 @@ async fn test_v13_drops_archive_columns_with_generated_column_dependency() {
         .await
         .expect("v13 must drop archive columns even with a generated-column dependency");
     assert!(migrated, "expected migrate() to run the v13 cleanup");
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     let columns = column_names(&conn, "memory_facts").await;
     for col in [
@@ -1677,7 +1713,7 @@ async fn test_v14_adds_access_tracking_and_oplog() {
 
     let migrated = migrate(&conn).await.expect("v14 must apply cleanly");
     assert!(migrated, "expected migrate() to run the v14 additions");
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
 
     let columns = column_names(&conn, "memory_facts").await;
     for col in ["access_count", "last_recalled_at"] {
@@ -1703,7 +1739,7 @@ async fn test_v14_adds_access_tracking_and_oplog() {
         .await
         .expect("v14 must be idempotent on an already-upgraded schema");
     assert!(migrated_again);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
     assert_eq!(
         scalar_i64(&conn, "SELECT COUNT(*) FROM memory_facts").await,
         1
@@ -1733,7 +1769,7 @@ async fn test_v15_compacts_legacy_f64_vectors_and_enables_incremental_vacuum() {
         .await
         .expect("v15 must compact legacy vectors");
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         2,
@@ -1776,11 +1812,11 @@ async fn test_v15_repairs_incremental_vacuum_when_version_already_latest() {
     )
     .await
     .expect("failed to simulate pre-repair auto_vacuum mode");
-    set_user_version(&conn, 15).await;
+    set_user_version(&conn, 16).await;
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         0,
-        "fixture should start as an already-v15 database without incremental auto_vacuum"
+        "fixture should start as an already-latest database without incremental auto_vacuum"
     );
 
     let migrated = migrate(&conn)
@@ -1791,7 +1827,7 @@ async fn test_v15_repairs_incremental_vacuum_when_version_already_latest() {
         !migrated,
         "auto_vacuum repair should not report a schema migration"
     );
-    assert_eq!(get_user_version(&conn).await, 15);
+    assert_eq!(get_user_version(&conn).await, 16);
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         2,


### PR DESCRIPTION
Follow-on to #321, from a 16-agent adversarially-verified audit plus transcript mining of real cross-project usage.

**Scoring**: empty-shingle guard (tiny identical-structure bodies no longer score "definite"), shared severity floor making the body_vector relabel coherent with severity and include_naming_only, same-name rescue for verified cross-file duplicates (recall lever behind include_naming_only), broadened generic-helper downrank list.

**Determinism**: canonical pair orientation + total-order ranking independent of DB row order.

**Output**: typed markdown renderer sharing the JSON view data; duplicate groups with scope caveat; generated-path exclusion (dist/, node_modules/, .worktrees/…) with include_generated_paths opt-in.

**Evals**: 12 labeled cases (3 mined from real sessions), reject outcomes, per-case kind/severity assertions, recomputed p@k + AP; fixture ships in the crate package.

**Integration**: tracedecay_diagnose near-duplicates (cache-first), freshness-validated redundancy_pairs cache (v16), LSP diagnostics carry enclosing_node, edit-driven redundancy hint with evals, dedicated analytics category, Codex steering advertises managed subagents.

**Cleanup**: four-angle review applied (single-Jaccard scoring, single group walk, transactional cache writes, unified near-dup ranking, From impl, shared round4, short-circuit line gate).

Verified: full workspace suite 4019/4020 (single failure = the known pre-existing watcher flake, passes 3x in isolation; root-cause fix in flight separately), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)