### PR TITLE
feat(codex): auto-trust installed lifecycle hooks and detect hash drift

### DIFF
--- a/src/agents/codex.rs
+++ b/src/agents/codex.rs
@@ -15,6 +15,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 use crate::errors::{Result, TraceDecayError};
 
@@ -45,7 +46,7 @@ impl AgentIntegration for CodexIntegration {
         eprintln!("  1. cd into your project and run: tracedecay init");
         eprintln!("  2. In Codex, run: codex plugin add tracedecay@personal");
         eprintln!("  3. Start a new Codex session — tracedecay tools are now available");
-        print_hook_trust_guidance();
+        announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
         Ok(())
     }
 
@@ -145,7 +146,15 @@ impl AgentIntegration for CodexIntegration {
                  install to the personal plugin bundle."
             );
             eprintln!("  In Codex, run: codex plugin add tracedecay@personal");
-            print_hook_trust_guidance();
+        }
+        // Auto-trust the personal bundle's hooks whenever one is present, so a
+        // refresh (which may have changed hook content) re-pins trust without a
+        // manual /hooks approval. Repo-local-only installs ship no hooks and
+        // have no personal trust surface, so this is a no-op for them.
+        if codex_plugin_manifest_path(&ctx.home).exists()
+            || !codex_plugin_cached_install_dirs(&ctx.home).is_empty()
+        {
+            announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
         }
         Ok(UpdatePluginOutcome::Refreshed(refreshed))
     }
@@ -697,20 +706,310 @@ const CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX: &str = "tracedecay@personal:hooks
 #[derive(Debug, PartialEq, Eq)]
 enum CodexHookTrustState {
     Trusted,
+    /// Trust entries for these event labels are absent from `config.toml`.
     Missing(Vec<String>),
+    /// Trust entries exist for these event labels but their stored hash no
+    /// longer matches the current `hooks.json` content (e.g. after a bundle
+    /// upgrade changed a command or timeout). Codex silently skips such hooks.
+    Modified(Vec<String>),
 }
 
-/// Codex records hook state under `snake_case` event keys. Derive them from the
-/// managed hook's subcommand (`hook-codex-post-tool-use` -> `post_tool_use`)
-/// so the mapping stays anchored to the single-source-of-truth table instead
-/// of re-implementing Codex's name normalization.
-fn codex_hook_state_event_key(hook: &CodexManagedHook) -> String {
-    hook.subcommand
-        .trim_start_matches("hook-codex-")
-        .replace('-', "_")
+/// A single trust record Codex expects in `~/.codex/config.toml` for one
+/// tracedecay-personal-plugin command hook handler.
+///
+/// The `trust_key` is the fully-qualified `[hooks.state."…"]` table name and
+/// `hash` is the `sha256:<hex>` content hash Codex records as `trusted_hash`.
+/// `command` is retained so the installer's safety valve can confirm the hook
+/// actually invokes the tracedecay binary before recording trust for it.
+#[derive(Debug, Clone)]
+struct CodexHookTrustEntry {
+    event_label: String,
+    trust_key: String,
+    hash: String,
+    command: String,
 }
 
-fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
+/// Convert a Codex `CamelCase` lifecycle event name to the `snake_case` label
+/// Codex uses in trust keys and in the hook hash identity
+/// (`PostToolUse` -> `post_tool_use`). This mirrors Codex's own normalization
+/// so entries computed here match the TUI's `/hooks` approval byte-for-byte.
+fn codex_event_snake_case(event: &str) -> String {
+    let mut out = String::new();
+    for (index, ch) in event.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if index > 0 {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Serialize `value` as compact JSON with object keys sorted recursively —
+/// the canonical form Codex hashes (equivalent to Python's
+/// `json.dumps(sort_keys=True, separators=(",", ":"))`). `serde_json` may be
+/// built with `preserve_order`, so key ordering is enforced here rather than
+/// relying on the serializer's default.
+fn codex_canonical_json(value: &serde_json::Value) -> String {
+    let mut out = String::new();
+    codex_write_canonical_json(value, &mut out);
+    out
+}
+
+fn codex_write_canonical_json(value: &serde_json::Value, out: &mut String) {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                out.push_str(&serde_json::to_string(key).unwrap_or_default());
+                out.push(':');
+                codex_write_canonical_json(&map[key], out);
+            }
+            out.push('}');
+        }
+        serde_json::Value::Array(items) => {
+            out.push('[');
+            for (index, item) in items.iter().enumerate() {
+                if index > 0 {
+                    out.push(',');
+                }
+                codex_write_canonical_json(item, out);
+            }
+            out.push(']');
+        }
+        other => out.push_str(&serde_json::to_string(other).unwrap_or_default()),
+    }
+}
+
+/// Compute Codex's `trusted_hash` for one command-hook handler identity.
+///
+/// This is a direct port of Codex's `command_hook_hash`: build the handler
+/// identity object (`event_name`, optional `matcher`, and a single-element
+/// `hooks` array carrying the `command`/`timeout`/`async` handler), canonicalize
+/// it (recursively key-sorted, compact JSON), sha256 the bytes, and format
+/// `sha256:<lowercase hex>`. `async` and `timeout` are always present after
+/// normalization; `matcher` is omitted entirely when the group has none.
+fn codex_command_hook_hash(
+    event_name: &str,
+    matcher: Option<&str>,
+    command: &str,
+    timeout: u64,
+    is_async: bool,
+) -> String {
+    let handler = json!({
+        "type": "command",
+        "command": command,
+        "timeout": timeout,
+        "async": is_async,
+    });
+    let mut identity = serde_json::Map::new();
+    identity.insert("event_name".to_string(), json!(event_name));
+    if let Some(matcher) = matcher {
+        identity.insert("matcher".to_string(), json!(matcher));
+    }
+    identity.insert("hooks".to_string(), json!([handler]));
+    let canonical = codex_canonical_json(&serde_json::Value::Object(identity));
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+/// Derive the ordered trust records for a rendered Codex `hooks.json` value.
+///
+/// Iterates events -> groups -> handlers exactly as Codex indexes them, so the
+/// group/handler positions in each `trust_key` match what Codex records. The
+/// per-handler `timeout` is normalized the way Codex does (default 600, clamped
+/// to a minimum of 1) and `async` defaults to false, so the hash matches the
+/// TUI's `/hooks` approval regardless of whether those keys are present on disk.
+fn codex_hook_trust_entries(hooks: &serde_json::Value) -> Vec<CodexHookTrustEntry> {
+    let mut entries = Vec::new();
+    let Some(events) = hooks.get("hooks").and_then(|hooks| hooks.as_object()) else {
+        return entries;
+    };
+    for (event_key, groups) in events {
+        let event_label = codex_event_snake_case(event_key);
+        let Some(groups) = groups.as_array() else {
+            continue;
+        };
+        for (group_index, group) in groups.iter().enumerate() {
+            let matcher = group.get("matcher").and_then(|value| value.as_str());
+            let Some(handlers) = group.get("hooks").and_then(|value| value.as_array()) else {
+                continue;
+            };
+            for (handler_index, handler) in handlers.iter().enumerate() {
+                let Some(command) = handler.get("command").and_then(|value| value.as_str()) else {
+                    continue;
+                };
+                let timeout = handler
+                    .get("timeout")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(600)
+                    .max(1);
+                let is_async = handler
+                    .get("async")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                let hash =
+                    codex_command_hook_hash(&event_label, matcher, command, timeout, is_async);
+                let trust_key = format!(
+                    "{CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX}{event_label}:{group_index}:{handler_index}"
+                );
+                entries.push(CodexHookTrustEntry {
+                    event_label: event_label.clone(),
+                    trust_key,
+                    hash,
+                    command: command.to_string(),
+                });
+            }
+        }
+    }
+    entries
+}
+
+/// Render the personal-bundle `hooks.json` and derive its trust records. This
+/// is the single bridge from the hook generator ([`codex_plugin_hooks`]) to the
+/// trust machinery, so the installer, re-sync, and doctor all hash the exact
+/// bytes that ship in the bundle.
+fn codex_managed_hook_trust_entries(tracedecay_bin: &str) -> Result<Vec<CodexHookTrustEntry>> {
+    let seed = codex_embedded_plugin_files()
+        .into_iter()
+        .find_map(|(relative, contents)| (relative == "hooks/hooks.json").then_some(contents))
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "Codex plugin bundle is missing hooks/hooks.json".to_string(),
+        })?;
+    let rendered = codex_plugin_hooks(seed, tracedecay_bin)?;
+    let value: serde_json::Value = serde_json::from_str(&rendered)?;
+    Ok(codex_hook_trust_entries(&value))
+}
+
+/// Safety valve: only auto-trust a hook whose command invokes tracedecay's own
+/// binary (the exact quoted path the generator embeds). Anything else is left
+/// for manual `/hooks` review.
+fn codex_hook_command_invokes_tracedecay(command: &str, tracedecay_bin: &str) -> bool {
+    // `hook_command(bin, "")` yields `<quoted-bin> ` — the same quoting the
+    // generator uses — so a trailing-trimmed prefix match confirms the command
+    // starts with our binary token without re-implementing shell quoting.
+    let quoted_bin = super::hook_command(tracedecay_bin, "");
+    let quoted_bin = quoted_bin.trim_end();
+    !quoted_bin.is_empty() && command.starts_with(quoted_bin)
+}
+
+/// Outcome of a hook-trust re-sync: how many hooks were recorded as trusted and
+/// which (if any) were skipped by the safety valve and still need manual review.
+struct CodexHookTrustSyncOutcome {
+    trusted: usize,
+    skipped: Vec<String>,
+}
+
+/// Record trust for the personal plugin's lifecycle hooks in
+/// `~/.codex/config.toml` so Codex runs them without a manual `/hooks` approval.
+///
+/// Writes only `[hooks.state."tracedecay@personal:hooks/hooks.json:…"]` tables,
+/// pruning stale tracedecay-personal entries (removed events / shifted indices)
+/// while preserving every other plugin's and the user's own config. Hooks whose
+/// command does not invoke the tracedecay binary are skipped (see
+/// [`codex_hook_command_invokes_tracedecay`]). An unreadable/unparseable
+/// `config.toml` surfaces as `Err`, so callers leave it untouched and fall back
+/// to printed guidance.
+fn sync_codex_hook_trust(home: &Path, tracedecay_bin: &str) -> Result<CodexHookTrustSyncOutcome> {
+    let entries = codex_managed_hook_trust_entries(tracedecay_bin)?;
+    let config_path = codex_config_path(home);
+    let mut config = load_toml_file(&config_path)?;
+    let table = config
+        .as_table_mut()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("{} is not a TOML table", config_path.display()),
+        })?;
+    let hooks = table
+        .entry("hooks")
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let hooks = hooks
+        .as_table_mut()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("[hooks] in {} is not a table", config_path.display()),
+        })?;
+    let state = hooks
+        .entry("state")
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let state = state
+        .as_table_mut()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("[hooks.state] in {} is not a table", config_path.display()),
+        })?;
+
+    // Stale-entry hygiene: drop every tracedecay-personal trust record before
+    // re-adding the current set, so removed events or shifted indices do not
+    // linger. Foreign plugins' entries (different prefix) are untouched.
+    state.retain(|key, _| !key.starts_with(CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX));
+
+    let mut trusted = 0usize;
+    let mut skipped = Vec::new();
+    for entry in &entries {
+        if !codex_hook_command_invokes_tracedecay(&entry.command, tracedecay_bin) {
+            skipped.push(entry.event_label.clone());
+            continue;
+        }
+        let mut record = toml::value::Table::new();
+        record.insert(
+            "trusted_hash".to_string(),
+            toml::Value::String(entry.hash.clone()),
+        );
+        state.insert(entry.trust_key.clone(), toml::Value::Table(record));
+        trusted += 1;
+    }
+
+    write_toml_file(&config_path, &config)?;
+    Ok(CodexHookTrustSyncOutcome { trusted, skipped })
+}
+
+/// Auto-trust the personal plugin's hooks, printing a concise confirmation on
+/// full success and falling back to [`print_hook_trust_guidance`] whenever a
+/// hook is skipped by the safety valve or the config could not be written.
+fn announce_codex_hook_trust(home: &Path, tracedecay_bin: &str) {
+    let config_path = codex_config_path(home);
+    match sync_codex_hook_trust(home, tracedecay_bin) {
+        Ok(outcome) if outcome.skipped.is_empty() => {
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Trusted {} Codex hook(s) in {}",
+                outcome.trusted,
+                config_path.display()
+            );
+        }
+        Ok(outcome) => {
+            if outcome.trusted > 0 {
+                eprintln!(
+                    "\x1b[32m✔\x1b[0m Trusted {} Codex hook(s) in {}",
+                    outcome.trusted,
+                    config_path.display()
+                );
+            }
+            eprintln!(
+                "  Skipped auto-trust for {} (command does not invoke the tracedecay binary).",
+                outcome.skipped.join(", ")
+            );
+            print_hook_trust_guidance();
+        }
+        Err(err) => {
+            eprintln!("  Could not auto-trust Codex hooks: {err}");
+            print_hook_trust_guidance();
+        }
+    }
+}
+
+/// Classify the recorded Codex trust state for the personal plugin's hooks by
+/// comparing each expected [`CodexHookTrustEntry`] against `config.toml`.
+fn codex_plugin_hook_trust_state(
+    config: &toml::Value,
+    entries: &[CodexHookTrustEntry],
+) -> CodexHookTrustState {
     // A missing [hooks.state] table is just "nothing trusted yet" — treat it
     // as empty so one pipeline produces the missing list either way.
     let empty = toml::value::Table::new();
@@ -720,24 +1019,26 @@ fn codex_plugin_hook_trust_state(config: &toml::Value) -> CodexHookTrustState {
         .and_then(|state| state.as_table())
         .unwrap_or(&empty);
 
-    let missing: Vec<String> = CODEX_MANAGED_HOOKS
-        .iter()
-        .map(codex_hook_state_event_key)
-        .filter(|event_key| {
-            let trust_key = format!("{CODEX_PERSONAL_PLUGIN_HOOK_TRUST_PREFIX}{event_key}:0:0");
-            !state.get(&trust_key).is_some_and(|entry| {
-                entry
-                    .get("trusted_hash")
-                    .and_then(|hash| hash.as_str())
-                    .is_some_and(|hash| hash.starts_with("sha256:"))
-            })
-        })
-        .collect();
+    let mut missing = Vec::new();
+    let mut modified = Vec::new();
+    for entry in entries {
+        match state
+            .get(&entry.trust_key)
+            .and_then(|record| record.get("trusted_hash"))
+            .and_then(|hash| hash.as_str())
+        {
+            None => missing.push(entry.event_label.clone()),
+            Some(stored) if stored == entry.hash => {}
+            Some(_) => modified.push(entry.event_label.clone()),
+        }
+    }
 
-    if missing.is_empty() {
-        CodexHookTrustState::Trusted
-    } else {
+    if !missing.is_empty() {
         CodexHookTrustState::Missing(missing)
+    } else if !modified.is_empty() {
+        CodexHookTrustState::Modified(modified)
+    } else {
+        CodexHookTrustState::Trusted
     }
 }
 
@@ -1454,20 +1755,28 @@ fn doctor_check_hooks(dc: &mut DoctorCounters, hooks_path: &Path, config_path: &
         CODEX_MANAGED_HOOKS.len(),
         hooks_path.display()
     ));
+    // Hash the on-disk hooks.json exactly as Codex would, then compare against
+    // the trust records in config.toml to distinguish trusted / missing / stale.
+    let entries = codex_hook_trust_entries(&hooks);
     match load_toml_file(config_path) {
-        Ok(config) => match codex_plugin_hook_trust_state(&config) {
-            CodexHookTrustState::Trusted => dc.info(&format!(
-                "Codex hook trust entries recorded in {} — trust is pinned to hook content, so if hooks changed since trusting (e.g. after update-plugin), run /hooks in Codex to re-trust",
+        Ok(config) => match codex_plugin_hook_trust_state(&config, &entries) {
+            CodexHookTrustState::Trusted => dc.pass(&format!(
+                "Codex hook trust entries recorded and current in {}",
                 config_path.display()
             )),
             CodexHookTrustState::Missing(missing) => dc.info(&format!(
-                "Codex skips new/changed command hooks until trusted — missing trust for {} in {}; run `/hooks` in Codex",
+                "Codex skips untrusted command hooks — missing trust for {} in {}; run `tracedecay update-plugin` (or `/hooks` in Codex) to trust them",
                 missing.join(", "),
+                config_path.display()
+            )),
+            CodexHookTrustState::Modified(modified) => dc.warn(&format!(
+                "Codex hook trust is stale for {} in {} — the hook content changed since it was trusted, so Codex now skips it; run `tracedecay update-plugin` to re-trust",
+                modified.join(", "),
                 config_path.display()
             )),
         },
         Err(_) => dc.info(
-            "Codex skips new/changed command hooks until trusted — run `/hooks` in Codex to trust the tracedecay hooks",
+            "Codex skips untrusted command hooks — run `tracedecay update-plugin` (or `/hooks` in Codex) to trust the tracedecay hooks",
         ),
     }
 }

--- a/src/agents/codex/tests.rs
+++ b/src/agents/codex/tests.rs
@@ -65,59 +65,153 @@ fn native_memories_injection_detection_covers_config_shapes() {
     assert!(!codex_native_memories_injection_enabled(&parse("")));
 }
 
+/// A stable binary path for hashing tests. The real trust hash depends only on
+/// the rendered command string, so any fixed path yields deterministic hashes.
+const TEST_BIN: &str = "/usr/local/bin/tracedecay";
+
+/// Render the personal-bundle hooks and derive their trust records with `bin`.
+fn managed_entries(bin: &str) -> Vec<CodexHookTrustEntry> {
+    codex_managed_hook_trust_entries(bin).expect("managed hook trust entries render")
+}
+
+/// Build a `config.toml` value whose `[hooks.state]` records exactly the given
+/// trust entries (each as `trusted_hash = <entry.hash>`).
+fn config_from_entries(entries: &[CodexHookTrustEntry]) -> toml::Value {
+    let mut state = toml::value::Table::new();
+    for entry in entries {
+        let mut record = toml::value::Table::new();
+        record.insert(
+            "trusted_hash".to_string(),
+            toml::Value::String(entry.hash.clone()),
+        );
+        state.insert(entry.trust_key.clone(), toml::Value::Table(record));
+    }
+    let mut hooks = toml::value::Table::new();
+    hooks.insert("state".to_string(), toml::Value::Table(state));
+    let mut root = toml::value::Table::new();
+    root.insert("hooks".to_string(), toml::Value::Table(hooks));
+    toml::Value::Table(root)
+}
+
+/// The five live-trusted golden hashes verified byte-for-byte against a real
+/// Codex `~/.codex/config.toml` on the reference machine. The hash function must
+/// reproduce each from its raw command-hook identity, or the installer would
+/// record trust Codex rejects.
+#[test]
+fn codex_command_hook_hash_reproduces_live_golden_vectors() {
+    let cmd = |sub: &str| format!("'/home/zack/.local/bin/tracedecay' {sub}");
+    let cases = [
+        (
+            "session_start",
+            None,
+            cmd("hook-codex-session-start"),
+            5u64,
+            "sha256:839cc2cfa576115dfa9e184eb267eb5bd565750c20babcb2d0358c68ec7c5c42",
+        ),
+        (
+            "post_tool_use",
+            Some("Bash|apply_patch"),
+            cmd("hook-codex-post-tool-use"),
+            60,
+            "sha256:9dd11f4b944d2b9b8f14d4f17ca8a52e1550e575d3087177ec42d7c7f8848c97",
+        ),
+        (
+            "user_prompt_submit",
+            None,
+            cmd("hook-codex-user-prompt-submit"),
+            5,
+            "sha256:d482382b39ab1f031943d27359c8626b36ebfff66259468377fffcd7174e9313",
+        ),
+        (
+            "subagent_start",
+            None,
+            cmd("hook-codex-subagent-start"),
+            5,
+            "sha256:4042991d127afeef0452f5b9a3fed48b48596e1b6de114b7e3392764f1c467ab",
+        ),
+        (
+            "post_compact",
+            Some("auto|manual"),
+            cmd("hook-codex-post-compact"),
+            120,
+            "sha256:85ce51c00b972536033286d8d8489dbb396dd1ea97bd2a4f10dbaf7aa39a0764",
+        ),
+    ];
+    for (event, matcher, command, timeout, expected) in cases {
+        assert_eq!(
+            codex_command_hook_hash(event, matcher, &command, timeout, false),
+            expected,
+            "hash mismatch for {event}"
+        );
+    }
+}
+
 #[test]
 fn codex_hook_trust_state_reports_all_trusted_entries() {
-    let config = r#"
-[hooks.state]
-
-[hooks.state."tracedecay@personal:hooks/hooks.json:post_tool_use:0:0"]
-trusted_hash = "sha256:post"
-
-[hooks.state."tracedecay@personal:hooks/hooks.json:session_start:0:0"]
-trusted_hash = "sha256:session"
-
-[hooks.state."tracedecay@personal:hooks/hooks.json:user_prompt_submit:0:0"]
-trusted_hash = "sha256:prompt"
-
-[hooks.state."tracedecay@personal:hooks/hooks.json:subagent_start:0:0"]
-trusted_hash = "sha256:subagent"
-
-[hooks.state."tracedecay@personal:hooks/hooks.json:post_compact:0:0"]
-trusted_hash = "sha256:compact"
-"#;
-    let config = toml::from_str::<toml::Value>(config).unwrap();
+    let entries = managed_entries(TEST_BIN);
+    let config = config_from_entries(&entries);
 
     assert_eq!(
-        codex_plugin_hook_trust_state(&config),
+        codex_plugin_hook_trust_state(&config, &entries),
         CodexHookTrustState::Trusted
     );
 }
 
 #[test]
 fn codex_hook_trust_state_reports_missing_entries() {
-    let config = toml::from_str::<toml::Value>(
-        r#"
-[hooks.state]
-
-[hooks.state."tracedecay@personal:hooks/hooks.json:post_tool_use:0:0"]
-trusted_hash = "sha256:post"
-"#,
-    )
-    .unwrap();
+    let entries = managed_entries(TEST_BIN);
+    // Record trust for only the post_tool_use hook; the rest are missing.
+    let present: Vec<CodexHookTrustEntry> = entries
+        .iter()
+        .filter(|entry| entry.event_label == "post_tool_use")
+        .cloned()
+        .collect();
+    let config = config_from_entries(&present);
 
     assert_eq!(
-        codex_plugin_hook_trust_state(&config),
+        codex_plugin_hook_trust_state(&config, &entries),
         CodexHookTrustState::Missing(vec![
-            "session_start".to_string(),
-            "user_prompt_submit".to_string(),
-            "subagent_start".to_string(),
             "post_compact".to_string(),
+            "session_start".to_string(),
+            "subagent_start".to_string(),
+            "user_prompt_submit".to_string(),
         ])
     );
 }
 
 #[test]
+fn codex_hook_trust_state_flags_modified_when_hash_drifts() {
+    let entries = managed_entries(TEST_BIN);
+    // Simulate a bundle change: bump one hook's timeout so its content hash
+    // drifts from what was previously trusted.
+    let raw = codex_embedded_plugin_files()
+        .into_iter()
+        .find_map(|(relative, contents)| (relative == "hooks/hooks.json").then_some(contents))
+        .unwrap();
+    let rendered = codex_plugin_hooks(raw, TEST_BIN).unwrap();
+    let mut value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+    value["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] = json!(9);
+    let changed_entries = codex_hook_trust_entries(&value);
+
+    // config still records the *original* hashes; against the changed bundle,
+    // only session_start drifts.
+    let config = config_from_entries(&entries);
+    assert_eq!(
+        codex_plugin_hook_trust_state(&config, &changed_entries),
+        CodexHookTrustState::Modified(vec!["session_start".to_string()])
+    );
+
+    // Re-syncing to the changed bundle restores Trusted.
+    let resynced = config_from_entries(&changed_entries);
+    assert_eq!(
+        codex_plugin_hook_trust_state(&resynced, &changed_entries),
+        CodexHookTrustState::Trusted
+    );
+}
+
+#[test]
 fn codex_hook_trust_state_ignores_repo_local_plugin_entries() {
+    let entries = managed_entries(TEST_BIN);
     let config = toml::from_str::<toml::Value>(
         r#"
 [hooks.state]
@@ -141,15 +235,132 @@ trusted_hash = "sha256:compact"
     .unwrap();
 
     assert_eq!(
-        codex_plugin_hook_trust_state(&config),
+        codex_plugin_hook_trust_state(&config, &entries),
         CodexHookTrustState::Missing(vec![
-            "session_start".to_string(),
-            "user_prompt_submit".to_string(),
-            "subagent_start".to_string(),
-            "post_tool_use".to_string(),
             "post_compact".to_string(),
+            "post_tool_use".to_string(),
+            "session_start".to_string(),
+            "subagent_start".to_string(),
+            "user_prompt_submit".to_string(),
         ])
     );
+}
+
+#[test]
+fn sync_codex_hook_trust_records_entries_and_preserves_unrelated_config() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    // Seed unrelated user content plus a foreign plugin's trust entry.
+    std::fs::write(
+        &config_path,
+        r#"model = "o4-mini"
+
+[hooks.state."other@plugin:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:foreign"
+"#,
+    )
+    .unwrap();
+
+    let outcome = sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    assert_eq!(outcome.trusted, CODEX_MANAGED_HOOKS.len());
+    assert!(outcome.skipped.is_empty());
+
+    let entries = managed_entries(TEST_BIN);
+    let config = load_toml_file(&config_path).unwrap();
+    let state = config["hooks"]["state"].as_table().unwrap();
+    for entry in &entries {
+        assert_eq!(
+            state[&entry.trust_key]["trusted_hash"].as_str().unwrap(),
+            entry.hash,
+            "trust entry for {} not recorded exactly",
+            entry.event_label
+        );
+    }
+    // Unrelated content and the foreign entry survive.
+    assert_eq!(config["model"].as_str().unwrap(), "o4-mini");
+    assert_eq!(
+        state["other@plugin:hooks/hooks.json:session_start:0:0"]["trusted_hash"]
+            .as_str()
+            .unwrap(),
+        "sha256:foreign"
+    );
+    assert_eq!(
+        codex_plugin_hook_trust_state(&config, &entries),
+        CodexHookTrustState::Trusted
+    );
+
+    // Idempotent: a second sync leaves the same records (managed + 1 foreign).
+    let outcome2 = sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    assert_eq!(outcome2.trusted, CODEX_MANAGED_HOOKS.len());
+    let config2 = load_toml_file(&config_path).unwrap();
+    assert_eq!(
+        config2["hooks"]["state"].as_table().unwrap().len(),
+        CODEX_MANAGED_HOOKS.len() + 1
+    );
+}
+
+#[test]
+fn sync_codex_hook_trust_prunes_stale_and_preserves_foreign_entries() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    // A leftover tracedecay-personal entry for a removed event, plus a foreign
+    // plugin entry that must be preserved.
+    std::fs::write(
+        &config_path,
+        r#"
+[hooks.state."tracedecay@personal:hooks/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:stale"
+
+[hooks.state."other@plugin:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:foreign"
+"#,
+    )
+    .unwrap();
+
+    sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+
+    let config = load_toml_file(&config_path).unwrap();
+    let state = config["hooks"]["state"].as_table().unwrap();
+    assert!(
+        !state.contains_key("tracedecay@personal:hooks/hooks.json:pre_tool_use:0:0"),
+        "stale tracedecay-personal entry should be pruned"
+    );
+    assert_eq!(
+        state["other@plugin:hooks/hooks.json:session_start:0:0"]["trusted_hash"]
+            .as_str()
+            .unwrap(),
+        "sha256:foreign",
+        "foreign plugin entry must be preserved"
+    );
+    assert!(
+        state.contains_key("tracedecay@personal:hooks/hooks.json:session_start:0:0"),
+        "current managed events should be recorded"
+    );
+}
+
+#[test]
+fn codex_hook_command_invokes_tracedecay_is_a_safety_valve() {
+    // A hook that actually invokes the tracedecay binary is trustable. Build
+    // the command through the same hook_command helper the generator uses so
+    // the assertion holds under each platform's quoting (single quotes on
+    // Unix, different quoting on Windows).
+    assert!(codex_hook_command_invokes_tracedecay(
+        &crate::agents::hook_command(TEST_BIN, "hook-codex-session-start"),
+        TEST_BIN
+    ));
+    // A hook that does not invoke the tracedecay binary is never auto-trusted.
+    assert!(!codex_hook_command_invokes_tracedecay(
+        "/usr/bin/rm -rf /",
+        TEST_BIN
+    ));
+    assert!(!codex_hook_command_invokes_tracedecay(
+        &crate::agents::hook_command("/somewhere/else/tracedecay", "hook-codex-session-start"),
+        TEST_BIN
+    ));
 }
 
 #[test]

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -3307,9 +3307,19 @@ fn test_codex_install_creates_plugin_bundle_and_marketplace() {
     );
     assert_codex_personal_marketplace_entry(home);
 
+    // Global Codex install auto-trusts the bundled lifecycle hooks by writing
+    // their content hashes into ~/.codex/config.toml, so Codex runs them without
+    // a manual /hooks approval. The MCP server itself still comes from the
+    // plugin bundle, not config.toml.
+    let config = std::fs::read_to_string(home.join(".codex/config.toml"))
+        .expect("global Codex install should record hook trust in config.toml");
     assert!(
-        !home.join(".codex/config.toml").exists(),
-        "global Codex install should rely on the plugin MCP config, not mutate config.toml"
+        config.contains("tracedecay@personal:hooks/hooks.json:") && config.contains("trusted_hash"),
+        "global Codex install should record tracedecay hook trust entries, got:\n{config}"
+    );
+    assert!(
+        !config.contains("[mcp_servers.tracedecay]"),
+        "global Codex install should not register the MCP server in config.toml"
     );
     assert!(
         !home.join(".codex/hooks.json").exists(),
@@ -3560,9 +3570,24 @@ fn test_codex_install_sweeps_legacy_global_config() {
     let ctx = make_install_ctx(home);
     CodexIntegration.install(&ctx).unwrap();
 
+    // The legacy MCP registration is swept, and the installer records hook
+    // trust in its place — so config.toml survives with only [hooks.state].
+    let migrated: toml::Value =
+        toml::from_str(&std::fs::read_to_string(codex_dir.join("config.toml")).unwrap()).unwrap();
     assert!(
-        !codex_dir.join("config.toml").exists(),
+        migrated
+            .get("mcp_servers")
+            .and_then(|servers| servers.get("tracedecay"))
+            .is_none(),
         "legacy global Codex MCP config should be removed when it only contained tracedecay"
+    );
+    assert!(
+        migrated["hooks"]["state"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
+        "install should record tracedecay hook trust in config.toml"
     );
     assert!(
         !codex_dir.join("hooks.json").exists(),
@@ -4455,8 +4480,10 @@ fn test_codex_local_uninstall_unrecords_legacy_repo_memory_digest_target() {
 #[test]
 fn test_codex_install_preserves_existing_config() {
     // Regression test for issue #63: installing tracedecay used to wipe out the
-    // entire ~/.codex/config.toml because load_toml_file silently returned an
-    // empty table.
+    // entire ~/.codex/config.toml. The installer now records hook trust in
+    // config.toml, so it must add only its [hooks.state] entries while
+    // preserving every unrelated key the user already had, and back the file up
+    // first (issue #63) before rewriting it.
     let dir = TempDir::new().unwrap();
     let home = dir.path();
     let _agent_env = crate::common::AgentEnvLock::pin(home);
@@ -4475,14 +4502,29 @@ args = [\"--flag\"]
     let ctx = make_install_ctx(home);
     CodexIntegration.install(&ctx).unwrap();
 
+    let updated: toml::Value =
+        toml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    // Unrelated user content survives untouched.
+    assert_eq!(updated["model"].as_str().unwrap(), "o4-mini");
+    assert_eq!(updated["approval_policy"].as_str().unwrap(), "on-failure");
     assert_eq!(
-        std::fs::read_to_string(&config_path).unwrap(),
-        original,
-        "global Codex plugin install must leave user config.toml byte-identical"
+        updated["mcp_servers"]["other"]["command"].as_str().unwrap(),
+        "other-bin"
     );
+    // Hook trust entries were added for the personal plugin bundle.
     assert!(
-        !home.join(".codex/config.toml.bak").exists(),
-        "global Codex plugin install should not back up config.toml because it does not rewrite it"
+        updated["hooks"]["state"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
+        "install should record tracedecay hook trust entries"
+    );
+    // Issue #63: the pre-existing config is backed up before the rewrite.
+    assert_eq!(
+        std::fs::read_to_string(home.join(".codex/config.toml.bak")).unwrap(),
+        original,
+        "install should back up the original config before rewriting it"
     );
     assert_codex_plugin_bundle(
         &codex_plugin_install_dir(home),

--- a/tests/agent_suite/update_plugin_test.rs
+++ b/tests/agent_suite/update_plugin_test.rs
@@ -144,6 +144,28 @@ fn write_codex_legacy_config(home: &Path) -> PathBuf {
     config_path
 }
 
+/// After a legacy-config migration, `config.toml` no longer holds a direct
+/// tracedecay MCP registration, but the installer now records hook trust there,
+/// so the file exists with `[hooks.state]` entries instead of being deleted.
+fn assert_codex_legacy_config_migrated(config_path: &Path) {
+    let migrated: toml::Value = toml::from_str(&text(config_path)).unwrap();
+    assert!(
+        migrated
+            .get("mcp_servers")
+            .and_then(|servers| servers.get("tracedecay"))
+            .is_none(),
+        "Codex update-plugin should sweep the legacy MCP server entry"
+    );
+    assert!(
+        migrated["hooks"]["state"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
+        "and record tracedecay hook trust in config.toml in its place"
+    );
+}
+
 fn write_stale_codex_skill(plugin_dir: &Path) {
     std::fs::create_dir_all(plugin_dir.join("skills/stale-skill")).unwrap();
     std::fs::write(
@@ -488,7 +510,7 @@ fn claude_update_plugin_reports_not_installed_without_a_bundle() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn codex_update_plugin_refreshes_bundle_without_touching_config() {
+fn codex_update_plugin_refreshes_bundle_and_records_hook_trust() {
     let home = TempDir::new().unwrap();
     let _agent_env = AgentEnvLock::pin(&home);
     let project_root = home.path().join("workspace");
@@ -515,7 +537,6 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
         "---\nname: project-status\ndescription: My private project status workflow\n---\n",
     )
     .unwrap();
-    let config_before = bytes(&codex_config);
 
     let outcome = codex
         .update_plugin(&ctx_with_project(home.path(), NEW_BIN, &project_root))
@@ -525,7 +546,18 @@ fn codex_update_plugin_refreshes_bundle_without_touching_config() {
     };
     assert_eq!(paths, vec![plugin_dir.clone()]);
 
-    assert_eq!(bytes(&codex_config), config_before);
+    // update-plugin auto-trusts the refreshed hooks by recording their content
+    // hashes in config.toml, while leaving the user's unrelated keys intact.
+    let updated: toml::Value = toml::from_str(&text(&codex_config)).unwrap();
+    assert_eq!(updated["model"].as_str().unwrap(), "gpt-5");
+    assert!(
+        updated["hooks"]["state"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
+        "update-plugin should record tracedecay hook trust entries"
+    );
     assert_eq!(text(&plugin_dir.join("user-note.txt")), "mine\n");
     assert_eq!(
         text(&plugin_dir.join("skills/private-skill/SKILL.md")),
@@ -709,10 +741,7 @@ fn codex_update_plugin_sweeps_legacy_config_when_cache_exists() {
         paths,
         vec![cached_plugin_dir.clone(), codex_bootstrap_dir(home.path())]
     );
-    assert!(
-        !legacy_config.exists(),
-        "Codex update-plugin should remove legacy config even when a plugin cache exists"
-    );
+    assert_codex_legacy_config_migrated(&legacy_config);
 }
 
 #[test]
@@ -834,10 +863,7 @@ fn codex_update_plugin_migrates_legacy_config_only_install_to_plugin() {
         panic!("expected codex update_plugin to migrate legacy config to plugin");
     };
     assert_eq!(paths, vec![home.path().join("plugins/tracedecay")]);
-    assert!(
-        !legacy_config.exists(),
-        "Codex update-plugin should remove the migrated legacy config-managed install"
-    );
+    assert_codex_legacy_config_migrated(&legacy_config);
     assert_codex_bundle_contains_bin(
         &home.path().join("plugins/tracedecay"),
         NEW_BIN,
@@ -879,10 +905,7 @@ fn codex_update_plugin_migrates_legacy_config_even_when_repo_bundle_refreshes() 
             .exists(),
         "personal plugin bundle must exist after migrating a legacy install"
     );
-    assert!(
-        !legacy_config.exists(),
-        "legacy config-managed install should be swept after migration"
-    );
+    assert_codex_legacy_config_migrated(&legacy_config);
 }
 
 #[test]


### PR DESCRIPTION
Codex only runs plugin hooks whose hooks.state trusted_hash matches the hook's normalized identity hash; its /hooks approval just writes those config entries. Install/update-plugin now write them for the hooks they install — no manual approval step. The hash algorithm was reverse-engineered from codex-cli 0.142.5 source and pinned by five golden vectors captured from a live trusted config. Safety valve: only hooks invoking tracedecay's own binary are auto-trusted; prune scoped strictly to tracedecay@personal entries; unparseable config falls back to printed guidance. Doctor now distinguishes Trusted/Missing/Modified and recommends update-plugin on drift.

Verified: agent suite + codex unit tests 472/472, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)