### PR TITLE
refactor(config): unify generated-path exclusion behind one shared list

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,37 +20,96 @@ pub const USER_DATA_DIR_ENV: &str = "TRACEDECAY_DATA_DIR";
 /// Project graph database filename inside a `.tracedecay/` data dir.
 pub const DB_FILENAME: &str = "tracedecay.db";
 
-const DEFAULT_EXCLUDE_PATTERNS: &[&str] = &[
-    "target/**",
-    ".git/**",
-    ".tracedecay/**",
-    "**/node_modules/**",
-    "vendor/**",
-    "**/vendor/**",
-    "**/*.min.*",
-    "bin/**",
-    "build/**",
-    "**/build/**",
-    "dist/**",
-    "**/dist/**",
-    "out/**",
-    "**/out/**",
-    "coverage/**",
-    "**/coverage/**",
-    ".cache/**",
-    "**/.cache/**",
-    ".next/**",
-    "**/.next/**",
-    ".turbo/**",
-    "**/.turbo/**",
-    ".gradle/**",
-    "**/.gradle/**",
-    ".venv/**",
-    "**/.venv/**",
-    "venv/**",
-    "**/venv/**",
-    "**/__pycache__/**",
+/// Directory-name segments treated as generated or vendored content:
+/// build output, package-manager caches, and vendored dependencies.
+///
+/// This is the single source of truth for "what counts as generated" and is
+/// shared by four call sites that used to hand-maintain independent lists
+/// which had drifted out of sync with each other:
+///
+/// - [`is_excluded`] / [`default_exclude_patterns`] below (config-driven,
+///   glob-pattern based — this list seeds the *default* patterns, but a
+///   project's `config.exclude` can still be overridden by the user).
+/// - `tracedecay::scan::TraceDecay::is_skipped_dir_hint` (an informational
+///   hint only; the authoritative gate there is still [`is_excluded_dir`]).
+/// - `migrate::inventory::should_prune_dir` (authoritative directory prune
+///   during migration inventory scans).
+/// - `mcp::tools::handlers::redundancy::is_generated_path` (candidate
+///   filtering for the duplicate-code scanner).
+///
+/// Each call site may still layer its own local additions on top where
+/// something is specific to that tool's purpose (see call-site comments);
+/// this list only covers the shared "generated/vendored" core.
+pub const GENERATED_DIR_SEGMENTS: &[&str] = &[
+    ".cache",
+    ".gradle",
+    ".next",
+    ".turbo",
+    ".venv",
+    ".worktrees",
+    "__pycache__",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "target",
+    "vendor",
+    "venv",
 ];
+
+/// Returns `true` if `segment` (a single path component, e.g. a directory
+/// name) is one of the shared [`GENERATED_DIR_SEGMENTS`].
+pub fn is_generated_dir_segment(segment: &str) -> bool {
+    GENERATED_DIR_SEGMENTS.contains(&segment)
+}
+
+/// Returns `true` if any component of `path` is a generated/vendored
+/// directory segment, or `path` itself carries a minified-asset suffix
+/// (`app.min.js`, `app.min.css`, ...) — mirrors the `**/*.min.*` default
+/// exclude pattern built by [`default_exclude_patterns`].
+///
+/// Path-level (not just directory-level) so callers can filter a flat list
+/// of file paths in one pass, e.g. the redundancy scanner's candidate list.
+pub fn is_generated_path_segment(path: &str) -> bool {
+    has_minified_suffix(path) || path.split('/').any(is_generated_dir_segment)
+}
+
+/// `true` for paths like `app.min.js` / `app.min.css.map` — a `.min.`
+/// component followed by at least one more character.
+fn has_minified_suffix(path: &str) -> bool {
+    path.rfind(".min.").is_some_and(|idx| idx + 5 < path.len())
+}
+
+/// Default glob-pattern exclude list for [`TraceDecayConfig::default`].
+///
+/// Built from [`GENERATED_DIR_SEGMENTS`] (both the `segment/**` root form
+/// and the `**/segment/**` nested form, since a generated directory can
+/// appear at the project root or anywhere below it) plus site-local
+/// additions that intentionally are *not* part of the shared segment set:
+///
+/// - `.git/**`, `.tracedecay/**` — VCS and `TraceDecay`'s own metadata dirs;
+///   these are tool/repo bookkeeping, not generated *code*, so they stay
+///   local to the config's default patterns rather than joining
+///   [`GENERATED_DIR_SEGMENTS`] (which the migrate/scan/redundancy call
+///   sites also consult for non-config-driven decisions).
+/// - `bin/**` — historically excluded here by default, but not treated as
+///   "generated" elsewhere: a `bin/` directory can hold real source in some
+///   project layouts, so it isn't added to the shared segment list.
+/// - `**/*.min.*` — mirrors [`is_generated_path_segment`]'s suffix check.
+fn default_exclude_patterns() -> Vec<String> {
+    let mut patterns: Vec<String> = vec![
+        ".git/**".to_string(),
+        ".tracedecay/**".to_string(),
+        "bin/**".to_string(),
+        "**/*.min.*".to_string(),
+    ];
+    for segment in GENERATED_DIR_SEGMENTS {
+        patterns.push(format!("{segment}/**"));
+        patterns.push(format!("**/{segment}/**"));
+    }
+    patterns
+}
 
 /// Configuration for a `TraceDecay` project.
 ///
@@ -323,10 +382,7 @@ impl Default for TraceDecayConfig {
         Self {
             version: 1,
             root_dir: String::new(),
-            exclude: DEFAULT_EXCLUDE_PATTERNS
-                .iter()
-                .map(|pattern| (*pattern).to_string())
-                .collect(),
+            exclude: default_exclude_patterns(),
             include: Vec::new(),
             max_file_size: 1_048_576,
             extract_docstrings: true,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    TraceDecayConfig, USER_DATA_DIR_ENV, db_filename, get_project_db_path, get_tracedecay_dir,
-    is_excluded, is_excluded_dir, is_ignored_by_explicit_global_excludes, is_ignored_by_git,
+    GENERATED_DIR_SEGMENTS, TraceDecayConfig, USER_DATA_DIR_ENV, db_filename, get_project_db_path,
+    get_tracedecay_dir, is_excluded, is_excluded_dir, is_generated_dir_segment,
+    is_generated_path_segment, is_ignored_by_explicit_global_excludes, is_ignored_by_git,
     is_included, lock_user_data_dir_test_env, user_data_dir,
 };
 use std::ffi::OsString;
@@ -551,4 +552,89 @@ async fn discover_project_root_with_identity_preserves_sync_fast_path() {
         sync,
         "identity wrapper fast path must equal the sync result"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Shared generated/vendored segment list
+//
+// GENERATED_DIR_SEGMENTS unifies what used to be four independently
+// hand-maintained lists: this module's own DEFAULT_EXCLUDE_PATTERNS,
+// tracedecay::scan's is_skipped_dir_hint, migrate::inventory's
+// should_prune_dir, and mcp::tools::handlers::redundancy's
+// is_generated_path. These tests pin the union those four call sites need
+// and spot-check that segments unique to one of the formerly-separate lists
+// are now recognized everywhere.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generated_dir_segments_cover_the_union_all_call_sites_need() {
+    // Formerly scan.rs-only (its HINTABLE_DIRS list).
+    for segment in [
+        "node_modules",
+        "vendor",
+        "build",
+        "dist",
+        "out",
+        "coverage",
+        ".cache",
+        ".next",
+        ".turbo",
+        ".gradle",
+        ".venv",
+        "venv",
+        "__pycache__",
+    ] {
+        assert!(
+            GENERATED_DIR_SEGMENTS.contains(&segment),
+            "{segment} (from scan.rs's old list) missing from GENERATED_DIR_SEGMENTS"
+        );
+    }
+    // Formerly migrate::inventory-only addition beyond the scan.rs set.
+    assert!(GENERATED_DIR_SEGMENTS.contains(&"target"));
+    // Formerly redundancy.rs-only addition beyond the scan.rs set.
+    assert!(GENERATED_DIR_SEGMENTS.contains(&".worktrees"));
+    // `.git` is intentionally NOT part of the shared list — it stays a
+    // site-local addition in migrate::inventory::should_prune_dir (see its
+    // doc comment) because it's VCS metadata, not generated/vendored code.
+    assert!(!GENERATED_DIR_SEGMENTS.contains(&".git"));
+}
+
+#[test]
+fn is_generated_dir_segment_delegates_for_segments_unique_to_one_former_list() {
+    // Every one of these previously lived in only one of the four lists;
+    // is_generated_dir_segment must now recognize all of them.
+    for segment in ["target", ".worktrees", "coverage", ".venv", "__pycache__"] {
+        assert!(
+            is_generated_dir_segment(segment),
+            "{segment} should be recognized as a generated/vendored segment"
+        );
+    }
+    assert!(!is_generated_dir_segment("src"));
+    assert!(!is_generated_dir_segment("builder"));
+}
+
+#[test]
+fn is_generated_path_segment_matches_segments_and_minified_suffix() {
+    assert!(is_generated_path_segment("packages/web/target/debug/x"));
+    assert!(is_generated_path_segment(".worktrees/feature/src/lib.rs"));
+    assert!(is_generated_path_segment("assets/app.min.js"));
+    assert!(is_generated_path_segment("assets/app.min.css"));
+    assert!(!is_generated_path_segment("src/redundancy.rs"));
+    assert!(!is_generated_path_segment("builder/mod.rs"));
+}
+
+#[test]
+fn default_excludes_still_catch_target_and_worktrees() {
+    // Regression guard for the DEFAULT_EXCLUDE_PATTERNS rebuild: target/**
+    // previously had no **/target/** nested form (a real drift bug this
+    // unification fixes), and .worktrees was never excluded by default at
+    // all.
+    let config = TraceDecayConfig::default();
+    assert!(is_excluded("target/debug/build", &config));
+    assert!(is_excluded("crates/sub/target/debug/build", &config));
+    assert!(is_excluded(".worktrees/feature/src/lib.rs", &config));
+    // Site-local additions (not part of GENERATED_DIR_SEGMENTS) still work.
+    assert!(is_excluded(".git/HEAD", &config));
+    assert!(is_excluded(".tracedecay/tracedecay.db", &config));
+    assert!(is_excluded("bin/cli.js", &config));
 }

--- a/src/mcp/tools/handlers/redundancy.rs
+++ b/src/mcp/tools/handlers/redundancy.rs
@@ -277,16 +277,16 @@ async fn collect_candidates(
 /// collection (a recurring noise source in real scans: dist mirrors, package
 /// twins, and `.worktrees` self-duplicates). Opt back in with
 /// `include_generated_paths: true`.
+///
+/// Delegates to the shared [`crate::config::is_generated_path_segment`]
+/// (segment list plus minified-asset suffix), which folds in this scanner's
+/// former standalone `.min.js` check as the more general `*.min.*` suffix,
+/// and now also picks up `.cache`, `.gradle`, `.next`, `.turbo`, `.venv`,
+/// `coverage`, and `venv` — segments this scanner didn't previously
+/// exclude but the other generated/vendored lists in the codebase already
+/// did.
 fn is_generated_path(path: &str) -> bool {
-    if path.ends_with(".min.js") {
-        return true;
-    }
-    path.split('/').any(|segment| {
-        matches!(
-            segment,
-            "dist" | "build" | "out" | "node_modules" | "vendor" | "target" | ".worktrees"
-        )
-    })
+    crate::config::is_generated_path_segment(path)
 }
 
 // ---------------------------------------------------------------------------
@@ -587,6 +587,29 @@ mod tests {
             "builder/mod.rs",
         ] {
             assert!(!is_generated_path(path), "{path} is real source");
+        }
+    }
+
+    #[test]
+    fn generated_paths_gain_segments_from_the_shared_list() {
+        // These segments weren't in this file's old standalone list but are
+        // part of the shared GENERATED_DIR_SEGMENTS union that scan.rs and
+        // migrate::inventory already recognized — closing this drift is the
+        // point of routing through crate::config::is_generated_path_segment.
+        for path in [
+            "packages/web/coverage/lcov.info",
+            "env/.venv/pyvenv.cfg",
+            "apps/site/.next/server/app.js",
+            "tool/.cache/entry",
+            "repo/.turbo/cache",
+            "android/.gradle/wrapper",
+            "scripts/venv/bin/python",
+            "assets/app.min.css",
+        ] {
+            assert!(
+                is_generated_path(path),
+                "{path} should now count as generated"
+            );
         }
     }
 

--- a/src/migrate/inventory.rs
+++ b/src/migrate/inventory.rs
@@ -918,11 +918,17 @@ fn leading_spaces(line: &str) -> usize {
     line.bytes().take_while(|byte| *byte == b' ').count()
 }
 
+/// Authoritative prune during migration inventory scans (unlike the
+/// scan.rs hint, nothing here is config-overridable — these directories are
+/// always skipped while hunting for legacy data stores). Delegates the
+/// generated/vendored segment check to the shared
+/// [`crate::config::is_generated_dir_segment`] list, plus one site-local
+/// addition: `.git`, which migration scans always want to skip but which
+/// isn't part of the shared "generated/vendored" concept (the other three
+/// call sites — scan hint, config default excludes, redundancy scanner —
+/// don't all treat `.git` the same way).
 fn should_prune_dir(name: &str) -> bool {
-    matches!(
-        name,
-        "node_modules" | "target" | ".git" | "vendor" | "dist" | "build" | ".next" | ".venv"
-    )
+    name == ".git" || config::is_generated_dir_segment(name)
 }
 
 fn file_size(path: &Path) -> u64 {
@@ -960,4 +966,42 @@ fn dir_size(dir: &Path) -> u64 {
     let mut visited_dirs = HashSet::new();
     walk(dir, &mut total, &mut visited_dirs);
     total
+}
+
+#[cfg(test)]
+mod prune_dir_tests {
+    use super::should_prune_dir;
+
+    #[test]
+    fn prunes_shared_generated_segments_and_the_local_git_addition() {
+        for name in [
+            "node_modules",
+            "target",
+            "vendor",
+            "dist",
+            "build",
+            ".next",
+            ".venv",
+            ".git", // site-local addition, not part of GENERATED_DIR_SEGMENTS
+        ] {
+            assert!(should_prune_dir(name), "{name} should be pruned");
+        }
+    }
+
+    #[test]
+    fn gains_segments_it_previously_missed_via_the_shared_list() {
+        // These were absent from the old hand-maintained should_prune_dir
+        // list but are part of the shared GENERATED_DIR_SEGMENTS union that
+        // other call sites already recognized.
+        for name in [".worktrees", "coverage", "out", ".cache", "venv"] {
+            assert!(should_prune_dir(name), "{name} should now be pruned too");
+        }
+    }
+
+    #[test]
+    fn does_not_prune_real_source_dirs() {
+        for name in ["src", "builder", "distributed"] {
+            assert!(!should_prune_dir(name), "{name} is real source");
+        }
+    }
 }

--- a/src/tracedecay/scan.rs
+++ b/src/tracedecay/scan.rs
@@ -370,27 +370,65 @@ impl TraceDecay {
         dirs
     }
 
+    /// Informational only: the authoritative skip decision during indexing
+    /// is [`is_excluded_dir`]/[`is_excluded`] against the (possibly
+    /// user-overridden) `config.exclude` patterns. This hint just decides
+    /// which *already-excluded* directories are common enough generated/
+    /// vendored names to be worth surfacing in [`IndexCoverageHint`], so it
+    /// delegates the "is this name generated?" question to the shared
+    /// [`crate::config::is_generated_dir_segment`] list rather than
+    /// hand-maintaining its own copy.
     fn is_skipped_dir_hint(rel_str: &str, name: &str, config: &TraceDecayConfig) -> bool {
-        const HINTABLE_DIRS: &[&str] = &[
-            "node_modules",
-            "vendor",
-            "build",
-            "dist",
-            "out",
-            "coverage",
-            ".cache",
-            ".next",
-            ".turbo",
-            ".gradle",
-            ".venv",
-            "venv",
-            "__pycache__",
-        ];
-
         if is_included_dir(rel_str, config) || is_included(rel_str, config) {
             return false;
         }
 
-        HINTABLE_DIRS.contains(&name) && is_excluded_dir(rel_str, config)
+        crate::config::is_generated_dir_segment(name) && is_excluded_dir(rel_str, config)
+    }
+}
+
+#[cfg(test)]
+mod skipped_dir_hint_tests {
+    use super::TraceDecay;
+    use crate::config::TraceDecayConfig;
+
+    #[test]
+    fn hints_on_excluded_generated_dirs() {
+        let config = TraceDecayConfig::default();
+        assert!(TraceDecay::is_skipped_dir_hint(
+            "node_modules",
+            "node_modules",
+            &config
+        ));
+        assert!(TraceDecay::is_skipped_dir_hint("dist", "dist", &config));
+    }
+
+    #[test]
+    fn gains_segments_previously_absent_from_its_own_hintable_list() {
+        // "target" and ".worktrees" weren't in scan.rs's old hand-maintained
+        // HINTABLE_DIRS but are part of the shared GENERATED_DIR_SEGMENTS
+        // union other call sites already recognized.
+        let config = TraceDecayConfig::default();
+        assert!(TraceDecay::is_skipped_dir_hint("target", "target", &config));
+        assert!(TraceDecay::is_skipped_dir_hint(
+            ".worktrees",
+            ".worktrees",
+            &config
+        ));
+    }
+
+    #[test]
+    fn does_not_hint_on_real_source_dirs() {
+        let config = TraceDecayConfig::default();
+        assert!(!TraceDecay::is_skipped_dir_hint("src", "src", &config));
+    }
+
+    #[test]
+    fn explicit_include_overrides_the_hint() {
+        let config = TraceDecayConfig {
+            include: vec!["dist/**".to_string()],
+            ..TraceDecayConfig::default()
+        };
+        assert!(!TraceDecay::is_skipped_dir_hint("dist", "dist", &config));
     }
 }


### PR DESCRIPTION
Merges four drifted generated-directory exclusion lists into one canonical GENERATED_DIR_SEGMENTS in crate::config, consumed by scan hints, migrate pruning, default exclude patterns, and the redundancy tool — per-site extras kept local and documented, gained segments enumerated, union-coverage test so the lists cannot drift again. Fixes a missing nested **/target/** default exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)