### PR TITLE
fix: eliminate three CI test flakes at their roots

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -967,6 +967,21 @@ impl McpServer {
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
         {
+            // Clear the completion flags *before* spawning. They default to
+            // `true` (so the no-sync path reports "done" immediately), and
+            // `run_startup_catch_up_sync` only flips them to `false` once it
+            // actually starts running. Without this pre-clear there is a
+            // window between the spawn and the task's first instruction where
+            // both flags still read `true`, so a caller that reaches
+            // `wait_for_startup_catch_up` in that window observes "done" and
+            // returns immediately — then the detached catch-up sync runs
+            // concurrently with the caller's own work (e.g. racing it to index
+            // a just-written file). Clearing here closes that window so the
+            // wait blocks until the catch-up sync genuinely completes.
+            server.startup_catch_up_done.store(false, Ordering::Release);
+            server
+                .transcript_ingest_done
+                .store(false, Ordering::Release);
             let s = Arc::clone(&server);
             tokio::spawn(async move {
                 s.run_startup_catch_up_sync().await;

--- a/tests/core_cli_suite/tool_daemon_test.rs
+++ b/tests/core_cli_suite/tool_daemon_test.rs
@@ -290,6 +290,23 @@ fn spawn_hook_event_daemon(socket_path: PathBuf) -> mpsc::Receiver<Value> {
                 Err(e) => panic!("accept fake daemon client: {e}"),
             }
         };
+        // The listener above is intentionally nonblocking so the accept loop
+        // can poll against a deadline. The accepted stream must be switched
+        // back to blocking (matching spawn_sentinel_daemon_with_notification)
+        // before reading: on some platforms an accepted Unix socket can carry
+        // over the listener's nonblocking flag, which would otherwise make
+        // read_line() return a transient WouldBlock-shaped I/O error instead
+        // of blocking until the CLI child has written its handshake line.
+        stream
+            .set_nonblocking(false)
+            .expect("set accepted stream blocking");
+        // Best-effort: fire-and-forget hook CLIs (the cursor notifications)
+        // connect, write, and exit before this line runs, and on macOS
+        // setsockopt(SO_RCVTIMEO) fails with EINVAL once the peer has hung
+        // up — while the written bytes remain buffered and readable. The
+        // timeout is only defense-in-depth (nextest's per-test timeout is
+        // the real backstop), so a failure here must not panic the helper.
+        let _ = stream.set_read_timeout(Some(CLI_ROUNDTRIP_TIMEOUT));
         let mut reader = BufReader::new(stream);
         let mut handshake = String::new();
         reader

--- a/tests/daemon_suite/git_watch_test.rs
+++ b/tests/daemon_suite/git_watch_test.rs
@@ -45,6 +45,19 @@ fn git(project: &Path, args: &[&str]) {
         // developer's global hooks (or an installed tracedecay hook) cannot
         // perturb the "unhooked git operation" scenarios under test.
         .args(["-c", "core.hooksPath=.git/no-hooks"])
+        // Disable git's background auto-maintenance. By default every `git
+        // commit` forks a detached `git maintenance run --auto` (gc / pack-refs
+        // / incremental-repack). In a tight commit burst (e.g. the 50-commit
+        // rebase test) that detached process can still be mutating `.git/objects`
+        // or refs when the NEXT `git add`/`git commit` runs, so under load the
+        // foreground command intermittently fails (e.g. "unable to write file
+        // .git/objects/...: No such file or directory" or a ref/index lock
+        // error), tripping the assertion below. Suppressing the fork removes the
+        // only concurrent writer and makes the git setup deterministic, without
+        // changing what any test proves.
+        .args(["-c", "gc.auto=0"])
+        .args(["-c", "gc.autoDetach=false"])
+        .args(["-c", "maintenance.auto=false"])
         .args(args)
         .current_dir(project)
         .output()


### PR DESCRIPTION
Root-cause fixes for every flaky test mined from recent CI runs (plus the git-watch flake that hit PR #321's run): a real McpServer startup race (wait_for_startup_catch_up could no-op), the tool_daemon fake-daemon handshake reading a nonblocking socket, and git auto-maintenance racing the 50-commit git-watch loop. No sleep-padding, no weakened assertions; each fix stress-verified 20-25x with retries disabled. The cursor ingest flake was verified already fixed by #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)