### PR TITLE
feat(hooks): bring edit-driven hints to Codex and Cursor surfaces

### DIFF
--- a/src/hooks/codex.rs
+++ b/src/hooks/codex.rs
@@ -10,7 +10,9 @@ use serde_json::Value;
 
 use super::claude::is_code_research_prompt;
 use super::memory_inject;
-use super::post_tool_use::{CODEX_POST_TOOL_USE_SPEC, notify_post_tool_use};
+use super::post_tool_use::{
+    CODEX_POST_TOOL_USE_SPEC, notify_post_tool_use, tool_input_command_str,
+};
 use super::steering::{
     HookWorkspaceStatus, append_context_block, append_context_recovery_hint,
     build_codex_session_context_for_workspace, cursor_index_signals_for_root,
@@ -18,9 +20,9 @@ use super::steering::{
 };
 use super::tool_hints::{HintAgent, HintCategory, ToolHint, ToolHintInput, decide_hint};
 use super::{
-    append_tool_hint, deduped_project_hint_with_id, event_cwd_from_parsed, event_session_id,
-    format_tool_hint, is_project_like_workspace, mint_hint_id, prompt_like_text, read_hook_event,
-    record_hint_analytics, record_hook_analytics, record_hook_invoked,
+    append_tool_hint, deduped_project_hint, deduped_project_hint_with_id, event_cwd_from_parsed,
+    event_session_id, format_tool_hint, is_project_like_workspace, mint_hint_id, prompt_like_text,
+    read_hook_event, record_hint_analytics, record_hook_analytics, record_hook_invoked,
     record_workspace_status_analytics, rel_under_root, text_field,
 };
 
@@ -179,14 +181,87 @@ fn merge_codex_subagent_output(output: Option<String>, digest: Option<String>) -
     Some(parsed.to_string())
 }
 
-/// Codex `PostToolUse` hook handler used to keep the graph fresh.
+/// Codex `PostToolUse` hook handler used to keep the graph fresh and to surface
+/// a soft tracedecay hint for edits and shell commands.
+///
+/// Two independent outputs, mirroring [`super::claude::hook_claude_post_tool_use`]:
+/// the daemon notification (targeted sync / branch tracking, via IPC only) and,
+/// for `apply_patch` edits plus `Bash`/`shell` commands, a `PostToolUse`
+/// `additionalContext` hint printed to stdout (Codex injects it as developer
+/// context). The daemon path never writes stdout, so the two do not interfere.
+/// Fail-open: no surviving hint leaves prior behavior unchanged.
 pub async fn hook_codex_post_tool_use() -> i32 {
     let event = read_hook_event!();
     let root = codex_project_root_from_event_with_identity(&event).await;
     let _hook_telemetry =
         record_hook_invoked(root.as_deref(), HintAgent::Codex, "PostToolUse", &event);
+    if let Some(context) = codex_post_tool_use_hint(&event) {
+        println!("{}", codex_additional_context_json("PostToolUse", &context));
+    }
     notify_post_tool_use(&CODEX_POST_TOOL_USE_SPEC, &event).await;
     0
+}
+
+/// Builds the `PostToolUse` `additionalContext` string for a Codex edit or
+/// shell event, or `None` when no hint survives dedupe. Decides the raw hint
+/// with [`decide_codex_post_tool_use_hint`], then dedupes per (session,
+/// category) via [`deduped_project_hint`] exactly like the Claude post-tool-use
+/// surface (which mints its own candidate id and records only the terminal row).
+fn codex_post_tool_use_hint(event_json: &str) -> Option<String> {
+    let parsed = serde_json::from_str::<Value>(event_json).ok()?;
+    let hint = decide_codex_post_tool_use_hint(&parsed)?;
+    let root = codex_project_root_from_parsed_event(&parsed);
+    let session_id = event_session_id(&parsed);
+    let hint = deduped_project_hint(root, HintAgent::Codex, session_id, hint)?;
+    Some(format_tool_hint(&hint))
+}
+
+/// Pure hint decision for a Codex `PostToolUse` event: shapes a
+/// [`ToolHintInput`] from the event's tool name and `tool_input.command`, then
+/// runs [`decide_hint`]. Returns `None` for tools outside the installed
+/// `Bash|apply_patch` matcher and when no hint applies. No I/O, so it is
+/// unit-testable without a profile store.
+///
+/// The tool name is mapped onto the hint system's Claude-shaped vocabulary so
+/// the shared classifiers apply unchanged: `apply_patch` -> `Edit` (an edit
+/// tool, with the added source and target path extracted from the patch
+/// envelope so the redundancy heuristic sees the same function-body shape
+/// Claude's `new_string` carries), and `shell`/`bash` -> `Bash` (the command
+/// drives the search/build classifiers). The patch envelope is never forwarded
+/// as a shell `command`, so command classifiers cannot misfire on patch text.
+fn decide_codex_post_tool_use_hint(parsed: &Value) -> Option<ToolHint> {
+    let tool_name = parsed.get("tool_name").and_then(Value::as_str)?;
+    let command = tool_input_command_str(parsed);
+    let session_id = event_session_id(parsed);
+    let input = match tool_name.to_ascii_lowercase().as_str() {
+        "apply_patch" => {
+            let command = command?;
+            ToolHintInput {
+                agent: HintAgent::Codex,
+                session_id,
+                tool_name: Some("Edit".to_string()),
+                command: None,
+                prompt: None,
+                subagent_type: None,
+                file_path: codex_apply_patch_first_target_path(&command),
+                edit_text: codex_apply_patch_added_text(&command),
+                hints_enabled: true,
+            }
+        }
+        "bash" | "shell" => ToolHintInput {
+            agent: HintAgent::Codex,
+            session_id,
+            tool_name: Some("Bash".to_string()),
+            command,
+            prompt: None,
+            subagent_type: None,
+            file_path: None,
+            edit_text: None,
+            hints_enabled: true,
+        },
+        _ => return None,
+    };
+    decide_hint(&input)
 }
 
 /// Codex `PostCompact` hook handler.
@@ -437,18 +512,20 @@ pub fn codex_workspace_status_from_event(event_json: &str) -> HookWorkspaceStatu
     codex_workspace_status(root.as_deref(), cwd.as_deref())
 }
 
+/// Codex `apply_patch` envelope prefixes that name a target file path.
+const CODEX_APPLY_PATCH_PATH_PREFIXES: [&str; 4] = [
+    "*** Add File:",
+    "*** Update File:",
+    "*** Delete File:",
+    "*** Move to:",
+];
+
 /// Extracts the project-relative paths touched by a Codex `apply_patch` command.
 pub fn codex_apply_patch_rel_paths(command: &str, cwd: &Path, project_root: &Path) -> Vec<String> {
-    const PREFIXES: [&str; 4] = [
-        "*** Add File:",
-        "*** Update File:",
-        "*** Delete File:",
-        "*** Move to:",
-    ];
     let mut rels: Vec<String> = Vec::new();
     for line in command.lines() {
         let line = line.trim();
-        for prefix in PREFIXES {
+        for prefix in CODEX_APPLY_PATCH_PATH_PREFIXES {
             if let Some(rest) = line.strip_prefix(prefix) {
                 let raw = rest.trim();
                 if raw.is_empty() {
@@ -469,6 +546,42 @@ pub fn codex_apply_patch_rel_paths(command: &str, cwd: &Path, project_root: &Pat
         }
     }
     rels
+}
+
+/// First target file path named by a Codex `apply_patch` envelope, verbatim (not
+/// resolved against any root). Enough for the redundancy hint classifier, which
+/// keys only off the path's extension to pick the language. `O(len(command))`.
+fn codex_apply_patch_first_target_path(command: &str) -> Option<String> {
+    command.lines().find_map(|line| {
+        let line = line.trim();
+        CODEX_APPLY_PATCH_PATH_PREFIXES.iter().find_map(|prefix| {
+            line.strip_prefix(prefix)
+                .map(str::trim)
+                .filter(|raw| !raw.is_empty())
+                .map(str::to_string)
+        })
+    })
+}
+
+/// The added-line text of a Codex `apply_patch` envelope: the body of every
+/// `+`-prefixed addition with the marker stripped, joined by newlines. This is
+/// the Codex analogue of Claude's edit `new_string`/`content` — the source the
+/// model just wrote — so it feeds the shared function-body redundancy heuristic
+/// without the envelope markers, hunk headers, or unchanged context lines
+/// defeating the line-count and keyword checks. Returns `None` when the patch
+/// adds nothing. `O(len(command))`: one line scan, no patch application.
+fn codex_apply_patch_added_text(command: &str) -> Option<String> {
+    let mut added: Vec<&str> = Vec::new();
+    for line in command.lines() {
+        // Envelope (`*** …`) and hunk (`@@ …`) markers are never added source.
+        if line.starts_with("***") || line.starts_with("@@") {
+            continue;
+        }
+        if let Some(body) = line.strip_prefix('+') {
+            added.push(body);
+        }
+    }
+    (!added.is_empty()).then(|| added.join("\n"))
 }
 
 async fn codex_post_compact(event_json: &str) {
@@ -579,6 +692,121 @@ fn codex_prompt_hint(event_json: &str) -> Option<ToolHint> {
 mod tests {
     use super::*;
     use crate::config::USER_DATA_DIR_ENV;
+
+    const QUALIFYING_RUST_PATCH: &str = "*** Begin Patch\n\
+*** Add File: src/util.rs\n\
++pub fn summarize(hits: &[Hit]) -> u32 {\n\
++    let mut total = 0;\n\
++    for hit in hits {\n\
++        if hit.active {\n\
++            total += hit.count;\n\
++        }\n\
++    }\n\
++    total\n\
++}\n\
+*** End Patch\n";
+
+    #[test]
+    fn codex_apply_patch_added_text_strips_markers_and_plus() {
+        let added = codex_apply_patch_added_text(QUALIFYING_RUST_PATCH).unwrap();
+        assert!(added.starts_with("pub fn summarize("));
+        assert!(added.contains("fn "));
+        // Envelope markers and hunk headers must not leak into the added text.
+        assert!(!added.contains("*** "));
+        assert!(!added.contains("Begin Patch"));
+        // Nine `+` body lines, one per addition, marker stripped.
+        assert_eq!(added.lines().count(), 9);
+        assert!(!added.lines().any(|line| line.starts_with('+')));
+
+        // A patch that adds nothing yields no text.
+        let no_adds = "*** Begin Patch\n*** Delete File: src/gone.rs\n*** End Patch\n";
+        assert!(codex_apply_patch_added_text(no_adds).is_none());
+    }
+
+    #[test]
+    fn codex_apply_patch_first_target_path_reads_first_marker() {
+        assert_eq!(
+            codex_apply_patch_first_target_path(QUALIFYING_RUST_PATCH).as_deref(),
+            Some("src/util.rs")
+        );
+        assert!(codex_apply_patch_first_target_path("no markers here").is_none());
+    }
+
+    fn post_tool_use_event(tool_name: &str, command: &str) -> Value {
+        serde_json::json!({
+            "session_id": "codex-post-tool",
+            "cwd": "/repo",
+            "tool_name": tool_name,
+            "tool_input": { "command": command },
+        })
+    }
+
+    #[test]
+    fn codex_apply_patch_event_nudges_edit_redundancy() {
+        let event = post_tool_use_event("apply_patch", QUALIFYING_RUST_PATCH);
+        let hint = decide_codex_post_tool_use_hint(&event)
+            .expect("a function-sized apply_patch must nudge edit redundancy");
+        assert_eq!(hint.category, HintCategory::EditRedundancy);
+    }
+
+    #[test]
+    fn codex_small_apply_patch_stays_silent() {
+        let small = "*** Begin Patch\n\
+*** Update File: src/util.rs\n\
++    let x = compute();\n\
+*** End Patch\n";
+        let event = post_tool_use_event("apply_patch", small);
+        assert!(
+            decide_codex_post_tool_use_hint(&event).is_none(),
+            "a one-line apply_patch is below the redundancy line threshold"
+        );
+    }
+
+    #[test]
+    fn codex_non_code_apply_patch_stays_silent() {
+        let notes = "*** Begin Patch\n\
+*** Add File: NOTES.md\n\
++# Heading\n\
++first paragraph line\n\
++second paragraph line\n\
++third paragraph line\n\
++fourth paragraph line\n\
++fifth paragraph line\n\
++sixth paragraph line\n\
++seventh paragraph line\n\
++eighth paragraph line\n\
+*** End Patch\n";
+        let event = post_tool_use_event("apply_patch", notes);
+        assert!(
+            decide_codex_post_tool_use_hint(&event).is_none(),
+            "a prose markdown patch has no function shape and must stay silent"
+        );
+    }
+
+    #[test]
+    fn codex_shell_event_carries_command_and_no_edit_text() {
+        // A recursive shell search routes to the graph-search hint off the
+        // command alone, with no edit_text — the Bash-shaped surface.
+        let event = post_tool_use_event("shell", "grep -r needle src/");
+        let hint = decide_codex_post_tool_use_hint(&event)
+            .expect("a recursive shell search must produce a search hint");
+        assert_eq!(hint.category, HintCategory::Search);
+
+        // A plain shell command is not a candidate.
+        let plain = post_tool_use_event("bash", "ls -la");
+        assert!(decide_codex_post_tool_use_hint(&plain).is_none());
+    }
+
+    #[test]
+    fn codex_post_tool_use_ignores_untracked_tools() {
+        // No tool_name and tools outside the Bash|apply_patch matcher are silent.
+        assert!(decide_codex_post_tool_use_hint(&serde_json::json!({})).is_none());
+        let read = serde_json::json!({
+            "tool_name": "read",
+            "tool_input": { "command": "" },
+        });
+        assert!(decide_codex_post_tool_use_hint(&read).is_none());
+    }
 
     #[test]
     fn codex_subagent_start_context_carries_diagnostics_moment() {

--- a/src/hooks/cursor.rs
+++ b/src/hooks/cursor.rs
@@ -255,15 +255,28 @@ pub async fn hook_cursor_pre_compact() -> i32 {
 
 /// Cursor `afterFileEdit` hook handler.
 ///
-/// Keeps the graph fresh after Cursor Agent writes files by notifying the
-/// daemon about the edited path(s). The daemon owns targeted sync scheduling
-/// and the hook fails open when no daemon is available.
+/// Two jobs, both fail-open:
+/// 1. Keeps the graph fresh after Cursor Agent writes files by notifying the
+///    daemon about the edited path(s). The daemon owns targeted sync scheduling
+///    and the notification no-ops when no daemon is available.
+/// 2. Emits the edit-driven redundancy nudge ([`HintCategory::EditRedundancy`]),
+///    matching Claude's `PostToolUse` surface. `afterFileEdit` is the only
+///    Cursor hook whose recorded payload carries the *applied* edit body
+///    (`edits[].new_string`); Cursor's `postToolUse` edit payload carries only
+///    the target `file_path` (see the recorded fixtures in
+///    `tests/hooks_lsp_suite/hooks_test.rs`), so the redundancy classifier —
+///    which needs the added text — can only run here. The hint rides Cursor's
+///    documented `additional_context` output shape with the same per-session
+///    dedupe and initialized-store gating as `postToolUse`.
 pub async fn hook_cursor_after_file_edit() -> i32 {
     let event = read_hook_event!();
     let root = cursor_project_root_from_event_with_identity(&event).await;
     let _hook_telemetry =
         record_hook_invoked(root.as_deref(), HintAgent::Cursor, "afterFileEdit", &event);
     notify_cursor_after_file_edit(&event).await;
+    if let Some(decision) = cursor_after_file_edit_decision_for_hook(&event).await {
+        println!("{decision}");
+    }
     0
 }
 
@@ -799,11 +812,100 @@ fn cursor_tool_hint_input(parsed: &Value) -> ToolHintInput {
         subagent_type: text_field(parsed, &["subagent_type", "subagentType", "agent_type"]),
         file_path: text_field(tool_input, CURSOR_FILE_PATH_FIELDS)
             .or_else(|| text_field(parsed, CURSOR_FILE_PATH_FIELDS)),
-        // Cursor's prompt/pre-tool surface does not carry edit bodies; the
-        // edit-redundancy nudge is a Claude post-tool-use surface only.
+        // Cursor's `postToolUse` edit payload carries only the target
+        // `file_path`, not the applied edit body (confirmed by the recorded
+        // fixtures in `tests/hooks_lsp_suite/hooks_test.rs`), so the
+        // edit-redundancy nudge cannot run from this surface. The applied edit
+        // text only reaches TraceDecay on `afterFileEdit`, where
+        // [`cursor_after_file_edit_hint_input`] populates `edit_text` from
+        // `edits[].new_string`.
         edit_text: None,
         hints_enabled: true,
     }
+}
+
+/// Builds the redundancy-hint input for a Cursor `afterFileEdit` event.
+///
+/// `afterFileEdit` reports `file_path` at the top level and the applied edit(s)
+/// as `edits: [{ old_string, new_string }]`. We join the `new_string`s (mirroring
+/// the Claude `MultiEdit` handling in [`super::post_tool_use::tool_input_edit_text`])
+/// into `edit_text` and label the synthetic tool `Edit` so the shared
+/// [`is_redundancy_candidate_edit`](super::tool_hints) classifier recognizes it.
+/// Prompt/command/subagent fields are left empty: this surface only ever drives
+/// the edit-shaped categories (redundancy and harness-memory edits), never a
+/// prompt- or shell-shaped hint.
+fn cursor_after_file_edit_hint_input(parsed: &Value) -> ToolHintInput {
+    ToolHintInput {
+        agent: HintAgent::Cursor,
+        session_id: event_session_id(parsed),
+        tool_name: Some("Edit".to_string()),
+        command: None,
+        prompt: None,
+        subagent_type: None,
+        file_path: text_field(parsed, CURSOR_FILE_PATH_FIELDS),
+        edit_text: cursor_after_file_edit_new_text(parsed),
+        hints_enabled: true,
+    }
+}
+
+/// Joins the `new_string`s an `afterFileEdit` event applied, or `None` when the
+/// event carries no non-empty added text. `O(len)`: concatenates existing JSON
+/// string fields without parsing code.
+fn cursor_after_file_edit_new_text(parsed: &Value) -> Option<String> {
+    let joined = parsed
+        .get("edits")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|edit| edit.get("new_string").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!joined.trim().is_empty()).then_some(joined)
+}
+
+/// Pure decision logic for Cursor `afterFileEdit` redundancy hints.
+///
+/// Returns a soft `additional_context` payload (the same shape `postToolUse`
+/// uses) when the applied edit adds a new function-sized body. Non-qualifying
+/// edits (too small, no function shape, non-source file) and events without an
+/// edit body fail open with no output. Session-level dedupe lives in the impure
+/// paths; this stays pure for tests.
+pub fn evaluate_cursor_after_file_edit(event_json: &str) -> Option<String> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let hint = decide_hint(&cursor_after_file_edit_hint_input(&parsed))?;
+    Some(format_cursor_post_tool_use_decision(&hint))
+}
+
+fn prepare_cursor_after_file_edit_hint(event_json: &str) -> Option<(String, ToolHint)> {
+    let parsed: Value = serde_json::from_str(event_json).ok()?;
+    let hint = decide_hint(&cursor_after_file_edit_hint_input(&parsed))?;
+    let root = cursor_project_root_candidate_from_parsed_event(&parsed);
+    let hint_id = mint_hint_id();
+    record_hint_analytics(
+        root.as_deref(),
+        "hint_candidate",
+        HintAgent::Cursor,
+        event_session_id(&parsed).as_deref(),
+        &hint_id,
+        &hint,
+    );
+    Some((hint_id, hint))
+}
+
+/// Impure `afterFileEdit` redundancy path: [`evaluate_cursor_after_file_edit`]
+/// plus per-session hint dedupe persisted under the project's `.tracedecay/` dir.
+/// Shares [`deduped_cursor_hint`] with `postToolUse`, so the redundancy category
+/// surfaces at most once per Cursor session regardless of which surface first
+/// emits it.
+pub fn cursor_after_file_edit_decision(event_json: &str) -> Option<String> {
+    let (hint_id, hint) = prepare_cursor_after_file_edit_hint(event_json)?;
+    let hint = deduped_cursor_hint(event_json, &hint_id, hint)?;
+    Some(format_cursor_post_tool_use_decision(&hint))
+}
+
+async fn cursor_after_file_edit_decision_for_hook(event_json: &str) -> Option<String> {
+    let (hint_id, hint) = prepare_cursor_after_file_edit_hint(event_json)?;
+    let hint = deduped_cursor_hint_for_initialized_store(event_json, &hint_id, hint).await?;
+    Some(format_cursor_post_tool_use_decision(&hint))
 }
 
 #[cfg(test)]
@@ -963,6 +1065,167 @@ mod tests {
         assert_eq!(
             cursor_project_root_from_parsed_event_with_identity(&parsed).await,
             Some(project_root)
+        );
+    }
+
+    /// A qualifying `afterFileEdit` (a new function-sized body written to a
+    /// source file) must fire the edit-redundancy nudge on the Cursor surface,
+    /// mirroring Claude's `PostToolUse`. The applied text arrives as
+    /// `edits[].new_string`, which the handler joins into `edit_text`.
+    #[test]
+    fn cursor_after_file_edit_nudges_redundancy_for_new_function_body() {
+        let body = [
+            "fn compute_widget_total(items: &[Item]) -> u64 {",
+            "    let mut total = 0;",
+            "    for item in items {",
+            "        if item.active {",
+            "            total += item.count;",
+            "        }",
+            "    }",
+            "    total",
+            "}",
+        ]
+        .join("\n");
+        let event = serde_json::json!({
+            "hook_event_name": "afterFileEdit",
+            "file_path": "src/widgets.rs",
+            "edits": [{ "old_string": "", "new_string": body }],
+            "session_id": "cursor-after-edit"
+        })
+        .to_string();
+
+        let output = evaluate_cursor_after_file_edit(&event)
+            .expect("a new function-sized edit should nudge redundancy");
+        let v: Value = serde_json::from_str(&output).unwrap();
+        let context = v["additional_context"].as_str().unwrap_or_default();
+        assert!(context.contains("tracedecay hint:"), "context: {context}");
+        assert!(
+            context.contains("tracedecay_redundancy"),
+            "context: {context}"
+        );
+        // The Cursor surface uses the soft `additional_context` shape only — no
+        // permission / hookSpecificOutput keys.
+        assert!(v.get("permission").is_none());
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    /// A qualifying edit split across multiple `edits[]` entries still reaches
+    /// the line/keyword heuristic: the handler joins every `new_string`.
+    #[test]
+    fn cursor_after_file_edit_joins_multiple_edits() {
+        let event = serde_json::json!({
+            "hook_event_name": "afterFileEdit",
+            "file_path": "src/widgets.rs",
+            "edits": [
+                { "old_string": "", "new_string": "fn compute_widget_total(items: &[Item]) -> u64 {\n    let mut total = 0;" },
+                { "old_string": "", "new_string": "    for item in items {\n        if item.active {\n            total += item.count;\n        }\n    }\n    total\n}" }
+            ],
+            "session_id": "cursor-after-edit-multi"
+        })
+        .to_string();
+
+        let output = evaluate_cursor_after_file_edit(&event)
+            .expect("a function body spread across edits should still nudge");
+        let v: Value = serde_json::from_str(&output).unwrap();
+        assert!(
+            v["additional_context"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("tracedecay_redundancy")
+        );
+    }
+
+    /// Small edits, non-source files, and edit-less events stay silent so the
+    /// nudge never spams ordinary Cursor edits.
+    #[test]
+    fn cursor_after_file_edit_stays_silent_for_non_redundancy_edits() {
+        // A one-line edit is below the redundancy line threshold.
+        let small = serde_json::json!({
+            "hook_event_name": "afterFileEdit",
+            "file_path": "src/widgets.rs",
+            "edits": [{ "old_string": "", "new_string": "fn tiny() -> u8 { 1 }" }],
+            "session_id": "s1"
+        })
+        .to_string();
+        assert!(evaluate_cursor_after_file_edit(&small).is_none());
+
+        // A markdown/data file never trips the source-language heuristic even
+        // with a long body.
+        let long_body = (0..12)
+            .map(|i| format!("line number {i} of prose"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let markdown = serde_json::json!({
+            "hook_event_name": "afterFileEdit",
+            "file_path": "notes.md",
+            "edits": [{ "old_string": "", "new_string": long_body }],
+            "session_id": "s2"
+        })
+        .to_string();
+        assert!(evaluate_cursor_after_file_edit(&markdown).is_none());
+
+        // An event with no `edits` array carries no added text.
+        let no_edits = serde_json::json!({
+            "hook_event_name": "afterFileEdit",
+            "file_path": "src/widgets.rs",
+            "session_id": "s3"
+        })
+        .to_string();
+        assert!(evaluate_cursor_after_file_edit(&no_edits).is_none());
+    }
+
+    /// End-to-end dedupe: the impure `afterFileEdit` decision emits the nudge
+    /// once per session and reuses the shared per-session hint dedupe (so the
+    /// same category never double-fires across the `postToolUse` /
+    /// `afterFileEdit` surfaces).
+    #[test]
+    fn cursor_after_file_edit_decision_dedupes_per_session() {
+        let _lock = crate::hooks::lock_test_env();
+        let project = tempfile::tempdir().unwrap();
+        let profile = tempfile::tempdir().unwrap();
+        let project_root = project.path().canonicalize().unwrap();
+        let profile_root = profile.path().canonicalize().unwrap();
+        let _profile_env = EnvGuard::set_path(USER_DATA_DIR_ENV, &profile_root);
+        crate::storage::write_enrollment_marker(
+            &project_root,
+            &crate::storage::EnrollmentMarker {
+                project_id: "proj_hook_cursor_after_edit".to_string(),
+                storage_mode: crate::storage::StorageMode::ProfileSharded,
+            },
+        )
+        .unwrap();
+        let layout = crate::storage::resolve_layout_for_current_profile(&project_root).unwrap();
+        std::fs::create_dir_all(&layout.data_root).unwrap();
+        std::fs::write(&layout.graph_db_path, "").unwrap();
+        let body = [
+            "fn compute_widget_total(items: &[Item]) -> u64 {",
+            "    let mut total = 0;",
+            "    for item in items {",
+            "        if item.active {",
+            "            total += item.count;",
+            "        }",
+            "    }",
+            "    total",
+            "}",
+        ]
+        .join("\n");
+        let event = serde_json::json!({
+            "hook_event_name": "afterFileEdit",
+            "file_path": project_root.join("src/widgets.rs"),
+            "edits": [{ "old_string": "", "new_string": body }],
+            "session_id": "cursor-after-edit-dedupe",
+            "cwd": project_root,
+            "workspace_roots": [project_root],
+        })
+        .to_string();
+
+        assert!(
+            cursor_after_file_edit_decision(&event).is_some(),
+            "first qualifying edit in a session must emit the nudge"
+        );
+        assert!(
+            cursor_after_file_edit_decision(&event).is_none(),
+            "the redundancy nudge must be deduped within the session"
         );
     }
 }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -33,12 +33,13 @@ pub use codex::{
     hook_codex_user_prompt_submit, record_codex_subagent_start,
 };
 pub use cursor::{
-    CURSOR_CATCH_UP_INGEST_MAX_BYTES, cursor_after_file_edit_rel_paths,
-    cursor_before_submit_prompt_json, cursor_post_tool_use_decision,
-    cursor_project_root_from_event, cursor_session_start_json, cursor_should_run_sync,
-    evaluate_cursor_post_tool_use, evaluate_cursor_subagent_start, hook_cursor_after_file_edit,
-    hook_cursor_after_shell, hook_cursor_before_submit_prompt, hook_cursor_post_tool_use,
-    hook_cursor_pre_compact, hook_cursor_session_end, hook_cursor_session_start, hook_cursor_stop,
+    CURSOR_CATCH_UP_INGEST_MAX_BYTES, cursor_after_file_edit_decision,
+    cursor_after_file_edit_rel_paths, cursor_before_submit_prompt_json,
+    cursor_post_tool_use_decision, cursor_project_root_from_event, cursor_session_start_json,
+    cursor_should_run_sync, evaluate_cursor_after_file_edit, evaluate_cursor_post_tool_use,
+    evaluate_cursor_subagent_start, hook_cursor_after_file_edit, hook_cursor_after_shell,
+    hook_cursor_before_submit_prompt, hook_cursor_post_tool_use, hook_cursor_pre_compact,
+    hook_cursor_session_end, hook_cursor_session_start, hook_cursor_stop,
     hook_cursor_subagent_start, hook_cursor_workspace_open,
 };
 pub use cursor_compact::{CursorPreCompactOutcome, cursor_pre_compact_for_event_with_config};

--- a/src/hooks/tool_hints/evals/mod.rs
+++ b/src/hooks/tool_hints/evals/mod.rs
@@ -604,6 +604,32 @@ fn dynamic_action_context_cases() -> Vec<HintEval> {
             None,
             &[],
         ),
+        // Codex surface: `hook_codex_post_tool_use` maps an `apply_patch` event
+        // onto this Claude-shaped input (tool_name `Edit`, patch target path,
+        // and the `+`-stripped added source as edit_text), so the shared
+        // redundancy classifier fires identically for Codex.
+        input_eval(
+            "codex-apply-patch-nudges-redundancy",
+            ToolHintInput {
+                agent: HintAgent::Codex,
+                tool_name: Some("Edit".to_string()),
+                file_path: Some("src/util.rs".to_string()),
+                edit_text: Some(
+                    "pub fn summarize(hits: &[Hit]) -> u32 {\n    \
+                     let mut total = 0;\n    \
+                     for hit in hits {\n        \
+                     if hit.active {\n            \
+                     total += hit.count;\n        \
+                     }\n    \
+                     }\n    \
+                     total\n}\n"
+                        .to_string(),
+                ),
+                ..ToolHintInput::default()
+            },
+            Some(HintCategory::EditRedundancy),
+            &["tracedecay_redundancy", "tracedecay_similar"],
+        ),
     ]
 }
 


### PR DESCRIPTION
Equalizes the edit-driven hint capability across the three primary host facades, grounded in web research of each host's current extension surfaces plus the repo's own recorded fixtures: Codex post-tool-use now feeds decide_hint (apply_patch → Edit vocabulary with envelope-stripped added source), and Cursor rides afterFileEdit (fixtures prove postToolUse lacks edit bodies; afterFileEdit also covers cloud agents). Claude's classifier is untouched. The Cursor cloud-agent steering fallback was verified already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)