### PR TITLE
fix(config): atomic user-config saves with honest errors and recovery

### DIFF
--- a/src/accounting/pricing.rs
+++ b/src/accounting/pricing.rs
@@ -289,7 +289,9 @@ pub fn refresh_if_stale() {
 
     if refresh_pricing() {
         config.last_pricing_fetch_at = now;
-        config.save();
+        if let Err(err) = config.save() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
     }
 }
 

--- a/src/agent_cmd.rs
+++ b/src/agent_cmd.rs
@@ -347,7 +347,11 @@ pub(crate) async fn handle_install_command(
             user_cfg.installed_agents.push(id);
             installed_names.push(name);
         }
-        user_cfg.save();
+        user_cfg
+            .save()
+            .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+                message: format!("failed to save user config: {err}"),
+            })?;
     } else {
         let (to_install, to_uninstall) =
             tracedecay::agents::pick_integrations_interactive(&home, &user_cfg.installed_agents)?;
@@ -383,7 +387,11 @@ pub(crate) async fn handle_install_command(
                 user_cfg.installed_agents.push(id.clone());
             }
         }
-        user_cfg.save();
+        user_cfg
+            .save()
+            .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+                message: format!("failed to save user config: {err}"),
+            })?;
     }
 
     eprintln!();
@@ -399,7 +407,11 @@ pub(crate) async fn handle_install_command(
     }
 
     user_cfg.last_installed_version = env!("CARGO_PKG_VERSION").to_string();
-    user_cfg.save();
+    user_cfg
+        .save()
+        .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+            message: format!("failed to save user config: {err}"),
+        })?;
 
     tracedecay::agents::offer_git_post_commit_hook(&tracedecay_bin);
     Ok(())
@@ -440,7 +452,11 @@ pub(crate) async fn handle_reinstall_command() -> tracedecay::errors::Result<()>
         }
         eprintln!("\x1b[32m✔\x1b[0m All agents reinstalled");
         user_cfg.last_installed_version = env!("CARGO_PKG_VERSION").to_string();
-        user_cfg.save();
+        user_cfg
+            .save()
+            .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+                message: format!("failed to save user config: {err}"),
+            })?;
     }
     Ok(())
 }
@@ -523,7 +539,11 @@ pub(crate) async fn handle_uninstall_command(
             ag.uninstall(&ctx)?;
         }
         user_cfg.installed_agents.retain(|a| a != &id);
-        user_cfg.save();
+        user_cfg
+            .save()
+            .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+                message: format!("failed to save user config: {err}"),
+            })?;
     } else {
         for id in user_cfg.installed_agents.clone() {
             if let Ok(ag) = tracedecay::agents::get_integration(&id) {
@@ -539,7 +559,11 @@ pub(crate) async fn handle_uninstall_command(
             }
         }
         user_cfg.installed_agents.clear();
-        user_cfg.save();
+        user_cfg
+            .save()
+            .map_err(|err| tracedecay::errors::TraceDecayError::Config {
+                message: format!("failed to save user config: {err}"),
+            })?;
         eprintln!("All agent integrations removed.");
     }
     Ok(())

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -1266,7 +1266,9 @@ pub fn migrate_installed_agents(home: &Path, config: &mut crate::user_config::Us
         return;
     }
     config.installed_agents.extend(additions);
-    config.save();
+    if let Err(err) = config.save() {
+        eprintln!("warning: could not save tracedecay config: {err}");
+    }
 }
 
 #[cfg(test)]

--- a/src/automation_cli.rs
+++ b/src/automation_cli.rs
@@ -754,10 +754,19 @@ async fn handle_automation_config_command(
     if scope == AutomationConfigScope::Global {
         let effective = effective_config(&global, Some(&patch))?;
         user_config.automation = effective.clone();
-        if !user_config.save() {
-            return Err(tracedecay::errors::TraceDecayError::Config {
-                message: "failed to save global automation config".to_string(),
-            });
+        match user_config.save_with_recovery() {
+            Ok(Some(backup)) => {
+                eprintln!(
+                    "note: the previous config.toml was corrupt and was backed up to {} before regenerating",
+                    backup.display()
+                );
+            }
+            Ok(None) => {}
+            Err(err) => {
+                return Err(tracedecay::errors::TraceDecayError::Config {
+                    message: format!("failed to save global automation config: {err}"),
+                });
+            }
         }
         return print_automation_config(&user_config.automation, None, &effective, true, false);
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1115,7 +1115,14 @@ async fn close_project_graph(cg: TraceDecay) -> tracedecay::errors::Result<()> {
 pub(crate) fn handle_upload_counter(enable: bool) {
     let mut config = tracedecay::user_config::UserConfig::load();
     config.upload_enabled = enable;
-    config.save();
+    match config.save_with_recovery() {
+        Ok(Some(backup)) => eprintln!(
+            "note: corrupt config.toml backed up to {} before regenerating",
+            backup.display()
+        ),
+        Ok(None) => {}
+        Err(err) => eprintln!("warning: could not save tracedecay config: {err}"),
+    }
     if enable {
         eprintln!("Worldwide counter upload enabled.");
     } else {
@@ -1202,7 +1209,9 @@ fn maybe_print_parallel_update_notice(version_handle: std::thread::JoinHandle<Op
         let mut config = tracedecay::user_config::UserConfig::load();
         config.cached_latest_version = latest.clone();
         config.last_version_check_at = now;
-        config.save_if_exists();
+        if let Err(err) = config.save_if_exists() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
         if tracedecay::cloud::is_newer_version(current_version, &latest)
             && now - config.last_version_warning_at >= 900
         {
@@ -1211,7 +1220,9 @@ fn maybe_print_parallel_update_notice(version_handle: std::thread::JoinHandle<Op
                 current_version, latest
             );
             config.last_version_warning_at = now;
-            config.save_if_exists();
+            if let Err(err) = config.save_if_exists() {
+                eprintln!("warning: could not save tracedecay config: {err}");
+            }
         }
     }
 }

--- a/src/dashboard/settings_api.rs
+++ b/src/dashboard/settings_api.rs
@@ -156,8 +156,19 @@ pub(crate) async fn patch_user_settings(
     if let Some(timeout) = patch.extraction_timeout_secs {
         config.extraction_timeout_secs = timeout;
     }
-    if !config.save() {
-        return Err(internal_error(&"failed to save user config"));
+    match config.save_with_recovery() {
+        Ok(Some(backup)) => {
+            eprintln!(
+                "[tracedecay] note: corrupt config.toml backed up to {} before regenerating",
+                backup.display()
+            );
+        }
+        Ok(None) => {}
+        Err(err) => {
+            return Err(internal_error(&format!(
+                "failed to save user config: {err}"
+            )));
+        }
     }
 
     let mut payload = settings_payload(&state).await?;

--- a/src/global.rs
+++ b/src/global.rs
@@ -227,7 +227,9 @@ pub(crate) async fn update_global_db(cg: &TraceDecay) {
         if tokens > previous {
             let mut config = tracedecay::user_config::UserConfig::load();
             config.pending_upload += tokens - previous;
-            config.save_if_exists();
+            if let Err(err) = config.save_if_exists() {
+                eprintln!("warning: could not save tracedecay config: {err}");
+            }
         }
     }
 }
@@ -283,7 +285,9 @@ pub(crate) fn check_for_update(
     } else if let Some(v) = tracedecay::cloud::fetch_latest_version() {
         config.cached_latest_version = v.clone();
         config.last_version_check_at = now;
-        config.save_if_exists();
+        if let Err(err) = config.save_if_exists() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
         v
     } else {
         return;
@@ -305,7 +309,9 @@ pub(crate) fn check_for_update(
         );
         if !skip_suppression {
             config.last_version_warning_at = now;
-            config.save_if_exists();
+            if let Err(err) = config.save_if_exists() {
+                eprintln!("warning: could not save tracedecay config: {err}");
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,9 @@ async fn run_startup_preamble(command: &Commands) {
         global::try_flush(&mut user_config, is_force_flush);
     }
     if !is_local_install_command(command) {
-        user_config.save_if_exists();
+        if let Err(err) = user_config.save_if_exists() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
     }
 
     if is_first_run && !skip_startup_maintenance {
@@ -320,7 +322,9 @@ async fn maybe_run_silent_reinstall(user_config: &mut tracedecay::user_config::U
         SilentReinstallAction::Reinstall => run_silent_reinstall(user_config, running).await,
         SilentReinstallAction::AdvanceMarker => {
             user_config.previous_version = running.to_string();
-            user_config.save();
+            if let Err(err) = user_config.save() {
+                eprintln!("warning: could not save tracedecay config: {err}");
+            }
         }
         SilentReinstallAction::Nothing => {}
     }
@@ -334,7 +338,9 @@ async fn run_silent_reinstall(
         update_cmd::reinstall_tracked_agents(user_config).await
     {
         user_config.mark_version_installed(running);
-        user_config.save();
+        if let Err(err) = user_config.save() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1594,10 +1594,14 @@ impl McpServer {
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_secs() as i64;
-                config.save();
+                if let Err(err) = config.save() {
+                    eprintln!("[tracedecay] warning: could not save config: {err}");
+                }
                 return true;
             }
-            config.save();
+            if let Err(err) = config.save() {
+                eprintln!("[tracedecay] warning: could not save config: {err}");
+            }
             false
         })
         .await
@@ -1919,7 +1923,9 @@ impl McpServer {
                     config.last_upload_at = now;
                 }
             }
-            config.save();
+            if let Err(err) = config.save() {
+                eprintln!("[tracedecay] warning: could not save config: {err}");
+            }
         }
 
         // Checkpoint WAL to merge it into the main database file

--- a/src/status_cmd.rs
+++ b/src/status_cmd.rs
@@ -149,7 +149,9 @@ pub(crate) async fn handle_status_command(
     } else if let Some(total) = tracedecay::cloud::fetch_worldwide_total() {
         config.last_worldwide_total = total;
         config.last_worldwide_fetch_at = now;
-        config.save_if_exists();
+        if let Err(err) = config.save_if_exists() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
         Some(total)
     } else {
         (config.last_worldwide_total > 0).then_some(config.last_worldwide_total)
@@ -163,7 +165,9 @@ pub(crate) async fn handle_status_command(
         if !fresh.is_empty() {
             config.cached_country_flags = fresh.clone();
             config.last_flags_fetch_at = now;
-            config.save_if_exists();
+            if let Err(err) = config.save_if_exists() {
+                eprintln!("warning: could not save tracedecay config: {err}");
+            }
         }
         if fresh.is_empty() && !config.cached_country_flags.is_empty() {
             config.cached_country_flags.clone()

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -348,7 +348,9 @@ pub(crate) async fn run_post_update_tasks(
         // anyway. The next real upgrade re-arms the reinstall as usual.
         let mut config = UserConfig::load();
         if config.mark_version_installed(env!("CARGO_PKG_VERSION")) {
-            config.save();
+            if let Err(err) = config.save() {
+                eprintln!("warning: could not save tracedecay config: {err}");
+            }
         }
         return Ok(());
     }
@@ -378,7 +380,9 @@ pub(crate) async fn run_post_update_tasks(
         .installed_agents
         .retain(|id| tracedecay::agents::get_integration(id).is_ok());
     if config.installed_agents.len() != before {
-        config.save();
+        if let Err(err) = config.save() {
+            eprintln!("warning: could not save tracedecay config: {err}");
+        }
     }
     if config.installed_agents.is_empty() {
         eprintln!("Refreshing agent integrations: nothing to refresh");
@@ -391,7 +395,9 @@ pub(crate) async fn run_post_update_tasks(
     match reinstall_tracked_agents(&config).await {
         ReinstallOutcome::AllOk => {
             if config.mark_version_installed(env!("CARGO_PKG_VERSION")) {
-                config.save();
+                if let Err(err) = config.save() {
+                    eprintln!("warning: could not save tracedecay config: {err}");
+                }
             }
         }
         ReinstallOutcome::PartialFailure { failed } => {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -714,9 +714,9 @@ fn record_previous_version() {
         return;
     }
     cfg.previous_version = current.to_string();
-    if !cfg.save() {
+    if let Err(err) = cfg.save() {
         eprintln!(
-            "  \x1b[33mwarning:\x1b[0m could not record previous version; \
+            "  \x1b[33mwarning:\x1b[0m could not record previous version ({err}); \
              run `tracedecay reinstall` manually if new tools aren't registered"
         );
     }

--- a/src/user_config.rs
+++ b/src/user_config.rs
@@ -4,11 +4,15 @@
 //! gracefully. Unknown fields are preserved for forward compatibility.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 use crate::automation::config::AutomationConfig;
+use crate::storage::{append_lock_path, retry_transient_file_op};
 
 /// User-level tracedecay configuration.
 #[derive(Debug, Serialize, Deserialize)]
@@ -150,6 +154,151 @@ pub fn config_path() -> Option<PathBuf> {
     crate::config::user_data_dir().map(|dir| dir.join("config.toml"))
 }
 
+/// Errors returned by [`UserConfig::save`] / [`UserConfig::save_with_recovery`].
+///
+/// Distinguishes the ways a save can fail so callers can surface an actionable
+/// message instead of a bare boolean. The corrupt-existing-file case carries
+/// the path and the TOML parse error (whose message includes the line/column),
+/// so a user can find and fix — or delete — the offending file.
+#[derive(Debug)]
+pub enum ConfigSaveError {
+    /// The user data directory could not be resolved, so there is no path to
+    /// write to.
+    PathUnavailable,
+    /// The existing config file is present but could not be read.
+    ExistingUnreadable { path: PathBuf, source: io::Error },
+    /// The existing config file is present but is not valid TOML. It is left
+    /// untouched (never clobbered) unless recovery was requested.
+    CorruptExisting {
+        path: PathBuf,
+        line: Option<usize>,
+        message: String,
+    },
+    /// Serializing the in-memory config to TOML failed.
+    Serialize { message: String },
+    /// Creating the parent directory, writing the temp file, or renaming it
+    /// over the target failed.
+    Io {
+        path: PathBuf,
+        message: String,
+        source: io::Error,
+    },
+    /// Acquiring the sidecar write lock failed.
+    Lock { path: PathBuf, source: io::Error },
+}
+
+impl ConfigSaveError {
+    /// True when the failure is a corrupt existing file that was left intact.
+    #[must_use]
+    pub fn is_corrupt(&self) -> bool {
+        matches!(self, Self::CorruptExisting { .. })
+    }
+}
+
+impl std::fmt::Display for ConfigSaveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PathUnavailable => write!(
+                f,
+                "cannot resolve the tracedecay user config path (no user data directory)"
+            ),
+            Self::ExistingUnreadable { path, source } => {
+                write!(
+                    f,
+                    "cannot read existing config file {}: {source}",
+                    path.display()
+                )
+            }
+            Self::CorruptExisting {
+                path,
+                line,
+                message,
+            } => match line {
+                Some(line) => write!(
+                    f,
+                    "config file {} is corrupt at line {line}: {message} \
+                     — back it up or delete it to regenerate",
+                    path.display()
+                ),
+                None => write!(
+                    f,
+                    "config file {} is corrupt: {message} \
+                     — back it up or delete it to regenerate",
+                    path.display()
+                ),
+            },
+            Self::Serialize { message } => {
+                write!(f, "failed to serialize config to TOML: {message}")
+            }
+            Self::Io {
+                path,
+                message,
+                source,
+            } => write!(f, "{message} ({}): {source}", path.display()),
+            Self::Lock { path, source } => {
+                write!(
+                    f,
+                    "failed to acquire config write lock {}: {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigSaveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ExistingUnreadable { source, .. }
+            | Self::Io { source, .. }
+            | Self::Lock { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Sibling temp path in the same directory as `path`, used for the atomic
+/// write-then-rename. Includes pid and a nanosecond stamp so a stale temp from
+/// a crashed writer never collides with a live one.
+fn temp_write_path(path: &Path) -> PathBuf {
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_else(|| std::ffi::OsString::from("config.toml"));
+    name.push(format!(".tmp-{pid}-{unique}"));
+    path.with_file_name(name)
+}
+
+/// Quarantine path (`config.toml.corrupt-<unix-ts>`) for a corrupt config file
+/// preserved during recovery. Mirrors the branch-meta quarantine naming in
+/// `src/storage.rs` / `src/doctor/heal.rs`.
+fn corrupt_backup_path(path: &Path) -> PathBuf {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_else(|| std::ffi::OsString::from("config.toml"));
+    name.push(format!(".corrupt-{now}"));
+    path.with_file_name(name)
+}
+
+/// Best-effort 1-based line number for a TOML parse error, derived from the
+/// error's byte span. `None` when the span is unavailable; the error's own
+/// message still carries the line/column in that case.
+fn parse_error_line(contents: &str, err: &toml::de::Error) -> Option<usize> {
+    let span = err.span()?;
+    let end = span.start.min(contents.len());
+    Some(contents[..end].bytes().filter(|&b| b == b'\n').count() + 1)
+}
+
 impl UserConfig {
     /// Loads the user-level config file.
     /// Returns defaults if the file is missing or unreadable.
@@ -163,38 +312,154 @@ impl UserConfig {
         toml::from_str(&contents).unwrap_or_default()
     }
 
-    /// Saves the user-level config file. Best-effort.
-    /// Returns true if the file was saved, false on any error.
-    pub fn save(&self) -> bool {
+    /// Saves the user-level config file atomically.
+    ///
+    /// The in-memory config is serialized up front so a serialize failure never
+    /// touches the existing file. Writers are serialized across threads and
+    /// processes (daemon, MCP servers, CLI all write this file) with a sidecar
+    /// `<config>.lock`, mirroring the append lock in `src/storage.rs`: the lock
+    /// is taken on a dedicated read/write handle, never on the target file — see
+    /// the `LockFileEx` note there. The fresh config is written to a temp file
+    /// in the same directory and renamed over `config.toml`, so a concurrent
+    /// reader never observes a torn write.
+    ///
+    /// If the existing file is present but unparseable it is left untouched and
+    /// [`ConfigSaveError::CorruptExisting`] is returned (carrying the path and
+    /// the parse error's line). Use [`UserConfig::save_with_recovery`] from
+    /// explicit config-set commands to quarantine a corrupt file and regenerate.
+    pub fn save(&self) -> std::result::Result<(), ConfigSaveError> {
+        self.save_inner(false).map(|_| ())
+    }
+
+    /// Like [`UserConfig::save`], but self-heals a corrupt existing file.
+    ///
+    /// When the existing file is unparseable it is renamed to
+    /// `config.toml.corrupt-<unix-ts>` (preserving the evidence) and the fresh
+    /// in-memory config is written in its place. Returns `Ok(Some(backup_path))`
+    /// when a corrupt file was quarantined, `Ok(None)` for an ordinary save.
+    ///
+    /// Only call this from explicit, user-driven config-set entry points.
+    /// Because [`UserConfig::load`] silently returns defaults for a corrupt
+    /// file, a background saver's in-memory config after a corrupt load is
+    /// mostly defaults, so clobbering there would discard real user data
+    /// (upload counters, installed agents, version markers). Config-set commands
+    /// set the value the user just asked for, so regenerating is the safe,
+    /// unbricking choice.
+    pub fn save_with_recovery(&self) -> std::result::Result<Option<PathBuf>, ConfigSaveError> {
+        self.save_inner(true)
+    }
+
+    fn save_inner(&self, recover: bool) -> std::result::Result<Option<PathBuf>, ConfigSaveError> {
         let Some(path) = config_path() else {
-            return false;
+            return Err(ConfigSaveError::PathUnavailable);
         };
-        if path.exists() {
-            let Ok(contents) = std::fs::read_to_string(&path) else {
-                return false;
-            };
-            if toml::from_str::<Self>(&contents).is_err() {
-                return false;
-            }
-        }
+
+        // Serialize first: a serialize failure must never mutate the filesystem
+        // or truncate the existing config.
+        let contents = toml::to_string_pretty(self).map_err(|err| ConfigSaveError::Serialize {
+            message: err.to_string(),
+        })?;
+
         if let Some(parent) = path.parent() {
-            if std::fs::create_dir_all(parent).is_err() {
-                return false;
+            fs::create_dir_all(parent).map_err(|source| ConfigSaveError::Io {
+                path: parent.to_path_buf(),
+                message: "failed to create config directory".to_string(),
+                source,
+            })?;
+        }
+
+        // Serialize concurrent writers on a dedicated sidecar lock handle; never
+        // lock the target handle (mirrors `src/storage.rs::append_line_once`).
+        let lock_path = append_lock_path(&path);
+        let lock_file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|source| ConfigSaveError::Lock {
+                path: lock_path.clone(),
+                source,
+            })?;
+        lock_file
+            .lock_exclusive()
+            .map_err(|source| ConfigSaveError::Lock {
+                path: lock_path.clone(),
+                source,
+            })?;
+
+        let result = Self::write_locked(&path, &contents, recover);
+        let _ = lock_file.unlock();
+        result
+    }
+
+    fn write_locked(
+        path: &Path,
+        contents: &str,
+        recover: bool,
+    ) -> std::result::Result<Option<PathBuf>, ConfigSaveError> {
+        let mut backup: Option<PathBuf> = None;
+        if path.exists() {
+            match fs::read_to_string(path) {
+                Ok(existing) => {
+                    if let Err(err) = toml::from_str::<Self>(&existing) {
+                        if recover {
+                            let backup_path = corrupt_backup_path(path);
+                            fs::rename(path, &backup_path).map_err(|source| {
+                                ConfigSaveError::Io {
+                                    path: backup_path.clone(),
+                                    message: "failed to quarantine corrupt config file".to_string(),
+                                    source,
+                                }
+                            })?;
+                            backup = Some(backup_path);
+                        } else {
+                            return Err(ConfigSaveError::CorruptExisting {
+                                path: path.to_path_buf(),
+                                line: parse_error_line(&existing, &err),
+                                message: err.to_string(),
+                            });
+                        }
+                    }
+                }
+                Err(source) => {
+                    return Err(ConfigSaveError::ExistingUnreadable {
+                        path: path.to_path_buf(),
+                        source,
+                    });
+                }
             }
         }
-        let Ok(contents) = toml::to_string_pretty(self) else {
-            return false;
-        };
-        std::fs::write(&path, contents).is_ok()
+
+        // Atomic replace: write a temp file in the same directory, then rename
+        // it over the target. `rename` is atomic on POSIX and Windows, so a
+        // concurrent reader always sees either the old or the new file whole.
+        let temp_path = temp_write_path(path);
+        retry_transient_file_op(|| {
+            fs::write(&temp_path, contents)?;
+            fs::rename(&temp_path, path)
+        })
+        .map_err(|source| {
+            let _ = fs::remove_file(&temp_path);
+            ConfigSaveError::Io {
+                path: path.to_path_buf(),
+                message: "failed to write config file".to_string(),
+                source,
+            }
+        })?;
+
+        Ok(backup)
     }
 
     /// Saves only when the user-level config file already exists.
     ///
     /// This lets repo-local commands update an existing user profile without
-    /// creating one as an incidental side effect.
-    pub fn save_if_exists(&self) -> bool {
+    /// creating one as an incidental side effect. A missing file is a no-op and
+    /// returns `Ok(())`; a present-but-corrupt file surfaces the same
+    /// [`ConfigSaveError::CorruptExisting`] as [`UserConfig::save`].
+    pub fn save_if_exists(&self) -> std::result::Result<(), ConfigSaveError> {
         if !Self::exists() {
-            return false;
+            return Ok(());
         }
         self.save()
     }
@@ -320,11 +585,184 @@ mod tests {
         let mut config = UserConfig::load();
         config.upload_enabled = false;
 
+        let err = config
+            .save()
+            .expect_err("saving must fail when the existing file is corrupt");
         assert!(
-            !config.save(),
-            "saving a defaulted config must fail when the existing file is corrupt"
+            err.is_corrupt(),
+            "expected a corrupt-file error, got: {err}"
         );
         assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn save_reports_torn_line_with_path_and_line_number() {
+        let _lock = lock_user_data_dir_test_env();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Reproduce the exact torn-write seen in the wild: a valid line followed
+        // by a bare " true" orphan with no key.
+        let torn = "upload_enabled = false\n true";
+        std::fs::write(&path, torn).unwrap();
+
+        let config = UserConfig::load();
+        let err = config
+            .save()
+            .expect_err("torn config must not save via the plain path");
+        assert!(err.is_corrupt(), "expected corrupt error, got: {err}");
+        let message = err.to_string();
+        assert!(
+            message.contains(&path.display().to_string()),
+            "error should name the file path: {message}"
+        );
+        assert!(
+            message.contains("line 2") || message.contains("line "),
+            "error should carry a line number: {message}"
+        );
+        // The corrupt file is preserved untouched.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), torn);
+    }
+
+    #[test]
+    fn save_with_recovery_backs_up_and_regenerates() {
+        let _lock = lock_user_data_dir_test_env();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let torn = "upload_enabled = false\n true";
+        std::fs::write(&path, torn).unwrap();
+
+        let mut config = UserConfig::load();
+        config.upload_enabled = true;
+        let backup = config
+            .save_with_recovery()
+            .expect("recovery save should succeed")
+            .expect("a corrupt file should have been quarantined");
+
+        // The corrupt content is preserved at the backup path.
+        assert!(
+            backup
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("config.toml.corrupt-")),
+            "backup should be config.toml.corrupt-<ts>: {backup:?}"
+        );
+        assert_eq!(std::fs::read_to_string(&backup).unwrap(), torn);
+
+        // The regenerated file parses and reflects the in-memory value.
+        let saved = std::fs::read_to_string(&path).unwrap();
+        let reparsed: UserConfig = toml::from_str(&saved).expect("regenerated config parses");
+        assert!(reparsed.upload_enabled);
+
+        // A subsequent ordinary save now succeeds (no longer bricked).
+        config.save().expect("save after recovery should succeed");
+    }
+
+    #[test]
+    fn save_regenerates_when_no_file_exists() {
+        let _lock = lock_user_data_dir_test_env();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+
+        let config = UserConfig::default();
+        config.save().expect("save should create a fresh file");
+        let saved = std::fs::read_to_string(&path).unwrap();
+        toml::from_str::<UserConfig>(&saved).expect("fresh config parses");
+    }
+
+    #[test]
+    fn save_reports_unreadable_existing_file() {
+        let _lock = lock_user_data_dir_test_env();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // A directory where the config file should be: exists(), but reading it
+        // yields an I/O error rather than a parse error.
+        std::fs::create_dir_all(&path).unwrap();
+
+        let config = UserConfig::default();
+        let err = config
+            .save()
+            .expect_err("an unreadable existing path must not save");
+        assert!(
+            matches!(err, ConfigSaveError::ExistingUnreadable { .. }),
+            "expected ExistingUnreadable, got: {err}"
+        );
+    }
+
+    #[test]
+    fn path_unavailable_error_displays() {
+        let err = ConfigSaveError::PathUnavailable;
+        assert!(err.to_string().contains("user config path"));
+    }
+
+    #[test]
+    fn concurrent_saves_always_leave_a_parseable_file() {
+        let _lock = lock_user_data_dir_test_env();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let handles: Vec<_> = (0..8u64)
+            .map(|thread_idx| {
+                std::thread::spawn(move || {
+                    for i in 0..20u64 {
+                        let config = UserConfig {
+                            pending_upload: thread_idx * 100 + i,
+                            ..UserConfig::default()
+                        };
+                        // Every write must succeed and leave a parseable file.
+                        config.save().expect("concurrent save should succeed");
+                    }
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("writer thread should not panic");
+        }
+
+        let saved = std::fs::read_to_string(&path).unwrap();
+        toml::from_str::<UserConfig>(&saved)
+            .expect("file must be parseable after concurrent saves");
+    }
+
+    #[test]
+    fn concurrent_reader_never_observes_a_torn_write() {
+        let _lock = lock_user_data_dir_test_env();
+        let temp = TempDir::new().unwrap();
+        let _env = EnvRestore::set(USER_DATA_DIR_ENV, temp.path());
+        let path = config_path().expect("config path should resolve");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Seed a valid file so the reader always has something to read.
+        UserConfig::default().save().expect("seed save");
+
+        let reader_path = path.clone();
+        let reader = std::thread::spawn(move || {
+            for _ in 0..300 {
+                if let Ok(contents) = std::fs::read_to_string(&reader_path) {
+                    if !contents.is_empty() {
+                        toml::from_str::<UserConfig>(&contents).unwrap_or_else(|err| {
+                            panic!("reader observed a torn/partial config: {err}\n{contents}")
+                        });
+                    }
+                }
+            }
+        });
+
+        for i in 0..150u64 {
+            let config = UserConfig {
+                pending_upload: i,
+                ..UserConfig::default()
+            };
+            config.save().expect("writer save should succeed");
+        }
+        reader.join().expect("reader thread should not panic");
     }
 
     #[test]
@@ -343,7 +781,9 @@ mod tests {
         let mut config = UserConfig::load();
         config.upload_enabled = false;
 
-        assert!(config.save());
+        config
+            .save()
+            .expect("save should succeed with a valid existing file");
         let saved = std::fs::read_to_string(&path).unwrap();
         assert!(saved.contains("future_key = \"keep-me\""));
         assert!(saved.contains("[future_table]"));

--- a/tests/dashboard_api_test/automation_config.rs
+++ b/tests/dashboard_api_test/automation_config.rs
@@ -24,7 +24,9 @@ fn automation_config_is_dashboard_controllable_and_persistent() {
         global_config.automation.enabled = true;
         global_config.automation.backend =
             tracedecay::automation::config::AutomationBackend::CodexAppServer;
-        assert!(global_config.save(), "global user config should save");
+        global_config
+            .save()
+            .expect("global user config should save");
 
         let cg = setup_project(&project_root).await;
         let sidecar = cg


### PR DESCRIPTION
Root-caused from a live corruption: concurrent non-atomic writes tore ~/.tracedecay/config.toml, and save()'s parse-guard then silently bricked all config writes. Atomic temp+rename writes under a sidecar lock (storage.rs pattern), Result-based errors naming the corrupt file and line, and a data-loss-safe two-tier recovery (background saves never clobber; explicit config-set commands quarantine and regenerate). All 32 call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)