### PR TITLE
feat(automation): retry transient backend errors, surface autonomy

### DIFF
--- a/docs/HERMES-LOOPS-PARITY-AUDIT.md
+++ b/docs/HERMES-LOOPS-PARITY-AUDIT.md
@@ -182,10 +182,10 @@ curator's conservative invariants.
   similarity-dedup + hygiene planner (`dashboard/memory_curate.rs`), sends the
   bounded `llm_review` clusters to the backend, then **re-validates the
   returned ops against freshly recomputed evidence** before any apply. Apply
-  policy: auto-apply only when `auto_apply_memory_ops=true` **and**
-  `require_dashboard_approval=false`; otherwise ops surface for dashboard
-  review. Destructive-op counts (permanent deletes, merge losers) are
-  reported explicitly.
+  policy: auto-apply when `auto_apply_memory_ops=true` — automation applies
+  without any human approval gate (`require_dashboard_approval` is deprecated
+  and ignored); otherwise ops surface for dashboard review. Destructive-op
+  counts (permanent deletes, merge losers) are reported explicitly.
 - **session_reflector** (`runner.rs:170-420`, `session_reflector.rs`):
   evidence = `lcm_grep` over the LCM session store with a **fixed keyword
   query** (`"remember prefer decision requirement workflow"`, limit 20 hits,

--- a/docs/SELF-IMPROVING-LOOPS-CONTRACTS.md
+++ b/docs/SELF-IMPROVING-LOOPS-CONTRACTS.md
@@ -19,7 +19,7 @@ This is the durable contract for TraceDecay-owned self-improvement loops. Hermes
 
 Hermes is the reference behavior for self-improvement cadence, but TraceDecay owns its own scheduler in standalone mode. Hermes memory review and skill review are turn/iteration nudges: memory defaults to every 10 user turns when memory is enabled, skill review defaults to every 10 tool-calling iterations, and both run as a whitelisted background review fork after the foreground response. Hermes skill-library curator is separate: it runs after `curator.interval_hours` elapses, defaults to 168 hours, requires the idle gate (`curator.min_idle_hours`, default 2 hours), seeds the first run instead of mutating immediately, snapshots before real runs, and archives rather than deletes.
 
-TraceDecay standalone automation is time-scheduled by the daemon, not by Codex native automations or Hermes cron. The default scheduler tick is 60 seconds. `tracedecay install --agent codex --automation` enables the Codex app-server backend with `require_dashboard_approval=false`, `auto_apply_memory_ops=true`, `auto_enable_skills=false`, and these task cadences:
+TraceDecay standalone automation is time-scheduled by the daemon, not by Codex native automations or Hermes cron. The default scheduler tick is 60 seconds. `tracedecay install --agent codex --automation` enables the Codex app-server backend with autonomous apply (automation applies its output without any human approval; `require_dashboard_approval` is **deprecated** — still parsed from legacy configs for back-compat but ignored for gating), `auto_apply_memory_ops=true`, `auto_enable_skills=false`, and these task cadences:
 
 | Task | Default cadence | Default mutation behavior |
 | --- | --- | --- |

--- a/src/automation/backend.rs
+++ b/src/automation/backend.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::errors::{Result, TraceDecayError};
 use crate::sessions::codex_app_server::{
@@ -293,6 +293,110 @@ fn request_input_hash(
 
 pub trait AgentTaskBackend: Send + Sync {
     fn run_task(&self, request: &AgentTaskRequest) -> Result<AgentTaskResponse>;
+}
+
+/// Default cap on total backend attempts for a single task: the first try plus
+/// two bounded retries for transient codex app-server failures.
+pub const AGENT_TASK_MAX_ATTEMPTS: u32 = 3;
+
+/// Backoff before the 2nd and 3rd attempts. Kept short so retries stay inside
+/// the automation job's `timeout_secs` budget.
+pub const AGENT_TASK_RETRY_BACKOFFS: [Duration; 2] =
+    [Duration::from_secs(2), Duration::from_secs(5)];
+
+/// Bounded retry policy for a single backend task invocation.
+///
+/// Only transient app-server failures are retried — the ones the ledger already
+/// classifies as retryable via [`classify_agent_task_error_message`] /
+/// [`AgentTaskFailureClass::is_retryable`] (`Timeout`, `Unavailable`,
+/// `Retryable`). This covers the observed transient shapes:
+/// `"timed out waiting for codex app-server"` (→ `Timeout`) and
+/// `"closed stdout before completing"` (→ `Unavailable`). Permanent and
+/// malformed-output failures fail immediately.
+///
+/// Accumulated backoff never pushes total wall time past `budget` (the job
+/// `timeout_secs`); on the final failure the original error propagates
+/// unchanged so existing fallback/classification behavior is preserved.
+#[derive(Debug, Clone)]
+pub struct BackendRetryPolicy {
+    max_attempts: u32,
+    backoffs: Vec<Duration>,
+    budget: Duration,
+}
+
+impl BackendRetryPolicy {
+    /// Production policy derived from the automation job timeout: up to
+    /// [`AGENT_TASK_MAX_ATTEMPTS`] attempts with [`AGENT_TASK_RETRY_BACKOFFS`]
+    /// backoff, bounded by the job `timeout_secs` budget.
+    #[must_use]
+    pub fn from_timeout_secs(timeout_secs: u64) -> Self {
+        Self {
+            max_attempts: AGENT_TASK_MAX_ATTEMPTS,
+            backoffs: AGENT_TASK_RETRY_BACKOFFS.to_vec(),
+            budget: Duration::from_secs(timeout_secs.max(1)),
+        }
+    }
+
+    /// Explicit policy, primarily for tests that need deterministic (zero)
+    /// backoff and precise budgets. `max_attempts` is clamped to at least 1.
+    #[must_use]
+    pub fn new(max_attempts: u32, backoffs: Vec<Duration>, budget: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            backoffs,
+            budget,
+        }
+    }
+
+    /// Backoff to wait before making `next_attempt` (1-based). The pause before
+    /// attempt N uses `backoffs[N - 2]`, saturating on the last configured value.
+    fn backoff_before_attempt(&self, next_attempt: u32) -> Duration {
+        let idx = (next_attempt.saturating_sub(2)) as usize;
+        self.backoffs
+            .get(idx)
+            .or_else(|| self.backoffs.last())
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+/// Run a backend task with bounded, transient-only retries.
+///
+/// This is the single choke point every automation job funnels through instead
+/// of calling [`AgentTaskBackend::run_task`] directly, so the retry lives in one
+/// place rather than being duplicated per job. See [`BackendRetryPolicy`].
+pub async fn run_agent_task_with_retry(
+    backend: &dyn AgentTaskBackend,
+    request: &AgentTaskRequest,
+    policy: &BackendRetryPolicy,
+) -> Result<AgentTaskResponse> {
+    let start = Instant::now();
+    let max_attempts = policy.max_attempts.max(1);
+    let mut attempt: u32 = 1;
+    loop {
+        match backend.run_task(request) {
+            Ok(response) => return Ok(response),
+            Err(err) => {
+                // Out of attempts: propagate the final error unchanged.
+                if attempt >= max_attempts {
+                    return Err(err);
+                }
+                // Only transient app-server failures are worth retrying.
+                if !classify_agent_task_error_message(&err.to_string()).is_retryable() {
+                    return Err(err);
+                }
+                let backoff = policy.backoff_before_attempt(attempt + 1);
+                // Respect the overall job timeout: never sleep/retry past budget.
+                if start.elapsed().saturating_add(backoff) >= policy.budget {
+                    return Err(err);
+                }
+                if !backoff.is_zero() {
+                    tokio::time::sleep(backoff).await;
+                }
+                attempt += 1;
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/automation/config.rs
+++ b/src/automation/config.rs
@@ -196,6 +196,12 @@ pub struct AutomationConfigPatch {
         skip_serializing
     )]
     pub temperature: Option<Option<f32>>,
+    /// Deprecated: automation applies its output without any human approval, so
+    /// this flag no longer gates anything. It is still parsed from legacy
+    /// on-disk configs for back-compat (and never re-serialized) but is ignored
+    /// by `apply_patch`/`merge_patch`. The effective, autonomous apply policy is
+    /// surfaced by `tracedecay automation config get`
+    /// (`explanation.effective_apply_policy`).
     #[serde(default, skip_serializing)]
     pub require_dashboard_approval: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/automation/jobs.rs
+++ b/src/automation/jobs.rs
@@ -23,8 +23,8 @@ use serde_json::{Value, json};
 
 use super::artifacts::{sha256_json, write_improvement_artifacts};
 use super::backend::{
-    AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse,
-    classify_agent_task_error_message,
+    AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse, BackendRetryPolicy,
+    classify_agent_task_error_message, run_agent_task_with_retry,
 };
 use super::config::{AutomationBackend, AutomationConfig, AutomationHostMode};
 use super::job_webhook;
@@ -538,7 +538,8 @@ pub async fn run_user_job_with_backend(
     let request = request.with_strict_json(false);
     let input_hash = Some(request.input_hash.clone());
 
-    let response = match backend.run_task(&request) {
+    let retry_policy = BackendRetryPolicy::from_timeout_secs(config.timeout_secs);
+    let response = match run_agent_task_with_retry(backend, &request, &retry_policy).await {
         Ok(response) => response,
         Err(err) => {
             let record = ctx.append_failed(input_hash, err.to_string(), None).await?;

--- a/src/automation/lifecycle.rs
+++ b/src/automation/lifecycle.rs
@@ -7,8 +7,9 @@ use serde_json::{Value, json};
 
 use super::artifacts::{sha256_json, write_improvement_artifacts};
 use super::backend::{
-    AgentTaskKind, AgentTaskRequest, AgentTaskResponse, agent_task_contract,
-    classify_agent_task_error_message, extract_json_object_prefix, prompt_version, task_key,
+    AgentTaskKind, AgentTaskRequest, AgentTaskResponse, BackendRetryPolicy, agent_task_contract,
+    classify_agent_task_error_message, extract_json_object_prefix, prompt_version,
+    run_agent_task_with_retry, task_key,
 };
 use super::config::{AutomationBackend, AutomationConfig, AutomationHostMode};
 use super::run_ledger::{
@@ -456,7 +457,8 @@ impl<'a> AgentRunFinalizer<'a> {
         request: &AgentTaskRequest,
         evidence_hash: Option<String>,
     ) -> Result<BackendTaskRun> {
-        match backend.run_task(request) {
+        let retry_policy = BackendRetryPolicy::from_timeout_secs(self.config.timeout_secs);
+        match run_agent_task_with_retry(backend, request, &retry_policy).await {
             Ok(response) => Ok(BackendTaskRun::Response(response)),
             Err(err) => self
                 .append_backend_fallback_record(evidence_hash, err.to_string())

--- a/src/automation/memory_curator.rs
+++ b/src/automation/memory_curator.rs
@@ -3,7 +3,10 @@ use serde_json::{Value, json};
 
 use super::apply_policy::{MemoryApplyDecision, MemoryApplyPolicy, value_as_usize};
 use super::artifacts::sha256_json;
-use super::backend::{AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse};
+use super::backend::{
+    AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse, BackendRetryPolicy,
+    run_agent_task_with_retry,
+};
 use super::config::AutomationConfig;
 use super::lifecycle::{AgentTaskRunContext, SchedulerGate, failed_backend_fallback_report};
 use super::run_ledger::{AutomationRunLedgerRecord, AutomationTrigger};
@@ -108,7 +111,8 @@ pub async fn run_memory_curator_with_backend(
     let input_hash = Some(request.input_hash.clone());
     let finalizer = run.finalizer(input_hash.clone());
 
-    let response = match backend.run_task(&request) {
+    let retry_policy = BackendRetryPolicy::from_timeout_secs(config.timeout_secs);
+    let response = match run_agent_task_with_retry(backend, &request, &retry_policy).await {
         Ok(response) => response,
         Err(err) => {
             let record = finalizer

--- a/src/automation/runner.rs
+++ b/src/automation/runner.rs
@@ -6,8 +6,8 @@ use serde_json::{Value, json};
 use super::apply_policy::MemoryApplyPolicy;
 use super::artifacts::sha256_json;
 use super::backend::{
-    AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse,
-    extract_json_object_prefix,
+    AgentTaskBackend, AgentTaskKind, AgentTaskRequest, AgentTaskResponse, BackendRetryPolicy,
+    extract_json_object_prefix, run_agent_task_with_retry,
 };
 use super::config::AutomationConfig;
 use super::fact_proposals::{
@@ -1143,7 +1143,8 @@ pub async fn run_combined_review_with_backend(
     )
     .for_combined_run(run_id.clone());
 
-    let response = match backend.run_task(&request) {
+    let retry_policy = BackendRetryPolicy::from_timeout_secs(config.timeout_secs);
+    let response = match run_agent_task_with_retry(backend, &request, &retry_policy).await {
         Ok(response) => response,
         Err(err) => {
             let reflector_record = reflector_finalizer

--- a/src/automation_cli.rs
+++ b/src/automation_cli.rs
@@ -848,6 +848,20 @@ fn print_automation_config(
         && effective.host_mode == tracedecay::automation::config::AutomationHostMode::Standalone;
     let delegated_host =
         effective.host_mode == tracedecay::automation::config::AutomationHostMode::DelegatedHost;
+    // Automation applies its output without any human approval; `require_dashboard_approval`
+    // is deprecated and ignored for gating. The effective apply behavior per category is
+    // governed solely by the `auto_apply_*` switches, so surface it explicitly here so the
+    // config is not self-contradictory to a reader.
+    let memory_ops_policy = if effective.auto_apply_memory_ops {
+        "auto_apply"
+    } else {
+        "propose_only"
+    };
+    let skills_policy = if effective.auto_enable_skills {
+        "auto_enable"
+    } else {
+        "draft_for_approval"
+    };
     let payload = serde_json::json!({
         "global": global,
         "project": project,
@@ -860,6 +874,13 @@ fn print_automation_config(
             "auto_apply_memory_ops": effective.auto_apply_memory_ops,
             "auto_enable_skills": effective.auto_enable_skills,
             "export_memory_digest": effective.export_memory_digest,
+            "effective_apply_policy": {
+                "mode": "autonomous",
+                "human_approval_required": false,
+                "dashboard_approval": "deprecated",
+                "memory_ops": memory_ops_policy,
+                "skills": skills_policy,
+            },
         },
     });
     if json {
@@ -884,6 +905,7 @@ fn print_automation_config(
         println!("timeout_secs: {}", effective.timeout_secs);
         println!("scheduler_tick_secs: {}", effective.scheduler_tick_secs);
         println!("memory_curator: {}", effective.tasks.memory_curator.enabled);
+        println!("effective_apply_policy: autonomous");
         if explain {
             println!(
                 "session_reflector: {}",
@@ -893,6 +915,10 @@ fn print_automation_config(
             println!("auto_apply_memory_ops: {}", effective.auto_apply_memory_ops);
             println!("auto_enable_skills: {}", effective.auto_enable_skills);
             println!("export_memory_digest: {}", effective.export_memory_digest);
+            println!("apply_policy.human_approval_required: false");
+            println!("apply_policy.dashboard_approval: deprecated");
+            println!("apply_policy.memory_ops: {memory_ops_policy}");
+            println!("apply_policy.skills: {skills_policy}");
         }
     }
     Ok(())

--- a/tests/automation_runner_test/backend.rs
+++ b/tests/automation_runner_test/backend.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(target_os = "linux")]
 use std::thread;
 use std::time::Duration;
@@ -10,10 +11,12 @@ use tempfile::TempDir;
 
 use tracedecay::automation::backend::{
     AgentTaskBackend, AgentTaskFailureClass, AgentTaskKind, AgentTaskRequest, AgentTaskResponse,
-    CodexAppServerBackend, agent_task_failure_disposition, backend_availability,
-    classify_agent_task_error_message, extract_json_object_prefix,
+    BackendRetryPolicy, CodexAppServerBackend, agent_task_failure_disposition,
+    backend_availability, classify_agent_task_error_message, extract_json_object_prefix,
+    run_agent_task_with_retry,
 };
 use tracedecay::automation::config::{AutomationBackend, AutomationConfig};
+use tracedecay::errors::TraceDecayError;
 use tracedecay::sessions::codex_app_server::{
     CodexAppServerSummaryConfig, run_prompt_with_codex_app_server,
 };
@@ -792,4 +795,147 @@ fn windows_python_launcher_prefers_setup_python_and_preserves_exit_status() {
     assert!(launcher.contains("%pythonLocation%\\python.exe"));
     assert!(launcher.contains("exit /b %ERRORLEVEL%"));
     assert!(!launcher.contains("if not errorlevel 1 exit /b 0"));
+}
+
+/// Backend fake whose first `fail_until` invocations fail with a fixed error
+/// message, then every later invocation succeeds. Counts total invocations so
+/// tests can assert exactly how many attempts the retry helper made.
+struct FlakyBackend {
+    calls: AtomicUsize,
+    fail_until: usize,
+    fail_message: &'static str,
+}
+
+impl FlakyBackend {
+    fn new(fail_until: usize, fail_message: &'static str) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            fail_until,
+            fail_message,
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl AgentTaskBackend for FlakyBackend {
+    fn run_task(
+        &self,
+        request: &AgentTaskRequest,
+    ) -> tracedecay::errors::Result<AgentTaskResponse> {
+        let attempt = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if attempt <= self.fail_until {
+            return Err(TraceDecayError::Config {
+                message: self.fail_message.to_string(),
+            });
+        }
+        Ok(AgentTaskResponse {
+            run_id: request.run_id.clone(),
+            task: request.task,
+            output_text: "recovered".to_string(),
+            output_json: None,
+            model: Some("test-model".to_string()),
+            input_tokens: None,
+            output_tokens: None,
+        })
+    }
+}
+
+fn retry_test_request() -> AgentTaskRequest {
+    AgentTaskRequest::new(
+        "run_retry".to_string(),
+        AgentTaskKind::MemoryCurator,
+        r#"{"ops":[]}"#.to_string(),
+        None,
+        json!({}),
+    )
+}
+
+/// Zero-backoff policy with a generous budget so retry logic can be exercised
+/// deterministically without real sleeps.
+fn instant_retry_policy(max_attempts: u32) -> BackendRetryPolicy {
+    BackendRetryPolicy::new(
+        max_attempts,
+        vec![Duration::ZERO, Duration::ZERO],
+        Duration::from_secs(120),
+    )
+}
+
+#[tokio::test]
+async fn retry_recovers_transient_backend_failure_on_second_attempt() {
+    let backend = FlakyBackend::new(1, "timed out waiting for codex app-server response");
+    let request = retry_test_request();
+
+    let response = run_agent_task_with_retry(&backend, &request, &instant_retry_policy(3))
+        .await
+        .expect("transient failure should be retried into a success");
+
+    assert_eq!(backend.calls(), 2, "should succeed on the second attempt");
+    assert_eq!(response.run_id, "run_retry");
+    assert_eq!(response.output_text, "recovered");
+}
+
+#[tokio::test]
+async fn retry_stops_after_exhausting_bounded_attempts() {
+    // Always-transient failure with a generous budget: the helper should make
+    // the first attempt plus two retries (3 total) then propagate the error.
+    let backend = FlakyBackend::new(usize::MAX, "closed stdout before completing");
+    let request = retry_test_request();
+
+    let err = run_agent_task_with_retry(&backend, &request, &instant_retry_policy(3))
+        .await
+        .expect_err("exhausted retries should propagate the final error");
+
+    assert_eq!(backend.calls(), 3, "first attempt plus two bounded retries");
+    assert!(
+        err.to_string().contains("closed stdout before completing"),
+        "final error should propagate unchanged: {err}"
+    );
+}
+
+#[tokio::test]
+async fn retry_does_not_retry_non_transient_backend_failure() {
+    let backend = FlakyBackend::new(
+        usize::MAX,
+        "model refused the request because policy rejected the prompt",
+    );
+    let request = retry_test_request();
+
+    let err = run_agent_task_with_retry(&backend, &request, &instant_retry_policy(3))
+        .await
+        .expect_err("permanent failure should not be retried");
+
+    assert_eq!(
+        classify_agent_task_error_message(&err.to_string()),
+        AgentTaskFailureClass::Permanent
+    );
+    assert_eq!(backend.calls(), 1, "non-transient failure must fail fast");
+}
+
+#[tokio::test]
+async fn retry_respects_job_timeout_budget() {
+    // Transient failure, but the configured backoff (10s) would exceed the tiny
+    // 1s budget, so no retry may be attempted.
+    let backend = FlakyBackend::new(
+        usize::MAX,
+        "timed out waiting for codex app-server response",
+    );
+    let request = retry_test_request();
+    let policy = BackendRetryPolicy::new(3, vec![Duration::from_secs(10)], Duration::from_secs(1));
+
+    let err = run_agent_task_with_retry(&backend, &request, &policy)
+        .await
+        .expect_err("budget-exhausted retry should propagate the failure");
+
+    assert_eq!(
+        backend.calls(),
+        1,
+        "retry must not exceed the overall job timeout budget"
+    );
+    assert!(
+        err.to_string()
+            .contains("timed out waiting for codex app-server")
+    );
 }

--- a/tests/automation_runner_test/combined_review.rs
+++ b/tests/automation_runner_test/combined_review.rs
@@ -316,7 +316,10 @@ async fn combined_review_records_noop_fallbacks_for_both_tasks_when_backend_fail
     let cg = init_project(temp.path()).await;
     seed_session_evidence(&cg).await;
     let _global_db = isolate_global_db(&cg);
-    let config = scheduler_config(Some(3600), None);
+    let config = AutomationConfig {
+        timeout_secs: 1,
+        ..scheduler_config(Some(3600), None)
+    };
     let backend = FailingBackend::new(AgentTaskKind::CombinedReview);
 
     let dispatch =
@@ -324,6 +327,9 @@ async fn combined_review_records_noop_fallbacks_for_both_tasks_when_backend_fail
             .await
             .unwrap();
 
+    // The backend failure is transient, but this test pins the noop-fallback
+    // record, not retry semantics (covered by backend.rs retry tests) —
+    // timeout_secs: 1 short-circuits the backoff so the test stays fast.
     assert_eq!(backend.calls(), 1);
     let CombinedReviewDispatch::Ran(run) = dispatch else {
         panic!("expected combined dispatch to record fallbacks, got {dispatch:?}");

--- a/tests/automation_runner_test/jobs.rs
+++ b/tests/automation_runner_test/jobs.rs
@@ -659,7 +659,10 @@ async fn user_job_backend_failure_records_failed_ledger_entry() {
     fs::create_dir_all(&profile_root).unwrap();
 
     let job = sample_job("fails");
-    let config = enabled_job_config();
+    let config = AutomationConfig {
+        timeout_secs: 1,
+        ..enabled_job_config()
+    };
     let backend = FailingBackend::new(AgentTaskKind::UserJob);
     let run = run_user_job_with_backend(
         &dashboard_root,
@@ -676,6 +679,9 @@ async fn user_job_backend_failure_records_failed_ledger_entry() {
     .await
     .unwrap();
 
+    // The backend failure is transient, but this test pins the failed-ledger
+    // record, not retry semantics (covered by backend.rs retry tests) —
+    // timeout_secs: 1 short-circuits the backoff so the test stays fast.
     assert_eq!(backend.calls(), 1);
     assert_eq!(run.report["status"], json!("failed"));
     assert_eq!(run.ledger_record.status, AutomationRunStatus::Failed);

--- a/tests/automation_runner_test/memory_curator.rs
+++ b/tests/automation_runner_test/memory_curator.rs
@@ -1044,6 +1044,7 @@ async fn memory_curator_runner_records_noop_fallback_when_backend_run_task_fails
         enabled: true,
         backend: AutomationBackend::CodexAppServer,
         host_mode: AutomationHostMode::Standalone,
+        timeout_secs: 1,
         tasks: AutomationTaskSet {
             memory_curator: AutomationTaskConfig {
                 enabled: true,
@@ -1069,6 +1070,9 @@ async fn memory_curator_runner_records_noop_fallback_when_backend_run_task_fails
     .await
     .unwrap();
 
+    // The backend failure is transient, but this test pins the noop-fallback
+    // record, not retry semantics (covered by backend.rs retry tests) —
+    // timeout_secs: 1 short-circuits the backoff so the test stays fast.
     assert_eq!(backend.calls(), 1);
     assert_noop_fallback_record(
         &run.ledger_record,

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -1114,6 +1114,7 @@ async fn session_reflector_runner_records_noop_fallback_when_backend_run_task_fa
         enabled: true,
         backend: AutomationBackend::CodexAppServer,
         host_mode: AutomationHostMode::Standalone,
+        timeout_secs: 1,
         tasks: AutomationTaskSet {
             session_reflector: AutomationTaskConfig {
                 enabled: true,
@@ -1141,6 +1142,9 @@ async fn session_reflector_runner_records_noop_fallback_when_backend_run_task_fa
     .await
     .unwrap();
 
+    // The backend failure is transient, but this test pins the noop-fallback
+    // record, not retry semantics (covered by backend.rs retry tests) —
+    // timeout_secs: 1 short-circuits the backoff so the test stays fast.
     assert_eq!(backend.calls(), 1);
     assert_noop_fallback_record(
         &run.ledger_record,

--- a/tests/automation_runner_test/skill_writer.rs
+++ b/tests/automation_runner_test/skill_writer.rs
@@ -926,7 +926,10 @@ async fn skill_writer_runner_records_noop_fallback_when_backend_run_task_fails()
     seed_session_evidence(&cg).await;
     let _global_db = isolate_global_db(&cg);
     let backend = FailingBackend::new(AgentTaskKind::SkillWriter);
-    let config = enabled_skill_writer_config();
+    let config = AutomationConfig {
+        timeout_secs: 1,
+        ..enabled_skill_writer_config()
+    };
 
     let run = run_skill_writer_with_backend(
         &cg,
@@ -937,6 +940,9 @@ async fn skill_writer_runner_records_noop_fallback_when_backend_run_task_fails()
     .await
     .unwrap();
 
+    // The backend failure is transient, but this test pins the noop-fallback
+    // record, not retry semantics (covered by backend.rs retry tests) —
+    // timeout_secs: 1 short-circuits the backoff so the test stays fast.
     assert_eq!(backend.calls(), 1);
     assert_noop_fallback_record(
         &run.ledger_record,


### PR DESCRIPTION
Bounded transient-only retry at the single backend boundary (evidence: 19/19 observed automation failures over 11 days were transient app-server errors), reusing existing retryable classifications and honoring the job timeout budget. Autonomy made explicit per user directive: effective_apply_policy surfaced in config get, the already-deprecated require_dashboard_approval documented as such, docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)