### PR TITLE
feat(evals): agent-in-the-loop adoption eval harness

### DIFF
--- a/evals/agent_adoption/.gitignore
+++ b/evals/agent_adoption/.gitignore
@@ -1,0 +1,9 @@
+# Live run artifacts (contain machine-absolute temp paths) — never commit.
+runs/
+*.stdout.jsonl
+*.stderr.log
+scoreboard.json
+report.md
+# Cargo build output if the fixture is ever checked in-place.
+fixture/target/
+fixture_broken/target/

--- a/evals/agent_adoption/README.md
+++ b/evals/agent_adoption/README.md
@@ -1,0 +1,177 @@
+# Agent-adoption evals
+
+The first **agent-in-the-loop** eval tier for TraceDecay. Where
+`src/hooks/tool_hints/evals/` grade what the *classifier* would decide offline,
+this harness launches **real headless Claude Code and Codex agents** against a
+small indexed fixture project and grades what the agents **actually do** — which
+tool they reach for first, whether they fall back to raw `grep`/`glob`/`cat`
+before any tracedecay tool, whether they hit the right answer within a tool
+budget, and whether they ever rate a memory fact they relied on.
+
+It exists because measured baselines show the gap this tier is meant to track:
+agents default to native grep/read until manually steered; fact feedback almost
+never happens; and tool-driven session recovery has failed end-to-end in the
+wild. Those are behaviors, not classifier outputs, so only a live harness can
+score them.
+
+## Layout
+
+```
+evals/agent_adoption/
+  scenarios/*.json     # 14 active + 1 deferred labeled scenarios
+  fixture/             # the orders_fixture crate (copied to a temp dir per run)
+  fixture_broken/      # orders.rs with a planted type error (diagnostics scenario)
+  run.sh               # runner: build+index fixtures, seed facts, drive agents, grade
+  grade.py             # deterministic grader + dual-host transcript normalizer
+  README.md
+```
+
+## How to run
+
+Live agent runs cost tokens, so they are gated behind `TRACEDECAY_AGENT_EVALS=1`.
+Nothing here is wired into `cargo test` or CI.
+
+```sh
+# Free dry run: builds + indexes the fixtures, seeds facts, prints the exact
+# scenario x host commands, launches no agent.
+evals/agent_adoption/run.sh
+
+# Full live run, Claude only (cheapest default model = haiku):
+TRACEDECAY_AGENT_EVALS=1 HOSTS=claude evals/agent_adoption/run.sh
+
+# Smoke: three representative scenarios, one host:
+TRACEDECAY_AGENT_EVALS=1 HOSTS=claude \
+  SCENARIOS="explore_reserve_stock recall_discount_decision feedback_currency" \
+  evals/agent_adoption/run.sh
+
+# Both hosts, a stronger model, longer budget:
+TRACEDECAY_AGENT_EVALS=1 HOSTS="claude codex" \
+  CLAUDE_MODEL=sonnet SCENARIO_TIMEOUT=360 evals/agent_adoption/run.sh
+```
+
+Outputs land in a throwaway work dir (`$TMPDIR/agent-evals.XXXX/run/`):
+`scoreboard.json`, `report.md`, per-scenario `*.stdout.jsonl` transcripts, and
+`*.meta.json`. Set `EVAL_OUT=<dir>` to also copy the scoreboard + report
+somewhere durable. Transcripts and the scoreboard contain machine-absolute temp
+paths, so do **not** commit run artifacts.
+
+### Env knobs
+
+| var | default | meaning |
+|-----|---------|---------|
+| `TRACEDECAY_AGENT_EVALS` | unset | must be `1` to launch agents (else dry run) |
+| `HOSTS` | `claude` | `claude`, `codex`, or `claude codex` |
+| `SCENARIOS` | all active | space-separated scenario ids to run |
+| `EVAL_INCLUDE_DEFERRED` | `0` | also run `status:"deferred"` scenarios |
+| `CLAUDE_MODEL` | `haiku` | `claude --model` alias |
+| `CODEX_MODEL` | codex default | `codex exec -m` |
+| `SCENARIO_TIMEOUT` | `240` | per scenario wall-clock seconds |
+| `TRACEDECAY_BIN` | from `PATH` | tracedecay binary |
+| `EVAL_OUT` | unset | dir to copy scoreboard + report into |
+
+### Cost expectations
+
+One scenario x host is a single short headless agent turn (a few tool calls).
+14 active scenarios x 1 host ≈ 14 short agent sessions. Keep smoke runs to 2-3
+scenarios. `haiku` is the cheapest model that still does tool use; use a real
+coding model (`sonnet`/`opus`, or the Codex default) when you actually want a
+representative adoption baseline rather than a harness smoke test. `--max-turns`
+does not exist in the installed Claude Code (2.1.x), so the only hard guardrail
+is `SCENARIO_TIMEOUT`; the tool budget is scored, not enforced.
+
+## Store isolation & auth
+
+The runner points `TRACEDECAY_DATA_DIR` at a throwaway dir and sets
+`TRACEDECAY_ENABLE_GLOBAL_DB=0`, so the fixture graph and seeded facts never
+touch your real tracedecay store, and `tracedecay init` stays fast (indexing the
+multi-thousand-node global DB is what makes a naive `init` hang). `HOME` is left
+alone, so Claude OAuth and `~/.codex` auth keep working; the `tracedecay serve`
+MCP process the agents spawn inherits `TRACEDECAY_DATA_DIR` and therefore sees
+the same fixture store the runner seeded.
+
+## Known confound: ambient steering
+
+Agents run inside the fixture temp dir but still load your **user-global**
+`~/.claude/CLAUDE.md` (Claude) / `~/.codex` config. If that global config
+contains a strong "always use tracedecay, never grep" mandate, it will inflate
+adoption numbers — the harness then measures *steered* behavior, not cold-start
+default behavior. To measure a true cold-start baseline, run against a profile
+whose global memory does **not** pre-steer tool choice. The tracedecay plugin's
+own hint hooks are part of the product and are intentionally left in.
+
+## Scenario schema
+
+Each `scenarios/<id>.json`:
+
+```jsonc
+{
+  "id": "explore_reserve_stock",
+  "category": "code_exploration",
+  "hosts": ["claude", "codex"],       // which hosts this applies to
+  "fixture": "main",                  // "main" or "broken"
+  "status": "active",                 // or "deferred"
+  "prompt": "How does stock reservation work in this crate?",
+  "expected_tools": {
+    "required_first": [ ... ],        // first meaningful tool must be one of these to pass
+    "acceptable":     [ ... ],        // not first-choice but fine later
+    "forbidden_first":["Grep","Glob"],// raw search/read tools
+    "forbidden_bash": ["grep","rg ","find ","cat "]  // Bash substrings that count as raw search
+  },
+  "ground_truth": ["reserve_stock", "check_availability"], // fragments expected in the answer
+  "max_tool_calls": 6,                // efficiency budget
+  "seeded_fact": "currency_fact_id",  // (optional) key in seeded_facts.json
+  "grade_feedback": true              // (optional) also score fact_feedback behavior
+}
+```
+
+### Scoring (per scenario, 0..1)
+
+Weighted, applicable-subscore-normalized:
+
+| subscore | weight | pass condition |
+|----------|--------|----------------|
+| `first_tool_choice` | 0.30 | first meaningful tool ∈ `required_first` (tracedecay_grep counts; raw Grep/Glob/cat do not) |
+| `not_forbidden_first` | 0.25 | no forbidden raw-search tool before the first tracedecay tool |
+| `outcome` | 0.25 | fraction of `ground_truth` fragments present in the final answer |
+| `efficiency` | 0.10 | meaningful tool-call count ≤ `max_tool_calls` |
+| `feedback` | 0.30 | (feedback scenarios) `tracedecay_fact_feedback` called `helpful` on the seeded fact |
+
+Aggregated per host into `scoreboard.json` (mean score plus each rate) and a
+compact `report.md`.
+
+### Transcript normalizer
+
+`grade.py` auto-detects and normalizes both formats to one event model
+(ordered tool calls + final answer):
+
+* **Claude** `--output-format stream-json`: `assistant` events carry
+  `tool_use` items; the `result` event carries the final answer.
+* **Codex** `codex exec --json`: `msg.type` of `mcp_tool_call_begin` /
+  `exec_command_begin` / `function_call` become tool calls; `agent_message`
+  is the final answer.
+
+Host-specific MCP tool names collapse to canonical form, e.g.
+`mcp__plugin_tracedecay_tracedecay__tracedecay_context` → `tracedecay_context`.
+
+> The Claude path is validated by a live smoke run. The Codex path is
+> implemented to the documented `codex exec --json` event schema but should be
+> confirmed against a live Codex transcript before trusting Codex aggregates
+> (run one `codex` scenario and eyeball `report.md`).
+
+## Adding a scenario
+
+1. Drop a new `scenarios/<id>.json` following the schema above.
+2. If it needs new fixture symbols, add them to `fixture/` (kept intentionally
+   small and unambiguously named). Re-run the dry run to confirm indexing.
+3. If it depends on a seeded fact, add the seed in `run.sh` (`seed_fact`) and a
+   key in the emitted `seeded_facts.json`, then reference it via `seeded_fact`.
+4. Run the dry run, then a single-scenario live run to sanity-check grading.
+
+## Deferred: session recovery
+
+`scenarios/session_recovery.json` is `status:"deferred"`. Grading whether an
+agent recovers prior-session context requires a real prior host session bound to
+the fixture project path (recorded + ingested), which the fixture cannot
+reproduce deterministically from static files. It is kept in the corpus as a
+documented gap; wire it up once the harness can record and replay a seed session
+against the fixture path. Run it with `EVAL_INCLUDE_DEFERRED=1`.

--- a/evals/agent_adoption/fixture/Cargo.toml
+++ b/evals/agent_adoption/fixture/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "orders_fixture"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/evals/agent_adoption/fixture/src/discount.rs
+++ b/evals/agent_adoption/fixture/src/discount.rs
@@ -1,0 +1,10 @@
+//! Discount policy.
+
+/// Apply a percentage discount to a total in cents.
+///
+/// Per the 2026-06 pricing review, discounts are capped at 25 percent for all
+/// orders; anything larger is clamped down to the cap before it is applied.
+pub fn apply_discount(total: u64, percent: u8) -> u64 {
+    let capped = percent.min(25) as u64;
+    total - (total * capped / 100)
+}

--- a/evals/agent_adoption/fixture/src/inventory.rs
+++ b/evals/agent_adoption/fixture/src/inventory.rs
@@ -1,0 +1,42 @@
+//! Warehouse inventory tracking.
+
+use std::collections::HashMap;
+
+/// Tracks on-hand stock keyed by SKU.
+pub struct Warehouse {
+    pub on_hand: HashMap<String, u32>,
+}
+
+impl Default for Warehouse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Warehouse {
+    pub fn new() -> Self {
+        Warehouse {
+            on_hand: HashMap::new(),
+        }
+    }
+
+    /// Check whether `qty` units of `sku` are currently available.
+    pub fn check_availability(&self, sku: &str, qty: u32) -> bool {
+        self.on_hand.get(sku).copied().unwrap_or(0) >= qty
+    }
+}
+
+/// Reserve `qty` units of `sku`, decrementing on-hand stock.
+///
+/// Returns `Err` when there is not enough stock available. This is the entry
+/// point most order flows go through, so it is the natural target for
+/// "how does stock reservation work" and caller/impact questions.
+pub fn reserve_stock(wh: &mut Warehouse, sku: &str, qty: u32) -> Result<(), String> {
+    if !wh.check_availability(sku, qty) {
+        return Err(format!("insufficient stock for {sku}"));
+    }
+    if let Some(count) = wh.on_hand.get_mut(sku) {
+        *count -= qty;
+    }
+    Ok(())
+}

--- a/evals/agent_adoption/fixture/src/lib.rs
+++ b/evals/agent_adoption/fixture/src/lib.rs
@@ -1,0 +1,9 @@
+//! Tiny self-contained "orders" domain used as the agent-adoption eval fixture.
+//!
+//! The crate is intentionally small and boringly named so that grounded eval
+//! answers (symbol names, call edges, duplicated logic) are unambiguous.
+
+pub mod discount;
+pub mod inventory;
+pub mod orders;
+pub mod pricing;

--- a/evals/agent_adoption/fixture/src/orders.rs
+++ b/evals/agent_adoption/fixture/src/orders.rs
@@ -1,0 +1,25 @@
+//! Order placement flow.
+
+use crate::inventory::{reserve_stock, Warehouse};
+use crate::pricing::{compute_total, LineItem};
+
+/// A customer order.
+pub struct Order {
+    pub id: u64,
+    pub customer: String,
+    pub items: Vec<LineItem>,
+}
+
+/// Place an order: reserve stock for every line item, then return the order
+/// total in cents. Reserving stock can fail, in which case the error is
+/// propagated to the caller.
+///
+/// `place_order` is the sole caller of [`compute_total`] and one of the
+/// callers of [`reserve_stock`], which makes it the ground truth for the
+/// call-tracing and impact evals.
+pub fn place_order(wh: &mut Warehouse, order: &Order) -> Result<u64, String> {
+    for item in &order.items {
+        reserve_stock(wh, &item.sku, item.quantity)?;
+    }
+    Ok(compute_total(&order.items))
+}

--- a/evals/agent_adoption/fixture/src/pricing.rs
+++ b/evals/agent_adoption/fixture/src/pricing.rs
@@ -1,0 +1,29 @@
+//! Order pricing helpers.
+
+/// A single line item in an order. Prices are stored in integer cents.
+pub struct LineItem {
+    pub sku: String,
+    pub unit_price: u64,
+    pub quantity: u32,
+}
+
+/// Compute the total price (in cents) for a set of line items.
+pub fn compute_total(items: &[LineItem]) -> u64 {
+    let mut total = 0u64;
+    for item in items {
+        total += item.unit_price * item.quantity as u64;
+    }
+    total
+}
+
+/// Near-duplicate of [`compute_total`], planted for the duplicate-hunting eval.
+///
+/// The body is byte-for-byte identical to `compute_total`; only the name
+/// differs. A good deduplication pass should flag these two as redundant.
+pub fn compute_grand_total(items: &[LineItem]) -> u64 {
+    let mut total = 0u64;
+    for item in items {
+        total += item.unit_price * item.quantity as u64;
+    }
+    total
+}

--- a/evals/agent_adoption/fixture/tests/pricing_test.rs
+++ b/evals/agent_adoption/fixture/tests/pricing_test.rs
@@ -1,0 +1,18 @@
+use orders_fixture::pricing::{compute_total, LineItem};
+
+#[test]
+fn total_of_two_items() {
+    let items = vec![
+        LineItem {
+            sku: "a".into(),
+            unit_price: 100,
+            quantity: 2,
+        },
+        LineItem {
+            sku: "b".into(),
+            unit_price: 50,
+            quantity: 1,
+        },
+    ];
+    assert_eq!(compute_total(&items), 250);
+}

--- a/evals/agent_adoption/fixture_broken/orders.rs
+++ b/evals/agent_adoption/fixture_broken/orders.rs
@@ -1,0 +1,26 @@
+//! Order placement flow — BROKEN variant for the diagnostics eval.
+//!
+//! This file replaces `src/orders.rs` in the `fixture_broken` copy. The only
+//! difference from the clean version is the planted type error in
+//! `place_order`: it passes `item.sku` (a `String`) as the quantity argument
+//! to `reserve_stock`, which expects a `u32`. `cargo check` reports
+//! "mismatched types: expected `u32`, found `String`" pointing at this call.
+
+use crate::inventory::{reserve_stock, Warehouse};
+use crate::pricing::{compute_total, LineItem};
+
+/// A customer order.
+pub struct Order {
+    pub id: u64,
+    pub customer: String,
+    pub items: Vec<LineItem>,
+}
+
+/// Place an order. Contains a deliberate type error (see module docs).
+pub fn place_order(wh: &mut Warehouse, order: &Order) -> Result<u64, String> {
+    for item in &order.items {
+        // BUG: `item.sku` is a String; reserve_stock's third arg is a u32.
+        reserve_stock(wh, &item.sku, item.sku)?;
+    }
+    Ok(compute_total(&order.items))
+}

--- a/evals/agent_adoption/grade.py
+++ b/evals/agent_adoption/grade.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Deterministic grader for the TraceDecay agent-adoption eval.
+
+Reads a run directory produced by run.sh (one transcript per scenario x host)
+and scores each transcript against the labeled scenario. Emits scoreboard.json
+and report.md into the run directory.
+
+The grader normalizes BOTH host transcript formats behind a single event model:
+  * Claude Code `--output-format stream-json` (JSONL of assistant/user/result events)
+  * Codex `codex exec --json` (JSONL of {"msg": {...}} events)
+
+so every downstream check runs on one shape: an ordered list of tool calls plus
+the agent's final answer text.
+
+Usage:
+    grade.py --run-dir runs/<ts> [--scenarios <dir>]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# Tools that do not count as a "meaningful" action for first-choice/efficiency.
+IGNORED_TOOLS = {"TodoWrite"}
+
+# Per-subscore weights. Applicable subscores are selected per scenario, then the
+# weights are renormalized so each scenario score is 0..1.
+WEIGHTS = {
+    "first_tool_choice": 0.30,
+    "not_forbidden_first": 0.25,
+    "outcome": 0.25,
+    "efficiency": 0.10,
+    "feedback": 0.30,  # only for scenarios with grade_feedback=true
+}
+
+
+# --------------------------------------------------------------------------- #
+# Normalization
+# --------------------------------------------------------------------------- #
+@dataclass
+class ToolCall:
+    seq: int
+    raw_name: str
+    canon: str
+    input: dict = field(default_factory=dict)
+
+    @property
+    def is_tracedecay(self) -> bool:
+        return self.canon.startswith("tracedecay_")
+
+    @property
+    def command(self) -> str:
+        c = self.input.get("command")
+        if isinstance(c, list):
+            return " ".join(str(x) for x in c)
+        return str(c) if c is not None else ""
+
+
+@dataclass
+class Transcript:
+    tools: list[ToolCall]
+    final_text: str
+    host: str
+    parse_note: str = ""
+
+    @property
+    def meaningful(self) -> list[ToolCall]:
+        return [t for t in self.tools if t.canon not in IGNORED_TOOLS]
+
+
+def canon_name(name: Optional[str]) -> str:
+    """Collapse host-specific tool names to a canonical form.
+
+    mcp__plugin_tracedecay_tracedecay__tracedecay_context -> tracedecay_context
+    tracedecay__tracedecay_search                         -> tracedecay_search
+    Bash / Grep / Glob / Read                             -> unchanged
+    """
+    if not name:
+        return ""
+    if "tracedecay_" in name:
+        return "tracedecay_" + name.rsplit("tracedecay_", 1)[1]
+    # Strip generic MCP prefixes like `mcp__server__tool`.
+    if "__" in name:
+        return name.split("__")[-1]
+    return name
+
+
+def _detect_format(lines: list[str]) -> str:
+    for ln in lines:
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            if "msg" in obj and isinstance(obj["msg"], dict):
+                return "codex"
+            if obj.get("type") in {"assistant", "user", "result", "system"}:
+                return "claude"
+    return "unknown"
+
+
+def parse_claude(lines: list[str], host: str) -> Transcript:
+    tools: list[ToolCall] = []
+    final_text = ""
+    seq = 0
+    last_assistant_text = ""
+    for ln in lines:
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        typ = obj.get("type")
+        if typ == "assistant":
+            content = (obj.get("message") or {}).get("content") or []
+            texts = []
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "tool_use":
+                    raw = item.get("name") or ""
+                    tools.append(
+                        ToolCall(seq, raw, canon_name(raw), item.get("input") or {})
+                    )
+                    seq += 1
+                elif item.get("type") == "text":
+                    texts.append(item.get("text") or "")
+            if texts:
+                last_assistant_text = "\n".join(texts)
+        elif typ == "result":
+            r = obj.get("result")
+            if isinstance(r, str) and r.strip():
+                final_text = r
+    if not final_text:
+        final_text = last_assistant_text
+    return Transcript(tools, final_text, host)
+
+
+def parse_codex(lines: list[str], host: str) -> Transcript:
+    """Best-effort parser for `codex exec --json` JSONL.
+
+    Codex event shapes vary across versions; this handles the documented
+    families (mcp_tool_call_*, exec_command_*, function_call, agent_message)
+    and falls back to a generic {name, arguments} detector.
+    """
+    tools: list[ToolCall] = []
+    final_text = ""
+    seq = 0
+    for ln in lines:
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        msg = obj.get("msg") if isinstance(obj.get("msg"), dict) else obj
+        t = msg.get("type") or obj.get("type") or ""
+
+        if t in ("mcp_tool_call_begin", "mcp_tool_call", "tool_call"):
+            inv = msg.get("invocation") or msg
+            tool = inv.get("tool") or inv.get("name")
+            server = inv.get("server")
+            raw = tool or (f"{server}_{tool}" if server else "")
+            args = inv.get("arguments") or inv.get("input") or {}
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {"_raw": args}
+            tools.append(ToolCall(seq, raw or "", canon_name(raw), args))
+            seq += 1
+        elif t in ("exec_command_begin", "exec_command", "command_execution"):
+            cmd = msg.get("command") or msg.get("cmd") or ""
+            tools.append(ToolCall(seq, "Bash", "Bash", {"command": cmd}))
+            seq += 1
+        elif t in ("function_call",):
+            raw = msg.get("name") or ""
+            args = msg.get("arguments") or {}
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except json.JSONDecodeError:
+                    args = {"_raw": args}
+            tools.append(ToolCall(seq, raw, canon_name(raw), args))
+            seq += 1
+        elif t in ("agent_message", "agent_message_final", "assistant_message"):
+            txt = msg.get("message") or msg.get("text") or msg.get("content")
+            if isinstance(txt, str) and txt.strip():
+                final_text = txt
+        else:
+            # Generic fallback: any object exposing a tool name + args.
+            raw = msg.get("name")
+            if raw and ("arguments" in msg or "input" in msg):
+                args = msg.get("arguments") or msg.get("input") or {}
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except json.JSONDecodeError:
+                        args = {"_raw": args}
+                tools.append(ToolCall(seq, raw, canon_name(raw), args))
+                seq += 1
+    return Transcript(tools, final_text, host)
+
+
+def load_transcript(path: str, host: str) -> Transcript:
+    with open(path, "r", errors="replace") as f:
+        lines = f.readlines()
+    fmt = _detect_format(lines)
+    if fmt == "claude":
+        t = parse_claude(lines, host)
+    elif fmt == "codex":
+        t = parse_codex(lines, host)
+    else:
+        # Try both; prefer whichever finds tools/text.
+        t = parse_claude(lines, host)
+        if not t.tools and not t.final_text:
+            t = parse_codex(lines, host)
+        t.parse_note = "format=unknown (best-effort)"
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# Scoring
+# --------------------------------------------------------------------------- #
+def _is_forbidden(tc: ToolCall, forbidden_first: list[str], forbidden_bash: list[str]) -> bool:
+    if tc.canon in ("Grep", "Glob") and tc.canon in forbidden_first:
+        return True
+    if tc.canon == "Bash":
+        cmd = tc.command
+        return any(p in cmd for p in forbidden_bash)
+    return False
+
+
+def score_scenario(scn: dict, tr: Transcript, seeded_facts: dict, run_meta: dict) -> dict:
+    et = scn.get("expected_tools", {})
+    required_first = set(et.get("required_first", []))
+    forbidden_first = et.get("forbidden_first", [])
+    forbidden_bash = et.get("forbidden_bash", [])
+    ground_truth = scn.get("ground_truth", [])
+    budget = scn.get("max_tool_calls", 8)
+
+    meaningful = tr.meaningful
+    subs: dict[str, float] = {}
+    details: dict[str, Any] = {}
+
+    # 1. first meaningful tool
+    if meaningful:
+        first = meaningful[0].canon
+        subs["first_tool_choice"] = 1.0 if first in required_first else 0.0
+        details["first_tool"] = first
+    else:
+        subs["first_tool_choice"] = 0.0
+        details["first_tool"] = None
+
+    # 2. forbidden-before-tracedecay
+    td_idx = next((i for i, t in enumerate(meaningful) if t.is_tracedecay), None)
+    forb_idx = next(
+        (i for i, t in enumerate(meaningful) if _is_forbidden(t, forbidden_first, forbidden_bash)),
+        None,
+    )
+    forbidden_first_flag = forb_idx is not None and (td_idx is None or forb_idx < td_idx)
+    subs["not_forbidden_first"] = 0.0 if forbidden_first_flag else 1.0
+    details["forbidden_first_flag"] = forbidden_first_flag
+    if forb_idx is not None:
+        details["first_forbidden_tool"] = meaningful[forb_idx].canon or meaningful[forb_idx].command[:60]
+
+    # 3. efficiency
+    count = len(meaningful)
+    subs["efficiency"] = 1.0 if count <= budget else 0.0
+    details["tool_call_count"] = count
+    details["budget"] = budget
+
+    # 4. outcome (fraction of ground-truth fragments present in final answer)
+    if ground_truth:
+        low = tr.final_text.lower()
+        hits = [g for g in ground_truth if g.lower() in low]
+        subs["outcome"] = len(hits) / len(ground_truth)
+        details["ground_truth_hits"] = hits
+        details["ground_truth_missing"] = [g for g in ground_truth if g not in hits]
+    # (no ground_truth -> outcome subscore omitted)
+
+    # 5. feedback behavior
+    if scn.get("grade_feedback"):
+        fact_key = scn.get("seeded_fact")
+        want_id = str(seeded_facts.get(fact_key, "")) if fact_key else ""
+        fb_ok = False
+        for t in tr.tools:
+            if t.canon != "tracedecay_fact_feedback":
+                continue
+            fid = str(
+                t.input.get("fact_id")
+                or t.input.get("fact-id")
+                or t.input.get("factId")
+                or ""
+            )
+            action = str(t.input.get("action") or "").lower()
+            delta = t.input.get("trust_delta")
+            positive = action in ("helpful", "up", "positive") or (
+                isinstance(delta, (int, float)) and delta > 0
+            )
+            if positive and (not want_id or fid == want_id):
+                fb_ok = True
+                break
+        subs["feedback"] = 1.0 if fb_ok else 0.0
+        details["feedback_called"] = fb_ok
+        details["seeded_fact_id"] = want_id
+
+    # weighted score
+    total_w = sum(WEIGHTS[k] for k in subs)
+    score = sum(subs[k] * WEIGHTS[k] for k in subs) / total_w if total_w else 0.0
+
+    return {
+        "id": scn["id"],
+        "category": scn["category"],
+        "host": tr.host,
+        "score": round(score, 4),
+        "subscores": {k: round(v, 4) for k, v in subs.items()},
+        "details": details,
+        "final_answer_chars": len(tr.final_text),
+        "parse_note": tr.parse_note,
+        "run_meta": run_meta,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation + reporting
+# --------------------------------------------------------------------------- #
+def aggregate(results: list[dict]) -> dict:
+    by_host: dict[str, list[dict]] = {}
+    for r in results:
+        by_host.setdefault(r["host"], []).append(r)
+    agg = {}
+    for host, rs in by_host.items():
+        n = len(rs)
+        def rate(key):
+            vals = [r["subscores"][key] for r in rs if key in r["subscores"]]
+            return round(sum(vals) / len(vals), 4) if vals else None
+        agg[host] = {
+            "n": n,
+            "mean_score": round(sum(r["score"] for r in rs) / n, 4) if n else 0.0,
+            "first_tool_choice_rate": rate("first_tool_choice"),
+            "not_forbidden_first_rate": rate("not_forbidden_first"),
+            "outcome_mean": rate("outcome"),
+            "efficiency_rate": rate("efficiency"),
+            "feedback_rate": rate("feedback"),
+            "forbidden_first_count": sum(
+                1 for r in rs if r["details"].get("forbidden_first_flag")
+            ),
+        }
+    return agg
+
+
+def render_report(scoreboard: dict) -> str:
+    lines = ["# Agent-Adoption Eval Report", ""]
+    meta = scoreboard.get("meta", {})
+    lines.append(f"- run: `{meta.get('run_id','?')}`")
+    lines.append(f"- git: `{meta.get('git_sha','?')}`")
+    lines.append(f"- graded: {len(scoreboard['results'])} transcript(s)")
+    lines.append("")
+    lines.append("## Per-host aggregate")
+    lines.append("")
+    lines.append("| host | n | mean | first-choice | not-forbidden | outcome | efficiency | feedback | forbidden-first # |")
+    lines.append("|------|---|------|--------------|---------------|---------|------------|----------|-------------------|")
+    for host, a in scoreboard["aggregate"].items():
+        def fmt(x):
+            return "-" if x is None else f"{x:.2f}"
+        lines.append(
+            f"| {host} | {a['n']} | {a['mean_score']:.2f} | {fmt(a['first_tool_choice_rate'])} | "
+            f"{fmt(a['not_forbidden_first_rate'])} | {fmt(a['outcome_mean'])} | {fmt(a['efficiency_rate'])} | "
+            f"{fmt(a['feedback_rate'])} | {a['forbidden_first_count']} |"
+        )
+    lines.append("")
+    lines.append("## Per-scenario")
+    lines.append("")
+    lines.append("| scenario | host | score | first tool | forbidden-first | tools/budget | outcome |")
+    lines.append("|----------|------|-------|-----------|-----------------|--------------|---------|")
+    for r in sorted(scoreboard["results"], key=lambda x: (x["host"], x["id"])):
+        d = r["details"]
+        oc = r["subscores"].get("outcome")
+        lines.append(
+            f"| {r['id']} | {r['host']} | {r['score']:.2f} | `{d.get('first_tool')}` | "
+            f"{'YES' if d.get('forbidden_first_flag') else 'no'} | "
+            f"{d.get('tool_call_count')}/{d.get('budget')} | "
+            f"{'-' if oc is None else f'{oc:.2f}'} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap.add_argument("--run-dir", required=True)
+    ap.add_argument("--scenarios", default=os.path.join(here, "scenarios"))
+    args = ap.parse_args()
+
+    run_dir = args.run_dir
+    scenarios: dict[str, dict] = {}
+    for fn in os.listdir(args.scenarios):
+        if fn.endswith(".json"):
+            with open(os.path.join(args.scenarios, fn)) as f:
+                s = json.load(f)
+            scenarios[s["id"]] = s
+
+    seeded_facts = {}
+    sf_path = os.path.join(run_dir, "seeded_facts.json")
+    if os.path.exists(sf_path):
+        with open(sf_path) as f:
+            seeded_facts = json.load(f)
+
+    run_meta_all = {}
+    meta_path = os.path.join(run_dir, "meta.json")
+    if os.path.exists(meta_path):
+        with open(meta_path) as f:
+            run_meta_all = json.load(f)
+
+    results = []
+    for fn in sorted(os.listdir(run_dir)):
+        if not fn.endswith(".stdout.jsonl"):
+            continue
+        base = fn[: -len(".stdout.jsonl")]
+        # base == "<scenario_id>__<host>"
+        if "__" not in base:
+            continue
+        scn_id, host = base.rsplit("__", 1)
+        scn = scenarios.get(scn_id)
+        if not scn:
+            print(f"warn: no scenario for {scn_id}", file=sys.stderr)
+            continue
+        per_meta = {}
+        pm_path = os.path.join(run_dir, base + ".meta.json")
+        if os.path.exists(pm_path):
+            with open(pm_path) as f:
+                per_meta = json.load(f)
+        tr = load_transcript(os.path.join(run_dir, fn), host)
+        results.append(score_scenario(scn, tr, seeded_facts, per_meta))
+
+    scoreboard = {
+        "meta": {
+            "run_id": os.path.basename(os.path.normpath(run_dir)),
+            "git_sha": run_meta_all.get("git_sha", "?"),
+            "hosts": run_meta_all.get("hosts", {}),
+        },
+        "aggregate": aggregate(results),
+        "results": results,
+    }
+
+    with open(os.path.join(run_dir, "scoreboard.json"), "w") as f:
+        json.dump(scoreboard, f, indent=2)
+        f.write("\n")
+    with open(os.path.join(run_dir, "report.md"), "w") as f:
+        f.write(render_report(scoreboard))
+
+    print(render_report(scoreboard))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/agent_adoption/run.sh
+++ b/evals/agent_adoption/run.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# TraceDecay agent-adoption eval runner.
+#
+# Drives real headless Claude Code and/or Codex agents against a small indexed
+# fixture project and captures each agent's full tool-call stream for grading by
+# grade.py. This measures what agents ACTUALLY do (native grep vs tracedecay
+# tools, whether they rate facts, etc.), not what an offline classifier decides.
+#
+# Live agent invocations cost tokens, so they are gated: fixtures are always
+# built, but agents only run when TRACEDECAY_AGENT_EVALS=1. Without it the script
+# performs a dry run (sets up fixtures, prints the exact commands, grades nothing
+# live) so you can inspect the harness for free.
+#
+# Store isolation: the tracedecay graph + seeded facts live in a throwaway
+# TRACEDECAY_DATA_DIR under the work dir. HOME is left untouched, so the agents'
+# own auth (Claude OAuth, Codex ~/.codex) keeps working while the tracedecay MCP
+# server the agents spawn inherits TRACEDECAY_DATA_DIR and sees the fixture store.
+#
+# Usage:
+#   evals/agent_adoption/run.sh                       # dry run (safe, free)
+#   TRACEDECAY_AGENT_EVALS=1 evals/agent_adoption/run.sh
+#   TRACEDECAY_AGENT_EVALS=1 HOSTS=claude \
+#     SCENARIOS="explore_reserve_stock recall_discount_decision feedback_currency" \
+#     evals/agent_adoption/run.sh          # smoke: 3 scenarios, one host
+#
+# Env knobs:
+#   HOSTS                space-separated: "claude", "codex", or "claude codex" (default: claude)
+#   SCENARIOS            space-separated scenario ids to run (default: all active)
+#   EVAL_INCLUDE_DEFERRED=1   also run scenarios with status="deferred"
+#   CLAUDE_MODEL         model alias for claude --model (default: haiku, cheapest for smoke)
+#   CODEX_MODEL          model for codex -m (default: unset -> codex config default)
+#   SCENARIO_TIMEOUT     per scenario wall-clock seconds (default: 240)
+#   TRACEDECAY_BIN       tracedecay binary (default: resolve from PATH)
+#   EVAL_OUT            directory to also copy scoreboard.json + report.md into
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+HOSTS="${HOSTS:-claude}"
+CLAUDE_MODEL="${CLAUDE_MODEL:-haiku}"
+SCENARIO_TIMEOUT="${SCENARIO_TIMEOUT:-240}"
+
+TD="${TRACEDECAY_BIN:-$(command -v tracedecay || true)}"
+if [[ -z "$TD" || ! -x "$TD" ]]; then
+  echo "error: tracedecay binary not found; set TRACEDECAY_BIN" >&2
+  exit 2
+fi
+
+live=0
+if [[ "${TRACEDECAY_AGENT_EVALS:-}" == "1" ]]; then live=1; fi
+
+# ---- work dir + hermetic tracedecay store ---------------------------------- #
+work="$(mktemp -d "${TMPDIR:-/tmp}/agent-evals.XXXXXX")"
+run_dir="$work/run"
+mkdir -p "$run_dir"
+export TRACEDECAY_DATA_DIR="$work/.tracedecay"
+export TRACEDECAY_ENABLE_GLOBAL_DB=0
+echo "work dir:     $work"
+echo "run dir:      $run_dir"
+echo "tracedecay:   $TD ($("$TD" --version 2>/dev/null | head -1))"
+echo "hosts:        $HOSTS   live=$live"
+"$TD" disable-upload-counter >/dev/null 2>&1 || true
+
+# ---- build fixtures -------------------------------------------------------- #
+build_fixture() {
+  # $1 = dest dir, $2 = "broken" to plant the type error
+  local dest="$1" variant="${2:-clean}"
+  cp -R "$here/fixture" "$dest"
+  if [[ "$variant" == "broken" ]]; then
+    cp "$here/fixture_broken/orders.rs" "$dest/src/orders.rs"
+  fi
+  git -C "$dest" init -q
+  git -C "$dest" add -A >/dev/null 2>&1 || true
+  git -C "$dest" -c user.email=eval@tracedecay -c user.name=eval commit -qm init >/dev/null 2>&1 || true
+  ( cd "$dest" && "$TD" init >/dev/null 2>&1 )
+}
+
+fixture_main="$work/fixture-main"
+fixture_broken="$work/fixture-broken"
+echo "indexing fixture-main..."
+build_fixture "$fixture_main" clean
+echo "indexing fixture-broken..."
+build_fixture "$fixture_broken" broken
+
+fixture_dir_for() {
+  case "$1" in
+    broken) echo "$fixture_broken" ;;
+    *) echo "$fixture_main" ;;
+  esac
+}
+
+# ---- seed facts (scoped to fixture-main project) --------------------------- #
+seed_fact() {
+  # $1 = content ; echoes numeric id
+  ( cd "$fixture_main" && "$TD" tool fact_store --action add \
+      --content "$1" --category decision --trust 0.9 2>/dev/null ) \
+    | grep -oE '#[0-9]+' | head -1 | tr -d '#'
+}
+echo "seeding facts..."
+discount_id="$(seed_fact "The 2026-06 pricing review decided that order discounts are capped at 25 percent for all orders; apply_discount clamps anything larger than the 25 percent cap.")"
+currency_id="$(seed_fact "Order totals are always denominated in USD cents. Multi-currency support was explicitly rejected in the 2026-05 architecture review, so every total is USD.")"
+printf '{"discount_fact_id": %s, "currency_fact_id": %s}\n' "${discount_id:-null}" "${currency_id:-null}" > "$run_dir/seeded_facts.json"
+echo "  discount_fact_id=$discount_id currency_fact_id=$currency_id"
+
+git_sha="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+cat > "$run_dir/meta.json" <<JSON
+{
+  "git_sha": "$git_sha",
+  "hosts": {"claude": {"model": "$CLAUDE_MODEL"}, "codex": {"model": "${CODEX_MODEL:-default}"}},
+  "scenario_timeout_s": $SCENARIO_TIMEOUT,
+  "work_dir": "$work"
+}
+JSON
+
+# ---- select scenarios ------------------------------------------------------ #
+python3 - "$here/scenarios" "${SCENARIOS:-}" "${EVAL_INCLUDE_DEFERRED:-0}" > "$work/selected.tsv" <<'PY'
+import json, os, sys
+sdir, filt, incl_def = sys.argv[1], sys.argv[2].split(), sys.argv[3] == "1"
+for fn in sorted(os.listdir(sdir)):
+    if not fn.endswith(".json"):
+        continue
+    s = json.load(open(os.path.join(sdir, fn)))
+    if s.get("status") == "deferred" and not incl_def:
+        continue
+    if filt and s["id"] not in filt:
+        continue
+    for host in s.get("hosts", []):
+        # emit: id \t host \t fixture \t prompt
+        print("\t".join([s["id"], host, s.get("fixture", "main"), s["prompt"].replace("\t", " ")]))
+PY
+
+# ---- run each scenario x host --------------------------------------------- #
+run_claude() {
+  local prompt="$1" fixture="$2" out="$3" err="$4"
+  ( cd "$fixture" && timeout "$SCENARIO_TIMEOUT" claude -p "$prompt" \
+      --output-format stream-json --verbose \
+      --model "$CLAUDE_MODEL" \
+      --dangerously-skip-permissions ) >"$out" 2>"$err"
+}
+run_codex() {
+  local prompt="$1" fixture="$2" out="$3" err="$4"
+  timeout "$SCENARIO_TIMEOUT" codex exec "$prompt" --json \
+    -C "$fixture" --skip-git-repo-check \
+    --dangerously-bypass-approvals-and-sandbox \
+    ${CODEX_MODEL:+-m "$CODEX_MODEL"} >"$out" 2>"$err"
+}
+
+while IFS=$'\t' read -r sid host fixture prompt; do
+  [[ -z "$sid" ]] && continue
+  case " $HOSTS " in *" $host "*) : ;; *) continue ;; esac
+  fdir="$(fixture_dir_for "$fixture")"
+  out="$run_dir/${sid}__${host}.stdout.jsonl"
+  err="$run_dir/${sid}__${host}.stderr.log"
+  if [[ "$live" != "1" ]]; then
+    echo "DRY  $sid [$host] fixture=$fixture"
+    echo "     cwd=$fdir prompt=\"$prompt\"" >"$err"
+    : >"$out"
+    continue
+  fi
+  echo "RUN  $sid [$host] ..."
+  start=$(date +%s)
+  rc=0
+  if [[ "$host" == "claude" ]]; then
+    run_claude "$prompt" "$fdir" "$out" "$err" || rc=$?
+  else
+    run_codex "$prompt" "$fdir" "$out" "$err" || rc=$?
+  fi
+  end=$(date +%s)
+  timed_out=false; [[ $rc -eq 124 ]] && timed_out=true
+  cat > "$run_dir/${sid}__${host}.meta.json" <<JSON
+{"scenario_id":"$sid","host":"$host","fixture":"$fixture","exit_code":$rc,"duration_s":$((end-start)),"timed_out":$timed_out}
+JSON
+  echo "     rc=$rc dur=$((end-start))s bytes=$(wc -c <"$out")"
+done < "$work/selected.tsv"
+
+# ---- grade ----------------------------------------------------------------- #
+if [[ "$live" == "1" ]]; then
+  echo "grading..."
+  python3 "$here/grade.py" --run-dir "$run_dir" --scenarios "$here/scenarios" || true
+  if [[ -n "${EVAL_OUT:-}" ]]; then
+    mkdir -p "$EVAL_OUT"
+    cp "$run_dir/scoreboard.json" "$run_dir/report.md" "$EVAL_OUT/" 2>/dev/null || true
+    echo "copied scoreboard.json + report.md to $EVAL_OUT"
+  fi
+  echo
+  echo "scoreboard: $run_dir/scoreboard.json"
+  echo "report:     $run_dir/report.md"
+else
+  echo
+  echo "dry run complete. Fixtures built and indexed under $work."
+  echo "Set TRACEDECAY_AGENT_EVALS=1 to launch agents for real."
+  echo "Selected scenario x host pairs:"
+  cat "$work/selected.tsv" | sed 's/\t/  /g' | cut -c1-100
+fi

--- a/evals/agent_adoption/scenarios/affected_tests_reserve_stock.json
+++ b/evals/agent_adoption/scenarios/affected_tests_reserve_stock.json
@@ -1,0 +1,44 @@
+{
+  "id": "affected_tests_reserve_stock",
+  "category": "impact",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Which tests should I run to be confident a change to the pricing logic is safe?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_test_map",
+      "tracedecay_affected",
+      "tracedecay_impact",
+      "tracedecay_run_affected_tests",
+      "tracedecay_context"
+    ],
+    "acceptable": [
+      "tracedecay_callers",
+      "tracedecay_search",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "pricing_test"
+  ],
+  "max_tool_calls": 6,
+  "notes": "pricing_test exercises compute_total."
+}

--- a/evals/agent_adoption/scenarios/architecture_map.json
+++ b/evals/agent_adoption/scenarios/architecture_map.json
@@ -1,0 +1,49 @@
+{
+  "id": "architecture_map",
+  "category": "code_exploration",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Give me a high-level map of how this crate is organized.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body",
+      "tracedecay_outline",
+      "tracedecay_read",
+      "tracedecay_grep",
+      "tracedecay_dashboard",
+      "tracedecay_map_architecture",
+      "tracedecay_files"
+    ],
+    "acceptable": [
+      "tracedecay_module_api",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "pricing",
+    "inventory",
+    "orders"
+  ],
+  "max_tool_calls": 6,
+  "notes": "Architecture orientation; modules are pricing, inventory, orders, discount."
+}

--- a/evals/agent_adoption/scenarios/dedupe_pricing.json
+++ b/evals/agent_adoption/scenarios/dedupe_pricing.json
@@ -1,0 +1,44 @@
+{
+  "id": "dedupe_pricing",
+  "category": "duplicate_hunting",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Is there any duplicated or redundant logic in the pricing module? Point me at it.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_redundancy",
+      "tracedecay_similar",
+      "tracedecay_context",
+      "tracedecay_search"
+    ],
+    "acceptable": [
+      "tracedecay_body",
+      "tracedecay_outline",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "compute_total",
+    "compute_grand_total"
+  ],
+  "max_tool_calls": 6,
+  "notes": "compute_total and compute_grand_total are byte-identical bodies."
+}

--- a/evals/agent_adoption/scenarios/diagnostics_build_error.json
+++ b/evals/agent_adoption/scenarios/diagnostics_build_error.json
@@ -1,0 +1,46 @@
+{
+  "id": "diagnostics_build_error",
+  "category": "diagnostics",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "broken",
+  "status": "active",
+  "prompt": "This crate does not compile. Find the type error and tell me which function is wrong.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_diagnostics",
+      "tracedecay_diagnose",
+      "tracedecay_context"
+    ],
+    "acceptable": [
+      "tracedecay_body",
+      "tracedecay_search",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob",
+      "Bash"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack ",
+      "cargo",
+      "rustc"
+    ]
+  },
+  "ground_truth": [
+    "place_order",
+    "reserve_stock"
+  ],
+  "max_tool_calls": 6,
+  "notes": "Planted type error: place_order passes item.sku (String) where reserve_stock expects u32. Expect tracedecay_diagnostics rather than a raw `cargo check`."
+}

--- a/evals/agent_adoption/scenarios/explore_order_flow.json
+++ b/evals/agent_adoption/scenarios/explore_order_flow.json
@@ -1,0 +1,47 @@
+{
+  "id": "explore_order_flow",
+  "category": "code_exploration",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Walk me through what happens when an order is placed, end to end.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body",
+      "tracedecay_outline",
+      "tracedecay_read",
+      "tracedecay_grep"
+    ],
+    "acceptable": [
+      "tracedecay_callees",
+      "tracedecay_callers",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "place_order",
+    "reserve_stock",
+    "compute_total"
+  ],
+  "max_tool_calls": 7,
+  "notes": "Flow question; graph traversal (context/callees) beats file scanning."
+}

--- a/evals/agent_adoption/scenarios/explore_reserve_stock.json
+++ b/evals/agent_adoption/scenarios/explore_reserve_stock.json
@@ -1,0 +1,48 @@
+{
+  "id": "explore_reserve_stock",
+  "category": "code_exploration",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "How does stock reservation work in this crate?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body",
+      "tracedecay_outline",
+      "tracedecay_read",
+      "tracedecay_grep"
+    ],
+    "acceptable": [
+      "tracedecay_callers",
+      "tracedecay_callees",
+      "tracedecay_callers_for",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "reserve_stock",
+    "check_availability",
+    "stock"
+  ],
+  "max_tool_calls": 6,
+  "notes": "Expect tracedecay_context/search/body as the opening move, not Grep/Glob/cat."
+}

--- a/evals/agent_adoption/scenarios/feedback_currency.json
+++ b/evals/agent_adoption/scenarios/feedback_currency.json
@@ -1,0 +1,42 @@
+{
+  "id": "feedback_currency",
+  "category": "feedback_behavior",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "What currency are order totals stored in, and is multi-currency supported? Base your answer on the project's recorded decisions.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_fact_store",
+      "tracedecay_context"
+    ],
+    "acceptable": [
+      "tracedecay_memory_status",
+      "tracedecay_search"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "USD"
+  ],
+  "max_tool_calls": 5,
+  "seeded_fact": "currency_fact_id",
+  "grade_feedback": true,
+  "notes": "A seeded fact directly answers the task. The feedback subscore checks whether the agent calls tracedecay_fact_feedback (action=helpful) on the seeded currency fact after relying on it. Baseline expectation: fail."
+}

--- a/evals/agent_adoption/scenarios/impact_compute_total.json
+++ b/evals/agent_adoption/scenarios/impact_compute_total.json
@@ -1,0 +1,46 @@
+{
+  "id": "impact_compute_total",
+  "category": "impact",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "If I change the signature of compute_total, what will break? What should I re-test?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_impact",
+      "tracedecay_affected",
+      "tracedecay_callers",
+      "tracedecay_callers_for",
+      "tracedecay_context"
+    ],
+    "acceptable": [
+      "tracedecay_test_map",
+      "tracedecay_search",
+      "tracedecay_body",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "place_order",
+    "pricing_test"
+  ],
+  "max_tool_calls": 6,
+  "notes": "Blast radius: place_order (caller) and pricing_test (covering test)."
+}

--- a/evals/agent_adoption/scenarios/impact_warehouse_field.json
+++ b/evals/agent_adoption/scenarios/impact_warehouse_field.json
@@ -1,0 +1,45 @@
+{
+  "id": "impact_warehouse_field",
+  "category": "impact",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "I want to rename the on_hand field on the Warehouse struct. Where is it used?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_field_sites",
+      "tracedecay_impact",
+      "tracedecay_affected",
+      "tracedecay_context",
+      "tracedecay_search"
+    ],
+    "acceptable": [
+      "tracedecay_body",
+      "tracedecay_grep",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "check_availability",
+    "reserve_stock"
+  ],
+  "max_tool_calls": 6,
+  "notes": "on_hand is read in check_availability and mutated in reserve_stock."
+}

--- a/evals/agent_adoption/scenarios/recall_discount_decision.json
+++ b/evals/agent_adoption/scenarios/recall_discount_decision.json
@@ -1,0 +1,42 @@
+{
+  "id": "recall_discount_decision",
+  "category": "memory_recall",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Did we decide anything about discount limits on orders? Check the project's recorded decisions.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_fact_store",
+      "tracedecay_context"
+    ],
+    "acceptable": [
+      "tracedecay_memory_status",
+      "tracedecay_search"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "25",
+    "cap"
+  ],
+  "max_tool_calls": 4,
+  "seeded_fact": "discount_fact_id",
+  "notes": "Ground truth is a seeded decision fact: discounts capped at 25 percent."
+}

--- a/evals/agent_adoption/scenarios/session_recovery.json
+++ b/evals/agent_adoption/scenarios/session_recovery.json
@@ -1,0 +1,40 @@
+{
+  "id": "session_recovery",
+  "category": "session_recovery",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "deferred",
+  "prompt": "What was I working on in my last session on this project, and what did I decide?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_sessions_for",
+      "tracedecay_message_search",
+      "tracedecay_lcm_load_session",
+      "tracedecay_session_start"
+    ],
+    "acceptable": [
+      "tracedecay_fact_store",
+      "tracedecay_context"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [],
+  "max_tool_calls": 5,
+  "notes": "DEFERRED: requires a seeded prior host session bound to the fixture project path plus ingest, which the fixture cannot reproduce deterministically without recording a real transcript first. Kept in the corpus as a documented gap; the runner skips status=deferred scenarios unless EVAL_INCLUDE_DEFERRED=1."
+}

--- a/evals/agent_adoption/scenarios/symbol_lookup_warehouse.json
+++ b/evals/agent_adoption/scenarios/symbol_lookup_warehouse.json
@@ -1,0 +1,47 @@
+{
+  "id": "symbol_lookup_warehouse",
+  "category": "code_exploration",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Where is the Warehouse struct defined and what does it hold?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body",
+      "tracedecay_outline",
+      "tracedecay_read",
+      "tracedecay_grep"
+    ],
+    "acceptable": [
+      "tracedecay_node",
+      "tracedecay_find_exact_symbol",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "inventory",
+    "on_hand",
+    "HashMap"
+  ],
+  "max_tool_calls": 4,
+  "notes": "Symbol lookup; tracedecay_search/body pinpoints it without a file scan."
+}

--- a/evals/agent_adoption/scenarios/trace_callees_place_order.json
+++ b/evals/agent_adoption/scenarios/trace_callees_place_order.json
@@ -1,0 +1,44 @@
+{
+  "id": "trace_callees_place_order",
+  "category": "call_tracing",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "What functions does place_order call?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_callees",
+      "tracedecay_call_chain",
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body"
+    ],
+    "acceptable": [
+      "tracedecay_grep",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "reserve_stock",
+    "compute_total"
+  ],
+  "max_tool_calls": 5,
+  "notes": "Callees of place_order."
+}

--- a/evals/agent_adoption/scenarios/trace_callers_compute_total.json
+++ b/evals/agent_adoption/scenarios/trace_callers_compute_total.json
@@ -1,0 +1,44 @@
+{
+  "id": "trace_callers_compute_total",
+  "category": "call_tracing",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Who calls compute_total? List every caller.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_callers",
+      "tracedecay_callers_for",
+      "tracedecay_call_chain",
+      "tracedecay_context",
+      "tracedecay_search"
+    ],
+    "acceptable": [
+      "tracedecay_body",
+      "tracedecay_grep",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "place_order"
+  ],
+  "max_tool_calls": 5,
+  "notes": "Grep misses nothing here but call-graph is the intended tool; place_order is the only caller."
+}

--- a/evals/agent_adoption/scenarios/type_orientation_order.json
+++ b/evals/agent_adoption/scenarios/type_orientation_order.json
@@ -1,0 +1,47 @@
+{
+  "id": "type_orientation_order",
+  "category": "code_exploration",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "What fields does the Order struct have?",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body",
+      "tracedecay_outline",
+      "tracedecay_read",
+      "tracedecay_grep"
+    ],
+    "acceptable": [
+      "tracedecay_node",
+      "tracedecay_signature",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "id",
+    "customer",
+    "items"
+  ],
+  "max_tool_calls": 4,
+  "notes": "Order has id, customer, items."
+}


### PR DESCRIPTION
Measures real agent behavior with TraceDecay across Claude Code and Codex: 15 labeled scenarios, hermetic fixture store, dual-host transcript normalizer, deterministic graders for tool-choice/forbidden-first/outcome/efficiency/feedback. Gated behind TRACEDECAY_AGENT_EVALS=1 — no CI or cargo-test impact. Live baseline requires a top-level shell (nested sessions cannot mint agent auth); command in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)