### PR TITLE
feat(hints): correlate hint outcomes and route acted/ignored telemetry

### DIFF
--- a/plugin/skills/assessing-impact/SKILL.md
+++ b/plugin/skills/assessing-impact/SKILL.md
@@ -29,6 +29,7 @@ Announce: "Using tracedecay:assessing-impact for <change>."
 | Which tests reach this symbol/file | `tracedecay_test_map` (empty result = no indexed path, strong-not-absolute evidence of untested) |
 | Which tests can see these changed files | `tracedecay_affected` (`files`) |
 | Where the next test is most needed | `tracedecay_test_risk` (`path?`, `limit?`) |
+| "What breaks if I change/touch this" | `tracedecay_impact` (`node_id`) for a symbol, `tracedecay_affected` (`files`) for changed files |
 
 ## Running the impacted tests
 

--- a/plugin/skills/exploring-code/SKILL.md
+++ b/plugin/skills/exploring-code/SKILL.md
@@ -24,6 +24,7 @@ row below, run it, and stop when the question is answered.
 | Half-remembered name | `tracedecay_similar` | guessing greps |
 | Code by shape (return type, params, async) | `tracedecay_signature_search` | reading modules |
 | Duplicate code / similar function bodies / repeated helper logic | `tracedecay_redundancy` (`path`, `min_lines`, `max_pairs`) | name-only search |
+| A trait/interface/class's full type hierarchy (implementors + extenders, recursively) | `tracedecay_type_hierarchy` | manually grepping `impl X for` / `extends X` |
 
 ## Read cheaply — stop at the first rung that answers
 

--- a/plugin/skills/using-tracedecay/SKILL.md
+++ b/plugin/skills/using-tracedecay/SKILL.md
@@ -48,6 +48,7 @@ errors or times out, the same tool runs as `tracedecay tool <name> --args '<json
 | User names another repo/project/workspace, sibling checkout, or cross-repo/cross-project context | `tracedecay_project_list` / `tracedecay_project_search` → `tracedecay_project_context`; pass `project_id`, `project_path`, or `project_selector` to `tracedecay_context`, `tracedecay_search`, and `tracedecay_message_search` |
 | "Who calls X" / "what does X call" / "trace this" | `tracedecay:tracing-functions` |
 | Wondering what breaks or which tests to run | `tracedecay:assessing-impact` |
+| Trait/interface/class type-hierarchy question (implementors, extenders, inheritance) | `tracedecay_type_hierarchy` — skill: `tracedecay:exploring-code` |
 | About to run `gh pr diff` / read a raw diff to review | `tracedecay_pr_context` / `tracedecay_diff_context` (offline, no gh needed) — `tracedecay:reviewing-changes` |
 | About to write a new helper, rename, or mass-edit | `tracedecay:editing-safely` |
 | Looking for duplicate code, similar function bodies, repeated helper logic, or consolidation targets | `tracedecay_redundancy` first for body/functionality matches; `tracedecay_similar` only for near-duplicate names — `tracedecay:code-health` / `tracedecay:editing-safely` |

--- a/src/dashboard/analytics_api.rs
+++ b/src/dashboard/analytics_api.rs
@@ -262,6 +262,75 @@ fn hint_summary_from_events(events: &[Value]) -> Value {
     })
 }
 
+#[derive(Default)]
+struct HintEfficacyCounts {
+    emitted: i64,
+    acted: i64,
+    ignored: i64,
+}
+
+/// Per-category hint efficacy from durable `hint_emitted` + `hint_outcome`
+/// events: how many hints were emitted, how many the model then acted on, how
+/// many it ignored, and how many remain unresolved (emitted with no outcome yet
+/// — the correlator's later-pass backlog). `unresolved` is derived so it stays
+/// non-negative even if the event sample is truncated mid-pair.
+fn hint_efficacy_from_events(events: &[Value]) -> Value {
+    let mut by_category: BTreeMap<String, HintEfficacyCounts> = BTreeMap::new();
+    let mut totals = HintEfficacyCounts::default();
+
+    for event in events {
+        let category = str_field(event, "hint_category");
+        if category.is_empty() {
+            continue;
+        }
+        let entry = by_category.entry(category.to_string()).or_default();
+        match str_field(event, "event_kind") {
+            "hint_emitted" => {
+                entry.emitted += 1;
+                totals.emitted += 1;
+            }
+            "hint_outcome" => match normalize(str_field(event, "outcome")).as_str() {
+                "acted" => {
+                    entry.acted += 1;
+                    totals.acted += 1;
+                }
+                "ignored" => {
+                    entry.ignored += 1;
+                    totals.ignored += 1;
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    let rows = by_category
+        .into_iter()
+        .map(|(category, counts)| {
+            let unresolved = (counts.emitted - counts.acted - counts.ignored).max(0);
+            json!({
+                "category": category,
+                "emitted": counts.emitted,
+                "acted": counts.acted,
+                "ignored": counts.ignored,
+                "unresolved": unresolved,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "available": !rows.is_empty(),
+        "source": "analytics_events",
+        "totals": {
+            "emitted": totals.emitted,
+            "acted": totals.acted,
+            "ignored": totals.ignored,
+            "unresolved": (totals.emitted - totals.acted - totals.ignored).max(0),
+        },
+        "by_category": rows,
+    })
+}
+
 async fn hint_summary(
     conn: Option<&libsql::Connection>,
     durable_events: Option<&[Value]>,
@@ -526,6 +595,12 @@ pub(crate) fn diagnostics_summary_from_parts(
             "by_outcome": [],
             "by_hook": hook_count_rows(hook_rows),
             "by_prompt_category": hook_prompt_category_rows(hook_rows),
+            "hint_efficacy": json!({
+                "available": false,
+                "source": "analytics_events_unavailable",
+                "totals": {"emitted": 0, "acted": 0, "ignored": 0, "unresolved": 0},
+                "by_category": [],
+            }),
             "recent_events": [],
             "recent_hooks": recent_hook_rows(hook_rows, 20),
         });
@@ -602,6 +677,7 @@ pub(crate) fn diagnostics_summary_from_parts(
         "by_outcome": count_rows("outcome", by_outcome),
         "by_hook": hook_count_rows(hook_rows),
         "by_prompt_category": hook_prompt_category_rows(hook_rows),
+        "hint_efficacy": hint_efficacy_from_events(events),
         "recent_events": recent_event_rows(events, 20),
         "recent_hooks": recent_hook_rows(hook_rows, 20),
     })
@@ -827,7 +903,55 @@ fn normalize(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{HookAnalyticsRows, read_hook_analytics_file};
+    use serde_json::json;
+
+    use super::{HookAnalyticsRows, hint_efficacy_from_events, read_hook_analytics_file};
+
+    #[test]
+    fn hint_efficacy_counts_emitted_acted_ignored_and_unresolved() {
+        let events = vec![
+            json!({"event_kind": "hint_emitted", "hint_category": "search"}),
+            json!({"event_kind": "hint_emitted", "hint_category": "search"}),
+            json!({"event_kind": "hint_emitted", "hint_category": "search"}),
+            json!({"event_kind": "hint_outcome", "hint_category": "search", "outcome": "acted"}),
+            json!({"event_kind": "hint_outcome", "hint_category": "search", "outcome": "ignored"}),
+            json!({"event_kind": "hint_emitted", "hint_category": "impact"}),
+            // Unrelated events must not affect hint efficacy.
+            json!({"event_kind": "mcp_tool_call", "tool_name": "tracedecay_context"}),
+        ];
+
+        let summary = hint_efficacy_from_events(&events);
+        assert_eq!(summary["available"], json!(true));
+        assert_eq!(summary["totals"]["emitted"], json!(4));
+        assert_eq!(summary["totals"]["acted"], json!(1));
+        assert_eq!(summary["totals"]["ignored"], json!(1));
+        // 4 emitted - 1 acted - 1 ignored = 2 still unresolved.
+        assert_eq!(summary["totals"]["unresolved"], json!(2));
+
+        let by_category = summary["by_category"].as_array().unwrap();
+        let search = by_category
+            .iter()
+            .find(|row| row["category"] == json!("search"))
+            .unwrap();
+        assert_eq!(search["emitted"], json!(3));
+        assert_eq!(search["acted"], json!(1));
+        assert_eq!(search["ignored"], json!(1));
+        assert_eq!(search["unresolved"], json!(1));
+
+        let impact = by_category
+            .iter()
+            .find(|row| row["category"] == json!("impact"))
+            .unwrap();
+        assert_eq!(impact["emitted"], json!(1));
+        assert_eq!(impact["unresolved"], json!(1));
+    }
+
+    #[test]
+    fn hint_efficacy_is_unavailable_without_hint_events() {
+        let summary = hint_efficacy_from_events(&[json!({"event_kind": "mcp_tool_call"})]);
+        assert_eq!(summary["available"], json!(false));
+        assert!(summary["by_category"].as_array().unwrap().is_empty());
+    }
 
     #[test]
     fn hook_analytics_sources_report_malformed_jsonl_rows() {

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -105,6 +105,19 @@ pub struct SessionToolUsageRow {
     pub metadata_json: String,
 }
 
+/// One ingested session message, projected to the fields the hint-outcome
+/// correlator needs: the timestamp/ordinal that order activity after a hint and
+/// the tool-activity carriers (`kind='tool_event'` + `tool_names` for Codex,
+/// `tool_names`/`metadata_json.tool_events` for Claude/Cursor).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionActivityRow {
+    pub timestamp: Option<i64>,
+    pub ordinal: i64,
+    pub kind: Option<String>,
+    pub tool_names: Option<String>,
+    pub metadata_json: Option<String>,
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct AnalyticsEventQuery {
     pub provider: Option<String>,
@@ -2496,6 +2509,55 @@ impl GlobalDb {
             .ok_or_else(|| "project session message count returned no row".to_string())?;
         row.get::<i64>(0)
             .map_err(|e| format!("failed to decode project session message count: {e}"))
+    }
+
+    /// Session messages for one provider session with `timestamp >= since_ts`,
+    /// ordered oldest-first, capped at `limit`. Powers the hint-outcome
+    /// correlator's bounded post-hint activity scan. Rows without a timestamp
+    /// are excluded because the correlator's horizon is time-anchored.
+    pub async fn session_messages_after(
+        &self,
+        provider: &str,
+        session_id: &str,
+        since_ts: i64,
+        limit: usize,
+    ) -> Result<Vec<SessionActivityRow>, String> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT timestamp, ordinal, kind, tool_names, metadata_json
+                 FROM session_messages
+                 WHERE provider = ?1 AND session_id = ?2
+                   AND timestamp IS NOT NULL AND timestamp >= ?3
+                 ORDER BY timestamp, ordinal
+                 LIMIT ?4",
+                params![
+                    provider,
+                    session_id,
+                    since_ts,
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
+            )
+            .await
+            .map_err(|e| format!("failed to query session messages after hint: {e}"))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read session messages after hint: {e}"))?
+        {
+            out.push(SessionActivityRow {
+                timestamp: row.get::<Option<i64>>(0).ok().flatten(),
+                ordinal: row.get::<i64>(1).unwrap_or_default(),
+                kind: row.get::<Option<String>>(2).ok().flatten(),
+                tool_names: row.get::<Option<String>>(3).ok().flatten(),
+                metadata_json: row.get::<Option<String>>(4).ok().flatten(),
+            });
+        }
+        Ok(out)
     }
 
     pub async fn query_analytics_events(

--- a/src/hooks/hint_outcomes.rs
+++ b/src/hooks/hint_outcomes.rs
@@ -1,0 +1,333 @@
+//! Post-hoc correlation of emitted tool hints with what the model actually did.
+//!
+//! Hooks record a `hint_emitted` analytics event (carrying a first-class
+//! `hint_id`, `hint_category`, `session_id`, and `hook_<agent>` provider) every
+//! time a soft hint surfaces. Whether the model *acted* on that hint is not
+//! known at emit time — it depends on which tools fire next. This module closes
+//! that loop after the fact: for each emitted hint that has not yet been
+//! resolved, it inspects the session's ingested [`session_messages`] activity
+//! *after* the hint timestamp and appends a new `hint_outcome` analytics event:
+//!
+//! * `acted`   — a tracedecay tool matching the hint's category fired inside the
+//!   bounded horizon after the hint.
+//! * `ignored` — the horizon closed (see below) with post-hint activity but no
+//!   matching tool.
+//! * *(unresolved)* — the session has no ingested tool activity after the hint
+//!   yet, so nothing is written and a later pass re-evaluates it.
+//!
+//! ## Horizon
+//!
+//! A hint is judged over the earlier of two bounds after its timestamp:
+//! [`HORIZON_TOOL_STEPS`] tool-activity steps or [`HORIZON_SECS`] of wall time.
+//! The window is treated as *closed* (making a no-match verdict `ignored`
+//! rather than unresolved) when any of these hold:
+//!   * a tool-activity step is observed beyond `hint_ts + HORIZON_SECS`
+//!     (activity ingested past the time horizon), or
+//!   * [`HORIZON_TOOL_STEPS`] steps were observed inside the window, or
+//!   * wall-clock `now` is already past `hint_ts + HORIZON_SECS` (the horizon
+//!     has elapsed in real time even if the session then went quiet).
+//!
+//! ## Idempotency
+//!
+//! Existing `hint_outcome` events are loaded first; any `hint_id` already
+//! carrying an outcome is skipped, so re-runs never double-write. Unresolved
+//! hints are intentionally left without an outcome event so a later sweep can
+//! resolve them once more activity is ingested.
+//!
+//! The `analytics_db` (where `hint_emitted`/`hint_outcome` rows live) and the
+//! `sessions_db` (where `session_messages` are ingested) may be the same handle
+//! or two distinct stores; the correlator only reads/writes through the two
+//! handles it is given.
+
+use std::collections::HashSet;
+
+use serde_json::{Value, json};
+
+use crate::global_db::{AnalyticsEventInsert, AnalyticsEventQuery, AnalyticsEventRecord, GlobalDb};
+
+use super::tool_hints::expected_tools_for_key;
+
+/// Wall-clock horizon after a hint within which a matching tool counts as
+/// "acted": 30 minutes.
+const HORIZON_SECS: i64 = 30 * 60;
+
+/// Tool-activity-step horizon after a hint: at most this many post-hint steps
+/// are inspected before the window closes.
+const HORIZON_TOOL_STEPS: usize = 25;
+
+/// Upper bound on session-message rows fetched per hint when scanning for
+/// post-hint tool activity. Comfortably exceeds [`HORIZON_TOOL_STEPS`] so the
+/// horizon — not this cap — decides the window.
+const SESSION_SCAN_LIMIT: usize = 256;
+
+/// Upper bound on emitted/outcome hint events pulled per correlation pass.
+const HINT_EVENT_LIMIT: usize = 5_000;
+
+/// Aggregate result of one correlation pass, for logging and tests.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HintOutcomeStats {
+    /// Emitted hints inspected this pass (excludes already-resolved ones).
+    pub scanned: usize,
+    /// Hints newly resolved as `acted`.
+    pub acted: usize,
+    /// Hints newly resolved as `ignored`.
+    pub ignored: usize,
+    /// Hints left unresolved (no ingested activity after the hint yet).
+    pub unresolved: usize,
+}
+
+impl HintOutcomeStats {
+    /// Total `hint_outcome` events written this pass.
+    pub fn written(self) -> usize {
+        self.acted + self.ignored
+    }
+}
+
+/// One post-hint tool-activity step: the timestamp it occurred at and the tool
+/// names it fired. A single ingested message can carry several tool calls.
+struct ToolStep {
+    ts: i64,
+    tools: Vec<String>,
+}
+
+/// Verdict for a single hint after inspecting its post-hint window.
+enum Resolution {
+    /// A matching tool fired; carries the matched tool name for the event.
+    Acted(String),
+    Ignored,
+}
+
+/// Correlates emitted hints for `project_id` with post-hint session activity and
+/// appends `hint_outcome` events. Reads hint events from (and writes outcomes
+/// to) `analytics_db`; reads session activity from `sessions_db`. Best-effort:
+/// query errors are swallowed and simply leave hints unresolved for a later
+/// pass.
+pub async fn correlate_hint_outcomes(
+    analytics_db: &GlobalDb,
+    sessions_db: &GlobalDb,
+    project_id: &str,
+    now_secs: i64,
+) -> HintOutcomeStats {
+    let mut stats = HintOutcomeStats::default();
+
+    // Hints that already carry an outcome: never re-resolve them.
+    let mut resolved = resolved_hint_ids(analytics_db, project_id).await;
+
+    let Ok(emitted) = analytics_db
+        .query_analytics_events(&AnalyticsEventQuery {
+            project_id: Some(project_id.to_string()),
+            event_kind: Some("hint_emitted".to_string()),
+            limit: HINT_EVENT_LIMIT,
+            ..Default::default()
+        })
+        .await
+    else {
+        return stats;
+    };
+
+    let mut pending: Vec<AnalyticsEventInsert> = Vec::new();
+    for event in &emitted {
+        let (Some(hint_id), Some(session_id), Some(category)) = (
+            non_empty(event.hint_id.as_deref()),
+            non_empty(event.session_id.as_deref()),
+            non_empty(event.hint_category.as_deref()),
+        ) else {
+            continue;
+        };
+        // Idempotency: skip anything already resolved, and guard against the
+        // same hint_id appearing twice within this batch.
+        if resolved.contains(hint_id) {
+            continue;
+        }
+        let Some(expected) = expected_tools_for_key(category) else {
+            continue;
+        };
+
+        stats.scanned += 1;
+        resolved.insert(hint_id.to_string());
+
+        let provider = session_provider(&event.provider);
+        let steps = match sessions_db
+            .session_messages_after(provider, session_id, event.timestamp, SESSION_SCAN_LIMIT)
+            .await
+        {
+            Ok(rows) => tool_steps(&rows),
+            Err(_) => Vec::new(),
+        };
+
+        match resolve(event.timestamp, &steps, expected, now_secs) {
+            Some(resolution) => {
+                let (outcome, tool_name) = match resolution {
+                    Resolution::Acted(tool) => {
+                        stats.acted += 1;
+                        ("acted", Some(tool))
+                    }
+                    Resolution::Ignored => {
+                        stats.ignored += 1;
+                        ("ignored", None)
+                    }
+                };
+                pending.push(outcome_event(event, outcome, tool_name, now_secs));
+            }
+            None => stats.unresolved += 1,
+        }
+    }
+
+    if !pending.is_empty() {
+        let _ = analytics_db.append_analytics_events(&pending).await;
+    }
+    stats
+}
+
+/// Loads the set of `hint_id`s that already carry a `hint_outcome` event for
+/// this project so resolved hints are never rewritten.
+async fn resolved_hint_ids(analytics_db: &GlobalDb, project_id: &str) -> HashSet<String> {
+    let outcomes = analytics_db
+        .query_analytics_events(&AnalyticsEventQuery {
+            project_id: Some(project_id.to_string()),
+            event_kind: Some("hint_outcome".to_string()),
+            limit: HINT_EVENT_LIMIT,
+            ..Default::default()
+        })
+        .await
+        .unwrap_or_default();
+    outcomes
+        .into_iter()
+        .filter_map(|event| event.hint_id)
+        .filter(|id| !id.is_empty())
+        .collect()
+}
+
+/// Maps a hint event's `hook_<agent>` provider to the session-store provider
+/// (`claude`, `codex`, `cursor`, `kiro`) that ingested messages carry.
+fn session_provider(hint_provider: &str) -> &str {
+    hint_provider.strip_prefix("hook_").unwrap_or(hint_provider)
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.filter(|text| !text.is_empty())
+}
+
+/// Projects ingested session rows into ordered tool-activity steps, dropping
+/// rows that fired no tools.
+fn tool_steps(rows: &[crate::global_db::SessionActivityRow]) -> Vec<ToolStep> {
+    let mut steps = Vec::new();
+    for row in rows {
+        let Some(ts) = row.timestamp else {
+            continue;
+        };
+        let tools = row_tools(row);
+        if !tools.is_empty() {
+            steps.push(ToolStep { ts, tools });
+        }
+    }
+    steps
+}
+
+/// Collects tool names a single ingested message fired: the `tool_names`
+/// column (Codex `tool_event` rows and Claude/Cursor message rows both populate
+/// it) plus any `metadata_json.tool_events[].tool_name` entries.
+fn row_tools(row: &crate::global_db::SessionActivityRow) -> Vec<String> {
+    let mut tools = Vec::new();
+    if let Some(names) = &row.tool_names {
+        tools.extend(crate::analytics::split_tool_names(names));
+    }
+    if let Some(metadata) = &row.metadata_json {
+        if let Ok(value) = serde_json::from_str::<Value>(metadata) {
+            if let Some(events) = value.get("tool_events").and_then(Value::as_array) {
+                for event in events {
+                    if let Some(name) = event.get("tool_name").and_then(Value::as_str) {
+                        if !name.is_empty() {
+                            tools.push(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    tools
+}
+
+/// Applies the horizon rules to a hint's post-hint tool steps. Returns `None`
+/// when the window is still open (unresolved) so a later pass can retry.
+fn resolve(
+    hint_ts: i64,
+    steps: &[ToolStep],
+    expected: &[&str],
+    now_secs: i64,
+) -> Option<Resolution> {
+    if steps.is_empty() {
+        return None;
+    }
+
+    let time_horizon = hint_ts.saturating_add(HORIZON_SECS);
+    let mut considered = 0usize;
+    let mut activity_beyond_horizon = false;
+    for step in steps {
+        if step.ts > time_horizon {
+            activity_beyond_horizon = true;
+            break;
+        }
+        if considered >= HORIZON_TOOL_STEPS {
+            break;
+        }
+        considered += 1;
+        for tool in &step.tools {
+            if tool_matches_expected(tool, expected) {
+                return Some(Resolution::Acted(tool.clone()));
+            }
+        }
+    }
+
+    let step_horizon_full = considered >= HORIZON_TOOL_STEPS;
+    let time_horizon_elapsed = activity_beyond_horizon || now_secs >= time_horizon;
+    if step_horizon_full || time_horizon_elapsed {
+        Some(Resolution::Ignored)
+    } else {
+        None
+    }
+}
+
+/// True when a fired tool name satisfies one of a category's expected tools,
+/// tolerating MCP prefixes (`mcp__tracedecay__…`, plugin-namespaced variants)
+/// and hyphen/underscore/case differences. The `_`-boundary check avoids
+/// matching an unrelated tool that merely ends with the same letters.
+fn tool_matches_expected(fired: &str, expected: &[&str]) -> bool {
+    let normalized = fired.trim().to_ascii_lowercase().replace('-', "_");
+    expected
+        .iter()
+        .any(|tool| normalized == *tool || normalized.ends_with(&format!("_{tool}")))
+}
+
+fn outcome_event(
+    emitted: &AnalyticsEventRecord,
+    outcome: &str,
+    tool_name: Option<String>,
+    now_secs: i64,
+) -> AnalyticsEventInsert {
+    AnalyticsEventInsert {
+        provider: emitted.provider.clone(),
+        project_id: emitted.project_id.clone(),
+        session_id: emitted.session_id.clone(),
+        timestamp: now_secs,
+        event_kind: "hint_outcome".to_string(),
+        hook_name: None,
+        tool_name,
+        tool_category: None,
+        skill_name: None,
+        hint_category: emitted.hint_category.clone(),
+        hint_id: emitted.hint_id.clone(),
+        outcome: Some(outcome.to_string()),
+        metadata_json: Some(
+            json!({
+                "source": "hint_outcome_correlator",
+                "hint_ts": emitted.timestamp,
+            })
+            .to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests;

--- a/src/hooks/hint_outcomes/tests.rs
+++ b/src/hooks/hint_outcomes/tests.rs
@@ -1,0 +1,356 @@
+use tempfile::TempDir;
+
+use crate::global_db::{AnalyticsEventInsert, AnalyticsEventQuery, GlobalDb};
+use crate::sessions::{SessionMessageRecord, SessionRecord};
+
+use super::{
+    HORIZON_TOOL_STEPS, HintOutcomeStats, Resolution, ToolStep, correlate_hint_outcomes, resolve,
+    tool_matches_expected,
+};
+
+const PROJECT: &str = "proj_hint_outcomes";
+const HINT_TS: i64 = 1_000_000;
+
+async fn open_db(dir: &TempDir) -> GlobalDb {
+    GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .expect("open global db")
+}
+
+async fn seed_session(db: &GlobalDb, provider: &str, session_id: &str) {
+    let ok = db
+        .upsert_session(&SessionRecord {
+            provider: provider.to_string(),
+            session_id: session_id.to_string(),
+            project_key: PROJECT.to_string(),
+            project_path: "/tmp/proj".to_string(),
+            title: None,
+            started_at: Some(HINT_TS),
+            ended_at: None,
+            transcript_path: None,
+            metadata_json: None,
+            parent_session_id: None,
+            is_subagent: false,
+            agent_id: None,
+            parent_tool_use_id: None,
+        })
+        .await;
+    assert!(ok, "session should upsert");
+}
+
+/// Builder for a seeded post-hint session message, keeping the seed helper to a
+/// single struct argument (clippy `too_many_arguments`) while staying readable.
+#[derive(Clone, Copy)]
+struct Msg<'a> {
+    provider: &'a str,
+    session_id: &'a str,
+    ordinal: i64,
+    ts: i64,
+    kind: Option<&'a str>,
+    tool_names: Option<&'a str>,
+    metadata_json: Option<&'a str>,
+}
+
+impl<'a> Msg<'a> {
+    fn new(provider: &'a str, session_id: &'a str, ts: i64) -> Self {
+        Self {
+            provider,
+            session_id,
+            ordinal: 1,
+            ts,
+            kind: None,
+            tool_names: None,
+            metadata_json: None,
+        }
+    }
+
+    fn tools(mut self, names: &'a str) -> Self {
+        self.tool_names = Some(names);
+        self
+    }
+
+    fn kind(mut self, kind: &'a str) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    fn metadata(mut self, metadata_json: &'a str) -> Self {
+        self.metadata_json = Some(metadata_json);
+        self
+    }
+}
+
+async fn seed_message(db: &GlobalDb, msg: Msg<'_>) {
+    let ok = db
+        .upsert_session_message(&SessionMessageRecord {
+            provider: msg.provider.to_string(),
+            message_id: format!("{}:{}", msg.session_id, msg.ordinal),
+            session_id: msg.session_id.to_string(),
+            role: "assistant".to_string(),
+            timestamp: Some(msg.ts),
+            ordinal: msg.ordinal,
+            text: "activity".to_string(),
+            kind: msg.kind.map(str::to_string),
+            model: None,
+            tool_names: msg.tool_names.map(str::to_string),
+            source_path: None,
+            source_offset: Some(msg.ordinal),
+            metadata_json: msg.metadata_json.map(str::to_string),
+        })
+        .await;
+    assert!(ok, "session message should upsert");
+}
+
+async fn seed_hint_emitted(db: &GlobalDb, session_id: &str, hint_id: &str, category: &str) {
+    seed_hint_emitted_for(db, "hook_claude", session_id, hint_id, category).await;
+}
+
+async fn seed_hint_emitted_for(
+    db: &GlobalDb,
+    provider: &str,
+    session_id: &str,
+    hint_id: &str,
+    category: &str,
+) {
+    db.append_analytics_event(&AnalyticsEventInsert {
+        provider: provider.to_string(),
+        project_id: PROJECT.to_string(),
+        session_id: Some(session_id.to_string()),
+        timestamp: HINT_TS,
+        event_kind: "hint_emitted".to_string(),
+        hook_name: None,
+        tool_name: None,
+        tool_category: None,
+        skill_name: None,
+        hint_category: Some(category.to_string()),
+        hint_id: Some(hint_id.to_string()),
+        outcome: Some("observed".to_string()),
+        metadata_json: None,
+    })
+    .await
+    .expect("hint_emitted should append");
+}
+
+async fn outcome_events(db: &GlobalDb) -> Vec<crate::global_db::AnalyticsEventRecord> {
+    db.query_analytics_events(&AnalyticsEventQuery {
+        project_id: Some(PROJECT.to_string()),
+        event_kind: Some("hint_outcome".to_string()),
+        limit: 100,
+        ..Default::default()
+    })
+    .await
+    .expect("query outcomes")
+}
+
+#[tokio::test]
+async fn matching_tool_after_hint_resolves_acted() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "claude", "s1").await;
+    seed_hint_emitted(&db, "s1", "h1", "search").await;
+    // A matching tracedecay tool (search category expects tracedecay_context)
+    // fires shortly after the hint, MCP-prefixed as a client would report it.
+    seed_message(
+        &db,
+        Msg::new("claude", "s1", HINT_TS + 60).tools("mcp__tracedecay__tracedecay_context"),
+    )
+    .await;
+
+    let stats = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 120).await;
+    assert_eq!(
+        stats,
+        HintOutcomeStats {
+            scanned: 1,
+            acted: 1,
+            ignored: 0,
+            unresolved: 0,
+        }
+    );
+    let outcomes = outcome_events(&db).await;
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0].outcome.as_deref(), Some("acted"));
+    assert_eq!(outcomes[0].hint_id.as_deref(), Some("h1"));
+    assert_eq!(outcomes[0].hint_category.as_deref(), Some("search"));
+}
+
+#[tokio::test]
+async fn codex_tool_event_row_resolves_acted() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "codex", "c1").await;
+    seed_hint_emitted_for(&db, "hook_codex", "c1", "hc", "impact").await;
+    // Codex records a dedicated kind='tool_event' row carrying the tool name.
+    seed_message(
+        &db,
+        Msg::new("codex", "c1", HINT_TS + 30)
+            .kind("tool_event")
+            .tools("tracedecay_impact"),
+    )
+    .await;
+
+    let stats = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 60).await;
+    assert_eq!(stats.acted, 1);
+    let outcomes = outcome_events(&db).await;
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0].outcome.as_deref(), Some("acted"));
+    assert_eq!(outcomes[0].tool_name.as_deref(), Some("tracedecay_impact"));
+}
+
+#[tokio::test]
+async fn claude_metadata_tool_events_resolve_acted() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "claude", "s1").await;
+    seed_hint_emitted(&db, "s1", "hm", "file_read").await;
+    // Claude/Cursor carry bounded tool metadata on the message row instead of
+    // the tool_names column.
+    seed_message(
+        &db,
+        Msg::new("claude", "s1", HINT_TS + 45)
+            .metadata(r#"{"tool_events":[{"type":"tool_use","tool_name":"tracedecay_outline"}]}"#),
+    )
+    .await;
+
+    let stats = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 90).await;
+    assert_eq!(stats.acted, 1);
+}
+
+#[tokio::test]
+async fn non_matching_activity_past_horizon_resolves_ignored() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "claude", "s1").await;
+    seed_hint_emitted(&db, "s1", "h2", "search").await;
+    // Native reads only — no tracedecay search tool — and the wall clock is now
+    // past the 30-minute horizon, so the window is closed with no match.
+    seed_message(&db, Msg::new("claude", "s1", HINT_TS + 60).tools("Read")).await;
+
+    let stats = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 2_000).await;
+    assert_eq!(
+        stats,
+        HintOutcomeStats {
+            scanned: 1,
+            acted: 0,
+            ignored: 1,
+            unresolved: 0,
+        }
+    );
+    let outcomes = outcome_events(&db).await;
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0].outcome.as_deref(), Some("ignored"));
+    assert!(outcomes[0].tool_name.is_none());
+}
+
+#[tokio::test]
+async fn no_post_hint_activity_stays_unresolved() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "claude", "s1").await;
+    seed_hint_emitted(&db, "s1", "h3", "search").await;
+    // Only a pre-hint message exists; nothing is ingested after the hint yet.
+    seed_message(
+        &db,
+        Msg::new("claude", "s1", HINT_TS - 30).tools("tracedecay_context"),
+    )
+    .await;
+
+    let stats = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 120).await;
+    assert_eq!(
+        stats,
+        HintOutcomeStats {
+            scanned: 1,
+            acted: 0,
+            ignored: 0,
+            unresolved: 1,
+        }
+    );
+    assert!(outcome_events(&db).await.is_empty());
+}
+
+#[tokio::test]
+async fn short_quiet_session_before_wall_clock_horizon_stays_unresolved() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "claude", "s1").await;
+    seed_hint_emitted(&db, "s1", "h4", "search").await;
+    // A single non-matching step, fewer than the step horizon, and the wall
+    // clock has not yet reached the time horizon: the window is still open.
+    seed_message(&db, Msg::new("claude", "s1", HINT_TS + 60).tools("Read")).await;
+
+    let stats = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 120).await;
+    assert_eq!(stats.unresolved, 1);
+    assert_eq!(stats.acted, 0);
+    assert_eq!(stats.ignored, 0);
+    assert!(outcome_events(&db).await.is_empty());
+}
+
+#[tokio::test]
+async fn correlation_is_idempotent_across_runs() {
+    let dir = TempDir::new().unwrap();
+    let db = open_db(&dir).await;
+    seed_session(&db, "claude", "s1").await;
+    seed_hint_emitted(&db, "s1", "h1", "search").await;
+    seed_message(
+        &db,
+        Msg::new("claude", "s1", HINT_TS + 60).tools("tracedecay_context"),
+    )
+    .await;
+
+    let first = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 120).await;
+    assert_eq!(first.acted, 1);
+    // Re-running must not re-scan or re-write the already-resolved hint.
+    let second = correlate_hint_outcomes(&db, &db, PROJECT, HINT_TS + 240).await;
+    assert_eq!(
+        second,
+        HintOutcomeStats {
+            scanned: 0,
+            acted: 0,
+            ignored: 0,
+            unresolved: 0,
+        }
+    );
+    assert_eq!(outcome_events(&db).await.len(), 1);
+}
+
+#[test]
+fn tool_matches_expected_tolerates_prefixes_and_boundaries() {
+    let expected = ["tracedecay_context", "tracedecay_search"];
+    assert!(tool_matches_expected("tracedecay_context", &expected));
+    assert!(tool_matches_expected(
+        "mcp__tracedecay__tracedecay_context",
+        &expected
+    ));
+    assert!(tool_matches_expected(
+        "mcp__plugin_tracedecay_tracedecay__tracedecay_search",
+        &expected
+    ));
+    assert!(tool_matches_expected("TraceDecay-Context", &expected));
+    // A different tool that merely shares a suffix fragment must not match.
+    assert!(!tool_matches_expected(
+        "tracedecay_signature_search",
+        &expected
+    ));
+    assert!(!tool_matches_expected("Read", &expected));
+}
+
+#[test]
+fn resolve_step_horizon_closes_window_without_wall_clock() {
+    let expected = ["tracedecay_context"];
+    // HORIZON_TOOL_STEPS non-matching steps, all inside the time horizon, and
+    // `now` still before the wall-clock horizon: the step horizon alone closes
+    // the window as ignored.
+    let steps: Vec<ToolStep> = (0..HORIZON_TOOL_STEPS as i64)
+        .map(|i| ToolStep {
+            ts: HINT_TS + i + 1,
+            tools: vec!["Read".to_string()],
+        })
+        .collect();
+    let resolution = resolve(HINT_TS, &steps, &expected, HINT_TS + 5);
+    assert!(matches!(resolution, Some(Resolution::Ignored)));
+
+    // The same steps but with a matching tool in the last slot resolve acted.
+    let mut acted_steps = steps;
+    acted_steps.last_mut().unwrap().tools = vec!["tracedecay_context".to_string()];
+    let resolution = resolve(HINT_TS, &acted_steps, &expected, HINT_TS + 5);
+    assert!(matches!(resolution, Some(Resolution::Acted(_))));
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -14,6 +14,7 @@ mod codex;
 mod cursor;
 mod cursor_compact;
 mod cursor_shell;
+pub mod hint_outcomes;
 mod kiro;
 pub(crate) mod memory_inject;
 mod post_tool_use;

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -73,6 +73,20 @@ impl HintCategory {
             .find(|spec| spec.key == key)
             .map(|spec| spec.category)
     }
+
+    /// The tracedecay MCP tools this category steers toward. Used by the
+    /// hint-outcome correlator to decide whether a fired tool satisfied a hint.
+    pub(crate) fn expected_tools(self) -> &'static [&'static str] {
+        self.spec().expected_tools
+    }
+}
+
+/// Machine-readable expected-tool list for a hint-category `key` (the value
+/// stored in `analytics_events.hint_category`), or `None` when the key is
+/// unknown. Lets the hint-outcome correlator map an emitted hint to the tools
+/// that would satisfy it without re-parsing hint prose.
+pub(crate) fn expected_tools_for_key(key: &str) -> Option<&'static [&'static str]> {
+    HintCategory::from_key(key).map(HintCategory::expected_tools)
 }
 
 struct HintCategorySpec {
@@ -82,6 +96,12 @@ struct HintCategorySpec {
     skill: &'static str,
     message: &'static str,
     context: &'static str,
+    /// Machine-readable list of the tracedecay MCP tools this hint steers the
+    /// model toward, derived from the tools named in `context`. The
+    /// hint-outcome correlator (`super::hint_outcomes`) treats a hint as
+    /// "acted" when one of these tools fires in the session after the hint,
+    /// instead of re-parsing the prose. Keep in sync with `context`.
+    expected_tools: &'static [&'static str],
     nonblocking: bool,
 }
 
@@ -93,6 +113,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "exploring-code",
         message: "For codebase search, route by what you're matching: literal/regex text -> tracedecay_grep; symbol name -> tracedecay_search; concept -> tracedecay_context.",
         context: "tracedecay_grep runs a literal or regex content search over the indexed tree (pattern, fixed_strings, path_glob) and enriches each hit with its enclosing symbol; tracedecay_search ranks symbols by name; tracedecay_context answers concept-level questions. Grep/ripgrep still fit prose and un-indexed files.",
+        expected_tools: &["tracedecay_grep", "tracedecay_search", "tracedecay_context"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -102,6 +123,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "exploring-code",
         message: "For conceptual codebase questions, consider tracedecay_context.",
         context: "tracedecay_context answers concept-level queries from the pre-built code graph (add keywords to expand synonyms); tracedecay_search ranks symbols by name/keyword; tracedecay_grep matches a literal or regex string when you want exact text, not a concept.",
+        expected_tools: &["tracedecay_context", "tracedecay_search", "tracedecay_grep"],
         nonblocking: true,
     },
     HintCategorySpec {
@@ -111,6 +133,12 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "exploring-code",
         message: "Before reading whole files, consider tracedecay_outline, tracedecay_body, or tracedecay_read.",
         context: "tracedecay_outline gives a file's table of contents, tracedecay_body returns one symbol's source, and tracedecay_read (mode: \"lines\") slices a range — usually far cheaper than a full-file read. If you are opening the file only to find a string in it, tracedecay_grep locates the literal or regex match with its enclosing symbol instead.",
+        expected_tools: &[
+            "tracedecay_outline",
+            "tracedecay_body",
+            "tracedecay_read",
+            "tracedecay_grep",
+        ],
         nonblocking: true,
     },
     HintCategorySpec {
@@ -120,6 +148,11 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "tracing-functions",
         message: "This looks like a TraceDecay MCP tool descriptor; use the tool surface instead of reading schema JSON.",
         context: "Call the named tracedecay_* MCP tool directly when available, or use tool discovery for its schema; for function tracing that usually means tracedecay_find_exact_symbol plus tracedecay_callers/tracedecay_callees.",
+        expected_tools: &[
+            "tracedecay_find_exact_symbol",
+            "tracedecay_callers",
+            "tracedecay_callees",
+        ],
         nonblocking: true,
     },
     HintCategorySpec {
@@ -129,6 +162,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "exploring-code",
         message: "For broad codebase reading, consider starting with focused tracedecay context.",
         context: "tracedecay_context gathers relevant code slices without reading entire directories or the whole repository; tracedecay_grep sweeps the indexed tree for a literal or regex string when you are hunting for exact text rather than a concept.",
+        expected_tools: &["tracedecay_context", "tracedecay_grep"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -138,6 +172,13 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "tracing-functions",
         message: "For function tracing, use the indexed call graph before grep/file reads.",
         context: "Resolve the symbol with tracedecay_find_exact_symbol or tracedecay_search, then use tracedecay_callers for who depends on it and tracedecay_callees for what it calls; use tracedecay_impact for broader dependents before opening files.",
+        expected_tools: &[
+            "tracedecay_find_exact_symbol",
+            "tracedecay_search",
+            "tracedecay_callers",
+            "tracedecay_callees",
+            "tracedecay_impact",
+        ],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -147,6 +188,12 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "assessing-impact",
         message: "For impact, affected-test, or blast-radius questions, use TraceDecay's dependency tools.",
         context: "Start with tracedecay_diff_context when you have changed files, tracedecay_impact for a resolved symbol, tracedecay_affected for affected tests, and tracedecay_test_map when you need direct test attribution.",
+        expected_tools: &[
+            "tracedecay_diff_context",
+            "tracedecay_impact",
+            "tracedecay_affected",
+            "tracedecay_test_map",
+        ],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -156,6 +203,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "exploring-code",
         message: "For symbol lookup, consider using tracedecay indexed symbol tools.",
         context: "tracedecay_context and tracedecay_node can locate definitions and nearby relationships from the code graph.",
+        expected_tools: &["tracedecay_context", "tracedecay_node"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -165,6 +213,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "exploring-code",
         message: "For finding files by role or path, consider using tracedecay_files.",
         context: "tracedecay_files can list indexed files and narrow file lookup before opening individual files.",
+        expected_tools: &["tracedecay_files"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -174,6 +223,12 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "code-health",
         message: "For other repos or registered projects, consider TraceDecay project registry tools.",
         context: "tracedecay_project_list shows known projects; tracedecay_project_search can find a sibling repo by name/path/remote; pass project_path or project_id to tracedecay_context/search for cross-project code context before scanning parent directories.",
+        expected_tools: &[
+            "tracedecay_project_list",
+            "tracedecay_project_search",
+            "tracedecay_context",
+            "tracedecay_search",
+        ],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -183,6 +238,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "managing-session-context",
         message: "For prior conversation context, consider TraceDecay session search.",
         context: "tracedecay_message_search searches ingested agent transcripts across providers; tracedecay_lcm_grep can search bounded raw-message snippets and summaries when you need session-level recall before re-discovering context.",
+        expected_tools: &["tracedecay_message_search", "tracedecay_lcm_grep"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -192,6 +248,11 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "editing-safely",
         message: "For safe mechanical edits, use TraceDecay's anchored edit tools.",
         context: "Use tracedecay_multi_str_replace for all-or-nothing anchored replacements, tracedecay_ast_grep_rewrite for structural rewrites, and tracedecay_replace_symbol when replacing one resolved symbol.",
+        expected_tools: &[
+            "tracedecay_multi_str_replace",
+            "tracedecay_ast_grep_rewrite",
+            "tracedecay_replace_symbol",
+        ],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -200,7 +261,15 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         label: "type orientation",
         skill: "exploring-code",
         message: "For type, constructor, field, trait, or duplicate-logic questions, use TraceDecay's AST orientation tools.",
-        context: "Use tracedecay_constructors for struct literal sites, tracedecay_field_sites for reads/writes, tracedecay_impls or tracedecay_implementations for trait methods, and tracedecay_redundancy before adding similar helpers.",
+        context: "Use tracedecay_constructors for struct literal sites, tracedecay_field_sites for reads/writes, tracedecay_impls or tracedecay_implementations for trait methods, tracedecay_type_hierarchy for a trait/interface/class's full recursive implementor/extender tree, and tracedecay_redundancy before adding similar helpers.",
+        expected_tools: &[
+            "tracedecay_constructors",
+            "tracedecay_field_sites",
+            "tracedecay_impls",
+            "tracedecay_implementations",
+            "tracedecay_type_hierarchy",
+            "tracedecay_redundancy",
+        ],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -210,6 +279,12 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "using-tracedecay",
         message: "For code research subagents, consider adding tracedecay MCP context before broad exploration.",
         context: "tracedecay_context can gather focused code context, while tracedecay_search, tracedecay_callers, and tracedecay_impact can answer common research questions without a broad scan.",
+        expected_tools: &[
+            "tracedecay_context",
+            "tracedecay_search",
+            "tracedecay_callers",
+            "tracedecay_impact",
+        ],
         nonblocking: true,
     },
     HintCategorySpec {
@@ -219,6 +294,11 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "using-tracedecay",
         message: "For subagent handoff, include focused TraceDecay context instead of broad repo instructions.",
         context: "Use tracedecay_context, tracedecay_search, and tracedecay_impact to provide only the code graph slices the subagent needs; keep workflow depth in bundled skills.",
+        expected_tools: &[
+            "tracedecay_context",
+            "tracedecay_search",
+            "tracedecay_impact",
+        ],
         nonblocking: true,
     },
     HintCategorySpec {
@@ -228,6 +308,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "fixing-build-and-type-errors",
         message: "For build/type-check errors, use TraceDecay's diagnostics tools instead of parsing raw compiler output.",
         context: "tracedecay_diagnostics runs (or reads) the project's diagnostics and maps each error to its enclosing symbol; tracedecay_diagnose adds caller/impact context for a specific failure so you fix the root cause, not just the line the compiler points at.",
+        expected_tools: &["tracedecay_diagnostics", "tracedecay_diagnose"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -237,6 +318,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "reviewing-changes",
         message: "For reviewing diffs or PR changes, use TraceDecay's change-context tools before raw diff reading.",
         context: "tracedecay_diff_context maps local changed files to touched symbols, dependents, and tests; tracedecay_pr_context does the same for a PR branch when available, so use GitHub only for review comments, metadata, and CI state.",
+        expected_tools: &["tracedecay_diff_context", "tracedecay_pr_context"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -246,6 +328,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "project-memory",
         message: "For durable facts, prefer tracedecay_fact_store over hand-editing harness memory files.",
         context: "tracedecay_fact_store persists a trust-ranked project/user fact that survives across sessions and is recalled by tracedecay_context and tracedecay_recall; a memory markdown edit is only visible to the current harness. Keep secrets and unnecessary PII out of stored facts.",
+        expected_tools: &["tracedecay_fact_store"],
         nonblocking: false,
     },
     HintCategorySpec {
@@ -255,6 +338,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         skill: "editing-safely",
         message: "You just added a new function-sized block; before moving on, confirm it does not duplicate logic that already exists.",
         context: "tracedecay_redundancy surfaces near-duplicate function bodies and tracedecay_similar finds structurally similar code; if a match exists, reuse or refactor the existing helper instead of keeping a second copy.",
+        expected_tools: &["tracedecay_redundancy", "tracedecay_similar"],
         nonblocking: true,
     },
 ];

--- a/src/hooks/tool_hints/classifiers.rs
+++ b/src/hooks/tool_hints/classifiers.rs
@@ -510,6 +510,13 @@ pub(super) fn asks_for_impact(text: &str) -> bool {
             "what code is affected",
             "which tests",
             "what tests",
+            "what breaks",
+            "what would break",
+            "what will break",
+            "will this break",
+            "would this break",
+            "does this break",
+            "what could break",
         ],
     )
 }
@@ -816,6 +823,15 @@ pub(super) fn asks_for_type_orientation(text: &str) -> bool {
             "duplicate logic",
             "redundant",
             "similar helper",
+            "type hierarchy",
+            "trait hierarchy",
+            "class hierarchy",
+            "interface hierarchy",
+            "inheritance hierarchy",
+            "inheritance depth",
+            "extenders of",
+            "subtypes of",
+            "supertypes of",
         ],
     )
 }

--- a/src/hooks/tool_hints/evals/mod.rs
+++ b/src/hooks/tool_hints/evals/mod.rs
@@ -806,6 +806,12 @@ fn synthetic_prompt_cases() -> Vec<HintEval> {
             &["tracedecay_diff_context", "tracedecay_impact"],
         ),
         prompt_eval(
+            "what-breaks-question",
+            "what breaks if I change the signature of classify_hint?",
+            Some(HintCategory::Impact),
+            &["tracedecay_impact", "tracedecay_affected"],
+        ),
+        prompt_eval(
             "symbol-definition-question",
             "find definition of ToolHintInput",
             Some(HintCategory::SymbolLookup),
@@ -852,6 +858,12 @@ fn synthetic_prompt_cases() -> Vec<HintEval> {
             "is there duplicate logic or a similar helper before I add another classifier?",
             Some(HintCategory::TypeOrientation),
             &["tracedecay_redundancy"],
+        ),
+        prompt_eval(
+            "type-hierarchy-question",
+            "what is the full trait hierarchy for HintCategory, all implementors and extenders?",
+            Some(HintCategory::TypeOrientation),
+            &["tracedecay_type_hierarchy"],
         ),
         prompt_eval(
             "safe-mechanical-edit",

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1271,10 +1271,36 @@ impl McpServer {
             let project_root = cg.project_root().to_path_buf();
             let session_db_path = cg.store_layout().sessions_db_path.clone();
             let ingest_done_flag = Arc::clone(&self.transcript_ingest_done);
+            let analytics_db = self.global_db.clone();
             tokio::spawn(async move {
                 let _ = tokio::time::timeout(std::time::Duration::from_secs(20), async move {
                     if let Some(db) = GlobalDb::open_at(&session_db_path).await {
                         let _ = crate::sessions::ingest_global_sources(&db, &project_root).await;
+                        // With transcripts freshly ingested into `db`'s
+                        // session_messages, close the hint-efficacy loop: import
+                        // any new hook telemetry into the durable analytics store
+                        // and correlate emitted hints against the tool activity
+                        // that followed them. Best-effort and idempotent (own
+                        // parse cursors + hint_outcome watermark), so it never
+                        // blocks readiness and re-runs safely each startup.
+                        if let Some(analytics_db) = analytics_db.as_deref() {
+                            let sources =
+                                crate::analytics_bridge::hook_import_sources(Some(&project_root));
+                            let _ = crate::analytics_bridge::import_hook_analytics(
+                                analytics_db,
+                                &sources,
+                            )
+                            .await;
+                            let project_id = GlobalDb::canonical_project_key(&project_root);
+                            let now = crate::tracedecay::current_timestamp();
+                            let _ = crate::hooks::hint_outcomes::correlate_hint_outcomes(
+                                analytics_db,
+                                &db,
+                                &project_id,
+                                now,
+                            )
+                            .await;
+                        }
                     }
                 })
                 .await;

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1632,7 +1632,7 @@ fn def_type_hierarchy() -> ToolDefinition {
     def(
         "tracedecay_type_hierarchy",
         "Type Hierarchy",
-        "Show the full type hierarchy for a trait/interface/class: all implementors and extenders, recursively.",
+        "Use when asked a trait/interface/class type-hierarchy question — trigger before manually grepping `impl X for` / `extends X` chains across files. Returns the full recursive tree of implementors and extenders for a resolved type node.",
         json!({
             "type": "object",
             "properties": {
@@ -2959,7 +2959,7 @@ fn def_lcm_compress() -> ToolDefinition {
     def_rw(
         "tracedecay_lcm_compress",
         "LCM Compress",
-        "Advance the LCM compression lifecycle in the active project or Hermes profile store without invoking an auxiliary LLM.",
+        "Operator/host-lifecycle tool: called by an agent host's own pre-compact or compaction hook, not by a model in response to a user request. Advances the LCM compression lifecycle in the active project or Hermes profile store without invoking an auxiliary LLM.",
         json!({
             "type": "object",
             "properties": {
@@ -3072,7 +3072,7 @@ fn def_lcm_session_boundary() -> ToolDefinition {
     def_rw(
         "tracedecay_lcm_session_boundary",
         "LCM Session Boundary",
-        "Report a compression-boundary session start. When the old session does not match the bound session the boundary skipped carry-over and a short compression cooldown starts for the new session.",
+        "Operator/host-lifecycle tool: called by an agent host's own session-boundary hook to report a compression-boundary session start, not by a model in response to a user request. When the old session does not match the bound session the boundary skipped carry-over and a short compression cooldown starts for the new session.",
         json!({
             "type": "object",
             "properties": {

--- a/src/project_registry.rs
+++ b/src/project_registry.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -260,6 +260,50 @@ fn project_kind(project: &CodeProjectRecord) -> String {
     }
 }
 
+/// Resolves the canonical registration root for a project store rooted at
+/// `project_root`.
+///
+/// A tracedecay project id is shared across every linked worktree of a
+/// repository: [`crate::global_db::GlobalDb::upsert_code_project`] indexes a
+/// `git-common-dir:<common dir>` alias back to whichever project id first
+/// registered it, so a session opened from *any* linked worktree resolves
+/// to the same project id as the primary checkout. Because that same upsert
+/// persists whichever `project_root` it is called with as `canonical_root`
+/// and `display_root`, registering straight from a worktree's own root lets
+/// the last worktree to touch the project pin the shared row to its
+/// (often transient) path — silently dropping analytics/path-matching for
+/// the primary checkout.
+///
+/// Given the worktree's own root and its already-resolved
+/// [`crate::worktree::git_common_dir`], this returns `Some(primary_root)`
+/// when `project_root` is a linked worktree and the primary checkout still
+/// exists on disk. It returns `None` — meaning "register `project_root` as
+/// given" — when `project_root` already *is* the primary checkout, isn't a
+/// git checkout at all, or the primary checkout no longer exists (a
+/// worktree-only project is legitimate and must keep registering itself).
+pub fn primary_checkout_root(
+    project_root: &Path,
+    git_common_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    let common_dir = git_common_dir?;
+    // Only a plain, non-bare `<repo>/.git` common dir has a parent that is
+    // reliably the checkout root. Bare repos and submodule gitlinks (whose
+    // common dir lives under `.git/modules/...`) are left alone rather than
+    // risk deriving a bogus "primary" and redirecting registration there.
+    if common_dir.file_name().and_then(|name| name.to_str()) != Some(".git") {
+        return None;
+    }
+    let primary_root = common_dir.parent()?;
+    let canonical_project_root = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    if primary_root == canonical_project_root {
+        // `project_root` already is the primary checkout.
+        return None;
+    }
+    primary_root.is_dir().then(|| primary_root.to_path_buf())
+}
+
 fn path_label(path: &str) -> String {
     Path::new(path)
         .file_name()
@@ -401,5 +445,94 @@ mod tests {
         };
 
         assert_eq!(repo_label_with_parent(&group), "root");
+    }
+
+    #[test]
+    fn primary_checkout_root_redirects_linked_worktree_to_existing_primary() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let primary = tmp.path().join("main");
+        let worktree = tmp.path().join("main-wt");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        // `crate::worktree::git_common_dir` always returns a canonicalized
+        // path — mirror that guarantee here rather than a raw join.
+        let primary = primary.canonicalize().unwrap();
+        let common_dir = primary.join(".git");
+        std::fs::create_dir_all(&common_dir).unwrap();
+
+        let redirected = primary_checkout_root(&worktree, Some(&common_dir));
+
+        assert_eq!(
+            redirected,
+            Some(primary),
+            "a linked worktree with a live primary checkout must redirect to it"
+        );
+    }
+
+    #[test]
+    fn primary_checkout_root_is_none_when_project_root_is_already_primary() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let primary = tmp.path().join("main");
+        std::fs::create_dir_all(&primary).unwrap();
+        let primary = primary.canonicalize().unwrap();
+        let common_dir = primary.join(".git");
+        std::fs::create_dir_all(&common_dir).unwrap();
+
+        assert_eq!(
+            primary_checkout_root(&primary, Some(&common_dir)),
+            None,
+            "the primary checkout must never be redirected to itself"
+        );
+    }
+
+    #[test]
+    fn primary_checkout_root_is_none_without_git_common_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_root = tmp.path().join("not-a-worktree");
+        std::fs::create_dir_all(&project_root).unwrap();
+
+        assert_eq!(
+            primary_checkout_root(&project_root, None),
+            None,
+            "non-git projects must register themselves unchanged"
+        );
+    }
+
+    #[test]
+    fn primary_checkout_root_keeps_worktree_when_primary_checkout_is_missing() {
+        // The primary checkout no longer exists on disk (deleted, moved off
+        // this machine, ...). A worktree-only project is legitimate and
+        // must keep registering its own root rather than redirecting to a
+        // path that doesn't exist.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let missing_primary = tmp.path().join("deleted-main");
+        let worktree = tmp.path().join("main-wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let common_dir = missing_primary.join(".git");
+
+        assert_eq!(
+            primary_checkout_root(&worktree, Some(&common_dir)),
+            None,
+            "a missing primary checkout must not be adopted as canonical_root"
+        );
+    }
+
+    #[test]
+    fn primary_checkout_root_ignores_non_dot_git_common_dirs() {
+        // Bare repos and submodule gitlinks resolve `git_common_dir` to a
+        // path that isn't a plain `<repo>/.git`, so the parent directory
+        // isn't reliably a checkout root — leave registration alone rather
+        // than risk deriving a bogus "primary".
+        let tmp = tempfile::TempDir::new().unwrap();
+        let worktree = tmp.path().join("checkout");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let submodule_common_dir = tmp.path().join("main/.git/modules/sub");
+        std::fs::create_dir_all(&submodule_common_dir).unwrap();
+
+        assert_eq!(
+            primary_checkout_root(&worktree, Some(&submodule_common_dir)),
+            None,
+            "non-`.git` common dirs must not redirect registration"
+        );
     }
 }

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -648,10 +648,31 @@ impl TraceDecay {
         let default_branch = meta.as_ref().map(|meta| meta.default_branch.as_str());
         let git_common_dir = crate::worktree::git_common_dir(&self.project_root);
         let git_remote_url = git_remote_url(&self.project_root);
+
+        // A shared project id can be reached from any linked worktree (see
+        // the git-common-dir alias registered below), so registering
+        // straight from `self.project_root` would let whichever worktree
+        // happens to touch the project last pin its canonical_root /
+        // display_root to a transient worktree path. Redirect registration
+        // to the primary checkout when one is detected and still exists.
+        let primary_root = crate::project_registry::primary_checkout_root(
+            &self.project_root,
+            git_common_dir.as_deref(),
+        );
+        let previous_canonical_root = if primary_root.is_some() {
+            global_db
+                .get_code_project(project_id)
+                .await
+                .map(|record| record.canonical_root)
+        } else {
+            None
+        };
+        let registration_root = primary_root.as_deref().unwrap_or(&self.project_root);
+
         let Some(project) = global_db
             .upsert_code_project(
                 project_id,
-                &self.project_root,
+                registration_root,
                 git_common_dir.as_deref(),
                 git_remote_url.as_deref(),
                 default_branch,
@@ -660,6 +681,27 @@ impl TraceDecay {
         else {
             return;
         };
+
+        if let Some(primary_root) = primary_root.as_deref() {
+            // The registry now points canonical_root/display_root at the
+            // primary checkout; keep this worktree itself resolvable for
+            // future lookups by registering its own path as an alias.
+            let _ = global_db
+                .upsert_project_alias(&self.project_root, &project.project_id)
+                .await;
+
+            let repaired_stale_worktree_root = previous_canonical_root.is_some_and(|previous| {
+                previous != crate::global_db::GlobalDb::canonical_project_key(primary_root)
+            });
+            if repaired_stale_worktree_root {
+                eprintln!(
+                    "warning: repaired tracedecay project '{project_id}' canonical_root — \
+                     it was pinned to a linked worktree ({}); restored to the primary checkout ({})",
+                    self.project_root.display(),
+                    primary_root.display()
+                );
+            }
+        }
 
         let store_id = profile_store_id(&project.project_id);
         let manifest_relpath = self

--- a/tests/storage_suite/main.rs
+++ b/tests/storage_suite/main.rs
@@ -22,3 +22,4 @@ mod migration_manifest_test;
 mod migration_test;
 mod profile_storage_migration_test;
 mod storage_resolver_test;
+mod worktree_canonical_root_guard_test;

--- a/tests/storage_suite/worktree_canonical_root_guard_test.rs
+++ b/tests/storage_suite/worktree_canonical_root_guard_test.rs
@@ -1,0 +1,250 @@
+//! End-to-end coverage for the registry canonical_root worktree guard.
+//!
+//! A tracedecay project id is shared across every linked worktree of a
+//! repository (see `crate::global_db::GlobalDb::upsert_code_project`'s
+//! `git-common-dir:<common dir>` alias). Before the guard in
+//! `tracedecay::project_registry::primary_checkout_root`, opening a session
+//! from *any* linked worktree would re-register the shared project with
+//! `canonical_root`/`display_root` pinned to that worktree's own (often
+//! transient) path — the last worktree to touch the project would win.
+//!
+//! These tests drive the real registration/touch call site
+//! (`TraceDecay::init_with_options` / `TraceDecay::open_with_options`)
+//! against real git worktrees, rather than exercising the guard function in
+//! isolation.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+use tracedecay::global_db::GlobalDb;
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
+
+use crate::support::HOME_ENV_LOCK;
+
+fn canonical_temp_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn git(project: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(["-c", "core.hooksPath=.git/no-hooks"])
+        .args(args)
+        .current_dir(project)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_all(project: &Path, message: &str) {
+    git(project, &["add", "."]);
+    git(
+        project,
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "-m",
+            message,
+        ],
+    );
+}
+
+/// Builds a primary checkout with one commit plus a linked worktree on a
+/// separate branch, and a `TraceDecayOpenOptions` pointed at an isolated
+/// profile root/global db under the same temp dir.
+struct Fixture {
+    _tmp: TempDir,
+    profile_root: PathBuf,
+    main: PathBuf,
+    worktree: PathBuf,
+    open_options: TraceDecayOpenOptions,
+}
+
+fn build_fixture() -> Fixture {
+    let tmp = TempDir::new().unwrap();
+    let root = canonical_temp_path(tmp.path());
+    let profile_root = root.join("profile");
+    let main = root.join("main");
+    let worktree = root.join("main-wt");
+    std::fs::create_dir_all(&main).unwrap();
+
+    git(&main, &["init", "-b", "main", "--quiet"]);
+    std::fs::write(main.join("README.md"), "worktree canonical_root fixture\n").unwrap();
+    commit_all(&main, "initial commit");
+    git(
+        &main,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/worktree-guard",
+            worktree.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(profile_root.join("global.db")),
+    };
+
+    Fixture {
+        _tmp: tmp,
+        profile_root,
+        main,
+        worktree,
+        open_options,
+    }
+}
+
+async fn init_primary(fx: &Fixture) -> String {
+    let primary = TraceDecay::init_with_options(&fx.main, fx.open_options.clone())
+        .await
+        .expect("primary init should succeed");
+    primary
+        .index_all()
+        .await
+        .expect("primary index should succeed");
+    primary.db().checkpoint().await.expect("primary checkpoint");
+    let project_id = primary
+        .store_layout()
+        .identity
+        .project_id
+        .clone()
+        .expect("profile-sharded store must have a project id");
+    drop(primary);
+    project_id
+}
+
+#[tokio::test]
+async fn opening_from_linked_worktree_keeps_canonical_root_on_primary() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let fx = build_fixture();
+    let project_id = init_primary(&fx).await;
+
+    // Opening from the linked worktree resolves the *same* project id via
+    // the git-common-dir identity alias registered during primary init.
+    let from_worktree = TraceDecay::open_with_options(&fx.worktree, fx.open_options.clone())
+        .await
+        .expect("open from linked worktree should succeed");
+    assert_eq!(
+        from_worktree.store_layout().identity.project_id.as_deref(),
+        Some(project_id.as_str()),
+        "a linked worktree session must resolve the primary's shared project id"
+    );
+    drop(from_worktree);
+
+    let db = GlobalDb::open_at(&fx.profile_root.join("global.db"))
+        .await
+        .expect("global db should open");
+    let record = db
+        .get_code_project(&project_id)
+        .await
+        .expect("project should be registered");
+    assert_eq!(
+        record.canonical_root,
+        GlobalDb::canonical_project_key(&fx.main),
+        "canonical_root must stay pinned to the primary checkout, not the worktree that just touched it"
+    );
+    assert_eq!(
+        record.display_root,
+        fx.main.to_string_lossy(),
+        "display_root must stay pinned to the primary checkout"
+    );
+
+    // The worktree's own path must still resolve (as an alias) to the same
+    // shared project id, so future sessions opened from the worktree keep
+    // working.
+    let context = db
+        .project_registry_context_by_id(&project_id)
+        .await
+        .expect("registry context should exist");
+    let worktree_key = GlobalDb::canonical_project_key(&fx.worktree);
+    assert!(
+        context
+            .aliases
+            .iter()
+            .any(|alias| alias.alias_path == worktree_key),
+        "the worktree path must remain a resolvable alias: {:?}",
+        context.aliases
+    );
+}
+
+#[tokio::test]
+async fn stale_worktree_canonical_root_heals_on_next_touch() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let fx = build_fixture();
+    let project_id = init_primary(&fx).await;
+
+    // Simulate the pre-guard bug: some earlier session registered straight
+    // from the worktree and pinned canonical_root/display_root to it.
+    {
+        let db = GlobalDb::open_at(&fx.profile_root.join("global.db"))
+            .await
+            .expect("global db should open");
+        let git_common_dir = tracedecay::worktree::git_common_dir(&fx.worktree);
+        db.upsert_code_project(
+            &project_id,
+            &fx.worktree,
+            git_common_dir.as_deref(),
+            None,
+            Some("feature/worktree-guard"),
+        )
+        .await
+        .expect("seeding the stale row should succeed");
+        db.checkpoint().await;
+        db.close();
+
+        let db = GlobalDb::open_at(&fx.profile_root.join("global.db"))
+            .await
+            .expect("global db should reopen");
+        let stale = db
+            .get_code_project(&project_id)
+            .await
+            .expect("stale row should exist");
+        assert_eq!(
+            stale.canonical_root,
+            GlobalDb::canonical_project_key(&fx.worktree),
+            "fixture setup should have produced the stale (bug) state"
+        );
+        db.close();
+    }
+
+    // Any subsequent touch — even one opened from the same worktree — must
+    // self-heal canonical_root/display_root back to the primary checkout.
+    let reopened = TraceDecay::open_with_options(&fx.worktree, fx.open_options.clone())
+        .await
+        .expect("reopen from worktree should succeed");
+    drop(reopened);
+
+    let db = GlobalDb::open_at(&fx.profile_root.join("global.db"))
+        .await
+        .expect("global db should open");
+    let healed = db
+        .get_code_project(&project_id)
+        .await
+        .expect("project should still be registered");
+    assert_eq!(
+        healed.canonical_root,
+        GlobalDb::canonical_project_key(&fx.main),
+        "a stale worktree-pinned canonical_root must heal back to the primary checkout on touch"
+    );
+    assert_eq!(healed.display_root, fx.main.to_string_lossy());
+}
+
+// Coverage for "the primary checkout no longer exists on disk" lives in
+// `tracedecay::project_registry::tests::primary_checkout_root_keeps_worktree_when_primary_checkout_is_missing`.
+// A real git worktree cannot produce that state end-to-end: a linked
+// worktree resolves `git_common_dir` by reading files inside the primary's
+// `.git` directory, so deleting the primary also deletes the very metadata
+// the worktree needs to resolve a common dir at all — the unit test exposes
+// the guard function directly to exercise that branch precisely instead.


### PR DESCRIPTION
Wave 2A: hint emissions are correlated against subsequent tool activity (25-step/30-min horizon) into acted/ignored hint_outcome analytics rows, making the hint funnel measurable per category for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)