### PR TITLE
chore: release v0.0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.41](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.40...v0.0.41) - 2026-07-09
+
+### Added
+
+- *(sessions)* ingest and surface Codex thread goals
+
+### Fixed
+
+- *(db)* stop conflating attrs_start_line 0 with unset
+
+### Other
+
+- Merge pull request #347 from ScriptedAlchemy/codex/fix-unsafe-patterns
+- Merge pull request #340 from ScriptedAlchemy/codex/session-recovery-fixes
+- Merge pull request #346 from ScriptedAlchemy/codex/goal-ingestion
+
 ## [0.0.40](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.39...v0.0.40) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.40"
+version = "0.0.41"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.40"
+version = "0.0.41"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.40 -> 0.0.41

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.41](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.40...v0.0.41) - 2026-07-09

### Added

- *(sessions)* ingest and surface Codex thread goals

### Fixed

- *(db)* stop conflating attrs_start_line 0 with unset

### Other

- Merge pull request #347 from ScriptedAlchemy/codex/fix-unsafe-patterns
- Merge pull request #340 from ScriptedAlchemy/codex/session-recovery-fixes
- Merge pull request #346 from ScriptedAlchemy/codex/goal-ingestion
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).