### PR TITLE
feat(sessions): ingest and surface Codex thread goals

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -3883,6 +3883,68 @@ impl GlobalDb {
         results
     }
 
+    /// Lists each session's latest Codex goal state (`kind = 'goal'`), newest
+    /// first, for the `message_search` `goals` view. One row per session — the
+    /// goal row with the highest `ordinal` (byte offset), i.e. the last
+    /// lifecycle transition ingested — so the returned `metadata_json.status`
+    /// is the current status. `score` is always 0: this is a listing, not a
+    /// relevance search. Optionally scoped to one `project_key`.
+    pub async fn recent_session_goals(
+        &self,
+        project_key: Option<&str>,
+        limit: usize,
+    ) -> Vec<SessionMessageSearchResult> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        let mut sql = "SELECT
+                s.provider, s.session_id, s.project_key, s.project_path, s.title, s.started_at,
+                s.ended_at, s.transcript_path, s.metadata_json, s.parent_session_id,
+                s.is_subagent, s.agent_id, s.parent_tool_use_id,
+                m.provider, m.message_id, m.session_id, m.role, m.timestamp, m.ordinal, m.text,
+                m.kind, m.model, m.tool_names, m.source_path, m.source_offset, m.metadata_json
+             FROM session_messages m
+             JOIN sessions s ON s.provider = m.provider AND s.session_id = m.session_id
+             WHERE m.kind = 'goal'
+               AND m.ordinal = (
+                   SELECT MAX(m2.ordinal) FROM session_messages m2
+                   WHERE m2.provider = m.provider
+                     AND m2.session_id = m.session_id
+                     AND m2.kind = 'goal'
+               )"
+        .to_string();
+        let mut query_params: Vec<Value> = Vec::new();
+        if let Some(project_key) = project_key {
+            query_params.push(Value::Text(project_key.to_string()));
+            let _ = write!(sql, " AND s.project_key = ?{}", query_params.len());
+        }
+        query_params.push(Value::Integer(limit as i64));
+        let _ = write!(
+            sql,
+            " ORDER BY COALESCE(m.timestamp, 0) DESC, m.ordinal DESC LIMIT ?{}",
+            query_params.len()
+        );
+
+        let Ok(mut rows) = self.conn.query(&sql, query_params).await else {
+            return Vec::new();
+        };
+        let mut results = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            let Some(session) = row_to_session(&row) else {
+                continue;
+            };
+            let Some(message) = row_to_message(&row, 13) else {
+                continue;
+            };
+            results.push(SessionMessageSearchResult {
+                session,
+                message,
+                score: 0.0,
+            });
+        }
+        results
+    }
+
     // ── Accounting: turns table ──────────────────────────────────────
 
     /// Insert a parsed turn. Returns `true` if inserted, `false` if duplicate.

--- a/src/mcp/tools/definitions/session.rs
+++ b/src/mcp/tools/definitions/session.rs
@@ -7,13 +7,17 @@ pub(super) fn def_message_search() -> ToolDefinition {
     def(
         "tracedecay_message_search",
         "Message Search",
-        "Search ingested transcript messages across all supported providers by default. Searches catch up the selected provider scope unless catch_up is false; pass provider only when intentionally scoping results to one provider.",
+        "Search ingested transcript messages across all supported providers by default. Searches catch up the selected provider scope unless catch_up is false; pass provider only when intentionally scoping results to one provider. Set goals=true to instead list each session's latest Codex thread goal (objective + current status) — a quick 'what was this session working on / is it still active' view; goals mode makes query optional.",
         json!({
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "Full-text query to search in ingested transcript messages."
+                    "description": "Full-text query to search in ingested transcript messages. Required unless goals=true."
+                },
+                "goals": {
+                    "type": "boolean",
+                    "description": "When true, list each session's latest Codex goal (kind='goal') — objective as text plus lifecycle status (e.g. active/paused) from metadata — newest first, instead of running a full-text search. query becomes optional; limit and project_key still apply. Scoped to the selected project store."
                 },
                 "provider": {
                     "type": "string",
@@ -72,7 +76,7 @@ pub(super) fn def_message_search() -> ToolDefinition {
                 "workflow_run": workflow_run_scope_schema(),
                 "workflow_agent": workflow_agent_scope_schema()
             },
-            "required": ["query"]
+            "required": []
         }),
     )
 }

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -54,7 +54,18 @@ const MESSAGE_SEARCH_SNIPPET_CHARS: usize = 240;
 /// the full structured records.
 fn render_message_search_md(value: &Value) -> String {
     let mut md = Md::new();
-    md.heading(2, "Transcript Search");
+    let goals_mode = value.get("goals").and_then(Value::as_bool).unwrap_or(false);
+    md.heading(
+        2,
+        if goals_mode {
+            "Session Goals"
+        } else {
+            "Transcript Search"
+        },
+    );
+    if goals_mode {
+        md.field("mode", "goals (latest goal per session)");
+    }
     for key in ["query", "provider", "scope"] {
         let field = render::field_str(value, key);
         if !field.is_empty() {
@@ -89,7 +100,11 @@ fn render_message_search_md(value: &Value) -> String {
             }
         }
         _ => {
-            md.blank().empty_note("No matching messages.");
+            md.blank().empty_note(if goals_mode {
+                "No goals recorded for this project."
+            } else {
+                "No matching messages."
+            });
         }
     }
     md.render()
@@ -174,6 +189,11 @@ fn append_message_search_hit(md: &mut Md, hit: &Value) {
         let _ = write!(locator, " — {title}");
     }
     md.line(&format!("  {locator}"));
+    // A `goal` row carries its lifecycle status in metadata; surface it so a
+    // reader can tell whether the session's goal is still active.
+    if let Some(goal_line) = goal_status_line(message) {
+        md.line(&format!("  {goal_line}"));
+    }
     let text = message
         .and_then(|m| m.get("text"))
         .and_then(Value::as_str)
@@ -182,6 +202,29 @@ fn append_message_search_hit(md: &mut Md, hit: &Value) {
     if !snippet.is_empty() {
         md.line(&format!("  {snippet}"));
     }
+}
+
+/// `goal [status]` prefix for a `kind = 'goal'` hit, reading `status` out of the
+/// row's `metadata_json`. Returns `None` for non-goal rows (or goal rows with no
+/// recorded status, which still render their objective as the snippet).
+fn goal_status_line(message: Option<&Value>) -> Option<String> {
+    let message = message?;
+    if message.get("kind").and_then(Value::as_str) != Some("goal") {
+        return None;
+    }
+    let status = message
+        .get("metadata_json")
+        .and_then(Value::as_str)
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|meta| {
+            meta.get("status")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+    Some(match status {
+        Some(status) => format!("goal [{status}]"),
+        None => "goal".to_string(),
+    })
 }
 
 /// Best-effort single-line plain-text snippet from a stored message body.
@@ -342,17 +385,29 @@ struct MessageSearchRequest<'a> {
     git_filter: GitScopeFilter,
     time_range: SessionSearchTimeRange,
     workflow_scope: Option<WorkflowScopeFilter>,
+    /// When true, ignore FTS and list each session's latest Codex goal
+    /// (`kind = 'goal'`) instead. `query` is optional in this mode.
+    goals: bool,
 }
 
 fn parse_message_search_request(args: &Value) -> Result<MessageSearchRequest<'_>> {
-    let query = args
+    let goals = args.get("goals").and_then(Value::as_bool).unwrap_or(false);
+    let query = match args
         .get("query")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|query| !query.is_empty())
-        .ok_or_else(|| TraceDecayError::Config {
-            message: "missing required parameter: query".to_string(),
-        })?;
+    {
+        Some(query) => query,
+        // In goals-listing mode the query is optional: the listing is not an
+        // FTS search, so an absent query simply lists the most recent goals.
+        None if goals => "",
+        None => {
+            return Err(TraceDecayError::Config {
+                message: "missing required parameter: query".to_string(),
+            });
+        }
+    };
     let provider_scope = parse_message_search_provider_scope(args)?;
     let workflow_run = string_arg(args, "workflow_run");
     let workflow_agent = string_arg(args, "workflow_agent");
@@ -397,6 +452,7 @@ fn parse_message_search_request(args: &Value) -> Result<MessageSearchRequest<'_>
             run_id: run_id.to_string(),
             agent_label: workflow_agent.map(str::to_string),
         }),
+        goals,
     })
 }
 
@@ -500,6 +556,7 @@ fn message_search_payload(
         "since": request.time_range.start_time,
         "until": request.time_range.end_time,
         "query": request.query,
+        "goals": request.goals,
         "count": results.len(),
         "results": results,
     });
@@ -2348,7 +2405,12 @@ pub(super) async fn handle_message_search(
         },
         None => None,
     };
-    let results = search_session_messages_in_db(&db, &request).await;
+    let results = if request.goals {
+        db.recent_session_goals(request.project_key, request.limit)
+            .await
+    } else {
+        search_session_messages_in_db(&db, &request).await
+    };
     let mut payload = message_search_payload(&request, &results, catch_up_performed);
     if let Some(map) = payload.as_object_mut() {
         map.insert("selected_project_root".to_string(), json!(target_root));

--- a/src/mcp/tools/handlers/session/tests.rs
+++ b/src/mcp/tools/handlers/session/tests.rs
@@ -204,6 +204,51 @@ fn message_search_markdown_handles_empty_results() {
 }
 
 #[test]
+fn message_search_markdown_renders_goals_view_with_status() {
+    let payload = json!({
+        "status": "ok",
+        "goals": true,
+        "count": 1,
+        "results": [{
+            "score": 0.0,
+            "session": {"provider": "codex", "session_id": "sess-goal-1", "title": "Goal work"},
+            "message": {
+                "provider": "codex",
+                "role": "system",
+                "kind": "goal",
+                "timestamp": 1_783_500_100,
+                "text": "phlogiston pipeline overhaul",
+                "metadata_json": "{\"source\":\"codex_thread_goal\",\"status\":\"paused\"}",
+            },
+        }],
+    });
+    let md = render_message_search_md(&payload);
+    assert!(md.contains("## Session Goals"), "{md}");
+    assert!(
+        md.contains("**mode:** goals (latest goal per session)"),
+        "{md}"
+    );
+    assert!(md.contains("session `sess-goal-1`"), "{md}");
+    assert!(md.contains("goal [paused]"), "{md}");
+    assert!(md.contains("phlogiston pipeline overhaul"), "{md}");
+    // Raw metadata blob must not leak.
+    assert!(!md.contains("metadata_json"), "{md}");
+}
+
+#[test]
+fn message_search_markdown_goals_view_handles_empty() {
+    let payload = json!({
+        "status": "ok",
+        "goals": true,
+        "count": 0,
+        "results": [],
+    });
+    let md = render_message_search_md(&payload);
+    assert!(md.contains("## Session Goals"), "{md}");
+    assert!(md.contains("No goals recorded for this project."), "{md}");
+}
+
+#[test]
 fn message_text_snippet_extracts_readable_content_from_json() {
     let text =
         "[{\"type\":\"tool_result\",\"content\":\"hello world\",\"tool_use_id\":\"toolu_1\"}]";

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -16,6 +16,15 @@
 //! * `event_msg` with `payload.type == "token_count"` — per-API-call usage; a
 //!   turn's tool loop emits one per call, so a turn's true cost is the *sum*
 //!   (see [`CodexTurnUsage`]).
+//! * `event_msg` with `payload.type == "thread_goal_updated"` — the structured
+//!   session goal and its lifecycle (`payload.goal.{objective,status,tokensUsed,
+//!   timeUsedSeconds,createdAt,updatedAt}`). `TraceDecay` records each state as a
+//!   compact `goal` row (objective as text, the rest in `metadata_json`) so the
+//!   session's goal and whether it is still active is searchable. `status` is
+//!   stored verbatim — real rollouts emit `active`/`paused`, but any future
+//!   value (e.g. `completed`) is carried through unchanged rather than mapped to
+//!   a fixed enum. Consecutive events that repeat the same `(objective, status)`
+//!   within one parse pass are deduped; each genuine transition keeps its row.
 //! * `compacted` — Codex context-compression boundary. The rollout stores the
 //!   replacement history and an encrypted compaction body, so `TraceDecay` records
 //!   the boundary/provenance as a summary record without claiming plaintext
@@ -134,6 +143,10 @@ impl TranscriptSource for CodexSource {
         let new = stream_new_jsonl(path, prev, max_new_bytes)?;
         let mut messages = Vec::new();
         let mut turn_usage = CodexTurnUsage::default();
+        // Collapses identical consecutive goal states within this parse pass:
+        // `thread_goal_updated` fires on every token/time tick, so only an
+        // objective- or status-change opens a new `goal` row.
+        let mut last_goal_key: Option<(String, Option<String>)> = None;
         let replayed_from_start =
             prev.position > 0 && new.lines.first().is_some_and(|line| line.offset == 0);
         let mut context_state = if prev.position > 0 && !replayed_from_start {
@@ -146,6 +159,28 @@ impl TranscriptSource for CodexSource {
                 continue;
             }
             if context_state.observe_context_record(&line.value, path, &meta) {
+                continue;
+            }
+            if let Some(event) = codex_goal_event_from_line(&line.value) {
+                let key = event.dedup_key();
+                if last_goal_key.as_ref() == Some(&key) {
+                    continue;
+                }
+                last_goal_key = Some(key);
+                let mut message = goal_event_message(
+                    &meta,
+                    context_state.model.as_deref(),
+                    path,
+                    line.offset,
+                    timestamp_from_record(&line.value),
+                    &event,
+                );
+                context::annotate_message(
+                    &mut message,
+                    context_state.cwd.as_deref(),
+                    context_state.git.as_ref(),
+                );
+                messages.push(message);
                 continue;
             }
             if let Some(mut message) = response_item_goal_context_from_line(
@@ -666,6 +701,133 @@ fn goal_context_message(
     }
 }
 
+/// Codex's structured session goal, parsed from a `thread_goal_updated`
+/// `event_msg`. `status` is stored verbatim; the parser deliberately does not
+/// map it to a fixed enum so an unrecognized future value survives round-trip.
+struct CodexGoalEvent {
+    objective: String,
+    status: Option<String>,
+    thread_id: Option<String>,
+    tokens_used: Option<i64>,
+    time_used_seconds: Option<i64>,
+    created_at: Option<i64>,
+    updated_at: Option<i64>,
+}
+
+impl CodexGoalEvent {
+    /// Key used to collapse identical consecutive lifecycle states within one
+    /// parse pass. Token/time drift on the same `(objective, status)` is
+    /// progress within a state, not a transition, so it does not open a new row.
+    fn dedup_key(&self) -> (String, Option<String>) {
+        (self.objective.clone(), self.status.clone())
+    }
+
+    fn metadata(&self) -> Value {
+        let mut goal = serde_json::Map::new();
+        goal.insert(
+            "source".to_string(),
+            Value::String("codex_thread_goal".to_string()),
+        );
+        goal.insert(
+            "source_event".to_string(),
+            Value::String("thread_goal_updated".to_string()),
+        );
+        goal.insert(
+            "objective".to_string(),
+            Value::String(self.objective.clone()),
+        );
+        if let Some(status) = &self.status {
+            goal.insert("status".to_string(), Value::String(status.clone()));
+        }
+        if let Some(thread_id) = &self.thread_id {
+            goal.insert("thread_id".to_string(), Value::String(thread_id.clone()));
+        }
+        if let Some(tokens_used) = self.tokens_used {
+            goal.insert("tokens_used".to_string(), Value::from(tokens_used));
+        }
+        if let Some(time_used_seconds) = self.time_used_seconds {
+            goal.insert(
+                "time_used_seconds".to_string(),
+                Value::from(time_used_seconds),
+            );
+        }
+        if let Some(created_at) = self.created_at {
+            goal.insert("created_at".to_string(), Value::from(created_at));
+        }
+        if let Some(updated_at) = self.updated_at {
+            goal.insert("updated_at".to_string(), Value::from(updated_at));
+        }
+        Value::Object(goal)
+    }
+}
+
+/// Parse a `thread_goal_updated` `event_msg` into a [`CodexGoalEvent`], or
+/// `None` for any other line. A goal with an empty/absent objective is skipped
+/// (there is nothing to catalog or search).
+fn codex_goal_event_from_line(record: &Value) -> Option<CodexGoalEvent> {
+    if record.get("type").and_then(Value::as_str) != Some("event_msg") {
+        return None;
+    }
+    let payload = record.get("payload")?;
+    if payload.get("type").and_then(Value::as_str) != Some("thread_goal_updated") {
+        return None;
+    }
+    let goal = payload.get("goal")?;
+    let objective = goal
+        .get("objective")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|objective| !objective.is_empty())?
+        .to_string();
+    Some(CodexGoalEvent {
+        objective,
+        status: goal
+            .get("status")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|status| !status.is_empty())
+            .map(str::to_string),
+        thread_id: goal
+            .get("threadId")
+            .and_then(Value::as_str)
+            .or_else(|| payload.get("threadId").and_then(Value::as_str))
+            .filter(|thread_id| !thread_id.is_empty())
+            .map(str::to_string),
+        tokens_used: goal.get("tokensUsed").and_then(Value::as_i64),
+        time_used_seconds: goal.get("timeUsedSeconds").and_then(Value::as_i64),
+        created_at: goal.get("createdAt").and_then(Value::as_i64),
+        updated_at: goal.get("updatedAt").and_then(Value::as_i64),
+    })
+}
+
+/// Build the compact `goal` session row: the objective as searchable text, the
+/// lifecycle fields in `metadata_json`. Role `system` matches the other
+/// non-conversational Codex rows (goal context, compaction summaries).
+fn goal_event_message(
+    meta: &CodexMeta,
+    model: Option<&str>,
+    path: &Path,
+    offset: i64,
+    timestamp: Option<i64>,
+    event: &CodexGoalEvent,
+) -> SessionMessageRecord {
+    SessionMessageRecord {
+        provider: PROVIDER.to_string(),
+        message_id: format!("{}:{offset}", meta.session_id),
+        session_id: meta.session_id.clone(),
+        role: "system".to_string(),
+        timestamp,
+        ordinal: offset,
+        text: event.objective.clone(),
+        kind: Some("goal".to_string()),
+        model: model.map(str::to_string),
+        tool_names: None,
+        source_path: Some(path.to_string_lossy().to_string()),
+        source_offset: Some(offset),
+        metadata_json: serde_json::to_string(&event.metadata()).ok(),
+    }
+}
+
 fn collect_response_item_text(value: &Value) -> String {
     match value {
         Value::String(text) => text.clone(),
@@ -1166,5 +1328,125 @@ fn flush_turn_usage(messages: &mut [SessionMessageRecord], turn_usage: &mut Code
     }
     if let Ok(serialized) = serde_json::to_string(&Value::Object(metadata)) {
         message.metadata_json = Some(serialized);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod goal_event_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn goal_event_line(objective: &str, status: &str) -> Value {
+        json!({
+            "timestamp": "2026-07-08T08:49:29.711Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "thread_goal_updated",
+                "threadId": "thread-1",
+                "goal": {
+                    "threadId": "thread-1",
+                    "objective": objective,
+                    "status": status,
+                    "tokensUsed": 42,
+                    "timeUsedSeconds": 7,
+                    "createdAt": 1_783_500_569i64,
+                    "updatedAt": 1_783_500_600i64
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn parses_goal_event_into_row_with_metadata() {
+        let event =
+            codex_goal_event_from_line(&goal_event_line("ship the parser", "active")).unwrap();
+        let meta = CodexMeta {
+            cwd: std::path::PathBuf::from("/tmp/project"),
+            session_id: "sess-1".to_string(),
+            model: None,
+            git: None,
+            parent_session_id: None,
+            is_subagent: false,
+            agent_id: None,
+            agent_nickname: None,
+            agent_role: None,
+            thread_source: None,
+        };
+        let message = goal_event_message(
+            &meta,
+            Some("gpt-5.5"),
+            std::path::Path::new("/tmp/rollout.jsonl"),
+            128,
+            Some(1_783_500_600),
+            &event,
+        );
+        assert_eq!(message.role, "system");
+        assert_eq!(message.kind.as_deref(), Some("goal"));
+        assert_eq!(message.text, "ship the parser");
+        assert_eq!(message.ordinal, 128);
+        let metadata: Value =
+            serde_json::from_str(message.metadata_json.as_deref().unwrap()).unwrap();
+        assert_eq!(metadata["source"], "codex_thread_goal");
+        assert_eq!(metadata["source_event"], "thread_goal_updated");
+        assert_eq!(metadata["status"], "active");
+        assert_eq!(metadata["thread_id"], "thread-1");
+        assert_eq!(metadata["tokens_used"], 42);
+        assert_eq!(metadata["time_used_seconds"], 7);
+        assert_eq!(metadata["created_at"], 1_783_500_569i64);
+        assert_eq!(metadata["updated_at"], 1_783_500_600i64);
+    }
+
+    #[test]
+    fn consecutive_identical_states_share_a_dedup_key() {
+        let a = codex_goal_event_from_line(&goal_event_line("same goal", "active")).unwrap();
+        // Same objective+status, only token/time drift -> same dedup key (skipped).
+        let mut drift = goal_event_line("same goal", "active");
+        drift["payload"]["goal"]["tokensUsed"] = json!(9999);
+        drift["payload"]["goal"]["timeUsedSeconds"] = json!(321);
+        let b = codex_goal_event_from_line(&drift).unwrap();
+        assert_eq!(a.dedup_key(), b.dedup_key());
+        // A status transition is a distinct key (new row).
+        let c = codex_goal_event_from_line(&goal_event_line("same goal", "paused")).unwrap();
+        assert_ne!(a.dedup_key(), c.dedup_key());
+    }
+
+    #[test]
+    fn unknown_status_is_carried_through_verbatim() {
+        let event =
+            codex_goal_event_from_line(&goal_event_line("do the thing", "completed")).unwrap();
+        assert_eq!(event.status.as_deref(), Some("completed"));
+        let metadata = event.metadata();
+        assert_eq!(metadata["status"], "completed");
+    }
+
+    #[test]
+    fn missing_status_and_objective_are_handled_gracefully() {
+        // No status key at all -> status None, still a valid goal row.
+        let mut no_status = goal_event_line("objective only", "active");
+        no_status["payload"]["goal"]
+            .as_object_mut()
+            .unwrap()
+            .remove("status");
+        let event = codex_goal_event_from_line(&no_status).unwrap();
+        assert!(event.status.is_none());
+        assert!(!event.metadata().as_object().unwrap().contains_key("status"));
+        // Empty objective -> no goal row (nothing to catalog).
+        let empty = goal_event_line("   ", "active");
+        assert!(codex_goal_event_from_line(&empty).is_none());
+    }
+
+    #[test]
+    fn non_goal_event_lines_are_ignored() {
+        let token_count = json!({
+            "type": "event_msg",
+            "payload": {"type": "token_count", "info": {}}
+        });
+        assert!(codex_goal_event_from_line(&token_count).is_none());
+        let user = json!({
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "hi"}
+        });
+        assert!(codex_goal_event_from_line(&user).is_none());
     }
 }

--- a/tests/transcript_ingest_suite/codex.rs
+++ b/tests/transcript_ingest_suite/codex.rs
@@ -1856,3 +1856,162 @@ async fn codex_subagent_rollout_uses_parent_link_from_session_meta() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].session.session_id, "codex-child");
 }
+
+/// Writes a Codex rollout carrying a `thread_goal_updated` lifecycle: an
+/// initial `active` goal, an identical follow-up (only token/time drift — must
+/// be deduped), then a `paused` transition (a distinct state — must keep its
+/// own row).
+fn write_codex_rollout_with_goal_events(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".codex/sessions/2026/01/02");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("rollout-2026-01-02T00-00-00-{session}.jsonl"));
+    let goal = |status: &str, tokens: i64, secs: i64, updated: i64| {
+        serde_json::json!({
+            "type": "thread_goal_updated",
+            "threadId": session,
+            "goal": {
+                "threadId": session,
+                "objective": "phlogiston pipeline overhaul and reconciliation",
+                "status": status,
+                "tokensUsed": tokens,
+                "timeUsedSeconds": secs,
+                "createdAt": 1_783_500_000i64,
+                "updatedAt": updated
+            }
+        })
+    };
+    write_jsonl(
+        &path,
+        &[
+            serde_json::json!({
+                "timestamp": "2026-01-02T00:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": session, "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-02T00:00:01.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "start the overhaul"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-02T00:00:02.000Z",
+                "type": "event_msg",
+                "payload": goal("active", 0, 0, 1_783_500_000)
+            }),
+            // Same (objective, status) — only token/time drift. Deduped.
+            serde_json::json!({
+                "timestamp": "2026-01-02T00:00:03.000Z",
+                "type": "event_msg",
+                "payload": goal("active", 5000, 42, 1_783_500_042)
+            }),
+            // Status transition -> new goal row.
+            serde_json::json!({
+                "timestamp": "2026-01-02T00:00:04.000Z",
+                "type": "event_msg",
+                "payload": goal("paused", 5000, 42, 1_783_500_100)
+            }),
+            serde_json::json!({
+                "timestamp": "2026-01-02T00:00:05.000Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "paused for review"}
+            }),
+        ],
+    );
+    path
+}
+
+#[tokio::test]
+async fn codex_thread_goal_events_ingested_as_goal_rows_with_dedupe() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_codex_rollout_with_goal_events(&home, &project, "codex-goal-events");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+    let stats = ingest_source(&db, &source, &project, None).await;
+    // user_message + agent_message + two goal rows (active, paused). The
+    // drift-only `active` repeat is deduped away.
+    assert_eq!(stats.messages_upserted, 4);
+
+    // Both distinct goal states are searchable by their shared objective text.
+    let hits = db
+        .search_session_messages(
+            "codex",
+            Some(project.to_string_lossy().as_ref()),
+            "phlogiston overhaul",
+            10,
+        )
+        .await;
+    let goal_hits: Vec<_> = hits
+        .iter()
+        .filter(|hit| hit.message.kind.as_deref() == Some("goal"))
+        .collect();
+    assert_eq!(
+        goal_hits.len(),
+        2,
+        "active + paused transitions kept, drift deduped"
+    );
+    let mut statuses: Vec<String> = goal_hits
+        .iter()
+        .filter_map(|hit| {
+            let meta: serde_json::Value =
+                serde_json::from_str(hit.message.metadata_json.as_deref().unwrap()).ok()?;
+            meta.get("status")
+                .and_then(|s| s.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    statuses.sort();
+    assert_eq!(statuses, vec!["active".to_string(), "paused".to_string()]);
+    for hit in &goal_hits {
+        assert_eq!(hit.message.role, "system");
+        assert_eq!(
+            hit.message.text,
+            "phlogiston pipeline overhaul and reconciliation"
+        );
+        let meta: serde_json::Value =
+            serde_json::from_str(hit.message.metadata_json.as_deref().unwrap()).unwrap();
+        assert_eq!(meta["source"], "codex_thread_goal");
+        assert_eq!(meta["source_event"], "thread_goal_updated");
+        assert_eq!(meta["thread_id"], "codex-goal-events");
+    }
+}
+
+#[tokio::test]
+async fn recent_session_goals_surfaces_latest_status_per_session() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    write_codex_rollout_with_goal_events(&home, &project, "codex-goal-events");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+
+    let goals = db
+        .recent_session_goals(Some(project.to_string_lossy().as_ref()), 10)
+        .await;
+    // One row per session: the latest lifecycle state (paused).
+    assert_eq!(goals.len(), 1);
+    let goal = &goals[0];
+    assert_eq!(goal.session.session_id, "codex-goal-events");
+    assert_eq!(goal.message.kind.as_deref(), Some("goal"));
+    assert_eq!(
+        goal.message.text,
+        "phlogiston pipeline overhaul and reconciliation"
+    );
+    let meta: serde_json::Value =
+        serde_json::from_str(goal.message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(meta["status"], "paused");
+    assert_eq!(meta["updated_at"], 1_783_500_100i64);
+
+    // Re-ingest must be idempotent (upsert keyed by message_id): still one goal.
+    ingest_source(&db, &source, &project, None).await;
+    let goals_again = db
+        .recent_session_goals(Some(project.to_string_lossy().as_ref()), 10)
+        .await;
+    assert_eq!(goals_again.len(), 1);
+}


### PR DESCRIPTION
Ingests Codex thread_goal_updated events as kind='goal' session rows (objective + verbatim status + usage metadata, transition-deduped) and surfaces them: goal hits render with their status in message_search, and a goals:true mode lists the latest goal per session. Live-proven against a real /goal rollout under an isolated store. Historical backfill (insert-capable) is a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)