### PR TITLE
fix(tests): normalize worktree path for git on Windows

### DIFF
--- a/tests/storage_suite/worktree_canonical_root_guard_test.rs
+++ b/tests/storage_suite/worktree_canonical_root_guard_test.rs
@@ -26,6 +26,17 @@ fn canonical_temp_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
+fn git_cli_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let text = path.to_string_lossy();
+        if let Some(stripped) = text.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+    path.to_path_buf()
+}
+
 fn git(project: &Path, args: &[&str]) {
     let output = Command::new("git")
         .args(["-c", "core.hooksPath=.git/no-hooks"])
@@ -87,7 +98,7 @@ fn build_fixture() -> Fixture {
             "add",
             "-b",
             "feature/worktree-guard",
-            worktree.to_str().unwrap(),
+            git_cli_path(&worktree).to_str().unwrap(),
             "HEAD",
         ],
     );


### PR DESCRIPTION
Fixes the Windows CI failure where `Path::canonicalize()` returns a verbatim `\\?\` path and Git for Windows rejects it as a worktree destination. Keeps the normalization scoped to the storage worktree test helper.\n\nVerification:\n- `cargo fmt --check`\n- `git diff --check`\n- `cargo test -p tracedecay --test storage_suite worktree_canonical_root_guard -- --nocapture`