### PR TITLE
fix(db): stop conflating attrs_start_line 0 with unset

### DIFF
--- a/src/db/migrations.rs
+++ b/src/db/migrations.rs
@@ -16,7 +16,7 @@ use crate::memory::store::MemoryStore;
 
 /// The highest migration version defined in this file. Bump this and add a
 /// new entry to `run_migration` whenever the schema changes.
-const LATEST_VERSION: u32 = 16;
+const LATEST_VERSION: u32 = 17;
 
 /// Reads the current schema version from `PRAGMA user_version`.
 async fn get_version(conn: &Connection) -> Result<u32> {
@@ -148,7 +148,12 @@ pub async fn create_schema(conn: &Connection) -> Result<()> {
             unchecked_calls INTEGER NOT NULL DEFAULT 0,
             assertions INTEGER NOT NULL DEFAULT 0,
             updated_at INTEGER NOT NULL,
-            attrs_start_line INTEGER NOT NULL DEFAULT 0,
+            -- Nullable and no default: a real value (including a legitimate 0 for
+            -- an item documented at the very top of a file) is written by every
+            -- extractor, and SQL NULL is reserved as the honest unset marker so
+            -- that a stored 0 is never mistaken for a defaulted/unknown value.
+            -- See row_to_node in db/rows.rs for the read-side contract.
+            attrs_start_line INTEGER,
             parent_id TEXT
         );
 
@@ -370,6 +375,7 @@ async fn run_migration(conn: &Connection, version: u32) -> Result<()> {
         14 => migrate_v14(conn).await,
         15 => migrate_v15(conn).await,
         16 => migrate_v16(conn).await,
+        17 => migrate_v17(conn).await,
         _ => Err(TraceDecayError::Database {
             message: format!("unknown migration version: {version}"),
             operation: "run_migration".to_string(),
@@ -586,6 +592,41 @@ async fn migrate_v16(conn: &Connection) -> Result<()> {
             message: format!("v16: failed to create redundancy_pairs table: {e}"),
             operation: "migrate_v16".to_string(),
         })?;
+    Ok(())
+}
+
+/// v17: semantic marker for the `attrs_start_line` sentinel fix.
+///
+/// The read path used to treat a stored `attrs_start_line = 0` as "unset" and
+/// substitute `start_line`. But 0 is a *legitimate* value: an item whose
+/// doc-comment / attribute block starts at the very top of a file (row 0) —
+/// e.g. `/// doc\nfn foo() {}` extracts as `attrs_start_line=0`, `start_line=1`.
+/// The conflation collapsed that to `attrs_start_line=1` after a DB round-trip,
+/// so symbol-aware editing lost the leading doc block for first-in-file items.
+///
+/// The new scheme: the stored integer (including 0) is trusted verbatim; SQL
+/// NULL is the only "unset" marker, and readers fall back to `start_line` for
+/// NULL alone. Fresh databases now create the column as nullable with no
+/// default (see `create_schema`).
+///
+/// This migration intentionally rewrites no data:
+/// - Rows whose legitimate 0 was already overwritten by the v7 backfill
+///   (`SET attrs_start_line = start_line WHERE attrs_start_line = 0`) are
+///   indistinguishable from correct rows and cannot be recovered here; they
+///   self-heal the next time their file is re-indexed and the true value is
+///   written back.
+/// - After v7, any remaining `attrs_start_line = 0` row necessarily has
+///   `start_line = 0` (file-root nodes), for which 0 is already the correct
+///   real value — mapping it to NULL would read back identically.
+/// - The legacy `NOT NULL DEFAULT 0` column constraint on migrated databases
+///   is left in place: `SQLite` cannot relax a column constraint without
+///   rebuilding the table, and rebuilding `nodes` inside this exclusive
+///   transaction (where `PRAGMA foreign_keys` cannot be toggled) would
+///   cascade-delete every child table. The constraint is harmless — all
+///   writers supply an explicit value, so the DEFAULT can never manufacture a
+///   false 0, and NULL is only ever *read*, never written, on such databases.
+#[allow(clippy::unused_async)] // keeps the migration dispatch uniform
+async fn migrate_v17(_conn: &Connection) -> Result<()> {
     Ok(())
 }
 
@@ -901,6 +942,20 @@ async fn migrate_v6(conn: &Connection) -> Result<()> {
 ///
 /// Existing rows are backfilled with `start_line` so behaviour is preserved
 /// for nodes indexed before this migration.
+///
+/// NOTE (reconciliation): this backfill (`SET attrs_start_line = start_line
+/// WHERE attrs_start_line = 0`) treated a stored `0` as "unset". That conflates
+/// a *legitimate* 0 — an item documented at the very top of a file — with the
+/// column default, and irreversibly overwrites such rows with `start_line`. The
+/// read path in [`crate::db::rows`] no longer makes that mistake: it trusts the
+/// stored integer (including 0) and only falls back to `start_line` for a SQL
+/// NULL / absent column. The fresh schema (`create_schema`) now declares the
+/// column nullable so 0 and "unset" are distinct going forward. Rows whose
+/// legitimate 0 was already destroyed by this historical backfill cannot be
+/// recovered here — they self-heal the next time the file is re-indexed and the
+/// true `attrs_start_line` is written back. The DDL below is intentionally left
+/// as-is (not rewritten) to keep migration history stable for databases that
+/// have already applied it.
 async fn migrate_v7(conn: &Connection) -> Result<()> {
     conn.execute(
         "ALTER TABLE nodes ADD COLUMN attrs_start_line INTEGER NOT NULL DEFAULT 0",

--- a/src/db/rows.rs
+++ b/src/db/rows.rs
@@ -18,13 +18,20 @@ pub(super) fn row_to_node(row: &libsql::Row) -> std::result::Result<Node, libsql
     let vis_str = get_string_lossy(row, 11)?;
     let is_async_int = row.get::<i64>(12)?;
     let start_line = row.get::<u32>(5)?;
-    // Pre-v7 rows may have attrs_start_line == 0 (default); fall back to start_line.
-    let attrs_raw = row.get::<u32>(21).unwrap_or(0);
-    let attrs_start_line = if attrs_raw == 0 {
-        start_line
-    } else {
-        attrs_raw
-    };
+    // `attrs_start_line` is the first line of an item's leading doc-comment /
+    // attribute block. A stored `0` is a *legitimate* value — an item documented
+    // or attributed at the very top of a file (e.g. `/// doc\nfn foo() {}` yields
+    // attrs_start_line=0, start_line=1). We therefore trust the stored integer
+    // verbatim, including 0, and never conflate it with "unset". We only fall
+    // back to `start_line` when the column is genuinely absent: a SQL NULL (a
+    // legacy row that predates the column) or an older SELECT list that does not
+    // request column 21. `Option<u32>` distinguishes those cases (NULL / missing
+    // column => `None`) from a real zero (`Some(0)`).
+    let attrs_start_line = row
+        .get::<Option<u32>>(21)
+        .ok()
+        .flatten()
+        .unwrap_or(start_line);
     // `parent_id` is column 22 in v9+ SELECT lists. Older SELECTs in this
     // file don't request it; the .ok().flatten() chain swallows the missing-
     // column error and yields None.

--- a/src/graph/queries.rs
+++ b/src/graph/queries.rs
@@ -32,15 +32,16 @@ fn row_to_node_dead_code(row: &libsql::Row) -> std::result::Result<Node, libsql:
     let vis_str = get_string_lossy(row, 11)?;
     let is_async_int = row.get::<i64>(12)?;
     let start_line = row.get::<u32>(5)?;
-    // Pre-v7 rows lack attrs_start_line; fall back to start_line. The dead-code
-    // SELECT below does not include the new column, so attempts to read at 21
-    // will always error here — keep the fallback path explicit.
-    let attrs_raw = row.get::<u32>(21).unwrap_or(0);
-    let attrs_start_line = if attrs_raw == 0 {
-        start_line
-    } else {
-        attrs_raw
-    };
+    // Same contract as `row_to_node` in db/rows.rs: a stored 0 is a legitimate
+    // value (item documented at the very top of a file), so trust the stored
+    // integer verbatim and fall back to `start_line` only when the column is
+    // genuinely absent — SQL NULL on a legacy row, or a SELECT list that does
+    // not request column 21.
+    let attrs_start_line = row
+        .get::<Option<u32>>(21)
+        .ok()
+        .flatten()
+        .unwrap_or(start_line);
 
     Ok(Node {
         id: get_string_lossy(row, 0)?,

--- a/src/tracedecay/edits.rs
+++ b/src/tracedecay/edits.rs
@@ -381,7 +381,11 @@ impl TraceDecay {
         })?;
         let lines: Vec<&str> = source.lines().collect();
         let anchor_line = if before {
-            target.start_line as usize
+            // Anchor above the item's leading doc-comment / attribute block so
+            // "before" never splits docs from the item they document. For items
+            // with no leading block, attrs_start_line == start_line and this is
+            // the item line itself. The min() guards against inconsistent rows.
+            target.attrs_start_line.min(target.start_line) as usize
         } else {
             (target.end_line as usize).saturating_add(1)
         };

--- a/tests/core_cli_suite/tracedecay_test.rs
+++ b/tests/core_cli_suite/tracedecay_test.rs
@@ -790,3 +790,88 @@ async fn last_sync_timestamp_falls_back_to_indexed_at_without_metadata() {
     let fallback = cg.last_index_time().await.unwrap();
     assert_eq!(observed, fallback);
 }
+
+// ---------------------------------------------------------------------------
+// attrs_start_line = 0 (first-in-file documented item) end-to-end
+// ---------------------------------------------------------------------------
+
+/// Creates a temp project whose first file line is a doc comment for the fn
+/// on line two — the extractor emits attrs_start_line=0 / start_line=1.
+async fn setup_first_in_file_doc() -> (TempDir, TraceDecay) {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "/// doc\nfn foo() {}\n").unwrap();
+    let cg = TraceDecay::init(project).await.unwrap();
+    cg.index_all().await.unwrap();
+    (dir, cg)
+}
+
+/// Regression: a stored attrs_start_line of 0 is a legitimate value (doc block
+/// at the very top of a file) and must survive the DB round-trip. The read
+/// path used to treat 0 as "unset" and substitute start_line, collapsing the
+/// doc block out of the item's full span after indexing.
+#[tokio::test]
+async fn attrs_start_line_zero_survives_indexing_round_trip() {
+    let (_dir, cg) = setup_first_in_file_doc().await;
+
+    let nodes = cg
+        .get_nodes_by_qualified_name("src/lib.rs::foo")
+        .await
+        .unwrap();
+    assert_eq!(nodes.len(), 1, "expected exactly one foo node");
+    let n = &nodes[0];
+    assert_eq!(n.start_line, 1, "fn foo is on 0-based row 1");
+    assert_eq!(
+        n.attrs_start_line, 0,
+        "doc block starts at row 0 and must round-trip as 0, not be rewritten to start_line"
+    );
+    assert!(
+        n.attrs_start_line < n.start_line,
+        "leading doc block must remain part of the item's full span"
+    );
+}
+
+/// Regression: replace_symbol on a first-in-file documented fn must preserve
+/// the leading doc comment (replace only the item lines, never orphan or eat
+/// the doc block above).
+#[tokio::test]
+async fn replace_symbol_preserves_first_in_file_doc_comment() {
+    let (dir, cg) = setup_first_in_file_doc().await;
+
+    let result = cg
+        .replace_symbol("src/lib.rs::foo", "fn foo() { let _x = 1; }")
+        .await
+        .unwrap();
+    assert!(result.success, "replace failed: {}", result.message);
+
+    let content = fs::read_to_string(dir.path().join("src/lib.rs")).unwrap();
+    assert_eq!(
+        content, "/// doc\nfn foo() { let _x = 1; }\n",
+        "doc comment must stay attached above the replaced item"
+    );
+}
+
+/// Regression: insert_at_symbol position=before must insert ABOVE the leading
+/// doc block, not between the doc comment and the fn. Only works when the
+/// legitimate attrs_start_line=0 survives the DB round-trip.
+#[tokio::test]
+async fn insert_before_first_in_file_documented_fn_goes_above_doc_block() {
+    let (dir, cg) = setup_first_in_file_doc().await;
+
+    let result = cg
+        .insert_at_symbol(
+            "src/lib.rs::foo",
+            "// SPDX-License-Identifier: MIT",
+            "before",
+        )
+        .await
+        .unwrap();
+    assert!(result.success, "insert failed: {}", result.message);
+
+    let content = fs::read_to_string(dir.path().join("src/lib.rs")).unwrap();
+    assert_eq!(
+        content, "// SPDX-License-Identifier: MIT\n/// doc\nfn foo() {}\n",
+        "insertion must land above the doc block, not split doc from fn"
+    );
+}

--- a/tests/storage_suite/db_query_test.rs
+++ b/tests/storage_suite/db_query_test.rs
@@ -2796,6 +2796,93 @@ async fn test_attrs_start_line_round_trips_through_db() {
     assert_eq!(fetched.attrs_start_line, 6);
 }
 
+#[tokio::test]
+async fn test_attrs_start_line_zero_survives_round_trip() {
+    // An item documented at the very top of a file has its doc/attr block start
+    // at row 0 while the item itself starts at row 1 — exactly what RustExtractor
+    // emits for "/// doc\nfn foo() {}". A stored 0 is a *legitimate* value and
+    // must survive the DB round-trip strictly below start_line. Regression:
+    // `row_to_node` used to treat a stored 0 as "unset" and substitute
+    // start_line, which orphaned the leading doc/attr block for first-in-file
+    // items.
+    let db = setup_db().await;
+
+    let mut n = sample_node("first_in_file", "documented_fn", "src/lib.rs");
+    n.start_line = 1;
+    n.attrs_start_line = 0;
+    db.insert_node(&n).await.expect("insert failed");
+
+    let by_id = db
+        .get_node_by_id("first_in_file")
+        .await
+        .expect("query failed")
+        .expect("node missing");
+    assert_eq!(by_id.start_line, 1);
+    assert_eq!(
+        by_id.attrs_start_line, 0,
+        "a legitimate attrs_start_line=0 must not be rewritten to start_line"
+    );
+    assert!(
+        by_id.attrs_start_line < by_id.start_line,
+        "leading doc/attr block must remain above the item"
+    );
+
+    // The qualified-name path used by the edit/derive resolvers must agree.
+    let hits = db
+        .get_nodes_by_qualified_name("crate::documented_fn")
+        .await
+        .expect("query failed");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].attrs_start_line, 0);
+    assert!(hits[0].attrs_start_line < hits[0].start_line);
+}
+
+#[tokio::test]
+async fn test_attrs_start_line_null_falls_back_to_start_line() {
+    // A legacy row whose attrs_start_line is SQL NULL (a row predating the
+    // column, or an older writer that never set it) must fall back to start_line
+    // on read. This is now the *only* case the fallback covers, since a stored 0
+    // is trusted verbatim.
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let db_path = dir.path().join("test.db");
+    support::seed_latest_graph_db(&db_path).await;
+
+    // The fresh schema declares attrs_start_line nullable, so a raw connection
+    // can persist an explicit NULL for this row.
+    let raw = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("build raw db");
+    let conn = raw.connect().expect("connect raw");
+    conn.execute(
+        "INSERT INTO nodes (id, kind, name, qualified_name, file_path,
+                            start_line, end_line, start_column, end_column,
+                            updated_at, attrs_start_line)
+         VALUES ('legacy', 'function', 'legacy_fn', 'crate::legacy_fn', 'src/lib.rs',
+                 12, 20, 0, 1, 1000, NULL)",
+        (),
+    )
+    .await
+    .expect("insert legacy row");
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)", ())
+        .await
+        .ok();
+    drop(conn);
+    drop(raw);
+
+    let (db, _migrated) = Database::open(&db_path).await.expect("open db");
+    let fetched = db
+        .get_node_by_id("legacy")
+        .await
+        .expect("query failed")
+        .expect("node missing");
+    assert_eq!(fetched.start_line, 12);
+    assert_eq!(
+        fetched.attrs_start_line, fetched.start_line,
+        "a NULL attrs_start_line must fall back to start_line"
+    );
+}
+
 // -------------------------------------------------------------------------
 // get_test_annotated_node_ids
 // -------------------------------------------------------------------------

--- a/tests/storage_suite/db_test.rs
+++ b/tests/storage_suite/db_test.rs
@@ -503,7 +503,7 @@ async fn test_migrate_v7_adds_and_backfills_attrs_start_line() {
         .expect("read version");
     let row = rows.next().await.expect("row").expect("some row");
     let version: i64 = row.get(0).expect("version");
-    assert_eq!(version, 16);
+    assert_eq!(version, 17);
 
     // attrs_start_line is backfilled from start_line for both rows.
     // Row a: start_line=42 -> attrs_start_line=42.

--- a/tests/storage_suite/migration_test.rs
+++ b/tests/storage_suite/migration_test.rs
@@ -486,7 +486,7 @@ async fn test_create_schema_fresh_db() {
         .await
         .expect("create_schema should succeed");
 
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         2,
@@ -524,7 +524,7 @@ async fn test_create_schema_idempotent() {
         .await
         .expect("second create_schema should succeed");
 
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 }
 
 /// migrate returns false when already at the latest version.
@@ -538,7 +538,7 @@ async fn test_migrate_already_latest_returns_false() {
         !migrated,
         "migrate should return false when already at latest"
     );
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 }
 
 /// migrate from v0 (completely empty database) applies all migrations to latest.
@@ -557,7 +557,7 @@ async fn test_migrate_from_v0() {
         migrated,
         "migrate should return true when migrations were applied"
     );
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     // All expected tables should exist
     assert!(table_exists(&conn, "nodes").await);
@@ -598,7 +598,7 @@ async fn test_migrate_from_v1() {
         .expect("migrate from v1 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     // V2: metadata table
     assert!(table_exists(&conn, "metadata").await);
@@ -634,7 +634,7 @@ async fn test_migrate_from_v2() {
         .expect("migrate from v2 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     // V3 columns
     assert!(column_exists(&conn, "nodes", "branches").await);
@@ -664,7 +664,7 @@ async fn test_migrate_from_v3() {
         .expect("migrate from v3 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     // V4 columns
     assert!(column_exists(&conn, "nodes", "unsafe_blocks").await);
@@ -692,7 +692,7 @@ async fn test_migrate_from_v4() {
         .expect("migrate from v4 should succeed");
 
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     assert!(index_exists(&conn, "idx_edges_unique").await);
 }
@@ -822,7 +822,7 @@ async fn test_database_initialize_creates_latest_version() {
         .await
         .expect("Database::initialize should succeed");
 
-    assert_eq!(get_user_version(db.conn()).await, 16);
+    assert_eq!(get_user_version(db.conn()).await, 17);
 }
 
 /// Database::open on an already-current database does not re-migrate.
@@ -874,7 +874,7 @@ async fn test_database_open_migrates_v1_to_latest() {
 
     assert!(migrated, "opening a v1 database should trigger migration");
 
-    assert_eq!(get_user_version(db.conn()).await, 16);
+    assert_eq!(get_user_version(db.conn()).await, 17);
 }
 
 /// After create_schema, all v5 columns on nodes exist.
@@ -1017,7 +1017,7 @@ async fn test_v7_to_latest_upgrade_path() {
     let did_migrate = migrate(&conn).await.unwrap();
     assert!(did_migrate, "expected migrate() to return true");
 
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     let mut rows = conn
         .query(
@@ -1065,7 +1065,7 @@ async fn test_migrate_v16_adds_redundancy_pairs() {
     let migrated = migrate(&conn).await.expect("v16 migration should apply");
 
     assert!(migrated, "expected migrate() to run the v16 addition");
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert!(
         table_exists(&conn, "redundancy_pairs").await,
         "v16 migration should create the redundancy_pairs table"
@@ -1221,7 +1221,7 @@ async fn test_v10_to_v11_backfills_and_drops_legacy_memory_tables() {
     let did_migrate = migrate(&conn).await.expect("v10 to v11 should migrate");
 
     assert!(did_migrate);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert!(!table_exists(&conn, "memory_decisions").await);
     assert!(!table_exists(&conn, "memory_code_areas").await);
     assert!(table_exists(&conn, "memory_facts").await);
@@ -1241,7 +1241,7 @@ async fn test_v11_database_migrates_to_monotonic_v12() {
     let did_migrate = migrate(&conn).await.expect("v11 to v12 should migrate");
 
     assert!(did_migrate);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert!(table_exists(&conn, "memory_bank_dirty").await);
 }
 
@@ -1664,7 +1664,7 @@ async fn test_v13_drops_archive_columns_with_generated_column_dependency() {
         .await
         .expect("v13 must drop archive columns even with a generated-column dependency");
     assert!(migrated, "expected migrate() to run the v13 cleanup");
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     let columns = column_names(&conn, "memory_facts").await;
     for col in [
@@ -1713,7 +1713,7 @@ async fn test_v14_adds_access_tracking_and_oplog() {
 
     let migrated = migrate(&conn).await.expect("v14 must apply cleanly");
     assert!(migrated, "expected migrate() to run the v14 additions");
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
 
     let columns = column_names(&conn, "memory_facts").await;
     for col in ["access_count", "last_recalled_at"] {
@@ -1739,7 +1739,7 @@ async fn test_v14_adds_access_tracking_and_oplog() {
         .await
         .expect("v14 must be idempotent on an already-upgraded schema");
     assert!(migrated_again);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert_eq!(
         scalar_i64(&conn, "SELECT COUNT(*) FROM memory_facts").await,
         1
@@ -1769,7 +1769,7 @@ async fn test_v15_compacts_legacy_f64_vectors_and_enables_incremental_vacuum() {
         .await
         .expect("v15 must compact legacy vectors");
     assert!(migrated);
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         2,
@@ -1812,7 +1812,7 @@ async fn test_v15_repairs_incremental_vacuum_when_version_already_latest() {
     )
     .await
     .expect("failed to simulate pre-repair auto_vacuum mode");
-    set_user_version(&conn, 16).await;
+    set_user_version(&conn, 17).await;
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         0,
@@ -1827,7 +1827,7 @@ async fn test_v15_repairs_incremental_vacuum_when_version_already_latest() {
         !migrated,
         "auto_vacuum repair should not report a schema migration"
     );
-    assert_eq!(get_user_version(&conn).await, 16);
+    assert_eq!(get_user_version(&conn).await, 17);
     assert_eq!(
         scalar_i64(&conn, "PRAGMA auto_vacuum").await,
         2,


### PR DESCRIPTION
Fixes the sentinel collision that lost first-in-file doc blocks: read paths now trust stored values verbatim (both mappers — including a second live copy of the conflation in the dead-code query), NULL is the only unset marker, fresh schemas drop the 0 default, and insert-before anchors above doc blocks. Includes round-trip/edit-primitive regression tests proven by revert (fail on old read path, pass on new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)