### PR TITLE
feat(mcp): structural edit-failure truth and safety substrate

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -29,7 +29,7 @@ use crate::tracedecay::TraceDecay;
 
 use super::hook_events::{self, HookAgent, HookEventPlan};
 use super::tools::{
-    ToolCallRegistryOptions, explore_call_budget, get_tool_definitions_with_budget,
+    ToolCallRegistryOptions, ToolResult, explore_call_budget, get_tool_definitions_with_budget,
     handle_tool_call_with_registry_and_implicit_project,
 };
 use super::transport::{ErrorCode, JsonRpcRequest, JsonRpcResponse};
@@ -515,7 +515,24 @@ fn format_index_age_phrase(age_secs: i64) -> String {
     }
 }
 
-fn tool_result_has_semantic_error(value: &Value) -> bool {
+/// Whether an MCP tool result should be classified as a semantic failure for
+/// analytics/`isError` purposes.
+///
+/// Handlers that build results structurally (e.g. edit tools, whose result
+/// struct carries a `success: bool`) call
+/// [`crate::mcp::tools::ToolResult::with_semantic_error`] to record the
+/// outcome directly — that marker is authoritative and wins over the
+/// rendered text. Handlers that have not been migrated to set the marker
+/// leave it `None`, and this falls back to the pre-existing text-based
+/// heuristic (`value_has_semantic_error`) that sniffs the rendered response
+/// text for JSON failure shapes or known plain-text failure prefixes.
+fn tool_result_has_semantic_error(result: &ToolResult) -> bool {
+    result
+        .semantic_error()
+        .unwrap_or_else(|| value_has_semantic_error(&result.value))
+}
+
+fn value_has_semantic_error(value: &Value) -> bool {
     value
         .get("content")
         .and_then(Value::as_array)
@@ -551,11 +568,34 @@ fn plain_text_tool_failure(text: &str) -> bool {
     text.starts_with("git error:") || text.starts_with("git diff failed:")
 }
 
-fn mark_semantic_tool_error(value: &mut Value) {
-    if !tool_result_has_semantic_error(value) {
+/// Reason to record for a semantically-failed tool result, for the
+/// `failure_reason` analytics field. Prefers the handler-supplied structural
+/// [`ToolResult::failure_message`] (e.g. an edit result's `message`, such as
+/// "`old_str` not found"); falls back to the rendered response's first text
+/// block for handlers that only signal failure via `value_has_semantic_error`
+/// text heuristics. Callers must only invoke this once the result is already
+/// known to be a semantic failure — it does not itself re-check that.
+fn semantic_failure_reason(result: &ToolResult) -> Option<String> {
+    if let Some(message) = result.failure_message() {
+        return Some(message.to_string());
+    }
+    result
+        .value
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|content| {
+            content
+                .iter()
+                .find_map(|item| item.get("text").and_then(Value::as_str))
+        })
+        .map(|text| text.trim_start().to_string())
+}
+
+fn mark_semantic_tool_error(result: &mut ToolResult) {
+    if !tool_result_has_semantic_error(result) {
         return;
     }
-    if let Some(obj) = value.as_object_mut() {
+    if let Some(obj) = result.value.as_object_mut() {
         obj.insert("isError".to_string(), json!(true));
     }
 }
@@ -2615,7 +2655,7 @@ impl McpServer {
                         )}));
                     }
                 }
-                let analytics_outcome = if tool_result_has_semantic_error(&result.value) {
+                let analytics_outcome = if tool_result_has_semantic_error(&result) {
                     "error"
                 } else {
                     "success"
@@ -2631,6 +2671,9 @@ impl McpServer {
                     let tool_name_owned = tool_name.to_string();
                     let ts = crate::tracedecay::current_timestamp();
                     let client_name = self.client_name();
+                    let failure_reason = (analytics_outcome == "error")
+                        .then(|| semantic_failure_reason(&result))
+                        .flatten();
                     let analytics_event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
                         project_root: cg.project_root(),
                         session_id: analytics_session_id.clone(),
@@ -2645,6 +2688,7 @@ impl McpServer {
                         arguments: &analytics_arguments,
                         internal_analytics: result.internal_analytics(),
                         client_name: client_name.as_deref(),
+                        failure_reason: failure_reason.as_deref(),
                     });
                     self.spawn_observed_ledger_write(async move {
                         gdb.record_savings(
@@ -2819,7 +2863,7 @@ impl McpServer {
                     }
                 }
 
-                mark_semantic_tool_error(&mut result.value);
+                mark_semantic_tool_error(&mut result);
                 JsonRpcResponse::success(id, result.value)
             }
             Err(e) => {
@@ -2830,12 +2874,14 @@ impl McpServer {
                     &request_id,
                     &analytics_arguments,
                     handler_elapsed_us,
+                    &e,
                 );
                 tool_error_response(id, tool_name, &e)
             }
         }
     }
 
+    #[allow(clippy::too_many_arguments)] // internal fan-in of independent request/analytics fields
     fn record_mcp_tool_error_analytics(
         &self,
         project_root: &std::path::Path,
@@ -2844,11 +2890,17 @@ impl McpServer {
         request_id: &Value,
         arguments: &Value,
         duration_us: Option<u64>,
+        error: &TraceDecayError,
     ) {
         let Some(gdb) = self.global_db.clone() else {
             return;
         };
         let client_name = self.client_name();
+        // `TraceDecayError`'s `Display` (via `thiserror`) already carries a
+        // variant-classified, human-readable message (e.g. "config error:
+        // missing required parameter: handle"); bounded truncation happens
+        // in `mcp_tool_analytics_event`.
+        let failure_reason = error.to_string();
         let event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
             project_root,
             session_id,
@@ -2863,6 +2915,7 @@ impl McpServer {
             arguments,
             internal_analytics: None,
             client_name: client_name.as_deref(),
+            failure_reason: Some(&failure_reason),
         });
         self.spawn_observed_ledger_write(async move {
             if let Err(e) = gdb.append_analytics_event(&event).await {

--- a/src/mcp/tool_analytics.rs
+++ b/src/mcp/tool_analytics.rs
@@ -22,6 +22,30 @@ pub(super) struct McpToolAnalyticsEvent<'a> {
     /// observed yet (e.g. a daemon-proxied first call). Bounded to the
     /// negotiated name only — never the full `clientInfo` payload.
     pub(super) client_name: Option<&'a str>,
+    /// Bounded, sanitized (no argument bodies) reason for a `outcome ==
+    /// "error"` call, e.g. a structural edit-tool failure message or a
+    /// dispatch error's `Display` text. `None` falls back to a generic
+    /// marker so pre-existing callers that have not been migrated to supply
+    /// a real reason keep working.
+    pub(super) failure_reason: Option<&'a str>,
+}
+
+/// Failure reasons are capped well below the metadata column's practical
+/// size so a pathological message can't bloat the analytics event; this
+/// intentionally excludes tool `arguments`, which may carry user file
+/// contents.
+const FAILURE_REASON_MAX_CHARS: usize = 160;
+
+/// Collapse whitespace and cap a failure reason to
+/// [`FAILURE_REASON_MAX_CHARS`] characters (never argument bodies — callers
+/// must derive `reason` from response/error text only).
+pub(super) fn bounded_failure_reason(reason: &str) -> String {
+    let collapsed: String = reason.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= FAILURE_REASON_MAX_CHARS {
+        collapsed
+    } else {
+        collapsed.chars().take(FAILURE_REASON_MAX_CHARS).collect()
+    }
 }
 
 pub(super) fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> AnalyticsEventInsert {
@@ -38,7 +62,12 @@ pub(super) fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> Anal
         "client_name": input.client_name,
     });
     if input.outcome == "error" {
-        metadata["failure_reason"] = json!("tool_dispatch_error");
+        metadata["failure_reason"] = json!(
+            input
+                .failure_reason
+                .map(bounded_failure_reason)
+                .unwrap_or_else(|| "tool_dispatch_error".to_string())
+        );
     }
     if crate::analytics::is_skill_view_tool(input.tool_name) {
         metadata["arguments"] = input.arguments.clone();
@@ -59,6 +88,7 @@ pub(super) fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> Anal
             metadata["action"] = json!(action);
         }
     }
+
     append_tool_response_analytics(
         input.tool_name,
         input.arguments,
@@ -164,7 +194,10 @@ mod tests {
     use crate::daemon::HookRouteMetadata;
     use crate::mcp::hook_events::{HookAgent, HookEvent, HookEventKind};
 
-    use super::{McpToolAnalyticsEvent, hook_route_analytics_event, mcp_tool_analytics_event};
+    use super::{
+        FAILURE_REASON_MAX_CHARS, McpToolAnalyticsEvent, bounded_failure_reason,
+        hook_route_analytics_event, mcp_tool_analytics_event,
+    };
 
     #[test]
     fn hook_route_analytics_event_preserves_correlation_fields() {
@@ -207,6 +240,95 @@ mod tests {
     }
 
     #[test]
+    fn bounded_failure_reason_collapses_whitespace_and_truncates() {
+        assert_eq!(
+            bounded_failure_reason("old_str  not\nfound"),
+            "old_str not found"
+        );
+        let long = "x".repeat(FAILURE_REASON_MAX_CHARS + 50);
+        let bounded = bounded_failure_reason(&long);
+        assert_eq!(bounded.chars().count(), FAILURE_REASON_MAX_CHARS);
+    }
+
+    #[test]
+    fn mcp_tool_analytics_event_uses_real_failure_reason_when_provided() {
+        let request_id = json!(1);
+        let arguments = json!({});
+        let event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
+            project_root: Path::new("/repo"),
+            session_id: None,
+            tool_name: "tracedecay_str_replace",
+            outcome: "error",
+            raw_file_tokens: 0,
+            response_tokens: 0,
+            net_saved_tokens: 0,
+            duration_us: None,
+            timestamp: 0,
+            request_id: &request_id,
+            arguments: &arguments,
+            internal_analytics: None,
+            client_name: None,
+            failure_reason: Some("old_str not found in src/main.rs"),
+        });
+        let metadata: serde_json::Value =
+            serde_json::from_str(event.metadata_json.as_deref().unwrap_or("{}")).unwrap();
+        assert_eq!(
+            metadata["failure_reason"],
+            "old_str not found in src/main.rs"
+        );
+    }
+
+    #[test]
+    fn mcp_tool_analytics_event_falls_back_to_generic_reason_when_none_provided() {
+        let request_id = json!(1);
+        let arguments = json!({});
+        let event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
+            project_root: Path::new("/repo"),
+            session_id: None,
+            tool_name: "tracedecay_not_a_real_tool",
+            outcome: "error",
+            raw_file_tokens: 0,
+            response_tokens: 0,
+            net_saved_tokens: 0,
+            duration_us: None,
+            timestamp: 0,
+            request_id: &request_id,
+            arguments: &arguments,
+            internal_analytics: None,
+            client_name: None,
+            failure_reason: None,
+        });
+        let metadata: serde_json::Value =
+            serde_json::from_str(event.metadata_json.as_deref().unwrap_or("{}")).unwrap();
+        assert_eq!(metadata["failure_reason"], "tool_dispatch_error");
+    }
+
+    #[test]
+    fn mcp_tool_analytics_event_omits_failure_reason_on_success() {
+        let request_id = json!(1);
+        let arguments = json!({});
+        let event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
+            project_root: Path::new("/repo"),
+            session_id: None,
+            tool_name: "tracedecay_str_replace",
+            outcome: "success",
+            raw_file_tokens: 0,
+            response_tokens: 0,
+            net_saved_tokens: 0,
+            duration_us: None,
+            timestamp: 0,
+            request_id: &request_id,
+            arguments: &arguments,
+            internal_analytics: None,
+            client_name: None,
+            failure_reason: Some("should be ignored on success"),
+        });
+        let metadata: serde_json::Value =
+            serde_json::from_str(event.metadata_json.as_deref().unwrap_or("{}")).unwrap();
+        assert!(metadata.get("failure_reason").is_none());
+    }
+
+    #[test]
     fn mcp_tool_analytics_event_records_action_and_client_for_fact_store() {
         let request_id = json!(1);
         let arguments = json!({"action": "add", "content": "secret fact body"});
@@ -224,6 +346,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: Some("claude-code"),
+            failure_reason: None,
         });
 
         let metadata: serde_json::Value =
@@ -256,6 +379,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: None,
+            failure_reason: None,
         });
 
         let metadata: serde_json::Value =
@@ -284,6 +408,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: Some("codex"),
+            failure_reason: None,
         });
 
         let metadata: serde_json::Value =

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -1310,14 +1310,26 @@ fn def_similar() -> ToolDefinition {
 fn def_rename_preview() -> ToolDefinition {
     def(
         "tracedecay_rename_preview",
-        "References",
-        "Show all references to a symbol -- all edges where the node appears as source or target.",
+        "Rename Preview",
+        "READ-ONLY preview of what a rename would touch. Given a symbol node and \
+         an optional `new_name`, returns the declaration site plus every graph \
+         reference site (from call/use/etc. edges), each with its current-text \
+         line snippet, and a per-file count of literal textual occurrences of \
+         the name that are NOT graph references ('text-only matches — review \
+         manually'). It does NOT edit anything and does NOT rewrite occurrences \
+         — a true rename tool is a later addition. Graph call-edge coverage \
+         improves as the resolver does; text-only counts catch what the graph \
+         misses (comments, strings, dynamic dispatch, unresolved refs).",
         json!({
             "type": "object",
             "properties": {
                 "node_id": {
                     "type": "string",
-                    "description": "The unique node ID to find references for"
+                    "description": "The unique node ID of the symbol to preview renaming"
+                },
+                "new_name": {
+                    "type": "string",
+                    "description": "Proposed new name. Optional — only used to label the preview; no text is rewritten."
                 }
             },
             "required": ["node_id"]
@@ -1737,6 +1749,14 @@ fn def_str_replace() -> ToolDefinition {
                 "new_str": {
                     "type": "string",
                     "description": "Replacement string"
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, validate and compute the edit but write nothing; the response includes a bounded preview diff of the would-be change (default: false)."
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "If true, re-run file-scoped diagnostics after a real edit and include a compact verdict (clean / N new errors) in the response. Ignored for dry runs. Default: false to keep edits fast."
                 }
             },
             "required": ["path", "old_str", "new_str"]
@@ -1769,6 +1789,14 @@ fn def_multi_str_replace() -> ToolDefinition {
                         "minItems": 2,
                         "maxItems": 2
                     }
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, validate and compute all replacements but write nothing; the response includes a bounded preview diff of the would-be change (default: false)."
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "If true, re-run file-scoped diagnostics after a real edit and include a compact verdict (clean / N new errors) in the response. Ignored for dry runs. Default: false to keep edits fast."
                 }
             },
             "required": ["path", "replacements"]
@@ -1803,6 +1831,14 @@ fn def_insert_at() -> ToolDefinition {
                 "before": {
                     "type": "boolean",
                     "description": "If true, insert before the anchor line; if false, insert after (default: false)"
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, resolve the anchor and compute the insertion but write nothing; the response includes a bounded preview diff of the would-be change (default: false)."
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "If true, re-run file-scoped diagnostics after a real edit and include a compact verdict (clean / N new errors) in the response. Ignored for dry runs. Default: false to keep edits fast."
                 }
             },
             "required": ["path", "anchor", "content"]
@@ -3164,6 +3200,14 @@ fn def_ast_grep_rewrite() -> ToolDefinition {
                 "rewrite": {
                     "type": "string",
                     "description": "ast-grep rewrite rule"
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, preview the rewrite without applying it: ast-grep runs without --update-all (or the built-in literal fallback computes a diff) and the response returns the would-be change, writing nothing (default: false)."
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "If true, re-run file-scoped diagnostics after a real rewrite and include a compact verdict (clean / N new errors) in the response. Ignored for dry runs. Default: false to keep edits fast."
                 }
             },
             "required": ["path", "pattern", "rewrite"]
@@ -3627,8 +3671,14 @@ fn def_replace_symbol() -> ToolDefinition {
         "Replace the full source of a named symbol (function, method, struct, \
          enum, etc.) with new source text. Resolves the symbol via exact \
          qualified-name match; on ambiguity, callable kinds win, and if \
-         still ambiguous the edit is refused. Preserves the surrounding \
-         file untouched and reindexes the file after writing.",
+         still ambiguous the edit is refused. The replaced span covers the \
+         item's LEADING doc-comment / attribute block (e.g. `///` docs, `#[...]` \
+         attributes) as well as its body, so `new_source` must itself include \
+         any docs/attributes you want to keep — otherwise they are dropped. \
+         The result's `replaced_span` returns the exact text that was swapped \
+         out (docs/attrs included) so you can recover them; a `message` note \
+         flags when the old span had docs/attrs the replacement appears to omit. \
+         Preserves the surrounding file untouched and reindexes after writing.",
         json!({
             "type": "object",
             "properties": {
@@ -3638,7 +3688,15 @@ fn def_replace_symbol() -> ToolDefinition {
                 },
                 "new_source": {
                     "type": "string",
-                    "description": "Full replacement source — must include the symbol's own declaration line."
+                    "description": "Full replacement source — must include the symbol's own declaration line, plus any leading doc-comments/attributes to preserve (the replaced span includes the old ones)."
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, resolve the symbol span and compute the replacement but write nothing; the response includes a bounded preview diff and the replaced_span (default: false)."
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "If true, re-run file-scoped diagnostics after a real edit and include a compact verdict (clean / N new errors) in the response. Ignored for dry runs. Default: false to keep edits fast."
                 }
             },
             "required": ["symbol", "new_source"]
@@ -3698,6 +3756,14 @@ fn def_insert_at_symbol() -> ToolDefinition {
                     "type": "string",
                     "enum": ["before", "after"],
                     "description": "Where to insert relative to the symbol's range. Default: after."
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, resolve the insertion point and compute the change but write nothing; the response includes a bounded preview diff of the would-be change (default: false)."
+                },
+                "verify": {
+                    "type": "boolean",
+                    "description": "If true, re-run file-scoped diagnostics after a real edit and include a compact verdict (clean / N new errors) in the response. Ignored for dry runs. Default: false to keep edits fast."
                 }
             },
             "required": ["symbol", "content"]

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
+use crate::types::{AstGrepResult, EditResult, InsertResult, MultiEditResult};
 
 use super::super::ToolResult;
 use super::super::render;
@@ -29,35 +30,190 @@ fn required_array<'a>(args: &'a Value, name: &str) -> Result<&'a [Value]> {
         .ok_or_else(|| missing_required_param(name))
 }
 
-fn text_tool_result<T: Serialize>(
+/// Common shape shared by every edit-tool result payload: a handler-known
+/// `success` flag plus a human-readable `message` describing the outcome
+/// (e.g. "`old_str` not found in file" / "`old_str` matches 3 times"). Lets
+/// [`text_tool_result`] attach a structural semantic-error marker (and its
+/// reason) to the [`ToolResult`] instead of the dispatcher having to guess
+/// outcome from rendered — possibly markdown, not JSON — response text.
+trait EditOutcome {
+    fn success(&self) -> bool;
+    fn message(&self) -> &str;
+    fn file_path(&self) -> &str;
+}
+
+impl EditOutcome for EditResult {
+    fn success(&self) -> bool {
+        self.success
+    }
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn file_path(&self) -> &str {
+        &self.file_path
+    }
+}
+
+impl EditOutcome for MultiEditResult {
+    fn success(&self) -> bool {
+        self.success
+    }
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn file_path(&self) -> &str {
+        &self.file_path
+    }
+}
+
+impl EditOutcome for InsertResult {
+    fn success(&self) -> bool {
+        self.success
+    }
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn file_path(&self) -> &str {
+        &self.file_path
+    }
+}
+
+impl EditOutcome for AstGrepResult {
+    fn success(&self) -> bool {
+        self.success
+    }
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn file_path(&self) -> &str {
+        &self.file_path
+    }
+}
+
+/// Reads the shared `dry_run` edit flag (default `false`): when set, an edit
+/// primitive validates and computes the resulting content but writes nothing,
+/// returning a preview diff instead.
+fn dry_run_arg(args: &Value) -> bool {
+    args.get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Reads the shared `verify` edit flag (default `false`): when set, a real
+/// (non-dry-run) successful edit re-runs file-scoped diagnostics and attaches a
+/// compact verdict to the result. Off by default to keep edits fast; compound
+/// refactor tools are expected to default it on.
+fn verify_arg(args: &Value) -> bool {
+    args.get("verify").and_then(Value::as_bool).unwrap_or(false)
+}
+
+/// Files considered "touched" for downstream bookkeeping. A dry run writes
+/// nothing and a failure changes nothing, so only a real successful edit
+/// reports its file.
+fn edit_touched_files(result: &impl EditOutcome, dry_run: bool) -> Vec<String> {
+    if result.success() && !dry_run {
+        vec![result.file_path().to_string()]
+    } else {
+        vec![]
+    }
+}
+
+/// Post-edit verification loop. Runs file-scoped diagnostics over the edited
+/// file and returns a compact verdict (`clean` / `errors` with the first few
+/// error messages). Returns `None` if diagnostics could not run — verification
+/// is best-effort and never fails an edit that already applied.
+async fn run_edit_verification(cg: &TraceDecay, file_path: &str) -> Option<Value> {
+    let scope = crate::diagnostics::Scope::File {
+        path: file_path.to_string(),
+    };
+    let diagnostics = crate::diagnostics::run_all(cg.project_root(), &scope)
+        .await
+        .ok()?;
+
+    let mut error_count = 0usize;
+    let mut warning_count = 0usize;
+    let mut first_errors: Vec<Value> = Vec::new();
+    for diag in &diagnostics {
+        if diag.file != file_path {
+            continue;
+        }
+        match diag.level.as_str() {
+            "error" => {
+                error_count += 1;
+                if first_errors.len() < 3 {
+                    first_errors.push(json!({
+                        "line": diag.line_start,
+                        "code": diag.code,
+                        "message": diag.message,
+                    }));
+                }
+            }
+            "warning" => warning_count += 1,
+            _ => {}
+        }
+    }
+
+    Some(json!({
+        "verdict": if error_count == 0 { "clean" } else { "errors" },
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "first_errors": first_errors,
+    }))
+}
+
+async fn text_tool_result<T: Serialize + EditOutcome>(
     cg: &TraceDecay,
     args: &Value,
     result: &T,
     touched_files: Vec<String>,
+    dry_run: bool,
+    verify: bool,
 ) -> ToolResult {
-    let value = serde_json::to_value(result).unwrap_or_default();
+    let success = result.success();
+    let mut value = serde_json::to_value(result).unwrap_or_default();
+
+    // Verification only makes sense for a real (written) successful edit: a dry
+    // run changed nothing on disk, and a failure left the file as-is.
+    if verify && !dry_run && success {
+        if let Some(verdict) = run_edit_verification(cg, result.file_path()).await {
+            if let Some(obj) = value.as_object_mut() {
+                obj.insert("verification".to_string(), verdict);
+            }
+        }
+    }
+
     let text = render::finalize(Some(cg.project_root()), args, &value, || {
         render::generic_md(&value)
     });
-    ToolResult::new(
+    let tool_result = ToolResult::new(
         json!({ "content": [{ "type": "text", "text": text }] }),
         touched_files,
     )
+    .with_semantic_error(!success);
+    if success {
+        tool_result
+    } else {
+        tool_result.with_failure_message(result.message())
+    }
 }
 
 pub(super) async fn handle_str_replace(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let path = required_str(&args, "path")?;
     let old_str = required_str(&args, "old_str")?;
     let new_str = required_str(&args, "new_str")?;
+    let dry_run = dry_run_arg(&args);
+    let verify = verify_arg(&args);
 
-    let result = cg.str_replace(path, old_str, new_str).await?;
-    let touched_files = vec![result.file_path.clone()];
-    Ok(text_tool_result(cg, &args, &result, touched_files))
+    let result = cg.str_replace(path, old_str, new_str, dry_run).await?;
+    let touched_files = edit_touched_files(&result, dry_run);
+    Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }
 
 pub(super) async fn handle_multi_str_replace(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let path = required_str(&args, "path")?;
     let replacements = required_array(&args, "replacements")?;
+    let dry_run = dry_run_arg(&args);
+    let verify = verify_arg(&args);
 
     let parsed_replacements: Vec<(&str, &str)> = replacements
         .iter()
@@ -78,63 +234,63 @@ pub(super) async fn handle_multi_str_replace(cg: &TraceDecay, args: Value) -> Re
         });
     }
 
-    let result = cg.multi_str_replace(path, &parsed_replacements).await?;
-    let touched_files = vec![result.file_path.clone()];
-    Ok(text_tool_result(cg, &args, &result, touched_files))
+    let result = cg
+        .multi_str_replace(path, &parsed_replacements, dry_run)
+        .await?;
+    let touched_files = edit_touched_files(&result, dry_run);
+    Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }
 
 pub(super) async fn handle_insert_at(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let path = required_str(&args, "path")?;
     let anchor = required_str(&args, "anchor")?;
     let content = required_str(&args, "content")?;
+    let dry_run = dry_run_arg(&args);
+    let verify = verify_arg(&args);
 
     let before = args.get("before").and_then(Value::as_bool).unwrap_or(false);
 
-    let result = cg.insert_at(path, anchor, content, before).await?;
-    let touched_files = vec![result.file_path.clone()];
-    Ok(text_tool_result(cg, &args, &result, touched_files))
+    let result = cg.insert_at(path, anchor, content, before, dry_run).await?;
+    let touched_files = edit_touched_files(&result, dry_run);
+    Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }
 
 pub(super) async fn handle_replace_symbol(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let symbol = required_str(&args, "symbol")?;
     let new_source = required_str(&args, "new_source")?;
+    let dry_run = dry_run_arg(&args);
+    let verify = verify_arg(&args);
 
-    let result = cg.replace_symbol(symbol, new_source).await?;
-    let touched_files = if result.success {
-        vec![result.file_path.clone()]
-    } else {
-        vec![]
-    };
-    Ok(text_tool_result(cg, &args, &result, touched_files))
+    let result = cg.replace_symbol(symbol, new_source, dry_run).await?;
+    let touched_files = edit_touched_files(&result, dry_run);
+    Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }
 
 pub(super) async fn handle_insert_at_symbol(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let symbol = required_str(&args, "symbol")?;
     let content = required_str(&args, "content")?;
+    let dry_run = dry_run_arg(&args);
+    let verify = verify_arg(&args);
     let position = args
         .get("position")
         .and_then(|v| v.as_str())
         .unwrap_or("after");
 
-    let result = cg.insert_at_symbol(symbol, content, position).await?;
-    let touched_files = if result.success {
-        vec![result.file_path.clone()]
-    } else {
-        vec![]
-    };
-    Ok(text_tool_result(cg, &args, &result, touched_files))
+    let result = cg
+        .insert_at_symbol(symbol, content, position, dry_run)
+        .await?;
+    let touched_files = edit_touched_files(&result, dry_run);
+    Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }
 
 pub(super) async fn handle_ast_grep_rewrite(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let path = required_str(&args, "path")?;
     let pattern = required_str(&args, "pattern")?;
     let rewrite = required_str(&args, "rewrite")?;
+    let dry_run = dry_run_arg(&args);
+    let verify = verify_arg(&args);
 
-    let result = cg.ast_grep_rewrite(path, pattern, rewrite).await?;
-    let touched_files = if result.success {
-        vec![result.file_path.clone()]
-    } else {
-        vec![]
-    };
-    Ok(text_tool_result(cg, &args, &result, touched_files))
+    let result = cg.ast_grep_rewrite(path, pattern, rewrite, dry_run).await?;
+    let touched_files = edit_touched_files(&result, dry_run);
+    Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }

--- a/src/mcp/tools/handlers/graph.rs
+++ b/src/mcp/tools/handlers/graph.rs
@@ -1139,79 +1139,184 @@ pub(super) async fn handle_similar(cg: &TraceDecay, args: Value) -> Result<ToolR
     ))
 }
 
-/// Handles `tracedecay_rename_preview` tool calls.
+/// Reads a file's lines (0-based) for snippet extraction, memoizing by path so
+/// a file with many references is read once. `None` when the file cannot be
+/// read (e.g. deleted since indexing).
+fn cached_file_lines<'a>(
+    cg: &TraceDecay,
+    cache: &'a mut HashMap<String, Option<Vec<String>>>,
+    file_path: &str,
+) -> Option<&'a [String]> {
+    if !cache.contains_key(file_path) {
+        let abs = cg.project_root().join(file_path);
+        let lines = std::fs::read_to_string(&abs)
+            .ok()
+            .map(|source| source.lines().map(str::to_string).collect::<Vec<_>>());
+        cache.insert(file_path.to_string(), lines);
+    }
+    cache
+        .get(file_path)
+        .and_then(Option::as_ref)
+        .map(Vec::as_slice)
+}
+
+/// Trims and length-caps a source line for use as a preview snippet.
+fn snippet_text(line: &str) -> String {
+    utf8_prefix_at_or_before(line.trim(), 160).to_string()
+}
+
+/// Picks a current-text snippet near `approx_line` (0-based; edge line bases are
+/// approximate, so neighbors are tried) that actually contains `name`, falling
+/// back to the line itself. `None` when no line is available.
+fn reference_line_snippet(
+    lines: &[String],
+    approx_line: Option<u32>,
+    name: &str,
+) -> Option<String> {
+    let approx = approx_line? as usize;
+    let candidates = [approx, approx.saturating_sub(1), approx + 1];
+    let idx = candidates
+        .into_iter()
+        .find(|&i| lines.get(i).is_some_and(|line| line.contains(name)))
+        .unwrap_or(approx);
+    lines.get(idx).map(|line| snippet_text(line))
+}
+
+/// True for bytes that can appear inside an identifier. Non-ASCII bytes count so
+/// multi-byte unicode identifiers are not falsely split at a boundary.
+fn is_ident_byte(b: u8) -> bool {
+    b == b'_' || b.is_ascii_alphanumeric() || b >= 0x80
+}
+
+/// Counts occurrences of `name` in `haystack` bounded as a whole identifier
+/// (neither neighbouring byte is an identifier byte). Used to estimate the
+/// literal textual matches a rename would touch, independent of the graph.
+fn count_identifier_occurrences(haystack: &str, name: &str) -> usize {
+    if name.is_empty() {
+        return 0;
+    }
+    let bytes = haystack.as_bytes();
+    let name_len = name.len();
+    let mut count = 0;
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(name) {
+        let abs = start + pos;
+        let before_ok = abs == 0 || !is_ident_byte(bytes[abs - 1]);
+        let after_idx = abs + name_len;
+        let after_ok = after_idx >= bytes.len() || !is_ident_byte(bytes[after_idx]);
+        if before_ok && after_ok {
+            count += 1;
+        }
+        start = abs + name_len;
+    }
+    count
+}
+
+/// Handles `tracedecay_rename_preview` tool calls. READ-ONLY: reports what a
+/// rename of the given symbol WOULD touch — the declaration site and every graph
+/// reference site (incoming edges; outgoing edges reference other symbols and so
+/// are excluded), each with a current-text snippet, plus a per-file count of
+/// literal name occurrences that are NOT backed by a graph edge ("text-only
+/// matches — review manually"). Nothing is rewritten.
 pub(super) async fn handle_rename_preview(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let node_id = require_node_id(&args)?;
+    let new_name = args.get("new_name").and_then(Value::as_str);
 
-    // Get the node itself
-    let node = cg.get_node(node_id).await?;
-    let node_info = match &node {
-        Some(n) => json!({
-            "id": n.id,
-            "name": n.name,
-            "kind": n.kind.as_str(),
-            "file": n.file_path,
-            "line": user_line(n.start_line),
-        }),
-        None => {
-            return Ok(text_tool_result(
-                &format!("Node not found: {node_id}"),
-                vec![],
-            ));
-        }
+    let Some(node) = cg.get_node(node_id).await? else {
+        return Ok(text_tool_result(
+            &format!("Node not found: {node_id}"),
+            vec![],
+        ));
     };
+    let symbol_name = node.name.clone();
 
-    // Get all edges referencing this node
+    let mut lines_cache: HashMap<String, Option<Vec<String>>> = HashMap::new();
+    // Graph occurrences per file (declaration + reference sites) — subtracted
+    // from the literal textual count to isolate the text-only matches.
+    let mut graph_counts: HashMap<String, usize> = HashMap::new();
+    let mut touched: Vec<String> = vec![node.file_path.clone()];
+
+    *graph_counts.entry(node.file_path.clone()).or_default() += 1;
+    let decl_snippet = cached_file_lines(cg, &mut lines_cache, &node.file_path).and_then(|lines| {
+        lines
+            .get(node.start_line as usize)
+            .map(|line| snippet_text(line))
+    });
+    let declaration = json!({
+        "id": node.id,
+        "name": node.name,
+        "kind": node.kind.as_str(),
+        "file": node.file_path,
+        "line": user_line(node.start_line),
+        "snippet": decl_snippet,
+    });
+
+    // Reference sites: incoming edges are the callers/users that name this
+    // symbol. NOTE: call-edge coverage improves as the resolver improves; the
+    // text-only counts below catch what the graph currently misses.
     let incoming = cg.get_incoming_edges(node_id).await?;
-    let outgoing = cg.get_outgoing_edges(node_id).await?;
-
     let mut references: Vec<Value> = Vec::new();
-    let mut touched: Vec<String> = Vec::new();
-
-    if let Some(ref n) = node {
-        touched.push(n.file_path.clone());
-    }
-
-    // Incoming edges: other nodes that reference this node
     for edge in &incoming {
         if let Some(source_node) = cg.get_node(&edge.source).await? {
             touched.push(source_node.file_path.clone());
+            *graph_counts
+                .entry(source_node.file_path.clone())
+                .or_default() += 1;
+            let snippet = cached_file_lines(cg, &mut lines_cache, &source_node.file_path)
+                .and_then(|lines| reference_line_snippet(lines, edge.line, &symbol_name));
             references.push(json!({
-                "direction": "incoming",
-                "node_id": source_node.id,
-                "name": source_node.name,
-                "kind": source_node.kind.as_str(),
+                "from_node_id": source_node.id,
+                "from_name": source_node.name,
+                "from_kind": source_node.kind.as_str(),
+                "edge_kind": edge.kind.as_str(),
                 "file": source_node.file_path,
-                "line": user_line(source_node.start_line),
-                "edge_kind": edge.kind.as_str(),
-                "edge_line": edge.line,
-            }));
-        }
-    }
-
-    // Outgoing edges: nodes this node references
-    for edge in &outgoing {
-        if let Some(target_node) = cg.get_node(&edge.target).await? {
-            touched.push(target_node.file_path.clone());
-            references.push(json!({
-                "direction": "outgoing",
-                "node_id": target_node.id,
-                "name": target_node.name,
-                "kind": target_node.kind.as_str(),
-                "file": target_node.file_path,
-                "line": user_line(target_node.start_line),
-                "edge_kind": edge.kind.as_str(),
-                "edge_line": edge.line,
+                "line": edge.line,
+                "snippet": snippet,
             }));
         }
     }
 
     let touched_files = unique_file_paths(touched.iter().map(std::string::String::as_str));
 
+    // Text-only matches per touched file: literal identifier occurrences of the
+    // name minus the graph occurrences already accounted for. These are the
+    // comments/strings/dynamic-dispatch/unresolved sites a graph-only rename
+    // would miss — the scan is bounded to files that already appear in the
+    // preview, so occurrences in wholly unrelated files are not counted.
+    let mut text_only_matches: Vec<Value> = Vec::new();
+    for file in &touched_files {
+        let total = cached_file_lines(cg, &mut lines_cache, file)
+            .map(|lines| {
+                lines
+                    .iter()
+                    .map(|line| count_identifier_occurrences(line, &symbol_name))
+                    .sum::<usize>()
+            })
+            .unwrap_or(0);
+        let graph = graph_counts.get(file).copied().unwrap_or(0);
+        let text_only = total.saturating_sub(graph);
+        if text_only > 0 {
+            text_only_matches.push(json!({
+                "file": file,
+                "text_only_count": text_only,
+                "note": "text-only matches — review manually",
+            }));
+        }
+    }
+
     let output = json!({
-        "node": node_info,
+        "read_only": true,
+        "note": "Preview only — no files are edited. 'references' are graph reference \
+                 sites (the declaration is reported separately in 'node'); \
+                 'text_only_matches' are literal name occurrences NOT backed by a graph \
+                 edge (comments, strings, dynamic dispatch, unresolved refs) and must be \
+                 reviewed by hand. Graph call-edge coverage improves as the resolver does.",
+        "symbol": symbol_name,
+        "new_name": new_name,
+        "node": declaration,
         "reference_count": references.len(),
         "references": references,
+        "text_only_matches": text_only_matches,
     });
 
     Ok(rendered_tool_result(

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -57,6 +57,19 @@ pub struct ToolResult {
     /// Internal analytics metadata for the server runtime. This must never be
     /// serialized into the tool response payload.
     internal_analytics: Option<Value>,
+    /// Structural signal that the handler itself determined this call failed
+    /// semantically (e.g. an edit whose `success` field is `false`), set by
+    /// the handler rather than inferred later from rendered response text.
+    /// `None` means the handler did not classify outcome structurally, so
+    /// callers should fall back to text-based heuristics; `Some(true)`/
+    /// `Some(false)` are authoritative and skip those heuristics.
+    semantic_error: Option<bool>,
+    /// Handler-provided human-readable reason for a structural semantic
+    /// failure (e.g. an edit result's `message`, such as "`old_str` not
+    /// found"). Only meaningful when `semantic_error == Some(true)`; used to
+    /// populate analytics `failure_reason` without re-deriving it from
+    /// rendered response text.
+    failure_message: Option<String>,
 }
 
 impl ToolResult {
@@ -65,6 +78,8 @@ impl ToolResult {
             value,
             touched_files,
             internal_analytics: None,
+            semantic_error: None,
+            failure_message: None,
         }
     }
 
@@ -76,6 +91,34 @@ impl ToolResult {
 
     pub fn internal_analytics(&self) -> Option<&Value> {
         self.internal_analytics.as_ref()
+    }
+
+    /// Record a handler-determined semantic outcome for this call. Pass
+    /// `true` when the handler knows the operation failed (e.g. an edit's
+    /// `success: false`), `false` when the handler knows it succeeded.
+    #[must_use]
+    pub fn with_semantic_error(mut self, is_error: bool) -> Self {
+        self.semantic_error = Some(is_error);
+        self
+    }
+
+    /// The handler-determined semantic outcome, if the handler set one.
+    pub fn semantic_error(&self) -> Option<bool> {
+        self.semantic_error
+    }
+
+    /// Attach a human-readable reason for a structural semantic failure
+    /// (e.g. an edit result's `message`). No-op unless paired with
+    /// `with_semantic_error(true)`.
+    #[must_use]
+    pub fn with_failure_message(mut self, message: impl Into<String>) -> Self {
+        self.failure_message = Some(message.into());
+        self
+    }
+
+    /// The handler-provided failure reason, if one was set.
+    pub fn failure_message(&self) -> Option<&str> {
+        self.failure_message.as_deref()
     }
 }
 

--- a/src/tracedecay/edits.rs
+++ b/src/tracedecay/edits.rs
@@ -75,6 +75,38 @@ impl TraceDecay {
         Ok(())
     }
 
+    /// Write-or-preview gate shared by every edit primitive. On a real run this
+    /// writes `modified` to `abs_path` and reindexes the file, returning `None`.
+    /// On a dry run it writes nothing and reindexes nothing, instead returning a
+    /// bounded preview diff of the changed region (the would-be change) so
+    /// callers can review before committing. Centralizing the write here keeps
+    /// the dry-run gate in one place around each primitive's own validation and
+    /// span logic.
+    async fn commit_or_preview_edit(
+        &self,
+        rel_path: &str,
+        abs_path: &Path,
+        original: &str,
+        modified: &str,
+        dry_run: bool,
+    ) -> Result<Option<String>> {
+        if dry_run {
+            return Ok(Some(bounded_region_diff(
+                original,
+                modified,
+                PREVIEW_DIFF_CONTEXT,
+                MAX_PREVIEW_DIFF_LINES,
+            )));
+        }
+        tokio::fs::write(abs_path, modified)
+            .await
+            .map_err(|e| TraceDecayError::Config {
+                message: format!("failed to write {rel_path}: {e}"),
+            })?;
+        self.reindex_file(rel_path).await?;
+        Ok(None)
+    }
+
     /// Performs a single string replacement.
     /// Fails if `old_str` is not found or matches more than once.
     pub async fn str_replace(
@@ -82,6 +114,7 @@ impl TraceDecay {
         path: &str,
         old_str: &str,
         new_str: &str,
+        dry_run: bool,
     ) -> Result<EditResult> {
         let rel_path = self
             .resolve_path(path)
@@ -102,6 +135,9 @@ impl TraceDecay {
                     file_path: rel_path.clone(),
                     matched_str: old_str.to_string(),
                     new_str: new_str.to_string(),
+                    replaced_span: None,
+                    dry_run,
+                    diff: None,
                     message: format!("old_str not found in {path}"),
                 });
             }
@@ -112,6 +148,9 @@ impl TraceDecay {
                     file_path: rel_path.clone(),
                     matched_str: old_str.to_string(),
                     new_str: new_str.to_string(),
+                    replaced_span: None,
+                    dry_run,
+                    diff: None,
                     message: format!("old_str matches {n} times, must match exactly once"),
                 });
             }
@@ -119,20 +158,19 @@ impl TraceDecay {
 
         let modified = source.replacen(old_str, new_str, 1);
 
-        tokio::fs::write(&abs_path, &modified)
-            .await
-            .map_err(|e| TraceDecayError::Config {
-                message: format!("failed to write {path}: {e}"),
-            })?;
-
-        self.reindex_file(&rel_path).await?;
+        let diff = self
+            .commit_or_preview_edit(&rel_path, &abs_path, &source, &modified, dry_run)
+            .await?;
 
         Ok(EditResult {
             success: true,
             file_path: rel_path,
             matched_str: old_str.to_string(),
             new_str: new_str.to_string(),
-            message: "replacement successful".to_string(),
+            replaced_span: None,
+            dry_run,
+            diff,
+            message: edit_success_message(dry_run, "replacement successful"),
         })
     }
 
@@ -142,6 +180,7 @@ impl TraceDecay {
         &self,
         path: &str,
         replacements: &[(&str, &str)],
+        dry_run: bool,
     ) -> Result<MultiEditResult> {
         let rel_path = self
             .resolve_path(path)
@@ -154,13 +193,36 @@ impl TraceDecay {
             message: format!("failed to read {path}: {e}"),
         })?;
 
-        for (old, _) in replacements {
-            let count = source.matches(old).count();
-            if count != 1 {
+        // Resolve every replacement against the ORIGINAL source. Each `old`
+        // must match exactly once, and no two matched ranges may overlap.
+        // Splicing from the original (instead of applying `replacen`
+        // sequentially against progressively-edited text) guarantees a later
+        // `old` can never match text an earlier replacement introduced, and no
+        // match can land at a shifted offset.
+        let mut spans: Vec<(usize, usize, &str, &str)> = Vec::with_capacity(replacements.len());
+        for (old, new) in replacements {
+            let mut hits = source.match_indices(old);
+            let Some((start, matched)) = hits.next() else {
                 return Ok(MultiEditResult {
                     success: false,
                     file_path: rel_path.clone(),
                     applied_count: 0,
+                    dry_run,
+                    diff: None,
+                    message: format!(
+                        "replacement '{}' matches 0 times, must match exactly once",
+                        crate::text::utf8_prefix_at_or_before(old, 20)
+                    ),
+                });
+            };
+            if hits.next().is_some() {
+                let count = source.matches(old).count();
+                return Ok(MultiEditResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    applied_count: 0,
+                    dry_run,
+                    diff: None,
                     message: format!(
                         "replacement '{}' matches {} times, must match exactly once",
                         crate::text::utf8_prefix_at_or_before(old, 20),
@@ -168,26 +230,55 @@ impl TraceDecay {
                     ),
                 });
             }
+            spans.push((start, start + matched.len(), old, new));
         }
 
-        let mut modified = source;
-        for (old, new) in replacements {
-            modified = modified.replacen(old, new, 1);
+        // Order by match start so we can both detect overlaps and splice in one
+        // left-to-right pass. Touching ranges are fine; only true overlaps (a
+        // later match starting inside an earlier one) are rejected.
+        spans.sort_by_key(|&(start, _, _, _)| start);
+        for window in spans.windows(2) {
+            let (_, prev_end, prev_old, _) = window[0];
+            let (next_start, _, next_old, _) = window[1];
+            if next_start < prev_end {
+                return Ok(MultiEditResult {
+                    success: false,
+                    file_path: rel_path.clone(),
+                    applied_count: 0,
+                    dry_run,
+                    diff: None,
+                    message: format!(
+                        "replacements '{}' and '{}' target overlapping ranges; apply them separately",
+                        crate::text::utf8_prefix_at_or_before(prev_old, 20),
+                        crate::text::utf8_prefix_at_or_before(next_old, 20)
+                    ),
+                });
+            }
         }
 
-        tokio::fs::write(&abs_path, &modified)
-            .await
-            .map_err(|e| TraceDecayError::Config {
-                message: format!("failed to write {path}: {e}"),
-            })?;
+        let mut modified = String::with_capacity(source.len());
+        let mut cursor = 0usize;
+        for &(start, end, _, new) in &spans {
+            modified.push_str(&source[cursor..start]);
+            modified.push_str(new);
+            cursor = end;
+        }
+        modified.push_str(&source[cursor..]);
 
-        self.reindex_file(&rel_path).await?;
+        let diff = self
+            .commit_or_preview_edit(&rel_path, &abs_path, &source, &modified, dry_run)
+            .await?;
 
         Ok(MultiEditResult {
             success: true,
             file_path: rel_path,
             applied_count: replacements.len(),
-            message: format!("applied {} replacements", replacements.len()),
+            dry_run,
+            diff,
+            message: edit_success_message(
+                dry_run,
+                &format!("applied {} replacements", replacements.len()),
+            ),
         })
     }
 
@@ -199,6 +290,7 @@ impl TraceDecay {
         anchor: &str,
         content: &str,
         before: bool,
+        dry_run: bool,
     ) -> Result<InsertResult> {
         let rel_path = self
             .resolve_path(path)
@@ -224,6 +316,8 @@ impl TraceDecay {
                     anchor_line: line_num as u32,
                     content: content.to_string(),
                     before,
+                    dry_run,
+                    diff: None,
                     message: format!(
                         "line number {line_num} out of range (file has {} lines)",
                         lines.len()
@@ -247,6 +341,8 @@ impl TraceDecay {
                     anchor_line: 0,
                     content: content.to_string(),
                     before,
+                    dry_run,
+                    diff: None,
                     message: format!("anchor '{anchor}' not found"),
                 });
             }
@@ -257,6 +353,8 @@ impl TraceDecay {
                     anchor_line: matching_lines.len() as u32,
                     content: content.to_string(),
                     before,
+                    dry_run,
+                    diff: None,
                     message: format!(
                         "anchor '{anchor}' matches {} lines, must match exactly one",
                         matching_lines.len()
@@ -275,13 +373,9 @@ impl TraceDecay {
             modified.push('\n');
         }
 
-        tokio::fs::write(&abs_path, &modified)
-            .await
-            .map_err(|e| TraceDecayError::Config {
-                message: format!("failed to write {path}: {e}"),
-            })?;
-
-        self.reindex_file(&rel_path).await?;
+        let diff = self
+            .commit_or_preview_edit(&rel_path, &abs_path, &source, &modified, dry_run)
+            .await?;
 
         Ok(InsertResult {
             success: true,
@@ -289,7 +383,12 @@ impl TraceDecay {
             anchor_line: (anchor_line + 1) as u32,
             content: content.to_string(),
             before,
-            message: format!("inserted at line {}", anchor_line + 1),
+            dry_run,
+            diff,
+            message: edit_success_message(
+                dry_run,
+                &format!("inserted at line {}", anchor_line + 1),
+            ),
         })
     }
 
@@ -298,7 +397,12 @@ impl TraceDecay {
     /// match — if the name is ambiguous, callable definitions win; if still
     /// ambiguous after that filter, the edit is refused so we don't clobber
     /// the wrong site.
-    pub async fn replace_symbol(&self, symbol: &str, new_source: &str) -> Result<EditResult> {
+    pub async fn replace_symbol(
+        &self,
+        symbol: &str,
+        new_source: &str,
+        dry_run: bool,
+    ) -> Result<EditResult> {
         let target = resolve_symbol_for_edit(self, symbol).await?;
         let project_path =
             crate::storage::ProjectPath::resolve(&self.project_root, Path::new(&target.file_path))?;
@@ -308,7 +412,20 @@ impl TraceDecay {
             message: format!("failed to read {rel_path}: {e}"),
         })?;
         let lines: Vec<&str> = source.lines().collect();
-        let start = target.start_line as usize;
+        // Honor the leading doc-comment / attribute block adaptively. The
+        // extractor only sets `attrs_start_line` below `start_line` for an
+        // item that actually has such a block. When `new_source` carries its
+        // own leading docs/attrs, the whole span (docs included) is swapped so
+        // documentation is never duplicated; when it does not, the existing
+        // block is preserved above the replacement so replacing a symbol's
+        // body never silently deletes its documentation.
+        let has_leading_block = (target.attrs_start_line as usize) < target.start_line as usize;
+        let replacement_brings_block = leading_doc_or_attr(new_source);
+        let start = if has_leading_block && replacement_brings_block {
+            target.attrs_start_line as usize
+        } else {
+            target.start_line as usize
+        };
         let end_inclusive = (target.end_line as usize).min(lines.len().saturating_sub(1));
         if start >= lines.len() || start > end_inclusive {
             return Ok(EditResult {
@@ -316,14 +433,18 @@ impl TraceDecay {
                 file_path: rel_path,
                 matched_str: symbol.to_string(),
                 new_str: String::new(),
+                replaced_span: None,
+                dry_run,
+                diff: None,
                 message: format!(
                     "symbol range [{}..={}] out of bounds for {}-line file",
-                    target.start_line,
+                    start,
                     target.end_line,
                     lines.len()
                 ),
             });
         }
+        let replaced_span = lines[start..=end_inclusive].join("\n");
         let trailing_newline = source.ends_with('\n');
         let mut rebuilt: Vec<String> = Vec::with_capacity(lines.len());
         rebuilt.extend(lines[..start].iter().map(|s| (*s).to_string()));
@@ -333,23 +454,35 @@ impl TraceDecay {
         if trailing_newline {
             modified.push('\n');
         }
-        tokio::fs::write(&abs_path, &modified)
-            .await
-            .map_err(|e| TraceDecayError::Config {
-                message: format!("failed to write {rel_path}: {e}"),
-            })?;
-        self.reindex_file(&rel_path).await?;
+        let diff = self
+            .commit_or_preview_edit(&rel_path, &abs_path, &source, &modified, dry_run)
+            .await?;
+        // If the old span carried leading docs/attrs but the replacement text
+        // does not appear to, surface a note so the caller can recover them
+        // from `replaced_span` rather than silently losing documentation.
+        let base = format!(
+            "replaced {}:{}-{}",
+            target.file_path,
+            start + 1,
+            target.end_line + 1
+        );
+        let mut message = edit_success_message(dry_run, &base);
+        if has_leading_block && !replacement_brings_block {
+            message.push_str(
+                "; note: the item's leading docs/attrs were preserved above the \
+                 replacement — include a leading doc/attr block in new_source to \
+                 replace them",
+            );
+        }
         Ok(EditResult {
             success: true,
             file_path: rel_path,
             matched_str: format!("{} ({})", target.name, target.kind.as_str()),
             new_str: new_source.to_string(),
-            message: format!(
-                "replaced {}:{}-{}",
-                target.file_path,
-                target.start_line + 1,
-                target.end_line + 1
-            ),
+            replaced_span: Some(replaced_span),
+            dry_run,
+            diff,
+            message,
         })
     }
 
@@ -361,6 +494,7 @@ impl TraceDecay {
         symbol: &str,
         content: &str,
         position: &str,
+        dry_run: bool,
     ) -> Result<InsertResult> {
         let before = match position {
             "before" => true,
@@ -380,6 +514,9 @@ impl TraceDecay {
             message: format!("failed to read {rel_path}: {e}"),
         })?;
         let lines: Vec<&str> = source.lines().collect();
+        // `before` inserts above the item's leading doc-comment / attribute
+        // block (when the extractor recorded one) so new content lands above the
+        // docs rather than splitting them from their item; `after` is unaffected.
         let anchor_line = if before {
             // Anchor above the item's leading doc-comment / attribute block so
             // "before" never splits docs from the item they document. For items
@@ -396,6 +533,8 @@ impl TraceDecay {
                 anchor_line: anchor_line as u32,
                 content: content.to_string(),
                 before,
+                dry_run,
+                diff: None,
                 message: format!("anchor line {anchor_line} past EOF ({})", lines.len()),
             });
         }
@@ -408,24 +547,26 @@ impl TraceDecay {
         if trailing_newline {
             modified.push('\n');
         }
-        tokio::fs::write(&abs_path, &modified)
-            .await
-            .map_err(|e| TraceDecayError::Config {
-                message: format!("failed to write {rel_path}: {e}"),
-            })?;
-        self.reindex_file(&rel_path).await?;
+        let diff = self
+            .commit_or_preview_edit(&rel_path, &abs_path, &source, &modified, dry_run)
+            .await?;
         Ok(InsertResult {
             success: true,
             file_path: rel_path,
             anchor_line: (anchor_line + 1) as u32,
             content: content.to_string(),
             before,
-            message: format!(
-                "inserted {} {} ({}) at line {}",
-                position,
-                target.name,
-                target.kind.as_str(),
-                anchor_line + 1
+            dry_run,
+            diff,
+            message: edit_success_message(
+                dry_run,
+                &format!(
+                    "inserted {} {} ({}) at line {}",
+                    position,
+                    target.name,
+                    target.kind.as_str(),
+                    anchor_line + 1
+                ),
             ),
         })
     }
@@ -436,6 +577,7 @@ impl TraceDecay {
         path: &str,
         pattern: &str,
         rewrite: &str,
+        dry_run: bool,
     ) -> Result<AstGrepResult> {
         let rel_path = self
             .resolve_path(path)
@@ -451,25 +593,33 @@ impl TraceDecay {
 
         if check_output.is_err() {
             if can_use_literal_rewrite_fallback(pattern) {
-                let mut source = std::fs::read_to_string(&abs_path).map_err(TraceDecayError::Io)?;
+                let source = std::fs::read_to_string(&abs_path).map_err(TraceDecayError::Io)?;
                 if !source.contains(pattern) {
                     return Ok(AstGrepResult {
                         success: false,
                         file_path: rel_path.clone(),
                         pattern: pattern.to_string(),
                         rewrite: rewrite.to_string(),
+                        dry_run,
+                        diff: None,
                         message: "pattern not found (built-in literal fallback)".to_string(),
                     });
                 }
-                source = source.replace(pattern, rewrite);
-                std::fs::write(&abs_path, source).map_err(TraceDecayError::Io)?;
-                self.reindex_file(&rel_path).await?;
+                let modified = source.replace(pattern, rewrite);
+                let diff = self
+                    .commit_or_preview_edit(&rel_path, &abs_path, &source, &modified, dry_run)
+                    .await?;
                 return Ok(AstGrepResult {
                     success: true,
                     file_path: rel_path,
                     pattern: pattern.to_string(),
                     rewrite: rewrite.to_string(),
-                    message: "literal rewrite completed using built-in fallback".to_string(),
+                    dry_run,
+                    diff,
+                    message: edit_success_message(
+                        dry_run,
+                        "literal rewrite completed using built-in fallback",
+                    ),
                 });
             }
             return Ok(AstGrepResult {
@@ -477,20 +627,23 @@ impl TraceDecay {
                 file_path: rel_path.clone(),
                 pattern: pattern.to_string(),
                 rewrite: rewrite.to_string(),
+                dry_run,
+                diff: None,
                 message: "ast-grep is not installed and this pattern needs SGPattern matching. Simple literal rewrites are handled by the built-in fallback.".to_string(),
             });
         }
 
+        // On a dry run, omit `-U` (`--update-all`): ast-grep then prints the
+        // planned changes to stdout and leaves the file untouched, which is
+        // exactly the preview we want. A real run keeps `-U` to apply in place.
+        let abs_path_arg = abs_path.to_string_lossy();
+        let mut ast_grep_args: Vec<&str> = vec!["run", "-p", pattern, "-r", rewrite];
+        if !dry_run {
+            ast_grep_args.push("-U");
+        }
+        ast_grep_args.push(abs_path_arg.as_ref());
         let output = crate::external_tools::ast_grep_command()
-            .args([
-                "run",
-                "-p",
-                pattern,
-                "-r",
-                rewrite,
-                "-U",
-                abs_path.to_string_lossy().as_ref(),
-            ])
+            .args(&ast_grep_args)
             .output()
             .map_err(|e| TraceDecayError::Config {
                 message: format!("failed to run ast-grep: {e}"),
@@ -522,7 +675,24 @@ impl TraceDecay {
                 file_path: rel_path.clone(),
                 pattern: pattern.to_string(),
                 rewrite: rewrite.to_string(),
+                dry_run,
+                diff: None,
                 message,
+            });
+        }
+
+        if dry_run {
+            // ast-grep printed the would-be changes to stdout; surface them as
+            // the preview and leave the file (and index) untouched.
+            let preview = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            return Ok(AstGrepResult {
+                success: true,
+                file_path: rel_path,
+                pattern: pattern.to_string(),
+                rewrite: rewrite.to_string(),
+                dry_run: true,
+                diff: (!preview.is_empty()).then_some(preview),
+                message: edit_success_message(true, "ast-grep rewrite completed"),
             });
         }
 
@@ -533,9 +703,28 @@ impl TraceDecay {
             file_path: rel_path,
             pattern: pattern.to_string(),
             rewrite: rewrite.to_string(),
+            dry_run: false,
+            diff: None,
             message: "ast-grep rewrite completed".to_string(),
         })
     }
+}
+
+/// Cheap heuristic: does `source`'s first non-blank line look like a leading
+/// doc-comment (`//`, `///`, `//!`), block comment (`/*`), or attribute
+/// (`#[`, `#!`)? Used only to decide whether a `replace_symbol` note should
+/// warn that the replacement text may have dropped the item's docs/attrs.
+fn leading_doc_or_attr(source: &str) -> bool {
+    source
+        .lines()
+        .map(str::trim_start)
+        .find(|line| !line.is_empty())
+        .is_some_and(|line| {
+            line.starts_with("//")
+                || line.starts_with("/*")
+                || line.starts_with("#[")
+                || line.starts_with("#!")
+        })
 }
 
 fn can_use_literal_rewrite_fallback(pattern: &str) -> bool {
@@ -545,6 +734,89 @@ fn can_use_literal_rewrite_fallback(pattern: &str) -> bool {
         && !pattern.contains('$')
         && !pattern.contains('\n')
         && !pattern.contains('\r')
+}
+
+/// Unchanged context lines shown on each side of the changed region in a
+/// dry-run preview diff.
+const PREVIEW_DIFF_CONTEXT: usize = 3;
+
+/// Hard cap on the number of lines emitted in a dry-run preview diff. Keeps the
+/// preview bounded even when an edit rewrites a large span; the remainder is
+/// noted as truncated.
+const MAX_PREVIEW_DIFF_LINES: usize = 200;
+
+/// Success-path message wrapper: on a real edit returns `base` verbatim; on a
+/// dry run wraps it to make clear that nothing was written and only a preview
+/// was produced.
+fn edit_success_message(dry_run: bool, base: &str) -> String {
+    if dry_run {
+        format!("dry run — nothing written; preview only ({base})")
+    } else {
+        base.to_string()
+    }
+}
+
+/// Builds a bounded, unified-style diff of the single changed region between
+/// `original` and `modified`. The two texts are compared line-by-line: the
+/// common leading and trailing lines are trimmed and only the differing middle
+/// band — plus `context` unchanged lines on each side — is rendered, capped at
+/// `max_lines` (excess is noted as truncated). This is a cheap single-hunk
+/// preview for a localized edit, not a minimal multi-hunk LCS diff; a widely
+/// scattered set of changes collapses into one hunk spanning them.
+fn bounded_region_diff(original: &str, modified: &str, context: usize, max_lines: usize) -> String {
+    if original == modified {
+        return "(no changes)".to_string();
+    }
+    let old: Vec<&str> = original.lines().collect();
+    let new: Vec<&str> = modified.lines().collect();
+
+    // Longest common line prefix.
+    let mut prefix = 0;
+    while prefix < old.len() && prefix < new.len() && old[prefix] == new[prefix] {
+        prefix += 1;
+    }
+    // Longest common line suffix that does not overlap the prefix.
+    let mut suffix = 0;
+    while suffix < old.len().saturating_sub(prefix)
+        && suffix < new.len().saturating_sub(prefix)
+        && old[old.len() - 1 - suffix] == new[new.len() - 1 - suffix]
+    {
+        suffix += 1;
+    }
+
+    let old_change_end = old.len() - suffix; // exclusive
+    let new_change_end = new.len() - suffix; // exclusive
+    let ctx_start = prefix.saturating_sub(context);
+    let old_ctx_end = (old_change_end + context).min(old.len());
+    let new_ctx_end = (new_change_end + context).min(new.len());
+
+    let mut out: Vec<String> = Vec::new();
+    out.push(format!(
+        "@@ -{},{} +{},{} @@",
+        ctx_start + 1,
+        old_ctx_end - ctx_start,
+        ctx_start + 1,
+        new_ctx_end - ctx_start
+    ));
+    for line in &old[ctx_start..prefix] {
+        out.push(format!(" {line}"));
+    }
+    for line in &old[prefix..old_change_end] {
+        out.push(format!("-{line}"));
+    }
+    for line in &new[prefix..new_change_end] {
+        out.push(format!("+{line}"));
+    }
+    for line in &new[new_change_end..new_ctx_end] {
+        out.push(format!(" {line}"));
+    }
+
+    if out.len() > max_lines {
+        let omitted = out.len() - max_lines;
+        out.truncate(max_lines);
+        out.push(format!("... diff truncated ({omitted} more line(s))"));
+    }
+    out.join("\n")
 }
 
 /// Resolves a symbol name to a single node suitable for symbol-aware editing.
@@ -589,4 +861,110 @@ async fn resolve_symbol_for_edit(cg: &TraceDecay, symbol: &str) -> Result<Node> 
             "symbol '{symbol}' is ambiguous ({total} matches); pass a fully qualified name"
         ),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::leading_doc_or_attr;
+
+    #[test]
+    fn leading_doc_or_attr_detects_doc_comment() {
+        assert!(leading_doc_or_attr("/// docs\nfn f() {}"));
+        assert!(leading_doc_or_attr("//! module doc\nfn f() {}"));
+        assert!(leading_doc_or_attr("// plain\nfn f() {}"));
+    }
+
+    #[test]
+    fn leading_doc_or_attr_detects_attribute_and_block_comment() {
+        assert!(leading_doc_or_attr("#[inline]\nfn f() {}"));
+        assert!(leading_doc_or_attr("#![allow(dead_code)]"));
+        assert!(leading_doc_or_attr("/* block */\nfn f() {}"));
+    }
+
+    #[test]
+    fn leading_doc_or_attr_skips_leading_blank_lines() {
+        assert!(leading_doc_or_attr("\n\n   /// docs\nfn f() {}"));
+        assert!(!leading_doc_or_attr("\n\nfn f() {}"));
+    }
+
+    #[test]
+    fn leading_doc_or_attr_false_for_bare_code() {
+        assert!(!leading_doc_or_attr("fn f() {}"));
+        assert!(!leading_doc_or_attr(""));
+        assert!(!leading_doc_or_attr("pub struct S;"));
+    }
+
+    use super::{bounded_region_diff, edit_success_message};
+
+    #[test]
+    fn bounded_region_diff_reports_no_changes_when_identical() {
+        assert_eq!(
+            bounded_region_diff("a\nb\n", "a\nb\n", 3, 200),
+            "(no changes)"
+        );
+    }
+
+    #[test]
+    fn bounded_region_diff_shows_changed_line_with_context() {
+        let original = "one\ntwo\nthree\nfour\nfive\n";
+        let modified = "one\ntwo\nTHREE\nfour\nfive\n";
+        let diff = bounded_region_diff(original, modified, 1, 200);
+        assert!(diff.contains("-three"), "diff should mark removal: {diff}");
+        assert!(diff.contains("+THREE"), "diff should mark addition: {diff}");
+        // One line of context on each side, but not the far-away lines.
+        assert!(
+            diff.contains(" two"),
+            "diff should include leading context: {diff}"
+        );
+        assert!(
+            diff.contains(" four"),
+            "diff should include trailing context: {diff}"
+        );
+        assert!(
+            !diff.contains("one"),
+            "distant lines should be trimmed: {diff}"
+        );
+        assert!(
+            diff.starts_with("@@"),
+            "diff should carry a hunk header: {diff}"
+        );
+    }
+
+    #[test]
+    fn bounded_region_diff_handles_pure_insertion() {
+        let diff = bounded_region_diff("a\nb\n", "a\nNEW\nb\n", 3, 200);
+        assert!(diff.contains("+NEW"), "insertion should appear: {diff}");
+        assert!(
+            !diff.contains("-"),
+            "pure insertion has no removals: {diff}"
+        );
+    }
+
+    #[test]
+    fn bounded_region_diff_truncates_past_the_cap() {
+        let original = "keep\n";
+        let modified: String = std::iter::once("keep")
+            .chain((0..500).map(|_| "x"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let diff = bounded_region_diff(original, &modified, 3, 50);
+        assert!(
+            diff.contains("diff truncated"),
+            "large diff should truncate: {diff}"
+        );
+    }
+
+    #[test]
+    fn edit_success_message_marks_dry_runs() {
+        assert_eq!(edit_success_message(false, "done"), "done");
+        let dry = edit_success_message(true, "done");
+        assert!(
+            dry.contains("dry run"),
+            "dry-run message should say so: {dry}"
+        );
+        assert!(
+            dry.contains("done"),
+            "dry-run message should keep the base: {dry}"
+        );
+    }
 }

--- a/src/tracedecay/edits.rs
+++ b/src/tracedecay/edits.rs
@@ -935,7 +935,7 @@ mod tests {
         let diff = bounded_region_diff("a\nb\n", "a\nNEW\nb\n", 3, 200);
         assert!(diff.contains("+NEW"), "insertion should appear: {diff}");
         assert!(
-            !diff.contains("-"),
+            !diff.lines().any(|line| line.starts_with('-')),
             "pure insertion has no removals: {diff}"
         );
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 
+/// `serde` `skip_serializing_if` predicate: skip a `bool` field when it is
+/// `false`. Keeps default-off flags (e.g. `dry_run`) out of tool output unless
+/// they are actually set.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// Kinds of nodes in the code graph.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum NodeKind {
@@ -637,42 +645,80 @@ pub struct ResolvedRef {
 }
 
 /// Result of a single string replacement edit.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EditResult {
     pub success: bool,
     pub file_path: String,
     pub matched_str: String,
     pub new_str: String,
+    /// For `replace_symbol`: the exact source span that was replaced, including
+    /// any leading doc-comment / attribute block that belongs to the item. Lets
+    /// callers see precisely what was swapped out (and recover its docs/attrs if
+    /// the replacement dropped them). `None` for plain string replacements.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replaced_span: Option<String>,
+    /// True when this was a dry run: validation, spans, and the resulting
+    /// content were all computed, but nothing was written to disk.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+    /// Bounded preview diff of the would-be change. Populated only on a
+    /// successful dry run; `None` for real edits and for failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
     pub message: String,
 }
 
 /// Result of a multi-string replacement edit.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MultiEditResult {
     pub success: bool,
     pub file_path: String,
     pub applied_count: usize,
+    /// True when this was a dry run: replacements were validated and the
+    /// resulting content computed, but nothing was written to disk.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+    /// Bounded preview diff of the would-be change. Populated only on a
+    /// successful dry run; `None` for real edits and for failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
     pub message: String,
 }
 
 /// Result of an insert-at operation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InsertResult {
     pub success: bool,
     pub file_path: String,
     pub anchor_line: u32,
     pub content: String,
     pub before: bool,
+    /// True when this was a dry run: the insertion point was resolved and the
+    /// resulting content computed, but nothing was written to disk.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+    /// Bounded preview diff of the would-be change. Populated only on a
+    /// successful dry run; `None` for real edits and for failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
     pub message: String,
 }
 
 /// Result of an ast-grep rewrite operation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AstGrepResult {
     pub success: bool,
     pub file_path: String,
     pub pattern: String,
     pub rewrite: String,
+    /// True when this was a dry run: the rewrite was resolved (via the built-in
+    /// literal fallback or an ast-grep preview run) but nothing was written.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+    /// Bounded preview of the would-be change. Populated only on a successful
+    /// dry run; `None` for real edits and for failures.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
     pub message: String,
 }
 

--- a/tests/core_cli_suite/tracedecay_test.rs
+++ b/tests/core_cli_suite/tracedecay_test.rs
@@ -676,10 +676,20 @@ async fn str_replace_reindex_resolves_new_cross_file_call() {
             "src/caller.rs",
             "pub fn caller() {}\n",
             "pub fn caller() { target(); }\n",
+            false,
         )
         .await
         .unwrap();
     assert!(edit.success, "edit should succeed: {edit:?}");
+    // A real (non-dry-run) edit writes and carries no preview diff.
+    assert!(
+        !edit.dry_run,
+        "real edit should not be flagged dry_run: {edit:?}"
+    );
+    assert!(
+        edit.diff.is_none(),
+        "real edit should not return a diff: {edit:?}"
+    );
 
     let nodes = cg.get_all_nodes().await.unwrap();
     let caller = nodes
@@ -698,6 +708,234 @@ async fn str_replace_reindex_resolves_new_cross_file_call() {
         }),
         "direct edit reindex should resolve the new caller -> target edge; edges={edges:?}"
     );
+}
+
+#[tokio::test]
+async fn str_replace_dry_run_writes_nothing_but_returns_diff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    let original = "pub fn caller() {}\n";
+    fs::write(project.join("src/caller.rs"), original).unwrap();
+
+    let cg = TraceDecay::init(project).await.unwrap();
+    cg.sync().await.unwrap();
+
+    let edit = cg
+        .str_replace(
+            "src/caller.rs",
+            "pub fn caller() {}\n",
+            "pub fn caller() { target(); }\n",
+            true, // dry_run
+        )
+        .await
+        .unwrap();
+
+    assert!(edit.success, "dry run should still validate: {edit:?}");
+    assert!(
+        edit.dry_run,
+        "result should be flagged as a dry run: {edit:?}"
+    );
+    let diff = edit
+        .diff
+        .as_deref()
+        .expect("dry run should return a preview diff");
+    assert!(
+        diff.contains("+pub fn caller() { target(); }"),
+        "diff should show the would-be addition: {diff}"
+    );
+
+    // Nothing may be written to disk on a dry run.
+    let on_disk = fs::read_to_string(project.join("src/caller.rs")).unwrap();
+    assert_eq!(on_disk, original, "dry run must not modify the file");
+
+    // And the graph must not have picked up the (never-written) call edge.
+    let nodes = cg.get_all_nodes().await.unwrap();
+    let caller = nodes
+        .iter()
+        .find(|node| node.name == "caller" && node.file_path == "src/caller.rs")
+        .unwrap();
+    let edges = cg.get_all_edges().await.unwrap();
+    assert!(
+        !edges
+            .iter()
+            .any(|edge| edge.kind == EdgeKind::Calls && edge.source == caller.id),
+        "dry run must not reindex a new call edge; edges={edges:?}"
+    );
+}
+
+/// `rename_preview` with a `new_name` must list the declaration site and every
+/// resolved call site for a fixture symbol, read-only. Uses a same-file caller
+/// so the Calls edge resolves deterministically.
+#[tokio::test]
+async fn rename_preview_lists_declaration_and_call_sites() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/lib.rs"),
+        "pub fn greet() -> u32 { 1 }\npub fn caller() -> u32 { greet() }\n",
+    )
+    .unwrap();
+
+    let cg = TraceDecay::init(project).await.unwrap();
+    cg.sync().await.unwrap();
+
+    let nodes = cg.get_all_nodes().await.unwrap();
+    let greet = nodes
+        .iter()
+        .find(|node| node.name == "greet" && node.file_path == "src/lib.rs")
+        .expect("greet node should exist");
+
+    let result = tracedecay::mcp::handle_tool_call(
+        &cg,
+        "tracedecay_rename_preview",
+        serde_json::json!({
+            "node_id": greet.id,
+            "new_name": "salute",
+            "format": "json",
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = result.value["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+
+    // Declaration site with its current-text snippet.
+    assert!(
+        text.contains("greet"),
+        "preview should name the symbol: {text}"
+    );
+    assert!(
+        text.contains("pub fn greet"),
+        "preview should show the declaration snippet: {text}"
+    );
+    // Proposed name is echoed, read-only marker present.
+    assert!(
+        text.contains("salute"),
+        "preview should echo new_name: {text}"
+    );
+    assert!(
+        text.contains("read_only"),
+        "preview should flag itself read-only: {text}"
+    );
+    // The resolved call site from `caller`.
+    assert!(
+        text.contains("reference_count"),
+        "preview should report a reference count: {text}"
+    );
+    assert!(
+        text.contains("caller"),
+        "preview should list the calling symbol as a reference site: {text}"
+    );
+}
+
+/// Exercises the post-edit verification loop end-to-end through the MCP
+/// dispatcher: a real edit that plants a type error, with `verify: true`, must
+/// re-run file-scoped diagnostics and surface the planted error; the same edit
+/// tool without `verify` must not attach a verification verdict. Compiles a
+/// tiny throwaway crate, so it shells out to `cargo check` (into an isolated
+/// diagnostics target dir) and is intentionally on the slower side.
+#[tokio::test]
+async fn edit_verify_flag_surfaces_planted_compiler_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("Cargo.toml"),
+        "[package]\nname = \"verify_fixture\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn answer() -> u32 { 1 }\n").unwrap();
+
+    let cg = TraceDecay::init(project).await.unwrap();
+    cg.sync().await.unwrap();
+
+    // Default path (no `verify`): output must NOT carry a verification verdict.
+    let clean = tracedecay::mcp::handle_tool_call(
+        &cg,
+        "tracedecay_str_replace",
+        serde_json::json!({
+            "path": "src/lib.rs",
+            "old_str": "pub fn answer() -> u32 { 1 }",
+            "new_str": "pub fn answer() -> u32 { 2 }",
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let clean_text = clean.value["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        !clean_text.contains("verif"),
+        "edit without verify should not run verification: {clean_text}"
+    );
+
+    // verify=true on an edit that introduces `-> u32 { "no" }` (E0308) must
+    // surface the planted error in a verification verdict.
+    let broken = tracedecay::mcp::handle_tool_call(
+        &cg,
+        "tracedecay_str_replace",
+        serde_json::json!({
+            "path": "src/lib.rs",
+            "old_str": "pub fn answer() -> u32 { 2 }",
+            "new_str": "pub fn answer() -> u32 { \"no\" }",
+            "verify": true,
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let broken_text = broken.value["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        broken_text.contains("verif"),
+        "verify=true should attach a verification verdict: {broken_text}"
+    );
+    assert!(
+        broken_text.contains("mismatched types") || broken_text.contains("error"),
+        "verification should surface the planted compiler error: {broken_text}"
+    );
+}
+
+#[tokio::test]
+async fn replace_symbol_dry_run_previews_without_writing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    let original = "pub fn greet() -> u32 { 1 }\n";
+    fs::write(project.join("src/lib.rs"), original).unwrap();
+
+    let cg = TraceDecay::init(project).await.unwrap();
+    cg.sync().await.unwrap();
+
+    let edit = cg
+        .replace_symbol("greet", "pub fn greet() -> u32 { 2 }", true)
+        .await
+        .unwrap();
+
+    assert!(edit.success, "dry run should validate: {edit:?}");
+    assert!(edit.dry_run, "result should be flagged dry_run: {edit:?}");
+    assert!(
+        edit.diff.is_some(),
+        "symbol replace dry run should return a diff: {edit:?}"
+    );
+    // replaced_span is still computed so callers can review the old text.
+    assert!(
+        edit.replaced_span.is_some(),
+        "dry run should still report the span it would replace: {edit:?}"
+    );
+    let on_disk = fs::read_to_string(project.join("src/lib.rs")).unwrap();
+    assert_eq!(on_disk, original, "dry run must not modify the file");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -840,7 +1078,7 @@ async fn replace_symbol_preserves_first_in_file_doc_comment() {
     let (dir, cg) = setup_first_in_file_doc().await;
 
     let result = cg
-        .replace_symbol("src/lib.rs::foo", "fn foo() { let _x = 1; }")
+        .replace_symbol("src/lib.rs::foo", "fn foo() { let _x = 1; }", false)
         .await
         .unwrap();
     assert!(result.success, "replace failed: {}", result.message);
@@ -864,6 +1102,7 @@ async fn insert_before_first_in_file_documented_fn_goes_above_doc_block() {
             "src/lib.rs::foo",
             "// SPDX-License-Identifier: MIT",
             "before",
+            false,
         )
         .await
         .unwrap();

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -5459,6 +5459,201 @@ async fn test_multi_str_replace_unicode_preview_does_not_panic() {
 }
 
 #[tokio::test]
+async fn test_multi_str_replace_earlier_insertion_collision_lands_correctly() {
+    // Regression: match counts were validated against the ORIGINAL source but
+    // replacements were then applied sequentially against progressively-edited
+    // text. When an earlier replacement introduced a duplicate of a later
+    // `old_str`, `replacen` clobbered the freshly-inserted copy instead of the
+    // caller's intended original site. Resolving all ranges up-front against
+    // the original and splicing once makes each replacement land where the
+    // caller meant.
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    fs::write(
+        project.join("src/main.rs"),
+        "fn keep() {}\nfn target() {}\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_multi_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "replacements": [
+                ["fn keep() {}", "fn keep() {}\nfn target() {}"],
+                ["fn target() {}", "fn target_renamed() {}"]
+            ]
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["applied_count"], 2);
+
+    // The inserted `fn target() {}` (from the first replacement) is preserved,
+    // and the ORIGINAL second-line `fn target()` is the one that gets renamed.
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert_eq!(
+        content,
+        "fn keep() {}\nfn target() {}\nfn target_renamed() {}\n"
+    );
+}
+
+#[tokio::test]
+async fn test_multi_str_replace_overlapping_ranges_error() {
+    // Two replacements whose matched ranges overlap cannot both be applied
+    // coherently; the edit must be refused rather than silently dropping one.
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    let original = "abcdef\n";
+    fs::write(project.join("src/main.rs"), original).unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_multi_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "replacements": [
+                ["abcd", "WXYZ"],
+                ["cdef", "QRST"]
+            ]
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], false);
+    assert!(
+        parsed["message"]
+            .as_str()
+            .unwrap()
+            .contains("overlapping ranges")
+    );
+
+    // The file must be untouched when the edit is refused.
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert_eq!(content, original);
+}
+
+#[tokio::test]
+async fn test_replace_symbol_documented_fn_keeps_single_doc_comment() {
+    // The replaced span must cover the leading doc-comment block, so replacing
+    // a documented fn with new_source that carries its own doc yields exactly
+    // one doc comment — not the old one orphaned above the new one.
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    // A leading item keeps `foo` off row 0 so its extracted attrs_start_line is
+    // non-zero and survives the DB round-trip (a stored 0 is treated as a
+    // pre-v7 sentinel and falls back to start_line).
+    fs::write(
+        project.join("src/main.rs"),
+        "pub const N: u32 = 0;\n/// Doc for foo.\nfn foo() {\n    let _ = 1;\n}\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_replace_symbol",
+        json!({
+            "symbol": "foo",
+            "new_source": "/// Doc for foo.\nfn foo() {\n    let _ = 2;\n}"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+    // The returned replaced_span carries the old doc comment so the caller can
+    // recover it if needed.
+    assert!(
+        parsed["replaced_span"]
+            .as_str()
+            .unwrap()
+            .contains("/// Doc for foo.")
+    );
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    assert_eq!(content.matches("/// Doc for foo.").count(), 1);
+    assert!(content.contains("let _ = 2;"));
+    assert!(!content.contains("let _ = 1;"));
+}
+
+#[tokio::test]
+async fn test_insert_at_symbol_before_lands_above_attribute() {
+    // `position=before` must insert above the item's leading doc/attribute
+    // block, not between the docs and the item.
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+
+    // A leading item keeps `foo` off row 0 so its extracted attrs_start_line is
+    // non-zero and survives the DB round-trip.
+    fs::write(
+        project.join("src/main.rs"),
+        "pub const N: u32 = 0;\n/// Doc for foo.\nfn foo() {}\n",
+    )
+    .unwrap();
+
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_insert_at_symbol",
+        json!({
+            "symbol": "foo",
+            "content": "// INSERTED",
+            "position": "before"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let text = extract_text(&result.value);
+    let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["success"], true);
+
+    let content = fs::read_to_string(project.join("src/main.rs")).unwrap();
+    let inserted_at = content.find("// INSERTED").unwrap();
+    let doc_at = content.find("/// Doc for foo.").unwrap();
+    assert!(
+        inserted_at < doc_at,
+        "inserted content should land above the doc comment, got: {content:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_str_replace_unsupported_file_type_succeeds() {
     // Regression: editing unsupported types (e.g. .css) previously wrote the
     // file then returned a reindex error, silently mutating the file.

--- a/tests/mcp_suite/mcp_server_test.rs
+++ b/tests/mcp_suite/mcp_server_test.rs
@@ -2465,7 +2465,13 @@ async fn failed_tool_call_writes_mcp_runtime_analytics_event() {
     assert_eq!(metadata["tokens_saved"], 0);
     assert_eq!(metadata["transport"], "mcp");
     assert_eq!(metadata["tool_kind"], "mcp_tool");
-    assert_eq!(metadata["failure_reason"], "tool_dispatch_error");
+    let failure_reason = metadata["failure_reason"]
+        .as_str()
+        .expect("failure_reason should be a string");
+    assert!(
+        failure_reason.contains("unknown tool") && failure_reason.contains("not_a_real_tool"),
+        "failure_reason should carry the real dispatch error, not a generic marker, got: {failure_reason}"
+    );
 }
 
 #[tokio::test]
@@ -2556,6 +2562,61 @@ async fn semantic_tool_failure_writes_error_mcp_runtime_analytics_event() {
 
     assert_eq!(event.session_id.as_deref(), Some("mcp-session-9004"));
     assert_eq!(event.outcome.as_deref(), Some("error"));
+}
+
+#[tokio::test]
+// Intentional: serializes env-mutating savings tests; #[tokio::test]
+// defaults to a current-thread runtime, so no executor thread blocks.
+#[allow(clippy::await_holding_lock)]
+async fn structural_edit_failure_writes_real_failure_reason_to_analytics() {
+    let _env_guard = SAVINGS_ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp_global = persistent_temp_dir();
+    let _env = isolated_savings_env(&tmp_global.join("global.db"));
+
+    let (server, _proj_tmp) = setup_server().await;
+    let server_handle = server.clone();
+    let db_path = locked_global_db_path();
+
+    // An anchor mismatch (str_replace's `old_str` not present in the file) is
+    // a structural failure the handler already knows about via
+    // `EditResult::success == false` — the resulting analytics event should
+    // carry that exact message, not a generic "tool_dispatch_error" marker.
+    let resp = call_tool(
+        server,
+        9005,
+        "tracedecay_str_replace",
+        json!({
+            "path": "src/main.rs",
+            "old_str": "fn missing() {}",
+            "new_str": "fn replaced() {}",
+            "_meta": { "sessionId": "mcp-session-9005" }
+        }),
+    )
+    .await;
+
+    assert!(resp["error"].is_null(), "semantic failures are MCP results");
+    assert_eq!(resp["result"]["isError"], true);
+
+    server_handle.ledger_writes_settled().await;
+    let event = expect_mcp_runtime_event(
+        &db_path,
+        "tracedecay_str_replace",
+        "mcp-session-9005",
+        "durable structural-failure MCP runtime analytics event",
+    )
+    .await;
+    let metadata = analytics_metadata(&event);
+
+    assert_eq!(event.outcome.as_deref(), Some("error"));
+    let failure_reason = metadata["failure_reason"]
+        .as_str()
+        .expect("failure_reason should be a string");
+    assert!(
+        failure_reason.contains("old_str not found"),
+        "failure_reason should carry the anchor-mismatch message, got: {failure_reason}"
+    );
 }
 
 /// Regression test for the empty-ledger bug: the savings ledger must record


### PR DESCRIPTION
Wave 0 of the refactor-toolset roadmap: edit failures become structurally visible (ToolResult semantic_error/failure_message, real bounded failure reasons in analytics replacing the generic dispatch marker) plus the safety substrate (adaptive doc/attr-span handling in replace_symbol — swaps docs when new_source brings its own, preserves them when it doesn't — sequential apply, dry_run/verify with diffs, post-edit diagnostics). Rebase unions the concurrent client_name instrumentation and keeps the attrs-sentinel regression tests green under the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)