### PR TITLE
chore: release v0.0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.42](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.41...v0.0.42) - 2026-07-09
+
+### Fixed
+
+- *(storage)* preserve symlink guard under macOS temp roots
+- *(storage)* scope symlink guard to the final path component
+- *(graph)* reject external qualified calls, prune lcm table
+- *(graph)* resolver prefilter, scheduler hardening, security batch
+
 ## [0.0.41](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.40...v0.0.41) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.41"
+version = "0.0.42"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.41 -> 0.0.42

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.42](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.41...v0.0.42) - 2026-07-09

### Fixed

- *(storage)* preserve symlink guard under macOS temp roots
- *(storage)* scope symlink guard to the final path component
- *(graph)* reject external qualified calls, prune lcm table
- *(graph)* resolver prefilter, scheduler hardening, security batch
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).