### PR TITLE
feat(sessions): insert-capable structured-row backfill

### DIFF
--- a/src/daemon/git_watch.rs
+++ b/src/daemon/git_watch.rs
@@ -346,7 +346,8 @@ async fn supervise_project(inner: Arc<GitWatcherInner>, state: Arc<WatchState>) 
     loop {
         let inner_c = Arc::clone(&inner);
         let state_c = Arc::clone(&state);
-        let result = tokio::spawn(async move { project_task(inner_c, state_c).await }).await;
+        let result =
+            tokio::spawn(async move { Box::pin(project_task(inner_c, state_c)).await }).await;
         match result {
             Ok(()) => return, // clean exit (watcher gave up gracefully)
             Err(join_err) if join_err.is_cancelled() => return,
@@ -420,7 +421,7 @@ async fn project_task(inner: Arc<GitWatcherInner>, state: Arc<WatchState>) {
     state.health.set_degraded(false);
     state.health.beat();
 
-    debounce_loop(&inner, &state, &common_dir).await;
+    Box::pin(debounce_loop(&inner, &state, &common_dir)).await;
     // Keep the watcher alive for the whole loop.
     drop(watcher);
 }

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -5,7 +5,7 @@
 //! tokens-saved count. All operations are best-effort: failures are silently
 //! ignored so they never block the main MCP server loop.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
@@ -794,6 +794,29 @@ async fn add_session_parent_column_after_missing_check(
     }
 }
 
+/// Process-global switch for the detached structured-row backfill sweep that
+/// [`GlobalDb::open_at`] schedules. On by default; tests flip it off so they can
+/// drive [`GlobalDb::run_structured_backfill`] synchronously against a
+/// deterministic store.
+static BACKGROUND_STRUCTURED_BACKFILL_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+/// Store paths (by db path) that already have a structured-row sweep running in
+/// this process, so concurrent opens don't stack duplicate sweeps.
+fn structured_backfill_in_flight() -> &'static std::sync::Mutex<HashSet<PathBuf>> {
+    static IN_FLIGHT: std::sync::OnceLock<std::sync::Mutex<HashSet<PathBuf>>> =
+        std::sync::OnceLock::new();
+    IN_FLIGHT.get_or_init(|| std::sync::Mutex::new(HashSet::new()))
+}
+
+/// Enables or disables the detached background structured-row sweep. Intended
+/// for tests that need the sweep to run only when they explicitly drive it via
+/// [`GlobalDb::run_structured_backfill`].
+#[doc(hidden)]
+pub fn set_background_structured_backfill_enabled(enabled: bool) {
+    BACKGROUND_STRUCTURED_BACKFILL_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
 impl GlobalDb {
     pub fn db_path(&self) -> &Path {
         &self.db_path
@@ -1078,13 +1101,11 @@ impl GlobalDb {
         // Marker-guarded (runs once per store) and fail-open, like the LCM
         // schema migrations above.
         let _ = crate::sessions::transcript_backfill::backfill_transcript_facts(&db.conn).await;
-        // Insert-capable structured-row backfill: re-parses already-ingested
-        // Claude/Codex transcripts through the *current* parsers and inserts any
-        // structured rows (goals, telemetry, marker records) that older ingests
-        // never wrote, keyed by their stable ids so existing rows are untouched.
-        // Version-gated to run the full history once, then watermarked/bounded
-        // so each open only re-parses the next batch of files.
-        let _ = crate::sessions::transcript_backfill::backfill_structured_rows(&db).await;
+        // Recover structured rows skipped by legacy transcript parsers. This
+        // runs on every open (per hook event, per CLI/MCP invocation), so it
+        // must not block: schedule it on a detached background task rather than
+        // synchronously reading and re-parsing a batch of multi-MB transcripts.
+        db.spawn_structured_backfill();
 
         Some(db)
     }
@@ -1123,12 +1144,60 @@ impl GlobalDb {
         self.conn.clone()
     }
 
-    /// Borrow the underlying connection for crate-internal maintenance passes
-    /// (e.g. the transcript structured-row backfill) that run their own read
-    /// queries and marker/watermark bookkeeping alongside this DB's write
-    /// helpers.
     pub(crate) fn conn(&self) -> &Connection {
         &self.conn
+    }
+
+    /// Schedules the structured-row backfill sweep on a detached task so the
+    /// hot `open_at` path returns immediately instead of synchronously
+    /// re-reading and re-parsing a batch of multi-MB transcripts.
+    ///
+    /// Concurrency: the sweep opens its own connection, its writes are
+    /// idempotent upserts keyed on `(provider, message_id)`, and its path
+    /// watermark advances per file — so overlapping with live ingest is safe.
+    /// A process-wide in-flight guard (keyed by store path) skips the spawn
+    /// when a sweep for this store is already running, so stacked opens don't
+    /// stack sweeps. A short-lived runtime may drop the task before it
+    /// finishes; that is fine — the marker/watermark simply let a later open
+    /// resume where it left off.
+    fn spawn_structured_backfill(&self) {
+        if !BACKGROUND_STRUCTURED_BACKFILL_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
+        let db_path = self.db_path.clone();
+        {
+            let mut in_flight = match structured_backfill_in_flight().lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if !in_flight.insert(db_path.clone()) {
+                // A sweep for this store is already in flight in this process.
+                return;
+            }
+        }
+        tokio::spawn(async move {
+            // Re-open an independent handle to the same store (the scheduling
+            // open already ensured its schema) so the sweep never shares the
+            // connection handed back to the caller.
+            if let Some(db) = GlobalDb::open_at_assuming_schema(&db_path).await {
+                let _ = crate::sessions::transcript_backfill::backfill_structured_rows(&db).await;
+            }
+            let mut in_flight = match structured_backfill_in_flight().lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            in_flight.remove(&db_path);
+        });
+    }
+
+    /// Runs the structured-row backfill sweep synchronously to completion for
+    /// the current bounded batch, returning the number of rows inserted.
+    /// `open_at` drives this in the background; callers (and tests) that need a
+    /// deterministic sweep invoke it directly.
+    pub async fn run_structured_backfill(&self) -> Option<u64> {
+        crate::sessions::transcript_backfill::backfill_structured_rows(self)
+            .await
+            .map(|stats| stats.inserted)
     }
 
     /// Transcript-ingest backlog for the session store backing this DB.
@@ -2795,16 +2864,9 @@ impl GlobalDb {
         }
     }
 
-    /// Inserts only the messages whose `(provider, message_id)` key is not
-    /// already stored, using the same full write path as live ingest (raw
-    /// payload + searchable projection + any derived LCM summary node). Rows
-    /// that already exist are left **exactly** as they are — their timestamps,
-    /// text, and metadata are never touched — so re-parsing an already-ingested
-    /// transcript adds new structured rows without clobbering the originals.
-    ///
-    /// Runs the whole batch in one transaction. Returns the number of rows
-    /// newly inserted, or `None` on any database error (the transaction is
-    /// rolled back, so a later retry sees no partial write).
+    /// Inserts messages whose `(provider, message_id)` key is absent, leaving
+    /// existing rows untouched. Returns inserted row count, or `None` after
+    /// rolling back on any database error.
     pub(crate) async fn insert_absent_session_messages(
         &self,
         messages: &[SessionMessageRecord],
@@ -2812,22 +2874,33 @@ impl GlobalDb {
         if messages.is_empty() {
             return Some(0);
         }
+        // Do the presence filtering as plain reads *before* taking the write
+        // lock. The old code ran the per-message existence probe inside
+        // `BEGIN IMMEDIATE`, holding the store's single-writer slot for the
+        // whole batch just to discover most rows were already present.
+        let present = self.present_session_message_keys(messages).await?;
+        let absent: Vec<&SessionMessageRecord> = messages
+            .iter()
+            .filter(|message| {
+                !present.contains(&(message.provider.clone(), message.message_id.clone()))
+            })
+            .collect();
+        if absent.is_empty() {
+            return Some(0);
+        }
+
         if self.conn.execute("BEGIN IMMEDIATE", ()).await.is_err() {
             return None;
         }
         let mut inserted = 0u64;
-        for message in messages {
-            match self
-                .session_message_present(&message.provider, &message.message_id)
-                .await
-            {
-                Some(true) => continue,
-                Some(false) => {}
-                None => {
-                    let _ = self.conn.execute("ROLLBACK", ()).await;
-                    return None;
-                }
-            }
+        for message in absent {
+            // The presence probe ran outside this transaction, so a concurrent
+            // live ingest could insert this key in the small TOCTOU window.
+            // That is harmless: `upsert_session_message_in_existing_tx` writes
+            // through `ON CONFLICT(provider, message_id) DO UPDATE` upserts, and
+            // the row re-parsed from the *same* transcript is byte-for-byte what
+            // the racing writer stored — the update rewrites identical content
+            // rather than clobbering the row with foreign data.
             if !self.upsert_session_message_in_existing_tx(message).await {
                 let _ = self.conn.execute("ROLLBACK", ()).await;
                 return None;
@@ -2841,18 +2914,56 @@ impl GlobalDb {
         None
     }
 
-    /// True when a `(provider, message_id)` row already exists in the searchable
-    /// projection. `None` signals a query error the caller must treat as fatal.
-    async fn session_message_present(&self, provider: &str, message_id: &str) -> Option<bool> {
-        let mut rows = self
-            .conn
-            .query(
-                "SELECT 1 FROM session_messages WHERE provider = ?1 AND message_id = ?2",
-                params![provider, message_id],
-            )
-            .await
-            .ok()?;
-        Some(rows.next().await.ok()?.is_some())
+    /// Collects the `(provider, message_id)` keys from `messages` that already
+    /// exist in `session_messages`, probing in chunks of 500 ids grouped by
+    /// provider. Runs as plain reads *outside* any write transaction so the
+    /// presence filtering never holds the store's single writer slot. `None`
+    /// on a query error, so the caller aborts rather than treating an
+    /// unreadable row as absent.
+    async fn present_session_message_keys(
+        &self,
+        messages: &[SessionMessageRecord],
+    ) -> Option<HashSet<(String, String)>> {
+        const CHUNK: usize = 500;
+        let mut by_provider: HashMap<&str, Vec<&str>> = HashMap::new();
+        for message in messages {
+            by_provider
+                .entry(message.provider.as_str())
+                .or_default()
+                .push(message.message_id.as_str());
+        }
+        let mut present: HashSet<(String, String)> = HashSet::new();
+        for (provider, ids) in by_provider {
+            for chunk in ids.chunks(CHUNK) {
+                let placeholders = vec!["?"; chunk.len()].join(", ");
+                let sql = format!(
+                    "SELECT message_id FROM session_messages
+                     WHERE provider = ? AND message_id IN ({placeholders})"
+                );
+                let mut values: Vec<Value> = Vec::with_capacity(chunk.len() + 1);
+                values.push(Value::Text(provider.to_string()));
+                for id in chunk {
+                    values.push(Value::Text((*id).to_string()));
+                }
+                let mut rows = self
+                    .conn
+                    .query(&sql, libsql::params_from_iter(values))
+                    .await
+                    .ok()?;
+                loop {
+                    match rows.next().await {
+                        Ok(Some(row)) => {
+                            if let Ok(message_id) = row.get::<String>(0) {
+                                present.insert((provider.to_string(), message_id));
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(_) => return None,
+                    }
+                }
+            }
+        }
+        Some(present)
     }
 
     async fn upsert_lcm_summary_for_transcript_summary(

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -1078,6 +1078,13 @@ impl GlobalDb {
         // Marker-guarded (runs once per store) and fail-open, like the LCM
         // schema migrations above.
         let _ = crate::sessions::transcript_backfill::backfill_transcript_facts(&db.conn).await;
+        // Insert-capable structured-row backfill: re-parses already-ingested
+        // Claude/Codex transcripts through the *current* parsers and inserts any
+        // structured rows (goals, telemetry, marker records) that older ingests
+        // never wrote, keyed by their stable ids so existing rows are untouched.
+        // Version-gated to run the full history once, then watermarked/bounded
+        // so each open only re-parses the next batch of files.
+        let _ = crate::sessions::transcript_backfill::backfill_structured_rows(&db).await;
 
         Some(db)
     }
@@ -1114,6 +1121,14 @@ impl GlobalDb {
     /// server queries the LCM tables directly).
     pub(crate) fn dashboard_connection(&self) -> Connection {
         self.conn.clone()
+    }
+
+    /// Borrow the underlying connection for crate-internal maintenance passes
+    /// (e.g. the transcript structured-row backfill) that run their own read
+    /// queries and marker/watermark bookkeeping alongside this DB's write
+    /// helpers.
+    pub(crate) fn conn(&self) -> &Connection {
+        &self.conn
     }
 
     /// Transcript-ingest backlog for the session store backing this DB.
@@ -2778,6 +2793,66 @@ impl GlobalDb {
             }
             Err(_) => false,
         }
+    }
+
+    /// Inserts only the messages whose `(provider, message_id)` key is not
+    /// already stored, using the same full write path as live ingest (raw
+    /// payload + searchable projection + any derived LCM summary node). Rows
+    /// that already exist are left **exactly** as they are — their timestamps,
+    /// text, and metadata are never touched — so re-parsing an already-ingested
+    /// transcript adds new structured rows without clobbering the originals.
+    ///
+    /// Runs the whole batch in one transaction. Returns the number of rows
+    /// newly inserted, or `None` on any database error (the transaction is
+    /// rolled back, so a later retry sees no partial write).
+    pub(crate) async fn insert_absent_session_messages(
+        &self,
+        messages: &[SessionMessageRecord],
+    ) -> Option<u64> {
+        if messages.is_empty() {
+            return Some(0);
+        }
+        if self.conn.execute("BEGIN IMMEDIATE", ()).await.is_err() {
+            return None;
+        }
+        let mut inserted = 0u64;
+        for message in messages {
+            match self
+                .session_message_present(&message.provider, &message.message_id)
+                .await
+            {
+                Some(true) => continue,
+                Some(false) => {}
+                None => {
+                    let _ = self.conn.execute("ROLLBACK", ()).await;
+                    return None;
+                }
+            }
+            if !self.upsert_session_message_in_existing_tx(message).await {
+                let _ = self.conn.execute("ROLLBACK", ()).await;
+                return None;
+            }
+            inserted += 1;
+        }
+        if self.conn.execute("COMMIT", ()).await.is_ok() {
+            return Some(inserted);
+        }
+        let _ = self.conn.execute("ROLLBACK", ()).await;
+        None
+    }
+
+    /// True when a `(provider, message_id)` row already exists in the searchable
+    /// projection. `None` signals a query error the caller must treat as fatal.
+    async fn session_message_present(&self, provider: &str, message_id: &str) -> Option<bool> {
+        let mut rows = self
+            .conn
+            .query(
+                "SELECT 1 FROM session_messages WHERE provider = ?1 AND message_id = ?2",
+                params![provider, message_id],
+            )
+            .await
+            .ok()?;
+        Some(rows.next().await.ok()?.is_some())
     }
 
     async fn upsert_lcm_summary_for_transcript_summary(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1759,7 +1759,7 @@ impl McpServer {
         let parsed: std::result::Result<super::transport::JsonRpcRequest, _> =
             serde_json::from_str(line);
         let response = match parsed {
-            Ok(request) => self.handle_request(&request).await,
+            Ok(request) => Box::pin(self.handle_request(&request)).await,
             Err(e) => Some(super::transport::JsonRpcResponse::error(
                 Value::Null,
                 super::transport::ErrorCode::ParseError,
@@ -1906,12 +1906,12 @@ impl McpServer {
                             )
                             .await;
                     }
-                    self.handle_request_with_timings_and_implicit_project(
+                    Box::pin(self.handle_request_with_timings_and_implicit_project(
                         &request,
                         timings_override.unwrap_or_else(|| self.timings_enabled()),
                         &mut route_cache,
                         connection_route.implicit_project_path(),
-                    )
+                    ))
                     .await
                 }
                 Err(e) => Some(JsonRpcResponse::error(
@@ -2036,8 +2036,12 @@ impl McpServer {
     /// Returns `None` for notifications (requests without an `id`).
     pub(crate) async fn handle_request(&self, request: &JsonRpcRequest) -> Option<JsonRpcResponse> {
         let mut route_cache = self.hook_project_routes.snapshot();
-        self.handle_request_with_timings(request, self.timings_enabled(), &mut route_cache)
-            .await
+        Box::pin(self.handle_request_with_timings(
+            request,
+            self.timings_enabled(),
+            &mut route_cache,
+        ))
+        .await
     }
 
     async fn handle_request_with_timings(
@@ -2046,12 +2050,12 @@ impl McpServer {
         timings_enabled: bool,
         route_cache: &mut HookProjectRouteCache,
     ) -> Option<JsonRpcResponse> {
-        self.handle_request_with_timings_and_implicit_project(
+        Box::pin(self.handle_request_with_timings_and_implicit_project(
             request,
             timings_enabled,
             route_cache,
             None,
-        )
+        ))
         .await
     }
 

--- a/src/sessions/transcript_backfill.rs
+++ b/src/sessions/transcript_backfill.rs
@@ -25,14 +25,17 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use libsql::{Connection, params};
 use serde_json::Value;
 
+use crate::global_db::GlobalDb;
+use crate::sessions::SessionMessageRecord;
 use crate::sessions::codex::{CodexTurnUsage, merge_usage_counters};
 use crate::sessions::cursor::TimestampCarry;
 use crate::sessions::shared::usage_counters_from;
+use crate::sessions::source::{StoredCursor, TranscriptSource};
 
 const MARKER_NAME: &str = "transcript_facts_backfill";
 const MARKER_VERSION: i64 = 1;
@@ -64,7 +67,7 @@ pub(crate) struct BackfillStats {
 /// number of rows that gained facts, or `None` on database errors (in which
 /// case the marker is not written and a later open retries).
 pub(crate) async fn backfill_transcript_facts(conn: &Connection) -> Option<BackfillStats> {
-    if marker_version(conn).await >= MARKER_VERSION {
+    if marker_version(conn, MARKER_NAME).await >= MARKER_VERSION {
         return Some(BackfillStats::default());
     }
 
@@ -121,11 +124,11 @@ pub(crate) async fn backfill_transcript_facts(conn: &Connection) -> Option<Backf
     Some(stats)
 }
 
-async fn marker_version(conn: &Connection) -> i64 {
+async fn marker_version(conn: &Connection, name: &str) -> i64 {
     let Ok(mut rows) = conn
         .query(
             "SELECT version FROM session_schema_migrations WHERE name = ?1",
-            params![MARKER_NAME],
+            params![name],
         )
         .await
     else {
@@ -397,4 +400,286 @@ fn derive_usage(provider: &str, record: &Value) -> Option<Value> {
             .or_else(|| record.get("message").and_then(usage_counters_from)),
         _ => None,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Structured-row backfill
+// ---------------------------------------------------------------------------
+//
+// The pass above only *updates* facts on rows a prior ingest already wrote.
+// It cannot recover rows the old parser never emitted at all: append-only
+// ingest advances a per-file byte cursor, so once a transcript is past its
+// offset the newly-added row kinds (Codex `goal`/telemetry rows, Claude
+// `pr_link`/`compact_boundary`/`model_fallback` marker rows) never appear for
+// history ingested before those parsers shipped.
+//
+// This sibling pass re-parses each already-ingested Claude/Codex transcript
+// from byte 0 through the *current* parser and inserts any row whose
+// `(provider, message_id)` key is absent. Structured rows derive stable ids
+// from `session_id:offset` (or `kind:uuid`), so a re-parse reproduces the
+// original conversational rows (which are skipped as already-present) and the
+// new structured rows (which are inserted exactly once). Existing rows keep
+// their content — [`GlobalDb::insert_absent_session_messages`] never updates a
+// row that is already stored.
+//
+// Scope + safety:
+//   * per-provider allowlist ([`STRUCTURED_PROVIDERS`]) — Cursor is excluded
+//     because its composer store re-ingests through its own watermarks;
+//   * bounded work per sweep ([`STRUCTURED_BACKFILL_BATCH`] files) with a path
+//     watermark stored in `session_backfill_meta`, mirroring the incremental
+//     git-correlation sweep;
+//   * a version marker in `session_schema_migrations` runs the full history
+//     once and is bumpable when future row kinds are added.
+
+/// Marker recording that the whole transcript history has been swept for the
+/// current structured-row vocabulary. Bump [`STRUCTURED_MARKER_VERSION`] when a
+/// new row kind is added so the full re-sweep runs again.
+const STRUCTURED_MARKER_NAME: &str = "structured_rows_backfill";
+const STRUCTURED_MARKER_VERSION: i64 = 1;
+/// Meta-table key holding the last transcript path fully re-parsed by the sweep.
+const STRUCTURED_CURSOR_KEY: &str = "structured_backfill_cursor";
+/// Transcript files re-parsed per open. Keeps each catch-up open bounded while
+/// the version marker guarantees the whole history is eventually covered.
+const STRUCTURED_BACKFILL_BATCH: usize = 32;
+/// Providers whose current parsers emit structured rows an older ingest lacked.
+/// Cursor is intentionally excluded (its composer store self-heals).
+const STRUCTURED_PROVIDERS: [&str; 2] = ["claude", "codex"];
+
+/// Rows inserted (and files touched) by one structured-backfill sweep.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct StructuredBackfillStats {
+    pub(crate) inserted: u64,
+    pub(crate) files_scanned: u64,
+}
+
+/// One transcript file still owed a structured re-parse.
+struct StructuredCandidate {
+    provider: String,
+    source_path: String,
+}
+
+/// Re-parses the next bounded batch of already-ingested Claude/Codex
+/// transcripts through the current parsers and inserts any structured rows the
+/// original ingest missed. Marker-guarded (full history swept once), watermarked
+/// (each open advances through the remaining files), and idempotent (a second
+/// run inserts nothing). Returns `None` on a database error so the marker and
+/// watermark stay put and a later open retries.
+pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<StructuredBackfillStats> {
+    let conn = db.conn();
+    if marker_version(conn, STRUCTURED_MARKER_NAME).await >= STRUCTURED_MARKER_VERSION {
+        return Some(StructuredBackfillStats::default());
+    }
+    ensure_backfill_meta_table(conn).await?;
+    let cursor = read_backfill_cursor(conn, STRUCTURED_CURSOR_KEY).await;
+    let candidates = load_structured_candidates(conn, &cursor, STRUCTURED_BACKFILL_BATCH).await?;
+    if candidates.is_empty() {
+        // The whole history is swept: record completion so future opens skip
+        // straight past the marker check above. New transcripts ingested from
+        // here on already carry the current row kinds via live ingest.
+        mark_structured_backfill_complete(conn).await?;
+        return Some(StructuredBackfillStats::default());
+    }
+
+    let mut stats = StructuredBackfillStats::default();
+    for candidate in &candidates {
+        // A single transcript file can be attributed to more than one project
+        // root (Claude sessions that cross worktrees split by per-row cwd), so
+        // re-parse once per owning project so the parser's cwd filter accepts
+        // the same rows it did at live ingest.
+        let project_paths =
+            load_project_paths_for_source(conn, &candidate.provider, &candidate.source_path)
+                .await?;
+        for project_path in project_paths {
+            let provider = candidate.provider.clone();
+            let source_path = candidate.source_path.clone();
+            let messages = tokio::task::spawn_blocking(move || {
+                parse_structured_messages(&provider, &source_path, &project_path)
+            })
+            .await
+            .ok()?
+            .unwrap_or_default();
+            if messages.is_empty() {
+                continue;
+            }
+            let inserted = db.insert_absent_session_messages(&messages).await?;
+            stats.inserted += inserted;
+        }
+        stats.files_scanned += 1;
+        // Advance the watermark per file so a crash mid-batch resumes cleanly
+        // rather than re-reading everything from the start.
+        write_backfill_cursor(conn, STRUCTURED_CURSOR_KEY, &candidate.source_path).await?;
+    }
+
+    if stats.inserted > 0 {
+        eprintln!(
+            "Backfilled {} structured transcript row(s) across {} file(s).",
+            stats.inserted, stats.files_scanned
+        );
+    }
+    Some(stats)
+}
+
+/// Re-parses one transcript from byte 0 through its provider's current parser,
+/// returning every message record it would ingest today. `None` when the
+/// provider is unknown or the parser declines the file (missing/foreign
+/// transcript); the caller treats that as "no rows to insert".
+fn parse_structured_messages(
+    provider: &str,
+    source_path: &str,
+    project_path: &str,
+) -> Option<Vec<SessionMessageRecord>> {
+    let source = provider_source(provider)?;
+    // A zero cursor forces a full read from offset 0 regardless of the stored
+    // ingest offset, reproducing every row (existing rows are skipped later by
+    // their `(provider, message_id)` key).
+    let parsed = source.parse_new(
+        Path::new(source_path),
+        StoredCursor::default(),
+        Path::new(project_path),
+        None,
+    )?;
+    Some(parsed.messages)
+}
+
+/// Builds the transcript source for a backfill provider. The home-derived scan
+/// directory is unused by `parse_new` (it only reads the explicit path), so a
+/// missing home degrades to a harmless root and never blocks the backfill.
+fn provider_source(provider: &str) -> Option<Box<dyn TranscriptSource>> {
+    let home = crate::sessions::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+    match provider {
+        "claude" => Some(Box::new(crate::sessions::claude::ClaudeSource::with_home(
+            &home,
+        ))),
+        "codex" => Some(Box::new(crate::sessions::codex::CodexSource::with_home(
+            &home,
+        ))),
+        _ => None,
+    }
+}
+
+/// Distinct transcript files (past the watermark) still owed a structured
+/// re-parse, ordered by path so the watermark can advance monotonically.
+async fn load_structured_candidates(
+    conn: &Connection,
+    after_path: &str,
+    limit: usize,
+) -> Option<Vec<StructuredCandidate>> {
+    let providers = STRUCTURED_PROVIDERS
+        .map(|provider| format!("'{provider}'"))
+        .join(", ");
+    let sql = format!(
+        "SELECT DISTINCT sm.source_path, sm.provider
+         FROM session_messages sm
+         WHERE sm.provider IN ({providers})
+           AND sm.source_path IS NOT NULL
+           AND sm.source_path > ?1
+         ORDER BY sm.source_path
+         LIMIT ?2"
+    );
+    let mut rows = conn
+        .query(&sql, params![after_path, limit as i64])
+        .await
+        .ok()?;
+    let mut out = Vec::new();
+    while let Ok(Some(row)) = rows.next().await {
+        let (Ok(source_path), Ok(provider)) = (row.get::<String>(0), row.get::<String>(1)) else {
+            continue;
+        };
+        out.push(StructuredCandidate {
+            provider,
+            source_path,
+        });
+    }
+    Some(out)
+}
+
+/// Distinct project roots that own messages from one transcript file. Used as
+/// the `project_root` the parser filters rows against, so re-parsing accepts the
+/// same rows it accepted at live ingest.
+async fn load_project_paths_for_source(
+    conn: &Connection,
+    provider: &str,
+    source_path: &str,
+) -> Option<Vec<String>> {
+    let mut rows = conn
+        .query(
+            "SELECT DISTINCT s.project_path
+             FROM session_messages sm
+             JOIN sessions s
+               ON s.provider = sm.provider AND s.session_id = sm.session_id
+             WHERE sm.provider = ?1
+               AND sm.source_path = ?2
+               AND s.project_path IS NOT NULL
+               AND s.project_path <> ''",
+            params![provider, source_path],
+        )
+        .await
+        .ok()?;
+    let mut out = Vec::new();
+    while let Ok(Some(row)) = rows.next().await {
+        if let Ok(project_path) = row.get::<String>(0) {
+            out.push(project_path);
+        }
+    }
+    Some(out)
+}
+
+/// Lazily creates the small key/value table the sweep uses for its path
+/// watermark (mirrors `git_correlation_meta` / `workflow_index_meta`).
+async fn ensure_backfill_meta_table(conn: &Connection) -> Option<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS session_backfill_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+        )",
+        (),
+    )
+    .await
+    .ok()?;
+    Some(())
+}
+
+/// Reads the sweep watermark, defaulting to the empty string (which sorts
+/// before every real path, so the first sweep sees the whole history).
+async fn read_backfill_cursor(conn: &Connection, key: &str) -> String {
+    let Ok(mut rows) = conn
+        .query(
+            "SELECT value FROM session_backfill_meta WHERE key = ?1",
+            params![key],
+        )
+        .await
+    else {
+        return String::new();
+    };
+    match rows.next().await {
+        Ok(Some(row)) => row.get::<String>(0).unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+
+async fn write_backfill_cursor(conn: &Connection, key: &str, value: &str) -> Option<()> {
+    conn.execute(
+        "INSERT INTO session_backfill_meta(key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = unixepoch()",
+        params![key, value],
+    )
+    .await
+    .ok()?;
+    Some(())
+}
+
+/// Records that the structured sweep has covered the whole history.
+async fn mark_structured_backfill_complete(conn: &Connection) -> Option<()> {
+    conn.execute(
+        "INSERT INTO session_schema_migrations(name, version)
+         VALUES (?1, ?2)
+         ON CONFLICT(name) DO UPDATE SET
+            version = excluded.version,
+            applied_at = unixepoch()",
+        params![STRUCTURED_MARKER_NAME, STRUCTURED_MARKER_VERSION],
+    )
+    .await
+    .ok()?;
+    Some(())
 }

--- a/src/sessions/transcript_backfill.rs
+++ b/src/sessions/transcript_backfill.rs
@@ -402,102 +402,107 @@ fn derive_usage(provider: &str, record: &Value) -> Option<Value> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Structured-row backfill
-// ---------------------------------------------------------------------------
-//
-// The pass above only *updates* facts on rows a prior ingest already wrote.
-// It cannot recover rows the old parser never emitted at all: append-only
-// ingest advances a per-file byte cursor, so once a transcript is past its
-// offset the newly-added row kinds (Codex `goal`/telemetry rows, Claude
-// `pr_link`/`compact_boundary`/`model_fallback` marker rows) never appear for
-// history ingested before those parsers shipped.
-//
-// This sibling pass re-parses each already-ingested Claude/Codex transcript
-// from byte 0 through the *current* parser and inserts any row whose
-// `(provider, message_id)` key is absent. Structured rows derive stable ids
-// from `session_id:offset` (or `kind:uuid`), so a re-parse reproduces the
-// original conversational rows (which are skipped as already-present) and the
-// new structured rows (which are inserted exactly once). Existing rows keep
-// their content — [`GlobalDb::insert_absent_session_messages`] never updates a
-// row that is already stored.
-//
-// Scope + safety:
-//   * per-provider allowlist ([`STRUCTURED_PROVIDERS`]) — Cursor is excluded
-//     because its composer store re-ingests through its own watermarks;
-//   * bounded work per sweep ([`STRUCTURED_BACKFILL_BATCH`] files) with a path
-//     watermark stored in `session_backfill_meta`, mirroring the incremental
-//     git-correlation sweep;
-//   * a version marker in `session_schema_migrations` runs the full history
-//     once and is bumpable when future row kinds are added.
+// Structured-row backfill replays stored Claude/Codex transcripts through the
+// current parser and inserts message ids missing from legacy stores.
 
-/// Marker recording that the whole transcript history has been swept for the
-/// current structured-row vocabulary. Bump [`STRUCTURED_MARKER_VERSION`] when a
-/// new row kind is added so the full re-sweep runs again.
 const STRUCTURED_MARKER_NAME: &str = "structured_rows_backfill";
 const STRUCTURED_MARKER_VERSION: i64 = 1;
-/// Meta-table key holding the last transcript path fully re-parsed by the sweep.
-const STRUCTURED_CURSOR_KEY: &str = "structured_backfill_cursor";
-/// Transcript files re-parsed per open. Keeps each catch-up open bounded while
-/// the version marker guarantees the whole history is eventually covered.
+/// Base name of the sweep's path watermark. The live key is namespaced by the
+/// marker version (see [`structured_cursor_key`]) so bumping
+/// [`STRUCTURED_MARKER_VERSION`] naturally starts the re-sweep from a fresh
+/// (never-written) cursor instead of resuming past the last file the prior
+/// version already covered.
+const STRUCTURED_CURSOR_KEY_PREFIX: &str = "structured_backfill_cursor";
 const STRUCTURED_BACKFILL_BATCH: usize = 32;
-/// Providers whose current parsers emit structured rows an older ingest lacked.
-/// Cursor is intentionally excluded (its composer store self-heals).
+/// Transcripts larger than this are skipped (with a logged warning and a cursor
+/// advance) rather than materialized whole. Threading a byte offset through the
+/// watermark would balloon the diff, so we cap file size instead — pathological
+/// multi-hundred-MB JSONL transcripts are the only ones affected.
+const STRUCTURED_BACKFILL_MAX_FILE_BYTES: u64 = 256 * 1024 * 1024;
 const STRUCTURED_PROVIDERS: [&str; 2] = ["claude", "codex"];
 
-/// Rows inserted (and files touched) by one structured-backfill sweep.
+/// Version-namespaced watermark key. Because the version is part of the key, a
+/// bump to [`STRUCTURED_MARKER_VERSION`] yields a key that has never been
+/// written, so [`read_backfill_cursor`] returns the empty string and the sweep
+/// re-parses the whole history from the start.
+fn structured_cursor_key() -> String {
+    format!("{STRUCTURED_CURSOR_KEY_PREFIX}:v{STRUCTURED_MARKER_VERSION}")
+}
+
 #[derive(Default, Clone, Copy)]
 pub(crate) struct StructuredBackfillStats {
     pub(crate) inserted: u64,
     pub(crate) files_scanned: u64,
 }
 
-/// One transcript file still owed a structured re-parse.
 struct StructuredCandidate {
     provider: String,
     source_path: String,
 }
 
-/// Re-parses the next bounded batch of already-ingested Claude/Codex
-/// transcripts through the current parsers and inserts any structured rows the
-/// original ingest missed. Marker-guarded (full history swept once), watermarked
-/// (each open advances through the remaining files), and idempotent (a second
-/// run inserts nothing). Returns `None` on a database error so the marker and
-/// watermark stay put and a later open retries.
+/// Re-parses the next bounded transcript batch and inserts rows missing from
+/// legacy stores.
 pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<StructuredBackfillStats> {
     let conn = db.conn();
     if marker_version(conn, STRUCTURED_MARKER_NAME).await >= STRUCTURED_MARKER_VERSION {
         return Some(StructuredBackfillStats::default());
     }
     ensure_backfill_meta_table(conn).await?;
-    let cursor = read_backfill_cursor(conn, STRUCTURED_CURSOR_KEY).await;
+    let cursor_key = structured_cursor_key();
+    let cursor = read_backfill_cursor(conn, &cursor_key).await;
     let candidates = load_structured_candidates(conn, &cursor, STRUCTURED_BACKFILL_BATCH).await?;
     if candidates.is_empty() {
-        // The whole history is swept: record completion so future opens skip
-        // straight past the marker check above. New transcripts ingested from
-        // here on already carry the current row kinds via live ingest.
         mark_structured_backfill_complete(conn).await?;
         return Some(StructuredBackfillStats::default());
     }
 
     let mut stats = StructuredBackfillStats::default();
     for candidate in &candidates {
-        // A single transcript file can be attributed to more than one project
-        // root (Claude sessions that cross worktrees split by per-row cwd), so
-        // re-parse once per owning project so the parser's cwd filter accepts
-        // the same rows it did at live ingest.
+        // Bound memory cheaply: an oversized transcript would be materialized
+        // whole by the full-file parse below, so skip it (and advance past it)
+        // rather than risk pinning hundreds of MB per parse.
+        if let Ok(meta) = std::fs::metadata(&candidate.source_path) {
+            if meta.len() > STRUCTURED_BACKFILL_MAX_FILE_BYTES {
+                eprintln!(
+                    "Structured backfill: skipping oversized transcript ({} bytes > {STRUCTURED_BACKFILL_MAX_FILE_BYTES} cap): {}",
+                    meta.len(),
+                    candidate.source_path
+                );
+                stats.files_scanned += 1;
+                write_backfill_cursor(conn, &cursor_key, &candidate.source_path).await?;
+                continue;
+            }
+        }
+
         let project_paths =
             load_project_paths_for_source(conn, &candidate.provider, &candidate.source_path)
                 .await?;
         for project_path in project_paths {
             let provider = candidate.provider.clone();
             let source_path = candidate.source_path.clone();
-            let messages = tokio::task::spawn_blocking(move || {
+            let messages = match tokio::task::spawn_blocking(move || {
                 parse_structured_messages(&provider, &source_path, &project_path)
             })
             .await
-            .ok()?
-            .unwrap_or_default();
+            {
+                // The parser ran to completion: rows to insert, or a clean
+                // decline (foreign/missing transcript) that yields nothing.
+                Ok(parsed) => parsed.unwrap_or_default(),
+                // The parser panicked on this file — a deterministic per-file
+                // failure. Holding the cursor here would re-poison every future
+                // open and starve all lexically-later files, so log it and fall
+                // through to advance past the file (it self-heals on a future
+                // marker-version bump). Environment errors take a different
+                // path: `insert_absent_session_messages` returns `None` below,
+                // which propagates and holds the cursor for a later retry.
+                Err(join_error) => {
+                    eprintln!(
+                        "Structured backfill: skipping transcript that failed to re-parse ({}): {join_error}",
+                        candidate.source_path
+                    );
+                    break;
+                }
+            };
             if messages.is_empty() {
                 continue;
             }
@@ -505,9 +510,7 @@ pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<Structured
             stats.inserted += inserted;
         }
         stats.files_scanned += 1;
-        // Advance the watermark per file so a crash mid-batch resumes cleanly
-        // rather than re-reading everything from the start.
-        write_backfill_cursor(conn, STRUCTURED_CURSOR_KEY, &candidate.source_path).await?;
+        write_backfill_cursor(conn, &cursor_key, &candidate.source_path).await?;
     }
 
     if stats.inserted > 0 {
@@ -519,19 +522,12 @@ pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<Structured
     Some(stats)
 }
 
-/// Re-parses one transcript from byte 0 through its provider's current parser,
-/// returning every message record it would ingest today. `None` when the
-/// provider is unknown or the parser declines the file (missing/foreign
-/// transcript); the caller treats that as "no rows to insert".
 fn parse_structured_messages(
     provider: &str,
     source_path: &str,
     project_path: &str,
 ) -> Option<Vec<SessionMessageRecord>> {
     let source = provider_source(provider)?;
-    // A zero cursor forces a full read from offset 0 regardless of the stored
-    // ingest offset, reproducing every row (existing rows are skipped later by
-    // their `(provider, message_id)` key).
     let parsed = source.parse_new(
         Path::new(source_path),
         StoredCursor::default(),
@@ -541,9 +537,6 @@ fn parse_structured_messages(
     Some(parsed.messages)
 }
 
-/// Builds the transcript source for a backfill provider. The home-derived scan
-/// directory is unused by `parse_new` (it only reads the explicit path), so a
-/// missing home degrades to a harmless root and never blocks the backfill.
 fn provider_source(provider: &str) -> Option<Box<dyn TranscriptSource>> {
     let home = crate::sessions::home_dir().unwrap_or_else(|| PathBuf::from("/"));
     match provider {
@@ -557,8 +550,6 @@ fn provider_source(provider: &str) -> Option<Box<dyn TranscriptSource>> {
     }
 }
 
-/// Distinct transcript files (past the watermark) still owed a structured
-/// re-parse, ordered by path so the watermark can advance monotonically.
 async fn load_structured_candidates(
     conn: &Connection,
     after_path: &str,
@@ -581,21 +572,30 @@ async fn load_structured_candidates(
         .await
         .ok()?;
     let mut out = Vec::new();
-    while let Ok(Some(row)) = rows.next().await {
-        let (Ok(source_path), Ok(provider)) = (row.get::<String>(0), row.get::<String>(1)) else {
-            continue;
-        };
-        out.push(StructuredCandidate {
-            provider,
-            source_path,
-        });
+    // Match on `next()` explicitly: a mid-iteration `Err` must abort with `None`
+    // (this function's documented contract), not silently truncate — a partial
+    // list looks like fewer candidates and, once empty, would wrongly mark the
+    // whole sweep complete and advance the watermark past unscanned files.
+    loop {
+        match rows.next().await {
+            Ok(Some(row)) => {
+                let (Ok(source_path), Ok(provider)) =
+                    (row.get::<String>(0), row.get::<String>(1))
+                else {
+                    continue;
+                };
+                out.push(StructuredCandidate {
+                    provider,
+                    source_path,
+                });
+            }
+            Ok(None) => break,
+            Err(_) => return None,
+        }
     }
     Some(out)
 }
 
-/// Distinct project roots that own messages from one transcript file. Used as
-/// the `project_root` the parser filters rows against, so re-parsing accepts the
-/// same rows it accepted at live ingest.
 async fn load_project_paths_for_source(
     conn: &Connection,
     provider: &str,
@@ -616,16 +616,23 @@ async fn load_project_paths_for_source(
         .await
         .ok()?;
     let mut out = Vec::new();
-    while let Ok(Some(row)) = rows.next().await {
-        if let Ok(project_path) = row.get::<String>(0) {
-            out.push(project_path);
+    // As above: a mid-iteration `Err` must abort with `None` rather than drop
+    // project roots silently — a truncated list would parse against fewer cwds
+    // and then advance the watermark past the file forever.
+    loop {
+        match rows.next().await {
+            Ok(Some(row)) => {
+                if let Ok(project_path) = row.get::<String>(0) {
+                    out.push(project_path);
+                }
+            }
+            Ok(None) => break,
+            Err(_) => return None,
         }
     }
     Some(out)
 }
 
-/// Lazily creates the small key/value table the sweep uses for its path
-/// watermark (mirrors `git_correlation_meta` / `workflow_index_meta`).
 async fn ensure_backfill_meta_table(conn: &Connection) -> Option<()> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS session_backfill_meta (
@@ -640,8 +647,6 @@ async fn ensure_backfill_meta_table(conn: &Connection) -> Option<()> {
     Some(())
 }
 
-/// Reads the sweep watermark, defaulting to the empty string (which sorts
-/// before every real path, so the first sweep sees the whole history).
 async fn read_backfill_cursor(conn: &Connection, key: &str) -> String {
     let Ok(mut rows) = conn
         .query(
@@ -669,7 +674,6 @@ async fn write_backfill_cursor(conn: &Connection, key: &str, value: &str) -> Opt
     Some(())
 }
 
-/// Records that the structured sweep has covered the whole history.
 async fn mark_structured_backfill_complete(conn: &Connection) -> Option<()> {
     conn.execute(
         "INSERT INTO session_schema_migrations(name, version)
@@ -678,6 +682,18 @@ async fn mark_structured_backfill_complete(conn: &Connection) -> Option<()> {
             version = excluded.version,
             applied_at = unixepoch()",
         params![STRUCTURED_MARKER_NAME, STRUCTURED_MARKER_VERSION],
+    )
+    .await
+    .ok()?;
+    // The sweep is done, so drop every watermark row for it: this version's
+    // key and any stale prior-version (or legacy un-versioned) keys. Keeps the
+    // meta table from accumulating dead cursors across marker-version bumps.
+    conn.execute(
+        "DELETE FROM session_backfill_meta WHERE key = ?1 OR key LIKE ?2",
+        params![
+            STRUCTURED_CURSOR_KEY_PREFIX,
+            format!("{STRUCTURED_CURSOR_KEY_PREFIX}:%")
+        ],
     )
     .await
     .ok()?;

--- a/src/sessions/transcript_backfill.rs
+++ b/src/sessions/transcript_backfill.rs
@@ -579,8 +579,7 @@ async fn load_structured_candidates(
     loop {
         match rows.next().await {
             Ok(Some(row)) => {
-                let (Ok(source_path), Ok(provider)) =
-                    (row.get::<String>(0), row.get::<String>(1))
+                let (Ok(source_path), Ok(provider)) = (row.get::<String>(0), row.get::<String>(1))
                 else {
                     continue;
                 };

--- a/tests/session_suite/main.rs
+++ b/tests/session_suite/main.rs
@@ -20,4 +20,5 @@ mod lcm_query;
 mod lcm_raw;
 mod lcm_schema;
 mod message_search_eval_test;
+mod structured_backfill;
 mod transcript_backfill;

--- a/tests/session_suite/structured_backfill.rs
+++ b/tests/session_suite/structured_backfill.rs
@@ -1,11 +1,4 @@
-//! Coverage for the insert-capable structured-row backfill: transcripts
-//! ingested before the current parsers shipped are missing the newly-added row
-//! kinds (Codex `goal`/telemetry rows, Claude `pr_link`/marker rows) because
-//! append-only ingest never revisits bytes past its offset. The backfill
-//! re-parses each already-ingested Claude/Codex transcript from byte 0 through
-//! the current parser and inserts only the rows whose `(provider, message_id)`
-//! key is absent — existing rows keep their content, and a second run inserts
-//! nothing new.
+//! Insert-capable structured-row backfill coverage.
 
 use tempfile::TempDir;
 use tracedecay::sessions::claude::ClaudeSource;
@@ -22,9 +15,6 @@ fn init_project(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
     (home, project)
 }
 
-/// Raw connection to the project session DB for the low-level surgery these
-/// tests need (deleting rows to simulate an old-parser store, resetting the
-/// backfill marker/watermark, counting rows by kind).
 async fn raw_conn(project: &std::path::Path) -> libsql::Connection {
     let raw = libsql::Builder::new_local(project_session_db_path(project))
         .build()
@@ -45,10 +35,6 @@ async fn count_kind(project: &std::path::Path, provider: &str, kind: &str) -> i6
     rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
 }
 
-/// Deletes every row of `kind` from both the searchable projection and the raw
-/// store (simulating an ingest by a parser that never emitted that kind) and
-/// clears the structured-backfill marker + watermark so the next store open
-/// re-runs the sweep against the damaged store.
 async fn simulate_old_parser_store(project: &std::path::Path, provider: &str, kind: &str) {
     let conn = raw_conn(project).await;
     conn.execute(
@@ -74,14 +60,13 @@ async fn simulate_old_parser_store(project: &std::path::Path, provider: &str, ki
     .await
     .unwrap();
     conn.execute(
-        "DELETE FROM session_backfill_meta WHERE key = 'structured_backfill_cursor'",
+        "DELETE FROM session_backfill_meta WHERE key LIKE 'structured_backfill_cursor%'",
         (),
     )
     .await
     .unwrap();
 }
 
-/// Returns `(text, kind, metadata_json)` for the single codex `goal` row.
 async fn load_only_goal_row(project: &std::path::Path) -> (String, Option<String>, Option<String>) {
     let conn = raw_conn(project).await;
     let mut rows = conn
@@ -100,7 +85,6 @@ async fn load_only_goal_row(project: &std::path::Path) -> (String, Option<String
     )
 }
 
-/// Returns `(timestamp, text, metadata_json)` for the single row with `role`.
 async fn load_row_by_role(
     project: &std::path::Path,
     provider: &str,
@@ -231,25 +215,24 @@ fn write_claude_transcript_with_pr_link(
 
 #[tokio::test]
 async fn structured_backfill_inserts_codex_goal_rows_once() {
+    // `open_at` schedules the sweep on a detached background task; drive it
+    // synchronously here so the assertions observe a deterministic store.
+    tracedecay::global_db::set_background_structured_backfill_enabled(false);
     let tmp = TempDir::new().unwrap();
     let (home, project) = init_project(&tmp);
     write_codex_rollout_with_goal(&home, &project, "codex-backfill");
 
-    // Live ingest through the current parser writes the goal row.
     let db = open_project_session_db(&project).await.unwrap();
     let source = CodexSource::with_home(&home);
     ingest_source(&db, &source, &project, None).await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
     drop(db);
 
-    // Simulate a store ingested before the goal parser existed: drop the goal
-    // rows and clear the marker so the next open re-runs the sweep.
     simulate_old_parser_store(&project, "codex", "goal").await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 0);
 
-    // First re-open runs the backfill and re-inserts exactly one goal row,
-    // re-derived by the real parser (text/metadata intact).
     let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
     let goal = load_only_goal_row(&project).await;
     assert_eq!(goal.0, "ship the ingestion backfill", "goal text");
@@ -260,8 +243,10 @@ async fn structured_backfill_inserts_codex_goal_rows_once() {
     );
     drop(db);
 
-    // Second open: nothing new to insert, and the sweep marks itself complete.
+    // A second sweep finds no candidates past the watermark and marks the
+    // whole history complete.
     let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
     drop(db);
     assert_eq!(structured_marker_version(&project).await, Some(1));
@@ -269,6 +254,7 @@ async fn structured_backfill_inserts_codex_goal_rows_once() {
 
 #[tokio::test]
 async fn structured_backfill_preserves_existing_rows() {
+    tracedecay::global_db::set_background_structured_backfill_enabled(false);
     let tmp = TempDir::new().unwrap();
     let (home, project) = init_project(&tmp);
     write_codex_rollout_with_goal(&home, &project, "codex-preserve");
@@ -277,15 +263,14 @@ async fn structured_backfill_preserves_existing_rows() {
     let source = CodexSource::with_home(&home);
     ingest_source(&db, &source, &project, None).await;
 
-    // Snapshot the assistant conversational row before the backfill.
     let before = db.get_session("codex", "codex-preserve").await.unwrap();
     drop(db);
 
     simulate_old_parser_store(&project, "codex", "goal").await;
     let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
 
-    // The session window and existing conversational rows are unchanged.
     let after = db.get_session("codex", "codex-preserve").await.unwrap();
     assert_eq!(before.started_at, after.started_at);
     assert_eq!(before.ended_at, after.ended_at);
@@ -294,6 +279,7 @@ async fn structured_backfill_preserves_existing_rows() {
 
 #[tokio::test]
 async fn structured_backfill_inserts_claude_marker_rows_once() {
+    tracedecay::global_db::set_background_structured_backfill_enabled(false);
     let tmp = TempDir::new().unwrap();
     let (home, project) = init_project(&tmp);
     write_claude_transcript_with_pr_link(&home, &project, "claude-backfill");
@@ -308,17 +294,101 @@ async fn structured_backfill_inserts_claude_marker_rows_once() {
     simulate_old_parser_store(&project, "claude", "pr_link").await;
     assert_eq!(count_kind(&project, "claude", "pr_link").await, 0);
 
-    // Re-open: backfill re-inserts the marker row exactly once...
     let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
-    // ...without disturbing the surviving conversational row.
     let assistant_after = load_row_by_role(&project, "claude", "assistant").await;
     assert_eq!(assistant_before, assistant_after);
     drop(db);
 
-    // Running the sweep again is a no-op.
     let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
     drop(db);
     assert_eq!(structured_marker_version(&project).await, Some(1));
+}
+
+/// Regression for the stale-cursor-vs-version-bump defect: the sweep's path
+/// watermark is namespaced by marker version, so re-entering the sweep (as a
+/// version bump does by resetting the marker) reads a *fresh* cursor and
+/// re-parses from the start. A leftover, un-versioned cursor parked at the last
+/// path — the shape a pre-namespacing build wrote — must be ignored instead of
+/// zeroing out the candidate set.
+#[tokio::test]
+async fn structured_backfill_version_bump_reparses_from_start() {
+    tracedecay::global_db::set_background_structured_backfill_enabled(false);
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = init_project(&tmp);
+    write_codex_rollout_with_goal(&home, &project, "codex-versionbump");
+
+    // Live ingest, then run the sweep to completion for the current version.
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+    db.run_structured_backfill().await; // parses the file, advances the cursor
+    db.run_structured_backfill().await; // no candidates: marks complete, clears cursors
+    assert_eq!(structured_marker_version(&project).await, Some(1));
+    drop(db);
+
+    // Drop the structured rows and reset the marker so the sweep re-enters
+    // (exactly what a `STRUCTURED_MARKER_VERSION` bump does). Then plant a
+    // stale, *un-versioned* watermark parked at the last transcript path.
+    let conn = raw_conn(&project).await;
+    conn.execute(
+        "DELETE FROM lcm_raw_messages
+         WHERE provider = 'codex'
+           AND message_id IN (
+               SELECT message_id FROM session_messages
+               WHERE provider = 'codex' AND kind = 'goal')",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "DELETE FROM session_messages WHERE provider = 'codex' AND kind = 'goal'",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "DELETE FROM session_schema_migrations WHERE name = 'structured_rows_backfill'",
+        (),
+    )
+    .await
+    .unwrap();
+    let mut rows = conn
+        .query(
+            "SELECT MAX(source_path) FROM session_messages WHERE provider = 'codex'",
+            (),
+        )
+        .await
+        .unwrap();
+    let last_path = rows
+        .next()
+        .await
+        .unwrap()
+        .unwrap()
+        .get::<String>(0)
+        .unwrap();
+    conn.execute(
+        "INSERT INTO session_backfill_meta(key, value) VALUES ('structured_backfill_cursor', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        libsql::params![last_path],
+    )
+    .await
+    .unwrap();
+    assert_eq!(count_kind(&project, "codex", "goal").await, 0);
+
+    // The version-namespaced cursor key has never been written, so the sweep
+    // starts from the beginning and re-parses the whole history — the stale
+    // un-versioned cursor parked at the last path is ignored. (A regression to
+    // an un-versioned key would resume past `last_path`, see zero candidates,
+    // and leave the goal row missing.)
+    let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
+    assert_eq!(
+        count_kind(&project, "codex", "goal").await,
+        1,
+        "a stale un-versioned cursor must not block a fresh version-bumped sweep"
+    );
 }

--- a/tests/session_suite/structured_backfill.rs
+++ b/tests/session_suite/structured_backfill.rs
@@ -59,12 +59,12 @@ async fn simulate_old_parser_store(project: &std::path::Path, provider: &str, ki
     )
     .await
     .unwrap();
-    conn.execute(
-        "DELETE FROM session_backfill_meta WHERE key LIKE 'structured_backfill_cursor%'",
-        (),
-    )
-    .await
-    .unwrap();
+    let _ = conn
+        .execute(
+            "DELETE FROM session_backfill_meta WHERE key LIKE 'structured_backfill_cursor%'",
+            (),
+        )
+        .await;
 }
 
 async fn load_only_goal_row(project: &std::path::Path) -> (String, Option<String>, Option<String>) {
@@ -225,6 +225,10 @@ async fn structured_backfill_inserts_codex_goal_rows_once() {
     let db = open_project_session_db(&project).await.unwrap();
     let source = CodexSource::with_home(&home);
     ingest_source(&db, &source, &project, None).await;
+    // Drive one sweep so the backfill meta table exists (production creates it
+    // via the detached sweep `open_at` schedules); the goal row from live
+    // ingest is already present, so this inserts nothing.
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
     drop(db);
 
@@ -262,6 +266,8 @@ async fn structured_backfill_preserves_existing_rows() {
     let db = open_project_session_db(&project).await.unwrap();
     let source = CodexSource::with_home(&home);
     ingest_source(&db, &source, &project, None).await;
+    // Create the backfill meta table up front (see the note in the goal test).
+    db.run_structured_backfill().await;
 
     let before = db.get_session("codex", "codex-preserve").await.unwrap();
     drop(db);
@@ -287,6 +293,8 @@ async fn structured_backfill_inserts_claude_marker_rows_once() {
     let db = open_project_session_db(&project).await.unwrap();
     let source = ClaudeSource::with_home(&home);
     ingest_source(&db, &source, &project, None).await;
+    // Create the backfill meta table up front (see the note in the goal test).
+    db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
     let assistant_before = load_row_by_role(&project, "claude", "assistant").await;
     drop(db);

--- a/tests/session_suite/structured_backfill.rs
+++ b/tests/session_suite/structured_backfill.rs
@@ -1,0 +1,324 @@
+//! Coverage for the insert-capable structured-row backfill: transcripts
+//! ingested before the current parsers shipped are missing the newly-added row
+//! kinds (Codex `goal`/telemetry rows, Claude `pr_link`/marker rows) because
+//! append-only ingest never revisits bytes past its offset. The backfill
+//! re-parses each already-ingested Claude/Codex transcript from byte 0 through
+//! the current parser and inserts only the rows whose `(provider, message_id)`
+//! key is absent — existing rows keep their content, and a second run inserts
+//! nothing new.
+
+use tempfile::TempDir;
+use tracedecay::sessions::claude::ClaudeSource;
+use tracedecay::sessions::codex::CodexSource;
+use tracedecay::sessions::cursor::{open_project_session_db, project_session_db_path};
+use tracedecay::sessions::source::ingest_source;
+
+fn init_project(tmp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    let home = tmp.path().join("home");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(project.join(".tracedecay")).unwrap();
+    std::fs::write(project.join(".tracedecay/tracedecay.db"), "").unwrap();
+    (home, project)
+}
+
+/// Raw connection to the project session DB for the low-level surgery these
+/// tests need (deleting rows to simulate an old-parser store, resetting the
+/// backfill marker/watermark, counting rows by kind).
+async fn raw_conn(project: &std::path::Path) -> libsql::Connection {
+    let raw = libsql::Builder::new_local(project_session_db_path(project))
+        .build()
+        .await
+        .unwrap();
+    raw.connect().unwrap()
+}
+
+async fn count_kind(project: &std::path::Path, provider: &str, kind: &str) -> i64 {
+    let conn = raw_conn(project).await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM session_messages WHERE provider = ?1 AND kind = ?2",
+            libsql::params![provider, kind],
+        )
+        .await
+        .unwrap();
+    rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+}
+
+/// Deletes every row of `kind` from both the searchable projection and the raw
+/// store (simulating an ingest by a parser that never emitted that kind) and
+/// clears the structured-backfill marker + watermark so the next store open
+/// re-runs the sweep against the damaged store.
+async fn simulate_old_parser_store(project: &std::path::Path, provider: &str, kind: &str) {
+    let conn = raw_conn(project).await;
+    conn.execute(
+        "DELETE FROM lcm_raw_messages
+         WHERE provider = ?1
+           AND message_id IN (
+               SELECT message_id FROM session_messages
+               WHERE provider = ?1 AND kind = ?2)",
+        libsql::params![provider, kind],
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "DELETE FROM session_messages WHERE provider = ?1 AND kind = ?2",
+        libsql::params![provider, kind],
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "DELETE FROM session_schema_migrations WHERE name = 'structured_rows_backfill'",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "DELETE FROM session_backfill_meta WHERE key = 'structured_backfill_cursor'",
+        (),
+    )
+    .await
+    .unwrap();
+}
+
+/// Returns `(text, kind, metadata_json)` for the single codex `goal` row.
+async fn load_only_goal_row(project: &std::path::Path) -> (String, Option<String>, Option<String>) {
+    let conn = raw_conn(project).await;
+    let mut rows = conn
+        .query(
+            "SELECT text, kind, metadata_json FROM session_messages
+             WHERE provider = 'codex' AND kind = 'goal'",
+            (),
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("one goal row");
+    (
+        row.get::<String>(0).unwrap(),
+        row.get::<Option<String>>(1).unwrap(),
+        row.get::<Option<String>>(2).unwrap(),
+    )
+}
+
+/// Returns `(timestamp, text, metadata_json)` for the single row with `role`.
+async fn load_row_by_role(
+    project: &std::path::Path,
+    provider: &str,
+    role: &str,
+) -> (Option<i64>, String, Option<String>) {
+    let conn = raw_conn(project).await;
+    let mut rows = conn
+        .query(
+            "SELECT timestamp, text, metadata_json FROM session_messages
+             WHERE provider = ?1 AND role = ?2",
+            libsql::params![provider, role],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("one row for role");
+    (
+        row.get::<Option<i64>>(0).unwrap(),
+        row.get::<String>(1).unwrap(),
+        row.get::<Option<String>>(2).unwrap(),
+    )
+}
+
+async fn structured_marker_version(project: &std::path::Path) -> Option<i64> {
+    let conn = raw_conn(project).await;
+    let mut rows = conn
+        .query(
+            "SELECT version FROM session_schema_migrations WHERE name = 'structured_rows_backfill'",
+            (),
+        )
+        .await
+        .unwrap();
+    rows.next().await.unwrap().and_then(|row| row.get(0).ok())
+}
+
+fn write_codex_rollout_with_goal(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".codex/sessions/2026/01/01");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("rollout-2026-01-01T00-00-00-{session}.jsonl"));
+    let contents = format!(
+        "{}\n{}\n{}\n{}\n",
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "type": "session_meta",
+            "payload": {"id": session, "cwd": project.to_string_lossy(), "model": "gpt-5.5"}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:01.000Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "Ship the ingestion backfill"}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:02.000Z",
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "On it."}
+        }),
+        serde_json::json!({
+            "timestamp": "2026-01-01T00:00:03.000Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "thread_goal_updated",
+                "threadId": "thread-1",
+                "goal": {
+                    "threadId": "thread-1",
+                    "objective": "ship the ingestion backfill",
+                    "status": "active",
+                    "tokensUsed": 42,
+                    "timeUsedSeconds": 7,
+                    "createdAt": 1_783_500_569i64,
+                    "updatedAt": 1_783_500_600i64
+                }
+            }
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+fn write_claude_transcript_with_pr_link(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".claude/projects/-backfill-slug");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{session}.jsonl"));
+    let cwd = project.to_string_lossy();
+    let contents = format!(
+        "{}\n{}\n{}\n",
+        serde_json::json!({
+            "type": "user",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "u1",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "message": {"role": "user", "content": "Open the PR"}
+        }),
+        serde_json::json!({
+            "type": "assistant",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "u2",
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "message": {
+                "id": "msg_claude_1",
+                "role": "assistant",
+                "model": "claude-opus-4-8",
+                "content": [{"type": "text", "text": "Opened it."}]
+            }
+        }),
+        serde_json::json!({
+            "type": "pr-link",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "pr-1",
+            "timestamp": "2026-01-01T00:00:06.000Z",
+            "prNumber": 321,
+            "prUrl": "https://github.com/ScriptedAlchemy/tracedecay/pull/321",
+            "prRepository": "ScriptedAlchemy/tracedecay"
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn structured_backfill_inserts_codex_goal_rows_once() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = init_project(&tmp);
+    write_codex_rollout_with_goal(&home, &project, "codex-backfill");
+
+    // Live ingest through the current parser writes the goal row.
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+    assert_eq!(count_kind(&project, "codex", "goal").await, 1);
+    drop(db);
+
+    // Simulate a store ingested before the goal parser existed: drop the goal
+    // rows and clear the marker so the next open re-runs the sweep.
+    simulate_old_parser_store(&project, "codex", "goal").await;
+    assert_eq!(count_kind(&project, "codex", "goal").await, 0);
+
+    // First re-open runs the backfill and re-inserts exactly one goal row,
+    // re-derived by the real parser (text/metadata intact).
+    let db = open_project_session_db(&project).await.unwrap();
+    assert_eq!(count_kind(&project, "codex", "goal").await, 1);
+    let goal = load_only_goal_row(&project).await;
+    assert_eq!(goal.0, "ship the ingestion backfill", "goal text");
+    assert_eq!(goal.1.as_deref(), Some("goal"), "goal kind");
+    assert!(
+        goal.2.is_some_and(|meta| meta.contains("objective")),
+        "goal metadata should round-trip through the parser"
+    );
+    drop(db);
+
+    // Second open: nothing new to insert, and the sweep marks itself complete.
+    let db = open_project_session_db(&project).await.unwrap();
+    assert_eq!(count_kind(&project, "codex", "goal").await, 1);
+    drop(db);
+    assert_eq!(structured_marker_version(&project).await, Some(1));
+}
+
+#[tokio::test]
+async fn structured_backfill_preserves_existing_rows() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = init_project(&tmp);
+    write_codex_rollout_with_goal(&home, &project, "codex-preserve");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+
+    // Snapshot the assistant conversational row before the backfill.
+    let before = db.get_session("codex", "codex-preserve").await.unwrap();
+    drop(db);
+
+    simulate_old_parser_store(&project, "codex", "goal").await;
+    let db = open_project_session_db(&project).await.unwrap();
+    assert_eq!(count_kind(&project, "codex", "goal").await, 1);
+
+    // The session window and existing conversational rows are unchanged.
+    let after = db.get_session("codex", "codex-preserve").await.unwrap();
+    assert_eq!(before.started_at, after.started_at);
+    assert_eq!(before.ended_at, after.ended_at);
+    assert_eq!(before.title, after.title);
+}
+
+#[tokio::test]
+async fn structured_backfill_inserts_claude_marker_rows_once() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = init_project(&tmp);
+    write_claude_transcript_with_pr_link(&home, &project, "claude-backfill");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClaudeSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+    assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
+    let assistant_before = load_row_by_role(&project, "claude", "assistant").await;
+    drop(db);
+
+    simulate_old_parser_store(&project, "claude", "pr_link").await;
+    assert_eq!(count_kind(&project, "claude", "pr_link").await, 0);
+
+    // Re-open: backfill re-inserts the marker row exactly once...
+    let db = open_project_session_db(&project).await.unwrap();
+    assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
+    // ...without disturbing the surviving conversational row.
+    let assistant_after = load_row_by_role(&project, "claude", "assistant").await;
+    assert_eq!(assistant_before, assistant_after);
+    drop(db);
+
+    // Running the sweep again is a no-op.
+    let db = open_project_session_db(&project).await.unwrap();
+    assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
+    drop(db);
+    assert_eq!(structured_marker_version(&project).await, Some(1));
+}


### PR DESCRIPTION
Closes the shared follow-up from the ingestion expansion PRs (#346/#348/#352): historical Claude/Codex transcripts now gain the new structured row kinds via a bounded, resumable, idempotent backfill that re-runs the real parser and inserts only absent rows. Live-proven: deleting all structured rows from a real ingested store and re-running restores every kind to exact original counts with messages byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)