### PR TITLE
fix(sessions): downrank inventory noise in message_search ranking

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -620,6 +620,34 @@ fn row_to_store_artifact(row: &libsql::Row, offset: i32) -> Option<StoreArtifact
     })
 }
 
+/// Upper bound on the BM25 over-fetch that precedes the inventory downrank in
+/// [`GlobalDb::search_session_messages_filtered_inner`]. Keeps the pre-rerank
+/// fetch bounded even for large caller limits.
+const SESSION_MESSAGE_SEARCH_MAX_FETCH: usize = 200;
+
+/// Stable inventory downrank for a BM25 result page: transcript inventory/
+/// listing messages and prose branch/worktree rosters (per the shared
+/// [`crate::sessions::message_noise`] classifier) are moved below substantive
+/// hits while preserving the relative BM25 order within each group. Applied
+/// before truncation so a downranked hit still surfaces when it is the only
+/// match. Mirrors the lcm/grep re-rank (`sessions::lcm::query::rerank_grep_hits`).
+fn downrank_inventory_messages(results: &mut Vec<SessionMessageSearchResult>) {
+    if results.len() < 2 {
+        return;
+    }
+    let mut substantive = Vec::with_capacity(results.len());
+    let mut inventory = Vec::new();
+    for result in results.drain(..) {
+        if crate::sessions::message_noise::is_inventory_text(&result.message.text) {
+            inventory.push(result);
+        } else {
+            substantive.push(result);
+        }
+    }
+    substantive.append(&mut inventory);
+    *results = substantive;
+}
+
 fn session_fts_query(query: &str) -> String {
     query
         .split_whitespace()
@@ -4007,7 +4035,15 @@ impl GlobalDb {
                 query_params.len()
             );
         }
-        query_params.push(Value::Integer(limit as i64));
+        // Over-fetch before the deterministic inventory downrank so a
+        // substantive hit buried below inventory/listing noise in raw BM25
+        // order can still surface within the caller's `limit`. The downrank
+        // reorders, never drops, then we truncate back to `limit`.
+        let fetch_limit = crate::sessions::message_noise::rerank_fetch_limit(
+            limit,
+            SESSION_MESSAGE_SEARCH_MAX_FETCH,
+        );
+        query_params.push(Value::Integer(fetch_limit as i64));
         let _ = write!(
             sql,
             " ORDER BY bm25(session_messages_fts, 10.0, 2.0, 1.0, 1.0, 1.0)
@@ -4036,6 +4072,8 @@ impl GlobalDb {
                 score,
             });
         }
+        downrank_inventory_messages(&mut results);
+        results.truncate(limit);
         results
     }
 

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -515,17 +515,23 @@ async fn search_session_messages_in_db(
 /// be re-sorted by the *same* key for the distributed top-K to be exact.
 /// Sorting by recency here would drop a top-relevance row a shard kept while
 /// surfacing lower-relevance-but-newer rows the shards never returned. Key:
-/// score DESC (relevance), then timestamp DESC, then a stable session/message
-/// id tie-break so equal-score rows order deterministically. This matches the
-/// single-project path, which returns DB rows already in BM25 order without a
-/// resort.
+/// inventory-last (transcript/branch inventory noise sinks below substantive
+/// hits, matching the per-shard downrank in `search_session_messages_*` so the
+/// merge does not resurrect noise the shards demoted), then score DESC
+/// (relevance), then timestamp DESC, then a stable session/message id tie-break
+/// so equal-score rows order deterministically. This matches the single-project
+/// path, which returns DB rows already inventory-downranked in BM25 order
+/// without a resort.
 fn sort_and_truncate_message_results_by_relevance(
     results: &mut Vec<SessionMessageSearchResult>,
     limit: usize,
 ) {
     results.sort_by(|a, b| {
-        b.score
-            .total_cmp(&a.score)
+        crate::sessions::message_noise::is_inventory_text(&a.message.text)
+            .cmp(&crate::sessions::message_noise::is_inventory_text(
+                &b.message.text,
+            ))
+            .then_with(|| b.score.total_cmp(&a.score))
             .then_with(|| b.message.timestamp.cmp(&a.message.timestamp))
             .then_with(|| a.session.session_id.cmp(&b.session.session_id))
             .then_with(|| a.message.message_id.cmp(&b.message.message_id))

--- a/src/sessions/lcm/query.rs
+++ b/src/sessions/lcm/query.rs
@@ -46,11 +46,6 @@ const RAW_ROLE_PENALTY_CASE: &str =
 /// sessions. Single-session scopes (`current`/`session`) are exempt — capping
 /// there would silently drop legitimate same-session recall.
 const PER_SESSION_HIT_CAP: usize = 3;
-/// Over-fetch multiplier applied before the deterministic re-rank
-/// (inventory downrank + per-session cap) so that substantive hits buried
-/// below inventory/listing noise in the raw SQL order can still surface within
-/// the caller's `limit`.
-const RERANK_OVERFETCH_FACTOR: usize = 4;
 
 #[allow(clippy::struct_field_names)]
 struct LcmLifecycleMetadata {
@@ -409,12 +404,11 @@ pub(crate) async fn grep(
     Ok(hits)
 }
 
-/// Fetch budget before the re-rank stage: over-fetch by
-/// [`RERANK_OVERFETCH_FACTOR`], bounded by [`MAX_PAGE_LIMIT`].
+/// Fetch budget before the re-rank stage: over-fetch by the shared
+/// [`RERANK_OVERFETCH_FACTOR`](crate::sessions::message_noise::RERANK_OVERFETCH_FACTOR),
+/// bounded by [`MAX_PAGE_LIMIT`].
 fn rerank_fetch_limit(limit: usize) -> usize {
-    limit
-        .saturating_mul(RERANK_OVERFETCH_FACTOR)
-        .clamp(limit, MAX_PAGE_LIMIT)
+    crate::sessions::message_noise::rerank_fetch_limit(limit, MAX_PAGE_LIMIT)
 }
 
 /// Deterministic post-fetch re-rank applied to every grep page:
@@ -460,72 +454,16 @@ fn rerank_grep_hits(hits: &mut Vec<LcmGrepHit>, sort: LcmGrepSort, scope: LcmSco
 }
 
 /// Cheap, deterministic heuristic: is this hit a transcript inventory/listing
-/// tool call or an otherwise path-list-dominated message rather than
-/// substantive conversation? Such messages enumerate file paths, so they match
-/// many unrelated queries and drown out real answers when sorted by recency.
-/// Operates only on the returned snippet — no extra DB reads.
+/// tool call, an otherwise path-list-dominated message, or a prose branch/
+/// worktree roster rather than substantive conversation? Delegates to the
+/// shared [`message_noise`](crate::sessions::message_noise) classifier so the
+/// lcm/grep and global message-search re-ranks agree. Summary nodes are curated
+/// prose, never raw inventory, so they are exempt.
 fn hit_is_inventory(hit: &LcmGrepHit) -> bool {
-    // Summary nodes are curated prose, never raw inventory tool calls.
     if hit.kind != "raw_message" {
         return false;
     }
-    snippet_is_inventory(&hit.snippet)
-}
-
-fn snippet_is_inventory(snippet: &str) -> bool {
-    let lower = snippet.to_ascii_lowercase();
-    // A listing/glob/find/grep invocation aimed at transcript or session
-    // directories: the classic "inventory" tool call over `**/*.jsonl` etc.
-    let mentions_transcript_dir = lower.contains(".jsonl")
-        || lower.contains("sessions/")
-        || lower.contains(".claude")
-        || lower.contains(".codex")
-        || lower.contains("transcript");
-    let looks_like_listing = snippet.contains("**/")
-        || lower.contains("\"pattern\"")
-        || lower.contains("glob(")
-        || lower.contains("\"glob\"")
-        || lower.starts_with("ls ")
-        || lower.contains(" ls ")
-        || lower.contains("find ")
-        || lower.contains("rg -")
-        || lower.contains("grep -");
-    if mentions_transcript_dir && looks_like_listing {
-        return true;
-    }
-    path_list_dominated(snippet)
-}
-
-/// True when a snippet is mostly a list of filesystem paths rather than prose:
-/// at least three path-like tokens making up a majority of the content. A lone
-/// path mentioned inside a sentence stays below the threshold.
-fn path_list_dominated(snippet: &str) -> bool {
-    let mut total = 0usize;
-    let mut path_like = 0usize;
-    for token in snippet.split_whitespace() {
-        total += 1;
-        if token_is_path_like(token) {
-            path_like += 1;
-        }
-    }
-    total >= 4 && path_like >= 3 && path_like * 5 >= total * 3
-}
-
-/// A token counts as "path-like" when it embeds a directory separator and is
-/// long enough to be a real path, or ends in a common source/transcript
-/// extension.
-fn token_is_path_like(token: &str) -> bool {
-    let token = token.trim_matches(|c: char| matches!(c, '"' | '\'' | ',' | '`' | '(' | ')'));
-    if token.len() < 4 {
-        return false;
-    }
-    let has_sep = token.contains('/') && !token.starts_with("//");
-    let has_ext = [
-        ".jsonl", ".json", ".rs", ".ts", ".tsx", ".js", ".py", ".md", ".toml", ".txt", ".log",
-    ]
-    .iter()
-    .any(|ext| token.ends_with(ext));
-    has_sep && (has_ext || token.chars().any(|c| c.is_ascii_alphanumeric()))
+    crate::sessions::message_noise::is_inventory_text(&hit.snippet)
 }
 
 pub(crate) async fn expand(

--- a/src/sessions/message_noise.rs
+++ b/src/sessions/message_noise.rs
@@ -71,10 +71,6 @@ pub(crate) fn is_inventory_text(text: &str) -> bool {
 /// These name-drop the very branch a query targets while implementing nothing,
 /// so they must sit below the session that actually did the work.
 fn is_branch_inventory(lower: &str) -> bool {
-    let mentions_branch_or_worktree = lower.contains("branch") || lower.contains("worktree");
-    if !mentions_branch_or_worktree {
-        return false;
-    }
     const LISTING_INDICATORS: [&str; 9] = [
         "inventory",
         "roster",
@@ -86,6 +82,10 @@ fn is_branch_inventory(lower: &str) -> bool {
         "index of",
         "list of",
     ];
+    let mentions_branch_or_worktree = lower.contains("branch") || lower.contains("worktree");
+    if !mentions_branch_or_worktree {
+        return false;
+    }
     LISTING_INDICATORS
         .iter()
         .any(|indicator| lower.contains(indicator))

--- a/src/sessions/message_noise.rs
+++ b/src/sessions/message_noise.rs
@@ -1,0 +1,176 @@
+//! Shared transcript-noise classification for message retrieval re-ranking.
+//!
+//! Both the LCM grep path (`sessions::lcm::query`, BM25-free recency/relevance
+//! grep over the raw store) and the global session-message search path
+//! (`GlobalDb::search_session_messages*`, BM25 over `session_messages_fts`)
+//! surface the same failure mode: an *inventory/listing* message — a glob/find
+//! tool call over transcript directories, a path-list dump, or a prose branch/
+//! worktree roster that merely name-drops many identifiers — matches a query
+//! and outranks the message that actually did the work. This module is the one
+//! place the heuristic lives so the two retrieval surfaces classify noise
+//! identically instead of drifting apart.
+//!
+//! The treatment is always a *downrank, never a drop*: callers over-fetch by
+//! [`RERANK_OVERFETCH_FACTOR`] (via [`rerank_fetch_limit`]), stably move
+//! inventory hits below substantive ones, then truncate to the caller's limit,
+//! so a downranked hit still surfaces when it is the only match.
+
+/// Over-fetch multiplier applied before the deterministic re-rank so that
+/// substantive hits buried below inventory/listing noise in the raw ranking
+/// order can still surface within the caller's `limit`.
+pub(crate) const RERANK_OVERFETCH_FACTOR: usize = 4;
+
+/// Fetch budget before the re-rank stage: over-fetch by
+/// [`RERANK_OVERFETCH_FACTOR`], clamped into `[limit, max_fetch]`.
+pub(crate) fn rerank_fetch_limit(limit: usize, max_fetch: usize) -> usize {
+    limit
+        .saturating_mul(RERANK_OVERFETCH_FACTOR)
+        .clamp(limit, max_fetch)
+}
+
+/// Cheap, deterministic heuristic: is this message text a transcript
+/// inventory/listing (a glob/find tool call over transcript or session
+/// directories), a path-list-dominated dump, or a prose branch/worktree roster
+/// that merely enumerates identifiers — rather than substantive conversation?
+/// Such messages match many unrelated queries and drown out real answers.
+/// Operates only on the supplied text — no extra DB reads.
+pub(crate) fn is_inventory_text(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    // A listing/glob/find/grep invocation aimed at transcript or session
+    // directories: the classic "inventory" tool call over `**/*.jsonl` etc.
+    let mentions_transcript_dir = lower.contains(".jsonl")
+        || lower.contains("sessions/")
+        || lower.contains(".claude")
+        || lower.contains(".codex")
+        || lower.contains("transcript");
+    let looks_like_listing = text.contains("**/")
+        || lower.contains("\"pattern\"")
+        || lower.contains("glob(")
+        || lower.contains("\"glob\"")
+        || lower.starts_with("ls ")
+        || lower.contains(" ls ")
+        || lower.contains("find ")
+        || lower.contains("rg -")
+        || lower.contains("grep -");
+    if mentions_transcript_dir && looks_like_listing {
+        return true;
+    }
+    if path_list_dominated(text) {
+        return true;
+    }
+    is_branch_inventory(&lower)
+}
+
+/// A prose branch/worktree *inventory*: a message that mentions branches or
+/// worktrees and frames itself as an enumeration (an inventory, roster, fleet
+/// status, sweep, or an "index/list of" identifiers) rather than as work done.
+/// These name-drop the very branch a query targets while implementing nothing,
+/// so they must sit below the session that actually did the work.
+fn is_branch_inventory(lower: &str) -> bool {
+    let mentions_branch_or_worktree = lower.contains("branch") || lower.contains("worktree");
+    if !mentions_branch_or_worktree {
+        return false;
+    }
+    const LISTING_INDICATORS: [&str; 9] = [
+        "inventory",
+        "roster",
+        "fleet",
+        "sweep",
+        "listing",
+        "catalog",
+        "roll call",
+        "index of",
+        "list of",
+    ];
+    LISTING_INDICATORS
+        .iter()
+        .any(|indicator| lower.contains(indicator))
+}
+
+/// True when a message is mostly a list of filesystem paths rather than prose:
+/// at least three path-like tokens making up a majority of the content. A lone
+/// path mentioned inside a sentence stays below the threshold.
+fn path_list_dominated(text: &str) -> bool {
+    let mut total = 0usize;
+    let mut path_like = 0usize;
+    for token in text.split_whitespace() {
+        total += 1;
+        if token_is_path_like(token) {
+            path_like += 1;
+        }
+    }
+    total >= 4 && path_like >= 3 && path_like * 5 >= total * 3
+}
+
+/// A token counts as "path-like" when it embeds a directory separator and is
+/// long enough to be a real path, or ends in a common source/transcript
+/// extension.
+fn token_is_path_like(token: &str) -> bool {
+    let token = token.trim_matches(|c: char| matches!(c, '"' | '\'' | ',' | '`' | '(' | ')'));
+    if token.len() < 4 {
+        return false;
+    }
+    let has_sep = token.contains('/') && !token.starts_with("//");
+    let has_ext = [
+        ".jsonl", ".json", ".rs", ".ts", ".tsx", ".js", ".py", ".md", ".toml", ".txt", ".log",
+    ]
+    .iter()
+    .any(|ext| token.ends_with(ext));
+    has_sep && (has_ext || token.chars().any(|c| c.is_ascii_alphanumeric()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_glob_listing_is_inventory() {
+        assert!(is_inventory_text(
+            "Glob **/*.jsonl over .claude sessions for branch redundancy"
+        ));
+    }
+
+    #[test]
+    fn substantive_implementation_is_not_inventory() {
+        assert!(!is_inventory_text(
+            "implemented branch redundancy scoring in the ranker"
+        ));
+        assert!(!is_inventory_text(
+            "Implementing the retrieval eval harness on codex/retrieval-evals-analytics: \
+             seeded a fixture session store and scored message_search ranking with \
+             recomputed precision metrics."
+        ));
+    }
+
+    #[test]
+    fn prose_branch_inventory_is_inventory() {
+        assert!(is_inventory_text(
+            "Branch inventory sweep lists codex/retrieval-evals-analytics as one of many \
+             active branches, alongside codex/session-recovery-fixes, codex/redundancy-evals, \
+             release-plz, and master."
+        ));
+        assert!(is_inventory_text(
+            "Worktree fleet status again names codex/retrieval-evals-analytics amid twelve \
+             other branches; nothing is implemented in this session, it is only an index of \
+             branch names."
+        ));
+        assert!(is_inventory_text(
+            "Daily branch roster mentions codex/retrieval-evals-analytics once more among the \
+             archived and stale branches tracked across every worktree."
+        ));
+    }
+
+    #[test]
+    fn branch_mention_without_listing_vocab_is_not_inventory() {
+        assert!(!is_inventory_text(
+            "the literal foo-bar marker on a scoped branch"
+        ));
+    }
+
+    #[test]
+    fn rerank_fetch_limit_over_fetches_within_bounds() {
+        assert_eq!(rerank_fetch_limit(10, 100), 40);
+        assert_eq!(rerank_fetch_limit(30, 100), 100);
+        assert_eq!(rerank_fetch_limit(0, 100), 0);
+    }
+}

--- a/src/sessions/message_noise.rs
+++ b/src/sessions/message_noise.rs
@@ -21,11 +21,15 @@
 pub(crate) const RERANK_OVERFETCH_FACTOR: usize = 4;
 
 /// Fetch budget before the re-rank stage: over-fetch by
-/// [`RERANK_OVERFETCH_FACTOR`], clamped into `[limit, max_fetch]`.
+/// [`RERANK_OVERFETCH_FACTOR`], capped at `max_fetch` but never below the
+/// caller's explicit `limit`. The `min`-then-`max` order (rather than
+/// `clamp`) is deliberate: a limit above `max_fetch` must widen the fetch to
+/// honor the request, not panic on an inverted clamp range.
 pub(crate) fn rerank_fetch_limit(limit: usize, max_fetch: usize) -> usize {
     limit
         .saturating_mul(RERANK_OVERFETCH_FACTOR)
-        .clamp(limit, max_fetch)
+        .min(max_fetch)
+        .max(limit)
 }
 
 /// Cheap, deterministic heuristic: is this message text a transcript
@@ -121,6 +125,17 @@ fn token_is_path_like(token: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn rerank_fetch_limit_never_panics_when_limit_exceeds_cap() {
+        // limit > max_fetch used to invert the clamp range and panic
+        // (e.g. `sessions search --limit 500` against the 200 fetch cap);
+        // the request must widen the fetch instead.
+        assert_eq!(super::rerank_fetch_limit(500, 200), 500);
+        assert_eq!(super::rerank_fetch_limit(10, 200), 40);
+        assert_eq!(super::rerank_fetch_limit(80, 200), 200);
+        assert_eq!(super::rerank_fetch_limit(0, 200), 0);
+    }
+
     use super::*;
 
     #[test]

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -17,6 +17,7 @@ pub mod git_correlation;
 pub mod hermes;
 pub mod kiro;
 pub mod lcm;
+pub(crate) mod message_noise;
 pub mod providers;
 pub mod shared;
 pub mod source;

--- a/tests/fixtures/message_search_eval_labeled.json
+++ b/tests/fixtures/message_search_eval_labeled.json
@@ -5,10 +5,10 @@
   "project_key": "eval-project",
   "other_project_key": "other-project",
   "metrics": {
-    "_comment": "Mean p@1/p@3/MRR over the 10 positive queries, recomputed by the test from the LIVE ranking. mean_p_at_1 and mean_mrr are below 1.0 solely because exact_branch_impl_over_inventory is a documented current gap (impl-1 lands at rank 2 behind inv-3). When the ranking fix flips that case, set it top1=impl-1 / expected_current_failure:false and bump mean_p_at_1 to 1.0 and mean_mrr to 1.0.",
-    "mean_p_at_1": 0.9,
+    "_comment": "Mean p@1/p@3/MRR over the 10 positive queries, recomputed by the test from the LIVE ranking. mean_p_at_1 and mean_mrr are 1.0 because every positive query now ranks its sole relevant message first — including exact_branch_impl_over_inventory, where the inventory downrank in search_session_messages (shared sessions::message_noise classifier) moves the branch-roster noise (inv-1/inv-2/inv-3) below the real implementation message impl-1. mean_p_at_3 stays 0.37: nine single-relevant queries contribute 1/3 each and multi_term_partial_coverage_order contributes 2/3, so (9*(1/3)+2/3)/10 = 0.3667 rounds to 0.37.",
+    "mean_p_at_1": 1.0,
     "mean_p_at_3": 0.37,
-    "mean_mrr": 0.95
+    "mean_mrr": 1.0
   },
   "corpus": [
     {
@@ -212,16 +212,15 @@
   "queries": [
     {
       "label": "exact_branch_impl_over_inventory",
-      "note": "Exact-branch query. The implementation session should rank above the branch-inventory noise. Known production failure mode: bm25 cannot distinguish an inventory that name-drops the branch from the session that actually implemented it.",
+      "note": "Exact-branch query. The implementation session ranks above the branch-inventory noise: the inventory downrank in search_session_messages (shared sessions::message_noise classifier) demotes the branch-roster messages (inv-1/inv-2/inv-3) that merely name-drop the branch below impl-1, the session that actually implemented it. Before the fix, bm25 alone put the short, dense inv-3 roster on top.",
       "query": "codex/retrieval-evals-analytics",
       "provider": "codex",
       "project_key": "eval-project",
       "limit": 10,
       "expect": {
         "empty": false,
-        "expected_current_failure": true,
-        "current_top1": "inv-3",
-        "aspirational_top1": "impl-1",
+        "top1": "impl-1",
+        "ranked_above": [["impl-1", "inv-3"], ["impl-1", "inv-1"], ["impl-1", "inv-2"]],
         "relevant": ["impl-1"],
         "excluded": []
       }


### PR DESCRIPTION
Ports the lcm_grep inventory-downranking fix to the message_search BM25 path via a shared noise classifier (sessions::message_noise), flipping the labeled eval's known-gap case to green: p@1 and MRR now 1.0, no KNOWN GAP line. 570 session/mcp suite tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)