### PR TITLE
fix(automation): fold paraphrased fact proposals into one record

### DIFF
--- a/dashboard/holographic/src/types.ts
+++ b/dashboard/holographic/src/types.ts
@@ -715,6 +715,9 @@ export interface FactProposalRecord {
   apply_outcome?: unknown;
   created_at: number;
   updated_at: number;
+  duplicate_count?: number;
+  last_duplicate_run_id?: string | null;
+  folded_contents?: string[];
 }
 
 export interface FactProposalListResponse {

--- a/src/automation/fact_proposals.rs
+++ b/src/automation/fact_proposals.rs
@@ -59,6 +59,19 @@ pub struct FactProposalRecord {
     pub apply_outcome: Option<AddFactOutcome>,
     pub created_at: i64,
     pub updated_at: i64,
+    /// Number of later near-duplicate proposals folded into this record
+    /// instead of being enqueued as their own entries. A high count is a
+    /// strong repeated-evidence signal for reviewers.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub duplicate_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_duplicate_run_id: Option<String>,
+}
+
+// serde's `skip_serializing_if` requires the `fn(&T) -> bool` shape.
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_zero(count: &u32) -> bool {
+    *count == 0
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -170,6 +183,13 @@ pub async fn record_session_fact_proposals(
         if active_add_fact_request_exists(&store, &add_fact_request) {
             continue;
         }
+        if let Some(existing_idx) = find_similar_active_proposal(&store, &add_fact_request) {
+            let existing = &mut store.proposals[existing_idx];
+            existing.duplicate_count = existing.duplicate_count.saturating_add(1);
+            existing.last_duplicate_run_id = Some(run_id.to_string());
+            existing.updated_at = now;
+            continue;
+        }
         let proposal = value.get("proposal").cloned();
         let validation = value.get("validation").cloned();
         let record = FactProposalRecord {
@@ -187,6 +207,8 @@ pub async fn record_session_fact_proposals(
             apply_outcome: None,
             created_at: now,
             updated_at: now,
+            duplicate_count: 0,
+            last_duplicate_run_id: None,
         };
         records.push(record.clone());
         store.proposals.push(record);
@@ -210,12 +232,39 @@ pub async fn record_session_fact_proposals(
             apply_outcome: None,
             created_at: now,
             updated_at: now,
+            duplicate_count: 0,
+            last_duplicate_run_id: None,
         };
         records.push(record.clone());
         store.proposals.push(record);
     }
     save_fact_proposal_store(dashboard_root, &store).await?;
     Ok(records)
+}
+
+/// Near-duplicate gate: a live run showed one lesson restated 21 times across
+/// a 50-proposal queue because only exact normalized content matched. Reuses
+/// the shared lexical-overlap scoring (the same signals the memory curator's
+/// duplicate tiers use) so paraphrases of an already-queued proposal fold
+/// into it instead of multiplying.
+fn find_similar_active_proposal(
+    store: &FactProposalStore,
+    request: &AddFactRequest,
+) -> Option<usize> {
+    store.proposals.iter().position(|proposal| {
+        if proposal.state == FactProposalState::Rejected {
+            return false;
+        }
+        let Some(existing) = proposal.add_fact_request.as_ref() else {
+            return false;
+        };
+        if existing.category != request.category {
+            return false;
+        }
+        let (_, token_overlap, overlap_coefficient) =
+            crate::memory::similarity::lexical_overlap(&existing.content, &request.content);
+        overlap_coefficient >= 0.65 || token_overlap >= 0.45
+    })
 }
 
 fn active_add_fact_request_exists(store: &FactProposalStore, request: &AddFactRequest) -> bool {

--- a/src/automation/fact_proposals.rs
+++ b/src/automation/fact_proposals.rs
@@ -59,14 +59,18 @@ pub struct FactProposalRecord {
     pub apply_outcome: Option<AddFactOutcome>,
     pub created_at: i64,
     pub updated_at: i64,
-    /// Number of later near-duplicate proposals folded into this record
-    /// instead of being enqueued as their own entries. A high count is a
-    /// strong repeated-evidence signal for reviewers.
+    /// Later near-duplicate proposals folded into this record.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub duplicate_count: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_duplicate_run_id: Option<String>,
+    /// Capped content samples from folded near-duplicate proposals.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub folded_contents: Vec<String>,
 }
+
+const MAX_FOLDED_CONTENTS: usize = 10;
+const FOLDED_CONTENT_MAX_CHARS: usize = 500;
 
 // serde's `skip_serializing_if` requires the `fn(&T) -> bool` shape.
 #[allow(clippy::trivially_copy_pass_by_ref)]
@@ -180,14 +184,23 @@ pub async fn record_session_fact_proposals(
             .ok_or_else(|| config_error("accepted fact proposal missing add_fact_request"))?;
         let add_fact_request = serde_json::from_value::<AddFactRequest>(add_fact_request)
             .map_err(|e| config_error(format!("invalid accepted fact add_fact_request: {e}")))?;
-        if active_add_fact_request_exists(&store, &add_fact_request) {
+        let incoming_tokens = crate::memory::similarity::content_tokens(&add_fact_request.content);
+        if let Some(existing_idx) = find_exact_pending_proposal(&store, &add_fact_request) {
+            fold_duplicate(&mut store.proposals[existing_idx], run_id, now, None);
             continue;
         }
-        if let Some(existing_idx) = find_similar_active_proposal(&store, &add_fact_request) {
-            let existing = &mut store.proposals[existing_idx];
-            existing.duplicate_count = existing.duplicate_count.saturating_add(1);
-            existing.last_duplicate_run_id = Some(run_id.to_string());
-            existing.updated_at = now;
+        if applied_exact_match_exists(&store, &add_fact_request) {
+            continue;
+        }
+        if let Some(existing_idx) =
+            find_similar_pending_proposal(&store, &add_fact_request, &incoming_tokens)
+        {
+            fold_duplicate(
+                &mut store.proposals[existing_idx],
+                run_id,
+                now,
+                Some(&add_fact_request.content),
+            );
             continue;
         }
         let proposal = value.get("proposal").cloned();
@@ -209,6 +222,7 @@ pub async fn record_session_fact_proposals(
             updated_at: now,
             duplicate_count: 0,
             last_duplicate_run_id: None,
+            folded_contents: Vec::new(),
         };
         records.push(record.clone());
         store.proposals.push(record);
@@ -234,6 +248,7 @@ pub async fn record_session_fact_proposals(
             updated_at: now,
             duplicate_count: 0,
             last_duplicate_run_id: None,
+            folded_contents: Vec::new(),
         };
         records.push(record.clone());
         store.proposals.push(record);
@@ -242,17 +257,35 @@ pub async fn record_session_fact_proposals(
     Ok(records)
 }
 
-/// Near-duplicate gate: a live run showed one lesson restated 21 times across
-/// a 50-proposal queue because only exact normalized content matched. Reuses
-/// the shared lexical-overlap scoring (the same signals the memory curator's
-/// duplicate tiers use) so paraphrases of an already-queued proposal fold
-/// into it instead of multiplying.
-fn find_similar_active_proposal(
+const MIN_SIMILARITY_TOKENS: usize = 8;
+
+fn fold_duplicate(
+    target: &mut FactProposalRecord,
+    run_id: &str,
+    now: i64,
+    discarded_content: Option<&str>,
+) {
+    target.duplicate_count = target.duplicate_count.saturating_add(1);
+    target.last_duplicate_run_id = Some(run_id.to_string());
+    target.updated_at = now;
+    if let Some(content) = discarded_content {
+        if target.folded_contents.len() < MAX_FOLDED_CONTENTS {
+            let truncated: String = content.chars().take(FOLDED_CONTENT_MAX_CHARS).collect();
+            target.folded_contents.push(truncated);
+        }
+    }
+}
+
+fn find_similar_pending_proposal(
     store: &FactProposalStore,
     request: &AddFactRequest,
+    request_tokens: &std::collections::BTreeSet<String>,
 ) -> Option<usize> {
+    if request_tokens.len() < MIN_SIMILARITY_TOKENS {
+        return None;
+    }
     store.proposals.iter().position(|proposal| {
-        if proposal.state == FactProposalState::Rejected {
+        if proposal.state != FactProposalState::PendingApproval {
             return false;
         }
         let Some(existing) = proposal.add_fact_request.as_ref() else {
@@ -261,16 +294,34 @@ fn find_similar_active_proposal(
         if existing.category != request.category {
             return false;
         }
+        let existing_tokens = crate::memory::similarity::content_tokens(&existing.content);
+        if existing_tokens.len() < MIN_SIMILARITY_TOKENS {
+            return false;
+        }
         let (_, token_overlap, overlap_coefficient) =
-            crate::memory::similarity::lexical_overlap(&existing.content, &request.content);
-        overlap_coefficient >= 0.65 || token_overlap >= 0.45
+            crate::memory::similarity::lexical_overlap_tokens(&existing_tokens, request_tokens);
+        token_overlap >= 0.45 && overlap_coefficient >= 0.65
     })
 }
 
-fn active_add_fact_request_exists(store: &FactProposalStore, request: &AddFactRequest) -> bool {
+fn find_exact_pending_proposal(
+    store: &FactProposalStore,
+    request: &AddFactRequest,
+) -> Option<usize> {
+    let content = normalize_fact_content(&request.content);
+    store.proposals.iter().position(|proposal| {
+        proposal.state == FactProposalState::PendingApproval
+            && proposal.add_fact_request.as_ref().is_some_and(|existing| {
+                existing.category == request.category
+                    && normalize_fact_content(&existing.content) == content
+            })
+    })
+}
+
+fn applied_exact_match_exists(store: &FactProposalStore, request: &AddFactRequest) -> bool {
     let content = normalize_fact_content(&request.content);
     store.proposals.iter().any(|proposal| {
-        proposal.state != FactProposalState::Rejected
+        proposal.state == FactProposalState::Applied
             && proposal.add_fact_request.as_ref().is_some_and(|existing| {
                 existing.category == request.category
                     && normalize_fact_content(&existing.content) == content

--- a/src/automation/outcomes.rs
+++ b/src/automation/outcomes.rs
@@ -526,6 +526,8 @@ mod tests {
             apply_outcome: None,
             created_at: applied_at,
             updated_at: applied_at,
+            duplicate_count: 0,
+            last_duplicate_run_id: None,
         }
     }
 

--- a/src/automation/outcomes.rs
+++ b/src/automation/outcomes.rs
@@ -528,6 +528,7 @@ mod tests {
             updated_at: applied_at,
             duplicate_count: 0,
             last_duplicate_run_id: None,
+            folded_contents: Vec::new(),
         }
     }
 

--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -212,6 +212,7 @@ mod tests {
             updated_at: 1,
             duplicate_count: 0,
             last_duplicate_run_id: None,
+            folded_contents: Vec::new(),
         }
     }
 

--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -210,6 +210,8 @@ mod tests {
             apply_outcome: None,
             created_at: 1,
             updated_at: 1,
+            duplicate_count: 0,
+            last_duplicate_run_id: None,
         }
     }
 

--- a/src/memory/similarity.rs
+++ b/src/memory/similarity.rs
@@ -42,10 +42,16 @@ pub fn content_tokens(content: &str) -> BTreeSet<String> {
 }
 
 pub fn lexical_overlap(a: &str, b: &str) -> (serde_json::Value, f64, f64) {
-    let a_tokens = content_tokens(a);
-    let b_tokens = content_tokens(b);
-    let shared: Vec<&String> = a_tokens.intersection(&b_tokens).collect();
-    let union = a_tokens.union(&b_tokens).count();
+    lexical_overlap_tokens(&content_tokens(a), &content_tokens(b))
+}
+
+/// Pre-tokenized variant of [`lexical_overlap`].
+pub fn lexical_overlap_tokens(
+    a_tokens: &BTreeSet<String>,
+    b_tokens: &BTreeSet<String>,
+) -> (serde_json::Value, f64, f64) {
+    let shared: Vec<&String> = a_tokens.intersection(b_tokens).collect();
+    let union = a_tokens.union(b_tokens).count();
     let min_size = a_tokens.len().min(b_tokens.len());
     let token_overlap = if union > 0 {
         (shared.len() as f64 / union as f64 * 10_000.0).round() / 10_000.0

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -1170,10 +1170,6 @@ async fn session_reflector_runner_records_noop_fallback_when_backend_run_task_fa
     );
 }
 
-/// Near-duplicate paraphrases must fold into the existing pending proposal
-/// (bumping duplicate_count) instead of multiplying in the queue. Live
-/// evidence: one lesson was restated 21 times across a 50-proposal queue
-/// because only exact normalized content was deduped.
 #[tokio::test]
 async fn session_fact_proposals_fold_paraphrases_into_one_proposal() {
     let temp = tempdir().unwrap();
@@ -1200,17 +1196,14 @@ async fn session_fact_proposals_fold_paraphrases_into_one_proposal() {
             "Never merge a PR batch after a single flaky green pass; require stable \
              aggregate verification and a live PR-state recheck before merging",
         ),
-        // Paraphrase: heavy token overlap, different wording/order.
         fact(
             "Before merging a PR batch, require stable aggregate verification and a \
              live PR-state recheck — a single flaky green pass is never enough to merge",
         ),
-        // Second paraphrase of the same lesson.
         fact(
             "A single flaky green pass is not enough: merging the PR batch needs \
              stable aggregate verification plus a live PR-state recheck first",
         ),
-        // Genuinely different lesson in the same category: must stay separate.
         fact(
             "Cursor composer ingestion reads cursorDiskKV with immutable read-only \
              SQLite opens and indexed primary-key lookups only",
@@ -1227,7 +1220,6 @@ async fn session_fact_proposals_fold_paraphrases_into_one_proposal() {
         "paraphrases must fold into the first proposal"
     );
 
-    // A later run restating the same lesson folds in as well.
     let restated = vec![fact(
         "Require stable aggregate verification and live PR-state rechecks; never \
          merge the batch off one flaky green pass",
@@ -1259,6 +1251,32 @@ async fn session_fact_proposals_fold_paraphrases_into_one_proposal() {
         "two in-batch paraphrases plus one cross-run restatement"
     );
     assert_eq!(folded.last_duplicate_run_id.as_deref(), Some("run-b"));
+    assert_eq!(
+        folded.folded_contents.len(),
+        3,
+        "each folded paraphrase is captured for reviewer recovery"
+    );
+    assert!(
+        folded
+            .folded_contents
+            .iter()
+            .any(|c| c.contains("Before merging a PR batch")),
+        "first in-batch paraphrase captured verbatim"
+    );
+    assert!(
+        folded
+            .folded_contents
+            .iter()
+            .any(|c| c.contains("A single flaky green pass is not enough")),
+        "second in-batch paraphrase captured verbatim"
+    );
+    assert!(
+        folded
+            .folded_contents
+            .iter()
+            .any(|c| c.contains("Require stable aggregate verification and live PR-state rechecks")),
+        "cross-run restatement captured verbatim"
+    );
     let distinct = proposals
         .iter()
         .find(|p| {
@@ -1268,4 +1286,108 @@ async fn session_fact_proposals_fold_paraphrases_into_one_proposal() {
         })
         .expect("distinct proposal preserved");
     assert_eq!(distinct.duplicate_count, 0);
+    assert!(distinct.folded_contents.is_empty());
+}
+
+#[tokio::test]
+async fn session_fact_proposals_never_mutate_applied_records() {
+    use tracedecay::automation::fact_proposals::{
+        FactProposalRecord, FactProposalStore, load_fact_proposal_store, save_fact_proposal_store,
+    };
+
+    let temp = tempdir().unwrap();
+    let dashboard_root = temp.path().join("dashboard");
+
+    let applied_request = serde_json::from_value(json!({
+        "content": "Never merge a PR batch after a single flaky green pass; require stable \
+                    aggregate verification and a live PR-state recheck before merging",
+        "category": "project",
+        "source": "session_reflector",
+        "tags": ["session-reflector"],
+        "entities": ["merge discipline"],
+        "trust": 0.9,
+        "metadata": {
+            "source_span": { "session_id": "s", "message_id": "m" },
+            "trust_reason": "repeated evidence"
+        }
+    }))
+    .unwrap();
+    let applied = FactProposalRecord {
+        schema_version: 1,
+        proposal_id: "fact_applied".to_string(),
+        run_id: "run-old".to_string(),
+        evidence_hash: Some("evidence-old".to_string()),
+        state: FactProposalState::Applied,
+        add_fact_request: Some(applied_request),
+        proposal: None,
+        validation_reason: None,
+        validation: None,
+        reviewer: Some("dashboard".to_string()),
+        applied_fact_id: Some(42),
+        apply_outcome: None,
+        created_at: 1_000,
+        updated_at: 1_000,
+        duplicate_count: 0,
+        last_duplicate_run_id: None,
+        folded_contents: Vec::new(),
+    };
+    save_fact_proposal_store(
+        &dashboard_root,
+        &FactProposalStore {
+            schema_version: 1,
+            proposals: vec![applied],
+        },
+    )
+    .await
+    .unwrap();
+
+    let paraphrase = json!({
+        "add_fact_request": {
+            "content": "Before merging a PR batch, require stable aggregate verification and a \
+                        live PR-state recheck — a single flaky green pass is never enough to merge",
+            "category": "project",
+            "source": "session_reflector",
+            "tags": ["session-reflector"],
+            "entities": ["merge discipline"],
+            "trust": 0.9,
+            "metadata": {
+                "source_span": { "session_id": "s", "message_id": "m" },
+                "trust_reason": "repeated evidence"
+            }
+        },
+        "proposal": { "content": "paraphrase" }
+    });
+    let recorded = record_session_fact_proposals(
+        &dashboard_root,
+        "run-new",
+        Some("evidence-new"),
+        &[paraphrase],
+        &[],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "paraphrase of an applied fact enqueues as its own pending proposal"
+    );
+    assert_eq!(recorded[0].state, FactProposalState::PendingApproval);
+
+    let store = load_fact_proposal_store(&dashboard_root).await.unwrap();
+    assert_eq!(store.proposals.len(), 2, "new pending proposal enqueued");
+    let applied = store
+        .proposals
+        .iter()
+        .find(|p| p.proposal_id == "fact_applied")
+        .expect("applied record preserved");
+    assert_eq!(applied.state, FactProposalState::Applied);
+    assert_eq!(
+        applied.updated_at, 1_000,
+        "applied record's updated_at must not be corrupted by the fold path"
+    );
+    assert_eq!(
+        applied.duplicate_count, 0,
+        "applied record must not be folded into"
+    );
+    assert!(applied.folded_contents.is_empty());
 }

--- a/tests/automation_runner_test/session_reflector.rs
+++ b/tests/automation_runner_test/session_reflector.rs
@@ -1169,3 +1169,103 @@ async fn session_reflector_runner_records_noop_fallback_when_backend_run_task_fa
         json!({ "facts": [] }),
     );
 }
+
+/// Near-duplicate paraphrases must fold into the existing pending proposal
+/// (bumping duplicate_count) instead of multiplying in the queue. Live
+/// evidence: one lesson was restated 21 times across a 50-proposal queue
+/// because only exact normalized content was deduped.
+#[tokio::test]
+async fn session_fact_proposals_fold_paraphrases_into_one_proposal() {
+    let temp = tempdir().unwrap();
+    let dashboard_root = temp.path().join("dashboard");
+    let fact = |content: &str| {
+        json!({
+            "add_fact_request": {
+                "content": content,
+                "category": "project",
+                "source": "session_reflector",
+                "tags": ["session-reflector"],
+                "entities": ["merge discipline"],
+                "trust": 0.9,
+                "metadata": {
+                    "source_span": { "session_id": "s", "message_id": "m" },
+                    "trust_reason": "repeated evidence"
+                }
+            },
+            "proposal": { "content": content }
+        })
+    };
+    let batch = vec![
+        fact(
+            "Never merge a PR batch after a single flaky green pass; require stable \
+             aggregate verification and a live PR-state recheck before merging",
+        ),
+        // Paraphrase: heavy token overlap, different wording/order.
+        fact(
+            "Before merging a PR batch, require stable aggregate verification and a \
+             live PR-state recheck — a single flaky green pass is never enough to merge",
+        ),
+        // Second paraphrase of the same lesson.
+        fact(
+            "A single flaky green pass is not enough: merging the PR batch needs \
+             stable aggregate verification plus a live PR-state recheck first",
+        ),
+        // Genuinely different lesson in the same category: must stay separate.
+        fact(
+            "Cursor composer ingestion reads cursorDiskKV with immutable read-only \
+             SQLite opens and indexed primary-key lookups only",
+        ),
+    ];
+
+    let recorded =
+        record_session_fact_proposals(&dashboard_root, "run-a", Some("evidence-a"), &batch, &[])
+            .await
+            .unwrap();
+    assert_eq!(
+        recorded.len(),
+        2,
+        "paraphrases must fold into the first proposal"
+    );
+
+    // A later run restating the same lesson folds in as well.
+    let restated = vec![fact(
+        "Require stable aggregate verification and live PR-state rechecks; never \
+         merge the batch off one flaky green pass",
+    )];
+    let second =
+        record_session_fact_proposals(&dashboard_root, "run-b", Some("evidence-b"), &restated, &[])
+            .await
+            .unwrap();
+    assert_eq!(second.len(), 0);
+
+    let proposals = list_fact_proposals(
+        &dashboard_root,
+        Some(FactProposalState::PendingApproval),
+        10,
+    )
+    .await
+    .unwrap();
+    assert_eq!(proposals.len(), 2);
+    let folded = proposals
+        .iter()
+        .find(|p| {
+            p.add_fact_request
+                .as_ref()
+                .is_some_and(|r| r.content.contains("flaky green"))
+        })
+        .expect("merge-discipline proposal present");
+    assert_eq!(
+        folded.duplicate_count, 3,
+        "two in-batch paraphrases plus one cross-run restatement"
+    );
+    assert_eq!(folded.last_duplicate_run_id.as_deref(), Some("run-b"));
+    let distinct = proposals
+        .iter()
+        .find(|p| {
+            p.add_fact_request
+                .as_ref()
+                .is_some_and(|r| r.content.contains("cursorDiskKV"))
+        })
+        .expect("distinct proposal preserved");
+    assert_eq!(distinct.duplicate_count, 0);
+}

--- a/tests/dashboard_api_test/api.rs
+++ b/tests/dashboard_api_test/api.rs
@@ -108,6 +108,7 @@ fn automation_outcomes_endpoint_returns_live_read_only_outcomes() {
                     updated_at: 1_700_000_400,
                     duplicate_count: 0,
                     last_duplicate_run_id: None,
+                    folded_contents: Vec::new(),
                 }],
             },
         )

--- a/tests/dashboard_api_test/api.rs
+++ b/tests/dashboard_api_test/api.rs
@@ -106,6 +106,8 @@ fn automation_outcomes_endpoint_returns_live_read_only_outcomes() {
                     apply_outcome: None,
                     created_at: 1_700_000_400,
                     updated_at: 1_700_000_400,
+                    duplicate_count: 0,
+                    last_duplicate_run_id: None,
                 }],
             },
         )

--- a/tests/dashboard_api_test/automation.rs
+++ b/tests/dashboard_api_test/automation.rs
@@ -849,6 +849,7 @@ fn automation_outcomes_endpoint_reports_applied_fact_trajectories() {
                 updated_at: 1_700_000_050,
                 duplicate_count: 0,
                 last_duplicate_run_id: None,
+                folded_contents: Vec::new(),
             }
         };
         tracedecay::automation::fact_proposals::save_fact_proposal_store(

--- a/tests/dashboard_api_test/automation.rs
+++ b/tests/dashboard_api_test/automation.rs
@@ -847,6 +847,8 @@ fn automation_outcomes_endpoint_reports_applied_fact_trajectories() {
                 apply_outcome: None,
                 created_at: 1_700_000_000,
                 updated_at: 1_700_000_050,
+                duplicate_count: 0,
+                last_duplicate_run_id: None,
             }
         };
         tracedecay::automation::fact_proposals::save_fact_proposal_store(


### PR DESCRIPTION
Fixes the reflection queue redundancy observed live (50 proposals → 6 themes, one restated 21×): a similarity gate reusing memory::similarity's lexical-overlap scoring folds paraphrases into the existing pending proposal as duplicate_count instead of enqueueing clones. Additive serialization; regression-tested for in-batch, cross-run, and distinct-lesson cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)