### PR TITLE
feat: materialize managed skills as host-loadable SKILL.md files

### DIFF
--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -16,6 +16,12 @@ pub const MAX_MANAGED_SUPPORT_FILES: usize = 20;
 pub const MAX_MANAGED_SUPPORT_FILE_BYTES: usize = 64 * 1024;
 pub const MAX_MANAGED_SKILL_BODY_BYTES: usize = 256 * 1024;
 
+/// Provenance marker written into the frontmatter of every host-loadable
+/// skill file that `TraceDecay` automation materializes. The materialization
+/// reconciler owns (updates/removes) only files carrying this exact marker, so
+/// user-authored and repo-local dev skills are never touched.
+pub const MATERIALIZED_SKILL_MANAGED_BY: &str = "tracedecay-automation";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillInstallTarget {
@@ -392,6 +398,62 @@ impl ManagedSkill {
         output.push_str(&self.body_markdown);
         output.push('\n');
         validate_native_skill_markdown(&output)?;
+        Ok(output)
+    }
+
+    /// Kebab-case slug used as the directory name for the host-loadable
+    /// materialized skill (`<skills_dir>/<slug>/SKILL.md`). Derived from the
+    /// managed-skill id the same way the native overlay derives its `name:`.
+    pub fn host_skill_slug(&self) -> String {
+        native_skill_name(&self.metadata.id)
+    }
+
+    /// `sha256` of the skill body markdown. Embedded as the `content-hash`
+    /// provenance field so the reconciler can detect user edits (forks) of a
+    /// materialized file without re-reading the profile store.
+    pub fn materialized_body_hash(&self) -> String {
+        format!(
+            "sha256:{}",
+            hex::encode(Sha256::digest(self.body_markdown.as_bytes()))
+        )
+    }
+
+    /// Renders a host-loadable `SKILL.md` with provenance frontmatter marking
+    /// the file as owned by `TraceDecay` automation. Hosts (Claude Code, Codex)
+    /// read `name`/`description`; the extra `managed-by`/`skill-id`/
+    /// `content-hash`/`skill-version` keys are ignored by the host but let the
+    /// reconciler own exactly its own files and detect drift.
+    pub fn render_materialized_skill_markdown(&self) -> Result<String> {
+        // Reuse the native name/description derivation + bounds so the host
+        // frontmatter shape matches the overlay exactly.
+        let name = native_skill_name(&self.metadata.id);
+        let description = managed_skill_description(&self.metadata.summary);
+        {
+            // Validate the host-facing fields via the native validator by
+            // rendering a name/description-only document first.
+            let native_only = format!(
+                "---\nname: {name}\ndescription: {}\n---\n\n{}\n",
+                frontmatter_string(&description),
+                self.body_markdown
+            );
+            validate_native_skill_markdown(&native_only)?;
+        }
+
+        let mut output = String::new();
+        output.push_str("---\n");
+        let _ = writeln!(output, "name: {name}");
+        let _ = writeln!(output, "description: {}", frontmatter_string(&description));
+        let _ = writeln!(output, "managed-by: {MATERIALIZED_SKILL_MANAGED_BY}");
+        let _ = writeln!(
+            output,
+            "skill-id: {}",
+            frontmatter_string(&self.metadata.id)
+        );
+        let _ = writeln!(output, "content-hash: {}", self.materialized_body_hash());
+        let _ = writeln!(output, "skill-version: {}", self.metadata.updated_at);
+        output.push_str("---\n\n");
+        output.push_str(&self.body_markdown);
+        output.push('\n');
         Ok(output)
     }
 

--- a/src/automation/mod.rs
+++ b/src/automation/mod.rs
@@ -29,6 +29,7 @@ pub mod runner;
 pub mod scheduler;
 pub mod session_reflector;
 pub mod skill_frontmatter;
+pub mod skill_materialization;
 pub mod skill_targets;
 pub mod skill_usage;
 pub mod skill_writer;

--- a/src/automation/skill_materialization.rs
+++ b/src/automation/skill_materialization.rs
@@ -1,0 +1,689 @@
+//! Host-loadable materialization of managed skills (Hermes skill-directory
+//! analogue).
+//!
+//! Managed skills live in the `TraceDecay` profile store and are surfaced to
+//! prompt-index hosts through a marker block that points at the
+//! `tracedecay_skill_view` MCP tool (see [`crate::automation::skill_targets`]).
+//! That is discoverable but never *natively loaded*: the host does not treat a
+//! managed skill as one of its own skills.
+//!
+//! This module closes that gap the way Hermes does — by writing each active
+//! managed skill as a real, host-loadable `SKILL.md` into the host's own skills
+//! directory (`<base>/.claude/skills/<slug>/SKILL.md` for Claude Code, the
+//! `.codex` twin for Codex), so the agent loads it like any other skill.
+//!
+//! Ownership is provenance-scoped. Every materialized file carries
+//! `managed-by: tracedecay-automation`, the `skill-id`, and a body
+//! `content-hash` in its frontmatter. The reconciler updates or removes *only*
+//! files carrying that marker whose recorded hash still matches the file on
+//! disk. A user (or the repo's own dev skills under the same directory) that
+//! edits a materialized file forks it: the reconciler then leaves it untouched
+//! and [`doctor_scope`] reports the drift.
+//!
+//! Lifecycle:
+//! - **activate** (`skills approve` → Active, or auto-enable) → materialize.
+//! - **deactivate/archive/disable/remove** → the skill drops out of the active
+//!   set and the reconciler removes its materialized file (fork-protected).
+//! - **body update** → re-materialize (hash changes, file rewritten).
+//! - **`tracedecay update` / install** → reconcile every detected host+scope.
+//! - **`tracedecay doctor`** → report missing/forked/orphaned materializations.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::config_error;
+pub use crate::automation::managed_skills::managed_skill_root;
+use crate::automation::managed_skills::{ManagedSkill, ManagedSkillState};
+use crate::automation::skill_frontmatter::{SkillFrontmatterValue, parse_skill_frontmatter};
+use crate::errors::Result;
+
+pub use crate::automation::managed_skill_model::MATERIALIZED_SKILL_MANAGED_BY;
+
+const SKILL_FILE: &str = "SKILL.md";
+
+/// A host whose native skills directory can load a materialized `SKILL.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaterializationHost {
+    Claude,
+    Codex,
+}
+
+impl MaterializationHost {
+    /// Directory (relative to a scope base) that holds `<slug>/SKILL.md`.
+    pub fn skills_subdir(self) -> &'static Path {
+        match self {
+            Self::Claude => Path::new(".claude/skills"),
+            Self::Codex => Path::new(".codex/skills"),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+
+    /// Both hosts, in a stable order.
+    pub fn all() -> [MaterializationHost; 2] {
+        [Self::Claude, Self::Codex]
+    }
+}
+
+/// Whether a destination is a project checkout or the user's global home.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaterializationScopeKind {
+    Project,
+    Global,
+}
+
+impl MaterializationScopeKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::Global => "global",
+        }
+    }
+}
+
+/// One materialization destination: a host skills directory rooted at a base
+/// directory (a project checkout, or the user's home for the global scope).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializationScope {
+    pub host: MaterializationHost,
+    pub kind: MaterializationScopeKind,
+    /// Directory that contains `.claude` / `.codex` (project root or home).
+    pub base_dir: PathBuf,
+}
+
+impl MaterializationScope {
+    pub fn project(host: MaterializationHost, project_root: impl Into<PathBuf>) -> Self {
+        Self {
+            host,
+            kind: MaterializationScopeKind::Project,
+            base_dir: project_root.into(),
+        }
+    }
+
+    pub fn global(host: MaterializationHost, home: impl Into<PathBuf>) -> Self {
+        Self {
+            host,
+            kind: MaterializationScopeKind::Global,
+            base_dir: home.into(),
+        }
+    }
+
+    /// `<base>/.claude/skills` (or the `.codex` twin).
+    pub fn skills_dir(&self) -> PathBuf {
+        self.base_dir.join(self.host.skills_subdir())
+    }
+
+    fn skill_dir(&self, slug: &str) -> PathBuf {
+        self.skills_dir().join(slug)
+    }
+
+    fn skill_md(&self, slug: &str) -> PathBuf {
+        self.skill_dir(slug).join(SKILL_FILE)
+    }
+
+    /// Human-readable `host/scope` label for reports and doctor output.
+    pub fn describe(&self) -> String {
+        format!("{}/{}", self.host.label(), self.kind.label())
+    }
+}
+
+/// Outcome of materializing one skill into one scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterializeAction {
+    /// The file was created or rewritten to match the active skill.
+    Written,
+    /// The file already matched the active skill; nothing changed.
+    Unchanged,
+    /// A file already occupies the slot but is not `TraceDecay`-managed (a user
+    /// or repo-local dev skill); left untouched.
+    SkippedForeign,
+    /// A `TraceDecay`-managed file was edited by the user (fork); left untouched.
+    SkippedForked,
+}
+
+impl MaterializeAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Written => "written",
+            Self::Unchanged => "unchanged",
+            Self::SkippedForeign => "skipped_foreign",
+            Self::SkippedForked => "skipped_forked",
+        }
+    }
+}
+
+/// Outcome of removing one materialized skill from one scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoveAction {
+    /// The managed file was deleted.
+    Removed,
+    /// No file was present for the slug.
+    Absent,
+    /// A file exists but is not `TraceDecay`-managed; left untouched.
+    SkippedForeign,
+    /// A managed file was user-edited (fork); left untouched.
+    SkippedForked,
+}
+
+impl RemoveAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Removed => "removed",
+            Self::Absent => "absent",
+            Self::SkippedForeign => "skipped_foreign",
+            Self::SkippedForked => "skipped_forked",
+        }
+    }
+}
+
+/// A single materialize result within a reconcile report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializeEntry {
+    pub skill_id: String,
+    pub path: PathBuf,
+    pub action: MaterializeAction,
+}
+
+/// A single removal result within a reconcile report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoveEntry {
+    pub skill_id: String,
+    pub path: PathBuf,
+    pub action: RemoveAction,
+}
+
+/// Result of reconciling one scope against the active managed-skill set.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    pub materialized: Vec<MaterializeEntry>,
+    pub removed: Vec<RemoveEntry>,
+}
+
+impl ReconcileReport {
+    pub fn written_count(&self) -> usize {
+        self.materialized
+            .iter()
+            .filter(|entry| entry.action == MaterializeAction::Written)
+            .count()
+    }
+
+    pub fn removed_count(&self) -> usize {
+        self.removed
+            .iter()
+            .filter(|entry| entry.action == RemoveAction::Removed)
+            .count()
+    }
+
+    pub fn forked_count(&self) -> usize {
+        self.materialized
+            .iter()
+            .filter(|entry| entry.action == MaterializeAction::SkippedForked)
+            .count()
+            + self
+                .removed
+                .iter()
+                .filter(|entry| entry.action == RemoveAction::SkippedForked)
+                .count()
+    }
+}
+
+/// A drift finding reported by [`doctor_scope`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillDrift {
+    /// An active skill has no materialized file in this scope.
+    Missing { skill_id: String, path: PathBuf },
+    /// A managed file was edited by the user; the reconciler will not clobber
+    /// it (the skill is effectively user-forked here).
+    Forked { skill_id: String, path: PathBuf },
+    /// A foreign file occupies the slot an active skill would materialize to.
+    Conflict { skill_id: String, path: PathBuf },
+    /// A managed file exists for a skill that is no longer active; a reconcile
+    /// would remove it.
+    Orphan { skill_id: String, path: PathBuf },
+}
+
+impl SkillDrift {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Missing { .. } => "missing",
+            Self::Forked { .. } => "forked",
+            Self::Conflict { .. } => "conflict",
+            Self::Orphan { .. } => "orphan",
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Missing { path, .. }
+            | Self::Forked { path, .. }
+            | Self::Conflict { path, .. }
+            | Self::Orphan { path, .. } => path,
+        }
+    }
+
+    pub fn skill_id(&self) -> &str {
+        match self {
+            Self::Missing { skill_id, .. }
+            | Self::Forked { skill_id, .. }
+            | Self::Conflict { skill_id, .. }
+            | Self::Orphan { skill_id, .. } => skill_id,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance parsing / fork detection
+// ---------------------------------------------------------------------------
+
+/// The provenance a materialized file carries, plus the body markdown as it
+/// currently sits on disk (for fork detection).
+struct FileProvenance {
+    managed_by: Option<String>,
+    skill_id: Option<String>,
+    content_hash: Option<String>,
+    body_hash: Option<String>,
+}
+
+impl FileProvenance {
+    fn is_managed(&self) -> bool {
+        self.managed_by.as_deref() == Some(MATERIALIZED_SKILL_MANAGED_BY)
+    }
+
+    /// A managed file is forked when the body on disk no longer hashes to the
+    /// `content-hash` we recorded when we wrote it.
+    fn is_forked(&self) -> bool {
+        match (&self.content_hash, &self.body_hash) {
+            (Some(recorded), Some(actual)) => recorded != actual,
+            // A managed file missing a content-hash is treated as forked so we
+            // never silently overwrite something we cannot verify we authored.
+            _ => true,
+        }
+    }
+}
+
+fn frontmatter_scalar<'a>(
+    fields: &'a std::collections::BTreeMap<String, SkillFrontmatterValue>,
+    key: &str,
+) -> Option<&'a str> {
+    fields.get(key).and_then(SkillFrontmatterValue::as_scalar)
+}
+
+/// Extracts the raw body region after the leading frontmatter block, then
+/// strips exactly one leading and one trailing newline to recover the original
+/// `body_markdown` we wrote. Returns `None` when the file has no frontmatter.
+fn on_disk_body_markdown(contents: &str) -> Option<String> {
+    let after_open = contents.strip_prefix("---\n")?;
+    let close_at = after_open.find("\n---\n")?;
+    let region = &after_open[close_at + "\n---\n".len()..];
+    let region = region.strip_prefix('\n').unwrap_or(region);
+    let region = region.strip_suffix('\n').unwrap_or(region);
+    Some(region.to_string())
+}
+
+fn hash_body(body: &str) -> String {
+    use sha2::{Digest, Sha256};
+    format!("sha256:{}", hex::encode(Sha256::digest(body.as_bytes())))
+}
+
+fn read_file_provenance(path: &Path) -> Result<Option<FileProvenance>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let fields = parse_skill_frontmatter(&contents).ok();
+    let (managed_by, skill_id, content_hash) = match &fields {
+        Some(fields) => (
+            frontmatter_scalar(fields, "managed-by").map(str::to_string),
+            frontmatter_scalar(fields, "skill-id").map(str::to_string),
+            frontmatter_scalar(fields, "content-hash").map(str::to_string),
+        ),
+        None => (None, None, None),
+    };
+    let body_hash = on_disk_body_markdown(&contents).map(|body| hash_body(&body));
+    Ok(Some(FileProvenance {
+        managed_by,
+        skill_id,
+        content_hash,
+        body_hash,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Single-skill operations
+// ---------------------------------------------------------------------------
+
+/// Materializes one active skill into one scope. Never clobbers a foreign or
+/// user-forked file. Idempotent: an already-current managed file is left as
+/// [`MaterializeAction::Unchanged`].
+pub fn materialize_skill(
+    scope: &MaterializationScope,
+    skill: &ManagedSkill,
+) -> Result<MaterializeEntry> {
+    let slug = skill.host_skill_slug();
+    let path = scope.skill_md(&slug);
+
+    let action = match read_file_provenance(&path)? {
+        Some(existing) if !existing.is_managed() => MaterializeAction::SkippedForeign,
+        Some(existing) if existing.is_forked() => MaterializeAction::SkippedForked,
+        Some(existing)
+            if existing.content_hash.as_deref() == Some(&skill.materialized_body_hash()) =>
+        {
+            MaterializeAction::Unchanged
+        }
+        _ => {
+            write_skill_file(scope, skill, &slug)?;
+            MaterializeAction::Written
+        }
+    };
+
+    Ok(MaterializeEntry {
+        skill_id: skill.metadata.id.clone(),
+        path,
+        action,
+    })
+}
+
+fn write_skill_file(scope: &MaterializationScope, skill: &ManagedSkill, slug: &str) -> Result<()> {
+    let dir = scope.skill_dir(slug);
+    fs::create_dir_all(&dir)?;
+    let markdown = skill.render_materialized_skill_markdown()?;
+    crate::agents::safe_write_text_file(&dir.join(SKILL_FILE), &markdown, None)?;
+    write_support_files(&dir, skill)?;
+    Ok(())
+}
+
+fn write_support_files(dir: &Path, skill: &ManagedSkill) -> Result<()> {
+    for support in &skill.support_files {
+        let relative = safe_support_relative(&support.path)?;
+        let path = dir.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, &support.bytes)?;
+    }
+    Ok(())
+}
+
+fn safe_support_relative(path: &Path) -> Result<&Path> {
+    use std::path::Component;
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err(config_error(format!(
+            "unsafe materialized support path '{}'",
+            path.display()
+        )));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(part) if !part.to_string_lossy().contains('\\') => {}
+            _ => {
+                return Err(config_error(format!(
+                    "unsafe materialized support path '{}'",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(path)
+}
+
+/// Removes one materialized skill by slug from one scope. Fork-protected: a
+/// user-edited managed file is preserved (and later surfaces as a doctor
+/// `Forked` finding); a foreign file is never touched.
+pub fn remove_materialized_skill(scope: &MaterializationScope, slug: &str) -> Result<RemoveAction> {
+    let path = scope.skill_md(slug);
+    let action = match read_file_provenance(&path)? {
+        None => RemoveAction::Absent,
+        Some(existing) if !existing.is_managed() => RemoveAction::SkippedForeign,
+        Some(existing) if existing.is_forked() => RemoveAction::SkippedForked,
+        Some(_) => {
+            fs::remove_file(&path)?;
+            prune_skill_dir(scope, slug);
+            RemoveAction::Removed
+        }
+    };
+    Ok(action)
+}
+
+/// Removes the (now empty) skill package directory. Best effort: leftover
+/// user-added files keep the directory and are left in place.
+fn prune_skill_dir(scope: &MaterializationScope, slug: &str) {
+    let dir = scope.skill_dir(slug);
+    remove_dir_if_only_managed_leftovers(&dir);
+}
+
+fn remove_dir_if_only_managed_leftovers(dir: &Path) {
+    // Try a plain remove first (empty dir). If support files remain that we
+    // wrote, remove the whole package. We only reach here after deleting a
+    // managed SKILL.md, so the package is ours.
+    if fs::remove_dir(dir).is_ok() {
+        return;
+    }
+    let _ = fs::remove_dir_all(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Scope reconcile + doctor
+// ---------------------------------------------------------------------------
+
+/// Reconciles one scope against the active managed-skill set: materializes
+/// every active skill and removes managed files whose skill is no longer
+/// active. Fork- and foreign-safe throughout.
+pub fn reconcile_scope(
+    scope: &MaterializationScope,
+    active_skills: &[ManagedSkill],
+) -> Result<ReconcileReport> {
+    let mut report = ReconcileReport::default();
+    let mut active_slugs = std::collections::BTreeSet::new();
+
+    for skill in active_skills {
+        active_slugs.insert(skill.host_skill_slug());
+        report.materialized.push(materialize_skill(scope, skill)?);
+    }
+
+    for (slug, skill_id) in managed_slugs_in_scope(scope)? {
+        if active_slugs.contains(&slug) {
+            continue;
+        }
+        let action = remove_materialized_skill(scope, &slug)?;
+        report.removed.push(RemoveEntry {
+            skill_id,
+            path: scope.skill_md(&slug),
+            action,
+        });
+    }
+
+    Ok(report)
+}
+
+/// Reports drift between the active managed-skill set and one scope's
+/// materialized files: missing, forked, conflicting, or orphaned files.
+pub fn doctor_scope(
+    scope: &MaterializationScope,
+    active_skills: &[ManagedSkill],
+) -> Result<Vec<SkillDrift>> {
+    let mut drift = Vec::new();
+    let mut active_slugs = std::collections::BTreeSet::new();
+
+    for skill in active_skills {
+        let slug = skill.host_skill_slug();
+        active_slugs.insert(slug.clone());
+        let path = scope.skill_md(&slug);
+        match read_file_provenance(&path)? {
+            None => drift.push(SkillDrift::Missing {
+                skill_id: skill.metadata.id.clone(),
+                path,
+            }),
+            Some(existing) if !existing.is_managed() => drift.push(SkillDrift::Conflict {
+                skill_id: skill.metadata.id.clone(),
+                path,
+            }),
+            Some(existing) if existing.is_forked() => drift.push(SkillDrift::Forked {
+                skill_id: skill.metadata.id.clone(),
+                path,
+            }),
+            Some(_) => {}
+        }
+    }
+
+    for (slug, skill_id) in managed_slugs_in_scope(scope)? {
+        if active_slugs.contains(&slug) {
+            continue;
+        }
+        drift.push(SkillDrift::Orphan {
+            skill_id,
+            path: scope.skill_md(&slug),
+        });
+    }
+
+    Ok(drift)
+}
+
+/// Lists `(slug, skill_id)` for every `TraceDecay`-managed `SKILL.md` currently
+/// materialized in a scope's skills directory. Foreign directories (user or
+/// repo-local dev skills) are skipped.
+fn managed_slugs_in_scope(scope: &MaterializationScope) -> Result<Vec<(String, String)>> {
+    let skills_dir = scope.skills_dir();
+    let entries = match fs::read_dir(&skills_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if !entry.path().is_dir() {
+            continue;
+        }
+        let Some(slug) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let skill_md = entry.path().join(SKILL_FILE);
+        let Some(provenance) = read_file_provenance(&skill_md)? else {
+            continue;
+        };
+        if !provenance.is_managed() {
+            continue;
+        }
+        let skill_id = provenance.skill_id.unwrap_or_else(|| slug.clone());
+        out.push((slug, skill_id));
+    }
+    out.sort();
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Scope detection + profile-driven reconcile
+// ---------------------------------------------------------------------------
+
+/// Loads the active managed skills for materialization. Only `Active` skills
+/// that target Claude are materialized to Claude scopes, Codex to Codex — the
+/// same target filtering the overlay/prompt-index export applies.
+fn load_active_managed_skills(profile_root: &Path) -> Result<Vec<ManagedSkill>> {
+    crate::automation::skill_targets::load_active_managed_skills(profile_root)
+}
+
+fn skills_for_host(skills: &[ManagedSkill], host: MaterializationHost) -> Vec<ManagedSkill> {
+    let target = match host {
+        MaterializationHost::Claude => crate::automation::skill_targets::SkillInstallTarget::Claude,
+        MaterializationHost::Codex => crate::automation::skill_targets::SkillInstallTarget::Codex,
+    };
+    skills
+        .iter()
+        .filter(|skill| {
+            skill.metadata.state == ManagedSkillState::Active
+                && skill.metadata.targets.contains(&target)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Detects the materialization scopes that actually exist for `home` (global)
+/// and `project_root` (project): a scope is eligible when its host config
+/// directory (`.claude` / `.codex`) is present, so we never create a host
+/// integration the user has not opted into.
+pub fn detect_scopes(home: &Path, project_root: &Path) -> Vec<MaterializationScope> {
+    let mut scopes = Vec::new();
+    for host in MaterializationHost::all() {
+        let host_dir = host.skills_subdir().parent().unwrap_or(Path::new(""));
+        if home.join(host_dir).is_dir() {
+            scopes.push(MaterializationScope::global(host, home));
+        }
+        if project_root != home && project_root.join(host_dir).is_dir() {
+            scopes.push(MaterializationScope::project(host, project_root));
+        }
+    }
+    scopes
+}
+
+/// A per-scope reconcile result, tagged with the scope for reporting.
+#[derive(Debug, Clone)]
+pub struct ScopeReconcileResult {
+    pub scope: MaterializationScope,
+    pub report: ReconcileReport,
+}
+
+/// Reconciles every detected scope against the profile's active managed skills.
+/// Returns one result per scope. Errors from a single scope are surfaced in
+/// `errors` rather than aborting the whole sweep.
+pub fn reconcile_detected_scopes(
+    profile_root: &Path,
+    home: &Path,
+    project_root: &Path,
+) -> (Vec<ScopeReconcileResult>, Vec<String>) {
+    let mut results = Vec::new();
+    let mut errors = Vec::new();
+    let skills = match load_active_managed_skills(profile_root) {
+        Ok(skills) => skills,
+        Err(err) => {
+            errors.push(format!("load active managed skills: {err}"));
+            return (results, errors);
+        }
+    };
+    for scope in detect_scopes(home, project_root) {
+        let host_skills = skills_for_host(&skills, scope.host);
+        match reconcile_scope(&scope, &host_skills) {
+            Ok(report) => results.push(ScopeReconcileResult { scope, report }),
+            Err(err) => errors.push(format!("{}: {err}", scope.describe())),
+        }
+    }
+    (results, errors)
+}
+
+/// Non-fatal reconcile for lifecycle call sites (approve, auto-enable, install,
+/// update): resolves the profile root from the process environment, reconciles
+/// every detected host+scope, and logs (rather than propagates) failures so a
+/// materialization problem never breaks an activation or install.
+pub fn reconcile_after_activation(profile_root: &Path, project_root: &Path) {
+    let Some(home) = crate::agents::home_dir() else {
+        return;
+    };
+    let (_results, errors) = reconcile_detected_scopes(profile_root, &home, project_root);
+    for error in errors {
+        eprintln!("warning: managed skill materialization failed for {error}");
+    }
+}
+
+/// Reports materialization drift across every detected scope for `doctor`.
+pub fn doctor_detected_scopes(
+    profile_root: &Path,
+    home: &Path,
+    project_root: &Path,
+) -> Result<Vec<(MaterializationScope, Vec<SkillDrift>)>> {
+    let skills = load_active_managed_skills(profile_root)?;
+    let mut out = Vec::new();
+    for scope in detect_scopes(home, project_root) {
+        let host_skills = skills_for_host(&skills, scope.host);
+        out.push((scope.clone(), doctor_scope(&scope, &host_skills)?));
+    }
+    Ok(out)
+}

--- a/src/automation/skill_writer.rs
+++ b/src/automation/skill_writer.rs
@@ -399,6 +399,12 @@ fn refresh_managed_skill_exports_after_auto_enable(profile_root: &Path) {
             );
         }
     }
+    // Auto-applied (policy-off) skills also materialize their host-loadable
+    // SKILL.md files, matching the manual approve path.
+    crate::automation::skill_materialization::reconcile_after_activation(
+        profile_root,
+        &project_root,
+    );
 }
 
 fn accepted_skill_approval_status(

--- a/src/automation_cli.rs
+++ b/src/automation_cli.rs
@@ -429,6 +429,12 @@ fn refresh_managed_skill_exports_for_cli(profile_root: &std::path::Path) {
             );
         }
     }
+    // Materialize active managed skills as real, host-loadable SKILL.md files
+    // into every detected `.claude`/`.codex` skills directory (project + global).
+    tracedecay::automation::skill_materialization::reconcile_after_activation(
+        profile_root,
+        &project_root,
+    );
 }
 
 fn print_managed_skill(skill: &tracedecay::automation::managed_skills::ManagedSkill) {

--- a/src/dashboard/automation_skills_api.rs
+++ b/src/dashboard/automation_skills_api.rs
@@ -257,7 +257,14 @@ async fn export_skills_to_agent_hosts(
     let profile_root = profile_root.to_path_buf();
     let project_root = project_root.to_path_buf();
     tokio::task::spawn_blocking(move || {
-        export_managed_skills_to_agent_hosts(&home, &project_root, &profile_root)
+        let reports = export_managed_skills_to_agent_hosts(&home, &project_root, &profile_root);
+        // Materialize active managed skills as host-loadable SKILL.md files into
+        // every detected `.claude`/`.codex` skills directory (project + global).
+        crate::automation::skill_materialization::reconcile_after_activation(
+            &profile_root,
+            &project_root,
+        );
+        reports
     })
     .await
     .unwrap_or_else(|err| {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -76,12 +76,71 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
         for ag in &agents_to_check {
             ag.healthcheck(&mut dc, &hctx);
         }
+        check_managed_skill_materialization(&mut dc, home, &project_path);
     } else {
         dc.fail("Could not determine home directory");
     }
 
     check_network(&mut dc);
     print_summary(&dc);
+}
+
+/// Reports drift between the active managed-skill set and the host-loadable
+/// `SKILL.md` files `TraceDecay` automation materializes into detected
+/// `.claude`/`.codex` skills directories: missing (active but not on disk),
+/// forked (user-edited a managed file — the reconciler will not clobber it),
+/// conflict (a foreign file blocks the slot), or orphan (a managed file for a
+/// no-longer-active skill). A clean scope passes silently-ish with an info line.
+fn check_managed_skill_materialization(dc: &mut DoctorCounters, home: &Path, project_root: &Path) {
+    use crate::automation::skill_materialization::{SkillDrift, doctor_detected_scopes};
+
+    let Ok(profile_root) = crate::storage::default_profile_root() else {
+        return;
+    };
+    let scopes = match doctor_detected_scopes(&profile_root, home, project_root) {
+        Ok(scopes) => scopes,
+        Err(err) => {
+            dc.warn(&format!(
+                "Managed skill materialization check failed: {err}"
+            ));
+            return;
+        }
+    };
+    if scopes.is_empty() {
+        return;
+    }
+    eprintln!("\n\x1b[1mManaged skill materialization\x1b[0m");
+    for (scope, drift) in scopes {
+        if drift.is_empty() {
+            dc.pass(&format!(
+                "{}: materialized skills in sync",
+                scope.describe()
+            ));
+            continue;
+        }
+        for finding in drift {
+            let path = finding.path().display();
+            let skill_id = finding.skill_id();
+            match finding {
+                SkillDrift::Missing { .. } => dc.warn(&format!(
+                    "{}: '{skill_id}' active but not materialized ({path}); run `tracedecay update`",
+                    scope.describe()
+                )),
+                SkillDrift::Forked { .. } => dc.warn(&format!(
+                    "{}: '{skill_id}' materialized file was user-edited (forked); left untouched ({path})",
+                    scope.describe()
+                )),
+                SkillDrift::Conflict { .. } => dc.warn(&format!(
+                    "{}: '{skill_id}' cannot materialize — a non-managed file occupies {path}",
+                    scope.describe()
+                )),
+                SkillDrift::Orphan { .. } => dc.warn(&format!(
+                    "{}: stale materialized skill '{skill_id}' ({path}); run `tracedecay update` to remove",
+                    scope.describe()
+                )),
+            }
+        }
+    }
 }
 
 /// How the doctor "Current project" check sees the working directory's store.

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -408,7 +408,27 @@ pub(crate) async fn run_post_update_tasks(
             );
         }
     }
+    reconcile_materialized_managed_skills_after_update();
     Ok(())
+}
+
+/// Reconciles already-Active managed skills into every detected host skills
+/// directory on `tracedecay update`, so a skill approved before this binary
+/// shipped (or a body update applied since the last activation) still lands as
+/// a real, host-loadable `SKILL.md`. Fork-protected and best-effort: a failure
+/// here never fails the update.
+fn reconcile_materialized_managed_skills_after_update() {
+    let Ok(profile_root) = tracedecay::storage::default_profile_root() else {
+        return;
+    };
+    let project_root = std::env::current_dir()
+        .ok()
+        .or_else(tracedecay::agents::home_dir)
+        .unwrap_or_else(|| PathBuf::from("."));
+    tracedecay::automation::skill_materialization::reconcile_after_activation(
+        &profile_root,
+        &project_root,
+    );
 }
 
 #[cfg(test)]

--- a/tests/agent_suite/main.rs
+++ b/tests/agent_suite/main.rs
@@ -30,6 +30,7 @@ mod prompt_rules_parity_test;
 mod shared_skill_contract_test;
 mod skill_lint_claude_test;
 mod skill_lint_cursor_test;
+mod skill_materialization_test;
 mod skill_targets_test;
 mod skill_usage_test;
 mod tool_skill_coverage_test;

--- a/tests/agent_suite/skill_materialization_test.rs
+++ b/tests/agent_suite/skill_materialization_test.rs
@@ -1,0 +1,412 @@
+//! Host-loadable managed-skill materialization: activation writes real
+//! `SKILL.md` files into `.claude`/`.codex` skills dirs (project + global),
+//! deactivation removes them, user edits fork-protect the file, reconciles are
+//! idempotent, and `doctor` reports drift. Mirrors the install/update lifecycle
+//! test patterns in `skill_targets_test.rs`.
+
+use std::path::{Path, PathBuf};
+
+use tracedecay::automation::managed_skills::{
+    ManagedSkillDraft, ManagedSkillProvenance, ManagedSkillSource, ManagedSkillState,
+    ManagedSupportFile, create_managed_skill_draft, default_managed_skill_targets,
+    set_managed_skill_state,
+};
+use tracedecay::automation::skill_frontmatter::parse_skill_frontmatter;
+use tracedecay::automation::skill_materialization::{
+    MaterializationHost, MaterializationScope, MaterializeAction, RemoveAction, SkillDrift,
+    detect_scopes, doctor_detected_scopes, doctor_scope, materialize_skill,
+    reconcile_detected_scopes, reconcile_scope, remove_materialized_skill,
+};
+
+/// A canonicalized temp root: on macOS `/tmp` is a symlink to `/private/tmp`,
+/// so canonicalizing keeps materialized paths comparable to the profile paths.
+fn canonical_tempdir() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    (temp, root)
+}
+
+/// Creates the `.claude` and `.codex` host config directories under `base` so
+/// `detect_scopes` treats it as an eligible materialization scope.
+fn install_fake_hosts(base: &Path) {
+    std::fs::create_dir_all(base.join(".claude")).unwrap();
+    std::fs::create_dir_all(base.join(".codex")).unwrap();
+}
+
+fn draft(id: &str) -> ManagedSkillDraft {
+    ManagedSkillDraft {
+        id: id.to_string(),
+        title: "Code slop cleanup".to_string(),
+        summary: "Use when tidying obvious code slop before review.".to_string(),
+        category: "maintenance".to_string(),
+        targets: default_managed_skill_targets(),
+        body_markdown: "# Cleanup\n\nRemove dead code and stray debug prints.".to_string(),
+        support_files: vec![
+            ManagedSupportFile::new(
+                "references/checklist.md",
+                b"- drop debug prints\n- delete dead code\n".to_vec(),
+            )
+            .unwrap(),
+        ],
+        provenance: ManagedSkillProvenance {
+            source: ManagedSkillSource::AutomationRun,
+            actor: "tracedecay".to_string(),
+            run_id: Some("run_slop".to_string()),
+        },
+    }
+}
+
+/// Drafts a skill in `profile_root` and flips it to `Active`.
+async fn activate_skill(profile_root: &Path, id: &str) {
+    create_managed_skill_draft(profile_root, draft(id))
+        .await
+        .unwrap();
+    set_managed_skill_state(profile_root, id, ManagedSkillState::Active)
+        .await
+        .unwrap();
+}
+
+fn skill_md(scope: &MaterializationScope, slug: &str) -> PathBuf {
+    scope.skills_dir().join(slug).join("SKILL.md")
+}
+
+#[tokio::test]
+async fn materialize_on_activate_writes_both_hosts_and_scopes() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let project = root.join("project");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+    install_fake_hosts(&project);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+
+    let (results, errors) = reconcile_detected_scopes(&profile_root, &home, &project);
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    // 2 hosts x 2 scopes (project + global) = 4 destinations.
+    assert_eq!(results.len(), 4, "expected 4 detected scopes");
+
+    let expected = [
+        home.join(".claude/skills/code-slop-cleanup/SKILL.md"),
+        home.join(".codex/skills/code-slop-cleanup/SKILL.md"),
+        project.join(".claude/skills/code-slop-cleanup/SKILL.md"),
+        project.join(".codex/skills/code-slop-cleanup/SKILL.md"),
+    ];
+    for path in &expected {
+        assert!(
+            path.is_file(),
+            "missing materialized skill at {}",
+            path.display()
+        );
+    }
+    // Support files travel with the skill package.
+    assert!(
+        home.join(".claude/skills/code-slop-cleanup/references/checklist.md")
+            .is_file()
+    );
+
+    // Every reconcile entry wrote its file.
+    for result in &results {
+        assert_eq!(
+            result.report.written_count(),
+            1,
+            "scope {}",
+            result.scope.describe()
+        );
+    }
+}
+
+#[tokio::test]
+async fn materialized_file_carries_provenance_frontmatter() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    reconcile_detected_scopes(&profile_root, &home, &home);
+
+    let path = home.join(".claude/skills/code-slop-cleanup/SKILL.md");
+    let contents = std::fs::read_to_string(&path).unwrap();
+    let fm = parse_skill_frontmatter(&contents).unwrap();
+
+    assert_eq!(fm["name"].as_scalar(), Some("code-slop-cleanup"));
+    assert_eq!(fm["managed-by"].as_scalar(), Some("tracedecay-automation"));
+    assert_eq!(fm["skill-id"].as_scalar(), Some("code-slop-cleanup"));
+    let content_hash = fm["content-hash"].as_scalar().unwrap();
+    assert!(content_hash.starts_with("sha256:"), "hash: {content_hash}");
+    assert!(fm.contains_key("skill-version"));
+    assert!(fm.contains_key("description"));
+    // The host-facing body survives verbatim.
+    assert!(contents.contains("Remove dead code and stray debug prints."));
+}
+
+#[tokio::test]
+async fn remove_on_deactivate_deletes_materialized_file() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    reconcile_detected_scopes(&profile_root, &home, &home);
+    let path = home.join(".claude/skills/code-slop-cleanup/SKILL.md");
+    assert!(path.is_file());
+
+    // Deactivate: the skill drops out of the active set.
+    set_managed_skill_state(
+        &profile_root,
+        "code-slop-cleanup",
+        ManagedSkillState::Disabled,
+    )
+    .await
+    .unwrap();
+    let (results, errors) = reconcile_detected_scopes(&profile_root, &home, &home);
+    assert!(errors.is_empty(), "errors: {errors:?}");
+    assert!(
+        !path.exists(),
+        "materialized file should be removed on deactivate"
+    );
+    // The package directory is pruned too.
+    assert!(!home.join(".claude/skills/code-slop-cleanup").exists());
+    let removed: usize = results.iter().map(|r| r.report.removed_count()).sum();
+    assert_eq!(removed, 2, "both claude+codex managed files removed");
+}
+
+#[tokio::test]
+async fn idempotent_reconcile_is_unchanged_on_rerun() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    reconcile_detected_scopes(&profile_root, &home, &home);
+    let path = home.join(".claude/skills/code-slop-cleanup/SKILL.md");
+    let first = std::fs::read_to_string(&path).unwrap();
+
+    let (results, errors) = reconcile_detected_scopes(&profile_root, &home, &home);
+    assert!(errors.is_empty(), "errors: {errors:?}");
+    for result in &results {
+        assert_eq!(result.report.written_count(), 0, "rerun rewrote a file");
+        for entry in &result.report.materialized {
+            assert_eq!(entry.action, MaterializeAction::Unchanged);
+        }
+    }
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), first);
+}
+
+#[tokio::test]
+async fn body_update_re_materializes_the_file() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home.clone());
+    let mut skill = tracedecay::automation::managed_skills::load_managed_skill(
+        &profile_root,
+        "code-slop-cleanup",
+    )
+    .await
+    .unwrap();
+    let first = materialize_skill(&scope, &skill).unwrap();
+    assert_eq!(first.action, MaterializeAction::Written);
+
+    // Change the body: the content-hash changes, so the reconciler rewrites.
+    skill.body_markdown = "# Cleanup v2\n\nNow with extra rigor.".to_string();
+    let second = materialize_skill(&scope, &skill).unwrap();
+    assert_eq!(second.action, MaterializeAction::Written);
+    let contents = std::fs::read_to_string(skill_md(&scope, "code-slop-cleanup")).unwrap();
+    assert!(contents.contains("Now with extra rigor."));
+
+    // A third pass with the same content is a no-op.
+    let third = materialize_skill(&scope, &skill).unwrap();
+    assert_eq!(third.action, MaterializeAction::Unchanged);
+}
+
+#[tokio::test]
+async fn fork_protection_leaves_user_edited_file_and_doctor_flags_it() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home.clone());
+    let skill = tracedecay::automation::managed_skills::load_managed_skill(
+        &profile_root,
+        "code-slop-cleanup",
+    )
+    .await
+    .unwrap();
+    materialize_skill(&scope, &skill).unwrap();
+    let path = skill_md(&scope, "code-slop-cleanup");
+
+    // User edits the materialized body (the content-hash no longer matches).
+    let edited = format!(
+        "{}\n\n<!-- user note: keep this -->\n",
+        std::fs::read_to_string(&path).unwrap()
+    );
+    std::fs::write(&path, &edited).unwrap();
+
+    // Re-materialize: the reconciler must NOT clobber the fork.
+    let action = materialize_skill(&scope, &skill).unwrap();
+    assert_eq!(action.action, MaterializeAction::SkippedForked);
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), edited);
+
+    // Doctor flags the fork.
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill)).unwrap();
+    assert!(
+        drift.iter().any(
+            |d| matches!(d, SkillDrift::Forked { skill_id, .. } if skill_id == "code-slop-cleanup")
+        ),
+        "expected Forked drift, got {drift:?}"
+    );
+
+    // A deactivate reconcile must also refuse to delete the fork.
+    let removed = remove_materialized_skill(&scope, "code-slop-cleanup").unwrap();
+    assert_eq!(removed, RemoveAction::SkippedForked);
+    assert!(path.is_file(), "forked file must survive removal");
+}
+
+#[tokio::test]
+async fn foreign_file_is_never_touched_and_doctor_reports_conflict() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    // A user (or repo-local dev skill) already owns this slug — no provenance.
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home.clone());
+    let dir = scope.skills_dir().join("code-slop-cleanup");
+    std::fs::create_dir_all(&dir).unwrap();
+    let foreign = "---\nname: code-slop-cleanup\ndescription: hand-written\n---\n\nMine.\n";
+    std::fs::write(dir.join("SKILL.md"), foreign).unwrap();
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let skill = tracedecay::automation::managed_skills::load_managed_skill(
+        &profile_root,
+        "code-slop-cleanup",
+    )
+    .await
+    .unwrap();
+
+    let action = materialize_skill(&scope, &skill).unwrap();
+    assert_eq!(action.action, MaterializeAction::SkippedForeign);
+    assert_eq!(
+        std::fs::read_to_string(dir.join("SKILL.md")).unwrap(),
+        foreign
+    );
+
+    // Removal never touches a foreign file either.
+    assert_eq!(
+        remove_materialized_skill(&scope, "code-slop-cleanup").unwrap(),
+        RemoveAction::SkippedForeign
+    );
+
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill)).unwrap();
+    assert!(
+        drift
+            .iter()
+            .any(|d| matches!(d, SkillDrift::Conflict { .. })),
+        "expected Conflict drift, got {drift:?}"
+    );
+}
+
+#[tokio::test]
+async fn doctor_reports_missing_and_orphan_drift() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    // Active skill, nothing materialized yet -> Missing.
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let scopes = doctor_detected_scopes(&profile_root, &home, &home).unwrap();
+    let claude = scopes
+        .iter()
+        .find(|(scope, _)| scope.host == MaterializationHost::Claude)
+        .map(|(_, drift)| drift)
+        .unwrap();
+    assert!(
+        claude
+            .iter()
+            .any(|d| matches!(d, SkillDrift::Missing { .. })),
+        "expected Missing drift, got {claude:?}"
+    );
+
+    // Materialize, then deactivate WITHOUT reconciling -> Orphan on disk.
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home.clone());
+    let skill = tracedecay::automation::managed_skills::load_managed_skill(
+        &profile_root,
+        "code-slop-cleanup",
+    )
+    .await
+    .unwrap();
+    materialize_skill(&scope, &skill).unwrap();
+    let orphan_drift = doctor_scope(&scope, &[]).unwrap();
+    assert!(
+        orphan_drift.iter().any(
+            |d| matches!(d, SkillDrift::Orphan { skill_id, .. } if skill_id == "code-slop-cleanup")
+        ),
+        "expected Orphan drift, got {orphan_drift:?}"
+    );
+}
+
+#[tokio::test]
+async fn detect_scopes_only_covers_installed_hosts() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let project = root.join("project");
+    // Only Claude is installed globally; only Codex in the project.
+    std::fs::create_dir_all(home.join(".claude")).unwrap();
+    std::fs::create_dir_all(project.join(".codex")).unwrap();
+
+    let scopes = detect_scopes(&home, &project);
+    let described: Vec<String> = scopes.iter().map(MaterializationScope::describe).collect();
+    assert!(
+        described.contains(&"claude/global".to_string()),
+        "{described:?}"
+    );
+    assert!(
+        described.contains(&"codex/project".to_string()),
+        "{described:?}"
+    );
+    assert!(
+        !described.contains(&"codex/global".to_string()),
+        "{described:?}"
+    );
+    assert!(
+        !described.contains(&"claude/project".to_string()),
+        "{described:?}"
+    );
+}
+
+#[tokio::test]
+async fn reconcile_scope_removes_only_managed_orphans() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+    let _ = &profile_root;
+
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home.clone());
+    // A foreign dev skill sits alongside; reconcile with no active skills must
+    // leave it untouched and report nothing removed for it.
+    let foreign_dir = scope.skills_dir().join("dev-only");
+    std::fs::create_dir_all(&foreign_dir).unwrap();
+    std::fs::write(
+        foreign_dir.join("SKILL.md"),
+        "---\nname: dev-only\ndescription: repo dev skill\n---\n\nDev.\n",
+    )
+    .unwrap();
+
+    let report = reconcile_scope(&scope, &[]).unwrap();
+    assert!(
+        report.removed.is_empty(),
+        "foreign skill must not be enumerated for removal"
+    );
+    assert!(foreign_dir.join("SKILL.md").is_file());
+}


### PR DESCRIPTION
Implements the Hermes-parity skill lifecycle (user directive, fact #132): activating a managed skill now writes real SKILL.md files with provenance frontmatter (managed-by: tracedecay-automation + id + content hash) into project and global .claude/.codex skill dirs; disable removes only hash-matching managed files; user edits mark the skill forked and are never clobbered; doctor reports drift; tracedecay update reconciles; skill_writer auto-activates under the no-approval automation policy. 10 new lifecycle tests; live-demoed end to end (approve → 4 destinations materialized, fork detected, disable preserved the fork). Repo-local tracedecay-dev skills are out of scope by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)