### PR TITLE
feat: daemon auto-tracking of open PR branches

### DIFF
--- a/dashboard/settings/src/SettingsPanel.tsx
+++ b/dashboard/settings/src/SettingsPanel.tsx
@@ -48,7 +48,11 @@ export interface ProjectDraft {
   trackCallSites: boolean;
   gitIgnore: boolean;
   telemetryTimings: boolean;
+  autoTrackPrBranches: boolean;
+  autoTrackPrPollSecs: string;
 }
+
+const MIN_PR_POLL_SECS = 60;
 
 export interface UserDraft {
   uploadEnabled: boolean;
@@ -66,6 +70,8 @@ function projectDraftFrom(settings: SettingsPayload): ProjectDraft {
     trackCallSites: config.track_call_sites,
     gitIgnore: config.git_ignore,
     telemetryTimings: config.telemetry.timings,
+    autoTrackPrBranches: Boolean(config.sync?.auto_track_pr_branches),
+    autoTrackPrPollSecs: String(config.sync?.auto_track_pr_poll_secs ?? 300),
   };
 }
 
@@ -110,6 +116,20 @@ export function projectPatchFrom(
   }
   if (!saved || draft.telemetryTimings !== saved.telemetryTimings) {
     patch.telemetry = { timings: draft.telemetryTimings };
+  }
+
+  const pollSecs = Number(draft.autoTrackPrPollSecs);
+  const prBranchesChanged =
+    !saved || draft.autoTrackPrBranches !== saved.autoTrackPrBranches;
+  const pollSecsChanged = !saved || pollSecs !== Number(saved.autoTrackPrPollSecs);
+  if (prBranchesChanged || pollSecsChanged) {
+    patch.sync = {};
+    if (prBranchesChanged) {
+      patch.sync.auto_track_pr_branches = draft.autoTrackPrBranches;
+    }
+    if (pollSecsChanged) {
+      patch.sync.auto_track_pr_poll_secs = pollSecs;
+    }
   }
 
   return patch;
@@ -384,6 +404,59 @@ export default function SettingsPanel() {
               />
               <span>Capture timing telemetry</span>
             </label>
+
+            <label className="tdst-toggle">
+              <input
+                type="checkbox"
+                checked={projectDraft.autoTrackPrBranches}
+                onChange={(event) =>
+                  updateProject({ autoTrackPrBranches: event.currentTarget.checked })
+                }
+                disabled={projectSaving}
+                aria-label="Auto-track open PR branches"
+              />
+              <span>Auto-track open PR branches</span>
+            </label>
+            <span className="tdst-field-hint">
+              The daemon tracks every open PR branch on the repo&apos;s GitHub <code>origin</code> so{" "}
+              <code>branch_diff</code>/<code>branch_search</code> work against all open PRs. Same-repo
+              PRs only; forks are skipped. Takes effect after a daemon restart.
+            </span>
+
+            <label className="tdst-field tdst-field-inline">
+              <span className="tdst-field-label">PR poll interval (seconds)</span>
+              <input
+                type="number"
+                min={MIN_PR_POLL_SECS}
+                value={projectDraft.autoTrackPrPollSecs}
+                onChange={(event) =>
+                  updateProject({ autoTrackPrPollSecs: event.currentTarget.value })
+                }
+                disabled={projectSaving || !projectDraft.autoTrackPrBranches}
+                aria-label="PR auto-track poll interval"
+              />
+              {projectFieldErrors.auto_track_pr_poll_secs && (
+                <span className="tdst-field-error">
+                  {projectFieldErrors.auto_track_pr_poll_secs}
+                </span>
+              )}
+            </label>
+
+            {settings.project.pr_autotrack &&
+              settings.project.pr_autotrack.tracked.length > 0 && (
+                <div className="tdst-kv">
+                  {settings.project.pr_autotrack.tracked.map((entry) => (
+                    <React.Fragment key={entry.branch}>
+                      <span className="tdst-kv-key">
+                        <code>{entry.branch}</code>
+                      </span>
+                      <span>
+                        PR #{entry.pr} (head <code>{entry.head_branch}</code>)
+                      </span>
+                    </React.Fragment>
+                  ))}
+                </div>
+              )}
 
             <p className="tdst-section-hint">
               Changing these requires a re-sync before the code graph reflects them.

--- a/dashboard/settings/src/types.ts
+++ b/dashboard/settings/src/types.ts
@@ -8,16 +8,36 @@ export interface ProjectConfig {
   track_call_sites: boolean;
   git_ignore: boolean;
   telemetry: TelemetryConfig;
+  sync: SyncConfig;
 }
 
 export interface TelemetryConfig {
   timings: boolean;
 }
 
+// The server serializes the full `[sync]` table; the settings panel only edits
+// the PR auto-tracking fields, so the rest is captured loosely.
+export interface SyncConfig {
+  auto_track_pr_branches: boolean;
+  auto_track_pr_poll_secs: number;
+  [key: string]: unknown;
+}
+
+export interface TrackedPrBranch {
+  branch: string;
+  pr: number;
+  head_branch: string;
+}
+
+export interface PrAutotrackInfo {
+  tracked: TrackedPrBranch[];
+}
+
 export interface ProjectSettings {
   config_path: string;
   config: ProjectConfig;
   tracedecay_dir_gitignored: boolean;
+  pr_autotrack?: PrAutotrackInfo;
 }
 
 export interface UserSettings {
@@ -87,6 +107,12 @@ export interface ProjectSettingsPatch {
   track_call_sites?: boolean;
   git_ignore?: boolean;
   telemetry?: Partial<TelemetryConfig>;
+  sync?: SyncSettingsPatch;
+}
+
+export interface SyncSettingsPatch {
+  auto_track_pr_branches?: boolean;
+  auto_track_pr_poll_secs?: number;
 }
 
 export interface UserSettingsPatch {

--- a/dashboard/test/settings-panel-patches.vitest.ts
+++ b/dashboard/test/settings-panel-patches.vitest.ts
@@ -11,6 +11,8 @@ describe("settings panel patch builders", () => {
       trackCallSites: true,
       gitIgnore: true,
       telemetryTimings: true,
+      autoTrackPrBranches: false,
+      autoTrackPrPollSecs: "300",
     };
     const draft = {
       ...saved,
@@ -19,6 +21,29 @@ describe("settings panel patch builders", () => {
 
     expect(projectPatchFrom(draft, saved)).toEqual({
       include: ["src/**", "README.md", "examples/**"],
+    });
+  });
+
+  it("sends PR auto-tracking changes under the sync key", () => {
+    const saved = {
+      includeText: "src/**",
+      excludeText: "target/**",
+      maxFileSize: "1048576",
+      extractDocstrings: true,
+      trackCallSites: true,
+      gitIgnore: true,
+      telemetryTimings: true,
+      autoTrackPrBranches: false,
+      autoTrackPrPollSecs: "300",
+    };
+    const draft = {
+      ...saved,
+      autoTrackPrBranches: true,
+      autoTrackPrPollSecs: "120",
+    };
+
+    expect(projectPatchFrom(draft, saved)).toEqual({
+      sync: { auto_track_pr_branches: true, auto_track_pr_poll_secs: 120 },
     });
   });
 

--- a/dashboard/test/settings-panel.vitest.tsx
+++ b/dashboard/test/settings-panel.vitest.tsx
@@ -20,8 +20,13 @@ function basePayload(): SettingsPayload {
         telemetry: {
           timings: true,
         },
+        sync: {
+          auto_track_pr_branches: false,
+          auto_track_pr_poll_secs: 300,
+        },
       },
       tracedecay_dir_gitignored: true,
+      pr_autotrack: { tracked: [] },
     },
     user: {
       config_path: "/profile/.tracedecay/config.toml",

--- a/docs/BRANCHING-USER-GUIDE.md
+++ b/docs/BRANCHING-USER-GUIDE.md
@@ -214,6 +214,67 @@ Multi-branch is fully backward compatible:
 - `tracedecay sync` and `tracedecay sync --force` continue to work. With multi-branch active,
   they sync the current branch's database.
 
+## Auto-tracking open PR branches (daemon)
+
+The daemon can automatically track every open pull request on a repo's GitHub
+`origin` remote, so `tracedecay_branch_search` / `tracedecay_branch_diff` and
+graph queries work against every open PR without running `tracedecay branch add`
+by hand. When a PR merges or closes, its branch is untracked and its per-branch
+store is cleaned up. The feature is **off by default**.
+
+### Enabling it
+
+Per project, via the CLI:
+
+```
+tracedecay branch autotrack enable                 # default 300s poll cadence
+tracedecay branch autotrack enable --poll-secs 120 # custom cadence (min 60)
+tracedecay branch autotrack disable
+tracedecay branch autotrack status                 # show state + tracked PR branches
+```
+
+or in the dashboard **Settings → Indexing → Auto-track open PR branches**, or by
+editing the `[sync]` table in the project `config.json`:
+
+```json
+{
+  "sync": {
+    "auto_track_pr_branches": true,
+    "auto_track_pr_poll_secs": 300
+  }
+}
+```
+
+Both keys default off/`300` and are back-compatible: a `config.json` predating
+them keeps the feature disabled. Environment overrides
+`TRACEDECAY_SYNC_AUTO_TRACK_PR_BRANCHES` and
+`TRACEDECAY_SYNC_AUTO_TRACK_PR_POLL_SECS` apply on top. The poll interval is
+clamped up to a 60-second floor. Changes take effect after a daemon restart
+(`tracedecay daemon restart`).
+
+### How it works
+
+Each poll, the daemon discovers open PR heads — via `gh pr list` when `gh` is on
+`PATH` and `origin` is GitHub, otherwise via `git ls-remote origin
+'refs/pull/*/head'`. For each new same-repo PR it fetches `refs/pull/<N>/head`,
+checks it out into a linked worktree under the store's `pr-worktrees/` directory
+on a synthetic branch `pr/<N>`, and tracks that worktree exactly like any other
+branch (so the PR's own content is indexed, not your current checkout). Tracked
+PR branches appear in `tracedecay branch list` as `pr/<N>`. To keep a repo with
+many open PRs from stampeding, at most 10 new PR branches are tracked per poll
+cycle; the rest ramp up on subsequent cycles.
+
+The daemon logs structured events: `event=pr_autotrack action=tracked|untracked|skipped
+branch=pr/<N> pr=<N>` per change and an `action=poll` summary each cycle.
+
+### Scope: same-repo PRs only
+
+Only PRs whose head branch lives on the repo itself are tracked. Fork PRs (head
+on a different repository) are **skipped** with a logged reason
+(`action=skipped reason=fork`). Discovery treats a PR as a fork when its head
+SHA matches no `refs/heads/*` ref on `origin` (or, via `gh`, when
+`isCrossRepository` is true).
+
 ## FAQ
 
 **Does rebasing a branch break its database?**

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -569,6 +569,23 @@ fn clone_or_copy_db(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::copy(src, dst).map(|_| ())
 }
 
+/// Untracks a single non-default branch: removes its metadata entry and deletes
+/// its DB file (plus `-wal`/`-shm` sidecars). Returns `true` when an entry was
+/// removed. The default branch is never removed. This is the shared removal path
+/// used by `tracedecay branch remove` and the PR-autotrack lifecycle so both
+/// clean up identically.
+pub fn remove_tracked_branch_store(tracedecay_dir: &Path, branch: &str) -> bool {
+    let Some(mut meta) = crate::branch_meta::load_branch_meta(tracedecay_dir) else {
+        return false;
+    };
+    let Some(entry) = meta.remove_branch(branch) else {
+        return false;
+    };
+    remove_branch_db_files(&tracedecay_dir.join(&entry.db_file));
+    let _ = crate::branch_meta::save_branch_meta(tracedecay_dir, &meta);
+    true
+}
+
 /// Returns true if `branch` currently exists as a local `refs/heads/*` ref.
 ///
 /// Thin alias over [`local_branch_exists`] under the name the branch-store GC

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -880,6 +880,36 @@ pub enum BranchAction {
         #[arg(short, long)]
         path: Option<String>,
     },
+    /// Configure daemon auto-tracking of open PR branches
+    Autotrack {
+        #[command(subcommand)]
+        action: BranchAutotrackAction,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum BranchAutotrackAction {
+    /// Show whether PR auto-tracking is enabled and list tracked PR branches
+    Status {
+        /// Project path (default: current directory)
+        #[arg(short, long)]
+        path: Option<String>,
+    },
+    /// Enable PR auto-tracking for this project (daemon restart picks it up)
+    Enable {
+        /// Poll interval in seconds (minimum 60; default keeps the current value)
+        #[arg(long)]
+        poll_secs: Option<u64>,
+        /// Project path (default: current directory)
+        #[arg(short, long)]
+        path: Option<String>,
+    },
+    /// Disable PR auto-tracking for this project
+    Disable {
+        /// Project path (default: current directory)
+        #[arg(short, long)]
+        path: Option<String>,
+    },
 }
 
 #[cfg(test)]

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -470,6 +470,30 @@ fn status_and_branch_add_commands_dispatch_to_expected_variants() {
 }
 
 #[test]
+fn branch_autotrack_enable_parses_poll_secs_and_path() {
+    use super::BranchAutotrackAction;
+    let cli = Cli::try_parse_from([
+        "tracedecay",
+        "branch",
+        "autotrack",
+        "enable",
+        "--poll-secs",
+        "120",
+        "--path",
+        "/tmp/project",
+    ])
+    .expect("branch autotrack enable should parse");
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Branch {
+            action: BranchAction::Autotrack {
+                action: BranchAutotrackAction::Enable { poll_secs, path }
+            }
+        }) if poll_secs == Some(120) && path.as_deref() == Some("/tmp/project")
+    ));
+}
+
+#[test]
 fn init_and_sync_parse_runtime_skip_and_include_folders() {
     let init = Cli::try_parse_from([
         "tracedecay",

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -668,6 +668,78 @@ pub(crate) async fn handle_branch_action(action: BranchAction) -> tracedecay::er
                 );
             }
         }
+        BranchAction::Autotrack { action } => {
+            handle_branch_autotrack_action(action).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Reads or mutates the project-scoped `sync.auto_track_pr_branches` setting and
+/// reports the daemon's PR-autotrack status for a project.
+async fn handle_branch_autotrack_action(
+    action: crate::cli::BranchAutotrackAction,
+) -> tracedecay::errors::Result<()> {
+    use crate::cli::BranchAutotrackAction;
+    use tracedecay::config::{
+        MIN_AUTO_TRACK_PR_POLL_SECS, load_config_with_identity, save_config_with_identity,
+    };
+
+    match action {
+        BranchAutotrackAction::Status { path } => {
+            let project_path = tracedecay::config::resolve_path(path);
+            let config = load_config_with_identity(&project_path).await?;
+            let sync = &config.sync;
+            eprintln!(
+                "PR auto-tracking: {}",
+                if sync.auto_track_pr_branches {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
+            eprintln!(
+                "Poll interval: {}s (effective {}s)",
+                sync.auto_track_pr_poll_secs,
+                sync.effective_auto_track_pr_poll_secs()
+            );
+            #[cfg(unix)]
+            {
+                let data_root = resolve_branch_data_root(&project_path).await;
+                let managed = tracedecay::daemon::pr_autotrack::managed_summary(&data_root);
+                if managed.is_empty() {
+                    eprintln!("Tracked PR branches: none");
+                } else {
+                    eprintln!("Tracked PR branches:");
+                    for entry in managed {
+                        eprintln!(
+                            "  {} — PR #{} (head {})",
+                            entry.branch, entry.pr, entry.head_branch
+                        );
+                    }
+                }
+            }
+        }
+        BranchAutotrackAction::Enable { poll_secs, path } => {
+            let project_path = tracedecay::config::resolve_path(path);
+            let mut config = load_config_with_identity(&project_path).await?;
+            config.sync.auto_track_pr_branches = true;
+            if let Some(secs) = poll_secs {
+                config.sync.auto_track_pr_poll_secs = secs.max(MIN_AUTO_TRACK_PR_POLL_SECS);
+            }
+            save_config_with_identity(&project_path, &config).await?;
+            eprintln!(
+                "\x1b[32m✔\x1b[0m PR auto-tracking enabled (poll every {}s). Restart the daemon (`tracedecay daemon restart`) to apply.",
+                config.sync.effective_auto_track_pr_poll_secs()
+            );
+        }
+        BranchAutotrackAction::Disable { path } => {
+            let project_path = tracedecay::config::resolve_path(path);
+            let mut config = load_config_with_identity(&project_path).await?;
+            config.sync.auto_track_pr_branches = false;
+            save_config_with_identity(&project_path, &config).await?;
+            eprintln!("\x1b[32m✔\x1b[0m PR auto-tracking disabled.");
+        }
     }
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,16 @@ fn default_sync_orphan_db_gc_days() -> u64 {
 fn default_sync_auto_init() -> bool {
     true
 }
+fn default_sync_auto_track_pr_branches() -> bool {
+    false
+}
+fn default_sync_auto_track_pr_poll_secs() -> u64 {
+    300
+}
+/// Floor for the PR-autotrack poll interval; polls faster than this hammer the
+/// GitHub API / `git ls-remote` needlessly, so any smaller configured value is
+/// clamped up to this.
+pub const MIN_AUTO_TRACK_PR_POLL_SECS: u64 = 60;
 
 fn default_telemetry_timings() -> bool {
     true
@@ -271,6 +281,25 @@ pub struct SyncConfig {
     /// Auto-initialise never-indexed repos on first contact.
     #[serde(default = "default_sync_auto_init")]
     pub auto_init: bool,
+    /// Enable the daemon PR-branch auto-tracking mode: when on, the daemon polls
+    /// the repo's GitHub remote for open PRs and tracks/untracks each PR head
+    /// branch through the normal branch-tracking machinery. Off by default for
+    /// back-compat.
+    #[serde(default = "default_sync_auto_track_pr_branches")]
+    pub auto_track_pr_branches: bool,
+    /// Poll cadence (seconds) for PR-branch auto-tracking discovery. Clamped up
+    /// to [`MIN_AUTO_TRACK_PR_POLL_SECS`] at read time.
+    #[serde(default = "default_sync_auto_track_pr_poll_secs")]
+    pub auto_track_pr_poll_secs: u64,
+}
+
+impl SyncConfig {
+    /// The effective PR-autotrack poll interval, never below the safety floor.
+    #[must_use]
+    pub fn effective_auto_track_pr_poll_secs(&self) -> u64 {
+        self.auto_track_pr_poll_secs
+            .max(MIN_AUTO_TRACK_PR_POLL_SECS)
+    }
 }
 
 impl Default for SyncConfig {
@@ -290,6 +319,8 @@ impl Default for SyncConfig {
             branch_gc_days: default_sync_branch_gc_days(),
             orphan_db_gc_days: default_sync_orphan_db_gc_days(),
             auto_init: default_sync_auto_init(),
+            auto_track_pr_branches: default_sync_auto_track_pr_branches(),
+            auto_track_pr_poll_secs: default_sync_auto_track_pr_poll_secs(),
         }
     }
 }
@@ -363,6 +394,12 @@ impl SyncConfig {
         }
         if let Some(value) = env_bool("SYNC_AUTO_INIT") {
             self.auto_init = value;
+        }
+        if let Some(value) = env_bool("SYNC_AUTO_TRACK_PR_BRANCHES") {
+            self.auto_track_pr_branches = value;
+        }
+        if let Some(value) = env_parse("SYNC_AUTO_TRACK_PR_POLL_SECS") {
+            self.auto_track_pr_poll_secs = value;
         }
         self
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -328,6 +328,62 @@ fn partial_sync_table_fills_missing_fields_with_defaults() {
 }
 
 #[test]
+fn pr_autotrack_defaults_off_and_survives_missing_keys() {
+    // Back-compat: a config predating the PR-autotrack keys must default the
+    // feature OFF and to the 300s poll cadence.
+    let json = r#"{
+        "version": 1,
+        "root_dir": "/tmp/proj",
+        "exclude": [],
+        "max_file_size": 1048576,
+        "extract_docstrings": true,
+        "track_call_sites": true,
+        "sync": { "auto_watch": true }
+    }"#;
+    let parsed: TraceDecayConfig = serde_json::from_str(json).unwrap();
+    assert!(!parsed.sync.auto_track_pr_branches);
+    assert_eq!(parsed.sync.auto_track_pr_poll_secs, 300);
+    assert_eq!(parsed.sync.effective_auto_track_pr_poll_secs(), 300);
+}
+
+#[test]
+fn pr_autotrack_round_trips_and_clamps_poll_floor() {
+    let json = r#"{
+        "version": 1,
+        "root_dir": "/tmp/proj",
+        "exclude": [],
+        "max_file_size": 1048576,
+        "extract_docstrings": true,
+        "track_call_sites": true,
+        "sync": { "auto_track_pr_branches": true, "auto_track_pr_poll_secs": 5 }
+    }"#;
+    let parsed: TraceDecayConfig = serde_json::from_str(json).unwrap();
+    assert!(parsed.sync.auto_track_pr_branches);
+    assert_eq!(parsed.sync.auto_track_pr_poll_secs, 5);
+    // A too-small interval is clamped up to the safety floor.
+    assert_eq!(
+        parsed.sync.effective_auto_track_pr_poll_secs(),
+        super::MIN_AUTO_TRACK_PR_POLL_SECS
+    );
+
+    // Serialize → deserialize preserves the raw values.
+    let round = serde_json::to_string(&parsed).unwrap();
+    let reparsed: TraceDecayConfig = serde_json::from_str(&round).unwrap();
+    assert_eq!(reparsed.sync, parsed.sync);
+}
+
+#[test]
+fn pr_autotrack_env_overrides() {
+    let _lock = lock_user_data_dir_test_env();
+    let _enable = EnvRestore::set("TRACEDECAY_SYNC_AUTO_TRACK_PR_BRANCHES", "true");
+    let _poll = EnvRestore::set("TRACEDECAY_SYNC_AUTO_TRACK_PR_POLL_SECS", "120");
+
+    let overridden = super::SyncConfig::default().with_env_overrides();
+    assert!(overridden.auto_track_pr_branches);
+    assert_eq!(overridden.auto_track_pr_poll_secs, 120);
+}
+
+#[test]
 fn sync_config_env_overrides_bool_and_int() {
     let _lock = lock_user_data_dir_test_env();
     let _watch = EnvRestore::set("TRACEDECAY_SYNC_AUTO_WATCH", "false");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -38,6 +38,8 @@ const DAEMON_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(45);
 
 #[cfg(unix)]
 mod git_watch;
+#[cfg(unix)]
+pub mod pr_autotrack;
 mod service;
 pub use service::{
     DaemonServiceSpec, daemon_reachable, default_socket_path, install_service,
@@ -1270,6 +1272,10 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
     let git_watcher =
         git_watch::GitWatcher::new(crate::config::SyncConfig::default().with_env_overrides());
     git_watcher.spawn(crate::global_db::global_db_path()).await;
+    // PR-branch auto-tracking runs independently of the metadata watcher: it is
+    // gated per-project on `sync.auto_track_pr_branches` (default off), so this
+    // loop is inert unless a project opts in.
+    pr_autotrack::spawn(crate::global_db::global_db_path());
     let engine = DaemonEngine::default().with_git_watcher(git_watcher);
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
 

--- a/src/daemon/pr_autotrack.rs
+++ b/src/daemon/pr_autotrack.rs
@@ -1,0 +1,667 @@
+//! Daemon PR-branch auto-tracking (opt-in via `sync.auto_track_pr_branches`).
+//!
+//! # What this does
+//!
+//! When a project enables `sync.auto_track_pr_branches`, a daemon poll loop
+//! discovers the open pull requests on the repo's `origin` remote and tracks
+//! each PR head branch through the *existing* branch-tracking machinery so
+//! `branch_diff` / `branch_search` / `branch_list` and graph queries work against
+//! every open PR without anyone running `tracedecay branch add`. When a PR closes
+//! or merges, its branch is untracked and its per-branch store is cleaned up.
+//!
+//! # Why worktrees
+//!
+//! [`crate::tracedecay::indexing`] syncs a branch DB by scanning the *working
+//! tree* at the passed project root — it does not read blobs out of a git ref.
+//! So to index a PR head accurately the head must be checked out somewhere. We
+//! therefore fetch each PR head into a deterministic local ref
+//! (`refs/tracedecay/pr/<N>`), check it out into a linked worktree on a local
+//! branch named `pr/<N>` under the store's `pr-worktrees/` dir (a *named* branch,
+//! not detached HEAD — the branch-drift guard in sync refuses a detached
+//! worktree), and track that worktree exactly the way the
+//! git-metadata watcher tracks any other linked worktree
+//! ([`crate::tracedecay::TraceDecay::add_branch_tracking_with_options`]). A branch
+//! can only be checked out in one worktree at a time, so we never reuse the PR's
+//! real head-branch name (which the user may have checked out); instead every
+//! PR-managed entry is tracked under the synthetic label `pr/<N>`. That also keeps
+//! PR-managed entries cleanly separable from the user's own tracked branches, so
+//! we never untrack a branch a human added.
+//!
+//! # Scope decision: same-repo PRs only
+//!
+//! Fork PRs (head on a different repository) are **skipped** with a logged reason.
+//! Discovery classifies a PR as a fork when its head SHA matches no `refs/heads/*`
+//! ref on `origin` (or, via `gh`, when `isCrossRepository` is true). Supporting
+//! forks would mean fetching untrusted `refs/pull/N/head` from arbitrary
+//! repositories; that is deliberately out of scope for the first cut.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::time::Instant;
+
+use crate::config::SyncConfig;
+use crate::tracedecay::{TraceDecay, TraceDecayOpenOptions};
+
+use super::log_daemon_event;
+
+/// Filename of the PR-autotrack state sidecar, stored next to `branch-meta.json`
+/// in the project's store data root.
+const STATE_FILENAME: &str = "pr-autotrack.json";
+/// Maximum number of *new* PR branches tracked per poll cycle, so a repo with
+/// 100 open PRs ramps up gradually instead of forking 100 syncs at once.
+const MAX_NEW_TRACKS_PER_CYCLE: usize = 10;
+/// Base cadence of the poll loop; per-project intervals are honored on top of
+/// this floor via a last-run map.
+const BASE_TICK: Duration = Duration::from_mins(1);
+
+/// A PR head discovered on the origin remote that we can track (same-repo).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredPr {
+    /// PR number.
+    pub number: u64,
+    /// The PR's head branch name (for display only; tracking uses `pr/<N>`).
+    pub head_branch: String,
+}
+
+/// The result of one discovery pass over a repo's `origin` remote.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PrDiscovery {
+    /// Open, same-repo PR heads that can be tracked.
+    pub open: Vec<DiscoveredPr>,
+    /// PR numbers skipped because their head lives on a fork.
+    pub skipped_forks: Vec<u64>,
+}
+
+/// A currently-managed PR branch, persisted in the state sidecar.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManagedPr {
+    /// PR number.
+    pub pr: u64,
+    /// The PR's head branch name (display only).
+    pub head_branch: String,
+    /// Path to the linked worktree checked out on the `pr/<N>` branch.
+    pub worktree: PathBuf,
+    /// The deterministic local ref the PR head was fetched into.
+    pub tracking_ref: String,
+}
+
+/// PR-autotrack persistent state: label (`pr/<N>`) → managed entry.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PrAutotrackState {
+    /// Managed PR branches keyed by their tracking label (`pr/<N>`).
+    #[serde(default)]
+    pub managed: BTreeMap<String, ManagedPr>,
+}
+
+/// The tracking label a PR number maps to (`pr/<N>`).
+fn pr_label(number: u64) -> String {
+    format!("pr/{number}")
+}
+
+/// The deterministic local ref a PR head is fetched into.
+fn pr_tracking_ref(number: u64) -> String {
+    format!("refs/tracedecay/pr/{number}")
+}
+
+fn state_path(data_root: &Path) -> PathBuf {
+    data_root.join(STATE_FILENAME)
+}
+
+/// Loads the PR-autotrack state, returning an empty state when absent/corrupt.
+pub fn load_state(data_root: &Path) -> PrAutotrackState {
+    let path = state_path(data_root);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return PrAutotrackState::default();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+fn save_state(data_root: &Path, state: &PrAutotrackState) -> std::io::Result<()> {
+    let path = state_path(data_root);
+    let json = serde_json::to_string_pretty(state).map_err(std::io::Error::other)?;
+    let temp = path.with_extension("json.tmp");
+    crate::storage::PrivateStoreIo::write_file_atomically(&path, &temp, json.as_bytes())
+}
+
+/// A summary of managed PR branches for status surfaces (dashboard / CLI).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ManagedPrSummary {
+    /// Tracking label (`pr/<N>`).
+    pub branch: String,
+    /// PR number.
+    pub pr: u64,
+    /// PR head branch name.
+    pub head_branch: String,
+}
+
+/// Returns the managed PR branches (sorted by PR number) for a project's store.
+pub fn managed_summary(data_root: &Path) -> Vec<ManagedPrSummary> {
+    let state = load_state(data_root);
+    let mut out: Vec<ManagedPrSummary> = state
+        .managed
+        .into_iter()
+        .map(|(branch, m)| ManagedPrSummary {
+            branch,
+            pr: m.pr,
+            head_branch: m.head_branch,
+        })
+        .collect();
+    out.sort_by_key(|s| s.pr);
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Discovery (pure parsers + one impure orchestrator)
+// ---------------------------------------------------------------------------
+
+/// One entry from `gh pr list --json number,headRefName,state,isCrossRepository`.
+#[derive(Debug, Deserialize)]
+struct GhPr {
+    number: u64,
+    #[serde(default, rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default, rename = "isCrossRepository")]
+    is_cross_repository: bool,
+}
+
+/// Parses `gh pr list` JSON into a discovery result. Open same-repo PRs go to
+/// `open`; open cross-repository PRs are recorded as skipped forks; non-open PRs
+/// are ignored.
+fn parse_gh_pr_list(json: &str) -> serde_json::Result<PrDiscovery> {
+    let prs: Vec<GhPr> = serde_json::from_str(json)?;
+    let mut discovery = PrDiscovery::default();
+    for pr in prs {
+        if !pr.state.eq_ignore_ascii_case("open") {
+            continue;
+        }
+        if pr.is_cross_repository || pr.head_ref_name.is_empty() {
+            discovery.skipped_forks.push(pr.number);
+        } else {
+            discovery.open.push(DiscoveredPr {
+                number: pr.number,
+                head_branch: pr.head_ref_name,
+            });
+        }
+    }
+    Ok(discovery)
+}
+
+/// Parses `git ls-remote --heads origin` into a `sha → branch` map.
+fn parse_ls_remote_heads(output: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in output.lines() {
+        let Some((sha, refname)) = split_ls_remote_line(line) else {
+            continue;
+        };
+        if let Some(branch) = refname.strip_prefix("refs/heads/") {
+            map.insert(sha.to_string(), branch.to_string());
+        }
+    }
+    map
+}
+
+/// Parses `git ls-remote origin 'refs/pull/*/head'` into `(pr_number, sha)`
+/// pairs, ignoring `refs/pull/*/merge` and malformed lines.
+fn parse_ls_remote_pull_heads(output: &str) -> Vec<(u64, String)> {
+    let mut out = Vec::new();
+    for line in output.lines() {
+        let Some((sha, refname)) = split_ls_remote_line(line) else {
+            continue;
+        };
+        let Some(rest) = refname.strip_prefix("refs/pull/") else {
+            continue;
+        };
+        let Some(num_str) = rest.strip_suffix("/head") else {
+            continue;
+        };
+        if let Ok(number) = num_str.parse::<u64>() {
+            out.push((number, sha.to_string()));
+        }
+    }
+    out
+}
+
+fn split_ls_remote_line(line: &str) -> Option<(&str, &str)> {
+    let mut parts = line.split_whitespace();
+    let sha = parts.next()?;
+    let refname = parts.next()?;
+    if sha.is_empty() || refname.is_empty() {
+        return None;
+    }
+    Some((sha, refname))
+}
+
+/// Maps PR head SHAs to branch names via the origin's `refs/heads/*` SHA index.
+/// A PR whose head SHA matches a head ref is a same-repo PR (tracked under
+/// `head_branch`); one that matches nothing is treated as a fork and skipped.
+fn map_pull_heads_to_branches(
+    pull_heads: &[(u64, String)],
+    head_shas: &HashMap<String, String>,
+) -> PrDiscovery {
+    let mut discovery = PrDiscovery::default();
+    for (number, sha) in pull_heads {
+        match head_shas.get(sha) {
+            Some(branch) => discovery.open.push(DiscoveredPr {
+                number: *number,
+                head_branch: branch.clone(),
+            }),
+            None => discovery.skipped_forks.push(*number),
+        }
+    }
+    discovery.open.sort_by_key(|d| d.number);
+    discovery.skipped_forks.sort_unstable();
+    discovery
+}
+
+fn run_git(repo_root: &Path, args: &[&str]) -> Option<std::process::Output> {
+    std::process::Command::new(crate::git::git_program())
+        .args(args)
+        .current_dir(repo_root)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+}
+
+fn origin_is_github(repo_root: &Path) -> bool {
+    run_git(repo_root, &["remote", "get-url", "origin"])
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .is_some_and(|url| url.contains("github.com"))
+}
+
+fn gh_available() -> bool {
+    std::process::Command::new("gh")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Discovers open PR head branches on the repo's `origin` remote.
+///
+/// Prefers `gh pr list` when `gh` is on PATH and `origin` is GitHub; otherwise
+/// falls back to `git ls-remote` and SHA-matching. Same-repo PRs are returned in
+/// `open`; fork PRs are recorded in `skipped_forks`.
+pub fn discover_open_prs(repo_root: &Path) -> PrDiscovery {
+    if origin_is_github(repo_root) && gh_available() {
+        if let Some(discovery) = discover_via_gh(repo_root) {
+            return discovery;
+        }
+    }
+    discover_via_ls_remote(repo_root)
+}
+
+fn discover_via_gh(repo_root: &Path) -> Option<PrDiscovery> {
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,headRefName,state,isCrossRepository",
+        ])
+        .current_dir(repo_root)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let json = String::from_utf8(output.stdout).ok()?;
+    parse_gh_pr_list(&json).ok()
+}
+
+fn discover_via_ls_remote(repo_root: &Path) -> PrDiscovery {
+    let pull_heads = run_git(repo_root, &["ls-remote", "origin", "refs/pull/*/head"])
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|out| parse_ls_remote_pull_heads(&out))
+        .unwrap_or_default();
+    let head_shas = run_git(repo_root, &["ls-remote", "--heads", "origin"])
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|out| parse_ls_remote_heads(&out))
+        .unwrap_or_default();
+    map_pull_heads_to_branches(&pull_heads, &head_shas)
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle reconciliation
+// ---------------------------------------------------------------------------
+
+/// A summary of what one reconcile pass changed, for logging and tests.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Labels (`pr/<N>`) newly tracked this pass.
+    pub tracked: Vec<String>,
+    /// Labels untracked this pass (PR closed/merged).
+    pub untracked: Vec<String>,
+    /// PR numbers skipped as forks.
+    pub skipped_forks: Vec<u64>,
+    /// True when the per-cycle new-track cap held some additions back.
+    pub capped: bool,
+}
+
+/// Reconciles the managed PR set against a discovery result.
+///
+/// Additions are bounded by `cap` new tracks per call; removals (closed/merged
+/// PRs) are always processed. Idempotent: PRs already managed and still open are
+/// left untouched. State is persisted before returning.
+pub async fn reconcile_project(
+    repo_root: &Path,
+    data_root: &Path,
+    discovery: &PrDiscovery,
+    cap: usize,
+) -> ReconcileReport {
+    let mut state = load_state(data_root);
+    let mut report = ReconcileReport {
+        skipped_forks: discovery.skipped_forks.clone(),
+        ..Default::default()
+    };
+
+    // Desired label → discovered PR.
+    let desired: BTreeMap<String, &DiscoveredPr> = discovery
+        .open
+        .iter()
+        .map(|pr| (pr_label(pr.number), pr))
+        .collect();
+
+    // Removals first (cheap, unblocks disk) — managed entries no longer open.
+    let stale: Vec<String> = state
+        .managed
+        .keys()
+        .filter(|label| !desired.contains_key(*label))
+        .cloned()
+        .collect();
+    for label in stale {
+        if let Some(managed) = state.managed.get(&label).cloned() {
+            untrack_pr(repo_root, data_root, &label, &managed).await;
+            state.managed.remove(&label);
+            report.untracked.push(label.clone());
+            log_daemon_event(
+                "pr_autotrack",
+                &[
+                    ("project", repo_root.display().to_string()),
+                    ("action", "untracked".to_string()),
+                    ("branch", label),
+                    ("pr", managed.pr.to_string()),
+                ],
+            );
+        }
+    }
+
+    // Additions, capped per cycle.
+    let mut added = 0usize;
+    for (label, pr) in &desired {
+        if state.managed.contains_key(label) {
+            continue; // idempotent: already tracked
+        }
+        if added >= cap {
+            report.capped = true;
+            break;
+        }
+        match track_pr(repo_root, data_root, pr).await {
+            Ok(managed) => {
+                state.managed.insert(label.clone(), managed);
+                report.tracked.push(label.clone());
+                added += 1;
+                log_daemon_event(
+                    "pr_autotrack",
+                    &[
+                        ("project", repo_root.display().to_string()),
+                        ("action", "tracked".to_string()),
+                        ("branch", label.clone()),
+                        ("pr", pr.number.to_string()),
+                        ("head", pr.head_branch.clone()),
+                    ],
+                );
+            }
+            Err(reason) => {
+                log_daemon_event(
+                    "pr_autotrack",
+                    &[
+                        ("project", repo_root.display().to_string()),
+                        ("action", "skipped".to_string()),
+                        ("branch", label.clone()),
+                        ("pr", pr.number.to_string()),
+                        ("reason", reason),
+                    ],
+                );
+            }
+        }
+    }
+
+    for pr in &discovery.skipped_forks {
+        log_daemon_event(
+            "pr_autotrack",
+            &[
+                ("project", repo_root.display().to_string()),
+                ("action", "skipped".to_string()),
+                ("pr", pr.to_string()),
+                ("reason", "fork".to_string()),
+            ],
+        );
+    }
+
+    let _ = save_state(data_root, &state);
+    report
+}
+
+/// Fetches a PR head, checks it out into a detached linked worktree, and tracks
+/// that worktree under the `pr/<N>` label. Returns the managed record.
+async fn track_pr(
+    repo_root: &Path,
+    data_root: &Path,
+    pr: &DiscoveredPr,
+) -> std::result::Result<ManagedPr, String> {
+    let label = pr_label(pr.number);
+    let tracking_ref = pr_tracking_ref(pr.number);
+    let worktree = data_root
+        .join("pr-worktrees")
+        .join(format!("pr-{}", pr.number));
+
+    let repo = repo_root.to_path_buf();
+    let wt = worktree.clone();
+    let tref = tracking_ref.clone();
+    let label_for_prep = label.clone();
+    // git operations are blocking; keep them off the reactor.
+    let prep = tokio::task::spawn_blocking(move || {
+        prepare_pr_worktree(&repo, &wt, &tref, &label_for_prep)
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?;
+    prep?;
+
+    match TraceDecay::add_branch_tracking_with_options(
+        &worktree,
+        &label,
+        TraceDecayOpenOptions::default(),
+    )
+    .await
+    {
+        Ok(crate::branch::BranchAddOutcome::NotIndexed) => {
+            // Roll back the worktree we created but could not track.
+            cleanup_pr_worktree(repo_root, &worktree, &tracking_ref, &label);
+            Err("project not indexed".to_string())
+        }
+        Ok(_) => Ok(ManagedPr {
+            pr: pr.number,
+            head_branch: pr.head_branch.clone(),
+            worktree,
+            tracking_ref,
+        }),
+        Err(e) => {
+            cleanup_pr_worktree(repo_root, &worktree, &tracking_ref, &label);
+            Err(e.to_string())
+        }
+    }
+}
+
+/// Fetches `refs/pull/<N>/head` into `tracking_ref` and adds a linked worktree
+/// checked out on a local branch named `label` (`pr/<N>`) at that ref.
+///
+/// The worktree must be on a *named* branch matching the tracking label — a
+/// detached HEAD trips the branch-drift guard in sync (the DB serves `pr/<N>`
+/// but the working tree would report detached HEAD). Idempotent: a stale
+/// worktree at `worktree` is removed first, and `-B` resets the branch.
+fn prepare_pr_worktree(
+    repo_root: &Path,
+    worktree: &Path,
+    tracking_ref: &str,
+    label: &str,
+) -> std::result::Result<(), String> {
+    let pr_ref_spec = {
+        // tracking_ref is refs/tracedecay/pr/<N>; derive the pull ref from it.
+        let n = tracking_ref
+            .rsplit('/')
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        format!("+refs/pull/{n}/head:{tracking_ref}")
+    };
+    let fetch = run_git(repo_root, &["fetch", "--no-tags", "origin", &pr_ref_spec]);
+    if fetch.is_none() {
+        return Err("fetch of PR head failed".to_string());
+    }
+
+    if let Some(parent) = worktree.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    // Clear any stale worktree registration/dir so `worktree add` is idempotent.
+    remove_worktree(repo_root, worktree);
+
+    let wt_str = worktree.to_string_lossy();
+    let add = run_git(
+        repo_root,
+        &[
+            "worktree",
+            "add",
+            "-B",
+            label,
+            "--force",
+            &wt_str,
+            tracking_ref,
+        ],
+    );
+    if add.is_none() {
+        return Err("worktree add failed".to_string());
+    }
+    Ok(())
+}
+
+/// Untracks a managed PR: removes its branch store, its worktree, its local
+/// tracking branch, and its ref.
+async fn untrack_pr(repo_root: &Path, data_root: &Path, label: &str, managed: &ManagedPr) {
+    let data = data_root.to_path_buf();
+    let label_owned = label.to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        crate::branch::remove_tracked_branch_store(&data, &label_owned)
+    })
+    .await;
+    cleanup_pr_worktree(repo_root, &managed.worktree, &managed.tracking_ref, label);
+}
+
+fn cleanup_pr_worktree(repo_root: &Path, worktree: &Path, tracking_ref: &str, label: &str) {
+    remove_worktree(repo_root, worktree);
+    // Delete the synthetic local branch and the fetch ref we created.
+    let _ = run_git(repo_root, &["branch", "-D", label]);
+    let _ = run_git(repo_root, &["update-ref", "-d", tracking_ref]);
+}
+
+fn remove_worktree(repo_root: &Path, worktree: &Path) {
+    let wt_str = worktree.to_string_lossy();
+    // `worktree remove` unregisters and deletes the checkout; prune tidies any
+    // dangling administrative entry if the dir was removed out from under git.
+    let _ = run_git(repo_root, &["worktree", "remove", "--force", &wt_str]);
+    let _ = run_git(repo_root, &["worktree", "prune"]);
+    if worktree.exists() {
+        let _ = std::fs::remove_dir_all(worktree);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Poll loop (daemon wiring)
+// ---------------------------------------------------------------------------
+
+/// Spawns the PR-autotrack poll loop. Cheap and inert when no registered project
+/// has the feature enabled — each tick only reads per-project config.
+pub fn spawn(global_db_path: Option<PathBuf>) {
+    tokio::spawn(async move {
+        run(global_db_path).await;
+    });
+}
+
+async fn run(global_db_path: Option<PathBuf>) {
+    let mut last_poll: HashMap<PathBuf, Instant> = HashMap::new();
+    loop {
+        tick(global_db_path.as_deref(), &mut last_poll).await;
+        tokio::time::sleep(BASE_TICK).await;
+    }
+}
+
+async fn tick(global_db_path: Option<&Path>, last_poll: &mut HashMap<PathBuf, Instant>) {
+    let window = 14 * 86_400;
+    let cap = 64;
+    let db = match global_db_path {
+        Some(path) => crate::global_db::GlobalDb::open_at(path).await,
+        None => crate::global_db::GlobalDb::open().await,
+    };
+    let Some(db) = db else {
+        return;
+    };
+    for record in db.code_projects_seen_within(window, cap).await {
+        let root = PathBuf::from(&record.canonical_root);
+        if !root.is_dir() {
+            continue;
+        }
+        let cfg = crate::config::load_sync_config(&root);
+        if !cfg.auto_track_pr_branches {
+            continue;
+        }
+        let interval = Duration::from_secs(cfg.effective_auto_track_pr_poll_secs());
+        let due = last_poll.get(&root).is_none_or(|t| t.elapsed() >= interval);
+        if !due {
+            continue;
+        }
+        last_poll.insert(root.clone(), Instant::now());
+        poll_project(root, cfg).await;
+    }
+}
+
+/// Runs one discovery + reconcile pass for a project and logs a poll summary.
+async fn poll_project(repo_root: PathBuf, _cfg: SyncConfig) {
+    let opts = TraceDecayOpenOptions::default();
+    let Some(layout) = TraceDecay::initialized_store_layout_with_options(&repo_root, &opts).await
+    else {
+        return; // not indexed — nothing to attach PR branches to yet
+    };
+    let data_root = layout.data_root;
+
+    let repo_for_discovery = repo_root.clone();
+    let Ok(discovery) =
+        tokio::task::spawn_blocking(move || discover_open_prs(&repo_for_discovery)).await
+    else {
+        return;
+    };
+
+    let report =
+        reconcile_project(&repo_root, &data_root, &discovery, MAX_NEW_TRACKS_PER_CYCLE).await;
+    let managed = load_state(&data_root).managed.len();
+    log_daemon_event(
+        "pr_autotrack",
+        &[
+            ("project", repo_root.display().to_string()),
+            ("action", "poll".to_string()),
+            ("tracked_now", managed.to_string()),
+            ("new_tracked", report.tracked.len().to_string()),
+            ("untracked", report.untracked.len().to_string()),
+            ("skipped_forks", report.skipped_forks.len().to_string()),
+        ],
+    );
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests;

--- a/src/daemon/pr_autotrack/tests.rs
+++ b/src/daemon/pr_autotrack/tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+
+// ---- Pure discovery parsers -------------------------------------------------
+
+#[test]
+fn gh_pr_list_splits_open_same_repo_from_forks() {
+    let json = r#"[
+        {"number": 1, "headRefName": "feature-a", "state": "OPEN", "isCrossRepository": false},
+        {"number": 2, "headRefName": "fork-branch", "state": "OPEN", "isCrossRepository": true},
+        {"number": 3, "headRefName": "closed-branch", "state": "CLOSED", "isCrossRepository": false},
+        {"number": 4, "headRefName": "feature-b", "state": "OPEN", "isCrossRepository": false}
+    ]"#;
+    let discovery = parse_gh_pr_list(json).unwrap();
+    assert_eq!(
+        discovery.open,
+        vec![
+            DiscoveredPr {
+                number: 1,
+                head_branch: "feature-a".to_string()
+            },
+            DiscoveredPr {
+                number: 4,
+                head_branch: "feature-b".to_string()
+            },
+        ]
+    );
+    assert_eq!(discovery.skipped_forks, vec![2]);
+}
+
+#[test]
+fn ls_remote_heads_indexes_branch_shas() {
+    let output = "\
+deadbeef00000000000000000000000000000001\trefs/heads/main
+deadbeef00000000000000000000000000000002\trefs/heads/feature-1
+cafebabe00000000000000000000000000000003\trefs/tags/v1
+";
+    let map = parse_ls_remote_heads(output);
+    assert_eq!(map.len(), 2);
+    assert_eq!(
+        map.get("deadbeef00000000000000000000000000000002").unwrap(),
+        "feature-1"
+    );
+    assert!(!map.contains_key("cafebabe00000000000000000000000000000003"));
+}
+
+#[test]
+fn ls_remote_pull_heads_parses_numbers_and_ignores_merge_refs() {
+    let output = "\
+deadbeef00000000000000000000000000000002\trefs/pull/1/head
+feed000000000000000000000000000000000009\trefs/pull/1/merge
+beadfeed00000000000000000000000000000007\trefs/pull/42/head
+";
+    let heads = parse_ls_remote_pull_heads(output);
+    assert_eq!(
+        heads,
+        vec![
+            (1, "deadbeef00000000000000000000000000000002".to_string()),
+            (42, "beadfeed00000000000000000000000000000007".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn map_pull_heads_matches_same_repo_and_skips_forks() {
+    let pull_heads = vec![
+        (1, "sha_feature".to_string()),
+        (2, "sha_fork_only".to_string()),
+    ];
+    let mut head_shas = HashMap::new();
+    head_shas.insert("sha_feature".to_string(), "feature-1".to_string());
+    head_shas.insert("sha_main".to_string(), "main".to_string());
+
+    let discovery = map_pull_heads_to_branches(&pull_heads, &head_shas);
+    assert_eq!(
+        discovery.open,
+        vec![DiscoveredPr {
+            number: 1,
+            head_branch: "feature-1".to_string()
+        }]
+    );
+    assert_eq!(discovery.skipped_forks, vec![2]);
+}
+
+// ---- State persistence ------------------------------------------------------
+
+#[test]
+fn state_round_trips_and_defaults_when_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(load_state(dir.path()).managed.is_empty());
+
+    let mut state = PrAutotrackState::default();
+    state.managed.insert(
+        "pr/7".to_string(),
+        ManagedPr {
+            pr: 7,
+            head_branch: "feature-7".to_string(),
+            worktree: dir.path().join("pr-worktrees/pr-7"),
+            tracking_ref: "refs/tracedecay/pr/7".to_string(),
+        },
+    );
+    save_state(dir.path(), &state).unwrap();
+
+    let reloaded = load_state(dir.path());
+    assert_eq!(reloaded.managed.len(), 1);
+    assert_eq!(reloaded.managed["pr/7"].pr, 7);
+
+    let summary = managed_summary(dir.path());
+    assert_eq!(summary.len(), 1);
+    assert_eq!(summary[0].branch, "pr/7");
+    assert_eq!(summary[0].head_branch, "feature-7");
+}
+
+// ---- Reconcile: removal + idempotency (no index required) -------------------
+
+#[tokio::test]
+async fn reconcile_untracks_closed_pr_and_cleans_store() {
+    use crate::branch_meta::{BranchMeta, load_branch_meta, save_branch_meta};
+
+    let data_root = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap(); // not a git repo; git ops no-op
+
+    // Seed a tracked PR branch store entry + its DB file.
+    let mut meta = BranchMeta::new("main");
+    meta.add_branch("pr/5", "branches/pr_5.db", "main");
+    std::fs::create_dir_all(data_root.path().join("branches")).unwrap();
+    std::fs::write(data_root.path().join("branches/pr_5.db"), b"db").unwrap();
+    save_branch_meta(data_root.path(), &meta).unwrap();
+
+    // Seed autotrack state marking pr/5 as managed.
+    let mut state = PrAutotrackState::default();
+    state.managed.insert(
+        "pr/5".to_string(),
+        ManagedPr {
+            pr: 5,
+            head_branch: "feature-5".to_string(),
+            worktree: data_root.path().join("pr-worktrees/pr-5"),
+            tracking_ref: "refs/tracedecay/pr/5".to_string(),
+        },
+    );
+    save_state(data_root.path(), &state).unwrap();
+
+    // Empty discovery => PR 5 is closed/merged => must be untracked.
+    let report = reconcile_project(
+        repo_root.path(),
+        data_root.path(),
+        &PrDiscovery::default(),
+        10,
+    )
+    .await;
+
+    assert_eq!(report.untracked, vec!["pr/5".to_string()]);
+    assert!(report.tracked.is_empty());
+    assert!(load_state(data_root.path()).managed.is_empty());
+    let reloaded = load_branch_meta(data_root.path()).unwrap();
+    assert!(!reloaded.is_tracked("pr/5"));
+    assert!(!data_root.path().join("branches/pr_5.db").exists());
+}
+
+#[tokio::test]
+async fn reconcile_is_idempotent_for_already_managed_pr() {
+    let data_root = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+
+    let mut state = PrAutotrackState::default();
+    state.managed.insert(
+        "pr/3".to_string(),
+        ManagedPr {
+            pr: 3,
+            head_branch: "feature-3".to_string(),
+            worktree: data_root.path().join("pr-worktrees/pr-3"),
+            tracking_ref: "refs/tracedecay/pr/3".to_string(),
+        },
+    );
+    save_state(data_root.path(), &state).unwrap();
+
+    let discovery = PrDiscovery {
+        open: vec![DiscoveredPr {
+            number: 3,
+            head_branch: "feature-3".to_string(),
+        }],
+        skipped_forks: vec![],
+    };
+    let report = reconcile_project(repo_root.path(), data_root.path(), &discovery, 10).await;
+
+    // Already managed and still open: nothing changes.
+    assert!(report.tracked.is_empty());
+    assert!(report.untracked.is_empty());
+    assert!(load_state(data_root.path()).managed.contains_key("pr/3"));
+}

--- a/src/dashboard/settings_api.rs
+++ b/src/dashboard/settings_api.rs
@@ -35,6 +35,17 @@ struct ProjectSettingsPatch {
     git_ignore: Option<bool>,
     #[serde(default)]
     telemetry: Option<TelemetrySettingsPatch>,
+    #[serde(default)]
+    sync: Option<SyncSettingsPatch>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct SyncSettingsPatch {
+    #[serde(default)]
+    auto_track_pr_branches: Option<bool>,
+    #[serde(default)]
+    auto_track_pr_poll_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -79,12 +90,37 @@ pub(crate) async fn patch_project_settings(
             "max_file_size must be at least 1 byte",
         ));
     }
+    if let Some(sync) = &patch.sync {
+        if let Some(secs) = sync.auto_track_pr_poll_secs {
+            if secs < crate::config::MIN_AUTO_TRACK_PR_POLL_SECS {
+                errors.push(validation_error(
+                    "auto_track_pr_poll_secs",
+                    &format!(
+                        "auto_track_pr_poll_secs must be at least {} seconds",
+                        crate::config::MIN_AUTO_TRACK_PR_POLL_SECS
+                    ),
+                ));
+            }
+        }
+    }
     if !errors.is_empty() {
         return Err(validation_failed(&errors));
     }
 
     let current = load_config_from_path(&state.project_root, &state.config_path)
         .map_err(|err| internal_error(&err))?;
+    let sync = patch.sync.as_ref().map_or_else(
+        || current.sync.clone(),
+        |sync| crate::config::SyncConfig {
+            auto_track_pr_branches: sync
+                .auto_track_pr_branches
+                .unwrap_or(current.sync.auto_track_pr_branches),
+            auto_track_pr_poll_secs: sync
+                .auto_track_pr_poll_secs
+                .unwrap_or(current.sync.auto_track_pr_poll_secs),
+            ..current.sync.clone()
+        },
+    );
     let telemetry = patch.telemetry.map_or_else(
         || current.telemetry.clone(),
         |telemetry| TelemetryConfig {
@@ -101,6 +137,7 @@ pub(crate) async fn patch_project_settings(
         track_call_sites: patch.track_call_sites.unwrap_or(current.track_call_sites),
         git_ignore: patch.git_ignore.unwrap_or(current.git_ignore),
         telemetry,
+        sync,
         ..current.clone()
     };
     let resync_recommended = updated != current;
@@ -199,6 +236,7 @@ async fn settings_payload(state: &DashboardState) -> std::result::Result<Value, 
             "config_path": project_config_path.display().to_string(),
             "config": project_config,
             "tracedecay_dir_gitignored": crate::config::is_in_gitignore(&state.project_root),
+            "pr_autotrack": pr_autotrack_payload(state),
         },
         "user": {
             "config_path": user_config_path,
@@ -232,6 +270,31 @@ async fn settings_payload(state: &DashboardState) -> std::result::Result<Value, 
             "cached_latest_version": non_empty(&user.cached_latest_version),
         },
     }))
+}
+
+/// Lists the PR branches the daemon currently auto-tracks for this project, read
+/// from the store's PR-autotrack state sidecar. Empty on non-unix or when the
+/// feature has tracked nothing yet.
+fn pr_autotrack_payload(state: &DashboardState) -> Value {
+    #[cfg(unix)]
+    {
+        let tracked: Vec<Value> = crate::daemon::pr_autotrack::managed_summary(&state.store_root)
+            .into_iter()
+            .map(|entry| {
+                json!({
+                    "branch": entry.branch,
+                    "pr": entry.pr,
+                    "head_branch": entry.head_branch,
+                })
+            })
+            .collect();
+        json!({ "tracked": tracked })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = state;
+        json!({ "tracked": [] })
+    }
 }
 
 fn environment_payload() -> Value {

--- a/tests/daemon_suite/main.rs
+++ b/tests/daemon_suite/main.rs
@@ -17,3 +17,5 @@
 mod common;
 
 mod git_watch_test;
+#[cfg(unix)]
+mod pr_autotrack_test;

--- a/tests/daemon_suite/pr_autotrack_test.rs
+++ b/tests/daemon_suite/pr_autotrack_test.rs
@@ -1,0 +1,221 @@
+//! End-to-end lifecycle tests for daemon PR-branch auto-tracking.
+//!
+//! These drive the real discovery + reconcile path against a fixture repo whose
+//! `origin` is a local bare repo carrying `refs/pull/N/head` refs (created with
+//! `git update-ref`), exactly the shape GitHub exposes. Same-repo PRs are tracked
+//! through the normal branch machinery (fetch → detached worktree →
+//! `add_branch_tracking`); fork PRs (a `refs/pull/N/head` whose SHA matches no
+//! origin head) are skipped. The tests assert: a PR branch is tracked and its
+//! *own* content is indexed, a second poll is a no-op, closing the PR untracks it
+//! and cleans the store + worktree, and the per-cycle new-track cap ramps.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::common::IsolatedEnv;
+use tracedecay::branch_meta::load_branch_meta;
+use tracedecay::daemon::pr_autotrack;
+use tracedecay::storage::resolve_layout_for_current_profile;
+use tracedecay::tracedecay::TraceDecay;
+
+fn git_out(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .args(["-c", "core.hooksPath=.git/no-hooks"])
+        .args(["-c", "gc.auto=0"])
+        .args(["-c", "user.name=TraceDecay Test"])
+        .args(["-c", "user.email=tracedecay-test@example.com"])
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run git {args:?}: {e}"))
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let output = git_out(cwd, args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn head_sha(cwd: &Path) -> String {
+    let out = git_out(cwd, &["rev-parse", "HEAD"]);
+    assert!(out.status.success());
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+fn commit_all(project: &Path, message: &str) {
+    git(project, &["add", "."]);
+    git(project, &["commit", "-m", message]);
+}
+
+fn project_data_dir(project: &Path) -> PathBuf {
+    resolve_layout_for_current_profile(project)
+        .unwrap_or_else(|err| panic!("failed to resolve test project storage layout: {err}"))
+        .data_root
+}
+
+/// Fixture: an indexed project on `main` with a local bare `origin` it has been
+/// pushed to. Returns `(env, project, origin_bare)`.
+async fn indexed_repo_with_origin() -> (IsolatedEnv, PathBuf, PathBuf) {
+    let (env, project) = IsolatedEnv::acquire().await;
+    git(&project, &["init", "-b", "main"]);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn on_main() {}\n").unwrap();
+    commit_all(&project, "initial commit");
+
+    let main = TraceDecay::init(&project).await.unwrap();
+    main.index_all().await.unwrap();
+    drop(main);
+
+    // A sibling bare repo acts as `origin`. Keep it next to the project so it
+    // lives as long as the isolated env dir.
+    let origin = project.join("..").join("origin.git");
+    git(&project, &["init", "--bare", &origin.to_string_lossy()]);
+    let origin = origin.canonicalize().unwrap();
+    git(
+        &project,
+        &["remote", "add", "origin", &origin.to_string_lossy()],
+    );
+    git(&project, &["push", "origin", "main"]);
+
+    (env, project, origin)
+}
+
+/// Creates a same-repo PR: a new branch on `origin` with unique content, plus a
+/// matching `refs/pull/<n>/head`. Returns the PR head branch name. Leaves the
+/// project checked out on `main`.
+fn add_same_repo_pr(project: &Path, origin: &Path, n: u64, symbol: &str) -> String {
+    let branch = format!("feature-{n}");
+    git(project, &["checkout", "-b", &branch, "main"]);
+    fs::write(
+        project.join(format!("src/pr_{n}.rs")),
+        format!("pub fn {symbol}() {{}}\n"),
+    )
+    .unwrap();
+    commit_all(project, &format!("PR {n} content"));
+    git(project, &["push", "origin", &branch]);
+    // Mirror GitHub's refs/pull/<n>/head at the branch tip.
+    git(
+        origin,
+        &[
+            "update-ref",
+            &format!("refs/pull/{n}/head"),
+            &format!("refs/heads/{branch}"),
+        ],
+    );
+    git(project, &["checkout", "main"]);
+    git(project, &["branch", "-D", &branch]);
+    branch
+}
+
+/// Creates a fork PR: a `refs/pull/<n>/head` on `origin` whose SHA matches no
+/// origin head (so discovery classifies it as a fork).
+fn add_fork_pr(project: &Path, n: u64, symbol: &str) {
+    git(project, &["checkout", "-b", "tmp-fork", "main"]);
+    fs::write(
+        project.join("src/fork.rs"),
+        format!("pub fn {symbol}() {{}}\n"),
+    )
+    .unwrap();
+    commit_all(project, "fork content");
+    let sha = head_sha(project);
+    git(project, &["checkout", "main"]);
+    git(project, &["branch", "-D", "tmp-fork"]);
+    fs::remove_file(project.join("src/fork.rs")).ok();
+    // Push the bare commit object to origin under the pull ref only — no head.
+    git(
+        project,
+        &["push", "origin", &format!("{sha}:refs/pull/{n}/head")],
+    );
+}
+
+#[tokio::test]
+async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    let head_branch = add_same_repo_pr(&project, &origin, 1, "pr_one_symbol");
+    add_fork_pr(&project, 2, "fork_symbol");
+
+    let data_root = project_data_dir(&project);
+
+    // Discovery: PR 1 is a tracked same-repo PR; PR 2 is a skipped fork.
+    let discovery = pr_autotrack::discover_open_prs(&project);
+    assert_eq!(discovery.open.len(), 1, "one same-repo PR expected");
+    assert_eq!(discovery.open[0].number, 1);
+    assert_eq!(discovery.open[0].head_branch, head_branch);
+    assert_eq!(discovery.skipped_forks, vec![2]);
+
+    // Reconcile → PR 1 tracked.
+    let report = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(report.tracked, vec!["pr/1".to_string()]);
+    assert_eq!(report.skipped_forks, vec![2]);
+
+    // Branch metadata + state reflect the tracked PR.
+    let meta = load_branch_meta(&data_root).expect("branch meta exists");
+    assert!(meta.is_tracked("pr/1"), "pr/1 should be a tracked branch");
+    let summary = pr_autotrack::managed_summary(&data_root);
+    assert_eq!(summary.len(), 1);
+    assert_eq!(summary[0].pr, 1);
+    assert_eq!(summary[0].head_branch, head_branch);
+
+    // The PR branch DB indexed the PR's OWN content, not main's working tree.
+    let branch_cg = TraceDecay::open_branch(&project, "pr/1").await.unwrap();
+    let hits = branch_cg.search("pr_one_symbol", 10).await.unwrap();
+    assert!(
+        !hits.is_empty(),
+        "pr/1 store should contain the PR head's symbol (indexed from its worktree)"
+    );
+    drop(branch_cg);
+
+    // Idempotent: a second reconcile with the same discovery changes nothing.
+    let again = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert!(again.tracked.is_empty(), "no re-track on repeat poll");
+    assert!(again.untracked.is_empty());
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 1);
+
+    // Close PR 1 (delete its pull ref) → discovery no longer lists it → untrack.
+    git(&origin, &["update-ref", "-d", "refs/pull/1/head"]);
+    let after_close = pr_autotrack::discover_open_prs(&project);
+    assert!(
+        after_close.open.iter().all(|p| p.number != 1),
+        "closed PR must not be discovered"
+    );
+    let closing = pr_autotrack::reconcile_project(&project, &data_root, &after_close, 10).await;
+    assert_eq!(closing.untracked, vec!["pr/1".to_string()]);
+
+    let meta = load_branch_meta(&data_root).expect("branch meta exists");
+    assert!(!meta.is_tracked("pr/1"), "pr/1 should be untracked");
+    assert!(pr_autotrack::managed_summary(&data_root).is_empty());
+    assert!(
+        !data_root.join("pr-worktrees/pr-1").exists(),
+        "worktree should be removed on untrack"
+    );
+}
+
+#[tokio::test]
+async fn caps_new_tracks_per_cycle_and_ramps() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 1, "pr_one");
+    add_same_repo_pr(&project, &origin, 2, "pr_two");
+    add_same_repo_pr(&project, &origin, 3, "pr_three");
+
+    let data_root = project_data_dir(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project);
+    assert_eq!(discovery.open.len(), 3);
+
+    // First cycle with cap=2 tracks only two and flags the cap.
+    let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 2).await;
+    assert_eq!(first.tracked.len(), 2, "cap holds back the third PR");
+    assert!(first.capped, "cap flag set when additions are held back");
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 2);
+
+    // Second cycle tracks the remaining PR.
+    let second = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 2).await;
+    assert_eq!(second.tracked.len(), 1);
+    assert!(!second.capped);
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 3);
+}


### PR DESCRIPTION
Opt-in daemon mode (config + CLI + dashboard Settings toggle, default off) that discovers open PRs on the GitHub origin (gh when available, git ls-remote refs/pull/*/head fallback) and tracks each same-repo PR head through the existing branch-tracking machinery: fetched to refs/tracedecay/pr/<N>, checked out into a linked worktree on a synthetic pr/<N> branch, indexed like any tracked branch, and untracked with full store/worktree cleanup on close or merge. Capped ramp (10/cycle), idempotent reconcile, fork PRs skipped with logged reasons, structured event=pr_autotrack logging, 60s poll floor. Fixture-repo lifecycle test covers track/idempotence/untrack/cap; dashboard build + vitest green; CI-exact clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)