### PR TITLE
fix(daemon): reconcile owned PR tracking safely

### DIFF
--- a/src/daemon/pr_autotrack.rs
+++ b/src/daemon/pr_autotrack.rs
@@ -63,8 +63,10 @@ const BASE_TICK: Duration = Duration::from_mins(1);
 pub struct DiscoveredPr {
     /// PR number.
     pub number: u64,
-    /// The PR's head branch name (for display only; tracking uses `pr/<N>`).
+    /// The PR's head branch name (display only).
     pub head_branch: String,
+    /// The exact remote head commit observed during discovery.
+    pub head_sha: String,
 }
 
 /// The result of one discovery pass over a repo's `origin` remote.
@@ -83,23 +85,26 @@ pub struct ManagedPr {
     pub pr: u64,
     /// The PR's head branch name (display only).
     pub head_branch: String,
-    /// Path to the linked worktree checked out on the `pr/<N>` branch.
+    /// Last remote head commit successfully indexed.
+    #[serde(default)]
+    pub head_sha: String,
+    /// Path to the linked worktree on the owned synthetic branch.
     pub worktree: PathBuf,
     /// The deterministic local ref the PR head was fetched into.
     pub tracking_ref: String,
 }
 
-/// PR-autotrack persistent state: label (`pr/<N>`) → managed entry.
+/// PR-autotrack persistent state: internal branch label → managed entry.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PrAutotrackState {
-    /// Managed PR branches keyed by their tracking label (`pr/<N>`).
+    /// Managed PR branches keyed by their internal synthetic branch label.
     #[serde(default)]
     pub managed: BTreeMap<String, ManagedPr>,
 }
 
-/// The tracking label a PR number maps to (`pr/<N>`).
+/// The collision-proof internal tracking label for a PR.
 fn pr_label(number: u64) -> String {
-    format!("pr/{number}")
+    format!("tracedecay/autotrack/pr/{number}")
 }
 
 /// The deterministic local ref a PR head is fetched into.
@@ -130,7 +135,7 @@ fn save_state(data_root: &Path, state: &PrAutotrackState) -> std::io::Result<()>
 /// A summary of managed PR branches for status surfaces (dashboard / CLI).
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ManagedPrSummary {
-    /// Tracking label (`pr/<N>`).
+    /// Internal synthetic branch label.
     pub branch: String,
     /// PR number.
     pub pr: u64,
@@ -158,12 +163,14 @@ pub fn managed_summary(data_root: &Path) -> Vec<ManagedPrSummary> {
 // Discovery (pure parsers + one impure orchestrator)
 // ---------------------------------------------------------------------------
 
-/// One entry from `gh pr list --json number,headRefName,state,isCrossRepository`.
+/// One entry from `gh pr list --json number,headRefName,headRefOid,state,isCrossRepository`.
 #[derive(Debug, Deserialize)]
 struct GhPr {
     number: u64,
     #[serde(default, rename = "headRefName")]
     head_ref_name: String,
+    #[serde(default, rename = "headRefOid")]
+    head_ref_oid: String,
     #[serde(default)]
     state: String,
     #[serde(default, rename = "isCrossRepository")]
@@ -180,12 +187,13 @@ fn parse_gh_pr_list(json: &str) -> serde_json::Result<PrDiscovery> {
         if !pr.state.eq_ignore_ascii_case("open") {
             continue;
         }
-        if pr.is_cross_repository || pr.head_ref_name.is_empty() {
+        if pr.is_cross_repository || pr.head_ref_name.is_empty() || pr.head_ref_oid.is_empty() {
             discovery.skipped_forks.push(pr.number);
         } else {
             discovery.open.push(DiscoveredPr {
                 number: pr.number,
                 head_branch: pr.head_ref_name,
+                head_sha: pr.head_ref_oid,
             });
         }
     }
@@ -250,6 +258,7 @@ fn map_pull_heads_to_branches(
             Some(branch) => discovery.open.push(DiscoveredPr {
                 number: *number,
                 head_branch: branch.clone(),
+                head_sha: sha.clone(),
             }),
             None => discovery.skipped_forks.push(*number),
         }
@@ -305,7 +314,7 @@ fn discover_via_gh(repo_root: &Path) -> Option<PrDiscovery> {
             "--limit",
             "200",
             "--json",
-            "number,headRefName,state,isCrossRepository",
+            "number,headRefName,headRefOid,state,isCrossRepository",
         ])
         .current_dir(repo_root)
         .output()
@@ -334,7 +343,7 @@ fn discover_via_ls_remote(repo_root: &Path) -> PrDiscovery {
 /// A summary of what one reconcile pass changed, for logging and tests.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ReconcileReport {
-    /// Labels (`pr/<N>`) newly tracked this pass.
+    /// Internal labels newly tracked or recovered this pass.
     pub tracked: Vec<String>,
     /// Labels untracked this pass (PR closed/merged).
     pub untracked: Vec<String>,
@@ -342,6 +351,8 @@ pub struct ReconcileReport {
     pub skipped_forks: Vec<u64>,
     /// True when the per-cycle new-track cap held some additions back.
     pub capped: bool,
+    /// Tracking or persistence failures surfaced to callers.
+    pub failures: Vec<(String, String)>,
 }
 
 /// Reconciles the managed PR set against a discovery result.
@@ -360,6 +371,7 @@ pub async fn reconcile_project(
         skipped_forks: discovery.skipped_forks.clone(),
         ..Default::default()
     };
+    let mut state_dirty = false;
 
     // Desired label → discovered PR.
     let desired: BTreeMap<String, &DiscoveredPr> = discovery
@@ -379,6 +391,7 @@ pub async fn reconcile_project(
         if let Some(managed) = state.managed.get(&label).cloned() {
             untrack_pr(repo_root, data_root, &label, &managed).await;
             state.managed.remove(&label);
+            state_dirty = true;
             report.untracked.push(label.clone());
             log_daemon_event(
                 "pr_autotrack",
@@ -395,30 +408,67 @@ pub async fn reconcile_project(
     // Additions, capped per cycle.
     let mut added = 0usize;
     for (label, pr) in &desired {
-        if state.managed.contains_key(label) {
-            continue; // idempotent: already tracked
+        let current = state.managed.get(label).cloned();
+        if current.as_ref().is_some_and(|managed| {
+            managed.head_sha == pr.head_sha && managed.head_branch == pr.head_branch
+        }) {
+            continue;
         }
-        if added >= cap {
+        let is_new = current.is_none();
+        if is_new && added >= cap {
             report.capped = true;
             break;
         }
+        if let Some(managed) = current {
+            // A changed remote head invalidates the entire branch graph. Drop
+            // the owned store before rebuilding so stale data is never served.
+            untrack_pr(repo_root, data_root, label, &managed).await;
+            state.managed.remove(label);
+            state_dirty = true;
+        }
         match track_pr(repo_root, data_root, pr).await {
             Ok(managed) => {
-                state.managed.insert(label.clone(), managed);
-                report.tracked.push(label.clone());
-                added += 1;
-                log_daemon_event(
-                    "pr_autotrack",
-                    &[
-                        ("project", repo_root.display().to_string()),
-                        ("action", "tracked".to_string()),
-                        ("branch", label.clone()),
-                        ("pr", pr.number.to_string()),
-                        ("head", pr.head_branch.clone()),
-                    ],
-                );
+                let dirty_before_insert = state_dirty;
+                state.managed.insert(label.clone(), managed.clone());
+                match save_state(data_root, &state) {
+                    Ok(()) => {
+                        state_dirty = false;
+                        report.tracked.push(label.clone());
+                        if is_new {
+                            added += 1;
+                        }
+                        log_daemon_event(
+                            "pr_autotrack",
+                            &[
+                                ("project", repo_root.display().to_string()),
+                                ("action", "tracked".to_string()),
+                                ("branch", label.clone()),
+                                ("pr", pr.number.to_string()),
+                                ("head", pr.head_branch.clone()),
+                            ],
+                        );
+                    }
+                    Err(error) => {
+                        state.managed.remove(label);
+                        state_dirty = dirty_before_insert;
+                        untrack_pr(repo_root, data_root, label, &managed).await;
+                        let reason = format!("failed to persist managed state: {error}");
+                        report.failures.push((label.clone(), reason.clone()));
+                        log_daemon_event(
+                            "pr_autotrack",
+                            &[
+                                ("project", repo_root.display().to_string()),
+                                ("action", "skipped".to_string()),
+                                ("branch", label.clone()),
+                                ("pr", pr.number.to_string()),
+                                ("reason", reason),
+                            ],
+                        );
+                    }
+                }
             }
             Err(reason) => {
+                report.failures.push((label.clone(), reason.clone()));
                 log_daemon_event(
                     "pr_autotrack",
                     &[
@@ -445,7 +495,20 @@ pub async fn reconcile_project(
         );
     }
 
-    let _ = save_state(data_root, &state);
+    if state_dirty && let Err(error) = save_state(data_root, &state) {
+        let reason = format!("failed to persist reconciled state: {error}");
+        report
+            .failures
+            .push(("<state>".to_string(), reason.clone()));
+        log_daemon_event(
+            "pr_autotrack",
+            &[
+                ("project", repo_root.display().to_string()),
+                ("action", "skipped".to_string()),
+                ("reason", reason),
+            ],
+        );
+    }
     report
 }
 
@@ -462,13 +525,29 @@ async fn track_pr(
         .join("pr-worktrees")
         .join(format!("pr-{}", pr.number));
 
+    let graph_ready = crate::branch_meta::load_branch_meta(data_root)
+        .and_then(|meta| crate::branch::resolve_branch_db_path(data_root, &label, &meta))
+        .is_some_and(|path| path.is_file());
+    let branch_ref = format!("refs/heads/{label}");
+    let branch_ready = ref_points_to(repo_root, &branch_ref, &pr.head_sha);
+    let tracking_ref_ready = ref_points_to(repo_root, &tracking_ref, &pr.head_sha);
+    let worktree_ready = ref_points_to(&worktree, "HEAD", &pr.head_sha)
+        && crate::branch::current_branch(&worktree).as_deref() == Some(label.as_str());
+    let validated_orphan =
+        branch_ready && tracking_ref_ready && (!worktree.exists() || worktree_ready);
+    if graph_ready || validated_orphan {
+        let _ = crate::branch::remove_tracked_branch_store(data_root, &label);
+        cleanup_pr_worktree(repo_root, data_root, pr.number, &pr.head_sha, true);
+    }
+
     let repo = repo_root.to_path_buf();
     let wt = worktree.clone();
     let tref = tracking_ref.clone();
     let label_for_prep = label.clone();
+    let expected_head = pr.head_sha.clone();
     // git operations are blocking; keep them off the reactor.
     let prep = tokio::task::spawn_blocking(move || {
-        prepare_pr_worktree(&repo, &wt, &tref, &label_for_prep)
+        prepare_pr_worktree(&repo, &wt, &tref, &label_for_prep, &expected_head)
     })
     .await
     .map_err(|e| format!("join error: {e}"))?;
@@ -481,19 +560,31 @@ async fn track_pr(
     )
     .await
     {
-        Ok(crate::branch::BranchAddOutcome::NotIndexed) => {
-            // Roll back the worktree we created but could not track.
-            cleanup_pr_worktree(repo_root, &worktree, &tracking_ref, &label);
-            Err("project not indexed".to_string())
-        }
-        Ok(_) => Ok(ManagedPr {
+        Ok(crate::branch::BranchAddOutcome::Added) => Ok(ManagedPr {
             pr: pr.number,
             head_branch: pr.head_branch.clone(),
+            head_sha: pr.head_sha.clone(),
             worktree,
             tracking_ref,
         }),
+        Ok(outcome) => {
+            // Deferred may leave branch metadata behind. AlreadyTracked can
+            // be an orphan from an interrupted prior cycle. Neither proves a
+            // completed sync, so clear only our internal label and retry later.
+            let _ = crate::branch::remove_tracked_branch_store(data_root, &label);
+            cleanup_pr_worktree(repo_root, data_root, pr.number, &pr.head_sha, true);
+            let reason = match outcome {
+                crate::branch::BranchAddOutcome::NotIndexed => "project not indexed",
+                crate::branch::BranchAddOutcome::AlreadyTracked => {
+                    "internal PR branch was already tracked"
+                }
+                crate::branch::BranchAddOutcome::Deferred => "branch tracking deferred",
+                crate::branch::BranchAddOutcome::Added => unreachable!(),
+            };
+            Err(reason.to_string())
+        }
         Err(e) => {
-            cleanup_pr_worktree(repo_root, &worktree, &tracking_ref, &label);
+            cleanup_pr_worktree(repo_root, data_root, pr.number, &pr.head_sha, true);
             Err(e.to_string())
         }
     }
@@ -511,6 +602,7 @@ fn prepare_pr_worktree(
     worktree: &Path,
     tracking_ref: &str,
     label: &str,
+    expected_head: &str,
 ) -> std::result::Result<(), String> {
     let pr_ref_spec = {
         // tracking_ref is refs/tracedecay/pr/<N>; derive the pull ref from it.
@@ -525,6 +617,16 @@ fn prepare_pr_worktree(
     if fetch.is_none() {
         return Err("fetch of PR head failed".to_string());
     }
+    let fetched_head = run_git(repo_root, &["rev-parse", tracking_ref])
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|sha| sha.trim().to_string());
+    if fetched_head.as_deref() != Some(expected_head) {
+        return Err("PR head changed during reconciliation".to_string());
+    }
+    let branch_ref = format!("refs/heads/{label}");
+    if run_git(repo_root, &["show-ref", "--verify", "--quiet", &branch_ref]).is_some() {
+        return Err("internal PR worktree branch already exists".to_string());
+    }
 
     if let Some(parent) = worktree.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -538,7 +640,7 @@ fn prepare_pr_worktree(
         &[
             "worktree",
             "add",
-            "-B",
+            "-b",
             label,
             "--force",
             &wt_str,
@@ -554,20 +656,76 @@ fn prepare_pr_worktree(
 /// Untracks a managed PR: removes its branch store, its worktree, its local
 /// tracking branch, and its ref.
 async fn untrack_pr(repo_root: &Path, data_root: &Path, label: &str, managed: &ManagedPr) {
+    let expected_label = pr_label(managed.pr);
+    let legacy_label = format!("pr/{}", managed.pr);
+    let is_legacy = label == legacy_label;
+    let expected_worktree = data_root
+        .join("pr-worktrees")
+        .join(format!("pr-{}", managed.pr));
+    let expected_ref = pr_tracking_ref(managed.pr);
+    if (label != expected_label && !is_legacy)
+        || managed.worktree != expected_worktree
+        || managed.tracking_ref != expected_ref
+    {
+        return;
+    }
     let data = data_root.to_path_buf();
     let label_owned = label.to_string();
     let _ = tokio::task::spawn_blocking(move || {
         crate::branch::remove_tracked_branch_store(&data, &label_owned)
     })
     .await;
-    cleanup_pr_worktree(repo_root, &managed.worktree, &managed.tracking_ref, label);
+    // `pr/<N>` is the pre-namespace persisted format. Remove its owned store
+    // and worktree once, but never delete that ambiguous local branch name.
+    cleanup_pr_worktree(
+        repo_root,
+        data_root,
+        managed.pr,
+        &managed.head_sha,
+        !is_legacy,
+    );
 }
 
-fn cleanup_pr_worktree(repo_root: &Path, worktree: &Path, tracking_ref: &str, label: &str) {
-    remove_worktree(repo_root, worktree);
-    // Delete the synthetic local branch and the fetch ref we created.
-    let _ = run_git(repo_root, &["branch", "-D", label]);
-    let _ = run_git(repo_root, &["update-ref", "-d", tracking_ref]);
+fn cleanup_pr_worktree(
+    repo_root: &Path,
+    data_root: &Path,
+    pr: u64,
+    expected_head: &str,
+    remove_synthetic_branch: bool,
+) {
+    let worktree = data_root.join("pr-worktrees").join(format!("pr-{pr}"));
+    let tracking_ref = pr_tracking_ref(pr);
+    let owned_head = if expected_head.is_empty() {
+        let ref_head = ref_sha(repo_root, &tracking_ref);
+        let worktree_head = ref_sha(&worktree, "HEAD");
+        match (ref_head, worktree_head) {
+            (Some(ref_head), Some(worktree_head)) if ref_head == worktree_head => Some(ref_head),
+            _ => None,
+        }
+    } else {
+        Some(expected_head.to_string())
+    };
+    remove_worktree(repo_root, &worktree);
+    let label = pr_label(pr);
+    let branch_ref = format!("refs/heads/{label}");
+    if let Some(owned_head) = owned_head {
+        if remove_synthetic_branch && ref_points_to(repo_root, &branch_ref, &owned_head) {
+            let _ = run_git(repo_root, &["branch", "-D", &label]);
+        }
+        if ref_points_to(repo_root, &tracking_ref, &owned_head) {
+            let _ = run_git(repo_root, &["update-ref", "-d", &tracking_ref]);
+        }
+    }
+}
+
+fn ref_points_to(repo_root: &Path, reference: &str, expected_head: &str) -> bool {
+    ref_sha(repo_root, reference).is_some_and(|sha| sha == expected_head)
+}
+
+fn ref_sha(repo_root: &Path, reference: &str) -> Option<String> {
+    run_git(repo_root, &["rev-parse", reference])
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|sha| sha.trim().to_string())
 }
 
 fn remove_worktree(repo_root: &Path, worktree: &Path) {

--- a/src/daemon/pr_autotrack/tests.rs
+++ b/src/daemon/pr_autotrack/tests.rs
@@ -5,10 +5,10 @@ use super::*;
 #[test]
 fn gh_pr_list_splits_open_same_repo_from_forks() {
     let json = r#"[
-        {"number": 1, "headRefName": "feature-a", "state": "OPEN", "isCrossRepository": false},
-        {"number": 2, "headRefName": "fork-branch", "state": "OPEN", "isCrossRepository": true},
-        {"number": 3, "headRefName": "closed-branch", "state": "CLOSED", "isCrossRepository": false},
-        {"number": 4, "headRefName": "feature-b", "state": "OPEN", "isCrossRepository": false}
+        {"number": 1, "headRefName": "feature-a", "headRefOid": "sha-a", "state": "OPEN", "isCrossRepository": false},
+        {"number": 2, "headRefName": "fork-branch", "headRefOid": "sha-fork", "state": "OPEN", "isCrossRepository": true},
+        {"number": 3, "headRefName": "closed-branch", "headRefOid": "sha-closed", "state": "CLOSED", "isCrossRepository": false},
+        {"number": 4, "headRefName": "feature-b", "headRefOid": "sha-b", "state": "OPEN", "isCrossRepository": false}
     ]"#;
     let discovery = parse_gh_pr_list(json).unwrap();
     assert_eq!(
@@ -16,11 +16,13 @@ fn gh_pr_list_splits_open_same_repo_from_forks() {
         vec![
             DiscoveredPr {
                 number: 1,
-                head_branch: "feature-a".to_string()
+                head_branch: "feature-a".to_string(),
+                head_sha: "sha-a".to_string(),
             },
             DiscoveredPr {
                 number: 4,
-                head_branch: "feature-b".to_string()
+                head_branch: "feature-b".to_string(),
+                head_sha: "sha-b".to_string(),
             },
         ]
     );
@@ -75,7 +77,8 @@ fn map_pull_heads_matches_same_repo_and_skips_forks() {
         discovery.open,
         vec![DiscoveredPr {
             number: 1,
-            head_branch: "feature-1".to_string()
+            head_branch: "feature-1".to_string(),
+            head_sha: "sha_feature".to_string(),
         }]
     );
     assert_eq!(discovery.skipped_forks, vec![2]);
@@ -90,10 +93,11 @@ fn state_round_trips_and_defaults_when_absent() {
 
     let mut state = PrAutotrackState::default();
     state.managed.insert(
-        "pr/7".to_string(),
+        "tracedecay/autotrack/pr/7".to_string(),
         ManagedPr {
             pr: 7,
             head_branch: "feature-7".to_string(),
+            head_sha: "sha-7".to_string(),
             worktree: dir.path().join("pr-worktrees/pr-7"),
             tracking_ref: "refs/tracedecay/pr/7".to_string(),
         },
@@ -102,12 +106,23 @@ fn state_round_trips_and_defaults_when_absent() {
 
     let reloaded = load_state(dir.path());
     assert_eq!(reloaded.managed.len(), 1);
-    assert_eq!(reloaded.managed["pr/7"].pr, 7);
+    assert_eq!(reloaded.managed["tracedecay/autotrack/pr/7"].pr, 7);
 
     let summary = managed_summary(dir.path());
     assert_eq!(summary.len(), 1);
-    assert_eq!(summary[0].branch, "pr/7");
+    assert_eq!(summary[0].branch, "tracedecay/autotrack/pr/7");
     assert_eq!(summary[0].head_branch, "feature-7");
+
+    std::fs::write(
+        state_path(dir.path()),
+        r#"{"managed":{"pr/8":{"pr":8,"head_branch":"legacy","worktree":"pr-worktrees/pr-8","tracking_ref":"refs/tracedecay/pr/8"}}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        load_state(dir.path()).managed["pr/8"].head_sha,
+        "",
+        "legacy state without a head SHA must migrate as needing refresh"
+    );
 }
 
 // ---- Reconcile: removal + idempotency (no index required) -------------------
@@ -133,6 +148,7 @@ async fn reconcile_untracks_closed_pr_and_cleans_store() {
         ManagedPr {
             pr: 5,
             head_branch: "feature-5".to_string(),
+            head_sha: "sha-5".to_string(),
             worktree: data_root.path().join("pr-worktrees/pr-5"),
             tracking_ref: "refs/tracedecay/pr/5".to_string(),
         },
@@ -163,10 +179,11 @@ async fn reconcile_is_idempotent_for_already_managed_pr() {
 
     let mut state = PrAutotrackState::default();
     state.managed.insert(
-        "pr/3".to_string(),
+        "tracedecay/autotrack/pr/3".to_string(),
         ManagedPr {
             pr: 3,
             head_branch: "feature-3".to_string(),
+            head_sha: "sha-3".to_string(),
             worktree: data_root.path().join("pr-worktrees/pr-3"),
             tracking_ref: "refs/tracedecay/pr/3".to_string(),
         },
@@ -177,6 +194,7 @@ async fn reconcile_is_idempotent_for_already_managed_pr() {
         open: vec![DiscoveredPr {
             number: 3,
             head_branch: "feature-3".to_string(),
+            head_sha: "sha-3".to_string(),
         }],
         skipped_forks: vec![],
     };
@@ -185,5 +203,9 @@ async fn reconcile_is_idempotent_for_already_managed_pr() {
     // Already managed and still open: nothing changes.
     assert!(report.tracked.is_empty());
     assert!(report.untracked.is_empty());
-    assert!(load_state(data_root.path()).managed.contains_key("pr/3"));
+    assert!(
+        load_state(data_root.path())
+            .managed
+            .contains_key("tracedecay/autotrack/pr/3")
+    );
 }

--- a/tests/daemon_suite/pr_autotrack_test.rs
+++ b/tests/daemon_suite/pr_autotrack_test.rs
@@ -3,7 +3,7 @@
 //! These drive the real discovery + reconcile path against a fixture repo whose
 //! `origin` is a local bare repo carrying `refs/pull/N/head` refs (created with
 //! `git update-ref`), exactly the shape GitHub exposes. Same-repo PRs are tracked
-//! through the normal branch machinery (fetch → detached worktree →
+//! through the normal branch machinery (fetch → owned synthetic worktree →
 //! `add_branch_tracking`); fork PRs (a `refs/pull/N/head` whose SHA matches no
 //! origin head) are skipped. The tests assert: a PR branch is tracked and its
 //! *own* content is indexed, a second poll is a no-op, closing the PR untracks it
@@ -15,7 +15,8 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use crate::common::IsolatedEnv;
-use tracedecay::branch_meta::load_branch_meta;
+use fs2::FileExt;
+use tracedecay::branch_meta::{load_branch_meta, save_branch_meta};
 use tracedecay::daemon::pr_autotrack;
 use tracedecay::storage::resolve_layout_for_current_profile;
 use tracedecay::tracedecay::TraceDecay;
@@ -139,31 +140,50 @@ async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
     let head_branch = add_same_repo_pr(&project, &origin, 1, "pr_one_symbol");
     add_fork_pr(&project, 2, "fork_symbol");
+    git(&project, &["branch", "pr/1", "main"]);
+    let user_branch_sha =
+        String::from_utf8(git_out(&project, &["rev-parse", "refs/heads/pr/1"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
 
     let data_root = project_data_dir(&project);
+    let tracking_label = "tracedecay/autotrack/pr/1";
 
     // Discovery: PR 1 is a tracked same-repo PR; PR 2 is a skipped fork.
     let discovery = pr_autotrack::discover_open_prs(&project);
     assert_eq!(discovery.open.len(), 1, "one same-repo PR expected");
     assert_eq!(discovery.open[0].number, 1);
     assert_eq!(discovery.open[0].head_branch, head_branch);
+    assert!(!discovery.open[0].head_sha.is_empty());
     assert_eq!(discovery.skipped_forks, vec![2]);
 
     // Reconcile → PR 1 tracked.
     let report = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
-    assert_eq!(report.tracked, vec!["pr/1".to_string()]);
+    assert_eq!(report.tracked, vec![tracking_label.to_string()]);
     assert_eq!(report.skipped_forks, vec![2]);
 
     // Branch metadata + state reflect the tracked PR.
     let meta = load_branch_meta(&data_root).expect("branch meta exists");
-    assert!(meta.is_tracked("pr/1"), "pr/1 should be a tracked branch");
+    assert!(
+        meta.is_tracked(tracking_label),
+        "the internal PR ref should be a tracked branch"
+    );
     let summary = pr_autotrack::managed_summary(&data_root);
     assert_eq!(summary.len(), 1);
     assert_eq!(summary[0].pr, 1);
     assert_eq!(summary[0].head_branch, head_branch);
+    let user_branch_after_track =
+        String::from_utf8(git_out(&project, &["rev-parse", "refs/heads/pr/1"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+    assert_eq!(user_branch_after_track, user_branch_sha);
 
     // The PR branch DB indexed the PR's OWN content, not main's working tree.
-    let branch_cg = TraceDecay::open_branch(&project, "pr/1").await.unwrap();
+    let branch_cg = TraceDecay::open_branch(&project, tracking_label)
+        .await
+        .unwrap();
     let hits = branch_cg.search("pr_one_symbol", 10).await.unwrap();
     assert!(
         !hits.is_empty(),
@@ -177,6 +197,56 @@ async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
     assert!(again.untracked.is_empty());
     assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 1);
 
+    // Advance the remote PR head. Reconciliation must rebuild and sync the
+    // managed graph instead of serving the previous commit indefinitely.
+    git(
+        &project,
+        &[
+            "checkout",
+            "-b",
+            &head_branch,
+            &format!("origin/{head_branch}"),
+        ],
+    );
+    fs::write(
+        project.join("src/pr_1_updated.rs"),
+        "pub fn pr_one_updated_symbol() {}\n",
+    )
+    .unwrap();
+    commit_all(&project, "update PR 1 content");
+    git(&project, &["push", "origin", &head_branch]);
+    git(
+        &origin,
+        &[
+            "update-ref",
+            "refs/pull/1/head",
+            &format!("refs/heads/{head_branch}"),
+        ],
+    );
+    git(&project, &["checkout", "main"]);
+    git(&project, &["branch", "-D", &head_branch]);
+
+    let refreshed_discovery = pr_autotrack::discover_open_prs(&project);
+    assert_ne!(
+        refreshed_discovery.open[0].head_sha,
+        discovery.open[0].head_sha
+    );
+    let refreshed =
+        pr_autotrack::reconcile_project(&project, &data_root, &refreshed_discovery, 10).await;
+    assert_eq!(refreshed.tracked, vec![tracking_label.to_string()]);
+    let refreshed_cg = TraceDecay::open_branch(&project, tracking_label)
+        .await
+        .unwrap();
+    assert!(
+        !refreshed_cg
+            .search("pr_one_updated_symbol", 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "changed PR head must replace the stale branch graph"
+    );
+    drop(refreshed_cg);
+
     // Close PR 1 (delete its pull ref) → discovery no longer lists it → untrack.
     git(&origin, &["update-ref", "-d", "refs/pull/1/head"]);
     let after_close = pr_autotrack::discover_open_prs(&project);
@@ -185,14 +255,182 @@ async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
         "closed PR must not be discovered"
     );
     let closing = pr_autotrack::reconcile_project(&project, &data_root, &after_close, 10).await;
-    assert_eq!(closing.untracked, vec!["pr/1".to_string()]);
+    assert_eq!(closing.untracked, vec![tracking_label.to_string()]);
 
     let meta = load_branch_meta(&data_root).expect("branch meta exists");
-    assert!(!meta.is_tracked("pr/1"), "pr/1 should be untracked");
+    assert!(!meta.is_tracked(tracking_label));
     assert!(pr_autotrack::managed_summary(&data_root).is_empty());
     assert!(
         !data_root.join("pr-worktrees/pr-1").exists(),
         "worktree should be removed on untrack"
+    );
+    let user_branch_after_close =
+        String::from_utf8(git_out(&project, &["rev-parse", "refs/heads/pr/1"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+    assert_eq!(user_branch_after_close, user_branch_sha);
+}
+
+#[tokio::test]
+async fn deferred_tracking_is_not_persisted_and_retries_next_cycle() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 7, "pr_seven_symbol");
+    let data_root = project_data_dir(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project);
+
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(data_root.join(".branch-add.lock"))
+        .unwrap();
+    lock.lock_exclusive().unwrap();
+
+    let deferred = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert!(deferred.tracked.is_empty());
+    assert!(pr_autotrack::managed_summary(&data_root).is_empty());
+    assert!(
+        !data_root.join("pr-worktrees/pr-7").exists(),
+        "deferred tracking must roll back its worktree"
+    );
+
+    lock.unlock().unwrap();
+    let retried = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(
+        retried.tracked,
+        vec!["tracedecay/autotrack/pr/7".to_string()]
+    );
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 1);
+}
+
+#[tokio::test]
+async fn complete_orphan_is_rebuilt_after_interrupted_state_write() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 8, "pr_eight_symbol");
+    let data_root = project_data_dir(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project);
+    let label = "tracedecay/autotrack/pr/8";
+
+    let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(first.tracked, vec![label.to_string()]);
+    fs::remove_file(data_root.join("pr-autotrack.json")).unwrap();
+
+    let recovered = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(recovered.tracked, vec![label.to_string()]);
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 1);
+    assert!(load_branch_meta(&data_root).unwrap().is_tracked(label));
+}
+
+#[tokio::test]
+async fn validated_branch_ref_orphan_without_worktree_is_rebuilt() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 11, "pr_eleven_symbol");
+    let data_root = project_data_dir(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project);
+    let label = "tracedecay/autotrack/pr/11";
+    let worktree = data_root.join("pr-worktrees/pr-11");
+
+    let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(first.tracked, vec![label.to_string()]);
+    fs::remove_file(data_root.join("pr-autotrack.json")).unwrap();
+    assert!(tracedecay::branch::remove_tracked_branch_store(
+        &data_root, label
+    ));
+    git(
+        &project,
+        &["worktree", "remove", "--force", &worktree.to_string_lossy()],
+    );
+
+    let recovered = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(recovered.tracked, vec![label.to_string()]);
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 1);
+    assert!(worktree.exists());
+}
+
+#[tokio::test]
+async fn state_persistence_failure_rolls_back_completed_tracking() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 10, "pr_ten_symbol");
+    let data_root = project_data_dir(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project);
+    let label = "tracedecay/autotrack/pr/10";
+    fs::create_dir(data_root.join("pr-autotrack.json")).unwrap();
+
+    let report = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert!(report.tracked.is_empty());
+    assert!(
+        report
+            .failures
+            .iter()
+            .any(|(branch, reason)| branch == label && reason.contains("persist"))
+    );
+    assert!(!load_branch_meta(&data_root).unwrap().is_tracked(label));
+    assert!(!data_root.join("pr-worktrees/pr-10").exists());
+    assert!(
+        !git_out(
+            &project,
+            &[
+                "rev-parse",
+                "--verify",
+                "refs/heads/tracedecay/autotrack/pr/10"
+            ],
+        )
+        .status
+        .success()
+    );
+}
+
+#[tokio::test]
+async fn legacy_close_recovers_empty_head_sha_before_owned_ref_cleanup() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 9, "pr_nine_symbol");
+    let data_root = project_data_dir(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project);
+    let current_label = "tracedecay/autotrack/pr/9";
+    let legacy_label = "pr/9";
+    let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(first.tracked, vec![current_label.to_string()]);
+
+    let mut state = pr_autotrack::load_state(&data_root);
+    let mut managed = state.managed.remove(current_label).unwrap();
+    managed.head_sha.clear();
+    state.managed.insert(legacy_label.to_string(), managed);
+    fs::write(
+        data_root.join("pr-autotrack.json"),
+        serde_json::to_vec_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let mut meta = load_branch_meta(&data_root).unwrap();
+    let entry = meta.remove_branch(current_label).unwrap();
+    let parent = entry.parent.as_deref().unwrap_or("main");
+    meta.add_branch(legacy_label, &entry.db_file, parent);
+    save_branch_meta(&data_root, &meta).unwrap();
+    let worktree = data_root.join("pr-worktrees/pr-9");
+    git(&worktree, &["branch", "-m", legacy_label]);
+
+    git(&origin, &["update-ref", "-d", "refs/pull/9/head"]);
+    let closed = pr_autotrack::discover_open_prs(&project);
+    let report = pr_autotrack::reconcile_project(&project, &data_root, &closed, 10).await;
+    assert_eq!(report.untracked, vec![legacy_label.to_string()]);
+    assert!(
+        !load_branch_meta(&data_root)
+            .unwrap()
+            .is_tracked(legacy_label)
+    );
+    assert!(!worktree.exists());
+    assert!(
+        !git_out(&project, &["rev-parse", "--verify", "refs/tracedecay/pr/9"],)
+            .status
+            .success(),
+        "owned fetch ref must be removed after recovering its legacy SHA"
+    );
+    assert!(
+        git_out(&project, &["rev-parse", "--verify", "refs/heads/pr/9"])
+            .status
+            .success(),
+        "ambiguous legacy local branch must be preserved"
     );
 }
 


### PR DESCRIPTION
Tracks exact PR head SHAs, refreshes stale graphs, retries deferred/orphaned state, persists each successful reconciliation, and uses a collision-proof TraceDecay-owned branch namespace without deleting user pr/N branches.\n\nTests: cargo fmt --all -- --check; cargo test -q daemon::pr_autotrack::tests --lib; cargo test -q --test daemon_suite pr_autotrack (14 passed).