### PR TITLE
feat(plugins): add MCP-optional capability discovery

### DIFF
--- a/docs/superpowers/specs/2026-07-09-tracedecay-specialist-agents-design.md
+++ b/docs/superpowers/specs/2026-07-09-tracedecay-specialist-agents-design.md
@@ -1,0 +1,75 @@
+# TraceDecay Specialist Agents Design
+
+## Goal
+
+Expand TraceDecay's bundled agent set beyond generic code exploration, code
+health, and session history. The new agents cover the major operational and
+review surfaces without requiring MCP and without granting autonomous mutation
+authority.
+
+## Agent set
+
+1. `runtime-storage-doctor`: diagnoses daemon, database, migration, project
+   identity, move/rename/symlink, and index-health failures. It may run
+   read-only doctor, diagnostics, status, and storage inspection commands. It
+   reports root cause and a verification plan; the parent performs repairs.
+2. `cross-host-integration-auditor`: checks install/update/configuration and
+   capability parity across Codex, Claude, Cursor, and supported integrations.
+   It verifies skill, command, agent, hook, and tool discovery from packaged
+   artifacts and host-native diagnostics.
+3. `change-risk-reviewer`: reviews a PR, branch, or diff using semantic change
+   context, callers, affected tests, diagnostics, redundancy, and safety scans.
+   It returns only evidence-backed findings and does not edit or merge.
+4. `usage-intelligence-analyst`: analyzes tool adoption, fact recall and
+   feedback, hint relevance, session evidence, and discovery-channel gaps. It
+   uses TraceDecay analytics and transcript tools rather than raw databases.
+5. `automation-auditor`: inspects automation cycles, managed-skill drafts,
+   validation artifacts, apply policy, retry behavior, and adoption outcomes.
+   It does not approve, install, disable, archive, or apply artifacts.
+
+The existing `code-explorer`, `code-health-auditor`, and `session-historian`
+remain. The final bundled set is eight agents.
+
+## Transport and discovery
+
+Every agent prompt names intent, allowed evidence sources, stopping conditions,
+and a concise result schema. MCP is an optional transport. When MCP is absent,
+the agent uses the equivalent `tracedecay tool <name>` CLI surface and normal
+top-level CLI commands. It must discover exact flags from live `--help`, never
+query `.tracedecay` databases directly, and never invent a missing tool.
+
+The shared source lives under `plugin/agents/`. Claude and Cursor receive their
+native agent files. Codex materializes equivalent model-invocable agent skills
+through the existing bundle generator. Names, descriptions, bodies, and
+capability boundaries stay source-derived and parity-tested.
+
+## Authority boundaries
+
+All eight bundled agents are read-only analysts. They may inspect local files,
+git state, TraceDecay stores through supported commands, and remote PR/CI state
+when the parent provides that scope. They must not edit files, create commits,
+push, merge, release, mutate installations, change daemon state, run database
+maintenance, or apply automation artifacts. They hand exact recommended actions
+and verification commands to the parent agent, which owns executive decisions
+and mutations.
+
+## Testing and adoption evidence
+
+- Bundle contracts prove all eight agents deploy to Claude, Cursor, and Codex
+  with no missing support files or host-specific drift.
+- Static contracts reject MCP-only instructions, direct database access, and
+  mutation language in read-only agents.
+- Each new agent gets at least one neutral adoption scenario whose prompt names
+  neither TraceDecay nor the agent. Grading records first tool, invoked agent or
+  skill, discovery channel, tool budget, and evidence-backed outcome.
+- A CLI-only packaging test removes MCP configuration and proves each agent can
+  still discover the correct TraceDecay command path.
+- Existing plugin validation, formatting, bundle, and host materialization
+  suites remain green.
+
+## Non-goals
+
+- One agent per MCP tool.
+- Autonomous repair, release, or merge agents.
+- Host-specific agent behavior beyond the packaging adapter.
+- Replacing workflow skills or explicit commands with agents.

--- a/evals/agent_adoption/grade.py
+++ b/evals/agent_adoption/grade.py
@@ -133,7 +133,7 @@ _SKILL_IDS = (
     "exploring-code", "tracing-functions", "assessing-impact", "reviewing-changes",
     "project-memory", "editing-safely", "fixing-build-and-type-errors",
     "managing-session-context", "using-tracedecay", "using-the-cli", "code-health",
-    "diagnosing-analytics", "inspecting-managed-skills",
+    "diagnosing-analytics", "discovering-tracedecay", "inspecting-managed-skills",
 )
 # Substrings/regexes that must never appear in a scenario prompt (case-insensitive).
 _BANNED_PROMPT_PATTERNS = [

--- a/evals/agent_adoption/selftest.py
+++ b/evals/agent_adoption/selftest.py
@@ -67,6 +67,11 @@ def test_lint():
     check("lint: names tracedecay", "tracedecay" in grade.lint_prompt("Use tracedecay_context"))
     check("lint: names MCP", "MCP" in grade.lint_prompt("Run the MCP tool"))
     check("lint: names skill", "exploring-code" in grade.lint_prompt("use exploring-code"))
+    check(
+        "lint: names discovery skill",
+        "discovering-tracedecay"
+        in grade.lint_prompt("use discovering-tracedecay"),
+    )
     check("lint: names tool base", "fact_store" in grade.lint_prompt("call fact_store now"))
     scns = {"a": {"prompt": "neutral one"}, "b": {"prompt": "use tracedecay_grep"}}
     probs = grade.lint_scenarios(scns)

--- a/plugin/skills/discovering-tracedecay/SKILL.md
+++ b/plugin/skills/discovering-tracedecay/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: discovering-tracedecay
+description: 'Use when asking what TraceDecay can do, which TraceDecay tool, skill, command, or workflow fits a task, or how to discover capabilities when MCP is absent or optional.'
+---
+
+# Discovering TraceDecay
+
+Treat skills as workflow guidance and the CLI or MCP as interchangeable tool
+transports. MCP is optional: capability discovery must work from a shell alone.
+
+## Discovery ladder
+
+1. Run **`tracedecay tool`** to list every tool by category with a one-line
+   summary. Scan the relevant category; do not guess tool names.
+2. Run **`tracedecay tool <name> --help`** for the selected tool's exact
+   arguments, types, enum values, and examples.
+3. Run **`tracedecay --help`** for lifecycle commands such as `init`, `sync`,
+   `doctor`, `daemon`, `sessions`, `analytics`, `automation`, and `upgrade`.
+   Then inspect one command with `tracedecay <command> --help`.
+4. Choose the smallest matching workflow and continue with its skill:
+
+| Intent | Workflow skill |
+|---|---|
+| Locate or understand code | `tracedecay:exploring-code` |
+| Trace calls or assess blast radius | `tracedecay:tracing-functions` / `tracedecay:assessing-impact` |
+| Review or edit code | `tracedecay:reviewing-changes` / `tracedecay:editing-safely` |
+| Recover decisions or session history | `tracedecay:project-memory` / `tracedecay:managing-session-context` |
+| Diagnose adoption or host health | `tracedecay:diagnosing-analytics` / `tracedecay doctor` |
+| Fix compiler or type errors | `tracedecay:fixing-build-and-type-errors` |
+
+## Rules
+
+- Prefer live `--help` output over remembered flags; the installed binary is
+  the source of truth.
+- Do not query TraceDecay databases directly to discover capabilities.
+- Do not dump the entire catalog into the answer. Name the selected workflow,
+  exact command or tool, and why it matches.
+- Once a tool is selected, use MCP when available or the identical
+  `tracedecay tool <name>` CLI surface when it is not. See
+  `tracedecay:using-the-cli` for argument construction.
+
+## Deliverable
+
+Return the chosen skill or workflow, the exact next command/tool, and one-line
+reason. If no capability fits, say what is missing instead of inventing one.

--- a/plugin/skills/using-the-cli/SKILL.md
+++ b/plugin/skills/using-the-cli/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: using-the-cli
-description: 'Use when a tracedecay MCP call fails, times out, or the server is disconnected or unconfigured — every MCP tool is also a shell command, `tracedecay tool` plus the tool name. Switch to the CLI instead of querying .tracedecay databases directly or abandoning tracedecay.'
+description: 'Use when MCP is intentionally absent or unavailable, a host or subagent has shell access without MCP, or a tracedecay MCP call fails, times out, or disconnects.'
 ---
 
 # Using the tracedecay CLI
 
-The `tracedecay` binary exposes every MCP tool as a shell command. MCP and CLI hit the same project store and return the same payloads, so an MCP transport failure (timeout, disconnect, missing server config) loses nothing: run the same tool with the same arguments via `tracedecay tool <name>` and keep following whatever `tracedecay:*` skill you were in.
+MCP is optional. The `tracedecay` binary exposes every MCP tool as a first-class
+shell command with the same project store, arguments, and payloads. Use the CLI
+directly when MCP is intentionally unavailable, or switch to it after a
+transport failure, and keep following whatever `tracedecay:*` skill you were in.
 
 ## The one rule for arguments
 
@@ -71,13 +74,16 @@ identically over MCP (`tracedecay_retrieve`) and the CLI
   with `tracedecay_lcm_expand`; `tracedecay:managing-session-context` drives the
   LCM store and past-session retrieval.
 
-## When to switch
+## When to use the CLI
 
+- MCP is intentionally unavailable or omitted from the host integration.
 - An MCP call returns a client or transport error, times out, or the server drops mid-session.
 - The tracedecay MCP server is not configured in this host but `tracedecay` is on `PATH`.
 - A subagent or hook context has shell access but no MCP access.
 
-After falling back, diagnose the MCP side with `tracedecay doctor` and `tracedecay tool runtime`, and tell the user the session is running on the CLI fallback (and why) instead of silently downgrading.
+For a transport failure, diagnose the MCP side with `tracedecay doctor` and
+`tracedecay tool runtime`. When CLI-only operation is intentional, do not treat
+the missing MCP transport as an error.
 
 ## Corrective errors are the feedback loop
 

--- a/src/agents/claude/tests.rs
+++ b/src/agents/claude/tests.rs
@@ -66,7 +66,7 @@ fn claude_embedded_file_list_covers_the_whole_source_bundle() {
         .collect();
 
     let skills = plugin_subdir_names("skills");
-    assert_eq!(skills.len(), 13, "expected 13 shared skill dirs");
+    assert_eq!(skills.len(), 14, "expected 14 shared skill dirs");
     // Every file under plugin/skills/ (SKILL.md *and* any support files) is
     // deployed — the recursive embed leaves nothing on disk unwired.
     let skills_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin/skills");

--- a/src/agents/codex/tests.rs
+++ b/src/agents/codex/tests.rs
@@ -497,7 +497,7 @@ fn codex_embedded_file_list_covers_the_whole_source_bundle() {
         .map(|(relative, _)| relative.to_string())
         .collect();
 
-    // Every skill dir under plugin/skills is deployed by Codex (all 13).
+    // Every skill dir under plugin/skills is deployed by Codex (all 14).
     let skills_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin/skills");
     let mut skill_dirs: Vec<String> = std::fs::read_dir(&skills_root)
         .expect("plugin/skills should be readable")
@@ -506,7 +506,7 @@ fn codex_embedded_file_list_covers_the_whole_source_bundle() {
         .map(|entry| entry.file_name().to_string_lossy().into_owned())
         .collect();
     skill_dirs.sort();
-    assert_eq!(skill_dirs.len(), 13, "expected 13 shared skill dirs");
+    assert_eq!(skill_dirs.len(), 14, "expected 14 shared skill dirs");
     // Every file under plugin/skills/ (SKILL.md *and* any support files) is
     // deployed — the recursive embed leaves nothing on disk unwired.
     for relative in skill_tree_files(&skills_root) {

--- a/src/agents/plugin_bundle.rs
+++ b/src/agents/plugin_bundle.rs
@@ -5,7 +5,7 @@
 //! agent format.
 //!
 //! Layout of `plugin/`:
-//! - `plugin/skills/*/SKILL.md` — the 13 shared model-invocable skills. All
+//! - `plugin/skills/*/SKILL.md` — the 14 shared model-invocable skills. All
 //!   three hosts deploy the full set; the workflow dispatcher skills were
 //!   removed (their behavior lives in the native slash commands below), so no
 //!   host filters the skill set today. The `cursor_skill_files` filter is kept
@@ -306,6 +306,14 @@ mod tests {
         }
     }
 
+    fn embedded_skill(relative: &str) -> &'static str {
+        GENERATED_SKILL_FILES
+            .iter()
+            .find(|file| file.relative == relative)
+            .map(|file| file.contents)
+            .unwrap_or_else(|| panic!("shared skill should be embedded: {relative}"))
+    }
+
     #[test]
     fn each_host_deploys_unique_relative_paths() {
         assert_unique_relatives(&claude_files(), "claude");
@@ -343,6 +351,44 @@ mod tests {
         assert_eq!(cursor_files().len(), cursor_skills + 4 + 2 + 3 + 13);
         // Codex: skills + 4 manifest (dot + mcp + hooks + README).
         assert_eq!(codex_files().len(), all_skills + 4);
+    }
+
+    #[test]
+    fn capability_discovery_skill_is_shared_and_cli_native() {
+        let relative = "skills/discovering-tracedecay/SKILL.md";
+        let source = embedded_skill(relative);
+
+        assert!(source.contains("`tracedecay tool`"));
+        assert!(source.contains("`tracedecay tool <name> --help`"));
+        assert!(source.contains("`tracedecay --help`"));
+        assert!(
+            !source.contains("tool describe"),
+            "the CLI has no `tool describe` subcommand"
+        );
+
+        for (host, files) in [
+            ("claude", claude_files()),
+            ("cursor", cursor_files()),
+            ("codex", codex_files()),
+        ] {
+            let deployed = files
+                .iter()
+                .find(|(path, _)| *path == relative)
+                .map(|(_, contents)| *contents)
+                .unwrap_or_else(|| panic!("{host} is missing {relative}"));
+            assert_eq!(
+                deployed, source,
+                "{host} must ship the shared source verbatim"
+            );
+        }
+    }
+
+    #[test]
+    fn using_cli_skill_supports_intentional_mcp_absence() {
+        let source = embedded_skill("skills/using-the-cli/SKILL.md");
+
+        assert!(source.contains("MCP is optional"));
+        assert!(source.contains("intentionally unavailable"));
     }
 
     /// Every embedded skill file maps to an on-disk source under `plugin/`.

--- a/src/hooks/steering.rs
+++ b/src/hooks/steering.rs
@@ -11,6 +11,7 @@ pub const CURSOR_PLUGIN_SKILLS: &[&str] = &[
     "assessing-impact",
     "code-health",
     "diagnosing-analytics",
+    "discovering-tracedecay",
     "editing-safely",
     "exploring-code",
     "fixing-build-and-type-errors",

--- a/tests/agent_suite/claude_plugin_bundle_test.rs
+++ b/tests/agent_suite/claude_plugin_bundle_test.rs
@@ -29,7 +29,7 @@ fn bundle_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin")
 }
 
-/// The 13 model-invocable skills the bundle ships (also the codex skill set),
+/// The 14 model-invocable skills the bundle ships (also the Codex skill set),
 /// kept in sync across every skill-bundling surface. The `tracedecay-*`
 /// workflow dispatcher skills were removed (their behavior lives in the native
 /// slash commands), the memory write/read skills were folded into
@@ -39,6 +39,7 @@ const EXPECTED_SKILLS: &[&str] = &[
     "assessing-impact",
     "code-health",
     "diagnosing-analytics",
+    "discovering-tracedecay",
     "editing-safely",
     "exploring-code",
     "fixing-build-and-type-errors",


### PR DESCRIPTION
Adds a shared CLI-native TraceDecay discovery skill and aligns Codex, Claude, and Cursor plugin steering so agents can discover the full capability surface without MCP. Validated with adoption-grader selftests and plugin bundle tests.