### PR TITLE
fix(sessions): distinguish produced and observed commits

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -3143,12 +3143,36 @@ impl GlobalDb {
         parse_offset_path: &str,
         parse_offset: ParseOffset,
     ) -> bool {
+        self.upsert_transcript_batch_with_git_evidence(
+            session,
+            messages,
+            &[],
+            &[],
+            parse_offset_path,
+            parse_offset,
+        )
+        .await
+    }
+
+    /// Atomically persists transcript rows, direct commit evidence, and the
+    /// parse cursor so a failed attribution write is replayed on the next sync.
+    pub(crate) async fn upsert_transcript_batch_with_git_evidence(
+        &self,
+        session: &SessionRecord,
+        messages: &[SessionMessageRecord],
+        commit_records: &[crate::sessions::git_correlation::CommitSessionRecord],
+        span_observations: &[crate::sessions::git_correlation::SpanObservation],
+        parse_offset_path: &str,
+        parse_offset: ParseOffset,
+    ) -> bool {
         let batch = TranscriptBatch {
             session: session.clone(),
             messages: messages.to_vec(),
         };
         self.upsert_transcript_batches_inner(
             std::slice::from_ref(&batch),
+            commit_records,
+            span_observations,
             parse_offset_path,
             parse_offset,
             TranscriptWriteMode::Full,
@@ -3176,6 +3200,8 @@ impl GlobalDb {
     ) -> bool {
         self.upsert_transcript_batches_inner(
             batches,
+            &[],
+            &[],
             parse_offset_path,
             parse_offset,
             TranscriptWriteMode::ProjectionOnly,
@@ -3186,6 +3212,8 @@ impl GlobalDb {
     async fn upsert_transcript_batches_inner(
         &self,
         batches: &[TranscriptBatch],
+        commit_records: &[crate::sessions::git_correlation::CommitSessionRecord],
+        span_observations: &[crate::sessions::git_correlation::SpanObservation],
         parse_offset_path: &str,
         parse_offset: ParseOffset,
         mode: TranscriptWriteMode,
@@ -3217,6 +3245,28 @@ impl GlobalDb {
                     let _ = self.conn.execute("ROLLBACK", ()).await;
                     return false;
                 }
+            }
+        }
+        for record in commit_records {
+            if crate::sessions::git_correlation::upsert_commit_session(&self.conn, record)
+                .await
+                .is_err()
+            {
+                let _ = self.conn.execute("ROLLBACK", ()).await;
+                return false;
+            }
+        }
+        for observation in span_observations {
+            if crate::sessions::git_correlation::record_span_observation_in_transaction(
+                &self.conn,
+                observation,
+                crate::sessions::git_correlation::DEFAULT_SPAN_MERGE_GAP_SECS,
+            )
+            .await
+            .is_err()
+            {
+                let _ = self.conn.execute("ROLLBACK", ()).await;
+                return false;
             }
         }
         if !self
@@ -3813,6 +3863,20 @@ impl GlobalDb {
         crate::sessions::git_correlation::GitCorrelationError,
     > {
         crate::sessions::git_correlation::sessions_for(&self.conn, query).await
+    }
+
+    /// Returns sessions for a git ref with an explicit commit relationship
+    /// selector. Branch and worktree queries are unaffected by the selector.
+    pub async fn git_sessions_for_with_relation(
+        &self,
+        query: &crate::sessions::git_correlation::SessionsForQuery,
+        relation: crate::sessions::git_correlation::CommitRelationFilter,
+    ) -> Result<
+        Vec<crate::sessions::git_correlation::SessionGitCorrelationHit>,
+        crate::sessions::git_correlation::GitCorrelationError,
+    > {
+        crate::sessions::git_correlation::sessions_for_with_relation(&self.conn, query, relation)
+            .await
     }
 
     /// Reports the per-project session↔git correlation index health (span/commit

--- a/src/mcp/tools/definitions/session.rs
+++ b/src/mcp/tools/definitions/session.rs
@@ -85,7 +85,7 @@ pub(super) fn def_sessions_for() -> ToolDefinition {
     def(
         "tracedecay_sessions_for",
         "Sessions For Git Ref",
-        "Find agent sessions correlated with a git artifact in the active project: all sessions active on a branch, in a worktree, or attributed to a commit (the conversations that produced it). Attribution is span-based, so mid-session branch switches are respected. Supports time-scoped queries via since/until.",
+        "Find agent sessions correlated with a git artifact in the active project: sessions active on a branch or worktree, or sessions with evidence that they produced or observed a commit. Commit queries default to direct producer evidence; use relation=observed/all for weaker historical overlap. Supports time-scoped queries via since/until.",
         json!({
             "type": "object",
             "properties": {
@@ -100,6 +100,11 @@ pub(super) fn def_sessions_for() -> ToolDefinition {
                 },
                 "since": time_filter_schema("Optional inclusive minimum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."),
                 "until": time_filter_schema("Optional inclusive maximum activity/commit timestamp. Integer strings and timezone-aware ISO/RFC3339 strings are accepted."),
+                "relation": {
+                    "type": "string",
+                    "enum": ["produced", "observed", "all"],
+                    "description": "Commit relationship to return (default: produced). produced requires direct creation evidence; observed is weaker HEAD/reflog/time-overlap evidence. Ignored for branch/worktree queries."
+                },
                 "limit": {
                     "type": "integer",
                     "minimum": 1,

--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -17,7 +17,9 @@ use crate::mcp::response_handles::{
 };
 use crate::mcp::tools::{MAX_RESPONSE_CHARS, ToolResult};
 use crate::sessions::cursor::HermesProfileDbReadOnly;
-use crate::sessions::git_correlation::{GitRefFilter, GitScopeFilter, SessionsForQuery};
+use crate::sessions::git_correlation::{
+    CommitRelationFilter, GitRefFilter, GitScopeFilter, SessionsForQuery,
+};
 use crate::sessions::lcm::compression_decision::{self, AssemblyCapInput};
 use crate::sessions::lcm::{
     LCM_EXPAND_QUERY_SYNTHESIS_SYSTEM_PROMPT, LcmCleanConfig, LcmCompressionRequest,
@@ -2125,11 +2127,19 @@ fn render_sessions_for_md(value: &Value) -> String {
                 .unwrap_or(false);
             md.blank();
             if index_empty {
-                md.empty_note(
-                    "Correlation index is empty — no git spans recorded yet. It will \
-                     auto-backfill on the next MCP server startup, or run \
-                     `tracedecay sessions git-backfill` to populate it now.",
-                );
+                if value.get("git_ref").and_then(Value::as_str) == Some("commit") {
+                    md.empty_note(
+                        "No commit evidence is indexed yet. Run `tracedecay sync` to ingest \
+                         direct host/tool evidence; `tracedecay sessions git-backfill` adds \
+                         weaker historical overlap evidence.",
+                    );
+                } else {
+                    md.empty_note(
+                        "Correlation index is empty — no git spans recorded yet. It will \
+                         auto-backfill on the next MCP server startup, or run \
+                         `tracedecay sessions git-backfill` to populate it now.",
+                    );
+                }
             } else {
                 md.empty_note("No correlated sessions recorded for this git ref.");
             }
@@ -2176,6 +2186,15 @@ fn append_sessions_for_hit(md: &mut Md, hit: &Value) {
         }
         let short = sha.get(..12).unwrap_or(sha);
         let _ = write!(detail, "commit `{short}`");
+        if let Some(relation) = hit.get("relation").and_then(Value::as_str) {
+            let _ = write!(detail, " · {relation}");
+        }
+        if let Some(evidence) = hit.get("evidence").and_then(Value::as_str) {
+            let _ = write!(detail, " via {evidence}");
+        }
+        if let Some(confidence) = hit.get("confidence").and_then(Value::as_i64) {
+            let _ = write!(detail, " ({confidence}/100)");
+        }
         if let Some(committed_at) = hit.get("committed_at").and_then(Value::as_i64) {
             let _ = write!(
                 detail,
@@ -2198,6 +2217,8 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
     let until = non_negative_timestamp_arg(&args, "until", SearchTimeBound::End)?;
     let limit = bounded_usize_arg(&args, "limit", 1, MAX_LCM_RESULT_LIMIT)?
         .unwrap_or(DEFAULT_SESSIONS_FOR_LIMIT);
+    let relation = CommitRelationFilter::parse(string_arg(&args, "relation"))
+        .map_err(|err| argument_error(err.to_string()))?;
     let query = SessionsForQuery {
         git_ref,
         since,
@@ -2227,7 +2248,7 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
         // index that simply had no rows matching this git ref.
         let health = db.git_correlation_index_health().await.ok();
         let results = db
-            .git_sessions_for(&query)
+            .git_sessions_for_with_relation(&query, relation)
             .await
             .map_err(|err| TraceDecayError::Config {
                 message: err.to_string(),
@@ -2239,15 +2260,19 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
     };
 
     // The index is "empty" when there is no store, the correlation tables are
-    // absent, or they hold zero spans. In every such case `sessions_for` can
-    // only ever return nothing, which must not read as "no sessions matched".
-    let index_empty = index_health.as_ref().is_none_or(|health| health.is_empty());
+    // absent, or the row family for this ref kind is empty (spans for
+    // branch/worktree, commit rows for commit). That must not read as a genuine
+    // "no sessions matched" result.
+    let index_empty = index_health
+        .as_ref()
+        .is_none_or(|health| health.is_empty_for(&query.git_ref));
     let mut payload = json!({
         "status": "ok",
         "git_ref": query.git_ref.kind(),
         "value": query.git_ref.value(),
         "since": since,
         "until": until,
+        "relation": relation.as_str(),
         "count": results.len(),
         "results": results,
         "index_empty": index_empty,
@@ -2266,7 +2291,11 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
     // populated index genuinely had no session on this ref.
     if results.is_empty() {
         payload["message"] = json!(if index_empty {
-            "correlation index empty (no git spans recorded yet) — it will auto-backfill on the next MCP server startup, or run `tracedecay sessions git-backfill` to populate it now"
+            if matches!(&query.git_ref, GitRefFilter::Commit(_)) {
+                "no commit evidence indexed yet — run `tracedecay sync` to ingest direct host/tool evidence; `tracedecay sessions git-backfill` adds weaker historical overlap evidence"
+            } else {
+                "correlation index empty (no git spans recorded yet) — it will auto-backfill on the next MCP server startup, or run `tracedecay sessions git-backfill` to populate it now"
+            }
         } else {
             "no sessions matched this git ref"
         });

--- a/src/sessions/claude.rs
+++ b/src/sessions/claude.rs
@@ -969,6 +969,13 @@ fn message_metadata(
         CLAUDE_MESSAGE_LOCATION_KEYS,
         TranscriptLocation::new(location_cwd, location_provenance),
     );
+    if let Some(branch) = record
+        .get("gitBranch")
+        .and_then(Value::as_str)
+        .filter(|branch| !branch.is_empty())
+    {
+        metadata.insert("git_branch".to_string(), Value::String(branch.to_string()));
+    }
     append_tool_calls_metadata(&mut metadata, message);
     append_tool_event_metadata(&mut metadata, content);
     // Anthropic-style per-message counters: `message.usage.{input_tokens,
@@ -984,8 +991,51 @@ fn message_metadata(
     // patch bodies) and fold the file into the session summary.
     if kind == "user" {
         append_edited_file_metadata(&mut metadata, record, accumulator);
+        append_git_operation_metadata(&mut metadata, record);
     }
     Value::Object(metadata)
+}
+
+/// Preserve Claude's structured git-operation event as direct commit evidence.
+/// The abbreviated id is resolved against the repository before persistence;
+/// raw stdout/stderr stays in the lossless transcript rather than metadata.
+fn append_git_operation_metadata(metadata: &mut Map<String, Value>, record: &Value) {
+    let Some(commit) = record
+        .pointer("/toolUseResult/gitOperation/commit")
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    let Some(sha) = commit.get("sha").and_then(Value::as_str).filter(|sha| {
+        (7..=64).contains(&sha.len()) && sha.chars().all(|ch| ch.is_ascii_hexdigit())
+    }) else {
+        return;
+    };
+    metadata.insert(
+        "produced_commit_candidates".to_string(),
+        Value::Array(vec![Value::String(sha.to_ascii_lowercase())]),
+    );
+    metadata.insert(
+        "produced_commit_evidence".to_string(),
+        Value::String("host_event".to_string()),
+    );
+    if let Some(kind) = commit
+        .get("kind")
+        .and_then(Value::as_str)
+        .filter(|kind| !kind.is_empty())
+    {
+        metadata.insert(
+            "produced_commit_kind".to_string(),
+            Value::String(kind.to_string()),
+        );
+    }
+    if let Some(branch) = record
+        .get("gitBranch")
+        .and_then(Value::as_str)
+        .filter(|branch| !branch.is_empty())
+    {
+        metadata.insert("git_branch".to_string(), Value::String(branch.to_string()));
+    }
 }
 
 /// Copy Claude's top-level attribution fields onto an assistant row's metadata.
@@ -1067,4 +1117,39 @@ fn record_cwd(record: &Value) -> Option<PathBuf> {
         .and_then(Value::as_str)
         .filter(|cwd| !cwd.is_empty())
         .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn structured_git_operation_becomes_host_commit_evidence() {
+        let mut metadata = Map::new();
+        append_git_operation_metadata(
+            &mut metadata,
+            &json!({
+                "gitBranch": "feature/attribution",
+                "toolUseResult": {
+                    "gitOperation": {
+                        "commit": {"sha": "ABCDEF12", "kind": "commit"}
+                    }
+                }
+            }),
+        );
+        assert_eq!(metadata["produced_commit_candidates"], json!(["abcdef12"]));
+        assert_eq!(metadata["produced_commit_evidence"], "host_event");
+        assert_eq!(metadata["git_branch"], "feature/attribution");
+    }
+
+    #[test]
+    fn unstructured_user_content_cannot_spoof_commit_evidence() {
+        let mut metadata = Map::new();
+        append_git_operation_metadata(
+            &mut metadata,
+            &json!({"message": {"content": "gitOperation commit abcdef12"}}),
+        );
+        assert!(metadata.is_empty());
+    }
 }

--- a/src/sessions/codex/events.rs
+++ b/src/sessions/codex/events.rs
@@ -501,6 +501,17 @@ fn exec_command_row(
         "success".to_string(),
         success.map_or(Value::Null, Value::Bool),
     );
+    if success == Some(true) {
+        let candidates = output
+            .map(|output| produced_commit_candidates(&exec.cmd, output))
+            .unwrap_or_default();
+        if !candidates.is_empty() {
+            metadata.insert(
+                "produced_commit_candidates".to_string(),
+                Value::Array(candidates.into_iter().map(Value::String).collect()),
+            );
+        }
+    }
 
     build_row(
         meta,
@@ -514,6 +525,69 @@ fn exec_command_row(
         Some("exec_command".to_string()),
         &Value::Object(metadata),
     )
+}
+
+fn produced_commit_candidates(command: &str, wrapped_output: &str) -> Vec<String> {
+    let creates_commit = command
+        .split([';', '\n', '&', '|'])
+        .any(segment_creates_commit);
+    if !creates_commit {
+        return Vec::new();
+    }
+
+    let output = wrapped_output
+        .rsplit_once("\nOutput:\n")
+        .map_or(wrapped_output, |(_, output)| output);
+    let reports_head = command
+        .split([';', '\n', '&', '|'])
+        .any(segment_reports_head);
+    let mut candidates = Vec::new();
+    for line in output.lines() {
+        let trimmed = line.trim();
+        let bracket_candidate = trimmed
+            .strip_prefix('[')
+            .and_then(|line| line.split_once(']'))
+            .and_then(|(header, _)| header.split_whitespace().next_back())
+            .map(|token| token.trim_matches(|ch: char| !ch.is_ascii_hexdigit()));
+        let exact_head = reports_head.then_some(trimmed).filter(|candidate| {
+            matches!(candidate.len(), 40 | 64) && candidate.chars().all(|ch| ch.is_ascii_hexdigit())
+        });
+        for candidate in bracket_candidate.into_iter().chain(exact_head) {
+            if candidate.len() >= 7
+                && candidate.chars().all(|ch| ch.is_ascii_hexdigit())
+                && !candidates.iter().any(|known| known == candidate)
+            {
+                candidates.push(candidate.to_ascii_lowercase());
+            }
+        }
+    }
+    candidates
+}
+
+fn segment_reports_head(segment: &str) -> bool {
+    let tokens: Vec<_> = segment.split_whitespace().collect();
+    tokens
+        .windows(3)
+        .any(|tokens| tokens == ["git", "rev-parse", "HEAD"])
+}
+
+fn segment_creates_commit(segment: &str) -> bool {
+    let mut tokens = segment.split_whitespace();
+    let Some(git) = tokens.next() else {
+        return false;
+    };
+    if git.trim_matches(['\'', '"']) != "git" {
+        return false;
+    }
+    let mut subcommand = tokens.next();
+    while matches!(subcommand, Some("-C" | "-c" | "--git-dir" | "--work-tree")) {
+        let _ = tokens.next();
+        subcommand = tokens.next();
+    }
+    matches!(
+        subcommand,
+        Some("commit" | "cherry-pick" | "revert" | "merge")
+    ) || subcommand == Some("rebase") && tokens.any(|token| token == "--continue")
 }
 
 fn patch_apply_row(
@@ -1034,6 +1108,55 @@ mod tests {
         assert_eq!(md["exit_code"], 0);
         assert_eq!(md["wall_time_s"], 1.5);
         assert_eq!(md["success"], true);
+    }
+
+    #[test]
+    fn successful_git_commit_output_records_only_resolvable_candidates() {
+        let mut state = CodexStructuredState::new();
+        let path = std::path::Path::new("/tmp/rollout.jsonl");
+        let call = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": "{\"cmd\":\"git commit -m test && git rev-parse HEAD\"}",
+                "call_id": "commit-call"
+            }
+        });
+        state
+            .event_from_line(&call, &meta(), None, path, 10)
+            .unwrap();
+        let output = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "commit-call",
+                "output": "Chunk ID: deadbe\nProcess exited with code 0\nOutput:\n[main abcdef1] test\n0123456789abcdef0123456789abcdef01234567\n"
+            }
+        });
+        let rows = state
+            .event_from_line(&output, &meta(), None, path, 20)
+            .unwrap();
+        let md = metadata_of(&rows[0]);
+        assert_eq!(
+            md["produced_commit_candidates"],
+            json!(["abcdef1", "0123456789abcdef0123456789abcdef01234567"])
+        );
+    }
+
+    #[test]
+    fn failed_or_non_commit_commands_never_claim_commit_production() {
+        assert!(produced_commit_candidates("git status", "Output:\nabcdef1").is_empty());
+        assert!(
+            produced_commit_candidates("rg git commit", "Output:\n[main abcdef1] test").is_empty()
+        );
+        assert_eq!(
+            produced_commit_candidates(
+                "git commit -m 0123456789abcdef0123456789abcdef01234567",
+                "Output:\n[main abcdef1] 0123456789abcdef0123456789abcdef01234567"
+            ),
+            vec!["abcdef1"]
+        );
     }
 
     #[test]

--- a/src/sessions/git_correlation.rs
+++ b/src/sessions/git_correlation.rs
@@ -12,10 +12,24 @@ use std::fmt::Write as _;
 use libsql::{Connection, Value, params};
 use serde::{Deserialize, Serialize};
 
+use super::SessionMessageRecord;
+
 /// Schema version recorded in `session_schema_migrations`.
-pub const GIT_CORRELATION_SCHEMA_VERSION: i64 = 2;
+pub const GIT_CORRELATION_SCHEMA_VERSION: i64 = 3;
 
 const MIGRATION_NAME: &str = "git_correlation";
+
+const MESSAGE_WORKTREE_KEYS: [&str; 9] = [
+    "codex_turn_worktree",
+    "claude_message_worktree",
+    "cursor_event_worktree",
+    "kiro_workspace_worktree",
+    "cline_like_task_worktree",
+    "vibe_session_worktree",
+    "codex_session_worktree",
+    "claude_session_worktree",
+    "hermes_session_worktree",
+];
 
 /// Default gap (seconds) within which a new observation extends the newest
 /// matching span instead of opening a new one. Tool-use events inside one
@@ -92,6 +106,8 @@ impl SpanSource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SpanOverlapKind {
+    /// Direct producer evidence, not a span/time inference.
+    Direct,
     /// Commit time fell strictly inside `[first_ts, last_ts]` of a span on
     /// the same branch/worktree.
     WithinSpan,
@@ -106,6 +122,7 @@ pub enum SpanOverlapKind {
 impl SpanOverlapKind {
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Direct => "direct",
             Self::WithinSpan => "within_span",
             Self::ExtendedWindow => "extended_window",
             Self::Reflog => "reflog",
@@ -114,10 +131,107 @@ impl SpanOverlapKind {
 
     pub fn from_db(value: &str) -> Option<Self> {
         match value {
+            "direct" => Some(Self::Direct),
             "within_span" => Some(Self::WithinSpan),
             "extended_window" => Some(Self::ExtendedWindow),
             "reflog" => Some(Self::Reflog),
             _ => None,
+        }
+    }
+}
+
+/// What a commit/session relationship actually proves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitRelation {
+    /// Direct evidence says this session created the commit.
+    Produced,
+    /// The session merely saw the commit or overlapped it in time.
+    Observed,
+}
+
+impl CommitRelation {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Produced => "produced",
+            Self::Observed => "observed",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "produced" => Some(Self::Produced),
+            "observed" => Some(Self::Observed),
+            _ => None,
+        }
+    }
+}
+
+/// Durable evidence class behind a commit relationship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitEvidence {
+    /// Successful tool result containing the produced commit ref.
+    ToolResult,
+    /// Exact host-emitted commit event.
+    HostEvent,
+    /// The host reported this commit as current HEAD.
+    HeadObservation,
+    /// Reconstructed from reflog branch history plus a session window.
+    ReflogOverlap,
+    /// Inferred only from branch/worktree/time overlap.
+    TimeOverlap,
+}
+
+impl CommitEvidence {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ToolResult => "tool_result",
+            Self::HostEvent => "host_event",
+            Self::HeadObservation => "head_observation",
+            Self::ReflogOverlap => "reflog_overlap",
+            Self::TimeOverlap => "time_overlap",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "tool_result" => Some(Self::ToolResult),
+            "host_event" => Some(Self::HostEvent),
+            "head_observation" => Some(Self::HeadObservation),
+            "reflog_overlap" => Some(Self::ReflogOverlap),
+            "time_overlap" => Some(Self::TimeOverlap),
+            _ => None,
+        }
+    }
+}
+
+/// Relation selector for commit queries. Producer evidence is the safe default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CommitRelationFilter {
+    #[default]
+    Produced,
+    Observed,
+    All,
+}
+
+impl CommitRelationFilter {
+    pub fn parse(value: Option<&str>) -> Result<Self, GitCorrelationError> {
+        match value.unwrap_or("produced") {
+            "produced" => Ok(Self::Produced),
+            "observed" => Ok(Self::Observed),
+            "all" => Ok(Self::All),
+            other => Err(GitCorrelationError::InvalidArgument(format!(
+                "relation must be one of produced, observed, all (got `{other}`)"
+            ))),
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Produced => "produced",
+            Self::Observed => "observed",
+            Self::All => "all",
         }
     }
 }
@@ -167,6 +281,12 @@ pub struct CommitSessionRecord {
     pub span_overlap_kind: SpanOverlapKind,
     /// Span row that claimed the commit, when attribution was span-based.
     pub span_id: Option<i64>,
+    pub relation: CommitRelation,
+    pub evidence: CommitEvidence,
+    /// Evidence-class confidence on a fixed 0-100 scale.
+    pub confidence: i64,
+    /// Source message or host event that supplied direct evidence, when known.
+    pub evidence_message_id: Option<String>,
 }
 
 /// A parsed, validated git reference to correlate sessions against.
@@ -299,6 +419,14 @@ pub struct SessionGitCorrelationHit {
     pub committed_at: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub span_overlap_kind: Option<SpanOverlapKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation: Option<CommitRelation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<CommitEvidence>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_message_id: Option<String>,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)] // serde skip_serializing_if signature
@@ -397,19 +525,31 @@ pub fn span_debounce_key(
 pub(crate) async fn ensure_git_correlation_schema(
     conn: &Connection,
 ) -> Result<(), GitCorrelationError> {
-    if schema_version(conn)
-        .await
-        .is_some_and(|version| version >= GIT_CORRELATION_SCHEMA_VERSION)
-    {
-        return Ok(());
-    }
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS session_schema_migrations (
             name TEXT PRIMARY KEY,
             version INTEGER NOT NULL,
             applied_at INTEGER NOT NULL DEFAULT (unixepoch())
-        );
-        CREATE TABLE IF NOT EXISTS session_git_spans (
+        );",
+    )
+    .await?;
+    let version = schema_version(conn).await?;
+    if version.is_some_and(|version| version > GIT_CORRELATION_SCHEMA_VERSION) {
+        return Err(GitCorrelationError::Db(format!(
+            "database uses newer git correlation schema {} (this binary supports {})",
+            version.unwrap_or_default(),
+            GIT_CORRELATION_SCHEMA_VERSION
+        )));
+    }
+    if version == Some(GIT_CORRELATION_SCHEMA_VERSION) {
+        return Ok(());
+    }
+    let rebuild_commit_table = table_exists(conn, "commit_sessions").await?;
+
+    conn.execute("BEGIN IMMEDIATE", ()).await?;
+    let migration = async {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS session_git_spans (
             span_id INTEGER PRIMARY KEY AUTOINCREMENT,
             provider TEXT NOT NULL DEFAULT '',
             session_id TEXT NOT NULL,
@@ -430,7 +570,22 @@ pub(crate) async fn ensure_git_correlation_schema(
             ON session_git_spans(branch, last_ts);
         CREATE INDEX IF NOT EXISTS idx_session_git_spans_worktree
             ON session_git_spans(worktree, last_ts);
-        CREATE TABLE IF NOT EXISTS commit_sessions (
+        CREATE TABLE IF NOT EXISTS git_correlation_meta (
+            key TEXT PRIMARY KEY,
+            value INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+        );",
+        )
+        .await?;
+        if rebuild_commit_table {
+            conn.execute(
+                "ALTER TABLE commit_sessions RENAME TO commit_sessions_legacy_v3",
+                (),
+            )
+            .await?;
+        }
+        conn.execute_batch(
+            "CREATE TABLE commit_sessions (
             commit_sha TEXT NOT NULL,
             provider TEXT NOT NULL DEFAULT '',
             session_id TEXT NOT NULL,
@@ -438,47 +593,256 @@ pub(crate) async fn ensure_git_correlation_schema(
             worktree TEXT,
             committed_at INTEGER NOT NULL,
             span_overlap_kind TEXT NOT NULL
-                CHECK(span_overlap_kind IN ('within_span', 'extended_window', 'reflog')),
+                CHECK(span_overlap_kind IN ('direct', 'within_span', 'extended_window', 'reflog')),
             span_id INTEGER,
+            relation TEXT NOT NULL DEFAULT 'observed'
+                CHECK(relation IN ('produced', 'observed')),
+            evidence TEXT NOT NULL DEFAULT 'time_overlap'
+                CHECK(evidence IN ('tool_result', 'host_event', 'head_observation', 'reflog_overlap', 'time_overlap')),
+            confidence INTEGER NOT NULL DEFAULT 20
+                CHECK(confidence BETWEEN 0 AND 100),
+            evidence_message_id TEXT,
             created_at INTEGER NOT NULL DEFAULT (unixepoch()),
             PRIMARY KEY(commit_sha, provider, session_id)
-        );
-        CREATE INDEX IF NOT EXISTS idx_commit_sessions_session
-            ON commit_sessions(provider, session_id, committed_at);
-        CREATE INDEX IF NOT EXISTS idx_commit_sessions_branch
-            ON commit_sessions(branch, committed_at);
-        CREATE TABLE IF NOT EXISTS git_correlation_meta (
-            key TEXT PRIMARY KEY,
-            value INTEGER NOT NULL,
-            updated_at INTEGER NOT NULL DEFAULT (unixepoch())
         );",
-    )
-    .await?;
-    conn.execute(
-        "INSERT INTO session_schema_migrations(name, version)
+        )
+        .await?;
+        if rebuild_commit_table {
+            conn.execute(
+                "INSERT INTO commit_sessions (
+                    commit_sha, provider, session_id, branch, worktree,
+                    committed_at, span_overlap_kind, span_id,
+                    relation, evidence, confidence, evidence_message_id, created_at
+                 )
+                 SELECT commit_sha, provider, session_id, branch, worktree,
+                    committed_at, span_overlap_kind, span_id,
+                    'observed',
+                    CASE WHEN span_overlap_kind = 'reflog'
+                         THEN 'reflog_overlap' ELSE 'time_overlap' END,
+                    CASE WHEN span_overlap_kind = 'reflog' THEN 30 ELSE 20 END,
+                    NULL, created_at
+                 FROM commit_sessions_legacy_v3",
+                (),
+            )
+            .await?;
+            conn.execute("DROP TABLE commit_sessions_legacy_v3", ())
+                .await?;
+        }
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_commit_sessions_session
+                ON commit_sessions(provider, session_id, committed_at);
+             CREATE INDEX IF NOT EXISTS idx_commit_sessions_branch
+                ON commit_sessions(branch, committed_at);",
+        )
+        .await?;
+        conn.execute(
+            "INSERT INTO session_schema_migrations(name, version)
          VALUES (?1, ?2)
          ON CONFLICT(name) DO UPDATE SET
             version = excluded.version,
             applied_at = unixepoch()",
-        params![MIGRATION_NAME, GIT_CORRELATION_SCHEMA_VERSION],
-    )
-    .await?;
-    Ok(())
+            params![MIGRATION_NAME, GIT_CORRELATION_SCHEMA_VERSION],
+        )
+        .await?;
+        Ok::<(), GitCorrelationError>(())
+    }
+    .await;
+    match migration {
+        Ok(()) => {
+            if let Err(err) = conn.execute("COMMIT", ()).await {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(err.into())
+            } else {
+                Ok(())
+            }
+        }
+        Err(err) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(err)
+        }
+    }
 }
 
-async fn schema_version(conn: &Connection) -> Option<i64> {
+async fn schema_version(conn: &Connection) -> Result<Option<i64>, GitCorrelationError> {
     let mut rows = conn
         .query(
             "SELECT version FROM session_schema_migrations WHERE name = ?1",
             params![MIGRATION_NAME],
         )
-        .await
-        .ok()?;
-    rows.next().await.ok()??.get(0).ok()
+        .await?;
+    rows.next()
+        .await?
+        .map(|row| row.get(0).map_err(GitCorrelationError::from))
+        .transpose()
+}
+
+async fn table_exists(conn: &Connection, table: &str) -> Result<bool, GitCorrelationError> {
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            params![table],
+        )
+        .await?;
+    Ok(rows
+        .next()
+        .await?
+        .is_some_and(|row| row.get::<i64>(0).ok() == Some(1)))
 }
 
 fn opt_text(value: Option<&str>) -> Value {
     value.map_or(Value::Null, |text| Value::Text(text.to_string()))
+}
+
+/// Resolves provider-reported commit candidates against the repository and
+/// turns them into durable producer evidence. Ambiguous, missing, or non-commit
+/// object ids are ignored; transcript ingest can safely retry them later.
+pub(crate) fn direct_commit_records(
+    messages: &[SessionMessageRecord],
+    project_root: &std::path::Path,
+) -> Vec<CommitSessionRecord> {
+    if !messages.iter().any(|message| {
+        message
+            .metadata_json
+            .as_deref()
+            .is_some_and(|json| json.contains("\"produced_commit_candidates\""))
+    }) {
+        return Vec::new();
+    }
+    let Ok(repo) = gix::discover(project_root) else {
+        return Vec::new();
+    };
+    let mut seen = HashSet::new();
+    let mut records = Vec::new();
+    for message in messages {
+        let Some(metadata_value) = message
+            .metadata_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+        else {
+            continue;
+        };
+        let Some(metadata) = metadata_value.as_object() else {
+            continue;
+        };
+        let Some(candidates) = metadata
+            .get("produced_commit_candidates")
+            .and_then(serde_json::Value::as_array)
+        else {
+            continue;
+        };
+        for candidate in candidates.iter().filter_map(serde_json::Value::as_str) {
+            if !(7..=64).contains(&candidate.len())
+                || !candidate.chars().all(|ch| ch.is_ascii_hexdigit())
+            {
+                continue;
+            }
+            let Ok(spec) = repo.rev_parse_single(candidate) else {
+                continue;
+            };
+            let Ok(object) = spec.object() else {
+                continue;
+            };
+            let Ok(commit) = object.try_into_commit() else {
+                continue;
+            };
+            let sha = commit.id.to_string();
+            if !seen.insert((
+                sha.clone(),
+                message.provider.clone(),
+                message.session_id.clone(),
+            )) {
+                continue;
+            }
+            let worktree = metadata_worktree(metadata)
+                .map(normalize_worktree)
+                .or_else(|| Some(normalize_worktree(&project_root.to_string_lossy())));
+            let branch = metadata
+                .get("git_branch")
+                .or_else(|| metadata.get("codex_git_branch"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            let committed_at = commit.time().ok().map_or_else(
+                || message.timestamp.unwrap_or_default(),
+                |time| time.seconds,
+            );
+            let evidence = match metadata
+                .get("produced_commit_evidence")
+                .and_then(serde_json::Value::as_str)
+            {
+                Some("host_event") => CommitEvidence::HostEvent,
+                _ => CommitEvidence::ToolResult,
+            };
+            records.push(CommitSessionRecord {
+                commit_sha: sha,
+                provider: message.provider.clone(),
+                session_id: message.session_id.clone(),
+                branch,
+                worktree,
+                committed_at,
+                span_overlap_kind: SpanOverlapKind::Direct,
+                span_id: None,
+                relation: CommitRelation::Produced,
+                evidence,
+                confidence: 100,
+                evidence_message_id: Some(message.message_id.clone()),
+            });
+        }
+    }
+    records
+}
+
+/// Derives durable branch/worktree observations from provider message
+/// metadata. These rows survive worktree deletion and make transcript ingest,
+/// rather than a live hook, the source of truth for historical locations.
+pub(crate) fn ingest_span_observations(messages: &[SessionMessageRecord]) -> Vec<SpanObservation> {
+    let mut observations = Vec::new();
+    for message in messages {
+        let Some(ts) = message.timestamp else {
+            continue;
+        };
+        let Some(json) = message.metadata_json.as_deref() else {
+            continue;
+        };
+        if !json.contains("_worktree\"") {
+            continue;
+        }
+        let Some(metadata_value) = serde_json::from_str::<serde_json::Value>(json).ok() else {
+            continue;
+        };
+        let Some(metadata) = metadata_value.as_object() else {
+            continue;
+        };
+        let Some(worktree) = metadata_worktree(metadata).filter(|path| !path.is_empty()) else {
+            continue;
+        };
+        let branch = metadata
+            .get("git_branch")
+            .or_else(|| metadata.get("codex_git_branch"))
+            .and_then(serde_json::Value::as_str)
+            .filter(|branch| !branch.is_empty())
+            .map(str::to_string);
+        let thread_id = metadata
+            .get("turn_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string);
+        observations.push(SpanObservation {
+            provider: message.provider.clone(),
+            session_id: message.session_id.clone(),
+            thread_id,
+            branch,
+            worktree: normalize_worktree(worktree),
+            ts,
+            source: SpanSource::Ingest,
+        });
+    }
+    observations
+}
+
+fn metadata_worktree(metadata: &serde_json::Map<String, serde_json::Value>) -> Option<&str> {
+    MESSAGE_WORKTREE_KEYS
+        .into_iter()
+        .find_map(|key| metadata.get(key).and_then(serde_json::Value::as_str))
 }
 
 /// Folds one observation into the span table: extends the newest span for
@@ -511,7 +875,7 @@ pub(crate) async fn record_span_observation(
     }
 }
 
-async fn record_span_observation_in_transaction(
+pub(crate) async fn record_span_observation_in_transaction(
     conn: &Connection,
     observation: &SpanObservation,
     merge_gap_secs: i64,
@@ -578,9 +942,9 @@ async fn record_span_observation_in_transaction(
     Ok(conn.last_insert_rowid())
 }
 
-/// Inserts one commit attribution row; existing rows win (idempotent for
-/// re-runs of live attribution and the backfill command). Returns `true`
-/// when a new row was inserted.
+/// Inserts one commit attribution row. Stronger evidence replaces weaker
+/// evidence; identical or weaker replays are no-ops. Returns `true` when the
+/// row was inserted or strengthened.
 pub(crate) async fn upsert_commit_session(
     conn: &Connection,
     record: &CommitSessionRecord,
@@ -588,11 +952,25 @@ pub(crate) async fn upsert_commit_session(
     let worktree = record.worktree.as_deref().map(normalize_worktree);
     let inserted = conn
         .execute(
-            "INSERT OR IGNORE INTO commit_sessions (
+            "INSERT INTO commit_sessions (
                 commit_sha, provider, session_id, branch, worktree,
-                committed_at, span_overlap_kind, span_id
+                committed_at, span_overlap_kind, span_id,
+                relation, evidence, confidence, evidence_message_id
              )
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             ON CONFLICT(commit_sha, provider, session_id) DO UPDATE SET
+                branch = excluded.branch,
+                worktree = excluded.worktree,
+                committed_at = excluded.committed_at,
+                span_overlap_kind = excluded.span_overlap_kind,
+                span_id = excluded.span_id,
+                relation = excluded.relation,
+                evidence = excluded.evidence,
+                confidence = excluded.confidence,
+                evidence_message_id = excluded.evidence_message_id
+             WHERE (excluded.relation = 'produced' AND commit_sessions.relation != 'produced')
+                OR (excluded.relation = commit_sessions.relation
+                    AND excluded.confidence > commit_sessions.confidence)",
             params![
                 record.commit_sha.as_str(),
                 record.provider.as_str(),
@@ -602,6 +980,10 @@ pub(crate) async fn upsert_commit_session(
                 record.committed_at,
                 record.span_overlap_kind.as_str(),
                 record.span_id.map_or(Value::Null, Value::Integer),
+                record.relation.as_str(),
+                record.evidence.as_str(),
+                record.confidence,
+                opt_text(record.evidence_message_id.as_deref()),
             ],
         )
         .await?;
@@ -622,6 +1004,14 @@ pub(crate) use attribution::{read_meta_value, run_commit_attribution_sweep, writ
 pub(crate) async fn sessions_for(
     conn: &Connection,
     query: &SessionsForQuery,
+) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
+    sessions_for_with_relation(conn, query, CommitRelationFilter::Produced).await
+}
+
+pub(crate) async fn sessions_for_with_relation(
+    conn: &Connection,
+    query: &SessionsForQuery,
+    relation: CommitRelationFilter,
 ) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
     // Read-only opens never run DDL, so a store written before this schema
     // existed simply has no correlation rows yet — report that as "no
@@ -651,7 +1041,7 @@ pub(crate) async fn sessions_for(
             )
             .await
         }
-        GitRefFilter::Commit(sha) => commit_hits(conn, sha, query, limit).await,
+        GitRefFilter::Commit(sha) => commit_hits(conn, sha, query, relation, limit).await,
     }
 }
 
@@ -721,7 +1111,8 @@ async fn commit_session_ids(
     let mut rows = conn
         .query(
             "SELECT DISTINCT provider, session_id FROM commit_sessions
-             WHERE commit_sha = ?1 OR commit_sha LIKE ?2",
+             WHERE relation = 'produced'
+               AND (commit_sha = ?1 OR commit_sha LIKE ?2)",
             params![sha, format!("{sha}%")],
         )
         .await?;
@@ -766,7 +1157,7 @@ pub(crate) fn git_scope_exists_clauses(
         clauses.push((
             format!(
                 "EXISTS (SELECT 1 FROM commit_sessions c \
-                 WHERE c.session_id = {session_column} \
+                 WHERE c.session_id = {session_column} AND c.relation = 'produced' \
                  AND (c.commit_sha = ? OR c.commit_sha LIKE ?))"
             ),
             vec![
@@ -845,6 +1236,14 @@ impl CorrelationIndexHealth {
     /// populated index that simply had no rows matching a given git ref.
     pub const fn is_empty(&self) -> bool {
         self.span_count == 0
+    }
+
+    /// Whether the index lacks the row family needed by this reference kind.
+    pub const fn is_empty_for(&self, git_ref: &GitRefFilter) -> bool {
+        match git_ref {
+            GitRefFilter::Branch(_) | GitRefFilter::Worktree(_) => self.span_count == 0,
+            GitRefFilter::Commit(_) => self.commit_count == 0,
+        }
     }
 }
 
@@ -946,6 +1345,10 @@ async fn span_hits(
             commit_sha: None,
             committed_at: None,
             span_overlap_kind: None,
+            relation: None,
+            evidence: None,
+            confidence: None,
+            evidence_message_id: None,
         });
     }
     Ok(hits)
@@ -964,16 +1367,22 @@ async fn commit_hits(
     conn: &Connection,
     sha: &str,
     query: &SessionsForQuery,
+    relation: CommitRelationFilter,
     limit: i64,
 ) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
     let mut sql = "SELECT provider, session_id, branch, worktree,
-                commit_sha, committed_at, span_overlap_kind
+                commit_sha, committed_at, span_overlap_kind,
+                relation, evidence, confidence, evidence_message_id
          FROM commit_sessions
          WHERE (commit_sha = ?1 OR commit_sha LIKE ?2)"
         .to_string();
     // `parse_commit_sha` guarantees hex-only input, so the LIKE pattern
     // cannot contain wildcards other than the appended one.
     let mut query_params = vec![Value::Text(sha.to_string()), Value::Text(format!("{sha}%"))];
+    if relation != CommitRelationFilter::All {
+        query_params.push(Value::Text(relation.as_str().to_string()));
+        let _ = write!(sql, " AND relation = ?{}", query_params.len());
+    }
     if let Some(since) = query.since {
         query_params.push(Value::Integer(since));
         let _ = write!(sql, " AND committed_at >= ?{}", query_params.len());
@@ -993,6 +1402,8 @@ async fn commit_hits(
     let mut hits = Vec::new();
     while let Some(row) = rows.next().await? {
         let overlap: String = row.get(6)?;
+        let relation: String = row.get(7)?;
+        let evidence: String = row.get(8)?;
         hits.push(SessionGitCorrelationHit {
             provider: row.get(0)?,
             session_id: row.get(1)?,
@@ -1006,6 +1417,10 @@ async fn commit_hits(
             commit_sha: row.get(4)?,
             committed_at: row.get(5)?,
             span_overlap_kind: SpanOverlapKind::from_db(&overlap),
+            relation: CommitRelation::from_db(&relation),
+            evidence: CommitEvidence::from_db(&evidence),
+            confidence: row.get(9)?,
+            evidence_message_id: row.get(10)?,
         });
     }
     Ok(hits)

--- a/src/sessions/git_correlation/attribution.rs
+++ b/src/sessions/git_correlation/attribution.rs
@@ -1,8 +1,8 @@
 use libsql::{Connection, params};
 
 use super::{
-    CommitSessionRecord, GitCorrelationError, SpanOverlapKind, correlation_tables_present,
-    opt_text, upsert_commit_session,
+    CommitEvidence, CommitRelation, CommitSessionRecord, GitCorrelationError, SpanOverlapKind,
+    correlation_tables_present, opt_text, upsert_commit_session,
 };
 
 const COMMIT_SWEEP_WATERMARK_KEY: &str = "commit_attribution_watermark";
@@ -81,10 +81,9 @@ pub fn commit_overlap_kind(
     }
 }
 
-/// Attributes one commit to every span whose window contains it, preferring
-/// `WithinSpan` matches. Returns one record per `(span provider, session)`
-/// pair so a commit made while several sessions were concurrently active on
-/// the same branch is attributed to all of them.
+/// Records that every matching span observed a commit. Time overlap is
+/// candidate evidence only: concurrent sessions must never be labelled as
+/// producers without a direct tool/host event.
 pub fn match_commit_to_spans(
     commit_sha: &str,
     branch: Option<&str>,
@@ -111,6 +110,15 @@ pub fn match_commit_to_spans(
             committed_at,
             span_overlap_kind: kind,
             span_id: Some(span.span_id),
+            relation: CommitRelation::Observed,
+            evidence: CommitEvidence::TimeOverlap,
+            confidence: match kind {
+                SpanOverlapKind::Direct => 100,
+                SpanOverlapKind::WithinSpan => 20,
+                SpanOverlapKind::ExtendedWindow => 10,
+                SpanOverlapKind::Reflog => 30,
+            },
+            evidence_message_id: None,
         });
     }
     records

--- a/src/sessions/git_correlation/backfill.rs
+++ b/src/sessions/git_correlation/backfill.rs
@@ -1,8 +1,9 @@
 use libsql::{Connection, params};
 
 use super::{
-    AUTO_BACKFILL_WATERMARK_KEY, CommitSessionRecord, DEFAULT_SPAN_MERGE_GAP_SECS,
-    GitCorrelationError, SpanObservation, SpanOverlapKind, SpanSource, normalize_worktree,
+    AUTO_BACKFILL_WATERMARK_KEY, CommitEvidence, CommitRelation, CommitSessionRecord,
+    DEFAULT_SPAN_MERGE_GAP_SECS, GitCorrelationError, SpanObservation, SpanOverlapKind, SpanSource,
+    normalize_worktree,
 };
 
 // Historical backfill for sessions that predate live span recording.
@@ -591,6 +592,10 @@ async fn backfill_one_session(
                     committed_at,
                     span_overlap_kind: SpanOverlapKind::WithinSpan,
                     span_id: None,
+                    relation: CommitRelation::Observed,
+                    evidence: CommitEvidence::ReflogOverlap,
+                    confidence: 30,
+                    evidence_message_id: None,
                 })
                 .await
                 .map_err(|_| BackfillSkipReason::GitError)?;

--- a/src/sessions/git_correlation/tests.rs
+++ b/src/sessions/git_correlation/tests.rs
@@ -77,12 +77,233 @@ fn git_scope_filter_reports_emptiness_and_validates_commit() {
     assert!(GitScopeFilter::from_args(None, None, Some("xyz")).is_err());
 }
 
+#[test]
+fn direct_commit_candidates_resolve_to_producer_evidence() {
+    use std::process::Command;
+
+    let temp = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .output()
+            .unwrap()
+    };
+    assert!(git(&["init", "-q"]).status.success());
+    assert!(
+        git(&["config", "user.email", "test@example.com"])
+            .status
+            .success()
+    );
+    assert!(git(&["config", "user.name", "Test"]).status.success());
+    std::fs::write(temp.path().join("file.txt"), "one\n").unwrap();
+    assert!(git(&["add", "file.txt"]).status.success());
+    assert!(git(&["commit", "-q", "-m", "test"]).status.success());
+    let sha = String::from_utf8(git(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    let short = &sha[..8];
+    let message = SessionMessageRecord {
+        provider: "codex".to_string(),
+        message_id: "m1".to_string(),
+        session_id: "s1".to_string(),
+        role: "tool".to_string(),
+        timestamp: Some(10),
+        ordinal: 1,
+        text: "git commit -m test".to_string(),
+        kind: Some("tool_call".to_string()),
+        model: None,
+        tool_names: Some("exec_command".to_string()),
+        source_path: None,
+        source_offset: None,
+        metadata_json: Some(
+            serde_json::json!({
+                "produced_commit_candidates": [short],
+                "codex_git_branch": "main",
+                "codex_turn_worktree": temp.path(),
+            })
+            .to_string(),
+        ),
+    };
+    let records = direct_commit_records(&[message], temp.path());
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].commit_sha, sha);
+    assert_eq!(records[0].relation, CommitRelation::Produced);
+    assert_eq!(records[0].evidence, CommitEvidence::ToolResult);
+    assert_eq!(records[0].evidence_message_id.as_deref(), Some("m1"));
+}
+
+#[test]
+fn transcript_locations_become_durable_ingest_spans() {
+    let message = SessionMessageRecord {
+        provider: "codex".to_string(),
+        message_id: "m1".to_string(),
+        session_id: "s1".to_string(),
+        role: "assistant".to_string(),
+        timestamp: Some(1_234),
+        ordinal: 1,
+        text: "done".to_string(),
+        kind: Some("message".to_string()),
+        model: None,
+        tool_names: None,
+        source_path: None,
+        source_offset: None,
+        metadata_json: Some(
+            serde_json::json!({
+                "codex_session_worktree": "/stale/session",
+                "codex_turn_worktree": "/moved/repo/",
+                "codex_git_branch": "feature/history",
+                "turn_id": "turn-1"
+            })
+            .to_string(),
+        ),
+    };
+    let observations = ingest_span_observations(&[message]);
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].worktree, "/moved/repo");
+    assert_eq!(observations[0].branch.as_deref(), Some("feature/history"));
+    assert_eq!(observations[0].thread_id.as_deref(), Some("turn-1"));
+    assert_eq!(observations[0].source, SpanSource::Ingest);
+}
+
 #[tokio::test]
 async fn schema_is_idempotent() {
     let conn = test_conn().await;
     ensure_git_correlation_schema(&conn)
         .await
         .expect("second ensure should be a no-op");
+}
+
+#[tokio::test]
+async fn schema_v2_commit_rows_migrate_to_observed_without_becoming_producers() {
+    let db = Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE session_schema_migrations (
+            name TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            applied_at INTEGER NOT NULL DEFAULT (unixepoch())
+         );
+         INSERT INTO session_schema_migrations(name, version)
+            VALUES ('git_correlation', 2);
+         CREATE TABLE session_git_spans (
+            span_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider TEXT NOT NULL DEFAULT '',
+            session_id TEXT NOT NULL,
+            thread_id TEXT,
+            branch TEXT,
+            worktree TEXT NOT NULL,
+            first_ts INTEGER NOT NULL,
+            last_ts INTEGER NOT NULL,
+            event_count INTEGER NOT NULL DEFAULT 1,
+            source TEXT NOT NULL,
+            created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+         );
+         CREATE TABLE commit_sessions (
+            commit_sha TEXT NOT NULL,
+            provider TEXT NOT NULL DEFAULT '',
+            session_id TEXT NOT NULL,
+            branch TEXT,
+            worktree TEXT,
+            committed_at INTEGER NOT NULL,
+            span_overlap_kind TEXT NOT NULL,
+            span_id INTEGER,
+            created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            PRIMARY KEY(commit_sha, provider, session_id)
+         );
+         CREATE TABLE git_correlation_meta (
+            key TEXT PRIMARY KEY,
+            value INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+         );
+         INSERT INTO commit_sessions(
+            commit_sha, provider, session_id, branch, worktree,
+            committed_at, span_overlap_kind, span_id
+         ) VALUES (
+            'abcdef1234567890abcdef1234567890abcdef12',
+            'claude', 'observed-session', 'main', '/repo', 1150,
+            'within_span', NULL
+         );",
+    )
+    .await
+    .unwrap();
+
+    ensure_git_correlation_schema(&conn).await.unwrap();
+    let query = SessionsForQuery {
+        git_ref: GitRefFilter::Commit("abcdef12".to_string()),
+        since: None,
+        until: None,
+        limit: 10,
+    };
+    assert!(
+        sessions_for(&conn, &query).await.unwrap().is_empty(),
+        "migrated overlap rows must not satisfy producer-default queries"
+    );
+    let observed = sessions_for_with_relation(&conn, &query, CommitRelationFilter::Observed)
+        .await
+        .unwrap();
+    assert_eq!(observed.len(), 1);
+    assert_eq!(observed[0].relation, Some(CommitRelation::Observed));
+    assert_eq!(observed[0].evidence, Some(CommitEvidence::TimeOverlap));
+    assert_eq!(observed[0].confidence, Some(20));
+
+    let produced = CommitSessionRecord {
+        commit_sha: "1111111111111111111111111111111111111111".to_string(),
+        provider: "codex".to_string(),
+        session_id: "producer-session".to_string(),
+        branch: Some("main".to_string()),
+        worktree: Some("/repo".to_string()),
+        committed_at: 1200,
+        span_overlap_kind: SpanOverlapKind::Direct,
+        span_id: None,
+        relation: CommitRelation::Produced,
+        evidence: CommitEvidence::ToolResult,
+        confidence: 100,
+        evidence_message_id: Some("m1".to_string()),
+    };
+    assert!(upsert_commit_session(&conn, &produced).await.unwrap());
+    let produced_hits = sessions_for(
+        &conn,
+        &SessionsForQuery {
+            git_ref: GitRefFilter::Commit("11111111".to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        produced_hits[0].span_overlap_kind,
+        Some(SpanOverlapKind::Direct)
+    );
+
+    ensure_git_correlation_schema(&conn)
+        .await
+        .expect("v3 migration must be repeat-safe");
+}
+
+#[tokio::test]
+async fn future_git_correlation_schema_is_rejected_without_rewrite() {
+    let db = Builder::new_local(":memory:").build().await.unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE session_schema_migrations (
+            name TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            applied_at INTEGER NOT NULL DEFAULT (unixepoch())
+         );
+         INSERT INTO session_schema_migrations(name, version)
+            VALUES ('git_correlation', 99);",
+    )
+    .await
+    .unwrap();
+
+    let err = ensure_git_correlation_schema(&conn).await.unwrap_err();
+    assert!(err.to_string().contains("newer git correlation schema 99"));
+    assert_eq!(schema_version(&conn).await.unwrap(), Some(99));
 }
 
 #[tokio::test]
@@ -205,6 +426,10 @@ async fn sessions_for_branch_worktree_and_commit_round_trip() {
         committed_at: 1_150,
         span_overlap_kind: SpanOverlapKind::WithinSpan,
         span_id: None,
+        relation: CommitRelation::Produced,
+        evidence: CommitEvidence::ToolResult,
+        confidence: 100,
+        evidence_message_id: Some("tool-result-1".to_string()),
     };
     assert!(upsert_commit_session(&conn, &record).await.unwrap());
     assert!(
@@ -230,6 +455,13 @@ async fn sessions_for_branch_worktree_and_commit_round_trip() {
         Some("abcdef1234567890abcdef1234567890abcdef12")
     );
     assert_eq!(by_commit[0].committed_at, Some(1_150));
+    assert_eq!(by_commit[0].relation, Some(CommitRelation::Produced));
+    assert_eq!(by_commit[0].evidence, Some(CommitEvidence::ToolResult));
+    assert_eq!(by_commit[0].confidence, Some(100));
+    assert_eq!(
+        by_commit[0].evidence_message_id.as_deref(),
+        Some("tool-result-1")
+    );
     assert_eq!(
         by_commit[0].span_overlap_kind,
         Some(SpanOverlapKind::WithinSpan)
@@ -486,7 +718,8 @@ fn match_commit_to_spans_filters_by_branch_worktree_and_window() {
         },
     ];
 
-    // A within-window commit is attributed to both concurrent main spans.
+    // A within-window commit is observed by both concurrent main spans. Time
+    // overlap is never direct evidence that either session produced it.
     let records = match_commit_to_spans("deadbeef", Some("main"), "/repo", 150, &spans, 60);
     assert_eq!(records.len(), 2);
     let ids: Vec<i64> = records.iter().filter_map(|r| r.span_id).collect();
@@ -495,6 +728,16 @@ fn match_commit_to_spans_filters_by_branch_worktree_and_window() {
         records
             .iter()
             .all(|r| r.span_overlap_kind == SpanOverlapKind::WithinSpan)
+    );
+    assert!(
+        records
+            .iter()
+            .all(|r| r.relation == CommitRelation::Observed)
+    );
+    assert!(
+        records
+            .iter()
+            .all(|r| r.evidence == CommitEvidence::TimeOverlap && r.confidence == 20)
     );
     assert_eq!(records[0].session_id, "s1");
     assert_eq!(records[0].worktree.as_deref(), Some("/repo"));
@@ -543,21 +786,22 @@ async fn commit_attribution_sweep_attributes_and_advances_watermark() {
     .unwrap();
     assert_eq!(inserted, 1);
 
-    // The commit is now queryable by prefix.
-    let hits = sessions_for(
-        &conn,
-        &SessionsForQuery {
-            git_ref: GitRefFilter::Commit("abcdef12".to_string()),
-            since: None,
-            until: None,
-            limit: 10,
-        },
-    )
-    .await
-    .unwrap();
+    // Time-overlap sweep rows are not producer evidence. They remain available
+    // only through an explicit observed/all query.
+    let query = SessionsForQuery {
+        git_ref: GitRefFilter::Commit("abcdef12".to_string()),
+        since: None,
+        until: None,
+        limit: 10,
+    };
+    assert!(sessions_for(&conn, &query).await.unwrap().is_empty());
+    let hits = sessions_for_with_relation(&conn, &query, CommitRelationFilter::Observed)
+        .await
+        .unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].session_id, "s1");
     assert_eq!(hits[0].span_overlap_kind, Some(SpanOverlapKind::WithinSpan));
+    assert_eq!(hits[0].relation, Some(CommitRelation::Observed));
 
     // Re-running the sweep is idempotent: even if the boundary span is
     // re-scanned (watermark uses `>=` so nothing is ever missed), the

--- a/src/sessions/source.rs
+++ b/src/sessions/source.rs
@@ -177,6 +177,10 @@ async fn ingest_one(
     }
 
     let provider = source.provider();
+    let commit_records =
+        crate::sessions::git_correlation::direct_commit_records(&parsed.messages, project_root);
+    let span_observations =
+        crate::sessions::git_correlation::ingest_span_observations(&parsed.messages);
     let draft = parsed.draft;
     let existing = db.get_session(provider, &draft.session_id).await;
     // Preserve the session's original start time and title across appends; only
@@ -217,9 +221,11 @@ async fn ingest_one(
     };
 
     if !db
-        .upsert_transcript_batch(
+        .upsert_transcript_batch_with_git_evidence(
             &session,
             &parsed.messages,
+            &commit_records,
+            &span_observations,
             &path_str,
             ParseOffset {
                 byte_offset: parsed.new_cursor.position,

--- a/src/sessions/transcript_backfill.rs
+++ b/src/sessions/transcript_backfill.rs
@@ -406,7 +406,7 @@ fn derive_usage(provider: &str, record: &Value) -> Option<Value> {
 // current parser and inserts message ids missing from legacy stores.
 
 const STRUCTURED_MARKER_NAME: &str = "structured_rows_backfill";
-const STRUCTURED_MARKER_VERSION: i64 = 1;
+const STRUCTURED_MARKER_VERSION: i64 = 2;
 /// Base name of the sweep's path watermark. The live key is namespaced by the
 /// marker version (see [`structured_cursor_key`]) so bumping
 /// [`STRUCTURED_MARKER_VERSION`] naturally starts the re-sweep from a fresh
@@ -478,6 +478,7 @@ pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<Structured
             load_project_paths_for_source(conn, &candidate.provider, &candidate.source_path)
                 .await?;
         for project_path in project_paths {
+            let project_root = PathBuf::from(&project_path);
             let provider = candidate.provider.clone();
             let source_path = candidate.source_path.clone();
             let messages = match tokio::task::spawn_blocking(move || {
@@ -506,8 +507,23 @@ pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<Structured
             if messages.is_empty() {
                 continue;
             }
+            let commit_records =
+                crate::sessions::git_correlation::direct_commit_records(&messages, &project_root);
+            let span_observations =
+                crate::sessions::git_correlation::ingest_span_observations(&messages);
             let inserted = db.insert_absent_session_messages(&messages).await?;
             stats.inserted += inserted;
+            for record in &commit_records {
+                db.git_upsert_commit_session(record).await.ok()?;
+            }
+            for observation in &span_observations {
+                db.git_record_span_observation(
+                    observation,
+                    crate::sessions::git_correlation::DEFAULT_SPAN_MERGE_GAP_SECS,
+                )
+                .await
+                .ok()?;
+            }
         }
         stats.files_scanned += 1;
         write_backfill_cursor(conn, &cursor_key, &candidate.source_path).await?;

--- a/tests/mcp_suite/git_correlation_test.rs
+++ b/tests/mcp_suite/git_correlation_test.rs
@@ -11,7 +11,8 @@ use serde_json::{Value, json};
 
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::git_correlation::{
-    CommitSessionRecord, DEFAULT_SPAN_MERGE_GAP_SECS, SpanObservation, SpanOverlapKind, SpanSource,
+    CommitEvidence, CommitRelation, CommitSessionRecord, DEFAULT_SPAN_MERGE_GAP_SECS,
+    SpanObservation, SpanOverlapKind, SpanSource,
 };
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
@@ -241,8 +242,30 @@ async fn sessions_for_and_scoped_search_end_to_end() {
             branch: Some("feature/session".to_string()),
             worktree: Some(feature_worktree.clone()),
             committed_at: 8_850,
+            span_overlap_kind: SpanOverlapKind::Direct,
+            span_id: None,
+            relation: CommitRelation::Produced,
+            evidence: CommitEvidence::ToolResult,
+            confidence: 100,
+            evidence_message_id: Some("commit-tool-result".to_string()),
+        })
+        .await
+        .unwrap()
+    );
+    assert!(
+        db.git_upsert_commit_session(&CommitSessionRecord {
+            commit_sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+            provider: "claude".to_string(),
+            session_id: "s2".to_string(),
+            branch: Some("feature/session".to_string()),
+            worktree: Some(feature_worktree.clone()),
+            committed_at: 8_850,
             span_overlap_kind: SpanOverlapKind::WithinSpan,
             span_id: None,
+            relation: CommitRelation::Observed,
+            evidence: CommitEvidence::TimeOverlap,
+            confidence: 20,
+            evidence_message_id: None,
         })
         .await
         .unwrap()
@@ -298,7 +321,23 @@ async fn sessions_for_and_scoped_search_end_to_end() {
             by_commit["results"][0]["commit_sha"],
             "abcdef1234567890abcdef1234567890abcdef12"
         );
+        assert_eq!(by_commit["results"][0]["relation"], "produced");
     }
+    let observed_commit = call(
+        &cg,
+        "tracedecay_sessions_for",
+        json!({ "git_ref": "commit", "value": "abcdef12", "relation": "observed" }),
+    )
+    .await;
+    assert_eq!(session_ids(&observed_commit), vec!["s2".to_string()]);
+    assert_eq!(observed_commit["results"][0]["evidence"], "time_overlap");
+    let all_commit = call(
+        &cg,
+        "tracedecay_sessions_for",
+        json!({ "git_ref": "commit", "value": "abcdef12", "relation": "all" }),
+    )
+    .await;
+    assert_eq!(all_commit["count"], 2);
 
     // (d) mid-session branch switch: sessions_for(main) and (feature) both
     // return `switcher`.

--- a/tests/mcp_suite/mcp_server_test.rs
+++ b/tests/mcp_suite/mcp_server_test.rs
@@ -3168,7 +3168,9 @@ fn git_capture(project: &std::path::Path, args: &[&str]) -> String {
 ///      the ingest sweep.
 #[tokio::test]
 async fn hook_route_records_spans_and_ingest_attributes_commits() {
-    use tracedecay::sessions::git_correlation::{GitRefFilter, SessionsForQuery, SpanOverlapKind};
+    use tracedecay::sessions::git_correlation::{
+        CommitRelationFilter, GitRefFilter, SessionsForQuery, SpanOverlapKind,
+    };
 
     let (_env, project) = crate::common::IsolatedEnv::acquire().await;
     let worktree = project.with_file_name("feature-worktree");
@@ -3317,12 +3319,15 @@ async fn hook_route_records_spans_and_ingest_attributes_commits() {
     tracedecay::sessions::ingest_global_sources(&db, &project_root).await;
 
     let by_commit = db
-        .git_sessions_for(&SessionsForQuery {
-            git_ref: GitRefFilter::Commit(sha.clone()),
-            since: None,
-            until: None,
-            limit: 10,
-        })
+        .git_sessions_for_with_relation(
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Commit(sha.clone()),
+                since: None,
+                until: None,
+                limit: 10,
+            },
+            CommitRelationFilter::Observed,
+        )
         .await
         .unwrap();
     assert_eq!(

--- a/tests/session_suite/git_backfill.rs
+++ b/tests/session_suite/git_backfill.rs
@@ -16,8 +16,8 @@ use tempfile::TempDir;
 
 use tracedecay::global_db::GlobalDb;
 use tracedecay::sessions::git_correlation::{
-    BackfillOptions, BranchTimelineEntry, GitRefFilter, GitReflogSource, SessionsForQuery,
-    normalize_worktree, run_backfill,
+    BackfillOptions, BranchTimelineEntry, CommitRelationFilter, GitRefFilter, GitReflogSource,
+    SessionsForQuery, normalize_worktree, run_backfill,
 };
 use tracedecay::sessions::{SessionMessageRecord, SessionRecord};
 
@@ -269,12 +269,15 @@ async fn backfill_attributes_branch_switch_and_commits() {
         .find(|sha| !main_shas.contains(sha))
         .expect("feature-only commit");
     let commit_hits = db
-        .git_sessions_for(&SessionsForQuery {
-            git_ref: GitRefFilter::Commit(feature_sha.clone()),
-            since: None,
-            until: None,
-            limit: 20,
-        })
+        .git_sessions_for_with_relation(
+            &SessionsForQuery {
+                git_ref: GitRefFilter::Commit(feature_sha.clone()),
+                since: None,
+                until: None,
+                limit: 20,
+            },
+            CommitRelationFilter::Observed,
+        )
         .await
         .unwrap();
     let commit_ids: Vec<&str> = commit_hits.iter().map(|h| h.session_id.as_str()).collect();

--- a/tests/session_suite/structured_backfill.rs
+++ b/tests/session_suite/structured_backfill.rs
@@ -253,7 +253,7 @@ async fn structured_backfill_inserts_codex_goal_rows_once() {
     db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
     drop(db);
-    assert_eq!(structured_marker_version(&project).await, Some(1));
+    assert_eq!(structured_marker_version(&project).await, Some(2));
 }
 
 #[tokio::test]
@@ -313,7 +313,7 @@ async fn structured_backfill_inserts_claude_marker_rows_once() {
     db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
     drop(db);
-    assert_eq!(structured_marker_version(&project).await, Some(1));
+    assert_eq!(structured_marker_version(&project).await, Some(2));
 }
 
 /// Regression for the stale-cursor-vs-version-bump defect: the sweep's path
@@ -335,7 +335,7 @@ async fn structured_backfill_version_bump_reparses_from_start() {
     ingest_source(&db, &source, &project, None).await;
     db.run_structured_backfill().await; // parses the file, advances the cursor
     db.run_structured_backfill().await; // no candidates: marks complete, clears cursors
-    assert_eq!(structured_marker_version(&project).await, Some(1));
+    assert_eq!(structured_marker_version(&project).await, Some(2));
     drop(db);
 
     // Drop the structured rows and reset the marker so the sweep re-enters

--- a/tests/transcript_ingest_suite/claude.rs
+++ b/tests/transcript_ingest_suite/claude.rs
@@ -3,9 +3,12 @@ use std::io::Write;
 use tempfile::TempDir;
 use tracedecay::sessions::claude::ClaudeSource;
 use tracedecay::sessions::cursor::open_project_session_db;
+use tracedecay::sessions::git_correlation::{
+    CommitEvidence, CommitRelation, GitRefFilter, SessionsForQuery, SpanOverlapKind,
+};
 use tracedecay::sessions::source::ingest_source;
 
-use crate::support::{assert_metadata_path_eq, init_git_repo, init_project_at, setup};
+use crate::support::{assert_metadata_path_eq, init_git_repo, init_project_at, run_git, setup};
 
 /// Writes a Claude Code transcript (one JSON object per line) for `session` whose
 /// recorded `cwd` is `project`.
@@ -1068,4 +1071,108 @@ async fn claude_workflow_nested_subagent_links_to_parent_not_orphan() {
         .await;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].session.session_id, "agent-nested");
+}
+
+#[tokio::test]
+async fn claude_git_operation_becomes_direct_producer_evidence_atomically() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    init_git_repo(&project);
+    std::fs::write(project.join("commit.txt"), "commit evidence\n").unwrap();
+    run_git(&project, &["add", "commit.txt"]);
+    run_git(
+        &project,
+        &[
+            "-c",
+            "user.name=TraceDecay Tests",
+            "-c",
+            "user.email=tests@example.invalid",
+            "commit",
+            "-m",
+            "commit evidence",
+        ],
+    );
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    let sha = String::from_utf8(output.stdout).unwrap().trim().to_string();
+
+    let dir = home.join(".claude/projects/-some-slug");
+    std::fs::create_dir_all(&dir).unwrap();
+    let cwd = project.to_string_lossy();
+    std::fs::write(
+        dir.join("claude-commit.jsonl"),
+        format!(
+            "{}\n",
+            serde_json::json!({
+                "type": "user",
+                "cwd": cwd,
+                "gitBranch": "main",
+                "sessionId": "claude-commit",
+                "uuid": "commit-result-1",
+                "timestamp": "2026-01-01T00:00:00.000Z",
+                "message": {"role": "user", "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "tool-commit",
+                    "is_error": false,
+                    "content": "commit complete"
+                }]},
+                "toolUseResult": {"gitOperation": {"commit": {
+                    "sha": &sha[..8],
+                    "kind": "committed"
+                }}}
+            })
+        ),
+    )
+    .unwrap();
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClaudeSource::with_home(&home);
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 1);
+
+    let message = db
+        .get_session_message("claude", "commit-result-1")
+        .await
+        .unwrap();
+    let metadata: serde_json::Value =
+        serde_json::from_str(message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        metadata["produced_commit_candidates"],
+        serde_json::json!([&sha[..8]])
+    );
+    assert_eq!(metadata["produced_commit_evidence"], "host_event");
+    assert_eq!(metadata["produced_commit_kind"], "committed");
+
+    let hits = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Commit(sha[..8].to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].relation, Some(CommitRelation::Produced));
+    assert_eq!(hits[0].evidence, Some(CommitEvidence::HostEvent));
+    assert_eq!(hits[0].span_overlap_kind, Some(SpanOverlapKind::Direct));
+    assert_eq!(
+        hits[0].evidence_message_id.as_deref(),
+        Some("commit-result-1")
+    );
+    let branch_hits = db
+        .git_sessions_for(&SessionsForQuery {
+            git_ref: GitRefFilter::Branch("main".to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        })
+        .await
+        .unwrap();
+    assert_eq!(branch_hits.len(), 1);
+    assert_eq!(branch_hits[0].session_id, "claude-commit");
+    assert_eq!(branch_hits[0].sources, vec!["ingest".to_string()]);
 }


### PR DESCRIPTION
Adds transactional git-correlation schema migration, explicit produced versus observed commit evidence, direct host commit attribution, and truthful MCP/session filtering. Root cause: overlap-based correlation was presented as authorship. Validated with focused correlation, host-event, MCP, and backfill tests plus formatting and structured diagnostics.