### PR TITLE
fix(doctor): keep database checks read-only

### DIFF
--- a/plugin/skills/using-the-cli/SKILL.md
+++ b/plugin/skills/using-the-cli/SKILL.md
@@ -74,7 +74,7 @@ identically over MCP (`tracedecay_retrieve`) and the CLI
   with `tracedecay_lcm_expand`; `tracedecay:managing-session-context` drives the
   LCM store and past-session retrieval.
 
-## When to use the CLI
+## CLI fallback conditions
 
 - MCP is intentionally unavailable or omitted from the host integration.
 - An MCP call returns a client or transport error, times out, or the server drops mid-session.

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -223,17 +223,6 @@ impl Database {
     }
 
     /// Runs VACUUM and ANALYZE to reclaim space and update query planner statistics.
-    pub async fn optimize(&self) -> Result<()> {
-        self.conn
-            .execute_batch("VACUUM; ANALYZE;")
-            .await
-            .map_err(|e| TraceDecayError::Database {
-                message: format!("failed to optimize database: {e}"),
-                operation: "optimize".to_string(),
-            })?;
-        Ok(())
-    }
-
     /// Returns the on-disk size of the database file in bytes.
     pub async fn size(&self) -> Result<u64> {
         let mut rows = self

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -31,17 +31,18 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
 
     eprintln!("\n\x1b[1mCurrent project\x1b[0m");
     let project_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    match resolve_current_project_store(&project_path, &TraceDecayOpenOptions::default()).await {
+    let open_options = TraceDecayOpenOptions::default();
+    match resolve_current_project_store(&project_path, &open_options).await {
         CurrentProjectStore::Resolved(layout) => {
             dc.pass(&describe_resolved_store(&layout));
-            check_database(&mut dc, &project_path).await;
+            check_database(&mut dc, &project_path, open_options.clone()).await;
         }
         CurrentProjectStore::LegacyRepoLocal => {
             dc.pass(&format!(
                 "Index found: {}/ (legacy repo-local store)",
                 crate::config::get_tracedecay_dir(&project_path).display()
             ));
-            check_database(&mut dc, &project_path).await;
+            check_database(&mut dc, &project_path, open_options).await;
         }
         CurrentProjectStore::Uninitialized => {
             dc.warn(&format!(
@@ -186,15 +187,19 @@ fn describe_resolved_store(layout: &StoreLayout) -> String {
     )
 }
 
-/// Check database health: report size and run VACUUM to reclaim space.
+/// Check database health without mutating a store that may be owned by the daemon.
 ///
 /// The DB path is taken from the opened instance so the size measured is the
-/// same file (possibly a branch-specific DB) that VACUUM actually compacts.
-async fn check_database(dc: &mut DoctorCounters, project_path: &Path) {
-    let ts = match TraceDecay::open(project_path).await {
+/// same file that the active branch reader serves.
+async fn check_database(
+    dc: &mut DoctorCounters,
+    project_path: &Path,
+    open_options: TraceDecayOpenOptions,
+) {
+    let ts = match TraceDecay::open_read_only_with_options(project_path, open_options).await {
         Ok(ts) => ts,
         Err(e) => {
-            dc.fail(&format!("Could not open database: {e}"));
+            dc.fail(&format!("Could not open database read-only: {e}"));
             return;
         }
     };
@@ -203,25 +208,14 @@ async fn check_database(dc: &mut DoctorCounters, project_path: &Path) {
 
     dc.pass(&format!("DB size: {}", format_bytes(size_before)));
 
-    eprintln!("    Compacting database (VACUUM)…");
-    match ts.optimize().await {
-        Ok(()) => {
-            let size_after = std::fs::metadata(&db_path).map_or(size_before, |m| m.len());
-            if size_before > size_after {
-                let reclaimed = size_before - size_after;
-                dc.pass(&format!(
-                    "Compacted: {} → {} (reclaimed {})",
-                    format_bytes(size_before),
-                    format_bytes(size_after),
-                    format_bytes(reclaimed),
-                ));
-            } else {
-                dc.pass("Database already compact");
-            }
-        }
-        Err(e) => {
-            dc.warn(&format!("VACUUM failed: {e}"));
-        }
+    match ts.quick_check().await {
+        Ok(true) => dc.pass("DB integrity: ok"),
+        Ok(false) => dc.fail(
+            "Database integrity check failed; stop the daemon and preserve the store before repair",
+        ),
+        Err(e) => dc.warn(&format!(
+            "Could not complete read-only integrity check: {e}"
+        )),
     }
 }
 

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -39,6 +39,69 @@ fn format_bytes_fractional_kb() {
 }
 
 #[tokio::test]
+async fn database_check_is_read_only_while_a_writer_is_live()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::TempDir::new()?;
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(&project_root)?;
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+    let ts = TraceDecay::init_with_options(&project_root, open_options.clone()).await?;
+    let db_path = ts.db_path();
+    drop(ts);
+
+    let (writer, _) = crate::db::Database::open(&db_path).await?;
+    writer
+        .conn()
+        .execute_batch(
+            "CREATE TABLE doctor_probe (payload BLOB);\
+             WITH RECURSIVE count(x) AS (\
+                 VALUES(1) UNION ALL SELECT x + 1 FROM count WHERE x < 256\
+             )\
+             INSERT INTO doctor_probe SELECT zeroblob(8192) FROM count;\
+             DELETE FROM doctor_probe;",
+        )
+        .await?;
+    writer.checkpoint().await?;
+
+    let freelist_before: i64 = {
+        let mut rows = writer.conn().query("PRAGMA freelist_count", ()).await?;
+        rows.next().await?.expect("freelist row").get(0)?
+    };
+    assert!(
+        freelist_before > 0,
+        "fixture must contain reclaimable pages"
+    );
+
+    let mut counters = DoctorCounters::new();
+    check_database(&mut counters, &project_root, open_options).await;
+
+    let freelist_after: i64 = {
+        let mut rows = writer.conn().query("PRAGMA freelist_count", ()).await?;
+        rows.next().await?.expect("freelist row").get(0)?
+    };
+    assert_eq!(
+        freelist_after, freelist_before,
+        "doctor must not run VACUUM or otherwise compact a live database"
+    );
+    writer
+        .conn()
+        .execute(
+            "INSERT INTO doctor_probe(payload) VALUES (zeroblob(64))",
+            (),
+        )
+        .await?;
+    assert!(
+        writer.quick_check().await?,
+        "live writer must remain healthy"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn current_project_store_resolves_profile_shard_via_registry_alias()
 -> std::result::Result<(), Box<dyn std::error::Error>> {
     let dir = tempfile::TempDir::new()?;

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -954,7 +954,7 @@ fn delete_db_files(db_path: &std::path::Path) {
     let _ = std::fs::remove_file(&wal);
 }
 
-/// Build an actionable error without replacing any member of the SQLite
+/// Build an actionable error without replacing any member of the `SQLite`
 /// recovery set.
 fn recovery_required_error(
     db_path: &std::path::Path,

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -239,35 +239,15 @@ impl TraceDecay {
             );
         }
 
-        // Try to open; if the database is completely unreadable, delete and
-        // re-initialize rather than failing permanently.
+        // Ordinary opens never replace database files. A daemon or another MCP
+        // process may still hold the current DB/WAL/SHM inodes, and deleting
+        // them here would split readers and writers across different stores.
         let open_result = Database::open(&db_path).await;
         let (db, migrated) = match open_result {
             Ok(pair) => pair,
-            Err(ref e) if Database::is_corruption_error(e) || crashed => {
-                print_corruption_warning();
-                delete_db_files(&db_path);
-                clear_dirty_sentinel_at(&store_layout.dirty_path);
-                let (db, _) = Database::initialize(&db_path).await?;
-                let ts = Self {
-                    db,
-                    config,
-                    project_root: project_root.to_path_buf(),
-                    store_layout: store_layout.clone(),
-                    open_options: open_options.clone(),
-                    registry: LanguageRegistry::new(),
-                    active_branch: active_branch.clone(),
-                    serving_branch: serving_branch.clone(),
-                    fallback_warning: fallback_warning.clone(),
-                    read_only: false,
-                };
-                ts.index_all_with_progress(|c, t, f| {
-                    eprintln!("[tracedecay] re-indexing [{c}/{t}] {f}");
-                })
-                .await?;
-                eprintln!("[tracedecay] re-index complete.");
-                ts.register_project_store_in_global_registry().await;
-                return Ok(ts);
+            Err(e) if Database::is_corruption_error(&e) || crashed => {
+                print_corruption_warning(&db_path);
+                return Err(recovery_required_error(&db_path, &e));
             }
             Err(e) => return Err(e),
         };
@@ -275,35 +255,20 @@ impl TraceDecay {
         // If the sentinel was set but the database opened successfully, run a
         // quick integrity check.
         if crashed {
-            let intact = db.quick_check().await.unwrap_or(false);
-            if !intact {
-                print_corruption_warning();
-                drop(db);
-                delete_db_files(&db_path);
-                clear_dirty_sentinel_at(&store_layout.dirty_path);
-                let (new_db, _) = Database::initialize(&db_path).await?;
-                let ts = Self {
-                    db: new_db,
-                    config,
-                    project_root: project_root.to_path_buf(),
-                    store_layout: store_layout.clone(),
-                    open_options: open_options.clone(),
-                    registry: LanguageRegistry::new(),
-                    active_branch: active_branch.clone(),
-                    serving_branch: serving_branch.clone(),
-                    fallback_warning: fallback_warning.clone(),
-                    read_only: false,
-                };
-                ts.index_all_with_progress(|c, t, f| {
-                    eprintln!("[tracedecay] re-indexing [{c}/{t}] {f}");
-                })
-                .await?;
-                eprintln!("[tracedecay] re-index complete.");
-                ts.register_project_store_in_global_registry().await;
-                return Ok(ts);
+            match db.quick_check().await {
+                Ok(true) => clear_dirty_sentinel_at(&store_layout.dirty_path),
+                Ok(false) => {
+                    print_corruption_warning(&db_path);
+                    return Err(recovery_required_error(
+                        &db_path,
+                        "SQLite quick_check did not return ok",
+                    ));
+                }
+                Err(e) => {
+                    print_corruption_warning(&db_path);
+                    return Err(recovery_required_error(&db_path, &e));
+                }
             }
-            // DB is fine — clean up the stale sentinel.
-            clear_dirty_sentinel_at(&store_layout.dirty_path);
         }
 
         let ts = Self {
@@ -989,13 +954,28 @@ fn delete_db_files(db_path: &std::path::Path) {
     let _ = std::fs::remove_file(&wal);
 }
 
-/// Prints a user-facing warning about database corruption with a request to
-/// report the issue.
-fn print_corruption_warning() {
+/// Build an actionable error without replacing any member of the SQLite
+/// recovery set.
+fn recovery_required_error(
+    db_path: &std::path::Path,
+    detail: impl std::fmt::Display,
+) -> TraceDecayError {
+    TraceDecayError::Database {
+        message: format!(
+            "database recovery required at '{}'; DB/WAL/SHM and dirty sentinel were preserved: {detail}",
+            db_path.display()
+        ),
+        operation: "open_recovery_required".to_string(),
+    }
+}
+
+fn print_corruption_warning(db_path: &std::path::Path) {
     let version = env!("CARGO_PKG_VERSION");
-    eprintln!("[tracedecay] \x1b[33m⚠ database corruption detected — rebuilding index\x1b[0m");
+    eprintln!("[tracedecay] \x1b[33m⚠ database recovery required — store preserved\x1b[0m");
     eprintln!("[tracedecay]");
-    eprintln!("[tracedecay] This was likely caused by a crash or kill during indexing.");
+    eprintln!("[tracedecay] Store: {}", db_path.display());
+    eprintln!("[tracedecay] Stop TraceDecay daemon/MCP processes before explicit repair.");
+    eprintln!("[tracedecay] Preserve the DB, WAL, SHM, and dirty sentinel as one recovery set.");
     eprintln!("[tracedecay] Please report this at:");
     eprintln!("[tracedecay]   https://github.com/ScriptedAlchemy/tracedecay/issues");
     eprintln!(

--- a/src/tracedecay/queries.rs
+++ b/src/tracedecay/queries.rs
@@ -606,7 +606,7 @@ impl TraceDecay {
         self.db.close();
     }
 
-    /// Run SQLite's non-mutating quick integrity check on the active database.
+    /// Run `SQLite`'s non-mutating quick integrity check on the active database.
     pub(crate) async fn quick_check(&self) -> Result<bool> {
         self.db.quick_check().await
     }

--- a/src/tracedecay/queries.rs
+++ b/src/tracedecay/queries.rs
@@ -606,9 +606,9 @@ impl TraceDecay {
         self.db.close();
     }
 
-    /// Runs VACUUM and ANALYZE to reclaim disk space and update planner stats.
-    pub async fn optimize(&self) -> Result<()> {
-        self.db.optimize().await
+    /// Run SQLite's non-mutating quick integrity check on the active database.
+    pub(crate) async fn quick_check(&self) -> Result<bool> {
+        self.db.quick_check().await
     }
 
     /// Returns a reference to the current configuration.

--- a/tests/core_cli_suite/tool_daemon_test.rs
+++ b/tests/core_cli_suite/tool_daemon_test.rs
@@ -12,8 +12,10 @@ use crate::common::{
 };
 use serde_json::{Value, json};
 use tempfile::TempDir;
+use tracedecay::db::Database;
 use tracedecay::storage::{
-    EnrollmentMarker, StorageMode, default_profile_project_id, write_enrollment_marker,
+    EnrollmentMarker, StorageMode, default_profile_project_id, profile_sharded_data_root,
+    write_enrollment_marker,
 };
 
 /// Bound for waits that depend on spawning and running the real `tracedecay`
@@ -859,6 +861,61 @@ fn daemon_reuses_project_engine_across_tool_clients() {
     assert!(
         second_tool_calls >= 2,
         "second status call should reuse daemon engine and see accumulated tool calls, got {second_tool_calls}"
+    );
+}
+
+#[test]
+fn doctor_keeps_live_daemon_database_healthy_without_compaction() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let home_path = canonical_existing_path(home.path());
+    let project_path = canonical_existing_path(project.path());
+    init_project_with_cli(&home_path, &project_path);
+
+    let data_root = profile_sharded_data_root(
+        &home_path.join(".tracedecay"),
+        &default_profile_project_id(&project_path),
+    );
+    let db_path = data_root.join(tracedecay::config::db_filename(&data_root));
+    common::create_runtime().block_on(async {
+        let (db, _) = Database::open(&db_path).await.expect("open graph database");
+        db.conn()
+            .execute_batch(
+                "CREATE TABLE doctor_daemon_probe (payload BLOB);\
+                 WITH RECURSIVE count(x) AS (\
+                     VALUES(1) UNION ALL SELECT x + 1 FROM count WHERE x < 128\
+                 )\
+                 INSERT INTO doctor_daemon_probe SELECT zeroblob(8192) FROM count;\
+                 DELETE FROM doctor_daemon_probe;",
+            )
+            .await
+            .expect("seed reclaimable pages");
+        db.checkpoint().await.expect("checkpoint fixture");
+    });
+
+    let _daemon = spawn_tracedecay_daemon(&home_path);
+    let first_tool_calls = tool_status_server_tool_calls(&home_path, &project_path);
+    let output = tracedecay_command_with_home(&home_path)
+        .arg("doctor")
+        .current_dir(&project_path)
+        .output()
+        .expect("doctor should run");
+    assert!(
+        output.status.success(),
+        "doctor failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Compacting database") && !stderr.contains("VACUUM"),
+        "doctor must stay read-only while daemon owns the database:\n{stderr}"
+    );
+
+    let second_tool_calls = tool_status_server_tool_calls(&home_path, &project_path);
+    assert!(
+        second_tool_calls > first_tool_calls,
+        "daemon project engine must remain usable after doctor"
     );
 }
 

--- a/tests/storage_suite/corruption_test.rs
+++ b/tests/storage_suite/corruption_test.rs
@@ -14,6 +14,7 @@ use crate::support;
 use std::io::{Seek, Write};
 use tempfile::TempDir;
 use tracedecay::db::Database;
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 use tracedecay::types::*;
 
 /// Helper: create a temp database and return (Database, TempDir, db_path).
@@ -332,6 +333,43 @@ fn dirty_sentinel_survives_drop() {
 }
 
 // ─── Full crash→detect→repair cycle ──────────────────────────────────────
+
+#[tokio::test]
+async fn open_preserves_corrupt_store_and_dirty_sentinel_for_offline_repair()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(&project_root)?;
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(dir.path().join("profile")),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+
+    let ts = TraceDecay::init_with_options(&project_root, open_options.clone()).await?;
+    let layout = ts.store_layout().clone();
+    ts.close();
+
+    let mut corrupted = std::fs::read(&layout.graph_db_path)?;
+    corrupted[..16].copy_from_slice(b"not-a-sqlite-db!");
+    std::fs::write(&layout.graph_db_path, &corrupted)?;
+    std::fs::write(&layout.dirty_path, "pid=99999\nversion=test")?;
+
+    let result = TraceDecay::open_with_options(&project_root, open_options).await;
+    assert!(
+        result.is_err(),
+        "ordinary open must not silently replace a damaged store"
+    );
+    assert_eq!(
+        std::fs::read(&layout.graph_db_path)?,
+        corrupted,
+        "damaged database must remain available for explicit offline recovery"
+    );
+    assert!(
+        layout.dirty_path.exists(),
+        "dirty sentinel must remain until recovery succeeds"
+    );
+    Ok(())
+}
 
 #[tokio::test]
 async fn corrupt_db_detected_and_repaired_on_reopen() {

--- a/tests/storage_suite/db_test.rs
+++ b/tests/storage_suite/db_test.rs
@@ -410,12 +410,6 @@ async fn test_get_node_not_found() {
 }
 
 #[tokio::test]
-async fn test_optimize() {
-    let (db, _dir) = setup_db().await;
-    db.optimize().await.expect("optimize should not fail");
-}
-
-#[tokio::test]
 async fn test_database_size() {
     let (db, _dir) = setup_db().await;
     let size = db.size().await.expect("size should not fail");


### PR DESCRIPTION
Removes doctor-triggered VACUUM/ANALYZE and makes health checks use a read-only open plus quick_check. Ordinary opens now preserve DB/WAL/SHM and the dirty sentinel on corruption or crash recovery instead of deleting live SQLite files; errors direct operators to explicit recovery.\n\nTests: cargo fmt --all -- --check; 9 doctor unit tests; 265 storage-suite tests; live-daemon doctor regression.