### PR TITLE
fix(storage): persist repo identity and isolate worktrees

### DIFF
--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -179,6 +179,44 @@ async fn current_project_store_resolves_profile_shard_via_registry_alias()
 }
 
 #[tokio::test]
+async fn current_project_store_resolves_moved_repository_identity_read_only()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::TempDir::new()?;
+    let profile_root = dir.path().join("profile");
+    let original = dir.path().join("repo");
+    let moved = dir.path().join("repo-moved");
+    std::fs::create_dir_all(&original)?;
+    let status = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&original)
+        .status()?;
+    assert!(status.success());
+
+    let project_id = "proj_doctor_moved";
+    let shard_root = crate::storage::profile_sharded_data_root(&profile_root, project_id);
+    std::fs::create_dir_all(&shard_root)?;
+    std::fs::write(
+        shard_root.join(crate::config::db_filename(&shard_root)),
+        b"graph",
+    )?;
+    crate::storage::write_repository_identity_marker(&original, project_id)?;
+    std::fs::rename(&original, &moved)?;
+
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+    match resolve_current_project_store(&moved, &open_options).await {
+        CurrentProjectStore::Resolved(layout) => {
+            assert_eq!(layout.data_root, shard_root);
+            assert_eq!(layout.identity.project_id.as_deref(), Some(project_id));
+        }
+        other => panic!("expected moved repository identity, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn registry_backed_profile_shard_is_not_stale_without_marker()
 -> std::result::Result<(), Box<dyn std::error::Error>> {
     let dir = tempfile::TempDir::new()?;

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -2022,6 +2022,11 @@ impl GlobalDb {
         project_root: &Path,
         git_common_dir: Option<&Path>,
     ) -> Option<String> {
+        match crate::storage::read_repository_identity_marker(project_root) {
+            Ok(Some(marker)) => return Some(marker.project_id),
+            Ok(None) => {}
+            Err(_) => return None,
+        }
         for alias in project_identity_aliases(project_root, git_common_dir) {
             if let Some(project_id) = self.project_id_by_alias_key(&alias).await {
                 return Some(project_id);

--- a/src/sessions/cursor.rs
+++ b/src/sessions/cursor.rs
@@ -77,32 +77,12 @@ pub async fn resolved_project_session_db_path(project_root: &Path) -> Option<Pat
 async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf> {
     let profile_root = crate::storage::default_profile_root().ok()?;
     let global = GlobalDb::open().await?;
-    let git_common_dir = crate::worktree::git_common_dir(project_root);
-    // Mirror the graph store's identity-then-unique-remote fallback
-    // (`resolve_store_layout_for_project` in tracedecay/lifecycle.rs) so a
-    // renamed/moved checkout keeps routing its session history to the store it
-    // was originally registered under, instead of silently forking a fresh
-    // session DB at a new default path.
-    let resolution = if let Some(resolution) = global
+    let git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
+        .then(|| crate::worktree::git_common_dir(project_root))
+        .flatten();
+    let resolution = global
         .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
-        .await
-    {
-        resolution
-    } else {
-        let remote = crate::tracedecay::git_remote_url(project_root)?;
-        let resolution = global
-            .resolve_unique_project_store_by_git_remote(&remote)
-            .await?;
-        // Remote uniqueness alone cannot tell a renamed checkout (whose
-        // original registered location no longer exists on disk) apart from
-        // a second, still-present clone of the same remote. Only borrow the
-        // registered store when the original checkout is gone, so a live
-        // clone never inherits another checkout's session history.
-        if registered_checkout_present(&resolution.project) {
-            return None;
-        }
-        resolution
-    };
+        .await?;
     if resolution.store.storage_mode != "profile_sharded" {
         return None;
     }
@@ -111,23 +91,6 @@ async fn registry_profile_session_db_path(project_root: &Path) -> Option<PathBuf
             .join(resolution.store.store_relpath)
             .join(PROJECT_SESSION_DB_FILENAME),
     )
-}
-
-/// Returns `true` when the checkout a registered project was recorded at still
-/// exists on disk. A renamed/moved checkout leaves neither its canonical root
-/// nor its git common dir behind, whereas a separate clone of the same remote
-/// leaves the original checkout in place.
-fn registered_checkout_present(project: &crate::global_db::CodeProjectRecord) -> bool {
-    let roots = [
-        Some(project.canonical_root.as_str()),
-        Some(project.display_root.as_str()),
-        project.git_common_dir.as_deref(),
-    ];
-    roots
-        .into_iter()
-        .flatten()
-        .filter(|root| !root.is_empty())
-        .any(|root| Path::new(root).exists())
 }
 
 fn is_hermes_profile_home(path: &Path) -> bool {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,10 +14,12 @@ pub const ENROLLMENT_FILENAME: &str = "enrollment.json";
 pub const STORE_MANIFEST_FILENAME: &str = "store_manifest.json";
 pub const SESSIONS_DB_FILENAME: &str = "sessions.db";
 pub const BRANCH_META_FILENAME: &str = "branch-meta.json";
+pub const REPOSITORY_IDENTITY_FILENAME: &str = "tracedecay-project.json";
 /// Filename prefix for corrupt `branch-meta.json` files renamed out of the
 /// way by the post-update health pass (`branch-meta.json.corrupt-<timestamp>`).
 pub const BRANCH_META_QUARANTINE_PREFIX: &str = "branch-meta.json.corrupt-";
 pub const STORE_MANIFEST_SCHEMA_VERSION: u32 = 1;
+pub const REPOSITORY_IDENTITY_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,6 +39,13 @@ pub enum StoreKind {
 pub struct EnrollmentMarker {
     pub project_id: String,
     pub storage_mode: StorageMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryIdentityMarker {
+    pub schema_version: u32,
+    pub project_id: String,
+    pub git_common_dir: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -180,6 +189,141 @@ pub fn remove_enrollment_marker(project_root: &Path, project_id: &str) -> Result
     Ok(true)
 }
 
+pub fn repository_identity_path(project_root: &Path) -> Option<PathBuf> {
+    if crate::worktree::is_detached_linked_worktree(project_root) {
+        return None;
+    }
+    crate::worktree::git_common_dir(project_root)
+        .map(|common_dir| common_dir.join(REPOSITORY_IDENTITY_FILENAME))
+}
+
+pub fn read_repository_identity_marker(
+    project_root: &Path,
+) -> Result<Option<RepositoryIdentityMarker>> {
+    let Some(path) = repository_identity_path(project_root) else {
+        return Ok(None);
+    };
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let text = fs::read_to_string(&path).map_err(|e| TraceDecayError::Config {
+        message: format!(
+            "failed to read repository identity marker '{}': {e}",
+            path.display()
+        ),
+    })?;
+    let value: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| TraceDecayError::Config {
+            message: format!(
+                "failed to parse repository identity marker '{}': {e}",
+                path.display()
+            ),
+        })?;
+    let schema_version = value
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!(
+                "repository identity marker '{}' has no valid schema_version",
+                path.display()
+            ),
+        })?;
+    if schema_version != REPOSITORY_IDENTITY_SCHEMA_VERSION {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "unsupported repository identity schema_version={} in '{}'; expected {}",
+                schema_version,
+                path.display(),
+                REPOSITORY_IDENTITY_SCHEMA_VERSION
+            ),
+        });
+    }
+    let marker: RepositoryIdentityMarker =
+        serde_json::from_value(value).map_err(|e| TraceDecayError::Config {
+            message: format!(
+                "failed to parse repository identity marker '{}': {e}",
+                path.display()
+            ),
+        })?;
+    validate_project_id(&marker.project_id).map_err(|message| TraceDecayError::Config {
+        message: format!(
+            "invalid repository identity marker '{}': {message}",
+            path.display()
+        ),
+    })?;
+    let stored_common_dir = Path::new(&marker.git_common_dir);
+    if !stored_common_dir.is_absolute() {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "invalid repository identity marker '{}': git_common_dir must be absolute",
+                path.display()
+            ),
+        });
+    }
+    let current_common_dir = path.parent().ok_or_else(|| TraceDecayError::Config {
+        message: format!(
+            "repository identity marker '{}' has no parent directory",
+            path.display()
+        ),
+    })?;
+    let stored_key = stored_common_dir
+        .canonicalize()
+        .unwrap_or_else(|_| stored_common_dir.to_path_buf());
+    let current_key = current_common_dir
+        .canonicalize()
+        .unwrap_or_else(|_| current_common_dir.to_path_buf());
+    if stored_key != current_key && stored_common_dir.exists() {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "repository identity conflict: marker '{}' names project '{}' but its original \
+                 git common directory '{}' is still live; this checkout uses '{}'",
+                path.display(),
+                marker.project_id,
+                stored_common_dir.display(),
+                current_common_dir.display()
+            ),
+        });
+    }
+    Ok(Some(marker))
+}
+
+pub fn write_repository_identity_marker(project_root: &Path, project_id: &str) -> Result<bool> {
+    validate_project_id(project_id).map_err(|message| TraceDecayError::Config {
+        message: message.to_string(),
+    })?;
+    let Some(path) = repository_identity_path(project_root) else {
+        return Ok(false);
+    };
+    let git_common_dir = path.parent().ok_or_else(|| TraceDecayError::Config {
+        message: format!(
+            "repository identity marker '{}' has no parent directory",
+            path.display()
+        ),
+    })?;
+    let marker = RepositoryIdentityMarker {
+        schema_version: REPOSITORY_IDENTITY_SCHEMA_VERSION,
+        project_id: project_id.to_string(),
+        git_common_dir: git_common_dir.to_string_lossy().to_string(),
+    };
+    let contents = serde_json::to_vec_pretty(&marker).map_err(|e| TraceDecayError::Config {
+        message: format!(
+            "failed to serialize repository identity marker '{}': {e}",
+            path.display()
+        ),
+    })?;
+    let temp_path = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    PrivateStoreIo::write_file_atomically(&path, &temp_path, &contents).map_err(|e| {
+        TraceDecayError::Config {
+            message: format!(
+                "failed to write repository identity marker '{}': {e}",
+                path.display()
+            ),
+        }
+    })?;
+    Ok(true)
+}
+
 pub fn profile_sharded_data_root(profile_root: &Path, project_id: &str) -> PathBuf {
     profile_root.join("projects").join(project_id)
 }
@@ -241,20 +385,41 @@ pub fn profile_sharded_layout(
 }
 
 pub fn resolve_layout(project_root: &Path, profile_root: &Path) -> Result<StoreLayout> {
-    match read_enrollment_marker(project_root)? {
-        Some(marker) if marker.storage_mode == StorageMode::ProfileSharded => {
-            profile_sharded_layout(project_root, profile_root, &marker)
-        }
-        Some(marker) => Err(TraceDecayError::Config {
-            message: format!(
-                "unsupported storage_mode={:?} in enrollment marker for '{}'; \
-                 run TraceDecay migration to move this project into the user profile store",
-                marker.storage_mode,
-                project_root.display()
-            ),
-        }),
-        None => default_profile_sharded_layout(project_root, profile_root),
+    if let Some(layout) = resolve_persisted_layout(project_root, profile_root)? {
+        return Ok(layout);
     }
+    default_profile_sharded_layout(project_root, profile_root)
+}
+
+pub(crate) fn resolve_persisted_layout(
+    project_root: &Path,
+    profile_root: &Path,
+) -> Result<Option<StoreLayout>> {
+    if let Some(marker) = read_enrollment_marker(project_root)? {
+        if marker.storage_mode != StorageMode::ProfileSharded {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "unsupported storage_mode={:?} in enrollment marker for '{}'; \
+                     run TraceDecay migration to move this project into the user profile store",
+                    marker.storage_mode,
+                    project_root.display()
+                ),
+            });
+        }
+        return profile_sharded_layout(project_root, profile_root, &marker).map(Some);
+    }
+    let Some(marker) = read_repository_identity_marker(project_root)? else {
+        return Ok(None);
+    };
+    profile_sharded_layout(
+        project_root,
+        profile_root,
+        &EnrollmentMarker {
+            project_id: marker.project_id,
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .map(Some)
 }
 
 pub fn default_profile_root() -> Result<PathBuf> {

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -30,8 +30,6 @@ pub use diagnostics::{BranchDiagnostics, TrackedBranchDiagnostic};
 #[doc(hidden)]
 pub use locking::{SyncLockGuard, try_acquire_sync_lock};
 
-pub(crate) use lifecycle::git_remote_url;
-
 /// Central orchestrator that coordinates all subsystems of the code graph.
 ///
 /// Provides a high-level API for initializing, indexing, querying, and

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -150,29 +150,18 @@ impl TraceDecay {
         open_options: &TraceDecayOpenOptions,
     ) -> Result<StoreLayout> {
         let profile_root = open_options.resolved_profile_root()?;
-        if storage::read_enrollment_marker(project_root)?.is_some() {
-            return storage::resolve_layout(project_root, &profile_root);
+        if let Some(layout) = storage::resolve_persisted_layout(project_root, &profile_root)? {
+            return Ok(layout);
         }
 
-        let git_common_dir = crate::worktree::git_common_dir(project_root);
-        let git_remote_url = git_remote_url(project_root);
+        let git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
+            .then(|| crate::worktree::git_common_dir(project_root))
+            .flatten();
         if let Some(global_db) = open_options.open_global_db().await {
-            let resolution = match global_db
+            if let Some(resolution) = global_db
                 .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
                 .await
             {
-                Some(resolution) => Some(resolution),
-                None => match git_remote_url.as_deref() {
-                    Some(remote) => {
-                        global_db
-                            .resolve_unique_project_store_by_git_remote(remote)
-                            .await
-                    }
-                    None => None,
-                },
-            };
-
-            if let Some(resolution) = resolution {
                 return storage::profile_sharded_layout(
                     project_root,
                     &profile_root,
@@ -611,8 +600,13 @@ impl TraceDecay {
 
         let meta = branch_meta::load_branch_meta(&self.store_layout.data_root);
         let default_branch = meta.as_ref().map(|meta| meta.default_branch.as_str());
-        let git_common_dir = crate::worktree::git_common_dir(&self.project_root);
-        let git_remote_url = git_remote_url(&self.project_root);
+        let isolated_detached = crate::worktree::is_detached_linked_worktree(&self.project_root);
+        let git_common_dir = (!isolated_detached)
+            .then(|| crate::worktree::git_common_dir(&self.project_root))
+            .flatten();
+        let git_remote_url = (!isolated_detached)
+            .then(|| git_remote_url(&self.project_root))
+            .flatten();
 
         // A shared project id can be reached from any linked worktree (see
         // the git-common-dir alias registered below), so registering
@@ -620,10 +614,14 @@ impl TraceDecay {
         // happens to touch the project last pin its canonical_root /
         // display_root to a transient worktree path. Redirect registration
         // to the primary checkout when one is detected and still exists.
-        let primary_root = crate::project_registry::primary_checkout_root(
-            &self.project_root,
-            git_common_dir.as_deref(),
-        );
+        let primary_root = (!isolated_detached)
+            .then(|| {
+                crate::project_registry::primary_checkout_root(
+                    &self.project_root,
+                    git_common_dir.as_deref(),
+                )
+            })
+            .flatten();
         let previous_canonical_root = if primary_root.is_some() {
             global_db
                 .get_code_project(project_id)
@@ -646,6 +644,15 @@ impl TraceDecay {
         else {
             return;
         };
+
+        if let Err(error) =
+            storage::write_repository_identity_marker(&self.project_root, &project.project_id)
+        {
+            eprintln!(
+                "warning: could not persist TraceDecay repository identity for '{}': {error}",
+                self.project_root.display()
+            );
+        }
 
         if let Some(primary_root) = primary_root.as_deref() {
             // The registry now points canonical_root/display_root at the
@@ -832,11 +839,13 @@ impl TraceDecay {
         open_options: &TraceDecayOpenOptions,
     ) -> Result<StoreLayout> {
         let profile_root = open_options.resolved_profile_root()?;
-        if storage::read_enrollment_marker(project_root)?.is_some() {
-            return storage::resolve_layout(project_root, &profile_root);
+        if let Some(layout) = storage::resolve_persisted_layout(project_root, &profile_root)? {
+            return Ok(layout);
         }
 
-        let git_common_dir = crate::worktree::git_common_dir(project_root);
+        let git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
+            .then(|| crate::worktree::git_common_dir(project_root))
+            .flatten();
         if let Some(global_db) = open_options.open_global_db().await {
             if let Some(resolution) = global_db
                 .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
@@ -861,11 +870,7 @@ impl TraceDecay {
         open_options: &TraceDecayOpenOptions,
     ) -> Result<StoreLayout> {
         let profile_root = open_options.resolved_profile_root()?;
-        if storage::read_enrollment_marker(project_root)?.is_some() {
-            return storage::resolve_layout(project_root, &profile_root);
-        }
-
-        storage::default_profile_sharded_layout(project_root, &profile_root)
+        storage::resolve_layout(project_root, &profile_root)
     }
 }
 
@@ -883,7 +888,7 @@ fn profile_store_id(project_id: &str) -> String {
     format!("store:{project_id}:profile_sharded")
 }
 
-pub(crate) fn git_remote_url(project_root: &Path) -> Option<String> {
+fn git_remote_url(project_root: &Path) -> Option<String> {
     // gix reads the same config `git config --get` would (repo-local +
     // global) without a subprocess spawn.
     if let Ok(repo) = gix::discover(project_root) {

--- a/src/tracedecay/scan.rs
+++ b/src/tracedecay/scan.rs
@@ -65,6 +65,10 @@ fn include_may_match_descendant(dir_path: &str, config: &TraceDecayConfig) -> bo
     false
 }
 
+fn is_nested_repository_root(path: &Path, depth: usize, is_dir: bool) -> bool {
+    depth > 0 && is_dir && path.join(".git").exists()
+}
+
 impl TraceDecay {
     /// Appends runtime skip-folder patterns to the exclude list.
     ///
@@ -119,6 +123,13 @@ impl TraceDecay {
                     .follow_links(true)
                     .max_depth(2)
                     .into_iter()
+                    .filter_entry(|entry| {
+                        !is_nested_repository_root(
+                            entry.path(),
+                            entry.depth(),
+                            entry.file_type().is_dir(),
+                        )
+                    })
                     .filter_map(std::result::Result::ok)
                     .any(|e| {
                         e.file_type().is_file()
@@ -154,6 +165,9 @@ impl TraceDecay {
             .filter_entry(|e| {
                 if e.depth() == 0 {
                     return true;
+                }
+                if is_nested_repository_root(e.path(), e.depth(), e.file_type().is_dir()) {
+                    return false;
                 }
                 let name = e.file_name().to_string_lossy();
                 if name.starts_with('.') || name == "target" {
@@ -213,6 +227,15 @@ impl TraceDecay {
             .git_global(true)
             .git_exclude(true)
             .add_custom_ignore_filename(".gitignore")
+            .filter_entry(|entry| {
+                !is_nested_repository_root(
+                    entry.path(),
+                    entry.depth(),
+                    entry
+                        .file_type()
+                        .is_some_and(|file_type| file_type.is_dir()),
+                )
+            })
             .build();
 
         for entry in walker {
@@ -272,6 +295,9 @@ impl TraceDecay {
             .filter_entry(|entry| {
                 if entry.depth() == 0 || !entry.file_type().is_dir() {
                     return true;
+                }
+                if is_nested_repository_root(entry.path(), entry.depth(), true) {
+                    return false;
                 }
                 let Ok(rel) = entry.path().strip_prefix(&self.project_root) else {
                     return true;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -79,6 +79,21 @@ pub fn git_common_dir(dir: &Path) -> Option<PathBuf> {
     Some(resolved.canonicalize().unwrap_or(resolved))
 }
 
+pub fn is_detached_linked_worktree(dir: &Path) -> bool {
+    let Ok(repo) = gix::discover(dir) else {
+        return false;
+    };
+    let git_dir = repo
+        .git_dir()
+        .canonicalize()
+        .unwrap_or_else(|_| repo.git_dir().to_path_buf());
+    let common_dir = repo
+        .common_dir()
+        .canonicalize()
+        .unwrap_or_else(|_| repo.common_dir().to_path_buf());
+    git_dir != common_dir && crate::branch::current_branch(dir).is_none()
+}
+
 /// Cheap pre-flight for the `git` subprocess fallbacks in this crate: `git`
 /// can only resolve a repository for `dir` when a `.git` entry exists
 /// somewhere in its ancestor chain or the caller overrides discovery via

--- a/tests/storage_suite/profile_storage_migration_test.rs
+++ b/tests/storage_suite/profile_storage_migration_test.rs
@@ -678,7 +678,7 @@ async fn trace_decay_open_matches_renamed_git_checkout_by_registered_remote() {
 }
 
 #[tokio::test]
-async fn ensure_initialized_with_options_uses_registered_remote_store() {
+async fn ensure_initialized_with_options_uses_persisted_repository_identity() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let root = canonical_temp_path(dir.path());
@@ -711,8 +711,8 @@ async fn ensure_initialized_with_options_uses_registered_remote_store() {
     fs::rename(&project, &renamed).unwrap();
 
     assert!(
-        !TraceDecay::is_initialized_with_options(&renamed, &open_options),
-        "the synchronous marker check cannot see renamed registered stores"
+        TraceDecay::is_initialized_with_options(&renamed, &open_options),
+        "the durable git marker should resolve the moved profile store synchronously"
     );
     let reopened = serve::ensure_initialized_with_options(&renamed, open_options)
         .await

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde_json::Value;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
 use tempfile::TempDir;
@@ -19,8 +20,8 @@ use tracedecay::storage::{
     ActiveProjectContext, EnrollmentMarker, GraphScopeId, PrivateStoreIo, ProjectPath,
     STORE_MANIFEST_FILENAME, StorageMode, StoreArtifactPath, default_profile_project_id,
     default_profile_sharded_layout, profile_sharded_layout, read_enrollment_marker,
-    read_store_manifest, resolve_layout, resolve_lcm_payload_root, resolve_project_session_db_path,
-    resolve_response_handle_root, write_store_manifest,
+    read_repository_identity_marker, read_store_manifest, resolve_layout, resolve_lcm_payload_root,
+    resolve_project_session_db_path, resolve_response_handle_root, write_store_manifest,
 };
 use tracedecay::tracedecay::TraceDecay;
 
@@ -171,6 +172,31 @@ fn invalid_enrollment_marker_is_not_treated_as_initialized() {
     assert_eq!(discover_project_root(root), None);
     assert!(!TraceDecay::is_initialized(root));
     assert!(read_enrollment_marker(root).is_err());
+}
+
+#[test]
+fn repository_identity_marker_rejects_unknown_schema() {
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn marker_test() {}\n").unwrap();
+    init_repo_with_commit(&project);
+    let marker_path = tracedecay::worktree::git_common_dir(&project)
+        .unwrap()
+        .join("tracedecay-project.json");
+    fs::write(
+        marker_path,
+        r#"{"schema_version":99,"project_id":"proj_future"}"#,
+    )
+    .unwrap();
+
+    let error = read_repository_identity_marker(&project).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported repository identity schema_version=99"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
@@ -694,8 +720,10 @@ async fn trace_decay_init_registers_default_profile_shard_globally() {
     let dir = TempDir::new().unwrap();
     let project = dir.path().join("repo");
     let home = test_home(&dir);
-    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn registered() {}\n").unwrap();
     let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
     let project_id = default_profile_project_id(&project);
 
     TraceDecay::init(&project).await.unwrap();
@@ -703,6 +731,19 @@ async fn trace_decay_init_registers_default_profile_shard_globally() {
     let resolution = db.resolve_project_store_by_alias(&project).await.unwrap();
 
     assert_eq!(resolution.project.project_id, project_id);
+    let identity_path = tracedecay::worktree::git_common_dir(&project)
+        .unwrap()
+        .join("tracedecay-project.json");
+    let identity: Value = serde_json::from_slice(&fs::read(&identity_path).unwrap()).unwrap();
+    assert_eq!(identity["schema_version"], 1);
+    assert_eq!(identity["project_id"], project_id);
+
+    fs::remove_file(&identity_path).unwrap();
+    TraceDecay::open(&project).await.unwrap();
+    assert!(
+        identity_path.is_file(),
+        "opening a legacy registered checkout must migrate it to durable repository identity"
+    );
 }
 
 #[tokio::test]
@@ -810,6 +851,27 @@ async fn same_remote_clone_is_not_considered_initialized_without_local_identity(
         !TraceDecay::has_initialized_store(&clone).await,
         "a separate clone with the same origin is not a linked worktree and must not borrow the initialized store"
     );
+    assert_eq!(
+        resolved_project_session_db_path(&clone).await.unwrap(),
+        project_session_db_path(&clone),
+        "session storage must not use a same-remote clone as repository identity"
+    );
+
+    let original_identity = tracedecay::worktree::git_common_dir(&project)
+        .unwrap()
+        .join("tracedecay-project.json");
+    let copied_identity = tracedecay::worktree::git_common_dir(&clone)
+        .unwrap()
+        .join("tracedecay-project.json");
+    fs::copy(original_identity, copied_identity).unwrap();
+    let error = match TraceDecay::open(&clone).await {
+        Ok(_) => panic!("a copied repository marker must not bind a second live clone"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("repository identity conflict"),
+        "unexpected copied-marker error: {error}"
+    );
 }
 
 #[tokio::test]
@@ -846,6 +908,7 @@ async fn renamed_checkout_session_db_follows_registered_store() {
     // Move the whole checkout on disk; both its canonical root and git common
     // dir change, so registry identity resolution can no longer match by path.
     fs::rename(&original, &renamed).unwrap();
+    git(&renamed, &["remote", "remove", "origin"]);
 
     let resolved = resolved_project_session_db_path(&renamed)
         .await
@@ -855,6 +918,62 @@ async fn renamed_checkout_session_db_follows_registered_store() {
         normalize_test_path(&resolved),
         normalize_test_path(&project_session_db_path(&renamed)),
         "renamed checkout must not fork a fresh default-path session DB",
+    );
+
+    #[cfg(unix)]
+    {
+        let alias = dir.path().join("repo-alias");
+        symlink(&renamed, &alias).unwrap();
+        let via_alias = resolved_project_session_db_path(&alias)
+            .await
+            .expect("symlink alias should retain repository identity");
+        assert_path_eq(via_alias, registered_session_db);
+    }
+}
+
+#[tokio::test]
+async fn parent_index_excludes_nested_linked_worktree_sources() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let nested_worktree = project.join(".worktrees/feature");
+    let home = test_home(&dir);
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn parent_only() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
+
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/nested-index",
+            nested_worktree.to_str().unwrap(),
+        ],
+    );
+    fs::write(
+        nested_worktree.join("src/lib.rs"),
+        "pub fn parent_only() {}\npub fn nested_worktree_only() {}\n",
+    )
+    .unwrap();
+
+    let mut parent = TraceDecay::init(&project).await.unwrap();
+    parent.add_include_folders(&[".worktrees".to_string()]);
+    parent.index_all().await.unwrap();
+
+    assert!(
+        !parent.search("parent_only", 10).await.unwrap().is_empty(),
+        "the parent checkout must remain indexed"
+    );
+    assert!(
+        parent
+            .search("nested_worktree_only", 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a nested linked worktree must be a separate project view, not duplicate parent source"
     );
 }
 
@@ -904,7 +1023,7 @@ async fn same_remote_clone_session_db_does_not_borrow_registered_store() {
 }
 
 #[tokio::test]
-async fn ambiguous_remote_session_db_falls_back_to_default_path() {
+async fn same_remote_repositories_keep_distinct_persistent_identities() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();
     let remote = dir.path().join("remote.git");
@@ -931,17 +1050,25 @@ async fn ambiguous_remote_session_db_falls_back_to_default_path() {
         &["clone", remote.to_str().unwrap(), two.to_str().unwrap()],
     );
 
-    // Two registered checkouts share the same remote, so remote-based fallback
-    // is ambiguous and must be declined even after one checkout is renamed.
-    TraceDecay::init(&one).await.unwrap();
+    let one_session_db = TraceDecay::init(&one)
+        .await
+        .unwrap()
+        .store_layout()
+        .sessions_db_path
+        .clone();
     TraceDecay::init(&two).await.unwrap();
 
     fs::rename(&one, &renamed_one).unwrap();
 
     let resolved = resolved_project_session_db_path(&renamed_one)
         .await
-        .expect("ambiguous-remote checkout should still resolve a default path");
-    assert_path_eq(&resolved, project_session_db_path(&renamed_one));
+        .expect("moved checkout should resolve its persistent repository identity");
+    assert_path_eq(&resolved, one_session_db);
+    assert_ne!(
+        normalize_test_path(&resolved),
+        normalize_test_path(&project_session_db_path(&renamed_one)),
+        "remote ambiguity must not fork the moved repository into a new path-hash store"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Persists a versioned project identity marker in the Git common directory so profile-sharded stores survive directory moves, renames, symlink aliases, and named linked worktrees. Same-remote clones no longer borrow stores; copied live markers fail closed; detached worktrees remain isolated; parent scans prune nested Git roots. Runtime remote-based identity fallback is removed.\n\nTests: cargo fmt --all -- --check; storage suite 267/267; moved-project doctor regression.