### PR TITLE
feat(sessions): emit Claude reasoning rows from thinking blocks

### DIFF
--- a/src/sessions/claude.rs
+++ b/src/sessions/claude.rs
@@ -44,6 +44,10 @@ const PROVIDER: &str = "claude";
 const KIND_PR_LINK: &str = "pr_link";
 const KIND_COMPACT_BOUNDARY: &str = "compact_boundary";
 const KIND_MODEL_FALLBACK: &str = "model_fallback";
+/// A separate reasoning row per assistant message, matching how Codex and Cursor
+/// store the model's thinking as its own `kind="reasoning"` row instead of
+/// leaving it buried inside the serialized assistant-message content blob.
+const KIND_REASONING: &str = "reasoning";
 
 /// Cap on the capped preview text carried on a marker row.
 const MARKER_PREVIEW_BYTES: usize = 2000;
@@ -173,6 +177,12 @@ impl TranscriptSource for ClaudeSource {
                     line.offset,
                     &mut accumulator,
                 );
+            }
+            // Additive reasoning row for assistant thinking blocks. Emitted
+            // before the message row so the thinking precedes the visible answer
+            // in ordinal+insertion order (both share this line's byte offset).
+            if let Some(reasoning) = reasoning_from_line(record, &session_id, path, line.offset) {
+                messages.push(reasoning);
             }
             if let Some(message) = message {
                 messages.push(message);
@@ -446,12 +456,7 @@ fn message_from_line(
         return None;
     }
 
-    let message_id = message
-        .get("id")
-        .and_then(Value::as_str)
-        .or_else(|| record.get("uuid").and_then(Value::as_str))
-        .filter(|id| !id.is_empty())
-        .map_or_else(|| format!("{session_id}:{offset}"), ToString::to_string);
+    let message_id = conversational_message_id(message, record, session_id, offset);
     let model = message
         .get("model")
         .and_then(Value::as_str)
@@ -484,6 +489,131 @@ fn message_from_line(
             accumulator,
         ))
         .ok(),
+    })
+}
+
+/// Stable id for a conversational (`user`/`assistant`) row: the message `id`,
+/// else the record `uuid`, else a synthesized `{session}:{offset}`. Shared by
+/// the message row and the reasoning row so a reasoning row's
+/// `{base}:thinking` id always links back to its owning assistant message.
+fn conversational_message_id(
+    message: &Value,
+    record: &Value,
+    session_id: &str,
+    offset: i64,
+) -> String {
+    message
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| record.get("uuid").and_then(Value::as_str))
+        .filter(|id| !id.is_empty())
+        .map_or_else(|| format!("{session_id}:{offset}"), ToString::to_string)
+}
+
+/// Emit a separate `kind="reasoning"` row for an assistant message that carries
+/// one or more `thinking` blocks, so the model's reasoning is kind-filterable
+/// and searchable on its own row — matching how Codex
+/// ([`crate::sessions::codex`]) and Cursor ([`crate::sessions::cursor_composer`])
+/// store reasoning as a dedicated row (role "assistant", `kind="reasoning"`)
+/// rather than leaving the thinking text embedded in the serialized
+/// assistant-message content blob.
+///
+/// Multiple `thinking` blocks are concatenated in transcript order. A
+/// `redacted_thinking` block carries no plaintext, so — mirroring Codex's
+/// encrypted-reasoning convention, where
+/// `response_item_reasoning_summary_text` declines to emit a row when there is
+/// no plaintext summary — it never fabricates a body: a message whose only
+/// reasoning is redacted yields no row (the block count is recorded as metadata
+/// only when a plaintext row already exists).
+///
+/// Purely additive: the assistant message row itself is untouched (its content
+/// blob still carries the thinking blocks verbatim in lossless storage).
+fn reasoning_from_line(
+    record: &Value,
+    session_id: &str,
+    path: &Path,
+    offset: i64,
+) -> Option<SessionMessageRecord> {
+    if record.get("type").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let message = record.get("message").unwrap_or(record);
+    let blocks = message.get("content").and_then(Value::as_array)?;
+
+    let mut thinking_parts = Vec::new();
+    let mut redacted_blocks = 0usize;
+    for block in blocks {
+        match block.get("type").and_then(Value::as_str) {
+            Some("thinking") => {
+                if let Some(text) = block
+                    .get("thinking")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.trim().is_empty())
+                {
+                    thinking_parts.push(text.to_string());
+                }
+            }
+            Some("redacted_thinking") => redacted_blocks += 1,
+            _ => {}
+        }
+    }
+    // No plaintext thinking: mirror Codex, which records nothing for encrypted
+    // reasoning rather than fabricating a body from redacted content.
+    if thinking_parts.is_empty() {
+        return None;
+    }
+    let text = thinking_parts.join("\n\n");
+
+    let base_id = conversational_message_id(message, record, session_id, offset);
+    let role = message
+        .get("role")
+        .and_then(Value::as_str)
+        .filter(|role| !role.is_empty())
+        .unwrap_or("assistant")
+        .to_string();
+    let model = message
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    let mut metadata = Map::new();
+    metadata.insert(
+        "source".to_string(),
+        Value::String("claude_thinking".to_string()),
+    );
+    // Parent linkage back to the assistant message row that owns this reasoning.
+    metadata.insert(
+        "parent_message_id".to_string(),
+        Value::String(base_id.clone()),
+    );
+    metadata.insert(
+        "thinking_blocks".to_string(),
+        Value::from(thinking_parts.len() as i64),
+    );
+    if redacted_blocks > 0 {
+        metadata.insert(
+            "redacted_thinking_blocks".to_string(),
+            Value::from(redacted_blocks as i64),
+        );
+    }
+
+    Some(SessionMessageRecord {
+        provider: PROVIDER.to_string(),
+        // `{base}:thinking` keeps re-ingest idempotent and can never collide
+        // with the owning message row's `{base}` id under the
+        // `(provider, message_id)` primary key.
+        message_id: format!("{base_id}:thinking"),
+        session_id: session_id.to_string(),
+        role,
+        timestamp: record_timestamp(record),
+        ordinal: offset,
+        text,
+        kind: Some(KIND_REASONING.to_string()),
+        model,
+        tool_names: None,
+        source_path: Some(path.to_string_lossy().to_string()),
+        source_offset: Some(offset),
+        metadata_json: serde_json::to_string(&Value::Object(metadata)).ok(),
     })
 }
 
@@ -1151,5 +1281,120 @@ mod tests {
             &json!({"message": {"content": "gitOperation commit abcdef12"}}),
         );
         assert!(metadata.is_empty());
+    }
+
+    fn assistant_record(content: &Value) -> Value {
+        json!({
+            "type": "assistant",
+            "sessionId": "sess",
+            "uuid": "u-assistant",
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "message": {
+                "id": "msg_1",
+                "role": "assistant",
+                "model": "claude-opus-4-8",
+                "content": content.clone(),
+            }
+        })
+    }
+
+    #[test]
+    fn thinking_blocks_become_a_linked_reasoning_row_leaving_the_message_row_unchanged() {
+        let record = assistant_record(&json!([
+            {"type": "thinking", "thinking": "First I inspect the parser."},
+            {"type": "thinking", "thinking": "Then I add the row."},
+            {"type": "text", "text": "Done."}
+        ]));
+        let path = Path::new("/tmp/sess.jsonl");
+
+        let mut accumulator = SessionAccumulator::default();
+        let message = message_from_line(&record, "sess", path, 10, None, &mut accumulator)
+            .expect("assistant message row");
+        // The message row is untouched: it still stores the whole content array
+        // (thinking blocks included) as its lossless blob.
+        assert_eq!(message.message_id, "msg_1");
+        assert_eq!(message.kind.as_deref(), Some("message"));
+        assert!(message.text.contains("First I inspect the parser"));
+        assert!(message.text.contains("Done."));
+
+        let reasoning =
+            reasoning_from_line(&record, "sess", path, 10).expect("reasoning row for thinking");
+        assert_eq!(reasoning.message_id, "msg_1:thinking");
+        assert_eq!(reasoning.kind.as_deref(), Some("reasoning"));
+        assert_eq!(reasoning.role, "assistant");
+        assert_eq!(reasoning.model.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(reasoning.ordinal, 10);
+        assert_eq!(reasoning.timestamp, Some(1_767_225_605));
+        assert_eq!(
+            reasoning.text,
+            "First I inspect the parser.\n\nThen I add the row."
+        );
+        let metadata: Value = serde_json::from_str(reasoning.metadata_json.as_deref().unwrap())
+            .expect("reasoning metadata json");
+        assert_eq!(metadata["source"], "claude_thinking");
+        assert_eq!(metadata["parent_message_id"], "msg_1");
+        assert_eq!(metadata["thinking_blocks"], 2);
+        assert!(metadata.get("redacted_thinking_blocks").is_none());
+    }
+
+    #[test]
+    fn redacted_only_thinking_records_no_reasoning_row() {
+        // Matches Codex's encrypted-reasoning convention: no plaintext, no row.
+        let record = assistant_record(&json!([
+            {"type": "redacted_thinking", "data": "ENCRYPTED_SHOULD_NOT_INDEX"},
+            {"type": "text", "text": "Answer."}
+        ]));
+        assert!(reasoning_from_line(&record, "sess", Path::new("/tmp/sess.jsonl"), 3).is_none());
+    }
+
+    #[test]
+    fn mixed_thinking_and_redacted_records_the_redacted_count_but_no_plaintext() {
+        let record = assistant_record(&json!([
+            {"type": "thinking", "thinking": "Visible reasoning."},
+            {"type": "redacted_thinking", "data": "ENCRYPTED_SHOULD_NOT_INDEX"}
+        ]));
+        let reasoning = reasoning_from_line(&record, "sess", Path::new("/tmp/sess.jsonl"), 4)
+            .expect("reasoning row for the plaintext block");
+        assert_eq!(reasoning.text, "Visible reasoning.");
+        assert!(!reasoning.text.contains("ENCRYPTED"));
+        let metadata: Value =
+            serde_json::from_str(reasoning.metadata_json.as_deref().unwrap()).unwrap();
+        assert_eq!(metadata["thinking_blocks"], 1);
+        assert_eq!(metadata["redacted_thinking_blocks"], 1);
+    }
+
+    #[test]
+    fn assistant_message_without_thinking_records_no_reasoning_row() {
+        let record = assistant_record(&json!([{"type": "text", "text": "Just an answer."}]));
+        assert!(reasoning_from_line(&record, "sess", Path::new("/tmp/sess.jsonl"), 7).is_none());
+    }
+
+    #[test]
+    fn reasoning_row_id_falls_back_to_record_uuid_when_message_id_is_absent() {
+        let record = json!({
+            "type": "assistant",
+            "sessionId": "sess",
+            "uuid": "u-fallback",
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "Reasoning without a message id."}]
+            }
+        });
+        let reasoning = reasoning_from_line(&record, "sess", Path::new("/tmp/sess.jsonl"), 9)
+            .expect("reasoning row");
+        assert_eq!(reasoning.message_id, "u-fallback:thinking");
+        let metadata: Value =
+            serde_json::from_str(reasoning.metadata_json.as_deref().unwrap()).unwrap();
+        assert_eq!(metadata["parent_message_id"], "u-fallback");
+    }
+
+    #[test]
+    fn user_record_never_produces_a_reasoning_row() {
+        let record = json!({
+            "type": "user",
+            "message": {"role": "user", "content": [{"type": "thinking", "thinking": "nope"}]}
+        });
+        assert!(reasoning_from_line(&record, "sess", Path::new("/tmp/sess.jsonl"), 1).is_none());
     }
 }

--- a/src/sessions/transcript_backfill.rs
+++ b/src/sessions/transcript_backfill.rs
@@ -406,7 +406,10 @@ fn derive_usage(provider: &str, record: &Value) -> Option<Value> {
 // current parser and inserts message ids missing from legacy stores.
 
 const STRUCTURED_MARKER_NAME: &str = "structured_rows_backfill";
-const STRUCTURED_MARKER_VERSION: i64 = 2;
+// v3: Claude assistant `thinking` blocks now emit a separate `kind="reasoning"`
+// row (previously they lived only inside the serialized assistant-message blob),
+// so re-sweep already-ingested Claude transcripts to add the missing rows.
+const STRUCTURED_MARKER_VERSION: i64 = 3;
 /// Base name of the sweep's path watermark. The live key is namespaced by the
 /// marker version (see [`structured_cursor_key`]) so bumping
 /// [`STRUCTURED_MARKER_VERSION`] naturally starts the re-sweep from a fresh

--- a/tests/session_suite/structured_backfill.rs
+++ b/tests/session_suite/structured_backfill.rs
@@ -213,6 +213,87 @@ fn write_claude_transcript_with_pr_link(
     path
 }
 
+fn write_claude_transcript_with_thinking(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".claude/projects/-thinking-slug");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{session}.jsonl"));
+    let cwd = project.to_string_lossy();
+    let contents = format!(
+        "{}\n{}\n",
+        serde_json::json!({
+            "type": "user",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "tu1",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "message": {"role": "user", "content": "Fix the parser"}
+        }),
+        serde_json::json!({
+            "type": "assistant",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "tu2",
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "message": {
+                "id": "msg_thinking_1",
+                "role": "assistant",
+                "model": "claude-opus-4-8",
+                "content": [
+                    {"type": "thinking", "thinking": "Let me trace the ingestion path first."},
+                    {"type": "text", "text": "Fixed the parser."}
+                ]
+            }
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn structured_backfill_inserts_claude_reasoning_rows_once() {
+    tracedecay::global_db::set_background_structured_backfill_enabled(false);
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = init_project(&tmp);
+    write_claude_transcript_with_thinking(&home, &project, "claude-thinking");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClaudeSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+    // Live ingest already emits the reasoning row; drive one sweep so the
+    // backfill meta table exists (see the note in the goal test).
+    db.run_structured_backfill().await;
+    assert_eq!(count_kind(&project, "claude", "reasoning").await, 1);
+    // The user + assistant conversational rows (both kind "message") coexist
+    // with the reasoning row.
+    assert_eq!(count_kind(&project, "claude", "message").await, 2);
+    drop(db);
+
+    // Simulate a legacy store written before reasoning rows existed: drop them
+    // and reset the marker so the version-bumped sweep re-enters from the start.
+    simulate_old_parser_store(&project, "claude", "reasoning").await;
+    assert_eq!(count_kind(&project, "claude", "reasoning").await, 0);
+    // Dropping reasoning rows leaves the conversational message rows untouched.
+    assert_eq!(count_kind(&project, "claude", "message").await, 2);
+
+    let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
+    assert_eq!(count_kind(&project, "claude", "reasoning").await, 1);
+    // The reasoning backfill is additive: it did not duplicate the message rows.
+    assert_eq!(count_kind(&project, "claude", "message").await, 2);
+    drop(db);
+
+    // Idempotent: a second sweep inserts nothing more.
+    let db = open_project_session_db(&project).await.unwrap();
+    db.run_structured_backfill().await;
+    assert_eq!(count_kind(&project, "claude", "reasoning").await, 1);
+    drop(db);
+    assert_eq!(structured_marker_version(&project).await, Some(3));
+}
+
 #[tokio::test]
 async fn structured_backfill_inserts_codex_goal_rows_once() {
     // `open_at` schedules the sweep on a detached background task; drive it
@@ -253,7 +334,7 @@ async fn structured_backfill_inserts_codex_goal_rows_once() {
     db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "codex", "goal").await, 1);
     drop(db);
-    assert_eq!(structured_marker_version(&project).await, Some(2));
+    assert_eq!(structured_marker_version(&project).await, Some(3));
 }
 
 #[tokio::test]
@@ -313,7 +394,7 @@ async fn structured_backfill_inserts_claude_marker_rows_once() {
     db.run_structured_backfill().await;
     assert_eq!(count_kind(&project, "claude", "pr_link").await, 1);
     drop(db);
-    assert_eq!(structured_marker_version(&project).await, Some(2));
+    assert_eq!(structured_marker_version(&project).await, Some(3));
 }
 
 /// Regression for the stale-cursor-vs-version-bump defect: the sweep's path
@@ -335,7 +416,7 @@ async fn structured_backfill_version_bump_reparses_from_start() {
     ingest_source(&db, &source, &project, None).await;
     db.run_structured_backfill().await; // parses the file, advances the cursor
     db.run_structured_backfill().await; // no candidates: marks complete, clears cursors
-    assert_eq!(structured_marker_version(&project).await, Some(2));
+    assert_eq!(structured_marker_version(&project).await, Some(3));
     drop(db);
 
     // Drop the structured rows and reset the marker so the sweep re-enters

--- a/tests/transcript_ingest_suite/claude.rs
+++ b/tests/transcript_ingest_suite/claude.rs
@@ -193,6 +193,111 @@ async fn claude_transcript_populates_searchable_messages() {
     );
 }
 
+/// Writes a transcript whose assistant turn carries a `thinking` block followed
+/// by visible text, plus a `redacted_thinking` block that must never surface as
+/// plaintext.
+fn write_claude_transcript_with_thinking(
+    home: &std::path::Path,
+    project: &std::path::Path,
+    session: &str,
+) -> std::path::PathBuf {
+    let dir = home.join(".claude/projects/-thinking-slug");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{session}.jsonl"));
+    let cwd = project.to_string_lossy();
+    let contents = format!(
+        "{}\n{}\n",
+        serde_json::json!({
+            "type": "user",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "tu1",
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "message": {"role": "user", "content": "Trace the ingestion path"}
+        }),
+        serde_json::json!({
+            "type": "assistant",
+            "cwd": cwd,
+            "sessionId": session,
+            "uuid": "tu2",
+            "timestamp": "2026-01-01T00:00:05.000Z",
+            "message": {
+                "id": "msg_thinking_1",
+                "role": "assistant",
+                "model": "claude-opus-4-8",
+                "content": [
+                    {"type": "thinking", "thinking": "Reasoning breadcrumb about the parser."},
+                    {"type": "redacted_thinking", "data": "ENCRYPTED_SHOULD_NEVER_INDEX"},
+                    {"type": "text", "text": "Traced it."}
+                ]
+            }
+        }),
+    );
+    std::fs::write(&path, contents).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn claude_thinking_blocks_ingest_as_a_linked_reasoning_row() {
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = setup(&tmp);
+    init_git_repo(&project);
+    write_claude_transcript_with_thinking(&home, &project, "claude-thinking");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = ClaudeSource::with_home(&home);
+
+    // user message + assistant message + the reasoning row = 3 rows.
+    let stats = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(stats.messages_upserted, 3);
+
+    let results = db
+        .search_session_messages(
+            "claude",
+            Some(project.to_string_lossy().as_ref()),
+            "reasoning breadcrumb",
+            10,
+        )
+        .await;
+    let reasoning = results
+        .iter()
+        .find(|hit| hit.message.kind.as_deref() == Some("reasoning"))
+        .expect("thinking should surface as a reasoning row");
+    assert_eq!(reasoning.message.message_id, "msg_thinking_1:thinking");
+    assert_eq!(reasoning.message.role, "assistant");
+    assert_eq!(reasoning.message.model.as_deref(), Some("claude-opus-4-8"));
+    assert_eq!(
+        reasoning.message.text,
+        "Reasoning breadcrumb about the parser."
+    );
+    // The encrypted block never contributes plaintext to the reasoning row.
+    assert!(!reasoning.message.text.contains("ENCRYPTED"));
+    let metadata: serde_json::Value =
+        serde_json::from_str(reasoning.message.metadata_json.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["source"], "claude_thinking");
+    assert_eq!(metadata["parent_message_id"], "msg_thinking_1");
+    assert_eq!(metadata["thinking_blocks"], 1);
+    assert_eq!(metadata["redacted_thinking_blocks"], 1);
+
+    // The owning assistant message row is stored separately and still carries
+    // the whole content array (thinking blocks included) as its lossless blob.
+    let message = results
+        .iter()
+        .find(|hit| hit.message.kind.as_deref() == Some("message"))
+        .expect("assistant message row should coexist with its reasoning row");
+    assert_eq!(message.message.message_id, "msg_thinking_1");
+    let raw = db
+        .lcm_load_raw_message("claude", "msg_thinking_1")
+        .await
+        .expect("assistant message content should be in raw LCM storage");
+    assert!(raw.content.contains("redacted_thinking"));
+
+    // Re-ingesting the unchanged transcript is a no-op: the reasoning row's
+    // stable `:thinking` id keeps the insert idempotent.
+    let second = ingest_source(&db, &source, &project, None).await;
+    assert_eq!(second.messages_upserted, 0);
+}
+
 #[tokio::test]
 async fn claude_transcript_ingest_is_incremental() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Problem

Codex has 750 `kind='reasoning'` rows and Cursor 5,847, but Claude had **zero**. Claude thinking blocks stayed embedded inside the serialized assistant-message content blob (`message_storage_text` stores the whole content array as one JSON blob), so they were not kind-filterable and polluted text search with JSON.

## Change (purely additive)

- **Parser** (`src/sessions/claude.rs`): for an assistant record whose `message.content` carries one or more `thinking` blocks, emit a separate `kind="reasoning"` row — role `"assistant"`, text = the thinking blocks concatenated in transcript order, `model` carried through, `timestamp`/`ordinal` matching the owning line. Multiple thinking blocks are joined; `metadata_json` records `source: "claude_thinking"`, `parent_message_id`, `thinking_blocks`, and `redacted_thinking_blocks`.
- **Stable id**: the reasoning row id is `<assistant-message-id>:thinking` (shared `conversational_message_id` helper), so re-ingest is idempotent and it never collides with the message row under the `(provider, message_id)` primary key.
- **Redacted thinking**: `redacted_thinking` carries no plaintext, so — mirroring Codex's encrypted-reasoning convention (`response_item_reasoning_summary_text` declines when there is no summary) — no body is fabricated. A redacted-only message yields **no** row; the redacted count is recorded as metadata only when a plaintext row already exists.
- **Message row unchanged**: the assistant message row still stores the whole content array (thinking blocks included) as its lossless blob. No restructuring.
- **Historical coverage**: bumped `STRUCTURED_MARKER_VERSION` 2 → 3 in `src/sessions/transcript_backfill.rs` so the versioned backfill sweep re-parses already-ingested Claude transcripts and adds the missing reasoning rows.

## Tests

- Parser unit tests: thinking+text → message row unchanged + one linked reasoning row; multiple thinking blocks concatenated; redacted-only → no row; mixed thinking+redacted records the redacted count without plaintext; no-thinking → no row; uuid-fallback id; user record never produces a reasoning row.
- Fixture integration (`transcript_ingest_suite`): ingest a thinking+redacted+text transcript → 3 rows, reasoning row searchable with correct id/metadata, encrypted content never surfaces, idempotent re-ingest.
- Backfill (`session_suite`): version-bump re-sweep inserts the Claude reasoning row exactly once, leaves message rows untouched, idempotent; existing `Some(2)` marker assertions updated to `Some(3)`.

## Live proof

Real Claude transcript with 15 thinking-bearing assistant records → **15 reasoning rows** (before this change: **0**), 70 message rows unchanged, sample id `msg_011Ccr4GyzREX3XA4DVTQoBb:thinking`.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and nextest `transcript_ingest_suite` + `session_suite` (306 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)