### PR TITLE
fix(mcp): unused_imports empty results — mask comments in scan

### DIFF
--- a/evals/agent_adoption/README.md
+++ b/evals/agent_adoption/README.md
@@ -138,15 +138,21 @@ enriches the copied fixture at setup so more scenario tiers are gradable:
   markers: a genuine unused import (`use std::collections::BTreeMap;`), a `TODO`
   marker, and a needless `unsafe { }` block.
   * The `TODO` is reliably surfaced by `tracedecay_todos` (two matches).
-  * **Known tool gaps (tracedecay v0.0.40):** `tracedecay_unused_imports` did
-    **not** flag the planted unused import in this small crate (imports sharing a
-    path with a used one collapse to one node; even a crate-unique unused import
-    was not surfaced), and `tracedecay_unsafe_patterns` returned an empty
-    "No diagnostics" response even in the main repo for `unwrap`/`unsafe_block`
-    kinds. The plants are real (rustc warns on the import; the `unsafe` block
-    compiles), so anchor audit-tier scenarios on `tracedecay_todos` + the
-    audit-safety skill + `tracedecay_context` for now, and consider filing an
-    issue on those two tools (strip proprietary code first).
+  * All three plants now have working tool coverage:
+    * `tracedecay_unused_imports` flags the planted `BTreeMap` at
+      `src/audit.rs` (whole-crate run: `unused_import_count` 1). This was
+      previously an empty-result gap: the resolver drops `Uses` edges for
+      std/foreign-crate imports, so the tool falls back to a text scan of the
+      file — but it counted the import identifier appearing in the **comment
+      directly above the `use`** as a real reference, so the crate-unique
+      import was read as "used" and never surfaced. Fixed by masking comments
+      and string/char literals (`mask_rust_noise` in
+      `src/mcp/tools/handlers/analysis.rs`) before the scan, plus a dedicated
+      `unused_imports_md` renderer. Anchored by `analysis_unused_import_hunt`.
+    * `tracedecay_unsafe_patterns` surfaces the needless `unsafe { }` block
+      (dedicated `risky_patterns_md` renderer). Anchored by
+      `analysis_unsafe_panic_audit`.
+    * `tracedecay_todos` surfaces the `TODO`. Anchored by `diag_todo_inventory`.
 
 ### Seeding prior sessions — a gap
 

--- a/evals/agent_adoption/scenarios/analysis_unused_import_hunt.json
+++ b/evals/agent_adoption/scenarios/analysis_unused_import_hunt.json
@@ -1,0 +1,42 @@
+{
+  "id": "analysis_unused_import_hunt",
+  "category": "unused_imports",
+  "pack": "pack_analysis",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Is this crate carrying any imports that aren't actually referenced anywhere? I'd like to trim them before shipping.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_unused_imports",
+      "tracedecay_context"
+    ],
+    "acceptable": [
+      "tracedecay_grep",
+      "tracedecay_search",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "BTreeMap"
+  ],
+  "max_tool_calls": 5,
+  "notes": "ACTIVE. The tool bug is fixed: `tracedecay_unused_imports` previously returned empty results on small crates because its text-based scan treated an import merely named in a nearby comment as a real use (the resolver drops `Uses` edges for std/foreign-crate imports, so the scan is text-based by design). The planted `use std::collections::BTreeMap;` in fixture/src/audit.rs is described in the comment directly above it, so the identifier `BTreeMap` appeared on a non-use line and the import was read as 'used' -> zero findings. Fixed by masking comments and string/char literals (`mask_rust_noise` in src/mcp/tools/handlers/analysis.rs) before the identifier scan, plus a dedicated `unused_imports_md` renderer (src/mcp/tools/render.rs). Live-verified against the built fixture (fresh `tracedecay tool unused_imports`, whole crate): `unused_import_count` is 1 and the sole finding is `std::collections::BTreeMap` at fixture/src/audit.rs (node 0-based line 17 / source line 18); every other import in the crate is referenced and correctly left unflagged. ground_truth fragment `BTreeMap` is the import name any correct answer must report."
+}

--- a/src/mcp/tools/handlers/analysis.rs
+++ b/src/mcp/tools/handlers/analysis.rs
@@ -44,6 +44,229 @@ fn is_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
+/// Lexer state for [`mask_rust_noise`].
+#[derive(Clone, Copy)]
+enum MaskState {
+    Normal,
+    LineComment,
+    /// Nested `/* … */` comment; carries the nesting depth.
+    BlockComment(u32),
+    /// Regular or byte string `"…"` / `b"…"`.
+    Str,
+    /// Raw string `r"…"` / `r#"…"#`; carries the `#` count.
+    RawStr(u32),
+    /// Char or byte-char literal `'x'` / `b'x'`.
+    Char,
+}
+
+/// Returns a copy of `source` with the *contents* of comments and string,
+/// byte-string, raw-string, and char literals replaced by spaces, preserving
+/// newlines and byte length so line indexing stays valid.
+///
+/// The unused-import scan is text-based (the Rust resolver drops `Uses` edges
+/// for std/foreign-crate imports, so a graph-only check misses them). A bare
+/// substring search would treat an import merely *named in a comment* — e.g.
+/// the audit fixture's own `// Planted unused import: BTreeMap …` — as a real
+/// reference and never flag it, which is exactly why the tool returned empty
+/// results on small crates. Masking removes that whole class of false
+/// negatives; tracking string state keeps a `//` or `"` inside a string
+/// literal from being mistaken for a comment (which would blank real code and
+/// cause false positives).
+fn mask_rust_noise(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut state = MaskState::Normal;
+    // Whether the previously emitted byte was an identifier byte — used to tell
+    // a raw/byte-string prefix (`r"`, `b"`, `br"`) from an identifier that
+    // merely ends in `r`/`b` (e.g. `for`, `sub`).
+    let mut prev_ident = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match state {
+            MaskState::Normal => {
+                if b == b'/' && bytes.get(i + 1) == Some(&b'/') {
+                    out.push(b' ');
+                    out.push(b' ');
+                    state = MaskState::LineComment;
+                    prev_ident = false;
+                    i += 2;
+                } else if b == b'/' && bytes.get(i + 1) == Some(&b'*') {
+                    out.push(b' ');
+                    out.push(b' ');
+                    state = MaskState::BlockComment(1);
+                    prev_ident = false;
+                    i += 2;
+                } else if !prev_ident
+                    && (b == b'r' || b == b'b')
+                    && let Some(consumed) =
+                        try_open_raw_or_byte_string(bytes, i, &mut out, &mut state)
+                {
+                    prev_ident = false;
+                    i += consumed;
+                } else if b == b'"' {
+                    out.push(b' ');
+                    state = MaskState::Str;
+                    prev_ident = false;
+                    i += 1;
+                } else if b == b'\'' && is_char_literal_start(bytes, i) {
+                    out.push(b' ');
+                    state = MaskState::Char;
+                    prev_ident = false;
+                    i += 1;
+                } else {
+                    out.push(b);
+                    prev_ident = is_ident_byte(b);
+                    i += 1;
+                }
+            }
+            MaskState::LineComment => {
+                if b == b'\n' {
+                    out.push(b'\n');
+                    state = MaskState::Normal;
+                } else {
+                    out.push(b' ');
+                }
+                i += 1;
+            }
+            MaskState::BlockComment(depth) => {
+                if b == b'/' && bytes.get(i + 1) == Some(&b'*') {
+                    out.push(b' ');
+                    out.push(b' ');
+                    state = MaskState::BlockComment(depth + 1);
+                    i += 2;
+                } else if b == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                    out.push(b' ');
+                    out.push(b' ');
+                    state = if depth <= 1 {
+                        MaskState::Normal
+                    } else {
+                        MaskState::BlockComment(depth - 1)
+                    };
+                    i += 2;
+                } else {
+                    out.push(if b == b'\n' { b'\n' } else { b' ' });
+                    i += 1;
+                }
+            }
+            MaskState::Str => {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    out.push(b' ');
+                    out.push(if bytes[i + 1] == b'\n' { b'\n' } else { b' ' });
+                    i += 2;
+                } else if b == b'"' {
+                    out.push(b' ');
+                    state = MaskState::Normal;
+                    i += 1;
+                } else {
+                    out.push(if b == b'\n' { b'\n' } else { b' ' });
+                    i += 1;
+                }
+            }
+            MaskState::RawStr(hashes) => {
+                if b == b'"' && raw_string_closes(bytes, i, hashes) {
+                    let closing = hashes as usize + 1; // the `"` plus its `#`s
+                    out.resize(out.len() + closing, b' ');
+                    state = MaskState::Normal;
+                    i += closing;
+                } else {
+                    out.push(if b == b'\n' { b'\n' } else { b' ' });
+                    i += 1;
+                }
+            }
+            MaskState::Char => {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    out.push(b' ');
+                    out.push(if bytes[i + 1] == b'\n' { b'\n' } else { b' ' });
+                    i += 2;
+                } else if b == b'\'' {
+                    out.push(b' ');
+                    state = MaskState::Normal;
+                    i += 1;
+                } else {
+                    out.push(if b == b'\n' { b'\n' } else { b' ' });
+                    i += 1;
+                }
+            }
+        }
+    }
+    // Every replacement is an ASCII space and every original byte is copied
+    // whole, so the result is always valid UTF-8; fall back defensively.
+    String::from_utf8(out).unwrap_or_else(|_| source.to_string())
+}
+
+/// If a raw or byte string opens at `i` (`r"`, `r#"…`, `b"`, `br"`, `br#"…`),
+/// blanks its opening delimiter into `out`, sets `state`, and returns the byte
+/// count consumed. Returns `None` otherwise.
+fn try_open_raw_or_byte_string(
+    bytes: &[u8],
+    i: usize,
+    out: &mut Vec<u8>,
+    state: &mut MaskState,
+) -> Option<usize> {
+    let mut p = i;
+    if bytes.get(p) == Some(&b'b') {
+        p += 1;
+    }
+    let raw = bytes.get(p) == Some(&b'r');
+    if raw {
+        p += 1;
+        let mut hashes = 0u32;
+        while bytes.get(p) == Some(&b'#') {
+            hashes += 1;
+            p += 1;
+        }
+        if bytes.get(p) == Some(&b'"') {
+            let consumed = p + 1 - i;
+            out.resize(out.len() + consumed, b' ');
+            *state = MaskState::RawStr(hashes);
+            return Some(consumed);
+        }
+        return None;
+    }
+    // Non-raw byte string `b"…"` (regular escaping).
+    if p == i + 1 && bytes.get(p) == Some(&b'"') {
+        out.push(b' ');
+        out.push(b' ');
+        *state = MaskState::Str;
+        return Some(2);
+    }
+    None
+}
+
+/// True if the `'` at `quote` opens a char/byte-char literal rather than a
+/// lifetime or loop label. Handles `'a'`, `'\n'`, `'\''`, `'"'`, and multibyte
+/// content chars; bare `'a` (lifetime) returns false.
+fn is_char_literal_start(bytes: &[u8], quote: usize) -> bool {
+    let n = bytes.len();
+    let j = quote + 1;
+    if j >= n {
+        return false;
+    }
+    if bytes[j] == b'\\' {
+        // Escaped literal: a closing quote follows within a short window.
+        let end = (quote + 12).min(n);
+        return bytes[j + 1..end].contains(&b'\'');
+    }
+    // One content char (possibly multibyte) then a closing quote.
+    let mut k = j + 1;
+    while k < n && (bytes[k] & 0xC0) == 0x80 {
+        k += 1;
+    }
+    bytes.get(k) == Some(&b'\'')
+}
+
+/// True if the `"` at `i` closes a raw string opened with `hashes` `#`s, i.e.
+/// it is followed by exactly that many `#`s.
+fn raw_string_closes(bytes: &[u8], i: usize, hashes: u32) -> bool {
+    for h in 0..hashes as usize {
+        if bytes.get(i + 1 + h) != Some(&b'#') {
+            return false;
+        }
+    }
+    true
+}
+
 /// Returns the identifiers a `use` statement brings into scope, parsing
 /// grouped and aliased forms. Examples:
 ///   `foo::bar`             → bar
@@ -447,11 +670,15 @@ pub(super) async fn handle_unused_imports(
             continue;
         }
 
+        // Cache the *masked* source (comments and string/char literals blanked)
+        // so an import merely named in a comment isn't read as a real use.
         let source = file_cache
             .entry(use_node.file_path.clone())
             .or_insert_with(|| {
                 let abs = project_root.join(&use_node.file_path);
-                std::fs::read_to_string(&abs).ok()
+                std::fs::read_to_string(&abs)
+                    .ok()
+                    .map(|src| mask_rust_noise(&src))
             })
             .clone();
         let Some(source) = source else {
@@ -494,7 +721,7 @@ pub(super) async fn handle_unused_imports(
     });
 
     let text = render::finalize(Some(cg.project_root()), &args, &output, || {
-        render::generic_md(&output)
+        render::unused_imports_md(&output)
     });
     Ok(ToolResult::new(
         json!({
@@ -2593,5 +2820,84 @@ mod unsafe_pattern_detection_tests {
         // A substring of a longer identifier must not trip the word-boundary check.
         assert!(!contains_unsafe_block_start("let unsafely = 1;"));
         assert!(!contains_unsafe_block_start("let make_unsafe_thing = 2;"));
+    }
+}
+
+#[cfg(test)]
+mod mask_rust_noise_tests {
+    use super::{has_identifier_match, mask_rust_noise};
+
+    /// Helper: does `identifier` appear as a real token anywhere in the masked
+    /// source? This mirrors the unused-import scan.
+    fn referenced(source: &str, identifier: &str) -> bool {
+        mask_rust_noise(source)
+            .lines()
+            .any(|line| has_identifier_match(line, identifier))
+    }
+
+    #[test]
+    fn line_comment_mention_is_masked() {
+        // The exact false-negative from the audit fixture: the import is named
+        // only in the comment above it.
+        let src = "// Planted unused import: BTreeMap is referenced nowhere.\nuse std::collections::BTreeMap;\npub fn f() {}\n";
+        // Line 2 is the use statement itself; the scan skips it by line index,
+        // so masking the comment must leave zero references.
+        assert!(!referenced("// BTreeMap\npub fn f() {}", "BTreeMap"));
+        // Sanity: raw (unmasked) text would wrongly see the comment mention.
+        assert!(src.contains("BTreeMap"));
+    }
+
+    #[test]
+    fn block_and_doc_comments_are_masked() {
+        assert!(!referenced("/* uses HashMap here */\nfn f() {}", "HashMap"));
+        assert!(!referenced(
+            "/// doc mentions HashMap\nfn f() {}",
+            "HashMap"
+        ));
+        assert!(!referenced(
+            "/* outer /* nested HashMap */ still comment */\nfn f() {}",
+            "HashMap"
+        ));
+    }
+
+    #[test]
+    fn string_and_char_literals_are_masked() {
+        assert!(!referenced(r#"let s = "HashMap in a string";"#, "HashMap"));
+        // A `//` inside a string must NOT start a comment and swallow real code.
+        assert!(referenced(
+            "let url = \"http://x\"; let m = HashMap::new();",
+            "HashMap"
+        ));
+        // Char literal containing a quote must not desync the lexer.
+        assert!(referenced(
+            "let q = '\"'; let m = HashMap::new();",
+            "HashMap"
+        ));
+    }
+
+    #[test]
+    fn raw_strings_are_masked_without_desync() {
+        assert!(!referenced(
+            r##"let s = r#"HashMap "quoted" //"#;"##,
+            "HashMap"
+        ));
+        // Real usage after a raw string on the next line survives.
+        assert!(referenced(
+            "let s = r\"raw //\";\nlet m = HashMap::new();",
+            "HashMap"
+        ));
+    }
+
+    #[test]
+    fn real_usage_survives_masking() {
+        assert!(referenced(
+            "use std::collections::HashMap;\nfn f() -> HashMap<u32, u32> { HashMap::new() }",
+            "HashMap"
+        ));
+        // `r`/`b` starting an identifier must not be read as a raw/byte string.
+        assert!(referenced(
+            "for radius in bounds { let _ = radius; }",
+            "radius"
+        ));
     }
 }

--- a/src/mcp/tools/render.rs
+++ b/src/mcp/tools/render.rs
@@ -623,6 +623,55 @@ pub(super) fn risky_patterns_md(value: &Value) -> String {
     md.render()
 }
 
+/// Dedicated markdown renderer for `tracedecay_unused_imports`.
+///
+/// The generic renderer dumped the `imports` array as anonymous records; this
+/// spells each finding as `NAME unused in file:line` so agents (and tests) get
+/// a stable, greppable location — the same shape as [`risky_patterns_md`].
+pub(super) fn unused_imports_md(value: &Value) -> String {
+    let mut md = Md::new();
+    md.heading(2, "Unused Imports");
+
+    let imports = value
+        .get("imports")
+        .and_then(Value::as_array)
+        .map_or(&[][..], Vec::as_slice);
+    let count = value
+        .get("unused_import_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(imports.len() as u64);
+    md.field("Unused import count", &count.to_string());
+    md.blank();
+
+    if imports.is_empty() {
+        md.empty_note("No unused imports found.");
+        return md.render();
+    }
+
+    md.heading(3, "Findings");
+    for imp in imports {
+        let name = imp
+            .get("unused")
+            .and_then(Value::as_str)
+            .or_else(|| imp.get("name").and_then(Value::as_str));
+        let file = imp
+            .get("file")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let line = imp.get("line").and_then(Value::as_u64).unwrap_or(0);
+        let label = name.unwrap_or("<unknown>");
+        md.bullet(&format!("**{label} unused in {file}:{line}**"));
+        // Show the full import path when it differs from the flagged identifier
+        // (grouped/aliased imports like `foo::{a, b as c}`).
+        if let Some(full) = imp.get("name").and_then(Value::as_str)
+            && Some(full) != name
+        {
+            md.line(&format!("  **Import:** {full}"));
+        }
+    }
+    md.render()
+}
+
 fn render_diagnostic_record(md: &mut Md, diagnostic: &Value) {
     let level = diagnostic
         .get("level")

--- a/src/mcp/tools/render/tests.rs
+++ b/src/mcp/tools/render/tests.rs
@@ -425,6 +425,42 @@ fn risky_patterns_md_empty_is_noted() {
 }
 
 #[test]
+fn unused_imports_md_renders_findings() {
+    let v = json!({
+        "unused_import_count": 1,
+        "imports": [{
+            "id": "use:abc",
+            "name": "std::collections::BTreeMap",
+            "unused": "BTreeMap",
+            "file": "src/audit.rs",
+            "line": 18
+        }]
+    });
+
+    let out = unused_imports_md(&v);
+
+    assert!(out.contains("## Unused Imports"), "got: {out}");
+    assert!(out.contains("**Unused import count:** 1"), "got: {out}");
+    assert!(
+        out.contains("- **BTreeMap unused in src/audit.rs:18**"),
+        "got: {out}"
+    );
+    assert!(
+        out.contains("  **Import:** std::collections::BTreeMap"),
+        "got: {out}"
+    );
+    assert!(!out.contains("No unused imports"), "got: {out}");
+}
+
+#[test]
+fn unused_imports_md_empty_is_noted() {
+    let out = unused_imports_md(&json!({ "unused_import_count": 0, "imports": [] }));
+    assert!(out.contains("## Unused Imports"), "got: {out}");
+    assert!(out.contains("**Unused import count:** 0"), "got: {out}");
+    assert!(out.contains("No unused imports found."), "got: {out}");
+}
+
+#[test]
 fn generic_md_empty_is_noted() {
     assert!(generic_md(&json!([])).contains("None."));
     assert!(generic_md(&json!({})).contains("No results."));

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -13498,6 +13498,80 @@ pub fn used_one() -> HashMap<u32, u32> { HashMap::new() }
     );
 }
 
+/// Regression for the "empty results on small crates" bug: an import named only
+/// in a nearby comment (like the audit fixture's own
+/// `// Planted unused import: BTreeMap …`) was read as "used" by the text scan
+/// and never flagged. Asserts the masked scan flags it in BOTH markdown and
+/// JSON with file:line, and that a genuinely-used import is NOT flagged.
+#[tokio::test]
+async fn unused_imports_reports_in_markdown_and_json() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    // `HashMap` is used; `BTreeMap` is unused but named in the comment above it.
+    fs::write(
+        project.join("src/lib.rs"),
+        "use std::collections::HashMap;\n\
+         // Planted unused import: BTreeMap is referenced nowhere in real code.\n\
+         use std::collections::BTreeMap;\n\
+         \n\
+         pub fn used_one() -> HashMap<u32, u32> { HashMap::new() }\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    // Markdown (runtime default; request explicitly so the test helper does not
+    // force-inject `format=json`).
+    let md = handle_tool_call(
+        &cg,
+        "tracedecay_unused_imports",
+        json!({"format": "markdown"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let text = extract_text(&md.value);
+    assert!(text.contains("## Unused Imports"), "got: {text}");
+    // `line` is the node's 0-based start line (source line 3 → 2), matching the
+    // rest of the graph API.
+    assert!(
+        text.contains("**BTreeMap unused in src/lib.rs:2**"),
+        "markdown must report the unused import with file:line: {text}"
+    );
+    assert!(
+        !text.contains("HashMap unused"),
+        "used import must not be flagged: {text}"
+    );
+
+    // JSON output must carry the same structured finding.
+    let js = handle_tool_call(
+        &cg,
+        "tracedecay_unused_imports",
+        json!({"format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload: Value = serde_json::from_str(extract_text(&js.value)).unwrap();
+    assert_eq!(payload["unused_import_count"], 1, "payload: {payload}");
+    let imports = payload["imports"].as_array().unwrap();
+    assert_eq!(imports.len(), 1, "payload: {payload}");
+    let m = &imports[0];
+    assert_eq!(m["unused"], "BTreeMap");
+    assert_eq!(m["file"], "src/lib.rs");
+    assert_eq!(m["line"], 2);
+    // The used import must never appear.
+    assert!(
+        imports
+            .iter()
+            .all(|u| u["unused"].as_str() != Some("HashMap")),
+        "used HashMap must not be flagged: {payload}"
+    );
+}
+
 /// Regression for bug #8a: `tracedecay_dead_code` must support `include_public`
 /// so agents can audit pub items with no callers in the indexed scope. The
 /// previous SQL hard-coded `visibility != 'public'`, so on a codebase that


### PR DESCRIPTION
## Root cause

`tracedecay_unused_imports` returned empty results on small crates even when a genuinely unused import existed (documented known gap in `evals/agent_adoption/README.md`).

Unlike the sibling `unsafe_patterns` bug, this was **not** a renderer problem — the JSON output was also empty. The detector (`handle_unused_imports`, `src/mcp/tools/handlers/analysis.rs`) falls back to a text scan of the source file because the Rust resolver drops `Uses` edges for std/foreign-crate imports. That scan counted an import identifier appearing **in a comment** as a real reference. The eval fixture's planted unused import is described by the comment directly above it (`// Planted unused import: BTreeMap is referenced nowhere…`, `evals/agent_adoption/fixture/src/audit.rs:14-18`), so `BTreeMap` matched on the comment line and the import was read as "used" → zero findings.

## Fix

- **Detector:** new `mask_rust_noise` (`src/mcp/tools/handlers/analysis.rs`) blanks line/block/doc comments and string, raw-string, byte-string, and char literals before the identifier scan. It preserves newlines/byte offsets so line indexing stays valid, and tracks lexer state so a `//` or `"` inside a string literal doesn't swallow real code (which would cause false positives).
- **Renderer:** dedicated `unused_imports_md` (`src/mcp/tools/render.rs`) reporting each finding as `NAME unused in file:line`, mirroring the `risky_patterns_md` pattern from the unsafe_patterns fix (#347).

## Before / after (built binary vs the eval fixture crate)

Before:
```
**unused_import_count:** 0
imports: none
```

After (markdown):
```
## Unused Imports
**Unused import count:** 1

### Findings
- **BTreeMap unused in src/audit.rs:17**
  **Import:** std::collections::BTreeMap
```

After (json): `{"imports":[{"file":"src/audit.rs","line":17,"name":"std::collections::BTreeMap","unused":"BTreeMap",...}],"unused_import_count":1}`

Used imports (`HashMap`, `HashSet`, …) are correctly not flagged.

## Tests

- Unit: `mask_rust_noise_tests` (comment mention masked, nested block comments, strings/raw strings/char literals, `//` inside string not treated as comment, real usage survives) and `unused_imports_md` render tests.
- Integration (`tests/mcp_suite/mcp_handler_test.rs::unused_imports_reports_in_markdown_and_json`): indexes a small crate whose unused import is named in an adjacent comment; asserts markdown AND json report it with file:line and the used import is not flagged.

## Evals

- README known-gaps note updated: all three audit-tier plants now have working tool coverage.
- New neutral-prompt scenario `analysis_unused_import_hunt` with live-verified ground truth (`BTreeMap`), following the `analysis_unsafe_panic_audit` un-defer flow.

## Gates

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- `cargo nextest run --test mcp_suite`: 363/363 passed
- `python3 evals/agent_adoption/grade.py --lint-only`: 51 prompts neutral; `selftest.py`: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)