### PR TITLE
fix(backfill): make structured-row sweep process-safe

### DIFF
--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -829,6 +829,19 @@ async fn add_session_parent_column_after_missing_check(
 static BACKGROUND_STRUCTURED_BACKFILL_ENABLED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(true);
 
+/// Whether this process is a long-lived host that may run the detached
+/// structured-row sweep. Off by default: one-shot CLI and (crucially) hook
+/// processes never opt in, so [`GlobalDb::spawn_structured_backfill`] is a
+/// no-op for them. A hook process exits within milliseconds of the open that
+/// scheduled the sweep, and dropping its runtime cancels the sweep's async
+/// task mid-parse — the parsed rows and the cursor advance are discarded, so a
+/// hook-spawned sweep makes zero durable progress and only adds exit latency.
+/// The long-lived MCP `serve` loop and the daemon set this via
+/// [`mark_process_long_lived_for_structured_backfill`]; because every store is
+/// also opened under one of those hosts, coverage still converges there.
+static STRUCTURED_BACKFILL_LONG_LIVED_PROCESS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Store paths (by db path) that already have a structured-row sweep running in
 /// this process, so concurrent opens don't stack duplicate sweeps.
 fn structured_backfill_in_flight() -> &'static std::sync::Mutex<HashSet<PathBuf>> {
@@ -843,6 +856,24 @@ fn structured_backfill_in_flight() -> &'static std::sync::Mutex<HashSet<PathBuf>
 #[doc(hidden)]
 pub fn set_background_structured_backfill_enabled(enabled: bool) {
     BACKGROUND_STRUCTURED_BACKFILL_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Marks this process as a long-lived host (the MCP `serve` loop or the daemon)
+/// that is allowed to run the detached structured-row sweep. Called once at
+/// those entry points before any store is opened. One-shot CLI and hook
+/// processes must never call this: see [`STRUCTURED_BACKFILL_LONG_LIVED_PROCESS`].
+pub fn mark_process_long_lived_for_structured_backfill() {
+    STRUCTURED_BACKFILL_LONG_LIVED_PROCESS.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether [`GlobalDb::spawn_structured_backfill`] will schedule a sweep: the
+/// background switch is on *and* this process is a long-lived host. This is the
+/// single predicate the spawn path consults, exposed so tests can assert that a
+/// one-shot process never spawns the sweep.
+#[doc(hidden)]
+pub fn structured_backfill_will_spawn() -> bool {
+    BACKGROUND_STRUCTURED_BACKFILL_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
+        && STRUCTURED_BACKFILL_LONG_LIVED_PROCESS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 impl GlobalDb {
@@ -1182,14 +1213,21 @@ impl GlobalDb {
     ///
     /// Concurrency: the sweep opens its own connection, its writes are
     /// idempotent upserts keyed on `(provider, message_id)`, and its path
-    /// watermark advances per file — so overlapping with live ingest is safe.
-    /// A process-wide in-flight guard (keyed by store path) skips the spawn
-    /// when a sweep for this store is already running, so stacked opens don't
-    /// stack sweeps. A short-lived runtime may drop the task before it
-    /// finishes; that is fine — the marker/watermark simply let a later open
-    /// resume where it left off.
+    /// watermark advances per file under a cross-process lock — so overlapping
+    /// with live ingest is safe. A process-wide in-flight guard (keyed by store
+    /// path) skips the spawn when a sweep for this store is already running in
+    /// *this* process; a sibling file lock (see
+    /// `transcript_backfill::try_acquire_structured_backfill_lock`) excludes
+    /// other processes so concurrent hook processes never run duplicate sweeps.
+    ///
+    /// Only long-lived hosts spawn: [`structured_backfill_will_spawn`] gates on
+    /// [`mark_process_long_lived_for_structured_backfill`], so short-lived hook
+    /// and one-shot CLI processes never schedule the sweep at all (their
+    /// runtime would drop the task mid-parse before it made durable progress).
+    /// The daemon and MCP server open every store too, so coverage converges
+    /// there.
     fn spawn_structured_backfill(&self) {
-        if !BACKGROUND_STRUCTURED_BACKFILL_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
+        if !structured_backfill_will_spawn() {
             return;
         }
         let db_path = self.db_path.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,10 +538,16 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
                 // host does not retry.
                 return Ok(());
             }
+            // The MCP server is long-lived, so it may run the detached
+            // structured-row backfill sweep; one-shot CLI/hook processes never
+            // do (they would drop the sweep mid-parse on exit).
+            tracedecay::global_db::mark_process_long_lived_for_structured_backfill();
             serve::run_serve(path, timings).await?;
         }
         Commands::Daemon { action } => match action {
             DaemonAction::Run { socket } => {
+                // Long-lived host: allowed to run the structured-row sweep.
+                tracedecay::global_db::mark_process_long_lived_for_structured_backfill();
                 let socket_path = tracedecay::daemon::socket_path_or_default(socket)?;
                 tracedecay::daemon::run_foreground(socket_path).await?;
             }

--- a/src/sessions/mod.rs
+++ b/src/sessions/mod.rs
@@ -21,7 +21,10 @@ pub(crate) mod message_noise;
 pub mod providers;
 pub mod shared;
 pub mod source;
-pub(crate) mod transcript_backfill;
+// `pub` (not `pub(crate)`) only so integration tests can reach the three
+// `#[doc(hidden)]` process-safety test helpers; every other item stays
+// `pub(crate)`.
+pub mod transcript_backfill;
 pub mod vibe;
 pub mod workflow_index;
 pub mod workflow_ingest;

--- a/src/sessions/transcript_backfill.rs
+++ b/src/sessions/transcript_backfill.rs
@@ -440,6 +440,45 @@ struct StructuredCandidate {
     source_path: String,
 }
 
+/// Sibling `<store>.structured-backfill.lock` used to serialize the sweep
+/// across processes. The in-process in-flight guard in
+/// [`GlobalDb::spawn_structured_backfill`] only excludes stacked opens within
+/// one process; production runs many short-lived hook processes, so without a
+/// filesystem lock two of them could sweep the same store at once and race the
+/// watermark backwards.
+fn structured_backfill_lock_path(db_path: &Path) -> PathBuf {
+    let mut lock_name = db_path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_else(|| std::ffi::OsString::from("session"));
+    lock_name.push(".structured-backfill.lock");
+    db_path.with_file_name(lock_name)
+}
+
+/// Tries to claim the exclusive cross-process sweep lock for `db_path`. Returns
+/// the held lock file on success (drop releases it; the OS also releases it if
+/// the process dies), or `None` when another process/task already holds it — in
+/// which case the caller simply skips its sweep. Uses an advisory `flock`
+/// (`fs2`), the same primitive the branch-add and monitor single-instance
+/// guards use, so a crashed holder never leaves a stale lock behind.
+#[doc(hidden)]
+pub fn try_acquire_structured_backfill_lock(db_path: &Path) -> Option<std::fs::File> {
+    use fs2::FileExt;
+
+    let lock_path = structured_backfill_lock_path(db_path);
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .ok()?;
+    file.try_lock_exclusive().ok()?;
+    Some(file)
+}
+
 /// Re-parses the next bounded transcript batch and inserts rows missing from
 /// legacy stores.
 pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<StructuredBackfillStats> {
@@ -447,6 +486,13 @@ pub(crate) async fn backfill_structured_rows(db: &GlobalDb) -> Option<Structured
     if marker_version(conn, STRUCTURED_MARKER_NAME).await >= STRUCTURED_MARKER_VERSION {
         return Some(StructuredBackfillStats::default());
     }
+    // Claim the store cross-process before doing any parse or watermark work.
+    // A process that loses the race skips its sweep entirely rather than
+    // duplicating the whole-file re-parse and interleaving watermark writes
+    // with the winner. Held for the whole batch; released on drop / on exit.
+    let Some(_sweep_lock) = try_acquire_structured_backfill_lock(db.db_path()) else {
+        return Some(StructuredBackfillStats::default());
+    };
     ensure_backfill_meta_table(conn).await?;
     let cursor_key = structured_cursor_key();
     let cursor = read_backfill_cursor(conn, &cursor_key).await;
@@ -679,14 +725,38 @@ async fn read_backfill_cursor(conn: &Connection, key: &str) -> String {
 }
 
 async fn write_backfill_cursor(conn: &Connection, key: &str, value: &str) -> Option<()> {
+    // Compare-and-set: only ever move the watermark forward. Candidates are
+    // selected with `source_path > cursor` and ordered ascending, so a greater
+    // stored value means more files covered. The `WHERE excluded.value > …`
+    // guard makes a slower concurrent sweep writing an earlier path a no-op
+    // instead of regressing the cursor and re-queuing already-covered files.
+    // Binary (default) TEXT collation matches the candidate query's ordering.
     conn.execute(
         "INSERT INTO session_backfill_meta(key, value) VALUES (?1, ?2)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = unixepoch()",
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = unixepoch()
+            WHERE excluded.value > session_backfill_meta.value",
         params![key, value],
     )
     .await
     .ok()?;
     Some(())
+}
+
+/// Test-only accessor: writes the versioned structured-backfill watermark for
+/// `db` exactly as the sweep does, so tests can assert the compare-and-set
+/// monotonicity guard rejects backwards moves.
+#[doc(hidden)]
+pub async fn write_structured_backfill_cursor_for_test(db: &GlobalDb, value: &str) -> Option<()> {
+    let conn = db.conn();
+    ensure_backfill_meta_table(conn).await?;
+    write_backfill_cursor(conn, &structured_cursor_key(), value).await
+}
+
+/// Test-only accessor: reads the versioned structured-backfill watermark for
+/// `db`.
+#[doc(hidden)]
+pub async fn read_structured_backfill_cursor_for_test(db: &GlobalDb) -> String {
+    read_backfill_cursor(db.conn(), &structured_cursor_key()).await
 }
 
 async fn mark_structured_backfill_complete(conn: &Connection) -> Option<()> {

--- a/tests/session_suite/structured_backfill.rs
+++ b/tests/session_suite/structured_backfill.rs
@@ -400,3 +400,136 @@ async fn structured_backfill_version_bump_reparses_from_start() {
         "a stale un-versioned cursor must not block a fresh version-bumped sweep"
     );
 }
+
+// --- Process-safety coverage (adversarial-review findings on #357) ---
+
+/// A one-shot process (CLI/hook) must never schedule the detached sweep, even
+/// with the background switch on: it would drop the sweep mid-parse on exit.
+#[tokio::test]
+async fn structured_backfill_one_shot_process_never_spawns() {
+    // Fresh process state (nextest runs each test in its own process): the
+    // background switch defaults on, but a one-shot process is not long-lived.
+    assert!(
+        !tracedecay::global_db::structured_backfill_will_spawn(),
+        "a one-shot process must not spawn the sweep"
+    );
+    // A long-lived host (MCP serve / daemon) opts in and then does spawn.
+    tracedecay::global_db::mark_process_long_lived_for_structured_backfill();
+    assert!(
+        tracedecay::global_db::structured_backfill_will_spawn(),
+        "a long-lived host must spawn the sweep"
+    );
+}
+
+/// Two concurrent openers of the same store contend on the sibling lock file:
+/// exactly one may sweep at a time; the loser is excluded and reacquires only
+/// after the winner releases. Models the cross-process race between short-lived
+/// hook processes (advisory `flock` excludes across open file descriptions).
+#[tokio::test]
+async fn structured_backfill_lock_excludes_concurrent_openers() {
+    use tracedecay::sessions::transcript_backfill::try_acquire_structured_backfill_lock;
+
+    let tmp = TempDir::new().unwrap();
+    let (_home, project) = init_project(&tmp);
+    // Ensure the session store (and its parent dir) exists.
+    let _db = open_project_session_db(&project).await.unwrap();
+    let db_path = project_session_db_path(&project);
+
+    let winner = try_acquire_structured_backfill_lock(&db_path);
+    assert!(winner.is_some(), "first opener acquires the sweep lock");
+    let loser = try_acquire_structured_backfill_lock(&db_path);
+    assert!(
+        loser.is_none(),
+        "a concurrent opener must be excluded while the lock is held"
+    );
+
+    drop(winner);
+    let reacquired = try_acquire_structured_backfill_lock(&db_path);
+    assert!(
+        reacquired.is_some(),
+        "the lock must be reusable once the holder releases it"
+    );
+}
+
+/// Two sweeps driven concurrently against the same store: the lock lets exactly
+/// one do the work (insert the missing row) while the other skips with an empty
+/// result — no duplicate whole-file re-parse, no double insert.
+#[tokio::test]
+async fn structured_backfill_concurrent_sweeps_run_once() {
+    tracedecay::global_db::set_background_structured_backfill_enabled(false);
+    let tmp = TempDir::new().unwrap();
+    let (home, project) = init_project(&tmp);
+    write_codex_rollout_with_goal(&home, &project, "codex-concurrent");
+
+    let db = open_project_session_db(&project).await.unwrap();
+    let source = CodexSource::with_home(&home);
+    ingest_source(&db, &source, &project, None).await;
+    db.run_structured_backfill().await;
+    drop(db);
+
+    // Drop the one goal row so a sweep has exactly one row to re-insert.
+    simulate_old_parser_store(&project, "codex", "goal").await;
+    assert_eq!(count_kind(&project, "codex", "goal").await, 0);
+
+    // Two independent openers (separate connections) sweep the same store at
+    // once. The cross-process lock admits one; the other returns empty stats.
+    let db_a = open_project_session_db(&project).await.unwrap();
+    let db_b = open_project_session_db(&project).await.unwrap();
+    let (a, b) = tokio::join!(
+        db_a.run_structured_backfill(),
+        db_b.run_structured_backfill()
+    );
+
+    let a = a.expect("sweep a returns stats");
+    let b = b.expect("sweep b returns stats");
+    assert!(
+        (a > 0) ^ (b > 0),
+        "exactly one concurrent sweep inserts the missing row; the other is locked out (a={a}, b={b})"
+    );
+    assert_eq!(
+        count_kind(&project, "codex", "goal").await,
+        1,
+        "the store converges to a single goal row"
+    );
+}
+
+/// The watermark write is compare-and-set: it only ever moves forward, so a
+/// slower concurrent sweep writing an earlier path cannot regress the cursor
+/// and re-queue already-covered files.
+#[tokio::test]
+async fn structured_backfill_watermark_never_regresses() {
+    use tracedecay::sessions::transcript_backfill::{
+        read_structured_backfill_cursor_for_test, write_structured_backfill_cursor_for_test,
+    };
+
+    let tmp = TempDir::new().unwrap();
+    let (_home, project) = init_project(&tmp);
+    let db = open_project_session_db(&project).await.unwrap();
+
+    write_structured_backfill_cursor_for_test(&db, "codex/aaa.jsonl")
+        .await
+        .unwrap();
+    assert_eq!(
+        read_structured_backfill_cursor_for_test(&db).await,
+        "codex/aaa.jsonl"
+    );
+
+    // A forward move advances the cursor.
+    write_structured_backfill_cursor_for_test(&db, "codex/zzz.jsonl")
+        .await
+        .unwrap();
+    assert_eq!(
+        read_structured_backfill_cursor_for_test(&db).await,
+        "codex/zzz.jsonl"
+    );
+
+    // A backwards move (an earlier path from a slower/racing sweep) is a no-op.
+    write_structured_backfill_cursor_for_test(&db, "codex/mmm.jsonl")
+        .await
+        .unwrap();
+    assert_eq!(
+        read_structured_backfill_cursor_for_test(&db).await,
+        "codex/zzz.jsonl",
+        "the watermark must never move backwards"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the two adversarially-confirmed process-safety findings in the structured-row backfill (adversarial review on #357), now that the sweep runs on every `GlobalDb::open_at` — including once per short-lived hook process.

### Finding 1 (major) — process-local guard + non-monotonic watermark
The in-flight guard (`global_db.rs`) was a process-local `HashSet`, so concurrent short-lived hook processes each ran a full duplicate sweep on the same store, and their interleaved per-file cursor writes could move the watermark *backwards*, re-queuing already-covered files.

- **Cross-process exclusion:** `backfill_structured_rows` now claims a sibling `<store>.structured-backfill.lock` via an advisory `fs2` `flock` (`try_acquire_structured_backfill_lock`) before any parse/watermark work — the same primitive the branch-add and monitor single-instance guards use. A process that loses the race skips its sweep; the OS releases the lock on crash, so no stale lock lingers.
- **Monotonic watermark:** `write_backfill_cursor` is now compare-and-set in SQL (`... DO UPDATE SET value = excluded.value ... WHERE excluded.value > session_backfill_meta.value`), so the cursor can only ever advance. Binary TEXT collation matches the candidate query's `source_path > cursor` ordering.

### Finding 2 (major) — detached sweep in short-lived hook processes
A sweep spawned from a hook process stalled hook exit on its in-flight `spawn_blocking` parse and then discarded the result (the awaiting task is cancelled on runtime drop), so the cursor never advanced past a large transcript — a livelock paying seconds of exit latency per hook event.

- The spawn is now gated to **long-lived hosts only**. `spawn_structured_backfill` consults `structured_backfill_will_spawn()` (background switch **and** a process latch set by `mark_process_long_lived_for_structured_backfill`). The latch is set at exactly two entry points in `main.rs`: `Commands::Serve` (MCP server) and `DaemonAction::Run` (daemon). One-shot CLI and hook processes never opt in, so they never spawn the sweep. Coverage still converges because those long-lived hosts open every store too — documented in the `spawn_structured_backfill` doc comment.

## Tests (finding 3, combined effect)
New `session_suite` coverage:
- `structured_backfill_lock_excludes_concurrent_openers` — two openers of the same store: exactly one holds the lock; the loser is excluded and reacquires only after release.
- `structured_backfill_concurrent_sweeps_run_once` — two sweeps driven concurrently (`tokio::join!`, separate connections): exactly one inserts the missing row, the store converges to one row.
- `structured_backfill_watermark_never_regresses` — a backwards cursor write is a no-op.
- `structured_backfill_one_shot_process_never_spawns` — a one-shot process never spawns; a long-lived host does.

## Gates
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅
- `cargo nextest run --test session_suite --test transcript_ingest_suite` ✅ (308 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)