### PR TITLE
fix(sessions): harden produced-vs-observed commit attribution

### DIFF
--- a/src/mcp/tools/handlers/session.rs
+++ b/src/mcp/tools/handlers/session.rs
@@ -2230,7 +2230,7 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
     // means nothing was ever recorded, which is a valid empty result (the
     // tool never ghost-creates an empty sessions.db).
     let db_path = cg.store_layout().sessions_db_path.clone();
-    let (results, index_health) = if db_path.is_file() {
+    let (results, index_health, observed_fallback) = if db_path.is_file() {
         let Some(db) = GlobalDb::open_read_only_at(&db_path).await else {
             return Ok(tool_json(
                 Some(cg.project_root()),
@@ -2253,10 +2253,25 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
             .map_err(|err| TraceDecayError::Config {
                 message: err.to_string(),
             })?;
-        (results, health)
+        // A commit attributed only by time overlap (or a migrated v2 store) has
+        // observed rows but no producer, so the producer-default query is
+        // empty. That must not read as "no session touched this commit": look
+        // up the observed sessions so the caller can be pointed at them.
+        let observed_fallback = if results.is_empty()
+            && matches!(query.git_ref, GitRefFilter::Commit(_))
+            && relation == CommitRelationFilter::Produced
+        {
+            db.git_sessions_for_with_relation(&query, CommitRelationFilter::Observed)
+                .await
+                .ok()
+                .filter(|hits| !hits.is_empty())
+        } else {
+            None
+        };
+        (results, health, observed_fallback)
     } else {
         // No store file at all: the correlation index was never created.
-        (Vec::new(), None)
+        (Vec::new(), None, None)
     };
 
     // The index is "empty" when there is no store, the correlation tables are
@@ -2290,15 +2305,24 @@ pub(super) async fn handle_sessions_for(cg: &TraceDecay, args: Value) -> Result<
     // auto-backfill (or a manual `tracedecay sessions git-backfill`), whereas a
     // populated index genuinely had no session on this ref.
     if results.is_empty() {
-        payload["message"] = json!(if index_empty {
-            if matches!(&query.git_ref, GitRefFilter::Commit(_)) {
-                "no commit evidence indexed yet — run `tracedecay sync` to ingest direct host/tool evidence; `tracedecay sessions git-backfill` adds weaker historical overlap evidence"
-            } else {
-                "correlation index empty (no git spans recorded yet) — it will auto-backfill on the next MCP server startup, or run `tracedecay sessions git-backfill` to populate it now"
-            }
+        if let Some(observed) = &observed_fallback {
+            payload["observed_count"] = json!(observed.len());
+            payload["observed_sessions"] = json!(observed);
+            payload["message"] = json!(format!(
+                "no producing sessions; {} session(s) observed this commit — pass relation=observed to list them",
+                observed.len()
+            ));
         } else {
-            "no sessions matched this git ref"
-        });
+            payload["message"] = json!(if index_empty {
+                if matches!(&query.git_ref, GitRefFilter::Commit(_)) {
+                    "no commit evidence indexed yet — run `tracedecay sync` to ingest direct host/tool evidence; `tracedecay sessions git-backfill` adds weaker historical overlap evidence"
+                } else {
+                    "correlation index empty (no git spans recorded yet) — it will auto-backfill on the next MCP server startup, or run `tracedecay sessions git-backfill` to populate it now"
+                }
+            } else {
+                "no sessions matched this git ref"
+            });
+        }
     }
     Ok(tool_json_with_md(
         Some(cg.project_root()),

--- a/src/sessions/codex/events.rs
+++ b/src/sessions/codex/events.rs
@@ -503,12 +503,18 @@ fn exec_command_row(
     );
     if success == Some(true) {
         let candidates = output
-            .map(|output| produced_commit_candidates(&exec.cmd, output))
+            .map(|output| commit_candidates(&exec.cmd, output))
             .unwrap_or_default();
-        if !candidates.is_empty() {
+        if !candidates.produced.is_empty() {
             metadata.insert(
                 "produced_commit_candidates".to_string(),
-                Value::Array(candidates.into_iter().map(Value::String).collect()),
+                Value::Array(candidates.produced.into_iter().map(Value::String).collect()),
+            );
+        }
+        if !candidates.observed.is_empty() {
+            metadata.insert(
+                "observed_commit_candidates".to_string(),
+                Value::Array(candidates.observed.into_iter().map(Value::String).collect()),
             );
         }
     }
@@ -527,12 +533,28 @@ fn exec_command_row(
     )
 }
 
-fn produced_commit_candidates(command: &str, wrapped_output: &str) -> Vec<String> {
+/// Commit refs mined from one exec result, split by evidence strength.
+///
+/// `produced` refs come from output a commit-creating command emits only when
+/// it actually writes a commit (the `[branch sha] subject` line git prints for
+/// `commit`/`merge`/`cherry-pick`/`revert`). `observed` refs come from a
+/// read-only HEAD print (`git rev-parse HEAD`): that a session printed the
+/// current HEAD is proof it *saw* the commit, never that it created it. A
+/// pipeline like `git commit -m x; git rev-parse HEAD` exits 0 on the
+/// rev-parse even when the commit failed, so the printed HEAD must never be
+/// promoted to producer evidence.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct CommitCandidates {
+    produced: Vec<String>,
+    observed: Vec<String>,
+}
+
+fn commit_candidates(command: &str, wrapped_output: &str) -> CommitCandidates {
     let creates_commit = command
         .split([';', '\n', '&', '|'])
         .any(segment_creates_commit);
     if !creates_commit {
-        return Vec::new();
+        return CommitCandidates::default();
     }
 
     let output = wrapped_output
@@ -541,27 +563,38 @@ fn produced_commit_candidates(command: &str, wrapped_output: &str) -> Vec<String
     let reports_head = command
         .split([';', '\n', '&', '|'])
         .any(segment_reports_head);
-    let mut candidates = Vec::new();
+    let mut candidates = CommitCandidates::default();
     for line in output.lines() {
         let trimmed = line.trim();
+        // The `[branch sha] subject` line is emitted only when a commit was
+        // actually written, so it is genuine producer evidence.
         let bracket_candidate = trimmed
             .strip_prefix('[')
             .and_then(|line| line.split_once(']'))
             .and_then(|(header, _)| header.split_whitespace().next_back())
             .map(|token| token.trim_matches(|ch: char| !ch.is_ascii_hexdigit()));
-        let exact_head = reports_head.then_some(trimmed).filter(|candidate| {
-            matches!(candidate.len(), 40 | 64) && candidate.chars().all(|ch| ch.is_ascii_hexdigit())
-        });
-        for candidate in bracket_candidate.into_iter().chain(exact_head) {
-            if candidate.len() >= 7
-                && candidate.chars().all(|ch| ch.is_ascii_hexdigit())
-                && !candidates.iter().any(|known| known == candidate)
-            {
-                candidates.push(candidate.to_ascii_lowercase());
-            }
+        if let Some(candidate) = bracket_candidate {
+            push_commit_candidate(&mut candidates.produced, candidate);
+        }
+        // A bare full-length sha is the output of a read-only HEAD print. It
+        // only tells us the session observed the current HEAD.
+        if reports_head
+            && matches!(trimmed.len(), 40 | 64)
+            && trimmed.chars().all(|ch| ch.is_ascii_hexdigit())
+        {
+            push_commit_candidate(&mut candidates.observed, trimmed);
         }
     }
     candidates
+}
+
+fn push_commit_candidate(candidates: &mut Vec<String>, candidate: &str) {
+    if candidate.len() >= 7
+        && candidate.chars().all(|ch| ch.is_ascii_hexdigit())
+        && !candidates.iter().any(|known| known == candidate)
+    {
+        candidates.push(candidate.to_ascii_lowercase());
+    }
 }
 
 fn segment_reports_head(segment: &str) -> bool {
@@ -1138,23 +1171,63 @@ mod tests {
             .event_from_line(&output, &meta(), None, path, 20)
             .unwrap();
         let md = metadata_of(&rows[0]);
+        // The `[main abcdef1]` line is producer evidence; the bare HEAD sha that
+        // `git rev-parse HEAD` prints is only an observation of current HEAD.
+        assert_eq!(md["produced_commit_candidates"], json!(["abcdef1"]));
         assert_eq!(
-            md["produced_commit_candidates"],
-            json!(["abcdef1", "0123456789abcdef0123456789abcdef01234567"])
+            md["observed_commit_candidates"],
+            json!(["0123456789abcdef0123456789abcdef01234567"])
+        );
+    }
+
+    #[test]
+    fn rev_parse_head_after_failed_commit_is_observed_not_produced() {
+        // `;` keeps the process exit 0 on the rev-parse even though the commit
+        // failed, so the printed old HEAD must never become producer evidence.
+        let candidates = commit_candidates(
+            "git commit -m x; git rev-parse HEAD",
+            "Output:\nabcdef1234567890abcdef1234567890abcdef12",
+        );
+        assert!(candidates.produced.is_empty());
+        assert_eq!(
+            candidates.observed,
+            vec!["abcdef1234567890abcdef1234567890abcdef12"]
+        );
+    }
+
+    #[test]
+    fn fast_forward_merge_head_print_is_observed_not_produced() {
+        // A fast-forward merge creates no commit; the HEAD it prints belongs to
+        // whichever branch it advanced to, not to this session.
+        let candidates = commit_candidates(
+            "git merge feature && git rev-parse HEAD",
+            "Output:\nUpdating 1111111..2222222\nFast-forward\n2222222222222222222222222222222222222222",
+        );
+        assert!(candidates.produced.is_empty());
+        assert_eq!(
+            candidates.observed,
+            vec!["2222222222222222222222222222222222222222"]
         );
     }
 
     #[test]
     fn failed_or_non_commit_commands_never_claim_commit_production() {
-        assert!(produced_commit_candidates("git status", "Output:\nabcdef1").is_empty());
         assert!(
-            produced_commit_candidates("rg git commit", "Output:\n[main abcdef1] test").is_empty()
+            commit_candidates("git status", "Output:\nabcdef1")
+                .produced
+                .is_empty()
+        );
+        assert!(
+            commit_candidates("rg git commit", "Output:\n[main abcdef1] test")
+                .produced
+                .is_empty()
         );
         assert_eq!(
-            produced_commit_candidates(
+            commit_candidates(
                 "git commit -m 0123456789abcdef0123456789abcdef01234567",
                 "Output:\n[main abcdef1] 0123456789abcdef0123456789abcdef01234567"
-            ),
+            )
+            .produced,
             vec!["abcdef1"]
         );
     }

--- a/src/sessions/git_correlation.rs
+++ b/src/sessions/git_correlation.rs
@@ -701,10 +701,10 @@ pub(crate) fn direct_commit_records(
     project_root: &std::path::Path,
 ) -> Vec<CommitSessionRecord> {
     if !messages.iter().any(|message| {
-        message
-            .metadata_json
-            .as_deref()
-            .is_some_and(|json| json.contains("\"produced_commit_candidates\""))
+        message.metadata_json.as_deref().is_some_and(|json| {
+            json.contains("\"produced_commit_candidates\"")
+                || json.contains("\"observed_commit_candidates\"")
+        })
     }) {
         return Vec::new();
     }
@@ -713,82 +713,119 @@ pub(crate) fn direct_commit_records(
     };
     let mut seen = HashSet::new();
     let mut records = Vec::new();
-    for message in messages {
-        let Some(metadata_value) = message
-            .metadata_json
-            .as_deref()
-            .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-        else {
-            continue;
-        };
-        let Some(metadata) = metadata_value.as_object() else {
-            continue;
-        };
-        let Some(candidates) = metadata
-            .get("produced_commit_candidates")
-            .and_then(serde_json::Value::as_array)
-        else {
-            continue;
-        };
-        for candidate in candidates.iter().filter_map(serde_json::Value::as_str) {
-            if !(7..=64).contains(&candidate.len())
-                || !candidate.chars().all(|ch| ch.is_ascii_hexdigit())
-            {
+    // Producer evidence is collected first so it always claims the
+    // (sha, provider, session) slot ahead of a weaker head observation of the
+    // same commit made by the same session.
+    for kind in [DirectEvidenceKind::Produced, DirectEvidenceKind::Observed] {
+        for message in messages {
+            let Some(metadata_value) = message
+                .metadata_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+            else {
                 continue;
+            };
+            let Some(metadata) = metadata_value.as_object() else {
+                continue;
+            };
+            let Some(candidates) = metadata
+                .get(kind.metadata_key())
+                .and_then(serde_json::Value::as_array)
+            else {
+                continue;
+            };
+            for candidate in candidates.iter().filter_map(serde_json::Value::as_str) {
+                if !(7..=64).contains(&candidate.len())
+                    || !candidate.chars().all(|ch| ch.is_ascii_hexdigit())
+                {
+                    continue;
+                }
+                let Ok(spec) = repo.rev_parse_single(candidate) else {
+                    continue;
+                };
+                let Ok(object) = spec.object() else {
+                    continue;
+                };
+                let Ok(commit) = object.try_into_commit() else {
+                    continue;
+                };
+                let sha = commit.id.to_string();
+                if !seen.insert((
+                    sha.clone(),
+                    message.provider.clone(),
+                    message.session_id.clone(),
+                )) {
+                    continue;
+                }
+                let worktree = metadata_worktree(metadata)
+                    .map(normalize_worktree)
+                    .or_else(|| Some(normalize_worktree(&project_root.to_string_lossy())));
+                let branch = metadata
+                    .get("git_branch")
+                    .or_else(|| metadata.get("codex_git_branch"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                let committed_at = commit.time().ok().map_or_else(
+                    || message.timestamp.unwrap_or_default(),
+                    |time| time.seconds,
+                );
+                let (relation, evidence, confidence) = match kind {
+                    DirectEvidenceKind::Produced => {
+                        let evidence = match metadata
+                            .get("produced_commit_evidence")
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            Some("host_event") => CommitEvidence::HostEvent,
+                            _ => CommitEvidence::ToolResult,
+                        };
+                        (CommitRelation::Produced, evidence, 100)
+                    }
+                    // A printed HEAD proves the session saw the commit, not that
+                    // it made it: observed relation, sub-100 head-observation.
+                    DirectEvidenceKind::Observed => (
+                        CommitRelation::Observed,
+                        CommitEvidence::HeadObservation,
+                        HEAD_OBSERVATION_CONFIDENCE,
+                    ),
+                };
+                records.push(CommitSessionRecord {
+                    commit_sha: sha,
+                    provider: message.provider.clone(),
+                    session_id: message.session_id.clone(),
+                    branch,
+                    worktree,
+                    committed_at,
+                    span_overlap_kind: SpanOverlapKind::Direct,
+                    span_id: None,
+                    relation,
+                    evidence,
+                    confidence,
+                    evidence_message_id: Some(message.message_id.clone()),
+                });
             }
-            let Ok(spec) = repo.rev_parse_single(candidate) else {
-                continue;
-            };
-            let Ok(object) = spec.object() else {
-                continue;
-            };
-            let Ok(commit) = object.try_into_commit() else {
-                continue;
-            };
-            let sha = commit.id.to_string();
-            if !seen.insert((
-                sha.clone(),
-                message.provider.clone(),
-                message.session_id.clone(),
-            )) {
-                continue;
-            }
-            let worktree = metadata_worktree(metadata)
-                .map(normalize_worktree)
-                .or_else(|| Some(normalize_worktree(&project_root.to_string_lossy())));
-            let branch = metadata
-                .get("git_branch")
-                .or_else(|| metadata.get("codex_git_branch"))
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-            let committed_at = commit.time().ok().map_or_else(
-                || message.timestamp.unwrap_or_default(),
-                |time| time.seconds,
-            );
-            let evidence = match metadata
-                .get("produced_commit_evidence")
-                .and_then(serde_json::Value::as_str)
-            {
-                Some("host_event") => CommitEvidence::HostEvent,
-                _ => CommitEvidence::ToolResult,
-            };
-            records.push(CommitSessionRecord {
-                commit_sha: sha,
-                provider: message.provider.clone(),
-                session_id: message.session_id.clone(),
-                branch,
-                worktree,
-                committed_at,
-                span_overlap_kind: SpanOverlapKind::Direct,
-                span_id: None,
-                relation: CommitRelation::Produced,
-                evidence,
-                confidence: 100,
-                evidence_message_id: Some(message.message_id.clone()),
-            });
         }
     }
     records
+}
+
+/// Confidence for a commit a session printed as current HEAD: stronger than a
+/// pure time-overlap guess, well below direct producer evidence.
+const HEAD_OBSERVATION_CONFIDENCE: i64 = 60;
+
+/// Which direct-evidence candidate list a `direct_commit_records` pass reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DirectEvidenceKind {
+    Produced,
+    Observed,
+}
+
+impl DirectEvidenceKind {
+    const fn metadata_key(self) -> &'static str {
+        match self {
+            Self::Produced => "produced_commit_candidates",
+            Self::Observed => "observed_commit_candidates",
+        }
+    }
 }
 
 /// Derives durable branch/worktree observations from provider message
@@ -1093,8 +1130,12 @@ async fn span_session_ids(
     ref_predicate: &str,
     ref_value: Value,
 ) -> Result<Vec<(String, String)>, GitCorrelationError> {
+    // Canonicalize to one identity per session (see `span_hits`): `MAX(provider)`
+    // collapses the hook-route (`provider ''`) and ingest rows so scope
+    // intersection compares matching `(provider, session_id)` pairs.
     let sql = format!(
-        "SELECT DISTINCT provider, session_id FROM session_git_spans WHERE {ref_predicate}"
+        "SELECT MAX(provider), session_id FROM session_git_spans \
+         WHERE {ref_predicate} GROUP BY session_id"
     );
     let mut rows = conn.query(&sql, vec![ref_value]).await?;
     let mut ids = Vec::new();
@@ -1108,11 +1149,23 @@ async fn commit_session_ids(
     conn: &Connection,
     sha: &str,
 ) -> Result<Vec<(String, String)>, GitCorrelationError> {
+    // Prefer producer evidence, but fall back to every session correlated with
+    // the commit when no producer row exists. A store upgraded from schema v2
+    // whose transcripts were later pruned keeps only observed/overlap rows
+    // (they exist precisely to survive worktree deletion); a hard
+    // `relation = 'produced'` filter would drop them and make the commit look
+    // untouched forever. `MAX(provider)` collapses the hook-route (`provider
+    // ''`) and ingest identities of one session into a single row.
     let mut rows = conn
         .query(
-            "SELECT DISTINCT provider, session_id FROM commit_sessions
-             WHERE relation = 'produced'
-               AND (commit_sha = ?1 OR commit_sha LIKE ?2)",
+            "SELECT MAX(provider), session_id FROM commit_sessions c
+             WHERE (commit_sha = ?1 OR commit_sha LIKE ?2)
+               AND (c.relation = 'produced'
+                    OR NOT EXISTS (
+                        SELECT 1 FROM commit_sessions p
+                        WHERE (p.commit_sha = ?1 OR p.commit_sha LIKE ?2)
+                          AND p.relation = 'produced'))
+             GROUP BY session_id",
             params![sha, format!("{sha}%")],
         )
         .await?;
@@ -1154,15 +1207,26 @@ pub(crate) fn git_scope_exists_clauses(
         ));
     }
     if let Some(commit) = &filter.commit {
+        // Prefer producer evidence, but fall back to any correlation when no
+        // producer row exists for the commit (see `commit_session_ids`): a
+        // pruned v2-upgraded store keeps only observed rows, and dropping them
+        // would erase the commit scope entirely.
+        let pattern = format!("{commit}%");
         clauses.push((
             format!(
                 "EXISTS (SELECT 1 FROM commit_sessions c \
-                 WHERE c.session_id = {session_column} AND c.relation = 'produced' \
-                 AND (c.commit_sha = ? OR c.commit_sha LIKE ?))"
+                 WHERE c.session_id = {session_column} \
+                 AND (c.commit_sha = ? OR c.commit_sha LIKE ?) \
+                 AND (c.relation = 'produced' \
+                      OR NOT EXISTS (SELECT 1 FROM commit_sessions p \
+                                     WHERE (p.commit_sha = ? OR p.commit_sha LIKE ?) \
+                                       AND p.relation = 'produced')))"
             ),
             vec![
                 Value::Text(commit.clone()),
-                Value::Text(format!("{commit}%")),
+                Value::Text(pattern.clone()),
+                Value::Text(commit.clone()),
+                Value::Text(pattern),
             ],
         ));
     }
@@ -1296,8 +1360,13 @@ async fn span_hits(
     query: &SessionsForQuery,
     limit: i64,
 ) -> Result<Vec<SessionGitCorrelationHit>, GitCorrelationError> {
+    // Group by `session_id` alone, not `(provider, session_id)`: hook-route
+    // spans store `provider = ''` while transcript ingest stores the real
+    // provider, so keying on both splits one session into two rows with its
+    // event/span counts divided between them. `MAX(provider)` picks the real
+    // (non-empty) provider as the session's single canonical identity.
     let mut sql = format!(
-        "SELECT provider, session_id,
+        "SELECT MAX(provider), session_id,
                 MIN(first_ts), MAX(last_ts), SUM(event_count), COUNT(*),
                 GROUP_CONCAT(DISTINCT source),
                 GROUP_CONCAT(DISTINCT branch),
@@ -1317,7 +1386,7 @@ async fn span_hits(
     query_params.push(Value::Integer(limit));
     let _ = write!(
         sql,
-        " GROUP BY provider, session_id
+        " GROUP BY session_id
           ORDER BY MAX(last_ts) DESC
           LIMIT ?{}",
         query_params.len()
@@ -1399,12 +1468,19 @@ async fn commit_hits(
     );
 
     let mut rows = conn.query(&sql, query_params).await?;
-    let mut hits = Vec::new();
+    // One session can hold two rows for the same commit — a hook-route
+    // observation (`provider ''`) and an ingest/producer row — because the
+    // primary key includes provider. Collapse them into a single canonical hit
+    // per session, keeping the strongest evidence and the real provider, so a
+    // session is never double-counted for one commit.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_session: std::collections::HashMap<String, SessionGitCorrelationHit> =
+        std::collections::HashMap::new();
     while let Some(row) = rows.next().await? {
         let overlap: String = row.get(6)?;
         let relation: String = row.get(7)?;
         let evidence: String = row.get(8)?;
-        hits.push(SessionGitCorrelationHit {
+        let candidate = SessionGitCorrelationHit {
             provider: row.get(0)?,
             session_id: row.get(1)?,
             branch: row.get(2)?,
@@ -1421,9 +1497,48 @@ async fn commit_hits(
             evidence: CommitEvidence::from_db(&evidence),
             confidence: row.get(9)?,
             evidence_message_id: row.get(10)?,
-        });
+        };
+        if let Some(existing) = by_session.get_mut(&candidate.session_id) {
+            merge_commit_hit(existing, candidate);
+        } else {
+            order.push(candidate.session_id.clone());
+            by_session.insert(candidate.session_id.clone(), candidate);
+        }
     }
-    Ok(hits)
+    Ok(order
+        .into_iter()
+        .filter_map(|session_id| by_session.remove(&session_id))
+        .collect())
+}
+
+/// Folds a second commit hit for the same session into `existing`, keeping the
+/// stronger evidence and preferring a non-empty (real) provider.
+fn merge_commit_hit(existing: &mut SessionGitCorrelationHit, candidate: SessionGitCorrelationHit) {
+    if existing.provider.is_empty() && !candidate.provider.is_empty() {
+        existing.provider.clone_from(&candidate.provider);
+    }
+    if commit_hit_strength(&candidate) > commit_hit_strength(existing) {
+        let provider = if candidate.provider.is_empty() {
+            existing.provider.clone()
+        } else {
+            candidate.provider.clone()
+        };
+        *existing = SessionGitCorrelationHit {
+            provider,
+            ..candidate
+        };
+    }
+}
+
+/// Ranks a commit hit so producer evidence beats observation, breaking ties on
+/// confidence. Used to pick one canonical row per session.
+fn commit_hit_strength(hit: &SessionGitCorrelationHit) -> (u8, i64) {
+    let relation_rank = match hit.relation {
+        Some(CommitRelation::Produced) => 2,
+        Some(CommitRelation::Observed) => 1,
+        None => 0,
+    };
+    (relation_rank, hit.confidence.unwrap_or(0))
 }
 
 mod backfill;

--- a/src/sessions/git_correlation/attribution.rs
+++ b/src/sessions/git_correlation/attribution.rs
@@ -45,6 +45,11 @@ pub struct SpanScanTarget {
     pub worktree: String,
     pub window_start: i64,
     pub window_end: i64,
+    /// Newest span write time (`updated_at`) in this target. The sweep
+    /// watermark advances on this — ingest/write order — not on `window_end`
+    /// (event time), so a session ingested late for old commits is still
+    /// scanned even though its events predate the watermark.
+    pub max_updated_at: i64,
 }
 
 /// One span row a candidate commit may fall inside. Kept minimal so the
@@ -124,18 +129,22 @@ pub fn match_commit_to_spans(
     records
 }
 
-/// Loads the `(branch, worktree)` scan targets touched by spans updated at or
-/// after `since_ts` (the sweep watermark), each carrying the widest span
-/// window observed for it so the git scan can be time-bounded.
+/// Loads the `(branch, worktree)` scan targets whose spans were *written*
+/// (`updated_at`) at or after `since_ts` (the sweep watermark), each carrying
+/// the widest span window observed for it so the git scan can be time-bounded.
+///
+/// Selecting on `updated_at` (ingest/write time) rather than `last_ts` (event
+/// time) is deliberate: historical sessions ingested after the watermark carry
+/// old event times but a fresh `updated_at`, so they still get attributed.
 async fn scan_targets_since(
     conn: &Connection,
     since_ts: i64,
 ) -> Result<Vec<SpanScanTarget>, GitCorrelationError> {
     let mut rows = conn
         .query(
-            "SELECT branch, worktree, MIN(first_ts), MAX(last_ts)
+            "SELECT branch, worktree, MIN(first_ts), MAX(last_ts), MAX(updated_at)
              FROM session_git_spans
-             WHERE last_ts >= ?1
+             WHERE updated_at >= ?1
              GROUP BY branch, worktree",
             params![since_ts],
         )
@@ -147,6 +156,7 @@ async fn scan_targets_since(
             worktree: row.get(1)?,
             window_start: row.get(2)?,
             window_end: row.get(3)?,
+            max_updated_at: row.get(4)?,
         });
     }
     Ok(targets)
@@ -179,7 +189,32 @@ async fn span_windows_for(
             last_ts: row.get(6)?,
         });
     }
+    canonicalize_span_providers(&mut spans);
     Ok(spans)
+}
+
+/// Collapses the multiple provider identities of one session onto its single
+/// real provider. A live session is span-observed by the hook route (which
+/// stores `provider ''`, since it cannot know the provider) and again by
+/// transcript ingest (which stores the real provider). Left split, both
+/// windows attribute the same commit under different `(commit_sha, provider,
+/// session_id)` keys, double-counting the session. Resolving every window to
+/// the session's non-empty provider makes those attributions collapse onto one
+/// `commit_sessions` row via the upsert primary key.
+fn canonicalize_span_providers(spans: &mut [SpanWindow]) {
+    let mut canonical: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for span in spans.iter() {
+        if !span.provider.is_empty() {
+            canonical
+                .entry(span.session_id.clone())
+                .or_insert_with(|| span.provider.clone());
+        }
+    }
+    for span in spans.iter_mut() {
+        if let Some(provider) = canonical.get(&span.session_id) {
+            span.provider = provider.clone();
+        }
+    }
 }
 
 /// One commit observed by the bounded git scan.
@@ -208,7 +243,9 @@ where
     let mut inserted = 0usize;
     let mut new_watermark = watermark;
     for target in &targets {
-        new_watermark = new_watermark.max(target.window_end);
+        // Advance on write time, not event time, so the watermark reflects how
+        // far ingestion has progressed rather than how recent the commits are.
+        new_watermark = new_watermark.max(target.max_updated_at);
         let spans = span_windows_for(conn, target.branch.as_deref(), &target.worktree).await?;
         if spans.is_empty() {
             continue;

--- a/src/sessions/git_correlation/tests.rs
+++ b/src/sessions/git_correlation/tests.rs
@@ -817,6 +817,422 @@ async fn commit_attribution_sweep_attributes_and_advances_watermark() {
     assert_eq!(again, 0, "re-attribution of the same commit is a no-op");
 }
 
+fn span_with(
+    provider: &str,
+    session_id: &str,
+    branch: Option<&str>,
+    worktree: &str,
+    ts: i64,
+    source: SpanSource,
+) -> SpanObservation {
+    SpanObservation {
+        provider: provider.to_string(),
+        session_id: session_id.to_string(),
+        thread_id: None,
+        branch: branch.map(str::to_string),
+        worktree: worktree.to_string(),
+        ts,
+        source,
+    }
+}
+
+#[test]
+fn head_observation_candidates_record_observed_not_produced() {
+    use std::process::Command;
+
+    let temp = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .output()
+            .unwrap()
+    };
+    assert!(git(&["init", "-q"]).status.success());
+    assert!(
+        git(&["config", "user.email", "test@example.com"])
+            .status
+            .success()
+    );
+    assert!(git(&["config", "user.name", "Test"]).status.success());
+    std::fs::write(temp.path().join("file.txt"), "one\n").unwrap();
+    assert!(git(&["add", "file.txt"]).status.success());
+    assert!(git(&["commit", "-q", "-m", "test"]).status.success());
+    let sha = String::from_utf8(git(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+
+    let message = SessionMessageRecord {
+        provider: "codex".to_string(),
+        message_id: "m1".to_string(),
+        session_id: "s1".to_string(),
+        role: "tool".to_string(),
+        timestamp: Some(10),
+        ordinal: 1,
+        text: "git rev-parse HEAD".to_string(),
+        kind: Some("tool_call".to_string()),
+        model: None,
+        tool_names: Some("exec_command".to_string()),
+        source_path: None,
+        source_offset: None,
+        metadata_json: Some(
+            serde_json::json!({
+                "observed_commit_candidates": [sha],
+                "codex_git_branch": "main",
+                "codex_turn_worktree": temp.path(),
+            })
+            .to_string(),
+        ),
+    };
+    let records = direct_commit_records(&[message], temp.path());
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].commit_sha, sha);
+    assert_eq!(records[0].relation, CommitRelation::Observed);
+    assert_eq!(records[0].evidence, CommitEvidence::HeadObservation);
+    assert_eq!(records[0].confidence, HEAD_OBSERVATION_CONFIDENCE);
+}
+
+#[test]
+fn producer_evidence_wins_over_head_observation_of_same_commit() {
+    use std::process::Command;
+
+    let temp = tempfile::tempdir().unwrap();
+    let git = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(temp.path())
+            .output()
+            .unwrap()
+    };
+    assert!(git(&["init", "-q"]).status.success());
+    assert!(
+        git(&["config", "user.email", "test@example.com"])
+            .status
+            .success()
+    );
+    assert!(git(&["config", "user.name", "Test"]).status.success());
+    std::fs::write(temp.path().join("file.txt"), "one\n").unwrap();
+    assert!(git(&["add", "file.txt"]).status.success());
+    assert!(git(&["commit", "-q", "-m", "test"]).status.success());
+    let sha = String::from_utf8(git(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    let short = &sha[..8];
+
+    // The same exec both created the commit (bracket) and printed HEAD, so the
+    // one commit appears in both candidate lists. Only one producer record must
+    // survive.
+    let message = SessionMessageRecord {
+        provider: "codex".to_string(),
+        message_id: "m1".to_string(),
+        session_id: "s1".to_string(),
+        role: "tool".to_string(),
+        timestamp: Some(10),
+        ordinal: 1,
+        text: "git commit && git rev-parse HEAD".to_string(),
+        kind: Some("tool_call".to_string()),
+        model: None,
+        tool_names: Some("exec_command".to_string()),
+        source_path: None,
+        source_offset: None,
+        metadata_json: Some(
+            serde_json::json!({
+                "produced_commit_candidates": [short],
+                "observed_commit_candidates": [sha],
+                "codex_git_branch": "main",
+                "codex_turn_worktree": temp.path(),
+            })
+            .to_string(),
+        ),
+    };
+    let records = direct_commit_records(&[message], temp.path());
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].relation, CommitRelation::Produced);
+    assert_eq!(records[0].confidence, 100);
+}
+
+#[tokio::test]
+async fn mixed_provider_spans_collapse_to_one_session_in_branch_query() {
+    let conn = test_conn().await;
+    // A live session observed by the provider-agnostic hook route (provider '')
+    // and again by transcript ingest (provider 'claude').
+    record_span_observation(
+        &conn,
+        &span_with(
+            "",
+            "s1",
+            Some("main"),
+            "/repo",
+            1_000,
+            SpanSource::HookRoute,
+        ),
+        600,
+    )
+    .await
+    .unwrap();
+    record_span_observation(
+        &conn,
+        &span_with(
+            "claude",
+            "s1",
+            Some("main"),
+            "/repo",
+            1_050,
+            SpanSource::Ingest,
+        ),
+        600,
+    )
+    .await
+    .unwrap();
+
+    let hits = sessions_for(
+        &conn,
+        &SessionsForQuery {
+            git_ref: GitRefFilter::Branch("main".to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(hits.len(), 1, "one session must not split into two rows");
+    assert_eq!(hits[0].session_id, "s1");
+    assert_eq!(hits[0].provider, "claude", "real provider is canonical");
+    assert_eq!(hits[0].event_count, 2, "counts are summed, not split");
+    assert_eq!(hits[0].span_count, 2);
+}
+
+#[tokio::test]
+async fn mixed_provider_commit_rows_collapse_to_one_hit() {
+    let conn = test_conn().await;
+    let sha = "abcdef1234567890abcdef1234567890abcdef12";
+    for provider in ["", "claude"] {
+        upsert_commit_session(
+            &conn,
+            &CommitSessionRecord {
+                commit_sha: sha.to_string(),
+                provider: provider.to_string(),
+                session_id: "s1".to_string(),
+                branch: Some("main".to_string()),
+                worktree: Some("/repo".to_string()),
+                committed_at: 1_500,
+                span_overlap_kind: SpanOverlapKind::WithinSpan,
+                span_id: None,
+                relation: CommitRelation::Observed,
+                evidence: CommitEvidence::TimeOverlap,
+                confidence: 20,
+                evidence_message_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let hits = sessions_for_with_relation(
+        &conn,
+        &SessionsForQuery {
+            git_ref: GitRefFilter::Commit("abcdef12".to_string()),
+            since: None,
+            until: None,
+            limit: 10,
+        },
+        CommitRelationFilter::All,
+    )
+    .await
+    .unwrap();
+    assert_eq!(hits.len(), 1, "one session must not be double-counted");
+    assert_eq!(hits[0].session_id, "s1");
+    assert_eq!(hits[0].provider, "claude");
+}
+
+#[tokio::test]
+async fn attribution_sweep_writes_one_row_for_mixed_provider_session() {
+    let conn = test_conn().await;
+    // Same session, two provider identities, both overlapping the commit.
+    record_span_observation(
+        &conn,
+        &span_with(
+            "",
+            "s1",
+            Some("main"),
+            "/repo",
+            1_500,
+            SpanSource::HookRoute,
+        ),
+        600,
+    )
+    .await
+    .unwrap();
+    record_span_observation(
+        &conn,
+        &span_with(
+            "claude",
+            "s1",
+            Some("main"),
+            "/repo",
+            1_500,
+            SpanSource::Ingest,
+        ),
+        600,
+    )
+    .await
+    .unwrap();
+
+    let sha = "abcdef1234567890abcdef1234567890abcdef12";
+    run_commit_attribution_sweep(&conn, 600, |_| {
+        vec![ScannedCommit {
+            sha: sha.to_string(),
+            committed_at: 1_500,
+        }]
+    })
+    .await
+    .unwrap();
+
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM commit_sessions WHERE commit_sha = ?1",
+            libsql::params![sha],
+        )
+        .await
+        .unwrap();
+    let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(
+        count, 1,
+        "canonical provider yields a single attribution row"
+    );
+}
+
+#[tokio::test]
+async fn commit_scope_falls_back_to_observed_when_no_producer_exists() {
+    let conn = test_conn().await;
+    // Only an observed row exists (the state of every migrated v2 store).
+    upsert_commit_session(
+        &conn,
+        &CommitSessionRecord {
+            commit_sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+            provider: "claude".to_string(),
+            session_id: "observer".to_string(),
+            branch: Some("main".to_string()),
+            worktree: Some("/repo".to_string()),
+            committed_at: 1_500,
+            span_overlap_kind: SpanOverlapKind::WithinSpan,
+            span_id: None,
+            relation: CommitRelation::Observed,
+            evidence: CommitEvidence::TimeOverlap,
+            confidence: 20,
+            evidence_message_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let filter = GitScopeFilter::from_args(None, None, Some("abcdef12")).unwrap();
+    let ids = session_ids_for_scope(&conn, &filter)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        ids,
+        vec![("claude".to_string(), "observer".to_string())],
+        "observed-only commit rows must still resolve for commit scope"
+    );
+
+    // Once a producer is known, the observer no longer resolves — producer
+    // evidence takes precedence.
+    upsert_commit_session(
+        &conn,
+        &CommitSessionRecord {
+            commit_sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+            provider: "codex".to_string(),
+            session_id: "producer".to_string(),
+            branch: Some("main".to_string()),
+            worktree: Some("/repo".to_string()),
+            committed_at: 1_500,
+            span_overlap_kind: SpanOverlapKind::Direct,
+            span_id: None,
+            relation: CommitRelation::Produced,
+            evidence: CommitEvidence::ToolResult,
+            confidence: 100,
+            evidence_message_id: Some("m1".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    let ids = session_ids_for_scope(&conn, &filter)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(ids, vec![("codex".to_string(), "producer".to_string())]);
+}
+
+#[tokio::test]
+async fn sweep_watermark_tracks_ingest_time_so_late_history_is_attributed() {
+    let conn = test_conn().await;
+    // A recent session fixes the watermark near "now".
+    record_span_observation(
+        &conn,
+        &span_with(
+            "claude",
+            "recent",
+            Some("main"),
+            "/repo",
+            10_000,
+            SpanSource::Ingest,
+        ),
+        600,
+    )
+    .await
+    .unwrap();
+    run_commit_attribution_sweep(&conn, 600, |_| Vec::new())
+        .await
+        .unwrap();
+    let watermark = read_meta_value(&conn, "commit_attribution_watermark")
+        .await
+        .unwrap()
+        .unwrap();
+
+    // A historical session is ingested late: its event time (500) is far below
+    // the watermark, but its write time is now.
+    record_span_observation(
+        &conn,
+        &span_with(
+            "claude",
+            "historical",
+            Some("feat"),
+            "/repo",
+            500,
+            SpanSource::Ingest,
+        ),
+        600,
+    )
+    .await
+    .unwrap();
+    assert!(
+        500 < watermark,
+        "historical event time must sit below the watermark to exercise the fix"
+    );
+
+    let inserted = run_commit_attribution_sweep(&conn, 600, |target| {
+        if target.branch.as_deref() == Some("feat") {
+            vec![ScannedCommit {
+                sha: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+                committed_at: 500,
+            }]
+        } else {
+            Vec::new()
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        inserted, 1,
+        "a late-ingested historical span must still be attributed"
+    );
+}
+
 #[test]
 fn activity_sort_key_prefers_message_then_end_then_start() {
     let row = |started, ended, msg_max| SessionActivityRow {


### PR DESCRIPTION
Fixes the five adversarially-confirmed findings from review of merged PR #369 ("distinguish produced and observed commits"). Every fix ships with tests, and the full CI gate set passes (`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, nextest correlation lib + `mcp_suite`/`session_suite`/`transcript_ingest_suite` = 666 + 52 lib tests).

## Findings addressed

**1. [major] `git rev-parse HEAD` output became produced/confidence-100 evidence** (`src/sessions/codex/events.rs`)
`commit_candidates` now splits a commit-creating command's `[branch sha]` line — emitted by git only when a commit is actually written — from a bare full-length sha printed by a read-only `git rev-parse HEAD`. The bracket form stays producer evidence; the printed HEAD becomes an **observed** `head_observation` (confidence 60), carried in a new `observed_commit_candidates` metadata key and recorded by `direct_commit_records` as relation=observed. This kills both misclassification paths: `git commit -m x; git rev-parse HEAD` (commit fails, `;` keeps the process exit 0 on rev-parse) and fast-forward `git merge <branch> && git rev-parse HEAD`. Producer evidence is collected first so it always wins the `(sha, provider, session)` slot over a head observation of the same commit.

**2. [major] One session split into two correlation identities** (`git_correlation.rs`, `attribution.rs`)
Hook-route spans store `provider=''` while ingest stores the real provider. `span_hits`/`span_session_ids`/`commit_session_ids` now group by `session_id` and canonicalize to the non-empty provider (`MAX(provider)`); `commit_hits` collapses a session's rows to one canonical hit; and the attribution sweep canonicalizes each session's span windows onto one provider before matching, so a mixed-provider session yields a single `commit_sessions` row instead of two.

**3. [major] Commit-scoped search hard-coded relation='produced', dropping pre-migration rows** (`git_correlation.rs`)
`commit_session_ids` and `git_scope_exists_clauses` now use producer-with-observed-fallback: when no produced row exists for a sha (e.g. a v2-upgraded store whose transcripts were pruned), every correlated session still resolves instead of vanishing forever. When a producer *is* known, only it resolves.

**4. [minor] `sessions_for` said "no sessions matched" when only observed rows existed** (`handlers/session.rs`)
On a commit query that returns no producer rows, the handler now looks up the observed sessions and reports `"no producing sessions; N sessions observed this commit — pass relation=observed to list them"`, attaching them as `observed_sessions`/`observed_count`.

**5. [minor] Commit-sweep watermark used event time** (`attribution.rs`)
`scan_targets_since` selects and advances the watermark on span `updated_at` (ingest/write time) rather than `last_ts` (event time), so a session ingested late for historical commits is still attributed. `SpanScanTarget` gains `max_updated_at`; window bounds still come from `first_ts`/`last_ts`.

## Notes
- No schema/version bump. Legacy v2 rows keep migrating to `observed` (that contract and its test are intentionally preserved); finding 3 is fixed purely in the query surfaces so pruned-store commit scope recovers those rows without a destructive rewrite.
- New tests: producer/observed candidate split + precedence, mixed-provider span/commit/sweep collapse, observed-fallback commit scope, and ingest-time watermark for late historical spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)