### PR TITLE
fix(pr-autotrack): harden daemon PR-branch auto-tracking

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -545,6 +545,24 @@ fn try_acquire_branch_add_lock(tracedecay_dir: &Path) -> crate::errors::Result<s
     Ok(file)
 }
 
+/// Blocking-with-timeout variant of [`try_acquire_branch_add_lock`] for
+/// synchronous callers. Retries a briefly-contended lock (a concurrent branch
+/// add is only holding it for the duration of a DB clone) before giving up.
+/// Returns `None` on timeout or a non-contention error, so the caller can skip
+/// its mutation this round rather than proceed unsynchronized.
+fn acquire_branch_add_lock_blocking(tracedecay_dir: &Path) -> Option<std::fs::File> {
+    for _ in 0..20 {
+        match try_acquire_branch_add_lock(tracedecay_dir) {
+            Ok(lock) => return Some(lock),
+            Err(crate::errors::TraceDecayError::SyncLock { .. }) => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(_) => return None,
+        }
+    }
+    None
+}
+
 fn remove_branch_db_files(db_path: &Path) {
     let _ = std::fs::remove_file(db_path);
     let mut sidecar = db_path.to_path_buf();
@@ -575,6 +593,17 @@ fn clone_or_copy_db(src: &Path, dst: &Path) -> std::io::Result<()> {
 /// used by `tracedecay branch remove` and the PR-autotrack lifecycle so both
 /// clean up identically.
 pub fn remove_tracked_branch_store(tracedecay_dir: &Path, branch: &str) -> bool {
+    // Serialize on the same branch-add lock every other `branch-meta.json`
+    // mutator holds (prepare_branch_tracking_in_layout, gc_dead_branch_stores).
+    // Without it, this unlocked load→remove→save races a concurrent
+    // `branch add`: depending on write order it either silently drops the
+    // user's just-added branch or resurrects a removed entry pointing at a
+    // deleted DB. On sustained contention, skip removal (returning false); the
+    // caller retries next cycle — nothing is lost. Callers never hold this lock
+    // when calling in (branch add / GC acquire-then-release), so no deadlock.
+    let Some(_lock) = acquire_branch_add_lock_blocking(tracedecay_dir) else {
+        return false;
+    };
     let Some(mut meta) = crate::branch_meta::load_branch_meta(tracedecay_dir) else {
         return false;
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -738,7 +738,9 @@ async fn handle_branch_autotrack_action(
             let mut config = load_config_with_identity(&project_path).await?;
             config.sync.auto_track_pr_branches = false;
             save_config_with_identity(&project_path, &config).await?;
-            eprintln!("\x1b[32m✔\x1b[0m PR auto-tracking disabled.");
+            eprintln!(
+                "\x1b[32m✔\x1b[0m PR auto-tracking disabled. The daemon tears down any managed PR worktrees, refs, synthetic branches and stores on its next poll cycle."
+            );
         }
     }
     Ok(())

--- a/src/daemon/pr_autotrack.rs
+++ b/src/daemon/pr_autotrack.rs
@@ -76,6 +76,13 @@ pub struct PrDiscovery {
     pub open: Vec<DiscoveredPr>,
     /// PR numbers skipped because their head lives on a fork.
     pub skipped_forks: Vec<u64>,
+    /// True when discovery may be *incomplete* — e.g. `gh pr list` returned
+    /// exactly its page limit, so PRs beyond it were not seen. Reconciliation
+    /// suppresses removals against a partial discovery so a still-open PR that
+    /// merely fell outside the listing window is never mistaken for closed and
+    /// untracked. A failed discovery command is a different case: it never
+    /// produces a `PrDiscovery` at all (see [`discover_open_prs`]).
+    pub partial: bool,
 }
 
 /// A currently-managed PR branch, persisted in the state sidecar.
@@ -180,9 +187,16 @@ struct GhPr {
 /// Parses `gh pr list` JSON into a discovery result. Open same-repo PRs go to
 /// `open`; open cross-repository PRs are recorded as skipped forks; non-open PRs
 /// are ignored.
-fn parse_gh_pr_list(json: &str) -> serde_json::Result<PrDiscovery> {
+///
+/// `limit` is the `--limit` passed to `gh`: if the result count reaches it the
+/// listing was truncated (there may be more open PRs), so the discovery is
+/// flagged `partial` and reconciliation will not untrack anything this pass.
+fn parse_gh_pr_list(json: &str, limit: usize) -> serde_json::Result<PrDiscovery> {
     let prs: Vec<GhPr> = serde_json::from_str(json)?;
-    let mut discovery = PrDiscovery::default();
+    let mut discovery = PrDiscovery {
+        partial: limit > 0 && prs.len() >= limit,
+        ..Default::default()
+    };
     for pr in prs {
         if !pr.state.eq_ignore_ascii_case("open") {
             continue;
@@ -269,12 +283,22 @@ fn map_pull_heads_to_branches(
 }
 
 fn run_git(repo_root: &Path, args: &[&str]) -> Option<std::process::Output> {
-    std::process::Command::new(crate::git::git_program())
-        .args(args)
-        .current_dir(repo_root)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
+    let mut command = std::process::Command::new(crate::git::git_program());
+    command.args(args).current_dir(repo_root);
+    disable_git_credential_prompt(&mut command);
+    command.output().ok().filter(|o| o.status.success())
+}
+
+/// Forbids interactive credential prompts on a spawned git/gh subprocess. The
+/// daemon's single poll loop awaits each project sequentially, so one git
+/// process blocking on `/dev/tty` for a password (uncached HTTPS credential,
+/// passphrase-protected SSH key with no agent) would freeze PR-autotrack for
+/// *every* registered project. Failing fast instead keeps the loop live; the
+/// failure is then surfaced as a discovery error, never as "zero open PRs".
+fn disable_git_credential_prompt(command: &mut std::process::Command) {
+    command
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "echo");
 }
 
 fn origin_is_github(repo_root: &Path) -> bool {
@@ -283,11 +307,16 @@ fn origin_is_github(repo_root: &Path) -> bool {
         .is_some_and(|url| url.contains("github.com"))
 }
 
+/// Upper bound on PRs fetched in one `gh pr list` call. Reaching it means the
+/// listing was truncated, which flags the discovery `partial` (removals are then
+/// suppressed) rather than silently dropping the tail as if those PRs closed.
+const GH_PR_LIST_LIMIT: usize = 1000;
+
 fn gh_available() -> bool {
-    std::process::Command::new("gh")
-        .arg("--version")
-        .output()
-        .is_ok_and(|o| o.status.success())
+    let mut command = std::process::Command::new("gh");
+    command.arg("--version");
+    disable_git_credential_prompt(&mut command);
+    command.output().is_ok_and(|o| o.status.success())
 }
 
 /// Discovers open PR head branches on the repo's `origin` remote.
@@ -295,45 +324,55 @@ fn gh_available() -> bool {
 /// Prefers `gh pr list` when `gh` is on PATH and `origin` is GitHub; otherwise
 /// falls back to `git ls-remote` and SHA-matching. Same-repo PRs are returned in
 /// `open`; fork PRs are recorded in `skipped_forks`.
-pub fn discover_open_prs(repo_root: &Path) -> PrDiscovery {
+///
+/// Returns `Err` when the underlying discovery command *fails* (auth failure,
+/// network outage, expired credentials). A failed command is never collapsed
+/// into an empty `PrDiscovery`: the caller must skip reconciliation entirely, so
+/// a transient `gh`/`git` failure can never masquerade as "every PR closed" and
+/// mass-untrack the managed set. An empty `Ok` result means the remote genuinely
+/// has no open PRs.
+pub fn discover_open_prs(repo_root: &Path) -> Result<PrDiscovery, String> {
     if origin_is_github(repo_root) && gh_available() {
         if let Some(discovery) = discover_via_gh(repo_root) {
-            return discovery;
+            return Ok(discovery);
         }
+        // `gh` failed (rate limit, auth, transient). Fall through to ls-remote,
+        // which propagates its own failure as `Err` rather than empty.
     }
     discover_via_ls_remote(repo_root)
 }
 
 fn discover_via_gh(repo_root: &Path) -> Option<PrDiscovery> {
-    let output = std::process::Command::new("gh")
+    let limit = GH_PR_LIST_LIMIT.to_string();
+    let mut command = std::process::Command::new("gh");
+    command
         .args([
             "pr",
             "list",
             "--state",
             "open",
             "--limit",
-            "200",
+            &limit,
             "--json",
             "number,headRefName,headRefOid,state,isCrossRepository",
         ])
-        .current_dir(repo_root)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
+        .current_dir(repo_root);
+    disable_git_credential_prompt(&mut command);
+    let output = command.output().ok().filter(|o| o.status.success())?;
     let json = String::from_utf8(output.stdout).ok()?;
-    parse_gh_pr_list(&json).ok()
+    parse_gh_pr_list(&json, GH_PR_LIST_LIMIT).ok()
 }
 
-fn discover_via_ls_remote(repo_root: &Path) -> PrDiscovery {
-    let pull_heads = run_git(repo_root, &["ls-remote", "origin", "refs/pull/*/head"])
+fn discover_via_ls_remote(repo_root: &Path) -> Result<PrDiscovery, String> {
+    let pull_out = run_git(repo_root, &["ls-remote", "origin", "refs/pull/*/head"])
         .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|out| parse_ls_remote_pull_heads(&out))
-        .unwrap_or_default();
-    let head_shas = run_git(repo_root, &["ls-remote", "--heads", "origin"])
+        .ok_or_else(|| "git ls-remote of PR head refs failed".to_string())?;
+    let heads_out = run_git(repo_root, &["ls-remote", "--heads", "origin"])
         .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|out| parse_ls_remote_heads(&out))
-        .unwrap_or_default();
-    map_pull_heads_to_branches(&pull_heads, &head_shas)
+        .ok_or_else(|| "git ls-remote of head refs failed".to_string())?;
+    let pull_heads = parse_ls_remote_pull_heads(&pull_out);
+    let head_shas = parse_ls_remote_heads(&heads_out);
+    Ok(map_pull_heads_to_branches(&pull_heads, &head_shas))
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +390,9 @@ pub struct ReconcileReport {
     pub skipped_forks: Vec<u64>,
     /// True when the per-cycle new-track cap held some additions back.
     pub capped: bool,
+    /// True when removals were skipped because the discovery was `partial`
+    /// (possibly truncated) — no managed PR is untracked on an incomplete view.
+    pub removals_suppressed: bool,
     /// Tracking or persistence failures surfaced to callers.
     pub failures: Vec<(String, String)>,
 }
@@ -381,27 +423,52 @@ pub async fn reconcile_project(
         .collect();
 
     // Removals first (cheap, unblocks disk) — managed entries no longer open.
-    let stale: Vec<String> = state
-        .managed
-        .keys()
-        .filter(|label| !desired.contains_key(*label))
-        .cloned()
-        .collect();
-    for label in stale {
-        if let Some(managed) = state.managed.get(&label).cloned() {
-            untrack_pr(repo_root, data_root, &label, &managed).await;
-            state.managed.remove(&label);
-            state_dirty = true;
-            report.untracked.push(label.clone());
-            log_daemon_event(
-                "pr_autotrack",
-                &[
-                    ("project", repo_root.display().to_string()),
-                    ("action", "untracked".to_string()),
-                    ("branch", label),
-                    ("pr", managed.pr.to_string()),
-                ],
-            );
+    // Suppress them entirely when the discovery is `partial`: an incomplete
+    // listing must never be read as "these PRs closed", or a truncated `gh`
+    // page (or gh↔ls-remote flapping) would churn-untrack still-open PRs.
+    if discovery.partial {
+        report.removals_suppressed = true;
+        log_daemon_event(
+            "pr_autotrack",
+            &[
+                ("project", repo_root.display().to_string()),
+                ("action", "poll".to_string()),
+                ("outcome", "partial".to_string()),
+                (
+                    "reason",
+                    "removals suppressed: discovery incomplete".to_string(),
+                ),
+            ],
+        );
+    } else {
+        // Sweep leaked checkouts before removals: a `pr-worktrees/pr-<N>` dir
+        // whose PR is neither open nor managed is an orphan left by a daemon
+        // crash between `worktree add` and `save_state`. Remove it so stale
+        // worktrees don't accumulate on disk across restarts.
+        sweep_orphan_pr_worktrees(repo_root, data_root, &desired, &state);
+
+        let stale: Vec<String> = state
+            .managed
+            .keys()
+            .filter(|label| !desired.contains_key(*label))
+            .cloned()
+            .collect();
+        for label in stale {
+            if let Some(managed) = state.managed.get(&label).cloned() {
+                untrack_pr(repo_root, data_root, &label, &managed).await;
+                state.managed.remove(&label);
+                state_dirty = true;
+                report.untracked.push(label.clone());
+                log_daemon_event(
+                    "pr_autotrack",
+                    &[
+                        ("project", repo_root.display().to_string()),
+                        ("action", "untracked".to_string()),
+                        ("branch", label),
+                        ("pr", managed.pr.to_string()),
+                    ],
+                );
+            }
         }
     }
 
@@ -416,8 +483,12 @@ pub async fn reconcile_project(
         }
         let is_new = current.is_none();
         if is_new && added >= cap {
+            // The cap bounds only *new* tracks. `continue` (not `break`) so a
+            // later entry that is already managed but has a changed head_sha
+            // still gets its refresh — otherwise a burst of new PRs would starve
+            // head updates for existing managed PRs, serving stale graphs.
             report.capped = true;
-            break;
+            continue;
         }
         if let Some(managed) = current {
             // A changed remote head invalidates the entire branch graph. Drop
@@ -623,24 +694,28 @@ fn prepare_pr_worktree(
     if fetched_head.as_deref() != Some(expected_head) {
         return Err("PR head changed during reconciliation".to_string());
     }
-    let branch_ref = format!("refs/heads/{label}");
-    if run_git(repo_root, &["show-ref", "--verify", "--quiet", &branch_ref]).is_some() {
-        return Err("internal PR worktree branch already exists".to_string());
-    }
 
     if let Some(parent) = worktree.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    // Clear any stale worktree registration/dir so `worktree add` is idempotent.
+    // Clear any stale worktree registration/dir so `worktree add` is idempotent
+    // and frees the synthetic branch for reset.
     remove_worktree(repo_root, worktree);
 
+    // Adopt (reset) rather than fail if the synthetic branch survived an
+    // interrupted prior cycle (daemon death between `worktree add` and
+    // `save_state`). The `tracedecay/autotrack/pr/<N>` label namespace is
+    // collision-proof by construction, so a leftover branch at a stale SHA is
+    // unambiguously ours. `-B` force-creates-or-resets it to the freshly
+    // fetched head; a plain `-b` would wedge the PR forever with
+    // "branch already exists" once the head advanced past the orphan.
     let wt_str = worktree.to_string_lossy();
     let add = run_git(
         repo_root,
         &[
             "worktree",
             "add",
-            "-b",
+            "-B",
             label,
             "--force",
             &wt_str,
@@ -684,6 +759,52 @@ async fn untrack_pr(repo_root: &Path, data_root: &Path, label: &str, managed: &M
         &managed.head_sha,
         !is_legacy,
     );
+}
+
+/// Removes leaked PR worktrees from interrupted prior cycles.
+///
+/// Scans `pr-worktrees/` for `pr-<N>` checkouts whose PR is neither open
+/// (`desired`) nor currently managed. Such a dir is an orphan left when the
+/// daemon died between `git worktree add` and `save_state`: no state entry
+/// claims it and the PR is not open, so it would otherwise sit on disk forever.
+/// Its synthetic branch and fetch ref are cleaned up alongside the checkout.
+/// Only called for a *complete* discovery (never when `partial`), so an open PR
+/// that merely fell outside a truncated listing is never swept.
+fn sweep_orphan_pr_worktrees(
+    repo_root: &Path,
+    data_root: &Path,
+    desired: &BTreeMap<String, &DiscoveredPr>,
+    state: &PrAutotrackState,
+) {
+    let worktrees_dir = data_root.join("pr-worktrees");
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        return;
+    };
+    let managed_prs: std::collections::BTreeSet<u64> =
+        state.managed.values().map(|m| m.pr).collect();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(number) = name
+            .to_str()
+            .and_then(|n| n.strip_prefix("pr-"))
+            .and_then(|n| n.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        if managed_prs.contains(&number) || desired.contains_key(&pr_label(number)) {
+            continue;
+        }
+        cleanup_pr_worktree(repo_root, data_root, number, "", true);
+        log_daemon_event(
+            "pr_autotrack",
+            &[
+                ("project", repo_root.display().to_string()),
+                ("action", "swept".to_string()),
+                ("pr", number.to_string()),
+                ("reason", "orphan worktree".to_string()),
+            ],
+        );
+    }
 }
 
 fn cleanup_pr_worktree(
@@ -775,16 +896,21 @@ async fn tick(global_db_path: Option<&Path>, last_poll: &mut HashMap<PathBuf, In
             continue;
         }
         let cfg = crate::config::load_sync_config(&root);
-        if !cfg.auto_track_pr_branches {
-            continue;
-        }
         let interval = Duration::from_secs(cfg.effective_auto_track_pr_poll_secs());
         let due = last_poll.get(&root).is_none_or(|t| t.elapsed() >= interval);
         if !due {
             continue;
         }
         last_poll.insert(root.clone(), Instant::now());
-        poll_project(root, cfg).await;
+        if cfg.auto_track_pr_branches {
+            poll_project(root, cfg).await;
+        } else {
+            // Feature disabled: if it left managed PR state behind (it was on,
+            // then turned off), tear that state down once instead of stranding
+            // worktrees/refs/branches/stores forever. Gated on the poll cadence
+            // (via last_poll above) so a disabled project isn't probed each tick.
+            teardown_disabled_project(&root).await;
+        }
     }
 }
 
@@ -798,11 +924,27 @@ async fn poll_project(repo_root: PathBuf, _cfg: SyncConfig) {
     let data_root = layout.data_root;
 
     let repo_for_discovery = repo_root.clone();
-    let Ok(discovery) =
-        tokio::task::spawn_blocking(move || discover_open_prs(&repo_for_discovery)).await
-    else {
-        return;
-    };
+    let discovery =
+        match tokio::task::spawn_blocking(move || discover_open_prs(&repo_for_discovery)).await {
+            Ok(Ok(discovery)) => discovery,
+            Ok(Err(reason)) => {
+                // Discovery command failed (auth/network/credentials). Skip the
+                // whole reconcile cycle — never reconcile against a discovery
+                // produced by a failed command, or a transient failure would
+                // untrack every managed PR as if the repo had zero open PRs.
+                log_daemon_event(
+                    "pr_autotrack",
+                    &[
+                        ("project", repo_root.display().to_string()),
+                        ("action", "poll".to_string()),
+                        ("outcome", "error".to_string()),
+                        ("reason", reason),
+                    ],
+                );
+                return;
+            }
+            Err(_) => return, // join error (task panicked/cancelled)
+        };
 
     let report =
         reconcile_project(&repo_root, &data_root, &discovery, MAX_NEW_TRACKS_PER_CYCLE).await;
@@ -816,6 +958,44 @@ async fn poll_project(repo_root: PathBuf, _cfg: SyncConfig) {
             ("new_tracked", report.tracked.len().to_string()),
             ("untracked", report.untracked.len().to_string()),
             ("skipped_forks", report.skipped_forks.len().to_string()),
+        ],
+    );
+}
+
+/// Tears down all managed PR state for a project whose `auto_track_pr_branches`
+/// is now disabled.
+///
+/// When the feature is turned off after it has tracked PRs, every managed
+/// worktree, `refs/tracedecay/pr/*` ref, synthetic `pr/<N>` branch and
+/// per-branch store would otherwise be stranded forever (surfacing stale graphs
+/// in `branch_list` and consuming disk). This runs one removals-only reconcile
+/// (empty desired set) to clean the managed set down to empty. Cheap and inert
+/// once nothing is managed, so it is safe to call every poll cadence.
+pub async fn teardown_disabled_project(repo_root: &Path) {
+    let opts = TraceDecayOpenOptions::default();
+    let Some(layout) = TraceDecay::initialized_store_layout_with_options(repo_root, &opts).await
+    else {
+        return; // not indexed — no managed state to tear down
+    };
+    let data_root = layout.data_root;
+    if load_state(&data_root).managed.is_empty() {
+        return; // nothing stranded — the common case, kept cheap
+    }
+    // Empty (complete, non-partial) discovery → every managed entry is stale →
+    // untracked and cleaned up.
+    let report = reconcile_project(
+        repo_root,
+        &data_root,
+        &PrDiscovery::default(),
+        MAX_NEW_TRACKS_PER_CYCLE,
+    )
+    .await;
+    log_daemon_event(
+        "pr_autotrack",
+        &[
+            ("project", repo_root.display().to_string()),
+            ("action", "teardown".to_string()),
+            ("untracked", report.untracked.len().to_string()),
         ],
     );
 }

--- a/src/daemon/pr_autotrack/tests.rs
+++ b/src/daemon/pr_autotrack/tests.rs
@@ -10,7 +10,11 @@ fn gh_pr_list_splits_open_same_repo_from_forks() {
         {"number": 3, "headRefName": "closed-branch", "headRefOid": "sha-closed", "state": "CLOSED", "isCrossRepository": false},
         {"number": 4, "headRefName": "feature-b", "headRefOid": "sha-b", "state": "OPEN", "isCrossRepository": false}
     ]"#;
-    let discovery = parse_gh_pr_list(json).unwrap();
+    let discovery = parse_gh_pr_list(json, 200).unwrap();
+    assert!(
+        !discovery.partial,
+        "four PRs under a 200 limit are complete"
+    );
     assert_eq!(
         discovery.open,
         vec![
@@ -82,6 +86,23 @@ fn map_pull_heads_matches_same_repo_and_skips_forks() {
         }]
     );
     assert_eq!(discovery.skipped_forks, vec![2]);
+}
+
+#[test]
+fn gh_pr_list_flags_partial_when_result_reaches_limit() {
+    let json = r#"[
+        {"number": 1, "headRefName": "a", "headRefOid": "s1", "state": "OPEN", "isCrossRepository": false},
+        {"number": 2, "headRefName": "b", "headRefOid": "s2", "state": "OPEN", "isCrossRepository": false}
+    ]"#;
+    // Two results at a limit of two: the listing was truncated → partial.
+    let truncated = parse_gh_pr_list(json, 2).unwrap();
+    assert!(
+        truncated.partial,
+        "count == limit must be treated as possibly truncated"
+    );
+    // Same results under a higher limit are complete.
+    let complete = parse_gh_pr_list(json, 5).unwrap();
+    assert!(!complete.partial);
 }
 
 // ---- State persistence ------------------------------------------------------
@@ -197,6 +218,7 @@ async fn reconcile_is_idempotent_for_already_managed_pr() {
             head_sha: "sha-3".to_string(),
         }],
         skipped_forks: vec![],
+        ..Default::default()
     };
     let report = reconcile_project(repo_root.path(), data_root.path(), &discovery, 10).await;
 
@@ -208,4 +230,56 @@ async fn reconcile_is_idempotent_for_already_managed_pr() {
             .managed
             .contains_key("tracedecay/autotrack/pr/3")
     );
+}
+
+#[tokio::test]
+async fn partial_discovery_suppresses_removals() {
+    use crate::branch_meta::{BranchMeta, load_branch_meta, save_branch_meta};
+
+    let data_root = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+
+    // Seed a managed PR branch store + entry, exactly as the untrack test does.
+    let mut meta = BranchMeta::new("main");
+    meta.add_branch("pr/5", "branches/pr_5.db", "main");
+    std::fs::create_dir_all(data_root.path().join("branches")).unwrap();
+    std::fs::write(data_root.path().join("branches/pr_5.db"), b"db").unwrap();
+    save_branch_meta(data_root.path(), &meta).unwrap();
+
+    let mut state = PrAutotrackState::default();
+    state.managed.insert(
+        "pr/5".to_string(),
+        ManagedPr {
+            pr: 5,
+            head_branch: "feature-5".to_string(),
+            head_sha: "sha-5".to_string(),
+            worktree: data_root.path().join("pr-worktrees/pr-5"),
+            tracking_ref: "refs/tracedecay/pr/5".to_string(),
+        },
+    );
+    save_state(data_root.path(), &state).unwrap();
+
+    // Empty BUT partial discovery: PR 5 is absent only because the listing was
+    // truncated, not because it closed — it must NOT be untracked.
+    let discovery = PrDiscovery {
+        partial: true,
+        ..Default::default()
+    };
+    let report = reconcile_project(repo_root.path(), data_root.path(), &discovery, 10).await;
+
+    assert!(
+        report.removals_suppressed,
+        "partial view suppresses removals"
+    );
+    assert!(report.untracked.is_empty(), "no untrack on a partial view");
+    assert!(
+        load_state(data_root.path()).managed.contains_key("pr/5"),
+        "managed entry survives a partial discovery"
+    );
+    assert!(
+        load_branch_meta(data_root.path())
+            .unwrap()
+            .is_tracked("pr/5")
+    );
+    assert!(data_root.path().join("branches/pr_5.db").exists());
 }

--- a/tests/daemon_suite/pr_autotrack_test.rs
+++ b/tests/daemon_suite/pr_autotrack_test.rs
@@ -135,6 +135,34 @@ fn add_fork_pr(project: &Path, n: u64, symbol: &str) {
     );
 }
 
+/// Advances an existing same-repo PR's head: adds a commit carrying `symbol` on
+/// top of `origin/feature-<n>`, pushes it, and re-points `refs/pull/<n>/head` at
+/// the new tip. Leaves the project checked out on `main`.
+fn bump_pr(project: &Path, origin: &Path, n: u64, symbol: &str) {
+    let branch = format!("feature-{n}");
+    git(
+        project,
+        &["checkout", "-B", &branch, &format!("origin/{branch}")],
+    );
+    fs::write(
+        project.join(format!("src/pr_{n}_{symbol}.rs")),
+        format!("pub fn {symbol}() {{}}\n"),
+    )
+    .unwrap();
+    commit_all(project, &format!("bump PR {n}"));
+    git(project, &["push", "origin", &branch]);
+    git(
+        origin,
+        &[
+            "update-ref",
+            &format!("refs/pull/{n}/head"),
+            &format!("refs/heads/{branch}"),
+        ],
+    );
+    git(project, &["checkout", "main"]);
+    git(project, &["branch", "-D", &branch]);
+}
+
 #[tokio::test]
 async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
@@ -151,7 +179,7 @@ async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
     let tracking_label = "tracedecay/autotrack/pr/1";
 
     // Discovery: PR 1 is a tracked same-repo PR; PR 2 is a skipped fork.
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     assert_eq!(discovery.open.len(), 1, "one same-repo PR expected");
     assert_eq!(discovery.open[0].number, 1);
     assert_eq!(discovery.open[0].head_branch, head_branch);
@@ -226,7 +254,8 @@ async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
     git(&project, &["checkout", "main"]);
     git(&project, &["branch", "-D", &head_branch]);
 
-    let refreshed_discovery = pr_autotrack::discover_open_prs(&project);
+    let refreshed_discovery =
+        pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     assert_ne!(
         refreshed_discovery.open[0].head_sha,
         discovery.open[0].head_sha
@@ -249,7 +278,7 @@ async fn tracks_same_repo_pr_indexes_its_content_and_untracks_on_close() {
 
     // Close PR 1 (delete its pull ref) → discovery no longer lists it → untrack.
     git(&origin, &["update-ref", "-d", "refs/pull/1/head"]);
-    let after_close = pr_autotrack::discover_open_prs(&project);
+    let after_close = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     assert!(
         after_close.open.iter().all(|p| p.number != 1),
         "closed PR must not be discovered"
@@ -277,7 +306,7 @@ async fn deferred_tracking_is_not_persisted_and_retries_next_cycle() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
     add_same_repo_pr(&project, &origin, 7, "pr_seven_symbol");
     let data_root = project_data_dir(&project);
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
 
     let lock = std::fs::OpenOptions::new()
         .create(true)
@@ -309,7 +338,7 @@ async fn complete_orphan_is_rebuilt_after_interrupted_state_write() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
     add_same_repo_pr(&project, &origin, 8, "pr_eight_symbol");
     let data_root = project_data_dir(&project);
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     let label = "tracedecay/autotrack/pr/8";
 
     let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
@@ -327,7 +356,7 @@ async fn validated_branch_ref_orphan_without_worktree_is_rebuilt() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
     add_same_repo_pr(&project, &origin, 11, "pr_eleven_symbol");
     let data_root = project_data_dir(&project);
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     let label = "tracedecay/autotrack/pr/11";
     let worktree = data_root.join("pr-worktrees/pr-11");
 
@@ -353,7 +382,7 @@ async fn state_persistence_failure_rolls_back_completed_tracking() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
     add_same_repo_pr(&project, &origin, 10, "pr_ten_symbol");
     let data_root = project_data_dir(&project);
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     let label = "tracedecay/autotrack/pr/10";
     fs::create_dir(data_root.join("pr-autotrack.json")).unwrap();
 
@@ -386,7 +415,7 @@ async fn legacy_close_recovers_empty_head_sha_before_owned_ref_cleanup() {
     let (_env, project, origin) = indexed_repo_with_origin().await;
     add_same_repo_pr(&project, &origin, 9, "pr_nine_symbol");
     let data_root = project_data_dir(&project);
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     let current_label = "tracedecay/autotrack/pr/9";
     let legacy_label = "pr/9";
     let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
@@ -411,7 +440,7 @@ async fn legacy_close_recovers_empty_head_sha_before_owned_ref_cleanup() {
     git(&worktree, &["branch", "-m", legacy_label]);
 
     git(&origin, &["update-ref", "-d", "refs/pull/9/head"]);
-    let closed = pr_autotrack::discover_open_prs(&project);
+    let closed = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     let report = pr_autotrack::reconcile_project(&project, &data_root, &closed, 10).await;
     assert_eq!(report.untracked, vec![legacy_label.to_string()]);
     assert!(
@@ -442,7 +471,7 @@ async fn caps_new_tracks_per_cycle_and_ramps() {
     add_same_repo_pr(&project, &origin, 3, "pr_three");
 
     let data_root = project_data_dir(&project);
-    let discovery = pr_autotrack::discover_open_prs(&project);
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
     assert_eq!(discovery.open.len(), 3);
 
     // First cycle with cap=2 tracks only two and flags the cap.
@@ -456,4 +485,222 @@ async fn caps_new_tracks_per_cycle_and_ramps() {
     assert_eq!(second.tracked.len(), 1);
     assert!(!second.capped);
     assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 3);
+}
+
+/// Finding 1: a *failed* discovery command must be distinguishable from "zero
+/// open PRs". If `discover_open_prs` collapsed a git/gh failure into an empty
+/// discovery, reconcile would mass-untrack every managed PR on one transient
+/// network/credential blip. It must return `Err` instead so the daemon skips
+/// the cycle and leaves the managed set intact.
+#[tokio::test]
+async fn failed_discovery_returns_error_and_never_mass_untracks() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 1, "pr_one_symbol");
+    let data_root = project_data_dir(&project);
+    let label = "tracedecay/autotrack/pr/1";
+
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
+    let report = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(report.tracked, vec![label.to_string()]);
+
+    // Break `origin` so every ls-remote/gh discovery command fails.
+    git(
+        &project,
+        &["remote", "set-url", "origin", "/definitely/not/a/repo.git"],
+    );
+
+    let result = pr_autotrack::discover_open_prs(&project);
+    assert!(
+        result.is_err(),
+        "a failed discovery command must surface as Err, not an empty Ok"
+    );
+    // The daemon skips reconcile on Err, so the managed PR is untouched.
+    assert_eq!(pr_autotrack::managed_summary(&data_root).len(), 1);
+    assert!(load_branch_meta(&data_root).unwrap().is_tracked(label));
+}
+
+/// Finding 2: daemon death mid-track leaves the synthetic branch at an old SHA
+/// with no state and no DB. Once the PR head advances, the old `-b` path wedged
+/// forever on "branch already exists" (and leaked the worktree). Tracking must
+/// now be idempotent: adopt/reset the orphan branch to the new head and recover.
+#[tokio::test]
+async fn interrupted_track_with_advanced_head_recovers_instead_of_wedging() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 12, "pr_twelve_v1");
+    let data_root = project_data_dir(&project);
+    let label = "tracedecay/autotrack/pr/12";
+    let worktree = data_root.join("pr-worktrees/pr-12");
+
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
+    let first = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(first.tracked, vec![label.to_string()]);
+
+    // Reproduce the mid-track crash aftermath: state gone, DB gone, worktree
+    // gone — but the synthetic branch survives pointing at the OLD head.
+    fs::remove_file(data_root.join("pr-autotrack.json")).unwrap();
+    assert!(tracedecay::branch::remove_tracked_branch_store(
+        &data_root, label
+    ));
+    git(
+        &project,
+        &["worktree", "remove", "--force", &worktree.to_string_lossy()],
+    );
+    assert!(
+        git_out(
+            &project,
+            &[
+                "rev-parse",
+                "--verify",
+                "refs/heads/tracedecay/autotrack/pr/12"
+            ],
+        )
+        .status
+        .success(),
+        "orphan synthetic branch must survive to reproduce the wedge"
+    );
+
+    // Advance the PR head so the orphan branch (old SHA) no longer matches.
+    bump_pr(&project, &origin, 12, "pr_twelve_v2");
+    let refreshed = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
+    assert_ne!(refreshed.open[0].head_sha, discovery.open[0].head_sha);
+
+    let recovered = pr_autotrack::reconcile_project(&project, &data_root, &refreshed, 10).await;
+    assert_eq!(
+        recovered.tracked,
+        vec![label.to_string()],
+        "an interrupted track with an advanced head must recover, not wedge"
+    );
+    assert!(worktree.exists(), "recovery re-creates the worktree");
+    let cg = TraceDecay::open_branch(&project, label).await.unwrap();
+    assert!(
+        !cg.search("pr_twelve_v2", 10).await.unwrap().is_empty(),
+        "recovered branch graph serves the advanced head's content"
+    );
+}
+
+/// Finding 4: the per-cycle new-track cap must bound only NEW tracks — an
+/// already-managed PR whose head advanced must still be refreshed the same
+/// cycle, even when its label sorts after the capped new PRs. (Managed PR 9
+/// sorts lexically after new PRs 10/11/12.)
+#[tokio::test]
+async fn cap_does_not_starve_head_updates_for_managed_prs() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 9, "pr_nine_v1");
+    let data_root = project_data_dir(&project);
+    let label = "tracedecay/autotrack/pr/9";
+
+    let d0 = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
+    let r0 = pr_autotrack::reconcile_project(&project, &data_root, &d0, 10).await;
+    assert_eq!(r0.tracked, vec![label.to_string()]);
+
+    // Open three NEW PRs (cap will be 2) and advance managed PR 9's head.
+    add_same_repo_pr(&project, &origin, 10, "pr_ten");
+    add_same_repo_pr(&project, &origin, 11, "pr_eleven");
+    add_same_repo_pr(&project, &origin, 12, "pr_twelve");
+    bump_pr(&project, &origin, 9, "pr_nine_v2");
+
+    let d1 = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
+    let r1 = pr_autotrack::reconcile_project(&project, &data_root, &d1, 2).await;
+
+    assert!(r1.capped, "three new PRs under cap=2 flags the cap");
+    assert!(
+        r1.tracked.contains(&label.to_string()),
+        "managed PR 9's head refresh must run despite the new-track cap"
+    );
+    let new_tracked = r1.tracked.iter().filter(|l| l.as_str() != label).count();
+    assert_eq!(new_tracked, 2, "cap still bounds NEW tracks to 2");
+
+    let cg = TraceDecay::open_branch(&project, label).await.unwrap();
+    assert!(
+        !cg.search("pr_nine_v2", 10).await.unwrap().is_empty(),
+        "the refreshed managed branch serves the advanced head, not the stale one"
+    );
+}
+
+/// Finding 7: turning the feature off must tear down managed PR state rather
+/// than stranding worktrees, refs, synthetic branches and stores forever.
+#[tokio::test]
+async fn teardown_removes_all_managed_state_on_disable() {
+    let (_env, project, origin) = indexed_repo_with_origin().await;
+    add_same_repo_pr(&project, &origin, 4, "pr_four_symbol");
+    let data_root = project_data_dir(&project);
+    let label = "tracedecay/autotrack/pr/4";
+
+    let discovery = pr_autotrack::discover_open_prs(&project).expect("PR discovery succeeds");
+    let report = pr_autotrack::reconcile_project(&project, &data_root, &discovery, 10).await;
+    assert_eq!(report.tracked, vec![label.to_string()]);
+
+    // The daemon runs this when it observes the feature disabled.
+    pr_autotrack::teardown_disabled_project(&project).await;
+
+    assert!(pr_autotrack::managed_summary(&data_root).is_empty());
+    assert!(!load_branch_meta(&data_root).unwrap().is_tracked(label));
+    assert!(!data_root.join("pr-worktrees/pr-4").exists());
+    assert!(
+        !git_out(
+            &project,
+            &[
+                "rev-parse",
+                "--verify",
+                "refs/heads/tracedecay/autotrack/pr/4"
+            ],
+        )
+        .status
+        .success(),
+        "synthetic branch must be removed on teardown"
+    );
+    assert!(
+        !git_out(&project, &["rev-parse", "--verify", "refs/tracedecay/pr/4"])
+            .status
+            .success(),
+        "owned fetch ref must be removed on teardown"
+    );
+
+    // Idempotent: a second teardown with nothing managed is a no-op.
+    pr_autotrack::teardown_disabled_project(&project).await;
+    assert!(pr_autotrack::managed_summary(&data_root).is_empty());
+}
+
+/// Finding 3: `remove_tracked_branch_store` must serialize on the branch-add
+/// lock so it can't race a concurrent `branch add`. While the lock is held it
+/// skips (returns false) and leaves metadata intact; once released it proceeds.
+#[tokio::test]
+async fn remove_tracked_branch_store_respects_branch_add_lock() {
+    use tracedecay::branch_meta::BranchMeta;
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let mut meta = BranchMeta::new("main");
+    meta.add_branch("feature-x", "branches/feature_x.db", "main");
+    fs::create_dir_all(root.join("branches")).unwrap();
+    fs::write(root.join("branches/feature_x.db"), b"db").unwrap();
+    save_branch_meta(root, &meta).unwrap();
+
+    // Hold the branch-add lock exclusively, as a concurrent `branch add` would.
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(root.join(".branch-add.lock"))
+        .unwrap();
+    lock.lock_exclusive().unwrap();
+
+    assert!(
+        !tracedecay::branch::remove_tracked_branch_store(root, "feature-x"),
+        "removal must skip while the branch-add lock is held"
+    );
+    assert!(
+        load_branch_meta(root).unwrap().is_tracked("feature-x"),
+        "contended removal must not mutate branch metadata"
+    );
+    assert!(root.join("branches/feature_x.db").exists());
+
+    lock.unlock().unwrap();
+
+    assert!(
+        tracedecay::branch::remove_tracked_branch_store(root, "feature-x"),
+        "removal proceeds once the lock is released"
+    );
+    assert!(!load_branch_meta(root).unwrap().is_tracked("feature-x"));
+    assert!(!root.join("branches/feature_x.db").exists());
 }


### PR DESCRIPTION
Fixes 7 adversarially-confirmed findings in daemon PR-branch auto-tracking (from the adversarial review of #364 / #367). Each has a regression test.

## Findings & fixes

1. **[major] Failed discovery indistinguishable from zero open PRs → mass-untrack.** `discover_open_prs` now returns `Result`. A `git`/`gh` command failure surfaces as `Err`, and `poll_project` skips the entire reconcile cycle (logs `action=poll outcome=error`) instead of reconciling against an empty discovery. Untrack happens only on positive evidence a PR closed.
2. **[major] Daemon death mid-track + advanced head wedged the PR forever and leaked its worktree.** `prepare_pr_worktree` drops the erroring `show-ref` guard and adopts/resets the collision-proof synthetic branch with `git worktree add -B`. A stale-worktree sweep on each (complete) reconcile removes leaked `pr-worktrees/pr-<N>` checkouts.
3. **[major] `remove_tracked_branch_store` mutated `branch-meta.json` without the branch-add lock.** It now serializes on the same lock `prepare_branch_tracking_in_layout` and `gc_dead_branch_stores` hold; skips (returns false) on sustained contention so the daemon retries.
4. **[minor] Per-cycle cap `break` skipped head-SHA updates for managed PRs.** Changed to `continue` — the cap bounds only *new* tracks; refreshes always run.
5. **[minor] No `GIT_TERMINAL_PROMPT=0` on daemon git/gh subprocesses.** Every spawned `git`/`gh` command now sets `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=echo`, so a credential prompt can't hang the single sequential poll loop.
6. **[minor] `gh --limit` truncation treated PR #201+ as closed.** Limit raised and truncation detected (`count == limit → partial`); a `partial` discovery suppresses removals so unlisted-but-open PRs aren't untracked.
7. **[minor] Disabling the setting stranded all managed state.** The daemon now runs a one-shot removals-only reconcile (`teardown_disabled_project`) when the feature is off but managed entries remain; the `branch autotrack disable` output documents it.

## Tests
Extended `tests/daemon_suite/pr_autotrack_test.rs` and `src/daemon/pr_autotrack/tests.rs`:
- `failed_discovery_returns_error_and_never_mass_untracks`
- `interrupted_track_with_advanced_head_recovers_instead_of_wedging`
- `cap_does_not_starve_head_updates_for_managed_prs`
- `teardown_removes_all_managed_state_on_disable`
- `remove_tracked_branch_store_respects_branch_add_lock`
- `partial_discovery_suppresses_removals`, `gh_pr_list_flags_partial_when_result_reaches_limit`

## Gates
`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `nextest` daemon_suite + branch/config lib tests all green (full lib suite running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)