### PR TITLE
fix(mcp): bound ledger settle wait, thread mcp_instance_id into analytics

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -240,6 +240,13 @@ fn match_initialize_root_to_registered_project(
 /// Cache duration for version checks (15 minutes).
 const VERSION_CHECK_INTERVAL: Duration = Duration::from_mins(15);
 
+/// Upper bound for [`McpServer::ledger_writes_settled`]. Savings-ledger writes
+/// are fire-and-forget `SQLite` appends that finish in well under a second on a
+/// healthy machine, so 10 s is generous headroom; the point is that the wait
+/// is *finite* — a wedged recorder task can never hang the caller (tests,
+/// shutdown drains) indefinitely as the previous unbounded loop allowed.
+const LEDGER_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
+
 // Global accounting (savings ledger + worldwide-counter flushes) is enabled
 // by default; see `crate::global_db::global_accounting_mode` for the env
 // override precedence.
@@ -855,6 +862,31 @@ pub struct McpServer {
     /// connection that gets re-initialized by a different client picks up
     /// the new identity.
     client_name: std::sync::Mutex<Option<String>>,
+    /// Stable per-process instance id (random hex token minted once when this
+    /// server is constructed). Recorded in every analytics event's
+    /// `metadata.mcp_instance_id`.
+    ///
+    /// The MCP transport negotiates only `clientInfo` (host name) at
+    /// `initialize` — never a session/conversation id — and no session env var
+    /// is passed to the server process, so a call's `session_id` column is
+    /// populated only when the client happens to thread `session_id`/`sessionId`
+    /// through the tool arguments (rare; historically ~97.6% of events had a
+    /// NULL `session_id`). This id is the honest fallback: it cannot recover a
+    /// true session identity, but it lets every event from one server lifetime
+    /// be grouped. It is deliberately kept out of the `session_id` column so it
+    /// never masquerades as a real session.
+    mcp_instance_id: String,
+}
+
+/// Mint a random per-process MCP instance id (32 lowercase hex chars from 16
+/// random bytes). Best-effort: if the OS RNG is unavailable, fall back to a
+/// timestamped token so the field is always populated and never panics.
+fn new_mcp_instance_id() -> String {
+    let mut buf = [0u8; 16];
+    match getrandom::getrandom(&mut buf) {
+        Ok(()) => hex::encode(buf),
+        Err(_) => format!("mcp-{}", crate::tracedecay::current_timestamp()),
+    }
 }
 
 impl McpServer {
@@ -992,6 +1024,7 @@ impl McpServer {
                 crate::sessions::git_correlation::SpanObservationDebounce::new(),
             ),
             client_name: std::sync::Mutex::new(None),
+            mcp_instance_id: new_mcp_instance_id(),
         });
 
         tokio::task::spawn_blocking(move || {
@@ -1251,18 +1284,55 @@ impl McpServer {
     /// production code never calls this, so the request path stays
     /// non-blocking, while tests can await durability deterministically
     /// instead of polling the DB against a wall-clock deadline.
+    ///
+    /// Bounded by [`LEDGER_SETTLE_TIMEOUT`] so a spawned write that wedges
+    /// (a stuck DB handle, a task that never resolves) can never hang the
+    /// caller forever — the earlier unbounded loop made a wedged write
+    /// manifest as an un-observable, indefinitely-hung integration test.
     pub async fn ledger_writes_settled(&self) {
-        loop {
-            // Register interest *before* re-checking so a completion between
-            // the check and the await cannot be missed.
-            let notified = self.ledger_write_notify.notified();
-            let started = self.ledger_writes_started.load(Ordering::SeqCst);
-            let finished = self.ledger_writes_finished.load(Ordering::SeqCst);
-            if finished >= started {
-                return;
+        self.ledger_writes_settled_within(LEDGER_SETTLE_TIMEOUT)
+            .await;
+    }
+
+    /// Like [`Self::ledger_writes_settled`] but bounded by an explicit
+    /// `timeout`. Returns `true` when every spawned ledger write settled
+    /// within the bound, `false` when the bound elapsed with writes still
+    /// pending. A timeout is never silent: it logs a warning naming how many
+    /// writes were still outstanding so a wedged recorder is diagnosable.
+    pub async fn ledger_writes_settled_within(&self, timeout: std::time::Duration) -> bool {
+        let wait = async {
+            loop {
+                // Register interest *before* re-checking so a completion
+                // between the check and the await cannot be missed.
+                let notified = self.ledger_write_notify.notified();
+                let started = self.ledger_writes_started.load(Ordering::SeqCst);
+                let finished = self.ledger_writes_finished.load(Ordering::SeqCst);
+                if finished >= started {
+                    return;
+                }
+                notified.await;
             }
-            notified.await;
+        };
+        if tokio::time::timeout(timeout, wait).await.is_ok() {
+            return true;
         }
+        let started = self.ledger_writes_started.load(Ordering::SeqCst);
+        let finished = self.ledger_writes_finished.load(Ordering::SeqCst);
+        let pending = started.saturating_sub(finished);
+        eprintln!(
+            "[tracedecay] ledger_writes_settled timed out after {timeout:?} with \
+             {pending} savings-ledger write(s) still pending"
+        );
+        false
+    }
+
+    /// Test-only hook: spawn an observed ledger write that never completes, so
+    /// tests can prove [`Self::ledger_writes_settled`] stays bounded when a
+    /// recorder task wedges. Uses the same [`Self::spawn_observed_ledger_write`]
+    /// accounting the production path uses, so the counters advance identically.
+    #[cfg(test)]
+    pub(crate) fn spawn_wedged_ledger_write_for_test(&self) {
+        self.spawn_observed_ledger_write(std::future::pending::<()>());
     }
 
     /// Re-read the file-to-token-count map from the DB and swap it into the
@@ -2692,6 +2762,7 @@ impl McpServer {
                         arguments: &analytics_arguments,
                         internal_analytics: result.internal_analytics(),
                         client_name: client_name.as_deref(),
+                        mcp_instance_id: Some(self.mcp_instance_id.as_str()),
                         failure_reason: failure_reason.as_deref(),
                     });
                     self.spawn_observed_ledger_write(async move {
@@ -2919,6 +2990,7 @@ impl McpServer {
             arguments,
             internal_analytics: None,
             client_name: client_name.as_deref(),
+            mcp_instance_id: Some(self.mcp_instance_id.as_str()),
             failure_reason: Some(&failure_reason),
         });
         self.spawn_observed_ledger_write(async move {

--- a/src/mcp/server/freshness_tests.rs
+++ b/src/mcp/server/freshness_tests.rs
@@ -142,6 +142,37 @@ async fn startup_catch_up_spawned_once_per_server() {
     );
 }
 
+// ---- ledger settle is bounded when a recorder task wedges ---------
+
+// A dedicated multi-thread runtime keeps the timer driver off the same worker
+// that runs the server's startup catch-up sync, so the bound is honored
+// promptly regardless of machine load.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ledger_writes_settled_is_bounded_when_a_write_wedges() {
+    let (cg, _dir, _pin) = init_indexed_repo().await;
+    let server = McpServer::new(cg, None).await;
+
+    // Inject a never-completing observed ledger write via the same accounting
+    // the production path uses. Without a bound, awaiting settlement would hang
+    // forever (the defect this guards against).
+    server.spawn_wedged_ledger_write_for_test();
+
+    // Wrap in an outer wall-clock guard: if the bound were ever ignored the
+    // call would hang, so an elapsed outer timeout is itself the failure
+    // signal (a plain assertion could never fire on a hung await).
+    let bounded = tokio::time::timeout(
+        Duration::from_secs(30),
+        server.ledger_writes_settled_within(Duration::from_millis(150)),
+    )
+    .await
+    .expect("bounded settle must return, never hang on a wedged write");
+
+    assert!(
+        !bounded,
+        "a wedged ledger write must be reported as un-settled"
+    );
+}
+
 // ---- D4: sync-on-read never blocks + single-flight (tests a, d) ---
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/mcp/tool_analytics.rs
+++ b/src/mcp/tool_analytics.rs
@@ -22,6 +22,17 @@ pub(super) struct McpToolAnalyticsEvent<'a> {
     /// observed yet (e.g. a daemon-proxied first call). Bounded to the
     /// negotiated name only — never the full `clientInfo` payload.
     pub(super) client_name: Option<&'a str>,
+    /// Stable per-process MCP server instance id (a random hex token minted
+    /// once at server start). Recorded in `metadata.mcp_instance_id` on every
+    /// event so calls from one server lifetime can be grouped even when
+    /// `session_id` is absent — which is the common case: the MCP transport
+    /// negotiates only `clientInfo` (host name), never a session/conversation
+    /// id, so `session_id` is populated only when the client happens to thread
+    /// `session_id`/`sessionId` through the tool arguments (rare — ~97.6% of
+    /// historical events had a NULL `session_id`). This is an honest grouping
+    /// key, NOT a real session id, so it stays in metadata rather than
+    /// masquerading in the `session_id` column.
+    pub(super) mcp_instance_id: Option<&'a str>,
     /// Bounded, sanitized (no argument bodies) reason for a `outcome ==
     /// "error"` call, e.g. a structural edit-tool failure message or a
     /// dispatch error's `Display` text. `None` falls back to a generic
@@ -60,6 +71,7 @@ pub(super) fn mcp_tool_analytics_event(input: McpToolAnalyticsEvent<'_>) -> Anal
         "duration_us": input.duration_us,
         "duration_ms": input.duration_us.map(|us| us / 1000),
         "client_name": input.client_name,
+        "mcp_instance_id": input.mcp_instance_id,
     });
     if input.outcome == "error" {
         metadata["failure_reason"] = json!(
@@ -268,6 +280,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: None,
+            mcp_instance_id: None,
             failure_reason: Some("old_str not found in src/main.rs"),
         });
         let metadata: serde_json::Value =
@@ -296,6 +309,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: None,
+            mcp_instance_id: None,
             failure_reason: None,
         });
         let metadata: serde_json::Value =
@@ -321,6 +335,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: None,
+            mcp_instance_id: None,
             failure_reason: Some("should be ignored on success"),
         });
         let metadata: serde_json::Value =
@@ -346,6 +361,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: Some("claude-code"),
+            mcp_instance_id: Some("mcp-instance-test"),
             failure_reason: None,
         });
 
@@ -379,6 +395,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: None,
+            mcp_instance_id: None,
             failure_reason: None,
         });
 
@@ -408,6 +425,7 @@ mod tests {
             arguments: &arguments,
             internal_analytics: None,
             client_name: Some("codex"),
+            mcp_instance_id: Some("mcp-instance-test"),
             failure_reason: None,
         });
 
@@ -417,5 +435,41 @@ mod tests {
 
         assert!(metadata.get("action").is_none());
         assert_eq!(metadata["client_name"], "codex");
+        assert_eq!(metadata["mcp_instance_id"], "mcp-instance-test");
+    }
+
+    #[test]
+    fn mcp_tool_analytics_event_records_instance_id_when_session_absent() {
+        // The common case: no client-supplied session_id, so the honest
+        // grouping key is the per-process mcp_instance_id in metadata while
+        // the session_id column stays NULL.
+        let request_id = json!(9);
+        let arguments = json!({});
+        let event = mcp_tool_analytics_event(McpToolAnalyticsEvent {
+            project_root: Path::new("/repo"),
+            session_id: None,
+            tool_name: "tracedecay_search",
+            outcome: "success",
+            raw_file_tokens: 0,
+            response_tokens: 0,
+            net_saved_tokens: 0,
+            duration_us: None,
+            timestamp: 12345,
+            request_id: &request_id,
+            arguments: &arguments,
+            internal_analytics: None,
+            client_name: Some("claude-code"),
+            mcp_instance_id: Some("mcp-abc123"),
+            failure_reason: None,
+        });
+
+        assert!(
+            event.session_id.is_none(),
+            "instance id must not masquerade as a real session id"
+        );
+        let metadata: serde_json::Value =
+            serde_json::from_str(event.metadata_json.as_deref().unwrap_or("{}"))
+                .expect("metadata should parse");
+        assert_eq!(metadata["mcp_instance_id"], "mcp-abc123");
     }
 }


### PR DESCRIPTION
Fixes two confirmed-but-unfixed MCP observability defects surfaced by the repo's own audits.

## 1. Unbounded `ledger_writes_settled()` (`src/mcp/server.rs`)

The fire-and-forget savings-ledger recorder's settle helper looped on a `Notify` with **no timeout**, so a spawned write that wedged (stuck DB handle, never-resolving task) hung the caller indefinitely — the root cause of an un-observable integration test under machine load flagged during the edit-tier Wave 0 work.

- New `LEDGER_SETTLE_TIMEOUT` (10s) bounds the wait; `ledger_writes_settled()` delegates to a new `ledger_writes_settled_within(timeout) -> bool`.
- On timeout the helper logs a warning naming how many writes are still pending (**never silent**) and returns `false`.
- Sibling waiter `wait_for_startup_catch_up()` audited — already bounded, left as-is.
- Test `ledger_writes_settled_is_bounded_when_a_write_wedges` injects a never-completing observed write through a `#[cfg(test)]` hook (`spawn_wedged_ledger_write_for_test`) that reuses the production accounting, then asserts the settle returns rather than hanging.

## 2. ~97.6% NULL `session_id` on MCP analytics events

**Identity source investigation:** at MCP dispatch time the only real session id is what a client threads through the tool arguments (`session_id`/`sessionId`, incl. `_meta`) via `mcp_analytics_session_id` — rarely present. The `initialize` handshake negotiates only `clientInfo.name` (host name, already recorded as `client_name`), **not** a session/conversation id, and no session env var (`CLAUDE_SESSION_ID`, Codex rollout id, etc.) reaches the MCP server process. So no true session id exists at MCP time for the vast majority of calls.

**Honest alternative implemented:** mint a stable per-process `mcp_instance_id` (random hex via `getrandom`, once at server construction) and record it in every event's `metadata.mcp_instance_id` (threaded through `McpToolAnalyticsEvent` at both call sites — success path and `record_mcp_tool_error_analytics`). Events from one server lifetime can now be grouped. It is deliberately kept **out** of the `session_id` column so it never masquerades as a real session; the absence of true session ids is documented on the field. Change is purely additive to the metadata JSON — existing analytics/dashboard surfaces read the `session_id` column and specific metadata keys, so none assume a changed shape.

## Gates (CI-exact)
- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✅
- `cargo nextest run` mcp_suite + analytics/tool_analytics/freshness lib tests ✅ (49 passed incl. new bounded-settle + `mcp_tool_analytics_event_records_instance_id_when_session_absent`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)