### PR TITLE
docs: lock repo-local target dir, mandate /fast/cargo-target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,30 +3,26 @@
 ## Cargo
 
 - Do not commit an absolute `[build].target-dir`; hosted CI and published packages must use repo-local or runner-local paths.
-- On this machine, use the normal repo-local `target` directory; `/scratch` is no longer configured for Cargo targets.
-- Cargo-launched TraceDecay test data uses `target/test-profile/.tracedecay`.
-- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast`.
-- Do not set a shared `CARGO_TARGET_DIR`; use the repo-local default or a repo-specific temporary directory.
-- If you do need a custom `CARGO_TARGET_DIR` (isolated merge-verification builds, throwaway
-  worktrees, scratch experiments), it MUST live on the fast NVMe volume under the dedicated
-  targets folder: `/fast/cargo-target/<repo-or-worktree-name>` (e.g.
-  `/fast/cargo-target/tracedecay-merge-check`). Never place target dirs under `/tmp`, `$HOME`,
-  or anywhere on the root disk — those are on the slow volume and get wiped or fill up.
-  Repo checkouts under `/fast/projects/` already sit on the fast disk, so their repo-local
-  `target` needs no override. Toolchain caches (`sccache`, cargo registry) live under
+- **On this machine every Cargo invocation MUST set a custom target dir on the fast NVMe
+  volume: `CARGO_TARGET_DIR=/fast/cargo-target/<repo-or-worktree-name>` (e.g.
+  `/fast/cargo-target/tracedecay`, `/fast/cargo-target/tracedecay-merge-check`). The
+  repo-local `target/` directory is LOCKED — never build into it, never rely on it.**
+- Never place target dirs under `/tmp`, `$HOME`, or anywhere on the root disk — slow volume,
+  gets wiped or fills up. Toolchain caches (`sccache`, cargo registry) live under
   `/fast/cache/` and need no per-agent changes.
+- Cargo-launched TraceDecay test data uses `<CARGO_TARGET_DIR>/test-profile/.tracedecay`;
+  set `TRACEDECAY_DATA_DIR` alongside the target dir:
 
 ```sh
-CARGO_TARGET_DIR=/fast/cargo-target/tracedecay-<purpose> cargo check
+CARGO_TARGET_DIR=/fast/cargo-target/tracedecay-<checkout> \
+TRACEDECAY_DATA_DIR=/fast/cargo-target/tracedecay-<checkout>/test-profile/.tracedecay \
+cargo check
 ```
 
-- If local environment overrides point elsewhere, override both paths for that command:
-
-```sh
-CARGO_TARGET_DIR=target TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay cargo check
-```
-
-- CI should set an explicit per-job target dir, for example:
+- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast` — each with the env above.
+- One target dir per checkout/worktree (keyed by its directory name): concurrent agents in
+  different worktrees stay isolated while rebuilds inside one checkout stay warm.
+- CI is unchanged and keeps runner-local paths:
 
 ```sh
 CARGO_TARGET_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-cargo-target" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,22 +3,26 @@
 ## Cargo
 
 - Do not commit an absolute `[build].target-dir`; hosted CI and published packages must use repo-local or runner-local paths.
-- On this machine, use the normal repo-local `target` directory; `/scratch` is no longer configured for Cargo targets.
-- Cargo-launched TraceDecay processes use `target/test-profile/.tracedecay`.
-- Prefer plain Cargo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast`.
-- Do not override to a shared `CARGO_TARGET_DIR`; keep this repo isolated.
-- If a custom `CARGO_TARGET_DIR` is genuinely needed (isolated merge checks, throwaway
-  worktrees), it MUST live on the fast NVMe volume in the dedicated targets folder:
-  `/fast/cargo-target/<repo-or-worktree-name>` — never under `/tmp` or `$HOME` (slow root
-  disk). Checkouts under `/fast/projects/` are already on the fast disk, so repo-local
-  `target` needs no override; toolchain caches live under `/fast/cache/`.
-- If local environment overrides point elsewhere, run with explicit local overrides:
+- **On this machine every Cargo invocation MUST set a custom target dir on the fast NVMe
+  volume: `CARGO_TARGET_DIR=/fast/cargo-target/<repo-or-worktree-name>` (e.g.
+  `/fast/cargo-target/tracedecay`, `/fast/cargo-target/tracedecay-merge-check`). The
+  repo-local `target/` directory is LOCKED — never build into it, never rely on it.**
+- Never place target dirs under `/tmp`, `$HOME`, or anywhere on the root disk — slow volume,
+  gets wiped or fills up. Toolchain caches (`sccache`, cargo registry) live under
+  `/fast/cache/` and need no per-agent changes.
+- Cargo-launched TraceDecay test data uses `<CARGO_TARGET_DIR>/test-profile/.tracedecay`;
+  set `TRACEDECAY_DATA_DIR` alongside the target dir:
 
 ```sh
-CARGO_TARGET_DIR=target TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay cargo check
+CARGO_TARGET_DIR=/fast/cargo-target/tracedecay-<checkout> \
+TRACEDECAY_DATA_DIR=/fast/cargo-target/tracedecay-<checkout>/test-profile/.tracedecay \
+cargo check
 ```
 
-- In CI, set per-job paths explicitly:
+- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast` — each with the env above.
+- One target dir per checkout/worktree (keyed by its directory name): concurrent agents in
+  different worktrees stay isolated while rebuilds inside one checkout stay warm.
+- CI is unchanged and keeps runner-local paths:
 
 ```sh
 CARGO_TARGET_DIR="${RUNNER_TEMP:-/tmp}/tracedecay-cargo-target" \


### PR DESCRIPTION
Flips the machine-local Cargo policy per user directive: custom CARGO_TARGET_DIR under /fast/cargo-target/<checkout-name> is now mandatory for every invocation and the repo-local target/ is locked (never built into); per-checkout dirs keep concurrent agents isolated with warm rebuilds. CI guidance unchanged. AGENTS.md and CLAUDE.md kept identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)