### PR TITLE
docs: default to worktree target dir, fast-cache fallback on lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,25 +3,21 @@
 ## Cargo
 
 - Do not commit an absolute `[build].target-dir`; hosted CI and published packages must use repo-local or runner-local paths.
-- **On this machine every Cargo invocation MUST set a custom target dir on the fast NVMe
-  volume: `CARGO_TARGET_DIR=/fast/cargo-target/<repo-or-worktree-name>` (e.g.
-  `/fast/cargo-target/tracedecay`, `/fast/cargo-target/tracedecay-merge-check`). The
-  repo-local `target/` directory is LOCKED — never build into it, never rely on it.**
-- Never place target dirs under `/tmp`, `$HOME`, or anywhere on the root disk — slow volume,
-  gets wiped or fills up. Toolchain caches (`sccache`, cargo registry) live under
-  `/fast/cache/` and need no per-agent changes.
-- Cargo-launched TraceDecay test data uses `<CARGO_TARGET_DIR>/test-profile/.tracedecay`;
-  set `TRACEDECAY_DATA_DIR` alongside the target dir:
-
-```sh
-CARGO_TARGET_DIR=/fast/cargo-target/tracedecay-<checkout> \
-TRACEDECAY_DATA_DIR=/fast/cargo-target/tracedecay-<checkout>/test-profile/.tracedecay \
-cargo check
-```
-
-- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast` — each with the env above.
-- One target dir per checkout/worktree (keyed by its directory name): concurrent agents in
-  different worktrees stay isolated while rebuilds inside one checkout stay warm.
+- **Default: build into the checkout's own repo-local `target/` directory** (each worktree
+  has its own; checkouts under `/fast/projects/` are already on the fast disk, so this is
+  both isolated and fast). No `CARGO_TARGET_DIR` override needed in the normal case.
+- **If the repo-local target dir is locked/contended** (another process holds the cargo
+  build lock — "Blocking waiting for file lock on build directory" — or a concurrent agent
+  owns the checkout), fall back to a cache target dir on the fast volume:
+  `CARGO_TARGET_DIR=/fast/cargo-target/<repo-or-worktree-name>` (e.g.
+  `/fast/cargo-target/tracedecay-merge-check`). Never place target dirs under `/tmp`,
+  `$HOME`, or anywhere on the root disk.
+- Cargo-launched TraceDecay test data follows the active target dir:
+  repo-local default → `TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay`; fast-cache
+  fallback → `TRACEDECAY_DATA_DIR=<CARGO_TARGET_DIR>/test-profile/.tracedecay`.
+- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast`.
+- Toolchain caches (`sccache`, cargo registry) live under `/fast/cache/` and need no
+  per-agent changes.
 - CI is unchanged and keeps runner-local paths:
 
 ```sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,25 +3,21 @@
 ## Cargo
 
 - Do not commit an absolute `[build].target-dir`; hosted CI and published packages must use repo-local or runner-local paths.
-- **On this machine every Cargo invocation MUST set a custom target dir on the fast NVMe
-  volume: `CARGO_TARGET_DIR=/fast/cargo-target/<repo-or-worktree-name>` (e.g.
-  `/fast/cargo-target/tracedecay`, `/fast/cargo-target/tracedecay-merge-check`). The
-  repo-local `target/` directory is LOCKED — never build into it, never rely on it.**
-- Never place target dirs under `/tmp`, `$HOME`, or anywhere on the root disk — slow volume,
-  gets wiped or fills up. Toolchain caches (`sccache`, cargo registry) live under
-  `/fast/cache/` and need no per-agent changes.
-- Cargo-launched TraceDecay test data uses `<CARGO_TARGET_DIR>/test-profile/.tracedecay`;
-  set `TRACEDECAY_DATA_DIR` alongside the target dir:
-
-```sh
-CARGO_TARGET_DIR=/fast/cargo-target/tracedecay-<checkout> \
-TRACEDECAY_DATA_DIR=/fast/cargo-target/tracedecay-<checkout>/test-profile/.tracedecay \
-cargo check
-```
-
-- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast` — each with the env above.
-- One target dir per checkout/worktree (keyed by its directory name): concurrent agents in
-  different worktrees stay isolated while rebuilds inside one checkout stay warm.
+- **Default: build into the checkout's own repo-local `target/` directory** (each worktree
+  has its own; checkouts under `/fast/projects/` are already on the fast disk, so this is
+  both isolated and fast). No `CARGO_TARGET_DIR` override needed in the normal case.
+- **If the repo-local target dir is locked/contended** (another process holds the cargo
+  build lock — "Blocking waiting for file lock on build directory" — or a concurrent agent
+  owns the checkout), fall back to a cache target dir on the fast volume:
+  `CARGO_TARGET_DIR=/fast/cargo-target/<repo-or-worktree-name>` (e.g.
+  `/fast/cargo-target/tracedecay-merge-check`). Never place target dirs under `/tmp`,
+  `$HOME`, or anywhere on the root disk.
+- Cargo-launched TraceDecay test data follows the active target dir:
+  repo-local default → `TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay`; fast-cache
+  fallback → `TRACEDECAY_DATA_DIR=<CARGO_TARGET_DIR>/test-profile/.tracedecay`.
+- Run normal repo commands from the repo root: `cargo check`, `cargo test`, `cargo test-all`, `cargo nextest run --workspace --no-fail-fast`.
+- Toolchain caches (`sccache`, cargo registry) live under `/fast/cache/` and need no
+  per-agent changes.
 - CI is unchanged and keeps runner-local paths:
 
 ```sh


### PR DESCRIPTION
Third revision of the machine-local target-dir policy per user directive: worktree-local target/ is the default (isolated + already on fast disk), with /fast/cargo-target/<name> as the fallback only under build-lock contention. AGENTS.md and CLAUDE.md kept identical; CI guidance unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)