### PR TITLE
fix(skills): harden managed-skill materialization (adversarial review)

### DIFF
--- a/src/automation/managed_skill_model.rs
+++ b/src/automation/managed_skill_model.rs
@@ -141,6 +141,38 @@ pub enum ManagedSkillState {
     Archived,
 }
 
+/// Where an active managed skill is host-materialized as a real `SKILL.md`.
+///
+/// Defaults to [`Self::Global`]: a skill is written only into the user's global
+/// host dirs (`~/.claude`, `~/.codex`) and is never poured into every project
+/// checkout, so repos are not polluted with untracked `.claude/skills/**` files
+/// and hosts do not load duplicate copies. Skills whose evidence is genuinely
+/// project-local opt into [`Self::Project`] to also materialize into the
+/// enclosing project root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedSkillMaterializationScope {
+    #[default]
+    Global,
+    Project,
+}
+
+impl ManagedSkillMaterializationScope {
+    /// Whether this skill should also be materialized into project checkouts.
+    pub fn materializes_into_projects(self) -> bool {
+        matches!(self, Self::Project)
+    }
+
+    /// Whether this is the default (global-only) scope. Used to keep the
+    /// serialized record additive: the field is omitted for global skills, so
+    /// existing `skill.json` payloads are byte-for-byte unchanged.
+    // `serde(skip_serializing_if)` requires a `&self` predicate.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn is_global(&self) -> bool {
+        matches!(self, Self::Global)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManagedSkillProvenance {
     pub source: ManagedSkillSource,
@@ -190,6 +222,7 @@ impl ManagedSkillDraft {
                 category: self.category,
                 targets: self.targets,
                 state: ManagedSkillState::PendingApproval,
+                materialization_scope: ManagedSkillMaterializationScope::default(),
                 pinned: false,
                 checksum: String::new(),
                 created_at: now,
@@ -216,6 +249,14 @@ pub struct ManagedSkillMetadata {
     #[serde(default = "default_managed_skill_targets")]
     pub targets: Vec<SkillInstallTarget>,
     pub state: ManagedSkillState,
+    /// Host-materialization reach. Defaults to global-only so records written
+    /// before this field existed (and every automation-authored skill) never
+    /// spray materialized files into project checkouts.
+    #[serde(
+        default,
+        skip_serializing_if = "ManagedSkillMaterializationScope::is_global"
+    )]
+    pub materialization_scope: ManagedSkillMaterializationScope,
     pub pinned: bool,
     pub checksum: String,
     #[serde(default)]

--- a/src/automation/managed_skills.rs
+++ b/src/automation/managed_skills.rs
@@ -7,9 +7,9 @@ use crate::errors::{Result, TraceDecayError};
 use super::managed_skill_model::current_metadata_timestamp;
 pub use super::managed_skill_model::{
     MAX_MANAGED_SKILL_BODY_BYTES, MAX_MANAGED_SUPPORT_FILE_BYTES, MAX_MANAGED_SUPPORT_FILES,
-    ManagedSkill, ManagedSkillDraft, ManagedSkillMetadata, ManagedSkillPendingUpdate,
-    ManagedSkillProvenance, ManagedSkillSource, ManagedSkillState, ManagedSkillUpdate,
-    ManagedSupportFile, SkillInstallTarget, default_managed_skill_targets,
+    ManagedSkill, ManagedSkillDraft, ManagedSkillMaterializationScope, ManagedSkillMetadata,
+    ManagedSkillPendingUpdate, ManagedSkillProvenance, ManagedSkillSource, ManagedSkillState,
+    ManagedSkillUpdate, ManagedSupportFile, SkillInstallTarget, default_managed_skill_targets,
 };
 pub use super::managed_skill_validation::validate_managed_support_files;
 use super::managed_skill_validation::{

--- a/src/automation/skill_materialization.rs
+++ b/src/automation/skill_materialization.rs
@@ -719,8 +719,7 @@ fn read_materialization_manifest(dir: &Path, skill_id: &str) -> Result<ManifestS
 }
 
 fn hash_bytes(bytes: &[u8]) -> String {
-    use sha2::{Digest, Sha256};
-    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+    super::artifact_refs::sha256_bytes(bytes)
 }
 
 fn current_artifact_hash(path: &Path) -> Result<Option<String>> {
@@ -1055,21 +1054,27 @@ fn reconcile_owned_package(
     installation_id: &str,
     artifacts: &BTreeMap<String, Vec<u8>>,
 ) -> Result<MaterializeAction> {
+    // Hash every manifest-tracked file exactly once; the forked gate, the
+    // clean check, and the removal candidates below all read from this map
+    // instead of re-reading and re-hashing the same files per loop.
+    let mut states: BTreeMap<&String, ArtifactState> = BTreeMap::new();
+    for (relative, expected_hash) in &manifest.files {
+        states.insert(relative, artifact_state(dir, relative, expected_hash)?);
+    }
     for relative in artifacts.keys() {
-        if let Some(expected_hash) = manifest.files.get(relative) {
-            if artifact_state(dir, relative, expected_hash)? == ArtifactState::Forked {
-                return Ok(MaterializeAction::SkippedForked);
+        match states.get(relative) {
+            Some(ArtifactState::Forked) => return Ok(MaterializeAction::SkippedForked),
+            Some(_) => {}
+            None => {
+                if path_exists_without_following_links(&artifact_path(dir, relative)?)? {
+                    return Ok(MaterializeAction::SkippedForeign);
+                }
             }
-        } else if path_exists_without_following_links(&artifact_path(dir, relative)?)? {
-            return Ok(MaterializeAction::SkippedForeign);
         }
     }
 
     let exact_files = manifest.files.keys().eq(artifacts.keys());
-    let mut all_clean = true;
-    for (relative, expected_hash) in &manifest.files {
-        all_clean &= artifact_state(dir, relative, expected_hash)? == ArtifactState::Clean;
-    }
+    let all_clean = states.values().all(|state| *state == ArtifactState::Clean);
     if manifest.package_hash == package_hash
         && exact_files
         && all_clean
@@ -1080,8 +1085,7 @@ fn reconcile_owned_package(
 
     let mut remove_files = BTreeMap::new();
     for (relative, expected_hash) in &manifest.files {
-        if !artifacts.contains_key(relative)
-            && artifact_state(dir, relative, expected_hash)? == ArtifactState::Clean
+        if !artifacts.contains_key(relative) && states.get(relative) == Some(&ArtifactState::Clean)
         {
             remove_files.insert(relative.clone(), expected_hash.clone());
         }

--- a/src/automation/skill_materialization.rs
+++ b/src/automation/skill_materialization.rs
@@ -209,6 +209,9 @@ pub struct RemoveEntry {
 pub struct ReconcileReport {
     pub materialized: Vec<MaterializeEntry>,
     pub removed: Vec<RemoveEntry>,
+    /// Per-skill errors encountered while reconciling this scope. One failing
+    /// package never aborts materialization or orphan cleanup of the rest.
+    pub errors: Vec<String>,
 }
 
 impl ReconcileReport {
@@ -252,6 +255,14 @@ pub enum SkillDrift {
     /// A managed file exists for a skill that is no longer active; a reconcile
     /// would remove it.
     Orphan { skill_id: String, path: PathBuf },
+    /// A non-fatal problem: a per-skill check failed, or two active skill ids
+    /// collide on the same host slug. Reported so one bad package never hides
+    /// drift for the rest of the scope.
+    Warning {
+        skill_id: String,
+        path: PathBuf,
+        message: String,
+    },
 }
 
 impl SkillDrift {
@@ -261,6 +272,7 @@ impl SkillDrift {
             Self::Forked { .. } => "forked",
             Self::Conflict { .. } => "conflict",
             Self::Orphan { .. } => "orphan",
+            Self::Warning { .. } => "warning",
         }
     }
 
@@ -269,7 +281,8 @@ impl SkillDrift {
             Self::Missing { path, .. }
             | Self::Forked { path, .. }
             | Self::Conflict { path, .. }
-            | Self::Orphan { path, .. } => path,
+            | Self::Orphan { path, .. }
+            | Self::Warning { path, .. } => path,
         }
     }
 
@@ -278,7 +291,16 @@ impl SkillDrift {
             Self::Missing { skill_id, .. }
             | Self::Forked { skill_id, .. }
             | Self::Conflict { skill_id, .. }
-            | Self::Orphan { skill_id, .. } => skill_id,
+            | Self::Orphan { skill_id, .. }
+            | Self::Warning { skill_id, .. } => skill_id,
+        }
+    }
+
+    /// The human-readable detail for a [`Self::Warning`], if any.
+    pub fn message(&self) -> Option<&str> {
+        match self {
+            Self::Warning { message, .. } => Some(message.as_str()),
+            _ => None,
         }
     }
 }
@@ -301,6 +323,13 @@ struct MaterializationManifest {
     managed_by: String,
     skill_id: String,
     package_hash: String,
+    /// Stable id of the profile/installation that materialized this package.
+    /// Absent on manifests written before this field existed (and on packages
+    /// re-derived from disk without a known installation); such packages are
+    /// never auto-removed from a *project* scope — they may be another user's
+    /// committed files — but doctor still reports them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    materialized_by: Option<String>,
     files: BTreeMap<String, String>,
 }
 
@@ -338,16 +367,131 @@ impl FileProvenance {
         self.managed_by.as_deref() == Some(MATERIALIZED_SKILL_MANAGED_BY)
     }
 
-    /// A managed file is forked when the body on disk no longer hashes to the
-    /// `content-hash` we recorded when we wrote it.
+    /// Legacy (pre-package-hash, PR #362) fork check: the recorded
+    /// `content-hash` was the body-only hash, so a file is a fork when the body
+    /// on disk no longer hashes to it. Only meaningful for the body-hash domain;
+    /// callers first try [`recompute_on_disk_package`] for the package-hash
+    /// domain (PR #366+). A managed file missing a content-hash is treated as
+    /// forked so we never silently overwrite something we cannot verify.
     fn is_legacy_forked(&self) -> bool {
         match (&self.content_hash, &self.body_hash) {
             (Some(recorded), Some(actual)) => recorded != actual,
-            // A managed file missing a content-hash is treated as forked so we
-            // never silently overwrite something we cannot verify we authored.
             _ => true,
         }
     }
+}
+
+/// Reserved package-support paths that are never user support files.
+fn is_reserved_support_path(relative: &Path) -> bool {
+    use std::path::Component;
+    relative.components().any(|component| match component {
+        Component::Normal(part) => {
+            let part = part.to_string_lossy();
+            part == SKILL_FILE
+                || part == MATERIALIZATION_MANIFEST_FILE
+                || part == MATERIALIZATION_PENDING_FILE
+                || part.ends_with(".new")
+        }
+        _ => true,
+    })
+}
+
+/// Collects the on-disk support files of a materialized package (every regular
+/// file under `dir` except `SKILL.md`, the manifest/pending sidecars, and
+/// `*.new` staging), returned sorted by relative path to mirror the ordering
+/// [`ManagedSkill::materialized_package_hash`] hashes support files in.
+fn collect_on_disk_support_files(dir: &Path) -> Result<Vec<(PathBuf, Vec<u8>)>> {
+    fn walk(base: &Path, dir: &Path, out: &mut Vec<(PathBuf, Vec<u8>)>) -> Result<()> {
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                // Never follow symlinks when recomputing a package from disk.
+                continue;
+            }
+            if file_type.is_dir() {
+                walk(base, &path, out)?;
+                continue;
+            }
+            let Ok(relative) = path.strip_prefix(base) else {
+                continue;
+            };
+            if is_reserved_support_path(relative) || safe_support_relative(relative).is_err() {
+                continue;
+            }
+            out.push((relative.to_path_buf(), fs::read(&path)?));
+        }
+        Ok(())
+    }
+    let mut out = Vec::new();
+    walk(dir, dir, &mut out)?;
+    out.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(out)
+}
+
+/// Recomputes the package hash of a manifest-less managed package directly from
+/// disk (PR #366+ package-hash domain). Reconstructs the render placeholder by
+/// swapping the recorded `content-hash` back to `<package-hash>`, folds in the
+/// on-disk support files exactly as [`ManagedSkill::materialized_package_hash`]
+/// does, and — when the result matches the recorded hash — returns a re-derived
+/// manifest proving the package is pristine (safe to treat as owned). Returns
+/// `Ok(None)` when the file is missing, has no content-hash, or has drifted.
+fn recompute_on_disk_package(
+    dir: &Path,
+    provenance: &FileProvenance,
+) -> Result<Option<MaterializationManifest>> {
+    use sha2::{Digest, Sha256};
+
+    let Some(recorded) = provenance.content_hash.as_deref() else {
+        return Ok(None);
+    };
+    let skill_md_path = artifact_path(dir, SKILL_FILE)?;
+    let skill_bytes = match fs::read(&skill_md_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let Ok(contents) = std::str::from_utf8(&skill_bytes) else {
+        return Ok(None);
+    };
+    let needle = format!("content-hash: {recorded}\n");
+    if contents.matches(&needle).count() != 1 {
+        return Ok(None);
+    }
+    let reconstructed = contents.replacen(&needle, "content-hash: <package-hash>\n", 1);
+
+    let supports = collect_on_disk_support_files(dir)?;
+    let mut hasher = Sha256::new();
+    hasher.update(reconstructed.as_bytes());
+    let mut files = BTreeMap::new();
+    files.insert(SKILL_FILE.to_string(), hash_bytes(&skill_bytes));
+    for (relative, bytes) in &supports {
+        let key = support_relative_key(relative)?;
+        hasher.update(b"\0file:");
+        hasher.update(relative.to_string_lossy().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(bytes);
+        files.insert(key, hash_bytes(bytes));
+    }
+    let recomputed = format!("sha256:{}", hex::encode(hasher.finalize()));
+    if recomputed != recorded {
+        return Ok(None);
+    }
+    Ok(Some(MaterializationManifest {
+        managed_by: MATERIALIZED_SKILL_MANAGED_BY.to_string(),
+        skill_id: provenance.skill_id.clone().unwrap_or_default(),
+        package_hash: recorded.to_string(),
+        // Unknown authoring installation: a re-derived manifest is never used to
+        // authorize cross-profile removal in project scopes.
+        materialized_by: None,
+        files,
+    }))
 }
 
 fn frontmatter_scalar<'a>(
@@ -374,6 +518,44 @@ fn hash_body(body: &str) -> String {
     format!("sha256:{}", hex::encode(Sha256::digest(body.as_bytes())))
 }
 
+const INSTALLATION_ID_FILE: &str = ".materialization-installation-id";
+
+/// Returns a stable id for the local profile/installation, persisting a random
+/// token in the profile root on first use. Stamped into every manifest this
+/// installation writes so orphan cleanup in *project* scopes only removes files
+/// this installation authored — never another user's committed materialization.
+///
+/// Best-effort: if the token cannot be read or written (read-only profile), a
+/// per-process fallback is returned. A fallback id never matches a persisted
+/// manifest id, so cleanup stays conservative (reports, does not delete).
+pub fn installation_id(profile_root: &Path) -> String {
+    let path = profile_root.join(INSTALLATION_ID_FILE);
+    if let Ok(existing) = fs::read_to_string(&path) {
+        let trimmed = existing.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    let mut token = [0u8; 16];
+    let generated = match getrandom::getrandom(&mut token) {
+        Ok(()) => hex::encode(token),
+        Err(_) => format!(
+            "pid-{}-{}",
+            std::process::id(),
+            crate::tracedecay::current_timestamp()
+        ),
+    };
+    if fs::create_dir_all(profile_root).is_ok() {
+        // Ignore races/read-only failures: a transient id is still safe.
+        let _ = fs::write(&path, format!("{generated}\n"));
+    }
+    // Re-read so a concurrent creator's token wins deterministically.
+    match fs::read_to_string(&path) {
+        Ok(existing) if !existing.trim().is_empty() => existing.trim().to_string(),
+        _ => generated,
+    }
+}
+
 fn read_file_provenance(path: &Path) -> Result<Option<FileProvenance>> {
     let contents = match fs::read_to_string(path) {
         Ok(contents) => contents,
@@ -396,6 +578,41 @@ fn read_file_provenance(path: &Path) -> Result<Option<FileProvenance>> {
         content_hash,
         body_hash,
     }))
+}
+
+/// Inter-process lock held for the duration of a single package's
+/// materialize/remove transaction. Serializes concurrent `tracedecay update` /
+/// `skills approve` / background auto-enable runs (and multiple worktrees
+/// sharing a global scope) so the TOCTOU pending-file window cannot interleave
+/// two transactions and wedge a package as forked. The lock file lives outside
+/// the tracked skills tree (OS temp dir, keyed by the package path) so it never
+/// pollutes a repo; flock semantics only need to hold within one machine, which
+/// is exactly where the race occurs.
+struct PackageLock(fs::File);
+
+impl Drop for PackageLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+fn package_lock_path(package_dir: &Path) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    let key = hex::encode(Sha256::digest(package_dir.to_string_lossy().as_bytes()));
+    std::env::temp_dir().join(format!("tracedecay-materialization-{key}.lock"))
+}
+
+fn lock_package(package_dir: &Path) -> Result<PackageLock> {
+    use fs2::FileExt;
+    let path = package_lock_path(package_dir);
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    crate::storage::retry_transient_file_op(|| file.lock_exclusive())?;
+    Ok(PackageLock(file))
 }
 
 fn relative_artifact_path(relative: &str) -> Result<&Path> {
@@ -424,12 +641,15 @@ fn ensure_not_symlink(path: &Path) -> Result<()> {
     }
 }
 
+/// Rejects a symlink at any component the reconciler itself creates — i.e. only
+/// the `relative` components under `base`. `base` (the host skills directory and
+/// everything above it) may legitimately traverse symlinks: dotfile managers
+/// (stow, chezmoi, nix-home-manager) routinely symlink `~/.claude`, `.codex`, or
+/// even `/home` itself, and those are normal setups, not private-store roots.
+/// We follow them (operate on the resolved target) and guard only the final
+/// slug/support components we write into.
 fn ensure_no_symlink_components(base: &Path, relative: &Path) -> Result<()> {
-    let mut current = PathBuf::new();
-    for component in base.components() {
-        current.push(component.as_os_str());
-        ensure_not_symlink(&current)?;
-    }
+    let mut current = base.to_path_buf();
     for component in relative.components() {
         current.push(component.as_os_str());
         ensure_not_symlink(&current)?;
@@ -448,9 +668,12 @@ fn artifact_path(dir: &Path, relative: &str) -> Result<PathBuf> {
 }
 
 fn ensure_scope_package_path_safe(scope: &MaterializationScope, slug: &str) -> Result<()> {
-    let relative = Path::new(scope.host.skills_subdir()).join(slug);
-    safe_support_relative(&relative)?;
-    ensure_no_symlink_components(&scope.base_dir, &relative)
+    // The host skills dir (`<base>/.claude/skills`) is trusted and may traverse
+    // symlinks (dotfile managers); only the slug package directory we create
+    // must be a real directory, not a symlink escaping the skills tree.
+    let relative = Path::new(slug);
+    safe_support_relative(relative)?;
+    ensure_no_symlink_components(&scope.skills_dir(), relative)
 }
 
 fn support_relative_key(path: &Path) -> Result<String> {
@@ -583,12 +806,14 @@ fn write_artifacts(dir: &Path, artifacts: &BTreeMap<String, Vec<u8>>) -> Result<
 fn build_materialization_manifest(
     skill: &ManagedSkill,
     package_hash: String,
+    installation_id: &str,
     artifacts: &BTreeMap<String, Vec<u8>>,
 ) -> MaterializationManifest {
     MaterializationManifest {
         managed_by: MATERIALIZED_SKILL_MANAGED_BY.to_string(),
         skill_id: skill.metadata.id.clone(),
         package_hash,
+        materialized_by: Some(installation_id.to_string()),
         files: artifacts
             .iter()
             .map(|(relative, bytes)| (relative.clone(), hash_bytes(bytes)))
@@ -779,11 +1004,13 @@ fn commit_materialization_transaction(
     dir: &Path,
     skill: &ManagedSkill,
     package_hash: String,
+    installation_id: &str,
     artifacts: &BTreeMap<String, Vec<u8>>,
     previous_files: BTreeMap<String, String>,
     remove_files: BTreeMap<String, String>,
 ) -> Result<MaterializeAction> {
-    let next_manifest = build_materialization_manifest(skill, package_hash, artifacts);
+    let next_manifest =
+        build_materialization_manifest(skill, package_hash, installation_id, artifacts);
     validate_transaction_paths(dir, &next_manifest, &remove_files)?;
     if !matches!(
         read_pending_materialization(dir, Some(&skill.metadata.id))?,
@@ -825,6 +1052,7 @@ fn reconcile_owned_package(
     skill: &ManagedSkill,
     manifest: &MaterializationManifest,
     package_hash: String,
+    installation_id: &str,
     artifacts: &BTreeMap<String, Vec<u8>>,
 ) -> Result<MaterializeAction> {
     for relative in artifacts.keys() {
@@ -842,7 +1070,11 @@ fn reconcile_owned_package(
     for (relative, expected_hash) in &manifest.files {
         all_clean &= artifact_state(dir, relative, expected_hash)? == ArtifactState::Clean;
     }
-    if manifest.package_hash == package_hash && exact_files && all_clean {
+    if manifest.package_hash == package_hash
+        && exact_files
+        && all_clean
+        && manifest.materialized_by.as_deref() == Some(installation_id)
+    {
         return Ok(MaterializeAction::Unchanged);
     }
 
@@ -858,6 +1090,7 @@ fn reconcile_owned_package(
         dir,
         skill,
         package_hash,
+        installation_id,
         artifacts,
         manifest.files.clone(),
         remove_files,
@@ -902,7 +1135,16 @@ fn materialized_package_is_forked(
     provenance: &FileProvenance,
 ) -> Result<bool> {
     match read_materialization_manifest(dir, skill_id)? {
-        ManifestState::Missing => Ok(provenance.is_legacy_forked()),
+        ManifestState::Missing => {
+            // A lost manifest does not mean a fork: the package may still be
+            // pristine in the package-hash domain (#366+) or the legacy
+            // body-hash domain (#362). Only a genuine content drift is a fork.
+            if recompute_on_disk_package(dir, provenance)?.is_some() {
+                Ok(false)
+            } else {
+                Ok(provenance.is_legacy_forked())
+            }
+        }
         ManifestState::Foreign => Ok(true),
         ManifestState::Owned(manifest) => {
             for (relative, expected_hash) in &manifest.files {
@@ -925,13 +1167,29 @@ fn materialized_package_is_forked(
 pub fn materialize_skill(
     scope: &MaterializationScope,
     skill: &ManagedSkill,
+    installation_id: &str,
 ) -> Result<MaterializeEntry> {
     let slug = skill.host_skill_slug();
-    ensure_scope_package_path_safe(scope, &slug)?;
-    let dir = scope.skill_dir(&slug);
+    materialize_skill_into(scope, skill, &slug, installation_id)
+}
+
+/// Materializes one skill into an explicit host slug. `reconcile_scope` passes a
+/// collision-disambiguated slug here; the public entry point uses the skill's
+/// own base slug.
+fn materialize_skill_into(
+    scope: &MaterializationScope,
+    skill: &ManagedSkill,
+    slug: &str,
+    installation_id: &str,
+) -> Result<MaterializeEntry> {
+    ensure_scope_package_path_safe(scope, slug)?;
+    let dir = scope.skill_dir(slug);
     let path = artifact_path(&dir, SKILL_FILE)?;
     let package_hash = skill.materialized_package_hash()?;
     let artifacts = desired_artifacts(skill)?;
+    // Hold the per-package lock across the whole read-decide-commit window so a
+    // concurrent transaction cannot interleave (see [`PackageLock`]).
+    let _lock = lock_package(&dir)?;
     if let Some(action @ (MaterializeAction::SkippedForeign | MaterializeAction::SkippedForked)) =
         recover_pending_materialization(&dir, Some(&skill.metadata.id))?
     {
@@ -950,24 +1208,60 @@ pub fn materialize_skill(
         (_, ManifestState::Foreign) => MaterializeAction::SkippedForeign,
         (_, ManifestState::Owned(manifest)) => {
             fs::create_dir_all(&dir)?;
-            reconcile_owned_package(&dir, skill, &manifest, package_hash, &artifacts)?
+            reconcile_owned_package(
+                &dir,
+                skill,
+                &manifest,
+                package_hash,
+                installation_id,
+                &artifacts,
+            )?
         }
-        (Some(existing), ManifestState::Missing) if existing.is_legacy_forked() => {
-            MaterializeAction::SkippedForked
-        }
-        (Some(_), ManifestState::Missing) if legacy_support_files_are_forked(&dir, &artifacts)? => {
-            MaterializeAction::SkippedForked
+        (Some(existing), ManifestState::Missing) => {
+            // Manifest lost (e.g. gitignored/uncommitted sidecar on a fresh
+            // clone) but a managed file is on disk. Re-derive from disk: a
+            // pristine package-hash (#366+) package is treated as owned and
+            // reconciled (re-writing the manifest); otherwise fall back to the
+            // legacy body-hash (#362) domain before declaring a user fork.
+            if let Some(rederived) = recompute_on_disk_package(&dir, existing)? {
+                fs::create_dir_all(&dir)?;
+                reconcile_owned_package(
+                    &dir,
+                    skill,
+                    &rederived,
+                    package_hash,
+                    installation_id,
+                    &artifacts,
+                )?
+            } else if existing.is_legacy_forked()
+                || legacy_support_files_are_forked(&dir, &artifacts)?
+            {
+                MaterializeAction::SkippedForked
+            } else {
+                fs::create_dir_all(&dir)?;
+                let previous_files = current_artifact_hashes(&dir, &artifacts)?;
+                commit_materialization_transaction(
+                    &dir,
+                    skill,
+                    package_hash,
+                    installation_id,
+                    &artifacts,
+                    previous_files,
+                    BTreeMap::new(),
+                )?
+            }
         }
         (None, ManifestState::Missing) if initial_support_conflict => {
             MaterializeAction::SkippedForeign
         }
-        _ => {
+        (None, ManifestState::Missing) => {
             fs::create_dir_all(&dir)?;
             let previous_files = current_artifact_hashes(&dir, &artifacts)?;
             commit_materialization_transaction(
                 &dir,
                 skill,
                 package_hash,
+                installation_id,
                 &artifacts,
                 previous_files,
                 BTreeMap::new(),
@@ -1004,13 +1298,38 @@ fn safe_support_relative(path: &Path) -> Result<&Path> {
     Ok(path)
 }
 
+/// Whether this installation may auto-remove an owned package. Global (home)
+/// packages are the local user's own and are always removable. Project-scope
+/// packages live inside a repo working tree and are routinely committed and
+/// shared, so they are removed only when this installation authored them —
+/// never another developer's committed materialization (or a manifest-less
+/// package whose author is unknown).
+fn may_remove_owned(
+    scope: &MaterializationScope,
+    manifest: &MaterializationManifest,
+    installation_id: &str,
+) -> bool {
+    match scope.kind {
+        MaterializationScopeKind::Global => true,
+        MaterializationScopeKind::Project => {
+            manifest.materialized_by.as_deref() == Some(installation_id)
+        }
+    }
+}
+
 /// Removes one materialized skill by slug from one scope. Fork-protected: a
 /// user-edited managed file is preserved (and later surfaces as a doctor
-/// `Forked` finding); a foreign file is never touched.
-pub fn remove_materialized_skill(scope: &MaterializationScope, slug: &str) -> Result<RemoveAction> {
+/// `Forked` finding); a foreign file is never touched; a committed project-scope
+/// package authored by a different installation is left in place.
+pub fn remove_materialized_skill(
+    scope: &MaterializationScope,
+    slug: &str,
+    installation_id: &str,
+) -> Result<RemoveAction> {
     ensure_scope_package_path_safe(scope, slug)?;
     let dir = scope.skill_dir(slug);
     let path = artifact_path(&dir, SKILL_FILE)?;
+    let _lock = lock_package(&dir)?;
     if let Some(action) = recover_pending_materialization(&dir, None)? {
         match action {
             MaterializeAction::SkippedForeign => return Ok(RemoveAction::SkippedForeign),
@@ -1018,45 +1337,65 @@ pub fn remove_materialized_skill(scope: &MaterializationScope, slug: &str) -> Re
             MaterializeAction::Written | MaterializeAction::Unchanged => {}
         }
     }
-    let action = match read_file_provenance(&path)? {
-        None => RemoveAction::Absent,
-        Some(existing) if !existing.is_managed() => RemoveAction::SkippedForeign,
-        Some(existing) => {
-            match read_materialization_manifest(&dir, existing.skill_id.as_deref().unwrap_or(slug))?
-            {
-                ManifestState::Foreign => RemoveAction::SkippedForked,
-                ManifestState::Missing if existing.is_legacy_forked() => {
-                    RemoveAction::SkippedForked
-                }
-                ManifestState::Missing => {
-                    fs::remove_file(&path)?;
-                    prune_skill_dir(scope, slug);
-                    RemoveAction::Removed
-                }
-                ManifestState::Owned(manifest) => {
-                    let mut forked = false;
-                    for (relative, expected_hash) in &manifest.files {
-                        forked |=
-                            artifact_state(&dir, relative, expected_hash)? == ArtifactState::Forked;
+    let existing = match read_file_provenance(&path)? {
+        None => return Ok(RemoveAction::Absent),
+        Some(existing) if !existing.is_managed() => return Ok(RemoveAction::SkippedForeign),
+        Some(existing) => existing,
+    };
+    let manifest =
+        match read_materialization_manifest(&dir, existing.skill_id.as_deref().unwrap_or(slug))? {
+            ManifestState::Foreign => return Ok(RemoveAction::SkippedForked),
+            ManifestState::Owned(manifest) => manifest,
+            ManifestState::Missing => {
+                if let Some(rederived) = recompute_on_disk_package(&dir, &existing)? {
+                    // Pristine package-hash (#366+) package with a lost manifest.
+                    rederived
+                } else if existing.is_legacy_forked() {
+                    return Ok(RemoveAction::SkippedForked);
+                } else {
+                    // Pristine legacy (#362) single-file package: synthesize a
+                    // manifest so the profile gate and owned-removal path apply.
+                    let mut files = BTreeMap::new();
+                    if let Some(hash) = current_artifact_hash(&path)? {
+                        files.insert(SKILL_FILE.to_string(), hash);
                     }
-                    if forked {
-                        RemoveAction::SkippedForked
-                    } else {
-                        for (relative, expected_hash) in &manifest.files {
-                            remove_clean_artifact(&dir, relative, expected_hash)?;
-                        }
-                        fs::remove_file(checked_descendant_path(
-                            &dir,
-                            Path::new(MATERIALIZATION_MANIFEST_FILE),
-                        )?)?;
-                        prune_skill_dir(scope, slug);
-                        RemoveAction::Removed
+                    MaterializationManifest {
+                        managed_by: MATERIALIZED_SKILL_MANAGED_BY.to_string(),
+                        skill_id: existing
+                            .skill_id
+                            .clone()
+                            .unwrap_or_else(|| slug.to_string()),
+                        package_hash: existing.content_hash.clone().unwrap_or_default(),
+                        materialized_by: None,
+                        files,
                     }
                 }
             }
-        }
-    };
-    Ok(action)
+        };
+
+    if !may_remove_owned(scope, &manifest, installation_id) {
+        return Ok(RemoveAction::SkippedForeign);
+    }
+
+    let mut forked = false;
+    for (relative, expected_hash) in &manifest.files {
+        forked |= artifact_state(&dir, relative, expected_hash)? == ArtifactState::Forked;
+    }
+    if forked {
+        return Ok(RemoveAction::SkippedForked);
+    }
+    for (relative, expected_hash) in &manifest.files {
+        remove_clean_artifact(&dir, relative, expected_hash)?;
+    }
+    // A re-derived/synthesized manifest may have no sidecar on disk.
+    let manifest_path = checked_descendant_path(&dir, Path::new(MATERIALIZATION_MANIFEST_FILE))?;
+    match fs::remove_file(&manifest_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
+    prune_skill_dir(scope, slug);
+    Ok(RemoveAction::Removed)
 }
 
 /// Removes the (now empty) skill package directory. Best effort: leftover
@@ -1070,85 +1409,166 @@ fn prune_skill_dir(scope: &MaterializationScope, slug: &str) {
 // Scope reconcile + doctor
 // ---------------------------------------------------------------------------
 
+/// Short, stable disambiguator derived from a full skill id, used to suffix a
+/// host slug when two distinct ids collide on the same base slug.
+fn short_id_hash(skill_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(skill_id.as_bytes()))[..8].to_string()
+}
+
+/// Assigns a host slug to every active skill, disambiguating collisions.
+///
+/// Distinct managed-skill ids can normalize to the same host slug (`db_sync`
+/// vs `db-sync`, ids differing only by a stripped character, or two ids sharing
+/// a truncated prefix). Without disambiguation the second skill's package would
+/// be seen as `Foreign` and silently never load. Every skill whose base slug is
+/// shared by another active skill is suffixed with a short stable hash of its
+/// id; non-colliding skills keep their base slug. Returns `(slug, collided)`
+/// parallel to `active_skills`.
+fn assign_host_slugs(active_skills: &[ManagedSkill]) -> Vec<(String, bool)> {
+    let base: Vec<String> = active_skills
+        .iter()
+        .map(ManagedSkill::host_skill_slug)
+        .collect();
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for slug in &base {
+        *counts.entry(slug.as_str()).or_default() += 1;
+    }
+    active_skills
+        .iter()
+        .zip(base.iter())
+        .map(|(skill, slug)| {
+            if counts.get(slug.as_str()).copied().unwrap_or(0) > 1 {
+                (
+                    format!("{slug}-{}", short_id_hash(&skill.metadata.id)),
+                    true,
+                )
+            } else {
+                (slug.clone(), false)
+            }
+        })
+        .collect()
+}
+
 /// Reconciles one scope against the active managed-skill set: materializes
 /// every active skill and removes managed files whose skill is no longer
-/// active. Fork- and foreign-safe throughout.
+/// active. Fork- and foreign-safe throughout. A single failing package is
+/// recorded in `report.errors` and never aborts the rest of the sweep.
 pub fn reconcile_scope(
     scope: &MaterializationScope,
     active_skills: &[ManagedSkill],
+    installation_id: &str,
 ) -> Result<ReconcileReport> {
     let mut report = ReconcileReport::default();
     let mut active_slugs = std::collections::BTreeSet::new();
 
-    for skill in active_skills {
-        active_slugs.insert(skill.host_skill_slug());
-        report.materialized.push(materialize_skill(scope, skill)?);
+    let slugs = assign_host_slugs(active_skills);
+    for (skill, (slug, _collided)) in active_skills.iter().zip(slugs.iter()) {
+        active_slugs.insert(slug.clone());
+        match materialize_skill_into(scope, skill, slug, installation_id) {
+            Ok(entry) => report.materialized.push(entry),
+            Err(err) => report
+                .errors
+                .push(format!("materialize '{}': {err}", skill.metadata.id)),
+        }
     }
 
     for (slug, skill_id) in managed_slugs_in_scope(scope)? {
         if active_slugs.contains(&slug) {
             continue;
         }
-        let action = remove_materialized_skill(scope, &slug)?;
-        report.removed.push(RemoveEntry {
-            skill_id,
-            path: scope.skill_md(&slug),
-            action,
-        });
+        match remove_materialized_skill(scope, &slug, installation_id) {
+            Ok(action) => report.removed.push(RemoveEntry {
+                skill_id,
+                path: scope.skill_md(&slug),
+                action,
+            }),
+            Err(err) => report.errors.push(format!("remove '{skill_id}': {err}")),
+        }
     }
 
     Ok(report)
 }
 
 /// Reports drift between the active managed-skill set and one scope's
-/// materialized files: missing, forked, conflicting, or orphaned files.
+/// materialized files: missing, forked, conflicting, or orphaned files. Never
+/// aborts on a single bad package — a per-skill failure is surfaced as a
+/// [`SkillDrift::Warning`] so the rest of the scope's drift is still reported.
 pub fn doctor_scope(
     scope: &MaterializationScope,
     active_skills: &[ManagedSkill],
-) -> Result<Vec<SkillDrift>> {
+) -> Vec<SkillDrift> {
     let mut drift = Vec::new();
     let mut active_slugs = std::collections::BTreeSet::new();
 
-    for skill in active_skills {
-        let slug = skill.host_skill_slug();
+    let slugs = assign_host_slugs(active_skills);
+    for (skill, (slug, collided)) in active_skills.iter().zip(slugs.iter()) {
         active_slugs.insert(slug.clone());
-        let path = scope.skill_md(&slug);
-        match read_file_provenance(&path)? {
-            None => drift.push(SkillDrift::Missing {
+        let path = scope.skill_md(slug);
+        if *collided {
+            drift.push(SkillDrift::Warning {
+                skill_id: skill.metadata.id.clone(),
+                path: path.clone(),
+                message: format!(
+                    "host slug collides with another active skill; materialized as '{slug}'"
+                ),
+            });
+        }
+        match read_file_provenance(&path) {
+            Ok(None) => drift.push(SkillDrift::Missing {
                 skill_id: skill.metadata.id.clone(),
                 path,
             }),
-            Some(existing) if !existing.is_managed() => drift.push(SkillDrift::Conflict {
+            Ok(Some(existing)) if !existing.is_managed() => drift.push(SkillDrift::Conflict {
                 skill_id: skill.metadata.id.clone(),
                 path,
             }),
-            Some(existing)
-                if materialized_package_is_forked(
-                    &scope.skill_dir(&slug),
+            Ok(Some(existing)) => {
+                match materialized_package_is_forked(
+                    &scope.skill_dir(slug),
                     &skill.metadata.id,
                     &existing,
-                )? =>
-            {
-                drift.push(SkillDrift::Forked {
-                    skill_id: skill.metadata.id.clone(),
-                    path,
+                ) {
+                    Ok(true) => drift.push(SkillDrift::Forked {
+                        skill_id: skill.metadata.id.clone(),
+                        path,
+                    }),
+                    Ok(false) => {}
+                    Err(err) => drift.push(SkillDrift::Warning {
+                        skill_id: skill.metadata.id.clone(),
+                        path,
+                        message: format!("materialization check failed: {err}"),
+                    }),
+                }
+            }
+            Err(err) => drift.push(SkillDrift::Warning {
+                skill_id: skill.metadata.id.clone(),
+                path,
+                message: format!("materialization check failed: {err}"),
+            }),
+        }
+    }
+
+    match managed_slugs_in_scope(scope) {
+        Ok(slugs) => {
+            for (slug, skill_id) in slugs {
+                if active_slugs.contains(&slug) {
+                    continue;
+                }
+                drift.push(SkillDrift::Orphan {
+                    skill_id,
+                    path: scope.skill_md(&slug),
                 });
             }
-            Some(_) => {}
         }
+        Err(err) => drift.push(SkillDrift::Warning {
+            skill_id: String::new(),
+            path: scope.skills_dir(),
+            message: format!("could not enumerate materialized skills: {err}"),
+        }),
     }
 
-    for (slug, skill_id) in managed_slugs_in_scope(scope)? {
-        if active_slugs.contains(&slug) {
-            continue;
-        }
-        drift.push(SkillDrift::Orphan {
-            skill_id,
-            path: scope.skill_md(&slug),
-        });
-    }
-
-    Ok(drift)
+    drift
 }
 
 /// Lists `(slug, skill_id)` for every `TraceDecay`-managed `SKILL.md` currently
@@ -1210,6 +1630,27 @@ fn skills_for_host(skills: &[ManagedSkill], host: MaterializationHost) -> Vec<Ma
         .collect()
 }
 
+/// Skills that should materialize into a given scope. Every active host skill
+/// materializes into the user's global scope; only skills explicitly marked
+/// project-scoped also materialize into project checkouts, so a single approval
+/// never pours untracked `.claude/skills/**` files into every repo the user
+/// runs from (and hosts never load duplicate global+project copies).
+fn skills_for_scope(skills: &[ManagedSkill], scope: &MaterializationScope) -> Vec<ManagedSkill> {
+    let host_skills = skills_for_host(skills, scope.host);
+    match scope.kind {
+        MaterializationScopeKind::Global => host_skills,
+        MaterializationScopeKind::Project => host_skills
+            .into_iter()
+            .filter(|skill| {
+                skill
+                    .metadata
+                    .materialization_scope
+                    .materializes_into_projects()
+            })
+            .collect(),
+    }
+}
+
 /// Detects the materialization scopes that actually exist for `home` (global)
 /// and `project_root` (project): a scope is eligible when its host config
 /// directory (`.claude` / `.codex`) is present, so we never create a host
@@ -1252,14 +1693,32 @@ pub fn reconcile_detected_scopes(
             return (results, errors);
         }
     };
+    let installation = installation_id(profile_root);
     for scope in detect_scopes(home, project_root) {
-        let host_skills = skills_for_host(&skills, scope.host);
-        match reconcile_scope(&scope, &host_skills) {
-            Ok(report) => results.push(ScopeReconcileResult { scope, report }),
+        let scope_skills = skills_for_scope(&skills, &scope);
+        match reconcile_scope(&scope, &scope_skills, &installation) {
+            Ok(report) => {
+                for error in &report.errors {
+                    errors.push(format!("{}: {error}", scope.describe()));
+                }
+                results.push(ScopeReconcileResult { scope, report });
+            }
             Err(err) => errors.push(format!("{}: {err}", scope.describe())),
         }
     }
     (results, errors)
+}
+
+/// Resolves the enclosing project root for materialization from a starting
+/// directory (usually the process cwd), so running from a subdirectory
+/// materializes into the repo root rather than the subdir — and so drift is
+/// reported and cleaned up against a single stable root regardless of where the
+/// command is run. Prefers the tracedecay-registered project root, then the git
+/// worktree/repo checkout root, then falls back to the starting directory.
+pub fn resolve_project_root(start: &Path) -> PathBuf {
+    crate::config::discover_project_root(start)
+        .or_else(|| crate::worktree::git_worktree_root(start))
+        .unwrap_or_else(|| start.to_path_buf())
 }
 
 /// Non-fatal reconcile for lifecycle call sites (approve, auto-enable, install,
@@ -1285,8 +1744,9 @@ pub fn doctor_detected_scopes(
     let skills = load_active_managed_skills(profile_root)?;
     let mut out = Vec::new();
     for scope in detect_scopes(home, project_root) {
-        let host_skills = skills_for_host(&skills, scope.host);
-        out.push((scope.clone(), doctor_scope(&scope, &host_skills)?));
+        let scope_skills = skills_for_scope(&skills, &scope);
+        let drift = doctor_scope(&scope, &scope_skills);
+        out.push((scope.clone(), drift));
     }
     Ok(out)
 }

--- a/src/automation/skill_writer.rs
+++ b/src/automation/skill_writer.rs
@@ -387,7 +387,8 @@ fn refresh_managed_skill_exports_after_auto_enable(profile_root: &Path) {
     let Some(home) = crate::agents::home_dir() else {
         return;
     };
-    let project_root = std::env::current_dir().unwrap_or_else(|_| home.clone());
+    let start = std::env::current_dir().unwrap_or_else(|_| home.clone());
+    let project_root = crate::automation::skill_materialization::resolve_project_root(&start);
     for report in
         crate::agents::export_managed_skills_to_agent_hosts(&home, &project_root, profile_root)
     {

--- a/src/automation/staged_notice.rs
+++ b/src/automation/staged_notice.rs
@@ -225,6 +225,8 @@ mod tests {
                 category: "testing".to_string(),
                 targets: crate::automation::managed_skills::default_managed_skill_targets(),
                 state,
+                materialization_scope:
+                    crate::automation::managed_skill_model::ManagedSkillMaterializationScope::Global,
                 pinned: false,
                 checksum: String::new(),
                 created_at: 1,

--- a/src/automation_cli.rs
+++ b/src/automation_cli.rs
@@ -418,7 +418,8 @@ fn refresh_managed_skill_exports_for_cli(profile_root: &std::path::Path) {
     let Some(home) = tracedecay::agents::home_dir() else {
         return;
     };
-    let project_root = std::env::current_dir().unwrap_or_else(|_| home.clone());
+    let start = std::env::current_dir().unwrap_or_else(|_| home.clone());
+    let project_root = tracedecay::automation::skill_materialization::resolve_project_root(&start);
     for report in
         tracedecay::agents::export_managed_skills_to_agent_hosts(&home, &project_root, profile_root)
     {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -77,7 +77,9 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
         for ag in &agents_to_check {
             ag.healthcheck(&mut dc, &hctx);
         }
-        check_managed_skill_materialization(&mut dc, home, &project_path);
+        let materialization_root =
+            crate::automation::skill_materialization::resolve_project_root(&project_path);
+        check_managed_skill_materialization(&mut dc, home, &materialization_root);
     } else {
         dc.fail("Could not determine home directory");
     }
@@ -137,6 +139,10 @@ fn check_managed_skill_materialization(dc: &mut DoctorCounters, home: &Path, pro
                 )),
                 SkillDrift::Orphan { .. } => dc.warn(&format!(
                     "{}: stale materialized skill '{skill_id}' ({path}); run `tracedecay update` to remove",
+                    scope.describe()
+                )),
+                SkillDrift::Warning { ref message, .. } => dc.warn(&format!(
+                    "{}: '{skill_id}' {message} ({path})",
                     scope.describe()
                 )),
             }

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -421,10 +421,11 @@ fn reconcile_materialized_managed_skills_after_update() {
     let Ok(profile_root) = tracedecay::storage::default_profile_root() else {
         return;
     };
-    let project_root = std::env::current_dir()
+    let start = std::env::current_dir()
         .ok()
         .or_else(tracedecay::agents::home_dir)
         .unwrap_or_else(|| PathBuf::from("."));
+    let project_root = tracedecay::automation::skill_materialization::resolve_project_root(&start);
     tracedecay::automation::skill_materialization::reconcile_after_activation(
         &profile_root,
         &project_root,

--- a/tests/agent_suite/skill_materialization_test.rs
+++ b/tests/agent_suite/skill_materialization_test.rs
@@ -15,8 +15,13 @@ use tracedecay::automation::skill_frontmatter::parse_skill_frontmatter;
 use tracedecay::automation::skill_materialization::{
     MaterializationHost, MaterializationScope, MaterializeAction, RemoveAction, SkillDrift,
     detect_scopes, doctor_detected_scopes, doctor_scope, materialize_skill,
-    reconcile_detected_scopes, reconcile_scope, remove_materialized_skill,
+    reconcile_detected_scopes, reconcile_scope, remove_materialized_skill, resolve_project_root,
 };
+
+/// Stable installation id for the local test profile; distinct from `INSTALL_B`
+/// so cross-profile removal protection can be exercised.
+const INSTALL: &str = "install-test-a";
+const INSTALL_B: &str = "install-test-b";
 
 /// A canonicalized temp root: on macOS `/tmp` is a symlink to `/private/tmp`,
 /// so canonicalizing keeps materialized paths comparable to the profile paths.
@@ -71,7 +76,7 @@ fn skill_md(scope: &MaterializationScope, slug: &str) -> PathBuf {
 }
 
 #[tokio::test]
-async fn materialize_on_activate_writes_both_hosts_and_scopes() {
+async fn materialize_on_activate_writes_global_scope_only_by_default() {
     let (_temp, root) = canonical_tempdir();
     let home = root.join("home");
     let project = root.join("project");
@@ -83,33 +88,46 @@ async fn materialize_on_activate_writes_both_hosts_and_scopes() {
 
     let (results, errors) = reconcile_detected_scopes(&profile_root, &home, &project);
     assert!(errors.is_empty(), "unexpected errors: {errors:?}");
-    // 2 hosts x 2 scopes (project + global) = 4 destinations.
+    // 2 hosts x 2 scopes (project + global) are still detected...
     assert_eq!(results.len(), 4, "expected 4 detected scopes");
 
-    let expected = [
+    // ...but a default (global-scoped) skill materializes ONLY into the user's
+    // global host dirs — never into the project checkout (no repo pollution).
+    let global = [
         home.join(".claude/skills/code-slop-cleanup/SKILL.md"),
         home.join(".codex/skills/code-slop-cleanup/SKILL.md"),
-        project.join(".claude/skills/code-slop-cleanup/SKILL.md"),
-        project.join(".codex/skills/code-slop-cleanup/SKILL.md"),
     ];
-    for path in &expected {
-        assert!(
-            path.is_file(),
-            "missing materialized skill at {}",
-            path.display()
-        );
+    for path in &global {
+        assert!(path.is_file(), "missing global skill at {}", path.display());
     }
-    // Support files travel with the skill package.
     assert!(
         home.join(".claude/skills/code-slop-cleanup/references/checklist.md")
             .is_file()
     );
 
-    // Every reconcile entry wrote its file.
+    let project_paths = [
+        project.join(".claude/skills/code-slop-cleanup/SKILL.md"),
+        project.join(".codex/skills/code-slop-cleanup/SKILL.md"),
+    ];
+    for path in &project_paths {
+        assert!(
+            !path.exists(),
+            "global skill must not pollute project at {}",
+            path.display()
+        );
+    }
+
+    // Only the two global scopes wrote a file; project scopes wrote nothing.
+    let total_written: usize = results.iter().map(|r| r.report.written_count()).sum();
+    assert_eq!(total_written, 2, "only global claude+codex should write");
     for result in &results {
+        let expected = match result.scope.describe().as_str() {
+            desc if desc.ends_with("/global") => 1,
+            _ => 0,
+        };
         assert_eq!(
             result.report.written_count(),
-            1,
+            expected,
             "scope {}",
             result.scope.describe()
         );
@@ -211,18 +229,18 @@ async fn body_update_re_materializes_the_file() {
     )
     .await
     .unwrap();
-    let first = materialize_skill(&scope, &skill).unwrap();
+    let first = materialize_skill(&scope, &skill, INSTALL).unwrap();
     assert_eq!(first.action, MaterializeAction::Written);
 
     // Change the body: the content-hash changes, so the reconciler rewrites.
     skill.body_markdown = "# Cleanup v2\n\nNow with extra rigor.".to_string();
-    let second = materialize_skill(&scope, &skill).unwrap();
+    let second = materialize_skill(&scope, &skill, INSTALL).unwrap();
     assert_eq!(second.action, MaterializeAction::Written);
     let contents = std::fs::read_to_string(skill_md(&scope, "code-slop-cleanup")).unwrap();
     assert!(contents.contains("Now with extra rigor."));
 
     // A third pass with the same content is a no-op.
-    let third = materialize_skill(&scope, &skill).unwrap();
+    let third = materialize_skill(&scope, &skill, INSTALL).unwrap();
     assert_eq!(third.action, MaterializeAction::Unchanged);
 }
 
@@ -241,16 +259,16 @@ async fn metadata_update_re_materializes_the_file() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
 
     skill.metadata.summary = "Use when performing a strict cleanup before review.".to_string();
-    let updated = materialize_skill(&scope, &skill).unwrap();
+    let updated = materialize_skill(&scope, &skill, INSTALL).unwrap();
 
     assert_eq!(updated.action, MaterializeAction::Written);
     let contents = std::fs::read_to_string(skill_md(&scope, "code-slop-cleanup")).unwrap();
     assert!(contents.contains("performing a strict cleanup"));
     assert_eq!(
-        materialize_skill(&scope, &skill).unwrap().action,
+        materialize_skill(&scope, &skill, INSTALL).unwrap().action,
         MaterializeAction::Unchanged
     );
 }
@@ -270,7 +288,7 @@ async fn support_update_removes_only_stale_owned_files() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
     let dir = scope.skills_dir().join("code-slop-cleanup");
     let stale = dir.join("references/checklist.md");
     let foreign = dir.join("references/user-notes.md");
@@ -278,7 +296,7 @@ async fn support_update_removes_only_stale_owned_files() {
 
     skill.support_files =
         vec![ManagedSupportFile::new("references/guide.md", b"new guide\n".to_vec()).unwrap()];
-    let updated = materialize_skill(&scope, &skill).unwrap();
+    let updated = materialize_skill(&scope, &skill, INSTALL).unwrap();
 
     assert_eq!(updated.action, MaterializeAction::Written);
     assert!(
@@ -307,14 +325,14 @@ async fn user_edited_support_file_is_fork_protected() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
     let support = scope
         .skills_dir()
         .join("code-slop-cleanup/references/checklist.md");
     std::fs::write(&support, "user edit\n").unwrap();
 
     skill.support_files[0].bytes = b"automation update\n".to_vec();
-    let updated = materialize_skill(&scope, &skill).unwrap();
+    let updated = materialize_skill(&scope, &skill, INSTALL).unwrap();
 
     assert_eq!(updated.action, MaterializeAction::SkippedForked);
     assert_eq!(std::fs::read_to_string(support).unwrap(), "user edit\n");
@@ -335,12 +353,12 @@ async fn deactivation_removes_only_owned_artifacts() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
     let dir = scope.skills_dir().join("code-slop-cleanup");
     let foreign = dir.join("references/user-notes.md");
     std::fs::write(&foreign, "keep me\n").unwrap();
 
-    let removed = remove_materialized_skill(&scope, "code-slop-cleanup").unwrap();
+    let removed = remove_materialized_skill(&scope, "code-slop-cleanup", INSTALL).unwrap();
 
     assert_eq!(removed, RemoveAction::Removed);
     assert!(!dir.join("SKILL.md").exists());
@@ -372,7 +390,7 @@ async fn package_symlink_is_rejected_before_materialization() {
     .await
     .unwrap();
 
-    let error = materialize_skill(&scope, &skill).unwrap_err();
+    let error = materialize_skill(&scope, &skill, INSTALL).unwrap_err();
 
     assert!(error.to_string().contains("symlink"), "{error}");
     assert!(std::fs::read_dir(external).unwrap().next().is_none());
@@ -402,7 +420,7 @@ async fn nested_support_symlink_is_rejected_before_write() {
     .await
     .unwrap();
 
-    let error = materialize_skill(&scope, &skill).unwrap_err();
+    let error = materialize_skill(&scope, &skill, INSTALL).unwrap_err();
 
     assert!(error.to_string().contains("symlink"), "{error}");
     assert!(!external.join("checklist.md").exists());
@@ -427,7 +445,7 @@ async fn nested_support_symlink_is_rejected_before_remove() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
     let dir = scope.skills_dir().join("code-slop-cleanup");
     let support = dir.join("references/checklist.md");
     let contents = std::fs::read(&support).unwrap();
@@ -437,7 +455,7 @@ async fn nested_support_symlink_is_rejected_before_remove() {
     std::fs::write(external.join("checklist.md"), &contents).unwrap();
     symlink(&external, dir.join("references")).unwrap();
 
-    let error = remove_materialized_skill(&scope, "code-slop-cleanup").unwrap_err();
+    let error = remove_materialized_skill(&scope, "code-slop-cleanup", INSTALL).unwrap_err();
 
     assert!(error.to_string().contains("symlink"), "{error}");
     assert_eq!(
@@ -461,7 +479,7 @@ async fn interrupted_manifest_commit_recovers_on_retry() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
     skill.body_markdown = "# Cleanup v2\n\nRecover this update.".to_string();
     skill.support_files[0].bytes = b"updated checklist\n".to_vec();
 
@@ -469,10 +487,10 @@ async fn interrupted_manifest_commit_recovers_on_retry() {
     let manifest = dir.join(".tracedecay-materialization.json");
     let blocked_staging = PathBuf::from(format!("{}.new", manifest.display()));
     std::fs::create_dir(&blocked_staging).unwrap();
-    assert!(materialize_skill(&scope, &skill).is_err());
+    assert!(materialize_skill(&scope, &skill, INSTALL).is_err());
     std::fs::remove_dir(blocked_staging).unwrap();
 
-    let retried = materialize_skill(&scope, &skill).unwrap();
+    let retried = materialize_skill(&scope, &skill, INSTALL).unwrap();
 
     assert_ne!(retried.action, MaterializeAction::SkippedForked);
     assert!(
@@ -501,7 +519,7 @@ async fn fork_protection_leaves_user_edited_file_and_doctor_flags_it() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
     let path = skill_md(&scope, "code-slop-cleanup");
 
     // User edits the materialized body (the content-hash no longer matches).
@@ -512,12 +530,12 @@ async fn fork_protection_leaves_user_edited_file_and_doctor_flags_it() {
     std::fs::write(&path, &edited).unwrap();
 
     // Re-materialize: the reconciler must NOT clobber the fork.
-    let action = materialize_skill(&scope, &skill).unwrap();
+    let action = materialize_skill(&scope, &skill, INSTALL).unwrap();
     assert_eq!(action.action, MaterializeAction::SkippedForked);
     assert_eq!(std::fs::read_to_string(&path).unwrap(), edited);
 
     // Doctor flags the fork.
-    let drift = doctor_scope(&scope, std::slice::from_ref(&skill)).unwrap();
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
     assert!(
         drift.iter().any(
             |d| matches!(d, SkillDrift::Forked { skill_id, .. } if skill_id == "code-slop-cleanup")
@@ -526,7 +544,7 @@ async fn fork_protection_leaves_user_edited_file_and_doctor_flags_it() {
     );
 
     // A deactivate reconcile must also refuse to delete the fork.
-    let removed = remove_materialized_skill(&scope, "code-slop-cleanup").unwrap();
+    let removed = remove_materialized_skill(&scope, "code-slop-cleanup", INSTALL).unwrap();
     assert_eq!(removed, RemoveAction::SkippedForked);
     assert!(path.is_file(), "forked file must survive removal");
 }
@@ -553,7 +571,7 @@ async fn foreign_file_is_never_touched_and_doctor_reports_conflict() {
     .await
     .unwrap();
 
-    let action = materialize_skill(&scope, &skill).unwrap();
+    let action = materialize_skill(&scope, &skill, INSTALL).unwrap();
     assert_eq!(action.action, MaterializeAction::SkippedForeign);
     assert_eq!(
         std::fs::read_to_string(dir.join("SKILL.md")).unwrap(),
@@ -562,11 +580,11 @@ async fn foreign_file_is_never_touched_and_doctor_reports_conflict() {
 
     // Removal never touches a foreign file either.
     assert_eq!(
-        remove_materialized_skill(&scope, "code-slop-cleanup").unwrap(),
+        remove_materialized_skill(&scope, "code-slop-cleanup", INSTALL).unwrap(),
         RemoveAction::SkippedForeign
     );
 
-    let drift = doctor_scope(&scope, std::slice::from_ref(&skill)).unwrap();
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
     assert!(
         drift
             .iter()
@@ -605,8 +623,8 @@ async fn doctor_reports_missing_and_orphan_drift() {
     )
     .await
     .unwrap();
-    materialize_skill(&scope, &skill).unwrap();
-    let orphan_drift = doctor_scope(&scope, &[]).unwrap();
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
+    let orphan_drift = doctor_scope(&scope, &[]);
     assert!(
         orphan_drift.iter().any(
             |d| matches!(d, SkillDrift::Orphan { skill_id, .. } if skill_id == "code-slop-cleanup")
@@ -663,10 +681,352 @@ async fn reconcile_scope_removes_only_managed_orphans() {
     )
     .unwrap();
 
-    let report = reconcile_scope(&scope, &[]).unwrap();
+    let report = reconcile_scope(&scope, &[], INSTALL).unwrap();
     assert!(
         report.removed.is_empty(),
         "foreign skill must not be enumerated for removal"
     );
     assert!(foreign_dir.join("SKILL.md").is_file());
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial-review findings on #362/#366 (skill-materialization hardening).
+// ---------------------------------------------------------------------------
+
+use tracedecay::automation::managed_skills::ManagedSkill;
+
+async fn load_skill(profile_root: &Path, id: &str) -> ManagedSkill {
+    tracedecay::automation::managed_skills::load_managed_skill(profile_root, id)
+        .await
+        .unwrap()
+}
+
+/// #1 A pristine materialized file whose manifest sidecar is lost (fresh clone,
+/// gitignored dotfile, dotfile-sync) must be re-derived from disk — not frozen
+/// as `SkippedForked` and mislabeled by doctor.
+#[tokio::test]
+async fn lost_manifest_pristine_file_is_rederived_not_forked() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+    assert_eq!(
+        materialize_skill(&scope, &skill, INSTALL).unwrap().action,
+        MaterializeAction::Written
+    );
+
+    // Simulate a lost manifest sidecar (SKILL.md committed, dot-manifest not).
+    let dir = scope.skills_dir().join("code-slop-cleanup");
+    let manifest = dir.join(".tracedecay-materialization.json");
+    std::fs::remove_file(&manifest).unwrap();
+
+    // Re-materialize: the reconciler must recognize the pristine package and
+    // re-derive the manifest, never SkippedForked.
+    let again = materialize_skill(&scope, &skill, INSTALL).unwrap();
+    assert_ne!(again.action, MaterializeAction::SkippedForked);
+    assert!(manifest.is_file(), "manifest should be re-derived");
+
+    // Doctor must NOT report the pristine file as a user fork.
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
+    assert!(
+        !drift.iter().any(|d| matches!(d, SkillDrift::Forked { .. })),
+        "pristine file wrongly flagged as forked: {drift:?}"
+    );
+
+    // And it stays removable (no doctor-nag / update-refuses loop).
+    std::fs::remove_file(&manifest).unwrap();
+    assert_eq!(
+        remove_materialized_skill(&scope, "code-slop-cleanup", INSTALL).unwrap(),
+        RemoveAction::Removed
+    );
+    assert!(!dir.join("SKILL.md").exists());
+}
+
+/// #2 Materialization must resolve the enclosing project root, so running from a
+/// subdirectory targets the repo root rather than the subdir.
+#[tokio::test]
+async fn resolve_project_root_finds_enclosing_repo_root() {
+    let (_temp, root) = canonical_tempdir();
+    let repo = root.join("repo");
+    let subdir = repo.join("crates/inner/src");
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::create_dir_all(repo.join(".tracedecay")).unwrap();
+    std::fs::write(repo.join(".tracedecay/tracedecay.db"), b"stub").unwrap();
+
+    assert_eq!(resolve_project_root(&subdir), repo);
+    assert_eq!(resolve_project_root(&repo), repo);
+}
+
+/// #3 A default (global) skill materializes into the global scope but not into a
+/// project scope, even when both host dirs exist. (Complements
+/// `materialize_on_activate_writes_global_scope_only_by_default`.)
+#[tokio::test]
+async fn project_scope_filters_out_global_skills() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let project = root.join("project");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+    install_fake_hosts(&project);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    reconcile_detected_scopes(&profile_root, &home, &project);
+
+    assert!(
+        home.join(".claude/skills/code-slop-cleanup/SKILL.md")
+            .is_file()
+    );
+    assert!(
+        !project.join(".claude/skills/code-slop-cleanup").exists(),
+        "no project package dir should be created for a global skill"
+    );
+    // Doctor must not report Missing project drift for a global skill.
+    let scopes = doctor_detected_scopes(&profile_root, &home, &project).unwrap();
+    for (scope, drift) in &scopes {
+        if scope.describe().ends_with("/project") {
+            assert!(drift.is_empty(), "unexpected project drift: {drift:?}");
+        }
+    }
+}
+
+/// #4 Project-scope orphan cleanup must never delete a committed package another
+/// installation authored; the same file in a global scope is still removable.
+#[tokio::test]
+async fn project_scope_protects_another_installations_committed_package() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let project = root.join("project");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+    install_fake_hosts(&project);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+
+    // Installation A materializes into a project checkout and "commits" it.
+    let project_scope = MaterializationScope::project(MaterializationHost::Claude, project);
+    materialize_skill(&project_scope, &skill, INSTALL).unwrap();
+    let committed = project_scope
+        .skills_dir()
+        .join("code-slop-cleanup/SKILL.md");
+    assert!(committed.is_file());
+
+    // Installation B (skill not in its profile) must NOT delete A's committed
+    // file — it is reported, never auto-removed.
+    assert_eq!(
+        remove_materialized_skill(&project_scope, "code-slop-cleanup", INSTALL_B).unwrap(),
+        RemoveAction::SkippedForeign
+    );
+    assert!(committed.is_file(), "another user's file must survive");
+
+    // Installation A can still remove its own file.
+    assert_eq!(
+        remove_materialized_skill(&project_scope, "code-slop-cleanup", INSTALL).unwrap(),
+        RemoveAction::Removed
+    );
+
+    // Global scope is the user's own home: cross-installation removal is fine.
+    let global_scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    materialize_skill(&global_scope, &skill, INSTALL).unwrap();
+    assert_eq!(
+        remove_materialized_skill(&global_scope, "code-slop-cleanup", INSTALL_B).unwrap(),
+        RemoveAction::Removed
+    );
+}
+
+/// #5 Concurrent transactions on the same package must serialize and never wedge
+/// it as forked or leave a half-applied manifest.
+#[tokio::test]
+async fn concurrent_materialize_does_not_wedge_forked() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+
+    let actions: Vec<MaterializeAction> = std::thread::scope(|s| {
+        let handles: Vec<_> = (0..8)
+            .map(|_| s.spawn(|| materialize_skill(&scope, &skill, INSTALL).unwrap().action))
+            .collect();
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+
+    for action in &actions {
+        assert_ne!(
+            *action,
+            MaterializeAction::SkippedForked,
+            "a concurrent transaction wedged the package as forked"
+        );
+    }
+    // Final state is a clean, unchanged, fork-free package.
+    let final_pass = materialize_skill(&scope, &skill, INSTALL).unwrap();
+    assert_eq!(final_pass.action, MaterializeAction::Unchanged);
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
+    assert!(
+        drift.is_empty(),
+        "unexpected drift after concurrency: {drift:?}"
+    );
+}
+
+/// #6 A symlinked scope root (stow/chezmoi dotfiles) must be followed, not
+/// rejected: materialization writes through the link.
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinked_scope_root_materializes_through_link() {
+    use std::os::unix::fs::symlink;
+
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let real_claude = root.join("dotfiles/claude");
+    let profile_root = root.join("profile");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&real_claude).unwrap();
+    // ~/.claude is a symlink into a dotfiles repo — a normal setup.
+    symlink(&real_claude, home.join(".claude")).unwrap();
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+
+    let action = materialize_skill(&scope, &skill, INSTALL).unwrap();
+    assert_eq!(action.action, MaterializeAction::Written);
+    assert!(
+        real_claude
+            .join("skills/code-slop-cleanup/SKILL.md")
+            .is_file(),
+        "file should be written through the symlinked scope root"
+    );
+}
+
+/// #7/#8 (doctor) One package whose internal check errors must not suppress
+/// drift reporting for the rest of the scope.
+#[cfg(unix)]
+#[tokio::test]
+async fn doctor_reports_other_drift_when_one_package_errors() {
+    use std::os::unix::fs::symlink;
+
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let external = root.join("external");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+    std::fs::create_dir_all(&external).unwrap();
+
+    activate_skill(&profile_root, "good-skill").await;
+    activate_skill(&profile_root, "broken-skill").await;
+    let good = load_skill(&profile_root, "good-skill").await;
+    let broken = load_skill(&profile_root, "broken-skill").await;
+
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    materialize_skill(&scope, &broken, INSTALL).unwrap();
+
+    // Replace broken's support dir with a symlink so its check errors.
+    let dir = scope.skills_dir().join("broken-skill");
+    std::fs::remove_file(dir.join("references/checklist.md")).unwrap();
+    std::fs::remove_dir(dir.join("references")).unwrap();
+    symlink(&external, dir.join("references")).unwrap();
+
+    // good-skill is active but not materialized -> Missing; broken errors.
+    let drift = doctor_scope(&scope, &[good, broken]);
+    assert!(
+        drift
+            .iter()
+            .any(|d| matches!(d, SkillDrift::Missing { skill_id, .. } if skill_id == "good-skill")),
+        "healthy Missing drift suppressed by a broken package: {drift:?}"
+    );
+    assert!(
+        drift
+            .iter()
+            .any(|d| matches!(d, SkillDrift::Warning { .. })),
+        "broken package should surface as a Warning: {drift:?}"
+    );
+}
+
+/// #8 (reconcile) One poisoned package must not block materialization of the
+/// rest of the scope; its failure is recorded, not fatal.
+#[cfg(unix)]
+#[tokio::test]
+async fn reconcile_continues_past_one_poisoned_package() {
+    use std::os::unix::fs::symlink;
+
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let external = root.join("external");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+    std::fs::create_dir_all(&external).unwrap();
+
+    activate_skill(&profile_root, "good-skill").await;
+    activate_skill(&profile_root, "broken-skill").await;
+    let good = load_skill(&profile_root, "good-skill").await;
+    let broken = load_skill(&profile_root, "broken-skill").await;
+
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    // Poison broken-skill's package slot with a symlink escaping the tree.
+    std::fs::create_dir_all(scope.skills_dir()).unwrap();
+    symlink(&external, scope.skills_dir().join("broken-skill")).unwrap();
+
+    let report = reconcile_scope(&scope, &[good, broken], INSTALL).unwrap();
+
+    assert_eq!(report.written_count(), 1, "good skill should still write");
+    assert_eq!(
+        report.errors.len(),
+        1,
+        "one poisoned package recorded: {:?}",
+        report.errors
+    );
+    assert!(scope.skills_dir().join("good-skill/SKILL.md").is_file());
+}
+
+/// #9 Distinct ids that normalize to the same host slug are disambiguated (each
+/// materializes to its own dir) and doctor warns instead of silently dropping
+/// the second one.
+#[tokio::test]
+async fn colliding_host_slugs_are_disambiguated_and_warned() {
+    let (_temp, root) = canonical_tempdir();
+    let home = root.join("home");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&home);
+
+    // "team-sync" and "team_sync" both normalize to slug "team-sync".
+    activate_skill(&profile_root, "team-sync").await;
+    activate_skill(&profile_root, "team_sync").await;
+    let a = load_skill(&profile_root, "team-sync").await;
+    let b = load_skill(&profile_root, "team_sync").await;
+
+    let scope = MaterializationScope::global(MaterializationHost::Claude, home);
+    let report = reconcile_scope(&scope, &[a.clone(), b.clone()], INSTALL).unwrap();
+
+    assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+    assert_eq!(report.materialized.len(), 2);
+    for entry in &report.materialized {
+        assert_eq!(
+            entry.action,
+            MaterializeAction::Written,
+            "colliding skill silently dropped: {entry:?}"
+        );
+    }
+
+    // Two distinct managed packages exist on disk.
+    let managed: Vec<_> = std::fs::read_dir(scope.skills_dir())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().join("SKILL.md").is_file())
+        .collect();
+    assert_eq!(managed.len(), 2, "both colliding skills must materialize");
+
+    // Doctor warns about the collision for both.
+    let drift = doctor_scope(&scope, &[a, b]);
+    let warnings = drift
+        .iter()
+        .filter(|d| matches!(d, SkillDrift::Warning { .. }))
+        .count();
+    assert!(warnings >= 2, "expected collision warnings, got {drift:?}");
 }


### PR DESCRIPTION
Fixes the 9 adversarially-confirmed findings from the hostile review of the skill-materialization feature (#362 / #366).

## Major

1. **Hash-domain mismatch in `is_legacy_forked`** (`src/automation/skill_materialization.rs`) — #366 made the frontmatter `content-hash` a package hash while the manifest-loss fallback still compared it against a body-only hash, so a pristine `SKILL.md` whose `.tracedecay-materialization.json` sidecar was lost (fresh clone, gitignored dotfile) was permanently frozen as forked *and* unremovable (doctor-nags / update-refuses loop). Now: `recompute_on_disk_package` re-derives the package hash from disk (#366 domain), reconciles + rewrites the manifest when clean, and only then falls back to the legacy #362 body-hash check before declaring a fork. Removal follows the same ladder.
2. **cwd-as-project-root** (`src/update_cmd.rs`, `src/doctor.rs`, `src/automation_cli.rs`, `src/automation/skill_writer.rs`) — all four entry points now resolve the enclosing project root via new `resolve_project_root` (registered-project discovery, then git worktree root, then the start dir) instead of trusting raw `current_dir()`, so running from a subdirectory no longer skips or misplaces materialization.
3. **Global-vs-project scope routing** — `ManagedSkillMetadata` gains a serde-default `materialization_scope` (`ManagedSkillMaterializationScope`, default `Global`, omitted from JSON when default so existing records are byte-identical). `skills_for_scope` materializes into project checkouts only for explicitly project-scoped skills; default skills land only in `~/.claude` / `~/.codex`. No more repo pollution or duplicate global+project skill loading.
4. **Cross-profile orphan deletion** — manifests now record a `materialized_by` installation id (persisted token in the profile root, serde-default/optional). Project-scope orphan cleanup removes a package only when this installation authored it; another developer's committed `.claude/skills/**` files are reported by doctor but never auto-deleted. Global scope (the user's own home) remains freely removable.
5. **TOCTOU pending-file race** — a per-package inter-process `flock` (fs2, temp-dir sidecar keyed by package path — never pollutes the repo) is held across the whole read-decide-commit window of `materialize_skill` / `remove_materialized_skill`, so concurrent update/approve/auto-enable runs serialize instead of interleaving artifacts and wedging the package as forked.
6. **Symlinked `~/.claude` breakage** — `ensure_no_symlink_components` now guards only the components the reconciler itself writes (slug dir + package-internal paths); symlinked scope roots (`stow`/`chezmoi`-style `~/.claude`, or `/home` behind a symlink) are followed rather than refused.

## Minor

7. **doctor fail-fast** — `doctor_scope` is infallible; per-skill failures surface as a new `SkillDrift::Warning` and the rest of the scope (and all other scopes) keep reporting drift.
8. **reconcile fail-fast** — `reconcile_scope` continues past a poisoned package, aggregating per-skill failures into `ReconcileReport::errors` (surfaced through `reconcile_detected_scopes`' error channel).
9. **`host_skill_slug` collisions** — colliding active ids are disambiguated with a short stable id-hash suffix (`assign_host_slugs`), both packages materialize and load, and doctor emits a collision warning instead of silently misreporting the second skill as forked.

## Tests

`tests/agent_suite/skill_materialization_test.rs`: 9 new/updated scenario tests, one per finding (lost-manifest re-derivation + removability, subdir project-root resolution, global-only default + project filtering, cross-installation committed-package protection, 8-thread concurrent materialize, symlinked scope root write-through, doctor/reconcile continuation past a poisoned package, slug-collision disambiguation), plus updates to the existing suite for the new global-only default. 27/27 pass.

## Gates (CI-exact, post-rebase on latest master)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo nextest run --test agent_suite` — 497/497 passed
- `cargo nextest run --test automation_runner_test --test dashboard_api_test` — 193/193 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)