### PR TITLE
chore: release v0.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.45](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.44...v0.0.45) - 2026-07-09
+
+### Added
+
+- add investigating-unexpected-changes skill + hint
+
+### Fixed
+
+- *(mcp)* anchor PR context at merge base
+- *(skills)* reconcile bundled skill registries
+- narrow force-push hint triggers to possessive confusion forms
+
+### Other
+
+- *(runtime)* keep process identity API minimal ([#398](https://github.com/ScriptedAlchemy/tracedecay/pull/398))
+- *(mcp)* tree-sitter masked source for text scanners ([#391](https://github.com/ScriptedAlchemy/tracedecay/pull/391))
+- Merge pull request #395 from ScriptedAlchemy/codex/post-wave-cleanup
+- *(dashboard)* isolate fixtures from session catch-up ([#394](https://github.com/ScriptedAlchemy/tracedecay/pull/394))
+- *(git-watch)* observe exact debounce drains ([#393](https://github.com/ScriptedAlchemy/tracedecay/pull/393))
+- *(skills)* validate branch context against live Git
+
 ## [0.0.44](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.43...v0.0.44) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,7 +4826,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.44"
+version = "0.0.45"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.44 -> 0.0.45

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.45](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.44...v0.0.45) - 2026-07-09

### Added

- add investigating-unexpected-changes skill + hint

### Fixed

- *(mcp)* anchor PR context at merge base
- *(skills)* reconcile bundled skill registries
- narrow force-push hint triggers to possessive confusion forms

### Other

- *(runtime)* keep process identity API minimal ([#398](https://github.com/ScriptedAlchemy/tracedecay/pull/398))
- *(mcp)* tree-sitter masked source for text scanners ([#391](https://github.com/ScriptedAlchemy/tracedecay/pull/391))
- Merge pull request #395 from ScriptedAlchemy/codex/post-wave-cleanup
- *(dashboard)* isolate fixtures from session catch-up ([#394](https://github.com/ScriptedAlchemy/tracedecay/pull/394))
- *(git-watch)* observe exact debounce drains ([#393](https://github.com/ScriptedAlchemy/tracedecay/pull/393))
- *(skills)* validate branch context against live Git
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).