### PR TITLE
feat: in-process ast-grep structural search tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast-grep-core"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44135ff8104e5fbdcd5e0a8a8850b083694762530aa0212cac3a71158ac90a42"
+dependencies = [
+ "bit-set 0.10.0",
+ "regex",
+ "thiserror 2.0.18",
+ "tree-sitter",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +400,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -396,6 +417,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1071,7 +1101,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1082,7 +1112,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -4829,6 +4859,7 @@ name = "tracedecay"
 version = "0.0.45"
 dependencies = [
  "amari-holographic",
+ "ast-grep-core",
  "axum 0.8.9",
  "bincode",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,12 @@ tower = "0.5"
 libsql = "0.9.30"
 tree-sitter = "0.26"
 tree-sitter-language = "0.1"
+# In-process structural-search engine. ast-grep-core is generic over a
+# tree-sitter `Language`; we wire the repo's own bundled grammars (via
+# `extraction::ts_provider`) into its `Language` trait, so no extra grammar
+# crates are pulled in and no external `ast-grep` binary is required. Pinned to
+# tree-sitter ^0.26.3, ABI-compatible with the 0.26 grammars this repo builds.
+ast-grep-core = "0.44"
 tracedecay-medium-treesitters = { package = "tokensave-medium-treesitters", version = "0.2.0", optional = true }
 tracedecay-large-treesitters = { package = "tokensave-large-treesitters", version = "0.5.0", optional = true }
 clap = { version = "4.6", features = ["derive"] }

--- a/evals/agent_adoption/scenarios/edit_structural_swap_reserve_stock_args.json
+++ b/evals/agent_adoption/scenarios/edit_structural_swap_reserve_stock_args.json
@@ -1,0 +1,43 @@
+{
+  "id": "edit_structural_swap_reserve_stock_args",
+  "category": "edit_refactor",
+  "pack": "pack_edit_refactor",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "deferred",
+  "prompt": "Swap the first two arguments at every call site of the stock-reservation helper across this crate, so the SKU is passed before the warehouse.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_ast_grep_rewrite"
+    ],
+    "acceptable": [
+      "tracedecay_ast_grep_search",
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_body",
+      "Read",
+      "Edit"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [],
+  "max_tool_calls": 6,
+  "requires_tool": "ast_grep_rewrite",
+  "notes": "PENDING: structural cross-file argument-order swap targeting tracedecay_ast_grep_rewrite. Deferred because (a) ast_grep_rewrite is only advertised when the host ast-grep CLI is on PATH, and (b) the current fixture has a single reserve_stock(...) call site, so a true 'across the crate' multi-site swap is not yet gradable. Promote to active once the fixture grows additional call sites and live-run adoption is verified. Pair with tracedecay_ast_grep_search (in-process) to locate the sites first."
+}

--- a/evals/agent_adoption/scenarios/nav_structural_reserve_stock_call_shape.json
+++ b/evals/agent_adoption/scenarios/nav_structural_reserve_stock_call_shape.json
@@ -1,0 +1,46 @@
+{
+  "id": "nav_structural_reserve_stock_call_shape",
+  "category": "code_exploration",
+  "pack": "pack_navigation",
+  "hosts": [
+    "claude",
+    "codex"
+  ],
+  "fixture": "main",
+  "status": "active",
+  "prompt": "Find every call in this crate that reserves stock by passing a warehouse, a SKU, and a quantity. I want the exact call sites that match that three-argument shape, not just where the function is defined.",
+  "expected_tools": {
+    "required_first": [
+      "tracedecay_ast_grep_search",
+      "tracedecay_context",
+      "tracedecay_search",
+      "tracedecay_grep",
+      "tracedecay_callers"
+    ],
+    "acceptable": [
+      "tracedecay_body",
+      "tracedecay_callers_for",
+      "Read"
+    ],
+    "forbidden_first": [
+      "Grep",
+      "Glob"
+    ],
+    "forbidden_bash": [
+      "grep",
+      "rg ",
+      "rg\t",
+      "find ",
+      "cat ",
+      "sed ",
+      "awk ",
+      "ack "
+    ]
+  },
+  "ground_truth": [
+    "reserve_stock",
+    "place_order"
+  ],
+  "max_tool_calls": 4,
+  "notes": "structural call-shape search; the sole three-argument reserve_stock(...) call site is inside place_order (orders.rs). The neutral prompt stresses the argument shape so ast_grep_search is the natural opener, though callers/grep/context can also resolve it."
+}

--- a/plugin/README-cursor.md
+++ b/plugin/README-cursor.md
@@ -73,6 +73,7 @@ per-call review, add the snippet below to `~/.cursor/permissions.json`
     "tracedecay:tracedecay_active_project",
     "tracedecay:tracedecay_affected",
     "tracedecay:tracedecay_analytics",
+    "tracedecay:tracedecay_ast_grep_search",
     "tracedecay:tracedecay_automation_run_artifact_view",
     "tracedecay:tracedecay_body",
     "tracedecay:tracedecay_branch_diff",

--- a/plugin/skills/editing-safely/SKILL.md
+++ b/plugin/skills/editing-safely/SKILL.md
@@ -62,7 +62,9 @@ Run this read-only recon in one shot for a symbol or `Struct::field` with
 5. **Structural pattern rewrite → `tracedecay_ast_grep_rewrite`** (`path`,
    `pattern`, `rewrite`, ast-grep SGPattern syntax): rewrite every match of a
    syntactic pattern in one file (e.g. `foo($A)` → `bar(foo($A))`); repeat
-   per file for multi-file rewrites.
+   per file for multi-file rewrites. Scope the change first with
+   `tracedecay_ast_grep_search` (read-only, in-process, whole-tree) to see every
+   match and confirm the pattern before rewriting.
 
 ## Porting code
 

--- a/plugin/skills/exploring-code/SKILL.md
+++ b/plugin/skills/exploring-code/SKILL.md
@@ -18,6 +18,7 @@ row below, run it, and stop when the question is answered.
 | You are matching | Call | Not |
 |---|---|---|
 | Literal string / regex / config key / error text | `tracedecay_grep` (`fixed_strings` for plain literals) | raw Grep/rg |
+| A code structure — call shape, argument order, expression form (e.g. `foo($$$)`, `if ($C) { $$$ }`) a text regex cannot pin down | `tracedecay_ast_grep_search` (in-process AST match; then `tracedecay_ast_grep_rewrite` via `tracedecay:editing-safely` to change matches) | multi-line regex guesses |
 | A symbol by exact name | `tracedecay_find_exact_symbol`, else `tracedecay_search` | Glob + open |
 | A concept / "how does X work" (names unknown) | `tracedecay_context` (`task` = the question, add `keywords` synonyms) | Explore agent |
 | A file by role or path | `tracedecay_files` | find/ls -R |

--- a/src/ast_grep_search.rs
+++ b/src/ast_grep_search.rs
@@ -1,0 +1,521 @@
+//! In-process structural (AST) search over the project working tree.
+//!
+//! This is the read-only sibling of the `ast_grep_rewrite` edit tool. Where the
+//! rewrite path shells out to the host `ast-grep` binary, structural *search*
+//! runs entirely in-process: the [`ast_grep_core`] pattern engine is generic
+//! over a tree-sitter [`Language`], so we wire the repo's own bundled grammars
+//! (served by [`crate::extraction::ts_provider`]) into its `Language` trait.
+//!
+//! That means:
+//!   * no external `ast-grep` CLI requirement (the tool registers
+//!     unconditionally),
+//!   * no additional tree-sitter grammar crates — the same 0.26 grammars the
+//!     indexer builds against back the search,
+//!   * pattern parsing/matching happen with zero subprocess spawn per file.
+//!
+//! The metavariable pre-processing (`$A`, `$$$`, expando chars per language)
+//! mirrors `ast-grep-language`'s `pre_process_pattern`, which is the load-bearing
+//! transform that lets tree-sitter parse a pattern whose `$` sigils are not valid
+//! identifier characters in the target language.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::Path;
+
+use ast_grep_core::matcher::PatternBuilder;
+use ast_grep_core::tree_sitter::{LanguageExt, StrDoc, TSLanguage};
+use ast_grep_core::{AstGrep, Language, Pattern, PatternError};
+use ignore::WalkBuilder;
+use ignore::overrides::{Override, OverrideBuilder};
+
+use crate::extraction::ts_provider;
+
+/// Bytes sniffed from the head of each file to classify it as binary.
+const BINARY_SNIFF_BYTES: usize = 8_192;
+/// Skip files larger than this; structural search of a multi-MB generated blob
+/// is never what the caller wants and dominates the scan budget.
+const MAX_FILE_BYTES: usize = 2_000_000;
+
+/// A tree-sitter language wired into `ast_grep_core`'s pattern engine.
+///
+/// Wraps a [`TSLanguage`] (which is exactly `tree_sitter::Language`, the same
+/// 0.26 type the repo's grammars produce) plus the expando char used to make
+/// `$`-metavariable patterns parseable in that language.
+#[derive(Clone)]
+struct TdLang {
+    ts: TSLanguage,
+    /// Char substituted for `$` at parse time. `'$'` means "no substitution":
+    /// the language accepts `$` in identifiers, so the pattern parses as-is.
+    expando: char,
+}
+
+impl Language for TdLang {
+    fn kind_to_id(&self, kind: &str) -> u16 {
+        self.ts.id_for_node_kind(kind, /* named */ true)
+    }
+
+    fn field_to_id(&self, field: &str) -> Option<u16> {
+        self.ts.field_id_for_name(field).map(|f| f.get())
+    }
+
+    fn expando_char(&self) -> char {
+        self.expando
+    }
+
+    fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
+        if self.expando == '$' {
+            Cow::Borrowed(query)
+        } else {
+            pre_process_pattern(self.expando, query)
+        }
+    }
+
+    fn build_pattern(&self, builder: &PatternBuilder) -> Result<Pattern, PatternError> {
+        builder.build(|src| StrDoc::try_new(src, self.clone()))
+    }
+}
+
+impl LanguageExt for TdLang {
+    fn get_ts_language(&self) -> TSLanguage {
+        self.ts.clone()
+    }
+}
+
+/// Rewrites the `$` metavariable sigils of an ast-grep pattern to the language's
+/// expando char so tree-sitter can parse them as ordinary identifiers.
+///
+/// Ported verbatim from `ast-grep-language`'s `pre_process_pattern` (MIT).
+/// `$A`/`$$A`/`$$$A` (named), `$_`, and `$$$` (anonymous multi) become expando
+/// runs; positional/other `$` sequences are left untouched.
+fn pre_process_pattern(expando: char, query: &str) -> Cow<'_, str> {
+    let mut ret = Vec::with_capacity(query.len());
+    let mut dollar_count = 0;
+    for c in query.chars() {
+        if c == '$' {
+            dollar_count += 1;
+            continue;
+        }
+        let need_replace = matches!(c, 'A'..='Z' | '_') // $A or $$A or $$$A
+            || dollar_count == 3; // anonymous multiple
+        let sigil = if need_replace { expando } else { '$' };
+        ret.extend(std::iter::repeat_n(sigil, dollar_count));
+        dollar_count = 0;
+        ret.push(c);
+    }
+    // trailing anonymous multiple
+    let sigil = if dollar_count == 3 { expando } else { '$' };
+    ret.extend(std::iter::repeat_n(sigil, dollar_count));
+    Cow::Owned(ret.into_iter().collect())
+}
+
+/// Expando char for a `ts_provider` language key, or `None` when the language
+/// accepts `$` in identifiers (no substitution needed).
+///
+/// Values mirror `ast-grep-language`'s per-language `impl_lang_expando!`
+/// declarations so pattern semantics match the upstream CLI.
+fn expando_for_key(key: &str) -> Option<char> {
+    match key {
+        // Languages whose grammar rejects `$` as an identifier char: `µ`.
+        "c_sharp" | "elixir" | "go" | "haskell" | "hcl" | "kotlin" | "php" | "python" | "ruby"
+        | "rust" | "swift" => Some('µ'),
+        // C/C++ use an astral-plane char (any letter is a valid identifier start).
+        "c" | "cpp" => Some('𐀀'),
+        // CSS / Nix use `_` (`$` is interpolation / at-rule syntax there).
+        "css" | "nix" => Some('_'),
+        // Everything else (js/ts/tsx, java, scala, bash, lua, json, yaml,
+        // markdown, dart, solidity, …) parses `$` fine — no expando.
+        _ => None,
+    }
+}
+
+/// Maps a file extension to a `ts_provider` language key. Returns `None` for
+/// extensions we do not confidently route; the caller then skips the file. The
+/// key is still validated against the compiled grammar tier via
+/// [`ts_provider::try_language`], so listing a key here that is not bundled is
+/// harmless (the file is skipped).
+fn lang_key_for_ext(ext: &str) -> Option<&'static str> {
+    Some(match ext {
+        "rs" => "rust",
+        "go" => "go",
+        "py" | "pyi" => "python",
+        "js" | "jsx" | "mjs" | "cjs" => "javascript",
+        "ts" | "mts" | "cts" => "typescript",
+        "tsx" => "tsx",
+        "java" => "java",
+        "kt" | "kts" => "kotlin",
+        "scala" | "sc" => "scala",
+        "c" | "h" => "c",
+        "cc" | "cpp" | "cxx" | "c++" | "hpp" | "hh" | "hxx" => "cpp",
+        "cs" => "c_sharp",
+        "swift" => "swift",
+        "rb" => "ruby",
+        "php" => "php",
+        "lua" => "lua",
+        "sh" | "bash" => "bash",
+        "dart" => "dart",
+        "ex" | "exs" => "elixir",
+        "hs" => "haskell",
+        "nix" => "nix",
+        "css" => "css",
+        _ => return None,
+    })
+}
+
+/// One structural match, resolved to file + 1-based position and the source
+/// line it starts on.
+#[derive(Debug, Clone)]
+pub struct AstGrepSearchMatch {
+    pub file: String,
+    /// 1-based line of the match start.
+    pub line: u32,
+    /// 1-based column (character offset) of the match start.
+    pub column: u32,
+    /// The matched AST node text, collapsed to a single line and length-capped
+    /// for display.
+    pub matched_text: String,
+    /// The full source line the match starts on (trimmed of trailing newline).
+    pub line_text: String,
+    /// `ts_provider` language key the file was parsed with.
+    pub lang: String,
+}
+
+/// Result of a structural-search sweep over the working tree.
+#[derive(Debug, Clone, Default)]
+pub struct AstGrepSearchResult {
+    pub matches: Vec<AstGrepSearchMatch>,
+    pub files_scanned: usize,
+    pub truncated: bool,
+}
+
+/// Why a structural search could not run at all (as opposed to returning zero
+/// matches, which is a normal empty [`AstGrepSearchResult`]).
+#[derive(Debug, Clone)]
+pub enum AstGrepSearchError {
+    /// `pattern` was empty/whitespace.
+    EmptyPattern,
+    /// An explicit `lang` key is not a bundled grammar on this build.
+    UnknownLang(String),
+    /// The pattern failed to compile for the (explicit) language.
+    InvalidPattern { lang: String, message: String },
+    /// The `path_glob` was not a valid glob.
+    InvalidGlob(String),
+}
+
+impl std::fmt::Display for AstGrepSearchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AstGrepSearchError::EmptyPattern => write!(f, "pattern must not be empty"),
+            AstGrepSearchError::UnknownLang(lang) => write!(
+                f,
+                "unknown or unbundled language '{lang}'. Omit `lang` to auto-detect per file, \
+                 or pass a language compiled into this build."
+            ),
+            AstGrepSearchError::InvalidPattern { lang, message } => {
+                write!(f, "invalid {lang} pattern: {message}")
+            }
+            AstGrepSearchError::InvalidGlob(glob) => write!(f, "invalid path_glob '{glob}'"),
+        }
+    }
+}
+
+/// Compiles a pattern for a language key, or returns the language wrapper +
+/// compiled pattern. Cached by the caller.
+fn build_lang_pattern(key: &str, pattern: &str) -> Option<Result<(TdLang, Pattern), String>> {
+    let ts = ts_provider::try_language(key).ok()?;
+    let lang = TdLang {
+        ts,
+        expando: expando_for_key(key).unwrap_or('$'),
+    };
+    let compiled = Pattern::try_new(pattern, lang.clone()).map_err(|err| format!("{err}"));
+    Some(compiled.map(|pat| (lang, pat)))
+}
+
+/// Runs a structural search over `project_root`.
+///
+/// * `lang` — explicit `ts_provider` language key; when `None`, the language is
+///   inferred per file from its extension.
+/// * `path_glob` — optional `.gitignore`-style glob restricting the files
+///   scanned.
+/// * `max_results` — hard cap; one extra match past the cap is collected so
+///   truncation can be reported honestly.
+pub fn search_tree(
+    project_root: &Path,
+    pattern: &str,
+    lang: Option<&str>,
+    path_glob: Option<&str>,
+    max_results: usize,
+) -> Result<AstGrepSearchResult, AstGrepSearchError> {
+    if pattern.trim().is_empty() {
+        return Err(AstGrepSearchError::EmptyPattern);
+    }
+    let max_results = max_results.max(1);
+
+    // Per-language compiled-pattern cache. `None` = pattern did not compile for
+    // that language (skip its files); `Some(_)` = ready to match.
+    let mut cache: HashMap<String, Option<(TdLang, Pattern)>> = HashMap::new();
+
+    // With an explicit language, compile up front so a bad pattern is a hard
+    // error rather than a silent zero-result sweep.
+    if let Some(key) = lang {
+        match build_lang_pattern(key, pattern) {
+            None => return Err(AstGrepSearchError::UnknownLang(key.to_string())),
+            Some(Err(message)) => {
+                return Err(AstGrepSearchError::InvalidPattern {
+                    lang: key.to_string(),
+                    message,
+                });
+            }
+            Some(Ok(built)) => {
+                cache.insert(key.to_string(), Some(built));
+            }
+        }
+    }
+
+    let overrides = build_overrides(project_root, path_glob)?;
+
+    let mut builder = WalkBuilder::new(project_root);
+    builder
+        .follow_links(false)
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true);
+    if let Some(overrides) = overrides {
+        builder.overrides(overrides);
+    }
+
+    let mut result = AstGrepSearchResult::default();
+
+    for entry in builder.build() {
+        let Ok(entry) = entry else { continue };
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
+
+        // Resolve the language key: explicit override, else per-extension.
+        let key = match lang {
+            Some(explicit) => {
+                // Skip files that are not this language.
+                if lang_key_for_ext(ext) != Some(explicit) {
+                    continue;
+                }
+                explicit
+            }
+            None => match lang_key_for_ext(ext) {
+                Some(k) => k,
+                None => continue,
+            },
+        };
+
+        let Ok(rel) = path.strip_prefix(project_root) else {
+            continue;
+        };
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+
+        let Ok(bytes) = std::fs::read(path) else {
+            continue;
+        };
+        if bytes.len() > MAX_FILE_BYTES || looks_binary(&bytes) {
+            continue;
+        }
+        let Ok(source) = String::from_utf8(bytes) else {
+            continue;
+        };
+
+        // Get-or-compile the pattern for this language.
+        let entry = cache.entry(key.to_string()).or_insert_with(|| {
+            match build_lang_pattern(key, pattern) {
+                Some(Ok(built)) => Some(built),
+                _ => None,
+            }
+        });
+        let Some((td_lang, compiled)) = entry.as_ref() else {
+            continue;
+        };
+
+        result.files_scanned += 1;
+        let source_lines: Vec<&str> = source.lines().collect();
+
+        let Ok(doc) = StrDoc::try_new(&source, td_lang.clone()) else {
+            continue;
+        };
+        let ast = AstGrep::doc(doc);
+        for node in ast.root().find_all(compiled) {
+            let start = node.start_pos();
+            let line0 = start.line();
+            let line_text = source_lines
+                .get(line0)
+                .map(|l| (*l).to_string())
+                .unwrap_or_default();
+            result.matches.push(AstGrepSearchMatch {
+                file: rel_str.clone(),
+                line: (line0 as u32) + 1,
+                column: (start.column(&node) as u32) + 1,
+                matched_text: collapse_snippet(&node.text()),
+                line_text,
+                lang: key.to_string(),
+            });
+            if result.matches.len() > max_results {
+                result.truncated = true;
+                result.matches.truncate(max_results);
+                return Ok(result);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn build_overrides(
+    project_root: &Path,
+    path_glob: Option<&str>,
+) -> Result<Option<Override>, AstGrepSearchError> {
+    match path_glob {
+        Some(raw) if !raw.trim().is_empty() => {
+            let mut builder = OverrideBuilder::new(project_root);
+            builder
+                .add(raw)
+                .map_err(|_| AstGrepSearchError::InvalidGlob(raw.to_string()))?;
+            let overrides = builder
+                .build()
+                .map_err(|_| AstGrepSearchError::InvalidGlob(raw.to_string()))?;
+            Ok(Some(overrides))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Collapses a (possibly multi-line) matched snippet to a single display line,
+/// squeezing interior whitespace and capping length.
+fn collapse_snippet(text: &str) -> String {
+    const MAX: usize = 200;
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > MAX {
+        let truncated: String = collapsed.chars().take(MAX).collect();
+        format!("{truncated}…")
+    } else {
+        collapsed
+    }
+}
+
+/// Classifies a byte buffer as binary when a NUL byte appears in the head — the
+/// same heuristic `git` and `ripgrep` use.
+fn looks_binary(bytes: &[u8]) -> bool {
+    bytes[..bytes.len().min(BINARY_SNIFF_BYTES)].contains(&0)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        fs::write(dir.join(name), body).unwrap();
+    }
+
+    #[test]
+    fn pre_process_rewrites_named_and_anonymous_metavars() {
+        // Named single/double/triple -> expando; positional `$1` untouched.
+        assert_eq!(pre_process_pattern('µ', "f($A)"), "f(µA)");
+        assert_eq!(pre_process_pattern('µ', "f($$$)"), "f(µµµ)");
+        assert_eq!(pre_process_pattern('µ', "f($1)"), "f($1)");
+        assert_eq!(pre_process_pattern('µ', "f($_)"), "f(µ_)");
+    }
+
+    #[test]
+    fn expando_matches_upstream_table() {
+        assert_eq!(expando_for_key("rust"), Some('µ'));
+        assert_eq!(expando_for_key("c"), Some('𐀀'));
+        assert_eq!(expando_for_key("css"), Some('_'));
+        assert_eq!(expando_for_key("javascript"), None);
+    }
+
+    #[test]
+    fn finds_rust_call_shape_in_process() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "orders.rs",
+            "fn place(wh: &mut W, o: &O) {\n    reserve_stock(wh, &item.sku, item.quantity);\n    let t = compute_total(&o.items);\n}\n",
+        );
+        // A file whose only mention is a comment must not match the call shape.
+        write(
+            dir.path(),
+            "util.js",
+            "// reserve_stock is called elsewhere\n",
+        );
+
+        let res = search_tree(dir.path(), "reserve_stock($$$)", None, None, 50).unwrap();
+        assert_eq!(res.matches.len(), 1, "matches: {:?}", res.matches);
+        let m = &res.matches[0];
+        assert_eq!(m.file, "orders.rs");
+        assert_eq!(m.line, 2);
+        assert_eq!(m.lang, "rust");
+        assert!(m.matched_text.contains("reserve_stock"));
+    }
+
+    #[test]
+    fn explicit_lang_filters_other_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.rs", "fn f() { g(1); }\n");
+        write(dir.path(), "b.py", "g(1)\n");
+        let res = search_tree(dir.path(), "g($A)", Some("rust"), None, 50).unwrap();
+        assert!(res.matches.iter().all(|m| m.file == "a.rs"));
+        assert_eq!(res.matches.len(), 1);
+    }
+
+    #[test]
+    fn path_glob_scopes_the_sweep() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::create_dir(dir.path().join("tests")).unwrap();
+        write(
+            dir.path().join("src").as_path(),
+            "a.rs",
+            "fn f() { g(1); }\n",
+        );
+        write(
+            dir.path().join("tests").as_path(),
+            "b.rs",
+            "fn f() { g(2); }\n",
+        );
+        let res = search_tree(dir.path(), "g($A)", None, Some("src/**/*.rs"), 50).unwrap();
+        assert_eq!(res.matches.len(), 1);
+        assert_eq!(res.matches[0].file, "src/a.rs");
+    }
+
+    #[test]
+    fn unknown_explicit_lang_is_hard_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a.rs", "fn f() {}\n");
+        let err = search_tree(dir.path(), "g($A)", Some("klingon"), None, 50).unwrap_err();
+        assert!(matches!(err, AstGrepSearchError::UnknownLang(_)));
+    }
+
+    #[test]
+    fn empty_pattern_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            search_tree(dir.path(), "   ", None, None, 50).unwrap_err(),
+            AstGrepSearchError::EmptyPattern
+        ));
+    }
+
+    #[test]
+    fn truncates_at_max_results() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "a.rs",
+            "fn f() {\n g(1);\n g(2);\n g(3);\n g(4);\n}\n",
+        );
+        let res = search_tree(dir.path(), "g($A)", Some("rust"), None, 2).unwrap();
+        assert_eq!(res.matches.len(), 2);
+        assert!(res.truncated);
+    }
+}

--- a/src/ast_grep_search.rs
+++ b/src/ast_grep_search.rs
@@ -245,6 +245,40 @@ pub fn search_tree(
     path_glob: Option<&str>,
     max_results: usize,
 ) -> Result<AstGrepSearchResult, AstGrepSearchError> {
+    search_tree_scoped(project_root, pattern, lang, path_glob, max_results, None)
+}
+
+pub(crate) fn search_tree_scoped(
+    project_root: &Path,
+    pattern: &str,
+    lang: Option<&str>,
+    path_glob: Option<&str>,
+    max_results: usize,
+    scope_prefix: Option<&str>,
+) -> Result<AstGrepSearchResult, AstGrepSearchError> {
+    search_tree_scoped_with_cancel(
+        project_root,
+        pattern,
+        lang,
+        path_glob,
+        max_results,
+        scope_prefix,
+        || false,
+    )
+}
+
+pub(crate) fn search_tree_scoped_with_cancel<F>(
+    project_root: &Path,
+    pattern: &str,
+    lang: Option<&str>,
+    path_glob: Option<&str>,
+    max_results: usize,
+    scope_prefix: Option<&str>,
+    is_cancelled: F,
+) -> Result<AstGrepSearchResult, AstGrepSearchError>
+where
+    F: Fn() -> bool,
+{
     if pattern.trim().is_empty() {
         return Err(AstGrepSearchError::EmptyPattern);
     }
@@ -287,25 +321,24 @@ pub fn search_tree(
     let mut result = AstGrepSearchResult::default();
 
     for entry in builder.build() {
+        if is_cancelled() {
+            return Ok(result);
+        }
         let Ok(entry) = entry else { continue };
         if !entry.file_type().is_some_and(|ft| ft.is_file()) {
             continue;
         }
         let path = entry.path();
-        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
-            continue;
-        };
 
-        // Resolve the language key: explicit override, else per-extension.
+        // An explicit language applies to every caller-selected file, including
+        // extensionless names such as Dockerfile. Without one, infer by suffix.
         let key = match lang {
-            Some(explicit) => {
-                // Skip files that are not this language.
-                if lang_key_for_ext(ext) != Some(explicit) {
-                    continue;
-                }
-                explicit
-            }
-            None => match lang_key_for_ext(ext) {
+            Some(explicit) => explicit,
+            None => match path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .and_then(lang_key_for_ext)
+            {
                 Some(k) => k,
                 None => continue,
             },
@@ -315,6 +348,9 @@ pub fn search_tree(
             continue;
         };
         let rel_str = rel.to_string_lossy().replace('\\', "/");
+        if !crate::path_scope::path_matches_scope(&rel_str, scope_prefix) {
+            continue;
+        }
 
         let Ok(bytes) = std::fs::read(path) else {
             continue;
@@ -345,6 +381,9 @@ pub fn search_tree(
         };
         let ast = AstGrep::doc(doc);
         for node in ast.root().find_all(compiled) {
+            if is_cancelled() {
+                return Ok(result);
+            }
             let start = node.start_pos();
             let line0 = start.line();
             let line_text = source_lines
@@ -447,7 +486,7 @@ mod tests {
         write(
             dir.path(),
             "util.js",
-            "// reserve_stock is called elsewhere\n",
+            "// reserve_stock is called elsewhere\nconst note = 'reserve_stock(a, b, c)';\n",
         );
 
         let res = search_tree(dir.path(), "reserve_stock($$$)", None, None, 50).unwrap();
@@ -460,13 +499,53 @@ mod tests {
     }
 
     #[test]
-    fn explicit_lang_filters_other_files() {
+    fn cancelled_search_stops_before_scanning() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "calls.rs", "fn f() { target(1); }\n");
+
+        let res = search_tree_scoped_with_cancel(
+            dir.path(),
+            "target($A)",
+            Some("rust"),
+            None,
+            50,
+            None,
+            || true,
+        )
+        .unwrap();
+
+        assert_eq!(res.files_scanned, 0);
+        assert!(res.matches.is_empty());
+    }
+
+    #[test]
+    fn explicit_lang_overrides_extension_inference_for_selected_files() {
         let dir = tempfile::tempdir().unwrap();
         write(dir.path(), "a.rs", "fn f() { g(1); }\n");
         write(dir.path(), "b.py", "g(1)\n");
-        let res = search_tree(dir.path(), "g($A)", Some("rust"), None, 50).unwrap();
-        assert!(res.matches.iter().all(|m| m.file == "a.rs"));
+        let res = search_tree(dir.path(), "g($A)", Some("rust"), Some("b.py"), 50).unwrap();
         assert_eq!(res.matches.len(), 1);
+        assert_eq!(res.matches[0].file, "b.py");
+        assert_eq!(res.matches[0].lang, "rust");
+    }
+
+    #[test]
+    fn explicit_lang_scans_extensionless_caller_selected_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "Dockerfile", "FROM alpine\nRUN echo ready\n");
+
+        let res = search_tree(
+            dir.path(),
+            "RUN echo ready",
+            Some("dockerfile"),
+            Some("Dockerfile"),
+            50,
+        )
+        .unwrap();
+
+        assert_eq!(res.files_scanned, 1);
+        assert_eq!(res.matches.len(), 1, "matches: {:?}", res.matches);
+        assert_eq!(res.matches[0].file, "Dockerfile");
     }
 
     #[test]

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -112,9 +112,14 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
         key: "search",
         label: "search",
         skill: "exploring-code",
-        message: "For codebase search, route by what you're matching: literal/regex text -> tracedecay_grep; symbol name -> tracedecay_search; concept -> tracedecay_context.",
-        context: "tracedecay_grep runs a literal or regex content search over the indexed tree (pattern, fixed_strings, path_glob) and enriches each hit with its enclosing symbol; tracedecay_search ranks symbols by name; tracedecay_context answers concept-level questions. Grep/ripgrep still fit prose and un-indexed files.",
-        expected_tools: &["tracedecay_grep", "tracedecay_search", "tracedecay_context"],
+        message: "For codebase search, route by what you're matching: literal/regex text -> tracedecay_grep; a code structure like a call shape or argument order -> tracedecay_ast_grep_search; symbol name -> tracedecay_search; concept -> tracedecay_context.",
+        context: "tracedecay_grep runs a literal or regex content search over the indexed tree (pattern, fixed_strings, path_glob) and enriches each hit with its enclosing symbol; tracedecay_ast_grep_search matches a syntax-tree pattern in-process (e.g. `foo($$$)`, `if ($C) { $$$ }`) when a text regex cannot express the call/argument shape, then pair it with tracedecay_ast_grep_rewrite to change matches; tracedecay_search ranks symbols by name; tracedecay_context answers concept-level questions. Grep/ripgrep still fit prose and un-indexed files.",
+        expected_tools: &[
+            "tracedecay_grep",
+            "tracedecay_ast_grep_search",
+            "tracedecay_search",
+            "tracedecay_context",
+        ],
         nonblocking: false,
     },
     HintCategorySpec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod accounting;
 pub mod agents;
 mod analytics;
 pub mod analytics_bridge;
+pub mod ast_grep_search;
 pub mod automation;
 pub mod bench;
 pub mod branch;

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -238,6 +238,7 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
     let mut definitions = vec![
         def_search(),
         def_grep(),
+        def_ast_grep_search(),
         def_retrieve(),
         def_context(),
         def_callers(),
@@ -381,6 +382,7 @@ const FORMAT_CAPABLE_TOOL_NAMES: &[&str] = &[
     // graph
     "tracedecay_search",
     "tracedecay_grep",
+    "tracedecay_ast_grep_search",
     "tracedecay_context",
     "tracedecay_callers",
     "tracedecay_callees",
@@ -3178,6 +3180,43 @@ fn def_lcm_session_boundary() -> ToolDefinition {
             },
             "allOf": lcm_storage_scope_requires_hermes_home(),
             "required": ["provider", "session_id"]
+        }),
+    )
+}
+
+fn def_ast_grep_search() -> ToolDefinition {
+    def(
+        "tracedecay_ast_grep_search",
+        "AST Structural Search",
+        "Structural (AST) code search: find call shapes, argument orders, and other \
+         syntax-tree patterns that a text regex cannot express. Uses ast-grep's SGPattern \
+         syntax (metavariables: `$X` one node, `$$$` many). Runs IN-PROCESS over the project \
+         working tree using the bundled tree-sitter grammars — no external ast-grep binary, no \
+         gating. Each hit resolves its enclosing symbol, so the natural next call is \
+         tracedecay_body. Routing: use this when the pattern is structural (e.g. `foo($$$)`, \
+         `if ($C) { $$$ }`); for a literal/regex string use tracedecay_grep; for a symbol name \
+         use tracedecay_search. To rewrite a structural match, pair with tracedecay_ast_grep_rewrite.",
+        json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "ast-grep structural pattern (SGPattern syntax), e.g. 'reserve_stock($$$)' or 'Result<$T, $E>'."
+                },
+                "lang": {
+                    "type": "string",
+                    "description": "Optional language key to force (e.g. 'rust', 'typescript', 'python'). Omit to auto-detect each file from its extension."
+                },
+                "path_glob": {
+                    "type": "string",
+                    "description": "Optional glob restricting which files are searched, matched against project-relative paths (e.g. 'src/**/*.rs')."
+                },
+                "max_results": {
+                    "type": "number",
+                    "description": "Maximum number of matches to return (default: 50, max: 200)."
+                }
+            },
+            "required": ["pattern"]
         }),
     )
 }

--- a/src/mcp/tools/handlers/ast_grep_search.rs
+++ b/src/mcp/tools/handlers/ast_grep_search.rs
@@ -22,6 +22,33 @@ const MAX_RESULTS_CAP: usize = 200;
 /// Default `max_results` when the caller omits it.
 const DEFAULT_MAX_RESULTS: usize = 50;
 
+async fn search_tree_off_thread(
+    project_root: std::path::PathBuf,
+    pattern: String,
+    lang: Option<String>,
+    path_glob: Option<String>,
+    max_results: usize,
+) -> Result<crate::ast_grep_search::AstGrepSearchResult> {
+    let query = pattern.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        search_tree(
+            &project_root,
+            &pattern,
+            lang.as_deref(),
+            path_glob.as_deref(),
+            max_results,
+        )
+    })
+    .await
+    .map_err(|err| TraceDecayError::Search {
+        message: format!("structural search worker failed: {err}"),
+        query,
+    })?;
+    result.map_err(|err| TraceDecayError::Config {
+        message: err.to_string(),
+    })
+}
+
 /// Handles `tracedecay_ast_grep_search` tool calls.
 pub(super) async fn handle_ast_grep_search(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let pattern =
@@ -47,12 +74,14 @@ pub(super) async fn handle_ast_grep_search(cg: &TraceDecay, args: Value) -> Resu
         .max(1);
 
     let project_root = cg.project_root().to_path_buf();
-    let mut search =
-        search_tree(&project_root, pattern, lang, path_glob, max_results).map_err(|err| {
-            TraceDecayError::Config {
-                message: err.to_string(),
-            }
-        })?;
+    let mut search = search_tree_off_thread(
+        project_root,
+        pattern.to_string(),
+        lang.map(str::to_owned),
+        path_glob.map(str::to_owned),
+        max_results,
+    )
+    .await?;
 
     // Enrich each hit with the smallest graph node that contains it (mirrors
     // tracedecay_grep so the model can jump straight to tracedecay_body).
@@ -163,4 +192,28 @@ fn render_md(hits: &[EnrichedHit], truncated: bool, files_scanned: usize) -> Str
     }
     md.line(&summary);
     md.render()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_search_wrapper_finds_match() {
+        let temp = tempfile::tempdir().expect("temp project");
+        std::fs::write(temp.path().join("lib.rs"), "fn f() { target(1); }\n")
+            .expect("write fixture");
+
+        let result = search_tree_off_thread(
+            temp.path().to_path_buf(),
+            "target($A)".to_string(),
+            Some("rust".to_string()),
+            None,
+            10,
+        )
+        .await
+        .expect("structural search");
+
+        assert_eq!(result.matches.len(), 1);
+    }
 }

--- a/src/mcp/tools/handlers/ast_grep_search.rs
+++ b/src/mcp/tools/handlers/ast_grep_search.rs
@@ -1,0 +1,166 @@
+//! Structural-search tool handler: `tracedecay_ast_grep_search`.
+//!
+//! Runs an ast-grep structural pattern over the project working tree *in
+//! process* (via [`crate::ast_grep_search`], which wires the repo's bundled
+//! tree-sitter grammars into the `ast-grep-core` pattern engine — no external
+//! `ast-grep` binary required). Each hit is graph-enriched with its enclosing
+//! symbol, exactly like `tracedecay_grep`, so the natural follow-up is
+//! `tracedecay_body`.
+
+use serde_json::{Value, json};
+
+use crate::ast_grep_search::{AstGrepSearchMatch, search_tree};
+use crate::errors::{Result, TraceDecayError};
+use crate::tracedecay::TraceDecay;
+
+use super::super::ToolResult;
+use super::super::render::{self, Md};
+use super::support::unique_file_paths;
+
+/// Hard cap on `max_results` regardless of what the caller requests.
+const MAX_RESULTS_CAP: usize = 200;
+/// Default `max_results` when the caller omits it.
+const DEFAULT_MAX_RESULTS: usize = 50;
+
+/// Handles `tracedecay_ast_grep_search` tool calls.
+pub(super) async fn handle_ast_grep_search(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+    let pattern =
+        args.get("pattern")
+            .and_then(Value::as_str)
+            .ok_or_else(|| TraceDecayError::Config {
+                message: "missing required parameter: pattern".to_string(),
+            })?;
+    let lang = args
+        .get("lang")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let path_glob = args
+        .get("path_glob")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let max_results = args
+        .get("max_results")
+        .and_then(Value::as_u64)
+        .map_or(DEFAULT_MAX_RESULTS, |v| (v as usize).min(MAX_RESULTS_CAP))
+        .max(1);
+
+    let project_root = cg.project_root().to_path_buf();
+    let mut search =
+        search_tree(&project_root, pattern, lang, path_glob, max_results).map_err(|err| {
+            TraceDecayError::Config {
+                message: err.to_string(),
+            }
+        })?;
+
+    // Enrich each hit with the smallest graph node that contains it (mirrors
+    // tracedecay_grep so the model can jump straight to tracedecay_body).
+    let mut hits: Vec<EnrichedHit> = Vec::with_capacity(search.matches.len());
+    for m in search.matches.drain(..) {
+        let mut hit = EnrichedHit::new(m);
+        if let Ok(Some(node)) = cg.node_at_location(&hit.m.file, hit.m.line).await {
+            hit.symbol_name = Some(node.name);
+            hit.symbol_id = Some(node.id);
+            hit.symbol_kind = Some(node.kind.as_str().to_string());
+        }
+        hits.push(hit);
+    }
+
+    let touched_files = unique_file_paths(hits.iter().map(|h| h.m.file.as_str()));
+    let output_value = build_output_value(&hits, search.truncated, search.files_scanned);
+
+    let text = render::finalize(Some(cg.project_root()), &args, &output_value, || {
+        render_md(&hits, search.truncated, search.files_scanned)
+    });
+    Ok(ToolResult::new(
+        json!({ "content": [{ "type": "text", "text": text }] }),
+        touched_files,
+    ))
+}
+
+/// A structural match plus its resolved enclosing graph symbol.
+struct EnrichedHit {
+    m: AstGrepSearchMatch,
+    symbol_name: Option<String>,
+    symbol_id: Option<String>,
+    symbol_kind: Option<String>,
+}
+
+impl EnrichedHit {
+    fn new(m: AstGrepSearchMatch) -> Self {
+        Self {
+            m,
+            symbol_name: None,
+            symbol_id: None,
+            symbol_kind: None,
+        }
+    }
+}
+
+fn build_output_value(hits: &[EnrichedHit], truncated: bool, files_scanned: usize) -> Value {
+    let items: Vec<Value> = hits
+        .iter()
+        .map(|hit| {
+            let mut item = json!({
+                "file": hit.m.file,
+                "line": hit.m.line,
+                "column": hit.m.column,
+                "lang": hit.m.lang,
+                "match": hit.m.matched_text,
+                "line_text": hit.m.line_text,
+            });
+            if let Some(name) = &hit.symbol_name {
+                item["symbol"] = json!(name);
+            }
+            if let Some(id) = &hit.symbol_id {
+                item["node_id"] = json!(id);
+            }
+            if let Some(kind) = &hit.symbol_kind {
+                item["kind"] = json!(kind);
+            }
+            item
+        })
+        .collect();
+
+    json!({
+        "results": items,
+        "match_count": hits.len(),
+        "files_scanned": files_scanned,
+        "truncated": truncated,
+    })
+}
+
+fn render_md(hits: &[EnrichedHit], truncated: bool, files_scanned: usize) -> String {
+    let mut md = Md::new();
+    md.heading(2, "Structural Search Results");
+    if hits.is_empty() {
+        md.empty_note("No structural matches.");
+        md.line(&format!("_Scanned {files_scanned} files._"));
+        return md.render();
+    }
+
+    for hit in hits {
+        let location = match (&hit.symbol_name, &hit.symbol_kind) {
+            (Some(name), Some(kind)) => {
+                format!("{}:{} — **{name}** ({kind})", hit.m.file, hit.m.line)
+            }
+            _ => format!("{}:{}", hit.m.file, hit.m.line),
+        };
+        md.bullet(&location);
+        md.line(&format!("  > {}", hit.m.matched_text));
+        if let Some(id) = &hit.symbol_id {
+            md.line(&format!(
+                "  `{id}` · call `tracedecay_body` to read the symbol"
+            ));
+        }
+    }
+
+    md.blank();
+    let mut summary = format!("_{} matches across {files_scanned} files._", hits.len());
+    if truncated {
+        summary.push_str(" Results capped — narrow with `path_glob` or `max_results`.");
+    }
+    md.line(&summary);
+    md.render()
+}

--- a/src/mcp/tools/handlers/ast_grep_search.rs
+++ b/src/mcp/tools/handlers/ast_grep_search.rs
@@ -7,9 +7,12 @@
 //! symbol, exactly like `tracedecay_grep`, so the natural follow-up is
 //! `tracedecay_body`.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use serde_json::{Value, json};
 
-use crate::ast_grep_search::{AstGrepSearchMatch, search_tree};
+use crate::ast_grep_search::{AstGrepSearchMatch, search_tree_scoped_with_cancel};
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
 
@@ -22,21 +25,34 @@ const MAX_RESULTS_CAP: usize = 200;
 /// Default `max_results` when the caller omits it.
 const DEFAULT_MAX_RESULTS: usize = 50;
 
+struct CancelSearchOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelSearchOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
+
 async fn search_tree_off_thread(
     project_root: std::path::PathBuf,
     pattern: String,
     lang: Option<String>,
     path_glob: Option<String>,
     max_results: usize,
+    scope_prefix: Option<String>,
 ) -> Result<crate::ast_grep_search::AstGrepSearchResult> {
     let query = pattern.clone();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancel_on_drop = CancelSearchOnDrop(cancelled.clone());
     let result = tokio::task::spawn_blocking(move || {
-        search_tree(
+        search_tree_scoped_with_cancel(
             &project_root,
             &pattern,
             lang.as_deref(),
             path_glob.as_deref(),
             max_results,
+            scope_prefix.as_deref(),
+            || cancelled.load(Ordering::Acquire),
         )
     })
     .await
@@ -44,13 +60,18 @@ async fn search_tree_off_thread(
         message: format!("structural search worker failed: {err}"),
         query,
     })?;
+    drop(cancel_on_drop);
     result.map_err(|err| TraceDecayError::Config {
         message: err.to_string(),
     })
 }
 
 /// Handles `tracedecay_ast_grep_search` tool calls.
-pub(super) async fn handle_ast_grep_search(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+pub(super) async fn handle_ast_grep_search(
+    cg: &TraceDecay,
+    args: Value,
+    scope_prefix: Option<&str>,
+) -> Result<ToolResult> {
     let pattern =
         args.get("pattern")
             .and_then(Value::as_str)
@@ -80,6 +101,7 @@ pub(super) async fn handle_ast_grep_search(cg: &TraceDecay, args: Value) -> Resu
         lang.map(str::to_owned),
         path_glob.map(str::to_owned),
         max_results,
+        scope_prefix.map(str::to_owned),
     )
     .await?;
 
@@ -198,6 +220,15 @@ fn render_md(hits: &[EnrichedHit], truncated: bool, files_scanned: usize) -> Str
 mod tests {
     use super::*;
 
+    #[test]
+    fn cancellation_guard_signals_worker_on_drop() {
+        let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        {
+            let _guard = CancelSearchOnDrop(cancelled.clone());
+        }
+        assert!(cancelled.load(std::sync::atomic::Ordering::Acquire));
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn blocking_search_wrapper_finds_match() {
         let temp = tempfile::tempdir().expect("temp project");
@@ -210,6 +241,7 @@ mod tests {
             Some("rust".to_string()),
             None,
             10,
+            None,
         )
         .await
         .expect("structural search");

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod analysis;
 mod analytics;
+pub mod ast_grep_search;
 pub mod dashboard;
 mod dependency_hints;
 pub mod edit;
@@ -286,6 +287,7 @@ pub async fn handle_tool_call_with_registry_and_implicit_project(
     match tool_name {
         "tracedecay_search" => graph::handle_search(cg, args, selected_scope_prefix).await,
         "tracedecay_grep" => grep::handle_grep(cg, args, selected_scope_prefix).await,
+        "tracedecay_ast_grep_search" => ast_grep_search::handle_ast_grep_search(cg, args).await,
         "tracedecay_retrieve" => handle_retrieve(cg, &args),
         "tracedecay_context" => graph::handle_context(cg, args, selected_scope_prefix).await,
         "tracedecay_callers" => graph::handle_callers(cg, args).await,
@@ -1116,6 +1118,9 @@ mod tests {
         assert!(tool_names.contains(&"tracedecay_str_replace"));
         assert!(tool_names.contains(&"tracedecay_multi_str_replace"));
         assert!(tool_names.contains(&"tracedecay_insert_at"));
+        // Structural search runs in-process (bundled grammars), so it is always
+        // advertised — unlike the CLI-backed rewrite tool gated just below.
+        assert!(tool_names.contains(&"tracedecay_ast_grep_search"));
         if super::super::definitions::ast_grep_available() {
             assert!(tool_names.contains(&"tracedecay_ast_grep_rewrite"));
         } else {

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -287,7 +287,9 @@ pub async fn handle_tool_call_with_registry_and_implicit_project(
     match tool_name {
         "tracedecay_search" => graph::handle_search(cg, args, selected_scope_prefix).await,
         "tracedecay_grep" => grep::handle_grep(cg, args, selected_scope_prefix).await,
-        "tracedecay_ast_grep_search" => ast_grep_search::handle_ast_grep_search(cg, args).await,
+        "tracedecay_ast_grep_search" => {
+            ast_grep_search::handle_ast_grep_search(cg, args, selected_scope_prefix).await
+        }
         "tracedecay_retrieve" => handle_retrieve(cg, &args),
         "tracedecay_context" => graph::handle_context(cg, args, selected_scope_prefix).await,
         "tracedecay_callers" => graph::handle_callers(cg, args).await,

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -1058,7 +1058,7 @@ mod tests {
         // host CLI capabilities they need; agents should never see a tool that
         // will instantly fail. The count and per-tool checks below adapt to
         // the host's capability set.
-        let expected_total = 101 + usize::from(super::super::definitions::ast_grep_available());
+        let expected_total = 102 + usize::from(super::super::definitions::ast_grep_available());
         assert_eq!(tools.len(), expected_total);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -2075,6 +2075,41 @@ async fn test_grep_path_glob_filters_files() {
 }
 
 #[tokio::test]
+async fn test_ast_grep_search_respects_scope_prefix() {
+    let (cg, _dir) = setup_project().await;
+    let root = cg.project_root().to_path_buf();
+    fs::write(
+        root.join("src/outside_scope.rs"),
+        "fn outside() { scope_probe(1); }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("tests/inside_scope.rs"),
+        "fn inside() { scope_probe(2); }\n",
+    )
+    .unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_ast_grep_search",
+        json!({"pattern": "scope_probe($A)", "format": "json"}),
+        None,
+        Some("tests"),
+    )
+    .await
+    .unwrap();
+    let payload = extract_json(&result.value);
+    let files: Vec<&str> = payload["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hit| hit["file"].as_str().unwrap())
+        .collect();
+
+    assert_eq!(files, vec!["tests/inside_scope.rs"], "{payload}");
+}
+
+#[tokio::test]
 async fn test_grep_enforces_max_results_cap() {
     let (cg, _dir) = setup_project().await;
     let root = cg.project_root().to_path_buf();

--- a/tests/mcp_suite/mcp_test.rs
+++ b/tests/mcp_suite/mcp_test.rs
@@ -100,7 +100,8 @@ fn test_tool_definitions_count() {
     // is available. Outline stays registered and reports the ast-grep outline
     // requirement at runtime so plugin docs/rules can consistently reference it.
     // LCM comparison and profile-storage registry support add extra tools.
-    let expected = 101 + usize::from(tracedecay::mcp::tools::ast_grep_available());
+    // ast_grep_search (in-process structural search) is always registered.
+    let expected = 102 + usize::from(tracedecay::mcp::tools::ast_grep_available());
     assert_eq!(tools.len(), expected);
 }
 
@@ -114,6 +115,9 @@ fn test_ast_grep_tools_follow_capability_gates() {
         tracedecay::mcp::tools::ast_grep_available(),
         "rewrite should be gated on the external ast-grep CLI"
     );
+    // Structural search runs in-process (bundled grammars), so it is advertised
+    // unconditionally — no host ast-grep CLI required.
+    assert!(tool_names.contains(&"tracedecay_ast_grep_search"));
     assert!(tool_names.contains(&"tracedecay_outline"));
 }
 


### PR DESCRIPTION
## What

Adds **`tracedecay_ast_grep_search`** — a read-only structural (AST) search tool for call shapes, argument orders, and expression forms that a text regex cannot express. Structural *search* previously had no tool at all; only `tracedecay_ast_grep_rewrite` existed.

## Backend: ast-grep as a library, not the CLI

Per the design directive, this evaluates `ast-grep-core` as an in-process backend and ships it:

- **Compat check (passed):** `ast-grep-core` 0.44 pins `tree-sitter ^0.26.3`; this repo builds its grammars against `tree-sitter` 0.26.8 — same 0.26 minor, ABI-compatible. `ast_grep_core::tree_sitter::TSLanguage` is a re-export of `tree_sitter::Language`, exactly what `extraction::ts_provider::try_language` already returns.
- **Wiring:** a small `TdLang` wrapper implements ast-grep-core's `Language`/`LanguageExt` traits over the repo's **own bundled grammars** — no new grammar crates, no external `ast-grep` binary, and **no `ast_grep_available()` gating** (the tool registers unconditionally). Metavariable pre-processing and per-language expando chars (`µ`, `𐀀`, `_`) are mirrored from `ast-grep-language` so pattern semantics match the upstream CLI.
- The existing CLI-backed `ast_grep_rewrite` tool is **left unchanged** (library-backed rewrite, with its apply/diff semantics, is a follow-up).

New deps: `ast-grep-core` (+ `bit-set`/`bit-vec`). No new tree-sitter grammar crates.

## Tool

- Args: `pattern` (required), `lang` (optional; auto-detected per file otherwise), `path_glob` (optional scope), `max_results` (default 50, cap 200).
- Output: markdown (default) + `format: json`; each hit is graph-enriched with its enclosing symbol like `tracedecay_grep`, so the next call is `tracedecay_body`. CLI twin works: `tracedecay tool tracedecay_ast_grep_search`.

## Discovery wiring

- **Hints:** the search category now routes structural patterns to `tracedecay_ast_grep_search` (the edit category keeps its `ast_grep_rewrite` mention). Hint-signature drift guard stays green.
- **Skills:** `exploring-code` gains a structural-search routing row; `editing-safely` links search→rewrite.
- **Evals:** one **active** search scenario grounded in the fixture (`reserve_stock(...)` three-arg call shape in `place_order`), and one **deferred** rewrite scenario (fixture has a single call site and the rewrite tool is CLI-gated).

## Gates (all green)

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo nextest run --test mcp_suite --test agent_suite --no-fail-fast` → 852 + 488 pass
- `grade.py --lint-only` (53 neutral), `--check-hints` (21 signatures intact), `selftest.py` (all pass)
- 8 in-process engine unit tests

## Live smoke (against this repo)

`pattern: "ToolResult::new($$$)"` → real matches with enclosing symbols, e.g.:

```
- src/mcp/tools/handlers/edit.rs:188 — text_tool_result (function)
  > ToolResult::new( json!({ "content": [{ "type": "text", "text": text }] }), touched_files, )
- src/mcp/tools/handlers/workflow.rs:245 — handle_diagnose (function)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up

The working-tree walk and AST parsing now run on Tokio's blocking pool so a broad or zero-match search cannot stall the MCP async runtime. Added a current-thread wrapper regression; focused engine tests and full clippy remain green.