### PR TITLE
test(daemon): observe git watcher drains exactly

### DIFF
--- a/src/daemon/git_watch.rs
+++ b/src/daemon/git_watch.rs
@@ -125,6 +125,11 @@ struct WatchState {
     /// Test-only: `debounce_loop` signals once before its first `wake` wait.
     #[cfg(test)]
     entered_debounce: Notify,
+    /// Test-only: count and signal completed dirty-set drains before plan I/O.
+    #[cfg(test)]
+    drained_plans: AtomicU64,
+    #[cfg(test)]
+    plan_drained: Notify,
 }
 
 #[derive(Debug, Default)]
@@ -311,6 +316,10 @@ impl GitWatcher {
             task: Mutex::new(None),
             #[cfg(test)]
             entered_debounce: Notify::new(),
+            #[cfg(test)]
+            drained_plans: AtomicU64::new(0),
+            #[cfg(test)]
+            plan_drained: Notify::new(),
         });
         projects.insert(canonical.clone(), Arc::clone(&state));
         drop(projects);
@@ -555,6 +564,11 @@ async fn debounce_loop(inner: &Arc<GitWatcherInner>, state: &Arc<WatchState>, co
             dirty.take()
         };
         if !plan.is_empty() {
+            #[cfg(test)]
+            {
+                state.drained_plans.fetch_add(1, Ordering::Relaxed);
+                state.plan_drained.notify_one();
+            }
             execute_plan(inner, state, common, plan).await;
         }
         state.health.beat();

--- a/src/daemon/git_watch/tests.rs
+++ b/src/daemon/git_watch/tests.rs
@@ -30,6 +30,8 @@ fn ref_event_marks_branch_and_delete_marks_gc() {
         health: ProjectHealth::default(),
         task: Mutex::new(None),
         entered_debounce: Notify::new(),
+        drained_plans: AtomicU64::new(0),
+        plan_drained: Notify::new(),
     });
     let create = notify::Event {
         kind: EventKind::Create(notify::event::CreateKind::File),
@@ -288,18 +290,20 @@ async fn debounce_loop_coalesces_and_drains_events() {
 
     tokio::time::advance(Duration::from_millis(max_delay_ms + 1)).await;
 
-    let drained = tokio::time::timeout(Duration::from_secs(30), async {
-        loop {
-            if state.dirty.lock().await.is_clean() {
-                return true;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .unwrap_or(false);
+    let drained = tokio::time::timeout(Duration::from_secs(30), state.plan_drained.notified())
+        .await
+        .is_ok();
     assert!(
         drained,
         "the real debounce loop must coalesce the event burst and drain the dirty set"
+    );
+    assert_eq!(
+        state.drained_plans.load(Ordering::Relaxed),
+        1,
+        "one event burst must produce exactly one coalesced plan"
+    );
+    assert!(
+        state.dirty.lock().await.is_clean(),
+        "draining the coalesced plan must clear the dirty set"
     );
 }


### PR DESCRIPTION
## Summary\n- replace paused-time polling with a test-only drain counter and Notify\n- assert one coalesced watcher plan deterministically\n- leave production watcher behavior unchanged\n\n## Tests\n- focused git watcher: 25 passed\n- aggregate watcher repetitions: 10 passed\n- cargo fmt / clippy