### PR TITLE
test(dashboard): isolate host session catch-up

### DIFF
--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -367,12 +367,20 @@ pub async fn run_until_shutdown_for_tests<F>(
     cg: &TraceDecay,
     host: &str,
     port: u16,
+    repair_memory_on_startup: bool,
     shutdown: F,
 ) -> Result<()>
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
-    run_until_shutdown_inner(cg, host, port, shutdown, DashboardRunOptions::test()).await
+    run_until_shutdown_inner(
+        cg,
+        host,
+        port,
+        shutdown,
+        DashboardRunOptions::test(repair_memory_on_startup),
+    )
+    .await
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -393,10 +401,10 @@ impl DashboardRunOptions {
         }
     }
 
-    fn test() -> Self {
+    fn test(repair_memory_on_startup: bool) -> Self {
         Self {
             open: false,
-            repair_memory_on_startup: false,
+            repair_memory_on_startup,
             warm_token_counts: false,
             start_session_catch_up: false,
         }

--- a/tests/dashboard_api_test/analytics.rs
+++ b/tests/dashboard_api_test/analytics.rs
@@ -350,7 +350,14 @@ async fn start_fixture(seed_durable_events: bool) -> Fixture {
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
-        let _ = dashboard::run(&cg, "127.0.0.1", port, false).await;
+        let _ = dashboard::run_until_shutdown_for_tests(
+            &cg,
+            "127.0.0.1",
+            port,
+            false,
+            std::future::pending(),
+        )
+        .await;
     });
     wait_for_dashboard(&http_agent(), &base_url).await;
 

--- a/tests/dashboard_api_test/dashboard_api_support.rs
+++ b/tests/dashboard_api_test/dashboard_api_support.rs
@@ -72,33 +72,32 @@ impl Drop for DashboardServer {
 }
 
 pub(crate) fn spawn_dashboard_server(cg: TraceDecay, port: u16) -> DashboardServer {
-    spawn_dashboard_server_with_runner(cg, port, false)
+    spawn_dashboard_server_with_runner(cg, port, true)
 }
 
 pub(crate) fn spawn_dashboard_server_lightweight(cg: TraceDecay, port: u16) -> DashboardServer {
-    spawn_dashboard_server_with_runner(cg, port, true)
+    spawn_dashboard_server_with_runner(cg, port, false)
 }
 
 fn spawn_dashboard_server_with_runner(
     cg: TraceDecay,
     port: u16,
-    lightweight: bool,
+    repair_memory_on_startup: bool,
 ) -> DashboardServer {
     let (shutdown, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let thread = thread::spawn(move || {
         let runtime = create_runtime();
         runtime.block_on(async move {
-            let result = if lightweight {
-                dashboard::run_until_shutdown_for_tests(&cg, "127.0.0.1", port, async move {
+            let result = dashboard::run_until_shutdown_for_tests(
+                &cg,
+                "127.0.0.1",
+                port,
+                repair_memory_on_startup,
+                async move {
                     let _ = shutdown_rx.await;
-                })
-                .await
-            } else {
-                dashboard::run_until_shutdown(&cg, "127.0.0.1", port, false, async move {
-                    let _ = shutdown_rx.await;
-                })
-                .await
-            };
+                },
+            )
+            .await;
             let _ = cg.checkpoint().await;
             cg.close();
             let _ = result;

--- a/tests/dashboard_api_test/graph.rs
+++ b/tests/dashboard_api_test/graph.rs
@@ -195,7 +195,14 @@ async fn start_dashboard_fixture_with(with_orphan: bool) -> DashboardFixture {
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
-        let _ = dashboard::run(&cg, "127.0.0.1", port, false).await;
+        let _ = dashboard::run_until_shutdown_for_tests(
+            &cg,
+            "127.0.0.1",
+            port,
+            false,
+            std::future::pending(),
+        )
+        .await;
     });
 
     let agent = http_agent();

--- a/tests/dashboard_api_test/lcm.rs
+++ b/tests/dashboard_api_test/lcm.rs
@@ -228,7 +228,14 @@ async fn start_fixture() -> Fixture {
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
-        let _ = dashboard::run(&cg, "127.0.0.1", port, false).await;
+        let _ = dashboard::run_until_shutdown_for_tests(
+            &cg,
+            "127.0.0.1",
+            port,
+            false,
+            std::future::pending(),
+        )
+        .await;
     });
     wait_for_dashboard(&http_agent(), &base_url).await;
 

--- a/tests/dashboard_api_test/lcm_fixes.rs
+++ b/tests/dashboard_api_test/lcm_fixes.rs
@@ -353,7 +353,14 @@ async fn start_fixture(external_payload: bool) -> DashboardFixture {
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
-        let _ = dashboard::run(&cg, "127.0.0.1", port, false).await;
+        let _ = dashboard::run_until_shutdown_for_tests(
+            &cg,
+            "127.0.0.1",
+            port,
+            false,
+            std::future::pending(),
+        )
+        .await;
     });
 
     let agent = http_agent();

--- a/tests/dashboard_api_test/savings.rs
+++ b/tests/dashboard_api_test/savings.rs
@@ -461,7 +461,14 @@ async fn start_fixture(seed: FixtureSeed) -> Fixture {
     let port = pick_free_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let server = tokio::spawn(async move {
-        let _ = dashboard::run(&cg, "127.0.0.1", port, false).await;
+        let _ = dashboard::run_until_shutdown_for_tests(
+            &cg,
+            "127.0.0.1",
+            port,
+            false,
+            std::future::pending(),
+        )
+        .await;
     });
 
     wait_for_dashboard(&http_agent(), &base_url).await;


### PR DESCRIPTION
## Summary\n- keep dashboard tests from ingesting real user-profile sessions\n- preserve optional memory repair while disabling catch-up and warmup in test runners\n- reduce aggregate dashboard CPU from the observed 137s interruption path to 9-13s\n\n## Tests\n- dashboard API: 48 passed\n- cargo clippy --all-targets --all-features -- -D warnings