### PR TITLE
refactor: shared process run id and random-token minting

### DIFF
--- a/src/automation/lifecycle.rs
+++ b/src/automation/lifecycle.rs
@@ -647,6 +647,10 @@ fn scheduler_skip_reason(
 }
 
 pub(crate) fn generated_run_id(prefix: &str) -> String {
+    // Not folded into `runtime_identity::random_hex_token`: its RNG-failure
+    // fallback is the process id (stable, distinct per process), whereas
+    // `random_hex_token` falls back to a hex timestamp. Reusing it would change
+    // this function's output on the getrandom-failure path.
     let mut random = [0u8; 8];
     let entropy = match getrandom::getrandom(&mut random) {
         Ok(()) => hex::encode(random),

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -66,6 +66,10 @@ struct ExtractData {
     mtime: i64,
 }
 
+// Not folded into `runtime_identity::random_hex_token`: this returns the raw
+// bytes (not hex) and propagates an RNG failure as an `io::Error` rather than
+// falling back, both of which the String-returning, never-failing helper cannot
+// preserve.
 fn generate_token() -> io::Result<[u8; TOKEN_LEN]> {
     let mut buf = [0u8; TOKEN_LEN];
     getrandom::getrandom(&mut buf)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub mod project_registry;
 pub mod redundancy;
 pub mod resolution;
 pub mod retention;
+pub mod runtime_identity;
 pub mod runtime_telemetry;
 pub mod serve;
 pub mod sessions;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -862,9 +862,12 @@ pub struct McpServer {
     /// connection that gets re-initialized by a different client picks up
     /// the new identity.
     client_name: std::sync::Mutex<Option<String>>,
-    /// Stable per-process instance id (random hex token minted once when this
-    /// server is constructed). Recorded in every analytics event's
-    /// `metadata.mcp_instance_id`.
+    /// Stable per-process instance id from
+    /// [`crate::runtime_identity::process_run_id`] (a random hex token minted
+    /// once per process). Recorded in every analytics event's
+    /// `metadata.mcp_instance_id`. Hoisting it to `runtime_identity` lets the
+    /// daemon later stamp the *same* id on its own events, grouping one process
+    /// lifetime across both the MCP server and the daemon.
     ///
     /// The MCP transport negotiates only `clientInfo` (host name) at
     /// `initialize` — never a session/conversation id — and no session env var
@@ -876,17 +879,6 @@ pub struct McpServer {
     /// be grouped. It is deliberately kept out of the `session_id` column so it
     /// never masquerades as a real session.
     mcp_instance_id: String,
-}
-
-/// Mint a random per-process MCP instance id (32 lowercase hex chars from 16
-/// random bytes). Best-effort: if the OS RNG is unavailable, fall back to a
-/// timestamped token so the field is always populated and never panics.
-fn new_mcp_instance_id() -> String {
-    let mut buf = [0u8; 16];
-    match getrandom::getrandom(&mut buf) {
-        Ok(()) => hex::encode(buf),
-        Err(_) => format!("mcp-{}", crate::tracedecay::current_timestamp()),
-    }
 }
 
 impl McpServer {
@@ -1024,7 +1016,11 @@ impl McpServer {
                 crate::sessions::git_correlation::SpanObservationDebounce::new(),
             ),
             client_name: std::sync::Mutex::new(None),
-            mcp_instance_id: new_mcp_instance_id(),
+            // Shared process run id: the daemon should stamp this same id on its
+            // own events so one process lifetime groups across both surfaces.
+            // Field/metadata key stay `mcp_instance_id` (no analytics schema
+            // churn) even though the id now lives in `runtime_identity`.
+            mcp_instance_id: crate::runtime_identity::process_run_id().to_string(),
         });
 
         tokio::task::spawn_blocking(move || {

--- a/src/runtime_identity.rs
+++ b/src/runtime_identity.rs
@@ -1,0 +1,69 @@
+//! Process-wide runtime identity and random-token minting.
+//!
+//! Hoists the "mint a random per-process id" idiom out of the MCP server so
+//! other long-lived components (notably the daemon) can adopt the *same*
+//! process instance id later instead of each minting its own. Keeping it in one
+//! crate-level home means the entropy → hex → fallback logic is written once.
+
+use std::sync::OnceLock;
+
+/// Stable per-process run id, minted once on first call and reused for the
+/// lifetime of the process.
+///
+/// 32 lowercase hex chars from 16 bytes of OS entropy. Best-effort: if the OS
+/// RNG is unavailable it falls back to a timestamped token so the id is always
+/// populated and the call never panics.
+///
+/// This is the shared home for the value the MCP server records as
+/// `metadata.mcp_instance_id`. The daemon should stamp this *same* id on its own
+/// events so a single process lifetime can be grouped across the MCP server and
+/// the daemon, rather than each component minting an independent id.
+pub fn process_run_id() -> &'static str {
+    static RUN_ID: OnceLock<String> = OnceLock::new();
+    RUN_ID.get_or_init(|| {
+        let mut buf = [0u8; 16];
+        match getrandom::getrandom(&mut buf) {
+            Ok(()) => hex::encode(buf),
+            Err(_) => format!("mcp-{}", crate::tracedecay::current_timestamp()),
+        }
+    })
+}
+
+/// Mint a fresh lowercase-hex token from `bytes` bytes of OS entropy (two hex
+/// chars per byte). Best-effort: if the OS RNG is unavailable it falls back to a
+/// hex-encoded timestamp so the token is always populated and the call never
+/// panics.
+///
+/// This holds the raw getrandom → hex idiom so callers that need a one-off
+/// random hex segment do not each re-implement it.
+pub fn random_hex_token(bytes: usize) -> String {
+    let mut buf = vec![0u8; bytes];
+    match getrandom::getrandom(&mut buf) {
+        Ok(()) => hex::encode(&buf),
+        Err(_) => hex::encode(crate::tracedecay::current_timestamp().to_le_bytes()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_run_id_is_stable_within_the_process() {
+        let first = process_run_id();
+        let second = process_run_id();
+        // Same borrow of the same OnceLock-backed value on every call.
+        assert_eq!(first, second);
+        assert!(std::ptr::eq(first, second));
+        assert!(!first.is_empty());
+    }
+
+    #[test]
+    fn random_hex_token_has_two_hex_chars_per_byte() {
+        let token = random_hex_token(16);
+        assert_eq!(token.len(), 32);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+        // Distinct calls mint distinct tokens (entropy, not a cached value).
+        assert_ne!(random_hex_token(16), random_hex_token(16));
+    }
+}


### PR DESCRIPTION
Follow-up to #378 (merged): hoist process-instance identity to a shared home so the daemon can adopt it later.

- New `src/runtime_identity.rs` with `process_run_id() -> &'static str` (OnceLock-backed, minted once per process via the same getrandom -> hex -> timestamp-fallback logic `new_mcp_instance_id` used) and `random_hex_token(bytes)` holding the getrandom -> hex idiom with fallback.
- `McpServer::new` now uses `runtime_identity::process_run_id()`; the field and metadata key stay `mcp_instance_id` (no analytics schema churn), with a doc note that the daemon should stamp the same id later.
- `automation::lifecycle::generated_run_id` and `extraction_worker::generate_token` were left as-is with comments explaining why: the former's RNG-failure fallback is the process id (reusing the helper would change its output on that path), the latter returns raw bytes and propagates RNG failure as `io::Error`, which the never-failing String helper cannot preserve.

Verified: `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings` (0 errors), `cargo test --lib "mcp::"` (183 passed), `cargo test --lib tool_analytics` (9 passed), `cargo test --lib runtime_identity` (2 passed, including the new process-run-id stability unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)