### PR TITLE
refactor(runtime): keep process identity API minimal

### DIFF
--- a/src/automation/lifecycle.rs
+++ b/src/automation/lifecycle.rs
@@ -647,10 +647,6 @@ fn scheduler_skip_reason(
 }
 
 pub(crate) fn generated_run_id(prefix: &str) -> String {
-    // Not folded into `runtime_identity::random_hex_token`: its RNG-failure
-    // fallback is the process id (stable, distinct per process), whereas
-    // `random_hex_token` falls back to a hex timestamp. Reusing it would change
-    // this function's output on the getrandom-failure path.
     let mut random = [0u8; 8];
     let entropy = match getrandom::getrandom(&mut random) {
         Ok(()) => hex::encode(random),

--- a/src/extraction_worker.rs
+++ b/src/extraction_worker.rs
@@ -66,10 +66,6 @@ struct ExtractData {
     mtime: i64,
 }
 
-// Not folded into `runtime_identity::random_hex_token`: this returns the raw
-// bytes (not hex) and propagates an RNG failure as an `io::Error` rather than
-// falling back, both of which the String-returning, never-failing helper cannot
-// preserve.
 fn generate_token() -> io::Result<[u8; TOKEN_LEN]> {
     let mut buf = [0u8; TOKEN_LEN];
     getrandom::getrandom(&mut buf)

--- a/src/runtime_identity.rs
+++ b/src/runtime_identity.rs
@@ -1,9 +1,8 @@
-//! Process-wide runtime identity and random-token minting.
+//! Process-wide runtime identity.
 //!
 //! Hoists the "mint a random per-process id" idiom out of the MCP server so
 //! other long-lived components (notably the daemon) can adopt the *same*
-//! process instance id later instead of each minting its own. Keeping it in one
-//! crate-level home means the entropy → hex → fallback logic is written once.
+//! process instance id later instead of each minting its own.
 
 use std::sync::OnceLock;
 
@@ -29,21 +28,6 @@ pub fn process_run_id() -> &'static str {
     })
 }
 
-/// Mint a fresh lowercase-hex token from `bytes` bytes of OS entropy (two hex
-/// chars per byte). Best-effort: if the OS RNG is unavailable it falls back to a
-/// hex-encoded timestamp so the token is always populated and the call never
-/// panics.
-///
-/// This holds the raw getrandom → hex idiom so callers that need a one-off
-/// random hex segment do not each re-implement it.
-pub fn random_hex_token(bytes: usize) -> String {
-    let mut buf = vec![0u8; bytes];
-    match getrandom::getrandom(&mut buf) {
-        Ok(()) => hex::encode(&buf),
-        Err(_) => hex::encode(crate::tracedecay::current_timestamp().to_le_bytes()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -56,14 +40,5 @@ mod tests {
         assert_eq!(first, second);
         assert!(std::ptr::eq(first, second));
         assert!(!first.is_empty());
-    }
-
-    #[test]
-    fn random_hex_token_has_two_hex_chars_per_byte() {
-        let token = random_hex_token(16);
-        assert_eq!(token.len(), 32);
-        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
-        // Distinct calls mint distinct tokens (entropy, not a cached value).
-        assert_ne!(random_hex_token(16), random_hex_token(16));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged #396.

- remove the unused public `random_hex_token(bytes)` helper and its test
- remove comments added only to justify why existing token generators did not call that unused helper
- retain the actual shared `process_run_id()` API used by MCP analytics

## Why

The helper had no production caller and its RNG-failure fallback always returned a 16-character timestamp regardless of the requested byte count, contradicting its documented `2 * bytes` contract. Keeping it would publish speculative surface area with an untested failure-path bug.

## Tests

- `cargo test --lib runtime_identity`: pass
- `cargo test --lib mcp::`: 183 immediate tests passed; unrelated timer/global-store tests then starved under the concurrent local build load and the run was interrupted
- upstream #396 CI was green before merge; this follow-up only deletes unused code/comments