### PR TITLE
fix(storage): adopt legacy identity stores safely

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -446,7 +446,9 @@ pub(crate) fn matching_legacy_profile_layouts(
     manifest_paths.sort();
 
     let mut layouts = Vec::new();
-    let project_git_common_dir = crate::worktree::git_common_dir(project_root);
+    let project_git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
+        .then(|| crate::worktree::git_common_dir(project_root))
+        .flatten();
     let mut legacy_git_common_dirs = HashMap::<PathBuf, Option<PathBuf>>::new();
     for manifest_path in manifest_paths {
         let Ok(manifest) = read_store_manifest(&manifest_path) else {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,6 +12,8 @@ use crate::errors::{Result, TraceDecayError};
 
 pub const ENROLLMENT_FILENAME: &str = "enrollment.json";
 pub const STORE_MANIFEST_FILENAME: &str = "store_manifest.json";
+pub const IDENTITY_CUTOVER_BACKUP_MANIFEST_FILENAME: &str =
+    "store_manifest.identity-cutover-backup.json";
 pub const SESSIONS_DB_FILENAME: &str = "sessions.db";
 pub const BRANCH_META_FILENAME: &str = "branch-meta.json";
 pub const REPOSITORY_IDENTITY_FILENAME: &str = "tracedecay-project.json";
@@ -420,6 +422,135 @@ pub(crate) fn resolve_persisted_layout(
         },
     )
     .map(Some)
+}
+
+/// Finds pre-repository-identity profile stores that were keyed by an older
+/// path-derived project id but still name this exact local checkout in their
+/// manifest. Remote URLs are deliberately not considered: two clones of one
+/// remote are different local identities.
+pub(crate) fn matching_legacy_profile_layouts(
+    project_root: &Path,
+    profile_root: &Path,
+    excluded_project_id: Option<&str>,
+) -> Result<Vec<StoreLayout>> {
+    let projects_root = profile_root.join("projects");
+    let Ok(entries) = fs::read_dir(&projects_root) else {
+        return Ok(Vec::new());
+    };
+    let mut manifest_paths = entries
+        .flatten()
+        .map(|entry| entry.path().join(STORE_MANIFEST_FILENAME))
+        .filter(|path| path.is_file())
+        .collect::<Vec<_>>();
+    manifest_paths.sort();
+
+    let mut layouts = Vec::new();
+    for manifest_path in manifest_paths {
+        let Ok(manifest) = read_store_manifest(&manifest_path) else {
+            continue;
+        };
+        if !same_local_path(&manifest.project_root, project_root) {
+            continue;
+        }
+        let project_id = manifest
+            .project_id
+            .as_deref()
+            .ok_or_else(|| invalid_legacy_manifest(&manifest_path, "project_id is missing"))?;
+        validate_project_id(project_id)
+            .map_err(|message| invalid_legacy_manifest(&manifest_path, message))?;
+        if excluded_project_id == Some(project_id) {
+            continue;
+        }
+        if manifest.schema_version != STORE_MANIFEST_SCHEMA_VERSION
+            || manifest.store_kind != StoreKind::CodeProject
+            || manifest.storage_mode != StorageMode::ProfileSharded
+        {
+            return Err(invalid_legacy_manifest(
+                &manifest_path,
+                "unsupported schema, store kind, or storage mode",
+            ));
+        }
+
+        let layout = profile_sharded_layout(
+            project_root,
+            profile_root,
+            &EnrollmentMarker {
+                project_id: project_id.to_string(),
+                storage_mode: StorageMode::ProfileSharded,
+            },
+        )?;
+        let manifest_data_root = manifest
+            .data_root
+            .canonicalize()
+            .unwrap_or_else(|_| manifest.data_root.clone());
+        let layout_data_root = layout
+            .data_root
+            .canonicalize()
+            .unwrap_or_else(|_| layout.data_root.clone());
+        if manifest_path.parent() != Some(manifest.data_root.as_path())
+            || manifest_data_root != layout_data_root
+            || manifest.data_root.join(&manifest.graph_db_relpath) != layout.graph_db_path
+            || manifest.data_root.join(&manifest.sessions_db_relpath) != layout.sessions_db_path
+            || manifest.data_root.join(&manifest.branch_meta_relpath) != layout.branch_meta_path
+        {
+            return Err(invalid_legacy_manifest(
+                &manifest_path,
+                "manifest paths do not match the profile shard layout",
+            ));
+        }
+        layouts.push(layout);
+    }
+    Ok(layouts)
+}
+
+pub(crate) fn retire_identity_cutover_manifest(layout: &StoreLayout) -> Result<PathBuf> {
+    let source = layout
+        .manifest_path
+        .as_ref()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: "profile store has no manifest path".to_string(),
+        })?;
+    let backup = layout
+        .data_root
+        .join(IDENTITY_CUTOVER_BACKUP_MANIFEST_FILENAME);
+    if !source.exists() && backup.is_file() {
+        return Ok(backup);
+    }
+    if backup.exists() {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "refusing to replace existing identity-cutover backup '{}'",
+                backup.display()
+            ),
+        });
+    }
+    fs::rename(source, &backup).map_err(|error| TraceDecayError::Config {
+        message: format!(
+            "failed to retire empty identity-cutover manifest '{}' to '{}': {error}",
+            source.display(),
+            backup.display()
+        ),
+    })?;
+    Ok(backup)
+}
+
+fn same_local_path(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}
+
+fn invalid_legacy_manifest(path: &Path, detail: impl std::fmt::Display) -> TraceDecayError {
+    TraceDecayError::Config {
+        message: format!(
+            "legacy profile store manifest '{}' cannot be adopted safely: {detail}",
+            path.display()
+        ),
+    }
 }
 
 pub fn default_profile_root() -> Result<PathBuf> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
@@ -425,9 +426,9 @@ pub(crate) fn resolve_persisted_layout(
 }
 
 /// Finds pre-repository-identity profile stores that were keyed by an older
-/// path-derived project id but still name this exact local checkout in their
-/// manifest. Remote URLs are deliberately not considered: two clones of one
-/// remote are different local identities.
+/// path-derived project id but still name this exact local checkout, or one of
+/// its linked worktrees, in their manifest. Remote URLs are deliberately not
+/// considered: two clones of one remote are different local identities.
 pub(crate) fn matching_legacy_profile_layouts(
     project_root: &Path,
     profile_root: &Path,
@@ -445,11 +446,27 @@ pub(crate) fn matching_legacy_profile_layouts(
     manifest_paths.sort();
 
     let mut layouts = Vec::new();
+    let project_git_common_dir = crate::worktree::git_common_dir(project_root);
+    let mut legacy_git_common_dirs = HashMap::<PathBuf, Option<PathBuf>>::new();
     for manifest_path in manifest_paths {
         let Ok(manifest) = read_store_manifest(&manifest_path) else {
             continue;
         };
-        if !same_local_path(&manifest.project_root, project_root) {
+        let same_checkout = same_local_path(&manifest.project_root, project_root)
+            || project_git_common_dir.as_deref().is_some_and(|current| {
+                legacy_git_common_dirs
+                    .entry(manifest.project_root.clone())
+                    .or_insert_with(|| {
+                        manifest
+                            .project_root
+                            .is_dir()
+                            .then(|| crate::worktree::git_common_dir(&manifest.project_root))
+                            .flatten()
+                    })
+                    .as_deref()
+                    .is_some_and(|legacy| same_local_path(legacy, current))
+            });
+        if !same_checkout {
             continue;
         }
         let project_id = manifest

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -29,7 +29,8 @@ impl TraceDecay {
         project_root: &Path,
         open_options: TraceDecayOpenOptions,
     ) -> Result<Self> {
-        let store_layout = Self::resolve_store_layout_for_local_path(project_root, &open_options)?;
+        let store_layout =
+            Self::resolve_store_layout_for_project(project_root, &open_options).await?;
         let config = TraceDecayConfig {
             root_dir: project_root.to_string_lossy().to_string(),
             ..TraceDecayConfig::default()
@@ -149,31 +150,129 @@ impl TraceDecay {
         project_root: &Path,
         open_options: &TraceDecayOpenOptions,
     ) -> Result<StoreLayout> {
+        Self::resolve_store_layout_with_identity_migration(project_root, open_options, true).await
+    }
+
+    async fn resolve_store_layout_for_project_read_only(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> Result<StoreLayout> {
+        Self::resolve_store_layout_with_identity_migration(project_root, open_options, false).await
+    }
+
+    async fn resolve_store_layout_with_identity_migration(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+        allow_repair: bool,
+    ) -> Result<StoreLayout> {
         let profile_root = open_options.resolved_profile_root()?;
-        if let Some(layout) = storage::resolve_persisted_layout(project_root, &profile_root)? {
-            return Ok(layout);
+        if storage::read_enrollment_marker(project_root)?.is_some() {
+            return storage::resolve_persisted_layout(project_root, &profile_root)?.ok_or_else(
+                || TraceDecayError::Config {
+                    message: "enrollment marker did not resolve a profile store".to_string(),
+                },
+            );
         }
 
+        let mut selected = storage::resolve_persisted_layout(project_root, &profile_root)?;
         let git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
             .then(|| crate::worktree::git_common_dir(project_root))
             .flatten();
-        if let Some(global_db) = open_options.open_global_db().await {
+        if selected.is_none()
+            && let Some(global_db) = open_options.open_global_db().await
+        {
             if let Some(resolution) = global_db
                 .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
                 .await
             {
-                return storage::profile_sharded_layout(
+                selected = Some(storage::profile_sharded_layout(
                     project_root,
                     &profile_root,
                     &storage::EnrollmentMarker {
                         project_id: resolution.project.project_id,
                         storage_mode: storage::StorageMode::ProfileSharded,
                     },
-                );
+                )?);
             }
         }
 
-        storage::default_profile_sharded_layout(project_root, &profile_root)
+        let selected_id = selected
+            .as_ref()
+            .and_then(|layout| layout.identity.project_id.as_deref());
+        let candidates =
+            storage::matching_legacy_profile_layouts(project_root, &profile_root, selected_id)?;
+        Self::choose_identity_layout(project_root, selected, candidates, allow_repair)
+            .await?
+            .map_or_else(
+                || storage::default_profile_sharded_layout(project_root, &profile_root),
+                Ok,
+            )
+    }
+
+    async fn choose_identity_layout(
+        project_root: &Path,
+        selected: Option<StoreLayout>,
+        candidates: Vec<StoreLayout>,
+        allow_repair: bool,
+    ) -> Result<Option<StoreLayout>> {
+        if candidates.len() > 1 {
+            let mut details = Vec::new();
+            for candidate in &candidates {
+                details.push(store_identity_inventory(candidate).await.to_string());
+            }
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "ambiguous legacy profile stores for '{}': {}; no files changed",
+                    project_root.display(),
+                    details.join("; ")
+                ),
+            });
+        }
+        let Some(candidate) = candidates.into_iter().next() else {
+            return Ok(selected);
+        };
+        let Some(selected) = selected else {
+            return Ok(Some(candidate));
+        };
+
+        let selected_inventory = store_identity_inventory(&selected).await;
+        let candidate_inventory = store_identity_inventory(&candidate).await;
+        if selected_inventory.is_pristine() && candidate_inventory.is_healthy() {
+            if !allow_repair {
+                return Err(identity_cutover_conflict(
+                    project_root,
+                    &selected_inventory,
+                    &candidate_inventory,
+                    "safe empty-store repair is available during a writable open",
+                ));
+            }
+            let candidate_id = candidate.identity.project_id.as_deref().ok_or_else(|| {
+                TraceDecayError::Config {
+                    message: "legacy candidate has no project id".to_string(),
+                }
+            })?;
+            storage::write_repository_identity_marker(project_root, candidate_id)?;
+            storage::retire_identity_cutover_manifest(&selected)?;
+            return Ok(Some(candidate));
+        }
+        if candidate_inventory.is_pristine() && selected_inventory.is_healthy() {
+            if allow_repair {
+                let selected_id = selected.identity.project_id.as_deref().ok_or_else(|| {
+                    TraceDecayError::Config {
+                        message: "selected store has no project id".to_string(),
+                    }
+                })?;
+                storage::write_repository_identity_marker(project_root, selected_id)?;
+                storage::retire_identity_cutover_manifest(&candidate)?;
+            }
+            return Ok(Some(selected));
+        }
+        Err(identity_cutover_conflict(
+            project_root,
+            &selected_inventory,
+            &candidate_inventory,
+            "run an explicit backup-and-consolidate migration before changing the marker",
+        ))
     }
 
     /// Opens an existing `TraceDecay` project at the given root.
@@ -301,7 +400,7 @@ impl TraceDecay {
         open_options: TraceDecayOpenOptions,
     ) -> Result<Self> {
         let store_layout =
-            Self::resolve_store_layout_for_project(project_root, &open_options).await?;
+            Self::resolve_store_layout_for_project_read_only(project_root, &open_options).await?;
         let config = load_config_from_path(project_root, &store_layout.config_path)?;
         let active_branch = branch::current_branch(project_root);
 
@@ -838,39 +937,168 @@ impl TraceDecay {
         project_root: &Path,
         open_options: &TraceDecayOpenOptions,
     ) -> Result<StoreLayout> {
-        let profile_root = open_options.resolved_profile_root()?;
-        if let Some(layout) = storage::resolve_persisted_layout(project_root, &profile_root)? {
-            return Ok(layout);
-        }
+        Self::resolve_store_layout_with_identity_migration(project_root, open_options, false).await
+    }
+}
 
-        let git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
-            .then(|| crate::worktree::git_common_dir(project_root))
-            .flatten();
-        if let Some(global_db) = open_options.open_global_db().await {
-            if let Some(resolution) = global_db
-                .resolve_project_store_by_identity(project_root, git_common_dir.as_deref())
-                .await
-            {
-                return storage::profile_sharded_layout(
-                    project_root,
-                    &profile_root,
-                    &storage::EnrollmentMarker {
-                        project_id: resolution.project.project_id,
-                        storage_mode: storage::StorageMode::ProfileSharded,
-                    },
-                );
-            }
-        }
+#[derive(Debug)]
+struct StoreIdentityInventory {
+    project_id: String,
+    data_root: PathBuf,
+    graph_health: &'static str,
+    nodes: u64,
+    files: u64,
+    facts: u64,
+    sessions: u64,
+    messages: u64,
+    lcm_rows: u64,
+    branches: usize,
+    automation_files: u64,
+    payload_files: u64,
+    response_files: u64,
+}
 
-        storage::default_profile_sharded_layout(project_root, &profile_root)
+impl StoreIdentityInventory {
+    fn is_healthy(&self) -> bool {
+        self.graph_health == "healthy"
     }
 
-    fn resolve_store_layout_for_local_path(
-        project_root: &Path,
-        open_options: &TraceDecayOpenOptions,
-    ) -> Result<StoreLayout> {
-        let profile_root = open_options.resolved_profile_root()?;
-        storage::resolve_layout(project_root, &profile_root)
+    fn is_pristine(&self) -> bool {
+        self.is_healthy()
+            && self.nodes == 0
+            && self.files == 0
+            && self.facts == 0
+            && self.sessions == 0
+            && self.messages == 0
+            && self.lcm_rows == 0
+            && self.branches <= 1
+            && self.automation_files == 0
+            && self.payload_files == 0
+            && self.response_files == 0
+    }
+}
+
+impl std::fmt::Display for StoreIdentityInventory {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "project_id={} path='{}' graph_health={} nodes={} files={} facts={} sessions={} messages={} lcm={} branches={} automation_files={} payload_files={} response_files={}",
+            self.project_id,
+            self.data_root.display(),
+            self.graph_health,
+            self.nodes,
+            self.files,
+            self.facts,
+            self.sessions,
+            self.messages,
+            self.lcm_rows,
+            self.branches,
+            self.automation_files,
+            self.payload_files,
+            self.response_files,
+        )
+    }
+}
+
+async fn store_identity_inventory(layout: &StoreLayout) -> StoreIdentityInventory {
+    let (graph_health, nodes, files, facts) =
+        match Database::open_read_only(&layout.graph_db_path).await {
+            Ok((db, _)) => {
+                if let Ok(stats) = db.get_stats().await {
+                    let facts = count_rows(db.conn(), "memory_facts").await;
+                    db.close();
+                    ("healthy", stats.node_count, stats.file_count, facts)
+                } else {
+                    db.close();
+                    ("corrupt", 0, 0, 0)
+                }
+            }
+            Err(_) if layout.graph_db_path.exists() => ("corrupt", 0, 0, 0),
+            Err(_) => ("missing", 0, 0, 0),
+        };
+
+    let (sessions, messages, lcm_rows) = if let Some(db) =
+        crate::global_db::GlobalDb::open_read_only_at(&layout.sessions_db_path).await
+    {
+        let conn = db.dashboard_connection();
+        let counts = (
+            count_rows(&conn, "sessions").await,
+            count_rows(&conn, "session_messages").await,
+            count_rows(&conn, "lcm_raw_messages").await
+                + count_rows(&conn, "lcm_summary_nodes").await,
+        );
+        db.close();
+        counts
+    } else {
+        (0, 0, 0)
+    };
+
+    StoreIdentityInventory {
+        project_id: layout
+            .identity
+            .project_id
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string()),
+        data_root: layout.data_root.clone(),
+        graph_health,
+        nodes,
+        files,
+        facts,
+        sessions,
+        messages,
+        lcm_rows,
+        branches: branch_meta::load_branch_meta(&layout.data_root)
+            .map_or(0, |meta| meta.branches.len()),
+        automation_files: count_tree_files(&layout.dashboard_root),
+        payload_files: count_tree_files(&layout.lcm_payload_root),
+        response_files: count_tree_files(&layout.response_handle_root),
+    }
+}
+
+async fn count_rows(connection: &libsql::Connection, table: &str) -> u64 {
+    let Ok(mut rows) = connection
+        .query(&format!("SELECT COUNT(*) FROM {table}"), ())
+        .await
+    else {
+        return 0;
+    };
+    rows.next()
+        .await
+        .ok()
+        .flatten()
+        .and_then(|row| row.get::<i64>(0).ok())
+        .and_then(|count| u64::try_from(count).ok())
+        .unwrap_or(0)
+}
+
+fn count_tree_files(root: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .map(|path| match std::fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_file() => 1,
+            Ok(metadata) if metadata.is_dir() => count_tree_files(&path),
+            _ => 0,
+        })
+        .sum()
+}
+
+fn identity_cutover_conflict(
+    project_root: &Path,
+    selected: &StoreIdentityInventory,
+    legacy: &StoreIdentityInventory,
+    action: &str,
+) -> TraceDecayError {
+    TraceDecayError::Config {
+        message: format!(
+            "identity cutover conflict for '{}': selected [{}]; legacy [{}]; {action}; both shards were preserved and no files changed",
+            project_root.display(),
+            selected,
+            legacy
+        ),
     }
 }
 

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -9,21 +9,27 @@ use std::os::unix::fs::symlink;
 use tempfile::TempDir;
 use tracedecay::branch_meta::{self, BranchMeta};
 use tracedecay::config::{TraceDecayConfig, USER_DATA_DIR_ENV};
-use tracedecay::config::{discover_project_root, get_config_path, load_config};
+use tracedecay::config::{
+    discover_project_root, get_config_path, load_config, save_config_to_path,
+};
 use tracedecay::db::Database;
 use tracedecay::global_db::GlobalDb;
 use tracedecay::mcp::response_handles::{
     ResponseHandleLookup, retrieve_response_handle, store_response_handle,
 };
+use tracedecay::memory::types::{AddFactRequest, MemoryCategory};
+use tracedecay::sessions::SessionRecord;
 use tracedecay::sessions::cursor::{project_session_db_path, resolved_project_session_db_path};
 use tracedecay::storage::{
     ActiveProjectContext, EnrollmentMarker, GraphScopeId, PrivateStoreIo, ProjectPath,
-    STORE_MANIFEST_FILENAME, StorageMode, StoreArtifactPath, default_profile_project_id,
-    default_profile_sharded_layout, profile_sharded_layout, read_enrollment_marker,
-    read_repository_identity_marker, read_store_manifest, resolve_layout, resolve_lcm_payload_root,
-    resolve_project_session_db_path, resolve_response_handle_root, write_store_manifest,
+    STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode, StoreArtifactPath,
+    StoreKind, StoreManifest, default_profile_project_id, default_profile_sharded_layout,
+    profile_sharded_layout, read_enrollment_marker, read_repository_identity_marker,
+    read_store_manifest, repository_identity_path, resolve_layout, resolve_lcm_payload_root,
+    resolve_project_session_db_path, resolve_response_handle_root,
+    write_repository_identity_marker, write_store_manifest, write_store_manifest_to_path,
 };
-use tracedecay::tracedecay::TraceDecay;
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 use crate::support::HOME_ENV_LOCK;
 
@@ -126,6 +132,54 @@ fn init_repo_with_commit(project: &Path) {
     git(project, &["config", "user.name", "TraceDecay Test"]);
     git(project, &["add", "."]);
     git(project, &["commit", "-m", "initial"]);
+}
+
+fn remove_sqlite_family(path: &Path) {
+    let _ = fs::remove_file(path);
+    let _ = fs::remove_file(path.with_extension("db-wal"));
+    let _ = fs::remove_file(path.with_extension("db-shm"));
+}
+
+fn fact_request(content: &str) -> AddFactRequest {
+    AddFactRequest {
+        content: content.to_string(),
+        category: MemoryCategory::Project,
+        source: Some("legacy-store-adoption-test".to_string()),
+        tags: vec!["migration-sentinel".to_string()],
+        entities: Vec::new(),
+        trust: Some(0.9),
+        metadata: serde_json::json!({}),
+    }
+}
+
+fn relocate_store_as_legacy(
+    current_root: &Path,
+    legacy_root: &Path,
+    project_root: &Path,
+    legacy_project_id: &str,
+) {
+    fs::rename(current_root, legacy_root).unwrap();
+    let manifest_path = legacy_root.join(STORE_MANIFEST_FILENAME);
+    let mut manifest = read_store_manifest(&manifest_path).unwrap();
+    manifest.project_id = Some(legacy_project_id.to_string());
+    manifest.project_root = project_root.to_path_buf();
+    manifest.data_root = legacy_root.to_path_buf();
+    write_store_manifest_to_path(&manifest_path, &manifest).unwrap();
+}
+
+async fn initialize_empty_profile_layout(layout: &tracedecay::storage::StoreLayout) {
+    save_config_to_path(
+        &layout.config_path,
+        &TraceDecayConfig {
+            root_dir: layout.project_root.to_string_lossy().to_string(),
+            ..TraceDecayConfig::default()
+        },
+    )
+    .unwrap();
+    let (db, _) = Database::initialize(&layout.graph_db_path).await.unwrap();
+    db.checkpoint().await.unwrap();
+    db.close();
+    write_store_manifest(layout).unwrap();
 }
 
 #[test]
@@ -744,6 +798,392 @@ async fn trace_decay_init_registers_default_profile_shard_globally() {
         identity_path.is_file(),
         "opening a legacy registered checkout must migrate it to durable repository identity"
     );
+}
+
+#[tokio::test]
+async fn legacy_profile_store_upgrade_preserves_data_across_repo_identity_changes() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let remote = dir.path().join("remote.git");
+    let project = dir.path().join("repo");
+    let moved = dir.path().join("repo-moved");
+    let linked = dir.path().join("repo-linked");
+    let clone = dir.path().join("repo-clone");
+    let home = test_home(&dir);
+    let profile_root = home.join(".tracedecay");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn legacy_sentinel() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
+    git(dir.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    git(
+        &project,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git(&project, &["push", "-u", "origin", "main"]);
+    git(&remote, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
+    let cg = TraceDecay::init(&project).await.unwrap();
+    cg.index_all().await.unwrap();
+    let main_fact_id = cg
+        .add_fact(fact_request("legacy main fact sentinel"))
+        .await
+        .unwrap()
+        .fact
+        .unwrap()
+        .fact_id;
+    let current_root = cg.store_layout().data_root.clone();
+    let current_project_id = cg.store_layout().identity.project_id.clone().unwrap();
+
+    cg.checkpoint().await.unwrap();
+    cg.close();
+    git(&project, &["checkout", "-b", "feature/legacy-sentinel"]);
+    let branch = TraceDecay::open(&project).await.unwrap();
+    let branch_fact_id = branch
+        .add_fact(fact_request("legacy branch fact sentinel"))
+        .await
+        .unwrap()
+        .fact
+        .unwrap()
+        .fact_id;
+    branch.checkpoint().await.unwrap();
+    branch.close();
+    git(&project, &["checkout", "main"]);
+
+    let sessions = GlobalDb::open_at(&current_root.join("sessions.db"))
+        .await
+        .unwrap();
+    assert!(
+        sessions
+            .upsert_session(&SessionRecord {
+                provider: "codex".to_string(),
+                session_id: "legacy-session-sentinel".to_string(),
+                project_key: current_project_id,
+                project_path: project.to_string_lossy().to_string(),
+                title: Some("legacy session sentinel".to_string()),
+                started_at: Some(1_800_000_001),
+                ended_at: Some(1_800_000_002),
+                transcript_path: None,
+                metadata_json: None,
+                parent_session_id: None,
+                is_subagent: false,
+                agent_id: None,
+                parent_tool_use_id: None,
+            })
+            .await
+    );
+    sessions.checkpoint().await;
+    sessions.close();
+
+    let automation_sentinel = current_root.join("automation/migration-sentinel.json");
+    fs::create_dir_all(automation_sentinel.parent().unwrap()).unwrap();
+    fs::write(&automation_sentinel, br#"{"preserved":true}"#).unwrap();
+
+    fs::remove_file(repository_identity_path(&project).unwrap()).unwrap();
+    remove_sqlite_family(&profile_root.join("global.db"));
+
+    let legacy_project_id = "proj_legacy_path_hash";
+    let legacy_root = profile_root.join(format!("projects/{legacy_project_id}"));
+    relocate_store_as_legacy(&current_root, &legacy_root, &project, legacy_project_id);
+
+    let adopted = TraceDecay::open(&project)
+        .await
+        .expect("upgrade must adopt the manifest-backed legacy store");
+    assert_path_eq(&adopted.store_layout().data_root, &legacy_root);
+    assert_eq!(
+        adopted
+            .get_fact(main_fact_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .content,
+        "legacy main fact sentinel"
+    );
+    assert_eq!(
+        fs::read_to_string(legacy_root.join("automation/migration-sentinel.json")).unwrap(),
+        r#"{"preserved":true}"#
+    );
+
+    let sessions = GlobalDb::open_at(&legacy_root.join("sessions.db"))
+        .await
+        .unwrap();
+    assert_eq!(
+        sessions
+            .get_session("codex", "legacy-session-sentinel")
+            .await
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("legacy session sentinel")
+    );
+    sessions.close();
+
+    let branch = TraceDecay::open_branch(&project, "feature/legacy-sentinel")
+        .await
+        .unwrap();
+    assert_eq!(
+        branch
+            .get_fact(branch_fact_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .content,
+        "legacy branch fact sentinel"
+    );
+    branch.close();
+
+    let marker = read_repository_identity_marker(&project)
+        .unwrap()
+        .expect("successful adoption must persist repository identity");
+    assert_eq!(marker.project_id, legacy_project_id);
+    adopted.checkpoint().await.unwrap();
+    adopted.close();
+
+    fs::rename(&project, &moved).unwrap();
+    let reopened = TraceDecay::open(&moved).await.unwrap();
+    assert_path_eq(&reopened.store_layout().data_root, &legacy_root);
+    reopened.close();
+
+    #[cfg(unix)]
+    {
+        let alias = dir.path().join("repo-alias");
+        symlink(&moved, &alias).unwrap();
+        let via_alias = TraceDecay::open(&alias).await.unwrap();
+        assert_path_eq(&via_alias.store_layout().data_root, &legacy_root);
+        via_alias.close();
+    }
+
+    git(
+        &moved,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/adopted-linked",
+            linked.to_str().unwrap(),
+        ],
+    );
+    let linked_graph = TraceDecay::open(&linked).await.unwrap();
+    assert_path_eq(&linked_graph.store_layout().data_root, &legacy_root);
+    linked_graph.close();
+
+    git(
+        dir.path(),
+        &["clone", remote.to_str().unwrap(), clone.to_str().unwrap()],
+    );
+    assert!(
+        !TraceDecay::has_initialized_store(&clone).await,
+        "same-remote clones must not adopt another checkout's orphan manifest"
+    );
+    let clone_graph = TraceDecay::init(&clone).await.unwrap();
+    assert_ne!(
+        normalize_test_path(&clone_graph.store_layout().data_root),
+        normalize_test_path(&legacy_root),
+        "a separate clone must mint its own store identity"
+    );
+    clone_graph.close();
+}
+
+#[tokio::test]
+async fn empty_cutover_store_is_atomically_replaced_by_healthy_legacy_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let home = test_home(&dir);
+    let profile_root = home.join(".tracedecay");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn cutover() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
+
+    let old = TraceDecay::init(&project).await.unwrap();
+    let fact_id = old
+        .add_fact(fact_request("healthy legacy cutover fact"))
+        .await
+        .unwrap()
+        .fact
+        .unwrap()
+        .fact_id;
+    let original_root = old.store_layout().data_root.clone();
+    old.checkpoint().await.unwrap();
+    old.close();
+    fs::remove_file(repository_identity_path(&project).unwrap()).unwrap();
+    remove_sqlite_family(&profile_root.join("global.db"));
+
+    let legacy_project_id = "proj_healthy_legacy";
+    let legacy_root = profile_root.join(format!("projects/{legacy_project_id}"));
+    relocate_store_as_legacy(&original_root, &legacy_root, &project, legacy_project_id);
+
+    let cutover = default_profile_sharded_layout(&project, &profile_root).unwrap();
+    let cutover_project_id = cutover.identity.project_id.clone().unwrap();
+    initialize_empty_profile_layout(&cutover).await;
+    write_repository_identity_marker(&project, &cutover_project_id).unwrap();
+
+    let repaired = TraceDecay::open(&project)
+        .await
+        .expect("an empty cutover shard may safely yield to the healthy legacy shard");
+    assert_path_eq(&repaired.store_layout().data_root, &legacy_root);
+    assert_eq!(
+        repaired.get_fact(fact_id).await.unwrap().unwrap().content,
+        "healthy legacy cutover fact"
+    );
+    assert_eq!(
+        read_repository_identity_marker(&project)
+            .unwrap()
+            .unwrap()
+            .project_id,
+        legacy_project_id
+    );
+    assert!(
+        cutover.graph_db_path.is_file(),
+        "empty shard stays as a backup"
+    );
+    assert!(
+        cutover
+            .data_root
+            .join("store_manifest.identity-cutover-backup.json")
+            .is_file(),
+        "the retired empty shard must remain discoverable as an explicit backup"
+    );
+    assert!(!cutover.data_root.join(STORE_MANIFEST_FILENAME).exists());
+    repaired.close();
+}
+
+#[tokio::test]
+async fn corrupt_nonempty_cutover_store_reports_both_shards_without_switching() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let home = test_home(&dir);
+    let profile_root = home.join(".tracedecay");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn split() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
+
+    let old = TraceDecay::init(&project).await.unwrap();
+    old.add_fact(fact_request("legacy split identity fact"))
+        .await
+        .unwrap();
+    let original_root = old.store_layout().data_root.clone();
+    old.checkpoint().await.unwrap();
+    old.close();
+    fs::remove_file(repository_identity_path(&project).unwrap()).unwrap();
+    remove_sqlite_family(&profile_root.join("global.db"));
+
+    let legacy_project_id = "proj_split_legacy";
+    let legacy_root = profile_root.join(format!("projects/{legacy_project_id}"));
+    relocate_store_as_legacy(&original_root, &legacy_root, &project, legacy_project_id);
+
+    let cutover = default_profile_sharded_layout(&project, &profile_root).unwrap();
+    let cutover_project_id = cutover.identity.project_id.clone().unwrap();
+    initialize_empty_profile_layout(&cutover).await;
+    fs::write(&cutover.graph_db_path, b"not a sqlite database").unwrap();
+    let sessions = GlobalDb::open_at(&cutover.sessions_db_path).await.unwrap();
+    assert!(
+        sessions
+            .upsert_session(&SessionRecord {
+                provider: "codex".to_string(),
+                session_id: "new-cutover-session".to_string(),
+                project_key: cutover_project_id.clone(),
+                project_path: project.to_string_lossy().to_string(),
+                title: Some("new cutover session".to_string()),
+                started_at: Some(1_800_000_010),
+                ended_at: None,
+                transcript_path: None,
+                metadata_json: None,
+                parent_session_id: None,
+                is_subagent: false,
+                agent_id: None,
+                parent_tool_use_id: None,
+            })
+            .await
+    );
+    sessions.checkpoint().await;
+    sessions.close();
+    write_repository_identity_marker(&project, &cutover_project_id).unwrap();
+
+    let error = TraceDecay::resolve_store_layout_for_identity(&project)
+        .await
+        .expect_err("nonempty split stores require explicit consolidation");
+    let message = error.to_string();
+    assert!(message.contains("identity cutover conflict"), "{message}");
+    assert!(message.contains(&cutover_project_id), "{message}");
+    assert!(message.contains(legacy_project_id), "{message}");
+    assert!(message.contains("graph_health=corrupt"), "{message}");
+    assert!(message.contains("sessions=1"), "{message}");
+    assert!(message.contains("facts=1"), "{message}");
+    assert!(message.contains("no files changed"), "{message}");
+    assert_eq!(
+        read_repository_identity_marker(&project)
+            .unwrap()
+            .unwrap()
+            .project_id,
+        cutover_project_id
+    );
+    assert!(cutover.data_root.join(STORE_MANIFEST_FILENAME).is_file());
+    assert!(legacy_root.join(STORE_MANIFEST_FILENAME).is_file());
+}
+
+#[tokio::test]
+async fn ambiguous_legacy_store_adoption_preserves_every_candidate() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let profile_root = dir.path().join("profile");
+    let global_db_path = profile_root.join("global.db");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn conflict() {}\n").unwrap();
+    init_repo_with_commit(&project);
+
+    for project_id in ["proj_legacy_one", "proj_legacy_two"] {
+        let data_root = profile_root.join(format!("projects/{project_id}"));
+        fs::create_dir_all(&data_root).unwrap();
+        fs::write(data_root.join("tracedecay.db"), project_id).unwrap();
+        fs::write(data_root.join("sessions.db"), b"sessions").unwrap();
+        branch_meta::save_branch_meta(&data_root, &BranchMeta::new_for_dir(&data_root, "main"))
+            .unwrap();
+        write_store_manifest_to_path(
+            &data_root.join(STORE_MANIFEST_FILENAME),
+            &StoreManifest {
+                schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+                project_id: Some(project_id.to_string()),
+                store_kind: StoreKind::CodeProject,
+                storage_mode: StorageMode::ProfileSharded,
+                project_root: project.clone(),
+                data_root,
+                graph_db_relpath: "tracedecay.db".into(),
+                sessions_db_relpath: "sessions.db".into(),
+                branch_meta_relpath: "branch-meta.json".into(),
+            },
+        )
+        .unwrap();
+    }
+
+    let error = TraceDecay::resolve_store_layout_for_identity_with_options(
+        &project,
+        &TraceDecayOpenOptions {
+            profile_root: Some(profile_root.clone()),
+            global_db_path: Some(global_db_path),
+        },
+    )
+    .await
+    .expect_err("ambiguous legacy manifests must not be selected implicitly");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ambiguous legacy profile stores")
+    );
+    for project_id in ["proj_legacy_one", "proj_legacy_two"] {
+        assert_eq!(
+            fs::read_to_string(profile_root.join(format!("projects/{project_id}/tracedecay.db")))
+                .unwrap(),
+            project_id,
+            "conflict handling must retain every candidate as a recoverable backup"
+        );
+    }
+    assert!(!repository_identity_path(&project).unwrap().exists());
 }
 
 #[tokio::test]

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -1050,6 +1050,63 @@ async fn empty_cutover_store_is_atomically_replaced_by_healthy_legacy_store() {
 }
 
 #[tokio::test]
+async fn empty_cutover_store_adopts_healthy_legacy_linked_worktree_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let linked = dir.path().join("repo-linked");
+    let home = test_home(&dir);
+    let profile_root = home.join(".tracedecay");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn linked_cutover() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/legacy-linked-cutover",
+            linked.to_str().unwrap(),
+        ],
+    );
+
+    let old = TraceDecay::init(&project).await.unwrap();
+    let fact_id = old
+        .add_fact(fact_request("healthy linked legacy cutover fact"))
+        .await
+        .unwrap()
+        .fact
+        .unwrap()
+        .fact_id;
+    let original_root = old.store_layout().data_root.clone();
+    old.checkpoint().await.unwrap();
+    old.close();
+    fs::remove_file(repository_identity_path(&project).unwrap()).unwrap();
+    remove_sqlite_family(&profile_root.join("global.db"));
+
+    let legacy_project_id = "proj_healthy_linked_legacy";
+    let legacy_root = profile_root.join(format!("projects/{legacy_project_id}"));
+    relocate_store_as_legacy(&original_root, &legacy_root, &linked, legacy_project_id);
+
+    let cutover = default_profile_sharded_layout(&project, &profile_root).unwrap();
+    let cutover_project_id = cutover.identity.project_id.clone().unwrap();
+    initialize_empty_profile_layout(&cutover).await;
+    write_repository_identity_marker(&project, &cutover_project_id).unwrap();
+
+    let repaired = TraceDecay::open(&project)
+        .await
+        .expect("a linked worktree manifest with the same git common dir must be adopted");
+    assert_path_eq(&repaired.store_layout().data_root, &legacy_root);
+    assert_eq!(
+        repaired.get_fact(fact_id).await.unwrap().unwrap().content,
+        "healthy linked legacy cutover fact"
+    );
+    repaired.close();
+}
+
+#[tokio::test]
 async fn corrupt_nonempty_cutover_store_reports_both_shards_without_switching() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
- adopt a unique manifest-backed legacy shard before minting a new path identity
- detect split identities with graph/fact/session/LCM/branch inventories
- atomically retarget only pristine cutover shards; preserve nonempty conflicts for explicit consolidation
- cover moves, symlinks, linked worktrees, clone isolation, and data sentinels

## Tests
- `cargo test --test storage_suite storage_resolver_test -- --nocapture` (38 passed)
- `cargo clippy --lib --tests -- -D warnings`