### PR TITLE
fix(storage): preserve corrupt database recovery sets

### DIFF
--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -150,6 +150,7 @@ impl Database {
     /// Returns `(Self, migrated)` where `migrated` is `true` if schema
     /// migrations were applied during open.
     pub async fn open(db_path: &Path) -> Result<(Self, bool)> {
+        Self::validate_sqlite_header(db_path, "open", true)?;
         let db =
             Builder::new_local(db_path)
                 .build()
@@ -177,6 +178,7 @@ impl Database {
     /// status/verification paths can inspect read-only `SQLite` files without
     /// creating WAL files or attempting schema updates.
     pub async fn open_read_only(db_path: &Path) -> Result<(Self, bool)> {
+        Self::validate_sqlite_header(db_path, "open_read_only", false)?;
         let db = Builder::new_local(db_path)
             .flags(OpenFlags::SQLITE_OPEN_READ_ONLY)
             .build()
@@ -195,6 +197,46 @@ impl Database {
         Self::apply_read_only_pragmas(&conn, file_size).await?;
 
         Ok((Self { conn, _db: db }, false))
+    }
+
+    fn validate_sqlite_header(
+        db_path: &Path,
+        operation: &str,
+        allow_fresh_path: bool,
+    ) -> Result<()> {
+        match std::fs::metadata(db_path) {
+            Ok(metadata) if allow_fresh_path && metadata.len() == 0 => return Ok(()),
+            Ok(_) => {}
+            Err(e) if allow_fresh_path && e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(TraceDecayError::Database {
+                    message: format!(
+                        "failed to inspect database path at '{}': {e}",
+                        db_path.display()
+                    ),
+                    operation: operation.to_string(),
+                });
+            }
+        }
+        match crate::storage::has_sqlite_database_header(db_path) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(TraceDecayError::Database {
+                message: format!(
+                    "file is not a database: SQLite header is missing at '{}'",
+                    db_path.display()
+                ),
+                operation: operation.to_string(),
+            }),
+            Err(e) => Err(TraceDecayError::Database {
+                message: format!(
+                    "failed to read database header at '{}': {e}",
+                    db_path.display()
+                ),
+                operation: operation.to_string(),
+            }),
+        }
     }
 
     /// Returns a reference to the underlying libsql connection.

--- a/src/db/search.rs
+++ b/src/db/search.rs
@@ -305,9 +305,11 @@ impl Database {
     pub fn is_corruption_error(e: &TraceDecayError) -> bool {
         match e {
             TraceDecayError::Database { message, .. } => {
+                let message = message.to_ascii_lowercase();
                 message.contains("malformed")
                     || message.contains("corrupt")
                     || message.contains("disk image")
+                    || message.contains("file is not a database")
             }
             _ => false,
         }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -6,6 +6,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use crate::agents::{self, DoctorCounters, HealthcheckContext};
+use crate::db::Database;
 use crate::display::{format_bytes, format_token_count};
 use crate::migrate::registry::code_project_root_exists;
 use crate::storage::StoreLayout;
@@ -202,8 +203,18 @@ async fn check_database(
     project_path: &Path,
     open_options: TraceDecayOpenOptions,
 ) {
+    let db_path = active_database_path(project_path, &open_options).await;
     let ts = match TraceDecay::open_read_only_with_options(project_path, open_options).await {
         Ok(ts) => ts,
+        Err(e) if Database::is_corruption_error(&e) => {
+            dc.fail(&format!("Database recovery required: {e}"));
+            if let Some(db_path) = db_path.as_deref() {
+                print_database_recovery_guidance(dc, db_path);
+            } else {
+                dc.info("TraceDecay could not resolve the damaged database path; no files were changed.");
+            }
+            return;
+        }
         Err(e) => {
             dc.fail(&format!("Could not open database read-only: {e}"));
             return;
@@ -216,12 +227,67 @@ async fn check_database(
 
     match ts.quick_check().await {
         Ok(true) => dc.pass("DB integrity: ok"),
-        Ok(false) => dc.fail(
-            "Database integrity check failed; stop the daemon and preserve the store before repair",
-        ),
+        Ok(false) => {
+            dc.fail("Database integrity check failed; offline recovery is required");
+            print_database_recovery_guidance(dc, &db_path);
+        }
+        Err(e) if Database::is_corruption_error(&e) => {
+            dc.fail(&format!("Database recovery required: {e}"));
+            print_database_recovery_guidance(dc, &db_path);
+        }
         Err(e) => dc.warn(&format!(
             "Could not complete read-only integrity check: {e}"
         )),
+    }
+}
+
+async fn active_database_path(
+    project_path: &Path,
+    open_options: &TraceDecayOpenOptions,
+) -> Option<PathBuf> {
+    if let Some(layout) =
+        TraceDecay::initialized_store_layout_with_options(project_path, open_options).await
+    {
+        let branch = crate::branch::current_branch(project_path);
+        return Some(
+            TraceDecay::resolve_db_for_branch(project_path, &layout.data_root, branch.as_deref()).0,
+        );
+    }
+
+    let data_root = crate::config::get_tracedecay_dir(project_path);
+    let db_path = data_root.join(crate::config::db_filename(&data_root));
+    db_path.is_file().then_some(db_path)
+}
+
+fn database_recovery_guidance(db_path: &Path) -> String {
+    let wal_path = db_path.with_extension("db-wal");
+    let shm_path = db_path.with_extension("db-shm");
+    let data_root = db_path.parent().unwrap_or_else(|| Path::new("."));
+    let dirty_path = data_root.join("dirty");
+    let sessions_path = data_root.join(crate::storage::SESSIONS_DB_FILENAME);
+
+    format!(
+        "First stop all TraceDecay daemon and MCP processes. No files were changed.\n\
+         Preserve this recovery set together before any repair:\n\
+         DB: {}\n\
+         WAL: {}\n\
+         SHM: {}\n\
+         dirty sentinel: {}\n\
+         `sessions.db` is separate and must not be removed: {}\n\
+         Facts are stored in the graph database; automatic rebuild is intentionally blocked because it cannot preserve them generically.\n\
+         Do not run `tracedecay init`, `tracedecay sync --force`, or `tracedecay wipe` until that recovery set is safely copied.\n\
+         Report the preserved set at https://github.com/ScriptedAlchemy/tracedecay/issues for offline recovery.",
+        db_path.display(),
+        wal_path.display(),
+        shm_path.display(),
+        dirty_path.display(),
+        sessions_path.display(),
+    )
+}
+
+fn print_database_recovery_guidance(dc: &DoctorCounters, db_path: &Path) {
+    for line in database_recovery_guidance(db_path).lines() {
+        dc.info(line);
     }
 }
 

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -38,6 +38,65 @@ fn format_bytes_fractional_kb() {
     assert_eq!(format_bytes(1536), "1.5 KB");
 }
 
+#[test]
+fn database_recovery_guidance_names_the_preserved_recovery_set() {
+    let db_path = PathBuf::from("/profile/projects/proj_test/tracedecay.db");
+    let guidance = database_recovery_guidance(&db_path);
+
+    assert!(guidance.contains("/profile/projects/proj_test/tracedecay.db"));
+    assert!(guidance.contains("/profile/projects/proj_test/tracedecay.db-wal"));
+    assert!(guidance.contains("/profile/projects/proj_test/tracedecay.db-shm"));
+    assert!(guidance.contains("/profile/projects/proj_test/dirty"));
+    assert!(guidance.contains("stop all TraceDecay daemon and MCP processes"));
+    assert!(
+        guidance.contains(
+            "Do not run `tracedecay init`, `tracedecay sync --force`, or `tracedecay wipe`"
+        )
+    );
+    assert!(guidance.contains("`sessions.db` is separate and must not be removed"));
+    assert!(guidance.contains("Facts are stored in the graph database"));
+    assert!(guidance.contains("automatic rebuild is intentionally blocked"));
+}
+
+#[tokio::test]
+async fn database_check_preserves_corrupt_graph_and_adjacent_stores()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::TempDir::new()?;
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(&project_root)?;
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+    let ts = TraceDecay::init_with_options(&project_root, open_options.clone()).await?;
+    let layout = ts.store_layout().clone();
+    ts.close();
+
+    let corrupt_db = b"not-a-sqlite-database";
+    let wal_path = layout.graph_db_path.with_extension("db-wal");
+    let shm_path = layout.graph_db_path.with_extension("db-shm");
+    std::fs::write(&layout.graph_db_path, corrupt_db)?;
+    std::fs::write(&wal_path, b"preserve-wal")?;
+    std::fs::write(&shm_path, b"preserve-shm")?;
+    std::fs::write(&layout.dirty_path, b"preserve-dirty")?;
+    std::fs::write(&layout.sessions_db_path, b"preserve-sessions")?;
+
+    let mut counters = DoctorCounters::new();
+    check_database(&mut counters, &project_root, open_options).await;
+
+    assert_eq!(counters.issues, 1);
+    assert_eq!(std::fs::read(&layout.graph_db_path)?, corrupt_db);
+    assert_eq!(std::fs::read(&wal_path)?, b"preserve-wal");
+    assert_eq!(std::fs::read(&shm_path)?, b"preserve-shm");
+    assert_eq!(std::fs::read(&layout.dirty_path)?, b"preserve-dirty");
+    assert_eq!(
+        std::fs::read(&layout.sessions_db_path)?,
+        b"preserve-sessions"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn database_check_is_read_only_while_a_writer_is_live()
 -> std::result::Result<(), Box<dyn std::error::Error>> {

--- a/src/migrate/manifest.rs
+++ b/src/migrate/manifest.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fs;
-use std::io::{self, Read};
+use std::io;
 use std::path::{Component, Path, PathBuf};
 
 use libsql::{Builder, Connection, OpenFlags, Value};
@@ -13,8 +13,8 @@ use crate::migrate::registry::{
 };
 use crate::storage::{
     EnrollmentMarker, PrivateStoreIo, STORE_MANIFEST_FILENAME, StorageMode, StoreKind,
-    profile_sharded_data_root, profile_sharded_layout, read_enrollment_marker, read_store_manifest,
-    validate_project_id, write_store_manifest,
+    has_sqlite_database_header, profile_sharded_data_root, profile_sharded_layout,
+    read_enrollment_marker, read_store_manifest, validate_project_id, write_store_manifest,
 };
 
 pub const MIGRATION_MANIFEST_SCHEMA_VERSION: u32 = 1;
@@ -988,7 +988,7 @@ fn verify_artifact_contents(source: &Path, target: &Path) -> io::Result<()> {
     if !source_meta.is_file() || !target_meta.is_file() {
         return Err(invalid_manifest("migration artifact is not a regular file"));
     }
-    if is_sqlite_database_file(source)? && is_sqlite_database_file(target)? {
+    if has_sqlite_database_header(source)? && has_sqlite_database_header(target)? {
         return verify_sqlite_artifact_contents(source, target);
     }
     if fs::read(source)? != fs::read(target)? {
@@ -999,16 +999,6 @@ fn verify_artifact_contents(source: &Path, target: &Path) -> io::Result<()> {
         )));
     }
     Ok(())
-}
-
-fn is_sqlite_database_file(path: &Path) -> io::Result<bool> {
-    let mut file = fs::File::open(path)?;
-    let mut header = [0_u8; 16];
-    match file.read_exact(&mut header) {
-        Ok(()) => Ok(header == *b"SQLite format 3\0"),
-        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
-        Err(err) => Err(err),
-    }
 }
 
 fn verify_sqlite_artifact_contents(source: &Path, target: &Path) -> io::Result<()> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use fs2::FileExt;
@@ -20,6 +20,21 @@ pub const REPOSITORY_IDENTITY_FILENAME: &str = "tracedecay-project.json";
 pub const BRANCH_META_QUARANTINE_PREFIX: &str = "branch-meta.json.corrupt-";
 pub const STORE_MANIFEST_SCHEMA_VERSION: u32 = 1;
 pub const REPOSITORY_IDENTITY_SCHEMA_VERSION: u32 = 1;
+
+/// Checks the fixed 16-byte `SQLite` header without opening the database.
+///
+/// This is deliberately file-only: libsql may create or rewrite WAL/SHM
+/// sidecars before reporting that the main file is not a database. Recovery
+/// paths use this preflight to preserve the complete on-disk recovery set.
+pub(crate) fn has_sqlite_database_header(path: &Path) -> io::Result<bool> {
+    let mut file = fs::File::open(path)?;
+    let mut header = [0_u8; 16];
+    match file.read_exact(&mut header) {
+        Ok(()) => Ok(header == *b"SQLite format 3\0"),
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(err) => Err(err),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -457,7 +457,7 @@ impl TraceDecay {
     /// Returns `(db_path, serving_branch, fallback_warning)`.
     /// `serving_branch` is the branch whose DB is actually opened.
     /// The warning is `Some` when falling back to an ancestor branch's DB.
-    pub(super) fn resolve_db_for_branch(
+    pub(crate) fn resolve_db_for_branch(
         project_root: &Path,
         tracedecay_dir: &Path,
         branch: Option<&str>,
@@ -967,6 +967,7 @@ fn print_corruption_warning(db_path: &std::path::Path) {
     eprintln!("[tracedecay] Store: {}", db_path.display());
     eprintln!("[tracedecay] Stop TraceDecay daemon/MCP processes before explicit repair.");
     eprintln!("[tracedecay] Preserve the DB, WAL, SHM, and dirty sentinel as one recovery set.");
+    eprintln!("[tracedecay] Run `tracedecay doctor` from the project root for exact paths.");
     eprintln!("[tracedecay] Please report this at:");
     eprintln!("[tracedecay]   https://github.com/ScriptedAlchemy/tracedecay/issues");
     eprintln!(

--- a/tests/storage_suite/corruption_test.rs
+++ b/tests/storage_suite/corruption_test.rs
@@ -32,6 +32,20 @@ async fn setup_db() -> (Database, TempDir, std::path::PathBuf) {
     (db, dir, db_path)
 }
 
+#[tokio::test]
+async fn writable_open_bootstraps_a_missing_database_path() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("new.db");
+    assert!(!db_path.exists());
+
+    let (db, _) = Database::open(&db_path)
+        .await
+        .expect("writable open should preserve fresh-path bootstrap behavior");
+    assert!(db_path.exists());
+    assert!(db.quick_check().await.unwrap());
+    close_db(db).await;
+}
+
 async fn close_db(db: Database) {
     db.checkpoint().await.unwrap();
     db.close();
@@ -265,6 +279,15 @@ fn is_corruption_error_matches_corrupt() {
     let e = tracedecay::errors::TraceDecayError::Database {
         message: "database is corrupt".to_string(),
         operation: "test".to_string(),
+    };
+    assert!(Database::is_corruption_error(&e));
+}
+
+#[test]
+fn is_corruption_error_matches_file_is_not_a_database() {
+    let e = tracedecay::errors::TraceDecayError::Database {
+        message: "failed to apply pragmas: SQLite failure: `file is not a database`".to_string(),
+        operation: "apply_pragmas".to_string(),
     };
     assert!(Database::is_corruption_error(&e));
 }


### PR DESCRIPTION
## What changed

- preflight existing SQLite files by header before libsql can rewrite WAL/SHM sidecars
- classify SQLite's exact `file is not a database` failure as corruption
- make `tracedecay doctor` print the active branch DB/WAL/SHM/dirty recovery set and protect `sessions.db`
- explicitly block automatic rebuild because facts live in the graph database and cannot be preserved generically
- preserve writable `Database::open` bootstrap behavior for missing/empty fresh paths
- share the SQLite-header check with migration artifact verification

## Root cause

libsql can create or rewrite a `-shm` sidecar before returning `file is not a database`. TraceDecay did not classify that exact message as corruption, so ordinary opens and doctor missed the preservation path and gave no actionable recovery set.

This PR intentionally does not add an archive/restore mutation yet. Current `sync.lock` excludes sync only, not daemon/MCP readers and writers, so an offline rename has a check-to-mutate race until the lifecycle lease/drain work lands. Generic reindex is also unsafe because it would lose graph-resident facts.

## Verification

- `cargo test --lib doctor::tests::` — 12 passed
- `cargo test --test storage_suite corruption_test::` — 18 passed
- `cargo test --test storage_suite verify_manifest_accepts_logically_equal_sqlite_artifacts_with_different_bytes` — 1 passed
- `cargo clippy --lib -- -D warnings` — passed
- `cargo fmt --check` — passed
