### PR TITLE
fix(doctor): honest rebuild guidance for a corrupt graph index

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -193,6 +193,20 @@ fn describe_resolved_store(layout: &StoreLayout) -> String {
     )
 }
 
+/// Remediation for a graph store that is not a valid `SQLite` file. The graph
+/// index is derived from source, so the honest fix is quarantine + re-init —
+/// never `tracedecay install`, which cannot repair a corrupt DB. Session data
+/// (`sessions.db`) is a separate file and is deliberately not mentioned as
+/// removable. Returns `None` for any other open failure.
+fn graph_corruption_remediation(detail: &str) -> Option<String> {
+    if !detail.contains("file is not a database") {
+        return None;
+    }
+    Some(format!(
+        "Graph index is corrupt (not a SQLite file): {detail}. The graph store is          derived and rebuildable: stop TraceDecay daemon/MCP processes, rename          tracedecay.db aside (e.g. tracedecay.db.corrupt-<ts>) together with its          WAL/SHM, then run `tracedecay init` to rebuild. Session data          (sessions.db) is unaffected."
+    ))
+}
+
 /// Check database health without mutating a store that may be owned by the daemon.
 ///
 /// The DB path is taken from the opened instance so the size measured is the
@@ -205,6 +219,10 @@ async fn check_database(
     let ts = match TraceDecay::open_read_only_with_options(project_path, open_options).await {
         Ok(ts) => ts,
         Err(e) => {
+            if let Some(remediation) = graph_corruption_remediation(&e.to_string()) {
+                dc.fail(&remediation);
+                return;
+            }
             dc.fail(&format!("Could not open database read-only: {e}"));
             return;
         }

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -437,3 +437,45 @@ async fn registry_drift_findings_report_manifest_identity_mismatches()
 
     Ok(())
 }
+
+#[test]
+fn graph_corruption_remediation_names_rebuild_never_install() {
+    let msg = super::graph_corruption_remediation(
+        "database error: failed to apply read-only pragmas: SQLite failure: \
+         `file is not a database` (operation: apply_read_only_pragmas)",
+    )
+    .expect("corrupt graph store must get the rebuild remediation");
+    assert!(msg.contains("tracedecay init"), "{msg}");
+    assert!(msg.contains("sessions.db) is unaffected"), "{msg}");
+    assert!(!msg.contains("tracedecay install"), "{msg}");
+    assert!(
+        super::graph_corruption_remediation("failed to open database read-only: locked").is_none()
+    );
+}
+
+#[tokio::test]
+async fn database_check_flags_garbage_graph_db_with_rebuild_guidance()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::TempDir::new()?;
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(&project_root)?;
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+    let ts = TraceDecay::init_with_options(&project_root, open_options.clone()).await?;
+    let db_path = ts.db_path();
+    drop(ts);
+
+    // Simulate the ENOSPC-torn store: raw bytes where SQLite should be.
+    std::fs::write(&db_path, vec![0x42u8; 4096])?;
+    for sidecar in ["-wal", "-shm"] {
+        let _ = std::fs::remove_file(db_path.with_extension(format!("db{sidecar}")));
+    }
+
+    let mut counters = DoctorCounters::new();
+    super::check_database(&mut counters, &project_root, open_options).await;
+    assert_eq!(counters.issues, 1, "garbage graph db must be a hard issue");
+    Ok(())
+}

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -967,6 +967,9 @@ fn print_corruption_warning(db_path: &std::path::Path) {
     eprintln!("[tracedecay] Store: {}", db_path.display());
     eprintln!("[tracedecay] Stop TraceDecay daemon/MCP processes before explicit repair.");
     eprintln!("[tracedecay] Preserve the DB, WAL, SHM, and dirty sentinel as one recovery set.");
+    eprintln!(
+        "[tracedecay] The graph index is derived from source: after preserving the set,          rename it aside (e.g. tracedecay.db.corrupt-<ts>) and run `tracedecay init` to          rebuild. Session data (sessions.db) is a separate file and unaffected."
+    );
     eprintln!("[tracedecay] Please report this at:");
     eprintln!("[tracedecay]   https://github.com/ScriptedAlchemy/tracedecay/issues");
     eprintln!(


### PR DESCRIPTION
Completes the corruption-incident follow-up on top of the merged recovery machinery: doctor and the lifecycle corruption warning now tell users the graph index is derived and rebuildable (quarantine + tracedecay init, sessions.db unaffected) instead of pointing at `tracedecay install` or a preserve-and-file-an-issue dead end. Auto-quarantine on open is deliberately omitted per the documented live-inode constraint. Classifier + garbage-store tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)