### PR TITLE
fix(doctor): report foreign-installation skill packages as info, not update-nag

### DIFF
--- a/src/automation/skill_materialization.rs
+++ b/src/automation/skill_materialization.rs
@@ -255,6 +255,11 @@ pub enum SkillDrift {
     /// A managed file exists for a skill that is no longer active; a reconcile
     /// would remove it.
     Orphan { skill_id: String, path: PathBuf },
+    /// A managed file for a no-longer-active skill that this installation did
+    /// not author (committed by another installation, or a legacy manifest with
+    /// no recorded author). `tracedecay update` will refuse to remove it, so
+    /// doctor must not prescribe update.
+    ForeignOrphan { skill_id: String, path: PathBuf },
     /// A non-fatal problem: a per-skill check failed, or two active skill ids
     /// collide on the same host slug. Reported so one bad package never hides
     /// drift for the rest of the scope.
@@ -272,6 +277,7 @@ impl SkillDrift {
             Self::Forked { .. } => "forked",
             Self::Conflict { .. } => "conflict",
             Self::Orphan { .. } => "orphan",
+            Self::ForeignOrphan { .. } => "foreign-orphan",
             Self::Warning { .. } => "warning",
         }
     }
@@ -282,6 +288,7 @@ impl SkillDrift {
             | Self::Forked { path, .. }
             | Self::Conflict { path, .. }
             | Self::Orphan { path, .. }
+            | Self::ForeignOrphan { path, .. }
             | Self::Warning { path, .. } => path,
         }
     }
@@ -292,6 +299,7 @@ impl SkillDrift {
             | Self::Forked { skill_id, .. }
             | Self::Conflict { skill_id, .. }
             | Self::Orphan { skill_id, .. }
+            | Self::ForeignOrphan { skill_id, .. }
             | Self::Warning { skill_id, .. } => skill_id,
         }
     }
@@ -1317,10 +1325,22 @@ fn may_remove_owned(
     manifest: &MaterializationManifest,
     installation_id: &str,
 ) -> bool {
+    !package_is_foreign_to_installation(scope, Some(manifest), installation_id)
+}
+
+/// Single source of truth for foreign-installation protection: a project-scope
+/// package is foreign unless its manifest records this installation as author.
+/// `None` covers missing/unparseable manifests and legacy manifests without
+/// `materialized_by`. Global (home) packages are never foreign.
+fn package_is_foreign_to_installation(
+    scope: &MaterializationScope,
+    manifest: Option<&MaterializationManifest>,
+    installation_id: &str,
+) -> bool {
     match scope.kind {
-        MaterializationScopeKind::Global => true,
+        MaterializationScopeKind::Global => false,
         MaterializationScopeKind::Project => {
-            manifest.materialized_by.as_deref() == Some(installation_id)
+            manifest.and_then(|m| m.materialized_by.as_deref()) != Some(installation_id)
         }
     }
 }
@@ -1505,6 +1525,7 @@ pub fn reconcile_scope(
 pub fn doctor_scope(
     scope: &MaterializationScope,
     active_skills: &[ManagedSkill],
+    installation_id: &str,
 ) -> Vec<SkillDrift> {
     let mut drift = Vec::new();
     let mut active_slugs = std::collections::BTreeSet::new();
@@ -1563,10 +1584,20 @@ pub fn doctor_scope(
                 if active_slugs.contains(&slug) {
                     continue;
                 }
-                drift.push(SkillDrift::Orphan {
-                    skill_id,
-                    path: scope.skill_md(&slug),
-                });
+                let dir = scope.skill_dir(&slug);
+                // Only an `Owned` manifest carries a trusted author. Missing,
+                // foreign, or unreadable manifests all mean the author is
+                // unknown — update cannot verify authorship, so treat as `None`.
+                let manifest = match read_materialization_manifest(&dir, &skill_id) {
+                    Ok(ManifestState::Owned(m)) => Some(m),
+                    Ok(ManifestState::Missing | ManifestState::Foreign) | Err(_) => None,
+                };
+                let path = scope.skill_md(&slug);
+                if package_is_foreign_to_installation(scope, manifest.as_ref(), installation_id) {
+                    drift.push(SkillDrift::ForeignOrphan { skill_id, path });
+                } else {
+                    drift.push(SkillDrift::Orphan { skill_id, path });
+                }
             }
         }
         Err(err) => drift.push(SkillDrift::Warning {
@@ -1750,10 +1781,11 @@ pub fn doctor_detected_scopes(
     project_root: &Path,
 ) -> Result<Vec<(MaterializationScope, Vec<SkillDrift>)>> {
     let skills = load_active_managed_skills(profile_root)?;
+    let installation = installation_id(profile_root);
     let mut out = Vec::new();
     for scope in detect_scopes(home, project_root) {
         let scope_skills = skills_for_scope(&skills, &scope);
-        let drift = doctor_scope(&scope, &scope_skills);
+        let drift = doctor_scope(&scope, &scope_skills, &installation);
         out.push((scope.clone(), drift));
     }
     Ok(out)

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -96,7 +96,7 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
 /// conflict (a foreign file blocks the slot), or orphan (a managed file for a
 /// no-longer-active skill). A clean scope passes silently-ish with an info line.
 fn check_managed_skill_materialization(dc: &mut DoctorCounters, home: &Path, project_root: &Path) {
-    use crate::automation::skill_materialization::{SkillDrift, doctor_detected_scopes};
+    use crate::automation::skill_materialization::doctor_detected_scopes;
 
     let Ok(profile_root) = crate::storage::default_profile_root() else {
         return;
@@ -122,32 +122,70 @@ fn check_managed_skill_materialization(dc: &mut DoctorCounters, home: &Path, pro
             ));
             continue;
         }
+        let scope_desc = scope.describe();
         for finding in drift {
-            let path = finding.path().display();
-            let skill_id = finding.skill_id();
-            match finding {
-                SkillDrift::Missing { .. } => dc.warn(&format!(
-                    "{}: '{skill_id}' active but not materialized ({path}); run `tracedecay update`",
-                    scope.describe()
-                )),
-                SkillDrift::Forked { .. } => dc.warn(&format!(
-                    "{}: '{skill_id}' materialized file was user-edited (forked); left untouched ({path})",
-                    scope.describe()
-                )),
-                SkillDrift::Conflict { .. } => dc.warn(&format!(
-                    "{}: '{skill_id}' cannot materialize — a non-managed file occupies {path}",
-                    scope.describe()
-                )),
-                SkillDrift::Orphan { .. } => dc.warn(&format!(
-                    "{}: stale materialized skill '{skill_id}' ({path}); run `tracedecay update` to remove",
-                    scope.describe()
-                )),
-                SkillDrift::Warning { ref message, .. } => dc.warn(&format!(
-                    "{}: '{skill_id}' {message} ({path})",
-                    scope.describe()
-                )),
+            match skill_drift_report(&scope_desc, &finding) {
+                (DriftLevel::Warn, msg) => dc.warn(&msg),
+                (DriftLevel::Info, msg) => dc.info(&msg),
             }
         }
+    }
+}
+
+/// Severity of a doctor materialization-drift line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DriftLevel {
+    Warn,
+    Info,
+}
+
+/// Pure classifier: maps a materialization drift finding to its doctor severity
+/// and rendered line. Split out from emission so it can be unit-tested — in
+/// particular that `ForeignOrphan` renders as `Info` and never prescribes
+/// `tracedecay update`, a remediation `update` refuses to perform on a foreign
+/// package.
+fn skill_drift_report(
+    scope_desc: &str,
+    finding: &crate::automation::skill_materialization::SkillDrift,
+) -> (DriftLevel, String) {
+    use crate::automation::skill_materialization::SkillDrift;
+    let path = finding.path().display();
+    let skill_id = finding.skill_id();
+    match finding {
+        SkillDrift::Missing { .. } => (
+            DriftLevel::Warn,
+            format!(
+                "{scope_desc}: '{skill_id}' active but not materialized ({path}); run `tracedecay update`"
+            ),
+        ),
+        SkillDrift::Forked { .. } => (
+            DriftLevel::Warn,
+            format!(
+                "{scope_desc}: '{skill_id}' materialized file was user-edited (forked); left untouched ({path})"
+            ),
+        ),
+        SkillDrift::Conflict { .. } => (
+            DriftLevel::Warn,
+            format!(
+                "{scope_desc}: '{skill_id}' cannot materialize — a non-managed file occupies {path}"
+            ),
+        ),
+        SkillDrift::Orphan { .. } => (
+            DriftLevel::Warn,
+            format!(
+                "{scope_desc}: stale materialized skill '{skill_id}' ({path}); run `tracedecay update` to remove"
+            ),
+        ),
+        SkillDrift::ForeignOrphan { .. } => (
+            DriftLevel::Info,
+            format!(
+                "{scope_desc}: '{skill_id}' project skill from another installation; leave in place, or delete the directory manually if unwanted ({path})"
+            ),
+        ),
+        SkillDrift::Warning { message, .. } => (
+            DriftLevel::Warn,
+            format!("{scope_desc}: '{skill_id}' {message} ({path})"),
+        ),
     }
 }
 

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -496,3 +496,43 @@ async fn registry_drift_findings_report_manifest_identity_mismatches()
 
     Ok(())
 }
+
+/// A `ForeignOrphan` drift line must render as `Info` severity (no warning
+/// count) and must never prescribe `tracedecay update` — the remediation the
+/// remove path refuses to perform on a foreign package. Mirrors the pure
+/// classifier pattern used for database-recovery guidance.
+#[test]
+fn foreign_orphan_renders_as_info_without_update_remediation() {
+    use crate::automation::skill_materialization::SkillDrift;
+    let finding = SkillDrift::ForeignOrphan {
+        skill_id: "code-slop-cleanup".to_string(),
+        path: std::path::PathBuf::from("/repo/.claude/skills/code-slop-cleanup/SKILL.md"),
+    };
+    let (level, msg) = super::skill_drift_report("claude/project", &finding);
+    assert_eq!(level, super::DriftLevel::Info);
+    assert!(
+        msg.contains("another installation"),
+        "message should explain the foreign origin: {msg}"
+    );
+    assert!(
+        !msg.contains("tracedecay update"),
+        "foreign orphan must not prescribe `tracedecay update`: {msg}"
+    );
+}
+
+/// A self-authored `Orphan` still renders as `Warn` and keeps the update
+/// remediation — the classifier must not blanket-downgrade every orphan.
+#[test]
+fn plain_orphan_still_warns_with_update_remediation() {
+    use crate::automation::skill_materialization::SkillDrift;
+    let finding = SkillDrift::Orphan {
+        skill_id: "code-slop-cleanup".to_string(),
+        path: std::path::PathBuf::from("/repo/.claude/skills/code-slop-cleanup/SKILL.md"),
+    };
+    let (level, msg) = super::skill_drift_report("claude/project", &finding);
+    assert_eq!(level, super::DriftLevel::Warn);
+    assert!(
+        msg.contains("tracedecay update"),
+        "plain orphan should still prescribe update: {msg}"
+    );
+}

--- a/tests/agent_suite/skill_materialization_test.rs
+++ b/tests/agent_suite/skill_materialization_test.rs
@@ -535,7 +535,7 @@ async fn fork_protection_leaves_user_edited_file_and_doctor_flags_it() {
     assert_eq!(std::fs::read_to_string(&path).unwrap(), edited);
 
     // Doctor flags the fork.
-    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill), INSTALL);
     assert!(
         drift.iter().any(
             |d| matches!(d, SkillDrift::Forked { skill_id, .. } if skill_id == "code-slop-cleanup")
@@ -584,7 +584,7 @@ async fn foreign_file_is_never_touched_and_doctor_reports_conflict() {
         RemoveAction::SkippedForeign
     );
 
-    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill), INSTALL);
     assert!(
         drift
             .iter()
@@ -624,7 +624,7 @@ async fn doctor_reports_missing_and_orphan_drift() {
     .await
     .unwrap();
     materialize_skill(&scope, &skill, INSTALL).unwrap();
-    let orphan_drift = doctor_scope(&scope, &[]);
+    let orphan_drift = doctor_scope(&scope, &[], INSTALL);
     assert!(
         orphan_drift.iter().any(
             |d| matches!(d, SkillDrift::Orphan { skill_id, .. } if skill_id == "code-slop-cleanup")
@@ -731,7 +731,7 @@ async fn lost_manifest_pristine_file_is_rederived_not_forked() {
     assert!(manifest.is_file(), "manifest should be re-derived");
 
     // Doctor must NOT report the pristine file as a user fork.
-    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill), INSTALL);
     assert!(
         !drift.iter().any(|d| matches!(d, SkillDrift::Forked { .. })),
         "pristine file wrongly flagged as forked: {drift:?}"
@@ -838,6 +838,128 @@ async fn project_scope_protects_another_installations_committed_package() {
     );
 }
 
+/// #4b A committed project package another installation authored (provenance
+/// clean, just a different `materialized_by`) must be reported as
+/// `ForeignOrphan`, never `Orphan` — doctor must not prescribe an `update`
+/// remove that the remove path refuses to perform. Predicate agreement is
+/// checked against `remove_materialized_skill`.
+#[tokio::test]
+async fn doctor_reports_foreign_installation_package_as_foreign_orphan() {
+    let (_temp, root) = canonical_tempdir();
+    let project = root.join("project");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&project);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+
+    // Installation B authored (and "committed") the package into the checkout.
+    let scope = MaterializationScope::project(MaterializationHost::Claude, project);
+    materialize_skill(&scope, &skill, INSTALL_B).unwrap();
+
+    // Installation A runs doctor with the skill inactive: foreign orphan, not
+    // a plain orphan (which would nag to run `tracedecay update`).
+    let drift = doctor_scope(&scope, &[], INSTALL);
+    assert_eq!(
+        drift
+            .iter()
+            .filter(|d| matches!(
+                d,
+                SkillDrift::ForeignOrphan { skill_id, .. } if skill_id == "code-slop-cleanup"
+            ))
+            .count(),
+        1,
+        "expected exactly one ForeignOrphan, got {drift:?}"
+    );
+    assert!(
+        !drift.iter().any(|d| matches!(d, SkillDrift::Orphan { .. })),
+        "foreign package must never be a plain Orphan: {drift:?}"
+    );
+
+    // Predicate agreement: the remove path also refuses this package.
+    assert_eq!(
+        remove_materialized_skill(&scope, "code-slop-cleanup", INSTALL).unwrap(),
+        RemoveAction::SkippedForeign
+    );
+}
+
+/// #4c A legacy manifest with no `materialized_by` field (pre-provenance shape),
+/// or no manifest at all, has an unknown author; doctor must treat it as a
+/// `ForeignOrphan` because the remove path also refuses to delete it.
+#[tokio::test]
+async fn doctor_reports_legacy_manifestless_author_as_foreign_orphan() {
+    let (_temp, root) = canonical_tempdir();
+    let project = root.join("project");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&project);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+
+    let scope = MaterializationScope::project(MaterializationHost::Claude, project);
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
+    let dir = scope.skills_dir().join("code-slop-cleanup");
+    let manifest = dir.join(".tracedecay-materialization.json");
+
+    // Legacy shape: strip `materialized_by` but keep the manifest otherwise
+    // valid (serde default makes the field optional).
+    let mut json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&manifest).unwrap()).unwrap();
+    json.as_object_mut().unwrap().remove("materialized_by");
+    std::fs::write(&manifest, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+    let drift = doctor_scope(&scope, &[], INSTALL);
+    assert!(
+        drift.iter().any(|d| matches!(
+            d,
+            SkillDrift::ForeignOrphan { skill_id, .. } if skill_id == "code-slop-cleanup"
+        )),
+        "legacy manifest-less author must be ForeignOrphan, got {drift:?}"
+    );
+
+    // Removing the manifest entirely (lost sidecar) is also unknown-author.
+    std::fs::remove_file(&manifest).unwrap();
+    let drift = doctor_scope(&scope, &[], INSTALL);
+    assert!(
+        drift.iter().any(|d| matches!(
+            d,
+            SkillDrift::ForeignOrphan { skill_id, .. } if skill_id == "code-slop-cleanup"
+        )),
+        "missing manifest must be ForeignOrphan, got {drift:?}"
+    );
+}
+
+/// #4d A package this installation authored, now inactive, remains a plain
+/// `Orphan` — `tracedecay update` correctly removes self-authored packages.
+#[tokio::test]
+async fn doctor_reports_own_inactive_skill_as_plain_orphan() {
+    let (_temp, root) = canonical_tempdir();
+    let project = root.join("project");
+    let profile_root = root.join("profile");
+    install_fake_hosts(&project);
+
+    activate_skill(&profile_root, "code-slop-cleanup").await;
+    let skill = load_skill(&profile_root, "code-slop-cleanup").await;
+
+    let scope = MaterializationScope::project(MaterializationHost::Claude, project);
+    materialize_skill(&scope, &skill, INSTALL).unwrap();
+
+    let drift = doctor_scope(&scope, &[], INSTALL);
+    assert!(
+        drift.iter().any(|d| matches!(
+            d,
+            SkillDrift::Orphan { skill_id, .. } if skill_id == "code-slop-cleanup"
+        )),
+        "self-authored inactive package must stay a plain Orphan, got {drift:?}"
+    );
+    assert!(
+        !drift
+            .iter()
+            .any(|d| matches!(d, SkillDrift::ForeignOrphan { .. })),
+        "self-authored package must never be ForeignOrphan: {drift:?}"
+    );
+}
+
 /// #5 Concurrent transactions on the same package must serialize and never wedge
 /// it as forked or leave a half-applied manifest.
 #[tokio::test]
@@ -868,7 +990,7 @@ async fn concurrent_materialize_does_not_wedge_forked() {
     // Final state is a clean, unchanged, fork-free package.
     let final_pass = materialize_skill(&scope, &skill, INSTALL).unwrap();
     assert_eq!(final_pass.action, MaterializeAction::Unchanged);
-    let drift = doctor_scope(&scope, std::slice::from_ref(&skill));
+    let drift = doctor_scope(&scope, std::slice::from_ref(&skill), INSTALL);
     assert!(
         drift.is_empty(),
         "unexpected drift after concurrency: {drift:?}"
@@ -934,7 +1056,7 @@ async fn doctor_reports_other_drift_when_one_package_errors() {
     symlink(&external, dir.join("references")).unwrap();
 
     // good-skill is active but not materialized -> Missing; broken errors.
-    let drift = doctor_scope(&scope, &[good, broken]);
+    let drift = doctor_scope(&scope, &[good, broken], INSTALL);
     assert!(
         drift
             .iter()
@@ -1023,7 +1145,7 @@ async fn colliding_host_slugs_are_disambiguated_and_warned() {
     assert_eq!(managed.len(), 2, "both colliding skills must materialize");
 
     // Doctor warns about the collision for both.
-    let drift = doctor_scope(&scope, &[a, b]);
+    let drift = doctor_scope(&scope, &[a, b], INSTALL);
     let warnings = drift
         .iter()
         .filter(|d| matches!(d, SkillDrift::Warning { .. }))


### PR DESCRIPTION
## Problem

`tracedecay doctor`'s managed-skill materialization check classified **every** inactive materialized package in a project scope as `Orphan` and told the user to run `tracedecay update` to remove it. But the update/remove path (`remove_materialized_skill` → `may_remove_owned`) already refuses to delete a project-scope package this installation did not author — a package committed by another installation (manifest `materialized_by` differs) or a legacy manifest with no `materialized_by` at all. So doctor emitted a **permanent warning nag prescribing a remediation that never runs**.

Concretely, in this repo the committed `.claude`/`.codex` skills `automation-run-review` and `scheduler-review` (manifests with `materialized_by: null`) were reported as two warnings each cycle, telling the user to run an `update` that would skip them as foreign.

## Fix

Route doctor and the remove path through **one shared predicate**, `package_is_foreign_to_installation`, so they classify identically by construction and doctor can never again prescribe an action `update` refuses to perform. `may_remove_owned` is now defined as its negation.

- New `SkillDrift::ForeignOrphan` variant, rendered at **info** severity (`DoctorCounters::info`) — indented, no `!` marker, does not increment the warning count, never names `tracedecay update`. Message: *"'<id>' project skill from another installation; leave in place, or delete the directory manually if unwanted (<path>)"*.
- Self-authored inactive packages still surface as plain `Orphan` with the `update` remediation (correct — update removes them).
- Global (home) packages are never foreign.
- The doctor render logic is extracted into a pure `skill_drift_report(scope_desc, finding) -> (DriftLevel, String)` classifier so severity/message is unit-testable.

Behavior of `reconcile_scope` / `remove_materialized_skill` is unchanged; this only aligns doctor's *reporting* with their existing protection.

## Tests

- `doctor_reports_foreign_installation_package_as_foreign_orphan` — committed package authored by another installation → exactly one `ForeignOrphan`, no `Orphan`, and `remove_materialized_skill` agrees with `SkippedForeign`.
- `doctor_reports_legacy_manifestless_author_as_foreign_orphan` — legacy manifest with `materialized_by` stripped, and missing-manifest case → `ForeignOrphan`.
- `doctor_reports_own_inactive_skill_as_plain_orphan` — self-authored inactive package stays `Orphan`.
- Lib unit tests `foreign_orphan_renders_as_info_without_update_remediation` and `plain_orphan_still_warns_with_update_remediation` on the pure classifier.
- Existing `doctor_scope` call sites updated with the installation-id arg.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- `cargo nextest run --test agent_suite --no-fail-fast` — 501 passed.
- Skill-materialization + doctor lib tests — all pass.
- Live: built binary's `tracedecay doctor` against this repo now emits the four packages (`{automation-run-review,scheduler-review}` × `.claude`/`.codex`) as info-level lines, no warning-count increment, no `update` prescription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)