### PR TITLE
fix(runtime): drain daemon safely during upgrades

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -343,6 +343,9 @@ pub enum Commands {
         /// Skip refreshing already-configured agent integrations
         #[arg(long)]
         no_reinstall: bool,
+        /// Lifecycle lease token passed only by the parent updater.
+        #[arg(long, hide = true)]
+        lifecycle_lease_token: Option<String>,
     },
     /// Show or switch the update channel (stable or beta)
     #[command(long_about = CHANNEL_LONG_ABOUT, after_help = CHANNEL_AFTER_HELP)]

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -258,14 +258,16 @@ fn update_and_post_update_parse_no_heal_flag() {
         post_update.command,
         Some(Commands::PostUpdate {
             no_heal: true,
-            no_reinstall: false
+            no_reinstall: false,
+            lifecycle_lease_token: None,
         })
     ));
     assert!(matches!(
         post_update_default.command,
         Some(Commands::PostUpdate {
             no_heal: false,
-            no_reinstall: false
+            no_reinstall: false,
+            lifecycle_lease_token: None,
         })
     ));
 }
@@ -320,7 +322,8 @@ fn upgrade_update_and_post_update_parse_no_reinstall_flag() {
         post_update.command,
         Some(Commands::PostUpdate {
             no_heal: false,
-            no_reinstall: true
+            no_reinstall: true,
+            lifecycle_lease_token: None,
         })
     ));
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4,8 +4,8 @@ use std::fmt::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-#[cfg(unix)]
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
@@ -15,7 +15,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 #[cfg(unix)]
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 #[cfg(unix)]
 use tokio::time::{Duration, timeout};
 
@@ -35,6 +35,82 @@ const HOOK_EVENT_NOTIFY_TIMEOUT: Duration = Duration::from_millis(750);
 /// being killed with `SIGKILL` mid-checkpoint.
 #[cfg(unix)]
 const DAEMON_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(45);
+#[cfg(unix)]
+const DAEMON_CLIENT_DRAIN_DEADLINE: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Default)]
+pub(crate) struct DaemonLifecycle {
+    inner: Arc<DaemonLifecycleInner>,
+}
+
+#[derive(Default)]
+struct DaemonLifecycleInner {
+    draining: AtomicBool,
+    active: AtomicUsize,
+    idle: tokio::sync::Notify,
+    draining_notify: tokio::sync::Notify,
+}
+
+pub(crate) struct DaemonActivity {
+    inner: Arc<DaemonLifecycleInner>,
+}
+
+impl DaemonLifecycle {
+    pub(crate) fn accepting(&self) -> bool {
+        !self.inner.draining.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn try_enter(&self) -> Option<DaemonActivity> {
+        if !self.accepting() {
+            return None;
+        }
+        self.inner.active.fetch_add(1, Ordering::AcqRel);
+        if self.accepting() {
+            Some(DaemonActivity {
+                inner: Arc::clone(&self.inner),
+            })
+        } else {
+            if self.inner.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+                self.inner.idle.notify_waiters();
+            }
+            None
+        }
+    }
+
+    fn begin_draining(&self) {
+        if !self.inner.draining.swap(true, Ordering::AcqRel) {
+            self.inner.draining_notify.notify_waiters();
+        }
+    }
+
+    pub(crate) async fn wait_for_draining(&self) {
+        loop {
+            let notified = self.inner.draining_notify.notified();
+            if !self.accepting() {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn wait_for_idle(&self) {
+        loop {
+            let notified = self.inner.idle.notified();
+            if self.inner.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+impl Drop for DaemonActivity {
+    fn drop(&mut self) {
+        if self.inner.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.inner.idle.notify_waiters();
+        }
+    }
+}
 
 #[cfg(unix)]
 mod git_watch;
@@ -42,8 +118,10 @@ mod git_watch;
 pub mod pr_autotrack;
 mod service;
 pub use service::{
-    DaemonServiceSpec, daemon_reachable, default_socket_path, install_service,
-    installed_service_socket_path, refresh_installed_service, refresh_service, service_spec,
+    DaemonServiceSpec, DaemonServiceState, daemon_reachable, default_socket_path, install_service,
+    installed_service_socket_path, quiesce_installed_service_under_lease,
+    refresh_installed_service, refresh_installed_service_under_lease,
+    refresh_installed_service_under_lease_with_state, refresh_service, service_spec,
     service_status, socket_path_or_default, uninstall_service,
 };
 
@@ -1275,26 +1353,30 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
     // PR-branch auto-tracking runs independently of the metadata watcher: it is
     // gated per-project on `sync.auto_track_pr_branches` (default off), so this
     // loop is inert unless a project opts in.
-    pr_autotrack::spawn(crate::global_db::global_db_path());
-    let engine = DaemonEngine::default().with_git_watcher(git_watcher);
+    let pr_autotrack_task = pr_autotrack::spawn(crate::global_db::global_db_path());
+    let engine = DaemonEngine::default()
+        .with_git_watcher(git_watcher)
+        .with_pr_autotrack_task(pr_autotrack_task)
+        .await;
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    let mut client_tasks: JoinSet<Result<()>> = JoinSet::new();
 
     loop {
         let stream = tokio::select! {
             accepted = listener.accept() => accepted?.0,
+            completed = client_tasks.join_next(), if !client_tasks.is_empty() => {
+                if let Some(completed) = completed {
+                    log_client_task_result(completed);
+                }
+                continue;
+            },
             _ = tokio::signal::ctrl_c() => break,
             _ = sigterm.recv() => break,
         };
         let engine = engine.clone();
-        tokio::spawn(async move {
-            if let Err(e) = Box::pin(serve_socket_client(stream, engine)).await {
-                log_daemon_event(
-                    "daemon_client",
-                    &[("outcome", "error".to_string()), ("error", e.to_string())],
-                );
-            }
-        });
+        client_tasks.spawn(async move { Box::pin(serve_socket_client(stream, engine)).await });
     }
+    engine.lifecycle.begin_draining();
     log_daemon_event(
         "daemon_shutdown",
         &[("socket", socket_path.display().to_string())],
@@ -1305,13 +1387,35 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
     // will never be served.
     drop(listener);
     let _ = std::fs::remove_file(&socket_path);
+    let clients_drained = drain_client_tasks(&mut client_tasks, DAEMON_CLIENT_DRAIN_DEADLINE).await;
+    engine.lifecycle.wait_for_idle().await;
+    // Client setup and in-flight requests may create schedulers or project
+    // servers. Sweep owned background tasks only after all client work drains.
+    engine.shutdown_background_tasks().await;
+    if !clients_drained {
+        log_daemon_event(
+            "daemon_shutdown",
+            &[
+                ("outcome", "client_drain_timeout".to_string()),
+                (
+                    "deadline_secs",
+                    DAEMON_CLIENT_DRAIN_DEADLINE.as_secs().to_string(),
+                ),
+                (
+                    "checkpoint",
+                    "skipped_active_clients_were_aborted".to_string(),
+                ),
+            ],
+        );
+        return Ok(());
+    }
     // Graceful shutdown persists tokens-saved counters and checkpoints WALs
     // for every live project server sequentially; with many servers or large
     // WALs that can exceed systemd's stop timeout, which then sends `SIGKILL`
     // to the daemon. On timeout the shutdown future is dropped and we proceed
     // to exit: the remaining persistence is best-effort and the database WAL
     // keeps state crash-safe.
-    let completed = timeout(DAEMON_SHUTDOWN_DEADLINE, engine.shutdown_all())
+    let completed = timeout(DAEMON_SHUTDOWN_DEADLINE, engine.shutdown_servers())
         .await
         .is_ok();
     if !completed {
@@ -1327,6 +1431,40 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn log_client_task_result(completed: std::result::Result<Result<()>, tokio::task::JoinError>) {
+    let error = match completed {
+        Ok(Ok(())) => return,
+        Ok(Err(error)) => error.to_string(),
+        Err(error) if error.is_cancelled() => return,
+        Err(error) => error.to_string(),
+    };
+    log_daemon_event(
+        "daemon_client",
+        &[("outcome", "error".to_string()), ("error", error)],
+    );
+}
+
+#[cfg(unix)]
+async fn drain_client_tasks(clients: &mut JoinSet<Result<()>>, deadline: Duration) -> bool {
+    let drained = timeout(deadline, async {
+        while let Some(completed) = clients.join_next().await {
+            log_client_task_result(completed);
+        }
+    })
+    .await
+    .is_ok();
+    if drained {
+        return true;
+    }
+
+    clients.abort_all();
+    while let Some(completed) = clients.join_next().await {
+        log_client_task_result(completed);
+    }
+    false
 }
 
 #[cfg(unix)]
@@ -1362,6 +1500,7 @@ async fn prepare_socket_path(socket_path: &Path) -> Result<()> {
 #[cfg(unix)]
 #[derive(Clone, Default)]
 struct DaemonEngine {
+    lifecycle: DaemonLifecycle,
     /// Shared daemon state, partitioned by the client-scoped project server key.
     project_servers: Arc<tokio::sync::Mutex<HashMap<ProjectServerKey, Arc<crate::mcp::McpServer>>>>,
     /// Background automation loops, partitioned with the same client/project identity as MCP state.
@@ -1373,6 +1512,8 @@ struct DaemonEngine {
     /// config-driven watcher is installed by `run_foreground_unix` via
     /// [`DaemonEngine::with_git_watcher`] before the accept loop starts.
     git_watcher: git_watch::GitWatcher,
+    /// PR reconciliation task, retained so shutdown never leaves it writing.
+    pr_autotrack_task: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
 }
 
 #[cfg(unix)]
@@ -1400,6 +1541,11 @@ impl DaemonEngine {
     /// once by `run_foreground_unix` before the accept loop.
     fn with_git_watcher(mut self, watcher: git_watch::GitWatcher) -> Self {
         self.git_watcher = watcher;
+        self
+    }
+
+    async fn with_pr_autotrack_task(self, task: JoinHandle<()>) -> Self {
+        *self.pr_autotrack_task.lock().await = Some(task);
         self
     }
 
@@ -1579,7 +1725,7 @@ impl DaemonEngine {
         schedulers.insert(key, handle);
     }
 
-    async fn shutdown_all(&self) {
+    async fn shutdown_background_tasks(&self) {
         let scheduler_handles: Vec<JoinHandle<()>> = {
             let mut schedulers = self.automation_schedulers.lock().await;
             schedulers.drain().map(|(_, handle)| handle).collect()
@@ -1589,13 +1735,33 @@ impl DaemonEngine {
             let _ = handle.await;
         }
 
+        self.git_watcher.shutdown().await;
+        if let Some(handle) = self.pr_autotrack_task.lock().await.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
+    async fn shutdown_servers(&self) {
         let servers: Vec<Arc<crate::mcp::McpServer>> = {
             let servers = self.project_servers.lock().await;
-            servers.values().cloned().collect()
+            let mut seen = HashSet::new();
+            servers
+                .values()
+                .filter(|server| seen.insert(Arc::as_ptr(server) as usize))
+                .cloned()
+                .collect()
         };
         for server in servers {
             server.shutdown().await;
         }
+    }
+
+    #[cfg(test)]
+    async fn shutdown_all(&self) {
+        self.lifecycle.begin_draining();
+        self.shutdown_background_tasks().await;
+        self.shutdown_servers().await;
     }
 }
 
@@ -2129,12 +2295,19 @@ async fn run_user_jobs_scheduler_pass(
 #[cfg(unix)]
 async fn serve_socket_client(stream: tokio::net::UnixStream, engine: DaemonEngine) -> Result<()> {
     let mut transport = UnixStreamTransport::new(stream);
-    let Some(line) = transport.read_line().await? else {
+    let line = tokio::select! {
+        result = transport.read_line() => result?,
+        () = engine.lifecycle.wait_for_draining() => return Ok(()),
+    };
+    let Some(line) = line else {
+        return Ok(());
+    };
+    let Some(setup_activity) = engine.lifecycle.try_enter() else {
         return Ok(());
     };
     let handshake = DaemonHandshake::from_line(&line)?;
     engine.log_client_version_skew(&handshake).await;
-    if handshake.project_path.is_some() {
+    let server = if handshake.project_path.is_some() {
         let server = match Box::pin(engine.project_server(&handshake)).await {
             Ok(server) => server,
             Err(e) => {
@@ -2142,9 +2315,29 @@ async fn serve_socket_client(stream: tokio::net::UnixStream, engine: DaemonEngin
                 return Err(e);
             }
         };
-        Box::pin(server.run_connection_with_timings(&mut transport, handshake.timings)).await?;
+        Some(server)
     } else {
-        serve_projectless_client(&mut transport, &handshake.client_identity).await?;
+        None
+    };
+    drop(setup_activity);
+    if !engine.lifecycle.accepting() {
+        return Ok(());
+    }
+
+    if let Some(server) = server {
+        Box::pin(server.run_daemon_connection_with_timings(
+            &mut transport,
+            handshake.timings,
+            &engine.lifecycle,
+        ))
+        .await?;
+    } else {
+        serve_projectless_client(
+            &mut transport,
+            &handshake.client_identity,
+            &engine.lifecycle,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -2283,8 +2476,19 @@ async fn write_json_rpc_response(
 async fn serve_projectless_client(
     transport: &mut UnixStreamTransport,
     client_identity: &DaemonClientIdentity,
+    lifecycle: &DaemonLifecycle,
 ) -> Result<()> {
-    while let Some(line) = transport.read_line().await? {
+    loop {
+        let line = tokio::select! {
+            result = transport.read_line() => result?,
+            () = lifecycle.wait_for_draining() => break,
+        };
+        let Some(line) = line else {
+            break;
+        };
+        let Some(_activity) = lifecycle.try_enter() else {
+            break;
+        };
         let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
             Ok(request) => projectless_response(&request, client_identity).await,
             Err(e) => Some(JsonRpcResponse::error(
@@ -2295,6 +2499,9 @@ async fn serve_projectless_client(
         };
         if let Some(response) = response {
             write_json_rpc_response(transport, &response).await?;
+        }
+        if !lifecycle.accepting() {
+            break;
         }
     }
     Ok(())

--- a/src/daemon/git_watch.rs
+++ b/src/daemon/git_watch.rs
@@ -32,11 +32,12 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use notify::{EventKind, RecursiveMode, Watcher};
 use tokio::sync::{Mutex, Notify, Semaphore};
+use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use crate::config::SyncConfig;
@@ -209,6 +210,9 @@ struct GitWatcherInner {
     sync_semaphore: Arc<Semaphore>,
     /// Canonical project root → watch state. Also the backstop's project set.
     projects: Mutex<HashMap<PathBuf, Arc<WatchState>>>,
+    /// Single backstop scheduler task, owned so shutdown can cancel and join it.
+    backstop_task: Mutex<Option<JoinHandle<()>>>,
+    shutting_down: AtomicBool,
 }
 
 impl Default for GitWatcher {
@@ -229,6 +233,8 @@ impl GitWatcher {
                 enabled: false,
                 sync_semaphore: Arc::new(Semaphore::new(1)),
                 projects: Mutex::new(HashMap::new()),
+                backstop_task: Mutex::new(None),
+                shutting_down: AtomicBool::new(false),
             }),
         }
     }
@@ -246,6 +252,8 @@ impl GitWatcher {
                 enabled: true,
                 sync_semaphore: Arc::new(Semaphore::new(permits)),
                 projects: Mutex::new(HashMap::new()),
+                backstop_task: Mutex::new(None),
+                shutting_down: AtomicBool::new(false),
             }),
         }
     }
@@ -261,7 +269,7 @@ impl GitWatcher {
     /// Called once from `run_foreground_unix` after the engine is built. Safe to
     /// call on a disabled watcher (no-op).
     pub async fn spawn(&self, global_db_path: Option<PathBuf>) {
-        if !self.inner.enabled {
+        if !self.inner.enabled || self.inner.shutting_down.load(Ordering::Acquire) {
             return;
         }
         // Enumerate recently-seen code projects (most-recent first, capped).
@@ -284,15 +292,16 @@ impl GitWatcher {
         // Start the single backstop timer.
         let watcher = self.clone();
         let db_path = global_db_path.clone();
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             backstop::run(watcher, db_path).await;
         });
+        *self.inner.backstop_task.lock().await = Some(handle);
     }
 
     /// Lazily starts watching `project_root` if not already watched and under
     /// the project cap. Idempotent and cheap on the hot path (a map lookup).
     pub async fn ensure_watching(&self, project_root: &Path) {
-        if !self.inner.enabled {
+        if !self.inner.enabled || self.inner.shutting_down.load(Ordering::Acquire) {
             return;
         }
         let canonical = project_root
@@ -332,6 +341,29 @@ impl GitWatcher {
             "git_watch_started",
             &[("project", canonical.display().to_string())],
         );
+    }
+
+    /// Stops every watcher-owned task and joins it before database shutdown.
+    pub async fn shutdown(&self) {
+        if !self.inner.enabled || self.inner.shutting_down.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        if let Some(handle) = self.inner.backstop_task.lock().await.take() {
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        let states: Vec<Arc<WatchState>> = {
+            let mut projects = self.inner.projects.lock().await;
+            projects.drain().map(|(_, state)| state).collect()
+        };
+        for state in states {
+            if let Some(handle) = state.task.lock().await.take() {
+                handle.abort();
+                let _ = handle.await;
+            }
+        }
     }
 
     /// A doctor-facing snapshot of every registered project's watch health.
@@ -482,7 +514,13 @@ fn classify_and_mark(state: &Arc<WatchState>, event: &notify::Event) {
             let s = path.to_string_lossy();
             if let Some(idx) = s.find("/refs/heads/") {
                 let branch = &s[idx + "/refs/heads/".len()..];
-                if !branch.is_empty() {
+                // Git creates `<ref>.lock` beside a branch ref while updating
+                // it. The sidecar is not a branch and may disappear before
+                // the debounce drain, so never enqueue it for catch-up sync.
+                let is_lock_sidecar = std::path::Path::new(branch)
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("lock"));
+                if !branch.is_empty() && !is_lock_sidecar {
                     dirty.branches.insert(branch.to_string());
                 }
                 if is_remove {

--- a/src/daemon/git_watch/tests.rs
+++ b/src/daemon/git_watch/tests.rs
@@ -53,6 +53,33 @@ fn ref_event_marks_branch_and_delete_marks_gc() {
 }
 
 #[test]
+fn ref_lock_sidecar_does_not_become_a_branch() {
+    let state = Arc::new(WatchState {
+        project_root: PathBuf::from("/repo"),
+        dirty: Mutex::new(DirtySet::default()),
+        wake: Notify::new(),
+        health: ProjectHealth::default(),
+        task: Mutex::new(None),
+        entered_debounce: Notify::new(),
+        drained_plans: AtomicU64::new(0),
+        plan_drained: Notify::new(),
+    });
+    let event = notify::Event {
+        kind: EventKind::Create(notify::event::CreateKind::File),
+        paths: vec![PathBuf::from("/repo/.git/refs/heads/codex/topic.lock")],
+        attrs: EventAttributes::new(),
+    };
+
+    classify_and_mark(&state, &event);
+
+    let dirty = state
+        .dirty
+        .try_lock()
+        .expect("dirty set should be unlocked");
+    assert!(dirty.branches.is_empty(), "git lock sidecars are not refs");
+}
+
+#[test]
 fn heartbeat_staleness() {
     let fresh = ProjectHealthSnapshot {
         last_heartbeat: now_secs(),
@@ -170,6 +197,24 @@ async fn disabled_watcher_never_registers() {
     assert!(!watcher.is_enabled());
     watcher.ensure_watching(repo.path()).await;
     assert!(watcher.health_report().await.is_empty());
+}
+
+#[tokio::test]
+async fn shutdown_cancels_and_joins_watcher_tasks() {
+    let repo = temp_repo();
+    let profile = tempfile::tempdir().unwrap();
+    let mut config = fast_watch_config();
+    config.backstop_interval_mins = 1;
+    let watcher = GitWatcher::new(config);
+    watcher.spawn(Some(profile.path().join("global.db"))).await;
+    watcher.ensure_watching(repo.path()).await;
+    let state = ready_registered_state(&watcher, repo.path()).await;
+
+    watcher.shutdown().await;
+
+    assert!(watcher.inner.projects.lock().await.is_empty());
+    assert!(state.task.lock().await.is_none());
+    assert!(watcher.inner.backstop_task.lock().await.is_none());
 }
 
 /// The safety-critical property that justifies this metadata watcher over the

--- a/src/daemon/pr_autotrack.rs
+++ b/src/daemon/pr_autotrack.rs
@@ -875,10 +875,10 @@ fn remove_worktree(repo_root: &Path, worktree: &Path) {
 
 /// Spawns the PR-autotrack poll loop. Cheap and inert when no registered project
 /// has the feature enabled — each tick only reads per-project config.
-pub fn spawn(global_db_path: Option<PathBuf>) {
+pub fn spawn(global_db_path: Option<PathBuf>) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         run(global_db_path).await;
-    });
+    })
 }
 
 async fn run(global_db_path: Option<PathBuf>) {

--- a/src/daemon/pr_autotrack/tests.rs
+++ b/src/daemon/pr_autotrack/tests.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+#[tokio::test]
+async fn spawned_loop_is_cancellable_and_joinable() {
+    let profile = tempfile::tempdir().unwrap();
+    let handle = spawn(Some(profile.path().join("global.db")));
+
+    handle.abort();
+
+    assert!(
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .is_ok()
+    );
+}
+
 // ---- Pure discovery parsers -------------------------------------------------
 
 #[test]

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -20,6 +20,26 @@ pub struct DaemonServiceSpec {
     pub data_dir_override: Option<PathBuf>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DaemonServiceState {
+    Missing,
+    RunningEnabled,
+    RunningDisabled,
+    StoppedEnabled,
+    StoppedDisabled,
+    Masked,
+}
+
+impl DaemonServiceState {
+    fn is_running(self) -> bool {
+        matches!(self, Self::RunningEnabled | Self::RunningDisabled)
+    }
+
+    fn is_enabled(self) -> bool {
+        matches!(self, Self::RunningEnabled | Self::StoppedEnabled)
+    }
+}
+
 impl DaemonServiceSpec {
     pub fn render_systemd_user_unit(&self) -> String {
         let service_path = daemon_service_path_env(&self.tracedecay_bin);
@@ -264,6 +284,11 @@ pub fn service_spec(
 }
 
 pub fn install_service(spec: &DaemonServiceSpec, start: bool) -> Result<PathBuf> {
+    let _lifecycle_lease = crate::lifecycle_lease::acquire_exclusive("daemon service install")?;
+    install_service_under_lease(spec, start)
+}
+
+fn install_service_under_lease(spec: &DaemonServiceSpec, start: bool) -> Result<PathBuf> {
     let runner = ServiceRunner::current()?;
     let service_path = write_service_unit(spec)?;
     runner.install(&service_path, start, &spec.socket_path)?;
@@ -272,13 +297,58 @@ pub fn install_service(spec: &DaemonServiceSpec, start: bool) -> Result<PathBuf>
 }
 
 pub fn refresh_service(spec: &DaemonServiceSpec) -> Result<PathBuf> {
+    let _lifecycle_lease = crate::lifecycle_lease::acquire_exclusive("daemon service refresh")?;
+    refresh_service_under_lease(spec)
+}
+
+fn refresh_service_under_lease(spec: &DaemonServiceSpec) -> Result<PathBuf> {
     let runner = ServiceRunner::current()?;
+    refresh_service_with_runner(&runner, spec, DaemonServiceState::RunningEnabled)
+}
+
+fn refresh_service_with_runner(
+    runner: &ServiceRunner,
+    spec: &DaemonServiceSpec,
+    previous_state: DaemonServiceState,
+) -> Result<PathBuf> {
+    if matches!(runner, ServiceRunner::Systemd) && previous_state == DaemonServiceState::Masked {
+        let service_path = service_unit_path()?;
+        if std::fs::read_link(&service_path).is_ok_and(|target| target == Path::new("/dev/null")) {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "TraceDecay daemon service '{}' is persistently masked; preserved the /dev/null mask and skipped rewriting it",
+                    service_path.display()
+                ),
+            });
+        }
+    }
     let service_path = write_service_unit(spec)?;
-    runner.refresh(&service_path, &spec.socket_path)?;
+    runner.refresh(&service_path, &spec.socket_path, previous_state)?;
     Ok(service_path)
 }
 
 pub fn refresh_installed_service(spec: &DaemonServiceSpec) -> Result<Option<PathBuf>> {
+    let _lifecycle_lease = crate::lifecycle_lease::acquire_exclusive("daemon service refresh")?;
+    refresh_installed_service_under_lease(spec)
+}
+
+#[doc(hidden)]
+pub fn refresh_installed_service_under_lease(spec: &DaemonServiceSpec) -> Result<Option<PathBuf>> {
+    refresh_installed_service_with_state(spec, None)
+}
+
+#[doc(hidden)]
+pub fn refresh_installed_service_under_lease_with_state(
+    spec: &DaemonServiceSpec,
+    previous_state: DaemonServiceState,
+) -> Result<Option<PathBuf>> {
+    refresh_installed_service_with_state(spec, Some(previous_state))
+}
+
+fn refresh_installed_service_with_state(
+    spec: &DaemonServiceSpec,
+    previous_state: Option<DaemonServiceState>,
+) -> Result<Option<PathBuf>> {
     let service_path = service_unit_path()?;
     if !service_path.exists() {
         return Ok(None);
@@ -288,13 +358,49 @@ pub fn refresh_installed_service(spec: &DaemonServiceSpec) -> Result<Option<Path
     if let Some(socket_path) = socket_path_from_unit_text(&unit) {
         refreshed_spec.socket_path = socket_path;
     }
-    if matches!(ServiceRunner::current(), Ok(ServiceRunner::Launchd)) {
+    let runner = ServiceRunner::current()?;
+    let previous_state =
+        previous_state.unwrap_or_else(|| runner.service_state(&refreshed_spec.socket_path));
+    if matches!(runner, ServiceRunner::Launchd) {
         // The installed plist is the source of truth for the daemon's data
         // directory; the refreshing shell may not have the override set.
         refreshed_spec.data_dir_override =
             launchd_plist_env_value(&unit, crate::config::USER_DATA_DIR_ENV).map(PathBuf::from);
     }
-    refresh_service(&refreshed_spec).map(Some)
+    refresh_service_with_runner(&runner, &refreshed_spec, previous_state).map(Some)
+}
+
+#[doc(hidden)]
+pub fn quiesce_installed_service_under_lease() -> Result<DaemonServiceState> {
+    let service_path = service_unit_path()?;
+    if !service_path.exists() {
+        if daemon_reachable() {
+            return Err(TraceDecayError::Config {
+                message: "refusing post-update mutations: a TraceDecay daemon is reachable but no managed service unit exists; stop the unmanaged daemon and retry".to_string(),
+            });
+        }
+        return Ok(DaemonServiceState::Missing);
+    }
+    let unit = read_service_unit(&service_path)?;
+    let socket_path = socket_path_from_unit_text(&unit).unwrap_or(default_socket_path()?);
+    let runner = ServiceRunner::current()?;
+    let state = runner.service_state(&socket_path);
+    if !state.is_running() {
+        if matches!(
+            daemon_socket_state(&socket_path),
+            DaemonSocketState::Connectable
+        ) {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "refusing post-update mutations: an unmanaged TraceDecay daemon is reachable at '{}'; stop it and retry",
+                    socket_path.display()
+                ),
+            });
+        }
+        return Ok(state);
+    }
+    runner.stop_for_update()?;
+    Ok(state)
 }
 
 fn write_service_unit(spec: &DaemonServiceSpec) -> Result<PathBuf> {
@@ -410,6 +516,11 @@ fn socket_path_from_unit_text(unit: &str) -> Option<PathBuf> {
 }
 
 pub fn uninstall_service(stop: bool) -> Result<PathBuf> {
+    let _lifecycle_lease = crate::lifecycle_lease::acquire_exclusive("daemon service uninstall")?;
+    uninstall_service_under_lease(stop)
+}
+
+fn uninstall_service_under_lease(stop: bool) -> Result<PathBuf> {
     let runner = ServiceRunner::current()?;
     let service_path = service_unit_path()?;
     runner.before_uninstall(stop)?;
@@ -553,15 +664,72 @@ impl ServiceRunner {
         }
     }
 
-    fn refresh(&self, service_path: &Path, socket_path: &Path) -> Result<()> {
+    fn refresh(
+        &self,
+        service_path: &Path,
+        socket_path: &Path,
+        previous_state: DaemonServiceState,
+    ) -> Result<()> {
         match self {
             Self::Systemd => {
                 run_systemctl(&["daemon-reload"])?;
-                run_systemctl(&["enable", super::SERVICE_NAME])?;
-                run_systemctl(&["restart", super::SERVICE_NAME])?;
+                if previous_state.is_enabled() {
+                    run_systemctl(&["enable", super::SERVICE_NAME])?;
+                }
+                if previous_state.is_running() {
+                    run_systemctl(&["restart", super::SERVICE_NAME])?;
+                }
                 Ok(())
             }
-            Self::Launchd => launchd_refresh(service_path, socket_path),
+            Self::Launchd if previous_state.is_running() => {
+                launchd_refresh(service_path, socket_path)?;
+                if !previous_state.is_enabled() {
+                    run_launchctl(&["disable", &launchd_service_target()?])?;
+                }
+                Ok(())
+            }
+            Self::Launchd => Ok(()),
+        }
+    }
+
+    fn service_state(&self, socket_path: &Path) -> DaemonServiceState {
+        match self {
+            Self::Systemd => {
+                let running = Command::new("systemctl")
+                    .args(["--user", "is-active", "--quiet", super::SERVICE_NAME])
+                    .status()
+                    .is_ok_and(|status| status.success());
+                let enablement = Command::new("systemctl")
+                    .args(["--user", "is-enabled", super::SERVICE_NAME])
+                    .output()
+                    .ok()
+                    .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+                    .unwrap_or_default();
+                if enablement.starts_with("masked") {
+                    DaemonServiceState::Masked
+                } else if running && enablement.starts_with("enabled") {
+                    DaemonServiceState::RunningEnabled
+                } else if running {
+                    DaemonServiceState::RunningDisabled
+                } else if enablement.starts_with("enabled") {
+                    DaemonServiceState::StoppedEnabled
+                } else {
+                    DaemonServiceState::StoppedDisabled
+                }
+            }
+            Self::Launchd => {
+                let running = matches!(
+                    daemon_socket_state(socket_path),
+                    DaemonSocketState::Connectable
+                );
+                let enabled = !launchd_service_is_disabled();
+                match (running, enabled) {
+                    (true, true) => DaemonServiceState::RunningEnabled,
+                    (true, false) => DaemonServiceState::RunningDisabled,
+                    (false, true) => DaemonServiceState::StoppedEnabled,
+                    (false, false) => DaemonServiceState::StoppedDisabled,
+                }
+            }
         }
     }
 
@@ -574,6 +742,13 @@ impl ServiceRunner {
                 Ok(())
             }
             Self::Launchd => launchd_before_uninstall(stop),
+        }
+    }
+
+    fn stop_for_update(&self) -> Result<()> {
+        match self {
+            Self::Systemd => run_systemctl(&["stop", super::SERVICE_NAME]),
+            Self::Launchd => launchd_before_uninstall(true),
         }
     }
 
@@ -764,6 +939,28 @@ fn launchd_service_target() -> Result<String> {
     Ok(format!("{}/{}", launchd_domain()?, LAUNCHD_LABEL))
 }
 
+fn launchd_service_is_disabled() -> bool {
+    let Ok(domain) = launchd_domain() else {
+        return false;
+    };
+    let Ok(output) = Command::new("launchctl")
+        .args(["print-disabled", &domain])
+        .output()
+    else {
+        return false;
+    };
+    launchd_disabled_output_contains_label(&String::from_utf8_lossy(&output.stdout), LAUNCHD_LABEL)
+}
+
+fn launchd_disabled_output_contains_label(output: &str, label: &str) -> bool {
+    output.lines().any(|line| {
+        line.contains(label)
+            && line
+                .split_once("=>")
+                .is_some_and(|(_, value)| value.trim().starts_with("true"))
+    })
+}
+
 fn ensure_launchd_runtime_dirs() -> Result<()> {
     let data_dir = tracedecay_data_dir()?;
     std::fs::create_dir_all(&data_dir).map_err(|e| TraceDecayError::Config {
@@ -875,7 +1072,9 @@ mod tests {
     #[cfg(unix)]
     use tempfile::TempDir;
 
-    use super::{DaemonServiceSpec, LaunchctlFailureMode, LaunchdCommand};
+    use super::{
+        DaemonServiceSpec, DaemonServiceState, LaunchctlFailureMode, LaunchdCommand, ServiceRunner,
+    };
     use crate::config::lock_user_data_dir_test_env;
 
     struct EnvVarGuard {
@@ -1228,6 +1427,22 @@ mod tests {
         assert!(!super::launchctl_stderr_is_not_loaded(""));
     }
 
+    #[test]
+    fn launchd_disabled_output_matches_only_the_tracedecay_label() {
+        assert!(super::launchd_disabled_output_contains_label(
+            "disabled services = {\n\t\"com.tracedecay.daemon\" => true\n}",
+            "com.tracedecay.daemon"
+        ));
+        assert!(!super::launchd_disabled_output_contains_label(
+            "disabled services = {\n\t\"com.tracedecay.daemon\" => false\n}",
+            "com.tracedecay.daemon"
+        ));
+        assert!(!super::launchd_disabled_output_contains_label(
+            "disabled services = {\n\t\"com.example.other\" => true\n}",
+            "com.tracedecay.daemon"
+        ));
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn refresh_service_rewrites_unit_and_restarts_daemon() {
@@ -1308,6 +1523,27 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn post_update_rejects_reachable_unmanaged_daemon() {
+        let _env_lock = lock_user_data_dir_test_env();
+        let dir = TempDir::new().expect("temp dir");
+        let data_dir = dir.path().join("profile");
+        let config_home = dir.path().join("config");
+        std::fs::create_dir_all(&data_dir).expect("data dir");
+        let _data_guard = EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &data_dir);
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _socket_guard = EnvVarGuard::unset(crate::daemon::SOCKET_ENV);
+        let socket_path = super::default_socket_path().expect("default socket");
+        let _listener = std::os::unix::net::UnixListener::bind(&socket_path).expect("bind socket");
+
+        let error = super::quiesce_installed_service_under_lease()
+            .expect_err("unmanaged daemon must block post-update mutations");
+
+        assert!(error.to_string().contains("unmanaged daemon"));
+        assert!(error.to_string().contains("stop"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn refresh_installed_service_preserves_existing_socket_path() {
         let _env_lock = lock_user_data_dir_test_env();
         let dir = TempDir::new().expect("temp dir");
@@ -1321,7 +1557,7 @@ mod tests {
         let log = dir.path().join("systemctl.log");
         std::fs::write(
             &systemctl,
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TRACEDECAY_SYSTEMCTL_LOG\"\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TRACEDECAY_SYSTEMCTL_LOG\"\n[ \"$2\" = is-enabled ] && echo enabled\nexit 0\n",
         )
         .expect("fake systemctl");
         std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
@@ -1353,7 +1589,11 @@ mod tests {
             data_dir_override: None,
         };
 
-        let outcome = super::refresh_installed_service(&spec).expect("refresh service");
+        let previous_state =
+            super::quiesce_installed_service_under_lease().expect("quiesce installed service");
+        let outcome =
+            super::refresh_installed_service_under_lease_with_state(&spec, previous_state)
+                .expect("refresh service");
 
         assert_eq!(outcome, Some(service_path.clone()));
         let unit = std::fs::read_to_string(service_path).expect("service unit");
@@ -1363,7 +1603,112 @@ mod tests {
         assert!(!unit.contains("/run/user/1000/tracedecay.sock"));
         assert_eq!(
             std::fs::read_to_string(log).expect("systemctl log"),
-            "--user daemon-reload\n--user enable tracedecay.service\n--user restart tracedecay.service\n"
+            "--user is-active --quiet tracedecay.service\n--user is-enabled tracedecay.service\n--user stop tracedecay.service\n--user daemon-reload\n--user enable tracedecay.service\n--user restart tracedecay.service\n"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refresh_installed_service_preserves_stopped_state() {
+        let _env_lock = lock_user_data_dir_test_env();
+        let dir = TempDir::new().expect("temp dir");
+        let config_home = dir.path().join("config");
+        let fake_bin = dir.path().join("bin");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+        std::fs::create_dir_all(&home).expect("home dir");
+        let systemctl = fake_bin.join("systemctl");
+        let log = dir.path().join("systemctl.log");
+        std::fs::write(
+            &systemctl,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TRACEDECAY_SYSTEMCTL_LOG\"\n[ \"$2\" = is-active ] && exit 3\nexit 0\n",
+        )
+        .expect("fake systemctl");
+        std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+            .expect("systemctl permissions");
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _home_guard = EnvVarGuard::set("HOME", &home);
+        let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+        let _log_guard = EnvVarGuard::set("TRACEDECAY_SYSTEMCTL_LOG", &log);
+        let service_path = config_home
+            .join("systemd/user")
+            .join(crate::daemon::SERVICE_NAME);
+        std::fs::create_dir_all(service_path.parent().expect("service parent"))
+            .expect("service dir");
+        std::fs::write(
+            &service_path,
+            "[Service]\nExecStart=/old/tracedecay daemon run --socket /custom/tracedecay.sock\n",
+        )
+        .expect("existing service unit");
+        let spec = DaemonServiceSpec {
+            tracedecay_bin: PathBuf::from("/opt/tracedecay/bin/tracedecay"),
+            socket_path: PathBuf::from("/run/user/1000/tracedecay.sock"),
+            data_dir_override: None,
+        };
+
+        super::refresh_installed_service(&spec).expect("refresh service");
+
+        let commands = std::fs::read_to_string(log).expect("systemctl log");
+        assert!(commands.contains("--user is-active --quiet tracedecay.service"));
+        assert!(!commands.contains("enable tracedecay.service"));
+        assert!(!commands.contains("restart tracedecay.service"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn systemd_service_state_detects_runtime_mask() {
+        let _env_lock = lock_user_data_dir_test_env();
+        let dir = TempDir::new().expect("temp dir");
+        let fake_bin = dir.path().join("bin");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+        let systemctl = fake_bin.join("systemctl");
+        std::fs::write(
+            &systemctl,
+            "#!/bin/sh\n[ \"$2\" = is-active ] && exit 3\n[ \"$2\" = is-enabled ] && { echo masked-runtime; exit 1; }\nexit 0\n",
+        )
+        .expect("fake systemctl");
+        std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+            .expect("systemctl permissions");
+        let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+
+        assert_eq!(
+            ServiceRunner::Systemd.service_state(&dir.path().join("daemon.sock")),
+            DaemonServiceState::Masked
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn refresh_preserves_persistent_systemd_mask_symlink() {
+        let _env_lock = lock_user_data_dir_test_env();
+        let dir = TempDir::new().expect("temp dir");
+        let config_home = dir.path().join("config");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&home).expect("home dir");
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _home_guard = EnvVarGuard::set("HOME", &home);
+        let service_path = config_home
+            .join("systemd/user")
+            .join(crate::daemon::SERVICE_NAME);
+        std::fs::create_dir_all(service_path.parent().expect("service parent"))
+            .expect("service dir");
+        std::os::unix::fs::symlink("/dev/null", &service_path).expect("mask service");
+        let spec = DaemonServiceSpec {
+            tracedecay_bin: PathBuf::from("/opt/tracedecay/bin/tracedecay"),
+            socket_path: PathBuf::from("/run/user/1000/tracedecay.sock"),
+            data_dir_override: None,
+        };
+
+        let error = super::refresh_installed_service_under_lease_with_state(
+            &spec,
+            DaemonServiceState::Masked,
+        )
+        .expect_err("persistent mask must not be overwritten");
+
+        assert!(error.to_string().contains("persistently masked"));
+        assert_eq!(
+            std::fs::read_link(service_path).unwrap(),
+            PathBuf::from("/dev/null")
         );
     }
 

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -11,7 +11,78 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 #[cfg(unix)]
 use tokio::task::JoinHandle;
 
-use super::{DaemonClientIdentity, DaemonHandshake};
+use super::{DaemonClientIdentity, DaemonHandshake, DaemonLifecycle, drain_client_tasks};
+
+#[test]
+fn daemon_lifecycle_rejects_new_work_after_draining() {
+    let lifecycle = DaemonLifecycle::default();
+    assert!(lifecycle.accepting());
+
+    lifecycle.begin_draining();
+
+    assert!(!lifecycle.accepting());
+}
+
+#[tokio::test]
+async fn client_drain_timeout_aborts_and_joins_remaining_work() {
+    let mut clients = tokio::task::JoinSet::new();
+    clients.spawn(async {
+        std::future::pending::<()>().await;
+        Ok(())
+    });
+
+    let drained = drain_client_tasks(&mut clients, tokio::time::Duration::from_millis(5)).await;
+
+    assert!(!drained);
+    assert!(clients.is_empty());
+}
+
+#[tokio::test]
+async fn client_drain_waits_for_completed_work() {
+    let mut clients = tokio::task::JoinSet::new();
+    clients.spawn(async { Ok(()) });
+
+    let drained = drain_client_tasks(&mut clients, tokio::time::Duration::from_secs(1)).await;
+
+    assert!(drained);
+    assert!(clients.is_empty());
+}
+
+#[tokio::test]
+async fn persistent_idle_client_closes_on_draining_without_timeout() {
+    let lifecycle = DaemonLifecycle::default();
+    let idle_lifecycle = lifecycle.clone();
+    let mut clients = tokio::task::JoinSet::new();
+    clients.spawn(async move {
+        idle_lifecycle.wait_for_draining().await;
+        Ok(())
+    });
+
+    lifecycle.begin_draining();
+    let drained = drain_client_tasks(&mut clients, tokio::time::Duration::from_secs(1)).await;
+
+    assert!(drained);
+    assert!(lifecycle.try_enter().is_none());
+}
+
+#[tokio::test]
+async fn draining_waits_for_one_bounded_in_flight_request() {
+    let lifecycle = DaemonLifecycle::default();
+    let activity = lifecycle.try_enter().expect("request should start");
+    let mut clients = tokio::task::JoinSet::new();
+    clients.spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+        drop(activity);
+        Ok(())
+    });
+
+    lifecycle.begin_draining();
+    let drained = drain_client_tasks(&mut clients, tokio::time::Duration::from_secs(1)).await;
+    lifecycle.wait_for_idle().await;
+
+    assert!(drained);
+    assert!(lifecycle.try_enter().is_none());
+}
 
 fn test_client_identity() -> DaemonClientIdentity {
     test_client_identity_for(PathBuf::from("/profiles/client"))

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -17,6 +17,13 @@ pub(crate) mod registry_drift;
 
 /// Runs a comprehensive health check of the tracedecay installation.
 pub async fn run_doctor(agent_filter: Option<&str>) {
+    let _lifecycle_lease = match crate::lifecycle_lease::acquire_shared_or_inherited("doctor") {
+        Ok(lease) => lease,
+        Err(error) => {
+            eprintln!("tracedecay doctor could not start: {error}");
+            return;
+        }
+    };
     debug_assert!(
         !env!("CARGO_PKG_VERSION").is_empty(),
         "CARGO_PKG_VERSION must not be empty"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod git;
 pub mod global_db;
 pub mod graph;
 pub mod hooks;
+pub mod lifecycle_lease;
 pub mod mcp;
 pub mod memory;
 pub mod migrate;

--- a/src/lifecycle_lease.rs
+++ b/src/lifecycle_lease.rs
@@ -1,0 +1,327 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::errors::{Result, TraceDecayError};
+
+const LIFECYCLE_LOCK_FILENAME: &str = "lifecycle.lock";
+static LEASE_NONCE: AtomicU64 = AtomicU64::new(0);
+static PROCESS_LEASE_TOKENS: LazyLock<Mutex<Vec<String>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+
+#[derive(Debug)]
+enum LeaseHold {
+    File(File),
+    Inherited,
+}
+
+/// Cross-process guard for operations that may replace binaries, restart the
+/// daemon, or inspect stores while those mutations are in progress.
+#[derive(Debug)]
+pub struct LifecycleLease {
+    hold: LeaseHold,
+    token: Option<String>,
+}
+
+impl LifecycleLease {
+    pub fn token(&self) -> Option<&str> {
+        self.token.as_deref()
+    }
+}
+
+impl Drop for LifecycleLease {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.as_deref() {
+            unregister_process_token(token);
+        }
+        if let LeaseHold::File(file) = &self.hold {
+            let _ = fs2::FileExt::unlock(file);
+        }
+    }
+}
+
+pub fn acquire_exclusive(operation: &str) -> Result<LifecycleLease> {
+    acquire_exclusive_at(&lifecycle_lock_path()?, operation)
+}
+
+pub fn acquire_shared(operation: &str) -> Result<LifecycleLease> {
+    acquire_shared_at(&lifecycle_lock_path()?, operation)
+}
+
+/// Acquires a shared diagnostic lease, or joins the exclusive lease held by
+/// this process's post-update parent.
+pub fn acquire_shared_or_inherited(operation: &str) -> Result<LifecycleLease> {
+    let path = lifecycle_lock_path()?;
+    acquire_shared_or_inherited_at(&path, operation)
+}
+
+fn acquire_shared_or_inherited_at(path: &Path, operation: &str) -> Result<LifecycleLease> {
+    let mut file = open_lock_file(path)?;
+    match fs2::FileExt::try_lock_shared(&file) {
+        Ok(()) => Ok(LifecycleLease {
+            hold: LeaseHold::File(file),
+            token: None,
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            let owner = read_owner(&mut file);
+            let owner_token = owner.as_deref().and_then(|line| line.split('\t').next());
+            if owner_token.is_some_and(process_owns_token) {
+                Ok(LifecycleLease {
+                    hold: LeaseHold::Inherited,
+                    token: None,
+                })
+            } else {
+                Err(busy_error(operation, owner.as_deref()))
+            }
+        }
+        Err(error) => Err(lock_error(path, operation, &error)),
+    }
+}
+
+/// Acquires the lifecycle lease, or proves that this process is the
+/// post-update child of the process that still owns it.
+pub fn acquire_exclusive_or_inherited(
+    operation: &str,
+    inherited_token: Option<&str>,
+) -> Result<LifecycleLease> {
+    acquire_exclusive_or_inherited_at(
+        &lifecycle_lock_path()?,
+        operation,
+        inherited_token.map(str::to_string),
+    )
+}
+
+fn acquire_exclusive_or_inherited_at(
+    path: &Path,
+    operation: &str,
+    inherited: Option<String>,
+) -> Result<LifecycleLease> {
+    let mut file = open_lock_file(path)?;
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => own_exclusive(file, operation),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            let owner = read_owner(&mut file);
+            if let Some(token) = inherited.filter(|token| {
+                owner.as_deref().and_then(|line| line.split('\t').next()) == Some(token.as_str())
+            }) {
+                register_process_token(&token);
+                Ok(LifecycleLease {
+                    hold: LeaseHold::Inherited,
+                    token: Some(token),
+                })
+            } else {
+                Err(busy_error(operation, owner.as_deref()))
+            }
+        }
+        Err(error) => Err(lock_error(path, operation, &error)),
+    }
+}
+
+fn lifecycle_lock_path() -> Result<PathBuf> {
+    let root = crate::config::user_data_dir().ok_or_else(|| TraceDecayError::Config {
+        message: "could not determine TraceDecay user data directory for lifecycle lease"
+            .to_string(),
+    })?;
+    std::fs::create_dir_all(&root).map_err(|error| TraceDecayError::Config {
+        message: format!(
+            "failed to create TraceDecay user data directory '{}': {error}",
+            root.display()
+        ),
+    })?;
+    Ok(root.join(LIFECYCLE_LOCK_FILENAME))
+}
+
+fn acquire_exclusive_at(path: &Path, operation: &str) -> Result<LifecycleLease> {
+    let file = open_lock_file(path)?;
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => own_exclusive(file, operation),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            let mut file = file;
+            let owner = read_owner(&mut file);
+            Err(busy_error(operation, owner.as_deref()))
+        }
+        Err(error) => Err(lock_error(path, operation, &error)),
+    }
+}
+
+fn acquire_shared_at(path: &Path, operation: &str) -> Result<LifecycleLease> {
+    let mut file = open_lock_file(path)?;
+    match fs2::FileExt::try_lock_shared(&file) {
+        Ok(()) => Ok(LifecycleLease {
+            hold: LeaseHold::File(file),
+            token: None,
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            let owner = read_owner(&mut file);
+            Err(busy_error(operation, owner.as_deref()))
+        }
+        Err(error) => Err(lock_error(path, operation, &error)),
+    }
+}
+
+fn own_exclusive(mut file: File, operation: &str) -> Result<LifecycleLease> {
+    let token = lease_token();
+    file.set_len(0).map_err(|error| owner_write_error(&error))?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| owner_write_error(&error))?;
+    writeln!(file, "{token}\t{operation}\t{}", std::process::id())
+        .map_err(|error| owner_write_error(&error))?;
+    file.flush().map_err(|error| owner_write_error(&error))?;
+    register_process_token(&token);
+    Ok(LifecycleLease {
+        hold: LeaseHold::File(file),
+        token: Some(token),
+    })
+}
+
+fn register_process_token(token: &str) {
+    PROCESS_LEASE_TOKENS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(token.to_string());
+}
+
+fn unregister_process_token(token: &str) {
+    let mut tokens = PROCESS_LEASE_TOKENS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(index) = tokens.iter().rposition(|candidate| candidate == token) {
+        tokens.swap_remove(index);
+    }
+}
+
+fn process_owns_token(token: &str) -> bool {
+    PROCESS_LEASE_TOKENS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .any(|candidate| candidate == token)
+}
+
+fn open_lock_file(path: &Path) -> Result<File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| lock_error(path, "open", &error))?;
+    }
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .map_err(|error| lock_error(path, "open", &error))
+}
+
+fn read_owner(file: &mut File) -> Option<String> {
+    let mut owner = String::new();
+    file.seek(SeekFrom::Start(0)).ok()?;
+    file.read_to_string(&mut owner).ok()?;
+    let owner = owner.trim();
+    (!owner.is_empty()).then(|| owner.to_string())
+}
+
+fn lease_token() -> String {
+    let epoch_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let nonce = LEASE_NONCE.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "{}:{}:{epoch_nanos}:{nonce}",
+        crate::runtime_identity::process_run_id(),
+        std::process::id()
+    )
+}
+
+fn busy_error(operation: &str, owner: Option<&str>) -> TraceDecayError {
+    let owner_operation = owner
+        .and_then(|line| line.split('\t').nth(1))
+        .unwrap_or("another lifecycle operation");
+    TraceDecayError::Config {
+        message: format!(
+            "cannot start {operation}: {owner_operation} is already active; retry after it finishes"
+        ),
+    }
+}
+
+fn lock_error(path: &Path, operation: &str, error: &std::io::Error) -> TraceDecayError {
+    TraceDecayError::Config {
+        message: format!(
+            "failed to acquire lifecycle lease for {operation} at '{}': {error}",
+            path.display()
+        ),
+    }
+}
+
+fn owner_write_error(error: &std::io::Error) -> TraceDecayError {
+    TraceDecayError::Config {
+        message: format!("failed to record TraceDecay lifecycle lease owner: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        acquire_exclusive_at, acquire_exclusive_or_inherited_at, acquire_shared_at,
+        acquire_shared_or_inherited_at,
+    };
+
+    #[test]
+    fn exclusive_lease_rejects_a_concurrent_mutator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lifecycle.lock");
+        let held = acquire_exclusive_at(&path, "upgrade").unwrap();
+
+        let error = acquire_exclusive_at(&path, "update").unwrap_err();
+
+        assert!(error.to_string().contains("upgrade"));
+        drop(held);
+        acquire_exclusive_at(&path, "update").unwrap();
+    }
+
+    #[test]
+    fn shared_doctor_lease_blocks_mutation_but_not_another_reader() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lifecycle.lock");
+        let first = acquire_shared_at(&path, "doctor").unwrap();
+        let second = acquire_shared_at(&path, "doctor").unwrap();
+
+        let error = acquire_exclusive_at(&path, "upgrade").unwrap_err();
+
+        assert!(error.to_string().contains("lifecycle operation"));
+        drop((first, second));
+        acquire_exclusive_at(&path, "upgrade").unwrap();
+    }
+
+    #[test]
+    fn nested_doctor_joins_the_process_owned_exclusive_lease() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lifecycle.lock");
+        let _parent = acquire_exclusive_at(&path, "post-update").unwrap();
+
+        acquire_shared_or_inherited_at(&path, "doctor").unwrap();
+    }
+
+    #[test]
+    fn post_update_child_must_present_the_live_parent_token() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lifecycle.lock");
+        let parent = acquire_exclusive_at(&path, "update").unwrap();
+        let token = parent.token().unwrap().to_string();
+
+        acquire_exclusive_or_inherited_at(&path, "post-update", Some(token)).unwrap();
+        let error = acquire_exclusive_or_inherited_at(
+            &path,
+            "post-update",
+            Some("stale-token".to_string()),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("update"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -595,7 +595,12 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
         Commands::PostUpdate {
             no_heal,
             no_reinstall,
+            lifecycle_lease_token,
         } => {
+            let _lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive_or_inherited(
+                "post-update",
+                lifecycle_lease_token.as_deref(),
+            )?;
             update_cmd::run_post_update_tasks(no_heal, no_reinstall).await?;
         }
         Commands::Channel { channel } => match channel {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1845,7 +1845,7 @@ impl McpServer {
     /// responses to stdout. Runs until stdin is closed or a shutdown signal
     /// (SIGINT/SIGTERM) is received, then performs graceful cleanup.
     pub async fn run(&self, transport: &mut impl super::transport::McpTransport) -> Result<()> {
-        self.run_with_shutdown_policy(transport, true, true, None)
+        self.run_with_shutdown_policy(transport, true, true, None, None)
             .await
     }
 
@@ -1856,7 +1856,7 @@ impl McpServer {
         &self,
         transport: &mut impl super::transport::McpTransport,
     ) -> Result<()> {
-        self.run_with_shutdown_policy(transport, false, false, None)
+        self.run_with_shutdown_policy(transport, false, false, None, None)
             .await
     }
 
@@ -1867,8 +1867,24 @@ impl McpServer {
         transport: &mut impl super::transport::McpTransport,
         timings_enabled: bool,
     ) -> Result<()> {
-        self.run_with_shutdown_policy(transport, false, false, Some(timings_enabled))
+        self.run_with_shutdown_policy(transport, false, false, Some(timings_enabled), None)
             .await
+    }
+
+    pub(crate) async fn run_daemon_connection_with_timings(
+        &self,
+        transport: &mut impl super::transport::McpTransport,
+        timings_enabled: bool,
+        lifecycle: &crate::daemon::DaemonLifecycle,
+    ) -> Result<()> {
+        self.run_with_shutdown_policy(
+            transport,
+            false,
+            false,
+            Some(timings_enabled),
+            Some(lifecycle),
+        )
+        .await
     }
 
     async fn run_with_shutdown_policy(
@@ -1877,6 +1893,7 @@ impl McpServer {
         shutdown_on_exit: bool,
         listen_for_process_signals: bool,
         timings_override: Option<bool>,
+        request_lifecycle: Option<&crate::daemon::DaemonLifecycle>,
     ) -> Result<()> {
         let mut route_cache = self.hook_project_routes.snapshot();
 
@@ -1911,6 +1928,20 @@ impl McpServer {
                             }
                             _ = tokio::signal::ctrl_c() => break,
                             _ = sigterm.recv() => break,
+                        }
+                    } else if let Some(lifecycle) = request_lifecycle {
+                        tokio::select! {
+                            result = transport.read_line() => {
+                                match result {
+                                    Ok(Some(line)) => line,
+                                    Ok(None) => break,
+                                    Err(e) => {
+                                        self.shutdown_if(shutdown_on_exit).await;
+                                        return Err(e.into());
+                                    }
+                                }
+                            }
+                            () = lifecycle.wait_for_draining() => break,
                         }
                     } else {
                         match transport.read_line().await {
@@ -1959,32 +1990,47 @@ impl McpServer {
 
             // Parse the incoming JSON
             let parsed: std::result::Result<JsonRpcRequest, _> = serde_json::from_str(&line);
+            let request_activity = request_lifecycle.and_then(|lifecycle| lifecycle.try_enter());
+            let rejecting_for_drain = request_lifecycle.is_some() && request_activity.is_none();
 
-            let response = match parsed {
-                Ok(request) => {
-                    if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
-                        && self.initialize_root_routing_enabled.load(Ordering::Relaxed)
-                    {
-                        connection_route
-                            .observe_initialize(
-                                request.params.as_ref(),
-                                self.registry_db.as_deref(),
-                            )
-                            .await;
+            let response = if rejecting_for_drain {
+                parsed.as_ref().ok().and_then(|request| {
+                    request.id.clone().map(|id| {
+                        JsonRpcResponse::error(
+                            id,
+                            ErrorCode::InternalError,
+                            "TraceDecay daemon is draining for upgrade; retry the request"
+                                .to_string(),
+                        )
+                    })
+                })
+            } else {
+                match parsed {
+                    Ok(request) => {
+                        if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
+                            && self.initialize_root_routing_enabled.load(Ordering::Relaxed)
+                        {
+                            connection_route
+                                .observe_initialize(
+                                    request.params.as_ref(),
+                                    self.registry_db.as_deref(),
+                                )
+                                .await;
+                        }
+                        Box::pin(self.handle_request_with_timings_and_implicit_project(
+                            &request,
+                            timings_override.unwrap_or_else(|| self.timings_enabled()),
+                            &mut route_cache,
+                            connection_route.implicit_project_path(),
+                        ))
+                        .await
                     }
-                    Box::pin(self.handle_request_with_timings_and_implicit_project(
-                        &request,
-                        timings_override.unwrap_or_else(|| self.timings_enabled()),
-                        &mut route_cache,
-                        connection_route.implicit_project_path(),
-                    ))
-                    .await
+                    Err(e) => Some(JsonRpcResponse::error(
+                        Value::Null,
+                        ErrorCode::ParseError,
+                        format!("failed to parse JSON-RPC request: {e}"),
+                    )),
                 }
-                Err(e) => Some(JsonRpcResponse::error(
-                    Value::Null,
-                    ErrorCode::ParseError,
-                    format!("failed to parse JSON-RPC request: {e}"),
-                )),
             };
 
             // Drain and write any pending notifications (e.g., version warnings).
@@ -2022,6 +2068,12 @@ impl McpServer {
                     self.shutdown_if(shutdown_on_exit).await;
                     return Err(e.into());
                 }
+            }
+            drop(request_activity);
+            if rejecting_for_drain
+                || request_lifecycle.is_some_and(|lifecycle| !lifecycle.accepting())
+            {
+                break;
             }
         }
 

--- a/src/startup_tests.rs
+++ b/src/startup_tests.rs
@@ -42,7 +42,8 @@ fn explicit_agent_config_commands_skip_startup_maintenance() {
     }));
     assert!(should_skip_startup_maintenance(&Commands::PostUpdate {
         no_heal: false,
-        no_reinstall: false
+        no_reinstall: false,
+        lifecycle_lease_token: None,
     }));
     assert!(should_skip_startup_maintenance(&Commands::Uninstall {
         agent: Some("kiro".to_string()),
@@ -100,7 +101,8 @@ fn agent_install_maintenance_is_selective() {
     assert!(should_skip_agent_install_maintenance(
         &Commands::PostUpdate {
             no_heal: false,
-            no_reinstall: false
+            no_reinstall: false,
+            lifecycle_lease_token: None,
         }
     ));
     assert!(should_skip_agent_install_maintenance(&Commands::Tool {

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -65,17 +65,26 @@ pub(crate) fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
 
 /// Rewrites and restarts the installed daemon service, returning the service
 /// path and its socket, or `None` when no service is installed.
-fn refresh_daemon_service() -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>> {
+fn refresh_daemon_service(
+    previous_state: tracedecay::daemon::DaemonServiceState,
+) -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>> {
     let tracedecay_bin = tracedecay_bin_on_path()?;
     let spec = tracedecay::daemon::service_spec(tracedecay_bin, None)?;
     let socket_path = tracedecay::daemon::installed_service_socket_path()?
         .unwrap_or_else(|| spec.socket_path.clone());
-    Ok(tracedecay::daemon::refresh_installed_service(&spec)?
-        .map(|service_path| (service_path, socket_path)))
+    Ok(
+        tracedecay::daemon::refresh_installed_service_under_lease_with_state(
+            &spec,
+            previous_state,
+        )?
+        .map(|service_path| (service_path, socket_path)),
+    )
 }
 
-fn refresh_daemon_service_after_update() -> tracedecay::errors::Result<()> {
-    match refresh_daemon_service()? {
+fn refresh_daemon_service_after_update(
+    previous_state: tracedecay::daemon::DaemonServiceState,
+) -> tracedecay::errors::Result<()> {
+    match refresh_daemon_service(previous_state)? {
         Some((service_path, socket_path)) => {
             eprintln!(
                 "\x1b[32m✔\x1b[0m Daemon service refreshed at {}",
@@ -97,7 +106,8 @@ fn refresh_daemon_service_after_update() -> tracedecay::errors::Result<()> {
 }
 
 pub(crate) fn restart_daemon_service() -> tracedecay::errors::Result<()> {
-    match refresh_daemon_service()? {
+    let _lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive("daemon restart")?;
+    match refresh_daemon_service(tracedecay::daemon::DaemonServiceState::RunningEnabled)? {
         Some((service_path, socket_path)) => {
             eprintln!(
                 "\x1b[32m✔\x1b[0m Daemon service restarted at {}",
@@ -213,10 +223,17 @@ pub(crate) fn run_update_command(
     no_heal: bool,
     no_reinstall: bool,
 ) -> tracedecay::errors::Result<()> {
+    let lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive("update")?;
+    let lease_token = lifecycle_lease
+        .token()
+        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+            message: "update lifecycle lease did not provide an owner token".to_string(),
+        })?
+        .to_string();
     run_install_then_refresh(
         RefreshPolicy::Always,
         tracedecay::upgrade::run_upgrade,
-        |binary| run_post_update_subcommand(no_heal, no_reinstall, binary),
+        |binary| run_post_update_subcommand(no_heal, no_reinstall, binary, &lease_token),
     )
 }
 
@@ -224,10 +241,17 @@ pub(crate) fn run_upgrade_command(
     no_heal: bool,
     no_reinstall: bool,
 ) -> tracedecay::errors::Result<()> {
+    let lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive("upgrade")?;
+    let lease_token = lifecycle_lease
+        .token()
+        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+            message: "upgrade lifecycle lease did not provide an owner token".to_string(),
+        })?
+        .to_string();
     run_install_then_refresh(
         RefreshPolicy::AfterInstall,
         tracedecay::upgrade::run_upgrade,
-        |binary| run_post_update_subcommand(no_heal, no_reinstall, binary),
+        |binary| run_post_update_subcommand(no_heal, no_reinstall, binary, &lease_token),
     )
 }
 
@@ -246,10 +270,14 @@ fn run_post_update_subcommand(
     no_heal: bool,
     no_reinstall: bool,
     installed: Option<&Path>,
+    lifecycle_lease_token: &str,
 ) -> tracedecay::errors::Result<()> {
     let tracedecay_bin = post_update_binary(installed)?;
     let mut command = std::process::Command::new(&tracedecay_bin);
-    command.arg("post-update");
+    command
+        .arg("post-update")
+        .arg("--lifecycle-lease-token")
+        .arg(lifecycle_lease_token);
     if no_heal {
         command.arg("--no-heal");
     }
@@ -329,10 +357,18 @@ pub(crate) async fn run_post_update_tasks(
     no_heal: bool,
     no_reinstall: bool,
 ) -> tracedecay::errors::Result<()> {
+    let previous_daemon_state = tracedecay::daemon::quiesce_installed_service_under_lease()?;
+    let mutation_result = run_post_update_mutations(no_heal, no_reinstall).await;
+    let restart_result = refresh_daemon_service_after_update(previous_daemon_state);
+    mutation_result?;
+    restart_result
+}
+
+async fn run_post_update_mutations(
+    no_heal: bool,
+    no_reinstall: bool,
+) -> tracedecay::errors::Result<()> {
     refresh_generated_plugins()?;
-    if let Err(error) = refresh_daemon_service_after_update() {
-        eprintln!("  \x1b[33mwarning:\x1b[0m daemon service refresh failed: {error}");
-    }
     if no_heal {
         eprintln!("Skipping post-update health pass (--no-heal).");
     } else {


### PR DESCRIPTION
## Summary
- serialize update/upgrade/doctor lifecycle operations without inheritable environment bypasses
- quiesce the managed daemon before post-update store/plugin work, drain in-flight requests, stop owned background writers, deduplicate server shutdown, and checkpoint only after writers stop
- preserve running/stopped and enabled/disabled/masked service state on systemd and launchd; reject unmanaged reachable daemons and persistent `/dev/null` masks safely
- own watcher/PR-autotrack tasks and ignore transient Git ref lock files

## Root cause
Post-update doctor/store opens could run while the old daemon still held live WAL connections; daemon shutdown also left persistent clients and background tasks outside the checkpoint boundary. Service refresh unconditionally restarted/enabled stopped or masked installations.

## Verification
- `cargo check --all-targets --all-features`
- daemon service tests: 22 passed
- daemon tests: 36 passed
- lifecycle lease tests: 4 passed
- watcher shutdown test, CLI post-update parse test, fmt/diff-check: passed