### PR TITLE
feat(mcp): add tracedecay_move_symbol with impact report

### DIFF
--- a/evals/agent_adoption/scenarios/edit_move_compute_grand_total_out.json
+++ b/evals/agent_adoption/scenarios/edit_move_compute_grand_total_out.json
@@ -7,7 +7,7 @@
     "codex"
   ],
   "fixture": "main",
-  "status": "deferred",
+  "status": "active",
   "prompt": "Move compute_grand_total out of pricing.rs into its own module.",
   "expected_tools": {
     "required_first": [
@@ -15,7 +15,8 @@
     ],
     "acceptable": [
       "tracedecay_context",
-      "tracedecay_search"
+      "tracedecay_search",
+      "tracedecay_body"
     ],
     "forbidden_first": [
       "Grep",
@@ -32,8 +33,10 @@
       "ack "
     ]
   },
-  "ground_truth": [],
+  "ground_truth": [
+    "compute_grand_total"
+  ],
   "max_tool_calls": 6,
   "requires_tool": "move_symbol",
-  "notes": "PENDING: forward-looking scenario for a move_symbol tool that does not exist yet in the refactor toolset."
+  "notes": "move-a-function-to-its-own-module. tracedecay_move_symbol relocates compute_grand_total from pricing.rs, auto-inserts `use crate::pricing::LineItem;` at the destination, and reports the module_missing hint (`pub mod grand_total;`) — verified live against the fixture crate. Ground truth is the moved symbol name, which any correct final answer states regardless of the destination module the agent picks. Live runs mutate the throwaway fixture copy."
 }

--- a/plugin/skills/editing-safely/SKILL.md
+++ b/plugin/skills/editing-safely/SKILL.md
@@ -65,6 +65,14 @@ Run this read-only recon in one shot for a symbol or `Struct::field` with
    per file for multi-file rewrites. Scope the change first with
    `tracedecay_ast_grep_search` (read-only, in-process, whole-tree) to see every
    match and confirm the pattern before rewriting.
+6. **Move a function to another file → `tracedecay_move_symbol`** (`symbol`,
+   `dest_file`, `dry_run` defaults true). Relocates the symbol with its
+   docs/attrs and returns an **impact report** — broken callers, dependencies
+   the body loses at the destination, visibility escalations, collisions, and
+   missing `mod` declarations — as actionable hints. Unambiguous needed imports
+   are auto-inserted at the destination (`applied_imports`); caller references
+   are reported, never auto-edited. Preview first, then re-run with
+   `dry_run: false` to apply.
 
 ## Porting code
 

--- a/src/hooks/tool_hints.rs
+++ b/src/hooks/tool_hints.rs
@@ -261,6 +261,7 @@ const CATEGORY_SPECS: &[HintCategorySpec] = &[
             "tracedecay_insert_at_symbol",
             "tracedecay_ast_grep_rewrite",
             "tracedecay_replace_symbol",
+            "tracedecay_move_symbol",
         ],
         nonblocking: false,
     },

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -426,6 +426,7 @@ fn needs_lazy_sync_before_dispatch(tool_name: &str) -> bool {
         "tracedecay_ast_grep_rewrite"
             | "tracedecay_insert_at"
             | "tracedecay_insert_at_symbol"
+            | "tracedecay_move_symbol"
             | "tracedecay_multi_str_replace"
             | "tracedecay_replace_symbol"
             | "tracedecay_str_replace"

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -338,6 +338,7 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
         def_file_dependents(),
         def_replace_symbol(),
         def_insert_at_symbol(),
+        def_move_symbol(),
         def_find_exact_symbol(),
     ];
     add_registered_project_selector_properties(&mut definitions);
@@ -481,6 +482,7 @@ const FORMAT_CAPABLE_TOOL_NAMES: &[&str] = &[
     "tracedecay_insert_at",
     "tracedecay_insert_at_symbol",
     "tracedecay_replace_symbol",
+    "tracedecay_move_symbol",
     "tracedecay_ast_grep_rewrite",
     // git & info
     "tracedecay_branch_list",
@@ -3739,6 +3741,49 @@ fn def_replace_symbol() -> ToolDefinition {
                 }
             },
             "required": ["symbol", "new_source"]
+        }),
+    )
+}
+
+fn def_move_symbol() -> ToolDefinition {
+    def_rw(
+        "tracedecay_move_symbol",
+        "Move Symbol Across Files",
+        "Move a function (Rust-first) from its file to a destination file, and \
+         — the centerpiece — report the full IMPACT of the move: every caller \
+         whose reference breaks, every dependency the body loses at the \
+         destination, visibility that must be escalated, destination collisions, \
+         and missing module declarations. Each finding is an evidence-based hint \
+         { kind, file, line, detail, suggestion } derived from the code graph \
+         (callers/callees) and parse-level facts (identifiers, `use` lines), not \
+         regex guessing. The moved span includes the item's leading \
+         doc-comment / attribute block. Defaults to a DRY RUN — the report and a \
+         combined source+destination preview diff are the product; applying is \
+         opt-in via `dry_run: false`, which removes the span from the source, \
+         inserts it at the destination, and auto-inserts unambiguous needed \
+         imports (returned in `applied_imports`). Caller references are never \
+         auto-edited in v1; the exact change rides in each hint.",
+        json!({
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string",
+                    "description": "Symbol to move. Prefer a fully qualified name for disambiguation; on ambiguity callable kinds win, else the move is refused."
+                },
+                "dest_file": {
+                    "type": "string",
+                    "description": "Destination file (project-relative or absolute, within the project). May be a new module file; parent directories are created on apply."
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true (DEFAULT), compute the move, the combined preview diff, and the impact report but write nothing. Set false to apply the move."
+                },
+                "update_references": {
+                    "type": "boolean",
+                    "description": "Reserved for a future version. In v1 callers are never auto-edited; the exact change is reported as a hint instead (default: false)."
+                }
+            },
+            "required": ["symbol", "dest_file"]
         }),
     )
 }

--- a/src/mcp/tools/handlers/edit.rs
+++ b/src/mcp/tools/handlers/edit.rs
@@ -283,6 +283,84 @@ pub(super) async fn handle_insert_at_symbol(cg: &TraceDecay, args: Value) -> Res
     Ok(text_tool_result(cg, &args, &result, touched_files, dry_run, verify).await)
 }
 
+pub(super) async fn handle_move_symbol(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
+    let symbol = required_str(&args, "symbol")?;
+    let dest_file = required_str(&args, "dest_file")?;
+    // The impact report is the product; applying is opt-in.
+    let dry_run = args.get("dry_run").and_then(Value::as_bool).unwrap_or(true);
+    let update_references = args
+        .get("update_references")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let result = cg
+        .move_symbol(symbol, dest_file, dry_run, update_references)
+        .await?;
+
+    let success = result.success;
+    let touched_files = if success && !dry_run {
+        vec![result.source_file.clone(), result.dest_file.clone()]
+    } else {
+        vec![]
+    };
+    let value = serde_json::to_value(&result).unwrap_or_default();
+    let text = render::finalize(Some(cg.project_root()), &args, &value, || {
+        move_result_md(&result)
+    });
+    let tool_result = ToolResult::new(
+        json!({ "content": [{ "type": "text", "text": text }] }),
+        touched_files,
+    )
+    .with_semantic_error(!success);
+    Ok(if success {
+        tool_result
+    } else {
+        tool_result.with_failure_message(&result.message)
+    })
+}
+
+/// Human-readable markdown for a move result: the outcome line, applied
+/// imports, the impact report (the centerpiece), and the preview diff.
+fn move_result_md(result: &crate::types::MoveResult) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let verb = if result.dry_run {
+        "Would move"
+    } else {
+        "Moved"
+    };
+    let _ = writeln!(
+        out,
+        "## {verb} `{}`\n\n{} → {}\n\n{}",
+        result.symbol, result.source_file, result.dest_file, result.message
+    );
+    if !result.applied_imports.is_empty() {
+        out.push_str("\n### Auto-inserted imports (destination)\n");
+        for imp in &result.applied_imports {
+            let _ = writeln!(out, "- `{}`", imp.trim());
+        }
+    }
+    out.push_str("\n### Impact\n");
+    if result.impact.is_empty() {
+        out.push_str("Clean move — no references, dependencies, or module concerns detected.\n");
+    } else {
+        for hint in &result.impact {
+            let loc = hint
+                .line
+                .map(|l| format!("{}:{}", hint.file, l))
+                .unwrap_or_else(|| hint.file.clone());
+            let _ = writeln!(out, "- **{}** ({}) — {}", hint.kind, loc, hint.detail);
+            if let Some(sug) = &hint.suggestion {
+                let _ = writeln!(out, "  - suggestion: {sug}");
+            }
+        }
+    }
+    if let Some(diff) = &result.diff {
+        let _ = write!(out, "\n### Preview diff\n```diff\n{diff}\n```\n");
+    }
+    out
+}
+
 pub(super) async fn handle_ast_grep_rewrite(cg: &TraceDecay, args: Value) -> Result<ToolResult> {
     let path = required_str(&args, "path")?;
     let pattern = required_str(&args, "pattern")?;

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -410,6 +410,7 @@ pub async fn handle_tool_call_with_registry_and_implicit_project(
         "tracedecay_file_dependents" => graph::handle_file_dependents(cg, args).await,
         "tracedecay_replace_symbol" => edit::handle_replace_symbol(cg, args).await,
         "tracedecay_insert_at_symbol" => edit::handle_insert_at_symbol(cg, args).await,
+        "tracedecay_move_symbol" => edit::handle_move_symbol(cg, args).await,
         "tracedecay_find_exact_symbol" => {
             graph::handle_find_exact_symbol(cg, args, selected_scope_prefix).await
         }
@@ -1169,6 +1170,7 @@ mod tests {
         assert!(tool_names.contains(&"tracedecay_file_dependents"));
         assert!(tool_names.contains(&"tracedecay_replace_symbol"));
         assert!(tool_names.contains(&"tracedecay_insert_at_symbol"));
+        assert!(tool_names.contains(&"tracedecay_move_symbol"));
         assert!(tool_names.contains(&"tracedecay_find_exact_symbol"));
     }
 
@@ -1251,6 +1253,7 @@ mod tests {
             "tracedecay_insert_at",
             "tracedecay_replace_symbol",
             "tracedecay_insert_at_symbol",
+            "tracedecay_move_symbol",
             "tracedecay_ast_grep_rewrite",
             "tracedecay_run_affected_tests",
             "tracedecay_session_start",

--- a/src/mcp/tools/handlers/mod.rs
+++ b/src/mcp/tools/handlers/mod.rs
@@ -1059,11 +1059,12 @@ mod tests {
         // host CLI capabilities they need; agents should never see a tool that
         // will instantly fail. The count and per-tool checks below adapt to
         // the host's capability set.
-        let expected_total = 102 + usize::from(super::super::definitions::ast_grep_available());
+        let expected_total = 103 + usize::from(super::super::definitions::ast_grep_available());
         assert_eq!(tools.len(), expected_total);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
         assert!(tool_names.contains(&"tracedecay_search"));
+        assert!(tool_names.contains(&"tracedecay_move_symbol"));
         assert!(tool_names.contains(&"tracedecay_analytics"));
         assert!(tool_names.contains(&"tracedecay_retrieve"));
         assert!(tool_names.contains(&"tracedecay_context"));

--- a/src/tool_command.rs
+++ b/src/tool_command.rs
@@ -418,6 +418,7 @@ fn group_for(def: &ToolDefinition) -> &'static str {
         || n == "tracedecay_ast_grep_rewrite"
         || n == "tracedecay_replace_symbol"
         || n == "tracedecay_insert_at_symbol"
+        || n == "tracedecay_move_symbol"
     {
         "edit"
     } else if n == "tracedecay_fact_store"

--- a/src/tracedecay.rs
+++ b/src/tracedecay.rs
@@ -22,6 +22,7 @@ mod facts;
 mod indexing;
 mod lifecycle;
 mod locking;
+mod move_symbol;
 mod queries;
 mod scan;
 

--- a/src/tracedecay/edits.rs
+++ b/src/tracedecay/edits.rs
@@ -28,7 +28,7 @@ impl TraceDecay {
     }
 
     /// Re-indexes a single file after an edit.
-    async fn reindex_file(&self, file_path: &str) -> Result<()> {
+    pub(super) async fn reindex_file(&self, file_path: &str) -> Result<()> {
         let abs_path = self.absolute_path(file_path);
         let source = std::fs::read_to_string(&abs_path).map_err(|e| TraceDecayError::Config {
             message: format!("failed to read file {file_path}: {e}"),
@@ -738,17 +738,17 @@ fn can_use_literal_rewrite_fallback(pattern: &str) -> bool {
 
 /// Unchanged context lines shown on each side of the changed region in a
 /// dry-run preview diff.
-const PREVIEW_DIFF_CONTEXT: usize = 3;
+pub(super) const PREVIEW_DIFF_CONTEXT: usize = 3;
 
 /// Hard cap on the number of lines emitted in a dry-run preview diff. Keeps the
 /// preview bounded even when an edit rewrites a large span; the remainder is
 /// noted as truncated.
-const MAX_PREVIEW_DIFF_LINES: usize = 200;
+pub(super) const MAX_PREVIEW_DIFF_LINES: usize = 200;
 
 /// Success-path message wrapper: on a real edit returns `base` verbatim; on a
 /// dry run wraps it to make clear that nothing was written and only a preview
 /// was produced.
-fn edit_success_message(dry_run: bool, base: &str) -> String {
+pub(super) fn edit_success_message(dry_run: bool, base: &str) -> String {
     if dry_run {
         format!("dry run — nothing written; preview only ({base})")
     } else {
@@ -763,7 +763,12 @@ fn edit_success_message(dry_run: bool, base: &str) -> String {
 /// `max_lines` (excess is noted as truncated). This is a cheap single-hunk
 /// preview for a localized edit, not a minimal multi-hunk LCS diff; a widely
 /// scattered set of changes collapses into one hunk spanning them.
-fn bounded_region_diff(original: &str, modified: &str, context: usize, max_lines: usize) -> String {
+pub(super) fn bounded_region_diff(
+    original: &str,
+    modified: &str,
+    context: usize,
+    max_lines: usize,
+) -> String {
     if original == modified {
         return "(no changes)".to_string();
     }
@@ -825,7 +830,7 @@ fn bounded_region_diff(original: &str, modified: &str, context: usize, max_lines
 /// callable kinds (function/method/etc.). If still more than one candidate
 /// remains the edit is refused — silently picking the wrong site is far
 /// worse than asking the caller to disambiguate.
-async fn resolve_symbol_for_edit(cg: &TraceDecay, symbol: &str) -> Result<Node> {
+pub(super) async fn resolve_symbol_for_edit(cg: &TraceDecay, symbol: &str) -> Result<Node> {
     let nodes = cg.get_nodes_by_qualified_name(symbol).await?;
     let mut iter = nodes.into_iter();
     let Some(first) = iter.next() else {

--- a/src/tracedecay/move_symbol.rs
+++ b/src/tracedecay/move_symbol.rs
@@ -73,7 +73,7 @@ impl TraceDecay {
 
         // Mirror replace_symbol's span semantics but ALWAYS include the leading
         // doc-comment / attribute block: a moved item carries its own docs.
-        let start = target.attrs_start_line as usize;
+        let mut start = target.attrs_start_line as usize;
         let end_inclusive = (target.end_line as usize).min(src_lines.len().saturating_sub(1));
         if start >= src_lines.len() || start > end_inclusive {
             return Ok(fail(
@@ -85,6 +85,14 @@ impl TraceDecay {
                 ),
                 Vec::new(),
             ));
+        }
+        // A contiguous leading `//!` inner module-doc line (no blank line before
+        // the item) can never belong to the moved item — inner docs attach to the
+        // enclosing module, not the following item. If `attrs_start_line` picked
+        // up such a line, advance past it so the source keeps its module doc and
+        // the destination doesn't receive a stray `//!` mid-file (a hard E0753).
+        while start < end_inclusive && src_lines[start].trim_start().starts_with("//!") {
+            start += 1;
         }
         let moved_text = src_lines[start..=end_inclusive].join("\n");
 
@@ -123,9 +131,21 @@ impl TraceDecay {
 
         // Dependency + import analysis: what the moved body needs at the
         // destination, and which of those we can auto-insert unambiguously.
-        let dest_original = std::fs::read_to_string(self.project_root.join(&dest_rel))
-            .ok()
-            .unwrap_or_default();
+        // Read the destination, distinguishing "does not exist yet" (a fresh
+        // destination file) from "exists but unreadable" (e.g. non-UTF8). Only
+        // the former is treated as empty; an unreadable existing file must refuse
+        // rather than be silently clobbered.
+        let dest_abs = self.project_root.join(&dest_rel);
+        let (dest_original, dest_existed) = match std::fs::read_to_string(&dest_abs) {
+            Ok(text) => (text, true),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (String::new(), false),
+            Err(e) => {
+                return Ok(fail(
+                    format!("failed to read destination {dest_rel}: {e}"),
+                    Vec::new(),
+                ));
+            }
+        };
         let dest_module = rust_module_path(&dest_rel);
         let src_module = rust_module_path(&source_rel);
         let analysis = self
@@ -191,7 +211,6 @@ impl TraceDecay {
 
         // Apply: write the destination first (the symbol now exists in both
         // places — recoverable), then remove it from the source. Reindex both.
-        let dest_abs = self.project_root.join(&dest_rel);
         if let Some(parent) = dest_abs.parent() {
             std::fs::create_dir_all(parent).map_err(|e| TraceDecayError::Config {
                 message: format!("failed to create destination directory: {e}"),
@@ -203,11 +222,29 @@ impl TraceDecay {
                 message: format!("failed to write {dest_rel}: {e}"),
             })?;
         if let Err(e) = tokio::fs::write(&source_abs, &source_modified).await {
-            // Best-effort rollback of the destination so we don't leave a
-            // duplicate behind on a half-applied move.
-            let _ = tokio::fs::write(&dest_abs, &dest_original).await;
+            // Roll back so a half-applied move leaves no trace. If the
+            // destination existed before, restore its original bytes; if we
+            // created it, delete it (and any now-empty parent dirs we created)
+            // rather than leaving an empty file behind.
+            if dest_existed {
+                let _ = tokio::fs::write(&dest_abs, &dest_original).await;
+            } else {
+                let _ = tokio::fs::remove_file(&dest_abs).await;
+                let mut dir = dest_abs.parent().map(Path::to_path_buf);
+                while let Some(d) = dir {
+                    if d == self.project_root {
+                        break;
+                    }
+                    // `remove_dir` removes only empty dirs and errors otherwise,
+                    // so this naturally stops at the first non-empty ancestor.
+                    if std::fs::remove_dir(&d).is_err() {
+                        break;
+                    }
+                    dir = d.parent().map(Path::to_path_buf);
+                }
+            }
             return Err(TraceDecayError::Config {
-                message: format!("failed to write {source_rel}: {e}; destination restored"),
+                message: format!("failed to write {source_rel}: {e}; destination rolled back"),
             });
         }
         self.reindex_file(&dest_rel).await?;
@@ -240,12 +277,29 @@ impl TraceDecay {
         } else {
             PathBuf::from(dest_file)
         };
-        if rel.components().any(|c| matches!(c, Component::ParentDir)) {
-            return Err(TraceDecayError::Config {
-                message: "destination path must not contain '..'".to_string(),
-            });
+        // Canonicalize the relative path BEFORE the equality guard and collision
+        // check compare it: reject `..` escapes and drop `.` (CurDir) components,
+        // rebuilding from `Component::Normal` parts only. Without this a
+        // `./src/pricing.rs` destination compares unequal to the graph's
+        // normalized `src/pricing.rs`, slipping past the same-file guard and the
+        // collision check — the apply would then write and truncate the very same
+        // inode, silently deleting the symbol.
+        let mut normalized = PathBuf::new();
+        for comp in rel.components() {
+            match comp {
+                Component::Normal(part) => normalized.push(part),
+                Component::ParentDir => {
+                    return Err(TraceDecayError::Config {
+                        message: "destination path must not contain '..'".to_string(),
+                    });
+                }
+                // Drop `.` (CurDir) so `./x` canonicalizes to `x`, and drop any
+                // root/prefix components (they cannot survive `strip_prefix`
+                // above) rather than embed them in a relative path.
+                Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+            }
         }
-        let s = rel.to_string_lossy().replace('\\', "/");
+        let s = normalized.to_string_lossy().replace('\\', "/");
         if s.is_empty() {
             return Err(TraceDecayError::Config {
                 message: "destination path is empty".to_string(),
@@ -822,6 +876,14 @@ fn insert_imports(dest_source: &str, imports: &[String]) -> String {
     let mut idx = 0;
     while idx < lines.len() {
         let t = lines[idx].trim();
+        // Stop before an OUTER doc-comment block (`///` or `/**`): it documents
+        // the first item, and inserting a `use` between the doc and its item
+        // detaches the doc. Inner docs (`//!`) and plain comments (`//`) stay in
+        // the header region. Check `///`/`/**` first since `///` also matches the
+        // generic `//` prefix below.
+        if t.starts_with("///") || t.starts_with("/**") {
+            break;
+        }
         let header = t.is_empty()
             || t.starts_with("//!")
             || t.starts_with("//")
@@ -870,11 +932,18 @@ fn cfg_context_hints(moved_text: &str, dest_rel: &str) -> Vec<MoveHint> {
     for (idx, raw) in moved_text.lines().enumerate() {
         let t = raw.trim();
         if t.starts_with("#[cfg(") || t.starts_with("#[cfg_attr(") {
+            // The gate's offset is within the moved snippet, not a real line in
+            // the destination file — reporting it as `line` (which every other
+            // hint uses for a concrete file site) points at nothing. Leave `line`
+            // unset and describe the moved-span offset in the detail instead.
             out.push(MoveHint {
                 kind: "cfg_context".to_string(),
                 file: dest_rel.to_string(),
-                line: Some((idx + 1) as u32),
-                detail: format!("moved item is gated by `{t}`"),
+                line: None,
+                detail: format!(
+                    "moved item is gated by `{t}` (at line {} of the moved span)",
+                    idx + 1
+                ),
                 suggestion: Some(
                     "confirm the destination module builds under the same cfg".to_string(),
                 ),
@@ -1072,6 +1141,52 @@ mod tests {
             &["use crate::X;".to_string()],
         );
         assert_eq!(out, "//! module doc\n\nuse crate::X;\nfn a() {}\n");
+    }
+
+    #[test]
+    fn insert_imports_keeps_outer_doc_attached_to_first_item() {
+        // An outer doc-comment (`///`) documents the first item; the `use` must
+        // NOT be wedged between the doc and its `pub fn`.
+        let out = insert_imports(
+            "/// Docs for other.\npub fn other() {}\n",
+            &["use crate::X;".to_string()],
+        );
+        assert_eq!(
+            out,
+            "use crate::X;\n/// Docs for other.\npub fn other() {}\n"
+        );
+        // The doc line stays immediately above the item.
+        let lines: Vec<&str> = out.lines().collect();
+        let doc = lines
+            .iter()
+            .position(|l| l.trim() == "/// Docs for other.")
+            .unwrap();
+        assert_eq!(lines[doc + 1].trim(), "pub fn other() {}");
+    }
+
+    #[test]
+    fn insert_imports_stops_before_outer_block_doc() {
+        let out = insert_imports(
+            "/** Block doc. */\npub fn other() {}\n",
+            &["use crate::X;".to_string()],
+        );
+        assert_eq!(out, "use crate::X;\n/** Block doc. */\npub fn other() {}\n");
+    }
+
+    #[test]
+    fn cfg_context_hint_reports_moved_span_offset_not_dest_line() {
+        let moved = "#[cfg(feature = \"x\")]\npub fn gated() {}\n";
+        let hints = cfg_context_hints(moved, "src/dest.rs");
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].kind, "cfg_context");
+        // `line` must be unset — the offset is within the snippet, not a real
+        // destination line.
+        assert_eq!(hints[0].line, None, "hint: {:?}", hints[0]);
+        assert!(
+            hints[0].detail.contains("moved span"),
+            "detail should describe the moved-span offset: {}",
+            hints[0].detail
+        );
     }
 
     /// Mirror `analyze_dependencies`' scan: mask comments/strings (preserving

--- a/src/tracedecay/move_symbol.rs
+++ b/src/tracedecay/move_symbol.rs
@@ -1,0 +1,1166 @@
+//! `move_symbol`: relocate a function (Rust-first, provider-agnostic shape)
+//! from its file to a destination file. The centerpiece is the post-move
+//! **impact report** — every reference, dependency, visibility, or module
+//! concern the move raises, surfaced as evidence-based, actionable hints
+//! derived from the code graph (callers/callees) and parse-level facts
+//! (identifiers, `use` lines, module declarations). Never regex-only guessing.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+use tree_sitter::{Node as TsNode, Parser};
+
+use crate::errors::{Result, TraceDecayError};
+use crate::extraction::source_mask::{MaskOptions, masked_rust_source_with};
+use crate::types::{MoveHint, MoveResult, Node, NodeKind, Visibility};
+
+use super::TraceDecay;
+use super::edits::{
+    MAX_PREVIEW_DIFF_LINES, PREVIEW_DIFF_CONTEXT, bounded_region_diff, edit_success_message,
+    resolve_symbol_for_edit,
+};
+
+impl TraceDecay {
+    /// Moves a resolved symbol from its current file to `dest_file`.
+    ///
+    /// `dry_run` (the default at the tool layer) computes the removal span, the
+    /// destination shape, the combined preview diff, and the full impact report
+    /// while writing nothing. `dry_run = false` performs the move (remove the
+    /// span — docs/attrs included — from the source, insert it at the
+    /// destination with a blank-line separator, and auto-insert unambiguous
+    /// needed imports), then returns the same impact report of everything that
+    /// still needs manual attention (callers, module declaration, visibility).
+    ///
+    /// `update_references` is reserved for a future version; in v1 caller
+    /// references are never auto-edited — the exact change rides in the hints.
+    pub async fn move_symbol(
+        &self,
+        symbol: &str,
+        dest_file: &str,
+        dry_run: bool,
+        _update_references: bool,
+    ) -> Result<MoveResult> {
+        let target = resolve_symbol_for_edit(self, symbol).await?;
+        let symbol_label = format!("{} ({})", target.name, target.kind.as_str());
+        let source_rel = target.file_path.clone();
+        let dest_rel = self.resolve_dest_rel(dest_file)?;
+
+        let fail = |message: String, impact: Vec<MoveHint>| MoveResult {
+            success: false,
+            symbol: symbol_label.clone(),
+            source_file: source_rel.clone(),
+            dest_file: dest_rel.clone(),
+            moved_span: None,
+            dry_run,
+            diff: None,
+            applied_imports: Vec::new(),
+            impact,
+            message,
+        };
+
+        if dest_rel == source_rel {
+            return Ok(fail(
+                format!("destination is the symbol's own file ({source_rel}); nothing to move"),
+                Vec::new(),
+            ));
+        }
+
+        let source_abs = self.project_root.join(&source_rel);
+        let source = std::fs::read_to_string(&source_abs).map_err(|e| TraceDecayError::Config {
+            message: format!("failed to read {source_rel}: {e}"),
+        })?;
+        let src_lines: Vec<&str> = source.lines().collect();
+
+        // Mirror replace_symbol's span semantics but ALWAYS include the leading
+        // doc-comment / attribute block: a moved item carries its own docs.
+        let start = target.attrs_start_line as usize;
+        let end_inclusive = (target.end_line as usize).min(src_lines.len().saturating_sub(1));
+        if start >= src_lines.len() || start > end_inclusive {
+            return Ok(fail(
+                format!(
+                    "symbol span [{}..={}] out of bounds for {}-line file",
+                    start,
+                    target.end_line,
+                    src_lines.len()
+                ),
+                Vec::new(),
+            ));
+        }
+        let moved_text = src_lines[start..=end_inclusive].join("\n");
+
+        // Destination collision: refuse rather than clobber.
+        let dest_nodes = self.get_nodes_by_file(&dest_rel).await.unwrap_or_default();
+        if let Some(clash) = dest_nodes
+            .iter()
+            .find(|n| n.name == target.name && is_importable_item(&n.kind))
+        {
+            let hint = MoveHint {
+                kind: "collision".to_string(),
+                file: dest_rel.clone(),
+                line: Some(clash.start_line + 1),
+                detail: format!(
+                    "destination already defines `{}` ({})",
+                    clash.name,
+                    clash.kind.as_str()
+                ),
+                suggestion: Some(
+                    "rename one of them or choose a different destination".to_string(),
+                ),
+            };
+            return Ok(fail(
+                format!("destination {dest_rel} already defines `{}`", target.name),
+                vec![hint],
+            ));
+        }
+
+        // Build the source with the span removed (with blank-line cleanup).
+        let trailing_newline = source.ends_with('\n');
+        let residual = remove_span_with_cleanup(&src_lines, start, end_inclusive);
+        let mut source_modified = residual.join("\n");
+        if trailing_newline && !source_modified.is_empty() {
+            source_modified.push('\n');
+        }
+
+        // Dependency + import analysis: what the moved body needs at the
+        // destination, and which of those we can auto-insert unambiguously.
+        let dest_original = std::fs::read_to_string(self.project_root.join(&dest_rel))
+            .ok()
+            .unwrap_or_default();
+        let dest_module = rust_module_path(&dest_rel);
+        let src_module = rust_module_path(&source_rel);
+        let analysis = self
+            .analyze_dependencies(
+                &target,
+                &source_rel,
+                &dest_rel,
+                &source,
+                &source_modified,
+                &moved_text,
+                src_module.as_deref(),
+            )
+            .await?;
+
+        // Assemble the destination content.
+        let applied_imports = dedup_preserve(&analysis.auto_imports, &dest_original);
+        let dest_modified = build_dest_content(&dest_original, &applied_imports, &moved_text);
+
+        // Impact report.
+        let mut impact = analysis.hints;
+        impact.extend(
+            self.caller_hints(
+                &target,
+                &source_rel,
+                &dest_rel,
+                src_module.as_deref(),
+                dest_module.as_deref(),
+            )
+            .await?,
+        );
+        if let Some(hint) = self.module_missing_hint(&dest_rel, &dest_original).await {
+            impact.push(hint);
+        }
+        impact.extend(cfg_context_hints(&moved_text, &dest_rel));
+        impact.extend(cycle_risk_hints(
+            &dest_original,
+            &dest_rel,
+            src_module.as_deref(),
+        ));
+
+        if dry_run {
+            let diff = combined_diff(
+                &source_rel,
+                &source,
+                &source_modified,
+                &dest_rel,
+                &dest_original,
+                &dest_modified,
+            );
+            return Ok(MoveResult {
+                success: true,
+                symbol: symbol_label,
+                source_file: source_rel,
+                dest_file: dest_rel,
+                moved_span: Some(moved_text),
+                dry_run: true,
+                diff: Some(diff),
+                applied_imports,
+                impact,
+                message: edit_success_message(true, "move previewed"),
+            });
+        }
+
+        // Apply: write the destination first (the symbol now exists in both
+        // places — recoverable), then remove it from the source. Reindex both.
+        let dest_abs = self.project_root.join(&dest_rel);
+        if let Some(parent) = dest_abs.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| TraceDecayError::Config {
+                message: format!("failed to create destination directory: {e}"),
+            })?;
+        }
+        tokio::fs::write(&dest_abs, &dest_modified)
+            .await
+            .map_err(|e| TraceDecayError::Config {
+                message: format!("failed to write {dest_rel}: {e}"),
+            })?;
+        if let Err(e) = tokio::fs::write(&source_abs, &source_modified).await {
+            // Best-effort rollback of the destination so we don't leave a
+            // duplicate behind on a half-applied move.
+            let _ = tokio::fs::write(&dest_abs, &dest_original).await;
+            return Err(TraceDecayError::Config {
+                message: format!("failed to write {source_rel}: {e}; destination restored"),
+            });
+        }
+        self.reindex_file(&dest_rel).await?;
+        self.reindex_file(&source_rel).await?;
+
+        Ok(MoveResult {
+            success: true,
+            symbol: symbol_label,
+            source_file: source_rel,
+            dest_file: dest_rel,
+            moved_span: Some(moved_text),
+            dry_run: false,
+            diff: None,
+            applied_imports,
+            impact,
+            message: "move applied".to_string(),
+        })
+    }
+
+    /// Normalizes `dest_file` (absolute or project-relative) to a
+    /// project-relative, forward-slash path, rejecting escapes.
+    fn resolve_dest_rel(&self, dest_file: &str) -> Result<String> {
+        let raw = Path::new(dest_file);
+        let rel: PathBuf = if raw.is_absolute() {
+            raw.strip_prefix(&self.project_root)
+                .map_err(|_| TraceDecayError::Config {
+                    message: "destination is not within the project".to_string(),
+                })?
+                .to_path_buf()
+        } else {
+            PathBuf::from(dest_file)
+        };
+        if rel.components().any(|c| matches!(c, Component::ParentDir)) {
+            return Err(TraceDecayError::Config {
+                message: "destination path must not contain '..'".to_string(),
+            });
+        }
+        let s = rel.to_string_lossy().replace('\\', "/");
+        if s.is_empty() {
+            return Err(TraceDecayError::Config {
+                message: "destination path is empty".to_string(),
+            });
+        }
+        Ok(s)
+    }
+
+    /// Dependency analysis for the moved body: same-file symbols and source
+    /// `use`-imports the body references that will no longer resolve at the
+    /// destination. Produces auto-insertable imports plus hints for the rest.
+    #[allow(clippy::too_many_arguments)]
+    async fn analyze_dependencies(
+        &self,
+        target: &Node,
+        source_rel: &str,
+        dest_rel: &str,
+        source: &str,
+        source_modified: &str,
+        moved_text: &str,
+        src_module: Option<&str>,
+    ) -> Result<DependencyAnalysis> {
+        let mut out = DependencyAnalysis::default();
+        // Scan only real code: a doc-comment mention (e.g. ``[`compute_total`]``)
+        // and identifiers that appear only inside string literals are not
+        // dependencies, so comments and strings are masked before tokenizing.
+        // Implicit format captures (`format!("{helper}")`) survive the mask and
+        // remain counted as real uses.
+        let code_only = masked_rust_source_with(moved_text, MaskOptions::UNUSED_IMPORTS);
+        let idents = body_identifiers(&code_only);
+        let source_code_only =
+            masked_rust_source_with(source_modified, MaskOptions::UNUSED_IMPORTS);
+
+        // 1. Same-file item dependencies (structs, enums, helpers, consts, …).
+        let src_nodes = self.get_nodes_by_file(source_rel).await.unwrap_or_default();
+        let mut handled: HashSet<String> = HashSet::new();
+        for node in &src_nodes {
+            if node.id == target.id || node.name == target.name || !is_importable_item(&node.kind) {
+                continue;
+            }
+            if node.name.is_empty() || !idents.contains(&node.name) {
+                continue;
+            }
+            if !handled.insert(node.name.clone()) {
+                continue;
+            }
+            let module = src_module.unwrap_or("crate");
+            let use_line = format!("use {module}::{};", node.name);
+            let visible = matches!(node.visibility, Visibility::Pub | Visibility::PubCrate);
+            if visible {
+                out.auto_imports.push(use_line);
+            } else {
+                out.hints.push(MoveHint {
+                    kind: "dependency_broken".to_string(),
+                    file: dest_rel.to_string(),
+                    line: None,
+                    detail: format!(
+                        "moved body depends on `{}` ({}), which is {} in {source_rel}",
+                        node.name,
+                        node.kind.as_str(),
+                        visibility_word(&node.visibility)
+                    ),
+                    suggestion: Some(format!(
+                        "add `{use_line}` at the destination and escalate `{}` to `pub(crate)`",
+                        node.name
+                    )),
+                });
+                out.hints.push(MoveHint {
+                    kind: "visibility_required".to_string(),
+                    file: source_rel.to_string(),
+                    line: Some(node.start_line + 1),
+                    detail: format!(
+                        "`{}` is {} but is now referenced from another module",
+                        node.name,
+                        visibility_word(&node.visibility)
+                    ),
+                    suggestion: Some(format!("change `{}` to at least `pub(crate)`", node.name)),
+                });
+            }
+        }
+
+        // 2. Source `use`-import dependencies the moved body relies on.
+        for stmt in parse_use_statements(source) {
+            let matched: Vec<&UseLeaf> = stmt
+                .leaves
+                .iter()
+                .filter(|leaf| idents.contains(&leaf.binding))
+                .collect();
+            if matched.is_empty() {
+                continue;
+            }
+            if stmt.leaves.len() == 1 && !stmt.glob {
+                // Unambiguous single-item import: copy it verbatim.
+                out.auto_imports.push(stmt.text.clone());
+                // Orphaned-import: source no longer needs it after the move.
+                let leaf = &stmt.leaves[0].binding;
+                if !word_present(&source_code_only, leaf) {
+                    out.hints.push(MoveHint {
+                        kind: "orphaned_import".to_string(),
+                        file: source_rel.to_string(),
+                        line: Some(stmt.line),
+                        detail: format!(
+                            "`{}` is only used by the moved symbol and is now unused in {source_rel}",
+                            stmt.text.trim()
+                        ),
+                        suggestion: Some(format!("remove `{}` from {source_rel}", stmt.text.trim())),
+                    });
+                }
+            } else {
+                let names: Vec<&str> = matched.iter().map(|l| l.binding.as_str()).collect();
+                out.hints.push(MoveHint {
+                    kind: "import_needed".to_string(),
+                    file: dest_rel.to_string(),
+                    line: None,
+                    detail: format!(
+                        "moved body uses {names:?} from a grouped/glob import in {source_rel}"
+                    ),
+                    suggestion: Some(format!(
+                        "add an import for {names:?} at the destination (from `{}`)",
+                        stmt.text.trim()
+                    )),
+                });
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Caller hints: every graph call edge into the moved symbol, classified by
+    /// whether the caller shared the source module (unqualified call — needs a
+    /// `use` for the new module) or referenced it via another module (path/use
+    /// now points at the old location).
+    async fn caller_hints(
+        &self,
+        target: &Node,
+        source_rel: &str,
+        dest_rel: &str,
+        src_module: Option<&str>,
+        dest_module: Option<&str>,
+    ) -> Result<Vec<MoveHint>> {
+        let mut hints = Vec::new();
+        let callers = self.get_callers(&target.id, 1).await.unwrap_or_default();
+        let dest_mod = dest_module.unwrap_or("crate");
+        let src_mod = src_module.unwrap_or("crate");
+        for (caller, edge) in callers {
+            let same_module = caller.file_path == source_rel;
+            let detail;
+            let suggestion;
+            if same_module {
+                detail = format!(
+                    "`{}` called `{}` unqualified from the same module; it now lives in {dest_rel}",
+                    caller.name, target.name
+                );
+                suggestion = Some(format!(
+                    "add `use {dest_mod}::{};` to {}",
+                    target.name, caller.file_path
+                ));
+            } else {
+                detail = format!(
+                    "`{}` in {} references `{}` via `{src_mod}`; the path is now `{dest_mod}`",
+                    caller.name, caller.file_path, target.name
+                );
+                suggestion = Some(format!(
+                    "retarget the reference from `{src_mod}::{}` to `{dest_mod}::{}`",
+                    target.name, target.name
+                ));
+            }
+            hints.push(MoveHint {
+                kind: "caller_reference".to_string(),
+                file: caller.file_path.clone(),
+                line: edge.line.map(|l| l + 1),
+                detail,
+                suggestion,
+            });
+
+            // The moved fn's own visibility may be too narrow for a caller that
+            // is now in a different module tree.
+            if matches!(
+                target.visibility,
+                Visibility::Private | Visibility::PubSuper
+            ) && caller.file_path != dest_rel
+            {
+                hints.push(MoveHint {
+                    kind: "visibility_required".to_string(),
+                    file: dest_rel.to_string(),
+                    line: None,
+                    detail: format!(
+                        "`{}` is {} but has a caller in another module ({})",
+                        target.name,
+                        visibility_word(&target.visibility),
+                        caller.file_path
+                    ),
+                    suggestion: Some(format!(
+                        "escalate `{}` to at least `pub(crate)` at the destination",
+                        target.name
+                    )),
+                });
+            }
+        }
+        Ok(hints)
+    }
+
+    /// Hint when the destination file's module is not declared anywhere in the
+    /// crate (a fresh module file needs a `mod` statement to compile).
+    async fn module_missing_hint(&self, dest_rel: &str, dest_original: &str) -> Option<MoveHint> {
+        // Only relevant for a fresh/near-empty destination module.
+        let dest_had_items = !self
+            .get_nodes_by_file(dest_rel)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|n| is_importable_item(&n.kind));
+        let dest_is_new = dest_original.trim().is_empty() || dest_had_items;
+        if !dest_is_new {
+            return None;
+        }
+        let stem = module_stem(dest_rel)?;
+        if self.module_declared(dest_rel, &stem) {
+            return None;
+        }
+        Some(MoveHint {
+            kind: "module_missing".to_string(),
+            file: crate_root_file(dest_rel),
+            line: None,
+            detail: format!("module `{stem}` for {dest_rel} is not declared in the crate"),
+            suggestion: Some(format!(
+                "add `pub mod {stem};` to {}",
+                crate_root_file(dest_rel)
+            )),
+        })
+    }
+
+    /// True when some file that could be the parent module of `dest_rel`
+    /// already contains a `mod <stem>;` declaration.
+    fn module_declared(&self, dest_rel: &str, stem: &str) -> bool {
+        let needle_a = format!("mod {stem};");
+        let needle_b = format!("mod {stem} ");
+        for candidate in parent_module_candidates(dest_rel) {
+            if let Ok(text) = std::fs::read_to_string(self.project_root.join(&candidate)) {
+                if text.contains(&needle_a) || text.contains(&needle_b) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+/// Collected dependency findings for a move.
+#[derive(Default)]
+struct DependencyAnalysis {
+    /// `use` lines to auto-insert at the destination (unambiguous, visible).
+    auto_imports: Vec<String>,
+    /// Findings that need caller attention.
+    hints: Vec<MoveHint>,
+}
+
+/// A single binding brought into scope by a `use` statement.
+struct UseLeaf {
+    /// The name as referenced in code (the alias when `as` is present).
+    binding: String,
+}
+
+/// A parsed `use` statement from a source file.
+struct UseStatement {
+    /// The full statement text (single physical line).
+    text: String,
+    /// 1-based line of the statement.
+    line: u32,
+    /// Whether the statement is a glob import (`use a::*;`).
+    glob: bool,
+    leaves: Vec<UseLeaf>,
+}
+
+/// Item kinds that a `use` statement can bring into scope — the ones a moved
+/// body could depend on across a module boundary.
+fn is_importable_item(kind: &NodeKind) -> bool {
+    matches!(
+        kind,
+        NodeKind::Struct
+            | NodeKind::Enum
+            | NodeKind::Trait
+            | NodeKind::Function
+            | NodeKind::Const
+            | NodeKind::Static
+            | NodeKind::TypeAlias
+            | NodeKind::Macro
+            | NodeKind::Union
+            | NodeKind::Typedef
+            | NodeKind::Record
+    )
+}
+
+fn visibility_word(v: &Visibility) -> &'static str {
+    match v {
+        Visibility::Pub => "pub",
+        Visibility::PubCrate => "pub(crate)",
+        Visibility::PubSuper => "pub(super)",
+        Visibility::Private => "private",
+    }
+}
+
+/// Derives a Rust module path (`crate::a::b`) from a project-relative `.rs`
+/// file path under a `src/` root. Returns `None` for non-Rust files.
+fn rust_module_path(rel: &str) -> Option<String> {
+    let stem = rel.strip_suffix(".rs")?;
+    // Normalize to components after an optional `src/` (or `.../src/`) segment.
+    let parts: Vec<&str> = stem.split('/').collect();
+    let src_idx = parts.iter().rposition(|p| *p == "src");
+    let tail: &[&str] = match src_idx {
+        Some(i) => &parts[i + 1..],
+        None => &parts[..],
+    };
+    let mut segs: Vec<&str> = tail.to_vec();
+    // Crate roots and module files contribute no path segment.
+    match segs.last().copied() {
+        Some("lib" | "main" | "mod") => {
+            segs.pop();
+        }
+        _ => {}
+    }
+    let mut path = String::from("crate");
+    for seg in segs {
+        if seg.is_empty() {
+            continue;
+        }
+        path.push_str("::");
+        path.push_str(seg);
+    }
+    Some(path)
+}
+
+/// The module stem for a destination file (`src/foo/bar.rs` -> `bar`,
+/// `src/foo/mod.rs` -> `foo`).
+fn module_stem(rel: &str) -> Option<String> {
+    let stem = rel.strip_suffix(".rs")?;
+    let parts: Vec<&str> = stem.split('/').filter(|p| !p.is_empty()).collect();
+    let last = parts.last().copied()?;
+    if last == "mod" {
+        return parts
+            .get(parts.len().wrapping_sub(2))
+            .map(|s| (*s).to_string());
+    }
+    if last == "lib" || last == "main" {
+        return None;
+    }
+    Some(last.to_string())
+}
+
+/// The likely crate-root file for a destination, used to suggest where a
+/// `mod` statement belongs.
+fn crate_root_file(dest_rel: &str) -> String {
+    let src_prefix = dest_rel.rfind("src/").map(|i| &dest_rel[..i + 4]);
+    match src_prefix {
+        Some(prefix) => format!("{prefix}lib.rs"),
+        None => "src/lib.rs".to_string(),
+    }
+}
+
+/// Files that could declare `dest_rel`'s module with a `mod` statement.
+fn parent_module_candidates(dest_rel: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(parent) = dest_rel.rsplit_once('/').map(|(p, _)| p) {
+        out.push(format!("{parent}/mod.rs"));
+        out.push(format!("{parent}.rs"));
+        out.push(format!("{parent}/lib.rs"));
+        out.push(format!("{parent}/main.rs"));
+        // grandparent for `foo/mod.rs`-style parents
+    }
+    // Crate roots.
+    if let Some(prefix) = dest_rel.rfind("src/").map(|i| &dest_rel[..i + 4]) {
+        out.push(format!("{prefix}lib.rs"));
+        out.push(format!("{prefix}main.rs"));
+    } else {
+        out.push("src/lib.rs".to_string());
+        out.push("src/main.rs".to_string());
+    }
+    out
+}
+
+/// Collects identifier tokens from source text (Rust identifier rules). Used to
+/// test whether the moved body references a given symbol name.
+fn body_identifiers(text: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut cur = String::new();
+    for ch in text.chars() {
+        if ch == '_' || ch.is_ascii_alphanumeric() {
+            cur.push(ch);
+        } else if is_identifier(&cur) {
+            out.insert(std::mem::take(&mut cur));
+        } else {
+            cur.clear();
+        }
+    }
+    if is_identifier(&cur) {
+        out.insert(cur);
+    }
+    out
+}
+
+/// True when `s` is a non-empty Rust-style identifier (does not start with a
+/// digit).
+fn is_identifier(s: &str) -> bool {
+    matches!(s.chars().next(), Some(c) if c == '_' || c.is_ascii_alphabetic())
+}
+
+/// Whether `name` appears as a standalone identifier in `text`.
+fn word_present(text: &str, name: &str) -> bool {
+    body_identifiers(text).contains(name)
+}
+
+/// Parses `use` statements from Rust source into their brought-in bindings.
+/// Handles `use a::B;`, `use a::B as C;`, grouped `use a::{B, C};`, and
+/// multi-line grouped imports. Uses a tree-sitter walk so grouped imports that
+/// span several physical lines are captured whole and `use` tokens inside
+/// comments or strings are never matched; falls back to a line scan only when
+/// the Rust grammar is unavailable.
+fn parse_use_statements(source: &str) -> Vec<UseStatement> {
+    match parse_use_statements_ts(source) {
+        Some(stmts) => stmts,
+        None => parse_use_statements_linescan(source),
+    }
+}
+
+/// Tree-sitter path: collect every `use_declaration` node (top-level and inside
+/// `mod` blocks) and parse its full byte-range text. Returns `None` when the
+/// grammar cannot be loaded so the caller can fall back to the line scan.
+fn parse_use_statements_ts(source: &str) -> Option<Vec<UseStatement>> {
+    let mut parser = Parser::new();
+    let language = crate::extraction::ts_provider::try_language("rust").ok()?;
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(source, None)?;
+    let mut out = Vec::new();
+    collect_use_declarations(tree.root_node(), source.as_bytes(), &mut out);
+    Some(out)
+}
+
+/// Recursive pre-order walk collecting `use_declaration` nodes into parsed
+/// [`UseStatement`]s.
+fn collect_use_declarations(node: TsNode<'_>, src: &[u8], out: &mut Vec<UseStatement>) {
+    if node.kind() == "use_declaration" {
+        if let Ok(text) = node.utf8_text(src) {
+            if let Some((glob, leaves)) = parse_use_bindings(text) {
+                out.push(UseStatement {
+                    text: text.to_string(),
+                    line: node.start_position().row as u32 + 1,
+                    glob,
+                    leaves,
+                });
+            }
+        }
+        // `use_declaration` nodes do not nest; no need to descend further.
+        return;
+    }
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_use_declarations(cursor.node(), src, out);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+/// Fallback line scan (grammar unavailable): one physical line per statement.
+/// Misses multi-line grouped imports but never fails the move.
+fn parse_use_statements_linescan(source: &str) -> Vec<UseStatement> {
+    let mut out = Vec::new();
+    for (idx, raw) in source.lines().enumerate() {
+        if let Some((glob, leaves)) = parse_use_bindings(raw) {
+            out.push(UseStatement {
+                text: raw.to_string(),
+                line: (idx + 1) as u32,
+                glob,
+                leaves,
+            });
+        }
+    }
+    out
+}
+
+/// Parses the bindings out of a single `use` statement's text (possibly
+/// multi-line). Accepts `use ...;` and `pub use ...;`. Returns `None` for lines
+/// that are not a complete `use` statement or that bring nothing into scope.
+fn parse_use_bindings(stmt_text: &str) -> Option<(bool, Vec<UseLeaf>)> {
+    let line = stmt_text.trim();
+    let after_use = line
+        .strip_prefix("pub use ")
+        .or_else(|| line.strip_prefix("use "))?
+        .trim();
+    let body = after_use.strip_suffix(';')?;
+    let glob = body.contains('*');
+    let leaves: Vec<UseLeaf> = if let Some(open) = body.find('{') {
+        let inner = body[open + 1..].trim_end().trim_end_matches('}');
+        inner
+            .split(',')
+            .filter_map(|item| leaf_binding(item.trim()))
+            .map(|binding| UseLeaf { binding })
+            .collect()
+    } else {
+        leaf_binding(body)
+            .map(|binding| vec![UseLeaf { binding }])
+            .unwrap_or_default()
+    };
+    if leaves.is_empty() && !glob {
+        return None;
+    }
+    Some((glob, leaves))
+}
+
+/// The in-code binding for a single `use` path segment (`a::b::C` -> `C`,
+/// `a::C as D` -> `D`). Returns `None` for globs and empty items.
+fn leaf_binding(item: &str) -> Option<String> {
+    let item = item.trim();
+    if item.is_empty() || item == "*" || item.ends_with("::*") {
+        return None;
+    }
+    if let Some((_, alias)) = item.rsplit_once(" as ") {
+        let alias = alias.trim();
+        return (!alias.is_empty()).then(|| alias.to_string());
+    }
+    let last = item.rsplit("::").next()?.trim();
+    (!last.is_empty() && last != "self").then(|| last.to_string())
+}
+
+/// Removes `lines[start..=end]` and collapses the blank-line separator the
+/// removed item left behind so the source stays tidy.
+fn remove_span_with_cleanup(lines: &[&str], start: usize, end: usize) -> Vec<String> {
+    let mut out: Vec<String> = lines[..start].iter().map(|s| (*s).to_string()).collect();
+    let before_blank = start > 0 && lines[start - 1].trim().is_empty();
+    let tail_start = end + 1;
+    if tail_start < lines.len() {
+        let after_blank = lines[tail_start].trim().is_empty();
+        let ts = if before_blank && after_blank {
+            tail_start + 1
+        } else {
+            tail_start
+        };
+        out.extend(lines[ts..].iter().map(|s| (*s).to_string()));
+    } else if before_blank {
+        out.pop();
+    }
+    out
+}
+
+/// Builds the destination file content: leading imports (into an existing
+/// import region or at the top of a fresh file), then the moved block after a
+/// blank-line separator.
+fn build_dest_content(dest_original: &str, imports: &[String], moved_text: &str) -> String {
+    let moved_block = moved_text.trim_end_matches('\n');
+    if dest_original.trim().is_empty() {
+        let mut parts: Vec<String> = Vec::new();
+        if !imports.is_empty() {
+            parts.push(imports.join("\n"));
+        }
+        parts.push(moved_block.to_string());
+        let mut content = parts.join("\n\n");
+        content.push('\n');
+        content
+    } else {
+        let with_imports = insert_imports(dest_original, imports);
+        format!("{}\n\n{}\n", with_imports.trim_end(), moved_block)
+    }
+}
+
+/// Inserts `imports` into an existing Rust file after its leading module-doc /
+/// comment / existing-`use` region.
+fn insert_imports(dest_source: &str, imports: &[String]) -> String {
+    if imports.is_empty() {
+        return dest_source.to_string();
+    }
+    let lines: Vec<&str> = dest_source.lines().collect();
+    let mut idx = 0;
+    while idx < lines.len() {
+        let t = lines[idx].trim();
+        let header = t.is_empty()
+            || t.starts_with("//!")
+            || t.starts_with("//")
+            || t.starts_with("use ")
+            || t.starts_with("pub use ")
+            || t.starts_with("extern crate");
+        if header {
+            idx += 1;
+        } else {
+            break;
+        }
+    }
+    let mut rebuilt: Vec<String> = lines[..idx].iter().map(|s| (*s).to_string()).collect();
+    for imp in imports {
+        rebuilt.push(imp.clone());
+    }
+    rebuilt.extend(lines[idx..].iter().map(|s| (*s).to_string()));
+    let mut out = rebuilt.join("\n");
+    if dest_source.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+/// Drops imports already present verbatim in the destination and de-duplicates
+/// within the batch, preserving order.
+fn dedup_preserve(imports: &[String], dest_original: &str) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out = Vec::new();
+    for imp in imports {
+        let trimmed = imp.trim();
+        if dest_original.lines().any(|l| l.trim() == trimmed) {
+            continue;
+        }
+        if seen.insert(trimmed.to_string()) {
+            out.push(imp.clone());
+        }
+    }
+    out
+}
+
+/// Hints when the moved span carries a `#[cfg(...)]` gate the destination might
+/// not satisfy.
+fn cfg_context_hints(moved_text: &str, dest_rel: &str) -> Vec<MoveHint> {
+    let mut out = Vec::new();
+    for (idx, raw) in moved_text.lines().enumerate() {
+        let t = raw.trim();
+        if t.starts_with("#[cfg(") || t.starts_with("#[cfg_attr(") {
+            out.push(MoveHint {
+                kind: "cfg_context".to_string(),
+                file: dest_rel.to_string(),
+                line: Some((idx + 1) as u32),
+                detail: format!("moved item is gated by `{t}`"),
+                suggestion: Some(
+                    "confirm the destination module builds under the same cfg".to_string(),
+                ),
+            });
+            break;
+        }
+    }
+    out
+}
+
+/// File-level cycle-risk heuristic: if the destination already imports from the
+/// source module, moving a symbol here — while the source module's former call
+/// sites will now import it back from the destination — can form a two-way
+/// module dependency. Evidence is the destination's own `use` lines. Skipped
+/// when the source lives at the crate root (`crate`), where the signal is noise.
+fn cycle_risk_hints(
+    dest_original: &str,
+    dest_rel: &str,
+    src_module: Option<&str>,
+) -> Vec<MoveHint> {
+    let Some(src_module) = src_module else {
+        return Vec::new();
+    };
+    if src_module == "crate" {
+        return Vec::new();
+    }
+    for stmt in parse_use_statements(dest_original) {
+        if use_targets_module(&stmt.text, src_module) {
+            return vec![MoveHint {
+                kind: "cycle_risk".to_string(),
+                file: dest_rel.to_string(),
+                line: Some(stmt.line),
+                detail: format!(
+                    "destination already imports from `{src_module}` (`{}`); moving a symbol here while the source module imports it back can form a module dependency cycle",
+                    stmt.text.trim()
+                ),
+                suggestion: Some(format!(
+                    "verify `{src_module}` and this module do not end up importing each other; consider a shared leaf module"
+                )),
+            }];
+        }
+    }
+    Vec::new()
+}
+
+/// True when a `use` statement's path begins at `module` (exact module or a
+/// `module::…` descendant), respecting `::` boundaries.
+fn use_targets_module(use_stmt: &str, module: &str) -> bool {
+    let line = use_stmt.trim();
+    let Some(after) = line
+        .strip_prefix("pub use ")
+        .or_else(|| line.strip_prefix("use "))
+        .map(str::trim)
+    else {
+        return false;
+    };
+    let after = after.strip_suffix(';').unwrap_or(after).trim_start();
+    match after.strip_prefix(module) {
+        Some(rest) => rest.is_empty() || rest.trim_start().starts_with("::"),
+        None => false,
+    }
+}
+
+/// Builds a combined dry-run diff of the source removal and destination
+/// insertion.
+fn combined_diff(
+    source_rel: &str,
+    source: &str,
+    source_modified: &str,
+    dest_rel: &str,
+    dest_original: &str,
+    dest_modified: &str,
+) -> String {
+    let src_diff = bounded_region_diff(
+        source,
+        source_modified,
+        PREVIEW_DIFF_CONTEXT,
+        MAX_PREVIEW_DIFF_LINES,
+    );
+    let dest_diff = bounded_region_diff(
+        dest_original,
+        dest_modified,
+        PREVIEW_DIFF_CONTEXT,
+        MAX_PREVIEW_DIFF_LINES,
+    );
+    format!(
+        "--- {source_rel} (source, remove)\n{src_diff}\n\n+++ {dest_rel} (destination, insert)\n{dest_diff}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_module_path_maps_src_layout() {
+        assert_eq!(
+            rust_module_path("src/pricing.rs").as_deref(),
+            Some("crate::pricing")
+        );
+        assert_eq!(
+            rust_module_path("src/foo/bar.rs").as_deref(),
+            Some("crate::foo::bar")
+        );
+        assert_eq!(
+            rust_module_path("src/foo/mod.rs").as_deref(),
+            Some("crate::foo")
+        );
+        assert_eq!(rust_module_path("src/lib.rs").as_deref(), Some("crate"));
+        assert_eq!(rust_module_path("src/main.rs").as_deref(), Some("crate"));
+        assert_eq!(
+            rust_module_path("evals/fixture/src/pricing.rs").as_deref(),
+            Some("crate::pricing")
+        );
+        assert_eq!(rust_module_path("README.md"), None);
+    }
+
+    #[test]
+    fn module_stem_and_root() {
+        assert_eq!(
+            module_stem("src/grand_total.rs").as_deref(),
+            Some("grand_total")
+        );
+        assert_eq!(module_stem("src/foo/mod.rs").as_deref(), Some("foo"));
+        assert_eq!(module_stem("src/lib.rs"), None);
+        assert_eq!(
+            crate_root_file("evals/fixture/src/grand_total.rs"),
+            "evals/fixture/src/lib.rs"
+        );
+        assert_eq!(crate_root_file("src/a.rs"), "src/lib.rs");
+    }
+
+    #[test]
+    fn body_identifiers_collects_names_not_numbers() {
+        let ids = body_identifiers("let x = LineItem { unit_price: 3u64 };");
+        assert!(ids.contains("LineItem"));
+        assert!(ids.contains("unit_price"));
+        assert!(ids.contains("let"));
+        assert!(!ids.contains("3u64"));
+        assert!(!ids.contains("3"));
+    }
+
+    #[test]
+    fn parse_use_statements_handles_forms() {
+        let src = "use std::collections::HashMap;\npub use crate::a::B as C;\nuse crate::x::{Y, Z};\nuse crate::glob::*;\n";
+        let stmts = parse_use_statements(src);
+        assert_eq!(stmts.len(), 4);
+        assert_eq!(stmts[0].leaves[0].binding, "HashMap");
+        assert!(!stmts[0].glob);
+        assert_eq!(stmts[1].leaves[0].binding, "C");
+        assert_eq!(stmts[2].leaves.len(), 2);
+        assert_eq!(stmts[2].leaves[0].binding, "Y");
+        assert_eq!(stmts[2].leaves[1].binding, "Z");
+        assert!(stmts[3].glob);
+    }
+
+    #[test]
+    fn remove_span_collapses_trailing_blank_at_eof() {
+        let lines = vec!["fn a() {}", "", "/// doc", "fn b() {}"];
+        let out = remove_span_with_cleanup(&lines, 2, 3);
+        assert_eq!(out, vec!["fn a() {}".to_string()]);
+    }
+
+    #[test]
+    fn remove_span_collapses_interior_blank() {
+        let lines = vec!["a", "", "b", "", "c"];
+        // remove "b" (index 2) with blanks on both sides -> one blank collapses
+        let out = remove_span_with_cleanup(&lines, 2, 2);
+        assert_eq!(out, vec!["a".to_string(), String::new(), "c".to_string()]);
+    }
+
+    #[test]
+    fn build_dest_content_new_file_prepends_imports() {
+        let content = build_dest_content(
+            "",
+            &["use crate::pricing::LineItem;".to_string()],
+            "/// doc\nfn f() {}\n",
+        );
+        assert_eq!(
+            content,
+            "use crate::pricing::LineItem;\n\n/// doc\nfn f() {}\n"
+        );
+    }
+
+    #[test]
+    fn build_dest_content_existing_file_appends_after_blank() {
+        let content = build_dest_content("//! mod\n\nfn existing() {}\n", &[], "fn f() {}");
+        assert_eq!(content, "//! mod\n\nfn existing() {}\n\nfn f() {}\n");
+    }
+
+    #[test]
+    fn insert_imports_after_header_block() {
+        let out = insert_imports(
+            "//! module doc\n\nfn a() {}\n",
+            &["use crate::X;".to_string()],
+        );
+        assert_eq!(out, "//! module doc\n\nuse crate::X;\nfn a() {}\n");
+    }
+
+    /// Mirror `analyze_dependencies`' scan: mask comments/strings (preserving
+    /// format captures) then collect identifier tokens.
+    fn masked_idents(src: &str) -> HashSet<String> {
+        body_identifiers(&masked_rust_source_with(src, MaskOptions::UNUSED_IMPORTS))
+    }
+
+    #[test]
+    fn masked_scan_drops_doc_and_comment_mentions() {
+        let src = "/// see [`compute_total`]\npub fn f(x: LineItem) -> u64 {\n    x.v // compute_total again\n}\n";
+        let ids = masked_idents(src);
+        assert!(ids.contains("LineItem"), "code idents kept: {ids:?}");
+        assert!(
+            !ids.contains("compute_total"),
+            "doc/comment mention dropped: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn masked_scan_handles_block_comments() {
+        let ids = masked_idents("let a = 1; /* Foo bar */ let b = Baz;");
+        assert!(ids.contains("Baz"));
+        assert!(!ids.contains("Foo"));
+    }
+
+    #[test]
+    fn masked_scan_drops_string_literal_identifiers() {
+        // An identifier that appears only inside a string literal is not a
+        // dependency and must not be counted.
+        let ids = masked_idents(r#"fn f() { let s = "Widget in a string"; let x = Gadget; }"#);
+        assert!(ids.contains("Gadget"), "real code ident kept: {ids:?}");
+        assert!(
+            !ids.contains("Widget"),
+            "string-literal ident dropped: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn masked_scan_keeps_format_captures() {
+        // `format!("{helper_result}")`-style implicit captures ARE real uses.
+        let ids = masked_idents(r#"fn f() -> String { format!("{helper_result}") }"#);
+        assert!(
+            ids.contains("helper_result"),
+            "implicit format capture counted: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn parse_use_statements_handles_multiline_grouped_import() {
+        let src = "use crate::x::{\n    Alpha,\n    Beta,\n    Gamma,\n};\nfn f() {}\n";
+        let stmts = parse_use_statements(src);
+        assert_eq!(stmts.len(), 1, "one grouped statement: {}", stmts.len());
+        let bindings: Vec<&str> = stmts[0].leaves.iter().map(|l| l.binding.as_str()).collect();
+        assert_eq!(bindings, vec!["Alpha", "Beta", "Gamma"]);
+        assert_eq!(stmts[0].line, 1);
+        assert!(stmts[0].text.contains("Gamma"), "text is whole statement");
+    }
+
+    #[test]
+    fn cycle_risk_flags_dest_importing_source_module() {
+        let dest = "use crate::pricing::LineItem;\n\nfn helper() {}\n";
+        let hints = cycle_risk_hints(dest, "src/grand_total.rs", Some("crate::pricing"));
+        assert_eq!(hints.len(), 1, "one cycle_risk hint");
+        assert_eq!(hints[0].kind, "cycle_risk");
+        assert_eq!(hints[0].line, Some(1));
+        // No false positive on a sibling module with a shared prefix.
+        assert!(
+            cycle_risk_hints(
+                "use crate::pricing_utils::X;\n",
+                "src/grand_total.rs",
+                Some("crate::pricing")
+            )
+            .is_empty()
+        );
+        // Crate-root source is treated as noise and skipped.
+        assert!(cycle_risk_hints("use crate::pricing::X;\n", "src/g.rs", Some("crate")).is_empty());
+    }
+
+    #[test]
+    fn dedup_preserve_skips_existing() {
+        let out = dedup_preserve(
+            &[
+                "use a::B;".to_string(),
+                "use a::B;".to_string(),
+                "use c::D;".to_string(),
+            ],
+            "use c::D;\n",
+        );
+        assert_eq!(out, vec!["use a::B;".to_string()]);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -722,6 +722,65 @@ pub struct AstGrepResult {
     pub message: String,
 }
 
+/// One evidence-based, actionable finding produced by the `move_symbol` impact
+/// engine. Each hint points at a concrete file/line and carries a suggestion
+/// the caller (or a follow-up refactor) can act on. Hints are derived from graph
+/// edges (callers/callees) and parse-level facts (identifiers, `use` lines,
+/// module declarations) — never speculative noise.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveHint {
+    /// Taxonomy tag: `caller_reference`, `dependency_broken`, `import_needed`,
+    /// `visibility_required`, `collision`, `module_missing`, `cycle_risk`,
+    /// `orphaned_import`, or `cfg_context`.
+    pub kind: String,
+    /// File the finding concerns (the caller's file, the destination, or the
+    /// source), project-relative.
+    pub file: String,
+    /// 1-based line the finding concerns, when a specific site is known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    /// Human-readable description of what the move breaks or affects.
+    pub detail: String,
+    /// The exact change to make (e.g. a `use` line to add, a path to rewrite, a
+    /// visibility to escalate). `None` when no single mechanical fix applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggestion: Option<String>,
+}
+
+/// Result of a `move_symbol` operation: the moved span, a dry-run diff of the
+/// source + destination files, and — the centerpiece — the impact report of
+/// everything the move breaks or that needs attention.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MoveResult {
+    pub success: bool,
+    /// The resolved symbol that was (or would be) moved, `name (kind)`.
+    pub symbol: String,
+    pub source_file: String,
+    pub dest_file: String,
+    /// The exact source span that was moved, including its leading
+    /// doc-comment / attribute block. `None` on failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moved_span: Option<String>,
+    /// True when this was a dry run: spans, the destination shape, and the
+    /// impact report were all computed, but nothing was written to disk.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub dry_run: bool,
+    /// Combined preview diff of the source (removal) and destination (insertion)
+    /// files. Populated on a successful dry run; `None` for real moves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+    /// `use` lines auto-inserted at the destination because the moved body's
+    /// dependency on them was unambiguous. Reported so the caller sees exactly
+    /// what the move added.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applied_imports: Vec<String>,
+    /// The impact report — every actionable finding. Empty on a truly clean
+    /// move.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub impact: Vec<MoveHint>,
+    pub message: String,
+}
+
 /// A single parsed turn from a Claude Code session transcript,
 /// ready for DB insertion into the `turns` table.
 pub struct CostTurn {

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -6156,6 +6156,7 @@ fn test_read_only_tool_names_excludes_mutating_tools() {
         "tracedecay_ast_grep_rewrite",
         "tracedecay_replace_symbol",
         "tracedecay_insert_at_symbol",
+        "tracedecay_move_symbol",
         "tracedecay_run_affected_tests",
         "tracedecay_session_start",
         "tracedecay_session_end",

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -16342,3 +16342,467 @@ async fn unsafe_patterns_reports_unsafe_block_in_markdown_and_json() {
         "safe code should produce no findings: {text}"
     );
 }
+
+// --------------------------------------------------------------------------- //
+// tracedecay_move_symbol — fixture-crate integration through the MCP path.
+// --------------------------------------------------------------------------- //
+
+/// Parses the JSON payload text from a move_symbol ToolResult.
+fn move_payload(result: &ToolResult) -> Value {
+    let text = extract_text(&result.value);
+    serde_json::from_str(text).unwrap_or_else(|e| panic!("move payload not JSON: {e}\n{text}"))
+}
+
+/// A pricing/orders fixture mirroring the eval fixture: a `compute_grand_total`
+/// that depends on the same-file `LineItem`, plus a cross-file caller.
+async fn move_pricing_fixture(project: &Path) {
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/lib.rs"),
+        "pub mod pricing;\npub mod orders;\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/pricing.rs"),
+        "//! pricing\n\
+         pub struct LineItem {\n    pub unit_price: u64,\n    pub quantity: u32,\n}\n\n\
+         /// Grand total in cents.\n\
+         pub fn compute_grand_total(items: &[LineItem]) -> u64 {\n\
+         \x20   let mut total = 0u64;\n\
+         \x20   for item in items {\n\
+         \x20       total += item.unit_price * item.quantity as u64;\n\
+         \x20   }\n\
+         \x20   total\n\
+         }\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/orders.rs"),
+        "//! orders\n\
+         use crate::pricing::{compute_grand_total, LineItem};\n\n\
+         pub fn tally(items: &[LineItem]) -> u64 {\n    compute_grand_total(items)\n}\n",
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_move_symbol_dry_run_reports_impact_and_writes_nothing() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    move_pricing_fixture(project).await;
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let before_pricing = fs::read_to_string(project.join("src/pricing.rs")).unwrap();
+    let before_orders = fs::read_to_string(project.join("src/orders.rs")).unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "compute_grand_total", "dest_file": "src/grand_total.rs" }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+
+    assert_eq!(p["success"], true, "payload: {p}");
+    assert_eq!(p["dry_run"], true, "default must be a dry run: {p}");
+    // Docs travel with the function.
+    let span = p["moved_span"].as_str().unwrap();
+    assert!(span.contains("/// Grand total in cents."), "span: {span}");
+    assert!(span.contains("pub fn compute_grand_total"), "span: {span}");
+    // Same-file dependency `LineItem` is auto-inserted at the destination.
+    let applied: Vec<&str> = p["applied_imports"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        applied
+            .iter()
+            .any(|s| s.contains("use crate::pricing::LineItem;")),
+        "applied imports: {applied:?}"
+    );
+    // Impact carries the caller reference (cross-file) and the missing module.
+    let kinds: Vec<&str> = p["impact"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["kind"].as_str().unwrap())
+        .collect();
+    assert!(
+        kinds.contains(&"caller_reference"),
+        "impact kinds: {kinds:?}\n{p}"
+    );
+    assert!(
+        kinds.contains(&"module_missing"),
+        "impact kinds: {kinds:?}\n{p}"
+    );
+    let caller = p["impact"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|h| h["kind"] == "caller_reference")
+        .unwrap();
+    assert_eq!(caller["file"], "src/orders.rs");
+    assert!(
+        caller["suggestion"]
+            .as_str()
+            .unwrap()
+            .contains("crate::grand_total"),
+        "suggestion: {caller}"
+    );
+    assert!(p["diff"].as_str().unwrap().contains("compute_grand_total"));
+
+    // A dry run writes nothing: source files are byte-identical and the
+    // destination was never created.
+    assert_eq!(
+        fs::read_to_string(project.join("src/pricing.rs")).unwrap(),
+        before_pricing
+    );
+    assert_eq!(
+        fs::read_to_string(project.join("src/orders.rs")).unwrap(),
+        before_orders
+    );
+    assert!(!project.join("src/grand_total.rs").exists());
+}
+
+#[tokio::test]
+async fn test_move_symbol_apply_moves_and_rerun_errors_cleanly() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    move_pricing_fixture(project).await;
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "compute_grand_total", "dest_file": "src/grand_total.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+    // `dry_run: false` is omitted by skip_serializing_if; assert it is not true.
+    assert_ne!(p["dry_run"], json!(true), "payload: {p}");
+    assert_eq!(p["message"], "move applied", "payload: {p}");
+
+    // Source lost the function; destination gained it plus its import and docs.
+    let pricing = fs::read_to_string(project.join("src/pricing.rs")).unwrap();
+    assert!(
+        !pricing.contains("pub fn compute_grand_total"),
+        "pricing: {pricing}"
+    );
+    assert!(
+        pricing.contains("pub struct LineItem"),
+        "pricing: {pricing}"
+    );
+    let dest = fs::read_to_string(project.join("src/grand_total.rs")).unwrap();
+    assert!(
+        dest.contains("use crate::pricing::LineItem;"),
+        "dest: {dest}"
+    );
+    assert!(dest.contains("pub fn compute_grand_total"), "dest: {dest}");
+    assert!(
+        dest.contains("/// Grand total in cents."),
+        "dest docs travel: {dest}"
+    );
+
+    // Re-running the same move now that the symbol lives at the destination is a
+    // clean refusal (destination == source), not a panic or silent success.
+    let result2 = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "compute_grand_total", "dest_file": "src/grand_total.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p2 = move_payload(&result2);
+    assert_eq!(p2["success"], false, "re-run should refuse: {p2}");
+    assert_eq!(
+        result2.semantic_error(),
+        Some(true),
+        "re-run should mark a semantic error"
+    );
+}
+
+#[tokio::test]
+async fn test_move_symbol_clean_move_has_empty_impact() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub mod a;\npub mod b;\n").unwrap();
+    fs::write(
+        project.join("src/a.rs"),
+        "//! a\n\npub fn standalone() -> u32 {\n    42\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/b.rs"),
+        "//! b\n\npub fn other() -> u32 {\n    0\n}\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "standalone", "dest_file": "src/b.rs" }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+    assert!(
+        p["impact"].as_array().map(|a| a.is_empty()).unwrap_or(true),
+        "clean move should have empty impact: {p}"
+    );
+    assert!(
+        p["applied_imports"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true),
+        "clean move needs no imports: {p}"
+    );
+}
+
+#[tokio::test]
+async fn test_move_symbol_dest_collision_refuses() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub mod a;\npub mod b;\n").unwrap();
+    fs::write(
+        project.join("src/a.rs"),
+        "//! a\n\npub fn dup() -> u32 {\n    1\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/b.rs"),
+        "//! b\n\npub fn dup() -> u32 {\n    2\n}\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let before_b = fs::read_to_string(project.join("src/b.rs")).unwrap();
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "src/a.rs::dup", "dest_file": "src/b.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], false, "collision must refuse: {p}");
+    let kinds: Vec<&str> = p["impact"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["kind"].as_str().unwrap())
+        .collect();
+    assert!(kinds.contains(&"collision"), "impact: {p}");
+    // Refusal writes nothing.
+    assert_eq!(
+        fs::read_to_string(project.join("src/b.rs")).unwrap(),
+        before_b
+    );
+}
+
+#[tokio::test]
+async fn test_move_symbol_private_dependency_hints() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub mod a;\npub mod b;\n").unwrap();
+    fs::write(
+        project.join("src/a.rs"),
+        "//! a\n\n\
+         fn secret() -> u32 {\n    7\n}\n\n\
+         pub fn uses_secret() -> u32 {\n    secret()\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/b.rs"),
+        "//! b\n\npub fn other() -> u32 {\n    0\n}\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "uses_secret", "dest_file": "src/b.rs" }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+    let kinds: Vec<&str> = p["impact"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["kind"].as_str().unwrap())
+        .collect();
+    assert!(kinds.contains(&"dependency_broken"), "impact: {p}");
+    assert!(kinds.contains(&"visibility_required"), "impact: {p}");
+    // A private dependency is never silently auto-imported (would not compile),
+    // so applied_imports is empty and omitted from the payload entirely.
+    let applied = p["applied_imports"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !applied
+            .iter()
+            .any(|s| s.as_str().unwrap_or_default().contains("secret")),
+        "applied: {applied:?}"
+    );
+}
+
+/// Contract: a caller that invokes the symbol through a fully-qualified path
+/// (`crate::pricing::compute_grand_total(...)`) rather than a `use` import still
+/// earns a `caller_reference` hint whose suggestion carries the exact new path.
+#[tokio::test]
+async fn test_move_symbol_qualified_caller_hint() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(
+        project.join("src/lib.rs"),
+        "pub mod pricing;\npub mod orders;\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/pricing.rs"),
+        "//! pricing\n\
+         pub struct LineItem {\n    pub unit_price: u64,\n    pub quantity: u32,\n}\n\n\
+         /// Grand total in cents.\n\
+         pub fn compute_grand_total(items: &[LineItem]) -> u64 {\n\
+         \x20   let mut total = 0u64;\n\
+         \x20   for item in items {\n\
+         \x20       total += item.unit_price * item.quantity as u64;\n\
+         \x20   }\n\
+         \x20   total\n\
+         }\n",
+    )
+    .unwrap();
+    // Caller references the symbol via a qualified path, NOT a `use` import.
+    fs::write(
+        project.join("src/orders.rs"),
+        "//! orders\n\
+         use crate::pricing::LineItem;\n\n\
+         pub fn tally(items: &[LineItem]) -> u64 {\n\
+         \x20   crate::pricing::compute_grand_total(items)\n\
+         }\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "compute_grand_total", "dest_file": "src/grand_total.rs" }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+
+    let callers: Vec<&Value> = p["impact"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|h| h["kind"] == "caller_reference")
+        .collect();
+    assert_eq!(
+        callers.len(),
+        1,
+        "exactly one qualified caller reference: {p}"
+    );
+    let caller = callers[0];
+    assert_eq!(caller["file"], "src/orders.rs", "caller file: {caller}");
+    assert!(
+        caller["suggestion"]
+            .as_str()
+            .unwrap()
+            .contains("crate::grand_total::compute_grand_total"),
+        "suggestion must carry the exact new path: {caller}"
+    );
+}
+
+/// Contract (#353 `attrs_start_line` edge case): when the symbol's doc block is
+/// the very first lines of the file, the doc travels with the move and the
+/// source is left with no doc residue.
+#[tokio::test]
+async fn test_move_symbol_first_in_file_docs_travel() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub mod a;\npub mod b;\n").unwrap();
+    // The doc comment is literally the first line of the file — no module doc,
+    // no leading blank — so attrs_start_line must resolve to line 0.
+    fs::write(
+        project.join("src/a.rs"),
+        "/// The very first thing in the file.\n\
+         pub fn leading() -> u32 {\n    1\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/b.rs"),
+        "//! b\n\npub fn other() -> u32 {\n    0\n}\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "leading", "dest_file": "src/b.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+    // The moved span begins with the leading doc line.
+    let span = p["moved_span"].as_str().unwrap();
+    assert!(
+        span.starts_with("/// The very first thing in the file."),
+        "moved span must start with the leading doc: {span:?}"
+    );
+
+    // Apply left no doc residue at the source; the destination gained it.
+    let a = fs::read_to_string(project.join("src/a.rs")).unwrap();
+    assert!(
+        !a.contains("The very first thing in the file."),
+        "source must not retain the moved doc: {a:?}"
+    );
+    assert!(
+        !a.contains("pub fn leading"),
+        "source must not retain the moved fn: {a:?}"
+    );
+    let b = fs::read_to_string(project.join("src/b.rs")).unwrap();
+    assert!(
+        b.contains("The very first thing in the file.") && b.contains("pub fn leading"),
+        "destination must carry the doc and fn: {b:?}"
+    );
+}

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -16806,3 +16806,193 @@ async fn test_move_symbol_first_in_file_docs_travel() {
         "destination must carry the doc and fn: {b:?}"
     );
 }
+
+/// Ship-blocker (silent data loss): a `./`-prefixed destination that resolves to
+/// the symbol's OWN file must be refused. Before the normalization fix,
+/// `./src/pricing.rs` slipped past the same-file guard (it compared unequal to
+/// the graph's `src/pricing.rs`), and the apply then wrote-then-truncated the
+/// same inode, deleting the symbol while returning success.
+#[tokio::test]
+async fn test_move_symbol_dot_prefixed_same_file_refuses() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    move_pricing_fixture(project).await;
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let before_pricing = fs::read_to_string(project.join("src/pricing.rs")).unwrap();
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "compute_grand_total", "dest_file": "./src/pricing.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(
+        p["success"], false,
+        "`./`-prefixed same-file move must refuse: {p}"
+    );
+    assert!(
+        p["message"].as_str().unwrap().contains("symbol's own file"),
+        "refusal must be the same-file error: {p}"
+    );
+    // The symbol is untouched — no silent deletion.
+    assert_eq!(
+        fs::read_to_string(project.join("src/pricing.rs")).unwrap(),
+        before_pricing,
+        "source file must be byte-identical after the refusal"
+    );
+}
+
+/// A `./`-prefixed different-file destination must behave identically to the
+/// unprefixed form: the path is normalized, the move applies, and the reported
+/// `dest_file` is the canonical `src/grand_total.rs`.
+#[tokio::test]
+async fn test_move_symbol_dot_prefixed_dest_normalizes() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    move_pricing_fixture(project).await;
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "compute_grand_total", "dest_file": "./src/grand_total.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+    assert_eq!(
+        p["dest_file"], "src/grand_total.rs",
+        "dest_file must be normalized (no `./`): {p}"
+    );
+    // The move actually landed at the canonical path.
+    let dest = fs::read_to_string(project.join("src/grand_total.rs")).unwrap();
+    assert!(dest.contains("pub fn compute_grand_total"), "dest: {dest}");
+    let pricing = fs::read_to_string(project.join("src/pricing.rs")).unwrap();
+    assert!(
+        !pricing.contains("pub fn compute_grand_total"),
+        "source must have lost the symbol: {pricing}"
+    );
+}
+
+/// Ship-blocker (span correctness): a contiguous leading `//!` inner module-doc
+/// (no blank line before the item) must NOT be swallowed into the moved span.
+/// Otherwise the source loses its module doc and the destination gets a stray
+/// `//!` mid-file (a hard E0753).
+#[tokio::test]
+async fn test_move_symbol_leaves_contiguous_module_doc_behind() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub mod a;\npub mod b;\n").unwrap();
+    // Module doc is contiguous with the first item — no blank line between.
+    fs::write(
+        project.join("src/a.rs"),
+        "//! module a doc\npub fn fact() -> u32 {\n    1\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("src/b.rs"),
+        "//! b\n\npub fn other() -> u32 {\n    0\n}\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "fact", "dest_file": "src/b.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(p["success"], true, "payload: {p}");
+    // The moved span never carries the inner module doc.
+    let span = p["moved_span"].as_str().unwrap();
+    assert!(
+        !span.contains("//!"),
+        "moved span must not swallow the module doc: {span:?}"
+    );
+    assert!(span.contains("pub fn fact"), "span: {span:?}");
+
+    // Source keeps its module doc; destination has no stray `//!` mid-file.
+    let a = fs::read_to_string(project.join("src/a.rs")).unwrap();
+    assert!(
+        a.contains("//! module a doc"),
+        "source must keep its module doc: {a:?}"
+    );
+    let b = fs::read_to_string(project.join("src/b.rs")).unwrap();
+    assert!(b.contains("pub fn fact"), "dest must carry the fn: {b:?}");
+    // The only `//!` in the destination is its own leading module doc (line 0).
+    let stray_inner_doc = b
+        .lines()
+        .enumerate()
+        .any(|(i, l)| i > 0 && l.trim_start().starts_with("//!"));
+    assert!(
+        !stray_inner_doc,
+        "destination must not gain a mid-file `//!`: {b:?}"
+    );
+}
+
+/// Minor (destination read safety): an existing-but-unreadable destination
+/// (non-UTF8) must be refused with a clear message, never treated as empty and
+/// clobbered.
+#[tokio::test]
+async fn test_move_symbol_non_utf8_destination_refuses() {
+    let dir = test_temp_dir();
+    let project = dir.path();
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub mod a;\n").unwrap();
+    fs::write(
+        project.join("src/a.rs"),
+        "//! a\n\npub fn movable() -> u32 {\n    1\n}\n",
+    )
+    .unwrap();
+    let (cg, _env) = init_test_project(project).await;
+    cg.index_all().await.unwrap();
+
+    // Write an existing destination with invalid UTF-8 bytes AFTER indexing so
+    // the indexer never has to parse it.
+    let dest = project.join("src/blob.rs");
+    fs::write(&dest, [0xff, 0xfe, 0x00, 0xff]).unwrap();
+    let before_dest = fs::read(&dest).unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_move_symbol",
+        json!({ "symbol": "movable", "dest_file": "src/blob.rs", "dry_run": false }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let p = move_payload(&result);
+    assert_eq!(
+        p["success"], false,
+        "unreadable destination must refuse: {p}"
+    );
+    assert!(
+        p["message"]
+            .as_str()
+            .unwrap()
+            .contains("failed to read destination"),
+        "refusal message must name the read failure: {p}"
+    );
+    // The destination is untouched — not clobbered with the moved symbol.
+    assert_eq!(
+        fs::read(&dest).unwrap(),
+        before_dest,
+        "unreadable destination must be left byte-identical"
+    );
+}

--- a/tests/mcp_suite/mcp_test.rs
+++ b/tests/mcp_suite/mcp_test.rs
@@ -101,7 +101,8 @@ fn test_tool_definitions_count() {
     // requirement at runtime so plugin docs/rules can consistently reference it.
     // LCM comparison and profile-storage registry support add extra tools.
     // ast_grep_search (in-process structural search) is always registered.
-    let expected = 102 + usize::from(tracedecay::mcp::tools::ast_grep_available());
+    // move_symbol (relocate a symbol with an impact report) is always registered.
+    let expected = 103 + usize::from(tracedecay::mcp::tools::ast_grep_available());
     assert_eq!(tools.len(), expected);
 }
 
@@ -132,6 +133,7 @@ fn test_write_and_exec_tools_are_not_read_only() {
         "tracedecay_insert_at",
         "tracedecay_replace_symbol",
         "tracedecay_insert_at_symbol",
+        "tracedecay_move_symbol",
         "tracedecay_run_affected_tests",
         "tracedecay_ast_grep_rewrite",
         "tracedecay_lcm_doctor",


### PR DESCRIPTION
## Summary

Adds `tracedecay_move_symbol`, an edit-tier MCP tool that relocates a function to another file and returns an **evidence-based impact report** rather than silently rewriting call sites.

- `dry_run` defaults **true**: previews the combined source-removal / destination-insertion diff and the full impact report while writing nothing. `dry_run: false` applies (dest-first write with source-write rollback, reindex both).
- Impact classes: `caller_reference` (every breaking caller with its exact new path), `dependency_broken` / `import_needed`, `visibility_required`, `collision` / `module_missing` / `cycle_risk`, `orphaned_import` / `cfg_context`.
- Docs/attrs travel with the symbol (`attrs_start_line` semantics, incl. the #353 first-in-file edge case).
- Unambiguous needed imports are auto-inserted at the destination (`applied_imports`); callers are reported, never auto-edited (`update_references` reserved).
- Empty impact on a clean move is a tested contract.

## Implementation notes

- Dependency and `use`-statement analysis are built on the master `source_mask` facility (comments + string literals masked, implicit `format!("{ident}")` captures preserved) and a tree-sitter walk of `use_declaration` nodes, so multi-line grouped imports are captured whole and `use` tokens inside comments/strings are never matched. Falls back to a line scan when the Rust grammar is unavailable.
- `cycle_risk` is emitted by a file-level heuristic: the destination already importing from the source module.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `cargo nextest run --test mcp_suite` (372) and `--test agent_suite` (498): green; touched lib modules `move_symbol` + `edits` (25 tests): green.
- Agent-adoption scenario `edit_move_compute_grand_total_out` un-deferred (`status: active`) and live-verified through the built binary against the fixture crate: auto-inserts `use crate::pricing::LineItem;` and reports `module_missing` → `pub mod grand_total;`. `evals/agent_adoption/selftest.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)