### PR TITLE
ci: guard release PR integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Reject tracked ignored files
+        run: scripts/check-release-pr-integrity.sh HEAD HEAD
+
       - name: Validate PR commit messages
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/release-pr-integrity.yml
+++ b/.github/workflows/release-pr-integrity.yml
@@ -11,7 +11,9 @@ permissions:
 jobs:
   release-pr-integrity:
     name: Release PR integrity
-    if: startsWith(github.event.pull_request.head.ref, 'release-plz-')
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'release-plz-') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release-pr-integrity.yml
+++ b/.github/workflows/release-pr-integrity.yml
@@ -1,0 +1,40 @@
+name: Release PR integrity
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-pr-integrity:
+    name: Release PR integrity
+    if: startsWith(github.event.pull_request.head.ref, 'release-plz-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout proposed release commit without credentials
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Load guard from the trusted base commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git show "$BASE_SHA:scripts/check-release-pr-integrity.sh" >"$RUNNER_TEMP/check-release-pr-integrity.sh"
+
+      - name: Validate release PR paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EXTRA_FILES_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'release-extra-files-approved') }}
+        run: |
+          args=()
+          if [[ "$EXTRA_FILES_APPROVED" == "true" ]]; then
+            args+=(--allow-extra-files)
+          fi
+          bash "$RUNNER_TEMP/check-release-pr-integrity.sh" "$BASE_SHA" "$HEAD_SHA" "${args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 !plugin/.mcp.json
 .claude/settings.local.json
 .cursor/
-docs/superpowers
+docs/superpowers/plans/
 /local-only
 .worktrees
 .agents/

--- a/docs/RELEASE-AUTOMATION.md
+++ b/docs/RELEASE-AUTOMATION.md
@@ -40,6 +40,13 @@ The first version of a crate must exist before trusted publishing can be configu
 
 After that, release-plz detects unpublished changes from crates.io, opens a release PR, and publishes on merge.
 
+Release PRs may modify only `CHANGELOG.md`, `Cargo.lock`, and `Cargo.toml`. The
+read-only `Release PR integrity` workflow loads its guard from the trusted base
+commit, not from the proposed release branch. If a reviewed release PR must
+carry another change, apply the `release-extra-files-approved` label; tracked
+files that are also ignored remain forbidden because release-plz omits them
+when it creates its temporary repository copy.
+
 ## Normal Release Flow
 
 1. Merge feature/fix PRs into `master`.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-allow_dirty = true
+allow_dirty = false
 dependencies_update = false
 repo_url = "https://github.com/ScriptedAlchemy/tracedecay"
 release_always = false

--- a/scripts/check-release-pr-integrity.sh
+++ b/scripts/check-release-pr-integrity.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <base-ref> <head-ref> [--allow-extra-files]" >&2
+  exit 2
+}
+
+[[ $# -eq 2 || $# -eq 3 ]] || usage
+base_ref=$1
+head_ref=$2
+allow_extra_files=false
+if [[ $# -eq 3 ]]; then
+  [[ $3 == "--allow-extra-files" ]] || usage
+  allow_extra_files=true
+fi
+
+git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null || {
+  echo "release PR integrity: invalid base ref: $base_ref" >&2
+  exit 2
+}
+git rev-parse --verify --quiet "${head_ref}^{commit}" >/dev/null || {
+  echo "release PR integrity: invalid head ref: $head_ref" >&2
+  exit 2
+}
+
+checked_out_head=$(git rev-parse HEAD)
+requested_head=$(git rev-parse "${head_ref}^{commit}")
+if [[ $checked_out_head != "$requested_head" ]]; then
+  echo "release PR integrity: checkout HEAD must match head ref $head_ref" >&2
+  exit 2
+fi
+
+tracked_ignored=$(git ls-files --cached --ignored --exclude-standard)
+if [[ -n $tracked_ignored ]]; then
+  echo "release PR integrity: tracked files must not also be ignored:" >&2
+  printf '%s\n' "$tracked_ignored" >&2
+  echo "Remove the matching ignore rule before release-plz copies the repository." >&2
+  exit 1
+fi
+
+unexpected=()
+destructive_metadata=()
+while IFS=$'\t' read -r status path _; do
+  [[ -n ${status:-} ]] || continue
+  case "$path" in
+    CHANGELOG.md | Cargo.lock | Cargo.toml)
+      if [[ $status != M ]]; then
+        destructive_metadata+=("$status $path")
+      fi
+      ;;
+    *) unexpected+=("$status $path") ;;
+  esac
+done < <(git diff --name-status --no-renames "${base_ref}...${head_ref}")
+
+if ((${#destructive_metadata[@]})); then
+  echo "release PR integrity: release metadata may only be modified, not added, deleted, or type-changed:" >&2
+  printf '  %s\n' "${destructive_metadata[@]}" >&2
+  exit 1
+fi
+
+if ((${#unexpected[@]})) && [[ $allow_extra_files != true ]]; then
+  echo "release PR integrity: release PR contains changes outside CHANGELOG.md, Cargo.lock, and Cargo.toml:" >&2
+  printf '  %s\n' "${unexpected[@]}" >&2
+  echo "Apply the release-extra-files-approved label only after reviewing every listed path." >&2
+  exit 1
+fi
+
+if ((${#unexpected[@]})); then
+  echo "release PR integrity: explicitly approved extra paths:" >&2
+  printf '  %s\n' "${unexpected[@]}" >&2
+fi

--- a/tests/release_pr_integrity_test.sh
+++ b/tests/release_pr_integrity_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+guard="$repo_root/scripts/check-release-pr-integrity.sh"
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+new_repo() {
+  rm -rf "$fixture/repo"
+  mkdir -p "$fixture/repo"
+  git -C "$fixture/repo" init -q -b master
+  git -C "$fixture/repo" config user.name "Release Guard Test"
+  git -C "$fixture/repo" config user.email "release-guard@example.com"
+  printf '[package]\nname = "fixture"\nversion = "0.1.0"\n' >"$fixture/repo/Cargo.toml"
+  printf 'version = 3\n' >"$fixture/repo/Cargo.lock"
+  printf '# Changelog\n' >"$fixture/repo/CHANGELOG.md"
+  git -C "$fixture/repo" add Cargo.toml Cargo.lock CHANGELOG.md
+  git -C "$fixture/repo" commit -qm "initial"
+}
+
+commit_all() {
+  git -C "$fixture/repo" add -A
+  git -C "$fixture/repo" commit -qm "$1"
+}
+
+run_guard() {
+  (cd "$fixture/repo" && "$guard" "$@")
+}
+
+new_repo
+base=$(git -C "$fixture/repo" rev-parse HEAD)
+printf '\n## 0.2.0\n' >>"$fixture/repo/CHANGELOG.md"
+printf '[package]\nname = "fixture"\nversion = "0.2.0"\n' >"$fixture/repo/Cargo.toml"
+commit_all "release"
+head=$(git -C "$fixture/repo" rev-parse HEAD)
+run_guard "$base" "$head"
+
+new_repo
+base=$(git -C "$fixture/repo" rev-parse HEAD)
+mkdir -p "$fixture/repo/src"
+printf 'pub fn unexpected() {}\n' >"$fixture/repo/src/lib.rs"
+commit_all "unexpected source change"
+head=$(git -C "$fixture/repo" rev-parse HEAD)
+if output=$(run_guard "$base" "$head" 2>&1); then
+  fail "unexpected source changes must fail without explicit approval"
+fi
+[[ "$output" == *"src/lib.rs"* ]] || fail "failure must name the unexpected path"
+run_guard "$base" "$head" --allow-extra-files >/dev/null 2>&1
+
+new_repo
+base=$(git -C "$fixture/repo" rev-parse HEAD)
+rm "$fixture/repo/Cargo.toml"
+commit_all "delete manifest"
+head=$(git -C "$fixture/repo" rev-parse HEAD)
+if output=$(run_guard "$base" "$head" --allow-extra-files 2>&1); then
+  fail "approval must not permit deletion of release metadata"
+fi
+[[ "$output" == *"Cargo.toml"* ]] || fail "destructive metadata failure must name Cargo.toml"
+
+new_repo
+printf 'tracked.tmp\n' >"$fixture/repo/.gitignore"
+printf 'must remain visible to release tooling\n' >"$fixture/repo/tracked.tmp"
+git -C "$fixture/repo" add .gitignore
+git -C "$fixture/repo" add -f tracked.tmp
+git -C "$fixture/repo" commit -qm "track ignored file"
+head=$(git -C "$fixture/repo" rev-parse HEAD)
+if output=$(run_guard "$head" "$head" --allow-extra-files 2>&1); then
+  fail "tracked ignored files must fail even with extra-file approval"
+fi
+[[ "$output" == *"tracked.tmp"* ]] || fail "tracked ignored failure must name the path"

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 release_plz=".github/workflows/release-plz.yml"
 release_workflow=".github/workflows/release.yml"
+release_pr_integrity=".github/workflows/release-pr-integrity.yml"
 
 if grep -q 'GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}' "$release_plz"; then
   echo "release-plz must not publish releases with GITHUB_TOKEN" >&2
@@ -31,3 +32,27 @@ PY
 
 grep -q 'release:' "$release_workflow"
 grep -q 'types: \[published\]' "$release_workflow"
+
+python3 - "$release_pr_integrity" <<'PY'
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+
+required = [
+    "pull_request_target:",
+    "contents: read",
+    "pull-requests: read",
+    "persist-credentials: false",
+    "github.event.pull_request.head.sha",
+    "git show \"$BASE_SHA:scripts/check-release-pr-integrity.sh\"",
+    "release-extra-files-approved",
+    "scripts/check-release-pr-integrity.sh",
+]
+for item in required:
+    if item not in text:
+        raise SystemExit(f"release PR integrity workflow missing {item!r}")
+
+if "contents: write" in text or "pull-requests: write" in text:
+    raise SystemExit("release PR integrity workflow must remain read-only")
+PY

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -45,6 +45,7 @@ required = [
     "pull-requests: read",
     "persist-credentials: false",
     "github.event.pull_request.head.sha",
+    "github.event.pull_request.head.repo.full_name == github.repository",
     "git show \"$BASE_SHA:scripts/check-release-pr-integrity.sh\"",
     "release-extra-files-approved",
     "scripts/check-release-pr-integrity.sh",


### PR DESCRIPTION
## Summary
- reject release PR changes outside CHANGELOG.md, Cargo.lock, and Cargo.toml unless maintainers apply release-extra-files-approved
- run the guard from the trusted base commit in a read-only pull_request_target workflow
- reject tracked ignored files in normal CI and keep only local superpowers plans ignored
- restore release-plz clean-worktree enforcement

## Root cause
release-plz copies the repository with an ignore-aware walker. The tracked specialist-agent spec matched .gitignore, so the temporary copy omitted it. allow_dirty = true bypassed release-plz's own tracked-ignored clean check and turned that omission into a release commit deletion.

## Verification
- bash tests/release_pr_integrity_test.sh
- bash tests/release_workflow_contract_test.sh
- bash tests/release_drift_check_test.sh
- bash -n scripts/check-release-pr-integrity.sh tests/release_pr_integrity_test.sh tests/release_workflow_contract_test.sh
- scripts/check-release-pr-integrity.sh origin/master HEAD --allow-extra-files
- YAML parse for both touched workflows
- git diff --check origin/master...HEAD