### PR TITLE
fix(doctor): surface identity split conflicts

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -41,23 +41,24 @@ pub async fn run_doctor(agent_filter: Option<&str>) {
     let project_path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let open_options = TraceDecayOpenOptions::default();
     match resolve_current_project_store(&project_path, &open_options).await {
-        CurrentProjectStore::Resolved(layout) => {
+        Ok(CurrentProjectStore::Resolved(layout)) => {
             dc.pass(&describe_resolved_store(&layout));
             check_database(&mut dc, &project_path, open_options.clone()).await;
         }
-        CurrentProjectStore::LegacyRepoLocal => {
+        Ok(CurrentProjectStore::LegacyRepoLocal) => {
             dc.pass(&format!(
                 "Index found: {}/ (legacy repo-local store)",
                 crate::config::get_tracedecay_dir(&project_path).display()
             ));
             check_database(&mut dc, &project_path, open_options).await;
         }
-        CurrentProjectStore::Uninitialized => {
+        Ok(CurrentProjectStore::Uninitialized) => {
             dc.warn(&format!(
                 "No index found for {} — run `tracedecay init`",
                 project_path.display()
             ));
         }
+        Err(error) => dc.fail(&format!("Project storage resolution failed: {error}")),
     }
 
     check_global_db(&mut dc);
@@ -173,16 +174,16 @@ enum CurrentProjectStore {
 async fn resolve_current_project_store(
     project_path: &Path,
     open_options: &TraceDecayOpenOptions,
-) -> CurrentProjectStore {
+) -> crate::errors::Result<CurrentProjectStore> {
     if let Some(layout) =
-        TraceDecay::initialized_store_layout_with_options(project_path, open_options).await
+        TraceDecay::try_initialized_store_layout_with_options(project_path, open_options).await?
     {
-        return CurrentProjectStore::Resolved(Box::new(layout));
+        return Ok(CurrentProjectStore::Resolved(Box::new(layout)));
     }
     if crate::config::has_project_database(project_path) {
-        return CurrentProjectStore::LegacyRepoLocal;
+        return Ok(CurrentProjectStore::LegacyRepoLocal);
     }
-    CurrentProjectStore::Uninitialized
+    Ok(CurrentProjectStore::Uninitialized)
 }
 
 fn describe_resolved_store(layout: &StoreLayout) -> String {

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::global_db::StoreInstanceUpsert;
 use crate::storage::{
-    STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode, StoreKind, StoreManifest,
+    EnrollmentMarker, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode,
+    StoreKind, StoreManifest, profile_sharded_layout, write_repository_identity_marker,
+    write_store_manifest,
 };
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
@@ -213,7 +215,7 @@ async fn current_project_store_resolves_profile_shard_via_registry_alias()
     // No repo-local `.tracedecay/` index exists, yet the project must not
     // be reported as uninitialized: resolution finds the profile shard.
     assert!(!crate::config::has_project_database(&project_root));
-    match resolve_current_project_store(&project_root, &open_options).await {
+    match resolve_current_project_store(&project_root, &open_options).await? {
         CurrentProjectStore::Resolved(layout) => {
             assert_eq!(layout.data_root, shard_root);
             assert_eq!(
@@ -231,7 +233,7 @@ async fn current_project_store_resolves_profile_shard_via_registry_alias()
     std::fs::create_dir_all(&unregistered)?;
     let unregistered = canonical_temp_path(&unregistered);
     assert!(matches!(
-        resolve_current_project_store(&unregistered, &open_options).await,
+        resolve_current_project_store(&unregistered, &open_options).await?,
         CurrentProjectStore::Uninitialized
     ));
     Ok(())
@@ -265,13 +267,99 @@ async fn current_project_store_resolves_moved_repository_identity_read_only()
         profile_root: Some(profile_root),
         global_db_path: Some(dir.path().join("global.db")),
     };
-    match resolve_current_project_store(&moved, &open_options).await {
+    match resolve_current_project_store(&moved, &open_options).await? {
         CurrentProjectStore::Resolved(layout) => {
             assert_eq!(layout.data_root, shard_root);
             assert_eq!(layout.identity.project_id.as_deref(), Some(project_id));
         }
         other => panic!("expected moved repository identity, got {other:?}"),
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn current_project_store_surfaces_split_identity_conflict()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::TempDir::new()?;
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(&project_root)?;
+    let status = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&project_root)
+        .status()?;
+    assert!(status.success());
+
+    for (project_id, node_id) in [
+        ("proj_doctor_selected", "selected-node"),
+        ("proj_doctor_legacy", "legacy-node"),
+    ] {
+        let layout = profile_sharded_layout(
+            &project_root,
+            &profile_root,
+            &EnrollmentMarker {
+                project_id: project_id.to_string(),
+                storage_mode: StorageMode::ProfileSharded,
+            },
+        )?;
+        let (db, _) = crate::db::Database::initialize(&layout.graph_db_path).await?;
+        db.insert_node(&crate::types::Node {
+            id: node_id.to_string(),
+            kind: crate::types::NodeKind::Function,
+            name: node_id.to_string(),
+            qualified_name: node_id.to_string(),
+            file_path: "src/lib.rs".to_string(),
+            start_line: 1,
+            attrs_start_line: 1,
+            end_line: 1,
+            start_column: 0,
+            end_column: 1,
+            signature: None,
+            docstring: None,
+            visibility: crate::types::Visibility::Pub,
+            is_async: false,
+            branches: 0,
+            loops: 0,
+            returns: 0,
+            max_nesting: 0,
+            unsafe_blocks: 0,
+            unchecked_calls: 0,
+            assertions: 0,
+            updated_at: 1_800_000_000,
+            parent_id: None,
+        })
+        .await?;
+        db.checkpoint().await?;
+        db.close();
+        write_store_manifest(&layout)?;
+    }
+    write_repository_identity_marker(&project_root, "proj_doctor_selected")?;
+
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+    let selected_db = profile_root.join("projects/proj_doctor_selected/tracedecay.db");
+    let legacy_db = profile_root.join("projects/proj_doctor_legacy/tracedecay.db");
+    let selected_before = std::fs::read(&selected_db)?;
+    let legacy_before = std::fs::read(&legacy_db)?;
+
+    let resolution = resolve_current_project_store(&project_root, &open_options).await;
+    let diagnostic = format!("{resolution:?}");
+    assert!(
+        diagnostic.contains("identity cutover conflict"),
+        "{diagnostic}"
+    );
+    assert!(diagnostic.contains("proj_doctor_selected"), "{diagnostic}");
+    assert!(diagnostic.contains("proj_doctor_legacy"), "{diagnostic}");
+    assert!(
+        diagnostic.contains("backup-and-consolidate migration"),
+        "{diagnostic}"
+    );
+    assert!(diagnostic.contains("no files changed"), "{diagnostic}");
+    assert!(!diagnostic.contains("Uninitialized"), "{diagnostic}");
+    assert_eq!(std::fs::read(selected_db)?, selected_before);
+    assert_eq!(std::fs::read(legacy_db)?, legacy_before);
     Ok(())
 }
 

--- a/src/status_cmd.rs
+++ b/src/status_cmd.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::Path;
 
-use tracedecay::tracedecay::TraceDecay;
+use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
 use crate::{commands, current_unix_timestamp, global, resolve_cli_project_root};
 
@@ -90,7 +90,13 @@ pub(crate) async fn handle_status_command(
     runtime: bool,
 ) -> tracedecay::errors::Result<()> {
     let project_path = resolve_cli_project_root(path, project_id, project_path).await?;
-    let cg = if TraceDecay::has_initialized_store(&project_path).await {
+    let initialized = TraceDecay::try_initialized_store_layout_with_options(
+        &project_path,
+        &TraceDecayOpenOptions::default(),
+    )
+    .await?
+    .is_some();
+    let cg = if initialized {
         match TraceDecay::open(&project_path).await {
             Ok(cg) => cg,
             Err(_) => TraceDecay::open_read_only(&project_path).await?,

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -910,10 +910,22 @@ impl TraceDecay {
         project_root: &Path,
         open_options: &TraceDecayOpenOptions,
     ) -> Option<StoreLayout> {
-        Self::resolve_store_layout_for_local_identity(project_root, open_options)
+        Self::try_initialized_store_layout_with_options(project_root, open_options)
             .await
             .ok()
-            .filter(|layout| layout.graph_db_path.is_file())
+            .flatten()
+    }
+
+    /// Resolves an initialized store without discarding identity conflicts or
+    /// other storage errors. User-facing diagnostics must use this variant so
+    /// a preserved split store is never mislabeled as uninitialized.
+    pub async fn try_initialized_store_layout_with_options(
+        project_root: &Path,
+        open_options: &TraceDecayOpenOptions,
+    ) -> Result<Option<StoreLayout>> {
+        let layout =
+            Self::resolve_store_layout_for_local_identity(project_root, open_options).await?;
+        Ok(layout.graph_db_path.is_file().then_some(layout))
     }
 
     /// Resolves the profile store layout for a local path using enrollment

--- a/tests/core_cli_suite/cli_non_interactive_test.rs
+++ b/tests/core_cli_suite/cli_non_interactive_test.rs
@@ -20,7 +20,8 @@ use tracedecay::migrate::manifest::{
 use tracedecay::storage::{
     EnrollmentMarker, SESSIONS_DB_FILENAME, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
     StorageMode, StoreKind, StoreManifest, default_profile_project_id, profile_sharded_data_root,
-    read_enrollment_marker, write_enrollment_marker,
+    profile_sharded_layout, read_enrollment_marker, write_enrollment_marker,
+    write_repository_identity_marker, write_store_manifest,
 };
 use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
@@ -1073,6 +1074,62 @@ fn status_skips_create_prompt_when_stdin_not_a_terminal() {
         stderr.contains("Non-interactive: skipping index creation"),
         "stderr should explain the non-interactive default\nstderr:\n{stderr}"
     );
+}
+
+#[tokio::test]
+async fn status_surfaces_split_identity_conflict_without_suggesting_init() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let project_root = canonical_temp_path(project.path());
+    git(&project_root, &["init", "-b", "main"]);
+
+    for (project_id, node_id) in [
+        ("proj_status_selected", "status-selected-node"),
+        ("proj_status_legacy", "status-legacy-node"),
+    ] {
+        let layout = profile_sharded_layout(
+            &project_root,
+            &profile_root(home.path()),
+            &EnrollmentMarker {
+                project_id: project_id.to_string(),
+                storage_mode: StorageMode::ProfileSharded,
+            },
+        )
+        .unwrap();
+        let (db, _) = Database::initialize(&layout.graph_db_path).await.unwrap();
+        db.insert_node(&sample_node(node_id, node_id, "src/lib.rs"))
+            .await
+            .unwrap();
+        db.checkpoint().await.unwrap();
+        db.close();
+        write_store_manifest(&layout).unwrap();
+    }
+    write_repository_identity_marker(&project_root, "proj_status_selected").unwrap();
+
+    let selected_db = profile_root(home.path()).join("projects/proj_status_selected/tracedecay.db");
+    let legacy_db = profile_root(home.path()).join("projects/proj_status_legacy/tracedecay.db");
+    let selected_before = std::fs::read(&selected_db).unwrap();
+    let legacy_before = std::fs::read(&legacy_db).unwrap();
+
+    let mut command = tracedecay_command(home.path(), &project_root);
+    command.arg("status");
+    let output = run_with_timeout(command, cli_timeout());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "status should fail safely\n{stderr}"
+    );
+    assert!(stderr.contains("identity cutover conflict"), "{stderr}");
+    assert!(stderr.contains("proj_status_selected"), "{stderr}");
+    assert!(stderr.contains("proj_status_legacy"), "{stderr}");
+    assert!(
+        stderr.contains("backup-and-consolidate migration"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("run `tracedecay init`"), "{stderr}");
+    assert_eq!(std::fs::read(selected_db).unwrap(), selected_before);
+    assert_eq!(std::fs::read(legacy_db).unwrap(), legacy_before);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- preserve storage identity resolution errors in an error-aware initialized-store API
- make `tracedecay doctor` report the exact split-store inventory and backup/consolidation action
- make `tracedecay status` fail safely instead of suggesting `tracedecay init`
- verify both selected and legacy fixture databases remain byte-for-byte unchanged

## Root cause

`initialized_store_layout_with_options` converted every storage resolution error to `None`. Doctor and status therefore treated an intentional identity-cutover conflict as an absent index and offered an unsafe initialization path.

## Tests

- `cargo test --lib doctor::tests::current_project_store -- --nocapture`
- `cargo test --test core_cli_suite cli_non_interactive_test::status_ -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
