### PR TITLE
chore: release v0.0.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.48](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.47...v0.0.48) - 2026-07-10
+
+### Added
+
+- *(mcp)* refresh tools after daemon generation change ([#422](https://github.com/ScriptedAlchemy/tracedecay/pull/422))
+
+### Fixed
+
+- *(storage)* add explicit split-store consolidation ([#425](https://github.com/ScriptedAlchemy/tracedecay/pull/425))
+- *(analytics)* aggregate sections before sampling ([#424](https://github.com/ScriptedAlchemy/tracedecay/pull/424))
+- *(memory)* preserve FTS5 relevance direction ([#423](https://github.com/ScriptedAlchemy/tracedecay/pull/423))
+- *(hermes)* use the user TraceDecay profile ([#407](https://github.com/ScriptedAlchemy/tracedecay/pull/407))
+- *(runtime)* proxy MCP before opening local stores ([#420](https://github.com/ScriptedAlchemy/tracedecay/pull/420))
+- *(edit)* make move_symbol writes race-safe ([#419](https://github.com/ScriptedAlchemy/tracedecay/pull/419))
+- *(doctor)* surface identity split conflicts ([#417](https://github.com/ScriptedAlchemy/tracedecay/pull/417))
+
+### Other
+
+- Merge pull request #414 from ScriptedAlchemy/codex/move-symbol
+- Merge pull request #411 from ScriptedAlchemy/codex/doctor-foreign-skills
+
 ## [0.0.47](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.46...v0.0.47) - 2026-07-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.47"
+version = "0.0.48"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.47 -> 0.0.48

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.48](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.47...v0.0.48) - 2026-07-10

### Added

- *(mcp)* refresh tools after daemon generation change ([#422](https://github.com/ScriptedAlchemy/tracedecay/pull/422))

### Fixed

- *(storage)* add explicit split-store consolidation ([#425](https://github.com/ScriptedAlchemy/tracedecay/pull/425))
- *(analytics)* aggregate sections before sampling ([#424](https://github.com/ScriptedAlchemy/tracedecay/pull/424))
- *(memory)* preserve FTS5 relevance direction ([#423](https://github.com/ScriptedAlchemy/tracedecay/pull/423))
- *(hermes)* use the user TraceDecay profile ([#407](https://github.com/ScriptedAlchemy/tracedecay/pull/407))
- *(runtime)* proxy MCP before opening local stores ([#420](https://github.com/ScriptedAlchemy/tracedecay/pull/420))
- *(edit)* make move_symbol writes race-safe ([#419](https://github.com/ScriptedAlchemy/tracedecay/pull/419))
- *(doctor)* surface identity split conflicts ([#417](https://github.com/ScriptedAlchemy/tracedecay/pull/417))

### Other

- Merge pull request #414 from ScriptedAlchemy/codex/move-symbol
- Merge pull request #411 from ScriptedAlchemy/codex/doctor-foreign-skills
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).