### PR TITLE
fix(runtime): proxy MCP before opening local stores

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1067,16 +1067,9 @@ async fn update_proxy_handshake_from_initialize(
     if !base_handshake.allow_initialize_root_routing {
         return;
     }
-    let Some(registry) =
-        crate::global_db::GlobalDb::open_at(&base_handshake.client_identity.global_db_path).await
-    else {
-        return;
-    };
-    let Some(project_path) = crate::mcp::server::resolve_initialize_roots_project_path(
-        request.params.as_ref(),
-        Some(&registry),
-    )
-    .await
+    let Some((project_path, allow_init)) =
+        resolve_proxy_initialize_route(request.params.as_ref(), &base_handshake.client_identity)
+            .await
     else {
         return;
     };
@@ -1084,6 +1077,31 @@ async fn update_proxy_handshake_from_initialize(
         handshake.scope_prefix = None;
     }
     handshake.project_path = Some(project_path);
+    handshake.allow_init = allow_init;
+}
+
+#[cfg(unix)]
+async fn resolve_proxy_initialize_route(
+    params: Option<&serde_json::Value>,
+    client_identity: &DaemonClientIdentity,
+) -> Option<(PathBuf, bool)> {
+    let registry = crate::global_db::GlobalDb::open_at(&client_identity.global_db_path).await;
+    if let Some(project_path) =
+        crate::mcp::server::resolve_initialize_roots_project_path(params, registry.as_ref()).await
+    {
+        return Some((project_path, false));
+    }
+
+    for root in crate::mcp::server::initialize_root_paths(params) {
+        if let Some(project_path) = crate::config::discover_project_root(&root) {
+            return Some((project_path, false));
+        }
+        if let Some(git_root) = crate::worktree::git_worktree_root(&root) {
+            let allow_init = crate::config::load_sync_config(&git_root).auto_init;
+            return Some((git_root, allow_init));
+        }
+    }
+    None
 }
 
 #[cfg(unix)]
@@ -2375,6 +2393,8 @@ fn is_missing_index_error(err: &TraceDecayError) -> bool {
         TraceDecayError::Config { message }
             if message.contains("no TraceDecay index found")
                 || message.contains("no TraceDecay database found")
+                || message.contains("parent DB not found")
+                || (message.contains("parent branch '") && message.contains("' has no DB"))
     )
 }
 

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -11,7 +11,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 #[cfg(unix)]
 use tokio::task::JoinHandle;
 
-use super::{DaemonClientIdentity, DaemonHandshake, DaemonLifecycle, drain_client_tasks};
+#[cfg(unix)]
+use super::drain_client_tasks;
+use super::{DaemonClientIdentity, DaemonHandshake, DaemonLifecycle};
 
 #[test]
 fn daemon_lifecycle_rejects_new_work_after_draining() {
@@ -23,6 +25,7 @@ fn daemon_lifecycle_rejects_new_work_after_draining() {
     assert!(!lifecycle.accepting());
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn client_drain_timeout_aborts_and_joins_remaining_work() {
     let mut clients = tokio::task::JoinSet::new();
@@ -37,6 +40,7 @@ async fn client_drain_timeout_aborts_and_joins_remaining_work() {
     assert!(clients.is_empty());
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn client_drain_waits_for_completed_work() {
     let mut clients = tokio::task::JoinSet::new();
@@ -48,6 +52,7 @@ async fn client_drain_waits_for_completed_work() {
     assert!(clients.is_empty());
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn persistent_idle_client_closes_on_draining_without_timeout() {
     let lifecycle = DaemonLifecycle::default();
@@ -65,6 +70,7 @@ async fn persistent_idle_client_closes_on_draining_without_timeout() {
     assert!(lifecycle.try_enter().is_none());
 }
 
+#[cfg(unix)]
 #[tokio::test]
 async fn draining_waits_for_one_bounded_in_flight_request() {
     let lifecycle = DaemonLifecycle::default();
@@ -113,6 +119,40 @@ async fn await_test_task<T>(task: JoinHandle<T>, label: &str) -> T {
         .await
         .unwrap_or_else(|_| panic!("{label} timed out"))
         .unwrap_or_else(|e| panic!("{label} panicked: {e}"))
+}
+
+#[cfg(unix)]
+async fn answer_one_proxy_request(listener: tokio::net::UnixListener, generation: u64) {
+    let (stream, _addr) = listener.accept().await.expect("accept proxied client");
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    let handshake_line = lines
+        .next_line()
+        .await
+        .expect("read handshake")
+        .expect("handshake line");
+    DaemonHandshake::from_line(&handshake_line).expect("parse handshake");
+    let request_line = lines
+        .next_line()
+        .await
+        .expect("read request")
+        .expect("request line");
+    let request: Value = serde_json::from_str(&request_line).expect("request json");
+    let response = json!({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": { "generation": generation }
+    });
+    writer
+        .write_all(
+            serde_json::to_string(&response)
+                .expect("response json")
+                .as_bytes(),
+        )
+        .await
+        .expect("write response");
+    writer.write_all(b"\n").await.expect("write newline");
+    writer.shutdown().await.expect("shutdown fake daemon");
 }
 
 #[test]
@@ -458,6 +498,68 @@ async fn proxied_request_survives_daemon_restart_window() {
     assert_eq!(response["id"], json!(42));
     assert_eq!(response["result"]["ok"], json!(true));
     daemon.await.expect("fake daemon task");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn long_lived_proxy_reconnects_after_daemon_socket_rebind() {
+    let dir = TempDir::new().expect("temp dir");
+    let socket = dir.path().join("daemon.sock");
+    let first_listener = tokio::net::UnixListener::bind(&socket).expect("bind first daemon socket");
+    let rebound_socket = socket.clone();
+    let (unbound_tx, unbound_rx) = tokio::sync::oneshot::channel();
+    let daemon = tokio::spawn(async move {
+        answer_one_proxy_request(first_listener, 1).await;
+        std::fs::remove_file(&rebound_socket).expect("unlink first daemon socket");
+        unbound_tx.send(()).expect("notify daemon outage");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let second_listener =
+            tokio::net::UnixListener::bind(&rebound_socket).expect("bind second daemon socket");
+        answer_one_proxy_request(second_listener, 2).await;
+    });
+
+    let (mut transport, sender, mut receiver) = crate::mcp::transport::ChannelTransport::new();
+    let proxy_socket = socket.clone();
+    let proxy = tokio::spawn(async move {
+        super::proxy_transport_to_daemon(
+            &proxy_socket,
+            &test_handshake_defaults(),
+            None,
+            &mut transport,
+        )
+        .await
+    });
+
+    let request = |id| {
+        serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/list"
+        }))
+        .expect("request json")
+    };
+    sender.send(request(1)).expect("send first request");
+    let first = tokio::time::timeout(std::time::Duration::from_secs(2), receiver.recv())
+        .await
+        .expect("first response timed out")
+        .expect("first response");
+    let first: Value = serde_json::from_str(first.trim()).expect("first response json");
+    assert_eq!(first["result"]["generation"], json!(1));
+
+    unbound_rx.await.expect("first daemon should unlink socket");
+    sender.send(request(2)).expect("send second request");
+    let second = tokio::time::timeout(std::time::Duration::from_secs(2), receiver.recv())
+        .await
+        .expect("second response timed out")
+        .expect("second response");
+    let second: Value = serde_json::from_str(second.trim()).expect("second response json");
+    assert_eq!(second["result"]["generation"], json!(2));
+
+    drop(sender);
+    await_test_task(proxy, "long-lived proxy task")
+        .await
+        .expect("proxy transport");
+    await_test_task(daemon, "daemon rebind task").await;
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -340,6 +340,64 @@ async fn initialize_root_routing_replaces_cached_project_and_scope() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn initialize_root_routing_delegates_config_gated_git_auto_init() {
+    let profile = TempDir::new().expect("profile temp dir");
+    let fallback = TempDir::new().expect("fallback temp dir");
+    let project = TempDir::new().expect("git project temp dir");
+    let git_status = std::process::Command::new(crate::git::git_program())
+        .args(["init", "-q"])
+        .current_dir(project.path())
+        .status()
+        .expect("git init");
+    assert!(git_status.success(), "git init should succeed");
+    let project = project
+        .path()
+        .canonicalize()
+        .expect("canonical git project");
+
+    let mut base_handshake = test_handshake_defaults();
+    base_handshake.project_path = Some(fallback.path().to_path_buf());
+    base_handshake.allow_initialize_root_routing = true;
+    base_handshake.client_identity = test_client_identity_for(profile.path().to_path_buf());
+    let line = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "roots": [{
+                "uri": format!("file://{}", project.display()),
+                "name": "unindexed-git-project"
+            }]
+        }
+    })
+    .to_string();
+
+    let mut routed_handshake = base_handshake.clone();
+    super::update_proxy_handshake_from_initialize(&base_handshake, &mut routed_handshake, &line)
+        .await;
+    assert_eq!(
+        routed_handshake.project_path.as_deref(),
+        Some(project.as_path())
+    );
+    assert!(routed_handshake.allow_init);
+
+    let mut config = crate::config::TraceDecayConfig {
+        root_dir: project.display().to_string(),
+        ..crate::config::TraceDecayConfig::default()
+    };
+    config.sync.auto_init = false;
+    crate::config::save_config(&project, &config).expect("disable auto-init");
+    super::update_proxy_handshake_from_initialize(&base_handshake, &mut routed_handshake, &line)
+        .await;
+    assert_eq!(
+        routed_handshake.project_path.as_deref(),
+        Some(project.as_path())
+    );
+    assert!(!routed_handshake.allow_init);
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn serve_proxies_when_socket_already_exists() {
     let dir = TempDir::new().expect("temp dir");
     let socket = dir.path().join("daemon.sock");
@@ -898,6 +956,30 @@ fn daemon_handshake_advertises_binary_version() {
         value["client_version"],
         serde_json::json!(env!("CARGO_PKG_VERSION"))
     );
+}
+
+#[test]
+fn missing_index_classifier_covers_every_auto_init_store_miss() {
+    let missing_messages = [
+        "no TraceDecay index found at '/repo'",
+        "no TraceDecay database found at '/repo/store.db'",
+        "parent DB not found at '/repo/branches/main.db'",
+        "parent branch 'main' has no DB",
+    ];
+    for message in missing_messages {
+        let error = crate::errors::TraceDecayError::Config {
+            message: message.to_string(),
+        };
+        assert!(
+            super::is_missing_index_error(&error),
+            "intentional missing-store state should permit config-gated auto-init: {message}"
+        );
+    }
+
+    let unrelated = crate::errors::TraceDecayError::Config {
+        message: "identity cutover conflict".to_string(),
+    };
+    assert!(!super::is_missing_index_error(&unrelated));
 }
 
 #[cfg(unix)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -204,7 +204,7 @@ pub(crate) async fn resolve_initialize_roots_project_path(
     None
 }
 
-fn initialize_root_paths(params: Option<&Value>) -> Vec<PathBuf> {
+pub(crate) fn initialize_root_paths(params: Option<&Value>) -> Vec<PathBuf> {
     params
         .and_then(|p| p.get("roots"))
         .and_then(Value::as_array)

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -434,13 +434,19 @@ fn hex_value(byte: u8) -> Option<u8> {
 // Serve startup orchestration
 // ---------------------------------------------------------------------------
 
-/// Runs the `serve` command end to end: resolve the project (degrading
-/// instead of exiting when resolution fails — see
-/// [`ServeProjectResolver::resolve_once`] and [`run_degraded_mcp_server`]),
-/// then serve MCP over stdio, proxying to the daemon when one owns the
-/// socket.
+/// Runs the `serve` command end to end. When the daemon owns its socket,
+/// choose the proxy transport before opening any project database; otherwise
+/// resolve the project locally (degrading instead of exiting when resolution
+/// fails — see [`ServeProjectResolver::resolve_once`] and
+/// [`run_degraded_mcp_server`]).
 pub async fn run_serve(path_arg: Option<String>, timings: bool) -> Result<()> {
     let original_cwd = std::env::current_dir().ok();
+    let socket_path = crate::daemon::default_socket_path()?;
+    if crate::daemon::should_proxy_serve_to_daemon(&socket_path).await {
+        let handshake = proxy_serve_handshake(path_arg, original_cwd.as_deref(), timings)?;
+        return crate::daemon::proxy_stdio_to_daemon(&socket_path, &handshake, None).await;
+    }
+
     let (resolver, error, peeked_line) = match Box::pin(resolve_serve_startup(path_arg)).await {
         ServeStartup::Ready {
             cg,
@@ -488,6 +494,47 @@ pub async fn run_serve(path_arg: Option<String>, timings: bool) -> Result<()> {
     }
 }
 
+/// Builds daemon routing metadata without opening a project or global
+/// database. A running daemon is the sole database owner for this serve
+/// process; it performs the open (and the same config-gated git auto-init)
+/// after receiving the handshake.
+fn proxy_serve_handshake(
+    path_arg: Option<String>,
+    original_cwd: Option<&Path>,
+    timings: bool,
+) -> Result<crate::daemon::DaemonHandshake> {
+    let path = sanitize_serve_path_arg(path_arg);
+    let explicit_path = path.is_some();
+    let mut project_path = if explicit_path {
+        crate::config::resolve_path(path)
+    } else {
+        crate::config::resolve_path_with_discovery(None)
+    };
+
+    let initialized = TraceDecay::is_initialized(&project_path);
+    let auto_init_root = (!initialized && crate::config::load_sync_config(&project_path).auto_init)
+        .then(|| crate::worktree::git_worktree_root(&project_path))
+        .flatten();
+    if let Some(root) = auto_init_root.as_ref() {
+        project_path.clone_from(root);
+    }
+
+    let scope_prefix = serve_scope_prefix(original_cwd, &project_path);
+    let telemetry_timings = timings || crate::config::load_telemetry_config(&project_path).timings;
+    let mut handshake = crate::daemon::DaemonHandshake::for_current_client(
+        Some(project_path),
+        scope_prefix,
+        telemetry_timings,
+        auto_init_root.is_some(),
+    )?;
+    // An explicit path remains authoritative. Discovery-mode clients may use
+    // initialize roots only when cwd neither resolved nor can be auto-inited,
+    // matching the local resolver's fallback order.
+    handshake.allow_initialize_root_routing =
+        !explicit_path && !initialized && auto_init_root.is_none();
+    Ok(handshake)
+}
+
 /// Serves a startup-resolved project: proxy to the daemon when one owns the
 /// socket, otherwise run the in-process MCP engine.
 async fn serve_resolved_project(
@@ -509,6 +556,9 @@ async fn serve_resolved_project(
     handshake.allow_initialize_root_routing = allow_initialize_root_routing;
     let socket_path = crate::daemon::default_socket_path()?;
     if crate::daemon::should_proxy_serve_to_daemon(&socket_path).await {
+        // The daemon may have appeared while local resolution was in flight.
+        // Never retain those local DB handles for the lifetime of the proxy.
+        drop(cg);
         crate::daemon::proxy_stdio_to_daemon(&socket_path, &handshake, peeked_line).await
     } else {
         let server = crate::mcp::McpServer::new(cg, handshake.scope_prefix.clone()).await;

--- a/tests/mcp_suite/mcp_cli_serve_test.rs
+++ b/tests/mcp_suite/mcp_cli_serve_test.rs
@@ -496,6 +496,135 @@ async fn serve_stdio_smokes_automation_run_artifact_view() {
     );
 }
 
+/// A reachable daemon must win before serve opens either local database. The
+/// intentionally uninitialized explicit path also proves that proxy startup
+/// preserves authoritative path routing without invoking local resolution.
+#[cfg(unix)]
+#[tokio::test]
+async fn serve_with_reachable_daemon_proxies_before_opening_explicit_project() {
+    use std::io::{BufRead, BufReader, Read};
+    use std::os::unix::net::UnixListener;
+    use std::time::{Duration, Instant};
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let socket_path = common::daemon_socket_path(home.path());
+    fs::create_dir_all(socket_path.parent().unwrap()).unwrap();
+    let listener = UnixListener::bind(&socket_path).expect("bind fake daemon socket");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking fake daemon listener");
+
+    let fake_daemon = std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if Instant::now() >= deadline {
+                return None;
+            }
+            let mut stream = match listener.accept() {
+                Ok((stream, _addr)) => stream,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Err(error) => panic!("accept serve connection: {error}"),
+            };
+            stream
+                .set_nonblocking(false)
+                .expect("blocking fake daemon stream");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone fake daemon stream"));
+            let mut handshake_line = String::new();
+            reader
+                .read_line(&mut handshake_line)
+                .expect("read daemon handshake");
+            let handshake: Value =
+                serde_json::from_str(handshake_line.trim()).expect("daemon handshake json");
+            let mut request_line = String::new();
+            reader
+                .read_line(&mut request_line)
+                .expect("read proxied request");
+            let request: Value =
+                serde_json::from_str(request_line.trim()).expect("proxied request json");
+            let response = json!({
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": { "tools": {} },
+                    "serverInfo": {
+                        "name": "sentinel-proxy-first-daemon",
+                        "version": env!("CARGO_PKG_VERSION")
+                    }
+                }
+            });
+            writeln!(stream, "{response}").expect("write fake daemon response");
+            let mut scratch = [0_u8; 64];
+            while matches!(reader.read(&mut scratch), Ok(n) if n > 0) {}
+            return Some(handshake);
+        }
+    });
+
+    let mut child = tracedecay_command_with_home(home.path())
+        .arg("serve")
+        .arg("--path")
+        .arg(project.path())
+        .env("TRACEDECAY_DAEMON_SOCKET", &socket_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("tracedecay serve should run");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin should be piped");
+        writeln!(
+            stdin,
+            "{}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            })
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+
+    let output = child
+        .wait_with_output()
+        .expect("tracedecay serve should exit after stdin closes");
+    let handshake = fake_daemon
+        .join()
+        .expect("fake daemon thread should exit")
+        .expect("serve should connect to the daemon before project resolution");
+
+    assert!(
+        output.status.success(),
+        "proxy-first serve failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: Value = serde_json::from_slice(&output.stdout).expect("initialize response json");
+    assert_eq!(
+        response["result"]["serverInfo"]["name"],
+        json!("sentinel-proxy-first-daemon")
+    );
+    assert_eq!(
+        handshake["project_path"],
+        json!(project.path().display().to_string()),
+        "an explicit path must remain authoritative"
+    );
+    assert_eq!(handshake["allow_initialize_root_routing"], json!(false));
+    assert!(
+        !home.path().join(".tracedecay/global.db").exists(),
+        "the stdio proxy must not open the global database"
+    );
+    assert!(
+        !project.path().join(".tracedecay").exists(),
+        "the stdio proxy must not open or initialize the project"
+    );
+}
+
 /// Regression test for the serve/daemon-restart race: a serve process started
 /// while `tracedecay update` is restarting the daemon sees no socket file, but
 /// must not silently commit to in-process mode when an installed service is


### PR DESCRIPTION
## Summary
- choose the managed-daemon proxy before `tracedecay serve` resolves or opens project/global stores
- delegate config-gated git auto-init to the daemon and drop late-race local handles before proxying
- keep one daemon connection per request, so a long-lived stdio MCP process reconnects across socket/PID replacement without replaying requests after a write
- fix the Unix-only daemon drain test import that broke Windows test compilation

## Compatibility
No old tool-schema fallback is added. Existing stdio MCP processes can reconnect for already-known calls; hosts must start a new MCP session to refresh a cached `tools/list` after tool-schema changes.

## Tests
- `cargo test --lib daemon::tests::long_lived_proxy_reconnects_after_daemon_socket_rebind -- --exact`
- `cargo test --test mcp_suite mcp_cli_serve_test::serve_with_reachable_daemon_proxies_before_opening_explicit_project -- --exact`
- restart-window, initialize-root routing, and disconnect regression tests
- `cargo check --tests --target x86_64-pc-windows-gnu`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
