### PR TITLE
feat(mcp): refresh tools after daemon generation change

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,11 +22,17 @@ use tokio::time::{Duration, timeout};
 use crate::client_identity::DaemonClientIdentity;
 use crate::errors::{Result, TraceDecayError};
 #[cfg(unix)]
-use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, StdioTransport};
+use crate::mcp::{
+    ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, ReplayTransport, StdioTransport,
+};
 
 pub const SERVICE_NAME: &str = "tracedecay.service";
 pub const SOCKET_ENV: &str = "TRACEDECAY_DAEMON_SOCKET";
 pub const HOOK_EVENT_METHOD: &str = "tracedecay/hookEvent";
+#[cfg(unix)]
+const TOOL_LIST_CHANGED_METHOD: &str = "notifications/tools/list_changed";
+#[cfg(unix)]
+const MAX_CATALOG_REFRESH_CLIENTS_PER_GENERATION: usize = 1_024;
 #[cfg(unix)]
 const HOOK_EVENT_NOTIFY_TIMEOUT: Duration = Duration::from_millis(750);
 /// Upper bound on graceful-shutdown persistence work (per-server token
@@ -289,6 +295,21 @@ pub struct DaemonHandshake {
     /// `tracedecay update` replaced the binary.
     #[serde(default)]
     pub client_version: String,
+    /// Stable id for the connecting client process. A stdio MCP proxy reuses
+    /// this across its per-request daemon connections, allowing one
+    /// generation-local catalog refresh notification instead of one per
+    /// request. Old clients omit it and deserialize to an empty string.
+    #[serde(default)]
+    pub client_instance_id: String,
+    /// Whether this proxy already forwarded an initialize response declaring
+    /// `tools.listChanged=true` to its MCP host.
+    #[serde(default)]
+    pub tool_list_changed_capable: bool,
+    /// Daemon version whose initialize response established the host's
+    /// current tool catalog. A nonempty value proves explicit negotiation;
+    /// generation-local daemon state decides whether a refresh is due.
+    #[serde(default)]
+    pub catalog_version: String,
 }
 
 impl DaemonHandshake {
@@ -306,6 +327,9 @@ impl DaemonHandshake {
             allow_initialize_root_routing: false,
             client_identity: DaemonClientIdentity::current()?,
             client_version: binary_version().to_string(),
+            client_instance_id: crate::runtime_identity::process_run_id().to_string(),
+            tool_list_changed_capable: false,
+            catalog_version: String::new(),
         })
     }
 
@@ -341,6 +365,38 @@ fn client_version_skew(client_version: &str, daemon_version: &str) -> Option<Str
         return None;
     }
     Some(client_version.to_string())
+}
+
+#[cfg(unix)]
+fn release_version(version: &str) -> Option<(u64, u64, u64)> {
+    let core = version
+        .strip_prefix('v')
+        .unwrap_or(version)
+        .split(['-', '+'])
+        .next()?;
+    let mut parts = core.split('.');
+    let version = (
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+    );
+    parts.next().is_none().then_some(version)
+}
+
+#[cfg(unix)]
+fn version_skew_action(daemon_version: &str, client_version: &str) -> &'static str {
+    match release_version(daemon_version)
+        .zip(release_version(client_version))
+        .map(|(daemon, client)| daemon.cmp(&client))
+    {
+        Some(std::cmp::Ordering::Greater) => {
+            "restart or reconnect the MCP host so it loads the current TraceDecay client and tool catalog"
+        }
+        Some(std::cmp::Ordering::Less) => {
+            "run `tracedecay daemon restart` to load the current daemon binary"
+        }
+        _ => "restart or reconnect whichever TraceDecay component is stale",
+    }
 }
 
 #[cfg(unix)]
@@ -1041,14 +1097,39 @@ pub async fn proxy_transport_to_daemon(
     let mut routed_handshake = handshake.clone();
     if let Some(line) = replay_line {
         update_proxy_handshake_from_initialize(handshake, &mut routed_handshake, &line).await;
-        proxy_request_line_to_daemon(socket_path, &routed_handshake, &line, transport).await?;
+        let metadata =
+            proxy_request_line_to_daemon(socket_path, &routed_handshake, &line, transport).await?;
+        apply_proxy_initialize_metadata(&mut routed_handshake, metadata);
     }
 
     while let Some(line) = transport.read_line().await? {
         update_proxy_handshake_from_initialize(handshake, &mut routed_handshake, &line).await;
-        proxy_request_line_to_daemon(socket_path, &routed_handshake, &line, transport).await?;
+        let metadata =
+            proxy_request_line_to_daemon(socket_path, &routed_handshake, &line, transport).await?;
+        apply_proxy_initialize_metadata(&mut routed_handshake, metadata);
     }
     Ok(())
+}
+
+#[cfg(unix)]
+#[derive(Default)]
+struct ProxyInitializeMetadata {
+    daemon_version: Option<String>,
+    tool_list_changed: bool,
+}
+
+#[cfg(unix)]
+fn apply_proxy_initialize_metadata(
+    handshake: &mut DaemonHandshake,
+    metadata: ProxyInitializeMetadata,
+) {
+    if !metadata.tool_list_changed {
+        return;
+    }
+    handshake.tool_list_changed_capable = true;
+    if let Some(version) = metadata.daemon_version {
+        handshake.catalog_version = version;
+    }
 }
 
 #[cfg(unix)]
@@ -1110,13 +1191,14 @@ async fn proxy_request_line_to_daemon(
     handshake: &DaemonHandshake,
     line: &str,
     transport: &mut impl McpTransport,
-) -> Result<()> {
+) -> Result<ProxyInitializeMetadata> {
     if line.trim().is_empty() {
-        return Ok(());
+        return Ok(ProxyInitializeMetadata::default());
     }
 
     match send_daemon_request_line(socket_path, handshake, line).await {
         Ok(responses) => {
+            let metadata = proxy_initialize_metadata(line, &responses);
             if let Some(warning) = daemon_version_skew_warning(line, &responses, binary_version()) {
                 eprintln!("[tracedecay] warning: {warning}");
             }
@@ -1127,6 +1209,7 @@ async fn proxy_request_line_to_daemon(
                 }
             }
             transport.flush().await?;
+            Ok(metadata)
         }
         Err(err) => {
             if let Some(response) = daemon_proxy_error_response(line, &err) {
@@ -1143,9 +1226,9 @@ async fn proxy_request_line_to_daemon(
                     ],
                 );
             }
+            Ok(ProxyInitializeMetadata::default())
         }
     }
-    Ok(())
 }
 
 #[cfg(unix)]
@@ -1206,21 +1289,38 @@ async fn send_daemon_request_line(
 /// freshly-updated client can still detect a stale daemon left running by a
 /// non-systemd setup or a plain `tracedecay upgrade`.
 #[cfg(unix)]
+fn proxy_initialize_metadata(request_line: &str, responses: &[String]) -> ProxyInitializeMetadata {
+    let Ok(request) = serde_json::from_str::<JsonRpcRequest>(request_line) else {
+        return ProxyInitializeMetadata::default();
+    };
+    if request.method != "initialize" {
+        return ProxyInitializeMetadata::default();
+    }
+    let mut metadata = ProxyInitializeMetadata::default();
+    for line in responses {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if metadata.daemon_version.is_none() {
+            metadata.daemon_version = value
+                .pointer("/result/serverInfo/version")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+        }
+        metadata.tool_list_changed |= value
+            .pointer("/result/capabilities/tools/listChanged")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+    }
+    metadata
+}
+
+#[cfg(unix)]
 fn daemon_version_from_initialize_response(
     request_line: &str,
     responses: &[String],
 ) -> Option<String> {
-    let request = serde_json::from_str::<JsonRpcRequest>(request_line).ok()?;
-    if request.method != "initialize" {
-        return None;
-    }
-    responses.iter().find_map(|line| {
-        serde_json::from_str::<serde_json::Value>(line)
-            .ok()?
-            .pointer("/result/serverInfo/version")?
-            .as_str()
-            .map(str::to_string)
-    })
+    proxy_initialize_metadata(request_line, responses).daemon_version
 }
 
 /// The warning to surface when the daemon behind an `initialize` response is
@@ -1235,9 +1335,10 @@ fn daemon_version_skew_warning(
     if daemon_version == client_version {
         return None;
     }
+    let action = version_skew_action(&daemon_version, client_version);
     Some(format!(
         "TraceDecay daemon is version {daemon_version} but this client is {client_version} — \
-         run `tracedecay daemon restart` to reload the daemon binary"
+         {action}"
     ))
 }
 
@@ -1526,6 +1627,12 @@ struct DaemonEngine {
     /// Client versions whose skew was already logged. Proxy clients reconnect
     /// per request, so without this the mismatch would flood the daemon log.
     logged_client_version_skews: Arc<tokio::sync::Mutex<HashSet<String>>>,
+    /// Client processes already told to refresh their tool catalog during
+    /// this daemon generation. The set is process-local by design: a daemon
+    /// restart creates a new generation and permits one fresh notification.
+    catalog_refresh_notified_clients: Arc<tokio::sync::Mutex<HashSet<CatalogRefreshClientKey>>>,
+    /// Prevents capacity exhaustion from flooding the daemon log.
+    catalog_refresh_saturation_logged: Arc<AtomicBool>,
     /// Git-metadata watcher (design D3/D5). Default-constructed inert; the real
     /// config-driven watcher is installed by `run_foreground_unix` via
     /// [`DaemonEngine::with_git_watcher`] before the accept loop starts.
@@ -1540,6 +1647,35 @@ struct ProjectServerKey {
     project_path: PathBuf,
     scope_prefix: Option<String>,
     client_identity: DaemonClientIdentity,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CatalogRefreshClientKey {
+    client_identity: DaemonClientIdentity,
+    client_instance_id: String,
+}
+
+#[cfg(unix)]
+impl CatalogRefreshClientKey {
+    fn from_handshake(handshake: &DaemonHandshake) -> Self {
+        Self {
+            client_identity: handshake.client_identity.clone(),
+            client_instance_id: handshake.client_instance_id.clone(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn valid_client_instance_id(client_instance_id: &str) -> bool {
+    let bytes = client_instance_id.as_bytes();
+    (bytes.len() == 32
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte)))
+        || client_instance_id.strip_prefix("mcp-").is_some_and(|tail| {
+            !tail.is_empty() && tail.len() <= 20 && tail.bytes().all(|byte| byte.is_ascii_digit())
+        })
 }
 
 #[cfg(unix)]
@@ -1581,19 +1717,78 @@ impl DaemonEngine {
         let Some(client_version) = self.client_version_skew_to_log(handshake).await else {
             return;
         };
+        let hint = version_skew_action(binary_version(), &client_version).to_string();
         log_daemon_event(
             "daemon_version_skew",
             &[
                 ("daemon_version", binary_version().to_string()),
                 ("client_version", client_version),
-                (
-                    "hint",
-                    "daemon binary differs from the connecting client; \
-                     run `tracedecay daemon restart` to reload it"
-                        .to_string(),
-                ),
+                ("hint", hint),
             ],
         );
+    }
+
+    /// Claims the one catalog-refresh notification for this client in the
+    /// current daemon generation. Only proxies that already advertised the
+    /// capability are eligible. `initialize` and `tools/list` mark the client
+    /// current without emitting because those requests already fetch the new
+    /// generation's catalog.
+    async fn claim_catalog_refresh(
+        &self,
+        handshake: &DaemonHandshake,
+        request_line: &str,
+    ) -> Option<CatalogRefreshClientKey> {
+        if !valid_client_instance_id(&handshake.client_instance_id) {
+            return None;
+        }
+        let request = serde_json::from_str::<JsonRpcRequest>(request_line).ok()?;
+        if request.method == HOOK_EVENT_METHOD {
+            return None;
+        }
+        let catalog_is_current = matches!(request.method.as_str(), "initialize" | "tools/list");
+        if !catalog_is_current
+            && (!handshake.tool_list_changed_capable || handshake.catalog_version.is_empty())
+        {
+            return None;
+        }
+        let key = CatalogRefreshClientKey::from_handshake(handshake);
+        let mut notified_clients = self.catalog_refresh_notified_clients.lock().await;
+        if notified_clients.contains(&key) {
+            return None;
+        }
+        if notified_clients.len() >= MAX_CATALOG_REFRESH_CLIENTS_PER_GENERATION {
+            drop(notified_clients);
+            if !self
+                .catalog_refresh_saturation_logged
+                .swap(true, Ordering::Relaxed)
+            {
+                log_daemon_event(
+                    "catalog_refresh",
+                    &[
+                        ("outcome", "skipped".to_string()),
+                        ("reason", "client_capacity_reached".to_string()),
+                        (
+                            "capacity",
+                            MAX_CATALOG_REFRESH_CLIENTS_PER_GENERATION.to_string(),
+                        ),
+                    ],
+                );
+            }
+            return None;
+        }
+        notified_clients.insert(key.clone());
+        drop(notified_clients);
+        if catalog_is_current {
+            return None;
+        }
+        Some(key)
+    }
+
+    async fn release_catalog_refresh(&self, key: CatalogRefreshClientKey) {
+        self.catalog_refresh_notified_clients
+            .lock()
+            .await
+            .remove(&key);
     }
 
     async fn project_server(
@@ -2342,6 +2537,28 @@ async fn serve_socket_client(stream: tokio::net::UnixStream, engine: DaemonEngin
         return Ok(());
     }
 
+    // The stdio proxy creates one daemon connection per request. Peek exactly
+    // that request so this daemon generation can emit one catalog refresh for
+    // a skewed long-lived client, then replay it into the normal MCP server.
+    let first_request_line = tokio::select! {
+        result = transport.read_line() => result?,
+        () = engine.lifecycle.wait_for_draining() => return Ok(()),
+    };
+    let Some(first_request_line) = first_request_line else {
+        return Ok(());
+    };
+    if let Some(key) = engine
+        .claim_catalog_refresh(&handshake, &first_request_line)
+        .await
+    {
+        if let Err(error) = write_tool_list_changed_notification(&mut transport).await {
+            engine.release_catalog_refresh(key).await;
+            return Err(error);
+        }
+    }
+    let mut transport = ReplayTransport::new(transport);
+    transport.push_replay(first_request_line);
+
     if let Some(server) = server {
         Box::pin(server.run_daemon_connection_with_timings(
             &mut transport,
@@ -2357,6 +2574,19 @@ async fn serve_socket_client(stream: tokio::net::UnixStream, engine: DaemonEngin
         )
         .await?;
     }
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn write_tool_list_changed_notification(transport: &mut impl McpTransport) -> Result<()> {
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": TOOL_LIST_CHANGED_METHOD,
+    });
+    transport
+        .write_line(&format!("{}\n", serde_json::to_string(&notification)?))
+        .await?;
+    transport.flush().await?;
     Ok(())
 }
 
@@ -2481,7 +2711,7 @@ async fn read_json_rpc_request_id(
 
 #[cfg(unix)]
 async fn write_json_rpc_response(
-    transport: &mut UnixStreamTransport,
+    transport: &mut impl McpTransport,
     response: &crate::mcp::JsonRpcResponse,
 ) -> Result<()> {
     transport
@@ -2494,7 +2724,7 @@ async fn write_json_rpc_response(
 
 #[cfg(unix)]
 async fn serve_projectless_client(
-    transport: &mut UnixStreamTransport,
+    transport: &mut impl McpTransport,
     client_identity: &DaemonClientIdentity,
     lifecycle: &DaemonLifecycle,
 ) -> Result<()> {
@@ -2539,7 +2769,9 @@ async fn projectless_response(
             json!({
                 "protocolVersion": "2024-11-05",
                 "capabilities": {
-                    "tools": {}
+                    "tools": {
+                        "listChanged": true
+                    }
                 },
                 "serverInfo": {
                     "name": "tracedecay",

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -110,7 +110,15 @@ fn test_handshake_defaults() -> DaemonHandshake {
         allow_initialize_root_routing: false,
         client_identity: test_client_identity(),
         client_version: super::binary_version().to_string(),
+        client_instance_id: crate::runtime_identity::process_run_id().to_string(),
+        tool_list_changed_capable: false,
+        catalog_version: String::new(),
     }
+}
+
+#[cfg(unix)]
+fn test_client_instance_id(value: u128) -> String {
+    format!("{value:032x}")
 }
 
 #[cfg(unix)]
@@ -153,6 +161,50 @@ async fn answer_one_proxy_request(listener: tokio::net::UnixListener, generation
         .expect("write response");
     writer.write_all(b"\n").await.expect("write newline");
     writer.shutdown().await.expect("shutdown fake daemon");
+}
+
+#[cfg(unix)]
+async fn daemon_round_trip(
+    engine: super::DaemonEngine,
+    handshake: &DaemonHandshake,
+    request: Value,
+) -> Vec<Value> {
+    let (server_stream, client_stream) =
+        tokio::net::UnixStream::pair().expect("daemon socket pair");
+    let server =
+        tokio::spawn(async move { super::serve_socket_client(server_stream, engine).await });
+    let (reader, mut writer) = client_stream.into_split();
+    writer
+        .write_all(handshake.to_line().expect("handshake json").as_bytes())
+        .await
+        .expect("write handshake");
+    writer.write_all(b"\n").await.expect("write newline");
+    writer
+        .write_all(request.to_string().as_bytes())
+        .await
+        .expect("write request");
+    writer.write_all(b"\n").await.expect("write newline");
+    writer.shutdown().await.expect("shutdown daemon client");
+    drop(writer);
+
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    let read_responses = async {
+        let mut responses = Vec::new();
+        while let Some(line) = lines.next_line().await.expect("read daemon response") {
+            responses.push(serde_json::from_str(&line).expect("daemon response json"));
+        }
+        responses
+    };
+    let (server_result, responses) =
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            tokio::join!(server, read_responses)
+        })
+        .await
+        .expect("daemon request and response stream should finish");
+    server_result
+        .expect("daemon socket client task")
+        .expect("serve daemon socket client");
+    responses
 }
 
 #[test]
@@ -906,8 +958,8 @@ fn daemon_handshake_requires_client_identity() {
     assert!(DaemonHandshake::from_line(&encoded).is_err());
 }
 
-/// Old client → new daemon: handshakes without `client_version` (sent by
-/// binaries predating the field) must still parse, with an empty version.
+/// Old client → new daemon: handshakes without version/instance fields must
+/// still parse, with empty defaults.
 #[test]
 fn daemon_handshake_accepts_old_client_without_version() {
     let encoded = serde_json::json!({
@@ -925,6 +977,9 @@ fn daemon_handshake_accepts_old_client_without_version() {
     let decoded = DaemonHandshake::from_line(&encoded).expect("old handshake should decode");
 
     assert_eq!(decoded.client_version, "");
+    assert_eq!(decoded.client_instance_id, "");
+    assert!(!decoded.tool_list_changed_capable);
+    assert_eq!(decoded.catalog_version, "");
 }
 
 /// New client → old daemon: the serde derive ignores unknown fields, so a
@@ -955,6 +1010,10 @@ fn daemon_handshake_advertises_binary_version() {
     assert_eq!(
         value["client_version"],
         serde_json::json!(env!("CARGO_PKG_VERSION"))
+    );
+    assert_eq!(
+        value["client_instance_id"],
+        serde_json::json!(crate::runtime_identity::process_run_id())
     );
 }
 
@@ -1020,6 +1079,229 @@ async fn daemon_engine_logs_version_skew_once_per_client_version() {
 }
 
 #[cfg(unix)]
+#[tokio::test]
+async fn catalog_refresh_claim_is_negotiated_and_once_per_generation() {
+    let engine = super::DaemonEngine::default();
+    let mut handshake = test_handshake_defaults();
+    handshake.client_version = "0.0.0-old".to_string();
+    handshake.catalog_version = "0.0.0-old".to_string();
+    let ping = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"}).to_string();
+
+    handshake.client_instance_id.clear();
+    handshake.tool_list_changed_capable = true;
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none()
+    );
+
+    handshake.client_instance_id = test_client_instance_id(2);
+    handshake.tool_list_changed_capable = false;
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none()
+    );
+
+    handshake.tool_list_changed_capable = true;
+    handshake.catalog_version.clear();
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none(),
+        "catalog refresh requires an explicitly negotiated catalog version"
+    );
+    handshake.tool_list_changed_capable = false;
+    let initialize = json!({"jsonrpc": "2.0", "id": 2, "method": "initialize"}).to_string();
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &initialize)
+            .await
+            .is_none(),
+        "fresh initialize marks the generation current without notifying"
+    );
+    handshake.tool_list_changed_capable = true;
+    handshake.catalog_version = super::binary_version().to_string();
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none(),
+        "the initialized client must not get a redundant refresh"
+    );
+
+    handshake.client_instance_id = test_client_instance_id(3);
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_some()
+    );
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none()
+    );
+
+    let next_generation = super::DaemonEngine::default();
+    assert!(
+        next_generation
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_some(),
+        "a new daemon generation must notify the same long-lived client once"
+    );
+
+    handshake.catalog_version = super::binary_version().to_string();
+    let same_version_generation = super::DaemonEngine::default();
+    assert!(
+        same_version_generation
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_some(),
+        "generation identity, not a reused package version, controls refresh"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn catalog_refresh_rejects_untrusted_ids_and_stops_at_capacity() {
+    let engine = super::DaemonEngine::default();
+    let mut handshake = test_handshake_defaults();
+    handshake.tool_list_changed_capable = true;
+    handshake.catalog_version = "0.0.0-old".to_string();
+    let ping = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"}).to_string();
+
+    assert!(super::valid_client_instance_id(&test_client_instance_id(0)));
+    assert!(super::valid_client_instance_id("mcp-1234567890"));
+    for invalid_id in [
+        "A".repeat(32),
+        "x".repeat(4_096),
+        "mcp-".to_string(),
+        "mcp-not-a-timestamp".to_string(),
+    ] {
+        handshake.client_instance_id = invalid_id;
+        assert!(
+            engine
+                .claim_catalog_refresh(&handshake, &ping)
+                .await
+                .is_none()
+        );
+    }
+    assert!(
+        engine
+            .catalog_refresh_notified_clients
+            .lock()
+            .await
+            .is_empty()
+    );
+
+    for value in 0..super::MAX_CATALOG_REFRESH_CLIENTS_PER_GENERATION {
+        handshake.client_instance_id = test_client_instance_id(value as u128);
+        assert!(
+            engine
+                .claim_catalog_refresh(&handshake, &ping)
+                .await
+                .is_some()
+        );
+    }
+    handshake.client_instance_id =
+        test_client_instance_id(super::MAX_CATALOG_REFRESH_CLIENTS_PER_GENERATION as u128);
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none(),
+        "capacity saturation must skip rather than evicting an existing client"
+    );
+    assert_eq!(
+        engine.catalog_refresh_notified_clients.lock().await.len(),
+        super::MAX_CATALOG_REFRESH_CLIENTS_PER_GENERATION
+    );
+    handshake.client_instance_id = test_client_instance_id(0);
+    assert!(
+        engine
+            .claim_catalog_refresh(&handshake, &ping)
+            .await
+            .is_none(),
+        "saturation must preserve existing dedupe entries"
+    );
+    assert!(
+        engine
+            .catalog_refresh_saturation_logged
+            .load(std::sync::atomic::Ordering::Relaxed)
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn daemon_refreshes_once_only_after_generation_change() {
+    let mut handshake = test_handshake_defaults();
+    handshake.client_instance_id = test_client_instance_id(4);
+    let engine = super::DaemonEngine::default();
+
+    let initialize = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"});
+    let initialize_responses =
+        daemon_round_trip(engine.clone(), &handshake, initialize.clone()).await;
+    assert_eq!(initialize_responses.len(), 1);
+    let initialize_response_lines: Vec<String> = initialize_responses
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect();
+    let metadata =
+        super::proxy_initialize_metadata(&initialize.to_string(), &initialize_response_lines);
+    super::apply_proxy_initialize_metadata(&mut handshake, metadata);
+    assert!(handshake.tool_list_changed_capable);
+    assert_eq!(handshake.catalog_version, super::binary_version());
+
+    let same_generation = daemon_round_trip(
+        engine,
+        &handshake,
+        json!({"jsonrpc": "2.0", "id": 2, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(
+        same_generation.len(),
+        1,
+        "initialize already returned this generation's catalog"
+    );
+    assert_eq!(same_generation[0]["id"], json!(2));
+
+    let next_generation = super::DaemonEngine::default();
+    let first = daemon_round_trip(
+        next_generation.clone(),
+        &handshake,
+        json!({"jsonrpc": "2.0", "id": 3, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(
+        first.len(),
+        2,
+        "notification must precede the ping response"
+    );
+    assert_eq!(first[0]["jsonrpc"], json!("2.0"));
+    assert_eq!(
+        first[0]["method"],
+        json!("notifications/tools/list_changed")
+    );
+    assert!(first[0].get("id").is_none());
+    assert_eq!(first[1]["id"], json!(3));
+
+    let second = daemon_round_trip(
+        next_generation,
+        &handshake,
+        json!({"jsonrpc": "2.0", "id": 4, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(second.len(), 1, "the refresh must not loop");
+    assert_eq!(second[0]["id"], json!(4));
+}
+
+#[cfg(unix)]
 #[test]
 fn daemon_version_skew_warning_reads_initialize_server_info() {
     let initialize = serde_json::json!({
@@ -1047,8 +1329,15 @@ fn daemon_version_skew_warning_reads_initialize_server_info() {
         "warning should name both versions, got: {warning}"
     );
     assert!(
+        warning.contains("MCP host") && !warning.contains("tracedecay daemon restart"),
+        "a newer daemon should direct recovery at the stale host, got: {warning}"
+    );
+
+    let warning = super::daemon_version_skew_warning(&initialize, &response("1.0.0"), "9.9.9")
+        .expect("newer client should warn about stale daemon");
+    assert!(
         warning.contains("tracedecay daemon restart"),
-        "warning should point at the restart command, got: {warning}"
+        "a newer client should direct recovery at the stale daemon, got: {warning}"
     );
 
     assert_eq!(
@@ -1069,6 +1358,52 @@ fn daemon_version_skew_warning_reads_initialize_server_info() {
         None,
         "only initialize responses advertise the daemon version"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn proxy_records_negotiated_catalog_capability_and_version() {
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    })
+    .to_string();
+    let responses = vec![
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "capabilities": {"tools": {"listChanged": true}},
+                "serverInfo": {"name": "tracedecay", "version": "2.0.0"}
+            }
+        })
+        .to_string(),
+    ];
+    let metadata = super::proxy_initialize_metadata(&initialize, &responses);
+    let mut handshake = test_handshake_defaults();
+    super::apply_proxy_initialize_metadata(&mut handshake, metadata);
+
+    assert!(handshake.tool_list_changed_capable);
+    assert_eq!(handshake.catalog_version, "2.0.0");
+
+    let legacy_responses = vec![
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "tracedecay", "version": "1.0.0"}
+            }
+        })
+        .to_string(),
+    ];
+    let metadata = super::proxy_initialize_metadata(&initialize, &legacy_responses);
+    let mut legacy = test_handshake_defaults();
+    super::apply_proxy_initialize_metadata(&mut legacy, metadata);
+    assert!(!legacy.tool_list_changed_capable);
+    assert!(legacy.catalog_version.is_empty());
 }
 
 #[cfg(unix)]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -100,7 +100,9 @@ pub(crate) fn initialize_result(instructions: &str) -> Value {
     json!({
         "protocolVersion": "2024-11-05",
         "capabilities": {
-            "tools": {},
+            "tools": {
+                "listChanged": true
+            },
             "resources": {},
             "logging": {}
         },

--- a/tests/mcp_suite/mcp_server_test.rs
+++ b/tests/mcp_suite/mcp_server_test.rs
@@ -157,6 +157,10 @@ async fn test_initialize() {
     assert_eq!(resp["id"], 1);
     assert!(resp["result"]["protocolVersion"].is_string());
     assert_eq!(resp["result"]["protocolVersion"], "2024-11-05");
+    assert_eq!(
+        resp["result"]["capabilities"]["tools"]["listChanged"],
+        json!(true)
+    );
     assert_eq!(resp["result"]["serverInfo"]["name"], "tracedecay");
     assert!(resp["result"]["serverInfo"]["version"].is_string());
 }


### PR DESCRIPTION
Summary:
- advertise MCP `tools.listChanged` support
- preserve negotiated capability and catalog generation across per-request daemon connections
- notify each long-lived client once per daemon generation, including same-version restarts
- reject malformed client instance IDs and cap generation-local dedupe state without eviction
- treat fresh `initialize` and `tools/list` requests as catalog-current
- leave legacy handshakes untouched and preserve request no-replay semantics
- direct version-skew recovery at the stale host or daemon

Tests:
- focused catalog claim, generation, socket ordering, proxy metadata, and adversarial-capacity tests
- MCP initialize capability and skew-direction tests
- formatting and diff checks