### PR TITLE
fix(analytics): aggregate sections before sampling

### DIFF
--- a/src/dashboard/analytics_api.rs
+++ b/src/dashboard/analytics_api.rs
@@ -14,7 +14,7 @@ use crate::analytics::{
     ToolUsageObservation, UsageKind, categorize_skill, infer_usage_events,
     underused_tool_family_signals,
 };
-use crate::global_db::{AnalyticsEventQuery, AnalyticsEventRecord, GlobalDb};
+use crate::global_db::{AnalyticsEventQuery, AnalyticsEventRecord, AnalyticsHintCounts, GlobalDb};
 
 use super::DashboardState;
 use super::util::{i64_field, query_i64, query_rows, str_field};
@@ -251,6 +251,37 @@ pub(crate) fn hint_summary_from_events(events: &[Value]) -> Value {
         }
     }
 
+    json!({
+        "available": true,
+        "source": "analytics_events",
+        "by_category": by_category.into_iter().map(|(category, counts)| {
+            json!({
+                "category": category,
+                "emitted": counts.emitted,
+                "followed": counts.followed,
+                "ignored": counts.ignored,
+                "suppressed": counts.suppressed,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+pub(crate) fn hint_summary_from_counts(counts: &[AnalyticsHintCounts]) -> Value {
+    let mut by_category: BTreeMap<String, HintCounts> = HINT_CATEGORIES
+        .iter()
+        .map(|category| ((*category).to_string(), HintCounts::default()))
+        .collect();
+    for row in counts {
+        by_category.insert(
+            row.category.clone(),
+            HintCounts {
+                emitted: row.emitted,
+                followed: row.followed,
+                ignored: row.ignored,
+                suppressed: row.suppressed,
+            },
+        );
+    }
     json!({
         "available": true,
         "source": "analytics_events",

--- a/src/global_db.rs
+++ b/src/global_db.rs
@@ -99,6 +99,22 @@ pub struct AnalyticsEventRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyticsToolCounts {
+    pub tool_name: String,
+    pub calls: i64,
+    pub errors: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyticsHintCounts {
+    pub category: String,
+    pub emitted: i64,
+    pub followed: i64,
+    pub ignored: i64,
+    pub suppressed: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionToolUsageRow {
     pub tool_names: String,
     pub text: String,
@@ -566,6 +582,26 @@ fn push_optional_analytics_filter(
         values.push(Value::Text(value.to_string()));
         clauses.push(format!("{column} = ?{}", values.len()));
     }
+}
+
+fn analytics_scope_query(
+    select: &str,
+    project_id: Option<&str>,
+    since: i64,
+    fixed_clauses: &[&str],
+) -> (String, Vec<Value>) {
+    let mut sql = select.to_string();
+    let mut clauses = fixed_clauses
+        .iter()
+        .map(|clause| (*clause).to_string())
+        .collect::<Vec<_>>();
+    let mut values = Vec::new();
+    push_optional_analytics_filter(&mut clauses, &mut values, "project_id", project_id);
+    values.push(Value::Integer(since));
+    clauses.push(format!("timestamp >= ?{}", values.len()));
+    sql.push_str(" WHERE ");
+    sql.push_str(&clauses.join(" AND "));
+    (sql, values)
 }
 
 fn row_to_code_project(row: &libsql::Row, offset: i32) -> Option<CodeProjectRecord> {
@@ -1076,6 +1112,10 @@ impl GlobalDb {
                 ON analytics_events(provider, project_id, session_id, timestamp);
             CREATE INDEX IF NOT EXISTS idx_analytics_events_kind
                 ON analytics_events(event_kind, timestamp);
+            CREATE INDEX IF NOT EXISTS idx_analytics_events_project_time
+                ON analytics_events(project_id, timestamp);
+            CREATE INDEX IF NOT EXISTS idx_analytics_events_timestamp
+                ON analytics_events(timestamp);
             CREATE TABLE IF NOT EXISTS sessions (
                 provider TEXT NOT NULL,
                 session_id TEXT NOT NULL,
@@ -2807,6 +2847,131 @@ impl GlobalDb {
         }
         events.reverse();
         Ok(events)
+    }
+
+    pub async fn count_analytics_events(
+        &self,
+        project_id: Option<&str>,
+        since: i64,
+    ) -> Result<i64, String> {
+        let (sql, values) = analytics_scope_query(
+            "SELECT COUNT(*) FROM analytics_events",
+            project_id,
+            since,
+            &[],
+        );
+        let mut rows = self
+            .conn
+            .query(&sql, libsql::params_from_iter(values))
+            .await
+            .map_err(|e| format!("failed to count analytics events: {e}"))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read analytics event count: {e}"))?
+        else {
+            return Ok(0);
+        };
+        row.get::<i64>(0)
+            .map_err(|e| format!("failed to decode analytics event count: {e}"))
+    }
+
+    pub async fn query_analytics_tool_counts(
+        &self,
+        project_id: Option<&str>,
+        since: i64,
+    ) -> Result<Vec<AnalyticsToolCounts>, String> {
+        let (mut sql, values) = analytics_scope_query(
+            "SELECT tool_name,
+                    COUNT(*) AS calls,
+                    SUM(CASE WHEN outcome = 'error' THEN 1 ELSE 0 END) AS errors
+             FROM analytics_events",
+            project_id,
+            since,
+            &[
+                "event_kind = 'mcp_tool_call'",
+                "tool_name IS NOT NULL",
+                "tool_name <> ''",
+            ],
+        );
+        sql.push_str(" GROUP BY tool_name ORDER BY calls DESC, tool_name");
+        let mut rows = self
+            .conn
+            .query(&sql, libsql::params_from_iter(values))
+            .await
+            .map_err(|e| format!("failed to query analytics tool counts: {e}"))?;
+        let mut counts = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read analytics tool counts: {e}"))?
+        {
+            counts.push(AnalyticsToolCounts {
+                tool_name: row
+                    .get::<String>(0)
+                    .map_err(|e| format!("failed to decode analytics tool name: {e}"))?,
+                calls: row
+                    .get::<i64>(1)
+                    .map_err(|e| format!("failed to decode analytics tool calls: {e}"))?,
+                errors: row
+                    .get::<i64>(2)
+                    .map_err(|e| format!("failed to decode analytics tool errors: {e}"))?,
+            });
+        }
+        Ok(counts)
+    }
+
+    pub async fn query_analytics_hint_counts(
+        &self,
+        project_id: Option<&str>,
+        since: i64,
+    ) -> Result<Vec<AnalyticsHintCounts>, String> {
+        let (mut sql, values) = analytics_scope_query(
+            "SELECT hint_category,
+                    SUM(CASE WHEN event_kind IN ('hint_emitted', 'hint_escalated', 'missing_session') THEN 1 ELSE 0 END) AS emitted,
+                    SUM(CASE WHEN event_kind = 'hint_outcome' AND LOWER(TRIM(COALESCE(outcome, ''))) = 'acted' THEN 1 ELSE 0 END) AS followed,
+                    SUM(CASE WHEN event_kind = 'hint_outcome' AND LOWER(TRIM(COALESCE(outcome, ''))) = 'ignored' THEN 1 ELSE 0 END) AS ignored,
+                    SUM(CASE WHEN event_kind LIKE 'suppressed_%' THEN 1 ELSE 0 END) AS suppressed
+             FROM analytics_events",
+            project_id,
+            since,
+            &[
+                "hint_category IS NOT NULL",
+                "hint_category <> ''",
+                "(event_kind IN ('hint_emitted', 'hint_escalated', 'missing_session', 'hint_outcome') OR event_kind LIKE 'suppressed_%')",
+            ],
+        );
+        sql.push_str(" GROUP BY hint_category ORDER BY hint_category");
+        let mut rows = self
+            .conn
+            .query(&sql, libsql::params_from_iter(values))
+            .await
+            .map_err(|e| format!("failed to query analytics hint counts: {e}"))?;
+        let mut counts = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| format!("failed to read analytics hint counts: {e}"))?
+        {
+            counts.push(AnalyticsHintCounts {
+                category: row
+                    .get::<String>(0)
+                    .map_err(|e| format!("failed to decode analytics hint category: {e}"))?,
+                emitted: row
+                    .get::<i64>(1)
+                    .map_err(|e| format!("failed to decode analytics emitted count: {e}"))?,
+                followed: row
+                    .get::<i64>(2)
+                    .map_err(|e| format!("failed to decode analytics followed count: {e}"))?,
+                ignored: row
+                    .get::<i64>(3)
+                    .map_err(|e| format!("failed to decode analytics ignored count: {e}"))?,
+                suppressed: row
+                    .get::<i64>(4)
+                    .map_err(|e| format!("failed to decode analytics suppressed count: {e}"))?,
+            });
+        }
+        Ok(counts)
     }
 
     pub async fn session_tool_usage_rows(

--- a/src/mcp/tools/handlers/analytics.rs
+++ b/src/mcp/tools/handlers/analytics.rs
@@ -4,9 +4,9 @@
 //! without querying `.tracedecay` databases directly. Reuses the same
 //! durable-analytics service functions the `tracedecay analytics
 //! diagnostics` CLI and dashboard analytics API use
-//! ([`crate::global_db::GlobalDb::query_analytics_events`],
-//! [`crate::dashboard::analytics_api::durable_analytics_event_row`],
-//! [`crate::dashboard::analytics_api::hint_summary_from_events`],
+//! ([`crate::global_db::GlobalDb::query_analytics_tool_counts`],
+//! [`crate::global_db::GlobalDb::query_analytics_hint_counts`],
+//! [`crate::dashboard::analytics_api::hint_summary_from_counts`],
 //! [`crate::automation::run_ledger::load_run_records`]) rather than
 //! re-implementing queries against those tables.
 
@@ -17,7 +17,7 @@ use serde_json::{Value, json};
 
 use crate::automation::run_ledger::load_run_records;
 use crate::errors::{Result, TraceDecayError};
-use crate::global_db::{AnalyticsEventQuery, AnalyticsEventRecord, GlobalDb};
+use crate::global_db::{AnalyticsToolCounts, GlobalDb};
 use crate::timeutil::parse_rfc3339_timestamp;
 use crate::tracedecay::TraceDecay;
 use crate::tracedecay::current_timestamp;
@@ -26,8 +26,6 @@ use super::super::{ToolResult, renderers};
 use super::memory::open_target_memory_db;
 use super::support::{project_registry_context, tool_json_with_md};
 
-/// Bound on how many `analytics_events` rows a single call will scan.
-const EVENT_SAMPLE_LIMIT: usize = 10_000;
 /// Bound on how many automation run-ledger rows a single call will scan.
 const AUTOMATION_RECORD_LIMIT: usize = 200;
 /// Top-N tools shown by call volume.
@@ -307,18 +305,10 @@ pub(super) async fn handle_analytics(
     .await?;
 
     let since = current_timestamp().saturating_sub(window_days.saturating_mul(86_400));
-    let events = gdb
-        .query_analytics_events(&AnalyticsEventQuery {
-            provider: None,
-            project_id: scope.filter.clone(),
-            session_id: None,
-            event_kind: None,
-            since: Some(since),
-            limit: EVENT_SAMPLE_LIMIT,
-        })
+    let event_count = gdb
+        .count_analytics_events(scope.filter.as_deref(), since)
         .await
         .map_err(config_error)?;
-    let event_truncated = events.len() >= EVENT_SAMPLE_LIMIT;
 
     let mut value = json!({
         "status": "ok",
@@ -327,21 +317,25 @@ pub(super) async fn handle_analytics(
         "project_root": scope.display_root,
         "window_days": window_days,
         "since": since,
-        "event_count": events.len(),
-        "event_count_truncated": event_truncated,
+        "event_count": event_count,
+        "event_count_truncated": false,
     });
 
     if wants_section(section, "tools") {
+        let counts = gdb
+            .query_analytics_tool_counts(scope.filter.as_deref(), since)
+            .await
+            .map_err(config_error)?;
         if let Some(object) = value.as_object_mut() {
-            object.insert("tools".to_string(), tools_section(&events));
+            object.insert("tools".to_string(), tools_section(&counts));
         }
     }
     if wants_section(section, "hints") {
-        let rows: Vec<Value> = events
-            .iter()
-            .map(crate::dashboard::analytics_api::durable_analytics_event_row)
-            .collect();
-        let hints = crate::dashboard::analytics_api::hint_summary_from_events(&rows);
+        let counts = gdb
+            .query_analytics_hint_counts(scope.filter.as_deref(), since)
+            .await
+            .map_err(config_error)?;
+        let hints = crate::dashboard::analytics_api::hint_summary_from_counts(&counts);
         if let Some(object) = value.as_object_mut() {
             object.insert("hints".to_string(), hints);
         }
@@ -364,20 +358,12 @@ pub(super) async fn handle_analytics(
     }))
 }
 
-fn tools_section(events: &[AnalyticsEventRecord]) -> Value {
+fn tools_section(rows: &[AnalyticsToolCounts]) -> Value {
     let mut per_tool: BTreeMap<String, ToolCallCounts> = BTreeMap::new();
-    for event in events {
-        if event.event_kind != "mcp_tool_call" {
-            continue;
-        }
-        let Some(tool_name) = event.tool_name.as_deref().filter(|name| !name.is_empty()) else {
-            continue;
-        };
-        let counts = per_tool.entry(tool_name.to_string()).or_default();
-        counts.calls += 1;
-        if event.outcome.as_deref() == Some("error") {
-            counts.errors += 1;
-        }
+    for row in rows {
+        let counts = per_tool.entry(row.tool_name.clone()).or_default();
+        counts.calls += row.calls;
+        counts.errors += row.errors;
     }
 
     let mut per_tier: BTreeMap<&'static str, ToolCallCounts> = BTreeMap::new();
@@ -426,7 +412,7 @@ fn tools_section(events: &[AnalyticsEventRecord]) -> Value {
         zero_call.into_iter().take(ZERO_CALL_SAMPLE_LIMIT).collect();
 
     json!({
-        "available": !events.is_empty(),
+        "available": !rows.is_empty(),
         "tiers": tiers,
         "top_tools": top_tools,
         "distinct_tools_called": per_tool.len(),

--- a/tests/mcp_suite/analytics_test.rs
+++ b/tests/mcp_suite/analytics_test.rs
@@ -4,7 +4,7 @@
 
 use serde_json::{Value, json};
 
-use tracedecay::global_db::{AnalyticsEventInsert, GlobalDb};
+use tracedecay::global_db::{AnalyticsEventInsert, GlobalDb, global_db_path};
 use tracedecay::mcp::handle_tool_call;
 use tracedecay::tracedecay::current_timestamp;
 
@@ -41,6 +41,29 @@ fn tool_call_event(
         hint_category: None,
         hint_id: None,
         outcome: Some(outcome.to_string()),
+        metadata_json: None,
+    }
+}
+
+fn hint_event(
+    project_id: &str,
+    event_kind: &str,
+    outcome: Option<&str>,
+    timestamp: i64,
+) -> AnalyticsEventInsert {
+    AnalyticsEventInsert {
+        provider: "codex".to_string(),
+        project_id: project_id.to_string(),
+        session_id: Some("hint-session".to_string()),
+        timestamp,
+        event_kind: event_kind.to_string(),
+        hook_name: Some("PostToolUse".to_string()),
+        tool_name: None,
+        tool_category: None,
+        skill_name: None,
+        hint_category: Some("search".to_string()),
+        hint_id: Some("hint-search-1".to_string()),
+        outcome: outcome.map(str::to_string),
         metadata_json: None,
     }
 }
@@ -244,4 +267,83 @@ async fn analytics_degrades_gracefully_for_a_zero_data_project() {
         text.contains("No MCP tool calls recorded"),
         "expected an empty-state note in markdown: {text}"
     );
+}
+
+#[tokio::test]
+async fn analytics_aggregates_sections_before_any_event_sample_cap() {
+    let (cg, _env) = crate::mcp_handler_test::setup_project().await;
+    let project_id = GlobalDb::canonical_project_key(cg.project_root());
+    let timestamp = current_timestamp() - 60;
+    let gdb = GlobalDb::open()
+        .await
+        .expect("isolated test global db should open");
+
+    let events = vec![
+        hint_event(&project_id, "hint_emitted", None, timestamp),
+        hint_event(&project_id, "hint_outcome", Some("acted"), timestamp),
+        hint_event(&project_id, "suppressed_duplicate", None, timestamp),
+        tool_call_event(&project_id, "tracedecay_grep", "ok", timestamp),
+    ];
+    gdb.append_analytics_events(&events)
+        .await
+        .expect("seeding a busy analytics window should succeed");
+    let db = libsql::Builder::new_local(global_db_path().expect("test global DB path"))
+        .build()
+        .await
+        .expect("open test global DB directly");
+    let conn = db.connect().expect("connect test global DB");
+    conn.execute(
+        "WITH RECURSIVE seq(n) AS (
+             VALUES(0)
+             UNION ALL
+             SELECT n + 1 FROM seq WHERE n < 100
+         )
+         INSERT INTO analytics_events
+             (provider, project_id, session_id, timestamp, event_kind, hook_name, outcome)
+         SELECT 'codex', ?1, 'busy-session', ?2, 'hook_completed', 'PostToolUse', 'observed'
+         FROM seq AS left_seq CROSS JOIN seq AS right_seq
+         LIMIT 10001",
+        libsql::params![project_id.as_str(), timestamp],
+    )
+    .await
+    .expect("seed more than ten thousand unrelated newer events");
+
+    let hint_response = handle_tool_call(
+        &cg,
+        "tracedecay_analytics",
+        json!({"section": "hints", "format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .expect("hint analytics should succeed");
+    let hints = extract_json(&hint_response.value);
+    assert_eq!(hints["event_count"].as_i64(), Some(10_005));
+    assert_eq!(hints["event_count_truncated"].as_bool(), Some(false));
+    let search = hints["hints"]["by_category"]
+        .as_array()
+        .expect("hint categories")
+        .iter()
+        .find(|row| row["category"] == "search")
+        .expect("search hint category");
+    assert_eq!(search["emitted"].as_i64(), Some(1));
+    assert_eq!(search["followed"].as_i64(), Some(1));
+    assert_eq!(search["suppressed"].as_i64(), Some(1));
+
+    let tool_response = handle_tool_call(
+        &cg,
+        "tracedecay_analytics",
+        json!({"section": "tools", "format": "json"}),
+        None,
+        None,
+    )
+    .await
+    .expect("tool analytics should succeed");
+    let tools = extract_json(&tool_response.value);
+    assert_eq!(tools["tools"]["distinct_tools_called"].as_i64(), Some(1));
+    assert_eq!(
+        tools["tools"]["top_tools"][0]["tool_name"],
+        "tracedecay_grep"
+    );
+    assert_eq!(tools["tools"]["top_tools"][0]["calls"].as_i64(), Some(1));
 }

--- a/tests/session_suite/global_db.rs
+++ b/tests/session_suite/global_db.rs
@@ -370,6 +370,29 @@ async fn open_at_upgrades_existing_global_db_with_analytics_events_table() {
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].id, id);
     assert_eq!(events[0].hook_name.as_deref(), Some("post-tool-use"));
+
+    let verify_db = libsql::Builder::new_local(&db_path).build().await.unwrap();
+    let verify_conn = verify_db.connect().unwrap();
+    let mut index_rows = verify_conn
+        .query(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'index'
+               AND name IN ('idx_analytics_events_project_time', 'idx_analytics_events_timestamp')",
+            (),
+        )
+        .await
+        .unwrap();
+    let index_count = index_rows
+        .next()
+        .await
+        .unwrap()
+        .unwrap()
+        .get::<i64>(0)
+        .unwrap();
+    assert_eq!(
+        index_count, 2,
+        "analytics aggregate indexes must migrate on open"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- compute exact event totals and DB-side tool/hint rollups before rendering analytics sections
- remove the generic latest-10,000 cap that produced false zero hint/tool counts
- add upgrade-safe project/time indexes and a >10,000-event regression

## Verification
- `cargo test --test mcp_suite analytics_test::`
- `cargo test --test session_suite open_at_upgrades_existing_global_db_with_analytics_events_table`
- `cargo clippy --lib --test mcp_suite --test session_suite -- -D warnings`
- `cargo fmt --check`