### PR TITLE
chore: release v0.0.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.49](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.48...v0.0.49) - 2026-07-10
+
+### Fixed
+
+- *(storage)* recover untracked branch graphs
+
 ## [0.0.48](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.47...v0.0.48) - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.48"
+version = "0.0.49"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.48"
+version = "0.0.49"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.48 -> 0.0.49

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.49](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.48...v0.0.49) - 2026-07-10

### Fixed

- *(storage)* recover untracked branch graphs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).