### PR TITLE
chore: release v0.0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.51](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.50...v0.0.51) - 2026-07-10
+
+### Other
+
+- *(storage)* index consolidation message lookups
+
 ## [0.0.50](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.49...v0.0.50) - 2026-07-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.50"
+version = "0.0.51"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.50 -> 0.0.51

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.51](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.50...v0.0.51) - 2026-07-10

### Other

- *(storage)* index consolidation message lookups
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).