### PR TITLE
fix(storage): make registry reconstruction conflict-safe

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -267,6 +267,16 @@ pub(crate) async fn handle_migrate_action(action: MigrateAction) -> tracedecay::
                     message: "confirmation token does not match migration manifest".to_string(),
                 });
             }
+            let target_profile_root =
+                manifest.destination.profile_root.clone().ok_or_else(|| {
+                    tracedecay::errors::TraceDecayError::Config {
+                        message: "migration manifest has no destination profile_root".to_string(),
+                    }
+                })?;
+            let _lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive_for_profile(
+                &target_profile_root,
+                "legacy store migration",
+            )?;
             let apply_report = tracedecay::migrate::manifest::apply_migration_manifest(
                 &mut manifest,
             )
@@ -283,13 +293,15 @@ pub(crate) async fn handle_migrate_action(action: MigrateAction) -> tracedecay::
                     ),
                 });
             }
-            let global_db = tracedecay::global_db::GlobalDb::open()
-                .await
-                .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
-                    message: "could not open global DB for migrate apply".to_string(),
-                })?;
+            let global_db = tracedecay::global_db::GlobalDb::open_at(
+                &apply_report.profile_root.join("global.db"),
+            )
+            .await
+            .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+                message: "could not open global DB for migrate apply".to_string(),
+            })?;
             let registry_report =
-                tracedecay::migrate::registry::apply_registry_reconstruction_report(
+                tracedecay::migrate::registry::apply_single_registry_reconstruction_report(
                     &global_db,
                     &verify_report.registry_reconstruction,
                 )
@@ -354,16 +366,63 @@ pub(crate) async fn handle_migrate_action(action: MigrateAction) -> tracedecay::
             apply,
             json,
         } => {
+            let profile_root = PathBuf::from(profile_root);
+            if apply {
+                let projects_root = profile_root.join("projects");
+                std::fs::read_dir(&projects_root).map_err(|error| {
+                    tracedecay::errors::TraceDecayError::Config {
+                        message: format!(
+                            "could not read profile projects directory '{}': {error}",
+                            projects_root.display()
+                        ),
+                    }
+                })?;
+            }
+            let _lifecycle_lease = apply
+                .then(|| {
+                    tracedecay::lifecycle_lease::acquire_exclusive_for_profile(
+                        &profile_root,
+                        "registry reconstruction",
+                    )
+                })
+                .transpose()?;
             let report = tracedecay::migrate::registry::scan_profile_store_manifests(
-                &PathBuf::from(profile_root),
+                &profile_root,
                 tracedecay::tracedecay::current_timestamp(),
             );
             if apply {
-                let global_db = tracedecay::global_db::GlobalDb::open()
-                    .await
-                    .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
-                        message: "could not open global DB for registry reconstruction".to_string(),
-                    })?;
+                let mut blockers = report.issues.clone();
+                blockers.extend(
+                    report
+                        .plans
+                        .iter()
+                        .filter(|plan| {
+                            plan.status
+                                == tracedecay::migrate::registry::RegistryReconstructionStatus::Blocked
+                        })
+                        .map(|plan| {
+                            format!(
+                                "blocked manifest '{}': {}",
+                                plan.manifest_path.display(),
+                                plan.status_reason.as_deref().unwrap_or("not eligible")
+                            )
+                        }),
+                );
+                if !blockers.is_empty() {
+                    return Err(tracedecay::errors::TraceDecayError::Config {
+                        message: format!(
+                            "failed to preflight registry reconstruction: {}",
+                            blockers.join("; ")
+                        ),
+                    });
+                }
+                let global_db =
+                    tracedecay::global_db::GlobalDb::open_at(&profile_root.join("global.db"))
+                        .await
+                        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+                            message: "could not open global DB for registry reconstruction"
+                                .to_string(),
+                        })?;
                 let applied = tracedecay::migrate::registry::apply_registry_reconstruction_report(
                     &global_db, &report,
                 )
@@ -395,12 +454,27 @@ pub(crate) async fn handle_migrate_action(action: MigrateAction) -> tracedecay::
             } else if json {
                 println!("{}", serde_json::to_string_pretty(&report)?);
             } else {
+                use tracedecay::migrate::registry::RegistryReconstructionStatus;
+                let eligible = report.status_count(RegistryReconstructionStatus::Eligible);
+                let blocked = report.status_count(RegistryReconstructionStatus::Blocked);
+                let stale = report.status_count(RegistryReconstructionStatus::Stale);
+                let retired = report.status_count(RegistryReconstructionStatus::Retired);
                 println!(
-                    "registry reconstruction: {} plan(s), {} issue(s)",
-                    report.plans.len(),
+                    "registry reconstruction: {} eligible, {} blocked, {} stale, {} retired, {} issue(s)",
+                    eligible,
+                    blocked,
+                    stale,
+                    retired,
                     report.issues.len()
                 );
-                println!("apply supported: yes (re-run with --apply after review)");
+                println!(
+                    "apply supported: {} (atomic batch; skips stale/retired, inserts eligible missing rows only, fails on blocked/invalid/conflict)",
+                    if blocked == 0 && report.issues.is_empty() {
+                        "yes"
+                    } else {
+                        "no"
+                    }
+                );
             }
         }
         MigrateAction::RegistryGc {
@@ -1052,6 +1126,9 @@ fn append_orphan_manifest_rows(
         tracedecay::tracedecay::current_timestamp(),
     );
     for plan in report.plans {
+        if plan.status != tracedecay::migrate::registry::RegistryReconstructionStatus::Eligible {
+            continue;
+        }
         let key =
             tracedecay::global_db::GlobalDb::canonical_project_key(&plan.project.project_root);
         if registered.contains(&key) {

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -722,15 +722,29 @@ pub(crate) fn orphan_store_manifest_report(
         profile_root,
         crate::tracedecay::current_timestamp(),
     );
-    let orphan_count = report
-        .plans
-        .iter()
-        .filter(|plan| {
-            let key = crate::global_db::GlobalDb::canonical_project_key(&plan.project.project_root);
-            !registered.contains(&key)
-        })
-        .count();
-    (orphan_count, report.issues)
+    let mut orphan_count = 0;
+    let mut warnings = report.issues;
+    for plan in report.plans {
+        let key = crate::global_db::GlobalDb::canonical_project_key(&plan.project.project_root);
+        if registered.contains(&key) {
+            continue;
+        }
+        match plan.status {
+            crate::migrate::registry::RegistryReconstructionStatus::Eligible => {
+                orphan_count += 1;
+            }
+            crate::migrate::registry::RegistryReconstructionStatus::Blocked => {
+                warnings.push(format!(
+                    "blocked store manifest '{}': {}",
+                    plan.manifest_path.display(),
+                    plan.status_reason.as_deref().unwrap_or("not eligible")
+                ));
+            }
+            crate::migrate::registry::RegistryReconstructionStatus::Stale
+            | crate::migrate::registry::RegistryReconstructionStatus::Retired => {}
+        }
+    }
+    (orphan_count, warnings)
 }
 
 /// Reports git-metadata watcher health (design D3/D5).

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::global_db::StoreInstanceUpsert;
 use crate::storage::{
     EnrollmentMarker, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode,
-    StoreKind, StoreManifest, profile_sharded_layout, write_repository_identity_marker,
-    write_store_manifest,
+    StoreKind, StoreManifest, profile_sharded_layout, write_enrollment_marker,
+    write_repository_identity_marker, write_store_manifest,
 };
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
@@ -30,6 +30,60 @@ fn format_bytes_boundaries() {
     assert_eq!(format_bytes(1024 * 1024 * 512), "512.0 MB");
     assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GB");
     assert_eq!(format_bytes(1024 * 1024 * 1024 * 2), "2.0 GB");
+}
+
+#[test]
+fn orphan_reporting_counts_only_eligible_and_surfaces_blocked_reasons() {
+    let base = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let dir = tempfile::Builder::new()
+        .prefix("doctor-orphans-")
+        .tempdir_in(base)
+        .unwrap();
+    let profile_root = dir.path().join("profile");
+    let eligible_root = dir.path().join("eligible-repo");
+    let blocked_root = dir.path().join("blocked-repo");
+    std::fs::create_dir_all(&eligible_root).unwrap();
+    std::fs::create_dir_all(&blocked_root).unwrap();
+    write_enrollment_marker(
+        &eligible_root,
+        &EnrollmentMarker {
+            project_id: "proj_eligible".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    for (project_id, project_root) in [
+        ("proj_eligible", &eligible_root),
+        ("proj_blocked", &blocked_root),
+    ] {
+        let data_root = profile_root.join("projects").join(project_id);
+        std::fs::create_dir_all(&data_root).unwrap();
+        let manifest = StoreManifest {
+            schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+            project_id: Some(project_id.to_string()),
+            store_kind: StoreKind::CodeProject,
+            storage_mode: StorageMode::ProfileSharded,
+            project_root: project_root.clone(),
+            data_root: data_root.clone(),
+            graph_db_relpath: "tracedecay.db".into(),
+            sessions_db_relpath: "sessions.db".into(),
+            branch_meta_relpath: "branch-meta.json".into(),
+        };
+        std::fs::write(
+            data_root.join(STORE_MANIFEST_FILENAME),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    let (count, warnings) = orphan_store_manifest_report(&profile_root, &[]);
+
+    assert_eq!(count, 1);
+    assert!(
+        warnings
+            .iter()
+            .any(|warning| warning.contains("no repository identity or enrollment marker"))
+    );
 }
 
 #[test]

--- a/src/migrate/registry.rs
+++ b/src/migrate/registry.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
+use libsql::{Connection, params, params::IntoParams};
 use serde::Serialize;
 
 use crate::branch_meta;
@@ -9,8 +11,18 @@ use crate::global_db::{
 };
 use crate::storage::{
     STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode, StoreKind,
-    read_store_manifest, validate_project_id,
+    read_enrollment_marker, read_repository_identity_marker, read_store_manifest,
+    validate_project_id,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegistryReconstructionStatus {
+    Eligible,
+    Blocked,
+    Stale,
+    Retired,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RegistryProjectPlan {
@@ -23,6 +35,8 @@ pub struct RegistryProjectPlan {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RegistryReconstructionPlan {
     pub manifest_path: PathBuf,
+    pub status: RegistryReconstructionStatus,
+    pub status_reason: Option<String>,
     pub project: RegistryProjectPlan,
     pub store: StoreInstanceUpsert,
     pub graph_scopes: Vec<GraphScopeUpsert>,
@@ -33,6 +47,15 @@ pub struct RegistryReconstructionPlan {
 pub struct RegistryReconstructionReport {
     pub plans: Vec<RegistryReconstructionPlan>,
     pub issues: Vec<String>,
+}
+
+impl RegistryReconstructionReport {
+    pub fn status_count(&self, status: RegistryReconstructionStatus) -> usize {
+        self.plans
+            .iter()
+            .filter(|plan| plan.status == status)
+            .count()
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -48,86 +71,443 @@ pub async fn apply_registry_reconstruction_report(
     db: &GlobalDb,
     report: &RegistryReconstructionReport,
 ) -> std::result::Result<RegistryReconstructionApplyReport, Vec<String>> {
-    if !report.issues.is_empty() {
-        return Err(report.issues.clone());
+    let conn = db.conn();
+    conn.execute("BEGIN IMMEDIATE", ()).await.map_err(|error| {
+        vec![format!(
+            "could not start atomic registry reconstruction: {error}"
+        )]
+    })?;
+    let issues = preflight_registry_reconstruction(conn, report).await;
+    if !issues.is_empty() {
+        let _ = conn.execute("ROLLBACK", ()).await;
+        return Err(issues);
     }
+    match insert_missing_registry_rows(conn, report).await {
+        Ok(applied) => match conn.execute("COMMIT", ()).await {
+            Ok(_) => Ok(applied),
+            Err(error) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(vec![format!(
+                    "could not commit atomic registry reconstruction: {error}"
+                )])
+            }
+        },
+        Err(issue) => {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(vec![issue])
+        }
+    }
+}
 
-    let mut applied = RegistryReconstructionApplyReport::default();
-    let mut issues = Vec::new();
+pub async fn apply_single_registry_reconstruction_report(
+    db: &GlobalDb,
+    report: &RegistryReconstructionReport,
+) -> std::result::Result<RegistryReconstructionApplyReport, Vec<String>> {
+    let [plan] = report.plans.as_slice() else {
+        return Err(vec![format!(
+            "migration cutover requires exactly one registry reconstruction plan, found {}",
+            report.plans.len()
+        )]);
+    };
+    if plan.status != RegistryReconstructionStatus::Eligible {
+        return Err(vec![format!(
+            "migration cutover registry reconstruction plan for '{}' is {:?}: {}",
+            plan.project.project_id,
+            plan.status,
+            plan.status_reason.as_deref().unwrap_or("not eligible")
+        )]);
+    }
+    apply_registry_reconstruction_report(db, report).await
+}
+
+async fn preflight_registry_reconstruction(
+    conn: &Connection,
+    report: &RegistryReconstructionReport,
+) -> Vec<String> {
+    let mut issues = report.issues.clone();
+    let mut project_roots = BTreeMap::<String, String>::new();
+    let mut aliases = BTreeMap::<String, String>::new();
+    let mut stores = BTreeMap::<String, String>::new();
+    let mut store_paths = BTreeMap::<String, String>::new();
+    let mut scopes = BTreeMap::<String, String>::new();
+    let mut scope_paths = BTreeMap::<String, String>::new();
+
     for plan in &report.plans {
+        match plan.status {
+            RegistryReconstructionStatus::Eligible => {}
+            RegistryReconstructionStatus::Stale | RegistryReconstructionStatus::Retired => {
+                continue;
+            }
+            RegistryReconstructionStatus::Blocked => {
+                issues.push(format!(
+                    "{} reconstruction plan for '{}' is blocked: {}",
+                    plan.manifest_path.display(),
+                    plan.project.project_id,
+                    plan.status_reason.as_deref().unwrap_or("not eligible")
+                ));
+                continue;
+            }
+        }
         let project = &plan.project;
-        if db
-            .upsert_code_project(
+        let root = GlobalDb::canonical_project_key(&project.project_root);
+        record_batch_owner(
+            &mut project_roots,
+            &root,
+            &project.project_id,
+            "canonical project root",
+            &mut issues,
+        );
+        match query_optional_text(
+            conn,
+            "SELECT canonical_root FROM code_projects WHERE project_id=?1",
+            params![project.project_id.as_str()],
+        )
+        .await
+        {
+            Ok(Some(existing)) if existing != root => issues.push(format!(
+                "project '{}' already owns canonical root '{}' instead of '{}'",
+                project.project_id, existing, root
+            )),
+            Err(error) => issues.push(error),
+            _ => {}
+        }
+        match query_all_text(
+            conn,
+            "SELECT project_id FROM code_projects WHERE canonical_root=?1",
+            params![root.as_str()],
+        )
+        .await
+        {
+            Ok(owners) => {
+                for owner in owners {
+                    if owner != project.project_id {
+                        issues.push(format!(
+                            "canonical root '{root}' is already owned by project '{owner}'"
+                        ));
+                    }
+                }
+            }
+            Err(error) => issues.push(error),
+        }
+        for alias in &project.aliases {
+            let alias = GlobalDb::canonical_project_key(alias);
+            record_batch_owner(
+                &mut aliases,
+                &alias,
                 &project.project_id,
-                &project.project_root,
-                None,
-                None,
-                project.default_branch.as_deref(),
+                "project alias",
+                &mut issues,
+            );
+            match query_optional_text(
+                conn,
+                "SELECT project_id FROM project_aliases WHERE alias_path=?1",
+                params![alias.as_str()],
             )
             .await
-            .is_none()
-        {
-            issues.push(format!(
-                "failed to upsert code project '{}'",
-                project.project_id
-            ));
-            continue;
-        }
-        applied.projects += 1;
-
-        for alias in &project.aliases {
-            if db
-                .upsert_project_alias(alias, &project.project_id)
-                .await
-                .is_some()
             {
-                applied.aliases += 1;
-            } else {
-                issues.push(format!(
-                    "failed to upsert alias '{}' for project '{}'",
-                    alias.display(),
-                    project.project_id
-                ));
+                Ok(Some(owner)) if owner != project.project_id => issues.push(format!(
+                    "alias '{alias}' is already owned by project '{owner}'"
+                )),
+                Err(error) => issues.push(error),
+                _ => {}
             }
         }
 
-        if db.upsert_store_instance(plan.store.clone()).await.is_some() {
-            applied.stores += 1;
-        } else {
-            issues.push(format!(
-                "failed to upsert store '{}' for project '{}'",
-                plan.store.store_id, project.project_id
-            ));
-            continue;
+        let store_identity = serde_json::to_string(&(
+            &plan.store.project_id,
+            &plan.store.store_kind,
+            &plan.store.storage_mode,
+            &plan.store.store_relpath,
+            &plan.store.manifest_relpath,
+        ))
+        .unwrap_or_default();
+        record_batch_owner(
+            &mut stores,
+            &plan.store.store_id,
+            &store_identity,
+            "store id",
+            &mut issues,
+        );
+        match query_optional_text(
+            conn,
+            "SELECT json_array(project_id, store_kind, storage_mode, store_relpath, manifest_relpath)
+             FROM store_instances WHERE store_id=?1",
+            params![plan.store.store_id.as_str()],
+        )
+        .await
+        {
+            Ok(Some(existing)) if existing != store_identity => issues.push(format!(
+                "store '{}' already has conflicting ownership or location",
+                plan.store.store_id
+            )),
+            Err(error) => issues.push(error),
+            _ => {}
+        }
+        for physical_path in std::iter::once(plan.store.store_relpath.as_str())
+            .chain(plan.store.manifest_relpath.as_deref())
+        {
+            record_batch_owner(
+                &mut store_paths,
+                physical_path,
+                &plan.store.store_id,
+                "physical store path",
+                &mut issues,
+            );
+            match query_all_text(
+                conn,
+                "SELECT store_id FROM store_instances
+                 WHERE store_relpath=?1 OR manifest_relpath=?1",
+                params![physical_path],
+            )
+            .await
+            {
+                Ok(owners) => {
+                    for owner in owners {
+                        if owner != plan.store.store_id {
+                            issues.push(format!(
+                                "physical store path '{physical_path}' is already owned by store '{owner}'"
+                            ));
+                        }
+                    }
+                }
+                Err(error) => issues.push(error),
+            }
         }
 
         for scope in &plan.graph_scopes {
-            if db.upsert_graph_scope(scope.clone()).await.is_some() {
-                applied.graph_scopes += 1;
-            } else {
-                issues.push(format!(
-                    "failed to upsert graph scope '{}'",
+            let scope_identity = serde_json::to_string(&(
+                &scope.project_id,
+                &scope.store_id,
+                &scope.branch_name,
+                &scope.db_relpath,
+                &scope.parent_scope_id,
+            ))
+            .unwrap_or_default();
+            record_batch_owner(
+                &mut scopes,
+                &scope.graph_scope_id,
+                &scope_identity,
+                "graph scope id",
+                &mut issues,
+            );
+            match query_optional_text(
+                conn,
+                "SELECT json_array(project_id, store_id, branch_name, db_relpath, parent_scope_id)
+                 FROM graph_scopes WHERE graph_scope_id=?1",
+                params![scope.graph_scope_id.as_str()],
+            )
+            .await
+            {
+                Ok(Some(existing)) if existing != scope_identity => issues.push(format!(
+                    "graph scope '{}' already has conflicting ownership or location",
                     scope.graph_scope_id
-                ));
+                )),
+                Err(error) => issues.push(error),
+                _ => {}
             }
+            record_batch_owner(
+                &mut scope_paths,
+                &scope.db_relpath,
+                &scope.graph_scope_id,
+                "physical graph database path",
+                &mut issues,
+            );
+            match query_all_text(
+                conn,
+                "SELECT graph_scope_id FROM graph_scopes WHERE db_relpath=?1",
+                params![scope.db_relpath.as_str()],
+            )
+            .await
+            {
+                Ok(owners) => {
+                    for owner in owners {
+                        if owner != scope.graph_scope_id {
+                            issues.push(format!(
+                                "physical graph database path '{}' is already owned by scope '{}'",
+                                scope.db_relpath, owner
+                            ));
+                        }
+                    }
+                }
+                Err(error) => issues.push(error),
+            }
+        }
+    }
+    issues
+}
+
+fn record_batch_owner(
+    owners: &mut BTreeMap<String, String>,
+    key: &str,
+    owner: &str,
+    label: &str,
+    issues: &mut Vec<String>,
+) {
+    if let Some(existing) = owners.insert(key.to_string(), owner.to_string())
+        && existing != owner
+    {
+        issues.push(format!(
+            "{label} '{key}' has conflicting batch owners '{existing}' and '{owner}'"
+        ));
+    }
+}
+
+async fn query_optional_text(
+    conn: &Connection,
+    sql: &str,
+    params: impl IntoParams,
+) -> std::result::Result<Option<String>, String> {
+    let mut rows = conn
+        .query(sql, params)
+        .await
+        .map_err(|error| format!("registry reconstruction preflight query failed: {error}"))?;
+    rows.next()
+        .await
+        .map_err(|error| format!("registry reconstruction preflight row failed: {error}"))?
+        .map(|row| {
+            row.get::<String>(0)
+                .map_err(|error| format!("registry reconstruction preflight value failed: {error}"))
+        })
+        .transpose()
+}
+
+async fn query_all_text(
+    conn: &Connection,
+    sql: &str,
+    params: impl IntoParams,
+) -> std::result::Result<Vec<String>, String> {
+    let mut rows = conn
+        .query(sql, params)
+        .await
+        .map_err(|error| format!("registry reconstruction preflight query failed: {error}"))?;
+    let mut values = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| format!("registry reconstruction preflight row failed: {error}"))?
+    {
+        values.push(
+            row.get::<String>(0).map_err(|error| {
+                format!("registry reconstruction preflight value failed: {error}")
+            })?,
+        );
+    }
+    Ok(values)
+}
+
+async fn insert_missing_registry_rows(
+    conn: &Connection,
+    report: &RegistryReconstructionReport,
+) -> std::result::Result<RegistryReconstructionApplyReport, String> {
+    let mut applied = RegistryReconstructionApplyReport::default();
+    let now = crate::tracedecay::current_timestamp();
+    for plan in &report.plans {
+        if plan.status != RegistryReconstructionStatus::Eligible {
+            continue;
+        }
+        let project = &plan.project;
+        let canonical_root = GlobalDb::canonical_project_key(&project.project_root);
+        applied.projects += usize::try_from(
+            conn.execute(
+                "INSERT OR IGNORE INTO code_projects(
+                     project_id, canonical_root, display_root, git_common_dir, git_remote_url,
+                     default_branch, created_at, last_seen_at
+                 ) VALUES(?1, ?2, ?3, NULL, NULL, ?4, ?5, ?5)",
+                params![
+                    project.project_id.as_str(),
+                    canonical_root,
+                    project.project_root.to_string_lossy().to_string(),
+                    project.default_branch.as_deref(),
+                    now,
+                ],
+            )
+            .await
+            .map_err(|error| format!("failed to insert code project: {error}"))?,
+        )
+        .unwrap_or(usize::MAX);
+        for alias in &project.aliases {
+            applied.aliases += usize::try_from(
+                conn.execute(
+                    "INSERT OR IGNORE INTO project_aliases(alias_path, project_id, last_seen_at)
+                     VALUES(?1, ?2, ?3)",
+                    params![
+                        GlobalDb::canonical_project_key(alias),
+                        project.project_id.as_str(),
+                        now,
+                    ],
+                )
+                .await
+                .map_err(|error| format!("failed to insert project alias: {error}"))?,
+            )
+            .unwrap_or(usize::MAX);
+        }
+        applied.stores += usize::try_from(
+            conn.execute(
+                "INSERT OR IGNORE INTO store_instances(
+                     store_id, project_id, store_kind, storage_mode, store_relpath,
+                     manifest_relpath, created_at, last_verified_at, last_write_at
+                 ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    plan.store.store_id.as_str(),
+                    plan.store.project_id.as_str(),
+                    plan.store.store_kind.as_str(),
+                    plan.store.storage_mode.as_str(),
+                    plan.store.store_relpath.as_str(),
+                    plan.store.manifest_relpath.as_deref(),
+                    now,
+                    plan.store.last_verified_at,
+                    plan.store.last_write_at,
+                ],
+            )
+            .await
+            .map_err(|error| format!("failed to insert store instance: {error}"))?,
+        )
+        .unwrap_or(usize::MAX);
+        for scope in &plan.graph_scopes {
+            applied.graph_scopes += usize::try_from(
+                conn.execute(
+                    "INSERT OR IGNORE INTO graph_scopes(
+                         graph_scope_id, project_id, store_id, branch_name, db_relpath,
+                         parent_scope_id, last_synced_at, writable
+                     ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    params![
+                        scope.graph_scope_id.as_str(),
+                        scope.project_id.as_str(),
+                        scope.store_id.as_str(),
+                        scope.branch_name.as_str(),
+                        scope.db_relpath.as_str(),
+                        scope.parent_scope_id.as_deref(),
+                        scope.last_synced_at,
+                        i64::from(scope.writable),
+                    ],
+                )
+                .await
+                .map_err(|error| format!("failed to insert graph scope: {error}"))?,
+            )
+            .unwrap_or(usize::MAX);
         }
         for artifact in &plan.artifacts {
-            if db.upsert_store_artifact(artifact.clone()).await.is_some() {
-                applied.artifacts += 1;
-            } else {
-                issues.push(format!(
-                    "failed to upsert store artifact '{}:{}'",
-                    artifact.artifact_kind, artifact.relpath
-                ));
-            }
+            applied.artifacts += usize::try_from(
+                conn.execute(
+                    "INSERT OR IGNORE INTO store_artifacts(
+                         store_id, artifact_kind, relpath, size_bytes, schema_version, updated_at
+                     ) VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
+                    params![
+                        artifact.store_id.as_str(),
+                        artifact.artifact_kind.as_str(),
+                        artifact.relpath.as_str(),
+                        artifact.size_bytes,
+                        artifact.schema_version.as_deref(),
+                        artifact.updated_at,
+                    ],
+                )
+                .await
+                .map_err(|error| format!("failed to insert store artifact: {error}"))?,
+            )
+            .unwrap_or(usize::MAX);
         }
     }
-
-    if issues.is_empty() {
-        Ok(applied)
-    } else {
-        Err(issues)
-    }
+    Ok(applied)
 }
 
 /// How dead a registry row's project root must be before the row counts as
@@ -179,8 +559,15 @@ pub fn scan_profile_store_manifests(
 ) -> RegistryReconstructionReport {
     let mut report = RegistryReconstructionReport::default();
     let projects_root = profile_root.join("projects");
-    let Ok(entries) = fs::read_dir(&projects_root) else {
-        return report;
+    let entries = match fs::read_dir(&projects_root) {
+        Ok(entries) => entries,
+        Err(error) => {
+            report.issues.push(format!(
+                "could not read profile projects directory '{}': {error}",
+                projects_root.display()
+            ));
+            return report;
+        }
     };
     let mut manifest_paths = entries
         .flatten()
@@ -190,8 +577,12 @@ pub fn scan_profile_store_manifests(
     manifest_paths.sort();
 
     for manifest_path in manifest_paths {
-        let manifest_report =
-            reconstruct_registry_from_store_manifest(&manifest_path, profile_root, verified_at);
+        let manifest_report = reconstruct_registry_from_store_manifest_inner(
+            &manifest_path,
+            profile_root,
+            verified_at,
+            true,
+        );
         report.plans.extend(manifest_report.plans);
         report.issues.extend(manifest_report.issues);
     }
@@ -203,6 +594,15 @@ pub fn reconstruct_registry_from_store_manifest(
     manifest_path: &Path,
     profile_root: &Path,
     verified_at: i64,
+) -> RegistryReconstructionReport {
+    reconstruct_registry_from_store_manifest_inner(manifest_path, profile_root, verified_at, false)
+}
+
+fn reconstruct_registry_from_store_manifest_inner(
+    manifest_path: &Path,
+    profile_root: &Path,
+    verified_at: i64,
+    reject_ephemeral_root: bool,
 ) -> RegistryReconstructionReport {
     let mut report = RegistryReconstructionReport::default();
     let manifest = match read_store_manifest(manifest_path) {
@@ -267,6 +667,8 @@ pub fn reconstruct_registry_from_store_manifest(
         return report;
     };
 
+    let (status, status_reason, project_root) =
+        classify_project_root(&manifest.project_root, &project_id, reject_ephemeral_root);
     let store_id = format!("store:{project_id}:profile_sharded");
     let mut artifacts = Vec::new();
     push_artifact_if_present(
@@ -307,15 +709,20 @@ pub fn reconstruct_registry_from_store_manifest(
     );
 
     let branch_meta_path = manifest.data_root.join(&manifest.branch_meta_relpath);
-    let (default_branch, graph_scopes) =
+    let (default_branch, graph_scopes, graph_scope_issues) =
         reconstruct_graph_scopes(&branch_meta_path, &store_id, &project_id, profile_root);
+    if status == RegistryReconstructionStatus::Eligible {
+        report.issues.extend(graph_scope_issues);
+    }
 
     report.plans.push(RegistryReconstructionPlan {
         manifest_path: manifest_path.to_path_buf(),
+        status,
+        status_reason,
         project: RegistryProjectPlan {
             project_id: project_id.clone(),
-            project_root: manifest.project_root.clone(),
-            aliases: vec![manifest.project_root],
+            project_root: project_root.clone(),
+            aliases: vec![project_root],
             default_branch,
         },
         store: StoreInstanceUpsert {
@@ -332,6 +739,101 @@ pub fn reconstruct_registry_from_store_manifest(
         artifacts,
     });
     report
+}
+
+fn classify_project_root(
+    project_root: &Path,
+    project_id: &str,
+    reject_ephemeral_root: bool,
+) -> (RegistryReconstructionStatus, Option<String>, PathBuf) {
+    let canonical_root = match project_root.canonicalize() {
+        Ok(root) if root.is_dir() => root,
+        Ok(root) => {
+            return (
+                RegistryReconstructionStatus::Blocked,
+                Some(format!(
+                    "project root '{}' is not a directory",
+                    root.display()
+                )),
+                root,
+            );
+        }
+        Err(error) => {
+            return (
+                RegistryReconstructionStatus::Stale,
+                Some(format!(
+                    "project root '{}' is unavailable: {error}",
+                    project_root.display()
+                )),
+                project_root.to_path_buf(),
+            );
+        }
+    };
+    let temp_root = std::env::temp_dir()
+        .canonicalize()
+        .unwrap_or_else(|_| std::env::temp_dir());
+    if reject_ephemeral_root && canonical_root.starts_with(temp_root) {
+        return (
+            RegistryReconstructionStatus::Stale,
+            Some(format!(
+                "project root '{}' is under the temporary directory",
+                canonical_root.display()
+            )),
+            canonical_root,
+        );
+    }
+    let repository_identity = match read_repository_identity_marker(&canonical_root) {
+        Ok(marker) => marker.map(|marker| marker.project_id),
+        Err(error) => {
+            return (
+                RegistryReconstructionStatus::Blocked,
+                Some(format!("could not validate repository identity: {error}")),
+                canonical_root,
+            );
+        }
+    };
+    let enrollment = match read_enrollment_marker(&canonical_root) {
+        Ok(marker) => marker.map(|marker| marker.project_id),
+        Err(error) => {
+            return (
+                RegistryReconstructionStatus::Blocked,
+                Some(format!("could not validate enrollment marker: {error}")),
+                canonical_root,
+            );
+        }
+    };
+    let identity = match (repository_identity.as_deref(), enrollment.as_deref()) {
+        (Some(repository), Some(enrolled)) if repository != enrolled => (
+            RegistryReconstructionStatus::Blocked,
+            Some(format!(
+                "repository identity project '{repository}' disagrees with enrollment project '{enrolled}'"
+            )),
+        ),
+        (Some(repository), Some(_)) if repository == project_id => {
+            (RegistryReconstructionStatus::Eligible, None)
+        }
+        (Some(repository), Some(_)) => (
+            RegistryReconstructionStatus::Retired,
+            Some(format!(
+                "repository identity and enrollment name retired project '{repository}' instead of manifest project '{project_id}'"
+            )),
+        ),
+        (Some(owner), None) | (None, Some(owner)) if owner == project_id => {
+            (RegistryReconstructionStatus::Eligible, None)
+        }
+        (Some(owner), None) | (None, Some(owner)) => (
+            RegistryReconstructionStatus::Retired,
+            Some(format!(
+                "project marker names retired project '{owner}' instead of manifest project '{project_id}'"
+            )),
+        ),
+        (None, None) if reject_ephemeral_root => (
+            RegistryReconstructionStatus::Blocked,
+            Some("project has no repository identity or enrollment marker".to_string()),
+        ),
+        (None, None) => (RegistryReconstructionStatus::Eligible, None),
+    };
+    (identity.0, identity.1, canonical_root)
 }
 
 fn validate_manifest_shape(
@@ -361,14 +863,18 @@ fn validate_manifest_shape(
             manifest.storage_mode
         ));
     }
-    if !manifest.data_root.starts_with(profile_root) {
+    if strip_profile_root(profile_root, &manifest.data_root).is_none() {
         issues.push(format!(
             "store data root '{}' is outside profile root '{}'",
             manifest.data_root.display(),
             profile_root.display()
         ));
     }
-    if manifest_path.parent() != Some(manifest.data_root.as_path()) {
+    if manifest_path
+        .parent()
+        .and_then(|parent| parent.canonicalize().ok())
+        != manifest.data_root.canonicalize().ok()
+    {
         issues.push(format!(
             "store manifest '{}' is not inside its data root '{}'",
             manifest_path.display(),
@@ -383,40 +889,48 @@ fn reconstruct_graph_scopes(
     store_id: &str,
     project_id: &str,
     profile_root: &Path,
-) -> (Option<String>, Vec<GraphScopeUpsert>) {
-    let Some(meta) = branch_meta_path
-        .parent()
-        .and_then(branch_meta::load_branch_meta)
-    else {
-        return (None, Vec::new());
+) -> (Option<String>, Vec<GraphScopeUpsert>, Vec<String>) {
+    let Some(branch_dir) = branch_meta_path.parent() else {
+        return (None, Vec::new(), Vec::new());
     };
-    let mut scopes = meta
-        .branches
-        .iter()
-        .filter_map(|(branch_name, entry)| {
-            let db_relpath = Path::new(&entry.db_file);
-            if !is_safe_relpath(db_relpath) {
-                return None;
-            }
-            let absolute_db_path = branch_meta_path.parent()?.join(db_relpath);
-            let profile_db_relpath = strip_profile_root(profile_root, &absolute_db_path)?;
-            Some(GraphScopeUpsert {
-                graph_scope_id: graph_scope_id(store_id, branch_name),
-                project_id: project_id.to_string(),
-                store_id: store_id.to_string(),
-                branch_name: branch_name.clone(),
-                db_relpath: path_string(&profile_db_relpath),
-                parent_scope_id: entry
-                    .parent
-                    .as_ref()
-                    .map(|parent| graph_scope_id(store_id, parent)),
-                last_synced_at: entry.last_synced_at.parse::<i64>().ok(),
-                writable: true,
-            })
-        })
-        .collect::<Vec<_>>();
+    let Some(meta) = branch_meta::load_branch_meta(branch_dir) else {
+        return (None, Vec::new(), Vec::new());
+    };
+    let mut scopes = Vec::new();
+    let mut issues = Vec::new();
+    for (branch_name, entry) in &meta.branches {
+        let db_relpath = Path::new(&entry.db_file);
+        if !is_safe_relpath(db_relpath) {
+            issues.push(format!(
+                "branch '{branch_name}' has unsafe database path '{}'",
+                entry.db_file
+            ));
+            continue;
+        }
+        let absolute_db_path = branch_dir.join(db_relpath);
+        let Some(profile_db_relpath) = strip_profile_root(profile_root, &absolute_db_path) else {
+            issues.push(format!(
+                "branch '{branch_name}' database '{}' is missing or escapes profile root",
+                absolute_db_path.display()
+            ));
+            continue;
+        };
+        scopes.push(GraphScopeUpsert {
+            graph_scope_id: graph_scope_id(store_id, branch_name),
+            project_id: project_id.to_string(),
+            store_id: store_id.to_string(),
+            branch_name: branch_name.clone(),
+            db_relpath: path_string(&profile_db_relpath),
+            parent_scope_id: entry
+                .parent
+                .as_ref()
+                .map(|parent| graph_scope_id(store_id, parent)),
+            last_synced_at: entry.last_synced_at.parse::<i64>().ok(),
+            writable: true,
+        });
+    }
     scopes.sort_by(|a, b| a.branch_name.cmp(&b.branch_name));
-    (Some(meta.default_branch), scopes)
+    (Some(meta.default_branch), scopes, issues)
 }
 
 fn graph_scope_id(store_id: &str, branch_name: &str) -> String {
@@ -449,6 +963,8 @@ fn push_artifact_if_present(
 }
 
 fn strip_profile_root(profile_root: &Path, path: &Path) -> Option<PathBuf> {
+    let profile_root = profile_root.canonicalize().ok()?;
+    let path = path.canonicalize().ok()?;
     path.strip_prefix(profile_root).ok().map(PathBuf::from)
 }
 

--- a/tests/core_cli_suite/cli_non_interactive_test.rs
+++ b/tests/core_cli_suite/cli_non_interactive_test.rs
@@ -1452,8 +1452,19 @@ async fn wipe_all_removes_profile_sharded_store_and_global_row() {
 #[test]
 fn list_all_reports_orphan_manifest_reconstructable_store() {
     let home = TempDir::new().unwrap();
-    let project = TempDir::new().unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("list-orphan-project-")
+        .tempdir_in(Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap())
+        .unwrap();
     write_profile_sharded_fixture(home.path(), project.path());
+    write_enrollment_marker(
+        project.path(),
+        &EnrollmentMarker {
+            project_id: "proj_cli".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
     std::fs::create_dir_all(profile_root(home.path())).unwrap();
 
     let mut command = tracedecay_command(home.path(), project.path());

--- a/tests/storage_suite/migration_manifest_test.rs
+++ b/tests/storage_suite/migration_manifest_test.rs
@@ -7,6 +7,7 @@ use crate::common::sample_node;
 use std::os::unix::fs::symlink;
 use tempfile::TempDir;
 use tracedecay::global_db::GlobalDb;
+use tracedecay::lifecycle_lease::acquire_exclusive_for_profile;
 use tracedecay::migrate::inventory::{
     MigrationInventory, RegistryStatus, StoreArtifact, StoreBrand, StoreInventory, StoreRole,
     StoreStatus,
@@ -20,7 +21,8 @@ use tracedecay::migrate::manifest::{
 };
 use tracedecay::storage::{
     EnrollmentMarker, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode,
-    StoreKind, StoreManifest, read_enrollment_marker, read_store_manifest, write_enrollment_marker,
+    StoreKind, StoreManifest, read_enrollment_marker, read_store_manifest,
+    remove_enrollment_marker, write_enrollment_marker,
 };
 
 fn empty_inventory() -> MigrationInventory {
@@ -937,7 +939,8 @@ fn migrate_apply_copies_single_store_and_cuts_over_profile_shard() {
     let sessions_db = data_dir.join("sessions.db");
     let branch_meta = data_dir.join("branch-meta.json");
     let profile_root = root.join("profile");
-    let global_db_path = root.join("global/global.db");
+    let ambient_global_db_path = root.join("ambient/global.db");
+    let profile_global_db_path = profile_root.join("global.db");
     fs::create_dir_all(&data_dir).unwrap();
     fs::write(&graph_db, b"graph").unwrap();
     fs::write(&sessions_db, b"sessions").unwrap();
@@ -987,8 +990,28 @@ fn migrate_apply_copies_single_store_and_cuts_over_profile_shard() {
     let manifest = manifest.unwrap();
     save_manifest(&manifest).unwrap();
 
+    let lease = acquire_exclusive_for_profile(&profile_root, "test migrate cutover").unwrap();
+    let blocked = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+        .env("TRACEDECAY_GLOBAL_DB", &ambient_global_db_path)
+        .env("TRACEDECAY_ENABLE_GLOBAL_DB", "1")
+        .args([
+            "migrate",
+            "apply",
+            "--manifest",
+            manifest_path.to_str().unwrap(),
+            "--confirm-token",
+            "confirm-mig_123",
+        ])
+        .output()
+        .unwrap();
+    assert!(!blocked.status.success());
+    assert!(String::from_utf8_lossy(&blocked.stderr).contains("test migrate cutover"));
+    assert!(!profile_root.join("projects/proj_123").exists());
+    assert!(!profile_global_db_path.exists());
+    drop(lease);
+
     let output = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
-        .env("TRACEDECAY_GLOBAL_DB", &global_db_path)
+        .env("TRACEDECAY_GLOBAL_DB", &ambient_global_db_path)
         .env("TRACEDECAY_ENABLE_GLOBAL_DB", "1")
         .args([
             "migrate",
@@ -1048,7 +1071,7 @@ fn migrate_apply_copies_single_store_and_cuts_over_profile_shard() {
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let resolution = runtime.block_on(async {
-        GlobalDb::open_at(&global_db_path)
+        GlobalDb::open_at(&profile_global_db_path)
             .await
             .unwrap()
             .resolve_project_store_by_alias(&project)
@@ -1067,6 +1090,41 @@ fn migrate_apply_copies_single_store_and_cuts_over_profile_shard() {
     let verify = verify_migration_manifest(&applied);
     assert!(verify.apply_supported, "{:?}", verify.issues);
     assert!(verify.issues.is_empty(), "{:?}", verify.issues);
+    assert!(!ambient_global_db_path.exists());
+
+    remove_enrollment_marker(&project, "proj_123").unwrap();
+    let retry = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+        .env("TRACEDECAY_GLOBAL_DB", &ambient_global_db_path)
+        .env("TRACEDECAY_ENABLE_GLOBAL_DB", "1")
+        .args([
+            "migrate",
+            "apply",
+            "--manifest",
+            manifest_path.to_str().unwrap(),
+            "--confirm-token",
+            "confirm-mig_123",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        retry.status.success(),
+        "stderr was: {}",
+        String::from_utf8_lossy(&retry.stderr)
+    );
+    assert_eq!(
+        read_enrollment_marker(&project)
+            .unwrap()
+            .unwrap()
+            .project_id,
+        "proj_123"
+    );
+    let retried = load_manifest(&manifest_path).unwrap();
+    assert!(
+        retried
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.state == ArtifactState::Applied)
+    );
 }
 
 #[test]
@@ -1164,6 +1222,49 @@ fn migrate_reconstruct_reports_registry_plans_without_applying_them() {
     let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(payload["plans"].as_array().unwrap().len(), 1);
     assert_eq!(payload["plans"][0]["project"]["project_id"], "proj_123");
+}
+
+#[test]
+fn reconstruct_apply_rejects_missing_profile_before_creating_lease_or_database() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("missing-profile");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+        .args([
+            "migrate",
+            "reconstruct",
+            "--profile-root",
+            profile_root.to_str().unwrap(),
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(!profile_root.exists());
+}
+
+#[test]
+fn reconstruct_apply_respects_exclusive_profile_lifecycle_cutover() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    fs::create_dir_all(profile_root.join("projects")).unwrap();
+    let _lease = acquire_exclusive_for_profile(&profile_root, "test cutover").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tracedecay"))
+        .args([
+            "migrate",
+            "reconstruct",
+            "--profile-root",
+            profile_root.to_str().unwrap(),
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("test cutover"));
+    assert!(!profile_root.join("global.db").exists());
 }
 
 #[test]

--- a/tests/storage_suite/profile_storage_migration_test.rs
+++ b/tests/storage_suite/profile_storage_migration_test.rs
@@ -17,14 +17,16 @@ use tracedecay::migrate::manifest::{
     verify_migration_manifest,
 };
 use tracedecay::migrate::registry::{
-    apply_registry_reconstruction_report, reconstruct_registry_from_store_manifest,
-    scan_profile_store_manifests,
+    RegistryReconstructionReport, RegistryReconstructionStatus,
+    apply_registry_reconstruction_report, apply_single_registry_reconstruction_report,
+    reconstruct_registry_from_store_manifest, scan_profile_store_manifests,
 };
 use tracedecay::serve;
 use tracedecay::sessions::cursor::open_project_session_db;
 use tracedecay::storage::{
     EnrollmentMarker, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode,
     StoreKind, StoreManifest, read_enrollment_marker, write_enrollment_marker,
+    write_repository_identity_marker,
 };
 use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions};
 
@@ -145,7 +147,15 @@ async fn table_exists(db_path: &std::path::Path, table: &str) -> bool {
 }
 
 fn write_profile_store_manifest(profile_root: &Path, project_root: &Path) -> std::path::PathBuf {
-    let data_root = profile_root.join("projects/proj_123");
+    write_profile_store_manifest_for_id(profile_root, project_root, "proj_123")
+}
+
+fn write_profile_store_manifest_for_id(
+    profile_root: &Path,
+    project_root: &Path,
+    project_id: &str,
+) -> std::path::PathBuf {
+    let data_root = profile_root.join("projects").join(project_id);
     fs::create_dir_all(&data_root).unwrap();
     fs::create_dir_all(project_root).unwrap();
     fs::write(data_root.join("tracedecay.db"), b"graph").unwrap();
@@ -154,7 +164,7 @@ fn write_profile_store_manifest(profile_root: &Path, project_root: &Path) -> std
     branch_meta::save_branch_meta(&data_root, &branch_meta).unwrap();
     let manifest = StoreManifest {
         schema_version: STORE_MANIFEST_SCHEMA_VERSION,
-        project_id: Some("proj_123".to_string()),
+        project_id: Some(project_id.to_string()),
         store_kind: StoreKind::CodeProject,
         storage_mode: StorageMode::ProfileSharded,
         project_root: project_root.to_path_buf(),
@@ -202,9 +212,11 @@ fn reconstructs_registry_records_from_profile_store_manifest() {
     assert!(report.issues.is_empty(), "{:?}", report.issues);
     assert_eq!(report.plans.len(), 1);
     let plan = &report.plans[0];
+    let canonical_project_root = project_root.canonicalize().unwrap();
+    assert_eq!(plan.status, RegistryReconstructionStatus::Eligible);
     assert_eq!(plan.project.project_id, "proj_123");
-    assert_eq!(plan.project.project_root, project_root);
-    assert_eq!(plan.project.aliases, vec![project_root]);
+    assert_eq!(plan.project.project_root, canonical_project_root);
+    assert_eq!(plan.project.aliases, vec![canonical_project_root]);
     assert_eq!(plan.store.project_id, "proj_123");
     assert_eq!(plan.store.store_kind, "code_project");
     assert_eq!(plan.store.storage_mode, "profile_sharded");
@@ -267,6 +279,79 @@ fn scan_profile_store_manifests_rejects_unsafe_manifest_relpaths() {
             .issues
             .iter()
             .any(|issue| issue.contains("unsafe graph_db_relpath"))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn reconstruction_accepts_equivalent_profile_symlink_but_rejects_symlink_escape() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let profile_alias = dir.path().join("profile-alias");
+    let project_root = dir.path().join("repo");
+    let manifest = write_profile_store_manifest(&profile_root, &project_root);
+    std::os::unix::fs::symlink(&profile_root, &profile_alias).unwrap();
+
+    let equivalent = reconstruct_registry_from_store_manifest(&manifest, &profile_alias, 1);
+    assert!(equivalent.issues.is_empty(), "{:?}", equivalent.issues);
+    assert_eq!(equivalent.plans.len(), 1);
+
+    let outside = dir.path().join("outside");
+    fs::create_dir_all(&outside).unwrap();
+    let escaped_root = profile_root.join("projects/proj_escape");
+    std::os::unix::fs::symlink(&outside, &escaped_root).unwrap();
+    let escaped_manifest = StoreManifest {
+        schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+        project_id: Some("proj_escape".to_string()),
+        store_kind: StoreKind::CodeProject,
+        storage_mode: StorageMode::ProfileSharded,
+        project_root,
+        data_root: escaped_root.clone(),
+        graph_db_relpath: "tracedecay.db".into(),
+        sessions_db_relpath: "sessions.db".into(),
+        branch_meta_relpath: "branch-meta.json".into(),
+    };
+    let escaped_manifest_path = escaped_root.join(STORE_MANIFEST_FILENAME);
+    fs::write(
+        &escaped_manifest_path,
+        serde_json::to_string_pretty(&escaped_manifest).unwrap(),
+    )
+    .unwrap();
+
+    let escaped =
+        reconstruct_registry_from_store_manifest(&escaped_manifest_path, &profile_root, 1);
+    assert!(escaped.plans.is_empty());
+    assert!(
+        escaped
+            .issues
+            .iter()
+            .any(|issue| issue.contains("outside profile root"))
+    );
+}
+
+#[test]
+fn unsafe_branch_database_path_blocks_reconstruction() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    let manifest = write_profile_store_manifest(&profile_root, &project_root);
+    let branch_meta_path = manifest.parent().unwrap().join("branch-meta.json");
+    let mut branch_meta: serde_json::Value =
+        serde_json::from_slice(&fs::read(&branch_meta_path).unwrap()).unwrap();
+    branch_meta["branches"]["main"]["db_file"] = serde_json::json!("../escape.db");
+    fs::write(
+        &branch_meta_path,
+        serde_json::to_vec_pretty(&branch_meta).unwrap(),
+    )
+    .unwrap();
+
+    let report = reconstruct_registry_from_store_manifest(&manifest, &profile_root, 1);
+
+    assert!(
+        report
+            .issues
+            .iter()
+            .any(|issue| issue.contains("unsafe database path"))
     );
 }
 
@@ -466,6 +551,399 @@ async fn applies_registry_reconstruction_records_from_manifest() {
             .as_deref()
             .map(portable_relpath),
         Some("projects/proj_123/store_manifest.json".to_string())
+    );
+}
+
+#[tokio::test]
+async fn single_plan_reconstruction_rejects_noneligible_and_accepts_matching_existing_rows() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    let manifest_path = write_profile_store_manifest(&profile_root, &project_root);
+    let report =
+        reconstruct_registry_from_store_manifest(&manifest_path, &profile_root, 1_800_000_001);
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+
+    let mut retired = report.clone();
+    retired.plans[0].status = RegistryReconstructionStatus::Retired;
+    retired.plans[0].status_reason = Some("superseded project".to_string());
+    let error = apply_single_registry_reconstruction_report(&db, &retired)
+        .await
+        .unwrap_err();
+    assert!(error.iter().any(|issue| issue.contains("Retired")));
+    assert!(db.get_code_project("proj_123").await.is_none());
+
+    let inserted = apply_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap();
+    assert_eq!(inserted.projects, 1);
+    assert_eq!(inserted.stores, 1);
+
+    let resumed = apply_single_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap();
+    assert_eq!(resumed.projects, 0);
+    assert_eq!(resumed.stores, 0);
+    assert_eq!(
+        db.resolve_project_store_by_identity(&project_root, None)
+            .await
+            .unwrap()
+            .project
+            .project_id,
+        "proj_123"
+    );
+}
+
+#[tokio::test]
+async fn conflicting_alias_is_rejected_without_stealing_or_partial_writes() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    let manifest = write_profile_store_manifest(&profile_root, &project_root);
+    let report = reconstruct_registry_from_store_manifest(&manifest, &profile_root, 1);
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+    db.upsert_code_project("proj_owner", &project_root, None, None, None)
+        .await
+        .unwrap();
+
+    let error = apply_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap_err();
+
+    assert!(error.iter().any(|issue| issue.contains("already owned")));
+    assert!(db.get_code_project("proj_123").await.is_none());
+    assert_eq!(
+        db.project_registry_context_by_alias(&project_root)
+            .await
+            .unwrap()
+            .project
+            .project_id,
+        "proj_owner"
+    );
+}
+
+#[tokio::test]
+async fn conflicting_later_plan_rolls_back_the_entire_reconstruction_batch() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let first_root = dir.path().join("first-repo");
+    let second_root = dir.path().join("second-repo");
+    let first = write_profile_store_manifest_for_id(&profile_root, &first_root, "proj_first");
+    let second = write_profile_store_manifest_for_id(&profile_root, &second_root, "proj_second");
+    let first = reconstruct_registry_from_store_manifest(&first, &profile_root, 1);
+    let second = reconstruct_registry_from_store_manifest(&second, &profile_root, 1);
+    let report = RegistryReconstructionReport {
+        plans: first.plans.into_iter().chain(second.plans).collect(),
+        issues: Vec::new(),
+    };
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+    db.upsert_code_project("proj_owner", &second_root, None, None, None)
+        .await
+        .unwrap();
+
+    apply_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap_err();
+
+    assert!(db.get_code_project("proj_first").await.is_none());
+    assert!(db.get_code_project("proj_second").await.is_none());
+    assert!(db.get_code_project("proj_owner").await.is_some());
+}
+
+#[tokio::test]
+async fn physical_store_path_conflict_rolls_back_without_creating_project() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    let manifest = write_profile_store_manifest(&profile_root, &project_root);
+    let report = reconstruct_registry_from_store_manifest(&manifest, &profile_root, 1);
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+    let owner_root = dir.path().join("owner");
+    fs::create_dir_all(&owner_root).unwrap();
+    db.upsert_code_project("proj_owner", &owner_root, None, None, None)
+        .await
+        .unwrap();
+    db.upsert_store_instance(StoreInstanceUpsert {
+        store_id: "store:owner".to_string(),
+        project_id: "proj_owner".to_string(),
+        store_kind: "code_project".to_string(),
+        storage_mode: "profile_sharded".to_string(),
+        store_relpath: report.plans[0].store.store_relpath.clone(),
+        manifest_relpath: None,
+        last_verified_at: None,
+        last_write_at: None,
+    })
+    .await
+    .unwrap();
+
+    let error = apply_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .iter()
+            .any(|issue| issue.contains("physical store path"))
+    );
+    assert!(db.get_code_project("proj_123").await.is_none());
+}
+
+#[tokio::test]
+async fn physical_graph_scope_conflict_rolls_back_without_creating_project() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    let manifest = write_profile_store_manifest(&profile_root, &project_root);
+    let report = reconstruct_registry_from_store_manifest(&manifest, &profile_root, 1);
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+    let owner_root = dir.path().join("owner");
+    fs::create_dir_all(&owner_root).unwrap();
+    db.upsert_code_project("proj_owner", &owner_root, None, None, None)
+        .await
+        .unwrap();
+    db.upsert_store_instance(StoreInstanceUpsert {
+        store_id: "store:owner".to_string(),
+        project_id: "proj_owner".to_string(),
+        store_kind: "code_project".to_string(),
+        storage_mode: "profile_sharded".to_string(),
+        store_relpath: "projects/owner".to_string(),
+        manifest_relpath: None,
+        last_verified_at: None,
+        last_write_at: None,
+    })
+    .await
+    .unwrap();
+    db.upsert_graph_scope(GraphScopeUpsert {
+        graph_scope_id: "scope:owner".to_string(),
+        project_id: "proj_owner".to_string(),
+        store_id: "store:owner".to_string(),
+        branch_name: "owner".to_string(),
+        db_relpath: report.plans[0].graph_scopes[0].db_relpath.clone(),
+        parent_scope_id: None,
+        last_synced_at: None,
+        writable: true,
+    })
+    .await
+    .unwrap();
+
+    let error = apply_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .iter()
+            .any(|issue| issue.contains("physical graph database path"))
+    );
+    assert!(db.get_code_project("proj_123").await.is_none());
+}
+
+#[test]
+fn missing_and_temporary_project_roots_are_classified_stale() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("temporary-repo");
+    let manifest = write_profile_store_manifest(&profile_root, &project_root);
+    write_enrollment_marker(
+        &project_root,
+        &EnrollmentMarker {
+            project_id: "proj_123".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+
+    let scanned = scan_profile_store_manifests(&profile_root, 1);
+    assert_eq!(scanned.plans[0].status, RegistryReconstructionStatus::Stale);
+    assert!(
+        scanned.plans[0]
+            .status_reason
+            .as_deref()
+            .unwrap()
+            .contains("temporary directory")
+    );
+
+    fs::remove_dir_all(&project_root).unwrap();
+    let missing = reconstruct_registry_from_store_manifest(&manifest, &profile_root, 1);
+    assert_eq!(missing.plans[0].status, RegistryReconstructionStatus::Stale);
+    assert!(
+        missing.plans[0]
+            .status_reason
+            .as_deref()
+            .unwrap()
+            .contains("unavailable")
+    );
+}
+
+#[test]
+fn strict_scan_classifies_unmarked_temporary_project_root_stale() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("unmarked-repo");
+    write_profile_store_manifest(&profile_root, &project_root);
+
+    let scanned = scan_profile_store_manifests(&profile_root, 1);
+
+    assert_eq!(scanned.plans[0].status, RegistryReconstructionStatus::Stale);
+    assert!(
+        scanned.plans[0]
+            .status_reason
+            .as_deref()
+            .unwrap()
+            .contains("temporary directory")
+    );
+}
+
+#[test]
+fn strict_scan_requires_matching_repository_identity_or_enrollment() {
+    let target = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let dir = tempfile::Builder::new()
+        .prefix("reconstruct-identity-")
+        .tempdir_in(target)
+        .unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    write_profile_store_manifest(&profile_root, &project_root);
+
+    let unowned = scan_profile_store_manifests(&profile_root, 1);
+    assert_eq!(
+        unowned.plans[0].status,
+        RegistryReconstructionStatus::Blocked
+    );
+    assert!(
+        unowned.plans[0]
+            .status_reason
+            .as_deref()
+            .unwrap()
+            .contains("no repository identity or enrollment marker")
+    );
+
+    write_enrollment_marker(
+        &project_root,
+        &EnrollmentMarker {
+            project_id: "proj_123".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let enrolled = scan_profile_store_manifests(&profile_root, 1);
+    assert_eq!(
+        enrolled.plans[0].status,
+        RegistryReconstructionStatus::Eligible
+    );
+}
+
+#[tokio::test]
+async fn consolidation_source_is_skipped_while_destination_applies() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    fs::create_dir_all(&project_root).unwrap();
+    run_git(&project_root, &["init"]);
+    write_repository_identity_marker(&project_root, "proj_destination").unwrap();
+    let source = write_profile_store_manifest_for_id(
+        &profile_root,
+        &project_root,
+        "proj_consolidated_source",
+    );
+    fs::write(
+        source.parent().unwrap().join("branch-meta.json"),
+        r#"{"default_branch":"main","branches":{"main":{"db_file":"../outside.db","created_at":"1","last_synced_at":"1"}}}"#,
+    )
+    .unwrap();
+    let destination =
+        write_profile_store_manifest_for_id(&profile_root, &project_root, "proj_destination");
+
+    let source = reconstruct_registry_from_store_manifest(&source, &profile_root, 1);
+    let destination = reconstruct_registry_from_store_manifest(&destination, &profile_root, 1);
+
+    assert_eq!(
+        source.plans[0].status,
+        RegistryReconstructionStatus::Retired
+    );
+    assert!(source.issues.is_empty(), "{:?}", source.issues);
+    assert_eq!(
+        destination.plans[0].status,
+        RegistryReconstructionStatus::Eligible
+    );
+    let issues = source
+        .issues
+        .into_iter()
+        .chain(destination.issues)
+        .collect();
+    let report = RegistryReconstructionReport {
+        plans: source.plans.into_iter().chain(destination.plans).collect(),
+        issues,
+    };
+    let db = GlobalDb::open_at(&dir.path().join("global.db"))
+        .await
+        .unwrap();
+
+    let applied = apply_registry_reconstruction_report(&db, &report)
+        .await
+        .unwrap();
+
+    assert_eq!(applied.projects, 1);
+    assert!(
+        db.get_code_project("proj_consolidated_source")
+            .await
+            .is_none()
+    );
+    assert!(db.get_code_project("proj_destination").await.is_some());
+}
+
+#[test]
+fn disagreeing_dual_markers_block_and_matching_retired_markers_retire() {
+    let dir = TempDir::new().unwrap();
+    let profile_root = dir.path().join("profile");
+    let project_root = dir.path().join("repo");
+    fs::create_dir_all(&project_root).unwrap();
+    run_git(&project_root, &["init"]);
+    write_repository_identity_marker(&project_root, "proj_repository").unwrap();
+    write_enrollment_marker(
+        &project_root,
+        &EnrollmentMarker {
+            project_id: "proj_enrollment".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let manifest =
+        write_profile_store_manifest_for_id(&profile_root, &project_root, "proj_repository");
+
+    let disagreement = reconstruct_registry_from_store_manifest(&manifest, &profile_root, 1);
+    assert_eq!(
+        disagreement.plans[0].status,
+        RegistryReconstructionStatus::Blocked
+    );
+
+    write_enrollment_marker(
+        &project_root,
+        &EnrollmentMarker {
+            project_id: "proj_repository".to_string(),
+            storage_mode: StorageMode::ProfileSharded,
+        },
+    )
+    .unwrap();
+    let retired_manifest =
+        write_profile_store_manifest_for_id(&profile_root, &project_root, "proj_retired_manifest");
+    let retired = reconstruct_registry_from_store_manifest(&retired_manifest, &profile_root, 1);
+    assert_eq!(
+        retired.plans[0].status,
+        RegistryReconstructionStatus::Retired
     );
 }
 


### PR DESCRIPTION
## Summary
- classify profile manifests as eligible, blocked, stale, or retired before reconstruction
- preflight the eligible batch under one immediate transaction without stealing aliases or physical store/scope paths
- hold explicit profile lifecycle leases across reconstruction and legacy migration cutovers
- keep migration retry idempotent while rejecting retired or ambiguous cutovers
- suppress stale/retired doctor noise and report blocked evidence

## Verification
- 29 profile-storage migration tests
- migration apply lifecycle/cutover regression
- doctor orphan reporting regression
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- live dry-run: 28 eligible, 0 blocked, 9 stale, 2 retired, 0 issues
