### PR TITLE
chore: release v0.0.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.54](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.53...v0.0.54) - 2026-07-11
+
+### Added
+
+- *(memory)* add autonomous user-scoped learning
+- *(memory)* add transactional graph grooming
+- *(automation)* review Hermes terminal receipts
+- *(automation)* apply safe skill consolidations
+- *(hermes)* export managed skills through plugin discovery
+- *(automation)* wake reviews from fresh session activity
+- *(memory)* add profile-level user scope
+
+### Fixed
+
+- *(storage)* preserve fact relations in consolidation
+- *(memory)* bound and validate graph grooming
+- *(storage)* preserve branch snapshot recovery files
+- *(hermes)* gate receipt reviews on ingested turns
+- *(storage)* snapshot live branch databases safely
+- *(sessions)* backfill Hermes turns by project evidence
+- *(hermes)* correlate live turns with projects
+- *(mcp)* avoid panic in memory status schema
+- *(hermes)* configure all profile providers
+- *(hermes)* isolate memory routes and context clones
+- *(hermes)* route memory by session workspace
+- *(hermes)* guard plugin nudge and memory retrieval
+
+### Other
+
+- *(automation)* restore guarded skill consolidation
+- *(automation)* keep skill consolidations staged
+
 ## [0.0.53](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.52...v0.0.53) - 2026-07-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.53 -> 0.0.54

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.54](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.53...v0.0.54) - 2026-07-11

### Added

- *(memory)* add autonomous user-scoped learning
- *(memory)* add transactional graph grooming
- *(automation)* review Hermes terminal receipts
- *(automation)* apply safe skill consolidations
- *(hermes)* export managed skills through plugin discovery
- *(automation)* wake reviews from fresh session activity
- *(memory)* add profile-level user scope

### Fixed

- *(storage)* preserve fact relations in consolidation
- *(memory)* bound and validate graph grooming
- *(storage)* preserve branch snapshot recovery files
- *(hermes)* gate receipt reviews on ingested turns
- *(storage)* snapshot live branch databases safely
- *(sessions)* backfill Hermes turns by project evidence
- *(hermes)* correlate live turns with projects
- *(mcp)* avoid panic in memory status schema
- *(hermes)* configure all profile providers
- *(hermes)* isolate memory routes and context clones
- *(hermes)* route memory by session workspace
- *(hermes)* guard plugin nudge and memory retrieval

### Other

- *(automation)* restore guarded skill consolidation
- *(automation)* keep skill consolidations staged
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).