### PR TITLE
fix(agents): recover post-update integration state

### DIFF
--- a/src/agent_cmd.rs
+++ b/src/agent_cmd.rs
@@ -155,6 +155,49 @@ pub(crate) async fn migrate_legacy_hermes_data(home: &Path) -> tracedecay::error
     })
 }
 
+/// Automated upgrade reinstalls must not remain wedged on preserved legacy
+/// stores whose project evidence no longer resolves. Genuine read, integrity,
+/// or copy failures still block the reinstall; an explicit Hermes install
+/// continues to use the strict cutover above.
+async fn migrate_legacy_hermes_data_for_reinstall(home: &Path) -> tracedecay::errors::Result<()> {
+    let report = tracedecay::migrate::hermes::migrate_legacy_hermes_stores(home).await;
+    finish_legacy_hermes_reinstall_migration(report)
+}
+
+fn finish_legacy_hermes_reinstall_migration(
+    report: tracedecay::migrate::hermes::LegacyHermesMigrationReport,
+) -> tracedecay::errors::Result<()> {
+    for migration in report.migrated {
+        eprintln!(
+            "  \x1b[32m✔\x1b[0m Migrated legacy Hermes session store {} -> {} ({} rows)",
+            migration.source_db.display(),
+            migration.target_project.display(),
+            migration.rows_copied
+        );
+    }
+    for issue in report.unresolved {
+        eprintln!(
+            "  \x1b[33mwarning:\x1b[0m preserving unresolved legacy Hermes session store {}: {}",
+            issue.source_db.display(),
+            issue.reason
+        );
+    }
+    if report.failed.is_empty() {
+        return Ok(());
+    }
+    let issues = report
+        .failed
+        .into_iter()
+        .map(|issue| format!("{}: {}", issue.source_db.display(), issue.reason))
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(tracedecay::errors::TraceDecayError::Config {
+        message: format!(
+            "legacy Hermes session data migration failed; source data and project pins were preserved: {issues}"
+        ),
+    })
+}
+
 pub(crate) async fn handle_install_command(
     agent: Option<String>,
     local: bool,
@@ -384,7 +427,9 @@ pub(crate) async fn handle_reinstall_command() -> tracedecay::errors::Result<()>
 /// loop forever — `migrate_installed_agents` only ever adds ids, never prunes,
 /// so a stale id would never resolve and the markers would never advance. Only
 /// genuine `install()` failures are reported as `Err` so they still gate
-/// markers.
+/// markers. Unresolved legacy Hermes project evidence is preserved and warned
+/// during automated reinstall; actual source-integrity or copy failures still
+/// gate Hermes so corrupted or partially copied data cannot be hidden.
 pub(crate) async fn reinstall_agent_integrations(
     agent_ids: &[String],
     home: &Path,
@@ -393,7 +438,7 @@ pub(crate) async fn reinstall_agent_integrations(
     let project_path = std::env::current_dir().ok();
     let mut results = Vec::new();
     let hermes_migration_error = if agent_ids.iter().any(|id| id == "hermes") {
-        migrate_legacy_hermes_data(home)
+        migrate_legacy_hermes_data_for_reinstall(home)
             .await
             .err()
             .map(|error| error.to_string())
@@ -496,4 +541,42 @@ pub(crate) async fn handle_uninstall_command(
         eprintln!("All agent integrations removed.");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tracedecay::migrate::hermes::{LegacyHermesMigrationIssue, LegacyHermesMigrationReport};
+
+    use super::finish_legacy_hermes_reinstall_migration;
+
+    #[test]
+    fn automated_reinstall_preserves_unresolved_legacy_store_without_gating() {
+        let report = LegacyHermesMigrationReport {
+            unresolved: vec![LegacyHermesMigrationIssue {
+                source_db: PathBuf::from("legacy-sessions.db"),
+                reason: "project evidence is unresolved".to_string(),
+            }],
+            ..LegacyHermesMigrationReport::default()
+        };
+
+        assert!(finish_legacy_hermes_reinstall_migration(report).is_ok());
+    }
+
+    #[test]
+    fn automated_reinstall_gates_legacy_store_failures() {
+        let report = LegacyHermesMigrationReport {
+            failed: vec![LegacyHermesMigrationIssue {
+                source_db: PathBuf::from("legacy-sessions.db"),
+                reason: "integrity check failed".to_string(),
+            }],
+            ..LegacyHermesMigrationReport::default()
+        };
+
+        let error = finish_legacy_hermes_reinstall_migration(report)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("integrity check failed"));
+    }
 }

--- a/src/automation/memory_digest.rs
+++ b/src/automation/memory_digest.rs
@@ -47,6 +47,12 @@ use crate::user_config::UserConfig;
 
 pub const MEMORY_DIGEST_START: &str = "<!-- TRACEDECAY MEMORY DIGEST START -->";
 pub const MEMORY_DIGEST_END: &str = "<!-- TRACEDECAY MEMORY DIGEST END -->";
+const MEMORY_DIGEST_HEADING: &str = "## TraceDecay memory digest";
+const MEMORY_DIGEST_BODY_PREAMBLE: &str = "Curated durable facts from TraceDecay project memory (trust-ranked, newest first). \
+     For deeper recall call MCP tool `tracedecay_recall`.\n\
+     Rate facts you rely on with `tracedecay_fact_feedback` (fact_id, helpful/unhelpful) \
+     — flagging a wrong or misleading fact unhelpful matters as much as confirming a \
+     helpful one; trust is earned only from this feedback.\n";
 
 /// Minimum trust score for a fact to enter the digest.
 pub const DEFAULT_DIGEST_MIN_TRUST: f64 = 0.6;
@@ -285,13 +291,7 @@ pub fn compose_digest_body(snapshot: &MemoryDigestSnapshot, char_budget: usize) 
             .then(left.project_key.cmp(&right.project_key))
     });
 
-    let mut body = String::from(
-        "Curated durable facts from TraceDecay project memory (trust-ranked, newest first). \
-         For deeper recall call MCP tool `tracedecay_recall`.\n\
-         Rate facts you rely on with `tracedecay_fact_feedback` (fact_id, helpful/unhelpful) \
-         — flagging a wrong or misleading fact unhelpful matters as much as confirming a \
-         helpful one; trust is earned only from this feedback.\n",
-    );
+    let mut body = String::from(MEMORY_DIGEST_BODY_PREAMBLE);
     let mut budget_hit = false;
     for section in sections {
         let header = format!("\n## {}\n\n", section.project_label);
@@ -569,49 +569,35 @@ fn remove_native_digest(target: SkillInstallTarget, plugin_root: &Path) -> Resul
 }
 
 fn render_prompt_digest_block(body: &str) -> String {
-    format!("{MEMORY_DIGEST_START}\n## TraceDecay memory digest\n\n{body}{MEMORY_DIGEST_END}\n")
+    format!("{MEMORY_DIGEST_START}\n{MEMORY_DIGEST_HEADING}\n\n{body}{MEMORY_DIGEST_END}\n")
 }
 
 fn replace_or_append_digest_block(existing: &str, block: &str) -> Result<String> {
-    match (
-        existing.find(MEMORY_DIGEST_START),
-        existing.find(MEMORY_DIGEST_END),
-    ) {
-        (Some(start), Some(end)) if start <= end => {
-            let end = end + MEMORY_DIGEST_END.len();
-            let mut updated = String::new();
-            updated.push_str(existing[..start].trim_end());
-            if !updated.is_empty() {
-                updated.push_str("\n\n");
-            }
-            updated.push_str(block.trim_end());
+    if let Some((start, end)) = digest_block_range(existing)? {
+        let mut updated = String::new();
+        updated.push_str(existing[..start].trim_end());
+        if !updated.is_empty() {
             updated.push_str("\n\n");
-            updated.push_str(existing[end..].trim_start());
-            let trimmed = updated.trim_end().to_string();
-            Ok(trimmed + "\n")
         }
-        (None, None) => {
-            let mut updated = String::new();
-            updated.push_str(existing.trim_end());
-            if !updated.is_empty() {
-                updated.push_str("\n\n");
-            }
-            updated.push_str(block);
-            Ok(updated)
+        updated.push_str(block.trim_end());
+        updated.push_str("\n\n");
+        updated.push_str(existing[end..].trim_start());
+        let trimmed = updated.trim_end().to_string();
+        Ok(trimmed + "\n")
+    } else {
+        let mut updated = String::new();
+        updated.push_str(existing.trim_end());
+        if !updated.is_empty() {
+            updated.push_str("\n\n");
         }
-        _ => Err(config_error(
-            "memory digest prompt markers are unbalanced".to_string(),
-        )),
+        updated.push_str(block);
+        Ok(updated)
     }
 }
 
 fn remove_digest_block(existing: &str) -> Result<String> {
-    match (
-        existing.find(MEMORY_DIGEST_START),
-        existing.find(MEMORY_DIGEST_END),
-    ) {
-        (Some(start), Some(end)) if start <= end => {
-            let end = end + MEMORY_DIGEST_END.len();
+    match digest_block_range(existing)? {
+        Some((start, end)) => {
             let mut updated = String::new();
             updated.push_str(existing[..start].trim_end());
             updated.push_str("\n\n");
@@ -621,7 +607,48 @@ fn remove_digest_block(existing: &str) -> Result<String> {
             }
             Ok(updated)
         }
-        (None, None) => Ok(existing.to_string()),
+        None => Ok(existing.to_string()),
+    }
+}
+
+fn digest_block_range(existing: &str) -> Result<Option<(usize, usize)>> {
+    match (
+        existing.find(MEMORY_DIGEST_START),
+        existing.find(MEMORY_DIGEST_END),
+    ) {
+        (Some(start), Some(end)) if start <= end => {
+            if existing.match_indices(MEMORY_DIGEST_START).count() != 1
+                || existing.match_indices(MEMORY_DIGEST_END).count() != 1
+            {
+                return Err(config_error(
+                    "memory digest prompt markers are ambiguous".to_string(),
+                ));
+            }
+            Ok(Some((start, end + MEMORY_DIGEST_END.len())))
+        }
+        (None, Some(end)) => {
+            if existing.match_indices(MEMORY_DIGEST_END).count() != 1 {
+                return Err(config_error(
+                    "memory digest prompt markers are unbalanced".to_string(),
+                ));
+            }
+            let preamble = format!("{MEMORY_DIGEST_HEADING}\n\n{MEMORY_DIGEST_BODY_PREAMBLE}");
+            let mut matches = existing[..end].match_indices(&preamble);
+            let Some((start, _)) = matches.next() else {
+                return Err(config_error(
+                    "memory digest prompt markers are unbalanced".to_string(),
+                ));
+            };
+            if matches.next().is_some()
+                || existing[end + MEMORY_DIGEST_END.len()..].contains(&preamble)
+            {
+                return Err(config_error(
+                    "memory digest prompt markers are unbalanced".to_string(),
+                ));
+            }
+            Ok(Some((start, end + MEMORY_DIGEST_END.len())))
+        }
+        (None, None) => Ok(None),
         _ => Err(config_error(
             "memory digest prompt markers are unbalanced".to_string(),
         )),

--- a/src/automation/skill_targets.rs
+++ b/src/automation/skill_targets.rs
@@ -274,12 +274,7 @@ fn render_prompt_index_block(target: SkillInstallTarget, skills: &[ManagedSkill]
     let (start, end) = prompt_index_markers(target);
     block.push_str(&start);
     block.push('\n');
-    block.push_str("## TraceDecay managed skills\n\n");
-    let _ = write!(
-        block,
-        "This {} index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
-        target.prompt_label()
-    );
+    block.push_str(&prompt_index_preamble(target));
 
     if skills.is_empty() {
         block.push_str("- No approved managed skills are currently exported.\n");
@@ -305,9 +300,9 @@ fn replace_or_append_marked_block(
 ) -> Result<String> {
     let (start_marker, end_marker) = prompt_index_markers(target);
     // Prefer this target's slugged block; fall back to the legacy unslugged one.
-    let existing_range = match marked_block_range(existing, &start_marker, &end_marker)? {
+    let existing_range = match managed_block_range(existing, target, &start_marker, &end_marker)? {
         Some(range) => Some(range),
-        None => marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?,
+        None => managed_block_range(existing, target, PROMPT_INDEX_START, PROMPT_INDEX_END)?,
     };
     if let Some((start, end)) = existing_range {
         Ok(splice_range(existing, start, end, block))
@@ -339,7 +334,7 @@ fn splice_range(existing: &str, start: usize, end: usize, block: &str) -> String
 
 fn remove_marked_block_for_target(existing: &str, target: SkillInstallTarget) -> Result<String> {
     let (start_marker, end_marker) = prompt_index_markers(target);
-    if let Some((start, end)) = marked_block_range(existing, &start_marker, &end_marker)? {
+    if let Some((start, end)) = managed_block_range(existing, target, &start_marker, &end_marker)? {
         return Ok(remove_range(existing, start, end));
     }
     // Legacy fallback: older installs wrote an unslugged block. Only claim it as
@@ -349,7 +344,7 @@ fn remove_marked_block_for_target(existing: &str, target: SkillInstallTarget) ->
     // leave it untouched and let the remove-all path handle it instead.
     if !has_other_slugged_block(existing, target) {
         if let Some((start, end)) =
-            marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END)?
+            managed_block_range(existing, target, PROMPT_INDEX_START, PROMPT_INDEX_END)?
         {
             return Ok(remove_range(existing, start, end));
         }
@@ -373,10 +368,14 @@ fn remove_all_marked_blocks(existing: &str) -> Result<String> {
         .into_iter()
         .filter(|target| target.writes_prompt_index())
     {
-        updated = remove_marked_block_for_target(&updated, target)?;
+        let (start_marker, end_marker) = prompt_index_markers(target);
+        if let Some((start, end)) =
+            managed_block_range(&updated, target, &start_marker, &end_marker)?
+        {
+            updated = remove_range(&updated, start, end);
+        }
     }
-    if let Some((start, end)) = marked_block_range(&updated, PROMPT_INDEX_START, PROMPT_INDEX_END)?
-    {
+    if let Some((start, end)) = legacy_managed_block_range(&updated)? {
         updated = remove_range(&updated, start, end);
     }
     Ok(updated)
@@ -388,12 +387,125 @@ fn marked_block_range(
     end_marker: &str,
 ) -> Result<Option<(usize, usize)>> {
     match (existing.find(start_marker), existing.find(end_marker)) {
-        (Some(start), Some(end)) if start <= end => Ok(Some((start, end + end_marker.len()))),
+        (Some(start), Some(end)) if start <= end => {
+            if existing.match_indices(start_marker).count() != 1
+                || existing.match_indices(end_marker).count() != 1
+            {
+                return Err(config_error(
+                    "managed skill prompt index markers are ambiguous".to_string(),
+                ));
+            }
+            Ok(Some((start, end + end_marker.len())))
+        }
         (None, None) => Ok(None),
         _ => Err(config_error(
             "managed skill prompt index markers are unbalanced".to_string(),
         )),
     }
+}
+
+/// Finds a normal marker-delimited block, or a generated block whose start
+/// marker was lost while its exact preamble and end marker remain. Recovery
+/// begins at the preamble, so preceding user-authored text is never claimed.
+fn managed_block_range(
+    existing: &str,
+    target: SkillInstallTarget,
+    start_marker: &str,
+    end_marker: &str,
+) -> Result<Option<(usize, usize)>> {
+    match (existing.find(start_marker), existing.find(end_marker)) {
+        (Some(start), Some(end)) if start <= end => {
+            if existing.match_indices(start_marker).count() != 1
+                || existing.match_indices(end_marker).count() != 1
+            {
+                return Err(config_error(
+                    "managed skill prompt index markers are ambiguous".to_string(),
+                ));
+            }
+            Ok(Some((start, end + end_marker.len())))
+        }
+        (None, None) => Ok(None),
+        (None, Some(end)) => orphaned_generated_block_range(existing, target, end, end_marker),
+        _ => Err(config_error(
+            "managed skill prompt index markers are unbalanced".to_string(),
+        )),
+    }
+}
+
+fn legacy_managed_block_range(existing: &str) -> Result<Option<(usize, usize)>> {
+    match (
+        existing.find(PROMPT_INDEX_START),
+        existing.find(PROMPT_INDEX_END),
+    ) {
+        (Some(_), Some(_)) => marked_block_range(existing, PROMPT_INDEX_START, PROMPT_INDEX_END),
+        (None, None) => Ok(None),
+        (None, Some(end)) => {
+            if existing.match_indices(PROMPT_INDEX_END).count() != 1 {
+                return Err(config_error(
+                    "managed skill prompt index markers are ambiguous".to_string(),
+                ));
+            }
+            let mut starts = Vec::new();
+            for target in ALL_SKILL_INSTALL_TARGETS
+                .into_iter()
+                .filter(|target| target.writes_prompt_index())
+            {
+                let preamble = prompt_index_preamble(target);
+                starts.extend(
+                    existing[..end]
+                        .match_indices(&preamble)
+                        .map(|(start, _)| start),
+                );
+            }
+            let Some(start) = starts.first().copied() else {
+                return Err(config_error(
+                    "managed skill prompt index markers are unbalanced".to_string(),
+                ));
+            };
+            if starts.len() != 1 {
+                return Err(config_error(
+                    "managed skill prompt index markers are ambiguous".to_string(),
+                ));
+            }
+            Ok(Some((start, end + PROMPT_INDEX_END.len())))
+        }
+        _ => Err(config_error(
+            "managed skill prompt index markers are unbalanced".to_string(),
+        )),
+    }
+}
+
+fn orphaned_generated_block_range(
+    existing: &str,
+    target: SkillInstallTarget,
+    end: usize,
+    end_marker: &str,
+) -> Result<Option<(usize, usize)>> {
+    if existing.match_indices(end_marker).count() != 1 {
+        return Err(config_error(
+            "managed skill prompt index markers are unbalanced".to_string(),
+        ));
+    }
+    let preamble = prompt_index_preamble(target);
+    let mut matches = existing[..end].match_indices(&preamble);
+    let Some((start, _)) = matches.next() else {
+        return Err(config_error(
+            "managed skill prompt index markers are unbalanced".to_string(),
+        ));
+    };
+    if matches.next().is_some() || existing[end + end_marker.len()..].contains(&preamble) {
+        return Err(config_error(
+            "managed skill prompt index markers are unbalanced".to_string(),
+        ));
+    }
+    Ok(Some((start, end + end_marker.len())))
+}
+
+fn prompt_index_preamble(target: SkillInstallTarget) -> String {
+    format!(
+        "## TraceDecay managed skills\n\nThis {} index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        target.prompt_label()
+    )
 }
 
 fn remove_range(existing: &str, start: usize, end: usize) -> String {

--- a/src/migrate/hermes.rs
+++ b/src/migrate/hermes.rs
@@ -112,9 +112,13 @@ async fn migrate_legacy_hermes_stores_inner(
         )
         .await
         {
-            Ok(CandidateOutcome::Migrated(migration)) => report.migrated.push(migration),
-            Ok(CandidateOutcome::AlreadyMigrated(migration)) => {
+            Ok(CandidateOutcome::Migrated(migration, preserved_memory)) => {
+                report.migrated.push(migration);
+                report.unresolved.extend(preserved_memory);
+            }
+            Ok(CandidateOutcome::AlreadyMigrated(migration, preserved_memory)) => {
                 report.already_migrated.push(migration);
+                report.unresolved.extend(preserved_memory);
             }
             Err(CandidateError::Unresolved(reason)) => {
                 report
@@ -146,9 +150,13 @@ async fn migrate_legacy_hermes_stores_inner(
         )
         .await
         {
-            Ok(CandidateOutcome::Migrated(migration)) => report.migrated.push(migration),
-            Ok(CandidateOutcome::AlreadyMigrated(migration)) => {
+            Ok(CandidateOutcome::Migrated(migration, preserved_memory)) => {
+                report.migrated.push(migration);
+                report.unresolved.extend(preserved_memory);
+            }
+            Ok(CandidateOutcome::AlreadyMigrated(migration, preserved_memory)) => {
                 report.already_migrated.push(migration);
+                report.unresolved.extend(preserved_memory);
             }
             Err(CandidateError::Unresolved(reason)) => {
                 report.unresolved.push(LegacyHermesMigrationIssue {
@@ -289,8 +297,8 @@ fn legacy_profile_dirs_for_homes(hermes_homes: &[PathBuf]) -> Vec<PathBuf> {
 }
 
 enum CandidateOutcome {
-    Migrated(LegacyHermesMigration),
-    AlreadyMigrated(LegacyHermesMigration),
+    Migrated(LegacyHermesMigration, Option<LegacyHermesMigrationIssue>),
+    AlreadyMigrated(LegacyHermesMigration, Option<LegacyHermesMigrationIssue>),
 }
 
 enum CandidateError {
@@ -301,6 +309,13 @@ enum CandidateError {
 struct ResolvedTargetProject {
     root: PathBuf,
     registry_project_id: Option<String>,
+    user_scope: bool,
+}
+
+struct ResolvedTargetLayout {
+    sessions_db_path: PathBuf,
+    graph_db_path: Option<PathBuf>,
+    project_id: String,
 }
 
 async fn migrate_candidate(
@@ -384,9 +399,9 @@ async fn migrate_legacy_state_store(
         rows_copied,
     };
     Ok(if rows_copied == 0 {
-        CandidateOutcome::AlreadyMigrated(migration)
+        CandidateOutcome::AlreadyMigrated(migration, None)
     } else {
-        CandidateOutcome::Migrated(migration)
+        CandidateOutcome::Migrated(migration, None)
     })
 }
 
@@ -425,6 +440,18 @@ async fn migrate_candidate_snapshot(
     )
     .await
     .map_err(CandidateError::Unresolved)?;
+    let preserved_memory = if target_project.user_scope {
+        candidate
+            .source_memory_db
+            .as_ref()
+            .map(|source_db| LegacyHermesMigrationIssue {
+                source_db: source_db.clone(),
+                reason: "unscoped legacy memory was preserved because no durable project attribution exists"
+                    .to_string(),
+            })
+    } else {
+        None
+    };
     let target_layout = resolve_target_layout(&target_project, tracedecay_profile_root)
         .await
         .map_err(|error| {
@@ -442,13 +469,22 @@ async fn migrate_candidate_snapshot(
     if candidate
         .source_memory_db
         .as_deref()
-        .is_some_and(|source_path| same_path(source_path, &target_layout.graph_db_path))
+        .zip(target_layout.graph_db_path.as_deref())
+        .is_some_and(|(source_path, target_path)| same_path(source_path, target_path))
     {
         return Err(CandidateError::Failed(
             "source and target memory databases resolve to the same path".to_string(),
         ));
     }
-    let source_memory = match candidate.source_memory_db.as_deref() {
+    // Projectless sessions are safe to retain in the profile user-session
+    // store. Legacy memory facts are not: without a project pin or durable
+    // session attribution their scope cannot be proven, so leave that source
+    // database untouched for a later explicit recovery.
+    let source_memory = match candidate
+        .source_memory_db
+        .as_deref()
+        .filter(|_| !target_project.user_scope)
+    {
         Some(path) => {
             let (db, _) = Database::open_read_only(path).await.map_err(|error| {
                 CandidateError::Failed(format!(
@@ -490,11 +526,14 @@ async fn migrate_candidate_snapshot(
         .map_err(CandidateError::Failed)?;
     }
     let memory_rows = match source_memory.as_ref() {
-        Some(source_memory) => {
-            merge_memory_snapshot(source_memory.conn(), &target_layout.graph_db_path)
-                .await
-                .map_err(CandidateError::Failed)?
-        }
+        Some(source_memory) => merge_memory_snapshot(
+            source_memory.conn(),
+            target_layout.graph_db_path.as_deref().ok_or_else(|| {
+                CandidateError::Failed("project memory target disappeared".to_string())
+            })?,
+        )
+        .await
+        .map_err(CandidateError::Failed)?,
         None => 0,
     };
 
@@ -504,15 +543,7 @@ async fn migrate_candidate_snapshot(
         target_db.conn(),
         &target_layout.sessions_db_path,
         &target_project.root,
-        target_layout
-            .identity
-            .project_id
-            .as_deref()
-            .ok_or_else(|| {
-                CandidateError::Failed(
-                    "target user-profile shard has no durable project id".to_string(),
-                )
-            })?,
+        &target_layout.project_id,
         &fingerprint,
         source_schema_version,
         memory_rows,
@@ -535,16 +566,23 @@ async fn migrate_candidate_snapshot(
         rows_copied: result.rows_copied,
     };
     Ok(if result.already_migrated {
-        CandidateOutcome::AlreadyMigrated(migration)
+        CandidateOutcome::AlreadyMigrated(migration, preserved_memory)
     } else {
-        CandidateOutcome::Migrated(migration)
+        CandidateOutcome::Migrated(migration, preserved_memory)
     })
 }
 
 async fn resolve_target_layout(
     target_project: &ResolvedTargetProject,
     tracedecay_profile_root: &Path,
-) -> crate::errors::Result<crate::storage::StoreLayout> {
+) -> crate::errors::Result<ResolvedTargetLayout> {
+    if target_project.user_scope {
+        return Ok(ResolvedTargetLayout {
+            sessions_db_path: crate::sessions::user_sessions_db_path(tracedecay_profile_root),
+            graph_db_path: None,
+            project_id: "user".to_string(),
+        });
+    }
     if let Some(project_id) = target_project.registry_project_id.as_deref() {
         if let Some(layout) =
             crate::storage::resolve_persisted_layout(&target_project.root, tracedecay_profile_root)?
@@ -558,25 +596,41 @@ async fn resolve_target_layout(
                     ),
                 });
             }
-            return Ok(layout);
+            return project_layout(layout);
         }
-        return crate::storage::profile_sharded_layout(
+        return project_layout(crate::storage::profile_sharded_layout(
             &target_project.root,
             tracedecay_profile_root,
             &crate::storage::EnrollmentMarker {
                 project_id: project_id.to_string(),
                 storage_mode: crate::storage::StorageMode::ProfileSharded,
             },
-        );
+        )?);
     }
 
     let production_profile = crate::storage::default_profile_root()
         .is_ok_and(|default| same_path(&default, tracedecay_profile_root));
-    if production_profile {
+    let layout = if production_profile {
         crate::tracedecay::TraceDecay::resolve_store_layout_for_identity(&target_project.root).await
     } else {
         crate::storage::resolve_layout(&target_project.root, tracedecay_profile_root)
-    }
+    }?;
+    project_layout(layout)
+}
+
+fn project_layout(
+    layout: crate::storage::StoreLayout,
+) -> crate::errors::Result<ResolvedTargetLayout> {
+    let project_id = layout.identity.project_id.clone().ok_or_else(|| {
+        crate::errors::TraceDecayError::Config {
+            message: "target project shard has no durable project id".to_string(),
+        }
+    })?;
+    Ok(ResolvedTargetLayout {
+        sessions_db_path: layout.sessions_db_path,
+        graph_db_path: Some(layout.graph_db_path),
+        project_id,
+    })
 }
 
 async fn verify_source(source: &Connection) -> Result<(), String> {
@@ -749,12 +803,13 @@ async fn resolve_target_project(
         .query(&sql, ())
         .await
         .map_err(|error| format!("could not read source project metadata: {error}"))?;
-    let mut candidates = BTreeSet::new();
+    let mut candidate_rows = Vec::new();
     while let Some(row) = rows
         .next()
         .await
         .map_err(|error| format!("could not read source project metadata row: {error}"))?
     {
+        let mut candidates = BTreeSet::new();
         for candidate in [row.get::<Option<String>>(0), row.get::<Option<String>>(1)]
             .into_iter()
             .flatten()
@@ -762,50 +817,117 @@ async fn resolve_target_project(
         {
             candidates.insert(PathBuf::from(candidate));
         }
-        if let Ok(Some(metadata)) = row.get::<Option<String>>(2) {
-            collect_metadata_project_candidates(&metadata, &mut candidates);
-        }
+        let malformed_metadata = match row.get::<Option<String>>(2) {
+            Ok(Some(metadata)) => {
+                collect_metadata_project_candidates(&metadata, &mut candidates).is_err()
+            }
+            Ok(None) => false,
+            Err(_) => true,
+        };
+        candidate_rows.push((candidates, malformed_metadata));
     }
 
     let mut targets: BTreeMap<String, ResolvedTargetProject> = BTreeMap::new();
-    for candidate in candidates {
-        let Some(target) =
-            resolve_project_candidate(&candidate, user_home, hermes_homes, registry.as_ref())
-                .await?
-        else {
-            continue;
-        };
-        let key = target
-            .registry_project_id
-            .clone()
-            .unwrap_or_else(|| format!("path:{}", GlobalDb::canonical_project_key(&target.root)));
-        if let Some(existing) = targets.get(&key)
-            && !same_path(&existing.root, &target.root)
-        {
+    let mut has_projectless_evidence = false;
+    let mut has_unresolved_project_evidence = false;
+    for (candidates, malformed_metadata) in candidate_rows {
+        let mut row_targets: BTreeMap<String, ResolvedTargetProject> = BTreeMap::new();
+        let mut row_has_unresolved_project_evidence = malformed_metadata;
+        for candidate in candidates {
+            if is_projectless_candidate(&candidate, user_home, hermes_homes) {
+                continue;
+            }
+            let Some(target) =
+                resolve_project_candidate(&candidate, user_home, hermes_homes, registry.as_ref())
+                    .await?
+            else {
+                row_has_unresolved_project_evidence = true;
+                continue;
+            };
+            let key = target_key(&target);
+            if let Some(existing) = row_targets.get(&key)
+                && !same_path(&existing.root, &target.root)
+            {
+                return Err(project_identity_collision(&key, existing, &target));
+            }
+            row_targets.insert(key, target);
+        }
+        if row_targets.len() > 1 {
             return Err(format!(
-                "registered project identity '{key}' maps to both '{}' and '{}'; refusing a collision",
-                existing.root.display(),
-                target.root.display()
+                "one source session maps to {} projects; refusing an ambiguous migration",
+                row_targets.len()
             ));
         }
-        targets.insert(key, target);
+        if row_has_unresolved_project_evidence {
+            has_unresolved_project_evidence = true;
+        }
+        if let Some((key, target)) = row_targets.into_iter().next() {
+            if let Some(existing) = targets.get(&key)
+                && !same_path(&existing.root, &target.root)
+            {
+                return Err(project_identity_collision(&key, existing, &target));
+            }
+            targets.insert(key, target);
+        } else if !row_has_unresolved_project_evidence {
+            has_projectless_evidence = true;
+        }
     }
     match targets.len() {
-        1 => targets
+        1 if !has_projectless_evidence && !has_unresolved_project_evidence => targets
             .into_values()
             .next()
             .ok_or_else(|| "resolved project target disappeared".to_string()),
+        0 if !has_unresolved_project_evidence => Ok(ResolvedTargetProject {
+            root: PathBuf::from("user"),
+            registry_project_id: None,
+            user_scope: true,
+        }),
         0 => Err("no durable real project path exists in source session metadata".to_string()),
+        1 => Err(
+            "source session metadata mixes projectless or unresolved evidence with a project; refusing an ambiguous migration"
+                .to_string(),
+        ),
         count => Err(format!(
             "source session metadata maps to {count} projects; refusing an ambiguous migration"
         )),
     }
 }
 
-fn collect_metadata_project_candidates(raw: &str, candidates: &mut BTreeSet<PathBuf>) {
-    let Ok(metadata) = serde_json::from_str::<serde_json::Value>(raw) else {
-        return;
-    };
+fn target_key(target: &ResolvedTargetProject) -> String {
+    target
+        .registry_project_id
+        .clone()
+        .unwrap_or_else(|| format!("path:{}", GlobalDb::canonical_project_key(&target.root)))
+}
+
+fn project_identity_collision(
+    key: &str,
+    existing: &ResolvedTargetProject,
+    target: &ResolvedTargetProject,
+) -> String {
+    format!(
+        "registered project identity '{key}' maps to both '{}' and '{}'; refusing a collision",
+        existing.root.display(),
+        target.root.display()
+    )
+}
+
+fn is_projectless_candidate(candidate: &Path, user_home: &Path, hermes_homes: &[PathBuf]) -> bool {
+    if candidate.as_os_str().is_empty() || candidate == Path::new("user") {
+        return true;
+    }
+    same_path(candidate, user_home)
+        || hermes_homes
+            .iter()
+            .any(|hermes_home| same_path(candidate, hermes_home))
+}
+
+fn collect_metadata_project_candidates(
+    raw: &str,
+    candidates: &mut BTreeSet<PathBuf>,
+) -> Result<(), ()> {
+    let metadata = serde_json::from_str::<serde_json::Value>(raw).map_err(|_| ())?;
+    let metadata = metadata.as_object().ok_or(())?;
     for key in [
         "hermes_session_cwd",
         "hermes_session_worktree",
@@ -813,10 +935,12 @@ fn collect_metadata_project_candidates(raw: &str, candidates: &mut BTreeSet<Path
         "worktree",
         "project_root",
     ] {
-        if let Some(path) = metadata.get(key).and_then(serde_json::Value::as_str) {
+        if let Some(value) = metadata.get(key) {
+            let path = value.as_str().ok_or(())?;
             candidates.insert(PathBuf::from(path));
         }
     }
+    Ok(())
 }
 
 async fn resolve_project_candidate(
@@ -858,6 +982,7 @@ async fn resolve_project_candidate(
                 return Ok(Some(ResolvedTargetProject {
                     root,
                     registry_project_id: Some(context.project.project_id),
+                    user_scope: false,
                 }));
             }
         }
@@ -872,6 +997,7 @@ async fn resolve_project_candidate(
         real_project_root(candidate, user_home, hermes_homes).map(|root| ResolvedTargetProject {
             root,
             registry_project_id: None,
+            user_scope: false,
         }),
     )
 }
@@ -2846,7 +2972,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn removed_symlink_metadata_resolves_through_registered_canonical_alias() {
+    async fn removed_unprovable_symlink_metadata_is_preserved() {
         let temp = tempfile::tempdir().unwrap();
         let user_home = temp.path().join("home");
         let profile_root = temp.path().join("tracedecay-profile");
@@ -2887,13 +3013,10 @@ mod tests {
 
         let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
 
-        assert_eq!(report.migrated.len(), 1, "{report:?}");
-        assert_eq!(
-            report.migrated[0].target_project,
-            current_project.canonicalize().unwrap()
-        );
+        assert!(report.migrated.is_empty(), "{report:?}");
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
         assert!(
-            profile_root
+            !profile_root
                 .join("projects/stable-project/sessions.db")
                 .is_file()
         );
@@ -3006,19 +3129,183 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hermes_profile_path_is_never_a_migration_target() {
+    async fn projectless_profile_sessions_migrate_to_user_store_idempotently() {
         let temp = tempfile::tempdir().unwrap();
         let user_home = temp.path().join("home");
         let profile_root = temp.path().join("tracedecay-profile");
         let hermes = user_home.join(".hermes");
         let source = hermes.join(".tracedecay/sessions.db");
+        let source_memory = hermes.join(".tracedecay/tracedecay.db");
         fs::create_dir_all(source.parent().unwrap()).unwrap();
-        fs::write(hermes.join(".tracedecay/tracedecay.db"), []).unwrap();
+        let source_fact_id = seed_memory_fact(&source_memory, "unscoped legacy fact").await;
         seed_source(&source, &[("session", &hermes)]).await;
+
+        let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+        assert_eq!(report.migrated.len(), 1, "{report:?}");
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
+        assert_eq!(report.unresolved[0].source_db, source_memory);
+        assert!(report.unresolved[0].reason.contains("preserved"));
+        let target_path = crate::sessions::user_sessions_db_path(&profile_root);
+        let target = GlobalDb::open_read_only_at(&target_path).await.unwrap();
+        let session = target.get_session("hermes", "session").await.unwrap();
+        assert_eq!(session.project_path, "user");
+        assert!(!crate::memory::user::user_memory_db_path(&profile_root).exists());
+        let source_after = GlobalDb::open_read_only_at(&source).await.unwrap();
+        assert_eq!(count(source_after.conn(), "sessions").await, 1);
+        drop(source_after);
+        let (source_memory_after, _) = Database::open_read_only(&source_memory).await.unwrap();
+        assert!(
+            MemoryStore::new(source_memory_after.conn())
+                .get_fact(source_fact_id)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        let retry = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+        assert_eq!(retry.already_migrated.len(), 1, "{retry:?}");
+        assert_eq!(retry.unresolved.len(), 1, "{retry:?}");
+        assert_eq!(count(target.conn(), "sessions").await, 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_metadata_is_preserved_not_misrouted_to_user() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_home = temp.path().join("home");
+        let profile_root = temp.path().join("tracedecay-profile");
+        let source = user_home.join(".hermes/.tracedecay/sessions.db");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        seed_source(&source, &[("session", &user_home)]).await;
+        let source_rw = GlobalDb::open_at(&source).await.unwrap();
+        source_rw
+            .conn()
+            .execute(
+                "UPDATE sessions SET project_key = '', project_path = '', metadata_json = '{invalid' WHERE session_id = 'session'",
+                (),
+            )
+            .await
+            .unwrap();
+        drop(source_rw);
+
+        let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
+        assert!(report.migrated.is_empty());
+        assert!(!crate::sessions::user_sessions_db_path(&profile_root).exists());
+    }
+
+    #[tokio::test]
+    async fn structurally_invalid_metadata_is_preserved_not_misrouted_to_user() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_home = temp.path().join("home");
+        let profile_root = temp.path().join("tracedecay-profile");
+        let source = user_home.join(".hermes/.tracedecay/sessions.db");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        seed_source(&source, &[("session", &user_home)]).await;
+        let source_rw = GlobalDb::open_at(&source).await.unwrap();
+        source_rw
+            .conn()
+            .execute(
+                "UPDATE sessions SET project_key = '', project_path = '', metadata_json = '{\"project_root\":42}' WHERE session_id = 'session'",
+                (),
+            )
+            .await
+            .unwrap();
+        drop(source_rw);
+
+        let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
+        assert!(report.migrated.is_empty());
+        assert!(!crate::sessions::user_sessions_db_path(&profile_root).exists());
+    }
+
+    #[tokio::test]
+    async fn vanished_project_evidence_is_preserved_not_misrouted_to_user() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_home = temp.path().join("home");
+        let profile_root = temp.path().join("tracedecay-profile");
+        let vanished_project = user_home.join(".hermes/plugins/vanished-project");
+        let source = user_home.join(".hermes/.tracedecay/sessions.db");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        seed_source(&source, &[("session", &vanished_project)]).await;
 
         let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
         assert_eq!(report.unresolved.len(), 1, "{report:?}");
         assert!(report.migrated.is_empty());
+        assert!(!crate::sessions::user_sessions_db_path(&profile_root).exists());
+        let source_after = GlobalDb::open_read_only_at(&source).await.unwrap();
+        assert_eq!(count(source_after.conn(), "sessions").await, 1);
+    }
+
+    #[tokio::test]
+    async fn existing_unregistered_directory_is_not_assumed_projectless() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_home = temp.path().join("home");
+        let profile_root = temp.path().join("tracedecay-profile");
+        let unregistered = temp.path().join("unregistered-project");
+        fs::create_dir_all(&unregistered).unwrap();
+        let source = user_home.join(".hermes/.tracedecay/sessions.db");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        seed_source(&source, &[("session", &unregistered)]).await;
+
+        let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
+        assert!(report.migrated.is_empty());
+        assert!(!crate::sessions::user_sessions_db_path(&profile_root).exists());
+    }
+
+    #[tokio::test]
+    async fn same_session_resolved_and_unresolved_projects_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_home = temp.path().join("home");
+        let profile_root = temp.path().join("tracedecay-profile");
+        let project = temp.path().join("project");
+        let vanished = temp.path().join("vanished-project");
+        mark_real_project(&project);
+        let source = user_home.join(".hermes/.tracedecay/sessions.db");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        seed_source(&source, &[("session", &project)]).await;
+        let source_rw = GlobalDb::open_at(&source).await.unwrap();
+        source_rw
+            .conn()
+            .execute(
+                "UPDATE sessions SET project_path = ?1 WHERE session_id = 'session'",
+                [vanished.to_string_lossy().to_string()],
+            )
+            .await
+            .unwrap();
+        drop(source_rw);
+
+        let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
+        assert!(report.migrated.is_empty());
+        let layout = crate::storage::resolve_layout(&project, &profile_root).unwrap();
+        assert!(!layout.sessions_db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn mixed_user_and_project_sessions_fail_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let user_home = temp.path().join("home");
+        let profile_root = temp.path().join("tracedecay-profile");
+        let project = temp.path().join("project");
+        mark_real_project(&project);
+        let source = user_home.join(".hermes/.tracedecay/sessions.db");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        seed_source(
+            &source,
+            &[("user-session", &user_home), ("project-session", &project)],
+        )
+        .await;
+
+        let report = migrate_legacy_hermes_stores_to(&user_home, &profile_root).await;
+        assert_eq!(report.unresolved.len(), 1, "{report:?}");
+        assert!(report.unresolved[0].reason.contains("ambiguous"));
+        assert!(!crate::sessions::user_sessions_db_path(&profile_root).exists());
+        let project_layout = crate::storage::resolve_layout(&project, &profile_root).unwrap();
+        assert!(!project_layout.sessions_db_path.exists());
     }
 
     #[tokio::test]

--- a/tests/agent_suite/memory_digest_test.rs
+++ b/tests/agent_suite/memory_digest_test.rs
@@ -268,6 +268,102 @@ async fn prompt_index_block_preserves_user_content_and_is_idempotent() {
 }
 
 #[tokio::test]
+async fn prompt_index_repairs_owned_orphan_end_marker() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let prompt_path = temp.path().join("CLAUDE.md");
+    std::fs::write(&prompt_path, "# User rules\n\nKeep before.\n").unwrap();
+
+    update_project_digest_section(
+        &profile_root,
+        build_project_section(
+            "proj",
+            "proj",
+            vec![fact(1, "Stale digest", 0.9, 100)],
+            &MemoryDigestOptions::default(),
+        ),
+    )
+    .unwrap();
+    export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
+    let orphaned = std::fs::read_to_string(&prompt_path)
+        .unwrap()
+        .replace(&format!("{MEMORY_DIGEST_START}\n"), "");
+    std::fs::write(&prompt_path, format!("{orphaned}\nKeep after.\n")).unwrap();
+
+    update_project_digest_section(
+        &profile_root,
+        build_project_section(
+            "proj",
+            "proj",
+            vec![fact(2, "Recovered digest", 0.9, 101)],
+            &MemoryDigestOptions::default(),
+        ),
+    )
+    .unwrap();
+    export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
+
+    let contents = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(contents.contains("Keep before."));
+    assert!(contents.contains("Keep after."));
+    assert!(contents.contains("Recovered digest"));
+    assert!(!contents.contains("Stale digest"));
+    assert_eq!(contents.matches(MEMORY_DIGEST_START).count(), 1);
+    assert_eq!(contents.matches(MEMORY_DIGEST_END).count(), 1);
+}
+
+#[tokio::test]
+async fn prompt_index_keeps_start_only_marker_fail_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let prompt_path = temp.path().join("CLAUDE.md");
+    std::fs::write(
+        &prompt_path,
+        format!("# User rules\n\n{MEMORY_DIGEST_START}\n\nunknown content\n"),
+    )
+    .unwrap();
+
+    let error = export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("markers are unbalanced"));
+    assert!(
+        std::fs::read_to_string(&prompt_path)
+            .unwrap()
+            .contains("unknown content")
+    );
+}
+
+#[tokio::test]
+async fn prompt_index_duplicate_balanced_blocks_fail_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let prompt_path = temp.path().join("CLAUDE.md");
+    std::fs::write(&prompt_path, "# User rules\n").unwrap();
+    update_project_digest_section(
+        &profile_root,
+        build_project_section(
+            "proj",
+            "proj",
+            vec![fact(1, "Digest", 0.9, 100)],
+            &MemoryDigestOptions::default(),
+        ),
+    )
+    .unwrap();
+    export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path).unwrap();
+    let once = std::fs::read_to_string(&prompt_path).unwrap();
+    let block = &once[once.find(MEMORY_DIGEST_START).unwrap()..];
+    let duplicated = format!("{once}\n{block}");
+    std::fs::write(&prompt_path, &duplicated).unwrap();
+
+    let error = export_memory_digest(&profile_root, SkillInstallTarget::Claude, &prompt_path)
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("markers are ambiguous"));
+    assert_eq!(std::fs::read_to_string(&prompt_path).unwrap(), duplicated);
+}
+
+#[tokio::test]
 async fn config_gate_disables_export_and_strips_previous_artifacts() {
     let temp = tempfile::tempdir().unwrap();
     let profile_root = temp.path().join("profile");

--- a/tests/agent_suite/skill_targets_test.rs
+++ b/tests/agent_suite/skill_targets_test.rs
@@ -7,7 +7,7 @@ use tracedecay::automation::managed_skills::{
 };
 use tracedecay::automation::skill_targets::{
     SkillInstallTarget, export_native_skill_overlay, export_prompt_skill_index,
-    install_managed_skills, remove_prompt_skill_index_for_target,
+    install_managed_skills, remove_prompt_skill_index, remove_prompt_skill_index_for_target,
 };
 
 fn draft(id: &str, title: &str) -> ManagedSkillDraft {
@@ -443,6 +443,169 @@ async fn prompt_index_preserves_user_content_and_routes_full_body_through_mcp() 
     assert!(second.contains("TRACEDECAY MANAGED SKILLS START agents"));
     assert!(second.contains("TRACEDECAY MANAGED SKILLS START claude"));
     assert!(second.contains("This Claude index lists"));
+}
+
+#[tokio::test]
+async fn prompt_index_repairs_slugged_orphan_end_without_claiming_user_text() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_root = temp.path().join("profile");
+    let prompt_path = temp.path().join("AGENTS.md");
+
+    create_managed_skill_draft(
+        &profile_root,
+        targeted_draft(
+            "repo-hygiene",
+            "Repository hygiene",
+            vec![SkillInstallTarget::Agents],
+        ),
+    )
+    .await
+    .unwrap();
+    approve_managed_skill(&profile_root, "repo-hygiene")
+        .await
+        .unwrap();
+    std::fs::write(&prompt_path, "# User rules\n\nKeep before.\n").unwrap();
+    export_prompt_skill_index(&profile_root, SkillInstallTarget::Agents, &prompt_path).unwrap();
+
+    let stale = std::fs::read_to_string(&prompt_path)
+        .unwrap()
+        .replace("<!-- TRACEDECAY MANAGED SKILLS START agents -->\n", "");
+    std::fs::write(&prompt_path, format!("{stale}\nKeep after.\n")).unwrap();
+
+    export_prompt_skill_index(&profile_root, SkillInstallTarget::Agents, &prompt_path).unwrap();
+    let repaired = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(repaired.contains("Keep before."));
+    assert!(repaired.contains("Keep after."));
+    assert_eq!(
+        repaired
+            .matches("<!-- TRACEDECAY MANAGED SKILLS START agents -->")
+            .count(),
+        1
+    );
+
+    export_prompt_skill_index(&profile_root, SkillInstallTarget::Agents, &prompt_path).unwrap();
+    assert_eq!(std::fs::read_to_string(&prompt_path).unwrap(), repaired);
+}
+
+#[test]
+fn uninstall_repairs_legacy_orphan_end_without_claiming_user_text() {
+    let temp = tempfile::tempdir().unwrap();
+    let prompt_path = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# User rules\n\nKeep before.\n\n",
+        "## TraceDecay managed skills\n\n",
+        "This AGENTS.md index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        "- `generated`: Generated.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END -->\n\n",
+        "Keep after.\n",
+    );
+    std::fs::write(&prompt_path, contents).unwrap();
+
+    remove_prompt_skill_index_for_target(&prompt_path, SkillInstallTarget::Agents).unwrap();
+
+    let repaired = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(repaired.contains("Keep before."));
+    assert!(repaired.contains("Keep after."));
+    assert!(!repaired.contains("TraceDecay managed skills"));
+    assert!(!repaired.contains("`generated`"));
+
+    remove_prompt_skill_index_for_target(&prompt_path, SkillInstallTarget::Agents).unwrap();
+    assert_eq!(std::fs::read_to_string(&prompt_path).unwrap(), repaired);
+}
+
+#[test]
+fn prompt_index_start_only_remains_ambiguous_and_fails_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let prompt_path = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# User rules\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START agents -->\n",
+        "## TraceDecay managed skills\n\n",
+        "This AGENTS.md index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n",
+    );
+    std::fs::write(&prompt_path, contents).unwrap();
+
+    let error =
+        remove_prompt_skill_index_for_target(&prompt_path, SkillInstallTarget::Agents).unwrap_err();
+    assert!(error.to_string().contains("markers are unbalanced"));
+    assert_eq!(std::fs::read_to_string(&prompt_path).unwrap(), contents);
+}
+
+#[test]
+fn uninstall_all_removes_legacy_orphan_alongside_slugged_block() {
+    let temp = tempfile::tempdir().unwrap();
+    let prompt_path = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# User rules\n\nKeep before.\n\n",
+        "## TraceDecay managed skills\n\n",
+        "This AGENTS.md index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        "- `legacy`: Legacy.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END -->\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START claude -->\n",
+        "## TraceDecay managed skills\n\n",
+        "This Claude index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        "- `slugged`: Slugged.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END claude -->\n\n",
+        "Keep after.\n",
+    );
+    std::fs::write(&prompt_path, contents).unwrap();
+
+    remove_prompt_skill_index(&prompt_path).unwrap();
+
+    let repaired = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(repaired.contains("Keep before."));
+    assert!(repaired.contains("Keep after."));
+    assert!(!repaired.contains("TraceDecay managed skills"));
+    assert!(!repaired.contains("`legacy`"));
+    assert!(!repaired.contains("`slugged`"));
+}
+
+#[test]
+fn uninstall_all_removes_inverse_order_legacy_orphan_and_slugged_block() {
+    let temp = tempfile::tempdir().unwrap();
+    let prompt_path = temp.path().join("AGENTS.md");
+    let contents = concat!(
+        "# User rules\n\nKeep before.\n\n",
+        "## TraceDecay managed skills\n\n",
+        "This Claude index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        "- `legacy`: Legacy.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END -->\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS START agents -->\n",
+        "## TraceDecay managed skills\n\n",
+        "This AGENTS.md index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        "- `slugged`: Slugged.\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END agents -->\n\n",
+        "Keep after.\n",
+    );
+    std::fs::write(&prompt_path, contents).unwrap();
+
+    remove_prompt_skill_index(&prompt_path).unwrap();
+
+    let repaired = std::fs::read_to_string(&prompt_path).unwrap();
+    assert!(repaired.contains("Keep before."));
+    assert!(repaired.contains("Keep after."));
+    assert!(!repaired.contains("TraceDecay managed skills"));
+}
+
+#[test]
+fn prompt_index_duplicate_balanced_blocks_fail_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let prompt_path = temp.path().join("AGENTS.md");
+    let block = concat!(
+        "<!-- TRACEDECAY MANAGED SKILLS START agents -->\n",
+        "## TraceDecay managed skills\n\n",
+        "This AGENTS.md index lists approved profile-managed skills. For full instructions, call MCP tool `tracedecay_skill_view` with the listed `id`.\n\n",
+        "<!-- TRACEDECAY MANAGED SKILLS END agents -->\n",
+    );
+    let contents = format!("# User rules\n\n{block}\n{block}");
+    std::fs::write(&prompt_path, &contents).unwrap();
+
+    let error = remove_prompt_skill_index_for_target(&prompt_path, SkillInstallTarget::Agents)
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("markers are ambiguous"));
+    assert_eq!(std::fs::read_to_string(&prompt_path).unwrap(), contents);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This is the rollout follow-up to #441. The Hermes/TraceDecay architecture in #441 is intact: Hermes sessions resolve memory and LCM storage from the session workspace, project-backed sessions remain project-sharded, untethered sessions use profile-level user memory/session stores, autonomous post-turn review applies validated mutations, and TraceDecay-managed skills are exposed through Hermes's native plugin discovery and progressive tool discovery.

The v0.0.54 rollout exposed two pre-existing-state problems that could not be reproduced from a clean install:

1. Several generated prompt files had an intact TraceDecay-owned preamble and END marker but a missing START marker. Reinstall treated these files as unbalanced forever, so post-update integration refresh retried on every command.
2. A preserved historical Hermes-local `sessions.db` contained sessions whose original project path no longer exists. Explicit Hermes migration correctly refused to guess, but the same unresolved source also gated automatic post-update reinstall forever.

This PR makes those states recoverable without claiming user-authored text, guessing project identity, copying unscoped memory into user memory, or hiding real database failures.

## Generated prompt block recovery

Managed-skill indexes and memory-digest blocks now recognize a narrowly defined orphaned generated block:

- the START marker is absent;
- exactly one matching END marker remains;
- the exact TraceDecay-generated heading and target-specific preamble remain;
- the preamble occurs exactly once before the END marker;
- no duplicate or competing marker block exists.

When all of those ownership signals are present, reinstall replaces or removes only the generated range beginning at the exact preamble. Text before and after that range is preserved. This repairs the real rollout state while avoiding a broad heading-based deletion heuristic.

Ambiguous states remain fail-closed:

- START without END;
- END without the exact generated preamble;
- duplicate START or END markers;
- repeated generated preambles;
- multiple candidate legacy target preambles.

Shared prompt files receive a two-pass uninstall: all target-slugged blocks are removed first, then the one legacy unslugged block is evaluated. This removes ordering dependence when an orphaned legacy block and a newer target-slugged block coexist.

The memory digest uses the same ownership and ambiguity rules. The generated heading/body preamble is now a single constant shared by rendering and recovery, preventing recovery logic from drifting from emitted content.

## Hermes legacy session migration

The legacy migrator now has two explicit destination layouts:

- project scope: the registered project's existing profile-sharded `sessions.db` and `tracedecay.db`;
- user scope: profile-level `user-sessions.db`, with no project memory target.

Only sessions with provably neutral scope may enter `user-sessions.db`. Neutral evidence is limited to an empty selector, the explicit `user` selector, the exact user home, or the exact Hermes home. An arbitrary existing directory is not considered projectless. A vanished directory is not considered projectless. A Hermes plugin subdirectory is not considered projectless.

Project evidence is correlated per source session before the source store is assigned a destination. This prevents unrelated parallel or historical sessions from being flattened into one inferred project. Migration refuses:

- one session mapping to multiple projects;
- one source containing both project and projectless sessions;
- resolved project evidence mixed with unresolved evidence;
- multiple registered identities;
- registered identity collisions;
- vanished or unregistered project paths;
- malformed JSON metadata;
- syntactically valid but structurally invalid metadata;
- recognized project-attribution metadata keys with non-string values.

Deleted symlink metadata is now preserved when the removed alias can no longer be proven. A remaining registered path is not enough to silently assume that an unresolvable sibling field was merely an alias; privacy and project isolation take priority over opportunistic migration.

For genuinely projectless legacy sessions, copied session rows are normalized to project key/path `user` and written idempotently to `user-sessions.db`. The source is opened read-only and retained. Re-running migration recognizes the same logical source fingerprint and does not duplicate rows.

Legacy memory is deliberately stricter than session history. If a projectless legacy source also has a memory database, those facts are not copied to profile user memory because there is no durable proof that they are user-global. The session migration may complete, but the report now explicitly records the memory database as preserved/unresolved. Automatic reinstall prints that warning; explicit Hermes install remains strict. This prevents a successful-session message from silently implying that unscoped memory was migrated.

## Automatic reinstall versus explicit migration

Automatic post-update reinstall now distinguishes migration outcomes:

- migrated/already migrated: continue;
- unresolved project evidence or intentionally preserved unscoped memory: warn, preserve the source, and continue integration reinstall;
- source open failure, integrity failure, copy failure, identity conflict, or partial migration failure: fail and keep the version marker pending.

This prevents an unresolved historical source from wedging every future TraceDecay command while retaining the important retry behavior for actual corruption or incomplete copying. Explicit `tracedecay install --agent hermes` remains strict and reports unresolved sources as an error so an operator cannot mistake preservation for completed cutover.

## Autonomous curation boundary

This follow-up does not introduce a scheduler dry-run mode. Autonomous memory curation remains a two-phase validated mutation: proposed operations are evaluated read-only, accepted operations are then applied, and rejected operations remain audited. The read-only phase is validation, not the terminal behavior of an autonomous run.

An explicit operator preview remains useful and read-only. Destructive offline database repair, migration, garbage collection, and source-tree edits also retain their existing safety confirmations. That distinction lets TraceDecay self-improve and update/delete stale memories autonomously while preserving an audit boundary for operator-invoked destructive maintenance.

## Concurrency and isolation

No process-global "active project" is introduced. Hermes runtime routing remains session-specific, so parallel Hermes sessions may use separate projects or separate worktrees without overwriting one another's routing context. Sessions in the same project intentionally converge on the same project shard, where database transactions and idempotent receipts provide coordination. Generated prompt updates remain ownership-scoped and ambiguity-safe.

## Tests

Local verification on the final diff:

- Hermes migration module: 26/26 passed.
- Automatic reinstall outcome tests: 2/2 passed.
- Memory digest tests: 15/15 passed.
- Managed-skill target tests: 23/23 passed.
- Generated Hermes plugin checks: 38/38 passed.
- Stock Hermes integration: 24/24 passed against upstream `9dd9ef0ec99a87f078f7272b4323df5440b4b3f9`.
- Workspace structured diagnostics: 0 errors, 0 warnings.
- `cargo clippy --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Conventional commit validation: passed.

The Hermes harness verifies plugin loading, memory provider discovery, context-engine activation, project isolation, untethered user scope, exact-session LCM ingestion, structured tool correlation, managed-skill discovery, progressive tool discovery, graph dispatch, and clean Hermes doctor output.

## Rollout

After merge, release-plz should publish the follow-up release. The released artifact must then be installed, integrations reinstalled noninteractively, and both TraceDecay and Hermes restarted. Live verification should confirm that the preserved ambiguous legacy source produces a warning without a reinstall loop, project sessions remain in their project shards, untethered sessions use profile user scope, and the generated prompt markers remain balanced and idempotent.
