### PR TITLE
chore: release v0.0.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.58](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.57...v0.0.58) - 2026-07-11
+
+### Fixed
+
+- *(windows)* skip unsupported migration runtime
+- *(windows)* harden migration recovery tests
+- *(windows)* exercise migration recovery
+- *(windows)* secure lifecycle handoff
+
+### Other
+
+- *(windows)* exercise consolidation suite
+- *(windows)* isolate offline migration locks
+- *(windows)* skip unsupported consolidation suite
+
 ## [0.0.57](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.56...v0.0.57) - 2026-07-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.57"
+version = "0.0.58"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.57 -> 0.0.58

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.58](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.57...v0.0.58) - 2026-07-11

### Fixed

- *(windows)* skip unsupported migration runtime
- *(windows)* harden migration recovery tests
- *(windows)* exercise migration recovery
- *(windows)* secure lifecycle handoff

### Other

- *(windows)* exercise consolidation suite
- *(windows)* isolate offline migration locks
- *(windows)* skip unsupported consolidation suite
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).