### PR TITLE
test(windows): restore consolidation coverage

### DIFF
--- a/.changeset/windows-lifecycle-handoff.md
+++ b/.changeset/windows-lifecycle-handoff.md
@@ -2,4 +2,4 @@
 "tracedecay": patch
 ---
 
-Secure Windows update lifecycle handoff without trusting stale owner sidecars, and restore platform-neutral migration and post-update test coverage on Windows.
+Secure Windows update lifecycle handoff without trusting stale owner sidecars, make migration copies durable across Windows file-lock semantics, skip unavailable daemon-service operations, and restore platform-neutral migration and post-update coverage.

--- a/src/migrate/consolidate/mod.rs
+++ b/src/migrate/consolidate/mod.rs
@@ -1686,5 +1686,5 @@ fn io_error(error: io::Error) -> TraceDecayError {
     config_error(error.to_string())
 }
 
-#[cfg(all(test, not(windows)))]
+#[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

Follow-up to #450. That PR merged while GitHub still cached head `6a33ffe4`; two already-pushed descendants were not included in the merge.

This restores the Windows consolidation suite that an overlapping session temporarily gated while diagnosing Windows byte-range locking. The suite must execute, not disappear.

## Correctness

- Re-enables `src/migrate/consolidate/tests.rs` on Windows.
- Keeps the narrowly scoped test-only Windows offline-guard replacement from #450. Production remains fail-closed because Windows open-holder discovery is unsupported; isolated unit fixtures can exercise backup, merge, verification, restart, and recovery semantics without `BEGIN IMMEDIATE` preventing the same process from reading its own database files.
- Expands the patch changeset to describe the durable copy, lifecycle, unsupported-service, and Windows recovery work actually shipping.

## Why this follow-up is required

Windows SQLite uses byte-range locks. The real production safety gate rejects consolidation before mutation when holder discovery cannot prove the profile offline. Unit fixtures are isolated and separately test that fail-closed production policy. Holding a Windows `BEGIN IMMEDIATE` while then copying the fixture database tests an impossible same-process lock arrangement rather than migration behavior, so only that fixture guard is substituted.

The prior broad `#[cfg(all(test, not(windows)))]` removed all 36 consolidation tests and could let future Windows regressions ship silently. This PR restores the platform-neutral suite and lets CI prove the scoped fixture isolation works.

## Validation

- `cargo check --tests --target x86_64-pc-windows-gnu`: passed
- `cargo clippy --all-targets --all-features -- -D warnings`: passed
- Linux consolidation suite: passed
- Windows CI will execute the complete sharded suite
- formatting and diff checks: passed

Do not merge release PR #451 until this follow-up is green and merged.