### PR TITLE
fix(hermes): stabilize compression and live memory writes

### DIFF
--- a/scripts/hermes_plugin_unit_check.py
+++ b/scripts/hermes_plugin_unit_check.py
@@ -161,6 +161,7 @@ def run_checks(work: Path):
     sys.path.insert(0, str(plugin_dir.parent))
     plugin = __import__("tracedecay")
     assert Path(plugin.__file__).resolve() == (plugin_dir / "__init__.py").resolve()
+    assert plugin.STANDARD_HERMES_LCM_PROVIDER == "hermes"
     ok("plugin package imports standalone (no hermes on sys.path)")
 
     header = (plugin_dir / "__init__.py").read_text(encoding="utf-8").splitlines()[0]

--- a/scripts/hermes_stock_integration.sh
+++ b/scripts/hermes_stock_integration.sh
@@ -36,12 +36,17 @@ fi
 echo "== stock hermes ref: $(git -C "$HERMES_UPSTREAM_DIR" rev-parse HEAD 2>/dev/null || echo unknown)"
 echo "== tracedecay binary: $TRACEDECAY_BIN ($("$TRACEDECAY_BIN" --version))"
 
-# Upstream venv with upstream's exact-pinned lock (idempotent).
-if [ ! -x "$HERMES_UPSTREAM_DIR/.venv/bin/python" ]; then
+# Upstream source installs use either `.venv` (uv) or `venv` (Hermes installer).
+if [ -x "$HERMES_UPSTREAM_DIR/.venv/bin/python" ]; then
+    HERMES_VENV="$HERMES_UPSTREAM_DIR/.venv"
+elif [ -x "$HERMES_UPSTREAM_DIR/venv/bin/python" ]; then
+    HERMES_VENV="$HERMES_UPSTREAM_DIR/venv"
+else
     echo "== creating stock hermes venv (uv sync --frozen --no-dev)"
     (cd "$HERMES_UPSTREAM_DIR" && uv sync --frozen --no-dev)
+    HERMES_VENV="$HERMES_UPSTREAM_DIR/.venv"
 fi
-HERMES_PYTHON="$HERMES_UPSTREAM_DIR/.venv/bin/python"
+HERMES_PYTHON="$HERMES_VENV/bin/python"
 
 STAGE="$(mktemp -d -t hermes-stock-XXXXXX)"
 trap 'rm -rf "$STAGE"' EXIT
@@ -71,7 +76,7 @@ echo "== stock plugin manager / context engine / memory provider / dispatch chec
 
 echo "== hermes plugins list"
 PLUGINS_LIST="$(cd "$HERMES_UPSTREAM_DIR" && HOME="$FAKE_HOME" COLUMNS=200 \
-    timeout 120 "$HERMES_UPSTREAM_DIR/.venv/bin/hermes" plugins list)"
+    timeout 120 "$HERMES_VENV/bin/hermes" plugins list)"
 echo "$PLUGINS_LIST" | grep tracedecay
 echo "$PLUGINS_LIST" | grep tracedecay | grep -q enabled
 echo "ok - hermes plugins list shows tracedecay enabled"

--- a/src/agents/hermes/templates/plugin_init.py
+++ b/src/agents/hermes/templates/plugin_init.py
@@ -316,7 +316,7 @@ MESSAGE_DEPENDENT_TOOLS = frozenset((
     "tracedecay_lcm_preflight",
 ))
 
-STANDARD_HERMES_LCM_PROVIDER = "cursor"
+STANDARD_HERMES_LCM_PROVIDER = "hermes"
 
 LCM_PROVIDER_LOCAL_TOOL_NAMES = frozenset((
     "tracedecay_lcm_compress",

--- a/src/agents/hermes/templates/skill.md
+++ b/src/agents/hermes/templates/skill.md
@@ -20,6 +20,18 @@ shows parameters). Hermes tool calls already run through this CLI under the hood
 execution path without the plugin wrapper. Fall back to it instead of querying
 `.tracedecay` databases directly or abandoning tracedecay.
 
+Do not invent per-key CLI flags or enum values from memory. Preserve the native
+tool's exact JSON schema through `--args`; for example:
+
+```sh
+tracedecay tool context --args '{"task":"trace project routing","mode":"explore","max_nodes":20,"include_code":true}'
+```
+
+For `context`, the supported modes are `explore` and `plan`, and its result
+budget is expressed with `max_nodes` / `max_code_blocks`, not guessed flags such
+as `--max-tokens` or `--paths`. When uncertain, run
+`tracedecay tool <name> --help` before invoking the fallback.
+
 ## Storage and project identity
 
 Hermes may keep its own host files under its Hermes home, but that path never

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -825,6 +825,7 @@ or the server is disconnected, every tool is also available as a shell command: 
     cli_fallback_args_invocation_lit!(),
     " \
 (`tracedecay tool` lists all tools, `tracedecay tool <name> --help` shows parameters). \
+Pass schema fields inside the JSON object; never invent per-key flags or enum values from memory. \
 Fall back to that CLI instead of querying `.tracedecay` databases directly or abandoning tracedecay."
 );
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1568,22 +1568,12 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
     let clients_drained = drain_client_tasks(&mut client_tasks, DAEMON_TASK_ABORT_DEADLINE).await;
     // Client setup and in-flight requests may create schedulers or project
     // servers. Sweep owned background tasks only after all client work drains.
-    let background_tasks_drained = timeout(
-        DAEMON_TASK_ABORT_DEADLINE,
-        engine.shutdown_background_tasks(),
-    )
-    .await
-    .is_ok();
-    if !in_flight_drained || !clients_drained || !background_tasks_drained {
-        let outcome = if background_tasks_drained {
-            "client_drain_timeout"
-        } else {
-            "background_task_timeout"
-        };
+    engine.shutdown_background_tasks().await;
+    if !in_flight_drained || !clients_drained {
         log_daemon_event(
             "daemon_shutdown",
             &[
-                ("outcome", outcome.to_string()),
+                ("outcome", "client_drain_timeout".to_string()),
                 (
                     "deadline_secs",
                     DAEMON_CLIENT_DRAIN_DEADLINE.as_secs().to_string(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1568,12 +1568,22 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
     let clients_drained = drain_client_tasks(&mut client_tasks, DAEMON_TASK_ABORT_DEADLINE).await;
     // Client setup and in-flight requests may create schedulers or project
     // servers. Sweep owned background tasks only after all client work drains.
-    engine.shutdown_background_tasks().await;
-    if !in_flight_drained || !clients_drained {
+    let background_tasks_drained = timeout(
+        DAEMON_TASK_ABORT_DEADLINE,
+        engine.shutdown_background_tasks(),
+    )
+    .await
+    .is_ok();
+    if !in_flight_drained || !clients_drained || !background_tasks_drained {
+        let outcome = if background_tasks_drained {
+            "client_drain_timeout"
+        } else {
+            "background_task_timeout"
+        };
         log_daemon_event(
             "daemon_shutdown",
             &[
-                ("outcome", "client_drain_timeout".to_string()),
+                ("outcome", outcome.to_string()),
                 (
                     "deadline_secs",
                     DAEMON_CLIENT_DRAIN_DEADLINE.as_secs().to_string(),

--- a/src/hooks/steering.rs
+++ b/src/hooks/steering.rs
@@ -132,13 +132,6 @@ pub fn build_codex_session_context_for_workspace(
                  tracedecay_diagnostics for fresh errors or pass captured output to \
                  tracedecay_diagnose; both map errors to symbols and callers.\n",
             );
-            s.push_str(
-                "Specialists: tracedecay-code-explorer, tracedecay-code-health-auditor, \
-                 tracedecay-session-historian, tracedecay-runtime-storage-doctor, \
-                 tracedecay-cross-host-integration-auditor, tracedecay-change-risk-reviewer, \
-                 tracedecay-usage-intelligence-analyst, tracedecay-automation-auditor. \
-                 Delegate matching read-only research; the parent owns changes and releases.\n",
-            );
             s.push_str(crate::agents::CLI_FALLBACK_PROMPT_RULES);
             s.push('\n');
             append_codex_recall_and_registry_guidance(&mut s);

--- a/src/hooks/steering.rs
+++ b/src/hooks/steering.rs
@@ -132,6 +132,12 @@ pub fn build_codex_session_context_for_workspace(
                  tracedecay_diagnostics for fresh errors or pass captured output to \
                  tracedecay_diagnose; both map errors to symbols and callers.\n",
             );
+            s.push_str(
+                "Agents: tracedecay-code-explorer,tracedecay-code-health-auditor,\
+                 tracedecay-session-historian,tracedecay-runtime-storage-doctor,\
+                 tracedecay-cross-host-integration-auditor,tracedecay-change-risk-reviewer,\
+                 tracedecay-usage-intelligence-analyst,tracedecay-automation-auditor\n",
+            );
             s.push_str(crate::agents::CLI_FALLBACK_PROMPT_RULES);
             s.push('\n');
             append_codex_recall_and_registry_guidance(&mut s);

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,12 @@ fn async_main() -> tracedecay::errors::Result<()> {
         .map_err(|e| tracedecay::errors::TraceDecayError::Config {
             message: format!("failed to start async runtime: {e}"),
         })?;
-    runtime.block_on(run(cli))
+    let result = runtime.block_on(run(cli));
+    // Runtime drop waits indefinitely for blocking tasks. Daemon integrations
+    // can leave OS-backed watcher work behind after their async handles abort,
+    // so bound teardown after the command's own graceful shutdown completes.
+    runtime.shutdown_timeout(std::time::Duration::from_secs(2));
+    result
 }
 
 fn render_dynamic_command_help(args: &[String]) -> bool {

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -562,13 +562,8 @@ impl<'a> MemoryStore<'a> {
     }
 
     pub async fn remove_fact(&self, fact_id: i64) -> Result<bool> {
-        let changed = self
-            .with_immediate_tx("remove_fact", self.remove_fact_inner(fact_id))
-            .await?;
-        if changed {
-            self.incremental_vacuum().await?;
-        }
-        Ok(changed)
+        self.with_immediate_tx("remove_fact", self.remove_fact_inner(fact_id))
+            .await
     }
 
     async fn remove_fact_inner(&self, fact_id: i64) -> Result<bool> {
@@ -2304,34 +2299,6 @@ impl<'a> MemoryStore<'a> {
     async fn mark_fact_banks_dirty(&self, category: MemoryCategory) -> Result<()> {
         self.mark_bank_dirty("all").await?;
         self.mark_bank_dirty(category.as_str()).await
-    }
-
-    async fn incremental_vacuum(&self) -> Result<()> {
-        let freelist_pages = {
-            let mut rows = self
-                .conn
-                .query("PRAGMA freelist_count", ())
-                .await
-                .map_err(|e| db_error("incremental_vacuum", e))?;
-            let row = rows
-                .next()
-                .await
-                .map_err(|e| db_error("incremental_vacuum", e))?
-                .ok_or_else(|| {
-                    db_message("incremental_vacuum", "freelist_count returned no rows")
-                })?;
-            row.get::<i64>(0)
-                .map_err(|e| db_error("incremental_vacuum", e))?
-        };
-        if freelist_pages <= 0 {
-            return Ok(());
-        }
-
-        self.conn
-            .execute_batch(&format!("PRAGMA incremental_vacuum({freelist_pages});"))
-            .await
-            .map_err(|e| db_error("incremental_vacuum", e))?;
-        Ok(())
     }
 
     async fn mark_bank_dirty(&self, bank_name: &str) -> Result<()> {

--- a/src/sessions/lcm/compression.rs
+++ b/src/sessions/lcm/compression.rs
@@ -1866,6 +1866,16 @@ async fn ingest_active_messages(
         let original_content = message_content_value(message);
         let storage_text = message_storage_text(&original_content);
         let search_text = message_content(message);
+        if message
+            .get("lcm_summary_node_id")
+            .and_then(Value::as_str)
+            .is_some_and(|node_id| !node_id.is_empty())
+        {
+            let mut replay = message.clone();
+            replay["role"] = Value::String(role);
+            replay_messages.push(replay);
+            continue;
+        }
         if security::ignore_message_reason_with_compiled(&search_text, &compiled_ignore_patterns)
             .is_some()
         {
@@ -1874,15 +1884,26 @@ async fn ingest_active_messages(
             replay_messages.push(replay);
             continue;
         }
-        let message_id = message
+        let explicit_message_id = message
             .get("id")
             .or_else(|| message.get("message_id"))
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty())
-            .map_or_else(
-                || deterministic_message_id(provider, session_id, idx, &role, &storage_text),
-                str::to_string,
-            );
+            .map(str::to_string);
+        let stored_message_id = match (explicit_message_id.as_ref(), message.get("store_id")) {
+            (None, Some(store_id)) => match store_id.as_i64() {
+                Some(store_id) => {
+                    message_id_for_store_id(conn, provider, session_id, store_id).await?
+                }
+                None => None,
+            },
+            _ => None,
+        };
+        let message_id = explicit_message_id
+            .or(stored_message_id)
+            .unwrap_or_else(|| {
+                deterministic_message_id(provider, session_id, idx, &role, &storage_text)
+            });
         let existing_state = existing_active_message_state(conn, provider, &message_id).await?;
         let ordinal = if let Some(existing) = existing_state.as_ref() {
             existing.ordinal
@@ -1966,6 +1987,26 @@ async fn ingest_active_messages(
     Ok(IngestedActiveMessages {
         replay_messages,
         changed_replay,
+    })
+}
+
+async fn message_id_for_store_id(
+    conn: &Connection,
+    provider: &str,
+    session_id: &str,
+    store_id: i64,
+) -> Result<Option<String>, LcmError> {
+    let mut rows = conn
+        .query(
+            "SELECT message_id
+             FROM lcm_raw_messages
+             WHERE provider = ?1 AND session_id = ?2 AND store_id = ?3",
+            params![provider, session_id, store_id],
+        )
+        .await?;
+    Ok(match rows.next().await? {
+        Some(row) => Some(row.get(0)?),
+        None => None,
     })
 }
 

--- a/tests/agent_suite/agent_test.rs
+++ b/tests/agent_suite/agent_test.rs
@@ -1199,6 +1199,14 @@ fn test_hermes_user_install_writes_single_plugin() {
         skill.contains("instead of querying"),
         "Hermes skill must warn against querying .tracedecay databases directly"
     );
+    assert!(
+        skill.contains("Do not invent per-key CLI flags")
+            && skill.contains("\"mode\":\"explore\"")
+            && skill.contains("\"max_nodes\":20")
+            && skill.contains("supported modes are `explore` and `plan`")
+            && skill.contains("`--max-tokens` or `--paths`"),
+        "Hermes skill must give schema-safe context fallback guidance"
+    );
 
     assert_hermes_config_enables_tracedecay_memory(&home.path().join(".hermes/config.yaml"));
     assert!(!home.path().join(".hermes/profiles").exists());
@@ -1268,7 +1276,7 @@ fn test_hermes_plugin_init_snapshot_matches_embedded_asset() {
     hasher.update(body.as_bytes());
     assert_eq!(
         hex::encode(hasher.finalize()),
-        "d92997d9bef2c033022ac3b8ee559720ce08779099d2d8b58df6e5d849d428df",
+        "954dfa34aad7753f3ad6ff5e536061066e8339f3ee167e65ea3f27ca5a879575",
         "templates/plugin_init.py payload hash changed — verify the edit is intentional and update this snapshot"
     );
 }

--- a/tests/agent_suite/cli_args_contract_test.rs
+++ b/tests/agent_suite/cli_args_contract_test.rs
@@ -44,6 +44,11 @@ fn prompt_rules_teach_the_json_args_contract() {
         !rules.contains("<name> --key value"),
         "prompt rules must not lead with the per-key grammar"
     );
+    let source = read_repo_file("src/agents/mod.rs");
+    assert!(
+        source.contains("never invent per-key flags or enum values from memory"),
+        "CLI fallback prompt rules must prohibit guessed flags and enum values"
+    );
 }
 
 #[test]

--- a/tests/hermes_suite/lcm_bridge.rs
+++ b/tests/hermes_suite/lcm_bridge.rs
@@ -1233,7 +1233,7 @@ args_index = argv.index("--args")
 args = json.loads(argv[args_index + 1])
 assert args == {
     "format": "json",
-    "provider": "cursor",
+    "provider": "hermes",
     "fresh_tail_count": 64,
     "leaf_chunk_tokens": 20000,
     "dynamic_leaf_chunk_enabled": False,
@@ -1318,7 +1318,7 @@ assert argv[1:6] == ["tool", "--project", "/tmp/project", "tracedecay_lcm_sessio
 args = json.loads(argv[argv.index("--args") + 1])
 assert args == {
     "format": "json",
-    "provider": "cursor",
+    "provider": "hermes",
     "session_id": "session-b",
     "old_session_id": "session-c",
     "boundary_reason": "compression",
@@ -1427,7 +1427,7 @@ else:
 assert args == {
     "format": "json",
     "response_handle_project_root": "/tmp/project",
-    "provider": "cursor",
+    "provider": "hermes",
     "fresh_tail_count": 64,
     "leaf_chunk_tokens": 20000,
     "dynamic_leaf_chunk_enabled": False,

--- a/tests/memory_suite/memory_test.rs
+++ b/tests/memory_suite/memory_test.rs
@@ -1309,7 +1309,7 @@ async fn compact_vectors_keep_recall_ordering_after_bank_rebuild() {
 }
 
 #[tokio::test]
-async fn remove_fact_incremental_vacuum_reclaims_blob_pages() {
+async fn remove_fact_defers_vacuum_while_peer_connections_are_live() {
     let (db, tmp) = make_memory_store().await;
     let store = MemoryStore::new(db.conn());
     let db_path = tmp.path().join("tracedecay.db");
@@ -1351,6 +1351,7 @@ async fn remove_fact_incremental_vacuum_reclaims_blob_pages() {
         .await
         .unwrap();
     let size_after_insert = std::fs::metadata(&db_path).unwrap().len();
+    let (peer, _) = Database::open(&db_path).await.unwrap();
 
     for fact_id in fact_ids {
         assert!(store.remove_fact(fact_id).await.unwrap());
@@ -1362,8 +1363,23 @@ async fn remove_fact_incremental_vacuum_reclaims_blob_pages() {
     let size_after_delete = std::fs::metadata(&db_path).unwrap().len();
 
     assert!(
-        size_after_delete < size_after_insert,
-        "incremental_vacuum should shrink the DB file after deleting compact HRR blobs; before={size_after_insert}, after={size_after_delete}"
+        scalar_i64(&db, "PRAGMA freelist_count").await > 0,
+        "fact deletion must leave page reclamation for exclusive maintenance"
+    );
+    assert_eq!(
+        scalar_i64(&peer, "SELECT COUNT(*) FROM memory_facts").await,
+        0,
+        "a peer opened before deletion must remain usable"
+    );
+    let (fresh, _) = Database::open(&db_path).await.unwrap();
+    assert_eq!(
+        scalar_i64(&fresh, "SELECT COUNT(*) FROM memory_facts").await,
+        0,
+        "a fresh peer must open after repeated fact deletion"
+    );
+    assert!(
+        size_after_delete >= size_after_insert,
+        "online deletion must not compact a live peer store; before={size_after_insert}, after={size_after_delete}"
     );
 }
 

--- a/tests/session_suite/lcm_compression.rs
+++ b/tests/session_suite/lcm_compression.rs
@@ -1188,6 +1188,71 @@ async fn active_structured_content_survives_preflight_and_noop_compress_replay()
 }
 
 #[tokio::test]
+async fn idless_compression_replay_does_not_reingest_existing_raw_messages() {
+    let tmp = TempDir::new().unwrap();
+    let db = open_lcm_db(&tmp).await;
+    insert_session(&db, "cursor", "session-idless-replay").await;
+
+    let initial = db
+        .lcm_preflight(preflight_request(
+            "cursor",
+            "session-idless-replay",
+            vec![
+                json!({"role": "user", "content": "old user context"}),
+                json!({"role": "assistant", "content": "old assistant context"}),
+                json!({"role": "user", "content": "fresh user context"}),
+                json!({"role": "assistant", "content": "fresh assistant context"}),
+            ],
+            Some(100),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        db.lcm_status("cursor", Some("session-idless-replay"))
+            .await
+            .unwrap()
+            .raw_message_count,
+        4
+    );
+
+    let mut request = compress_request(
+        "cursor",
+        "session-idless-replay",
+        LcmSummarizerMode::Fake {
+            summary_text: "condensed old context".into(),
+        },
+    );
+    request.messages = initial.replay_messages;
+    let compressed = db.lcm_compress(request).await.unwrap();
+    assert_eq!(compressed.summary_nodes_created, 1);
+    assert!(compressed.replay_messages[0]["lcm_summary_node_id"].is_string());
+    assert!(
+        compressed
+            .replay_messages
+            .iter()
+            .skip(1)
+            .all(|message| message["store_id"].is_number())
+    );
+
+    db.lcm_preflight(preflight_request(
+        "cursor",
+        "session-idless-replay",
+        compressed.replay_messages,
+        Some(100),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(
+        db.lcm_status("cursor", Some("session-idless-replay"))
+            .await
+            .unwrap()
+            .raw_message_count,
+        4,
+        "replaying TraceDecay's own summary/tail must not duplicate raw history"
+    );
+}
+
+#[tokio::test]
 async fn active_replay_preserves_top_level_fields_that_collide_with_storage_metadata() {
     let tmp = TempDir::new().unwrap();
     let db = open_lcm_db(&tmp).await;


### PR DESCRIPTION
## Summary

This follow-up fixes the concrete runtime defects found by reading the current Hermes gateway logs, exported Hermes transcripts, TraceDecay daemon behavior, and the live project/user stores after v0.0.59 was installed.

The native Hermes plugin remains the default and only installed TraceDecay integration. Hermes already registers the TraceDecay memory provider, context engine, command, skill overlay, and progressively discoverable native tools. No MCP server is added: a second MCP surface would duplicate the same tools and create ambiguous routing without adding capability.

## Compression replay identity

The active Hermes session `20260712_003311_aac53c` exposed runaway context growth. Its first compression reduced 216 messages to 193, but repeated attempts then expanded 193 to 363, 317 to 582, 416 to 874, and 521 to 922. The TraceDecay LCM shard ultimately contained 1,363 raw messages for a host transcript that originally had 216.

The issue was not the upstream OpenAI 429 itself. The 429 caused Hermes to retry compression and made the defect visible quickly. The root cause was TraceDecay active-message ingestion:

- Host messages without an explicit `id` were assigned a deterministic ID containing their current array index.
- TraceDecay replay messages carry a stable `store_id`, but not necessarily the original host `id`.
- Compression inserts summary nodes and reorders the replay window.
- On the next preflight, the same raw messages appeared at new indices and received new IDs.
- TraceDecay therefore inserted duplicates on every compression attempt.
- Derived replay entries carrying `lcm_summary_node_id` were also incorrectly ingested as new raw messages.

The fix resolves an ID-less replay message back to its original message ID using the fully scoped `(provider, session_id, store_id)` key before the index-based fallback is considered. Derived summary-node replay entries remain in the returned host transcript but are not inserted into raw history.

A regression test now performs the real sequence: ID-less preflight, compression with a generated summary and reordered raw tail, then replay ingestion. Before the fix, raw history grew from 4 rows to 7. After the fix, it remains exactly 4.

## Correct Hermes provider identity

The generated Hermes plugin incorrectly used `cursor` as its LCM provider namespace. That made the current Hermes session invisible to provider-scoped `hermes` queries and mixed two distinct host identities.

The plugin now uses `hermes`. The generated-plugin check pins this contract. Existing `cursor` rows remain intact as historical data; newly loaded Hermes sessions use the correct namespace and start with clean host-scoped LCM state.

## Live fact deletion and SQLite WAL stability

Live `fact_store remove` operations previously ran `PRAGMA incremental_vacuum` after every successful delete. The daemon caches multiple long-lived server/database handles for the same project shard. Running online vacuum while peer WAL/SHM connections remained open could poison the active connection state and produce:

`database error: failed to apply pragmas: SQLite failure: disk I/O error`

The database passed offline integrity checks, and restarting the daemon restored it immediately, confirming stale live connection/WAL state rather than file corruption.

Fact deletion now remains an immediate atomic transaction but leaves page reclamation to exclusive maintenance. The replacement regression opens a peer connection before repeated deletion, verifies deleted facts are visible from both the existing and a fresh peer, and verifies free pages remain available for later exclusive maintenance instead of compacting the live database.

## CLI fallback correctness

One Hermes transcript invocation bypassed native deferred tools and invented unsupported per-key CLI flags such as `context --max-tokens`. The generated skill itself did not teach those flags, and the native plugin registration was healthy, but fallback guidance did not explicitly forbid guessing CLI flag names or enum values.

Shared agent guidance now states that fallback calls must use the MCP-equivalent JSON object through `tracedecay tool <name> --args ...`. The Hermes skill includes an exact `context` example and documents the valid `mode` values (`explore` or `plan`) plus the actual keys (`max_nodes`, `max_code_blocks`). Generator tests pin those instructions.

## Tool discovery and MCP decision

The installed Hermes plugin is correctly integrated with Hermes progressive discovery:

- native plugin enabled;
- memory provider and context engine registered;
- bundled TraceDecay skill registered;
- native TraceDecay schemas exposed to Hermes tool search;
- plugin tool calls route through the installed TraceDecay binary using the same JSON contracts;
- CLI remains a bounded fallback for hosts/children that do not receive a native schema.

MCP is intentionally not installed by this PR. It is unnecessary for Hermes and would duplicate the native plugin surface. This follows the user's final direction to keep Hermes native-plugin-only.

## Validation

- Memory suite: 52/52 passed.
- LCM compression suite: 79/79 passed.
- Agent suite: 503/503 passed.
- Generated Hermes plugin checks: 39/39 passed.
- `cargo fmt --check`: passed.
- `cargo check --all-targets`: passed.
- `cargo clippy --all-targets -- -D warnings`: passed.
- `git diff --check`: passed.
- Conventional commit validation: passed for all three commits.

## Runtime follow-up

After merge and release, the update path must regenerate/install the Hermes plugin, restart the TraceDecay daemon and Hermes gateway so the new Python module and Rust binary are loaded, and manually repeat an ID-less compression replay to confirm raw row counts remain stable. Long-lived old `tracedecay serve` processes should be replaced only after the new binary is installed so active agent integrations do not retain v0.0.59 code.
