### PR TITLE
chore: release v0.0.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.60](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.59...v0.0.60) - 2026-07-12
+
+### Fixed
+
+- *(hooks)* preserve compact agent discovery
+- *(daemon)* bound runtime teardown
+- *(daemon)* bound background task shutdown
+- *(hooks)* keep Codex steering within compact budget
+- *(agents)* document JSON tool fallback arguments
+- *(hermes)* preserve replay identity during compression
+- *(memory)* defer vacuum until exclusive maintenance
+
 ## [0.0.59](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.58...v0.0.59) - 2026-07-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.59"
+version = "0.0.60"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.59"
+version = "0.0.60"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.59 -> 0.0.60

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.60](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.59...v0.0.60) - 2026-07-12

### Fixed

- *(hooks)* preserve compact agent discovery
- *(daemon)* bound runtime teardown
- *(daemon)* bound background task shutdown
- *(hooks)* keep Codex steering within compact budget
- *(agents)* document JSON tool fallback arguments
- *(hermes)* preserve replay identity during compression
- *(memory)* defer vacuum until exclusive maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).