### PR TITLE
chore: release v0.0.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(storage)* close snapshots before scratch cleanup
 - *(storage)* normalize Windows consolidation state
+- *(hermes)* trust backend replay shrink estimates
+- *(hermes)* preserve atomic LCM tool transactions
 - *(storage)* preserve dirty markers in backups
+- *(memory)* preserve project store on branch databases
+- *(memory)* reuse daemon database handle
 - *(storage)* exclude runtime locks from backups
 - *(storage)* report locked migration copy path
 - *(storage)* avoid Windows snapshot copy locks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.64](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.63...v0.0.64) - 2026-07-12
+
+### Fixed
+
+- *(storage)* close snapshots before scratch cleanup
+- *(storage)* normalize Windows consolidation state
+- *(storage)* preserve dirty markers in backups
+- *(storage)* exclude runtime locks from backups
+- *(storage)* report locked migration copy path
+- *(storage)* avoid Windows snapshot copy locks
+
 ## [0.0.63](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.62...v0.0.63) - 2026-07-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.63"
+version = "0.0.64"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION
## New release

`tracedecay`: 0.0.63 → 0.0.64

### Fixed

- Storage: close snapshots before scratch cleanup; normalize Windows consolidation state; preserve dirty markers; exclude runtime locks; report locked copy paths; avoid Windows snapshot copy locks.
- Memory: preserve the project store on branch databases and reuse the daemon database handle.
- Hermes LCM: preserve atomic tool transactions and trust backend replay shrink estimates.

Generated by release-plz; nested aggregate commits were added explicitly to keep the release notes complete.