### PR TITLE
chore: release v0.0.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.67](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.66...v0.0.67) - 2026-07-27
+
+### Fixed
+
+- *(daemon)* bound project open only when a writer is busy
+- *(storage)* keep store inventory off the resolve path
+- restore daemon catalog build
+- *(daemon)* raise managed service file limit
+- address follow-up storage and daemon findings
+- address daemon and storage review findings
+- *(daemon)* cover full shutdown window
+- *(daemon)* wait for lifecycle lease release
+- *(daemon)* unblock managed service restart
+- *(daemon)* coordinate scheduler discovery
+- *(daemon)* unblock uncached worktree tools
+- *(daemon)* drain portable warmups safely
+- *(mcp)* preserve portable bootstrap parity
+- *(mcp)* unblock fresh daemon startup
+- *(daemon)* keep cached MCP servers responsive
+- *(storage)* prefer healthy exact worktree shard
+- *(storage)* prefer exact worktree manifest root
+- *(doctor)* use compact daemon health snapshot
+- *(tests)* harden Windows daemon fixtures
+- *(storage)* harden cross-platform daemon authority
+- *(daemon)* release legacy sync ownership after writes
+- *(daemon)* reuse global database authority
+- *(storage)* stabilize daemon-owned database access
+- *(tests)* isolate database ownership fixtures
+- *(storage)* clear integrity clippy blockers
+- *(storage)* repair integrity follow-up build
+- *(storage)* close sole-daemon integrity gaps
+- *(storage)* finish sole-daemon ownership integration
+- *(storage)* enforce sole-daemon database ownership
+
+### Other
+
+- Merge remote-tracking branch 'origin/master' into pr-478-fmt
+- *(daemon)* name the MCP bootstrap outcome enum
+- apply rustfmt to daemon and storage changes
+- *(storage)* normalize Windows authority paths
+- *(daemon)* share initialize registry authority
+
 ## [0.0.66](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.65...v0.0.66) - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(daemon)* bound project open only when a writer is busy
 - *(storage)* keep store inventory off the resolve path
+- *(storage)* sync preserved recovery set on Windows
+- auto-repair corrupt branch stores
 - restore daemon catalog build
 - *(daemon)* raise managed service file limit
 - address follow-up storage and daemon findings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.66"
+version = "0.0.67"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.66"
+version = "0.0.67"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.66 -> 0.0.67

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.67](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.66...v0.0.67) - 2026-07-27

### Fixed

- *(daemon)* bound project open only when a writer is busy
- *(storage)* keep store inventory off the resolve path
- restore daemon catalog build
- *(daemon)* raise managed service file limit
- address follow-up storage and daemon findings
- address daemon and storage review findings
- *(daemon)* cover full shutdown window
- *(daemon)* wait for lifecycle lease release
- *(daemon)* unblock managed service restart
- *(daemon)* coordinate scheduler discovery
- *(daemon)* unblock uncached worktree tools
- *(daemon)* drain portable warmups safely
- *(mcp)* preserve portable bootstrap parity
- *(mcp)* unblock fresh daemon startup
- *(daemon)* keep cached MCP servers responsive
- *(storage)* prefer healthy exact worktree shard
- *(storage)* prefer exact worktree manifest root
- *(doctor)* use compact daemon health snapshot
- *(tests)* harden Windows daemon fixtures
- *(storage)* harden cross-platform daemon authority
- *(daemon)* release legacy sync ownership after writes
- *(daemon)* reuse global database authority
- *(storage)* stabilize daemon-owned database access
- *(tests)* isolate database ownership fixtures
- *(storage)* clear integrity clippy blockers
- *(storage)* repair integrity follow-up build
- *(storage)* close sole-daemon integrity gaps
- *(storage)* finish sole-daemon ownership integration
- *(storage)* enforce sole-daemon database ownership

### Other

- Merge remote-tracking branch 'origin/master' into pr-478-fmt
- *(daemon)* name the MCP bootstrap outcome enum
- apply rustfmt to daemon and storage changes
- *(storage)* normalize Windows authority paths
- *(daemon)* share initialize registry authority
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).