### PR TITLE
fix(tests): harden Windows daemon fixtures

### DIFF
--- a/src/branch/admin/tests.rs
+++ b/src/branch/admin/tests.rs
@@ -454,6 +454,7 @@ fn metadata_commit_before_deleted_promotion_recovers_as_committed() {
     assert!(crate::db::database_path_is_tombstoned(&db).unwrap());
 }
 
+#[cfg(unix)]
 #[test]
 fn committed_recovery_syncs_metadata_before_tombstone_transition() {
     let (_temp, project_root, tracedecay_dir) = fixture();
@@ -549,6 +550,7 @@ fn orphan_commit_before_deleted_promotion_recovers_as_committed() {
     assert!(crate::db::database_path_is_tombstoned(&orphan).unwrap());
 }
 
+#[cfg(unix)]
 #[test]
 fn committed_recovery_syncs_store_directory_before_tombstone_transition() {
     let (_temp, project_root, tracedecay_dir) = fixture();

--- a/src/branch/admin/transaction.rs
+++ b/src/branch/admin/transaction.rs
@@ -241,19 +241,7 @@ where
                 if expected_present {
                     require_regular_file(&source, "branch store family member")?;
                     require_missing(&quarantine, "branch deletion quarantine")?;
-                    std::fs::rename(&source, &quarantine).map_err(|error| {
-                        config_error(format!(
-                            "failed to quarantine branch store file '{}' as '{}': {error}",
-                            source.display(),
-                            quarantine.display()
-                        ))
-                    })?;
-                    sync_directory(source.parent().ok_or_else(|| {
-                        config_error(format!(
-                            "branch store path '{}' has no parent",
-                            source.display()
-                        ))
-                    })?)?;
+                    move_file_durably(&source, &quarantine, "branch store quarantine")?;
                     moved += 1;
                     hook(TransactionPhase::AfterMove(moved))?;
                 } else {
@@ -590,6 +578,24 @@ fn quarantine_family_paths(database: &Path, transaction_id: &str) -> Result<[Pat
     Ok([database, PathBuf::from(wal), PathBuf::from(shm)])
 }
 
+fn move_file_durably(source: &Path, destination: &Path, record_name: &str) -> Result<()> {
+    crate::db::DatabaseAuthority::replace_file_atomically(source, destination, record_name)
+        .map_err(|error| {
+            config_error(format!(
+                "failed to move '{}' to '{}' for {record_name}: {error}",
+                source.display(),
+                destination.display()
+            ))
+        })?;
+    let parent = destination.parent().ok_or_else(|| {
+        config_error(format!(
+            "branch store path '{}' has no parent",
+            destination.display()
+        ))
+    })?;
+    sync_directory(parent)
+}
+
 fn rollback_files(tracedecay_dir: &Path, journal: &DeletionJournal) -> Result<()> {
     let states = journal
         .entries
@@ -615,19 +621,7 @@ fn rollback_files(tracedecay_dir: &Path, journal: &DeletionJournal) -> Result<()
     for family in states.into_iter().rev() {
         for (source, quarantine, expected_present) in family.into_iter().rev() {
             if expected_present && quarantine.exists() {
-                std::fs::rename(&quarantine, &source).map_err(|error| {
-                    config_error(format!(
-                        "failed to restore quarantined branch store '{}' to '{}': {error}",
-                        quarantine.display(),
-                        source.display()
-                    ))
-                })?;
-                sync_directory(source.parent().ok_or_else(|| {
-                    config_error(format!(
-                        "branch store path '{}' has no parent",
-                        source.display()
-                    ))
-                })?)?;
+                move_file_durably(&quarantine, &source, "branch store quarantine rollback")?;
             }
         }
     }

--- a/src/global_db/tests.rs
+++ b/src/global_db/tests.rs
@@ -166,13 +166,9 @@ async fn try_open_at_preserves_authority_error() {
         "{message}"
     );
     assert!(message.contains("open global database"), "{message}");
-    #[cfg(windows)]
-    assert!(
-        message.contains(&format!(r"\\?\{}", path.display())),
-        "{message}"
-    );
-    #[cfg(not(windows))]
-    assert!(message.contains(&path.display().to_string()), "{message}");
+    let displayed = path.display().to_string();
+    let expected = displayed.strip_prefix(r"\\?\").unwrap_or(&displayed);
+    assert!(message.contains(expected), "{message}");
 }
 
 #[tokio::test]

--- a/src/global_db/tests.rs
+++ b/src/global_db/tests.rs
@@ -167,8 +167,15 @@ async fn try_open_at_preserves_authority_error() {
     );
     assert!(message.contains("open global database"), "{message}");
     let displayed = path.display().to_string();
-    let expected = displayed.strip_prefix(r"\\?\").unwrap_or(&displayed);
-    assert!(message.contains(expected), "{message}");
+    #[cfg(windows)]
+    assert!(
+        message
+            .replace('\\', "/")
+            .contains(&displayed.replace('\\', "/")),
+        "{message}"
+    );
+    #[cfg(not(windows))]
+    assert!(message.contains(&displayed), "{message}");
 }
 
 #[tokio::test]

--- a/src/tracedecay/locking.rs
+++ b/src/tracedecay/locking.rs
@@ -466,6 +466,7 @@ fn is_pid_alive(pid: u32) -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(not(windows))]
     fn legacy_parser_classifies_stale(path: &Path) -> bool {
         std::fs::read_to_string(path)
             .ok()
@@ -474,16 +475,20 @@ mod tests {
     }
 
     #[test]
-    fn live_new_owner_is_not_stale_to_legacy_pid_parser() {
+    fn live_new_owner_blocks_legacy_create_and_new_lockers() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sync.lock");
         let guard = try_acquire_sync_lock_at(&path).unwrap();
 
-        assert!(!legacy_parser_classifies_stale(&path));
-        assert_eq!(
-            std::fs::read_to_string(&path).unwrap(),
-            std::process::id().to_string()
-        );
+        assert!(is_pid_alive(std::process::id()));
+        #[cfg(not(windows))]
+        {
+            assert!(!legacy_parser_classifies_stale(&path));
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                std::process::id().to_string()
+            );
+        }
         let legacy_create = OpenOptions::new().write(true).create_new(true).open(&path);
         assert_eq!(
             legacy_create.unwrap_err().kind(),

--- a/tests/core_cli_suite/cli_non_interactive_test.rs
+++ b/tests/core_cli_suite/cli_non_interactive_test.rs
@@ -393,7 +393,7 @@ fn init_skips_gitignore_prompt_when_stdin_not_a_terminal() {
     std::fs::create_dir_all(project.path().join("src")).unwrap();
     std::fs::write(project.path().join("src/lib.rs"), "pub fn marker() {}\n").unwrap();
 
-    let mut command = tracedecay_command_without_daemon(home.path(), project.path());
+    let mut command = tracedecay_command(home.path(), project.path());
     command.arg("init");
     let output = run_with_timeout(command, cli_timeout());
 
@@ -1782,7 +1782,6 @@ fn migrate_registry_gc_cleans_stale_storage_metadata_and_preserves_live_and_bloc
     std::fs::create_dir_all(&live_project).expect("live project dir");
     std::fs::write(live_project.join("lib.rs"), "pub fn live() {}\n").expect("live source");
 
-    #[cfg(unix)]
     let daemon = crate::common::spawn_tracedecay_daemon(home.path());
     let init = tracedecay_command_without_daemon(home.path(), &live_project)
         .args(["init", "."])
@@ -1794,7 +1793,6 @@ fn migrate_registry_gc_cleans_stale_storage_metadata_and_preserves_live_and_bloc
         String::from_utf8_lossy(&init.stdout),
         String::from_utf8_lossy(&init.stderr)
     );
-    #[cfg(unix)]
     drop(daemon);
 
     let stale_project = canonical_temp_path(home.path()).join("gone-project");

--- a/tests/hooks_lsp_suite/hook_replay_test.rs
+++ b/tests/hooks_lsp_suite/hook_replay_test.rs
@@ -253,6 +253,7 @@ async fn replayed_provider_hooks_record_attributed_rows_and_bridge_to_analytics_
                 .success()
         );
     }
+    let daemon = spawn_tracedecay_daemon(&home_root);
     let init = tracedecay_command_with_home(&home_root)
         .arg("init")
         .current_dir(&project_root)
@@ -315,7 +316,6 @@ async fn replayed_provider_hooks_record_attributed_rows_and_bridge_to_analytics_
     );
 
     // Bridge: `analytics sync` imports the JSONL rows into the durable table.
-    let daemon = spawn_tracedecay_daemon(&home_root);
     let sync = tracedecay_command_with_home(&home_root)
         .args(["analytics", "sync"])
         .current_dir(&project_root)

--- a/tests/memory_suite/memory_eval_test.rs
+++ b/tests/memory_suite/memory_eval_test.rs
@@ -229,7 +229,8 @@ struct FixtureSnapshot {
 
 #[cfg(windows)]
 impl FixtureSnapshot {
-    fn capture(fixture: &Fixture) -> Self {
+    fn capture(fixture: &mut Fixture) -> Self {
+        fixture.stop_daemon();
         let dir = TempDir::new().expect("fixture snapshot tempdir");
         let profile_path = dir.path().join(".tracedecay");
         std::fs::create_dir_all(&profile_path).unwrap_or_else(|e| {
@@ -239,13 +240,15 @@ impl FixtureSnapshot {
             )
         });
         copy_dir_contents(&fixture.home_path.join(".tracedecay"), &profile_path);
+        fixture.start_daemon();
         Self {
             _dir: dir,
             profile_path,
         }
     }
 
-    fn restore_into(&self, fixture: &Fixture) {
+    fn restore_into(&self, fixture: &mut Fixture) {
+        fixture.stop_daemon();
         let profile_path = fixture.home_path.join(".tracedecay");
         if profile_path.exists() {
             std::fs::remove_dir_all(&profile_path).unwrap_or_else(|e| {
@@ -262,10 +265,21 @@ impl FixtureSnapshot {
             )
         });
         copy_dir_contents(&self.profile_path, &profile_path);
+        fixture.start_daemon();
     }
 }
 
 impl Fixture {
+    fn start_daemon(&mut self) {
+        assert!(self._daemon.is_none(), "fixture daemon already running");
+        self._daemon = Some(common::spawn_tracedecay_daemon(&self.home_path));
+    }
+
+    #[cfg(windows)]
+    fn stop_daemon(&mut self) {
+        drop(self._daemon.take());
+    }
+
     fn db_path(&self) -> PathBuf {
         tracedecay::storage::resolve_layout(&self.project_path, &self.home_path.join(".tracedecay"))
             .expect("resolve fixture storage layout")
@@ -534,7 +548,7 @@ fn build_fixture(setup: &Setup) -> Fixture {
     }
     initialize_fixture_project(&fixture);
     seed_setup_facts(&fixture, &setup.facts);
-    fixture._daemon = Some(common::spawn_tracedecay_daemon(&fixture.home_path));
+    fixture.start_daemon();
     fixture
 }
 
@@ -816,7 +830,7 @@ fn run_scenario(id: &str) {
     #[cfg(windows)]
     let baseline_snapshot =
         if !well_behaved_steps.is_empty() && scenario.deterministic.violation.is_some() {
-            Some(FixtureSnapshot::capture(&fixture))
+            Some(FixtureSnapshot::capture(&mut fixture))
         } else {
             None
         };
@@ -854,7 +868,7 @@ fn run_scenario(id: &str) {
     if !well_behaved_steps.is_empty() {
         #[cfg(windows)]
         if let Some(snapshot) = &baseline_snapshot {
-            snapshot.restore_into(&fixture);
+            snapshot.restore_into(&mut fixture);
         }
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
## Summary
- stop the memory eval daemon before Windows profile snapshots and restart it afterward
- start daemon-authorized CLI and hook fixtures consistently on every platform
- make lock/path assertions portable and scope Unix fsync injection tests to Unix
- route branch quarantine and rollback moves through the canonical durable atomic replacement helper

## Verification
- `cargo test --lib branch::admin::tests:: -- --test-threads=1`
- `cargo test --lib tracedecay::locking::tests:: -- --test-threads=1`
- `cargo test --lib global_db::tests::try_open_at_preserves_authority_error -- --test-threads=1`
- `cargo nextest run --workspace --no-fail-fast --locked -E 'test(/(init_skips_gitignore_prompt_when_stdin_not_a_terminal|migrate_registry_gc_cleans_stale_storage_metadata_and_preserves_live_and_blocked_stores|replayed_provider_hooks_record_attributed_rows_and_bridge_to_analytics_events|eval_memory_multiturn_continuity|eval_memory_no_pollution|eval_memory_secret_rejection|eval_memory_supersede_without_dup)/)'`\n- `cargo clippy --workspace --all-targets --locked -- -D warnings`\n- `cargo fmt --all -- --check`\n- `git diff --check`\n\nWindows cross-check from Linux reaches native build scripts but cannot complete without the MSVC `lib.exe`; exact-head Windows CI is the execution authority.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)