### PR TITLE
fix(doctor): use compact daemon health snapshot

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -251,15 +251,35 @@ async fn daemon_project_status(project_path: &Path) -> crate::errors::Result<ser
     )?;
     let result = crate::daemon::call_default_tool(
         &handshake,
-        "tracedecay_status",
+        "tracedecay_runtime",
         serde_json::json!({ "format": "json" }),
     )
     .await?;
-    daemon_tool_json(&result)
+    daemon_runtime_status(&result)
 }
 
-fn daemon_tool_json(result: &serde_json::Value) -> crate::errors::Result<serde_json::Value> {
-    crate::daemon::tool_json_payload(result, "tracedecay_status")
+fn daemon_runtime_status(result: &serde_json::Value) -> crate::errors::Result<serde_json::Value> {
+    let runtime = crate::daemon::tool_json_payload(result, "tracedecay_runtime")?;
+    let mut storage =
+        runtime
+            .get("database")
+            .cloned()
+            .ok_or_else(|| crate::errors::TraceDecayError::Config {
+                message: "daemon runtime response omitted database telemetry".to_string(),
+            })?;
+    let storage =
+        storage
+            .as_object_mut()
+            .ok_or_else(|| crate::errors::TraceDecayError::Config {
+                message: "daemon runtime database telemetry was not an object".to_string(),
+            })?;
+    if let Some(pid) = runtime.pointer("/process/pid").cloned() {
+        storage.insert("daemon_owner_pid".to_string(), pid);
+    }
+    if let Some(version) = runtime.get("tracedecay_version").cloned() {
+        storage.insert("daemon_version".to_string(), version);
+    }
+    Ok(serde_json::json!({ "storage_health": storage }))
 }
 
 fn check_database(dc: &mut DoctorCounters, status: &serde_json::Value) -> bool {
@@ -423,12 +443,23 @@ fn check_stale_stores(dc: &mut DoctorCounters, status: Option<&serde_json::Value
             .get("daemon_owner_pid")
             .and_then(serde_json::Value::as_u64)
             .map_or_else(|| "unknown".to_string(), |pid| pid.to_string());
-        let generation = storage
+        let identity = storage
             .get("daemon_generation")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or("unknown");
+            .map_or_else(
+                || {
+                    storage
+                        .get("daemon_version")
+                        .and_then(serde_json::Value::as_str)
+                        .map_or_else(
+                            || "identity=unknown".to_string(),
+                            |version| format!("version={version}"),
+                        )
+                },
+                |generation| format!("generation={generation}"),
+            );
         dc.pass(&format!(
-            "Registry/database inspection delegated to daemon owner pid={owner}, generation={generation}"
+            "Registry/database inspection delegated to daemon owner pid={owner}, {identity}"
         ));
     } else {
         dc.warn("Registry diagnostics unavailable because the daemon owner did not answer; doctor did not open the global DB");

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -842,13 +842,13 @@ fn plain_orphan_still_warns_with_update_remediation() {
 }
 
 #[test]
-fn daemon_status_parser_extracts_storage_health() {
-    let parsed = super::daemon_tool_json(&serde_json::json!({
+fn daemon_runtime_parser_extracts_storage_health_and_owner() {
+    let parsed = super::daemon_runtime_status(&serde_json::json!({
         "content": [
             {"type": "text", "text": "daemon notice"},
             {
                 "type": "text",
-                "text": r#"{"storage_health":{"quick_check_ok":true,"daemon_generation":"run-7"}}"#
+                "text": r#"{"tracedecay_version":"0.0.66","process":{"pid":1234},"database":{"canonical_db_path":"/tmp/project.db","quick_check_ok":true,"dirty_marker":{"exists":false}}}"#
             }
         ]
     }))
@@ -859,13 +859,26 @@ fn daemon_status_parser_extracts_storage_health() {
         Some(&serde_json::Value::Bool(true))
     );
     assert_eq!(
-        parsed.pointer("/storage_health/daemon_generation"),
-        Some(&serde_json::Value::String("run-7".to_string()))
+        parsed.pointer("/storage_health/daemon_owner_pid"),
+        Some(&serde_json::json!(1234))
+    );
+    assert_eq!(
+        parsed.pointer("/storage_health/daemon_version"),
+        Some(&serde_json::json!("0.0.66"))
     );
 }
 
 #[test]
-fn daemon_status_parser_rejects_missing_json_payload() {
-    let error = super::daemon_tool_json(&serde_json::json!({ "content": [] })).unwrap_err();
+fn daemon_runtime_parser_rejects_missing_json_payload() {
+    let error = super::daemon_runtime_status(&serde_json::json!({ "content": [] })).unwrap_err();
     assert!(error.to_string().contains("returned no JSON payload"));
+}
+
+#[test]
+fn daemon_runtime_parser_rejects_missing_database_telemetry() {
+    let error = super::daemon_runtime_status(&serde_json::json!({
+        "content": [{"type": "text", "text": r#"{"process":{"pid":1234}}"#}]
+    }))
+    .unwrap_err();
+    assert!(error.to_string().contains("omitted database telemetry"));
 }


### PR DESCRIPTION
## Summary
- query `tracedecay_runtime` for doctor storage health instead of the unbounded `tracedecay_status` payload
- preserve the existing daemon-owned `storage_health` checker while carrying daemon PID/version from runtime telemetry
- add parser regressions for valid, missing, and malformed runtime payloads

## Recovery dogfood finding
The verified merged `0.0.66` daemon correctly returned a 192 KB status payload, which the MCP renderer converted into a reversible response handle. Doctor treated that envelope as status JSON and incorrectly failed with `Daemon status omitted storage health`; it never opened SQLite. The compact runtime endpoint already contains every health field doctor needs and stays below response-handle limits.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib doctor::tests --locked` (19 passed)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- built `target/debug/tracedecay doctor` against live managed daemon PID 999347: exit 0, DB integrity ok, daemon owner/version reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)