### PR TITLE
fix: stabilize worktree storage and daemon lifecycle

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -170,7 +170,8 @@ pub use service::{
     installed_service_socket_path, quiesce_installed_service_for_restart,
     quiesce_installed_service_under_lease, refresh_installed_service,
     refresh_installed_service_under_lease, refresh_installed_service_under_lease_with_state,
-    refresh_service, service_spec, service_status, socket_path_or_default, uninstall_service,
+    refresh_service, restore_quiesced_installed_service, service_spec, service_status,
+    socket_path_or_default, uninstall_service,
 };
 
 /// A host whose lifecycle hooks notify the daemon.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2221,6 +2221,19 @@ impl DaemonEngine {
         &self,
         handshake: &DaemonHandshake,
     ) -> Result<Arc<crate::mcp::McpServer>> {
+        let (project_path, route) = Self::project_route(handshake)?;
+        let cached = {
+            let servers = self.store_administration.project_servers().lock().await;
+            servers
+                .get_route(&route)
+                .map(|(key, server)| (key.clone(), Arc::clone(server)))
+        };
+        if let Some((key, server)) = cached {
+            return Ok(self
+                .activate_project_server(key, project_path, handshake, server)
+                .await);
+        }
+
         let (key, project_path, server) = self
             .store_administration
             .with_writer(|| self.open_project_server(handshake))
@@ -2237,15 +2250,7 @@ impl DaemonEngine {
         &self,
         handshake: &DaemonHandshake,
     ) -> Result<(ProjectServerKey, PathBuf, Arc<crate::mcp::McpServer>)> {
-        let Some(project_path) = handshake.project_path.as_ref() else {
-            return Err(TraceDecayError::Config {
-                message: "project server requested without project_path".to_string(),
-            });
-        };
-        let canonical_project_path = project_path
-            .canonicalize()
-            .unwrap_or_else(|_| project_path.clone());
-        let route = ProjectRouteKey::from_handshake(&canonical_project_path, handshake)?;
+        let (canonical_project_path, route) = Self::project_route(handshake)?;
         let cached = {
             let servers = self.store_administration.project_servers().lock().await;
             servers
@@ -2334,6 +2339,19 @@ impl DaemonEngine {
         Ok((key, canonical_project_path, server))
     }
 
+    fn project_route(handshake: &DaemonHandshake) -> Result<(PathBuf, ProjectRouteKey)> {
+        let Some(project_path) = handshake.project_path.as_ref() else {
+            return Err(TraceDecayError::Config {
+                message: "project server requested without project_path".to_string(),
+            });
+        };
+        let canonical_project_path = project_path
+            .canonicalize()
+            .unwrap_or_else(|_| project_path.clone());
+        let route = ProjectRouteKey::from_handshake(&canonical_project_path, handshake)?;
+        Ok((canonical_project_path, route))
+    }
+
     async fn activate_project_server(
         &self,
         key: ProjectServerKey,
@@ -2344,7 +2362,16 @@ impl DaemonEngine {
         // A freshly-handshaken project should be watched even on a cache hit
         // (the watcher may have started after this server was cached).
         self.git_watcher.ensure_watching(&project_path).await;
-        Box::pin(self.ensure_automation_scheduler(key, project_path, handshake.clone())).await;
+        // Scheduler discovery is ancillary and reacquires the daemon writer
+        // gate, so it must not make a cached MCP server wait behind unrelated
+        // store administration.
+        let engine = self.clone();
+        let handshake = handshake.clone();
+        let _scheduler_activation = tokio::spawn(async move {
+            engine
+                .ensure_automation_scheduler(key, project_path, handshake)
+                .await;
+        });
         server
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -19,8 +19,7 @@ use crate::errors::{Result, TraceDecayError};
 use crate::mcp::ReplayTransport;
 use crate::mcp::server::{McpMethod, SERVER_INSTRUCTIONS, classify_mcp_method, initialize_result};
 use crate::mcp::tools::{
-    explore_call_budget, get_tool_definitions_with_budget,
-    get_tool_definitions_with_warming_budget,
+    explore_call_budget, get_tool_definitions_with_budget, get_tool_definitions_with_warming_budget,
 };
 use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, StdioTransport};
 use branch_add::{branch_add_response, coordinated_hook_branch_writer, parse_branch_add_request};
@@ -2661,7 +2660,13 @@ async fn cached_project_node_count(
             .get_route(&route)
             .map(|(_, server)| Arc::clone(server))
     }?;
-    server.cg().await.get_stats().await.ok().map(|stats| stats.node_count)
+    server
+        .cg()
+        .await
+        .get_stats()
+        .await
+        .ok()
+        .map(|stats| stats.node_count)
 }
 
 fn spawn_lifecycle_project_server_warmup<OpenFuture>(
@@ -2839,8 +2844,7 @@ async fn serve_broker_socket_client(
         write_json_rpc_response(&mut transport, &response).await?;
         return Ok(());
     }
-    if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim())
-    {
+    if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim()) {
         let project_node_count =
             if matches!(classify_mcp_method(&request.method), McpMethod::ToolsList) {
                 if handshake.project_path.is_some() {
@@ -2851,11 +2855,9 @@ async fn serve_broker_socket_client(
             } else {
                 None
             };
-        if let Some(response) = daemon_bootstrap_response(
-            &request,
-            initialize_route.as_ref(),
-            project_node_count,
-        ) {
+        if let Some(response) =
+            daemon_bootstrap_response(&request, initialize_route.as_ref(), project_node_count)
+        {
             // Keep catalog-refresh bookkeeping consistent with the regular MCP
             // server path: initialize and tools/list mark this catalog current.
             if let Some(key) = engine
@@ -3020,8 +3022,7 @@ async fn serve_windows_broker_client(
         write_json_rpc_response(&mut transport, &response).await?;
         return Ok(());
     }
-    if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim())
-    {
+    if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim()) {
         let project_node_count =
             if matches!(classify_mcp_method(&request.method), McpMethod::ToolsList) {
                 if handshake.project_path.is_some() {
@@ -3032,11 +3033,9 @@ async fn serve_windows_broker_client(
             } else {
                 None
             };
-        if let Some(response) = daemon_bootstrap_response(
-            &request,
-            initialize_route.as_ref(),
-            project_node_count,
-        ) {
+        if let Some(response) =
+            daemon_bootstrap_response(&request, initialize_route.as_ref(), project_node_count)
+        {
             if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
                 && handshake.project_path.is_some()
             {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -78,6 +78,10 @@ const DAEMON_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(45);
 const DAEMON_CLIENT_DRAIN_DEADLINE: Duration = Duration::from_secs(15);
 #[cfg(unix)]
 const DAEMON_TASK_ABORT_DEADLINE: Duration = Duration::from_secs(2);
+/// How long a project open may queue behind an unrelated writer before the
+/// client is told to retry. The open itself keeps running in the background.
+#[cfg(unix)]
+const CONTENDED_PROJECT_OPEN_GRACE: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Default)]
 pub(crate) struct DaemonLifecycle {
@@ -2911,13 +2915,18 @@ async fn serve_broker_socket_client(
         }
     }
     let server = if let Some(project_path) = handshake.project_path.as_ref() {
+        // Queuing behind an unrelated writer can take that writer's whole
+        // operation, so answer with a retry hint rather than holding the
+        // client. An uncontended open is this client's own work and must run
+        // to completion, otherwise one-shot callers never get a result.
+        let contended = engine.store_administration.writer_is_busy();
         let mut project_open = engine.spawn_direct_project_server_open(handshake.clone());
-        let server = match tokio::time::timeout(
-            std::time::Duration::from_millis(500),
-            &mut project_open,
-        )
-        .await
-        {
+        let opened = if contended {
+            tokio::time::timeout(CONTENDED_PROJECT_OPEN_GRACE, &mut project_open).await
+        } else {
+            Ok((&mut project_open).await)
+        };
+        let server = match opened {
             Ok(Ok(Ok(server))) => server,
             Ok(Ok(Err(error))) => {
                 write_project_open_error(&mut transport, &first_request_line, &error).await?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2427,14 +2427,17 @@ impl DaemonEngine {
         // A freshly-handshaken project should be watched even on a cache hit
         // (the watcher may have started after this server was cached).
         self.git_watcher.ensure_watching(&project_path).await;
-        // Scheduler discovery is ancillary and reacquires the daemon writer
-        // gate, so it must not make a cached MCP server wait behind unrelated
-        // store administration.
+        // Scheduler discovery is ancillary, so it must not make a cached MCP
+        // server wait. Reuse the already-open project instead of opening the
+        // same writable store again, and count the detached task as lifecycle
+        // activity so shutdown cancels it before taking server snapshots.
         let engine = self.clone();
         let handshake = handshake.clone();
-        let _scheduler_activation = tokio::spawn(async move {
+        let scheduler_server = Arc::clone(&server);
+        spawn_lifecycle_automation_scheduler_activation(self.lifecycle.clone(), async move {
+            let cg = scheduler_server.cg().await;
             engine
-                .ensure_automation_scheduler(key, project_path, handshake)
+                .ensure_automation_scheduler(key, project_path, handshake, cg)
                 .await;
         });
         server
@@ -2664,6 +2667,25 @@ fn spawn_lifecycle_project_server_warmup<OpenFuture>(
                     ("error", error.to_string()),
                 ],
             ),
+        }
+    });
+}
+
+fn spawn_lifecycle_automation_scheduler_activation<ActivationFuture>(
+    lifecycle: DaemonLifecycle,
+    activation: ActivationFuture,
+) where
+    ActivationFuture: std::future::Future<Output = ()> + Send + 'static,
+{
+    let Some(activity) = lifecycle.try_enter() else {
+        return;
+    };
+    tokio::spawn(async move {
+        let _activity = activity;
+        tokio::select! {
+            biased;
+            () = lifecycle.wait_for_draining() => {}
+            () = activation => {}
         }
     });
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2615,32 +2615,47 @@ fn attach_initialize_route_metadata(
     result["_meta"]["tracedecayInitializeRoute"] = json!(route);
 }
 
-/// Returns `None` for project-dependent requests, `Some(None)` for handled
-/// notifications, and `Some(Some(response))` for static MCP bootstrap calls.
+/// A static MCP bootstrap call the daemon answers without opening a project.
+enum DaemonBootstrap {
+    /// A notification that needs no response written back.
+    Handled,
+    /// A static response to write back to the client.
+    Respond(JsonRpcResponse),
+}
+
+/// Returns `None` for project-dependent requests, which the caller must route
+/// to a project server instead.
 fn daemon_bootstrap_response(
     request: &JsonRpcRequest,
     route: Option<&InitializeRouteMetadata>,
     project_node_count: Option<u64>,
-) -> Option<Option<JsonRpcResponse>> {
+) -> Option<DaemonBootstrap> {
     match classify_mcp_method(&request.method) {
-        McpMethod::Initialize => Some(request.id.clone().map(|id| {
-            let mut response = JsonRpcResponse::success(id, initialize_result(SERVER_INSTRUCTIONS));
-            if let Some(route) = route {
-                attach_initialize_route_metadata(&mut response, route);
+        McpMethod::Initialize => Some(match request.id.clone() {
+            Some(id) => {
+                let mut response =
+                    JsonRpcResponse::success(id, initialize_result(SERVER_INSTRUCTIONS));
+                if let Some(route) = route {
+                    attach_initialize_route_metadata(&mut response, route);
+                }
+                DaemonBootstrap::Respond(response)
             }
-            response
-        })),
-        McpMethod::InitializedAck => Some(None),
-        McpMethod::ToolsList => Some(request.id.clone().map(|id| {
-            let tools = project_node_count.map_or_else(
-                || get_tool_definitions_with_warming_budget(10),
-                |node_count| {
-                    let budget = explore_call_budget(node_count);
-                    get_tool_definitions_with_budget(node_count, budget)
-                },
-            );
-            JsonRpcResponse::success(id, json!({ "tools": tools }))
-        })),
+            None => DaemonBootstrap::Handled,
+        }),
+        McpMethod::InitializedAck => Some(DaemonBootstrap::Handled),
+        McpMethod::ToolsList => Some(match request.id.clone() {
+            Some(id) => {
+                let tools = project_node_count.map_or_else(
+                    || get_tool_definitions_with_warming_budget(10),
+                    |node_count| {
+                        let budget = explore_call_budget(node_count);
+                        get_tool_definitions_with_budget(node_count, budget)
+                    },
+                );
+                DaemonBootstrap::Respond(JsonRpcResponse::success(id, json!({ "tools": tools })))
+            }
+            None => DaemonBootstrap::Handled,
+        }),
         _ => None,
     }
 }
@@ -2855,7 +2870,7 @@ async fn serve_broker_socket_client(
             } else {
                 None
             };
-        if let Some(response) =
+        if let Some(bootstrap) =
             daemon_bootstrap_response(&request, initialize_route.as_ref(), project_node_count)
         {
             // Keep catalog-refresh bookkeeping consistent with the regular MCP
@@ -2874,7 +2889,7 @@ async fn serve_broker_socket_client(
                 engine.spawn_project_server_warmup(handshake.clone(), request);
             }
             drop(setup_activity);
-            if let Some(response) = response {
+            if let DaemonBootstrap::Respond(response) = bootstrap {
                 write_json_rpc_response(&mut transport, &response).await?;
             }
             return Ok(());
@@ -3033,7 +3048,7 @@ async fn serve_windows_broker_client(
             } else {
                 None
             };
-        if let Some(response) =
+        if let Some(bootstrap) =
             daemon_bootstrap_response(&request, initialize_route.as_ref(), project_node_count)
         {
             if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
@@ -3050,7 +3065,7 @@ async fn serve_windows_broker_client(
                 );
             }
             drop(setup_activity);
-            if let Some(response) = response {
+            if let DaemonBootstrap::Respond(response) = bootstrap {
                 write_json_rpc_response(&mut transport, &response).await?;
             }
             return Ok(());

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -73,7 +73,6 @@ fn coordinated_background_refresh_writer(
 /// being killed with `SIGKILL` mid-checkpoint.
 #[cfg(unix)]
 const DAEMON_SHUTDOWN_DEADLINE: Duration = Duration::from_secs(45);
-#[cfg(unix)]
 const DAEMON_CLIENT_DRAIN_DEADLINE: Duration = Duration::from_secs(15);
 #[cfg(unix)]
 const DAEMON_TASK_ABORT_DEADLINE: Duration = Duration::from_secs(2);
@@ -133,7 +132,6 @@ impl DaemonLifecycle {
         }
     }
 
-    #[cfg(unix)]
     async fn wait_for_idle(&self) {
         loop {
             let notified = self.inner.idle.notified();
@@ -1071,9 +1069,29 @@ pub async fn run_foreground(_socket_path: PathBuf) -> Result<()> {
         });
     }
     lifecycle.begin_draining();
+    let in_flight_drained = timeout(DAEMON_CLIENT_DRAIN_DEADLINE, lifecycle.wait_for_idle())
+        .await
+        .is_ok();
     clients.abort_all();
     while clients.join_next().await.is_some() {}
     let endpoint_cleanup = authority.cleanup_owned_endpoint();
+    if !in_flight_drained {
+        log_daemon_event(
+            "daemon_shutdown",
+            &[
+                ("outcome", "client_drain_timeout".to_string()),
+                (
+                    "deadline_secs",
+                    DAEMON_CLIENT_DRAIN_DEADLINE.as_secs().to_string(),
+                ),
+                (
+                    "checkpoint",
+                    "skipped_active_clients_were_aborted".to_string(),
+                ),
+            ],
+        );
+        return endpoint_cleanup;
+    }
     shutdown_project_servers(&store_administration).await;
     endpoint_cleanup
 }
@@ -2597,8 +2615,9 @@ fn spawn_lifecycle_project_server_warmup<OpenFuture>(
     let _warmup = tokio::spawn(async move {
         let _activity = activity;
         let project_server = tokio::select! {
-            result = Box::pin(open_project_server) => result,
+            biased;
             () = lifecycle.wait_for_draining() => return,
+            result = Box::pin(open_project_server) => result,
         };
         match project_server {
             Ok(server) => {
@@ -2626,13 +2645,13 @@ fn spawn_portable_project_server_warmup(
     initialize_request: JsonRpcRequest,
     #[cfg(test)] project_open_attempts: Option<Arc<AtomicUsize>>,
 ) {
-    let Some(project_path) = handshake.project_path.as_deref() else {
+    let Some(project_path) = handshake.project_path.clone() else {
         return;
     };
-    let canonical_project_path = project_path
-        .canonicalize()
-        .unwrap_or_else(|_| project_path.to_path_buf());
     spawn_lifecycle_project_server_warmup(lifecycle, initialize_request, async move {
+        let canonical_project_path = project_path
+            .canonicalize()
+            .unwrap_or_else(|_| project_path.clone());
         store_administration
             .with_writer(|| {
                 portable_project_server(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -17,6 +17,8 @@ use tokio::time::{Duration, timeout};
 use crate::client_identity::DaemonClientIdentity;
 use crate::errors::{Result, TraceDecayError};
 use crate::mcp::ReplayTransport;
+use crate::mcp::server::{McpMethod, SERVER_INSTRUCTIONS, classify_mcp_method, initialize_result};
+use crate::mcp::tools::{explore_call_budget, get_tool_definitions_with_budget};
 use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, StdioTransport};
 use branch_add::{branch_add_response, coordinated_hook_branch_writer, parse_branch_add_request};
 use branch_admin::{StoreAdministration, parse_branch_admin_request, write_branch_admin_response};
@@ -2243,6 +2245,38 @@ impl DaemonEngine {
             .await)
     }
 
+    fn spawn_project_server_warmup(
+        &self,
+        handshake: DaemonHandshake,
+        initialize_request: JsonRpcRequest,
+    ) {
+        let Some(activity) = self.lifecycle.try_enter() else {
+            return;
+        };
+        let engine = self.clone();
+        let _warmup = tokio::spawn(async move {
+            let _activity = activity;
+            let project_server = tokio::select! {
+                result = Box::pin(engine.project_server(&handshake)) => result,
+                () = engine.lifecycle.wait_for_draining() => return,
+            };
+            match project_server {
+                Ok(server) => {
+                    // Preserve the regular initialize side effect that records
+                    // the negotiated MCP client name on the real server.
+                    let _ = server.handle_request(&initialize_request).await;
+                }
+                Err(error) => log_daemon_event(
+                    "project_server_warmup",
+                    &[
+                        ("outcome", "error".to_string()),
+                        ("error", error.to_string()),
+                    ],
+                ),
+            }
+        });
+    }
+
     /// Opens or resolves a project server while writer administration is held.
     /// Watcher and scheduler activation happen only after this returns so those
     /// components can acquire the same coordinator without recursive locking.
@@ -2544,6 +2578,31 @@ fn attach_initialize_route_metadata(
     result["_meta"]["tracedecayInitializeRoute"] = json!(route);
 }
 
+/// Returns `None` for project-dependent requests, `Some(None)` for handled
+/// notifications, and `Some(Some(response))` for static MCP bootstrap calls.
+fn daemon_bootstrap_response(
+    request: &JsonRpcRequest,
+    route: Option<&InitializeRouteMetadata>,
+) -> Option<Option<JsonRpcResponse>> {
+    match classify_mcp_method(&request.method) {
+        McpMethod::Initialize => Some(request.id.clone().map(|id| {
+            let mut response = JsonRpcResponse::success(id, initialize_result(SERVER_INSTRUCTIONS));
+            if let Some(route) = route {
+                attach_initialize_route_metadata(&mut response, route);
+            }
+            response
+        })),
+        McpMethod::InitializedAck => Some(None),
+        McpMethod::ToolsList => Some(request.id.clone().map(|id| {
+            let node_count = 0;
+            let budget = explore_call_budget(node_count);
+            let tools = get_tool_definitions_with_budget(node_count, budget);
+            JsonRpcResponse::success(id, json!({ "tools": tools }))
+        })),
+        _ => None,
+    }
+}
+
 async fn write_routed_initialize_response(
     server: &crate::mcp::McpServer,
     transport: &mut impl McpTransport,
@@ -2633,6 +2692,25 @@ async fn serve_broker_socket_client(
             branch_add_response(&engine.store_administration, &handshake, &request).await;
         drop(setup_activity);
         write_json_rpc_response(&mut transport, &response).await?;
+        return Ok(());
+    }
+    if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim())
+        && let Some(response) = daemon_bootstrap_response(&request, initialize_route.as_ref())
+    {
+        // Keep catalog-refresh bookkeeping consistent with the regular MCP
+        // server path: initialize and tools/list mark this catalog current.
+        let _ = engine
+            .claim_catalog_refresh(&handshake, &first_request_line)
+            .await;
+        if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
+            && handshake.project_path.is_some()
+        {
+            engine.spawn_project_server_warmup(handshake.clone(), request);
+        }
+        drop(setup_activity);
+        if let Some(response) = response {
+            write_json_rpc_response(&mut transport, &response).await?;
+        }
         return Ok(());
     }
     let server = if handshake.project_path.is_some() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -18,7 +18,10 @@ use crate::client_identity::DaemonClientIdentity;
 use crate::errors::{Result, TraceDecayError};
 use crate::mcp::ReplayTransport;
 use crate::mcp::server::{McpMethod, SERVER_INSTRUCTIONS, classify_mcp_method, initialize_result};
-use crate::mcp::tools::{explore_call_budget, get_tool_definitions_with_budget};
+use crate::mcp::tools::{
+    explore_call_budget, get_tool_definitions_with_budget,
+    get_tool_definitions_with_warming_budget,
+};
 use crate::mcp::{ErrorCode, JsonRpcRequest, JsonRpcResponse, McpTransport, StdioTransport};
 use branch_add::{branch_add_response, coordinated_hook_branch_writer, parse_branch_add_request};
 use branch_admin::{StoreAdministration, parse_branch_admin_request, write_branch_admin_response};
@@ -2617,6 +2620,7 @@ fn attach_initialize_route_metadata(
 fn daemon_bootstrap_response(
     request: &JsonRpcRequest,
     route: Option<&InitializeRouteMetadata>,
+    project_node_count: Option<u64>,
 ) -> Option<Option<JsonRpcResponse>> {
     match classify_mcp_method(&request.method) {
         McpMethod::Initialize => Some(request.id.clone().map(|id| {
@@ -2628,13 +2632,35 @@ fn daemon_bootstrap_response(
         })),
         McpMethod::InitializedAck => Some(None),
         McpMethod::ToolsList => Some(request.id.clone().map(|id| {
-            let node_count = 0;
-            let budget = explore_call_budget(node_count);
-            let tools = get_tool_definitions_with_budget(node_count, budget);
+            let tools = project_node_count.map_or_else(
+                || get_tool_definitions_with_warming_budget(10),
+                |node_count| {
+                    let budget = explore_call_budget(node_count);
+                    get_tool_definitions_with_budget(node_count, budget)
+                },
+            );
             JsonRpcResponse::success(id, json!({ "tools": tools }))
         })),
         _ => None,
     }
+}
+
+async fn cached_project_node_count(
+    store_administration: &StoreAdministration,
+    handshake: &DaemonHandshake,
+) -> Option<u64> {
+    let project_path = handshake.project_path.as_ref()?;
+    let canonical_project_path = project_path
+        .canonicalize()
+        .unwrap_or_else(|_| project_path.clone());
+    let route = ProjectRouteKey::from_handshake(&canonical_project_path, handshake).ok()?;
+    let server = {
+        let servers = store_administration.project_servers().lock().await;
+        servers
+            .get_route(&route)
+            .map(|(_, server)| Arc::clone(server))
+    }?;
+    server.cg().await.get_stats().await.ok().map(|stats| stats.node_count)
 }
 
 fn spawn_lifecycle_project_server_warmup<OpenFuture>(
@@ -2813,23 +2839,43 @@ async fn serve_broker_socket_client(
         return Ok(());
     }
     if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim())
-        && let Some(response) = daemon_bootstrap_response(&request, initialize_route.as_ref())
     {
-        // Keep catalog-refresh bookkeeping consistent with the regular MCP
-        // server path: initialize and tools/list mark this catalog current.
-        let _ = engine
-            .claim_catalog_refresh(&handshake, &first_request_line)
-            .await;
-        if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
-            && handshake.project_path.is_some()
-        {
-            engine.spawn_project_server_warmup(handshake.clone(), request);
+        let project_node_count =
+            if matches!(classify_mcp_method(&request.method), McpMethod::ToolsList) {
+                if handshake.project_path.is_some() {
+                    cached_project_node_count(&engine.store_administration, &handshake).await
+                } else {
+                    Some(0)
+                }
+            } else {
+                None
+            };
+        if let Some(response) = daemon_bootstrap_response(
+            &request,
+            initialize_route.as_ref(),
+            project_node_count,
+        ) {
+            // Keep catalog-refresh bookkeeping consistent with the regular MCP
+            // server path: initialize and tools/list mark this catalog current.
+            if let Some(key) = engine
+                .claim_catalog_refresh(&handshake, &first_request_line)
+                .await
+                && let Err(error) = write_tool_list_changed_notification(&mut transport).await
+            {
+                engine.release_catalog_refresh(key).await;
+                return Err(error);
+            }
+            if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
+                && handshake.project_path.is_some()
+            {
+                engine.spawn_project_server_warmup(handshake.clone(), request);
+            }
+            drop(setup_activity);
+            if let Some(response) = response {
+                write_json_rpc_response(&mut transport, &response).await?;
+            }
+            return Ok(());
         }
-        drop(setup_activity);
-        if let Some(response) = response {
-            write_json_rpc_response(&mut transport, &response).await?;
-        }
-        return Ok(());
     }
     let server = if let Some(project_path) = handshake.project_path.as_ref() {
         let mut project_open = engine.spawn_direct_project_server_open(handshake.clone());
@@ -2974,26 +3020,41 @@ async fn serve_windows_broker_client(
         return Ok(());
     }
     if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim())
-        && let Some(response) = daemon_bootstrap_response(&request, initialize_route.as_ref())
     {
-        if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
-            && handshake.project_path.is_some()
-        {
-            spawn_portable_project_server_warmup(
-                lifecycle.clone(),
-                store_administration.clone(),
-                Arc::clone(&project_open_gates),
-                handshake.clone(),
-                request,
-                #[cfg(test)]
-                project_open_attempts.clone(),
-            );
+        let project_node_count =
+            if matches!(classify_mcp_method(&request.method), McpMethod::ToolsList) {
+                if handshake.project_path.is_some() {
+                    cached_project_node_count(&store_administration, &handshake).await
+                } else {
+                    Some(0)
+                }
+            } else {
+                None
+            };
+        if let Some(response) = daemon_bootstrap_response(
+            &request,
+            initialize_route.as_ref(),
+            project_node_count,
+        ) {
+            if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
+                && handshake.project_path.is_some()
+            {
+                spawn_portable_project_server_warmup(
+                    lifecycle.clone(),
+                    store_administration.clone(),
+                    Arc::clone(&project_open_gates),
+                    handshake.clone(),
+                    request,
+                    #[cfg(test)]
+                    project_open_attempts.clone(),
+                );
+            }
+            drop(setup_activity);
+            if let Some(response) = response {
+                write_json_rpc_response(&mut transport, &response).await?;
+            }
+            return Ok(());
         }
-        drop(setup_activity);
-        if let Some(response) = response {
-            write_json_rpc_response(&mut transport, &response).await?;
-        }
-        return Ok(());
     }
     if let Some(project_path) = handshake.project_path.as_deref() {
         let canonical_project_path = project_path

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2250,31 +2250,12 @@ impl DaemonEngine {
         handshake: DaemonHandshake,
         initialize_request: JsonRpcRequest,
     ) {
-        let Some(activity) = self.lifecycle.try_enter() else {
-            return;
-        };
         let engine = self.clone();
-        let _warmup = tokio::spawn(async move {
-            let _activity = activity;
-            let project_server = tokio::select! {
-                result = Box::pin(engine.project_server(&handshake)) => result,
-                () = engine.lifecycle.wait_for_draining() => return,
-            };
-            match project_server {
-                Ok(server) => {
-                    // Preserve the regular initialize side effect that records
-                    // the negotiated MCP client name on the real server.
-                    let _ = server.handle_request(&initialize_request).await;
-                }
-                Err(error) => log_daemon_event(
-                    "project_server_warmup",
-                    &[
-                        ("outcome", "error".to_string()),
-                        ("error", error.to_string()),
-                    ],
-                ),
-            }
-        });
+        spawn_lifecycle_project_server_warmup(
+            self.lifecycle.clone(),
+            initialize_request,
+            async move { Box::pin(engine.project_server(&handshake)).await },
+        );
     }
 
     /// Opens or resolves a project server while writer administration is held.
@@ -2603,6 +2584,70 @@ fn daemon_bootstrap_response(
     }
 }
 
+fn spawn_lifecycle_project_server_warmup<OpenFuture>(
+    lifecycle: DaemonLifecycle,
+    initialize_request: JsonRpcRequest,
+    open_project_server: OpenFuture,
+) where
+    OpenFuture: std::future::Future<Output = Result<Arc<crate::mcp::McpServer>>> + Send + 'static,
+{
+    let Some(activity) = lifecycle.try_enter() else {
+        return;
+    };
+    let _warmup = tokio::spawn(async move {
+        let _activity = activity;
+        let project_server = tokio::select! {
+            result = Box::pin(open_project_server) => result,
+            () = lifecycle.wait_for_draining() => return,
+        };
+        match project_server {
+            Ok(server) => {
+                // Preserve the regular initialize side effect that records
+                // the negotiated MCP client name on the real server.
+                let _ = server.handle_request(&initialize_request).await;
+            }
+            Err(error) => log_daemon_event(
+                "project_server_warmup",
+                &[
+                    ("outcome", "error".to_string()),
+                    ("error", error.to_string()),
+                ],
+            ),
+        }
+    });
+}
+
+#[cfg(any(not(unix), test))]
+fn spawn_portable_project_server_warmup(
+    lifecycle: DaemonLifecycle,
+    store_administration: StoreAdministration,
+    project_open_gates: Arc<tokio::sync::Mutex<ProjectOpenGates>>,
+    handshake: DaemonHandshake,
+    initialize_request: JsonRpcRequest,
+    #[cfg(test)] project_open_attempts: Option<Arc<AtomicUsize>>,
+) {
+    let Some(project_path) = handshake.project_path.as_deref() else {
+        return;
+    };
+    let canonical_project_path = project_path
+        .canonicalize()
+        .unwrap_or_else(|_| project_path.to_path_buf());
+    spawn_lifecycle_project_server_warmup(lifecycle, initialize_request, async move {
+        store_administration
+            .with_writer(|| {
+                portable_project_server(
+                    &store_administration,
+                    &project_open_gates,
+                    &canonical_project_path,
+                    &handshake,
+                    #[cfg(test)]
+                    project_open_attempts.as_ref(),
+                )
+            })
+            .await
+    });
+}
+
 async fn write_routed_initialize_response(
     server: &crate::mcp::McpServer,
     transport: &mut impl McpTransport,
@@ -2829,6 +2874,28 @@ async fn serve_windows_broker_client(
         let response = branch_add_response(&store_administration, &handshake, &request).await;
         drop(setup_activity);
         write_json_rpc_response(&mut transport, &response).await?;
+        return Ok(());
+    }
+    if let Ok(request) = serde_json::from_str::<JsonRpcRequest>(first_request_line.trim())
+        && let Some(response) = daemon_bootstrap_response(&request, initialize_route.as_ref())
+    {
+        if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
+            && handshake.project_path.is_some()
+        {
+            spawn_portable_project_server_warmup(
+                lifecycle.clone(),
+                store_administration.clone(),
+                Arc::clone(&project_open_gates),
+                handshake.clone(),
+                request,
+                #[cfg(test)]
+                project_open_attempts.clone(),
+            );
+        }
+        drop(setup_activity);
+        if let Some(response) = response {
+            write_json_rpc_response(&mut transport, &response).await?;
+        }
         return Ok(());
     }
     if let Some(project_path) = handshake.project_path.as_deref() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2276,6 +2276,38 @@ impl DaemonEngine {
         );
     }
 
+    fn spawn_direct_project_server_open(
+        &self,
+        handshake: DaemonHandshake,
+    ) -> JoinHandle<Result<Arc<crate::mcp::McpServer>>> {
+        let engine = self.clone();
+        tokio::spawn(async move {
+            let Some(activity) = engine.lifecycle.try_enter() else {
+                return Err(TraceDecayError::Config {
+                    message: "daemon is draining before project warm-up".to_string(),
+                });
+            };
+            let _activity = activity;
+            let result = tokio::select! {
+                biased;
+                () = engine.lifecycle.wait_for_draining() => Err(TraceDecayError::Config {
+                    message: "daemon began draining during project warm-up".to_string(),
+                }),
+                result = Box::pin(engine.project_server(&handshake)) => result,
+            };
+            if let Err(error) = &result {
+                log_daemon_event(
+                    "project_server_warmup",
+                    &[
+                        ("outcome", "error".to_string()),
+                        ("error", error.to_string()),
+                    ],
+                );
+            }
+            result
+        })
+    }
+
     /// Opens or resolves a project server while writer administration is held.
     /// Watcher and scheduler activation happen only after this returns so those
     /// components can acquire the same coordinator without recursive locking.
@@ -2777,12 +2809,36 @@ async fn serve_broker_socket_client(
         }
         return Ok(());
     }
-    let server = if handshake.project_path.is_some() {
-        let server = match Box::pin(engine.project_server(&handshake)).await {
-            Ok(server) => server,
-            Err(e) => {
-                write_project_open_error(&mut transport, &first_request_line, &e).await?;
-                return Err(e);
+    let server = if let Some(project_path) = handshake.project_path.as_ref() {
+        let mut project_open = engine.spawn_direct_project_server_open(handshake.clone());
+        let server = match tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            &mut project_open,
+        )
+        .await
+        {
+            Ok(Ok(Ok(server))) => server,
+            Ok(Ok(Err(error))) => {
+                write_project_open_error(&mut transport, &first_request_line, &error).await?;
+                return Err(error);
+            }
+            Ok(Err(error)) => {
+                let error = TraceDecayError::Config {
+                    message: format!("project warm-up task failed: {error}"),
+                };
+                write_project_open_error(&mut transport, &first_request_line, &error).await?;
+                return Err(error);
+            }
+            Err(_) => {
+                let error = TraceDecayError::Config {
+                    message: format!(
+                        "TraceDecay project '{}' is warming in the background; retry the same tool shortly",
+                        project_path.display()
+                    ),
+                };
+                drop(setup_activity);
+                write_project_open_error(&mut transport, &first_request_line, &error).await?;
+                return Ok(());
             }
         };
         Some(server)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -164,10 +164,10 @@ mod service;
 pub(crate) mod transport;
 pub use service::{
     DaemonServiceSpec, DaemonServiceState, daemon_reachable, default_socket_path, install_service,
-    installed_service_socket_path, quiesce_installed_service_under_lease,
-    refresh_installed_service, refresh_installed_service_under_lease,
-    refresh_installed_service_under_lease_with_state, refresh_service, service_spec,
-    service_status, socket_path_or_default, uninstall_service,
+    installed_service_socket_path, quiesce_installed_service_for_restart,
+    quiesce_installed_service_under_lease, refresh_installed_service,
+    refresh_installed_service_under_lease, refresh_installed_service_under_lease_with_state,
+    refresh_service, service_spec, service_status, socket_path_or_default, uninstall_service,
 };
 
 /// A host whose lifecycle hooks notify the daemon.

--- a/src/daemon/branch_admin.rs
+++ b/src/daemon/branch_admin.rs
@@ -120,6 +120,13 @@ impl StoreAdministration {
         ensure_no_external_branch_store_holders(database_paths)
     }
 
+    /// Reports whether writer administration is already held. Work that would
+    /// queue behind an unrelated writer can be delayed for that writer's whole
+    /// operation, which callers may want to answer with a retry hint instead.
+    pub(super) fn writer_is_busy(&self) -> bool {
+        self.gate.try_lock().is_err()
+    }
+
     /// Acquires writer administration before constructing the supplied future
     /// and holds it until that future completes.
     pub(super) async fn with_writer<Operation, OperationFuture, Output>(

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -159,6 +159,55 @@ impl DaemonEngine {
         project_path: PathBuf,
         handshake: DaemonHandshake,
     ) {
+        if !self.lifecycle.accepting() {
+            return;
+        }
+        {
+            let schedulers = self
+                .store_administration
+                .automation_schedulers()
+                .lock()
+                .await;
+            if schedulers.contains_key(&key) {
+                return;
+            }
+        }
+
+        // Configuration discovery is read-only but can open a large project
+        // store and run branch resolution. Keep that work outside the
+        // daemon-wide writer gate so an ancillary scheduler check cannot
+        // starve an unrelated worktree's first project-server open.
+        let configured = match Box::pin(automation_scheduler_has_work_for_project(
+            &project_path,
+            &handshake,
+        ))
+        .await
+        {
+            Ok(configured) => configured,
+            Err(e) => {
+                log_daemon_event(
+                    "scheduler_config",
+                    &[
+                        ("project", project_path.display().to_string()),
+                        ("outcome", "error".to_string()),
+                        ("error", e.to_string()),
+                    ],
+                );
+                false
+            }
+        };
+        if !configured {
+            log_daemon_event(
+                "scheduler_config",
+                &[
+                    ("project", project_path.display().to_string()),
+                    ("outcome", "skipped".to_string()),
+                    ("reason", "not_configured".to_string()),
+                ],
+            );
+            return;
+        }
+
         self.store_administration
             .with_writer(|| async move {
                 if !self.lifecycle.accepting() {
@@ -174,38 +223,6 @@ impl DaemonEngine {
                         return;
                     }
                 }
-
-                let configured = match Box::pin(automation_scheduler_has_work_for_project(
-                    &project_path,
-                    &handshake,
-                ))
-                .await
-                {
-                    Ok(configured) => configured,
-                    Err(e) => {
-                        log_daemon_event(
-                            "scheduler_config",
-                            &[
-                                ("project", project_path.display().to_string()),
-                                ("outcome", "error".to_string()),
-                                ("error", e.to_string()),
-                            ],
-                        );
-                        false
-                    }
-                };
-                if !configured {
-                    log_daemon_event(
-                        "scheduler_config",
-                        &[
-                            ("project", project_path.display().to_string()),
-                            ("outcome", "skipped".to_string()),
-                            ("reason", "not_configured".to_string()),
-                        ],
-                    );
-                    return;
-                }
-
                 self.start_automation_scheduler(key, project_path, handshake)
                     .await;
             })

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -215,6 +215,16 @@ impl DaemonEngine {
                 if !self.lifecycle.accepting() {
                     return;
                 }
+                let owner_is_current = self
+                    .store_administration
+                    .project_servers()
+                    .lock()
+                    .await
+                    .get(&key)
+                    .is_some();
+                if !owner_is_current {
+                    return;
+                }
                 {
                     let schedulers = self
                         .store_administration

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -9,7 +9,7 @@ use crate::errors::{Result, TraceDecayError};
 
 use super::{
     DAEMON_TASK_ABORT_DEADLINE, DaemonEngine, DaemonHandshake, ProjectServerKey, log_daemon_event,
-    open_existing_project_with_options,
+    open_existing_project_with_options, spawn_lifecycle_automation_scheduler_activation,
 };
 
 pub(super) fn scheduler_task_log_fields(
@@ -158,6 +158,7 @@ impl DaemonEngine {
         key: ProjectServerKey,
         project_path: PathBuf,
         handshake: DaemonHandshake,
+        cg: Arc<crate::tracedecay::TraceDecay>,
     ) {
         if !self.lifecycle.accepting() {
             return;
@@ -173,14 +174,15 @@ impl DaemonEngine {
             }
         }
 
-        // Configuration discovery is read-only but can open a large project
-        // store and run branch resolution. Keep that work outside the
-        // daemon-wide writer gate so an ancillary scheduler check cannot
-        // starve an unrelated worktree's first project-server open.
-        let configured = match Box::pin(automation_scheduler_has_work_for_project(
-            &project_path,
-            &handshake,
-        ))
+        // Discover configuration from the project server that is already
+        // registered for this owner. This keeps writable project opening and
+        // identity repair under the project-server coordination path while
+        // avoiding the daemon-wide writer gate for read-only discovery.
+        let configured = match async {
+            let config =
+                effective_automation_config_for_project(&cg, &handshake.client_identity).await?;
+            automation_scheduler_has_work(&cg, &config).await
+        }
         .await
         {
             Ok(configured) => configured,
@@ -241,10 +243,24 @@ impl DaemonEngine {
             let current_key = Arc::clone(&current_key);
             let project_path = project_path.clone();
             let handshake = handshake.clone();
-            tokio::spawn(async move {
+            let lifecycle = engine.lifecycle.clone();
+            spawn_lifecycle_automation_scheduler_activation(lifecycle, async move {
                 let key = current_key.lock().await.clone();
+                let server = {
+                    engine
+                        .store_administration
+                        .project_servers()
+                        .lock()
+                        .await
+                        .get(&key)
+                        .cloned()
+                };
+                let Some(server) = server else {
+                    return;
+                };
+                let cg = server.cg().await;
                 engine
-                    .ensure_automation_scheduler(key.clone(), project_path, handshake)
+                    .ensure_automation_scheduler(key.clone(), project_path, handshake, cg)
                     .await;
                 if let Some(handle) = engine
                     .store_administration

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -12,6 +12,9 @@ use super::SOCKET_ENV;
 
 const LAUNCHD_LABEL: &str = "com.tracedecay.daemon";
 const LAUNCHD_PLIST_NAME: &str = "com.tracedecay.daemon.plist";
+// Cached project owners retain SQLite families and coordination locks. The
+// platform default of 256 descriptors is too small for multi-worktree use.
+const DAEMON_OPEN_FILE_LIMIT: u32 = 8_192;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DaemonServiceSpec {
@@ -54,12 +57,14 @@ impl DaemonServiceSpec {
              ExecStart={} daemon run --socket {}\n\
              Restart=on-failure\n\
              RestartSec=2\n\
+             LimitNOFILE={}\n\
              \n\
              [Install]\n\
              WantedBy=default.target\n",
             systemd_escape_env_value(&service_path),
             self.tracedecay_bin.display(),
-            self.socket_path.display()
+            self.socket_path.display(),
+            DAEMON_OPEN_FILE_LIMIT,
         )
     }
 
@@ -137,6 +142,12 @@ impl DaemonServiceSpec {
                <key>ThrottleInterval</key>\n\
                <integer>2</integer>\n\
              \n\
+               <key>SoftResourceLimits</key>\n\
+               <dict>\n\
+                 <key>NumberOfFiles</key>\n\
+                 <integer>{open_file_limit}</integer>\n\
+               </dict>\n\
+             \n\
                <key>StandardOutPath</key>\n\
                <string>{stdout}</string>\n\
              \n\
@@ -147,6 +158,7 @@ impl DaemonServiceSpec {
             label = plist_xml_escape(LAUNCHD_LABEL),
             bin = plist_xml_escape(&self.tracedecay_bin.display().to_string()),
             socket = plist_xml_escape(&self.socket_path.display().to_string()),
+            open_file_limit = DAEMON_OPEN_FILE_LIMIT,
             stdout = plist_xml_escape(&data_dir.join("daemon.out.log").display().to_string()),
             stderr = plist_xml_escape(&data_dir.join("daemon.err.log").display().to_string()),
         ))
@@ -1284,6 +1296,7 @@ mod tests {
         ));
         assert!(unit.contains("Environment=\"PATH="));
         assert!(unit.contains("Restart=on-failure"));
+        assert!(unit.contains("LimitNOFILE=8192"));
     }
 
     // The launchd render tests use Unix-style absolute binary paths, which
@@ -1325,6 +1338,9 @@ mod tests {
         assert!(plist.contains("<key>TRACEDECAY_DATA_DIR</key>"));
         assert!(plist.contains("<key>RunAtLoad</key>"));
         assert!(plist.contains("<key>KeepAlive</key>"));
+        assert!(plist.contains("<key>SoftResourceLimits</key>"));
+        assert!(plist.contains("<key>NumberOfFiles</key>"));
+        assert!(plist.contains("<integer>8192</integer>"));
     }
 
     #[cfg(unix)]

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -402,9 +402,7 @@ pub fn quiesce_installed_service_under_lease() -> Result<DaemonServiceState> {
 /// the caller invokes it only after exclusive lifecycle acquisition failed.
 #[doc(hidden)]
 pub fn restore_quiesced_installed_service(previous_state: DaemonServiceState) -> Result<()> {
-    if !cfg!(any(target_os = "linux", target_os = "macos"))
-        || !previous_state.is_running()
-    {
+    if !cfg!(any(target_os = "linux", target_os = "macos")) || !previous_state.is_running() {
         return Ok(());
     }
     let service_path = service_unit_path()?;
@@ -418,11 +416,7 @@ pub fn restore_quiesced_installed_service(previous_state: DaemonServiceState) ->
     }
     let unit = read_service_unit(&service_path)?;
     let socket_path = socket_path_from_unit_text(&unit).unwrap_or(default_socket_path()?);
-    ServiceRunner::current()?.restore_after_quiesce(
-        &service_path,
-        &socket_path,
-        previous_state,
-    )
+    ServiceRunner::current()?.restore_after_quiesce(&service_path, &socket_path, previous_state)
 }
 
 fn quiesce_installed_service() -> Result<DaemonServiceState> {

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -385,6 +385,34 @@ pub fn quiesce_installed_service_under_lease() -> Result<DaemonServiceState> {
     quiesce_installed_service()
 }
 
+/// Restores an installed service that was running before restart quiesced it.
+/// This deliberately reuses the existing unit instead of rewriting it because
+/// the caller invokes it only after exclusive lifecycle acquisition failed.
+#[doc(hidden)]
+pub fn restore_quiesced_installed_service(previous_state: DaemonServiceState) -> Result<()> {
+    if !cfg!(any(target_os = "linux", target_os = "macos"))
+        || !previous_state.is_running()
+    {
+        return Ok(());
+    }
+    let service_path = service_unit_path()?;
+    if !service_path.exists() {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "cannot restore missing TraceDecay daemon service '{}'",
+                service_path.display()
+            ),
+        });
+    }
+    let unit = read_service_unit(&service_path)?;
+    let socket_path = socket_path_from_unit_text(&unit).unwrap_or(default_socket_path()?);
+    ServiceRunner::current()?.restore_after_quiesce(
+        &service_path,
+        &socket_path,
+        previous_state,
+    )
+}
+
 fn quiesce_installed_service() -> Result<DaemonServiceState> {
     if !cfg!(any(target_os = "linux", target_os = "macos")) {
         return Ok(DaemonServiceState::Missing);
@@ -766,6 +794,27 @@ impl ServiceRunner {
         match self {
             Self::Systemd => run_systemctl(&["stop", super::SERVICE_NAME]),
             Self::Launchd => launchd_before_uninstall(true),
+        }
+    }
+
+    fn restore_after_quiesce(
+        &self,
+        service_path: &Path,
+        socket_path: &Path,
+        previous_state: DaemonServiceState,
+    ) -> Result<()> {
+        if !previous_state.is_running() {
+            return Ok(());
+        }
+        match self {
+            Self::Systemd => run_systemctl(&["start", super::SERVICE_NAME]),
+            Self::Launchd => {
+                launchd_refresh(service_path, socket_path)?;
+                if !previous_state.is_enabled() {
+                    run_launchctl(&["disable", &launchd_service_target()?])?;
+                }
+                Ok(())
+            }
         }
     }
 
@@ -1627,6 +1676,55 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(log).expect("systemctl log"),
             "--user is-active --quiet tracedecay.service\n--user is-enabled tracedecay.service\n--user stop tracedecay.service\n--user daemon-reload\n--user enable tracedecay.service\n--user restart tracedecay.service\n"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn restore_quiesced_service_starts_existing_unit_without_rewriting_it() {
+        let _env_lock = lock_user_data_dir_test_env();
+        let dir = TempDir::new().expect("temp dir");
+        let config_home = dir.path().join("config");
+        let fake_bin = dir.path().join("bin");
+        let home = dir.path().join("home");
+        std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+        std::fs::create_dir_all(&home).expect("home dir");
+
+        let systemctl = fake_bin.join("systemctl");
+        let log = dir.path().join("systemctl.log");
+        std::fs::write(
+            &systemctl,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TRACEDECAY_SYSTEMCTL_LOG\"\nexit 0\n",
+        )
+        .expect("fake systemctl");
+        std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+            .expect("systemctl permissions");
+
+        let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+        let _home_guard = EnvVarGuard::set("HOME", &home);
+        let _data_guard =
+            EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, dir.path().join("profile"));
+        let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+        let _log_guard = EnvVarGuard::set("TRACEDECAY_SYSTEMCTL_LOG", &log);
+        let service_path = config_home
+            .join("systemd/user")
+            .join(crate::daemon::SERVICE_NAME);
+        std::fs::create_dir_all(service_path.parent().expect("service parent"))
+            .expect("service dir");
+        let original_unit =
+            "[Service]\nExecStart=/old/tracedecay daemon run --socket /custom/tracedecay.sock\n";
+        std::fs::write(&service_path, original_unit).expect("existing service unit");
+
+        super::restore_quiesced_installed_service(DaemonServiceState::RunningEnabled)
+            .expect("restore service");
+
+        assert_eq!(
+            std::fs::read_to_string(service_path).expect("service unit"),
+            original_unit
+        );
+        assert_eq!(
+            std::fs::read_to_string(log).expect("systemctl log"),
+            "--user start tracedecay.service\n"
         );
     }
 

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -373,8 +373,19 @@ fn refresh_installed_service_with_state(
     refresh_service_with_runner(&runner, &refreshed_spec, previous_state).map(Some)
 }
 
+/// Stops a managed daemon before `daemon restart` acquires exclusive lifecycle
+/// ownership. The daemon itself holds a shared lease while it is running.
+#[doc(hidden)]
+pub fn quiesce_installed_service_for_restart() -> Result<DaemonServiceState> {
+    quiesce_installed_service()
+}
+
 #[doc(hidden)]
 pub fn quiesce_installed_service_under_lease() -> Result<DaemonServiceState> {
+    quiesce_installed_service()
+}
+
+fn quiesce_installed_service() -> Result<DaemonServiceState> {
     if !cfg!(any(target_os = "linux", target_os = "macos")) {
         return Ok(DaemonServiceState::Missing);
     }

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -31,6 +31,29 @@ fn daemon_lifecycle_rejects_new_work_after_draining() {
     assert!(!lifecycle.accepting());
 }
 
+#[test]
+fn bootstrap_tool_catalog_uses_project_node_count() {
+    let request: super::JsonRpcRequest = serde_json::from_value(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list"
+    }))
+    .expect("tools/list request");
+    let response = super::daemon_bootstrap_response(&request, None, Some(65_395))
+        .expect("bootstrap response")
+        .expect("tools/list response");
+    let context_description = response.result.expect("tools/list result")["tools"]
+        .as_array()
+        .expect("tool catalog")
+        .iter()
+        .find(|tool| tool["name"] == serde_json::json!("tracedecay_context"))
+        .and_then(|tool| tool["description"].as_str())
+        .expect("context tool description");
+
+    assert!(context_description.contains("5 calls maximum"));
+    assert!(context_description.contains("65395 nodes"));
+}
+
 #[tokio::test]
 async fn portable_broker_requests_reuse_one_authenticated_project_owner() {
     const TOKEN: &str = "0123456789abcdef0123456789abcdef";
@@ -334,6 +357,17 @@ async fn portable_broker_bootstrap_bypasses_project_writer_gate() {
             .is_some_and(|tools| !tools.is_empty()),
         "portable bootstrap tool catalog must not be empty"
     );
+    let portable_context_description = tools_list_response["result"]["tools"]
+        .as_array()
+        .and_then(|tools| {
+            tools
+                .iter()
+                .find(|tool| tool["name"] == serde_json::json!("tracedecay_context"))
+        })
+        .and_then(|tool| tool["description"].as_str())
+        .expect("portable context tool description");
+    assert!(portable_context_description.contains("10 calls maximum"));
+    assert!(portable_context_description.contains("project graph is warming"));
 
     tokio::time::timeout(PHASE_TIMEOUT, async {
         loop {
@@ -1107,6 +1141,13 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
         !tools.is_empty(),
         "bootstrap tool catalog must not be empty"
     );
+    let context_description = tools
+        .iter()
+        .find(|tool| tool["name"] == json!("tracedecay_context"))
+        .and_then(|tool| tool["description"].as_str())
+        .expect("context tool description");
+    assert!(context_description.contains("10 calls maximum"));
+    assert!(context_description.contains("project graph is warming"));
 
     let project_path = handshake.project_path.as_ref().expect("project path");
     let route = ProjectRouteKey::from_handshake(project_path, &handshake).expect("project route");
@@ -2648,6 +2689,37 @@ async fn daemon_refreshes_once_only_after_generation_change() {
     .await;
     assert_eq!(second.len(), 1, "the refresh must not loop");
     assert_eq!(second[0]["id"], json!(4));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn initialized_ack_preserves_pending_catalog_refresh_notification() {
+    let engine = super::DaemonEngine::default();
+    let mut handshake = test_handshake_defaults();
+    handshake.client_instance_id = test_client_instance_id(5);
+    handshake.tool_list_changed_capable = true;
+    handshake.catalog_version = "0.0.0-old".to_string();
+
+    let initialized = daemon_round_trip(
+        engine.clone(),
+        &handshake,
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    )
+    .await;
+    assert_eq!(initialized.len(), 1);
+    assert_eq!(
+        initialized[0]["method"],
+        json!("notifications/tools/list_changed")
+    );
+
+    let ping = daemon_round_trip(
+        engine,
+        &handshake,
+        json!({"jsonrpc": "2.0", "id": 6, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(ping.len(), 1, "refresh notification must be deduplicated");
+    assert_eq!(ping[0]["id"], json!(6));
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -3155,8 +3155,8 @@ async fn daemon_scheduler_skips_stale_owner_key_after_rekey() {
         ..test_handshake_defaults()
     };
     let engine = super::DaemonEngine::default();
-    let stale_key = super::ProjectServerKey::from_open_project(&cg, &handshake)
-        .expect("stale owner key");
+    let stale_key =
+        super::ProjectServerKey::from_open_project(&cg, &handshake).expect("stale owner key");
 
     save_project_config(
         &cg.store_layout().dashboard_root,
@@ -3177,11 +3177,7 @@ async fn daemon_scheduler_skips_stale_owner_key_after_rekey() {
     let mut current_key = stale_key.clone();
     current_key.scope_prefix = Some("rekeyed".to_string());
     {
-        let mut owners = engine
-            .store_administration
-            .project_servers()
-            .lock()
-            .await;
+        let mut owners = engine.store_administration.project_servers().lock().await;
         owners.insert(stale_key.clone(), server);
         assert!(owners.rekey(&stale_key, &current_key));
     }

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -1111,6 +1111,112 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
 }
 
 #[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn direct_tool_cache_miss_returns_warming_while_project_opens_in_background() {
+    const PHASE_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(20);
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let profile_root = temp.path().join("profile");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let project = project.canonicalize().expect("canonical project");
+    let client_identity = test_client_identity_for(profile_root.clone());
+    let options = crate::tracedecay::TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(client_identity.global_db_path.clone()),
+    };
+    drop(
+        crate::tracedecay::TraceDecay::init_with_options(&project, options)
+            .await
+            .expect("initialize project"),
+    );
+    let mut config = crate::config::load_config(&project).expect("load project config");
+    config.sync.session_start_sync = false;
+    crate::config::save_config(&project, &config)
+        .expect("disable unrelated startup transcript ingestion");
+    let _database_scope =
+        crate::db::enter_daemon_database_scope(&profile_root, 1, "direct-warmup-test")
+            .expect("daemon database scope");
+    let engine = DaemonEngine::default();
+    let handshake = DaemonHandshake {
+        project_path: Some(project.clone()),
+        client_identity,
+        ..test_handshake_defaults()
+    };
+
+    let store_administration = engine.store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        store_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "tracedecay_status",
+            "arguments": {"format": "json"}
+        }
+    });
+    let request_engine = engine.clone();
+    let request_handshake = handshake.clone();
+    let mut request_task = tokio::spawn(async move {
+        daemon_round_trip(request_engine, &request_handshake, request).await
+    });
+    let response_within_bound =
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), &mut request_task).await;
+
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+    if response_within_bound.is_err() {
+        let _ = request_task.await;
+    }
+
+    let responses = response_within_bound
+        .expect("direct tool cache miss must return a bounded warming response")
+        .expect("direct tool client task");
+    let response = responses
+        .iter()
+        .find(|response| response["id"] == json!(3))
+        .expect("direct tool response");
+    let message = response["error"]["message"]
+        .as_str()
+        .expect("warming error message");
+    assert!(message.contains("warming in the background"), "{message}");
+    assert!(message.contains("retry"), "{message}");
+
+    let route = ProjectRouteKey::from_handshake(&project, &handshake).expect("project route");
+    tokio::time::timeout(PHASE_TIMEOUT, async {
+        loop {
+            let warmed = engine
+                .store_administration
+                .project_servers()
+                .lock()
+                .await
+                .get_route(&route)
+                .is_some();
+            if warmed {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached project warmup timed out");
+    tokio::time::timeout(PHASE_TIMEOUT, engine.shutdown_all())
+        .await
+        .expect("direct warmup shutdown timed out");
+}
+
+#[cfg(unix)]
 #[test]
 fn store_owner_key_collapses_profile_and_store_aliases() {
     let temp = TempDir::new().expect("temp dir");
@@ -2777,6 +2883,51 @@ async fn daemon_ensure_scheduler_skips_before_project_has_configured_work() {
         .lock()
         .await;
     assert!(!schedulers.contains_key(&key));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn daemon_scheduler_discovery_without_work_does_not_wait_for_writer_gate() {
+    let dir = TempDir::new().expect("temp dir");
+    let project = dir.path().canonicalize().expect("canonical temp dir");
+    let client_identity = test_client_identity_for(project.join("profile"));
+    std::fs::create_dir_all(project.join("src")).expect("src dir");
+    std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
+    let handshake = DaemonHandshake {
+        project_path: Some(project.clone()),
+        client_identity,
+        ..test_handshake_defaults()
+    };
+    let cg = crate::tracedecay::TraceDecay::init_with_options(&project, handshake.open_options())
+        .await
+        .expect("project init");
+    let engine = super::DaemonEngine::default();
+    let key = super::ProjectServerKey::from_open_project(&cg, &handshake).expect("owner key");
+    drop(cg);
+
+    let store_administration = engine.store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        store_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    let discovery = tokio::time::timeout(
+        tokio::time::Duration::from_secs(2),
+        engine.ensure_automation_scheduler(key, project, handshake),
+    )
+    .await;
+
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+    discovery.expect("read-only scheduler discovery must not wait for the writer gate");
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -150,6 +150,16 @@ async fn portable_broker_requests_reuse_one_authenticated_project_owner() {
     tokio::join!(request(1), request(2));
     server.await.expect("broker server");
 
+    tokio::time::timeout(tokio::time::Duration::from_secs(20), async {
+        loop {
+            if owners.lock().await.get_route(&route).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("portable project warmup timed out");
     assert_eq!(
         attempts.load(std::sync::atomic::Ordering::Relaxed),
         1,
@@ -161,6 +171,190 @@ async fn portable_broker_requests_reuse_one_authenticated_project_owner() {
     let first = owners.get_route(&route).expect("first cached owner").1;
     let second = owners.get_route(&route).expect("second cached owner").1;
     assert!(std::sync::Arc::ptr_eq(first, second));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn portable_broker_bootstrap_bypasses_project_writer_gate() {
+    const TOKEN: &str = "0123456789abcdef0123456789abcdef";
+    const PHASE_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(20);
+
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let profile_root = temp.path().join("profile");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let client_identity = test_client_identity_for(profile_root.clone());
+    let options = crate::tracedecay::TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(client_identity.global_db_path.clone()),
+    };
+    drop(
+        crate::tracedecay::TraceDecay::init_with_options(&project, options)
+            .await
+            .expect("initialize project"),
+    );
+    let mut config = crate::config::load_config(&project).expect("load project config");
+    config.sync.session_start_sync = false;
+    crate::config::save_config(&project, &config)
+        .expect("disable unrelated startup transcript ingestion");
+    let _database_scope =
+        crate::db::enter_daemon_database_scope(&profile_root, 1, "portable-bootstrap-cache-test")
+            .expect("daemon database scope");
+    let handshake = DaemonHandshake {
+        project_path: Some(project.clone()),
+        client_identity,
+        ..test_handshake_defaults()
+    };
+    let route = ProjectRouteKey::from_handshake(&project, &handshake).expect("project route");
+    let owners = Arc::new(tokio::sync::Mutex::new(DatabaseOwnerRegistry::default()));
+    let store_administration = StoreAdministration::with_project_servers(Arc::clone(&owners));
+    let gates = Arc::new(tokio::sync::Mutex::new(super::ProjectOpenGates::default()));
+    let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let lifecycle = DaemonLifecycle::default();
+    let (listener, endpoint) =
+        super::transport::BrokerListener::bind(&super::transport::default_loopback_endpoint())
+            .await
+            .expect("loopback listener");
+
+    let blocker_administration = store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        blocker_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    let server_administration = store_administration.clone();
+    let server_gates = Arc::clone(&gates);
+    let server_attempts = Arc::clone(&attempts);
+    let server_lifecycle = lifecycle.clone();
+    let server = tokio::spawn(async move {
+        let mut clients = tokio::task::JoinSet::new();
+        for _ in 0..2 {
+            let stream = listener.accept().await.expect("accept client");
+            let administration = server_administration.clone();
+            let gates = Arc::clone(&server_gates);
+            let attempts = Arc::clone(&server_attempts);
+            let lifecycle = server_lifecycle.clone();
+            clients.spawn(async move {
+                Box::pin(super::serve_windows_broker_client(
+                    stream,
+                    TOKEN,
+                    &lifecycle,
+                    administration,
+                    gates,
+                    Some(attempts),
+                ))
+                .await
+            });
+        }
+        while let Some(client) = clients.join_next().await {
+            client.expect("client task").expect("serve client");
+        }
+    });
+
+    let request = |id: u64, method: &'static str| {
+        let endpoint = endpoint.clone();
+        let handshake = handshake.clone();
+        async move {
+            let stream = super::transport::BrokerStream::connect(&endpoint)
+                .await
+                .expect("connect client");
+            let (reader, mut writer) = stream.into_split();
+            let preface = super::transport::DaemonAuthPreface::new(TOKEN)
+                .to_line()
+                .expect("auth preface");
+            writer.write_all(preface.as_bytes()).await.expect("preface");
+            writer.write_all(b"\n").await.expect("preface newline");
+            writer
+                .write_all(handshake.to_line().expect("handshake").as_bytes())
+                .await
+                .expect("handshake");
+            writer.write_all(b"\n").await.expect("handshake newline");
+            let request = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": (method == "initialize").then_some(serde_json::json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "portable-bootstrap-test", "version": "1"}
+                }))
+            });
+            writer
+                .write_all(request.to_string().as_bytes())
+                .await
+                .expect("request");
+            writer.write_all(b"\n").await.expect("request newline");
+            writer.shutdown().await.expect("shutdown request writer");
+            let mut lines = tokio::io::BufReader::new(reader).lines();
+            let response = lines
+                .next_line()
+                .await
+                .expect("read response")
+                .expect("response line");
+            serde_json::from_str::<serde_json::Value>(&response).expect("response json")
+        }
+    };
+    let mut initialize_task = tokio::spawn(request(1, "initialize"));
+    let mut tools_list_task = tokio::spawn(request(2, "tools/list"));
+    let (initialize_within_bound, tools_list_within_bound) = tokio::join!(
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), &mut initialize_task),
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), &mut tools_list_task),
+    );
+
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+    if initialize_within_bound.is_err() {
+        let _ = initialize_task.await;
+    }
+    if tools_list_within_bound.is_err() {
+        let _ = tools_list_task.await;
+    }
+    server.await.expect("portable broker server");
+
+    let initialize_response = initialize_within_bound
+        .expect("portable initialize must not wait for project writer gate")
+        .expect("initialize client task");
+    assert_eq!(
+        initialize_response["result"]["protocolVersion"],
+        serde_json::json!("2024-11-05")
+    );
+    let tools_list_response = tools_list_within_bound
+        .expect("portable tools/list must not wait for project writer gate")
+        .expect("tools/list client task");
+    assert!(
+        tools_list_response["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| !tools.is_empty()),
+        "portable bootstrap tool catalog must not be empty"
+    );
+
+    tokio::time::timeout(PHASE_TIMEOUT, async {
+        loop {
+            if owners.lock().await.get_route(&route).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("portable initialize background warmup timed out");
+    assert_eq!(
+        attempts.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "portable initialize warmup must singleflight one project open"
+    );
+    lifecycle.begin_draining();
+    tokio::time::timeout(PHASE_TIMEOUT, lifecycle.wait_for_idle())
+        .await
+        .expect("portable warmup lifecycle drain timed out");
+    super::shutdown_project_servers(&store_administration).await;
 }
 
 #[cfg(unix)]
@@ -643,6 +837,7 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
     let project = temp.path().join("project");
     let profile_root = temp.path().join("profile");
     std::fs::create_dir_all(&project).expect("project dir");
+    let project = project.canonicalize().expect("canonical project");
     let client_identity = test_client_identity_for(profile_root.clone());
     let options = crate::tracedecay::TraceDecayOpenOptions {
         profile_root: Some(profile_root.clone()),
@@ -653,6 +848,14 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
             .await
             .expect("initialize project"),
     );
+    let registry = crate::global_db::GlobalDb::open_at(&client_identity.global_db_path)
+        .await
+        .expect("open global registry");
+    registry
+        .upsert_code_project("mcp-bootstrap-route-project", &project, None, None, None)
+        .await
+        .expect("register initialize root");
+    drop(registry);
     let mut config = crate::config::load_config(&project).expect("load project config");
     config.sync.session_start_sync = false;
     crate::config::save_config(&project, &config)
@@ -662,9 +865,9 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
             .expect("daemon database scope");
     let engine = DaemonEngine::default();
     let handshake = DaemonHandshake {
-        project_path: Some(project),
+        project_path: Some(project.clone()),
         client_identity,
-        allow_initialize_root_routing: false,
+        allow_initialize_root_routing: true,
         ..test_handshake_defaults()
     };
 
@@ -689,7 +892,8 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
         "params": {
             "protocolVersion": "2024-11-05",
             "capabilities": {},
-            "clientInfo": {"name": "bootstrap-cache-test", "version": "1"}
+            "clientInfo": {"name": "bootstrap-cache-test", "version": "1"},
+            "roots": [{"uri": project, "name": "registered-project"}]
         }
     });
     let tools_list = json!({
@@ -735,6 +939,13 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
     assert_eq!(
         initialize_response["result"]["serverInfo"]["name"],
         json!("tracedecay")
+    );
+    assert_eq!(
+        initialize_response["result"]["_meta"]["tracedecayInitializeRoute"],
+        json!({
+            "projectPath": handshake.project_path,
+            "allowInit": false,
+        })
     );
 
     let tools_list_responses = tools_list_within_bound

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -42,7 +42,8 @@ fn bootstrap_tool_catalog_uses_project_node_count() {
     let response = super::daemon_bootstrap_response(&request, None, Some(65_395))
         .expect("bootstrap response")
         .expect("tools/list response");
-    let context_description = response.result.expect("tools/list result")["tools"]
+    let result = response.result.expect("tools/list result");
+    let context_description = result["tools"]
         .as_array()
         .expect("tool catalog")
         .iter()

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -407,6 +407,63 @@ async fn draining_waits_for_one_bounded_in_flight_request() {
 }
 
 #[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn project_server_warmup_drops_lifecycle_activity_on_draining() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let profile_root = temp.path().join("profile");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let engine = DaemonEngine::default();
+    let handshake = DaemonHandshake {
+        project_path: Some(project),
+        client_identity: test_client_identity_for(profile_root),
+        ..test_handshake_defaults()
+    };
+    let initialize_request = serde_json::from_value(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    }))
+    .expect("initialize request");
+
+    let store_administration = engine.store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        store_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    engine.spawn_project_server_warmup(handshake, initialize_request);
+    engine.lifecycle.begin_draining();
+    let idle_while_writer_held = tokio::time::timeout(
+        tokio::time::Duration::from_secs(1),
+        engine.lifecycle.wait_for_idle(),
+    )
+    .await;
+
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+    if idle_while_writer_held.is_err() {
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(5),
+            engine.lifecycle.wait_for_idle(),
+        )
+        .await
+        .expect("warmup cleanup after writer release");
+    }
+
+    idle_while_writer_held.expect("draining must cancel project warmup before writer release");
+}
+
+#[cfg(unix)]
 #[tokio::test]
 async fn daemon_scheduler_shutdown_aborts_and_joins_every_loop() {
     let engine = DaemonEngine::default();
@@ -576,6 +633,153 @@ async fn project_server_cache_hit_skips_open_and_singleflights_first_miss() {
         .await
         .expect("cache-test shutdown phase timed out");
     eprintln!("[cache-test] phase=shutdown done");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
+    const PHASE_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(20);
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let profile_root = temp.path().join("profile");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let client_identity = test_client_identity_for(profile_root.clone());
+    let options = crate::tracedecay::TraceDecayOpenOptions {
+        profile_root: Some(profile_root.clone()),
+        global_db_path: Some(client_identity.global_db_path.clone()),
+    };
+    drop(
+        crate::tracedecay::TraceDecay::init_with_options(&project, options)
+            .await
+            .expect("initialize project"),
+    );
+    let mut config = crate::config::load_config(&project).expect("load project config");
+    config.sync.session_start_sync = false;
+    crate::config::save_config(&project, &config)
+        .expect("disable unrelated startup transcript ingestion");
+    let _database_scope =
+        crate::db::enter_daemon_database_scope(&profile_root, 1, "mcp-bootstrap-cache-test")
+            .expect("daemon database scope");
+    let engine = DaemonEngine::default();
+    let handshake = DaemonHandshake {
+        project_path: Some(project),
+        client_identity,
+        allow_initialize_root_routing: false,
+        ..test_handshake_defaults()
+    };
+
+    let store_administration = engine.store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        store_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "bootstrap-cache-test", "version": "1"}
+        }
+    });
+    let tools_list = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list"
+    });
+    let initialize_engine = engine.clone();
+    let initialize_handshake = handshake.clone();
+    let mut initialize_task = tokio::spawn(async move {
+        daemon_round_trip(initialize_engine, &initialize_handshake, initialize).await
+    });
+    let tools_list_engine = engine.clone();
+    let tools_list_handshake = handshake.clone();
+    let mut tools_list_task = tokio::spawn(async move {
+        daemon_round_trip(tools_list_engine, &tools_list_handshake, tools_list).await
+    });
+    let (initialize_within_bound, tools_list_within_bound) = tokio::join!(
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), &mut initialize_task),
+        tokio::time::timeout(tokio::time::Duration::from_secs(2), &mut tools_list_task),
+    );
+
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+    if initialize_within_bound.is_err() {
+        let _ = initialize_task.await;
+    }
+    if tools_list_within_bound.is_err() {
+        let _ = tools_list_task.await;
+    }
+
+    let initialize_responses = initialize_within_bound
+        .expect("initialize must not wait for project writer gate")
+        .expect("initialize client task");
+    let initialize_response = initialize_responses
+        .iter()
+        .find(|response| response["id"] == json!(1))
+        .expect("initialize response");
+    assert_eq!(
+        initialize_response["result"]["protocolVersion"],
+        json!("2024-11-05")
+    );
+    assert_eq!(
+        initialize_response["result"]["serverInfo"]["name"],
+        json!("tracedecay")
+    );
+
+    let tools_list_responses = tools_list_within_bound
+        .expect("tools/list must not wait for project writer gate")
+        .expect("tools/list client task");
+    let tools = tools_list_responses
+        .iter()
+        .find(|response| response["id"] == json!(2))
+        .and_then(|response| response["result"]["tools"].as_array())
+        .expect("tools/list result catalog");
+    assert!(
+        !tools.is_empty(),
+        "bootstrap tool catalog must not be empty"
+    );
+
+    let project_path = handshake.project_path.as_ref().expect("project path");
+    let route = ProjectRouteKey::from_handshake(project_path, &handshake).expect("project route");
+    tokio::time::timeout(PHASE_TIMEOUT, async {
+        loop {
+            let warmed = engine
+                .store_administration
+                .project_servers()
+                .lock()
+                .await
+                .get_route(&route)
+                .is_some();
+            if warmed {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("initialize background warmup timed out");
+    assert_eq!(
+        engine
+            .project_open_attempts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "initialize warmup must singleflight one project open"
+    );
+
+    tokio::time::timeout(PHASE_TIMEOUT, engine.shutdown_all())
+        .await
+        .expect("bootstrap-cache shutdown timed out");
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -39,9 +39,11 @@ fn bootstrap_tool_catalog_uses_project_node_count() {
         "method": "tools/list"
     }))
     .expect("tools/list request");
-    let response = super::daemon_bootstrap_response(&request, None, Some(65_395))
-        .expect("bootstrap response")
-        .expect("tools/list response");
+    let super::DaemonBootstrap::Respond(response) =
+        super::daemon_bootstrap_response(&request, None, Some(65_395)).expect("bootstrap response")
+    else {
+        panic!("tools/list must produce a response");
+    };
     let result = response.result.expect("tools/list result");
     let context_description = result["tools"]
         .as_array()

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -538,6 +538,36 @@ async fn project_server_cache_hit_skips_open_and_singleflights_first_miss() {
         1,
         "cache hits must return before opening project databases"
     );
+
+    let store_administration = engine.store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        store_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    let cached_while_writer_held = tokio::time::timeout(
+        tokio::time::Duration::from_secs(2),
+        engine.project_server(&direct),
+    )
+    .await;
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+
+    let cached_while_writer_held = cached_while_writer_held
+        .expect("cached project server must not wait for writer gate")
+        .expect("cached project server while writer gate held");
+    assert!(std::sync::Arc::ptr_eq(
+        &direct_server,
+        &cached_while_writer_held
+    ));
     drop(cached);
     drop(alias_server);
     drop(direct_server);

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -3047,17 +3047,17 @@ async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
     let client_identity = test_client_identity_for(project.join("profile"));
     std::fs::create_dir_all(project.join("src")).expect("src dir");
     std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
-    let cg = Arc::new(
-        crate::tracedecay::TraceDecay::init_with_options(
-            &project,
-            crate::tracedecay::TraceDecayOpenOptions {
-                profile_root: Some(client_identity.profile_root.clone()),
-                global_db_path: Some(client_identity.global_db_path.clone()),
-            },
-        )
-        .await
-        .expect("project init"),
-    );
+    let project_graph = crate::tracedecay::TraceDecay::init_with_options(
+        &project,
+        crate::tracedecay::TraceDecayOpenOptions {
+            profile_root: Some(client_identity.profile_root.clone()),
+            global_db_path: Some(client_identity.global_db_path.clone()),
+        },
+    )
+    .await
+    .expect("project init");
+    let server = crate::mcp::McpServer::new_with_global_db(project_graph, None, None).await;
+    let cg = server.cg().await;
     let handshake = DaemonHandshake {
         project_path: Some(project.clone()),
         client_identity,
@@ -3065,6 +3065,12 @@ async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
     };
     let engine = super::DaemonEngine::default();
     let key = super::ProjectServerKey::from_open_project(&cg, &handshake).expect("owner key");
+    engine
+        .store_administration
+        .project_servers()
+        .lock()
+        .await
+        .insert(key.clone(), server);
 
     engine
         .ensure_automation_scheduler(
@@ -3117,6 +3123,82 @@ async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
     assert!(schedulers.contains_key(&key));
     drop(schedulers);
     engine.shutdown_all().await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn daemon_scheduler_skips_stale_owner_key_after_rekey() {
+    use crate::automation::config::{
+        AutomationBackend, AutomationConfigPatch, AutomationTaskPatch, save_project_config,
+    };
+
+    let dir = TempDir::new().expect("temp dir");
+    let project = dir.path().canonicalize().expect("canonical temp dir");
+    let client_identity = test_client_identity_for(project.join("profile"));
+    std::fs::create_dir_all(project.join("src")).expect("src dir");
+    std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
+    let project_graph = crate::tracedecay::TraceDecay::init_with_options(
+        &project,
+        crate::tracedecay::TraceDecayOpenOptions {
+            profile_root: Some(client_identity.profile_root.clone()),
+            global_db_path: Some(client_identity.global_db_path.clone()),
+        },
+    )
+    .await
+    .expect("project init");
+    let server = crate::mcp::McpServer::new_with_global_db(project_graph, None, None).await;
+    let cg = server.cg().await;
+    let handshake = DaemonHandshake {
+        project_path: Some(project.clone()),
+        client_identity,
+        ..test_handshake_defaults()
+    };
+    let engine = super::DaemonEngine::default();
+    let stale_key = super::ProjectServerKey::from_open_project(&cg, &handshake)
+        .expect("stale owner key");
+
+    save_project_config(
+        &cg.store_layout().dashboard_root,
+        &AutomationConfigPatch {
+            enabled: Some(true),
+            backend: Some(AutomationBackend::CodexAppServer),
+            memory_curator: AutomationTaskPatch {
+                enabled: Some(true),
+                schedule: Some(Some("every:5m".to_string())),
+                ..AutomationTaskPatch::default()
+            },
+            ..AutomationConfigPatch::default()
+        },
+    )
+    .await
+    .expect("save automation config");
+
+    let mut current_key = stale_key.clone();
+    current_key.scope_prefix = Some("rekeyed".to_string());
+    {
+        let mut owners = engine
+            .store_administration
+            .project_servers()
+            .lock()
+            .await;
+        owners.insert(stale_key.clone(), server);
+        assert!(owners.rekey(&stale_key, &current_key));
+    }
+
+    engine
+        .ensure_automation_scheduler(stale_key.clone(), project, handshake, cg)
+        .await;
+
+    let schedulers = engine
+        .store_administration
+        .automation_schedulers()
+        .lock()
+        .await;
+    assert!(
+        !schedulers.contains_key(&stale_key),
+        "scheduler discovery must not start under a key that no longer owns the project server"
+    );
+    assert!(schedulers.is_empty());
 }
 
 #[cfg(unix)]

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -657,6 +657,36 @@ async fn project_server_warmup_drops_lifecycle_activity_on_draining() {
     idle_while_writer_held.expect("draining must cancel project warmup before writer release");
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn scheduler_activation_drain_wins_when_discovery_is_simultaneously_ready() {
+    for _ in 0..32 {
+        let lifecycle = DaemonLifecycle::default();
+        let discovery_polled = Arc::new(tokio::sync::Notify::new());
+        let discovery_polled_by_future = Arc::clone(&discovery_polled);
+        let discovery_lifecycle = lifecycle.clone();
+        let discovery_won = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let discovery_won_by_future = Arc::clone(&discovery_won);
+        super::spawn_lifecycle_automation_scheduler_activation(lifecycle.clone(), async move {
+            discovery_polled_by_future.notify_one();
+            discovery_lifecycle.wait_for_draining().await;
+            discovery_won_by_future.store(true, std::sync::atomic::Ordering::Release);
+        });
+        discovery_polled.notified().await;
+
+        lifecycle.begin_draining();
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(1),
+            lifecycle.wait_for_idle(),
+        )
+        .await
+        .expect("simultaneous scheduler discovery drain timed out");
+        assert!(
+            !discovery_won.load(std::sync::atomic::Ordering::Acquire),
+            "draining must win when scheduler discovery becomes ready on the same tick"
+        );
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn portable_project_warmup_cancels_before_shutdown_snapshot() {
     let temp = TempDir::new().expect("temp dir");
@@ -2867,14 +2897,16 @@ async fn daemon_ensure_scheduler_skips_before_project_has_configured_work() {
         client_identity,
         ..test_handshake_defaults()
     };
-    let cg = crate::tracedecay::TraceDecay::init_with_options(&project, handshake.open_options())
-        .await
-        .expect("project init");
+    let cg = Arc::new(
+        crate::tracedecay::TraceDecay::init_with_options(&project, handshake.open_options())
+            .await
+            .expect("project init"),
+    );
     let engine = super::DaemonEngine::default();
     let key = super::ProjectServerKey::from_open_project(&cg, &handshake).expect("owner key");
 
     engine
-        .ensure_automation_scheduler(key.clone(), project, handshake)
+        .ensure_automation_scheduler(key.clone(), project, handshake, cg)
         .await;
 
     let schedulers = engine
@@ -2898,12 +2930,13 @@ async fn daemon_scheduler_discovery_without_work_does_not_wait_for_writer_gate()
         client_identity,
         ..test_handshake_defaults()
     };
-    let cg = crate::tracedecay::TraceDecay::init_with_options(&project, handshake.open_options())
-        .await
-        .expect("project init");
+    let cg = Arc::new(
+        crate::tracedecay::TraceDecay::init_with_options(&project, handshake.open_options())
+            .await
+            .expect("project init"),
+    );
     let engine = super::DaemonEngine::default();
     let key = super::ProjectServerKey::from_open_project(&cg, &handshake).expect("owner key");
-    drop(cg);
 
     let store_administration = engine.store_administration.clone();
     let writer_held = Arc::new(tokio::sync::Notify::new());
@@ -2921,7 +2954,7 @@ async fn daemon_scheduler_discovery_without_work_does_not_wait_for_writer_gate()
 
     let discovery = tokio::time::timeout(
         tokio::time::Duration::from_secs(2),
-        engine.ensure_automation_scheduler(key, project, handshake),
+        engine.ensure_automation_scheduler(key, project, handshake, cg),
     )
     .await;
 
@@ -2942,15 +2975,17 @@ async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
     let client_identity = test_client_identity_for(project.join("profile"));
     std::fs::create_dir_all(project.join("src")).expect("src dir");
     std::fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("source file");
-    let cg = crate::tracedecay::TraceDecay::init_with_options(
-        &project,
-        crate::tracedecay::TraceDecayOpenOptions {
-            profile_root: Some(client_identity.profile_root.clone()),
-            global_db_path: Some(client_identity.global_db_path.clone()),
-        },
-    )
-    .await
-    .expect("project init");
+    let cg = Arc::new(
+        crate::tracedecay::TraceDecay::init_with_options(
+            &project,
+            crate::tracedecay::TraceDecayOpenOptions {
+                profile_root: Some(client_identity.profile_root.clone()),
+                global_db_path: Some(client_identity.global_db_path.clone()),
+            },
+        )
+        .await
+        .expect("project init"),
+    );
     let handshake = DaemonHandshake {
         project_path: Some(project.clone()),
         client_identity,
@@ -2960,7 +2995,12 @@ async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
     let key = super::ProjectServerKey::from_open_project(&cg, &handshake).expect("owner key");
 
     engine
-        .ensure_automation_scheduler(key.clone(), project.clone(), handshake.clone())
+        .ensure_automation_scheduler(
+            key.clone(),
+            project.clone(),
+            handshake.clone(),
+            Arc::clone(&cg),
+        )
         .await;
     assert!(
         !engine
@@ -2987,15 +3027,21 @@ async fn daemon_ensure_scheduler_starts_after_project_configures_work() {
     .await
     .expect("save automation config");
 
-    engine
-        .ensure_automation_scheduler(key.clone(), project, handshake)
-        .await;
+    let first = engine.ensure_automation_scheduler(
+        key.clone(),
+        project.clone(),
+        handshake.clone(),
+        Arc::clone(&cg),
+    );
+    let second = engine.ensure_automation_scheduler(key.clone(), project, handshake, cg);
+    tokio::join!(first, second);
 
     let schedulers = engine
         .store_administration
         .automation_schedulers()
         .lock()
         .await;
+    assert_eq!(schedulers.len(), 1);
     assert!(schedulers.contains_key(&key));
     drop(schedulers);
     engine.shutdown_all().await;

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -657,6 +657,123 @@ async fn project_server_warmup_drops_lifecycle_activity_on_draining() {
     idle_while_writer_held.expect("draining must cancel project warmup before writer release");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn portable_project_warmup_cancels_before_shutdown_snapshot() {
+    let temp = TempDir::new().expect("temp dir");
+    let project = temp.path().join("project");
+    let profile_root = temp.path().join("profile");
+    std::fs::create_dir_all(&project).expect("project dir");
+    let handshake = DaemonHandshake {
+        project_path: Some(project),
+        client_identity: test_client_identity_for(profile_root),
+        ..test_handshake_defaults()
+    };
+    let initialize_request: crate::mcp::JsonRpcRequest =
+        serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }))
+        .expect("initialize request");
+    let owners = Arc::new(tokio::sync::Mutex::new(DatabaseOwnerRegistry::default()));
+    let store_administration = StoreAdministration::with_project_servers(Arc::clone(&owners));
+    let project_open_gates = Arc::new(tokio::sync::Mutex::new(super::ProjectOpenGates::default()));
+    let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let lifecycle = DaemonLifecycle::default();
+
+    let blocker_administration = store_administration.clone();
+    let writer_held = Arc::new(tokio::sync::Notify::new());
+    let writer_held_by_blocker = Arc::clone(&writer_held);
+    let (release_writer, writer_release) = tokio::sync::oneshot::channel();
+    let blocker = tokio::spawn(async move {
+        blocker_administration
+            .with_writer(|| async move {
+                writer_held_by_blocker.notify_one();
+                writer_release.await.expect("release writer gate");
+            })
+            .await;
+    });
+    writer_held.notified().await;
+
+    super::spawn_portable_project_server_warmup(
+        lifecycle.clone(),
+        store_administration,
+        project_open_gates,
+        handshake,
+        initialize_request,
+        Some(Arc::clone(&attempts)),
+    );
+    tokio::task::yield_now().await;
+    lifecycle.begin_draining();
+    let idle_before_writer_release = tokio::time::timeout(
+        tokio::time::Duration::from_secs(1),
+        lifecycle.wait_for_idle(),
+    )
+    .await;
+
+    release_writer.send(()).expect("signal writer gate release");
+    blocker.await.expect("writer gate blocker task");
+
+    idle_before_writer_release
+        .expect("portable warmup must release lifecycle activity before writer release");
+    assert_eq!(
+        attempts.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "draining portable warmup must not start a project open"
+    );
+    assert!(
+        owners.lock().await.values().next().is_none(),
+        "draining portable warmup must not insert a server after shutdown snapshot"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn project_warmup_drain_wins_when_open_is_simultaneously_ready() {
+    let initialize_request: crate::mcp::JsonRpcRequest =
+        serde_json::from_value(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        }))
+        .expect("initialize request");
+
+    for _ in 0..32 {
+        let lifecycle = DaemonLifecycle::default();
+        let open_polled = Arc::new(tokio::sync::Notify::new());
+        let open_polled_by_future = Arc::clone(&open_polled);
+        let open_lifecycle = lifecycle.clone();
+        let open_won = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let open_won_by_future = Arc::clone(&open_won);
+        super::spawn_lifecycle_project_server_warmup(
+            lifecycle.clone(),
+            initialize_request.clone(),
+            async move {
+                open_polled_by_future.notify_one();
+                open_lifecycle.wait_for_draining().await;
+                open_won_by_future.store(true, std::sync::atomic::Ordering::Release);
+                Err(crate::errors::TraceDecayError::Config {
+                    message: "simultaneous warmup completion".to_string(),
+                })
+            },
+        );
+        open_polled.notified().await;
+
+        lifecycle.begin_draining();
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(1),
+            lifecycle.wait_for_idle(),
+        )
+        .await
+        .expect("simultaneous warmup drain timed out");
+        assert!(
+            !open_won.load(std::sync::atomic::Ordering::Acquire),
+            "draining must win when project open becomes ready on the same tick"
+        );
+    }
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn daemon_scheduler_shutdown_aborts_and_joins_every_loop() {

--- a/src/lifecycle_lease.rs
+++ b/src/lifecycle_lease.rs
@@ -3,11 +3,12 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::errors::{Result, TraceDecayError};
 
 const LIFECYCLE_LOCK_FILENAME: &str = "lifecycle.lock";
+const EXCLUSIVE_LEASE_POLL_INTERVAL: Duration = Duration::from_millis(25);
 static LEASE_NONCE: AtomicU64 = AtomicU64::new(0);
 static PROCESS_LEASE_TOKENS: LazyLock<Mutex<Vec<String>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
@@ -70,6 +71,16 @@ impl Drop for LifecycleLease {
 
 pub fn acquire_exclusive(operation: &str) -> Result<LifecycleLease> {
     acquire_exclusive_at(&lifecycle_lock_path()?, operation)
+}
+
+/// Waits up to `timeout` for existing lifecycle readers or writers to release
+/// before acquiring exclusive ownership. Non-contention errors still fail
+/// immediately.
+pub fn acquire_exclusive_with_timeout(
+    operation: &str,
+    timeout: Duration,
+) -> Result<LifecycleLease> {
+    acquire_exclusive_at_with_timeout(&lifecycle_lock_path()?, operation, timeout)
 }
 
 /// Acquires the lifecycle lease rooted in an explicit profile. Migration
@@ -259,15 +270,29 @@ fn lifecycle_lock_path_for_profile(profile_root: &Path) -> Result<PathBuf> {
 }
 
 fn acquire_exclusive_at(path: &Path, operation: &str) -> Result<LifecycleLease> {
-    let file = open_lock_file(path)?;
-    match fs2::FileExt::try_lock_exclusive(&file) {
-        Ok(()) => own_exclusive(file, path, operation),
-        Err(error) if is_lock_contended(&error) => {
-            let mut file = file;
-            let owner = read_owner(&mut file, path);
-            Err(busy_error(operation, owner.as_deref()))
+    acquire_exclusive_at_with_timeout(path, operation, Duration::ZERO)
+}
+
+fn acquire_exclusive_at_with_timeout(
+    path: &Path,
+    operation: &str,
+    timeout: Duration,
+) -> Result<LifecycleLease> {
+    let mut file = open_lock_file(path)?;
+    let started = Instant::now();
+    loop {
+        match fs2::FileExt::try_lock_exclusive(&file) {
+            Ok(()) => return own_exclusive(file, path, operation),
+            Err(error) if is_lock_contended(&error) => {
+                let remaining = timeout.saturating_sub(started.elapsed());
+                if remaining.is_zero() {
+                    let owner = read_owner(&mut file, path);
+                    return Err(busy_error(operation, owner.as_deref()));
+                }
+                std::thread::sleep(remaining.min(EXCLUSIVE_LEASE_POLL_INTERVAL));
+            }
+            Err(error) => return Err(lock_error(path, operation, &error)),
         }
-        Err(error) => Err(lock_error(path, operation, &error)),
     }
 }
 
@@ -487,11 +512,14 @@ fn owner_write_error(error: &std::io::Error) -> TraceDecayError {
 mod tests {
     use std::fs::OpenOptions;
     use std::io::Write;
+    use std::sync::mpsc;
+    use std::time::Duration;
 
     use super::{
-        SharedLeaseAttempt, acquire_exclusive_at, acquire_exclusive_or_inherited_at,
-        acquire_shared_at, acquire_shared_or_inherited_at, try_acquire_shared_at,
-        try_acquire_shared_or_inherited_at, try_acquire_shared_or_inherited_for_profile,
+        SharedLeaseAttempt, acquire_exclusive_at, acquire_exclusive_at_with_timeout,
+        acquire_exclusive_or_inherited_at, acquire_shared_at, acquire_shared_or_inherited_at,
+        try_acquire_shared_at, try_acquire_shared_or_inherited_at,
+        try_acquire_shared_or_inherited_for_profile,
     };
 
     #[test]
@@ -505,6 +533,41 @@ mod tests {
         assert!(error.to_string().contains("upgrade"));
         drop(held);
         acquire_exclusive_at(&path, "update").unwrap();
+    }
+
+    #[test]
+    fn exclusive_lease_waits_for_a_shared_holder_to_release() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lifecycle.lock");
+        let holder_path = path.clone();
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            let held = acquire_shared_at(&holder_path, "daemon run").unwrap();
+            ready_tx.send(()).unwrap();
+            std::thread::sleep(Duration::from_millis(50));
+            drop(held);
+        });
+        ready_rx.recv().unwrap();
+
+        let acquired =
+            acquire_exclusive_at_with_timeout(&path, "daemon restart", Duration::from_secs(1))
+                .unwrap();
+
+        assert!(acquired.is_exclusive());
+        holder.join().unwrap();
+    }
+
+    #[test]
+    fn exclusive_lease_wait_timeout_preserves_the_active_owner() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("lifecycle.lock");
+        let _held = acquire_exclusive_at(&path, "service install").unwrap();
+
+        let error =
+            acquire_exclusive_at_with_timeout(&path, "daemon restart", Duration::from_millis(40))
+                .unwrap_err();
+
+        assert!(error.to_string().contains("service install"));
     }
 
     #[test]

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -231,6 +231,29 @@ pub fn get_tool_definitions_with_budget(node_count: u64, budget: u8) -> Vec<Tool
     defs
 }
 
+/// Returns tool definitions with a conservative temporary context budget while
+/// a daemon opens the project graph needed to calculate the exact node count.
+pub fn get_tool_definitions_with_warming_budget(budget: u8) -> Vec<ToolDefinition> {
+    let mut defs = get_tool_definitions();
+    for def in &mut defs {
+        if def.name == "tracedecay_context" {
+            def.description = format!(
+                "Build an AI-ready context for a task description. Returns relevant symbols, \
+                 relationships, up to three untracked project memory matches when available, \
+                 and optionally code snippets.\n\n\
+                 CALL BUDGET (applies to tracedecay_context ONLY): {budget} calls maximum while \
+                 this project graph is warming. The narrow follow-up tools — tracedecay_search, \
+                 tracedecay_grep, tracedecay_callers, tracedecay_callees, tracedecay_body, \
+                 tracedecay_read, tracedecay_outline — are cheap and UNBUDGETED; call them freely. \
+                 When the context budget is spent, keep going with those narrow tracedecay tools \
+                 to drill in; do NOT fall back to native grep/glob/file reads. Only re-run \
+                 tracedecay_context if you genuinely need another broad semantic sweep."
+            );
+        }
+    }
+    defs
+}
+
 /// Returns the list of all tool definitions exposed by this MCP server.
 ///
 /// Tools whose backing dependency is missing on the current host are

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -18,7 +18,7 @@ pub use definitions::{
     ALWAYS_REGISTERED_TOOL_COUNT, ast_grep_available, ast_grep_diagnostics_json,
     ast_grep_outline_available, context_description, explore_call_budget,
     format_capable_tool_names, get_tool_definitions, get_tool_definitions_with_budget,
-    tool_defaults_to_markdown,
+    get_tool_definitions_with_warming_budget, tool_defaults_to_markdown,
 };
 pub(crate) use dispatch_policy::tool_dispatches_registered_project_reader;
 pub use handlers::memory::handle_user_memory_tool;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -490,9 +490,7 @@ where
             continue;
         };
         let exact_root = same_local_path(&manifest.project_root, project_root);
-        if manifest.project_id.is_some()
-            && manifest.project_id.as_deref() == excluded_project_id
-        {
+        if manifest.project_id.is_some() && manifest.project_id.as_deref() == excluded_project_id {
             selected_manifest_matches_exact_root |= exact_root;
             continue;
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -447,13 +447,11 @@ pub(crate) fn matching_legacy_profile_layouts(
     project_root: &Path,
     profile_root: &Path,
     excluded_project_id: Option<&str>,
-    selected_layout_is_authoritative: bool,
 ) -> Result<(Vec<StoreLayout>, bool)> {
     matching_legacy_profile_layouts_with_git_resolver(
         project_root,
         profile_root,
         excluded_project_id,
-        selected_layout_is_authoritative,
         crate::worktree::is_detached_linked_worktree,
         crate::worktree::git_common_dir,
     )
@@ -463,7 +461,6 @@ fn matching_legacy_profile_layouts_with_git_resolver<D, G>(
     project_root: &Path,
     profile_root: &Path,
     excluded_project_id: Option<&str>,
-    selected_layout_is_authoritative: bool,
     mut is_detached_linked_worktree: D,
     mut git_common_dir: G,
 ) -> Result<(Vec<StoreLayout>, bool)>
@@ -503,17 +500,12 @@ where
 
     // A linked worktree may have its own profile shard while sharing a Git
     // common directory with every sibling checkout. A non-excluded exact
-    // manifest overrides the selected identity. A healthy and populated
-    // marker/registry-selected layout is authoritative only when its manifest
-    // names this exact checkout; a sibling-root selection must retain the
-    // shared-Git recovery path.
+    // manifest overrides the selected identity. Otherwise the shared-Git
+    // recovery path still runs, and the caller decides whether a selected
+    // identity naming this exact checkout outranks what it finds.
     let selected_is_sole_exact_root =
         selected_manifest_matches_exact_root && exact_manifests.is_empty();
-    let matching_manifests = if !exact_manifests.is_empty()
-        || (selected_layout_is_authoritative && selected_manifest_matches_exact_root)
-    {
-        exact_manifests
-    } else {
+    let matching_manifests = if exact_manifests.is_empty() {
         let project_git_common_dir = (!is_detached_linked_worktree(project_root))
             .then(|| git_common_dir(project_root))
             .flatten();
@@ -536,6 +528,8 @@ where
                 })
             })
             .collect()
+    } else {
+        exact_manifests
     };
     let mut layouts = Vec::new();
     for (manifest_path, manifest) in matching_manifests {
@@ -1321,7 +1315,7 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     #[test]
-    fn exact_root_authority_controls_shared_git_discovery() {
+    fn exact_root_manifest_overrides_shared_git_discovery() {
         fn write_manifest(profile_root: &Path, project_id: &str, project_root: &Path) {
             let data_root = profile_root.join("projects").join(project_id);
             fs::create_dir_all(&data_root).unwrap();
@@ -1357,7 +1351,6 @@ mod tests {
                 &project_root,
                 &profile_root,
                 None,
-                false,
                 |_| false,
                 |root| {
                     resolver_calls.borrow_mut().push(root.to_path_buf());
@@ -1382,28 +1375,6 @@ mod tests {
                 &project_root,
                 &profile_root,
                 Some("proj_exact"),
-                true,
-                |_| false,
-                |root| {
-                    resolver_calls.borrow_mut().push(root.to_path_buf());
-                    Some(dir.path().join("shared.git"))
-                },
-            )
-            .unwrap();
-        assert!(layouts.is_empty());
-        assert!(selected_is_sole_exact_root);
-        assert!(
-            resolver_calls.borrow().is_empty(),
-            "an authoritative selected exact root must not invoke shared-Git discovery"
-        );
-
-        resolver_calls.borrow_mut().clear();
-        let (layouts, selected_is_sole_exact_root) =
-            matching_legacy_profile_layouts_with_git_resolver(
-                &project_root,
-                &profile_root,
-                Some("proj_exact"),
-                false,
                 |_| false,
                 |root| {
                     resolver_calls.borrow_mut().push(root.to_path_buf());
@@ -1416,11 +1387,14 @@ mod tests {
             layouts[0].identity.project_id.as_deref(),
             Some("proj_unrelated")
         );
-        assert!(selected_is_sole_exact_root);
+        assert!(
+            selected_is_sole_exact_root,
+            "the caller decides whether the selected exact root outranks recovery"
+        );
         assert_eq!(
             resolver_calls.borrow().as_slice(),
             [project_root, unrelated_root],
-            "a non-authoritative selected exact root must retain shared-Git recovery"
+            "an excluded selected exact root must retain shared-Git recovery"
         );
     }
 
@@ -1452,7 +1426,6 @@ mod tests {
             &project_root,
             &profile_root,
             None,
-            false,
             |_| false,
             |_| None,
         )
@@ -1461,7 +1434,7 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_non_exact_identity_retains_historical_git_discovery() {
+    fn non_exact_identity_retains_historical_git_discovery() {
         fn write_manifest(profile_root: &Path, project_id: &str, project_root: &Path) {
             let data_root = profile_root.join("projects").join(project_id);
             fs::create_dir_all(&data_root).unwrap();
@@ -1499,7 +1472,6 @@ mod tests {
                 &worktree_root,
                 &profile_root,
                 Some("proj_selected"),
-                true,
                 |_| false,
                 |root| {
                     resolver_calls.borrow_mut().push(root.to_path_buf());
@@ -1512,28 +1484,8 @@ mod tests {
         assert!(!selected_is_sole_exact_root);
         assert_eq!(
             resolver_calls.borrow().as_slice(),
-            [worktree_root.clone(), historical_root.clone()],
-            "a healthy selected identity from a sibling root must retain shared-Git recovery"
-        );
-
-        resolver_calls.borrow_mut().clear();
-        let (layouts, _) = matching_legacy_profile_layouts_with_git_resolver(
-            &worktree_root,
-            &profile_root,
-            Some("proj_selected"),
-            false,
-            |_| false,
-            |root| {
-                resolver_calls.borrow_mut().push(root.to_path_buf());
-                Some(dir.path().join("shared.git"))
-            },
-        )
-        .unwrap();
-        assert_eq!(layouts.len(), 1);
-        assert_eq!(
-            resolver_calls.borrow().as_slice(),
             [worktree_root, historical_root],
-            "an unhealthy or pristine selection must retain shared-Git recovery"
+            "a selected identity from a sibling root must retain shared-Git recovery"
         );
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -447,7 +447,30 @@ pub(crate) fn matching_legacy_profile_layouts(
     project_root: &Path,
     profile_root: &Path,
     excluded_project_id: Option<&str>,
+    selected_exact_root_is_authoritative: bool,
 ) -> Result<(Vec<StoreLayout>, bool)> {
+    matching_legacy_profile_layouts_with_git_resolver(
+        project_root,
+        profile_root,
+        excluded_project_id,
+        selected_exact_root_is_authoritative,
+        crate::worktree::is_detached_linked_worktree,
+        crate::worktree::git_common_dir,
+    )
+}
+
+fn matching_legacy_profile_layouts_with_git_resolver<D, G>(
+    project_root: &Path,
+    profile_root: &Path,
+    excluded_project_id: Option<&str>,
+    selected_exact_root_is_authoritative: bool,
+    mut is_detached_linked_worktree: D,
+    mut git_common_dir: G,
+) -> Result<(Vec<StoreLayout>, bool)>
+where
+    D: FnMut(&Path) -> bool,
+    G: FnMut(&Path) -> Option<PathBuf>,
+{
     let projects_root = profile_root.join("projects");
     let Ok(entries) = fs::read_dir(&projects_root) else {
         return Ok((Vec::new(), false));
@@ -459,12 +482,8 @@ pub(crate) fn matching_legacy_profile_layouts(
         .collect::<Vec<_>>();
     manifest_paths.sort();
 
-    let project_git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
-        .then(|| crate::worktree::git_common_dir(project_root))
-        .flatten();
-    let mut legacy_git_common_dirs = HashMap::<PathBuf, Option<PathBuf>>::new();
     let mut exact_manifests = Vec::new();
-    let mut shared_git_manifests = Vec::new();
+    let mut non_exact_manifests = Vec::new();
     let mut selected_manifest_matches_exact_root = false;
     for manifest_path in manifest_paths {
         let Ok(manifest) = read_store_manifest(&manifest_path) else {
@@ -479,34 +498,43 @@ pub(crate) fn matching_legacy_profile_layouts(
             exact_manifests.push((manifest_path, manifest));
             continue;
         }
-        let same_git_checkout = project_git_common_dir.as_deref().is_some_and(|current| {
-            legacy_git_common_dirs
-                .entry(manifest.project_root.clone())
-                .or_insert_with(|| {
-                    manifest
-                        .project_root
-                        .is_dir()
-                        .then(|| crate::worktree::git_common_dir(&manifest.project_root))
-                        .flatten()
-                })
-                .as_deref()
-                .is_some_and(|legacy| same_local_path(legacy, current))
-        });
-        if same_git_checkout {
-            shared_git_manifests.push((manifest_path, manifest));
-        }
+        non_exact_manifests.push((manifest_path, manifest));
     }
 
     // A linked worktree may have its own profile shard while sharing a Git
-    // common directory with every sibling checkout. Treat an exact manifest
-    // root as authoritative; the shared-Git fallback is only for worktrees
-    // that have not yet acquired their own shard.
+    // common directory with every sibling checkout. A non-excluded exact
+    // manifest is authoritative. The selected exact manifest is authoritative
+    // only when its inventory is healthy and populated; a pristine or
+    // unhealthy selection must retain the shared-Git recovery path.
     let selected_is_sole_exact_root =
         selected_manifest_matches_exact_root && exact_manifests.is_empty();
-    let matching_manifests = if exact_manifests.is_empty() {
-        shared_git_manifests
-    } else {
+    let matching_manifests = if !exact_manifests.is_empty()
+        || (selected_is_sole_exact_root && selected_exact_root_is_authoritative)
+    {
         exact_manifests
+    } else {
+        let project_git_common_dir = (!is_detached_linked_worktree(project_root))
+            .then(|| git_common_dir(project_root))
+            .flatten();
+        let mut legacy_git_common_dirs = HashMap::<PathBuf, Option<PathBuf>>::new();
+        non_exact_manifests
+            .into_iter()
+            .filter(|(_, manifest)| {
+                project_git_common_dir.as_deref().is_some_and(|current| {
+                    legacy_git_common_dirs
+                        .entry(manifest.project_root.clone())
+                        .or_insert_with(|| {
+                            manifest
+                                .project_root
+                                .is_dir()
+                                .then(|| git_common_dir(&manifest.project_root))
+                                .flatten()
+                        })
+                        .as_deref()
+                        .is_some_and(|legacy| same_local_path(legacy, current))
+                })
+            })
+            .collect()
     };
     let mut layouts = Vec::new();
     for (manifest_path, manifest) in matching_manifests {
@@ -1288,7 +1316,112 @@ fn set_private_file_permissions(_path: &Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use serde_json::Value;
+    use std::cell::RefCell;
     use std::sync::{Arc, Barrier};
+
+    #[test]
+    fn exact_root_authority_controls_shared_git_discovery() {
+        fn write_manifest(profile_root: &Path, project_id: &str, project_root: &Path) {
+            let data_root = profile_root.join("projects").join(project_id);
+            fs::create_dir_all(&data_root).unwrap();
+            write_store_manifest_to_path(
+                &data_root.join(STORE_MANIFEST_FILENAME),
+                &StoreManifest {
+                    schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+                    project_id: Some(project_id.to_string()),
+                    store_kind: StoreKind::CodeProject,
+                    storage_mode: StorageMode::ProfileSharded,
+                    project_root: project_root.to_path_buf(),
+                    data_root,
+                    graph_db_relpath: "tracedecay.db".into(),
+                    sessions_db_relpath: "sessions.db".into(),
+                    branch_meta_relpath: "branch-meta.json".into(),
+                },
+            )
+            .unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path().join("repo");
+        let unrelated_root = dir.path().join("unrelated");
+        let profile_root = dir.path().join("profile");
+        fs::create_dir_all(&project_root).unwrap();
+        fs::create_dir_all(&unrelated_root).unwrap();
+        write_manifest(&profile_root, "proj_exact", &project_root);
+        write_manifest(&profile_root, "proj_unrelated", &unrelated_root);
+
+        let resolver_calls = RefCell::new(Vec::new());
+        let (layouts, selected_is_sole_exact_root) =
+            matching_legacy_profile_layouts_with_git_resolver(
+                &project_root,
+                &profile_root,
+                None,
+                false,
+                |_| false,
+                |root| {
+                    resolver_calls.borrow_mut().push(root.to_path_buf());
+                    Some(dir.path().join("shared.git"))
+                },
+            )
+            .unwrap();
+        assert_eq!(layouts.len(), 1);
+        assert_eq!(
+            layouts[0].identity.project_id.as_deref(),
+            Some("proj_exact")
+        );
+        assert!(!selected_is_sole_exact_root);
+        assert!(
+            resolver_calls.borrow().is_empty(),
+            "exact-root selection must not invoke shared-Git discovery"
+        );
+
+        resolver_calls.borrow_mut().clear();
+        let (layouts, selected_is_sole_exact_root) =
+            matching_legacy_profile_layouts_with_git_resolver(
+                &project_root,
+                &profile_root,
+                Some("proj_exact"),
+                true,
+                |_| false,
+                |root| {
+                    resolver_calls.borrow_mut().push(root.to_path_buf());
+                    Some(dir.path().join("shared.git"))
+                },
+            )
+            .unwrap();
+        assert!(layouts.is_empty());
+        assert!(selected_is_sole_exact_root);
+        assert!(
+            resolver_calls.borrow().is_empty(),
+            "an authoritative selected exact root must not invoke shared-Git discovery"
+        );
+
+        resolver_calls.borrow_mut().clear();
+        let (layouts, selected_is_sole_exact_root) =
+            matching_legacy_profile_layouts_with_git_resolver(
+                &project_root,
+                &profile_root,
+                Some("proj_exact"),
+                false,
+                |_| false,
+                |root| {
+                    resolver_calls.borrow_mut().push(root.to_path_buf());
+                    Some(dir.path().join("shared.git"))
+                },
+            )
+            .unwrap();
+        assert_eq!(layouts.len(), 1);
+        assert_eq!(
+            layouts[0].identity.project_id.as_deref(),
+            Some("proj_unrelated")
+        );
+        assert!(selected_is_sole_exact_root);
+        assert_eq!(
+            resolver_calls.borrow().as_slice(),
+            [project_root, unrelated_root],
+            "a non-authoritative selected exact root must retain shared-Git recovery"
+        );
+    }
 
     #[test]
     fn append_line_keeps_concurrent_jsonl_writes_intact() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -490,7 +490,9 @@ where
             continue;
         };
         let exact_root = same_local_path(&manifest.project_root, project_root);
-        if manifest.project_id.as_deref() == excluded_project_id {
+        if manifest.project_id.is_some()
+            && manifest.project_id.as_deref() == excluded_project_id
+        {
             selected_manifest_matches_exact_root |= exact_root;
             continue;
         }
@@ -1420,6 +1422,42 @@ mod tests {
             [project_root, unrelated_root],
             "a non-authoritative selected exact root must retain shared-Git recovery"
         );
+    }
+
+    #[test]
+    fn exact_root_manifest_without_project_id_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path().join("repo");
+        let profile_root = dir.path().join("profile");
+        let data_root = profile_root.join("projects").join("legacy-missing-id");
+        fs::create_dir_all(&project_root).unwrap();
+        fs::create_dir_all(&data_root).unwrap();
+        write_store_manifest_to_path(
+            &data_root.join(STORE_MANIFEST_FILENAME),
+            &StoreManifest {
+                schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+                project_id: None,
+                store_kind: StoreKind::CodeProject,
+                storage_mode: StorageMode::ProfileSharded,
+                project_root: project_root.clone(),
+                data_root,
+                graph_db_relpath: "tracedecay.db".into(),
+                sessions_db_relpath: "sessions.db".into(),
+                branch_meta_relpath: "branch-meta.json".into(),
+            },
+        )
+        .unwrap();
+
+        let error = matching_legacy_profile_layouts_with_git_resolver(
+            &project_root,
+            &profile_root,
+            None,
+            false,
+            |_| false,
+            |_| None,
+        )
+        .expect_err("missing project_id must fail closed");
+        assert!(error.to_string().contains("project_id is missing"));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -447,13 +447,13 @@ pub(crate) fn matching_legacy_profile_layouts(
     project_root: &Path,
     profile_root: &Path,
     excluded_project_id: Option<&str>,
-    selected_exact_root_is_authoritative: bool,
+    selected_layout_is_authoritative: bool,
 ) -> Result<(Vec<StoreLayout>, bool)> {
     matching_legacy_profile_layouts_with_git_resolver(
         project_root,
         profile_root,
         excluded_project_id,
-        selected_exact_root_is_authoritative,
+        selected_layout_is_authoritative,
         crate::worktree::is_detached_linked_worktree,
         crate::worktree::git_common_dir,
     )
@@ -463,7 +463,7 @@ fn matching_legacy_profile_layouts_with_git_resolver<D, G>(
     project_root: &Path,
     profile_root: &Path,
     excluded_project_id: Option<&str>,
-    selected_exact_root_is_authoritative: bool,
+    selected_layout_is_authoritative: bool,
     mut is_detached_linked_worktree: D,
     mut git_common_dir: G,
 ) -> Result<(Vec<StoreLayout>, bool)>
@@ -503,14 +503,13 @@ where
 
     // A linked worktree may have its own profile shard while sharing a Git
     // common directory with every sibling checkout. A non-excluded exact
-    // manifest is authoritative. The selected exact manifest is authoritative
-    // only when its inventory is healthy and populated; a pristine or
-    // unhealthy selection must retain the shared-Git recovery path.
+    // manifest overrides the selected identity. Otherwise, a healthy and
+    // populated marker/registry-selected layout is authoritative without
+    // probing historical roots. A pristine or unhealthy selection retains
+    // the shared-Git recovery path.
     let selected_is_sole_exact_root =
         selected_manifest_matches_exact_root && exact_manifests.is_empty();
-    let matching_manifests = if !exact_manifests.is_empty()
-        || (selected_is_sole_exact_root && selected_exact_root_is_authoritative)
-    {
+    let matching_manifests = if !exact_manifests.is_empty() || selected_layout_is_authoritative {
         exact_manifests
     } else {
         let project_git_common_dir = (!is_detached_linked_worktree(project_root))
@@ -1420,6 +1419,82 @@ mod tests {
             resolver_calls.borrow().as_slice(),
             [project_root, unrelated_root],
             "a non-authoritative selected exact root must retain shared-Git recovery"
+        );
+    }
+
+    #[test]
+    fn authoritative_shared_identity_skips_historical_git_discovery() {
+        fn write_manifest(profile_root: &Path, project_id: &str, project_root: &Path) {
+            let data_root = profile_root.join("projects").join(project_id);
+            fs::create_dir_all(&data_root).unwrap();
+            write_store_manifest_to_path(
+                &data_root.join(STORE_MANIFEST_FILENAME),
+                &StoreManifest {
+                    schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+                    project_id: Some(project_id.to_string()),
+                    store_kind: StoreKind::CodeProject,
+                    storage_mode: StorageMode::ProfileSharded,
+                    project_root: project_root.to_path_buf(),
+                    data_root,
+                    graph_db_relpath: "tracedecay.db".into(),
+                    sessions_db_relpath: "sessions.db".into(),
+                    branch_meta_relpath: "branch-meta.json".into(),
+                },
+            )
+            .unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let main_root = dir.path().join("repo");
+        let worktree_root = dir.path().join("repo-worktree");
+        let historical_root = dir.path().join("historical-worktree");
+        let profile_root = dir.path().join("profile");
+        for root in [&main_root, &worktree_root, &historical_root] {
+            fs::create_dir_all(root).unwrap();
+        }
+        write_manifest(&profile_root, "proj_selected", &main_root);
+        write_manifest(&profile_root, "proj_historical", &historical_root);
+
+        let resolver_calls = RefCell::new(Vec::new());
+        let (layouts, selected_is_sole_exact_root) =
+            matching_legacy_profile_layouts_with_git_resolver(
+                &worktree_root,
+                &profile_root,
+                Some("proj_selected"),
+                true,
+                |_| false,
+                |root| {
+                    resolver_calls.borrow_mut().push(root.to_path_buf());
+                    Some(dir.path().join("shared.git"))
+                },
+            )
+            .unwrap();
+
+        assert!(layouts.is_empty());
+        assert!(!selected_is_sole_exact_root);
+        assert!(
+            resolver_calls.borrow().is_empty(),
+            "a healthy selected shared identity must not probe historical roots"
+        );
+
+        resolver_calls.borrow_mut().clear();
+        let (layouts, _) = matching_legacy_profile_layouts_with_git_resolver(
+            &worktree_root,
+            &profile_root,
+            Some("proj_selected"),
+            false,
+            |_| false,
+            |root| {
+                resolver_calls.borrow_mut().push(root.to_path_buf());
+                Some(dir.path().join("shared.git"))
+            },
+        )
+        .unwrap();
+        assert_eq!(layouts.len(), 1);
+        assert_eq!(
+            resolver_calls.borrow().as_slice(),
+            [worktree_root, historical_root],
+            "an unhealthy or pristine selection must retain shared-Git recovery"
         );
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -447,10 +447,10 @@ pub(crate) fn matching_legacy_profile_layouts(
     project_root: &Path,
     profile_root: &Path,
     excluded_project_id: Option<&str>,
-) -> Result<Vec<StoreLayout>> {
+) -> Result<(Vec<StoreLayout>, bool)> {
     let projects_root = profile_root.join("projects");
     let Ok(entries) = fs::read_dir(&projects_root) else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), false));
     };
     let mut manifest_paths = entries
         .flatten()
@@ -459,41 +459,63 @@ pub(crate) fn matching_legacy_profile_layouts(
         .collect::<Vec<_>>();
     manifest_paths.sort();
 
-    let mut layouts = Vec::new();
     let project_git_common_dir = (!crate::worktree::is_detached_linked_worktree(project_root))
         .then(|| crate::worktree::git_common_dir(project_root))
         .flatten();
     let mut legacy_git_common_dirs = HashMap::<PathBuf, Option<PathBuf>>::new();
+    let mut exact_manifests = Vec::new();
+    let mut shared_git_manifests = Vec::new();
+    let mut selected_manifest_matches_exact_root = false;
     for manifest_path in manifest_paths {
         let Ok(manifest) = read_store_manifest(&manifest_path) else {
             continue;
         };
-        let same_checkout = same_local_path(&manifest.project_root, project_root)
-            || project_git_common_dir.as_deref().is_some_and(|current| {
-                legacy_git_common_dirs
-                    .entry(manifest.project_root.clone())
-                    .or_insert_with(|| {
-                        manifest
-                            .project_root
-                            .is_dir()
-                            .then(|| crate::worktree::git_common_dir(&manifest.project_root))
-                            .flatten()
-                    })
-                    .as_deref()
-                    .is_some_and(|legacy| same_local_path(legacy, current))
-            });
-        if !same_checkout {
+        let exact_root = same_local_path(&manifest.project_root, project_root);
+        if manifest.project_id.as_deref() == excluded_project_id {
+            selected_manifest_matches_exact_root |= exact_root;
             continue;
         }
+        if exact_root {
+            exact_manifests.push((manifest_path, manifest));
+            continue;
+        }
+        let same_git_checkout = project_git_common_dir.as_deref().is_some_and(|current| {
+            legacy_git_common_dirs
+                .entry(manifest.project_root.clone())
+                .or_insert_with(|| {
+                    manifest
+                        .project_root
+                        .is_dir()
+                        .then(|| crate::worktree::git_common_dir(&manifest.project_root))
+                        .flatten()
+                })
+                .as_deref()
+                .is_some_and(|legacy| same_local_path(legacy, current))
+        });
+        if same_git_checkout {
+            shared_git_manifests.push((manifest_path, manifest));
+        }
+    }
+
+    // A linked worktree may have its own profile shard while sharing a Git
+    // common directory with every sibling checkout. Treat an exact manifest
+    // root as authoritative; the shared-Git fallback is only for worktrees
+    // that have not yet acquired their own shard.
+    let selected_is_sole_exact_root =
+        selected_manifest_matches_exact_root && exact_manifests.is_empty();
+    let matching_manifests = if exact_manifests.is_empty() {
+        shared_git_manifests
+    } else {
+        exact_manifests
+    };
+    let mut layouts = Vec::new();
+    for (manifest_path, manifest) in matching_manifests {
         let project_id = manifest
             .project_id
             .as_deref()
             .ok_or_else(|| invalid_legacy_manifest(&manifest_path, "project_id is missing"))?;
         validate_project_id(project_id)
             .map_err(|message| invalid_legacy_manifest(&manifest_path, message))?;
-        if excluded_project_id == Some(project_id) {
-            continue;
-        }
         if manifest.schema_version != STORE_MANIFEST_SCHEMA_VERSION
             || manifest.store_kind != StoreKind::CodeProject
             || manifest.storage_mode != StorageMode::ProfileSharded
@@ -533,7 +555,7 @@ pub(crate) fn matching_legacy_profile_layouts(
         }
         layouts.push(layout);
     }
-    Ok(layouts)
+    Ok((layouts, selected_is_sole_exact_root))
 }
 
 pub(crate) fn retire_identity_cutover_manifest(layout: &StoreLayout) -> Result<PathBuf> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -505,13 +505,15 @@ where
 
     // A linked worktree may have its own profile shard while sharing a Git
     // common directory with every sibling checkout. A non-excluded exact
-    // manifest overrides the selected identity. Otherwise, a healthy and
-    // populated marker/registry-selected layout is authoritative without
-    // probing historical roots. A pristine or unhealthy selection retains
-    // the shared-Git recovery path.
+    // manifest overrides the selected identity. A healthy and populated
+    // marker/registry-selected layout is authoritative only when its manifest
+    // names this exact checkout; a sibling-root selection must retain the
+    // shared-Git recovery path.
     let selected_is_sole_exact_root =
         selected_manifest_matches_exact_root && exact_manifests.is_empty();
-    let matching_manifests = if !exact_manifests.is_empty() || selected_layout_is_authoritative {
+    let matching_manifests = if !exact_manifests.is_empty()
+        || (selected_layout_is_authoritative && selected_manifest_matches_exact_root)
+    {
         exact_manifests
     } else {
         let project_git_common_dir = (!is_detached_linked_worktree(project_root))
@@ -1461,7 +1463,7 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_shared_identity_skips_historical_git_discovery() {
+    fn authoritative_non_exact_identity_retains_historical_git_discovery() {
         fn write_manifest(profile_root: &Path, project_id: &str, project_root: &Path) {
             let data_root = profile_root.join("projects").join(project_id);
             fs::create_dir_all(&data_root).unwrap();
@@ -1508,11 +1510,12 @@ mod tests {
             )
             .unwrap();
 
-        assert!(layouts.is_empty());
+        assert_eq!(layouts.len(), 1);
         assert!(!selected_is_sole_exact_root);
-        assert!(
-            resolver_calls.borrow().is_empty(),
-            "a healthy selected shared identity must not probe historical roots"
+        assert_eq!(
+            resolver_calls.borrow().as_slice(),
+            [worktree_root.clone(), historical_root.clone()],
+            "a healthy selected identity from a sibling root must retain shared-Git recovery"
         );
 
         resolver_calls.borrow_mut().clear();

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -205,8 +205,18 @@ impl TraceDecay {
         let selected_id = selected
             .as_ref()
             .and_then(|layout| layout.identity.project_id.as_deref());
-        let (candidates, selected_is_sole_exact_root) =
-            storage::matching_legacy_profile_layouts(project_root, &profile_root, selected_id)?;
+        let selected_exact_root_is_authoritative = if let Some(selected) = selected.as_ref() {
+            let inventory = store_identity_inventory(selected).await;
+            inventory.is_healthy() && !inventory.is_pristine()
+        } else {
+            false
+        };
+        let (candidates, selected_is_sole_exact_root) = storage::matching_legacy_profile_layouts(
+            project_root,
+            &profile_root,
+            selected_id,
+            selected_exact_root_is_authoritative,
+        )?;
         Self::choose_identity_layout(
             project_root,
             selected,

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -205,22 +205,35 @@ impl TraceDecay {
         let selected_id = selected
             .as_ref()
             .and_then(|layout| layout.identity.project_id.as_deref());
-        let candidates =
+        let (candidates, selected_is_sole_exact_root) =
             storage::matching_legacy_profile_layouts(project_root, &profile_root, selected_id)?;
-        Self::choose_identity_layout(project_root, selected, candidates, allow_repair)
-            .await?
-            .map_or_else(
-                || storage::default_profile_sharded_layout(project_root, &profile_root),
-                Ok,
-            )
+        Self::choose_identity_layout(
+            project_root,
+            selected,
+            candidates,
+            selected_is_sole_exact_root,
+            allow_repair,
+        )
+        .await?
+        .map_or_else(
+            || storage::default_profile_sharded_layout(project_root, &profile_root),
+            Ok,
+        )
     }
 
     async fn choose_identity_layout(
         project_root: &Path,
         selected: Option<StoreLayout>,
         candidates: Vec<StoreLayout>,
+        selected_is_sole_exact_root: bool,
         allow_repair: bool,
     ) -> Result<Option<StoreLayout>> {
+        if selected_is_sole_exact_root && let Some(selected) = selected.as_ref() {
+            let selected_inventory = store_identity_inventory(selected).await;
+            if selected_inventory.is_healthy() && !selected_inventory.is_pristine() {
+                return Ok(Some(selected.clone()));
+            }
+        }
         if candidates.len() > 1 {
             let mut details = Vec::new();
             for candidate in &candidates {

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -256,6 +256,29 @@ impl TraceDecay {
 
         let selected_inventory = store_identity_inventory(&selected).await;
         let candidate_inventory = store_identity_inventory(&candidate).await;
+        let manifest_matches_project_root = |layout: &StoreLayout| {
+            let manifest_path = layout.manifest_path.as_deref()?;
+            let manifest = storage::read_store_manifest(manifest_path).ok()?;
+            Some(
+                manifest.project_root == project_root
+                    || match (
+                        manifest.project_root.canonicalize(),
+                        project_root.canonicalize(),
+                    ) {
+                        (Ok(manifest_root), Ok(project_root)) => manifest_root == project_root,
+                        _ => false,
+                    },
+            )
+        };
+        if manifest_matches_project_root(&candidate) == Some(true)
+            && manifest_matches_project_root(&selected) == Some(false)
+            && candidate_inventory.is_healthy()
+            && !candidate_inventory.is_pristine()
+            && selected_inventory.is_healthy()
+            && !selected_inventory.is_pristine()
+        {
+            return Ok(Some(candidate));
+        }
         if selected_inventory.is_pristine() && candidate_inventory.is_healthy() {
             if !allow_repair {
                 return Err(identity_cutover_conflict(

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -205,7 +205,7 @@ impl TraceDecay {
         let selected_id = selected
             .as_ref()
             .and_then(|layout| layout.identity.project_id.as_deref());
-        let selected_exact_root_is_authoritative = if let Some(selected) = selected.as_ref() {
+        let selected_layout_is_authoritative = if let Some(selected) = selected.as_ref() {
             let inventory = store_identity_inventory(selected).await;
             inventory.is_healthy() && !inventory.is_pristine()
         } else {
@@ -215,7 +215,7 @@ impl TraceDecay {
             project_root,
             &profile_root,
             selected_id,
-            selected_exact_root_is_authoritative,
+            selected_layout_is_authoritative,
         )?;
         Self::choose_identity_layout(
             project_root,

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -205,18 +205,12 @@ impl TraceDecay {
         let selected_id = selected
             .as_ref()
             .and_then(|layout| layout.identity.project_id.as_deref());
-        let selected_layout_is_authoritative = if let Some(selected) = selected.as_ref() {
-            let inventory = store_identity_inventory(selected).await;
-            inventory.is_healthy() && !inventory.is_pristine()
-        } else {
-            false
-        };
-        let (candidates, selected_is_sole_exact_root) = storage::matching_legacy_profile_layouts(
-            project_root,
-            &profile_root,
-            selected_id,
-            selected_layout_is_authoritative,
-        )?;
+        // Store inventory opens the graph and sessions databases, so it must
+        // stay behind the rare paths that actually compare stores. Resolving a
+        // layout is on every open, including fail-closed clients that must not
+        // touch the store at all.
+        let (candidates, selected_is_sole_exact_root) =
+            storage::matching_legacy_profile_layouts(project_root, &profile_root, selected_id)?;
         Self::choose_identity_layout(
             project_root,
             selected,
@@ -238,7 +232,12 @@ impl TraceDecay {
         selected_is_sole_exact_root: bool,
         allow_repair: bool,
     ) -> Result<Option<StoreLayout>> {
-        if selected_is_sole_exact_root && let Some(selected) = selected.as_ref() {
+        // With no competing candidate the selected layout wins regardless, so
+        // skip the inventory rather than opening the store to confirm it.
+        if selected_is_sole_exact_root
+            && !candidates.is_empty()
+            && let Some(selected) = selected.as_ref()
+        {
             let selected_inventory = store_identity_inventory(selected).await;
             if selected_inventory.is_healthy() && !selected_inventory.is_pristine() {
                 return Ok(Some(selected.clone()));

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -144,9 +144,11 @@ where
     // The managed daemon holds a shared lifecycle lease while serving its
     // databases. Stop it first, then acquire exclusive ownership before the
     // service unit is rewritten and restarted.
-    let previous_state = quiesce()?;
+    quiesce()?;
     let _lifecycle_lease = acquire()?;
-    refresh(previous_state)
+    // `daemon restart` is an explicit request to bring the installed service
+    // up, even when it was stopped before restart began.
+    refresh(tracedecay::daemon::DaemonServiceState::RunningEnabled)
 }
 
 pub(crate) fn restart_daemon_service() -> tracedecay::errors::Result<()> {
@@ -628,6 +630,24 @@ mod tests {
             Some((PathBuf::from("service"), PathBuf::from("socket")))
         );
         assert_eq!(order.into_inner(), ["quiesce", "acquire", "refresh"]);
+    }
+
+    #[test]
+    fn daemon_restart_forces_stopped_service_running() {
+        let result = restart_daemon_service_with(
+            || Ok(tracedecay::daemon::DaemonServiceState::StoppedEnabled),
+            || Ok(()),
+            |state| {
+                assert_eq!(
+                    state,
+                    tracedecay::daemon::DaemonServiceState::RunningEnabled
+                );
+                Ok(Some((PathBuf::from("service"), PathBuf::from("socket"))))
+            },
+        )
+        .expect("restart orchestration");
+
+        assert!(result.is_some());
     }
 
     #[test]

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -129,10 +129,11 @@ fn refresh_daemon_service_after_update(
     Ok(())
 }
 
-fn restart_daemon_service_with<Lease, Quiesce, Acquire, Refresh>(
+fn restart_daemon_service_with<Lease, Quiesce, Acquire, Refresh, Restore>(
     quiesce: Quiesce,
     acquire: Acquire,
     refresh: Refresh,
+    restore: Restore,
 ) -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>>
 where
     Quiesce: FnOnce() -> tracedecay::errors::Result<tracedecay::daemon::DaemonServiceState>,
@@ -140,12 +141,33 @@ where
     Refresh: FnOnce(
         tracedecay::daemon::DaemonServiceState,
     ) -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>>,
+    Restore: FnOnce(
+        tracedecay::daemon::DaemonServiceState,
+    ) -> tracedecay::errors::Result<()>,
 {
     // The managed daemon holds a shared lifecycle lease while serving its
     // databases. Stop it first, then acquire exclusive ownership before the
     // service unit is rewritten and restarted.
-    quiesce()?;
-    let _lifecycle_lease = acquire()?;
+    let previous_state = quiesce()?;
+    let _lifecycle_lease = match acquire() {
+        Ok(lease) => lease,
+        Err(acquire_error) => {
+            if matches!(
+                previous_state,
+                tracedecay::daemon::DaemonServiceState::RunningEnabled
+                    | tracedecay::daemon::DaemonServiceState::RunningDisabled
+            ) {
+                if let Err(restore_error) = restore(previous_state) {
+                    return Err(tracedecay::errors::TraceDecayError::Config {
+                        message: format!(
+                            "{acquire_error}; additionally failed to restore the managed daemon service: {restore_error}"
+                        ),
+                    });
+                }
+            }
+            return Err(acquire_error);
+        }
+    };
     // `daemon restart` is an explicit request to bring the installed service
     // up, even when it was stopped before restart began.
     refresh(tracedecay::daemon::DaemonServiceState::RunningEnabled)
@@ -161,6 +183,7 @@ pub(crate) fn restart_daemon_service() -> tracedecay::errors::Result<()> {
             )
         },
         refresh_daemon_service,
+        tracedecay::daemon::restore_quiesced_installed_service,
     )?;
     match restarted {
         Some((service_path, socket_path)) => {
@@ -622,6 +645,7 @@ mod tests {
                 order.borrow_mut().push("refresh");
                 Ok(Some((PathBuf::from("service"), PathBuf::from("socket"))))
             },
+            |_| panic!("successful lease acquisition must not restore the old service"),
         )
         .expect("restart orchestration");
 
@@ -644,6 +668,7 @@ mod tests {
                 );
                 Ok(Some((PathBuf::from("service"), PathBuf::from("socket"))))
             },
+            |_| panic!("successful lease acquisition must not restore the old service"),
         )
         .expect("restart orchestration");
 
@@ -651,7 +676,7 @@ mod tests {
     }
 
     #[test]
-    fn daemon_restart_does_not_refresh_when_exclusive_lease_acquisition_fails() {
+    fn daemon_restart_restores_running_service_when_exclusive_lease_acquisition_fails() {
         let order = RefCell::new(Vec::new());
         let result = restart_daemon_service_with(
             || {
@@ -666,6 +691,14 @@ mod tests {
                 order.borrow_mut().push("refresh");
                 Ok(None)
             },
+            |state| {
+                assert_eq!(
+                    state,
+                    tracedecay::daemon::DaemonServiceState::RunningEnabled
+                );
+                order.borrow_mut().push("restore");
+                Ok(())
+            },
         );
 
         assert!(
@@ -674,7 +707,7 @@ mod tests {
                 .to_string()
                 .contains("lifecycle lease busy")
         );
-        assert_eq!(order.into_inner(), ["quiesce", "acquire"]);
+        assert_eq!(order.into_inner(), ["quiesce", "acquire", "restore"]);
     }
 
     #[test]

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -9,9 +9,12 @@
 //! `--no-reinstall` to skip that agent-integration refresh.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use tracedecay::upgrade::UpgradeOutcome;
 use tracedecay::user_config::UserConfig;
+
+const DAEMON_RESTART_LEASE_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub(crate) async fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
     let home = tracedecay_home_dir()?;
@@ -147,7 +150,12 @@ where
 pub(crate) fn restart_daemon_service() -> tracedecay::errors::Result<()> {
     let restarted = restart_daemon_service_with(
         tracedecay::daemon::quiesce_installed_service_for_restart,
-        || tracedecay::lifecycle_lease::acquire_exclusive("daemon restart"),
+        || {
+            tracedecay::lifecycle_lease::acquire_exclusive_with_timeout(
+                "daemon restart",
+                DAEMON_RESTART_LEASE_TIMEOUT,
+            )
+        },
         refresh_daemon_service,
     )?;
     match restarted {

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -14,7 +14,9 @@ use std::time::Duration;
 use tracedecay::upgrade::UpgradeOutcome;
 use tracedecay::user_config::UserConfig;
 
-const DAEMON_RESTART_LEASE_TIMEOUT: Duration = Duration::from_secs(60);
+// Exceeds the daemon's sequential 15s client drain, 2s task abort, and 45s
+// server-shutdown bounds with margin for service-manager/process-exit latency.
+const DAEMON_RESTART_LEASE_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub(crate) async fn refresh_generated_plugins() -> tracedecay::errors::Result<()> {
     let home = tracedecay_home_dir()?;

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -124,9 +124,33 @@ fn refresh_daemon_service_after_update(
     Ok(())
 }
 
+fn restart_daemon_service_with<Lease, Quiesce, Acquire, Refresh>(
+    quiesce: Quiesce,
+    acquire: Acquire,
+    refresh: Refresh,
+) -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>>
+where
+    Quiesce: FnOnce() -> tracedecay::errors::Result<tracedecay::daemon::DaemonServiceState>,
+    Acquire: FnOnce() -> tracedecay::errors::Result<Lease>,
+    Refresh: FnOnce(
+        tracedecay::daemon::DaemonServiceState,
+    ) -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>>,
+{
+    // The managed daemon holds a shared lifecycle lease while serving its
+    // databases. Stop it first, then acquire exclusive ownership before the
+    // service unit is rewritten and restarted.
+    let previous_state = quiesce()?;
+    let _lifecycle_lease = acquire()?;
+    refresh(previous_state)
+}
+
 pub(crate) fn restart_daemon_service() -> tracedecay::errors::Result<()> {
-    let _lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive("daemon restart")?;
-    match refresh_daemon_service(tracedecay::daemon::DaemonServiceState::RunningEnabled)? {
+    let restarted = restart_daemon_service_with(
+        tracedecay::daemon::quiesce_installed_service_for_restart,
+        || tracedecay::lifecycle_lease::acquire_exclusive("daemon restart"),
+        refresh_daemon_service,
+    )?;
+    match restarted {
         Some((service_path, socket_path)) => {
             eprintln!(
                 "\x1b[32m✔\x1b[0m Daemon service restarted at {}",
@@ -560,10 +584,68 @@ mod tests {
     use super::{
         RefreshPolicy, ReinstallOutcome, current_tracedecay_exe_from, normalize_bin_path,
         partition_reinstall_results, post_update_binary, post_update_binary_from,
-        prepare_post_update_lease, run_install_then_refresh,
+        prepare_post_update_lease, restart_daemon_service_with, run_install_then_refresh,
     };
     use tempfile::TempDir;
     use tracedecay::upgrade::UpgradeOutcome;
+
+    #[test]
+    fn daemon_restart_quiesces_service_before_acquiring_exclusive_lease() {
+        let order = RefCell::new(Vec::new());
+        let result = restart_daemon_service_with(
+            || {
+                order.borrow_mut().push("quiesce");
+                Ok(tracedecay::daemon::DaemonServiceState::RunningEnabled)
+            },
+            || {
+                assert_eq!(order.borrow().as_slice(), ["quiesce"]);
+                order.borrow_mut().push("acquire");
+                Ok(())
+            },
+            |state| {
+                assert_eq!(
+                    state,
+                    tracedecay::daemon::DaemonServiceState::RunningEnabled
+                );
+                order.borrow_mut().push("refresh");
+                Ok(Some((PathBuf::from("service"), PathBuf::from("socket"))))
+            },
+        )
+        .expect("restart orchestration");
+
+        assert_eq!(
+            result,
+            Some((PathBuf::from("service"), PathBuf::from("socket")))
+        );
+        assert_eq!(order.into_inner(), ["quiesce", "acquire", "refresh"]);
+    }
+
+    #[test]
+    fn daemon_restart_does_not_refresh_when_exclusive_lease_acquisition_fails() {
+        let order = RefCell::new(Vec::new());
+        let result = restart_daemon_service_with(
+            || {
+                order.borrow_mut().push("quiesce");
+                Ok(tracedecay::daemon::DaemonServiceState::RunningEnabled)
+            },
+            || -> tracedecay::errors::Result<()> {
+                order.borrow_mut().push("acquire");
+                Err(config_err("lifecycle lease busy"))
+            },
+            |_| {
+                order.borrow_mut().push("refresh");
+                Ok(None)
+            },
+        );
+
+        assert!(
+            result
+                .expect_err("lease acquisition should fail")
+                .to_string()
+                .contains("lifecycle lease busy")
+        );
+        assert_eq!(order.into_inner(), ["quiesce", "acquire"]);
+    }
 
     #[test]
     fn post_update_lease_handoff_matches_platform_contract() {

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -141,9 +141,7 @@ where
     Refresh: FnOnce(
         tracedecay::daemon::DaemonServiceState,
     ) -> tracedecay::errors::Result<Option<(PathBuf, PathBuf)>>,
-    Restore: FnOnce(
-        tracedecay::daemon::DaemonServiceState,
-    ) -> tracedecay::errors::Result<()>,
+    Restore: FnOnce(tracedecay::daemon::DaemonServiceState) -> tracedecay::errors::Result<()>,
 {
     // The managed daemon holds a shared lifecycle lease while serving its
     // databases. Stop it first, then acquire exclusive ownership before the

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -1325,6 +1325,76 @@ async fn worktree_profile_stores_prefer_the_exact_manifest_root() {
 }
 
 #[tokio::test]
+async fn linked_worktree_exact_manifest_overrides_healthy_shared_identity_store() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let worktree = dir.path().join("repo-wt");
+    let candidate_source = dir.path().join("candidate-source");
+    let home = test_home(&dir);
+    let profile_root = home.join(".tracedecay");
+    let _home_guard = HomeGuard::set(&home);
+
+    for root in [&project, &candidate_source] {
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/lib.rs"), "pub fn indexed() {}\n").unwrap();
+        init_repo_with_commit(root);
+    }
+
+    let main = TraceDecay::init(&project).await.unwrap();
+    main.index_all().await.unwrap();
+    let main_project_id = main.store_layout().identity.project_id.clone().unwrap();
+    main.close();
+
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/exact-over-shared",
+            worktree.to_str().unwrap(),
+        ],
+    );
+
+    let candidate = TraceDecay::init(&candidate_source).await.unwrap();
+    candidate.index_all().await.unwrap();
+    let candidate_root = candidate.store_layout().data_root.clone();
+    candidate.close();
+
+    let exact_project_id = "proj_linked_exact_over_shared";
+    let exact_root = profile_root.join(format!("projects/{exact_project_id}"));
+    relocate_store_as_legacy(&candidate_root, &exact_root, &worktree, exact_project_id);
+    assert_eq!(
+        read_repository_identity_marker(&worktree)
+            .unwrap()
+            .unwrap()
+            .project_id,
+        main_project_id
+    );
+
+    let layout = TraceDecay::resolve_store_layout_for_identity_with_options(
+        &worktree,
+        &TraceDecayOpenOptions {
+            profile_root: Some(profile_root.clone()),
+            global_db_path: Some(profile_root.join("global.db")),
+        },
+    )
+    .await
+    .expect("the healthy exact-root worktree shard must override the healthy shared shard");
+
+    assert_ne!(
+        layout.identity.project_id.as_deref(),
+        Some(main_project_id.as_str())
+    );
+    assert_eq!(
+        layout.identity.project_id.as_deref(),
+        Some(exact_project_id)
+    );
+    assert_path_eq(&layout.data_root, &exact_root);
+}
+
+#[tokio::test]
 async fn registered_exact_root_ignores_sibling_worktree_manifests() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();

--- a/tests/storage_suite/storage_resolver_test.rs
+++ b/tests/storage_suite/storage_resolver_test.rs
@@ -1255,6 +1255,160 @@ async fn ambiguous_legacy_store_adoption_preserves_every_candidate() {
 }
 
 #[tokio::test]
+async fn worktree_profile_stores_prefer_the_exact_manifest_root() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let worktree = dir.path().join("repo-wt");
+    let profile_root = dir.path().join("profile");
+    let global_db_path = profile_root.join("global.db");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn main_root() {}\n").unwrap();
+    init_repo_with_commit(&project);
+    git(
+        &project,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/exact-manifest-root",
+            worktree.to_str().unwrap(),
+        ],
+    );
+
+    for (project_id, manifest_root) in [
+        ("proj_main_worktree", project.as_path()),
+        ("proj_linked_worktree", worktree.as_path()),
+    ] {
+        let data_root = profile_root.join(format!("projects/{project_id}"));
+        fs::create_dir_all(&data_root).unwrap();
+        fs::write(data_root.join("tracedecay.db"), project_id).unwrap();
+        fs::write(data_root.join("sessions.db"), b"sessions").unwrap();
+        branch_meta::save_branch_meta(&data_root, &BranchMeta::new_for_dir(&data_root, "main"))
+            .unwrap();
+        write_store_manifest_to_path(
+            &data_root.join(STORE_MANIFEST_FILENAME),
+            &StoreManifest {
+                schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+                project_id: Some(project_id.to_string()),
+                store_kind: StoreKind::CodeProject,
+                storage_mode: StorageMode::ProfileSharded,
+                project_root: manifest_root.to_path_buf(),
+                data_root,
+                graph_db_relpath: "tracedecay.db".into(),
+                sessions_db_relpath: "sessions.db".into(),
+                branch_meta_relpath: "branch-meta.json".into(),
+            },
+        )
+        .unwrap();
+    }
+
+    for (root, expected_project_id) in [
+        (project.as_path(), "proj_main_worktree"),
+        (worktree.as_path(), "proj_linked_worktree"),
+    ] {
+        let layout = TraceDecay::resolve_store_layout_for_identity_with_options(
+            root,
+            &TraceDecayOpenOptions {
+                profile_root: Some(profile_root.clone()),
+                global_db_path: Some(global_db_path.clone()),
+            },
+        )
+        .await
+        .expect("the manifest whose project_root exactly matches must win");
+
+        assert_eq!(
+            layout.identity.project_id.as_deref(),
+            Some(expected_project_id)
+        );
+    }
+}
+
+#[tokio::test]
+async fn registered_exact_root_ignores_sibling_worktree_manifests() {
+    let _guard = HOME_ENV_LOCK.lock().await;
+    let dir = TempDir::new().unwrap();
+    let project = dir.path().join("repo");
+    let first_worktree = dir.path().join("repo-wt-one");
+    let second_worktree = dir.path().join("repo-wt-two");
+    let home = test_home(&dir);
+    let profile_root = home.join(".tracedecay");
+    let global_db_path = profile_root.join("global.db");
+    fs::create_dir_all(project.join("src")).unwrap();
+    fs::write(project.join("src/lib.rs"), "pub fn registered_root() {}\n").unwrap();
+    let _home_guard = HomeGuard::set(&home);
+    init_repo_with_commit(&project);
+
+    let main = TraceDecay::init(&project).await.unwrap();
+    main.index_all().await.unwrap();
+    let main_project_id = main.store_layout().identity.project_id.clone().unwrap();
+    let main_data_root = main.store_layout().data_root.clone();
+    main.close();
+
+    for (branch, worktree) in [
+        ("feature/registered-sibling-one", first_worktree.as_path()),
+        ("feature/registered-sibling-two", second_worktree.as_path()),
+    ] {
+        git(
+            &project,
+            &["worktree", "add", "-b", branch, worktree.to_str().unwrap()],
+        );
+    }
+
+    for (project_id, manifest_root) in [
+        ("proj_registered_sibling_one", first_worktree.as_path()),
+        ("proj_registered_sibling_two", second_worktree.as_path()),
+    ] {
+        let data_root = profile_root.join(format!("projects/{project_id}"));
+        fs::create_dir_all(&data_root).unwrap();
+        fs::write(data_root.join("tracedecay.db"), project_id).unwrap();
+        fs::write(data_root.join("sessions.db"), b"sessions").unwrap();
+        branch_meta::save_branch_meta(&data_root, &BranchMeta::new_for_dir(&data_root, "main"))
+            .unwrap();
+        write_store_manifest_to_path(
+            &data_root.join(STORE_MANIFEST_FILENAME),
+            &StoreManifest {
+                schema_version: STORE_MANIFEST_SCHEMA_VERSION,
+                project_id: Some(project_id.to_string()),
+                store_kind: StoreKind::CodeProject,
+                storage_mode: StorageMode::ProfileSharded,
+                project_root: manifest_root.to_path_buf(),
+                data_root,
+                graph_db_relpath: "tracedecay.db".into(),
+                sessions_db_relpath: "sessions.db".into(),
+                branch_meta_relpath: "branch-meta.json".into(),
+            },
+        )
+        .unwrap();
+    }
+
+    let git_common_dir = tracedecay::worktree::git_common_dir(&project).unwrap();
+    let global_db = GlobalDb::open().await.unwrap();
+    let registered = global_db
+        .resolve_project_store_by_identity(&project, Some(&git_common_dir))
+        .await
+        .expect("the exact main checkout must resolve through GlobalDb");
+    assert_eq!(registered.project.project_id, main_project_id);
+
+    fs::remove_file(repository_identity_path(&project).unwrap()).unwrap();
+    let layout = TraceDecay::resolve_store_layout_for_identity_with_options(
+        &project,
+        &TraceDecayOpenOptions {
+            profile_root: Some(profile_root),
+            global_db_path: Some(global_db_path),
+        },
+    )
+    .await
+    .expect("a registered exact-root shard must ignore sibling worktree manifests");
+
+    assert_eq!(
+        layout.identity.project_id.as_deref(),
+        Some(main_project_id.as_str())
+    );
+    assert_path_eq(&layout.data_root, &main_data_root);
+}
+
+#[tokio::test]
 async fn linked_worktree_uses_initialized_git_common_dir_store_without_init() {
     let _guard = HOME_ENV_LOCK.lock().await;
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
> [!IMPORTANT]
> **Status: combined-fix validation in progress.**
>
> This PR intentionally keeps the coupled library fixes discovered while reproducing #477:
>
> 1. worktree/store resolution and the daemon routing/warm-up behavior required for worktrees; and
> 2. managed daemon restart/service lifecycle plus managed-service open-file headroom.
>
> The latest restart remediation will remain in this PR. It is intentionally draft until the local candidate is committed, independently audited at its exact hash, pushed, and validated through local multi-worktree dogfooding.
>
> The description below documents the current remote head and will be refreshed after the remediation push.

## Summary

- prefer profile-store manifests whose canonical root exactly matches the current checkout
- preserve shared-Git fallback and fail-closed ambiguity behavior for non-exact or unhealthy stores
- skip unrelated historical Git discovery when a healthy populated selected store is already authoritative
- serve cached project routes and static MCP bootstrap/catalog requests without waiting on unrelated writer work
- preserve exact project-size tool budgets for cached routes and use an explicit warming budget before the graph is ready
- bound direct CLI cache misses with a short actionable warm-up response
- reuse cached project graphs for scheduler discovery and make activation lifecycle-safe
- restart managed daemons without lifecycle-lease self-deadlock or shutdown races
- provision managed services for the descriptor footprint of multi-project and multi-worktree use

## Root cause

Worktree resolution treated exact-root manifests and sibling worktrees sharing one Git common directory as equivalent candidates. A healthy selected shard could also conflict with an exact-root shard whose manifest positively belonged to the current checkout. Historical Git discovery then added avoidable latency even after an authoritative store was already known.

Separately, daemon project opening took a global writer gate before checking the route cache. Long-running writer work could therefore delay cached clients and bootstrap discovery. Scheduler discovery also reopened writable project state instead of reusing the already-open graph.

The daemon restart path had a lifecycle ordering defect. The running daemon holds a shared lifecycle lease, while restart attempted to acquire exclusive ownership before stopping it. After correcting that ordering, a second race remained: service-manager stop can return before the daemon process releases its shared lease. Restart now quiesces the managed service, waits up to 90 seconds for exclusive ownership, retries only genuine lock contention, preserves owner diagnostics on timeout, and refreshes the service only after the lease is acquired.

A live managed daemon later reproduced the reported mid-session MCP failure and exited with `Too many open files (os error 24)`. The service inherited launchd's 256-descriptor soft limit while legitimately retaining SQLite families and coordination locks for multiple cached project owners. Repeated calls remained flat after a project owner was first opened, ruling out a per-request descriptor leak. Managed launchd and systemd units now set an 8,192-descriptor soft limit.

## Review follow-up

Automated review found seven valid edge cases, all addressed in the current candidate:

- cached bootstrap catalogs now use the real project node count; cold routes no longer advertise a false zero-node/three-call budget
- matching legacy manifests with a missing project identifier now fail closed
- initialized acknowledgements preserve pending catalog-change notifications
- explicit restart starts an installed service even when it was previously stopped
- an authoritative selected shard suppresses shared-Git discovery only when its manifest belongs to the exact checkout
- failed exclusive-lease acquisition restores a managed service that restart had already quiesced
- scheduler discovery revalidates project-server ownership under the writer coordinator before starting a scheduler

## Impact

Linked worktrees resolve their exact healthy stores without probing unrelated historical roots, while shared-store recovery and true ambiguity handling remain intact. MCP bootstrap and cached routes remain responsive during project warm-up or unrelated writer activity. Scheduler activation no longer reopens the same writable store, races shutdown, or starts under a stale owner key.

Managed daemon restart now completes through graceful shutdown instead of failing against its own shared lease. If post-quiesce exclusive acquisition fails, the prior running service is restored without rewriting its installed unit; disabled state is preserved. Managed services also have sufficient open-file headroom for multi-project use instead of crashing at the platform default.

## Validation

Earlier lifecycle candidate:

- `cargo fmt --check`
- `cargo check`
- `cargo build --release`
- storage resolver lane: 42 passed
- lifecycle lease wait regressions: 2 passed
- daemon restart path: 3 passed
- daemon service tests: 15 passed
- focused cache, bootstrap, scheduler, and shutdown regressions passed
- release candidate restarted the managed daemon successfully in 7.14 seconds
- daemon socket connectable after restart
- MCP status and writable-storage checks passed after restart
- direct CLI warm-up returned promptly and the immediate retry succeeded

Current candidate:

- candidate: `4056550809a3405659ec50bb6c1574fa12fac5eb`
- exact-commit whitespace checks passed
- two independent narrow exact-commit audits: PASS, no actionable findings
- focused regression coverage added for all three latest review findings
- systemd and launchd render tests now assert the managed open-file limit
- Apple `launchd.plist(5)` locally confirms `SoftResourceLimits` / `NumberOfFiles` as the correct integer job configuration
- TraceDecay semantic diff and production unsafe-pattern scans completed; no new production unsafe or panic sites were found
- local `cargo` and `rustfmt` are unavailable in the current shell, so compilation and focused regression execution for the latest candidates remain pending CI
- upstream fork workflows may require maintainer approval before CI jobs execute

Fixes #477
