### PR TITLE
fix: auto-repair corrupt derived branch stores

### DIFF
--- a/.changeset/derived-branch-corruption-recovery.md
+++ b/.changeset/derived-branch-corruption-recovery.md
@@ -1,0 +1,5 @@
+---
+"tracedecay": patch
+---
+
+Preserve corrupt derived-branch database families under the project recovery directory and rebuild the active branch index from a healthy tracked ancestor, while keeping default stores fail-closed, correcting branch-specific doctor recovery paths, and reloading rotated daemon credentials when long-lived clients reconnect after a restart.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -917,9 +917,9 @@ fn is_transient_daemon_connect_error(kind: std::io::ErrorKind) -> bool {
     )
 }
 
-async fn connect_to_daemon_connection(connection: &DaemonConnection) -> Result<BrokerStream> {
-    connect_with_restart_grace(
-        connection,
+async fn connect_to_current_daemon(socket_path: &Path) -> Result<(DaemonConnection, BrokerStream)> {
+    connect_with_restart_grace_resolving(
+        || client_connection(socket_path),
         DAEMON_RESTART_GRACE,
         DAEMON_RESTART_POLL_INTERVAL,
     )
@@ -935,10 +935,27 @@ async fn connect_with_restart_grace(
     grace: Duration,
     poll_interval: Duration,
 ) -> Result<BrokerStream> {
+    let (_, stream) =
+        connect_with_restart_grace_resolving(|| Ok(connection.clone()), grace, poll_interval)
+            .await?;
+    Ok(stream)
+}
+
+/// Resolves the current authority record on every connect attempt.
+///
+/// A daemon restart replaces both its endpoint authority epoch and auth token.
+/// Resolving only before the restart window would connect to the new socket
+/// with stale credentials after it rebinds.
+async fn connect_with_restart_grace_resolving(
+    mut resolve: impl FnMut() -> Result<DaemonConnection>,
+    grace: Duration,
+    poll_interval: Duration,
+) -> Result<(DaemonConnection, BrokerStream)> {
     let deadline = tokio::time::Instant::now() + grace;
     loop {
+        let connection = resolve()?;
         match BrokerStream::connect(&connection.endpoint).await {
-            Ok(stream) => return Ok(stream),
+            Ok(stream) => return Ok((connection, stream)),
             Err(TraceDecayError::Io(err)) => {
                 if !is_transient_daemon_connect_error(err.kind())
                     || tokio::time::Instant::now() >= deadline
@@ -1291,8 +1308,7 @@ async fn send_daemon_request_line_with_liveness_poll(
     line: &str,
     liveness_poll_interval: Duration,
 ) -> Result<Vec<String>> {
-    let connection = client_connection(socket_path)?;
-    let stream = connect_to_daemon_connection(&connection).await?;
+    let (connection, stream) = connect_to_current_daemon(socket_path).await?;
     let (reader, mut writer) = stream.into_split();
 
     write_daemon_preamble(&mut writer, &connection, handshake).await?;
@@ -1490,8 +1506,7 @@ async fn call_tool_with_liveness_poll(
     arguments: serde_json::Value,
     liveness_poll_interval: Duration,
 ) -> Result<serde_json::Value> {
-    let connection = client_connection(socket_path)?;
-    let stream = connect_to_daemon_connection(&connection).await?;
+    let (connection, stream) = connect_to_current_daemon(socket_path).await?;
     let (reader, mut writer) = stream.into_split();
     let id = json!(1);
     let request = JsonRpcRequest {

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -1078,9 +1078,9 @@ mod tests {
     #[cfg(unix)]
     use tempfile::TempDir;
 
-    use super::{
-        DaemonServiceSpec, DaemonServiceState, LaunchctlFailureMode, LaunchdCommand, ServiceRunner,
-    };
+    use super::{DaemonServiceSpec, LaunchctlFailureMode, LaunchdCommand};
+    #[cfg(target_os = "linux")]
+    use super::{DaemonServiceState, ServiceRunner};
     use crate::config::lock_user_data_dir_test_env;
 
     struct EnvVarGuard {

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -730,6 +730,55 @@ async fn answer_one_proxy_request(listener: tokio::net::UnixListener, generation
 }
 
 #[cfg(unix)]
+async fn answer_one_authenticated_proxy_request(
+    listener: tokio::net::UnixListener,
+    expected_token: &str,
+    generation: u64,
+) {
+    let (stream, _addr) = listener.accept().await.expect("accept proxied client");
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = tokio::io::BufReader::new(reader).lines();
+    let auth_line = lines
+        .next_line()
+        .await
+        .expect("read auth preface")
+        .expect("auth preface line");
+    let preface =
+        super::transport::DaemonAuthPreface::from_line(auth_line.trim()).expect("auth preface");
+    assert!(
+        preface.authenticate(expected_token),
+        "proxy must reload the current daemon authority token"
+    );
+    let handshake_line = lines
+        .next_line()
+        .await
+        .expect("read handshake")
+        .expect("handshake line");
+    DaemonHandshake::from_line(&handshake_line).expect("parse handshake");
+    let request_line = lines
+        .next_line()
+        .await
+        .expect("read request")
+        .expect("request line");
+    let request: Value = serde_json::from_str(&request_line).expect("request json");
+    let response = json!({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "result": { "generation": generation }
+    });
+    writer
+        .write_all(
+            serde_json::to_string(&response)
+                .expect("response json")
+                .as_bytes(),
+        )
+        .await
+        .expect("write response");
+    writer.write_all(b"\n").await.expect("write newline");
+    writer.shutdown().await.expect("shutdown fake daemon");
+}
+
+#[cfg(unix)]
 async fn daemon_round_trip(
     engine: super::DaemonEngine,
     handshake: &DaemonHandshake,
@@ -1304,6 +1353,86 @@ async fn long_lived_proxy_reconnects_after_daemon_socket_rebind() {
         .await
         .expect("proxy transport");
     await_test_task(daemon, "daemon rebind task").await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn long_lived_proxy_reloads_rotated_auth_after_daemon_restart() {
+    let dir = TempDir::new().expect("temp dir");
+    let profile = dir.path().canonicalize().expect("canonical profile");
+    let socket = profile.join("daemon.sock");
+    let endpoint = super::transport::DaemonEndpoint::Unix(socket.clone());
+    let first_listener = tokio::net::UnixListener::bind(&socket).expect("bind first daemon socket");
+    let first_authority = super::authority::DaemonAuthority::acquire(&profile, &endpoint, "first")
+        .expect("first daemon authority");
+    let first_token = first_authority.auth_token().to_string();
+    let rebound_socket = socket.clone();
+    let rebound_profile = profile.clone();
+    let rebound_endpoint = endpoint.clone();
+    let (unbound_tx, unbound_rx) = tokio::sync::oneshot::channel();
+    let daemon = tokio::spawn(async move {
+        answer_one_authenticated_proxy_request(first_listener, &first_token, 1).await;
+        drop(first_authority);
+        std::fs::remove_file(&rebound_socket).expect("unlink first daemon socket");
+        unbound_tx.send(()).expect("notify daemon outage");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let second_listener =
+            tokio::net::UnixListener::bind(&rebound_socket).expect("bind second daemon socket");
+        let second_authority = super::authority::DaemonAuthority::acquire(
+            &rebound_profile,
+            &rebound_endpoint,
+            "second",
+        )
+        .expect("second daemon authority");
+        let second_token = second_authority.auth_token().to_string();
+        assert_ne!(first_token, second_token, "daemon restart must rotate auth");
+        answer_one_authenticated_proxy_request(second_listener, &second_token, 2).await;
+        drop(second_authority);
+    });
+
+    let (mut transport, sender, mut receiver) = crate::mcp::transport::ChannelTransport::new();
+    let proxy_socket = socket.clone();
+    let proxy = tokio::spawn(async move {
+        super::proxy_transport_to_daemon(
+            &proxy_socket,
+            &test_handshake_defaults(),
+            None,
+            &mut transport,
+        )
+        .await
+    });
+    let request = |id| {
+        serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/list"
+        }))
+        .expect("request json")
+    };
+
+    sender.send(request(1)).expect("send first request");
+    let first = tokio::time::timeout(std::time::Duration::from_secs(2), receiver.recv())
+        .await
+        .expect("first response timed out")
+        .expect("first response");
+    let first: Value = serde_json::from_str(first.trim()).expect("first response json");
+    assert_eq!(first["result"]["generation"], json!(1));
+
+    unbound_rx.await.expect("first daemon should unlink socket");
+    sender.send(request(2)).expect("send second request");
+    let second = tokio::time::timeout(std::time::Duration::from_secs(2), receiver.recv())
+        .await
+        .expect("second response timed out")
+        .expect("second response");
+    let second: Value = serde_json::from_str(second.trim()).expect("second response json");
+    assert_eq!(second["result"]["generation"], json!(2));
+
+    drop(sender);
+    await_test_task(proxy, "rotating-auth proxy task")
+        .await
+        .expect("proxy transport");
+    await_test_task(daemon, "rotating-auth daemon task").await;
 }
 
 #[cfg(unix)]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -375,7 +375,12 @@ fn fallback_database_path(project_path: &Path) -> Option<PathBuf> {
 fn database_recovery_guidance(db_path: &Path) -> String {
     let wal_path = db_path.with_extension("db-wal");
     let shm_path = db_path.with_extension("db-shm");
-    let data_root = db_path.parent().unwrap_or_else(|| Path::new("."));
+    let graph_parent = db_path.parent().unwrap_or_else(|| Path::new("."));
+    let data_root = if graph_parent.file_name() == Some(std::ffi::OsStr::new("branches")) {
+        graph_parent.parent().unwrap_or(graph_parent)
+    } else {
+        graph_parent
+    };
     let mut graph_dirty = db_path.as_os_str().to_os_string();
     graph_dirty.push(".dirty");
     let graph_dirty = PathBuf::from(graph_dirty);
@@ -391,7 +396,8 @@ fn database_recovery_guidance(db_path: &Path) -> String {
          graph dirty sentinel: {}\n\
          legacy dirty sentinel (if present): {}\n\
          `sessions.db` is separate and must not be removed: {}\n\
-         Facts are stored in the graph database; automatic rebuild is intentionally blocked because it cannot preserve them generically.\n\
+         Facts are stored in the graph database; automatic default-store rebuild is intentionally blocked because it cannot preserve them generically.\n\
+         Derived branch indexes are preserved under `recovery/` and rebuilt automatically from a healthy tracked ancestor.\n\
          Do not run `tracedecay init`, `tracedecay sync --force`, or `tracedecay wipe` until that recovery set is safely copied.\n\
          Report the preserved set at https://github.com/ScriptedAlchemy/tracedecay/issues for offline recovery.",
         db_path.display(),

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -241,9 +241,11 @@ fn database_recovery_guidance_names_the_preserved_recovery_set() {
 
     let branch_db = PathBuf::from("/profile/projects/proj_test/branches/feature.db");
     let branch_guidance = database_recovery_guidance(&branch_db);
-    assert!(branch_guidance.contains("/profile/projects/proj_test/dirty"));
-    assert!(branch_guidance.contains("/profile/projects/proj_test/sessions.db"));
-    assert!(!branch_guidance.contains("/branches/sessions.db"));
+    let branches_root = branch_db.parent().unwrap();
+    let data_root = branches_root.parent().unwrap();
+    assert!(branch_guidance.contains(&data_root.join("dirty").display().to_string()));
+    assert!(branch_guidance.contains(&data_root.join("sessions.db").display().to_string()));
+    assert!(!branch_guidance.contains(&branches_root.join("sessions.db").display().to_string()));
 }
 
 #[tokio::test]

--- a/src/doctor/tests.rs
+++ b/src/doctor/tests.rs
@@ -236,7 +236,14 @@ fn database_recovery_guidance_names_the_preserved_recovery_set() {
     );
     assert!(guidance.contains("`sessions.db` is separate and must not be removed"));
     assert!(guidance.contains("Facts are stored in the graph database"));
-    assert!(guidance.contains("automatic rebuild is intentionally blocked"));
+    assert!(guidance.contains("automatic default-store rebuild is intentionally blocked"));
+    assert!(guidance.contains("Derived branch indexes are preserved"));
+
+    let branch_db = PathBuf::from("/profile/projects/proj_test/branches/feature.db");
+    let branch_guidance = database_recovery_guidance(&branch_db);
+    assert!(branch_guidance.contains("/profile/projects/proj_test/dirty"));
+    assert!(branch_guidance.contains("/profile/projects/proj_test/sessions.db"));
+    assert!(!branch_guidance.contains("/branches/sessions.db"));
 }
 
 #[tokio::test]

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -1207,7 +1207,11 @@ fn preserve_corrupt_branch_store(store_layout: &StoreLayout, db_path: &Path) -> 
                 ),
             });
         }
-        std::fs::File::open(&target)
+        // Windows `FlushFileBuffers` requires a write handle, so a read-only
+        // open would fail the durability sync with "access is denied".
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&target)
             .and_then(|file| file.sync_all())
             .map_err(|error| TraceDecayError::Config {
                 message: format!(

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -299,6 +299,14 @@ impl TraceDecay {
         project_root: &Path,
         open_options: TraceDecayOpenOptions,
     ) -> Result<Self> {
+        Self::open_with_options_inner(project_root, open_options, true).await
+    }
+
+    async fn open_with_options_inner(
+        project_root: &Path,
+        open_options: TraceDecayOpenOptions,
+        allow_corrupt_branch_repair: bool,
+    ) -> Result<Self> {
         let store_layout =
             Self::resolve_store_layout_for_project(project_root, &open_options).await?;
         let config = load_config_from_path(project_root, &store_layout.config_path)?;
@@ -321,6 +329,11 @@ impl TraceDecay {
         // store root. Different tracked branches have independent databases
         // and must never clear or inherit one another's dirty marker or lock.
         let active_graph_layout = active_graph_layout(&db_path);
+        let repair_corrupt_branch = allow_corrupt_branch_repair
+            && active_branch.is_some()
+            && active_branch == serving_branch
+            && db_path != store_layout.graph_db_path
+            && db_path.parent() == Some(store_layout.data_root.join("branches").as_path());
 
         if !db_path.exists() {
             return Err(TraceDecayError::Config {
@@ -346,7 +359,7 @@ impl TraceDecay {
         // it cannot race that writer or clear its sentinel. Preflight through
         // the read-only connection before Database::open applies writable
         // pragmas or migrations to a potentially damaged recovery set.
-        let _recovery_lock = if crashed {
+        let recovery_lock = if crashed {
             Some(try_acquire_graph_sync_locks(
                 &active_graph_layout.sync_lock_path,
                 &store_layout.sync_lock_path,
@@ -359,8 +372,16 @@ impl TraceDecay {
             let verification = match Database::open_read_only(&db_path, &authority).await {
                 Ok((db, _)) => db,
                 Err(error) => {
-                    print_corruption_warning(&db_path);
-                    return Err(recovery_required_error(&db_path, error));
+                    drop(recovery_lock);
+                    return Self::recover_corrupt_branch_or_fail(
+                        project_root,
+                        open_options,
+                        &store_layout,
+                        &db_path,
+                        error,
+                        repair_corrupt_branch,
+                    )
+                    .await;
                 }
             };
             let integrity = verification.quick_check().await;
@@ -368,15 +389,28 @@ impl TraceDecay {
             match integrity {
                 Ok(true) => {}
                 Ok(false) => {
-                    print_corruption_warning(&db_path);
-                    return Err(recovery_required_error(
+                    drop(recovery_lock);
+                    return Self::recover_corrupt_branch_or_fail(
+                        project_root,
+                        open_options,
+                        &store_layout,
                         &db_path,
                         "read-only SQLite quick_check did not return ok",
-                    ));
+                        repair_corrupt_branch,
+                    )
+                    .await;
                 }
                 Err(error) => {
-                    print_corruption_warning(&db_path);
-                    return Err(recovery_required_error(&db_path, error));
+                    drop(recovery_lock);
+                    return Self::recover_corrupt_branch_or_fail(
+                        project_root,
+                        open_options,
+                        &store_layout,
+                        &db_path,
+                        error,
+                        repair_corrupt_branch,
+                    )
+                    .await;
                 }
             }
         }
@@ -389,8 +423,16 @@ impl TraceDecay {
         let (db, migrated) = match open_result {
             Ok(pair) => pair,
             Err(e) if Database::is_corruption_error(&e) || crashed => {
-                print_corruption_warning(&db_path);
-                return Err(recovery_required_error(&db_path, &e));
+                drop(recovery_lock);
+                return Self::recover_corrupt_branch_or_fail(
+                    project_root,
+                    open_options,
+                    &store_layout,
+                    &db_path,
+                    e,
+                    repair_corrupt_branch,
+                )
+                .await;
             }
             Err(e) => return Err(e),
         };
@@ -404,15 +446,30 @@ impl TraceDecay {
                     clear_dirty_sentinel_at(&store_layout.dirty_path);
                 }
                 Ok(false) => {
-                    print_corruption_warning(&db_path);
-                    return Err(recovery_required_error(
+                    db.close();
+                    drop(recovery_lock);
+                    return Self::recover_corrupt_branch_or_fail(
+                        project_root,
+                        open_options,
+                        &store_layout,
                         &db_path,
                         "SQLite quick_check did not return ok",
-                    ));
+                        repair_corrupt_branch,
+                    )
+                    .await;
                 }
                 Err(e) => {
-                    print_corruption_warning(&db_path);
-                    return Err(recovery_required_error(&db_path, &e));
+                    db.close();
+                    drop(recovery_lock);
+                    return Self::recover_corrupt_branch_or_fail(
+                        project_root,
+                        open_options,
+                        &store_layout,
+                        &db_path,
+                        e,
+                        repair_corrupt_branch,
+                    )
+                    .await;
                 }
             }
         }
@@ -442,6 +499,54 @@ impl TraceDecay {
 
         ts.register_project_store_in_global_registry().await;
         Ok(ts)
+    }
+
+    async fn recover_corrupt_branch_or_fail(
+        project_root: &Path,
+        open_options: TraceDecayOpenOptions,
+        store_layout: &StoreLayout,
+        db_path: &Path,
+        detail: impl std::fmt::Display,
+        repair_corrupt_branch: bool,
+    ) -> Result<Self> {
+        let detail = detail.to_string();
+        if repair_corrupt_branch {
+            let active_graph_layout = active_graph_layout(db_path);
+            let repair_result = (|| {
+                let _sync_locks = try_acquire_graph_sync_locks(
+                    &active_graph_layout.sync_lock_path,
+                    &store_layout.sync_lock_path,
+                )?;
+                let _authority =
+                    DatabaseAuthority::for_runtime(db_path, "preserve corrupt branch store")?;
+                preserve_corrupt_branch_store(store_layout, db_path)
+            })();
+
+            match repair_result {
+                Ok(recovery_dir) => {
+                    eprintln!(
+                        "[tracedecay] corrupt derived branch index preserved at '{}' — rebuilding from a healthy tracked ancestor",
+                        recovery_dir.display()
+                    );
+                    return Box::pin(Self::open_with_options_inner(
+                        project_root,
+                        open_options,
+                        false,
+                    ))
+                    .await;
+                }
+                Err(repair_error) => {
+                    print_corruption_warning(db_path);
+                    return Err(recovery_required_error(
+                        db_path,
+                        format!("{detail}; automatic derived-branch repair failed: {repair_error}"),
+                    ));
+                }
+            }
+        }
+
+        print_corruption_warning(db_path);
+        Err(recovery_required_error(db_path, detail))
     }
 
     /// Opens an existing project for read-only inspection.
@@ -1026,6 +1131,126 @@ fn graph_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
     let mut file_name = db_path.file_name().unwrap_or_default().to_os_string();
     file_name.push(suffix);
     db_path.with_file_name(file_name)
+}
+
+fn preserve_corrupt_branch_store(store_layout: &StoreLayout, db_path: &Path) -> Result<PathBuf> {
+    let db_name = db_path.file_name().ok_or_else(|| TraceDecayError::Config {
+        message: format!(
+            "cannot preserve corrupt branch store with no filename: '{}'",
+            db_path.display()
+        ),
+    })?;
+    let recovery_root = store_layout.data_root.join("recovery");
+    std::fs::create_dir_all(&recovery_root).map_err(|error| TraceDecayError::Config {
+        message: format!(
+            "failed to create branch recovery directory '{}': {error}",
+            recovery_root.display()
+        ),
+    })?;
+    let recovery_dir = recovery_root.join(format!(
+        "{}-{}-{}",
+        db_name.to_string_lossy(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos(),
+        std::process::id()
+    ));
+    std::fs::create_dir(&recovery_dir).map_err(|error| TraceDecayError::Config {
+        message: format!(
+            "failed to create branch recovery set '{}': {error}",
+            recovery_dir.display()
+        ),
+    })?;
+
+    let db_wal = graph_sidecar_path(db_path, "-wal");
+    let db_shm = graph_sidecar_path(db_path, "-shm");
+    let db_dirty = graph_sidecar_path(db_path, ".dirty");
+    let sources = [&db_wal, &db_shm, &db_dirty, db_path];
+    let mut preserved_db = false;
+    let mut preserved = Vec::new();
+    for source in sources {
+        let metadata = match std::fs::symlink_metadata(source) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(TraceDecayError::Config {
+                    message: format!(
+                        "failed to inspect recovery-set member '{}': {error}",
+                        source.display()
+                    ),
+                });
+            }
+        };
+        if !metadata.file_type().is_file() {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "refusing to preserve non-regular recovery-set member '{}'",
+                    source.display()
+                ),
+            });
+        }
+        let target = recovery_dir.join(source.file_name().unwrap_or_default());
+        let copied = std::fs::copy(source, &target).map_err(|error| TraceDecayError::Config {
+            message: format!(
+                "failed to preserve recovery-set member '{}' at '{}': {error}",
+                source.display(),
+                target.display()
+            ),
+        })?;
+        if copied != metadata.len() {
+            return Err(TraceDecayError::Config {
+                message: format!(
+                    "incomplete recovery-set copy for '{}': copied {copied} of {} bytes",
+                    source.display(),
+                    metadata.len()
+                ),
+            });
+        }
+        std::fs::File::open(&target)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| TraceDecayError::Config {
+                message: format!(
+                    "failed to sync preserved recovery-set member '{}': {error}",
+                    target.display()
+                ),
+            })?;
+        preserved_db |= source == db_path;
+        preserved.push(source.to_path_buf());
+    }
+    if !preserved_db {
+        return Err(TraceDecayError::Config {
+            message: format!(
+                "corrupt branch database '{}' disappeared",
+                db_path.display()
+            ),
+        });
+    }
+    #[cfg(unix)]
+    for directory in [&recovery_dir, &recovery_root, &store_layout.data_root] {
+        std::fs::File::open(directory)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| TraceDecayError::Config {
+                message: format!(
+                    "failed to sync preserved recovery-set directory '{}': {error}",
+                    directory.display()
+                ),
+            })?;
+    }
+
+    // Delete the source database last. If any sidecar deletion fails, the
+    // corrupt DB remains in place and the complete copied recovery set is
+    // still available for a later retry or offline salvage.
+    for source in preserved {
+        std::fs::remove_file(&source).map_err(|error| TraceDecayError::Config {
+            message: format!(
+                "preserved recovery set at '{}', but failed to retire '{}': {error}",
+                recovery_dir.display(),
+                source.display()
+            ),
+        })?;
+    }
+    Ok(recovery_dir)
 }
 
 fn active_graph_layout(db_path: &Path) -> super::ActiveGraphLayout {

--- a/tests/automation_runner_test/backend.rs
+++ b/tests/automation_runner_test/backend.rs
@@ -643,6 +643,7 @@ struct FakeCodexAppServer {
     _temp: TempDir,
     bin: PathBuf,
     log: PathBuf,
+    #[cfg(target_os = "linux")]
     pid: PathBuf,
 }
 
@@ -683,6 +684,7 @@ impl FakeCodexAppServer {
             _temp: temp,
             bin,
             log,
+            #[cfg(target_os = "linux")]
             pid,
         }
     }

--- a/tests/storage_suite/branch_db_safety_test.rs
+++ b/tests/storage_suite/branch_db_safety_test.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
+use fs2::FileExt;
 #[cfg(unix)]
 use serde_json::Value;
 
@@ -104,6 +105,124 @@ async fn init_index_uses_graph_specific_sync_lock() {
         err.to_string()
             .contains("another sync is already in progress")
     );
+}
+
+#[tokio::test]
+async fn corrupt_derived_branch_store_is_preserved_and_rebuilt_automatically() {
+    let (_env, project, feature) = open_untracked_project().await;
+    let layout = feature.store_layout().clone();
+    let corrupt_db = feature.db_path().to_path_buf();
+    feature.checkpoint().await.unwrap();
+    feature.close();
+
+    let sessions_bytes = b"sessions-are-separate";
+    fs::write(&layout.sessions_db_path, sessions_bytes).unwrap();
+    let mut corrupted = fs::read(&corrupt_db).unwrap();
+    corrupted[..16].copy_from_slice(b"not-a-sqlite-db!");
+    fs::write(&corrupt_db, &corrupted).unwrap();
+
+    let wal_path = PathBuf::from(format!("{}-wal", corrupt_db.display()));
+    let shm_path = PathBuf::from(format!("{}-shm", corrupt_db.display()));
+    let dirty_path = PathBuf::from(format!("{}.dirty", corrupt_db.display()));
+    let wal_bytes = b"preserve-corrupt-wal";
+    let shm_bytes = b"preserve-corrupt-shm";
+    let dirty_bytes = b"pid=99999\nversion=old";
+    fs::write(&wal_path, wal_bytes).unwrap();
+    fs::write(&shm_path, shm_bytes).unwrap();
+    fs::write(&dirty_path, dirty_bytes).unwrap();
+    fs::write(&layout.dirty_path, dirty_bytes).unwrap();
+
+    let repaired = TraceDecay::open(&project)
+        .await
+        .expect("a corrupt derived branch index should rebuild from its tracked ancestor");
+    assert_eq!(repaired.active_branch(), Some("feature/untracked"));
+    assert_eq!(repaired.serving_branch(), Some("feature/untracked"));
+    assert!(!repaired.is_fallback());
+    assert!(repaired.db().quick_check().await.unwrap());
+    assert!(
+        !repaired
+            .search("untracked_only", 10)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the rebuilt branch index must include branch-only working-tree symbols"
+    );
+    assert_eq!(fs::read(&layout.sessions_db_path).unwrap(), sessions_bytes);
+    assert!(!layout.dirty_path.exists());
+
+    let recovery_root = layout.data_root.join("recovery");
+    let recovery_dirs = fs::read_dir(&recovery_root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    assert_eq!(recovery_dirs.len(), 1);
+    let recovery_dir = &recovery_dirs[0];
+    assert_eq!(
+        fs::read(recovery_dir.join(corrupt_db.file_name().unwrap())).unwrap(),
+        corrupted
+    );
+    assert_eq!(
+        fs::read(recovery_dir.join(wal_path.file_name().unwrap())).unwrap(),
+        wal_bytes
+    );
+    assert_eq!(
+        fs::read(recovery_dir.join(shm_path.file_name().unwrap())).unwrap(),
+        shm_bytes
+    );
+    assert_eq!(
+        fs::read(recovery_dir.join(dirty_path.file_name().unwrap())).unwrap(),
+        dirty_bytes
+    );
+    assert!(corrupt_db.exists());
+    assert_ne!(fs::read(&corrupt_db).unwrap(), corrupted);
+    assert!(!dirty_path.exists());
+    repaired.close();
+}
+
+#[tokio::test]
+async fn corrupt_derived_branch_repair_waits_for_the_active_sync_lease() {
+    let (_env, project, feature) = open_untracked_project().await;
+    let corrupt_db = feature.db_path().to_path_buf();
+    let recovery_root = feature.store_layout().data_root.join("recovery");
+    feature.checkpoint().await.unwrap();
+    feature.close();
+
+    let mut corrupted = fs::read(&corrupt_db).unwrap();
+    corrupted[..16].copy_from_slice(b"not-a-sqlite-db!");
+    fs::write(&corrupt_db, &corrupted).unwrap();
+    let lock_path = corrupt_db.with_file_name(format!(
+        "{}.sync.lock",
+        corrupt_db.file_name().unwrap().to_string_lossy()
+    ));
+    let active_lock = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    active_lock.try_lock_exclusive().unwrap();
+
+    let error = match TraceDecay::open(&project).await {
+        Ok(_) => panic!("active writer lease must block branch recovery"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("another sync is already in progress")
+    );
+    assert_eq!(fs::read(&corrupt_db).unwrap(), corrupted);
+    assert!(!recovery_root.exists());
+
+    drop(active_lock);
+    let repaired = TraceDecay::open(&project)
+        .await
+        .expect("repair should proceed after the active lease is released");
+    assert!(repaired.db().quick_check().await.unwrap());
+    assert_ne!(fs::read(&corrupt_db).unwrap(), corrupted);
+    repaired.close();
 }
 
 #[tokio::test]

--- a/tests/storage_suite/multi_connection_test/harness.rs
+++ b/tests/storage_suite/multi_connection_test/harness.rs
@@ -250,6 +250,7 @@ impl McpProxy {
         proxy
     }
 
+    #[cfg(target_os = "linux")]
     pub(super) fn pid(&self) -> u32 {
         self.child.id()
     }


### PR DESCRIPTION
## Summary

- preserve a corrupt active derived-branch DB/WAL/SHM/dirty set under `recovery/`, then rebuild that branch index from a healthy tracked ancestor
- keep default, fallback, detached, and non-branch stores fail-closed, with corrected branch-specific doctor recovery paths
- re-resolve daemon authority and rotated auth credentials on every restart-window reconnect attempt
- scope Linux-only test helpers/imports so the repository's cross-platform clippy gate stays clean

## Root cause

Derived branch indexes were treated like the default graph store after corruption, so a recoverable branch cache entered a repeated manual-recovery loop. Separately, long-lived MCP proxies resolved daemon credentials before waiting for a restarted socket; after token rotation they connected to the new daemon with stale authentication.

## Safety

- only the exact active, non-default DB inside the project `branches/` directory is eligible for automatic repair
- graph and legacy sync leases plus database authority prevent repair from racing another writer
- every recovery member is copied, length-verified, fsynced, and its directory chain synced before sources are retired; the source DB is removed last
- repair recurses only once, while default stores continue to preserve evidence and fail closed

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- TraceDecay package diagnostics: 0 errors, 0 warnings
- 91 graph-selected affected tests
- 8 corruption-focused storage tests
- 2 daemon restart/auth tests and 2 reconnect-boundary tests
- 40 automation backend tests
- 12-client sole-daemon SQLite ownership test
- live Safivo recovery on `feat/SAF-15-lambda-durable-function`: exact branch resolution, `quick_check_ok: true`, no dirty marker, and byte-identical preserved recovery evidence
