### PR TITLE
fix(grep): bound filesystem scans

### DIFF
--- a/src/mcp/tools/handlers/ast_grep_search.rs
+++ b/src/mcp/tools/handlers/ast_grep_search.rs
@@ -18,20 +18,12 @@ use crate::tracedecay::TraceDecay;
 
 use super::super::ToolResult;
 use super::super::render::{self, Md};
-use super::support::unique_file_paths;
+use super::support::{CancelSearchOnDrop, unique_file_paths};
 
 /// Hard cap on `max_results` regardless of what the caller requests.
 const MAX_RESULTS_CAP: usize = 200;
 /// Default `max_results` when the caller omits it.
 const DEFAULT_MAX_RESULTS: usize = 50;
-
-struct CancelSearchOnDrop(Arc<AtomicBool>);
-
-impl Drop for CancelSearchOnDrop {
-    fn drop(&mut self) {
-        self.0.store(true, Ordering::Release);
-    }
-}
 
 async fn search_tree_off_thread(
     project_root: std::path::PathBuf,
@@ -43,7 +35,7 @@ async fn search_tree_off_thread(
 ) -> Result<crate::ast_grep_search::AstGrepSearchResult> {
     let query = pattern.clone();
     let cancelled = Arc::new(AtomicBool::new(false));
-    let cancel_on_drop = CancelSearchOnDrop(cancelled.clone());
+    let cancel_on_drop = CancelSearchOnDrop::new(cancelled.clone());
     let result = tokio::task::spawn_blocking(move || {
         search_tree_scoped_with_cancel(
             &project_root,
@@ -224,7 +216,7 @@ mod tests {
     fn cancellation_guard_signals_worker_on_drop() {
         let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         {
-            let _guard = CancelSearchOnDrop(cancelled.clone());
+            let _guard = CancelSearchOnDrop::new(cancelled.clone());
         }
         assert!(cancelled.load(std::sync::atomic::Ordering::Acquire));
     }

--- a/src/mcp/tools/handlers/grep.rs
+++ b/src/mcp/tools/handlers/grep.rs
@@ -7,7 +7,7 @@
 //! matches symbol *names*, not file *content*.
 
 use std::fmt::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -82,7 +82,10 @@ pub(super) async fn handle_grep(
         .get("case_sensitive")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let path_glob = args.get("path_glob").and_then(Value::as_str);
+    let path_glob = args
+        .get("path_glob")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
     let max_results = args
         .get("max_results")
         .and_then(Value::as_u64)
@@ -100,7 +103,7 @@ pub(super) async fn handle_grep(
     // Optional path filter. A caller-supplied glob whitelists candidate files
     // via the `ignore` crate's override mechanism (same glob semantics as a
     // `.gitignore` line), so it prunes at the walker level.
-    let overrides = match path_glob {
+    let overrides = match path_glob.as_deref() {
         Some(raw) if !raw.trim().is_empty() => {
             let mut builder = OverrideBuilder::new(&project_root);
             builder.add(raw).map_err(|err| TraceDecayError::Config {
@@ -114,8 +117,15 @@ pub(super) async fn handle_grep(
     };
 
     // Collect one extra past the cap so we can honestly report truncation.
-    let scan =
-        scan_tree_off_thread(project_root, matcher, overrides, context_lines, max_results).await?;
+    let scan = scan_tree_off_thread(
+        project_root,
+        matcher,
+        overrides,
+        path_glob,
+        context_lines,
+        max_results,
+    )
+    .await?;
 
     // Scope filtering mirrors `tracedecay_search`: when the client pins a
     // subtree, only hits under it are returned.
@@ -161,9 +171,10 @@ fn build_matcher(pattern: &str, fixed_strings: bool, case_sensitive: bool) -> Re
 }
 
 async fn scan_tree_off_thread(
-    project_root: std::path::PathBuf,
+    project_root: PathBuf,
     matcher: Regex,
     overrides: Option<Override>,
+    path_glob: Option<String>,
     context_lines: usize,
     max_results: usize,
 ) -> Result<ScanResult> {
@@ -188,6 +199,7 @@ async fn scan_tree_off_thread(
                 &project_root,
                 &matcher,
                 overrides,
+                path_glob.as_deref(),
                 context_lines,
                 max_results,
                 || worker_cancelled.load(Ordering::Acquire),
@@ -222,6 +234,63 @@ struct ScanResult {
     truncated: bool,
 }
 
+struct GeneratedDirScope {
+    literal_prefix: PathBuf,
+    may_match_descendants: bool,
+}
+
+impl GeneratedDirScope {
+    fn from_path_glob(path_glob: &str) -> Option<Self> {
+        let path_glob = path_glob.trim();
+        if path_glob.is_empty() || path_glob.starts_with('!') {
+            return None;
+        }
+        let segments: Vec<&str> = path_glob
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect();
+        let wildcard_start = segments
+            .iter()
+            .position(|segment| {
+                segment.contains('*')
+                    || segment.contains('?')
+                    || segment.contains('[')
+                    || segment.contains('{')
+            })
+            .unwrap_or(segments.len());
+        let literal_prefix =
+            segments[..wildcard_start]
+                .iter()
+                .fold(PathBuf::new(), |mut prefix, segment| {
+                    prefix.push(segment);
+                    prefix
+                });
+        let wildcard_suffix = &segments[wildcard_start..];
+        let may_match_descendants = wildcard_suffix
+            .iter()
+            .enumerate()
+            .any(|(index, segment)| index > 0 || *segment == "**");
+
+        Some(Self {
+            literal_prefix,
+            may_match_descendants,
+        })
+    }
+
+    fn allows(&self, project_root: &Path, path: &Path) -> bool {
+        let Ok(relative) = path.strip_prefix(project_root) else {
+            return false;
+        };
+        if self.literal_prefix.as_os_str().is_empty() {
+            return self.may_match_descendants;
+        }
+        self.literal_prefix.starts_with(relative)
+            || relative == self.literal_prefix
+            || (self.may_match_descendants && relative.starts_with(&self.literal_prefix))
+    }
+}
+
 /// Walks the working tree respecting `.gitignore`, skipping binary files, and
 /// collects matching lines. Stops early once `max_results` + 1 hits are found
 /// so the caller can report truncation without scanning the whole tree.
@@ -229,6 +298,7 @@ fn scan_tree<F>(
     project_root: &Path,
     matcher: &Regex,
     overrides: Option<Override>,
+    path_glob: Option<&str>,
     context_lines: usize,
     max_results: usize,
     is_cancelled: F,
@@ -236,9 +306,12 @@ fn scan_tree<F>(
 where
     F: Fn() -> bool,
 {
-    let allow_generated_dirs = overrides
+    let has_positive_override = overrides
         .as_ref()
         .is_some_and(|overrides| overrides.num_whitelists() > 0);
+    let generated_dir_overrides = overrides.clone();
+    let generated_dir_scope = path_glob.and_then(GeneratedDirScope::from_path_glob);
+    let filter_root = project_root.to_path_buf();
     let mut builder = WalkBuilder::new(project_root);
     builder
         .follow_links(false)
@@ -255,8 +328,15 @@ where
             if segment == ".git" || segment == ".tracedecay" {
                 return false;
             }
+            let requested_generated_dir = has_positive_override
+                && (generated_dir_overrides
+                    .as_ref()
+                    .is_some_and(|overrides| overrides.matched(entry.path(), true).is_whitelist())
+                    || generated_dir_scope
+                        .as_ref()
+                        .is_some_and(|scope| scope.allows(&filter_root, entry.path())));
             !entry.file_type().is_some_and(|kind| kind.is_dir())
-                || allow_generated_dirs
+                || requested_generated_dir
                 || !crate::config::is_generated_dir_segment(&segment)
         });
     if let Some(overrides) = overrides {
@@ -490,7 +570,7 @@ mod tests {
         .expect("metadata fixture");
 
         let matcher = Regex::new("UNIQUE_GENERATED_DIR_TOKEN").expect("matcher");
-        let scan = scan_tree(project.path(), &matcher, None, 0, 10, || false);
+        let scan = scan_tree(project.path(), &matcher, None, None, 0, 10, || false);
         let files = scan
             .hits
             .iter()
@@ -513,6 +593,66 @@ mod tests {
     }
 
     #[test]
+    fn scan_tree_path_glob_prunes_unrelated_generated_directories() {
+        let project = tempfile::tempdir().expect("temp project");
+        std::fs::create_dir_all(project.path().join("src")).expect("source fixture directory");
+        std::fs::write(
+            project.path().join("src/selected.rs"),
+            "NORMAL_PATH_GLOB_TOKEN\n",
+        )
+        .expect("source fixture");
+
+        let overrides = |root: &Path| {
+            let mut builder = OverrideBuilder::new(root);
+            builder.add("src/**").expect("path glob");
+            builder.build().expect("overrides")
+        };
+        let matcher = Regex::new("NORMAL_PATH_GLOB_TOKEN").expect("matcher");
+        let baseline_checks = std::sync::atomic::AtomicUsize::new(0);
+        let baseline = scan_tree(
+            project.path(),
+            &matcher,
+            Some(overrides(project.path())),
+            Some("src/**"),
+            0,
+            10,
+            || {
+                baseline_checks.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                false
+            },
+        );
+
+        std::fs::create_dir_all(project.path().join("target/generated"))
+            .expect("generated fixture directory");
+        std::fs::write(
+            project.path().join("target/generated/unrelated.rs"),
+            "NORMAL_PATH_GLOB_TOKEN\n",
+        )
+        .expect("generated fixture");
+
+        let checks = std::sync::atomic::AtomicUsize::new(0);
+        let scan = scan_tree(
+            project.path(),
+            &matcher,
+            Some(overrides(project.path())),
+            Some("src/**"),
+            0,
+            10,
+            || {
+                checks.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                false
+            },
+        );
+
+        assert_eq!(scan.hits.len(), baseline.hits.len());
+        assert_eq!(
+            checks.load(std::sync::atomic::Ordering::Relaxed),
+            baseline_checks.load(std::sync::atomic::Ordering::Relaxed),
+            "unrelated generated directories must not reach the scan loop"
+        );
+    }
+
+    #[test]
     fn scan_tree_stops_when_cancelled_during_line_matching() {
         let project = tempfile::tempdir().expect("temp project");
         let source = "CANCELLATION_TOKEN\n".repeat(100);
@@ -520,7 +660,7 @@ mod tests {
 
         let matcher = Regex::new("CANCELLATION_TOKEN").expect("matcher");
         let checks = std::sync::atomic::AtomicUsize::new(0);
-        let scan = scan_tree(project.path(), &matcher, None, 0, 200, || {
+        let scan = scan_tree(project.path(), &matcher, None, None, 0, 200, || {
             checks.fetch_add(1, Ordering::Relaxed) >= 10
         });
 
@@ -542,7 +682,7 @@ mod tests {
             .expect("source fixture");
 
         let matcher = Regex::new("OVERSIZED_FILE_TOKEN").expect("matcher");
-        let scan = scan_tree(project.path(), &matcher, None, 0, 10, || false);
+        let scan = scan_tree(project.path(), &matcher, None, None, 0, 10, || false);
         let files = scan
             .hits
             .iter()

--- a/src/mcp/tools/handlers/grep.rs
+++ b/src/mcp/tools/handlers/grep.rs
@@ -8,18 +8,22 @@
 
 use std::fmt::Write as _;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use ignore::WalkBuilder;
 use ignore::overrides::{Override, OverrideBuilder};
 use regex::{Regex, RegexBuilder};
 use serde_json::{Value, json};
+use tokio::sync::Semaphore;
 
 use crate::errors::{Result, TraceDecayError};
 use crate::tracedecay::TraceDecay;
 
 use super::super::ToolResult;
 use super::super::render::{self, Md};
-use super::support::{filter_by_scope, unique_file_paths};
+use super::support::{CancelSearchOnDrop, filter_by_scope, unique_file_paths};
 
 /// Hard cap on `max_results` regardless of what the caller requests.
 const MAX_RESULTS_CAP: usize = 200;
@@ -33,6 +37,12 @@ const MAX_HITS_PER_FILE: usize = 20;
 const BINARY_SNIFF_BYTES: usize = 8_192;
 /// Skip individual lines longer than this (minified bundles, embedded blobs).
 const MAX_LINE_BYTES: usize = 4_096;
+/// Skip files too large for a bounded interactive content search.
+const MAX_FILE_BYTES: u64 = 2_000_000;
+/// Bound each grep request, including time spent waiting for a worker permit.
+const GREP_SCAN_TIMEOUT: Duration = Duration::from_secs(10);
+/// Keep concurrent blocking scans from monopolizing the daemon's worker pool.
+static GREP_SCAN_SEMAPHORE: Semaphore = Semaphore::const_new(2);
 
 /// A single content-search hit, enriched with the enclosing graph symbol.
 struct GrepHit {
@@ -104,13 +114,8 @@ pub(super) async fn handle_grep(
     };
 
     // Collect one extra past the cap so we can honestly report truncation.
-    let scan = scan_tree(
-        &project_root,
-        &matcher,
-        overrides,
-        context_lines,
-        max_results,
-    );
+    let scan =
+        scan_tree_off_thread(project_root, matcher, overrides, context_lines, max_results).await?;
 
     // Scope filtering mirrors `tracedecay_search`: when the client pins a
     // subtree, only hits under it are returned.
@@ -155,6 +160,62 @@ fn build_matcher(pattern: &str, fixed_strings: bool, case_sensitive: bool) -> Re
         })
 }
 
+async fn scan_tree_off_thread(
+    project_root: std::path::PathBuf,
+    matcher: Regex,
+    overrides: Option<Override>,
+    context_lines: usize,
+    max_results: usize,
+) -> Result<ScanResult> {
+    let query = matcher.as_str().to_string();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancel_on_drop = CancelSearchOnDrop::new(cancelled.clone());
+    let worker_cancelled = cancelled.clone();
+    let worker_query = query.clone();
+
+    let result = tokio::time::timeout(GREP_SCAN_TIMEOUT, async move {
+        let permit =
+            GREP_SCAN_SEMAPHORE
+                .acquire()
+                .await
+                .map_err(|err| TraceDecayError::Search {
+                    message: format!("grep scan concurrency gate closed: {err}"),
+                    query: worker_query.clone(),
+                })?;
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            scan_tree(
+                &project_root,
+                &matcher,
+                overrides,
+                context_lines,
+                max_results,
+                || worker_cancelled.load(Ordering::Acquire),
+            )
+        })
+        .await
+        .map_err(|err| TraceDecayError::Search {
+            message: format!("grep scan worker failed: {err}"),
+            query: worker_query,
+        })
+    })
+    .await;
+
+    match result {
+        Ok(scan) => {
+            drop(cancel_on_drop);
+            scan
+        }
+        Err(_) => Err(TraceDecayError::Search {
+            message: format!(
+                "grep scan timed out after {} seconds; narrow the search with path_glob",
+                GREP_SCAN_TIMEOUT.as_secs()
+            ),
+            query,
+        }),
+    }
+}
+
 struct ScanResult {
     hits: Vec<GrepHit>,
     files_scanned: usize,
@@ -164,13 +225,17 @@ struct ScanResult {
 /// Walks the working tree respecting `.gitignore`, skipping binary files, and
 /// collects matching lines. Stops early once `max_results` + 1 hits are found
 /// so the caller can report truncation without scanning the whole tree.
-fn scan_tree(
+fn scan_tree<F>(
     project_root: &Path,
     matcher: &Regex,
     overrides: Option<Override>,
     context_lines: usize,
     max_results: usize,
-) -> ScanResult {
+    is_cancelled: F,
+) -> ScanResult
+where
+    F: Fn() -> bool,
+{
     let mut builder = WalkBuilder::new(project_root);
     builder
         .follow_links(false)
@@ -178,7 +243,18 @@ fn scan_tree(
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true)
-        .add_custom_ignore_filename(".gitignore");
+        .add_custom_ignore_filename(".gitignore")
+        .filter_entry(|entry| {
+            if entry.depth() == 0 {
+                return true;
+            }
+            let segment = entry.file_name().to_string_lossy();
+            if segment == ".git" || segment == ".tracedecay" {
+                return false;
+            }
+            !entry.file_type().is_some_and(|kind| kind.is_dir())
+                || !crate::config::is_generated_dir_segment(&segment)
+        });
     if let Some(overrides) = overrides {
         builder.overrides(overrides);
     }
@@ -189,6 +265,9 @@ fn scan_tree(
     let mut truncated = false;
 
     for entry in walker {
+        if is_cancelled() {
+            break;
+        }
         let Ok(entry) = entry else { continue };
         let Some(ft) = entry.file_type() else {
             continue;
@@ -202,6 +281,18 @@ fn scan_tree(
         };
         let rel_str = rel.to_string_lossy().replace('\\', "/");
 
+        if is_cancelled() {
+            break;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.len() > MAX_FILE_BYTES {
+            continue;
+        }
+        if is_cancelled() {
+            break;
+        }
         let Ok(bytes) = std::fs::read(path) else {
             continue;
         };
@@ -216,6 +307,13 @@ fn scan_tree(
         let lines: Vec<&str> = content.lines().collect();
         let mut file_hits = 0usize;
         for (idx, line) in lines.iter().enumerate() {
+            if is_cancelled() {
+                return ScanResult {
+                    hits,
+                    files_scanned,
+                    truncated,
+                };
+            }
             if line.len() > MAX_LINE_BYTES {
                 continue;
             }
@@ -352,4 +450,102 @@ fn render_grep_md(hits: &[GrepHit], truncated: bool, files_scanned: usize) -> St
     }
     md.line(&summary);
     md.render()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_tree_prunes_generated_dependency_directories_without_gitignore() {
+        let project = tempfile::tempdir().expect("temp project");
+        let generated = project.path().join(".venv/lib/python/site-packages/pkg");
+        std::fs::create_dir_all(&generated).expect("generated fixture directory");
+        std::fs::create_dir_all(project.path().join("src")).expect("source fixture directory");
+        std::fs::create_dir_all(project.path().join(".tracedecay"))
+            .expect("metadata fixture directory");
+        std::fs::write(
+            generated.join("generated.py"),
+            "UNIQUE_GENERATED_DIR_TOKEN\n",
+        )
+        .expect("generated fixture");
+        std::fs::write(
+            project.path().join("src/tracked.rs"),
+            "// UNIQUE_GENERATED_DIR_TOKEN\n",
+        )
+        .expect("source fixture");
+        std::fs::write(
+            project.path().join(".git"),
+            "gitdir: UNIQUE_GENERATED_DIR_TOKEN\n",
+        )
+        .expect("linked-worktree git file fixture");
+        std::fs::write(
+            project.path().join(".tracedecay/internal.txt"),
+            "UNIQUE_GENERATED_DIR_TOKEN\n",
+        )
+        .expect("metadata fixture");
+
+        let matcher = Regex::new("UNIQUE_GENERATED_DIR_TOKEN").expect("matcher");
+        let scan = scan_tree(project.path(), &matcher, None, 0, 10, || false);
+        let files = scan
+            .hits
+            .iter()
+            .map(|hit| hit.file.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(files.contains(&"src/tracked.rs"), "{files:?}");
+        assert!(
+            !files.iter().any(|file| file.starts_with(".venv/")),
+            "generated dependency trees must be pruned: {files:?}"
+        );
+        assert!(
+            !files.contains(&".git"),
+            "git metadata must be pruned: {files:?}"
+        );
+        assert!(
+            !files.iter().any(|file| file.starts_with(".tracedecay/")),
+            "TraceDecay metadata must be pruned: {files:?}"
+        );
+    }
+
+    #[test]
+    fn scan_tree_stops_when_cancelled_during_line_matching() {
+        let project = tempfile::tempdir().expect("temp project");
+        let source = "CANCELLATION_TOKEN\n".repeat(100);
+        std::fs::write(project.path().join("fixture.txt"), source).expect("fixture");
+
+        let matcher = Regex::new("CANCELLATION_TOKEN").expect("matcher");
+        let checks = std::sync::atomic::AtomicUsize::new(0);
+        let scan = scan_tree(project.path(), &matcher, None, 0, 200, || {
+            checks.fetch_add(1, Ordering::Relaxed) >= 10
+        });
+
+        assert!(
+            scan.hits.len() < MAX_HITS_PER_FILE,
+            "cancelled scan should stop before the per-file cap: {}",
+            scan.hits.len()
+        );
+        assert!(checks.load(Ordering::Relaxed) > 10);
+    }
+
+    #[test]
+    fn scan_tree_skips_files_larger_than_two_megabytes() {
+        let project = tempfile::tempdir().expect("temp project");
+        let mut oversized = b"OVERSIZED_FILE_TOKEN\n".to_vec();
+        oversized.resize((MAX_FILE_BYTES as usize) + 1, b'x');
+        std::fs::write(project.path().join("oversized.txt"), oversized).expect("oversized fixture");
+        std::fs::write(project.path().join("tracked.txt"), "OVERSIZED_FILE_TOKEN\n")
+            .expect("source fixture");
+
+        let matcher = Regex::new("OVERSIZED_FILE_TOKEN").expect("matcher");
+        let scan = scan_tree(project.path(), &matcher, None, 0, 10, || false);
+        let files = scan
+            .hits
+            .iter()
+            .map(|hit| hit.file.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(files.contains(&"tracked.txt"), "{files:?}");
+        assert!(!files.contains(&"oversized.txt"), "{files:?}");
+    }
 }

--- a/src/mcp/tools/handlers/grep.rs
+++ b/src/mcp/tools/handlers/grep.rs
@@ -236,6 +236,9 @@ fn scan_tree<F>(
 where
     F: Fn() -> bool,
 {
+    let allow_generated_dirs = overrides
+        .as_ref()
+        .is_some_and(|overrides| overrides.num_whitelists() > 0);
     let mut builder = WalkBuilder::new(project_root);
     builder
         .follow_links(false)
@@ -244,7 +247,7 @@ where
         .git_global(true)
         .git_exclude(true)
         .add_custom_ignore_filename(".gitignore")
-        .filter_entry(|entry| {
+        .filter_entry(move |entry| {
             if entry.depth() == 0 {
                 return true;
             }
@@ -253,6 +256,7 @@ where
                 return false;
             }
             !entry.file_type().is_some_and(|kind| kind.is_dir())
+                || allow_generated_dirs
                 || !crate::config::is_generated_dir_segment(&segment)
         });
     if let Some(overrides) = overrides {

--- a/src/mcp/tools/handlers/support.rs
+++ b/src/mcp/tools/handlers/support.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::{Value, json};
 
@@ -12,6 +14,20 @@ use super::super::ToolResult;
 use super::super::render;
 use crate::errors::{Result, TraceDecayError};
 use crate::global_db::{CodeProjectRecord, GlobalDb, ProjectRegistryContext};
+
+pub(super) struct CancelSearchOnDrop(Arc<AtomicBool>);
+
+impl CancelSearchOnDrop {
+    pub(super) fn new(cancelled: Arc<AtomicBool>) -> Self {
+        Self(cancelled)
+    }
+}
+
+impl Drop for CancelSearchOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
 
 /// Trimmed, non-empty string argument by key, or `None` when absent, non-string,
 /// or blank after trimming.

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -2049,6 +2049,42 @@ async fn test_grep_prunes_generated_dependency_directories_without_gitignore() {
 }
 
 #[tokio::test]
+async fn test_grep_path_glob_includes_explicit_generated_directory() {
+    let (cg, _dir) = setup_project().await;
+    let root = cg.project_root().to_path_buf();
+    fs::create_dir_all(root.join("dist")).unwrap();
+    fs::write(
+        root.join("dist/generated.js"),
+        "UNIQUE_GENERATED_WHITELIST_TOKEN\n",
+    )
+    .unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_grep",
+        json!({
+            "pattern": "UNIQUE_GENERATED_WHITELIST_TOKEN",
+            "path_glob": "dist/**"
+        }),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload = extract_json(&result.value);
+    let files: Vec<&str> = payload["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hit| hit["file"].as_str().unwrap())
+        .collect();
+    assert!(
+        files.contains(&"dist/generated.js"),
+        "explicit path_glob should include generated directory: {payload}"
+    );
+}
+
+#[tokio::test]
 async fn test_grep_skips_binary_files() {
     let (cg, _dir) = setup_project().await;
     let root = cg.project_root().to_path_buf();

--- a/tests/mcp_suite/mcp_handler_test.rs
+++ b/tests/mcp_suite/mcp_handler_test.rs
@@ -2007,6 +2007,48 @@ async fn test_grep_respects_gitignore() {
 }
 
 #[tokio::test]
+async fn test_grep_prunes_generated_dependency_directories_without_gitignore() {
+    let (cg, _dir) = setup_project().await;
+    let root = cg.project_root().to_path_buf();
+    fs::create_dir_all(root.join(".venv/lib/python/site-packages/pkg")).unwrap();
+    fs::write(
+        root.join(".venv/lib/python/site-packages/pkg/generated.py"),
+        "UNIQUE_GENERATED_DIR_TOKEN\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/tracked.rs"),
+        "// UNIQUE_GENERATED_DIR_TOKEN\n",
+    )
+    .unwrap();
+
+    let result = handle_tool_call(
+        &cg,
+        "tracedecay_grep",
+        json!({"pattern": "UNIQUE_GENERATED_DIR_TOKEN"}),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let payload = extract_json(&result.value);
+    let files: Vec<&str> = payload["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|hit| hit["file"].as_str().unwrap())
+        .collect();
+    assert!(
+        files.contains(&"src/tracked.rs"),
+        "source file should match: {payload}"
+    );
+    assert!(
+        !files.iter().any(|file| file.starts_with(".venv/")),
+        "generated dependency trees must be pruned even without .gitignore coverage: {payload}"
+    );
+}
+
+#[tokio::test]
 async fn test_grep_skips_binary_files() {
     let (cg, _dir) = setup_project().await;
     let root = cg.project_root().to_path_buf();


### PR DESCRIPTION
## Summary

- run `tracedecay_grep` filesystem traversal and reads off the async runtime
- bound concurrent grep scans to two and time each request out after 10 seconds
- cooperatively cancel timed-out or abandoned blocking workers
- prune generated dependency trees and TraceDecay/Git metadata
- skip files larger than 2 MB before reading them

## Root cause

`tracedecay_grep` performed a synchronous `WalkBuilder` traversal and
`std::fs::read` directly inside its async MCP handler. On repositories whose
ignore files did not cover generated dependency trees, the walker could enter
large directories such as virtual environments. When a client timed out or
disconnected, the daemon-side scan continued, and concurrent requests could
repeat the same work. The CLI fallback used the same daemon and scanner, so it
could stall behind the original request.

## Behavior

- at most two grep scans run concurrently
- the 10-second timeout includes time waiting for a scan permit
- timeout or caller cancellation signals the blocking worker, which checks
  cancellation during traversal, before file reads, and while matching lines
- timeout errors suggest narrowing the request with `path_glob`
- the shared generated-directory classifier prunes dependency/build output
- `.git` and `.tracedecay` are always excluded, including linked-worktree
  `.git` files
- files larger than 2,000,000 bytes are skipped using metadata before
  `std::fs::read`

This is intentionally separate from #481. It does not change worktree identity
resolution, daemon lifecycle, project routing, or store migration.

## Validation

- TDD regression before the fix: generated `.venv` match reproduced
- grep handler unit regressions: 3 passed
- shared AST cancellation/off-thread regressions: 2 passed
- MCP generated-directory integration regression: 1 passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- conventional commit validation: passed
- independent exact-tip audit of
  `2b48fb4b94e3bed156c307275ce428351e45f6c8`: PASS, no findings

The target worktree was not registered in the local TraceDecay project index,
so semantic impact lookup was unavailable without initializing another store.
Validation stayed bounded to the exact diff and focused compiled regressions.
