### PR TITLE
chore: release v0.0.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(cargo)* isolate nested worktrees without dropping packaged dashboard assets
 - *(grep)* scope generated path glob traversal
 - *(grep)* honor generated directory path globs
 - *(grep)* bound filesystem scans
+- *(sessions)* preserve and retry uncertain worktree membership
+- *(sessions)* defer uncertain session routing
+- *(storage)* bound legacy worktree probing
+- *(worktrees)* avoid blocking Git discovery
+
+### Performance
+
+- *(sessions)* cache worktree metadata resolution
 
 ## [0.0.67](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.66...v0.0.67) - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.68](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.67...v0.0.68) - 2026-08-03
+
+### Fixed
+
+- *(grep)* scope generated path glob traversal
+- *(grep)* honor generated directory path globs
+- *(grep)* bound filesystem scans
+
 ## [0.0.67](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.66...v0.0.67) - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.67"
+version = "0.0.68"
 dependencies = [
  "amari-holographic",
  "ast-grep-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracedecay"
-version = "0.0.67"
+version = "0.0.68"
 edition = "2024"
 description = "Code intelligence tool that builds a semantic knowledge graph from Rust, Go, Java, Scala, TypeScript, Python, C, C++, Kotlin, C#, Swift, and many more codebases"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `tracedecay`: 0.0.67 -> 0.0.68

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.68](https://github.com/ScriptedAlchemy/tracedecay/compare/v0.0.67...v0.0.68) - 2026-08-03

### Fixed

- *(grep)* scope generated path glob traversal
- *(grep)* honor generated directory path globs
- *(grep)* bound filesystem scans
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).