### PR TITLE
fix: harden session routing and nested worktrees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ homepage = "https://github.com/ScriptedAlchemy/tracedecay"
 readme = "README.md"
 keywords = ["code-intelligence", "knowledge-graph", "mcp", "tree-sitter", "claude"]
 categories = ["development-tools", "command-line-utilities"]
+
+[workspace]
+exclude = [".worktrees", ".codex-worktrees"]
+
 # Explicit whitelist so `cargo package`/`cargo publish` ship everything the
 # build needs — including the PREBUILT dashboard dist bundles, which are
 # gitignored (an `exclude`-style package can never pick them up). Run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ readme = "README.md"
 keywords = ["code-intelligence", "knowledge-graph", "mcp", "tree-sitter", "claude"]
 categories = ["development-tools", "command-line-utilities"]
 
-[workspace]
-exclude = [".worktrees", ".codex-worktrees"]
-
 # Explicit whitelist so `cargo package`/`cargo publish` ship everything the
 # build needs — including the PREBUILT dashboard dist bundles, which are
 # gitignored (an `exclude`-style package can never pick them up). Run
@@ -43,6 +40,9 @@ include = [
     "/dashboard/hermes-wrapper/plugin_api.py",
     "/dashboard/hermes-wrapper/src/**",
 ]
+
+[workspace]
+exclude = [".worktrees", ".codex-worktrees"]
 
 [features]
 default = ["full", "token-counting"]

--- a/src/git.rs
+++ b/src/git.rs
@@ -171,6 +171,9 @@ pub(crate) fn git_capture_at(repo_root: &Path, args: &[&str]) -> GitCaptureAtRes
 
 fn git_command_at(repo_root: &Path, args: &[&str]) -> Command {
     let mut command = Command::new(git_program());
+    command.env_remove("GIT_DIR");
+    command.env_remove("GIT_WORK_TREE");
+    command.env_remove("GIT_COMMON_DIR");
     command.arg("-C").arg(repo_root).args(args);
     command
 }
@@ -264,6 +267,22 @@ mod tests {
                 OsString::from("--git-common-dir"),
             ]
         );
+    }
+
+    #[test]
+    fn git_at_command_clears_repository_selection_overrides() {
+        let command = git_command_at(Path::new("/problematic/project/root"), &["status"]);
+
+        for key in ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"] {
+            assert_eq!(
+                command
+                    .get_envs()
+                    .find(|(candidate, _)| *candidate == OsStr::new(key))
+                    .map(|(_, value)| value),
+                Some(None),
+                "git -C must resolve the supplied root rather than inherited {key}"
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/src/sessions/claude.rs
+++ b/src/sessions/claude.rs
@@ -1379,7 +1379,7 @@ mod tests {
             .ancestors()
             .find(|ancestor| ancestor.file_name().is_some_and(|name| name == "repo"))
             .unwrap_or(path);
-        if UNKNOWN_PATH_ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 0 {
+        if UNKNOWN_PATH_ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 1 {
             return crate::worktree::GitRepoIdentityOutcome::Unknown;
         }
         crate::worktree::GitRepoIdentityOutcome::Resolved(crate::worktree::GitRepoIdentity {

--- a/src/sessions/cline_like.rs
+++ b/src/sessions/cline_like.rs
@@ -329,7 +329,7 @@ fn metadata_project_location(
             }
             ProjectMembership::NoMatch => {}
             ProjectMembership::Unknown => return None,
-        };
+        }
     }
     matched
 }

--- a/src/sessions/cline_like.rs
+++ b/src/sessions/cline_like.rs
@@ -22,9 +22,9 @@ use serde_json::{Map, Value};
 
 use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
-    StoredCursor, TranscriptLocation, TranscriptLocationMetadataKeys, append_location_metadata,
-    append_tool_calls_metadata, append_usage_metadata, content_storage_text_and_tools,
-    path_belongs_to_project, title_from_messages,
+    ProjectMembership, ProjectRootMatcherCache, StoredCursor, TranscriptLocation,
+    TranscriptLocationMetadataKeys, append_location_metadata, append_tool_calls_metadata,
+    append_usage_metadata, content_storage_text_and_tools, title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, read_changed_with_companion,
@@ -46,6 +46,7 @@ pub struct ClineLikeSource {
     provider: &'static str,
     storage_roots: Vec<PathBuf>,
     user_registered_roots: Option<Vec<PathBuf>>,
+    project_matchers: ProjectRootMatcherCache,
 }
 
 impl ClineLikeSource {
@@ -78,6 +79,7 @@ impl ClineLikeSource {
                     .join("User/globalStorage/saoudrizwan.claude-dev/tasks"),
             ],
             user_registered_roots: None,
+            project_matchers: ProjectRootMatcherCache::default(),
         }
     }
 
@@ -89,6 +91,7 @@ impl ClineLikeSource {
                     .join("User/globalStorage/rooveterinaryinc.roo-cline/tasks"),
             ],
             user_registered_roots: None,
+            project_matchers: ProjectRootMatcherCache::default(),
         }
     }
 
@@ -101,6 +104,7 @@ impl ClineLikeSource {
                 home.join(".kilocode/cli/global/tasks"),
             ],
             user_registered_roots: None,
+            project_matchers: ProjectRootMatcherCache::default(),
         }
     }
 
@@ -137,15 +141,15 @@ impl TranscriptSource for ClineLikeSource {
         let metadata = read_task_metadata(task_dir)?;
         let location_cwd = if let Some(roots) = &self.user_registered_roots {
             let paths = metadata_project_paths(&metadata);
-            if paths
-                .iter()
-                .any(|path| roots.iter().any(|root| path_belongs_to_project(path, root)))
-            {
+            if paths.iter().any(|path| {
+                self.project_matchers.membership_against_roots(path, roots)
+                    != ProjectMembership::NoMatch
+            }) {
                 return None;
             }
             paths.into_iter().next()?
         } else {
-            metadata_project_location(&metadata, project_root)?
+            metadata_project_location(&metadata, project_root, &self.project_matchers)?
         };
 
         let document: Value = match serde_json::from_str(&changed.contents) {
@@ -310,10 +314,24 @@ fn read_task_metadata(task_dir: &Path) -> Option<Value> {
     None
 }
 
-fn metadata_project_location(metadata: &Value, project_root: &Path) -> Option<PathBuf> {
-    metadata_project_paths(metadata)
-        .into_iter()
-        .find(|path| path_belongs_to_project(path, project_root))
+fn metadata_project_location(
+    metadata: &Value,
+    project_root: &Path,
+    project_matchers: &ProjectRootMatcherCache,
+) -> Option<PathBuf> {
+    let mut matched = None;
+    for path in metadata_project_paths(metadata) {
+        match project_matchers.membership(&path, project_root) {
+            ProjectMembership::Match => {
+                if matched.is_none() {
+                    matched = Some(path);
+                }
+            }
+            ProjectMembership::NoMatch => {}
+            ProjectMembership::Unknown => return None,
+        };
+    }
+    matched
 }
 
 fn metadata_project_paths(value: &Value) -> Vec<PathBuf> {

--- a/src/sessions/codex.rs
+++ b/src/sessions/codex.rs
@@ -1623,7 +1623,7 @@ mod source_matcher_cache_tests {
             .ancestors()
             .find(|ancestor| ancestor.file_name().is_some_and(|name| name == "repo"))
             .unwrap_or(path);
-        if UNKNOWN_PATH_ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 0 {
+        if UNKNOWN_PATH_ATTEMPTS.fetch_add(1, Ordering::SeqCst) == 1 {
             return crate::worktree::GitRepoIdentityOutcome::Unknown;
         }
         crate::worktree::GitRepoIdentityOutcome::Resolved(crate::worktree::GitRepoIdentity {

--- a/src/sessions/cursor_composer.rs
+++ b/src/sessions/cursor_composer.rs
@@ -45,7 +45,7 @@ use libsql::{Builder, OpenFlags};
 use serde_json::{Value, json};
 
 use crate::global_db::{GlobalDb, ParseOffset};
-use crate::sessions::shared::path_belongs_to_project;
+use crate::sessions::shared::{ProjectMembership, ProjectRootMatcherCache};
 use crate::sessions::{SessionMessageRecord, SessionRecord};
 
 /// `SQLITE_OPEN_URI` — not exposed by libsql's [`OpenFlags`], so we OR the raw
@@ -84,6 +84,7 @@ impl CursorComposerSweepOutcome {
 pub struct CursorComposerSource {
     state_db_path: PathBuf,
     chats_dir: PathBuf,
+    project_matchers: ProjectRootMatcherCache,
 }
 
 impl CursorComposerSource {
@@ -104,6 +105,7 @@ impl CursorComposerSource {
                 .join("globalStorage")
                 .join("state.vscdb"),
             chats_dir: home.join(".cursor").join("chats"),
+            project_matchers: ProjectRootMatcherCache::default(),
         }
     }
 
@@ -209,20 +211,23 @@ impl CursorComposerSource {
                     .or_insert_with(|| project.path.clone());
             }
             let selected_project = match project_root {
-                Some(root) if path_belongs_to_project(Path::new(&project.path), root) => {
-                    ComposerProject {
-                        path: project.path.clone(),
-                    }
-                }
-                Some(_) => continue,
-                None if registered_roots
-                    .iter()
-                    .any(|root| path_belongs_to_project(Path::new(&project.path), root)) =>
+                Some(root) => match self
+                    .project_matchers
+                    .membership(Path::new(&project.path), root)
                 {
-                    continue;
-                }
-                None => ComposerProject {
-                    path: "user".to_string(),
+                    ProjectMembership::Match => ComposerProject {
+                        path: project.path.clone(),
+                    },
+                    ProjectMembership::NoMatch | ProjectMembership::Unknown => continue,
+                },
+                None => match self
+                    .project_matchers
+                    .membership_against_roots(Path::new(&project.path), registered_roots)
+                {
+                    ProjectMembership::NoMatch => ComposerProject {
+                        path: "user".to_string(),
+                    },
+                    ProjectMembership::Match | ProjectMembership::Unknown => continue,
                 },
             };
             // Own this session for JSONL dedupe regardless of the per-pass cap.
@@ -322,18 +327,20 @@ impl CursorComposerSource {
             let ws_hash = ws_entry.file_name().to_string_lossy().to_string();
             // Scope by ws-hash -> project mapping harvested from the envelopes.
             let project_path = match (workspace_paths.get(&ws_hash), project_root) {
-                (Some(path), Some(root)) if path_belongs_to_project(Path::new(path), root) => {
-                    path.clone()
+                (Some(path), Some(root)) => {
+                    match self.project_matchers.membership(Path::new(path), root) {
+                        ProjectMembership::Match => path.clone(),
+                        ProjectMembership::NoMatch | ProjectMembership::Unknown => continue,
+                    }
                 }
-                (Some(_), Some(_)) | (None, _) => continue,
-                (Some(path), None)
-                    if registered_roots
-                        .iter()
-                        .any(|root| path_belongs_to_project(Path::new(path), root)) =>
+                (None, _) => continue,
+                (Some(path), None) => match self
+                    .project_matchers
+                    .membership_against_roots(Path::new(path), registered_roots)
                 {
-                    continue;
-                }
-                (Some(_), None) => "user".to_string(),
+                    ProjectMembership::NoMatch => "user".to_string(),
+                    ProjectMembership::Match | ProjectMembership::Unknown => continue,
+                },
             };
             let Ok(agent_entries) = std::fs::read_dir(ws_entry.path()) else {
                 continue;

--- a/src/sessions/kiro.rs
+++ b/src/sessions/kiro.rs
@@ -25,9 +25,10 @@ use serde_json::Value;
 
 use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
-    StoredCursor, TranscriptIngestStats, TranscriptLocation, TranscriptLocationMetadataKeys,
-    append_location_metadata, append_tool_calls_metadata, append_usage_metadata,
-    content_storage_text_and_tools, path_belongs_to_project, title_from_messages,
+    ProjectMembership, ProjectRootMatcherCache, StoredCursor, TranscriptIngestStats,
+    TranscriptLocation, TranscriptLocationMetadataKeys, append_location_metadata,
+    append_tool_calls_metadata, append_usage_metadata, content_storage_text_and_tools,
+    title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, read_changed_file,
@@ -49,6 +50,7 @@ pub struct KiroSource {
     agent_dir: PathBuf,
     workspace_storage_dir: PathBuf,
     user_registered_roots: Option<Vec<PathBuf>>,
+    project_matchers: ProjectRootMatcherCache,
 }
 
 impl KiroSource {
@@ -66,6 +68,7 @@ impl KiroSource {
             agent_dir: data_dir.join("User/globalStorage/kiro.kiroagent"),
             workspace_storage_dir: data_dir.join("User/workspaceStorage"),
             user_registered_roots: None,
+            project_matchers: ProjectRootMatcherCache::default(),
         }
     }
 
@@ -86,11 +89,13 @@ impl TranscriptSource for KiroSource {
             let mut out = collect_user_workspace_session_files(
                 &self.agent_dir.join("workspace-sessions"),
                 registered_roots,
+                &self.project_matchers,
             );
             out.extend(collect_user_agent_storage_files(
                 &self.agent_dir,
                 &self.workspace_storage_dir,
                 registered_roots,
+                &self.project_matchers,
             ));
             return out;
         }
@@ -98,11 +103,13 @@ impl TranscriptSource for KiroSource {
         out.extend(collect_workspace_session_files(
             &self.agent_dir.join("workspace-sessions"),
             project_root,
+            &self.project_matchers,
         ));
         out.extend(collect_agent_storage_files(
             &self.agent_dir,
             &self.workspace_storage_dir,
             project_root,
+            &self.project_matchers,
         ));
         out
     }
@@ -116,13 +123,18 @@ impl TranscriptSource for KiroSource {
     ) -> Option<ParsedTranscript> {
         let location_cwd = transcript_location_path(path, &self.workspace_storage_dir)?;
         if let Some(roots) = &self.user_registered_roots {
-            if roots
-                .iter()
-                .any(|root| path_belongs_to_project(&location_cwd, root))
+            if self
+                .project_matchers
+                .membership_against_roots(&location_cwd, roots)
+                != ProjectMembership::NoMatch
             {
                 return None;
             }
-        } else if !path_belongs_to_project(&location_cwd, project_root) {
+        } else if self
+            .project_matchers
+            .membership(&location_cwd, project_root)
+            != ProjectMembership::Match
+        {
             return None;
         }
 
@@ -187,6 +199,7 @@ impl TranscriptSource for KiroSource {
 fn collect_user_workspace_session_files(
     sessions_root: &Path,
     registered_roots: &[PathBuf],
+    project_matchers: &ProjectRootMatcherCache,
 ) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(sessions_root) else {
         return Vec::new();
@@ -200,9 +213,8 @@ fn collect_user_workspace_session_files(
             }
             let workspace =
                 decode_workspace_sessions_dir(entry.file_name().to_string_lossy().as_ref())?;
-            if registered_roots
-                .iter()
-                .any(|root| path_belongs_to_project(&workspace, root))
+            if project_matchers.membership_against_roots(&workspace, registered_roots)
+                != ProjectMembership::NoMatch
             {
                 return None;
             }
@@ -273,7 +285,11 @@ fn empty_changed_transcript(
     }
 }
 
-fn collect_workspace_session_files(sessions_root: &Path, project_root: &Path) -> Vec<PathBuf> {
+fn collect_workspace_session_files(
+    sessions_root: &Path,
+    project_root: &Path,
+    project_matchers: &ProjectRootMatcherCache,
+) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(sessions_root) else {
         return Vec::new();
     };
@@ -288,7 +304,7 @@ fn collect_workspace_session_files(sessions_root: &Path, project_root: &Path) ->
         else {
             continue;
         };
-        if !path_belongs_to_project(&workspace, project_root) {
+        if project_matchers.membership(&workspace, project_root) != ProjectMembership::Match {
             continue;
         }
         let Ok(session_entries) = std::fs::read_dir(&encoded_dir) else {
@@ -308,6 +324,7 @@ fn collect_agent_storage_files(
     agent_dir: &Path,
     workspace_storage_dir: &Path,
     project_root: &Path,
+    project_matchers: &ProjectRootMatcherCache,
 ) -> Vec<PathBuf> {
     let mut workspace_dirs: Vec<(u64, PathBuf, PathBuf)> = Vec::new();
     let Ok(entries) = std::fs::read_dir(agent_dir) else {
@@ -326,7 +343,7 @@ fn collect_agent_storage_files(
         let Some(workspace) = workspace_path_from_hash(workspace_storage_dir, &name) else {
             continue;
         };
-        if !path_belongs_to_project(&workspace, project_root) {
+        if project_matchers.membership(&workspace, project_root) != ProjectMembership::Match {
             continue;
         }
         let mtime = entry
@@ -356,6 +373,7 @@ fn collect_user_agent_storage_files(
     agent_dir: &Path,
     workspace_storage_dir: &Path,
     registered_roots: &[PathBuf],
+    project_matchers: &ProjectRootMatcherCache,
 ) -> Vec<PathBuf> {
     let Ok(entries) = std::fs::read_dir(agent_dir) else {
         return Vec::new();
@@ -374,9 +392,8 @@ fn collect_user_agent_storage_files(
                 return None;
             }
             let workspace = workspace_path_from_hash(workspace_storage_dir, &name)?;
-            if registered_roots
-                .iter()
-                .any(|root| path_belongs_to_project(&workspace, root))
+            if project_matchers.membership_against_roots(&workspace, registered_roots)
+                != ProjectMembership::NoMatch
             {
                 return None;
             }

--- a/src/sessions/shared.rs
+++ b/src/sessions/shared.rs
@@ -167,6 +167,12 @@ struct LocationWorktreeCacheEntry {
     unknown_retry_after: Mutex<Option<Instant>>,
 }
 
+#[derive(Debug)]
+struct ProjectRootMatcherCacheEntry {
+    matcher: Arc<ProjectRootMatcher>,
+    unknown_retry_after: Mutex<Option<Instant>>,
+}
+
 /// A project root with its git worktree/common-dir resolutions computed once,
 /// so repeated membership tests (e.g. one per discovered workflow run) do not
 /// re-run `git_worktree_root`/`git_common_dir` on the fixed project side. A
@@ -287,7 +293,7 @@ impl ProjectRootMatcher {
 /// retaining per-path membership caching inside [`ProjectRootMatcher`].
 #[derive(Clone, Debug)]
 pub(crate) struct ProjectRootMatcherCache {
-    matchers: Arc<Mutex<HashMap<PathBuf, Arc<ProjectRootMatcher>>>>,
+    matchers: Arc<Mutex<HashMap<PathBuf, Arc<ProjectRootMatcherCacheEntry>>>>,
     location_worktrees: Arc<Mutex<HashMap<PathBuf, Arc<LocationWorktreeCacheEntry>>>>,
     identity_resolver: GitIdentityResolver,
 }
@@ -312,33 +318,81 @@ impl ProjectRootMatcherCache {
     }
 
     pub(crate) fn get(&self, project_root: &Path) -> Arc<ProjectRootMatcher> {
+        self.get_at(project_root, Instant::now())
+    }
+
+    fn get_at(&self, project_root: &Path, now: Instant) -> Arc<ProjectRootMatcher> {
         let key = project_root
             .canonicalize()
             .unwrap_or_else(|_| project_root.to_path_buf());
-        if let Some(matcher) = self
-            .matchers
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get(&key)
-            .cloned()
-        {
-            return matcher;
-        }
+        loop {
+            let entry = self
+                .matchers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    Arc::new(ProjectRootMatcherCacheEntry {
+                        matcher: Arc::new(ProjectRootMatcher::new_with_identity_resolver(
+                            project_root,
+                            self.identity_resolver,
+                        )),
+                        unknown_retry_after: Mutex::new(None),
+                    })
+                })
+                .clone();
+            if entry.matcher.identity != crate::worktree::GitRepoIdentityOutcome::Unknown {
+                return entry.matcher.clone();
+            }
 
-        let matcher = Arc::new(ProjectRootMatcher::new_with_identity_resolver(
-            project_root,
-            self.identity_resolver,
-        ));
-        if matcher.identity == crate::worktree::GitRepoIdentityOutcome::Unknown {
-            return matcher;
-        }
+            let should_retry = {
+                let mut retry_after = entry
+                    .unknown_retry_after
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let retry_after =
+                    retry_after.get_or_insert(now + LOCATION_WORKTREE_UNKNOWN_RETRY_COOLDOWN);
+                now >= *retry_after
+            };
+            if !should_retry {
+                return entry.matcher.clone();
+            }
 
-        self.matchers
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .entry(key)
-            .or_insert_with(|| matcher.clone())
-            .clone()
+            let mut matchers = self
+                .matchers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if matchers
+                .get(&key)
+                .is_some_and(|cached| Arc::ptr_eq(cached, &entry))
+            {
+                matchers.remove(&key);
+            }
+        }
+    }
+
+    pub(crate) fn membership(&self, path: &Path, project_root: &Path) -> ProjectMembership {
+        self.get(project_root).contains_status(path)
+    }
+
+    pub(crate) fn membership_against_roots(
+        &self,
+        path: &Path,
+        project_roots: &[PathBuf],
+    ) -> ProjectMembership {
+        let mut unknown = false;
+        for root in project_roots {
+            match self.membership(path, root) {
+                ProjectMembership::Match => return ProjectMembership::Match,
+                ProjectMembership::NoMatch => {}
+                ProjectMembership::Unknown => unknown = true,
+            }
+        }
+        if unknown {
+            ProjectMembership::Unknown
+        } else {
+            ProjectMembership::NoMatch
+        }
     }
 
     /// Resolve a transcript cwd's worktree once for this ingest source.
@@ -803,6 +857,7 @@ pub(crate) fn title_from_messages(messages: &[SessionMessageRecord]) -> Option<S
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Instant;
 
@@ -818,6 +873,19 @@ mod tests {
     use super::append_location_metadata_cached;
     use super::one_line_truncated;
     use super::usage_counters_from;
+
+    static MATCHER_CACHE_RESOLVER_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn unknown_then_resolved_identity(path: &Path) -> crate::worktree::GitRepoIdentityOutcome {
+        if MATCHER_CACHE_RESOLVER_CALLS.fetch_add(1, Ordering::SeqCst) == 0 {
+            crate::worktree::GitRepoIdentityOutcome::Unknown
+        } else {
+            crate::worktree::GitRepoIdentityOutcome::Resolved(crate::worktree::GitRepoIdentity {
+                worktree_root: path.to_path_buf(),
+                common_dir: path.join(".git"),
+            })
+        }
+    }
 
     fn resolved_test_identity(path: &Path) -> crate::worktree::GitRepoIdentityOutcome {
         let root = path
@@ -846,6 +914,47 @@ mod tests {
         );
 
         assert_eq!(membership, ProjectMembership::Unknown);
+    }
+
+    #[test]
+    fn matcher_cache_suppresses_repeated_unknown_identity_lookups() {
+        let temp = TempDir::new().expect("temp dir");
+        let root = temp.path().join("repo");
+        std::fs::create_dir_all(&root).expect("root");
+        MATCHER_CACHE_RESOLVER_CALLS.store(0, Ordering::SeqCst);
+        let cache = ProjectRootMatcherCache::with_identity_resolver(unknown_then_resolved_identity);
+        let now = Instant::now();
+
+        let first = cache.get_at(&root, now);
+        let first_path = root.join("first-session");
+        let second_path = root.join("second-session");
+        std::fs::create_dir_all(&first_path).expect("first session");
+        std::fs::create_dir_all(&second_path).expect("second session");
+        assert_eq!(
+            first.contains_status(&first_path),
+            ProjectMembership::Unknown
+        );
+        assert_eq!(
+            first.contains_status(&second_path),
+            ProjectMembership::Unknown
+        );
+        let during_cooldown =
+            cache.get_at(&root, now + LOCATION_WORKTREE_UNKNOWN_RETRY_COOLDOWN / 2);
+
+        assert!(Arc::ptr_eq(&first, &during_cooldown));
+        assert_eq!(
+            first.identity,
+            crate::worktree::GitRepoIdentityOutcome::Unknown
+        );
+        assert_eq!(MATCHER_CACHE_RESOLVER_CALLS.load(Ordering::SeqCst), 1);
+
+        let retried = cache.get_at(&root, now + LOCATION_WORKTREE_UNKNOWN_RETRY_COOLDOWN);
+        assert!(!Arc::ptr_eq(&first, &retried));
+        assert!(matches!(
+            retried.identity,
+            crate::worktree::GitRepoIdentityOutcome::Resolved(_)
+        ));
+        assert_eq!(MATCHER_CACHE_RESOLVER_CALLS.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/src/sessions/vibe.rs
+++ b/src/sessions/vibe.rs
@@ -18,9 +18,9 @@ use serde_json::Value;
 
 use crate::sessions::SessionMessageRecord;
 use crate::sessions::shared::{
-    StoredCursor, TranscriptLocation, TranscriptLocationMetadataKeys, append_location_metadata,
-    append_tool_calls_metadata, append_usage_metadata, content_storage_text_and_tools,
-    path_belongs_to_project, title_from_messages,
+    ProjectMembership, ProjectRootMatcherCache, StoredCursor, TranscriptLocation,
+    TranscriptLocationMetadataKeys, append_location_metadata, append_tool_calls_metadata,
+    append_usage_metadata, content_storage_text_and_tools, title_from_messages,
 };
 use crate::sessions::source::{
     ParsedTranscript, SessionDraft, TranscriptSource, collect_files_with_ext, stream_new_jsonl,
@@ -40,6 +40,7 @@ const VIBE_LOCATION_KEYS: TranscriptLocationMetadataKeys = TranscriptLocationMet
 pub struct VibeSource {
     session_root: PathBuf,
     user_registered_roots: Option<Vec<PathBuf>>,
+    project_matchers: ProjectRootMatcherCache,
 }
 
 impl VibeSource {
@@ -61,6 +62,7 @@ impl VibeSource {
         Self {
             session_root: vibe_home.join("logs").join("session"),
             user_registered_roots: None,
+            project_matchers: ProjectRootMatcherCache::default(),
         }
     }
 
@@ -106,13 +108,18 @@ impl TranscriptSource for VibeSource {
         let meta_path = path.parent()?.join("meta.json");
         let meta = read_meta(&meta_path)?;
         if let Some(roots) = &self.user_registered_roots {
-            if roots
-                .iter()
-                .any(|root| path_belongs_to_project(&meta.working_directory, root))
+            if self
+                .project_matchers
+                .membership_against_roots(&meta.working_directory, roots)
+                != ProjectMembership::NoMatch
             {
                 return None;
             }
-        } else if !path_belongs_to_project(&meta.working_directory, project_root) {
+        } else if self
+            .project_matchers
+            .membership(&meta.working_directory, project_root)
+            != ProjectMembership::Match
+        {
             return None;
         }
 

--- a/tests/transcript_ingest_suite/cline_like.rs
+++ b/tests/transcript_ingest_suite/cline_like.rs
@@ -542,3 +542,56 @@ async fn cline_like_user_scope_includes_only_unregistered_tasks() {
     assert_eq!(session.project_key, "user");
     assert_eq!(session.project_path, "user");
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn cline_like_unknown_project_membership_defers_persistence_and_offset() {
+    const CHILD_ENV: &str = "TRACEDECAY_CLINE_UNKNOWN_MEMBERSHIP_CHILD";
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let tmp = TempDir::new().unwrap();
+        let (home, project) = setup(&tmp);
+        let nested = project.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let api = write_task(
+            &vscode_storage_root(&home, "saoudrizwan.claude-dev"),
+            &nested,
+            "unknown-cline",
+        );
+
+        let db = open_project_session_db(&project).await.unwrap();
+        let source = ClineLikeSource::cline_with_home(&home).for_user_scope(vec![project.clone()]);
+        assert_eq!(
+            ingest_source(&db, &source, tmp.path(), None)
+                .await
+                .messages_upserted,
+            0
+        );
+        assert!(db.get_session("cline", "unknown-cline").await.is_none());
+        assert!(
+            parse_offset_for_task_history(&db, &project, &api)
+                .await
+                .is_none()
+        );
+        return;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let tmp = TempDir::new().unwrap();
+    let fake_git = tmp.path().join("git-timeout");
+    std::fs::write(&fake_git, "#!/bin/sh\nexec /bin/sleep 3\n").unwrap();
+    std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("cline_like::cline_like_unknown_project_membership_defers_persistence_and_offset")
+        .arg("--exact")
+        .env(CHILD_ENV, "1")
+        .env("GIT", fake_git)
+        .env("GIT_DIR", "/nonexistent/tracedecay-cline-timeout-git-dir")
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "child must defer unknown project membership"
+    );
+}

--- a/tests/transcript_ingest_suite/cursor_composer.rs
+++ b/tests/transcript_ingest_suite/cursor_composer.rs
@@ -82,6 +82,66 @@ fn kv(key: &str, value: &serde_json::Value) -> (String, String) {
     (key.to_string(), value.to_string())
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn composer_unknown_project_membership_defers_persistence_and_offset() {
+    const CHILD_ENV: &str = "TRACEDECAY_COMPOSER_UNKNOWN_MEMBERSHIP_CHILD";
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let tmp = TempDir::new().unwrap();
+        let project = init_project(&tmp);
+        let nested = project.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let home = tmp.path().join("home");
+        let env = envelope("unknown-composer", &nested, &["b-user"]);
+        let bubble = serde_json::json!({"type": 1, "text": "defer this session"});
+        write_state_vscdb(
+            &home,
+            &[
+                kv("composerData:unknown-composer", &env),
+                kv("bubbleId:unknown-composer:b-user", &bubble),
+            ],
+        )
+        .await;
+
+        let db = open_project_session_db(&project).await.unwrap();
+        let outcome = CursorComposerSource::with_home(&home)
+            .ingest_user(&db, &[project], CAP)
+            .await;
+        assert_eq!(outcome.sessions_upserted, 0);
+        assert!(outcome.owned_session_ids.is_empty());
+        assert!(db.get_session("cursor", "unknown-composer").await.is_none());
+        assert!(
+            db.get_parse_offset("cursor-composer:unknown-composer")
+                .await
+                .is_none()
+        );
+        return;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let tmp = TempDir::new().unwrap();
+    let fake_git = tmp.path().join("git-timeout");
+    std::fs::write(&fake_git, "#!/bin/sh\nexec /bin/sleep 3\n").unwrap();
+    std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("cursor_composer::composer_unknown_project_membership_defers_persistence_and_offset")
+        .arg("--exact")
+        .env(CHILD_ENV, "1")
+        .env("GIT", fake_git)
+        .env(
+            "GIT_DIR",
+            "/nonexistent/tracedecay-composer-timeout-git-dir",
+        )
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "child must defer unknown project membership"
+    );
+}
+
 /// Envelope + user bubble + a rich assistant bubble (text, thinking, tool call,
 /// token counts) + todos map to the expected provider-neutral rows.
 #[tokio::test]

--- a/tests/transcript_ingest_suite/kiro.rs
+++ b/tests/transcript_ingest_suite/kiro.rs
@@ -316,3 +316,52 @@ async fn kiro_user_scope_includes_only_unregistered_sessions() {
     let extensionless = db.get_session("kiro", "user-extensionless").await.unwrap();
     assert_eq!(extensionless.project_key, "user");
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn kiro_unknown_project_membership_defers_persistence_and_offset() {
+    const CHILD_ENV: &str = "TRACEDECAY_KIRO_UNKNOWN_MEMBERSHIP_CHILD";
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let tmp = TempDir::new().unwrap();
+        let (home, project) = setup(&tmp);
+        let nested = project.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let transcript = write_workspace_session_json(&home, &nested, "unknown-kiro");
+
+        let db = open_project_session_db(&project).await.unwrap();
+        let source = KiroSource::with_home(&home).for_user_scope(vec![project]);
+        assert_eq!(
+            ingest_source(&db, &source, tmp.path(), None)
+                .await
+                .messages_upserted,
+            0
+        );
+        assert!(db.get_session("kiro", "unknown-kiro").await.is_none());
+        assert!(
+            db.get_parse_offset(transcript.to_string_lossy().as_ref())
+                .await
+                .is_none()
+        );
+        return;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let tmp = TempDir::new().unwrap();
+    let fake_git = tmp.path().join("git-timeout");
+    std::fs::write(&fake_git, "#!/bin/sh\nexec /bin/sleep 3\n").unwrap();
+    std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("kiro::kiro_unknown_project_membership_defers_persistence_and_offset")
+        .arg("--exact")
+        .env(CHILD_ENV, "1")
+        .env("GIT", fake_git)
+        .env("GIT_DIR", "/nonexistent/tracedecay-kiro-timeout-git-dir")
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "child must defer unknown project membership"
+    );
+}

--- a/tests/transcript_ingest_suite/vibe.rs
+++ b/tests/transcript_ingest_suite/vibe.rs
@@ -200,6 +200,55 @@ async fn vibe_user_scope_includes_only_unregistered_sessions() {
     assert_eq!(session.project_path, "user");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn vibe_unknown_project_membership_defers_persistence_and_offset() {
+    const CHILD_ENV: &str = "TRACEDECAY_VIBE_UNKNOWN_MEMBERSHIP_CHILD";
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let tmp = TempDir::new().unwrap();
+        let (home, project) = setup(&tmp);
+        let nested = project.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let messages = write_vibe_session(&home, &nested, "unknown-vibe");
+
+        let db = open_project_session_db(&project).await.unwrap();
+        let source = VibeSource::with_home(&home).for_user_scope(vec![project]);
+        assert_eq!(
+            ingest_source(&db, &source, tmp.path(), None)
+                .await
+                .messages_upserted,
+            0
+        );
+        assert!(db.get_session("vibe", "unknown-vibe").await.is_none());
+        assert!(
+            db.get_parse_offset(messages.to_string_lossy().as_ref())
+                .await
+                .is_none()
+        );
+        return;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let tmp = TempDir::new().unwrap();
+    let fake_git = tmp.path().join("git-timeout");
+    std::fs::write(&fake_git, "#!/bin/sh\nexec /bin/sleep 3\n").unwrap();
+    std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let status = Command::new(std::env::current_exe().unwrap())
+        .arg("vibe::vibe_unknown_project_membership_defers_persistence_and_offset")
+        .arg("--exact")
+        .env(CHILD_ENV, "1")
+        .env("GIT", fake_git)
+        .env("GIT_DIR", "/nonexistent/tracedecay-vibe-timeout-git-dir")
+        .status()
+        .unwrap();
+    assert!(
+        status.success(),
+        "child must defer unknown project membership"
+    );
+}
+
 #[test]
 fn vibe_history_enumeration_is_bounded() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- clear inherited Git discovery overrides before repository probes
- preserve unknown project-root matches so affected session sources defer instead of dropping data
- cooldown-cache unknown root matches
- exclude .worktrees and .codex-worktrees from parent Cargo workspace discovery

## Validation

- focused Git, routing, Vibe, Kiro, Cline-like, and Cursor Composer tests pass
- nested Cargo worktree probes pass
- commit subjects and diff validation pass
- full cross-platform CI is the broad gate