### PR TITLE
fix(release): keep root lockfile version aligned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.68"
+version = "0.0.68" # x-release-please-version
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,9 +14,8 @@
           "jsonpath": "$.package.version"
         },
         {
-          "type": "toml",
-          "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name == 'tracedecay')].version"
+          "type": "generic",
+          "path": "Cargo.lock"
         }
       ]
     }

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -44,12 +44,12 @@ if root_release.get("package-name") != "tracedecay":
     raise SystemExit("root release package must remain named tracedecay")
 
 extra_files = {
-    (entry.get("path"), entry.get("jsonpath"))
+    (entry.get("type"), entry.get("path"), entry.get("jsonpath"))
     for entry in root_release.get("extra-files", [])
 }
 required_extra_files = {
-    ("Cargo.toml", "$.package.version"),
-    ("Cargo.lock", "$.package[?(@.name == 'tracedecay')].version"),
+    ("toml", "Cargo.toml", "$.package.version"),
+    ("generic", "Cargo.lock", None),
 }
 if extra_files != required_extra_files:
     raise SystemExit("release automation must update only the root Cargo versions")
@@ -67,6 +67,11 @@ if release_manifest.get(".") != version:
 if not any(binary.get("name") == "tracedecay" for binary in root_manifest.get("bin", [])):
     raise SystemExit("root binary must remain named tracedecay")
 
+lock_text = Path(lock_path).read_text(encoding="utf-8")
+if lock_text.count("x-release-please-version") != 1:
+    raise SystemExit("Cargo.lock must carry exactly one root release marker")
+if 'version = "' + version + '" # x-release-please-version' not in lock_text:
+    raise SystemExit("Cargo.lock root package version must carry the release marker")
 with open(lock_path, "rb") as handle:
     lockfile = tomllib.load(handle)
 root_locks = [


### PR DESCRIPTION
## Summary
- use Release Please generic marker for the root Cargo.lock package version
- guard the marker and config contract
- keep all internal crates unpublished

## Verification
- bash tests/release_workflow_contract_test.sh
- cargo metadata --locked --no-deps --format-version 1
- release-please config validates against its upstream schema

Fixes the `cargo --locked` failure observed on generated release PR #490.