### PR TITLE
fix: address unresolved review and release issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: npm run lint:commit -- --from "$BASE_SHA" --to "$HEAD_SHA"
+        run: |
+          while IFS= read -r commit_sha; do
+            git show --no-patch --format=%B "$commit_sha" | npm run --silent lint:commit --
+          done < <(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
 
       - name: Validate pushed commit messages
         if: github.event_name == 'push'
@@ -56,13 +59,17 @@ jobs:
           set -euo pipefail
           if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             if git rev-parse "${HEAD_SHA}^" >/dev/null 2>&1; then
-              npm run lint:commit -- --from "${HEAD_SHA}^" --to "$HEAD_SHA"
+              range="${HEAD_SHA}^..${HEAD_SHA}"
             else
               git show --no-patch --format=%B "$HEAD_SHA" | npm run lint:commit --
+              exit 0
             fi
           else
-            npm run lint:commit -- --from "$BEFORE_SHA" --to "$HEAD_SHA"
+            range="$BEFORE_SHA..$HEAD_SHA"
           fi
+          while IFS= read -r commit_sha; do
+            git show --no-patch --format=%B "$commit_sha" | npm run --silent lint:commit --
+          done < <(git rev-list --no-merges "$range")
 
   release-version-drift:
     name: Release Version Drift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,12 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
+          commit_shas=$(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
           while IFS= read -r commit_sha; do
+            [[ -n "$commit_sha" ]] || continue
             git show --no-patch --format=%B "$commit_sha" | npm run --silent lint:commit --
-          done < <(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
+          done <<<"$commit_shas"
 
       - name: Validate pushed commit messages
         if: github.event_name == 'push'
@@ -67,9 +70,11 @@ jobs:
           else
             range="$BEFORE_SHA..$HEAD_SHA"
           fi
+          commit_shas=$(git rev-list --no-merges "$range")
           while IFS= read -r commit_sha; do
+            [[ -n "$commit_sha" ]] || continue
             git show --no-patch --format=%B "$commit_sha" | npm run --silent lint:commit --
-          done < <(git rev-list --no-merges "$range")
+          done <<<"$commit_shas"
 
   release-version-drift:
     name: Release Version Drift

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,10 +27,42 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
           target-branch: master
 
-      - name: Checkout repository
+      - name: Checkout release PR
+        if: steps.release.outputs.prs_created == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Update release PR lockfile
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          cargo metadata --format-version 1 --no-deps >/dev/null
+
+          if git diff --quiet -- Cargo.lock; then
+            exit 0
+          fi
+
+          unexpected_paths=$(git diff --name-only -- . ':(exclude)Cargo.lock')
+          if [[ -n "$unexpected_paths" ]]; then
+            echo "Cargo metadata changed unexpected paths:" >&2
+            echo "$unexpected_paths" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore(release): update root lockfile"
+          git push origin "HEAD:$RELEASE_PR_BRANCH"
+
+      - name: Checkout master
         if: always()
         uses: actions/checkout@v7
         with:
+          ref: master
           persist-credentials: false
 
       - name: Check GitHub release version drift

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracedecay"
-version = "0.0.68" # x-release-please-version
+version = "0.0.68"
 dependencies = [
  "amari-holographic",
  "axum 0.8.9",

--- a/crates/tracedecay-runtime-core/src/db/migrations.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations.rs
@@ -358,6 +358,7 @@ async fn run_migrations(conn: &Connection, current: u32) -> Result<()> {
         run_migration(conn, version).await?;
         set_version(conn, version).await?;
     }
+    ensure_metadata_table(conn, "migrate").await?;
     conn.execute(
         "INSERT OR REPLACE INTO metadata (key, value)
          VALUES (?1, ?2)",
@@ -896,18 +897,7 @@ async fn migrate_v1(conn: &Connection) -> Result<()> {
 
 /// Adds the key-value metadata table for persistent counters.
 async fn migrate_v2(conn: &Connection) -> Result<()> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS metadata (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL
-        )",
-        (),
-    )
-    .await
-    .map_err(|e| TraceDecayError::Database {
-        message: format!("v2: failed to create metadata table: {e}"),
-        operation: "migrate_v2".to_string(),
-    })?;
+    ensure_metadata_table(conn, "migrate_v2").await?;
 
     // Drop the legacy schema_versions table if it exists.
     conn.execute("DROP TABLE IF EXISTS schema_versions", ())
@@ -917,6 +907,22 @@ async fn migrate_v2(conn: &Connection) -> Result<()> {
             operation: "migrate_v2".to_string(),
         })?;
 
+    Ok(())
+}
+
+async fn ensure_metadata_table(conn: &Connection, operation: &str) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )",
+        (),
+    )
+    .await
+    .map_err(|e| TraceDecayError::Database {
+        message: format!("{operation}: failed to create metadata table: {e}"),
+        operation: operation.to_string(),
+    })?;
     Ok(())
 }
 

--- a/crates/tracedecay-runtime-core/src/db/migrations.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations.rs
@@ -9,7 +9,7 @@
 //! The current schema version is stored in `PRAGMA user_version`, which
 //! is an atomic integer built into `SQLite`. No extra table is needed.
 
-use libsql::Connection;
+use libsql::{Connection, params};
 
 use crate::errors::{Result, TraceDecayError};
 use crate::memory::store::MemoryStore;
@@ -17,6 +17,11 @@ use crate::memory::store::MemoryStore;
 /// The highest migration version defined in this file. Bump this and add a
 /// new entry to `run_migration` whenever the schema changes.
 const LATEST_VERSION: u32 = 18;
+
+/// Durable metadata set transactionally with schema migrations and cleared
+/// only after the owning project completes its required full reindex.
+pub const FULL_REINDEX_REQUIRED_KEY: &str = "full_reindex_required";
+pub const FULL_REINDEX_REQUIRED_VALUE: &str = "1";
 
 /// Reads the current schema version from `PRAGMA user_version`.
 async fn get_version(conn: &Connection) -> Result<u32> {
@@ -353,6 +358,16 @@ async fn run_migrations(conn: &Connection, current: u32) -> Result<()> {
         run_migration(conn, version).await?;
         set_version(conn, version).await?;
     }
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value)
+         VALUES (?1, ?2)",
+        params![FULL_REINDEX_REQUIRED_KEY, FULL_REINDEX_REQUIRED_VALUE],
+    )
+    .await
+    .map_err(|e| TraceDecayError::Database {
+        message: format!("failed to mark full reindex required: {e}"),
+        operation: "migrate".to_string(),
+    })?;
     Ok(())
 }
 

--- a/crates/tracedecay-sessions/src/runtime/cline_like.rs
+++ b/crates/tracedecay-sessions/src/runtime/cline_like.rs
@@ -326,8 +326,7 @@ fn metadata_project_location(
                     matched = Some(path);
                 }
             }
-            ProjectMembership::NoMatch => {}
-            ProjectMembership::Unknown => return None,
+            ProjectMembership::NoMatch | ProjectMembership::Unknown => {}
         }
     }
     matched
@@ -553,4 +552,35 @@ fn message_metadata(
         append_usage_metadata(&mut metadata, &[entry]);
     }
     Value::Object(metadata)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracedecay_runtime_core::worktree::{GitRepoIdentity, GitRepoIdentityOutcome};
+
+    fn mixed_identity(path: &Path) -> GitRepoIdentityOutcome {
+        if path == Path::new("/unavailable") {
+            GitRepoIdentityOutcome::Unknown
+        } else {
+            GitRepoIdentityOutcome::Resolved(GitRepoIdentity {
+                worktree_root: path.to_path_buf(),
+                common_dir: PathBuf::from("/shared/.git"),
+            })
+        }
+    }
+
+    #[test]
+    fn definitive_metadata_path_match_overrides_unknown_auxiliary_path() {
+        let metadata = serde_json::json!({
+            "projectPath": "/match",
+            "workspaceDirectory": "/unavailable"
+        });
+        let matchers = ProjectRootMatcherCache::with_identity_resolver(mixed_identity);
+
+        assert_eq!(
+            metadata_project_location(&metadata, Path::new("/project"), &matchers),
+            Some(PathBuf::from("/match"))
+        );
+    }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,10 +12,6 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.package.version"
-        },
-        {
-          "type": "generic",
-          "path": "Cargo.lock"
         }
       ]
     }

--- a/src/mcp/tools/handlers/grep.rs
+++ b/src/mcp/tools/handlers/grep.rs
@@ -250,6 +250,7 @@ impl GeneratedDirScope {
             .split('/')
             .filter(|segment| !segment.is_empty())
             .collect();
+        let matches_basename_at_any_depth = !path_glob.contains('/');
         let wildcard_start = segments
             .iter()
             .position(|segment| {
@@ -259,18 +260,22 @@ impl GeneratedDirScope {
                     || segment.contains('{')
             })
             .unwrap_or(segments.len());
-        let literal_prefix =
+        let literal_prefix = if matches_basename_at_any_depth {
+            PathBuf::new()
+        } else {
             segments[..wildcard_start]
                 .iter()
                 .fold(PathBuf::new(), |mut prefix, segment| {
                     prefix.push(segment);
                     prefix
-                });
+                })
+        };
         let wildcard_suffix = &segments[wildcard_start..];
-        let may_match_descendants = wildcard_suffix
-            .iter()
-            .enumerate()
-            .any(|(index, segment)| index > 0 || *segment == "**");
+        let may_match_descendants = matches_basename_at_any_depth
+            || wildcard_suffix
+                .iter()
+                .enumerate()
+                .any(|(index, segment)| index > 0 || *segment == "**");
 
         Some(Self {
             literal_prefix,
@@ -649,6 +654,41 @@ mod tests {
             checks.load(std::sync::atomic::Ordering::Relaxed),
             baseline_checks.load(std::sync::atomic::Ordering::Relaxed),
             "unrelated generated directories must not reach the scan loop"
+        );
+    }
+
+    #[test]
+    fn scan_tree_slashless_glob_includes_generated_directory_descendants() {
+        let project = tempfile::tempdir().expect("temp project");
+        std::fs::create_dir_all(project.path().join("dist")).expect("generated fixture directory");
+        std::fs::write(
+            project.path().join("dist/generated.js"),
+            "SLASHLESS_GENERATED_GLOB_TOKEN\n",
+        )
+        .expect("generated fixture");
+
+        let mut builder = OverrideBuilder::new(project.path());
+        builder.add("*.js").expect("path glob");
+        let overrides = builder.build().expect("overrides");
+        let matcher = Regex::new("SLASHLESS_GENERATED_GLOB_TOKEN").expect("matcher");
+        let scan = scan_tree(
+            project.path(),
+            &matcher,
+            Some(overrides),
+            Some("*.js"),
+            0,
+            10,
+            || false,
+        );
+
+        let files = scan
+            .hits
+            .iter()
+            .map(|hit| hit.file.as_str())
+            .collect::<Vec<_>>();
+        assert!(
+            files.contains(&"dist/generated.js"),
+            "slashless basename globs must match generated descendants: {files:?}"
         );
     }
 

--- a/src/tracedecay/indexing.rs
+++ b/src/tracedecay/indexing.rs
@@ -230,6 +230,7 @@ impl TraceDecay {
     where
         F: Fn(usize, usize, &str),
     {
+        self.ensure_branch_writable("full index")?;
         let sync_lease = match locks {
             Some(locks) => self.begin_active_sync_with_locks(locks)?,
             None => self.begin_active_sync()?,
@@ -255,6 +256,7 @@ impl TraceDecay {
         F: Fn(usize, usize, &str),
         V: Fn(&str),
     {
+        self.ensure_branch_writable("full index")?;
         let sync_lease = self.begin_active_sync()?;
         let (result, sync_lease) = self
             .index_all_with_progress_verbose_under_lease(on_file, on_verbose, sync_lease)
@@ -278,7 +280,6 @@ impl TraceDecay {
             self.project_root.is_dir(),
             "project root is not a directory"
         );
-        self.ensure_branch_writable("full index")?;
         let start = Instant::now();
 
         // 1. Clear existing data and enter bulk-load mode

--- a/src/tracedecay/indexing.rs
+++ b/src/tracedecay/indexing.rs
@@ -13,6 +13,7 @@ use crate::resolution::ReferenceResolver;
 use crate::sync;
 use crate::types::*;
 
+use super::locking::{ActiveSyncLease, ActiveSyncLockGuard};
 use super::{IndexResult, SyncResult, TraceDecay, current_timestamp};
 
 /// Convert any backslash in a *relative* project-root-relative path to a
@@ -220,6 +221,19 @@ impl TraceDecay {
         self.index_all_with_progress_verbose(on_file, |_| {}).await
     }
 
+    pub(super) async fn index_all_with_progress_holding_lock<F>(
+        &self,
+        on_file: F,
+        locks: ActiveSyncLockGuard,
+    ) -> Result<IndexResult>
+    where
+        F: Fn(usize, usize, &str),
+    {
+        let sync_lease = self.begin_active_sync_with_locks(locks)?;
+        self.index_all_with_progress_verbose_under_lease(on_file, |_| {}, sync_lease)
+            .await
+    }
+
     /// Like `index_all_with_progress()`, but also calls `on_verbose` after
     /// each phase completes with a diagnostic summary line.
     pub async fn index_all_with_progress_verbose<F, V>(
@@ -231,13 +245,27 @@ impl TraceDecay {
         F: Fn(usize, usize, &str),
         V: Fn(&str),
     {
+        let sync_lease = self.begin_active_sync()?;
+        self.index_all_with_progress_verbose_under_lease(on_file, on_verbose, sync_lease)
+            .await
+    }
+
+    async fn index_all_with_progress_verbose_under_lease<F, V>(
+        &self,
+        on_file: F,
+        on_verbose: V,
+        sync_lease: ActiveSyncLease,
+    ) -> Result<IndexResult>
+    where
+        F: Fn(usize, usize, &str),
+        V: Fn(&str),
+    {
         debug_assert!(self.project_root.exists(), "project root does not exist");
         debug_assert!(
             self.project_root.is_dir(),
             "project root is not a directory"
         );
         self.ensure_branch_writable("full index")?;
-        let sync_lease = self.begin_active_sync()?;
         let start = Instant::now();
 
         // 1. Clear existing data and enter bulk-load mode

--- a/src/tracedecay/indexing.rs
+++ b/src/tracedecay/indexing.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use rayon::prelude::*;
 
 use crate::config::brand_env;
+use crate::db::migrations::FULL_REINDEX_REQUIRED_KEY;
 use crate::errors::Result;
 use crate::resolution::ReferenceResolver;
 use crate::sync;
@@ -221,17 +222,26 @@ impl TraceDecay {
         self.index_all_with_progress_verbose(on_file, |_| {}).await
     }
 
-    pub(super) async fn index_all_with_progress_holding_lock<F>(
+    pub(super) async fn index_all_for_migration_with_progress<F>(
         &self,
         on_file: F,
-        locks: ActiveSyncLockGuard,
+        locks: Option<ActiveSyncLockGuard>,
     ) -> Result<IndexResult>
     where
         F: Fn(usize, usize, &str),
     {
-        let sync_lease = self.begin_active_sync_with_locks(locks)?;
-        self.index_all_with_progress_verbose_under_lease(on_file, |_| {}, sync_lease)
-            .await
+        let sync_lease = match locks {
+            Some(locks) => self.begin_active_sync_with_locks(locks)?,
+            None => self.begin_active_sync()?,
+        };
+        let (result, sync_lease) = self
+            .index_all_with_progress_verbose_under_lease(on_file, |_| {}, sync_lease)
+            .await?;
+        let locks = sync_lease.commit_holding_locks()?;
+        self.db.set_metadata(FULL_REINDEX_REQUIRED_KEY, "0").await?;
+        self.db.checkpoint().await?;
+        drop(locks);
+        Ok(result)
     }
 
     /// Like `index_all_with_progress()`, but also calls `on_verbose` after
@@ -246,8 +256,11 @@ impl TraceDecay {
         V: Fn(&str),
     {
         let sync_lease = self.begin_active_sync()?;
-        self.index_all_with_progress_verbose_under_lease(on_file, on_verbose, sync_lease)
-            .await
+        let (result, sync_lease) = self
+            .index_all_with_progress_verbose_under_lease(on_file, on_verbose, sync_lease)
+            .await?;
+        sync_lease.commit()?;
+        Ok(result)
     }
 
     async fn index_all_with_progress_verbose_under_lease<F, V>(
@@ -255,7 +268,7 @@ impl TraceDecay {
         on_file: F,
         on_verbose: V,
         sync_lease: ActiveSyncLease,
-    ) -> Result<IndexResult>
+    ) -> Result<(IndexResult, ActiveSyncLease)>
     where
         F: Fn(usize, usize, &str),
         V: Fn(&str),
@@ -405,8 +418,7 @@ impl TraceDecay {
             "non-empty index completed in zero milliseconds"
         );
         self.db.checkpoint().await?;
-        sync_lease.commit()?;
-        Ok(result)
+        Ok((result, sync_lease))
     }
 
     /// Performs an incremental sync: detects changed, new, and removed files

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -544,14 +544,8 @@ impl TraceDecay {
             let on_file = |current, total, file: &str| {
                 eprintln!("[tracedecay] re-indexing [{current}/{total}] {file}");
             };
-            match recovery_lock.take() {
-                Some(lock) => {
-                    ts.index_all_with_progress_holding_lock(on_file, lock)
-                        .await?
-                }
-                None => ts.index_all_with_progress(on_file).await?,
-            };
-            ts.db.set_metadata(FULL_REINDEX_REQUIRED_KEY, "0").await?;
+            ts.index_all_for_migration_with_progress(on_file, recovery_lock.take())
+                .await?;
             eprintln!("[tracedecay] re-index complete.");
         }
         drop(recovery_lock);

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -404,7 +404,7 @@ impl TraceDecay {
         // it cannot race that writer or clear its sentinel. Preflight through
         // the read-only connection before Database::open applies writable
         // pragmas or migrations to a potentially damaged recovery set.
-        let recovery_lock = if crashed {
+        let mut recovery_lock = if crashed {
             Some(try_acquire_graph_sync_locks(
                 &active_graph_layout.sync_lock_path,
                 &store_layout.sync_lock_path,
@@ -487,8 +487,10 @@ impl TraceDecay {
         if crashed {
             match db.quick_check().await {
                 Ok(true) => {
-                    clear_dirty_sentinel_at(&active_graph_layout.dirty_path);
-                    clear_dirty_sentinel_at(&store_layout.dirty_path);
+                    if !migrated {
+                        clear_dirty_sentinel_at(&active_graph_layout.dirty_path);
+                        clear_dirty_sentinel_at(&store_layout.dirty_path);
+                    }
                 }
                 Ok(false) => {
                     db.close();
@@ -518,7 +520,6 @@ impl TraceDecay {
                 }
             }
         }
-        drop(recovery_lock);
 
         let ts = Self {
             db,
@@ -536,12 +537,19 @@ impl TraceDecay {
 
         if migrated {
             eprintln!("[tracedecay] schema changed — performing full re-index…");
-            ts.index_all_with_progress(|current, total, file| {
+            let on_file = |current, total, file: &str| {
                 eprintln!("[tracedecay] re-indexing [{current}/{total}] {file}");
-            })
-            .await?;
+            };
+            match recovery_lock.take() {
+                Some(lock) => {
+                    ts.index_all_with_progress_holding_lock(on_file, lock)
+                        .await?
+                }
+                None => ts.index_all_with_progress(on_file).await?,
+            };
             eprintln!("[tracedecay] re-index complete.");
         }
+        drop(recovery_lock);
 
         ts.register_project_store_in_global_registry().await;
         Ok(ts)

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -518,6 +518,7 @@ impl TraceDecay {
                 }
             }
         }
+        drop(recovery_lock);
 
         let ts = Self {
             db,

--- a/src/tracedecay/lifecycle.rs
+++ b/src/tracedecay/lifecycle.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::branch;
 use crate::branch_meta::{self, BranchMeta};
 use crate::config::{TraceDecayConfig, db_filename, load_config_from_path, save_config_to_path};
+use crate::db::migrations::{FULL_REINDEX_REQUIRED_KEY, FULL_REINDEX_REQUIRED_VALUE};
 use crate::db::{Database, DatabaseAuthority};
 use crate::errors::{Result, TraceDecayError};
 use crate::extraction::LanguageRegistry;
@@ -481,13 +482,16 @@ impl TraceDecay {
             }
             Err(e) => return Err(e),
         };
+        let reindex_pending = db.get_metadata(FULL_REINDEX_REQUIRED_KEY).await?.as_deref()
+            == Some(FULL_REINDEX_REQUIRED_VALUE);
+        let needs_reindex = migrated || reindex_pending;
 
         // If the sentinel was set but the database opened successfully, run a
         // quick integrity check.
         if crashed {
             match db.quick_check().await {
                 Ok(true) => {
-                    if !migrated {
+                    if !needs_reindex {
                         clear_dirty_sentinel_at(&active_graph_layout.dirty_path);
                         clear_dirty_sentinel_at(&store_layout.dirty_path);
                     }
@@ -535,8 +539,8 @@ impl TraceDecay {
             read_only: false,
         };
 
-        if migrated {
-            eprintln!("[tracedecay] schema changed — performing full re-index…");
+        if needs_reindex {
+            eprintln!("[tracedecay] schema re-index required — performing full re-index…");
             let on_file = |current, total, file: &str| {
                 eprintln!("[tracedecay] re-indexing [{current}/{total}] {file}");
             };
@@ -547,6 +551,7 @@ impl TraceDecay {
                 }
                 None => ts.index_all_with_progress(on_file).await?,
             };
+            ts.db.set_metadata(FULL_REINDEX_REQUIRED_KEY, "0").await?;
             eprintln!("[tracedecay] re-index complete.");
         }
         drop(recovery_lock);

--- a/src/tracedecay/locking.rs
+++ b/src/tracedecay/locking.rs
@@ -146,7 +146,7 @@ pub(super) struct ActiveSyncLockGuard {
 }
 
 pub(super) struct ActiveSyncLease {
-    _locks: ActiveSyncLockGuard,
+    locks: ActiveSyncLockGuard,
     dirty_markers: Vec<(PathBuf, MarkerIdentity)>,
 }
 
@@ -183,7 +183,7 @@ impl super::TraceDecay {
             })?;
         }
         Ok(ActiveSyncLease {
-            _locks: locks,
+            locks,
             dirty_markers: paths
                 .into_iter()
                 .map(|path| (path, MarkerIdentity::Epoch(epoch.clone())))
@@ -196,6 +196,11 @@ impl ActiveSyncLease {
     /// Marks the operation clean while both active and legacy locks remain
     /// held. Drop without commit intentionally leaves every dirty marker.
     pub(super) fn commit(self) -> Result<()> {
+        drop(self.commit_holding_locks()?);
+        Ok(())
+    }
+
+    pub(super) fn commit_holding_locks(self) -> Result<ActiveSyncLockGuard> {
         // Validate every marker before mutating any of them. A changed epoch
         // fails closed and leaves recovery evidence in place.
         for (path, expected) in &self.dirty_markers {
@@ -216,7 +221,7 @@ impl ActiveSyncLease {
                 message: format!("could not clear dirty marker '{}': {error}", path.display()),
             })?;
         }
-        Ok(())
+        Ok(self.locks)
     }
 }
 
@@ -506,6 +511,28 @@ mod tests {
 
         drop(guard);
         assert!(try_acquire_sync_lock_at(&path).is_ok());
+    }
+
+    #[test]
+    fn committed_lease_can_retain_sync_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("sync.lock");
+        let dirty_path = dir.path().join("dirty");
+        let epoch = next_epoch();
+        write_dirty_sentinel_for_epoch(&dirty_path, &epoch).unwrap();
+        let lease = ActiveSyncLease {
+            locks: ActiveSyncLockGuard {
+                _active: try_acquire_sync_lock_at(&lock_path).unwrap(),
+                _legacy: None,
+            },
+            dirty_markers: vec![(dirty_path.clone(), MarkerIdentity::Epoch(epoch))],
+        };
+
+        let locks = lease.commit_holding_locks().unwrap();
+        assert!(!dirty_path.exists());
+        assert!(try_acquire_sync_lock_at(&lock_path).is_err());
+        drop(locks);
+        assert!(try_acquire_sync_lock_at(&lock_path).is_ok());
     }
 
     #[test]

--- a/src/tracedecay/locking.rs
+++ b/src/tracedecay/locking.rs
@@ -160,6 +160,13 @@ impl super::TraceDecay {
 
     pub(super) fn begin_active_sync(&self) -> Result<ActiveSyncLease> {
         let locks = self.try_acquire_active_sync_lock()?;
+        self.begin_active_sync_with_locks(locks)
+    }
+
+    pub(super) fn begin_active_sync_with_locks(
+        &self,
+        locks: ActiveSyncLockGuard,
+    ) -> Result<ActiveSyncLease> {
         let epoch = next_epoch();
         let mut paths = vec![self.active_graph_layout.dirty_path.clone()];
         if self.active_graph_layout.dirty_path != self.store_layout.dirty_path {

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -49,10 +49,9 @@ extra_files = {
 }
 required_extra_files = {
     ("toml", "Cargo.toml", "$.package.version"),
-    ("generic", "Cargo.lock", None),
 }
 if extra_files != required_extra_files:
-    raise SystemExit("release automation must update only the root Cargo versions")
+    raise SystemExit("release automation must update only the root Cargo manifest")
 
 with open(root_path, "rb") as handle:
     root_manifest = tomllib.load(handle)
@@ -68,10 +67,8 @@ if not any(binary.get("name") == "tracedecay" for binary in root_manifest.get("b
     raise SystemExit("root binary must remain named tracedecay")
 
 lock_text = Path(lock_path).read_text(encoding="utf-8")
-if lock_text.count("x-release-please-version") != 1:
-    raise SystemExit("Cargo.lock must carry exactly one root release marker")
-if 'version = "' + version + '" # x-release-please-version' not in lock_text:
-    raise SystemExit("Cargo.lock root package version must carry the release marker")
+if "x-release-please-version" in lock_text:
+    raise SystemExit("Cargo.lock must not use markers that Cargo strips")
 with open(lock_path, "rb") as handle:
     lockfile = tomllib.load(handle)
 root_locks = [
@@ -110,6 +107,10 @@ for required in [
     "googleapis/release-please-action@v5",
     "token: ${{ secrets.RELEASE_PLZ_TOKEN }}",
     "target-branch: master",
+    "steps.release.outputs.prs_created == 'true'",
+    "fromJSON(steps.release.outputs.pr).headBranchName",
+    "cargo metadata --format-version 1 --no-deps",
+    'git push origin "HEAD:$RELEASE_PR_BRANCH"',
     "Check GitHub release version drift",
 ]:
     if required not in release_please:

--- a/tests/storage_suite/branch_db_safety_test.rs
+++ b/tests/storage_suite/branch_db_safety_test.rs
@@ -331,6 +331,8 @@ async fn open_auto_tracks_untracked_branch_and_syncs_its_db() {
 async fn fallback_writes_are_refused_by_all_sync_entry_points() {
     let _env_lock = HOME_ENV_LOCK.lock().await;
     let (_env, project, fallback) = open_detached_fallback_project().await;
+    let active_dirty = PathBuf::from(format!("{}.dirty", fallback.db_path().display()));
+    let store_dirty = fallback.store_layout().dirty_path.clone();
 
     let err = fallback
         .sync()
@@ -343,6 +345,10 @@ async fn fallback_writes_are_refused_by_all_sync_entry_points() {
         Err(err) => err,
     };
     assert_fallback_write_refused("full index", err);
+    assert!(
+        !active_dirty.exists() && !store_dirty.exists(),
+        "rejected full index must not leave dirty recovery markers"
+    );
 
     let stale_files = ["src/detached_only.rs".to_string()];
     let err = fallback

--- a/tests/storage_suite/corruption_test.rs
+++ b/tests/storage_suite/corruption_test.rs
@@ -587,9 +587,10 @@ async fn dirty_open_reuses_recovery_lock_for_migration_reindex()
     std::fs::write(&layout.dirty_path, "pid=99999\nversion=test")?;
 
     let reopened = TraceDecay::open_with_options(&project_root, open_options).await?;
-    assert!(
-        reopened.get_nodes_by_name("migrated").await?.len() == 1,
-        "migration re-index must complete after dirty recovery"
+    assert_eq!(
+        reopened.get_nodes_by_name("migrated").await?.len(),
+        1,
+        "migration reindex must complete after dirty recovery"
     );
     assert!(!layout.dirty_path.exists());
     reopened.close();

--- a/tests/storage_suite/corruption_test.rs
+++ b/tests/storage_suite/corruption_test.rs
@@ -14,6 +14,7 @@ use crate::support;
 use std::io::{Seek, Write};
 use tempfile::TempDir;
 use tracedecay::db::Database;
+use tracedecay::db::migrations::{FULL_REINDEX_REQUIRED_KEY, FULL_REINDEX_REQUIRED_VALUE};
 use tracedecay::tracedecay::{TraceDecay, TraceDecayOpenOptions, try_acquire_sync_lock_at};
 use tracedecay::types::*;
 
@@ -591,6 +592,40 @@ async fn dirty_open_reuses_recovery_lock_for_migration_reindex()
         "migration re-index must complete after dirty recovery"
     );
     assert!(!layout.dirty_path.exists());
+    reopened.close();
+    Ok(())
+}
+
+#[tokio::test]
+async fn pending_migration_reindex_retries_after_migration_already_committed()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(project_root.join("src"))?;
+    std::fs::write(project_root.join("src/lib.rs"), "pub fn retried() {}\n")?;
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(dir.path().join("profile")),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+
+    let ts = TraceDecay::init_with_options(&project_root, open_options.clone()).await?;
+    ts.db()
+        .set_metadata(FULL_REINDEX_REQUIRED_KEY, FULL_REINDEX_REQUIRED_VALUE)
+        .await?;
+    ts.checkpoint().await?;
+    ts.close();
+
+    let reopened = TraceDecay::open_with_options(&project_root, open_options).await?;
+    assert_eq!(reopened.get_nodes_by_name("retried").await?.len(), 1);
+    assert_eq!(
+        reopened
+            .db()
+            .get_metadata(FULL_REINDEX_REQUIRED_KEY)
+            .await?
+            .as_deref(),
+        Some("0"),
+        "reindex intent must clear only after the retry commits"
+    );
     reopened.close();
     Ok(())
 }

--- a/tests/storage_suite/corruption_test.rs
+++ b/tests/storage_suite/corruption_test.rs
@@ -564,6 +564,38 @@ async fn dirty_open_checks_integrity_before_writable_migration()
 }
 
 #[tokio::test]
+async fn dirty_open_releases_recovery_lock_before_migration_reindex()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dir = TempDir::new()?;
+    let project_root = dir.path().join("repo");
+    std::fs::create_dir_all(project_root.join("src"))?;
+    std::fs::write(project_root.join("src/lib.rs"), "pub fn migrated() {}\n")?;
+    let open_options = TraceDecayOpenOptions {
+        profile_root: Some(dir.path().join("profile")),
+        global_db_path: Some(dir.path().join("global.db")),
+    };
+
+    let ts = TraceDecay::init_with_options(&project_root, open_options.clone()).await?;
+    let layout = ts.store_layout().clone();
+    ts.db()
+        .conn()
+        .execute_batch("PRAGMA user_version = 17")
+        .await?;
+    ts.checkpoint().await?;
+    ts.close();
+    std::fs::write(&layout.dirty_path, "pid=99999\nversion=test")?;
+
+    let reopened = TraceDecay::open_with_options(&project_root, open_options).await?;
+    assert!(
+        reopened.get_nodes_by_name("migrated").await?.len() == 1,
+        "migration re-index must complete after dirty recovery"
+    );
+    assert!(!layout.dirty_path.exists());
+    reopened.close();
+    Ok(())
+}
+
+#[tokio::test]
 async fn dirty_open_does_not_race_an_active_sync_lock()
 -> std::result::Result<(), Box<dyn std::error::Error>> {
     let dir = TempDir::new()?;

--- a/tests/storage_suite/corruption_test.rs
+++ b/tests/storage_suite/corruption_test.rs
@@ -564,7 +564,7 @@ async fn dirty_open_checks_integrity_before_writable_migration()
 }
 
 #[tokio::test]
-async fn dirty_open_releases_recovery_lock_before_migration_reindex()
+async fn dirty_open_reuses_recovery_lock_for_migration_reindex()
 -> std::result::Result<(), Box<dyn std::error::Error>> {
     let dir = TempDir::new()?;
     let project_root = dir.path().join("repo");

--- a/tests/storage_suite/migration_test.rs
+++ b/tests/storage_suite/migration_test.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 
 use libsql::{Builder, Connection, Database as LibsqlDatabase};
 use tempfile::TempDir;
-use tracedecay::db::migrations::{create_schema, migrate};
+use tracedecay::db::migrations::{
+    FULL_REINDEX_REQUIRED_KEY, FULL_REINDEX_REQUIRED_VALUE, create_schema, migrate,
+};
 
 use crate::support;
 
@@ -124,6 +126,20 @@ async fn get_user_version(conn: &Connection) -> u32 {
         .expect("user_version should return a row");
     let v: i64 = row.get(0).expect("failed to read user_version value");
     v as u32
+}
+
+async fn metadata_value(conn: &Connection, key: &str) -> Option<String> {
+    let mut rows = conn
+        .query(
+            "SELECT value FROM metadata WHERE key = ?1",
+            libsql::params![key],
+        )
+        .await
+        .expect("failed to query metadata");
+    rows.next()
+        .await
+        .expect("failed to read metadata row")
+        .map(|row| row.get(0).expect("failed to read metadata value"))
 }
 
 /// Checks whether a table exists in sqlite_master.
@@ -558,6 +574,10 @@ async fn test_migrate_from_v0() {
         "migrate should return true when migrations were applied"
     );
     assert_eq!(get_user_version(&conn).await, 18);
+    assert_eq!(
+        metadata_value(&conn, FULL_REINDEX_REQUIRED_KEY).await,
+        Some(FULL_REINDEX_REQUIRED_VALUE.to_string())
+    );
 
     // All expected tables should exist
     assert!(table_exists(&conn, "nodes").await);


### PR DESCRIPTION
## Summary
- exclude merge commits from commit-message linting by topology and fail closed on invalid ranges
- preserve definitive Cline project matches when auxiliary metadata is unavailable
- make slashless grep globs include generated-directory descendants
- reuse the dirty-recovery sync lock through migration reindexing, persist interrupted reindex intent, and clear it while the lease remains held
- reject non-writable full indexes before creating dirty markers
- regenerate the root Cargo.lock on Release Please branches without committing build artifacts or unstable inline markers

## Verification
- full GitHub CI matrix: Linux, macOS, Windows shards, Clippy, formatting, dashboard, Hermes, MCP/plugin validation
- `cargo test --test storage_suite branch_db_safety_test::fallback_writes_are_refused_by_all_sync_entry_points -- --exact` (1 passed)
- `bash tests/release_workflow_contract_test.sh`
- `actionlint .github/workflows/release-please.yml .github/workflows/ci.yml`
- focused grep, Cline, corruption, locking, and migration suites
- `cargo fmt --all -- --check`
- `git diff --check`
