### PR TITLE
fix(release): update root lockfile deterministically

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,12 @@ jobs:
         env:
           RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
         run: |
-          cargo metadata --format-version 1 --no-deps >/dev/null
+          release_version=$(tr -d '[:space:]' < version.txt)
+          if [[ -z "$release_version" ]]; then
+            echo "Release version is empty" >&2
+            exit 1
+          fi
+          cargo update -p tracedecay --precise "$release_version"
 
           if git diff --quiet -- Cargo.lock; then
             exit 0

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -109,7 +109,7 @@ for required in [
     "target-branch: master",
     "steps.release.outputs.prs_created == 'true'",
     "fromJSON(steps.release.outputs.pr).headBranchName",
-    "cargo metadata --format-version 1 --no-deps",
+    'cargo update -p tracedecay --precise "$release_version"',
     'git push origin "HEAD:$RELEASE_PR_BRANCH"',
     "Check GitHub release version drift",
 ]:


### PR DESCRIPTION
## Summary
- derive the Release Please version from `version.txt`
- update only the root `tracedecay` lock entry with Cargo's targeted update command
- fail closed when the generated release version is empty
- update the release workflow contract to require the effective command

## Root cause
`cargo metadata --no-deps` accepts a stale workspace root version in Cargo.lock and exits without modifying the file. The regenerated 0.1.0 release PR therefore failed locked Clippy. A disposable checkout of that release branch confirmed `cargo update -p tracedecay --precise 0.1.0` changes exactly the root version line.

## Verification
- `bash tests/release_workflow_contract_test.sh`
- `actionlint .github/workflows/release-please.yml`
- `git diff --check`
- disposable release-branch probe: Cargo.lock changed by one deletion and one insertion only
