### PR TITLE
fix(daemon): close startup readiness races

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -224,7 +224,7 @@ Examples:
   tracedecay daemon status                       Service and socket state
   tracedecay daemon install-service              Install + start the user service
   tracedecay daemon restart                      Restart after a version mismatch
-  tracedecay daemon run --socket /tmp/td.sock    Foreground run (debugging)
+  tracedecay daemon run --socket ~/.tracedecay/debug.sock    Foreground run (debugging)
 
 Related: tracedecay doctor (detects daemon problems), tracedecay serve.";
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2253,6 +2253,28 @@ impl DaemonEngine {
                 .await);
         }
 
+        let gate = project_open_gate(&self.project_open_gates, &route).await;
+        let _singleflight = gate.lock().await;
+        self.project_server_after_open_gate(handshake).await
+    }
+
+    async fn project_server_after_open_gate(
+        &self,
+        handshake: &DaemonHandshake,
+    ) -> Result<Arc<crate::mcp::McpServer>> {
+        let (project_path, route) = Self::project_route(handshake)?;
+        let cached = {
+            let servers = self.store_administration.project_servers().lock().await;
+            servers
+                .get_route(&route)
+                .map(|(key, server)| (key.clone(), Arc::clone(server)))
+        };
+        if let Some((key, server)) = cached {
+            return Ok(self
+                .activate_project_server(key, project_path, handshake, server)
+                .await);
+        }
+
         let (key, project_path, server) = self
             .store_administration
             .with_writer(|| self.open_project_server(handshake))
@@ -2262,37 +2284,78 @@ impl DaemonEngine {
             .await)
     }
 
-    fn spawn_project_server_warmup(
+    async fn spawn_project_server_warmup(
         &self,
         handshake: DaemonHandshake,
         initialize_request: JsonRpcRequest,
     ) {
+        let (_, route) = match Self::project_route(&handshake) {
+            Ok(route) => route,
+            Err(error) => {
+                spawn_lifecycle_project_server_warmup(
+                    self.lifecycle.clone(),
+                    initialize_request,
+                    async move { Err(error) },
+                );
+                return;
+            }
+        };
+        let gate = project_open_gate(&self.project_open_gates, &route).await;
         let engine = self.clone();
-        spawn_lifecycle_project_server_warmup(
-            self.lifecycle.clone(),
-            initialize_request,
-            async move { Box::pin(engine.project_server(&handshake)).await },
-        );
+        match Arc::clone(&gate).try_lock_owned() {
+            Ok(singleflight) => {
+                spawn_lifecycle_project_server_warmup(
+                    self.lifecycle.clone(),
+                    initialize_request,
+                    async move {
+                        let _singleflight = singleflight;
+                        Box::pin(engine.project_server_after_open_gate(&handshake)).await
+                    },
+                );
+            }
+            Err(_) => {
+                spawn_lifecycle_project_server_warmup(
+                    self.lifecycle.clone(),
+                    initialize_request,
+                    async move { Box::pin(engine.project_server(&handshake)).await },
+                );
+            }
+        }
     }
 
-    fn spawn_direct_project_server_open(
+    async fn spawn_direct_project_server_open(
         &self,
         handshake: DaemonHandshake,
-    ) -> JoinHandle<Result<Arc<crate::mcp::McpServer>>> {
+    ) -> Result<(JoinHandle<Result<Arc<crate::mcp::McpServer>>>, bool)> {
+        let (_, route) = Self::project_route(&handshake)?;
+        let gate = project_open_gate(&self.project_open_gates, &route).await;
         let engine = self.clone();
-        tokio::spawn(async move {
+        let (singleflight, joins_existing_open) = match Arc::clone(&gate).try_lock_owned() {
+            Ok(singleflight) => (Some(singleflight), false),
+            Err(_) => (None, true),
+        };
+        let task = tokio::spawn(async move {
             let Some(activity) = engine.lifecycle.try_enter() else {
                 return Err(TraceDecayError::Config {
                     message: "daemon is draining before project warm-up".to_string(),
                 });
             };
             let _activity = activity;
+            let open = async {
+                match singleflight {
+                    Some(singleflight) => {
+                        let _singleflight = singleflight;
+                        engine.project_server_after_open_gate(&handshake).await
+                    }
+                    None => engine.project_server(&handshake).await,
+                }
+            };
             let result = tokio::select! {
                 biased;
                 () = engine.lifecycle.wait_for_draining() => Err(TraceDecayError::Config {
                     message: "daemon began draining during project warm-up".to_string(),
                 }),
-                result = Box::pin(engine.project_server(&handshake)) => result,
+                result = Box::pin(open) => result,
             };
             if let Err(error) = &result {
                 log_daemon_event(
@@ -2304,7 +2367,8 @@ impl DaemonEngine {
                 );
             }
             result
-        })
+        });
+        Ok((task, joins_existing_open))
     }
 
     /// Opens or resolves a project server while writer administration is held.
@@ -2315,18 +2379,6 @@ impl DaemonEngine {
         handshake: &DaemonHandshake,
     ) -> Result<(ProjectServerKey, PathBuf, Arc<crate::mcp::McpServer>)> {
         let (canonical_project_path, route) = Self::project_route(handshake)?;
-        let cached = {
-            let servers = self.store_administration.project_servers().lock().await;
-            servers
-                .get_route(&route)
-                .map(|(key, server)| (key.clone(), Arc::clone(server)))
-        };
-        if let Some((key, server)) = cached {
-            return Ok((key, canonical_project_path, server));
-        }
-
-        let gate = project_open_gate(&self.project_open_gates, &route).await;
-        let _singleflight = gate.lock().await;
         let cached = {
             let servers = self.store_administration.project_servers().lock().await;
             servers
@@ -2882,7 +2934,9 @@ async fn serve_broker_socket_client(
             if matches!(classify_mcp_method(&request.method), McpMethod::Initialize)
                 && handshake.project_path.is_some()
             {
-                engine.spawn_project_server_warmup(handshake.clone(), request);
+                engine
+                    .spawn_project_server_warmup(handshake.clone(), request)
+                    .await;
             }
             drop(setup_activity);
             if let DaemonBootstrap::Respond(response) = bootstrap {
@@ -2896,8 +2950,11 @@ async fn serve_broker_socket_client(
         // operation, so answer with a retry hint rather than holding the
         // client. An uncontended open is this client's own work and must run
         // to completion, otherwise one-shot callers never get a result.
-        let contended = engine.store_administration.writer_is_busy();
-        let mut project_open = engine.spawn_direct_project_server_open(handshake.clone());
+        let writer_contended = engine.store_administration.writer_is_busy();
+        let (mut project_open, joins_existing_open) = engine
+            .spawn_direct_project_server_open(handshake.clone())
+            .await?;
+        let contended = writer_contended && !joins_existing_open;
         let opened = if contended {
             tokio::time::timeout(CONTENDED_PROJECT_OPEN_GRACE, &mut project_open).await
         } else {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1639,7 +1639,6 @@ async fn run_foreground_unix(socket_path: PathBuf) -> Result<()> {
 
     let (listener, bound_endpoint) = BrokerListener::bind(authority.endpoint()).await?;
     authority.publish_endpoint(&bound_endpoint)?;
-    set_owner_only_permissions(&socket_path, 0o600)?;
     log_daemon_event(
         "daemon_listening",
         &[("endpoint", bound_endpoint.to_string())],

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -672,7 +672,9 @@ async fn project_server_warmup_drops_lifecycle_activity_on_draining() {
     });
     writer_held.notified().await;
 
-    engine.spawn_project_server_warmup(handshake, initialize_request);
+    engine
+        .spawn_project_server_warmup(handshake, initialize_request)
+        .await;
     engine.lifecycle.begin_draining();
     let idle_while_writer_held = tokio::time::timeout(
         tokio::time::Duration::from_secs(1),
@@ -1100,6 +1102,30 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
         tokio::time::timeout(tokio::time::Duration::from_secs(2), &mut tools_list_task),
     );
 
+    let direct_tool = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "tracedecay_status",
+            "arguments": {"format": "json"}
+        }
+    });
+    let direct_tool_engine = engine.clone();
+    let direct_tool_handshake = handshake.clone();
+    let mut direct_tool_task = tokio::spawn(async move {
+        daemon_round_trip(direct_tool_engine, &direct_tool_handshake, direct_tool).await
+    });
+    let direct_tool_before_warmup = tokio::time::timeout(
+        super::CONTENDED_PROJECT_OPEN_GRACE + tokio::time::Duration::from_millis(250),
+        &mut direct_tool_task,
+    )
+    .await;
+    assert!(
+        direct_tool_before_warmup.is_err(),
+        "a same-route tool call must wait for initialize warmup"
+    );
+
     release_writer.send(()).expect("signal writer gate release");
     blocker.await.expect("writer gate blocker task");
     if initialize_within_bound.is_err() {
@@ -1108,6 +1134,18 @@ async fn mcp_bootstrap_catalog_bypasses_project_writer_gate() {
     if tools_list_within_bound.is_err() {
         let _ = tools_list_task.await;
     }
+    let direct_tool_responses = tokio::time::timeout(PHASE_TIMEOUT, &mut direct_tool_task)
+        .await
+        .expect("same-route tool call timed out after warmup")
+        .expect("direct tool client task");
+    let direct_tool_response = direct_tool_responses
+        .iter()
+        .find(|response| response["id"] == json!(3))
+        .expect("direct tool response");
+    assert!(
+        direct_tool_response.get("result").is_some(),
+        "{direct_tool_response}"
+    );
 
     let initialize_responses = initialize_within_bound
         .expect("initialize must not wait for project writer gate")

--- a/src/daemon/transport.rs
+++ b/src/daemon/transport.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 #[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -209,6 +211,21 @@ impl BrokerListener {
             #[cfg(unix)]
             DaemonEndpoint::Unix(path) => {
                 let listener = tokio::net::UnixListener::bind(path)?;
+                if let Err(error) =
+                    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                {
+                    drop(listener);
+                    let cleanup = match std::fs::remove_file(path) {
+                        Ok(()) => String::new(),
+                        Err(cleanup_error) => {
+                            format!("; cleanup also failed: {cleanup_error}")
+                        }
+                    };
+                    return Err(config_error(format!(
+                        "failed to restrict permissions on daemon socket '{}': {error}{cleanup}",
+                        path.display(),
+                    )));
+                }
                 Ok((Self::Unix(listener), endpoint.clone()))
             }
             DaemonEndpoint::Loopback(address) => {
@@ -242,7 +259,22 @@ pub fn default_loopback_endpoint() -> DaemonEndpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listener_is_owner_only_when_bind_returns() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("daemon.sock");
+        let endpoint = DaemonEndpoint::Unix(path.clone());
+
+        let (_listener, _) = BrokerListener::bind(&endpoint).await.unwrap();
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
 
     #[test]
     fn loopback_endpoint_round_trips_and_rejects_remote_addresses() {

--- a/src/daemon/transport.rs
+++ b/src/daemon/transport.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::task::{Context, Poll};
@@ -205,11 +205,41 @@ pub enum BrokerListener {
     Tcp(tokio::net::TcpListener),
 }
 
+#[cfg(unix)]
+fn ensure_private_socket_parent(path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let metadata = std::fs::metadata(parent).map_err(|error| {
+        config_error(format!(
+            "failed to inspect daemon socket directory '{}': {error}",
+            parent.display()
+        ))
+    })?;
+    if !metadata.is_dir() {
+        return Err(config_error(format!(
+            "daemon socket parent '{}' is not a directory",
+            parent.display()
+        )));
+    }
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        return Err(config_error(format!(
+            "refusing to publish daemon socket '{}' outside a private directory: '{}' has mode {mode:04o}; restrict it to 0700",
+            path.display(),
+            parent.display(),
+        )));
+    }
+    Ok(())
+}
+
 impl BrokerListener {
     pub async fn bind(endpoint: &DaemonEndpoint) -> Result<(Self, DaemonEndpoint)> {
         match endpoint {
             #[cfg(unix)]
             DaemonEndpoint::Unix(path) => {
+                ensure_private_socket_parent(path)?;
                 let listener = tokio::net::UnixListener::bind(path)?;
                 if let Err(error) =
                     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
@@ -267,6 +297,7 @@ mod tests {
     #[tokio::test]
     async fn unix_listener_is_owner_only_when_bind_returns() {
         let directory = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
         let path = directory.path().join("daemon.sock");
         let endpoint = DaemonEndpoint::Unix(path.clone());
 
@@ -274,6 +305,22 @@ mod tests {
 
         let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listener_rejects_public_parent_before_publishing_socket() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = directory.path().join("daemon.sock");
+        let endpoint = DaemonEndpoint::Unix(path.clone());
+
+        let Err(error) = BrokerListener::bind(&endpoint).await else {
+            panic!("public socket parent must be rejected");
+        };
+
+        assert!(error.to_string().contains("private directory"), "{error}");
+        assert!(!path.exists());
     }
 
     #[test]

--- a/tests/transcript_ingest_suite/cursor.rs
+++ b/tests/transcript_ingest_suite/cursor.rs
@@ -264,7 +264,7 @@ async fn cursor_pre_compact_uses_cursor_agent_summary_for_lcm() {
             tmp.path().join("summary-workspace"),
         ),
     ];
-    let _daemon = spawn_tracedecay_daemon(&home);
+    let daemon = spawn_tracedecay_daemon(&home);
 
     let event = serde_json::json!({
         "hook_event_name": "preCompact",
@@ -280,6 +280,7 @@ async fn cursor_pre_compact_uses_cursor_agent_summary_for_lcm() {
     let outcome = cursor_pre_compact_via_daemon(&event.to_string()).await;
     assert_eq!(outcome.status, "ok", "{}", outcome.reason);
     assert_eq!(outcome.summary_nodes_created, 1);
+    drop(daemon);
 
     let db = open_project_session_db(&project).await.unwrap();
     let node_id = outcome


### PR DESCRIPTION
## Summary

- protect Unix socket publication with a private parent directory and normalize the socket to mode `0600` before returning it
- register project warmups before initialize replies so same-route tool calls join their own warmup
- stop the Cursor test daemon before opening its databases directly

## Root causes

The socket was briefly visible at its umask-derived mode, same-route requests could misclassify their own initialize warmup as unrelated writer contention, and one test retained the daemon database owner during direct assertions.

## Verification

- focused socket permission and public-parent rejection unit tests
- daemon socket integration test
- controlled same-route warmup regression test
- fresh-project auto-initialize MCP integration test
- Cursor pre-compact LCM integration test
- local `cargo clippy -p tracedecay --lib --tests -- -D warnings`
- full CI green on Linux, macOS, Windows (all five shards), dashboard, Hermes, formatting, clippy, commit policy, and release-contract checks
- actionable review thread answered and resolved