### PR TITLE
fix(release): use package-neutral GitHub tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "pull-request-title-pattern": "chore(release): release ${version}",
   "packages": {
     ".": {

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -36,6 +36,8 @@ if config.get("release-type") != "simple":
     raise SystemExit("release automation must use package-neutral tag versioning")
 if config.get("include-v-in-tag") is not True:
     raise SystemExit("GitHub release tags must use the v prefix")
+if config.get("include-component-in-tag") is not False:
+    raise SystemExit("GitHub release tags must not include the package component")
 
 root_release = config.get("packages", {}).get(".")
 if root_release is None:


### PR DESCRIPTION
## Summary

- configure Release Please to generate `vX.Y.Z` tags without the `tracedecay-` component prefix
- enforce the tag identity in the release workflow contract test

## Root cause

Release Please defaulted to `tracedecay-v0.1.0`, while the GitHub release workflow, installer, and `tracedecay upgrade` all use `v0.1.0`. The refreshed release PR therefore could not be merged safely.

## Verification

- reproduced the contract failure before the config change
- `bash tests/release_workflow_contract_test.sh`
- `git diff --check`
- confirmed against the official Release Please manifest documentation that `include-component-in-tag: false` produces `v<release-version>` tags