### PR TITLE
fix(release): tolerate missing release PR output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,8 +37,13 @@ jobs:
       - name: Update release PR lockfile
         if: steps.release.outputs.prs_created == 'true'
         env:
-          RELEASE_PR_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
+          RELEASE_PR_BRANCH=$(
+            jq --exit-status --raw-output \
+              '.headBranchName | select(type == "string" and length > 0)' \
+              <<<"$RELEASE_PR_JSON"
+          )
           release_version=$(tr -d '[:space:]' < version.txt)
           if [[ -z "$release_version" ]]; then
             echo "Release version is empty" >&2

--- a/tests/release_workflow_contract_test.sh
+++ b/tests/release_workflow_contract_test.sh
@@ -111,12 +111,17 @@ for required in [
     "target-branch: master",
     "steps.release.outputs.prs_created == 'true'",
     "fromJSON(steps.release.outputs.pr).headBranchName",
+    "RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}",
+    "jq --exit-status --raw-output",
     'cargo update -p tracedecay --precise "$release_version"',
     'git push origin "HEAD:$RELEASE_PR_BRANCH"',
     "Check GitHub release version drift",
 ]:
     if required not in release_please:
         raise SystemExit(f"GitHub-only release workflow missing {required!r}")
+
+if "RELEASE_PR_BRANCH: ${{ fromJSON(" in release_please:
+    raise SystemExit("skipped release PR steps must not parse an absent PR output")
 
 for path, text in [
     (sys.argv[1], release_please),


### PR DESCRIPTION
## Summary
- keep the release PR output as inert JSON in the lockfile step environment
- parse and validate the head branch only inside the step after `prs_created` is true
- prevent post-release runs from evaluating `fromJSON('')`

## Evidence
- reproduced in Release Please run 30901632675 after v0.0.69 was created
- `bash tests/release_workflow_contract_test.sh`
- `actionlint .github/workflows/release-please.yml`
- `git diff --check`
