### PR TITLE
fix(codex): pin managed agents to Terra

### DIFF
--- a/crates/tracedecay-agent-hosts/build.rs
+++ b/crates/tracedecay-agent-hosts/build.rs
@@ -185,14 +185,10 @@ fn main() {
         &mut code,
         "GENERATED_CODEX_AGENT_FILES",
         agents.iter().map(|agent| {
-            // Keep routine read-only specialists on Terra so they do not
-            // silently inherit an expensive primary Sol session. Semantic
-            // merge-risk review remains the one Sol-backed specialist.
-            let (model, model_reasoning_effort) = if agent.name == "change-risk-reviewer" {
-                ("gpt-5.6-sol", "high")
-            } else {
-                ("gpt-5.6-terra", "high")
-            };
+            // Keep read-only specialists on Terra so they do not silently
+            // inherit an expensive primary Sol session. Sol Advisor owns the
+            // separately configured explicit final/high-risk review lane.
+            let (model, model_reasoning_effort) = ("gpt-5.6-terra", "high");
             (
                 format!("tracedecay-{}.toml", agent.name),
                 format!(

--- a/crates/tracedecay-agent-hosts/build.rs
+++ b/crates/tracedecay-agent-hosts/build.rs
@@ -185,12 +185,22 @@ fn main() {
         &mut code,
         "GENERATED_CODEX_AGENT_FILES",
         agents.iter().map(|agent| {
+            // Keep routine read-only specialists on Terra so they do not
+            // silently inherit an expensive primary Sol session. Semantic
+            // merge-risk review remains the one Sol-backed specialist.
+            let (model, model_reasoning_effort) = if agent.name == "change-risk-reviewer" {
+                ("gpt-5.6-sol", "high")
+            } else {
+                ("gpt-5.6-terra", "high")
+            };
             (
                 format!("tracedecay-{}.toml", agent.name),
                 format!(
-                    "name = {}\ndescription = {}\nsandbox_mode = \"read-only\"\ndeveloper_instructions = {}\n",
+                    "name = {}\ndescription = {}\nmodel = {}\nmodel_reasoning_effort = {}\nsandbox_mode = \"read-only\"\ndeveloper_instructions = {}\n",
                     quoted_string(&format!("tracedecay-{}", agent.name)),
                     quoted_string(&agent.description),
+                    quoted_string(model),
+                    quoted_string(model_reasoning_effort),
                     quoted_string(&agent.body),
                 ),
             )

--- a/tests/agent_suite/claude_plugin_bundle_test.rs
+++ b/tests/agent_suite/claude_plugin_bundle_test.rs
@@ -588,6 +588,16 @@ fn cursor_and_codex_agents_are_generated_from_the_canonical_catalog() {
             Some(required_scalar(&claude, "description", &claude_path).as_str())
         );
         assert_eq!(codex_toml["sandbox_mode"].as_str(), Some("read-only"));
+        let (expected_model, expected_effort) = if stem == "change-risk-reviewer" {
+            ("gpt-5.6-sol", "high")
+        } else {
+            ("gpt-5.6-terra", "high")
+        };
+        assert_eq!(codex_toml["model"].as_str(), Some(expected_model));
+        assert_eq!(
+            codex_toml["model_reasoning_effort"].as_str(),
+            Some(expected_effort)
+        );
         assert_eq!(
             codex_toml["developer_instructions"].as_str().map(str::trim),
             Some(canonical_body.trim())

--- a/tests/agent_suite/claude_plugin_bundle_test.rs
+++ b/tests/agent_suite/claude_plugin_bundle_test.rs
@@ -588,16 +588,8 @@ fn cursor_and_codex_agents_are_generated_from_the_canonical_catalog() {
             Some(required_scalar(&claude, "description", &claude_path).as_str())
         );
         assert_eq!(codex_toml["sandbox_mode"].as_str(), Some("read-only"));
-        let (expected_model, expected_effort) = if stem == "change-risk-reviewer" {
-            ("gpt-5.6-sol", "high")
-        } else {
-            ("gpt-5.6-terra", "high")
-        };
-        assert_eq!(codex_toml["model"].as_str(), Some(expected_model));
-        assert_eq!(
-            codex_toml["model_reasoning_effort"].as_str(),
-            Some(expected_effort)
-        );
+        assert_eq!(codex_toml["model"].as_str(), Some("gpt-5.6-terra"));
+        assert_eq!(codex_toml["model_reasoning_effort"].as_str(), Some("high"));
         assert_eq!(
             codex_toml["developer_instructions"].as_str().map(str::trim),
             Some(canonical_body.trim())


### PR DESCRIPTION
## Summary

- emit explicit model and reasoning settings in generated Codex managed-agent TOML
- pin bundled read-only TraceDecay specialists to `gpt-5.6-terra` with high reasoning
- extend the cross-host catalog contract to prevent future model-routing drift

## Why

Generated Codex agents previously omitted model settings, allowing runtime model selection to vary with the calling session. Explicit Terra/high routing gives read-heavy specialists a stable quality and cost profile without changing their read-only sandbox or instructions.

## Validation

- `cargo test --test agent_suite cursor_and_codex_agents_are_generated_from_the_canonical_catalog`
- `cargo test --test agent_suite codex_managed_agents_export_to_user_agents_dir`
- `cargo fmt --check`
- `git diff --check`