### PR TITLE
fix(graph-db): bind supplied sealed manifests so first publish seats

### DIFF
--- a/crates/tracedecay-graph-db/src/generation/replay.rs
+++ b/crates/tracedecay-graph-db/src/generation/replay.rs
@@ -196,8 +196,24 @@ pub(crate) fn validate_supplied_manifest_binding(
         | GraphGenerationReplaySource::SemanticVectorGeneration(_) => {
             validate_metadata_binding(publication, manifest, validate_expected_digest, check)
         }
-        GraphGenerationReplaySource::InlineManifest(_)
-        | GraphGenerationReplaySource::SealedCodeGeneration(_) => Err(GraphDbError::Conflict),
+        // A sealed code generation journals only its replay source, so the
+        // supplied manifest cannot be compared field-by-field against a
+        // journaled manifest. The identity check below still pins it exactly:
+        // the journaled dependency-closure and expected-recovered digests were
+        // derived from the manifest at append time, so only the manifest that
+        // was journaled can pass. Refusing every supplied sealed manifest here
+        // made each code-graph publication fail as `Conflict` immediately
+        // after its own journal append, permanently wedging activation.
+        GraphGenerationReplaySource::SealedCodeGeneration(source) => {
+            validate_sealed_replay(&source)?;
+            validate_publication_manifest_identity(
+                publication,
+                manifest,
+                validate_expected_digest,
+                check,
+            )
+        }
+        GraphGenerationReplaySource::InlineManifest(_) => Err(GraphDbError::Conflict),
     }
 }
 

--- a/crates/tracedecay-graph-db/tests/verified_generation_contract.rs
+++ b/crates/tracedecay-graph-db/tests/verified_generation_contract.rs
@@ -444,6 +444,98 @@ fn stage_manifest(
     )
 }
 
+/// Sealed code generations journal only their replay source; the projection
+/// manifest is rebuilt from the sealed artifact and supplied by the
+/// publication owner. The supplied manifest must bind through the journaled
+/// identity digests and publish. Refusing every sealed supplied manifest as
+/// `Conflict` failed each code-graph publication immediately after its own
+/// journal append, so no sealed generation could ever become the verified
+/// head and code-index activation looped on `code graph database conflict`.
+#[test]
+fn sealed_code_generation_publishes_with_its_supplied_manifest() {
+    let temp = TempDir::new().unwrap();
+    let registered = RegisteredGraph::new_mounted(temp.path()).unwrap();
+    let mut authority = RelationalAuthority::default();
+    let identity = projection("code-scope:sealed-supplied", "code-generation");
+    let sealed_manifest = manifest(
+        identity.clone(),
+        "code-graph:sealed-supplied",
+        "sealed",
+        vec![],
+        vec![],
+    );
+    let sealed_source = SealedCodeGenerationReplay {
+        repository: RepositoryId::new("repository.sealed-supplied").unwrap(),
+        generation: CodeGenerationId::new("code-generation.sealed-supplied").unwrap(),
+        sealed_state_digest: SealedGraphStateDigest::try_from(format!("sha256:{}", "7".repeat(64)))
+            .unwrap(),
+        projector_revision: GraphProjectorRevision::try_from("projector.sealed-supplied".to_owned())
+            .unwrap(),
+    };
+    // The journal row is exactly what the code-index publisher appends: the
+    // sealed replay source rides in the payload while the identity digests
+    // pin the projection manifest built from the sealed artifact.
+    let record = authority.stage(
+        sealed_manifest
+            .relational_sealed_replay(
+                registered.binding.shard_id.clone(),
+                GraphIdempotencyKey::new("publish:code-graph:sealed-supplied").unwrap(),
+                digest('1'),
+                None,
+                sealed_source,
+                &|| Ok(()),
+            )
+            .unwrap(),
+    );
+
+    // A foreign manifest for the same journaled sealed replay stays refused:
+    // different projected content cannot pass the journaled recovered digest.
+    let foreign = manifest(
+        identity.clone(),
+        "code-graph:sealed-supplied",
+        "foreign-content",
+        vec![],
+        vec![],
+    );
+    let (control, probe) = control_and_probe();
+    let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+    assert_eq!(
+        registered
+            .registry
+            .publish_verified_manifest(
+                registration(registered.binding.clone(), temp.path()),
+                &mut authority,
+                &context,
+                &record.publication.key,
+                foreign,
+            )
+            .unwrap_err(),
+        GraphDbError::Conflict
+    );
+
+    let (control, probe) = control_and_probe();
+    let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+    let commit = registered
+        .registry
+        .publish_verified_manifest(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &record.publication.key,
+            sealed_manifest.clone(),
+        )
+        .expect("the exact supplied sealed projection manifest must publish");
+    assert_eq!(commit.head.key, record.publication.key);
+    let snapshot = registered
+        .registry
+        .verified_snapshot(
+            registration(registered.binding.clone(), temp.path()),
+            &identity,
+        )
+        .unwrap();
+    assert_eq!(snapshot.generation(), &sealed_manifest.generation);
+}
+
 #[test]
 fn retired_replay_survives_native_delete_failure_until_restart_cleanup_finalizes() {
     let temp = TempDir::new().unwrap();

--- a/crates/tracedecay-rusqlite-runtime/src/reader/worker.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/reader/worker.rs
@@ -557,7 +557,7 @@ fn run_snapshot<E: ReaderQueryExecutor>(
                 let _ = reply.send(result);
             }
             SnapshotCommand::ReleaseMemory { reply } => {
-                let _ = reply.send(shrink_connection_memory(&*transaction));
+                let _ = reply.send(shrink_connection_memory(&transaction));
             }
             SnapshotCommand::End { reply } => {
                 let result = transaction.rollback().map_err(|error| {

--- a/src/daemon/store_runtime/session_registry/code_graph.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph.rs
@@ -39,6 +39,8 @@ pub(super) use memory_runtime::{
     inline_graph_publication_input_digest, schedule_bound_memory_graph_reconciliation,
 };
 pub(super) mod graph_attachment;
+#[cfg(test)]
+mod sealed_publication_tests;
 mod seals;
 mod semantic_vector;
 use seals::{

--- a/src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs
@@ -1,0 +1,158 @@
+//! Direct persistent-activation coverage for sealed code generations.
+//!
+//! Production code-index activation flows through
+//! [`super::RetainedCodeGraphRuntimeV1::publish_verified_snapshot`], while the
+//! scheduler test registry mounts the in-memory activation authority, so this
+//! path had no direct regression. The live failure it now covers: every
+//! sealed publication answered `code graph database conflict` immediately
+//! after its own journal append, the retained-seat and reconcile retries
+//! looped on the same conflict, and the served census stayed
+//! `exact_scope_generation_not_ready` until the store was reset.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use tracedecay_domain::ProjectId;
+use tracedecay_graph_db::GraphProjectorRevision;
+use tracedecay_usecases::retention::code_index_generations::DurablePublicationPointerV1;
+
+use super::super::DaemonSessionRuntimeRegistryV1;
+use crate::daemon::code_index_scheduler::{
+    CodeGraphReplayBindingV1, CodeIndexWorktreeSchedulerV1, SharedCodeIndexBytePoolV1,
+    scoped_code_index_store_root,
+};
+use crate::daemon::profile_identity;
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("run git fixture command");
+    assert!(
+        output.status.success(),
+        "git fixture command failed: {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sealed_generation_publishes_and_republishes_as_the_verified_code_graph() {
+    let temporary = tempfile::tempdir().expect("temporary fixture parent");
+    let root = temporary
+        .path()
+        .canonicalize()
+        .expect("canonical fixture root");
+    let profile_root = root.join("profile");
+    let project_root = root.join("project");
+    std::fs::create_dir_all(project_root.join("src")).expect("project source directory");
+    git(&project_root, &["init", "-q", "-b", "main"]);
+    git(&project_root, &["config", "user.name", "TraceDecay Test"]);
+    git(
+        &project_root,
+        &["config", "user.email", "tracedecay@example.invalid"],
+    );
+    std::fs::write(
+        project_root.join("src/lib.rs"),
+        "pub fn sealed_publication_value() -> usize { 41 }\n",
+    )
+    .expect("project source");
+    git(&project_root, &["add", "."]);
+    git(&project_root, &["commit", "-qm", "sealed fixture"]);
+    let project_id = ProjectId::new("project.sealed-code-publication").expect("project id");
+    crate::storage::pin_fixture_repository_identity(&project_root, project_id.as_str())
+        .expect("project enrollment");
+    let canonical_project = project_root.canonicalize().expect("canonical project root");
+
+    // Seal one real generation through the production worktree scheduler.
+    let store_root = root.join("code-index-store");
+    let scoped_store = scoped_code_index_store_root(&store_root, &canonical_project);
+    let mut scheduler = CodeIndexWorktreeSchedulerV1::open(
+        project_id.clone(),
+        &canonical_project,
+        scoped_store.clone(),
+        Arc::new(SharedCodeIndexBytePoolV1::default()),
+    )
+    .expect("open worktree scheduler");
+    scheduler.reconcile_now().expect("seal the generation");
+    let latest = scheduler.latest_complete().expect("complete generation");
+    let repository_id = latest.generation().snapshot().repository.clone();
+    let reference = latest.generation().snapshot().reference.clone();
+    let worktree_id = scheduler.identity().worktree_id().clone();
+    let generation_id = latest.generation().manifest().generation_id.clone();
+    drop(scheduler);
+    let pointer: DurablePublicationPointerV1 = serde_json::from_slice(
+        &std::fs::read(scoped_store.join("active-code-generation-v1.json"))
+            .expect("active generation pointer"),
+    )
+    .expect("decode active generation pointer");
+    assert_eq!(pointer.generation_id, generation_id.as_str());
+    let replay_binding = || CodeGraphReplayBindingV1 {
+        generations_root: scoped_store.join("code-generations-v1"),
+        sealed_state_digest: tracedecay_graph_db::SealedGraphStateDigest::try_from(
+            pointer.state_digest.clone(),
+        )
+        .expect("sealed state digest"),
+    };
+
+    let identity = profile_identity::load_or_create(&profile_root).expect("profile identity");
+    let _database_scope =
+        crate::db::enter_daemon_database_scope(&profile_root, 43, "sealed code publication")
+            .expect("daemon database scope");
+    let registry = DaemonSessionRuntimeRegistryV1::open(identity)
+        .await
+        .expect("session runtime registry");
+    let project_database = registry
+        .project_memory(project_id.clone(), [canonical_project.clone()])
+        .await
+        .expect("project graph database");
+
+    let runtime = registry
+        .retain_code_graph_runtime(
+            project_id.clone(),
+            repository_id.clone(),
+            worktree_id.clone(),
+            reference.clone(),
+            generation_id.clone(),
+            Arc::clone(&project_database),
+            replay_binding(),
+        )
+        .await
+        .expect("retain code graph runtime");
+    let snapshot = runtime
+        .publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false)))
+        .expect("the sealed generation must publish as the verified code graph");
+    let expected_generation = tracedecay_code_index::graph_projection::code_graph_generation_id(
+        &generation_id,
+        &GraphProjectorRevision::try_from(
+            tracedecay_code_index::graph_projection::CODE_GRAPH_PROJECTOR_REVISION.to_owned(),
+        )
+        .expect("projector revision"),
+    )
+    .expect("code graph generation id");
+    assert_eq!(snapshot.generation(), &expected_generation);
+    let head = snapshot.verified_head().clone();
+    drop(snapshot);
+
+    // A retained-seat retry of the same sealed artifact resumes to the same
+    // verified head instead of conflicting with its own journaled replay.
+    let retried = registry
+        .retain_code_graph_runtime(
+            project_id,
+            repository_id,
+            worktree_id,
+            reference,
+            generation_id,
+            Arc::clone(&project_database),
+            replay_binding(),
+        )
+        .await
+        .expect("retain code graph runtime again");
+    let resumed = retried
+        .publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false)))
+        .expect("a repeated activation must resume the exact publication");
+    assert_eq!(resumed.generation(), &expected_generation);
+    assert_eq!(resumed.verified_head(), &head);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes the first `code graph database conflict` on a clean journal: `validate_supplied_manifest_binding` unconditionally rejected `SealedCodeGeneration` replay sources (`crates/tracedecay-graph-db/src/generation/replay.rs`, the `InlineManifest(_) | SealedCodeGeneration(_) => Err(GraphDbError::Conflict)` arm, formerly lines 199–200), so every sealed code generation's **own** publish failed immediately after its own journal append.
- Adds the missing direct regression for the persistent activation path (`RetainedCodeGraphRuntimeV1::publish_verified_snapshot`), which previously had no test — the scheduler test registry only mounts the in-memory activation authority.
- Fixes one pre-existing `clippy::explicit_auto_deref` in `tracedecay-rusqlite-runtime` that fails the `-D warnings` gate.

## Motivation

**Root cause of the remaining generation-seating failure.** The activation chain is `CodeGraphActivationAuthorityV1::activate` → `activate_persistent_graph` → `publish_verified_snapshot`:

1. `append_replay` journals a `relational_sealed_replay` whose canonical source is `SealedCodeGeneration` — this succeeds (`Appended`) on a fresh journal.
2. The same call then publishes with the manifest it just built: `publish(..., Some(manifest))` → `GraphDbRegistry::publish_verified_manifest`.
3. `publish_verified_manifest` → `validate_supplied_manifest_binding` hits the reject arm and answers `Conflict` — deterministically, for every sealed publication, before `apply_generation_unverified`/`reopen_and_verify`/CAS ever run.

This is why a fresh isolated profile conflicts seconds after `graph_admitted` and never seats. It also explains the exact residual after `421a9ad16` (orphaned-replay completion): predecessors drain through `publish_verified` (the provider-hydrate path, which has no supplied manifest and therefore never hits the reject arm), so conflicts drop to 1–2 per pass — but the pointer generation's own publish still conflicts, becomes the next orphan, and only lands after it is already superseded. Census stays `exact_scope_generation_not_ready` forever. The reject arm predates any sealed caller: sealed publication was routed onto the supplied-manifest publisher by the `9a01d4703` mitigation wave ("the already-built projection manifest rides along so first publication does not re-read and re-project the sealed artifact"), and the validation was never given a sealed arm.

**Why fix the manifest publisher rather than demote first-publish to `publish_verified` + hydrate:** `publish_verified_manifest` is the canonical `VerifiedGraphRuntimePortV1` publisher used across production (git topology, git correlation, native-integration topology, global-db, memory relations); the validation already accepts supplied manifests for metadata-only and semantic-vector sources, and sealed was simply the missing arm. Reverting to the hydrate path would re-read and re-project the entire sealed artifact (up to ~1.6 GB) that the caller just built — the exact double O(store) cost that produced the original activation deadline spiral. The hydrate path remains the completion authority for orphaned predecessors, where no manifest is in hand (`publish(..., None)`).

**The binding is not weakened.** The journaled row's `expected_recovered_digest` and `dependency_generation_closure_digest` are derived from the manifest at append time inside the same flow, so `validate_publication_manifest_identity` with `validate_expected_digest = true` admits only the manifest that was journaled; the sealed source itself is re-validated. A foreign manifest for the same journaled sealed replay still answers `Conflict` (asserted in the new contract test).

## Changes

- `crates/tracedecay-graph-db/src/generation/replay.rs` — give `validate_supplied_manifest_binding` a `SealedCodeGeneration` arm: `validate_sealed_replay` + `validate_publication_manifest_identity` instead of unconditional `Conflict`. `InlineManifest` mismatch stays refused.
- `crates/tracedecay-graph-db/tests/verified_generation_contract.rs` — `sealed_code_generation_publishes_with_its_supplied_manifest`: journals a sealed-source replay exactly as the code-index publisher does, proves the exact supplied manifest publishes to a verified head and a foreign manifest still conflicts. **Fails on the base with `Conflict`, passes with the fix.**
- `src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs` — end-to-end regression: seals a real generation with the production worktree scheduler, retains the code graph runtime through `DaemonSessionRuntimeRegistryV1`, and proves `publish_verified_snapshot` yields the exact verified snapshot on first publish **and** on a retained-seat retry of the same sealed artifact. **Fails on the base with `code graph database conflict`, passes with the fix.**
- `crates/tracedecay-rusqlite-runtime/src/reader/worker.rs` — one-token `clippy::explicit_auto_deref` fix (`&*transaction` → `&transaction`) unblocking the `-D warnings` gate.

No version bump; no operator-store reset; the on-disk `code-index-v1/` store shape is untouched.

## Test plan

- [x] `cargo test -p tracedecay-graph-db` (default and `--all-features`): all suites green; the new contract test fails with `Conflict` when the `replay.rs` fix is stashed and passes with it
- [x] `cargo test -p tracedecay --lib -- sealed_publication_tests verified_graph_runtime_port_contract_tests`: new sealed activation test passes; `orphaned_pending_replay_is_completed_by_the_next_generations_publication` (from `421a9ad16`) still passes; the new daemon test fails with `code graph database conflict` when the fix is stashed
- [x] `cargo clippy -p tracedecay-graph-db --all-targets --all-features -- -D warnings` green (with the rusqlite lint fix)
- [x] Pre-existing failure control: 6 `verified_graph_runtime_port_contract_tests` failures reproduce identically on the clean base tree in this VM (overlayfs test environment), unchanged by this PR
- [ ] `cargo nextest run --workspace --no-fail-fast` (full workspace gate left to CI)
- [ ] Isolated-profile dogfood on the Mac that reproduced the failure

## Checklist

- [ ] `CHANGELOG.md` updated (no `CHANGELOG.md` at repo root; release notes are release-please's concern per task constraints)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (none — persisted shapes and wire contracts unchanged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05956a2d-1544-4163-86f8-c1f7b4c5fd34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05956a2d-1544-4163-86f8-c1f7b4c5fd34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

