### PR TITLE
ci(test): upload Linux and macOS nextest JUnit reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,15 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --profile ci --locked
 
+      - name: Upload ${{ matrix.name }} nextest report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-junit-${{ matrix.name }}
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: ignore
+          retention-days: 7
+
   windows-build:
     name: Build Windows tests
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["master","feature/holographic-memory"]'), github.event.pull_request.base.ref) }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an always-run `actions/upload-artifact@v4` step to the `Test ${{ matrix.name }}` job (Linux + macOS) that uploads the nextest JUnit report from `target/nextest/ci/junit.xml`, mirroring the existing "Upload Windows nextest report" step on the Windows shards.

- Artifact name: `nextest-junit-Linux` / `nextest-junit-macOS`
- `if: always()` so failed runs still publish timings
- `if-no-files-found: ignore` and `retention-days: 7`, copied exactly from the Windows step

No changes to `.config/nextest.toml`, test filters, sharding, or Windows jobs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37496045-9dd2-4f04-8f94-c9d576287ad5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37496045-9dd2-4f04-8f94-c9d576287ad5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

