### PR TITLE
refactor(global-db): fail-closed registered attach and settled reset journey (B1/D10)

### DIFF
--- a/crates/tracedecay-dashboard-api/src/events_api.rs
+++ b/crates/tracedecay-dashboard-api/src/events_api.rs
@@ -1002,7 +1002,7 @@ mod tests {
         .expect("registered profile database runtime");
         let (database, runtime, _retirement) = fixture.into_parts();
         drop(runtime);
-        tracedecay_global_db::RegisteredGlobalDbOwnerV1::migrate_and_attach(database)
+        tracedecay_global_db::RegisteredGlobalDbOwnerV1::admit_and_attach(database)
             .await
             .expect("registered dashboard fixture")
             .issue_lease()

--- a/crates/tracedecay-global-db/src/lib.rs
+++ b/crates/tracedecay-global-db/src/lib.rs
@@ -153,8 +153,7 @@ pub use support::{
     global_accounting_mode, global_db_path, global_db_path_is_overridden,
 };
 use support::{
-    SESSION_MESSAGE_SEARCH_MAX_FETCH, analytics_scope_query,
-    code_projects_missing_primary_root_columns, downrank_inventory_messages,
+    SESSION_MESSAGE_SEARCH_MAX_FETCH, analytics_scope_query, downrank_inventory_messages,
     ensure_code_project_primary_root_columns, ensure_parse_offset_columns,
     ensure_session_parent_columns, ensure_table_columns, git_remote_search_alias,
     global_db_operation_error, global_db_operation_message, interleave_workflow_search_results,

--- a/crates/tracedecay-global-db/src/observation/mod.rs
+++ b/crates/tracedecay-global-db/src/observation/mod.rs
@@ -8,7 +8,7 @@ mod schema;
 pub use refusal_census::{ObservationRefusalCensusV1, ObservationRefusalCountV1};
 pub use reset::{ObservationAuthorityResetV1, reset_refused_observation_authority};
 pub use schema::OBSERVATION_AUTHORITY;
-pub(super) use schema::{ensure_observation_schema, require_admitted_observation_shape};
+pub(super) use schema::ensure_observation_schema;
 
 use tracedecay_domain::{
     AnchorSourceGenerationV2, CanonicalObservationIdV1, ObservationScopeV1,

--- a/crates/tracedecay-global-db/src/observation/schema.rs
+++ b/crates/tracedecay-global-db/src/observation/schema.rs
@@ -109,7 +109,7 @@ fn canonical_column_set(columns: &[&str]) -> BTreeSet<String> {
 /// surfaces a typed `ResetRequired` naming this authority instead of
 /// rewriting data in place. Runs at schema installation for fresh stores and
 /// at the attach boundary for existing ones.
-pub(crate) async fn require_admitted_observation_shape(
+async fn require_admitted_observation_shape(
     conn: &impl QueryExecutor,
 ) -> tracedecay_runtime_core::errors::Result<()> {
     if observation_table_exists(conn).await? {

--- a/crates/tracedecay-global-db/src/registered.rs
+++ b/crates/tracedecay-global-db/src/registered.rs
@@ -54,22 +54,21 @@ impl RegisteredGlobalDbOwnerV1 {
     /// version-skewed, or drifted store fails the attach with each
     /// authority's exact typed reset identity instead of opening on schema it
     /// cannot honor, and an admissibly-fresh existing store receives the full
-    /// install.
+    /// install. Nothing steps an incompatible store forward in place; the
+    /// only in-place changes admission performs are the additive columns for
+    /// shapes released binaries actually shipped.
     ///
     /// Short-lived attaches have no background maintenance task, so the
     /// authority-invariant convergence runs synchronously here: a store whose
     /// tamper-invalidation triggers deleted the trusted audit checkpoint (or
     /// whose guard triggers were altered) fails the attach instead of opening
     /// on unaudited authority rows.
-    pub async fn migrate_and_attach(
+    pub async fn admit_and_attach(
         database: DatabaseOwnerV1,
     ) -> tracedecay_runtime_core::errors::Result<Self> {
         let temporary = database.issue_lease().map_err(registered_owner_error)?;
         let registered = RegisteredGlobalDb::from_database(temporary);
         super::schema_stages::ensure_attached_registered_schema(&registered.database).await?;
-        registered.migrate_released_registry_columns().await?;
-        registered.require_admitted_registry_shape().await?;
-        registered.validate_authority_schema_contract().await?;
         registered.rearm_queued_projection_retries().await?;
         super::schema_stages::converge_attached_registered_schema(&registered.database).await?;
         drop(registered);
@@ -78,7 +77,7 @@ impl RegisteredGlobalDbOwnerV1 {
 
     /// Returns the resumable convergence plan for an already admitted schema
     /// without retaining an unowned client lease.
-    pub async fn migrate_and_attach_for_daemon(
+    pub async fn admit_and_attach_for_daemon(
         database: DatabaseOwnerV1,
     ) -> tracedecay_runtime_core::errors::Result<(
         Self,
@@ -87,9 +86,6 @@ impl RegisteredGlobalDbOwnerV1 {
         let temporary = database.issue_lease().map_err(registered_owner_error)?;
         let registered = RegisteredGlobalDb::from_database(temporary);
         super::schema_stages::ensure_attached_registered_schema(&registered.database).await?;
-        registered.migrate_released_registry_columns().await?;
-        registered.require_admitted_registry_shape().await?;
-        registered.validate_authority_schema_contract().await?;
         registered.rearm_queued_projection_retries().await?;
         drop(registered);
         Ok((
@@ -682,76 +678,6 @@ impl RegisteredGlobalDb {
             },
         )?;
         Ok(())
-    }
-
-    async fn validate_authority_schema_contract(
-        &self,
-    ) -> tracedecay_runtime_core::errors::Result<()> {
-        let snapshot = self.read_snapshot().await.map_err(|error| {
-            registered_error("begin registered authority schema validation", error)
-        })?;
-        // Classify pre-release observation shapes with their typed reset
-        // authority before the generic contract validation reports them as an
-        // untyped column mismatch. Like `require_admitted_registry_shape`,
-        // this is where an existing store meets the final contract.
-        super::observation::require_admitted_observation_shape(&snapshot).await?;
-        super::schema_contract::validate_authority_schema_contract(&snapshot).await
-    }
-
-    /// Classifies registry and remote-deletion contract drift on an existing
-    /// store with the same typed reset authorities as schema admission, so a
-    /// store that outlived its persisted shape surfaces `ResetRequired`
-    /// instead of an untyped database error. Admission only runs when a store
-    /// is first initialized, so this attach boundary is where existing stores
-    /// meet the final contract.
-    async fn require_admitted_registry_shape(&self) -> tracedecay_runtime_core::errors::Result<()> {
-        let snapshot = self.read_snapshot().await.map_err(|error| {
-            registered_error("begin registered authority schema validation", error)
-        })?;
-        if let Err(error) =
-            super::schema_contract::validate_remote_deletion_schema_contract(&snapshot).await
-        {
-            return Err(TraceDecayError::reset_required(
-                "remote deletion tombstones",
-                error.to_string(),
-            ));
-        }
-        if let Err(error) =
-            super::schema_contract::validate_registry_schema_contract(&snapshot).await
-        {
-            return Err(TraceDecayError::reset_required(
-                super::project_registry::PROJECT_REGISTRY_AUTHORITY,
-                error.to_string(),
-            ));
-        }
-        Ok(())
-    }
-
-    /// Migrates a registry created by a released pre-`primary_root` binary
-    /// (the 8-column `code_projects` shape shipped through 0.0.66) by adding
-    /// the final nullable columns in place. Purely additive: existing rows
-    /// are preserved and every other schema drift still fails validation.
-    /// Reads first so an already-final store never opens a write transaction.
-    async fn migrate_released_registry_columns(
-        &self,
-    ) -> tracedecay_runtime_core::errors::Result<()> {
-        const OPERATION: &str = "migrate released code_projects registry columns";
-        let snapshot = self
-            .read_snapshot()
-            .await
-            .map_err(|error| registered_error(OPERATION, error))?;
-        let missing = super::code_projects_missing_primary_root_columns(&snapshot)
-            .await
-            .map_err(|error| registered_error(OPERATION, error))?;
-        drop(snapshot);
-        if !missing {
-            return Ok(());
-        }
-        let transaction = self.database.begin_write_transaction(OPERATION).await?;
-        super::ensure_code_project_primary_root_columns(&transaction)
-            .await
-            .map_err(|error| registered_error(OPERATION, error))?;
-        transaction.commit().await
     }
 
     async fn rearm_queued_projection_retries(&self) -> tracedecay_runtime_core::errors::Result<()> {

--- a/crates/tracedecay-global-db/src/support.rs
+++ b/crates/tracedecay-global-db/src/support.rs
@@ -406,23 +406,6 @@ pub(crate) async fn table_exists(
     Ok(rows.next().await?.is_some())
 }
 
-/// True when `code_projects` exists but still carries the released
-/// pre-`primary_root` column shape (the 8-column registry shipped through
-/// 0.0.66). A missing table is an unknown shape, not a released one.
-pub(crate) async fn code_projects_missing_primary_root_columns(
-    conn: &(impl tracedecay_runtime_core::db::engine::QueryExecutor + ?Sized),
-) -> tracedecay_runtime_core::db::engine::Result<bool> {
-    if !table_exists(conn, "code_projects").await? {
-        return Ok(false);
-    }
-    for &(column, _) in CODE_PROJECT_PRIMARY_ROOT_COLUMNS {
-        if !table_column_exists(conn, "code_projects", column).await? {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
 /// Adds the nullable `primary_root_*` columns the final `code_projects`
 /// contract requires to a registry created by a released pre-`primary_root`
 /// binary. Purely additive: existing rows are preserved with NULL values

--- a/crates/tracedecay-global-db/src/tests/harness.rs
+++ b/crates/tracedecay-global-db/src/tests/harness.rs
@@ -55,7 +55,7 @@ impl RegisteredGlobalDbRetirementHarnessV1 {
         .await
         .expect("publish registered retirement test runtime");
         let (database, _runtime, retirement) = fixture.into_parts();
-        let database = RegisteredGlobalDbOwnerV1::migrate_and_attach(database)
+        let database = RegisteredGlobalDbOwnerV1::admit_and_attach(database)
             .await
             .expect("attach registered retirement test runtime");
         let registered = database
@@ -1219,7 +1219,7 @@ async fn open_registered_test_database_with(
     )
     .await?;
     let (database_owner, _runtime, _retirement) = fixture.into_parts();
-    let database = RegisteredGlobalDbOwnerV1::migrate_and_attach(database_owner).await?;
+    let database = RegisteredGlobalDbOwnerV1::admit_and_attach(database_owner).await?;
     // The physical fixture is already opened in the mode requested above.
     // Issuance preserves that capability; neither test branch manufactures a
     // second raw authority after publication.

--- a/src/daemon/store_runtime/session_registry/maintenance.rs
+++ b/src/daemon/store_runtime/session_registry/maintenance.rs
@@ -246,11 +246,11 @@ impl DaemonSessionRuntimeRegistryV1 {
         let long_lived = self.long_lived_session_maintenance();
         let (database, convergence) = if long_lived {
             let (database, convergence) =
-                RegisteredGlobalDbOwnerV1::migrate_and_attach_for_daemon(database).await?;
+                RegisteredGlobalDbOwnerV1::admit_and_attach_for_daemon(database).await?;
             (database, Some(convergence))
         } else {
             (
-                RegisteredGlobalDbOwnerV1::migrate_and_attach(database).await?,
+                RegisteredGlobalDbOwnerV1::admit_and_attach(database).await?,
                 None,
             )
         };

--- a/src/daemon/store_runtime/session_registry/remote_recovery/publication.rs
+++ b/src/daemon/store_runtime/session_registry/remote_recovery/publication.rs
@@ -315,7 +315,7 @@ impl RemoteRecoveryPublicationContextV1 {
         )
         .await?;
         let database = Database::publish_runtime(runtime, DatabaseAccessMode::ReadWrite).await?;
-        let database = RegisteredGlobalDbOwnerV1::migrate_and_attach(database).await?;
+        let database = RegisteredGlobalDbOwnerV1::admit_and_attach(database).await?;
         let (graph, store_target) =
             super::super::code_graph::graph_attachment::open_session_relation_owner(
                 &self.registry,

--- a/tests/typed_terminal_restart_acceptance.rs
+++ b/tests/typed_terminal_restart_acceptance.rs
@@ -368,21 +368,14 @@ fn partial_effect_survives_physical_daemon_restart_via_cli() {
 
 /// The `ResetRequired` half of the same journey.
 ///
-/// Ignored because it currently fails on a *product* gap, not on the fixture:
-/// a project store whose relational shape this binary refuses never publishes
-/// a typed `ResetRequired` through the daemon's project-open path. The open
-/// never settles, so `wait_for_project_open_publication`
-/// (`src/daemon/project_open_orchestration.rs`) reports warming, callers retry
-/// the pre-admission `application.surface.unavailable` for their whole budget,
-/// and the terminal they finally see is their own `timed_out` — never the
-/// `reset` legal action that is the only thing that can actually fix the store.
-/// `project_open_problem` (`src/daemon/invocation_dispatch.rs`) now maps a
-/// reset-required open to the typed terminal for every operation rather than
-/// only the workflow application, which is necessary but not sufficient: the
-/// open has to settle with that error for the mapping to ever run.
-///
-/// The assertions below are the contract this journey must eventually prove and
-/// are deliberately left unweakened.
+/// A refused store's project open settles with the typed reset terminal:
+/// `wait_for_project_open_publication`
+/// (`src/daemon/project_open_orchestration.rs`) publishes the failed open
+/// instead of reporting warming forever, and `project_open_problem`
+/// (`src/daemon/invocation_dispatch.rs`) maps it to the `reset`-only legal
+/// action for every operation. This journey proves that settlement — and that
+/// a physical restart repeats it identically, because a restart is not a
+/// reset.
 #[test]
 fn reset_required_survives_physical_daemon_restart_via_cli() {
     let home = tempfile::TempDir::new().expect("isolated home");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements audit items B1/D10 (final-shape cutover at the registered attach boundary) on top of the `ResetRequired` settlement already delivered on this branch.

- **`migrate_and_attach*` cutover**: `RegisteredGlobalDbOwnerV1::migrate_and_attach` / `migrate_and_attach_for_daemon` are renamed to `admit_and_attach` / `admit_and_attach_for_daemon`. The wrappers duplicated the schema admission `ensure_attached_registered_schema` already performs (released `code_projects` column add, registry/remote-deletion contract resets, observation shape and authority contract validation) and their names claimed a migration authority the attach boundary no longer holds: every incompatible shape fails closed with its exact typed `ResetRequired`/`ProfileResetRequired` identity, and the only in-place changes are the additive columns released binaries actually shipped (8-column `code_projects` through 0.0.66; transcript `sessions`/`parse_offsets` columns).
- **Deleted dead validators**: the private duplicate passes `migrate_released_registry_columns`, `require_admitted_registry_shape`, `RegisteredGlobalDb::validate_authority_schema_contract`, and the released-shape probe `code_projects_missing_primary_root_columns` had no remaining callers after the consolidation and are removed. `require_admitted_observation_shape` is now private: its only caller is `ensure_observation_schema` in the same module.
- **Deslop**: the CLI reset-required journey (`tests/typed_terminal_restart_acceptance.rs`) still carried the pre-settlement "Ignored because it currently fails on a product gap" doc block from before `c962cd627` enabled it; it now describes what the journey actually proves.

No producer was added: `ResetRequired` is still produced solely by schema admission / exact-final-shape verification, and the settled terminal reaches CLI, HTTP, MCP, and both SDK paths through the existing project-open settlement and problem-envelope mapping. Typed terminals and `EnrolledRemoteClient` from #511 are untouched. No version bump.

## Verification

- [x] `cargo check -p tracedecay-global-db -p tracedecay-dashboard-api --all-features --all-targets` — clean.
- [x] `cargo nextest run -p tracedecay-dashboard-api --all-features` — 199 passed (includes the renamed `admit_and_attach` fixture).
- [x] `cargo nextest run -p tracedecay-global-db --all-features` — 373 passed; the 13 failures reproduce byte-identically at the base merge `ac471d7eb` (they rely on shared-process schema-installer registration that nextest's process-per-test model does not provide) and are unrelated to this diff.
- [x] `typed_terminal_restart_acceptance` (on tmpfs; overlayfs is refused by the fail-closed locality check) — both `reset_required_*` journeys and `transport_boundaries::partial_effect_*` pass across physical daemon restarts. `partial_effect_survives_physical_daemon_restart_via_cli` fails identically at base `ac471d7eb` on this VM (post-restart warm-up exceeds the retry budget) and is unrelated to this diff.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae505fac-da61-4196-8e5f-ee7c2bd8c725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae505fac-da61-4196-8e5f-ee7c2bd8c725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

