### PR TITLE
test(code-index): A18 — verified-path generation publication, restore stays silent

### DIFF
--- a/docs/plans/tracedecay-v2/NEXT.md
+++ b/docs/plans/tracedecay-v2/NEXT.md
@@ -417,6 +417,20 @@ the commit as attribution evidence.
   workspace's integration-outcome and stack-capability accounting cards now
   decode the mounted `operation.work.topology_metrics` projection cell by
   cell instead of wearing a stale "read model is not published" absence.
+- A18 outcome (2026-08-19): `CodeIndexGenerationPublished` resolves as
+  unadvertise for the dashboard surface plus verified-path confirmation for
+  the daemon bus. The dashboard SSE variant
+  `DashboardEventKindV1::CodeIndexGenerationPublished` was declared-but-unfed
+  — no frontend subscriber, omitted from generated contracts — so it was
+  deleted rather than thin-wired (`afe627324`). The scheduler-internal
+  `CodeIndexGenerationPublishedV1` broadcast keeps its real production
+  consumer (the post-mount query-authority waiter in
+  `src/daemon/project_composition/code_index_activation.rs`) and is fed only
+  after the durable publication compare-and-swap, the verified graph snapshot
+  publish (`publish_verified_snapshot`, the Plan 39 watermark advance), and
+  the serving swap; retained restores stay `Noop` and never re-broadcast,
+  pinned by
+  `restart_remount_serves_the_retained_generation_without_republishing`.
 
 ## Remaining work by lane
 

--- a/src/daemon/code_index_scheduler/tests.rs
+++ b/src/daemon/code_index_scheduler/tests.rs
@@ -1346,6 +1346,66 @@ async fn registry_feeds_publications_and_bounded_freshness_reads() {
     assert_ne!(changed.generation_id, initial.generation_id);
 }
 
+/// The generation-publication broadcast carries only verified publishes: a
+/// generation that crossed the durable publication compare-and-swap, the
+/// verified graph snapshot publish, and the serving swap. A restart that
+/// restores a retained generation is a `Noop` apply, so it must reach the
+/// serving slot without re-broadcasting — the post-mount query-authority
+/// waiter re-reads the serving slot for restores and trusts this bus only
+/// for generations that were actually verified-published.
+#[tokio::test]
+async fn restart_remount_serves_the_retained_generation_without_republishing() {
+    let fixture = GitFixture::new(ALPHA_LIB_V1);
+    let store = TempDir::new().expect("store root");
+    let first = CodeIndexSchedulerRegistryV1::new(1);
+    first
+        .mount_worktree(
+            test_project_id(),
+            fixture.path(),
+            store.path().to_path_buf(),
+            None,
+        )
+        .await
+        .expect("mount worktree");
+    let sealed = wait_for_initial_generation(&first, fixture.path()).await;
+    first.shutdown().await;
+
+    let restarted = CodeIndexSchedulerRegistryV1::new(1);
+    // Subscribed before the remount, so any broadcast the restore pass emitted
+    // would be queued in this receiver by the time the quiet check polls it.
+    let mut publications = restarted.subscribe_generation_publications();
+    restarted
+        .mount_worktree(
+            test_project_id(),
+            fixture.path(),
+            store.path().to_path_buf(),
+            None,
+        )
+        .await
+        .expect("remount worktree over the retained store");
+    let restored = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(generation) = restarted.latest_generation_id(fixture.path()).await {
+                break generation;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("restart serves a generation");
+    assert_eq!(
+        restored, sealed,
+        "the restart serves the retained generation, not a rebuilt one"
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(300), publications.recv())
+            .await
+            .is_err(),
+        "a retained restore is not a verified publish and must not re-broadcast"
+    );
+    restarted.shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn scheduler_notifications_remain_nonblocking_while_reconcile_is_busy() {
     let fixture = GitFixture::new(ALPHA_LIB_V1);

--- a/src/daemon/code_index_scheduler/tests.rs
+++ b/src/daemon/code_index_scheduler/tests.rs
@@ -1346,13 +1346,12 @@ async fn registry_feeds_publications_and_bounded_freshness_reads() {
     assert_ne!(changed.generation_id, initial.generation_id);
 }
 
-/// The generation-publication broadcast carries only verified publishes: a
-/// generation that crossed the durable publication compare-and-swap, the
+/// The generation-publication broadcast carries only verified publishes —
+/// generations that crossed the durable publication compare-and-swap, the
 /// verified graph snapshot publish, and the serving swap. A restart that
-/// restores a retained generation is a `Noop` apply, so it must reach the
-/// serving slot without re-broadcasting — the post-mount query-authority
-/// waiter re-reads the serving slot for restores and trusts this bus only
-/// for generations that were actually verified-published.
+/// restores a retained generation is a `Noop` apply and must reach the
+/// serving slot silently: the post-mount query-authority waiter re-reads the
+/// serving slot for restores and trusts this bus only for verified publishes.
 #[tokio::test]
 async fn restart_remount_serves_the_retained_generation_without_republishing() {
     let fixture = GitFixture::new(ALPHA_LIB_V1);
@@ -1371,8 +1370,9 @@ async fn restart_remount_serves_the_retained_generation_without_republishing() {
     first.shutdown().await;
 
     let restarted = CodeIndexSchedulerRegistryV1::new(1);
-    // Subscribed before the remount, so any broadcast the restore pass emitted
-    // would be queued in this receiver by the time the quiet check polls it.
+    // Subscribed before the remount. The per-worktree worker is serial, so a
+    // broadcast wrongly emitted by the restore-era passes would sit in this
+    // receiver ahead of the edit-triggered publication received below.
     let mut publications = restarted.subscribe_generation_publications();
     restarted
         .mount_worktree(
@@ -1397,11 +1397,20 @@ async fn restart_remount_serves_the_retained_generation_without_republishing() {
         restored, sealed,
         "the restart serves the retained generation, not a rebuilt one"
     );
+
+    fixture.edit("src/lib.rs", "pub fn alpha() -> u32 { 2 }\n");
     assert!(
-        tokio::time::timeout(Duration::from_millis(300), publications.recv())
+        restarted
+            .notify_hook_paths(fixture.path(), &["src/lib.rs".to_owned()])
             .await
-            .is_err(),
-        "a retained restore is not a verified publish and must not re-broadcast"
+    );
+    let first_broadcast = tokio::time::timeout(Duration::from_secs(5), publications.recv())
+        .await
+        .expect("post-restart publication timeout")
+        .expect("post-restart publication event");
+    assert_ne!(
+        first_broadcast.generation_id, sealed,
+        "the retained restore stays silent; the first broadcast is the rebuilt generation"
     );
     restarted.shutdown().await;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## A18: `CodeIndexGenerationPublished` — emit vs unadvertise

Decision: **both halves were already correct on the base; this PR pins the one unasserted invariant and records the outcome.**

### Findings (all advertisers/consumers)

- **Dashboard SSE surface** — `DashboardEventKindV1::CodeIndexGenerationPublished` (the audit A18 subject) was declared-but-unfed: no frontend subscriber to the `code_index` SSE event name, omitted from generated contracts, only constructed in a serialization test. It was **unadvertised (deleted)** in `afe627324` (`fix(dashboard): drop unfed CodeIndexGenerationPublished event`), already on `codex/tracedecay-total-redesign-plan`. Nothing was thin-wired.
- **Daemon bus** — the scheduler-internal `CodeIndexGenerationPublishedV1` broadcast (`src/daemon/code_index_scheduler/registry.rs`) has a real production consumer: the post-mount query-authority waiter in `src/daemon/project_composition/code_index_activation.rs`. Its two emit sites (background worker publish, ignored-dependency admission) both fire only after the full verified publish path:
  1. durable publication compare-and-swap (`publish_atomically` / `active_publication_matches`),
  2. verified graph snapshot publish (`publish_verified_snapshot` — the Plan 39 watermark advance),
  3. the serving swap.

  Retained restores (`activate_retained_generation_from_frontier`) and unchanged-source reconciles return `Noop` and never broadcast; recovery/WalSync paths never touch the sender.

### Change

- New falsifiable regression `restart_remount_serves_the_retained_generation_without_republishing`: a restart remount over a retained store must serve the retained generation through the serving slot **without** re-broadcasting on the publication bus. This is the "never on unverified apply" half the production consumer's contract relies on but no test pinned.
- NEXT.md records the A18 outcome.

No version bump; no production code change was needed — the wiring already matched the requirement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0aaa76a9-e059-4d2a-92af-7da7aa7897c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0aaa76a9-e059-4d2a-92af-7da7aa7897c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

