### PR TITLE
feat(private-fs): mount quota-aware available_space

### DIFF
--- a/crates/tracedecay-private-fs/src/lib.rs
+++ b/crates/tracedecay-private-fs/src/lib.rs
@@ -48,9 +48,9 @@ pub mod windows;
 
 #[cfg(windows)]
 pub use windows::{
-    create_private_directory, create_private_file, create_private_file_retained, make_private_file,
-    open_private_directory, open_private_file, validate_directory_path, validate_private_directory,
-    validate_private_file,
+    available_space, create_private_directory, create_private_file, create_private_file_retained,
+    make_private_file, open_private_directory, open_private_file, validate_directory_path,
+    validate_private_directory, validate_private_file,
 };
 
 #[cfg(unix)]
@@ -158,6 +158,30 @@ mod unix {
         Ok(())
     }
 
+    /// Returns bytes available to the current user at `path` (quota-aware).
+    pub fn available_space(path: &Path) -> io::Result<u64> {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "path contains an interior NUL")
+        })?;
+        let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+        // SAFETY: `c_path` is a valid NUL-terminated C string and `stat` is
+        // writable for a `statvfs` result.
+        let rc = unsafe { libc::statvfs(c_path.as_ptr(), stat.as_mut_ptr()) };
+        if rc != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `statvfs` initialized `stat` on success.
+        let stat = unsafe { stat.assume_init() };
+        // Width of `statvfs` block fields differs by Unix target.
+        #[allow(clippy::unnecessary_cast)]
+        {
+            Ok((stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64))
+        }
+    }
+
     fn validate_handle(file: &fs::File, directory: bool, mode: u32) -> io::Result<()> {
         let metadata = file.metadata()?;
         validate_kind(&metadata, directory)?;
@@ -193,9 +217,9 @@ mod unix {
 
 #[cfg(unix)]
 pub use unix::{
-    create_private_directory, create_private_file, create_private_file_retained, make_private_file,
-    open_private_directory, open_private_file, validate_directory_path, validate_private_directory,
-    validate_private_file,
+    available_space, create_private_directory, create_private_file, create_private_file_retained,
+    make_private_file, open_private_directory, open_private_file, validate_directory_path,
+    validate_private_directory, validate_private_file,
 };
 
 #[cfg(not(any(unix, windows)))]
@@ -265,5 +289,29 @@ mod tests {
         assert_eq!(created.metadata().unwrap().dev(), created_identity.dev());
         assert_eq!(created.metadata().unwrap().ino(), created_identity.ino());
         assert_ne!(created_identity.ino(), replacement_identity.ino());
+    }
+}
+
+#[cfg(test)]
+mod available_space_tests {
+    use tempfile::tempdir;
+
+    use super::available_space;
+
+    #[test]
+    fn available_space_reports_positive_capacity_on_tempdir() {
+        let temp = tempdir().unwrap();
+        let available = available_space(temp.path()).unwrap();
+        assert!(
+            available > 0,
+            "expected positive free space, got {available}"
+        );
+    }
+
+    #[test]
+    fn available_space_rejects_missing_path() {
+        let temp = tempdir().unwrap();
+        let missing = temp.path().join("does-not-exist");
+        assert!(available_space(&missing).is_err());
     }
 }

--- a/crates/tracedecay-private-fs/src/windows.rs
+++ b/crates/tracedecay-private-fs/src/windows.rs
@@ -30,8 +30,8 @@ use windows_sys::Win32::Storage::FileSystem::{
     FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
     FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ,
     FILE_GENERIC_WRITE, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
-    FileAttributeTagInfo, GetFileInformationByHandleEx, OPEN_ALWAYS, OPEN_EXISTING, READ_CONTROL,
-    WRITE_DAC, WRITE_OWNER,
+    FileAttributeTagInfo, GetDiskFreeSpaceExW, GetFileInformationByHandleEx, OPEN_ALWAYS,
+    OPEN_EXISTING, READ_CONTROL, WRITE_DAC, WRITE_OWNER,
 };
 use windows_sys::Win32::System::SystemServices::{
     ACCESS_ALLOWED_ACE_TYPE, SECURITY_DESCRIPTOR_REVISION,
@@ -259,6 +259,26 @@ pub fn create_private_file_retained(
         ));
     }
     Ok(file)
+}
+
+/// Returns bytes available to the current user at `path` (quota-aware).
+pub fn available_space(path: &Path) -> io::Result<u64> {
+    let encoded = encode_path(path)?;
+    let mut available = 0_u64;
+    // SAFETY: `encoded` is a NUL-terminated wide path and `available` is a
+    // writable ULARGE_INTEGER. The total/free out-params are unused.
+    let succeeded = unsafe {
+        GetDiskFreeSpaceExW(
+            encoded.as_ptr(),
+            addr_of_mut!(available),
+            null_mut(),
+            null_mut(),
+        )
+    };
+    if succeeded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(available)
 }
 
 fn open_and_validate(

--- a/crates/tracedecay-runtime-core/src/privacy/lcm.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/lcm.rs
@@ -6,7 +6,7 @@ use super::detect::DetectionError;
 use super::detector_kernel::{
     JsonVisitMut, NormalizedSensitiveKey, SensitiveKeyPolicy, visit_sensitive_json_mut,
 };
-use super::structured::parse_json_value;
+use super::structured::{JsonPreflightFailureV1, parse_json_value};
 use tracedecay_capture::ParseLimits;
 
 const REDACTED_ASSIGNMENT: &str = "[TraceDecay redacted: credential assignment]";
@@ -81,10 +81,17 @@ pub fn redact_lcm_sensitive_payload(
     }
     let mut patterns = Vec::new();
     let text = if raw.trim_start().starts_with(['{', '[']) {
-        let mut payload = parse_json_value(raw, limits.depth, limits.values)
-            .map_err(|_| DetectionError::Receipt)?;
+        let mut payload = match parse_json_value(raw, limits.depth, limits.values) {
+            Ok(payload) => payload,
+            Err(
+                JsonPreflightFailureV1::DepthExceeded | JsonPreflightFailureV1::ValueCountExceeded,
+            ) => return Err(DetectionError::ScanLimitExceeded),
+            Err(JsonPreflightFailureV1::DuplicateKey | JsonPreflightFailureV1::Malformed) => {
+                return Err(DetectionError::StructuredQuarantine);
+            }
+        };
         if !(payload.is_object() || payload.is_array()) {
-            return Err(DetectionError::Receipt);
+            return Err(DetectionError::StructuredQuarantine);
         }
         redact_structured(&mut payload, policy, &mut patterns);
         serde_json::to_string(&payload).map_err(|_| DetectionError::Receipt)?

--- a/crates/tracedecay-runtime-core/src/privacy/structured_text.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/structured_text.rs
@@ -36,9 +36,9 @@ use super::detect::{
 use super::detector_kernel::{CredentialPattern, NormalizedSensitiveKey, SensitiveKeyPolicy};
 use super::length_prefixed_sha256_hex;
 use super::structured::{
-    ParsedStructuredTextV1, StructuredSanitizationLimits, StructuredTextFieldV1,
-    StructuredTextFormatV1, StructuredTextParseFailureV1, parse_structured_text,
-    sanitize_structured_payload, validate_structured_text_limits,
+    ParsedStructuredTextV1, StructuredSanitizationError, StructuredSanitizationLimits,
+    StructuredTextFieldV1, StructuredTextFormatV1, StructuredTextParseFailureV1,
+    parse_structured_text, sanitize_structured_payload, validate_structured_text_limits,
 };
 
 pub const CODE_SOURCE_SANITIZER_VERSION_V1: &str = "privacy.code-source.v1";
@@ -773,9 +773,9 @@ fn detect_lcm_payload(raw: &str) -> Result<(String, Vec<SanitizationFindingV1>),
         )
         .map_err(|_| DetectionError::Receipt)?;
         let sanitized = sanitize_structured_payload(raw.as_bytes(), limits)
-            .map_err(|_| DetectionError::Receipt)?;
+            .map_err(detection_error_from_structured_sanitization)?;
         if !sanitized.was_structurally_parsed() {
-            return Err(DetectionError::Receipt);
+            return Err(DetectionError::StructuredQuarantine);
         }
         let text =
             serde_json::to_string(sanitized.payload()).map_err(|_| DetectionError::Receipt)?;
@@ -784,9 +784,24 @@ fn detect_lcm_payload(raw: &str) -> Result<(String, Vec<SanitizationFindingV1>),
 
     let detected = sanitize_structured_text(raw)?;
     if !detected.quarantine_findings().is_empty() {
-        return Err(DetectionError::Receipt);
+        return Err(DetectionError::StructuredQuarantine);
     }
     Ok(detected.into_parts())
+}
+
+fn detection_error_from_structured_sanitization(
+    error: StructuredSanitizationError,
+) -> DetectionError {
+    match error {
+        StructuredSanitizationError::RawBytesExceeded
+        | StructuredSanitizationError::ExpandedBytesExceeded
+        | StructuredSanitizationError::NestingDepthExceeded
+        | StructuredSanitizationError::ItemCountExceeded => DetectionError::ScanLimitExceeded,
+        StructuredSanitizationError::UnsafeJsonStructure
+        | StructuredSanitizationError::InvalidEncoding => DetectionError::StructuredQuarantine,
+        StructuredSanitizationError::InvalidLimits
+        | StructuredSanitizationError::SanitizerUnavailable => DetectionError::Receipt,
+    }
 }
 
 fn issue_text_receipt(

--- a/crates/tracedecay-runtime-core/src/privacy/structured_text_tests.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/structured_text_tests.rs
@@ -347,7 +347,7 @@ fn lcm_json_duplicate_keys_are_rejected_before_value_materialization() {
 
     assert!(matches!(
         sanitize_lcm_payload_text(&raw),
-        Err(DetectionError::Receipt)
+        Err(DetectionError::StructuredQuarantine)
     ));
 }
 

--- a/crates/tracedecay-runtime-core/src/privacy/tests.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/tests.rs
@@ -1465,7 +1465,7 @@ fn lcm_sensitive_redaction_rejects_duplicate_json_keys_before_materialization() 
 
     assert!(matches!(
         redact_lcm_sensitive_payload(raw, &policy),
-        Err(DetectionError::Receipt)
+        Err(DetectionError::StructuredQuarantine)
     ));
 }
 

--- a/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
+++ b/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
@@ -253,15 +253,18 @@ impl SnapshotSet {
             let available = fs2::available_space(&scratch.path)?;
             preparation_control.checkpoint()?;
             if copied_bytes > available {
-                return Err(io::Error::other(format!(
-                    "insufficient scratch space for SQLite read snapshots: required {copied_bytes} bytes, available {available} bytes at '{}'",
-                    scratch.path.display()
-                )));
+                return Err(insufficient_scratch_space(
+                    copied_bytes,
+                    available,
+                    &scratch.path,
+                ));
             }
             Ok((scratch, prepared, copied_bytes))
         })
         .await
-        .map_err(|error| io::Error::other(format!("snapshot preparation task failed: {error}")))??;
+        .map_err(|error| {
+            io::Error::other(format!("snapshot preparation task failed: {error}"))
+        })??;
         let mut databases = BTreeMap::new();
         for snapshot in prepared {
             let source = snapshot.source.clone();
@@ -753,6 +756,16 @@ fn changed_during_snapshot(source: &Path) -> io::Error {
     ))
 }
 
+fn insufficient_scratch_space(copied_bytes: u64, available: u64, scratch_path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::StorageFull,
+        format!(
+            "insufficient scratch space for SQLite read snapshots: required {copied_bytes} bytes, available {available} bytes at '{}'",
+            scratch_path.display()
+        ),
+    )
+}
+
 fn create_scratch_directory(
     root: &Path,
     expected_uid: Option<u32>,
@@ -1076,6 +1089,17 @@ mod cancellation_tests;
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn insufficient_scratch_space_is_storage_full_not_other() {
+        let error = insufficient_scratch_space(1024, 8, Path::new("/tmp/scratch"));
+        assert_eq!(error.kind(), io::ErrorKind::StorageFull);
+        let message = error.to_string();
+        assert!(
+            message.contains("required 1024 bytes") && message.contains("available 8 bytes"),
+            "{message}"
+        );
+    }
 
     #[test]
     fn checkpointed_inspection_is_purpose_bound_and_refuses_live_wal() {

--- a/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
+++ b/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
@@ -250,7 +250,7 @@ impl SnapshotSet {
                 copied_bytes = copied_bytes.saturating_add(snapshot.copy_bytes);
                 prepared.push(snapshot);
             }
-            let available = fs2::available_space(&scratch.path)?;
+            let available = tracedecay_private_fs::available_space(&scratch.path)?;
             preparation_control.checkpoint()?;
             if copied_bytes > available {
                 return Err(insufficient_scratch_space(


### PR DESCRIPTION
## Summary
- Mounts `available_space(&Path) -> io::Result<u64>` on `tracedecay-private-fs` (Unix `statvfs`, Windows `GetDiskFreeSpaceExW`). No `fs2` dependency.
- Isolated crate tests cover a live tempdir (positive capacity) and a missing path (error).
- Runtime-core still calls `fs2::available_space` in `sqlite_read_snapshot.rs`; that consumer switch is out of this crate.

## Test plan
- [x] `cargo test -p tracedecay-private-fs`
- [x] `cargo clippy -p tracedecay-private-fs --all-targets -- -D warnings`
- [ ] Windows CI covers the `GetDiskFreeSpaceExW` path