### PR TITLE
fix(graph-db): seat live activation after Plan 39

### DIFF
--- a/crates/tracedecay-graph-db/src/limits.rs
+++ b/crates/tracedecay-graph-db/src/limits.rs
@@ -86,14 +86,9 @@ mod tests {
         // bound sat below that and refused live ~1.6 GB / >1M-entity activations
         // as a write budget on every hydrate retry.
         const SEALED_BOUND: usize = 2usize << 30;
-        const FORMER_BOUND: usize = 1usize << 30;
-        assert!(
-            super::MAX_GRAPH_BATCH_CANONICAL_BYTES > SEALED_BOUND,
-            "canonical write budget must exceed the sealed-generation bound"
-        );
         assert_eq!(
             super::MAX_GRAPH_BATCH_CANONICAL_BYTES,
-            FORMER_BOUND * 2,
+            SEALED_BOUND * 2,
             "canonical write budget must admit JSON-escape expansion of a max sealed generation"
         );
     }

--- a/crates/tracedecay-graph-db/src/registry.rs
+++ b/crates/tracedecay-graph-db/src/registry.rs
@@ -679,6 +679,11 @@ impl GraphDbRegistry {
                     drop(next);
                     continue;
                 }
+                // A `Closing` entry is always an in-flight close that settles
+                // within its owning call (entry removed, restored ready, or
+                // retained as a terminal fault). Wait for that settlement like
+                // an in-flight open instead of fabricating a conflict for the
+                // same owner's next operation.
                 Some(RegistryEntry::Closing {
                     binding: registered_binding,
                     verified_locator: registered_locator,
@@ -695,8 +700,20 @@ impl GraphDbRegistry {
                         ),
                         (&binding, &verified_locator, &path, expected_format),
                     )?;
-                    return Err(GraphDbError::Conflict);
+                    check_request(registration.cancellation.as_ref(), registration.deadline)?;
+                    let (next, _) = self
+                        .inner
+                        .changed
+                        .wait_timeout(state, OPEN_WAIT_POLL)
+                        .map_err(|_| {
+                            GraphDbError::unavailable("graph registry wait lock is poisoned")
+                        })?;
+                    drop(next);
+                    continue;
                 }
+                // A `Retiring` entry may be an armed pre-close retirement
+                // reservation held across calls; denying new resolution is its
+                // all-or-none contract, so it stays a typed conflict.
                 Some(RegistryEntry::Retiring {
                     binding: registered_binding,
                     verified_locator: registered_locator,
@@ -777,97 +794,117 @@ impl GraphDbRegistry {
         let shard_id = binding.shard_id.clone();
 
         {
-            let mut state = self.state_lock()?;
-            reject_path_alias(&state, &binding, &verified_locator, &path, expected_format)?;
-            match state.entries.get(&shard_id) {
-                None => {
-                    let eviction = reserve_capacity_eviction(
-                        &mut state,
-                        self.inner.config.max_open,
-                        &shard_id,
-                    )?;
-                    state.entries.insert(
-                        shard_id.clone(),
-                        RegistryEntry::Opening {
-                            authority_attachment,
-                            binding: binding.clone(),
-                            verified_locator: verified_locator.clone(),
-                            path: path.clone(),
-                            expected_format,
-                        },
-                    );
-                    drop(state);
-                    if let Some(eviction) = eviction
-                        && let Err(error) = self.finish_eviction(eviction)
-                    {
-                        self.remove_opening(
-                            &shard_id,
-                            &binding,
-                            &verified_locator,
-                            &path,
-                            expected_format,
+            let mut state = loop {
+                let state = self.state_lock()?;
+                reject_path_alias(&state, &binding, &verified_locator, &path, expected_format)?;
+                match state.entries.get(&shard_id) {
+                    None => break state,
+                    // An in-flight close settles within its owning call; wait
+                    // for it and remount instead of fabricating a conflict for
+                    // the same owner's next attach.
+                    Some(RegistryEntry::Closing {
+                        binding: registered_binding,
+                        verified_locator: registered_locator,
+                        path: registered_path,
+                        expected_format: registered_format,
+                        ..
+                    }) => {
+                        require_binding(
+                            (
+                                registered_binding,
+                                registered_locator,
+                                registered_path,
+                                *registered_format,
+                            ),
+                            (&binding, &verified_locator, &path, expected_format),
                         )?;
-                        return Err(error);
+                        check_request(operation.cancellation.as_ref(), operation.deadline)?;
+                        let (next, _) = self
+                            .inner
+                            .changed
+                            .wait_timeout(state, OPEN_WAIT_POLL)
+                            .map_err(|_| {
+                                GraphDbError::unavailable("graph registry wait lock is poisoned")
+                            })?;
+                        drop(next);
+                    }
+                    Some(RegistryEntry::Ready {
+                        binding: registered_binding,
+                        verified_locator: registered_locator,
+                        path: registered_path,
+                        expected_format: registered_format,
+                        ..
+                    })
+                    | Some(RegistryEntry::Opening {
+                        binding: registered_binding,
+                        verified_locator: registered_locator,
+                        path: registered_path,
+                        expected_format: registered_format,
+                        ..
+                    })
+                    | Some(RegistryEntry::Retiring {
+                        binding: registered_binding,
+                        verified_locator: registered_locator,
+                        path: registered_path,
+                        expected_format: registered_format,
+                        ..
+                    }) => {
+                        require_binding(
+                            (
+                                registered_binding,
+                                registered_locator,
+                                registered_path,
+                                *registered_format,
+                            ),
+                            (&binding, &verified_locator, &path, expected_format),
+                        )?;
+                        return Err(GraphDbError::Conflict);
+                    }
+                    Some(RegistryEntry::Faulted {
+                        binding: registered_binding,
+                        verified_locator: registered_locator,
+                        path: registered_path,
+                        expected_format: registered_format,
+                        error,
+                        ..
+                    }) => {
+                        require_binding(
+                            (
+                                registered_binding,
+                                registered_locator,
+                                registered_path,
+                                *registered_format,
+                            ),
+                            (&binding, &verified_locator, &path, expected_format),
+                        )?;
+                        return Err(error.clone());
                     }
                 }
-                Some(RegistryEntry::Ready {
-                    binding: registered_binding,
-                    verified_locator: registered_locator,
-                    path: registered_path,
-                    expected_format: registered_format,
-                    ..
-                })
-                | Some(RegistryEntry::Opening {
-                    binding: registered_binding,
-                    verified_locator: registered_locator,
-                    path: registered_path,
-                    expected_format: registered_format,
-                    ..
-                })
-                | Some(RegistryEntry::Closing {
-                    binding: registered_binding,
-                    verified_locator: registered_locator,
-                    path: registered_path,
-                    expected_format: registered_format,
-                    ..
-                })
-                | Some(RegistryEntry::Retiring {
-                    binding: registered_binding,
-                    verified_locator: registered_locator,
-                    path: registered_path,
-                    expected_format: registered_format,
-                    ..
-                }) => {
-                    require_binding(
-                        (
-                            registered_binding,
-                            registered_locator,
-                            registered_path,
-                            *registered_format,
-                        ),
-                        (&binding, &verified_locator, &path, expected_format),
-                    )?;
-                    return Err(GraphDbError::Conflict);
-                }
-                Some(RegistryEntry::Faulted {
-                    binding: registered_binding,
-                    verified_locator: registered_locator,
-                    path: registered_path,
-                    expected_format: registered_format,
-                    error,
-                    ..
-                }) => {
-                    require_binding(
-                        (
-                            registered_binding,
-                            registered_locator,
-                            registered_path,
-                            *registered_format,
-                        ),
-                        (&binding, &verified_locator, &path, expected_format),
-                    )?;
-                    return Err(error.clone());
-                }
+            };
+            let eviction =
+                reserve_capacity_eviction(&mut state, self.inner.config.max_open, &shard_id)?;
+            state.entries.insert(
+                shard_id.clone(),
+                RegistryEntry::Opening {
+                    authority_attachment,
+                    binding: binding.clone(),
+                    verified_locator: verified_locator.clone(),
+                    path: path.clone(),
+                    expected_format,
+                },
+            );
+            drop(state);
+            if let Some(eviction) = eviction
+                && let Err(error) = self.finish_eviction(eviction)
+            {
+                self.remove_opening(
+                    &shard_id,
+                    &binding,
+                    &verified_locator,
+                    &path,
+                    expected_format,
+                )?;
+                return Err(error);
             }
         }
 

--- a/crates/tracedecay-graph-db/src/registry.rs
+++ b/crates/tracedecay-graph-db/src/registry.rs
@@ -2355,7 +2355,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_runtime_denies_resolution_without_waiting() {
+    fn closing_runtime_defers_resolution_until_the_close_settles() {
         let temporary = TempDir::new().unwrap();
         let registry = GraphDbRegistry::new(GraphDbRegistryConfig { max_open: 1 }).unwrap();
         let registration = registration(temporary.path());
@@ -2376,11 +2376,16 @@ mod tests {
         else {
             panic!("ready runtime must enter closing for this test");
         };
+        // While the close is in flight, resolution waits and observes its own
+        // typed deadline, never a fabricated conflict for the same owner.
+        let mut bounded = registration.clone();
+        bounded.deadline = Instant::now() + Duration::from_millis(100);
         assert_eq!(
-            registry.resolve(registration.clone()).unwrap_err(),
-            GraphDbError::Conflict
+            registry.resolve(bounded).unwrap_err(),
+            GraphDbError::DeadlineExceeded
         );
         registry.restore_ready(*reservation).unwrap();
+        drop(registry.resolve(registration).unwrap());
     }
 
     #[test]

--- a/crates/tracedecay-graph-db/src/registry/publication.rs
+++ b/crates/tracedecay-graph-db/src/registry/publication.rs
@@ -496,9 +496,11 @@ impl GraphDbRegistry {
             .map_err(|error| GraphDbError::Corrupt {
                 message: format!("historical graph publication evidence is invalid: {error}"),
             })?;
-            if current
-                .as_ref()
-                .is_some_and(|head| head == &historical_head || head.sequence > replay.sequence)
+            let is_current_head = current.as_ref() == Some(&historical_head);
+            if is_current_head
+                || current
+                    .as_ref()
+                    .is_some_and(|head| head.sequence > replay.sequence)
             {
                 let mut visiting = BTreeSet::new();
                 let dependencies = self.load_dependencies(
@@ -542,7 +544,16 @@ impl GraphDbRegistry {
                     &mut visiting,
                 )?;
                 let lease = generation_lease(&manifest, historical_head.clone(), dependencies);
-                database.remember_verified_generation(&lease)?;
+                if is_current_head {
+                    // The durable CAS already advanced the head to this exact
+                    // publication (an earlier publish crashed after its
+                    // linearization point). Retrying it must seat the head for
+                    // reads, not file its own publication as history and leave
+                    // the projection without an installed verified head.
+                    database.install_verified_generation(Arc::clone(&lease))?;
+                } else {
+                    database.remember_verified_generation(&lease)?;
+                }
                 let mut closure = BTreeMap::new();
                 collect_closure(&lease, &mut closure)?;
                 return Ok(VerifiedGraphCommit {

--- a/crates/tracedecay-graph-db/tests/registry_contract.rs
+++ b/crates/tracedecay-graph-db/tests/registry_contract.rs
@@ -103,6 +103,26 @@ impl GraphCancellation for CancelOnPoll {
     }
 }
 
+/// Parks the polling operation at one exact cancellation probe so a test can
+/// hold a registry entry in its in-flight state deterministically.
+#[derive(Debug)]
+struct GateOnPoll {
+    polls: AtomicUsize,
+    gate_on: usize,
+    entered: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl GraphCancellation for GateOnPoll {
+    fn is_cancelled(&self) -> bool {
+        if self.polls.fetch_add(1, Ordering::SeqCst) + 1 == self.gate_on {
+            self.entered.wait();
+            self.release.wait();
+        }
+        false
+    }
+}
+
 fn identity(profile: &str, project: &str) -> StoreRuntimeBindingV1 {
     StoreRuntimeBindingV1::new(
         StoreShardIdV1::project(
@@ -684,6 +704,82 @@ fn retirement_reservation_denies_new_resolves_and_drop_restores_ready_entry() {
         Some(GraphDbRegistryStatus::Ready)
     );
     assert!(registry.resolve(request).is_ok());
+}
+
+/// An in-flight close holds the registry entry in `Closing` only while the
+/// native close settles. The same owner's next attach and resolve must wait
+/// for that settlement (or observe their own typed deadline), never answer a
+/// hard `Conflict`: live activation looped `reconcile_failed` /
+/// `retained_seat_failed` on `code graph database conflict` because every
+/// publish racing an eviction was refused outright.
+#[test]
+fn same_owner_attach_waits_for_in_flight_close_instead_of_conflicting() {
+    let temporary = TempDir::new().unwrap();
+    let registry = GraphDbRegistry::new(GraphDbRegistryConfig { max_open: 1 }).unwrap();
+    drop(
+        mount_and_resolve(
+            &registry,
+            registration(identity("profile-a", "project-a"), temporary.path()),
+        )
+        .unwrap(),
+    );
+
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    // `close` probes its cancellation once before reserving and once while
+    // the entry is `Closing`; the gate parks the closer at the second probe.
+    let mut gated = registration(identity("profile-a", "project-a"), temporary.path());
+    gated.cancellation = Arc::new(GateOnPoll {
+        polls: AtomicUsize::new(0),
+        gate_on: 2,
+        entered: Arc::clone(&entered),
+        release: Arc::clone(&release),
+    });
+    let closer = {
+        let registry = registry.clone();
+        thread::spawn(move || registry.close(&gated))
+    };
+    entered.wait();
+
+    // A bounded waiter observes its own typed deadline, not a fabricated
+    // conflict, while the close is still in flight.
+    let mut bounded_attach = registration(identity("profile-a", "project-a"), temporary.path());
+    bounded_attach.deadline = std::time::Instant::now() + Duration::from_millis(200);
+    assert_eq!(
+        registry
+            .resolve_owner_attachment(owner_registration(bounded_attach))
+            .unwrap_err(),
+        GraphDbError::DeadlineExceeded
+    );
+    let mut bounded_resolve = registration(identity("profile-a", "project-a"), temporary.path());
+    bounded_resolve.deadline = std::time::Instant::now() + Duration::from_millis(200);
+    assert_eq!(
+        registry.resolve(bounded_resolve).unwrap_err(),
+        GraphDbError::DeadlineExceeded
+    );
+
+    let attacher = {
+        let registry = registry.clone();
+        let request = registration(identity("profile-a", "project-a"), temporary.path());
+        thread::spawn(move || registry.resolve_owner_attachment(owner_registration(request)))
+    };
+    // Let the attacher observe the in-flight close before releasing it.
+    thread::sleep(Duration::from_millis(50));
+    release.wait();
+    assert!(closer.join().unwrap().unwrap());
+    let attachment = attacher
+        .join()
+        .unwrap()
+        .expect("the same owner's next attach must remount after the close settles");
+    drop(attachment);
+    drop(
+        registry
+            .resolve(registration(
+                identity("profile-a", "project-a"),
+                temporary.path(),
+            ))
+            .unwrap(),
+    );
 }
 
 #[test]

--- a/crates/tracedecay-graph-db/tests/verified_generation_contract.rs
+++ b/crates/tracedecay-graph-db/tests/verified_generation_contract.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
 
 use tempfile::TempDir;
 use tracedecay_domain::{CodeGenerationId, RepositoryId, UtcMicros};
@@ -34,7 +36,7 @@ mod metadata_replay;
 mod replay_decode;
 mod support;
 
-use support::{RegisteredGraph, TestCancellation, registration};
+use support::{RegisteredGraph, TestCancellation, owner_registration, registration};
 
 struct Probe {
     cancellation: RuntimeCancellationIdentityV1,
@@ -77,6 +79,26 @@ struct AtomicTestCancellation(Arc<AtomicU8>);
 impl GraphCancellation for AtomicTestCancellation {
     fn is_cancelled(&self) -> bool {
         self.0.load(Ordering::SeqCst) != 0
+    }
+}
+
+/// Parks the polling operation at one exact cancellation probe so a test can
+/// hold the registry entry in its in-flight state deterministically.
+#[derive(Debug)]
+struct GateOnPoll {
+    polls: AtomicUsize,
+    gate_on: usize,
+    entered: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl GraphCancellation for GateOnPoll {
+    fn is_cancelled(&self) -> bool {
+        if self.polls.fetch_add(1, Ordering::SeqCst) + 1 == self.gate_on {
+            self.entered.wait();
+            self.release.wait();
+        }
+        false
     }
 }
 
@@ -1164,6 +1186,186 @@ fn superseded_journaled_publication_seats_historically_on_retry() {
                 &mut authority,
                 &context,
                 &g2_record.publication.key.projection,
+            )
+            .unwrap()
+            .generation(),
+        &GraphGenerationId::new("g2").unwrap()
+    );
+}
+
+/// The complete Plan 39/25 live-activation conflict in one journey: the
+/// producer's publish retry arrives while the graph runtime is mid-close
+/// (`Closing`) and its journaled expected prior head has been superseded by
+/// the producer's own publication (the durable CAS already advanced). The
+/// attach must wait out the close and remount, and the publish must
+/// recompute the recovered generation digest from actual rows, match the
+/// journaled expectation, and seat the verified head that serves reads —
+/// never loop `Conflict` or leave the projection without an installed head.
+#[test]
+fn recovered_digest_seats_under_closing_and_superseded_head_conflict() {
+    let temp = TempDir::new().unwrap();
+    let registered = RegisteredGraph::new_mounted(temp.path()).unwrap();
+    let (control, probe) = control_and_probe();
+    let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+    let mut authority = RelationalAuthority::default();
+    let identity = projection("seat-journey", "work");
+    let g1 = manifest(identity.clone(), "g1", "g1", vec![], vec![]);
+    let g1_record = stage_manifest(
+        &mut authority,
+        &registered.binding,
+        &g1,
+        "publish:g1",
+        None,
+        'a',
+    );
+    let g1_commit = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &g1_record.publication.key,
+            None,
+        )
+        .unwrap();
+    let g1_head = g1_commit.head.clone();
+    drop(g1_commit);
+    let g2 = manifest(identity.clone(), "g2", "g2", vec![], vec![]);
+    let g2_record = stage_manifest(
+        &mut authority,
+        &registered.binding,
+        &g2,
+        "publish:g2",
+        Some(g1_head.clone()),
+        'b',
+    );
+    let g2_commit = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &g2_record.publication.key,
+            None,
+        )
+        .unwrap();
+    let g2_head = g2_commit.head.clone();
+    drop(g2_commit);
+
+    // Park a close mid-flight so the registry entry is `Closing` when the
+    // seat retry arrives. `close` probes its cancellation once before
+    // reserving and once while `Closing`; the gate parks the second probe.
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let mut gated = registration(registered.binding.clone(), temp.path());
+    gated.cancellation = Arc::new(GateOnPoll {
+        polls: AtomicUsize::new(0),
+        gate_on: 2,
+        entered: Arc::clone(&entered),
+        release: Arc::clone(&release),
+    });
+    let closer = {
+        let registry = registered.registry.clone();
+        thread::spawn(move || registry.close(&gated))
+    };
+    entered.wait();
+
+    // The seat retry: attach while the close is in flight, then publish the
+    // journaled g2 whose expected prior (g1's head) was superseded by g2's
+    // own durable publication.
+    let seat = {
+        let registry = registered.registry.clone();
+        let binding = registered.binding.clone();
+        let root = temp.path().to_path_buf();
+        thread::spawn(move || {
+            let attachment = registry
+                .resolve_owner_attachment(owner_registration(registration(binding.clone(), &root)))
+                .expect("the seat attach must wait for the in-flight close and remount");
+            drop(attachment);
+            let (control, probe) = control_and_probe();
+            let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+            let commit = registry.publish_verified(
+                registration(binding, &root),
+                &mut authority,
+                &context,
+                &g2_record.publication.key,
+                None,
+            );
+            (authority, g2_record, commit)
+        })
+    };
+    // Let the seat retry observe the in-flight close before releasing it.
+    thread::sleep(Duration::from_millis(50));
+    release.wait();
+    assert!(closer.join().unwrap().unwrap());
+    let (mut authority, g2_record, commit) = seat.join().unwrap();
+    let commit =
+        commit.expect("the producer's own superseded-head publication must seat, not conflict");
+
+    // The recovered digest was recomputed from actual rows after the remount
+    // and matches the journaled expectation bound at publication time.
+    assert_eq!(
+        commit.recovered_digest,
+        g2_record.publication.expected_recovered_digest
+    );
+    assert_eq!(commit.head, g2_head);
+    assert_eq!(
+        commit.head.recovered_digest,
+        g2_record.publication.expected_recovered_digest
+    );
+    // The seat installed the verified head: reads serve g2's actual rows
+    // without any further recovery.
+    let snapshot = registered
+        .registry
+        .verified_snapshot(
+            registration(registered.binding.clone(), temp.path()),
+            &identity,
+        )
+        .expect("the seated head must serve installed reads");
+    assert_eq!(
+        snapshot.generation(),
+        &GraphGenerationId::new("g2").unwrap()
+    );
+    assert_eq!(
+        snapshot
+            .entity(
+                &GraphEntityRef::new(
+                    identity.clone(),
+                    GraphEntityId::new("entity:shared").unwrap(),
+                ),
+                Arc::new(TestCancellation),
+            )
+            .unwrap()
+            .unwrap()
+            .properties
+            .get(&GraphPropertyName::new("marker").unwrap()),
+        Some(&GraphProperty::String("g2".to_owned()))
+    );
+    // The superseded g1 retry still seats as historical evidence with its own
+    // matching recovered digest and never displaces the installed head.
+    let (control, probe) = control_and_probe();
+    let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+    let historical = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &g1_record.publication.key,
+            None,
+        )
+        .expect("the superseded publication must seat historically");
+    assert_eq!(
+        historical.recovered_digest,
+        g1_record.publication.expected_recovered_digest
+    );
+    assert_eq!(historical.head, g1_head);
+    assert_eq!(
+        registered
+            .registry
+            .verified_snapshot(
+                registration(registered.binding.clone(), temp.path()),
+                &identity,
             )
             .unwrap()
             .generation(),

--- a/crates/tracedecay-graph-db/tests/verified_generation_contract.rs
+++ b/crates/tracedecay-graph-db/tests/verified_generation_contract.rs
@@ -1019,6 +1019,158 @@ fn restart_reverification_installs_once_and_steady_reads_need_no_authority() {
     drop(historical);
 }
 
+/// A publisher that crashed after the verified-head CAS retries the same
+/// first publication on restart: the head has already moved to its own
+/// journaled publication, and the retry must seat that publication instead
+/// of answering `Conflict` forever (observed live as `retained_seat_failed`
+/// looping on `code graph database conflict`).
+#[test]
+fn first_publish_retry_seats_its_own_publication_already_at_the_head() {
+    let temp = TempDir::new().unwrap();
+    let registered = RegisteredGraph::new_mounted(temp.path()).unwrap();
+    let (control, probe) = control_and_probe();
+    let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+    let mut authority = RelationalAuthority::default();
+    let identity = projection("own-head", "work");
+    let g1 = manifest(identity.clone(), "g1", "g1", vec![], vec![]);
+    let record = stage_manifest(
+        &mut authority,
+        &registered.binding,
+        &g1,
+        "publish:g1",
+        None,
+        'a',
+    );
+    let first = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &record.publication.key,
+            None,
+        )
+        .unwrap();
+    let first_head = first.head.clone();
+    drop(first);
+
+    // Restart: the completed CAS is durable, the in-process installation is
+    // gone, and the retry arrives with the same journaled expected prior.
+    assert!(registered.close().unwrap());
+    registered.mount().unwrap();
+    let retried = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &record.publication.key,
+            None,
+        )
+        .expect("a first publication already at the verified head must seat");
+    assert_eq!(retried.head, first_head);
+    assert_eq!(
+        registered
+            .registry
+            .verified_snapshot(
+                registration(registered.binding.clone(), temp.path()),
+                &identity,
+            )
+            .unwrap()
+            .generation(),
+        &GraphGenerationId::new("g1").unwrap()
+    );
+}
+
+/// A journaled publication superseded by the producer's own later
+/// publication must still seat as historical evidence on retry instead of
+/// looping `Conflict`: the retained-seat pass replays the older journaled
+/// generation while reconcile has already advanced the head past it.
+#[test]
+fn superseded_journaled_publication_seats_historically_on_retry() {
+    let temp = TempDir::new().unwrap();
+    let registered = RegisteredGraph::new_mounted(temp.path()).unwrap();
+    let (control, probe) = control_and_probe();
+    let context = GraphPublicationOperationContextV1::new(&control, &probe).unwrap();
+    let mut authority = RelationalAuthority::default();
+    let identity = projection("superseded", "work");
+    let g1 = manifest(identity.clone(), "g1", "g1", vec![], vec![]);
+    let g1_record = stage_manifest(
+        &mut authority,
+        &registered.binding,
+        &g1,
+        "publish:g1",
+        None,
+        'a',
+    );
+    let g1_commit = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &g1_record.publication.key,
+            None,
+        )
+        .unwrap();
+    let g1_head = g1_commit.head.clone();
+    drop(g1_commit);
+    let g2 = manifest(identity.clone(), "g2", "g2", vec![], vec![]);
+    let g2_record = stage_manifest(
+        &mut authority,
+        &registered.binding,
+        &g2,
+        "publish:g2",
+        Some(g1_head.clone()),
+        'b',
+    );
+    registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &g2_record.publication.key,
+            None,
+        )
+        .unwrap();
+
+    // Restart, then retry the superseded publication: its expected prior
+    // (`None`) no longer matches the advanced head, but the journaled replay
+    // is this producer's own history and must seat, not conflict.
+    assert!(registered.close().unwrap());
+    registered.mount().unwrap();
+    let historical = registered
+        .registry
+        .publish_verified(
+            registration(registered.binding.clone(), temp.path()),
+            &mut authority,
+            &context,
+            &g1_record.publication.key,
+            None,
+        )
+        .expect("a superseded journaled publication must seat historically");
+    assert_eq!(historical.head, g1_head);
+    assert_eq!(
+        historical.snapshot.generation(),
+        &GraphGenerationId::new("g1").unwrap()
+    );
+    // The historical seat must not displace the advanced verified head.
+    assert_eq!(
+        registered
+            .registry
+            .recover_verified_snapshot(
+                registration(registered.binding.clone(), temp.path()),
+                &mut authority,
+                &context,
+                &g2_record.publication.key.projection,
+            )
+            .unwrap()
+            .generation(),
+        &GraphGenerationId::new("g2").unwrap()
+    );
+}
+
 #[test]
 fn cancellation_before_relational_cas_keeps_the_prior_head_current() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live activation never seated after Plan 39's first-publish seat (#525): reconcile/retained-seat looped on `code graph database conflict`, and sealed generations stayed `exact_scope_generation_not_ready`. This PR fixes the two remaining `crates/tracedecay-graph-db` causes, restacked onto `4756385641041fc4c4e954da5d63898a4dd45abd` (the current 421 tip, which already carries the 4 GiB write-ceiling scale and `GraphBudgetKind::from_name` in `2af617019`).

### Fixes

1. **Superseded-head CAS now seats the producer's own publication.** A publish retried after the durable verified-head CAS already advanced to that exact publication (crash after the linearization point) previously filed its own publication as *historical* evidence (`remember_verified_generation`) and left the projection with **no installed verified head** — reads answered "graph projection is not recovered into an installed verified head" forever. The retry now installs the lease as the verified head (`install_verified_generation`), exactly like the CAS-success path, after the same apply → reopen → recovered-digest verification. A publication superseded by the producer's own later journaled publication still seats as historical evidence without displacing the advanced head.

2. **In-flight close no longer conflicts the same owner's next attach/publish.** `resolve` and `resolve_owner_attachment` answered a hard `Conflict` whenever the registry entry was `Closing`, even though a `Closing` entry always settles within its owning call (removed, restored ready, or retained as a terminal fault). Both now wait for that settlement like an in-flight `Opening` — bounded by the caller's own cancellation/deadline — and attach remounts once the close settles. `Retiring` keeps its hard `Conflict`: an armed pre-close retirement reservation's all-or-none denial is deliberate and may be held across calls.

3. **Repaired the base's write-ceiling bound contract.** `limits::tests::canonical_write_budget_admits_sealed_generation_bytes` (landed in `2af617019`) asserted the ceiling equals `2 × 1 GiB` instead of the intended `2 × 2 GiB` sealed admission bound, so it failed against the very 4 GiB ceiling it pins. The contract now asserts `MAX_GRAPH_BATCH_CANONICAL_BYTES == 2 × sealed bound` exactly.

### Recovered-digest seat proof (isolated tempfile fixtures only; no live `~/.tracedecay`)

`verified_generation_contract::recovered_digest_seats_under_closing_and_superseded_head_conflict` runs the complete Plan 39/25 conflict in one journey: with the runtime parked mid-`Closing`, a seat retry attaches (waits out the close, remounts) and publishes a journaled generation whose expected prior head was superseded by its own durable publication. The test asserts the recovered generation digest recomputed from actual rows equals the journaled `expected_recovered_digest`, the verified head is installed and serves the generation's actual row bytes, and the superseded predecessor still seats historically with its own matching digest without displacing the head. **Falsified against the base**: with this branch's tests but the base's production `registry.rs`/`registry/publication.rs`, the journey fails; with the fixes it passes.

Supporting tests:
- `verified_generation_contract::first_publish_retry_seats_its_own_publication_already_at_the_head` — red before the fix (publish "succeeded" but no head was installed; reads stayed unavailable).
- `verified_generation_contract::superseded_journaled_publication_seats_historically_on_retry`.
- `registry_contract::same_owner_attach_waits_for_in_flight_close_instead_of_conflicting` — bounded waiters get their own typed `DeadlineExceeded` (was `Conflict`); the armed-retirement denial contract is re-asserted by the existing reservation test.
- `registry::tests::closing_runtime_defers_resolution_until_the_close_settles` — updated from the superseded deny-without-waiting contract.

Full `cargo test -p tracedecay-graph-db --all-features --no-fail-fast`: 191 passed. The single failure, `registry_contract::canonical_runtime_resolver_locator_opens_through_graph_registry`, is environmental (`FilesystemLocalityUnverified { filesystem_type: "overlay" }` on the dev VM) and fails identically on the pristine base without these commits. rustfmt and clippy clean on the crate.

Scope: `crates/tracedecay-graph-db` only. Does not reopen #525's `publish_verified` fold; the recovered-digest protocol itself is untouched and proven to seat. The write-ceiling and budget-name work initially drafted here was dropped in favor of the equivalent already landed on the base (`2af617019`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30ddd43d-a5b1-44c1-a5b5-b9004a04aea6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30ddd43d-a5b1-44c1-a5b5-b9004a04aea6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

