### PR TITLE
fix(code-index): code-index leftover slice for #421 — full-scope dispatch, sealed-branch shard key

### DIFF
--- a/crates/tracedecay-code-index/src/production/mod.rs
+++ b/crates/tracedecay-code-index/src/production/mod.rs
@@ -181,15 +181,17 @@ impl CodeIndexGenerationScopeV1 {
 
     /// Whether two scopes name the same physical checkout.
     ///
-    /// Repository and worktree are identity: a generation sealed under either
-    /// of them differing belongs to another checkout and may never be adopted.
-    /// `reference` is not identity — it is the label HEAD happens to carry, and
-    /// it moves under a fixed worktree on every ordinary commit, branch switch,
-    /// or rebase. Treating it as identity made the active generation of the
-    /// branch you just left "incompatible", so the first reconcile after any
-    /// branch switch failed outright and the worktree stopped indexing until
-    /// the store was rebuilt. The reference the generation was sealed under is
-    /// still carried on its own snapshot, so attribution stays generation-bound.
+    /// Repository and worktree are checkout identity: a generation sealed
+    /// under either of them differing belongs to another checkout and may
+    /// never be adopted or served for this one. `reference` is deliberately
+    /// excluded — it is the branch label HEAD happens to carry, and it moves
+    /// under a fixed worktree on every ordinary commit, branch switch, or
+    /// rebase — so serving gates that need only checkout identity keep
+    /// admitting the checkout's own generations across a label move. Slot
+    /// dispatch is stricter: [`CodeIndexProductionOwnerV1::active_generation`]
+    /// demands the complete scope, label included, because branch and worktree
+    /// generations stay independently active inside one shared repository
+    /// store.
     #[must_use]
     pub fn identifies_same_checkout(&self, other: &Self) -> bool {
         self.repository == other.repository && self.worktree == other.worktree
@@ -202,6 +204,24 @@ impl CodeIndexGenerationScopeV1 {
             .and_then(|()| self.worktree.as_ref().map_or(Ok(()), WorktreeId::validate))
             .map_err(|error| CodeIndexPublicationStoreErrorV1::Unavailable(error.to_string()))
     }
+}
+
+/// Renders one scope for slot-dispatch refusals. An absent reference or
+/// worktree is a truthful non-git/unbound component, spelled out so operators
+/// can tell a misclassified checkout from a mispartitioned store.
+fn describe_scope(scope: &CodeIndexGenerationScopeV1) -> String {
+    format!(
+        "repository {}, reference {}, worktree {}",
+        scope.repository.as_str(),
+        scope
+            .reference
+            .as_ref()
+            .map_or("(none)", |reference| reference.as_str()),
+        scope
+            .worktree
+            .as_ref()
+            .map_or("(none)", |worktree| worktree.as_str()),
+    )
 }
 
 /// The only persistence seam for this production owner. Implementations retain
@@ -422,6 +442,17 @@ impl CodeIndexPublishedGenerationV1 {
 
     pub fn snapshot(&self) -> &SanitizedCodeSnapshotV1 {
         &self.snapshot
+    }
+
+    /// The exact generation scope this generation was sealed under:
+    /// repository, sealed branch label, and worktree.
+    ///
+    /// This — never a filesystem path and never the generation id — is the
+    /// key that partitions active-generation slots and code shards, so a
+    /// sealed generation can only ever be dispatched onto the scope whose
+    /// snapshot sealed it.
+    pub fn sealed_scope(&self) -> CodeIndexGenerationScopeV1 {
+        CodeIndexGenerationScopeV1::for_snapshot(&self.snapshot)
     }
 
     pub fn chunks(&self) -> &GenerationChunkManifestV1 {
@@ -978,6 +1009,17 @@ where
 
     /// Load the currently active immutable generation. A restart therefore
     /// resumes from the publication authority rather than mutable worker state.
+    ///
+    /// Dispatch is full-scope exact: the loaded generation must have been
+    /// sealed under the requested repository, reference, and worktree. A
+    /// publication authority that answers a scope with a generation sealed
+    /// for any other scope has broken its slot partition — or the caller's
+    /// checkout identity resolution regressed, e.g. a repository misclassified
+    /// as not-a-git-path. Both are the terminal
+    /// [`CodeIndexPublicationStoreErrorV1::CorruptionResetRequired`] state:
+    /// the foreign generation is never adopted, never config-checked, and the
+    /// refusal is a reset journey, not a transient error to retry on a
+    /// cadence.
     pub fn active_generation(
         &self,
         scope: &CodeIndexGenerationScopeV1,
@@ -990,10 +1032,18 @@ where
         }
         let active = self.publication.load_active(scope)?;
         if let Some(active) = &active {
+            let sealed_scope = active.sealed_scope();
+            if sealed_scope != *scope {
+                return Err(CodeIndexProductionErrorV1::Publication(
+                    CodeIndexPublicationStoreErrorV1::CorruptionResetRequired(format!(
+                        "the active-generation slot for {} returned a generation sealed for {}",
+                        describe_scope(scope),
+                        describe_scope(&sealed_scope),
+                    )),
+                ));
+            }
             active.validate()?;
             if active.manifest.project_id != self.config.project_id
-                || !CodeIndexGenerationScopeV1::for_snapshot(&active.snapshot)
-                    .identifies_same_checkout(scope)
                 || active.manifest.sanitizer_revision != self.config.sanitizer_revision
                 || active.manifest.chunker_revision != self.config.chunker_revision
                 || active.manifest.privacy_domain != self.config.privacy_domain

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -88,6 +88,47 @@ impl CodeIndexAtomicPublicationPort for SharedPublicationStore {
     }
 }
 
+/// Models the mispartitioned publication stores the production owner must
+/// refuse: one physical active pointer that ignores the requested scope, so
+/// the generation sealed for one branch/worktree is answered for every scope.
+#[derive(Clone, Default)]
+struct PartialKeyPublicationStore {
+    active: Arc<Mutex<Option<Arc<CodeIndexPublishedGenerationV1>>>>,
+}
+
+impl CodeIndexAtomicPublicationPort for PartialKeyPublicationStore {
+    fn load_active(
+        &self,
+        _scope: &CodeIndexGenerationScopeV1,
+    ) -> Result<Option<CodeIndexPublishedGenerationV1>, CodeIndexPublicationStoreErrorV1> {
+        Ok(self
+            .active
+            .lock()
+            .expect("publication lock")
+            .as_ref()
+            .map(|generation| generation.as_ref().clone()))
+    }
+
+    fn publish_atomically(
+        &mut self,
+        _scope: &CodeIndexGenerationScopeV1,
+        expected_active_generation: Option<&CodeGenerationId>,
+        generation: Arc<CodeIndexPublishedGenerationV1>,
+    ) -> Result<(), CodeIndexPublicationStoreErrorV1> {
+        let mut active = self.active.lock().expect("publication lock");
+        if active
+            .as_ref()
+            .map(|current| current.manifest().generation_id.clone())
+            .as_ref()
+            != expected_active_generation
+        {
+            return Err(CodeIndexPublicationStoreErrorV1::CompareAndSwap);
+        }
+        *active = Some(generation);
+        Ok(())
+    }
+}
+
 #[derive(Default)]
 pub(super) struct ApplyingProjectionSink;
 
@@ -940,6 +981,257 @@ fn linked_worktree_no_op_reuses_only_its_compatible_generation() {
     assert!(second.projection().request().changes.deleted.is_empty());
     assert!(!second.projection().request().changes.reused.is_empty());
     assert_eq!(store.scope_count(), 1);
+}
+
+/// A checkout misclassified as "not a git repository" resolves a scope
+/// without a reference or worktree while the store still answers with the
+/// sealed git-identified generation. That answer must be one terminal typed
+/// reset state — never the generic contract error callers can only retry on
+/// a one-second cadence — and the sealed generation's git identity must
+/// survive the refusal untouched.
+#[test]
+fn misclassified_non_git_scope_reaches_a_terminal_reset_state_instead_of_retrying() {
+    let store = PartialKeyPublicationStore::default();
+    let mut owner =
+        CodeIndexProductionOwnerV1::new(config(), store.clone(), ApplyingProjectionSink)
+            .expect("production owner");
+    let hawk_request = request_in_scope(
+        "file.identity.hawk",
+        1_100_000,
+        "refs/heads/hawk",
+        Some("worktree.primary"),
+        "commit.hawk.1",
+    );
+    let hawk_scope = CodeIndexGenerationScopeV1::for_snapshot(&hawk_request.snapshot);
+    let sealed = owner
+        .build_and_publish(hawk_request, &ActiveControl)
+        .expect("git-identified generation publishes");
+
+    let non_git = request("file.identity.non-git", 1_200_000);
+    let non_git_scope = CodeIndexGenerationScopeV1::for_snapshot(&non_git.snapshot);
+    assert_eq!(non_git_scope.reference, None);
+    assert_eq!(non_git_scope.worktree, None);
+
+    let read = owner
+        .active_generation(&non_git_scope)
+        .expect_err("a git-identified generation never dispatches onto a non-git scope");
+    assert!(
+        matches!(
+            &read,
+            CodeIndexProductionErrorV1::Publication(
+                CodeIndexPublicationStoreErrorV1::CorruptionResetRequired(_)
+            )
+        ),
+        "the refusal must be the terminal reset state, not a retryable error: {read}"
+    );
+
+    let rebuild = owner
+        .build_and_publish(non_git, &ActiveControl)
+        .expect_err("a reconcile under the misclassified identity refuses terminally");
+    assert!(
+        matches!(
+            &rebuild,
+            CodeIndexProductionErrorV1::Publication(
+                CodeIndexPublicationStoreErrorV1::CorruptionResetRequired(_)
+            )
+        ),
+        "repeat reconciles reach the same terminal state instead of spinning: {rebuild}"
+    );
+
+    // The sealed generation and its real git identity survive the refusal.
+    let retained = store
+        .load_active(&hawk_scope)
+        .expect("read publication state")
+        .expect("the sealed generation is never dropped by the refusal");
+    assert_eq!(retained.manifest(), sealed.manifest());
+    assert_eq!(retained.sealed_scope(), hawk_scope);
+}
+
+/// The complement of the terminal refusal: a genuinely non-git snapshot is a
+/// first-class terminal outcome. It indexes as its own genesis slot beside
+/// git-identified generations instead of erroring or adopting one of them.
+#[test]
+fn non_git_scope_stays_independently_active_beside_git_identified_generations() {
+    let store = SharedPublicationStore::default();
+    let mut owner =
+        CodeIndexProductionOwnerV1::new(config(), store.clone(), ApplyingProjectionSink)
+            .expect("production owner");
+    let hawk_request = request_in_scope(
+        "file.terminal.hawk",
+        1_100_000,
+        "refs/heads/hawk",
+        Some("worktree.primary"),
+        "commit.hawk.1",
+    );
+    let hawk_scope = CodeIndexGenerationScopeV1::for_snapshot(&hawk_request.snapshot);
+    let hawk = owner
+        .build_and_publish(hawk_request, &ActiveControl)
+        .expect("git-identified generation publishes");
+
+    let non_git_request = request("file.terminal.non-git", 1_200_000);
+    let non_git_scope = CodeIndexGenerationScopeV1::for_snapshot(&non_git_request.snapshot);
+    let non_git = owner
+        .build_and_publish(non_git_request, &ActiveControl)
+        .expect("a non-git snapshot indexes as its own terminal outcome");
+
+    assert!(non_git.manifest().parent_generation.is_none());
+    assert_eq!(store.scope_count(), 2);
+    assert_eq!(
+        owner
+            .active_generation(&hawk_scope)
+            .expect("hawk scope read")
+            .expect("hawk stays active")
+            .manifest(),
+        hawk.manifest()
+    );
+    assert_eq!(
+        owner
+            .active_generation(&non_git_scope)
+            .expect("non-git scope read")
+            .expect("non-git stays active")
+            .manifest(),
+        non_git.manifest()
+    );
+}
+
+/// Config dispatch is full-scope exact. A store matching on a partial key
+/// (repository-only pointer) must never get a generation sealed for one
+/// branch/worktree dispatched onto another scope — neither onto a different
+/// worktree (the PR checkout) nor onto the same worktree under a different
+/// sealed branch label.
+#[test]
+fn config_dispatch_refuses_a_generation_sealed_for_another_full_scope() {
+    let store = PartialKeyPublicationStore::default();
+    let mut owner = CodeIndexProductionOwnerV1::new(config(), store, ApplyingProjectionSink)
+        .expect("production owner");
+    let hawk_request = request_in_scope(
+        "file.dispatch.hawk",
+        1_100_000,
+        "refs/heads/hawk",
+        Some("worktree.hawk"),
+        "commit.hawk.1",
+    );
+    let hawk_scope = CodeIndexGenerationScopeV1::for_snapshot(&hawk_request.snapshot);
+    let hawk = owner
+        .build_and_publish(hawk_request, &ActiveControl)
+        .expect("hawk generation publishes");
+
+    let pr_worktree_scope = CodeIndexGenerationScopeV1 {
+        repository: hawk_scope.repository.clone(),
+        reference: Some(id::<RefId>("refs/heads/pr-1234")),
+        worktree: Some(id::<WorktreeId>("worktree.pr")),
+    };
+    let moved_label_scope = CodeIndexGenerationScopeV1 {
+        repository: hawk_scope.repository.clone(),
+        reference: Some(id::<RefId>("refs/heads/pr-1234")),
+        worktree: hawk_scope.worktree.clone(),
+    };
+    for foreign_scope in [&pr_worktree_scope, &moved_label_scope] {
+        let refused = owner
+            .active_generation(foreign_scope)
+            .expect_err("a generation sealed for hawk never dispatches onto another scope");
+        assert!(
+            matches!(
+                &refused,
+                CodeIndexProductionErrorV1::Publication(
+                    CodeIndexPublicationStoreErrorV1::CorruptionResetRequired(_)
+                )
+            ),
+            "full-scope dispatch mismatch must be the terminal reset state: {refused}"
+        );
+    }
+
+    // The exact sealed full scope still dispatches.
+    assert_eq!(
+        owner
+            .active_generation(&hawk_scope)
+            .expect("exact scope read")
+            .expect("hawk stays active for its own scope")
+            .manifest(),
+        hawk.manifest()
+    );
+}
+
+/// The code shard/slot key is the sealed branch label inside the full scope —
+/// never a filesystem path (the scope carries none) and never the generation
+/// id: successive generations share their branch's slot while a second branch
+/// on the same worktree splits into its own independently active slot.
+#[test]
+fn code_shard_slot_key_is_the_sealed_branch_label_not_a_generation_id() {
+    let store = SharedPublicationStore::default();
+    let mut owner =
+        CodeIndexProductionOwnerV1::new(config(), store.clone(), ApplyingProjectionSink)
+            .expect("production owner");
+    let first = owner
+        .build_and_publish(
+            request_in_scope(
+                "file.shard.hawk.1",
+                1_100_000,
+                "refs/heads/hawk",
+                Some("worktree.shared"),
+                "commit.hawk.1",
+            ),
+            &ActiveControl,
+        )
+        .expect("first hawk generation publishes");
+    let second = owner
+        .build_and_publish(
+            request_in_scope(
+                "file.shard.hawk.2",
+                1_200_000,
+                "refs/heads/hawk",
+                Some("worktree.shared"),
+                "commit.hawk.1",
+            ),
+            &ActiveControl,
+        )
+        .expect("second hawk generation publishes");
+
+    // A new generation id under the same sealed branch label reuses the slot.
+    assert_ne!(
+        first.manifest().generation_id,
+        second.manifest().generation_id
+    );
+    assert_eq!(second.sealed_scope(), first.sealed_scope());
+    assert_eq!(store.scope_count(), 1);
+
+    // The same worktree under another sealed branch label is its own slot.
+    let pr = owner
+        .build_and_publish(
+            request_in_scope(
+                "file.shard.pr.1",
+                1_300_000,
+                "refs/heads/pr-1234",
+                Some("worktree.shared"),
+                "commit.pr.1",
+            ),
+            &ActiveControl,
+        )
+        .expect("pr generation publishes");
+    assert_eq!(pr.sealed_scope().worktree, first.sealed_scope().worktree);
+    assert_ne!(pr.sealed_scope(), first.sealed_scope());
+    assert_eq!(
+        pr.sealed_scope().reference,
+        Some(id::<RefId>("refs/heads/pr-1234"))
+    );
+    assert!(pr.manifest().parent_generation.is_none());
+    assert_eq!(store.scope_count(), 2);
+    assert_eq!(
+        owner
+            .active_generation(&second.sealed_scope())
+            .expect("hawk slot read")
+            .expect("hawk slot stays active")
+            .manifest(),
+        second.manifest()
+    );
+
+    // The sealed branch label is durable through the sealed codec, so a
+    // restored generation still names the exact slot it was sealed for.
+    let restored = CodeIndexPublishedGenerationV1::decode_sealed(
+        &pr.encode_sealed().expect("pr generation seals"),
+    )
+    .expect("pr generation restores");
+    assert_eq!(restored.sealed_scope(), pr.sealed_scope());
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Code-index leftover slice for #421 (https://github.com/ScriptedAlchemy/tracedecay/pull/421). Branch is restacked onto `475638564` (current `codex/tracedecay-total-redesign-plan` tip; previously `ab6099e45`, never `327011a74`). The diff touches only `crates/tracedecay-code-index` — no other crate, no daemon, no docs.

Both leftovers land in the crate's production owner (`src/production/mod.rs`), which is the point where a publication authority's answer is dispatched onto a requested `CodeIndexGenerationScopeV1`:

### Leftover 1: git-identity ~1 Hz spin

When a tracedecay checkout is misclassified as "not a git repo", identity resolution yields a scope without reference/worktree while the store still answers with the sealed git-identified generation. `active_generation` classified that mismatch as a generic `Contract` error — a retry-shaped failure the scheduler re-hits identically on its 1-second cadence, forever.

Fix: a loaded generation whose sealed scope differs from the requested scope is now the terminal typed `CodeIndexPublicationStoreErrorV1::CorruptionResetRequired` state (already mapped downstream to the non-retryable `index_corruption_reset_required` wire code and the reset journey). The refusal happens before validation/adoption, and the sealed generation's real git identity survives untouched. A genuinely non-git snapshot remains a first-class terminal outcome: it indexes as its own genesis slot beside git-identified generations.

### Leftover 2: exact-graph config dispatch + shard key

- **Full-scope config dispatch**: `active_generation` previously matched on checkout identity only (repository + worktree via `identifies_same_checkout`), so a partial-key store could dispatch a graph/config sealed for `hawk` onto a PR worktree scope (and a same-worktree different-label scope was silently adopted). Dispatch now demands full-scope equality — repository + reference + worktree — matching the `CodeIndexAtomicPublicationPort` contract that linked worktrees share the repository store while branch/worktree generations stay independently active. `identifies_same_checkout` is retained for the daemon serving gates that legitimately need checkout identity only.
- **Shard key = sealed branch label**: new `CodeIndexPublishedGenerationV1::sealed_scope()` names the canonical slot/shard key — the full scope carrying the sealed branch label — never a filesystem path (the scope has none) and never an unbound generation id (successive generation ids share their branch's slot; a second branch on the same worktree splits into its own slot). The sealed label is durable through the sealed codec round trip.

### Serve path left alone

`code_graph_generation_id`, `from_verified_snapshot` worktree binding, and the shipped serving-scope gates are untouched, as required.

## Tests (isolated, `cargo test -p tracedecay-code-index`)

New in `tests/code_index_suite/production_orchestration.rs`, driven through a `PartialKeyPublicationStore` fixture that models the mispartitioned single-pointer store:

- `misclassified_non_git_scope_reaches_a_terminal_reset_state_instead_of_retrying` — non-git scope against a sealed git-identified generation refuses terminally (reset state, not `Contract`), repeat reconciles reach the same terminal state, sealed identity survives.
- `non_git_scope_stays_independently_active_beside_git_identified_generations` — the terminal non-git outcome indexes and coexists.
- `config_dispatch_refuses_a_generation_sealed_for_another_full_scope` — rejects both a different worktree (PR checkout) and a same-worktree different sealed branch label; exact full scope still dispatches.
- `code_shard_slot_key_is_the_sealed_branch_label_not_a_generation_id` — slot keyed by sealed branch label, not generation id or path; label durable through the sealed codec.

## Verification on `475638564` (this base)

- `cargo test -p tracedecay-code-index` — 273 passed / 0 failed across all targets (unit, every integration suite, doc-tests).
- `cargo fmt -p tracedecay-code-index -- --check` — clean.
- `cargo clippy -p tracedecay-code-index --all-targets --all-features -- -D warnings` — clean.
- Commit message passes commitlint.
- No workspace-wide suite was run (per slice constraints).

## Constraints honored

- Crate-only diff (`crates/tracedecay-code-index`).
- Restacked onto `475638564`.
- No live `~/.tracedecay` or in-repo `.tracedecay/` touched; all tests use in-memory fixtures.
- #509 untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2269ff9-95b7-4629-8055-5633ac389874?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2269ff9-95b7-4629-8055-5633ac389874&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

