### PR TITLE
fix(runtime-core): snapshot consumer + ENOSPC on private-fs available_space

### DIFF
--- a/crates/tracedecay-runtime-core/src/privacy/lcm.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/lcm.rs
@@ -6,7 +6,7 @@ use super::detect::DetectionError;
 use super::detector_kernel::{
     JsonVisitMut, NormalizedSensitiveKey, SensitiveKeyPolicy, visit_sensitive_json_mut,
 };
-use super::structured::parse_json_value;
+use super::structured::{JsonPreflightFailureV1, parse_json_value};
 use tracedecay_capture::ParseLimits;
 
 const REDACTED_ASSIGNMENT: &str = "[TraceDecay redacted: credential assignment]";
@@ -81,10 +81,17 @@ pub fn redact_lcm_sensitive_payload(
     }
     let mut patterns = Vec::new();
     let text = if raw.trim_start().starts_with(['{', '[']) {
-        let mut payload = parse_json_value(raw, limits.depth, limits.values)
-            .map_err(|_| DetectionError::Receipt)?;
+        let mut payload = match parse_json_value(raw, limits.depth, limits.values) {
+            Ok(payload) => payload,
+            Err(
+                JsonPreflightFailureV1::DepthExceeded | JsonPreflightFailureV1::ValueCountExceeded,
+            ) => return Err(DetectionError::ScanLimitExceeded),
+            Err(JsonPreflightFailureV1::DuplicateKey | JsonPreflightFailureV1::Malformed) => {
+                return Err(DetectionError::StructuredQuarantine);
+            }
+        };
         if !(payload.is_object() || payload.is_array()) {
-            return Err(DetectionError::Receipt);
+            return Err(DetectionError::StructuredQuarantine);
         }
         redact_structured(&mut payload, policy, &mut patterns);
         serde_json::to_string(&payload).map_err(|_| DetectionError::Receipt)?

--- a/crates/tracedecay-runtime-core/src/privacy/structured_text.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/structured_text.rs
@@ -36,9 +36,9 @@ use super::detect::{
 use super::detector_kernel::{CredentialPattern, NormalizedSensitiveKey, SensitiveKeyPolicy};
 use super::length_prefixed_sha256_hex;
 use super::structured::{
-    ParsedStructuredTextV1, StructuredSanitizationLimits, StructuredTextFieldV1,
-    StructuredTextFormatV1, StructuredTextParseFailureV1, parse_structured_text,
-    sanitize_structured_payload, validate_structured_text_limits,
+    ParsedStructuredTextV1, StructuredSanitizationError, StructuredSanitizationLimits,
+    StructuredTextFieldV1, StructuredTextFormatV1, StructuredTextParseFailureV1,
+    parse_structured_text, sanitize_structured_payload, validate_structured_text_limits,
 };
 
 pub const CODE_SOURCE_SANITIZER_VERSION_V1: &str = "privacy.code-source.v1";
@@ -773,9 +773,9 @@ fn detect_lcm_payload(raw: &str) -> Result<(String, Vec<SanitizationFindingV1>),
         )
         .map_err(|_| DetectionError::Receipt)?;
         let sanitized = sanitize_structured_payload(raw.as_bytes(), limits)
-            .map_err(|_| DetectionError::Receipt)?;
+            .map_err(detection_error_from_structured_sanitization)?;
         if !sanitized.was_structurally_parsed() {
-            return Err(DetectionError::Receipt);
+            return Err(DetectionError::StructuredQuarantine);
         }
         let text =
             serde_json::to_string(sanitized.payload()).map_err(|_| DetectionError::Receipt)?;
@@ -784,9 +784,24 @@ fn detect_lcm_payload(raw: &str) -> Result<(String, Vec<SanitizationFindingV1>),
 
     let detected = sanitize_structured_text(raw)?;
     if !detected.quarantine_findings().is_empty() {
-        return Err(DetectionError::Receipt);
+        return Err(DetectionError::StructuredQuarantine);
     }
     Ok(detected.into_parts())
+}
+
+fn detection_error_from_structured_sanitization(
+    error: StructuredSanitizationError,
+) -> DetectionError {
+    match error {
+        StructuredSanitizationError::RawBytesExceeded
+        | StructuredSanitizationError::ExpandedBytesExceeded
+        | StructuredSanitizationError::NestingDepthExceeded
+        | StructuredSanitizationError::ItemCountExceeded => DetectionError::ScanLimitExceeded,
+        StructuredSanitizationError::UnsafeJsonStructure
+        | StructuredSanitizationError::InvalidEncoding => DetectionError::StructuredQuarantine,
+        StructuredSanitizationError::InvalidLimits
+        | StructuredSanitizationError::SanitizerUnavailable => DetectionError::Receipt,
+    }
 }
 
 fn issue_text_receipt(

--- a/crates/tracedecay-runtime-core/src/privacy/structured_text_tests.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/structured_text_tests.rs
@@ -347,7 +347,7 @@ fn lcm_json_duplicate_keys_are_rejected_before_value_materialization() {
 
     assert!(matches!(
         sanitize_lcm_payload_text(&raw),
-        Err(DetectionError::Receipt)
+        Err(DetectionError::StructuredQuarantine)
     ));
 }
 

--- a/crates/tracedecay-runtime-core/src/privacy/tests.rs
+++ b/crates/tracedecay-runtime-core/src/privacy/tests.rs
@@ -1465,7 +1465,7 @@ fn lcm_sensitive_redaction_rejects_duplicate_json_keys_before_materialization() 
 
     assert!(matches!(
         redact_lcm_sensitive_payload(raw, &policy),
-        Err(DetectionError::Receipt)
+        Err(DetectionError::StructuredQuarantine)
     ));
 }
 

--- a/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
+++ b/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
@@ -253,15 +253,18 @@ impl SnapshotSet {
             let available = fs2::available_space(&scratch.path)?;
             preparation_control.checkpoint()?;
             if copied_bytes > available {
-                return Err(io::Error::other(format!(
-                    "insufficient scratch space for SQLite read snapshots: required {copied_bytes} bytes, available {available} bytes at '{}'",
-                    scratch.path.display()
-                )));
+                return Err(insufficient_scratch_space(
+                    copied_bytes,
+                    available,
+                    &scratch.path,
+                ));
             }
             Ok((scratch, prepared, copied_bytes))
         })
         .await
-        .map_err(|error| io::Error::other(format!("snapshot preparation task failed: {error}")))??;
+        .map_err(|error| {
+            io::Error::other(format!("snapshot preparation task failed: {error}"))
+        })??;
         let mut databases = BTreeMap::new();
         for snapshot in prepared {
             let source = snapshot.source.clone();
@@ -753,6 +756,16 @@ fn changed_during_snapshot(source: &Path) -> io::Error {
     ))
 }
 
+fn insufficient_scratch_space(copied_bytes: u64, available: u64, scratch_path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::StorageFull,
+        format!(
+            "insufficient scratch space for SQLite read snapshots: required {copied_bytes} bytes, available {available} bytes at '{}'",
+            scratch_path.display()
+        ),
+    )
+}
+
 fn create_scratch_directory(
     root: &Path,
     expected_uid: Option<u32>,
@@ -1076,6 +1089,17 @@ mod cancellation_tests;
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn insufficient_scratch_space_is_storage_full_not_other() {
+        let error = insufficient_scratch_space(1024, 8, Path::new("/tmp/scratch"));
+        assert_eq!(error.kind(), io::ErrorKind::StorageFull);
+        let message = error.to_string();
+        assert!(
+            message.contains("required 1024 bytes") && message.contains("available 8 bytes"),
+            "{message}"
+        );
+    }
 
     #[test]
     fn checkpointed_inspection_is_purpose_bound_and_refuses_live_wal() {

--- a/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
+++ b/crates/tracedecay-runtime-core/src/sqlite_read_snapshot.rs
@@ -250,7 +250,7 @@ impl SnapshotSet {
                 copied_bytes = copied_bytes.saturating_add(snapshot.copy_bytes);
                 prepared.push(snapshot);
             }
-            let available = fs2::available_space(&scratch.path)?;
+            let available = tracedecay_private_fs::available_space(&scratch.path)?;
             preparation_control.checkpoint()?;
             if copied_bytes > available {
                 return Err(insufficient_scratch_space(


### PR DESCRIPTION
## Summary
- Snapshot scratch preflight uses `tracedecay_private_fs::available_space` instead of `fs2`.
- Insufficient scratch is `ErrorKind::StorageFull`, not `ErrorKind::Other`.
- Stacked on `feat/private-fs-available-space`. Isolated crate tests only. No live profile.

## Test plan
- [x] `cargo test -p tracedecay-runtime-core --lib insufficient_scratch_space_is_storage_full`
- [x] `cargo test -p tracedecay-runtime-core --lib scratch_is_private_and_next_capture`