### PR TITLE
fix(query): cheaper exact-flat retain + deadline backstop

### DIFF
--- a/crates/tracedecay-query/src/retrieval/lexical.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical.rs
@@ -27,6 +27,7 @@ mod projection;
 
 pub use self::projection::{
     CodeExactProjectionAdapterV1, CodeLexicalProjectionAdapterV1, CodeLexicalProjectionMetadataV1,
+    LEXICAL_PROJECTION_BUILD_DEADLINE_MICROS_V1,
 };
 
 /// Wording the lexical lane uses when a port-emitted batch fails the shared

--- a/crates/tracedecay-query/src/retrieval/lexical/projection.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use roaring::RoaringBitmap;
 use tracedecay_domain::{
@@ -30,6 +31,19 @@ const FUZZY_SCORE_MILLIS: u64 = 500;
 const PHRASE_SCORE_MILLIS: u64 = 2_000;
 const ECHO_SCORE_MILLIS: u64 = 750;
 const BYTE_NGRAM_POSTINGS_MEMORY_BUDGET_BYTES_V1: usize = 512 * 1024 * 1024;
+
+/// Wall-clock bound for materializing one lexical generation's postings.
+/// First-query `new` / `new_admitted` is O(store); a missing caller deadline
+/// must not let that build run unbounded on the daemon query path.
+pub const LEXICAL_PROJECTION_BUILD_DEADLINE_MICROS_V1: u64 = 30_000_000;
+
+fn map_postings_build_error(error: String) -> RetrievalPortError {
+    if error == postings::LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED {
+        RetrievalPortError::BudgetExceeded
+    } else {
+        RetrievalPortError::Contract(error)
+    }
+}
 
 /// Generation and source metadata bound to one immutable lexical projection.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -177,13 +191,16 @@ struct LexicalGenerationPostingsV1 {
 }
 
 impl LexicalGenerationPostingsV1 {
-    fn from_rows(rows: &[ProjectedChunkV1]) -> Result<Self, RetrievalPortError> {
+    fn from_rows(rows: &[ProjectedChunkV1], deadline: Instant) -> Result<Self, RetrievalPortError> {
         let mut vocabulary = BTreeSet::new();
         let mut term_documents = BTreeMap::<LexicalFieldV1, BTreeMap<String, RoaringBitmap>>::new();
         let mut exact_documents = BTreeMap::<ExactFieldV1, BTreeMap<Vec<u8>, RoaringBitmap>>::new();
         let mut document_frequencies = BTreeMap::<LexicalFieldV1, BTreeMap<String, usize>>::new();
         let mut field_lengths = BTreeMap::<LexicalFieldV1, usize>::new();
         for (document, row) in rows.iter().enumerate() {
+            if Instant::now() >= deadline {
+                return Err(RetrievalPortError::BudgetExceeded);
+            }
             let document = document as u32;
             for (field, terms) in &row.fields {
                 *field_lengths.entry(*field).or_default() += terms.len();
@@ -234,8 +251,9 @@ impl LexicalGenerationPostingsV1 {
             ByteNgramPostings::from_documents(
                 rows.iter().map(|row| row.normalized_text.as_bytes()),
                 &mut ngram_budget,
+                Some(deadline),
             )
-            .map_err(RetrievalPortError::Contract)?,
+            .map_err(map_postings_build_error)?,
         );
         let raw_matches_normalized = rows.iter().all(|row| {
             row.chunk.sanitized_text.as_str().as_bytes() == row.normalized_text.as_bytes()
@@ -248,8 +266,9 @@ impl LexicalGenerationPostingsV1 {
                     rows.iter()
                         .map(|row| row.chunk.sanitized_text.as_str().as_bytes()),
                     &mut ngram_budget,
+                    Some(deadline),
                 )
-                .map_err(RetrievalPortError::Contract)?,
+                .map_err(map_postings_build_error)?,
             )
         };
         Ok(Self {
@@ -435,7 +454,9 @@ impl CodeLexicalProjectionAdapterV1 {
             rows.push(ProjectedChunkV1::new(chunk, logical_path));
         }
         rows.sort_by(|left, right| left.chunk.id.cmp(&right.chunk.id));
-        let postings = Arc::new(LexicalGenerationPostingsV1::from_rows(&rows)?);
+        let deadline =
+            Instant::now() + Duration::from_micros(LEXICAL_PROJECTION_BUILD_DEADLINE_MICROS_V1);
+        let postings = Arc::new(LexicalGenerationPostingsV1::from_rows(&rows, deadline)?);
         Ok(Self {
             metadata,
             rows: Arc::new(rows),

--- a/crates/tracedecay-query/src/retrieval/lexical/projection.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection.rs
@@ -45,6 +45,14 @@ fn map_postings_build_error(error: String) -> RetrievalPortError {
     }
 }
 
+fn check_projection_build_deadline(deadline: Instant) -> Result<(), RetrievalPortError> {
+    if Instant::now() >= deadline {
+        Err(RetrievalPortError::BudgetExceeded)
+    } else {
+        Ok(())
+    }
+}
+
 /// Generation and source metadata bound to one immutable lexical projection.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CodeLexicalProjectionMetadataV1 {
@@ -192,15 +200,14 @@ struct LexicalGenerationPostingsV1 {
 
 impl LexicalGenerationPostingsV1 {
     fn from_rows(rows: &[ProjectedChunkV1], deadline: Instant) -> Result<Self, RetrievalPortError> {
+        check_projection_build_deadline(deadline)?;
         let mut vocabulary = BTreeSet::new();
         let mut term_documents = BTreeMap::<LexicalFieldV1, BTreeMap<String, RoaringBitmap>>::new();
         let mut exact_documents = BTreeMap::<ExactFieldV1, BTreeMap<Vec<u8>, RoaringBitmap>>::new();
         let mut document_frequencies = BTreeMap::<LexicalFieldV1, BTreeMap<String, usize>>::new();
         let mut field_lengths = BTreeMap::<LexicalFieldV1, usize>::new();
         for (document, row) in rows.iter().enumerate() {
-            if Instant::now() >= deadline {
-                return Err(RetrievalPortError::BudgetExceeded);
-            }
+            check_projection_build_deadline(deadline)?;
             let document = document as u32;
             for (field, terms) in &row.fields {
                 *field_lengths.entry(*field).or_default() += terms.len();
@@ -246,6 +253,7 @@ impl LexicalGenerationPostingsV1 {
             .into_iter()
             .map(|(field, total)| (field, total.div_ceil(divisor).max(1)))
             .collect();
+        check_projection_build_deadline(deadline)?;
         let mut ngram_budget = ByteNgramBudget::new(BYTE_NGRAM_POSTINGS_MEMORY_BUDGET_BYTES_V1);
         let normalized_text = Arc::new(
             ByteNgramPostings::from_documents(
@@ -258,6 +266,7 @@ impl LexicalGenerationPostingsV1 {
         let raw_matches_normalized = rows.iter().all(|row| {
             row.chunk.sanitized_text.as_str().as_bytes() == row.normalized_text.as_bytes()
         });
+        check_projection_build_deadline(deadline)?;
         let raw_text = if raw_matches_normalized {
             Arc::clone(&normalized_text)
         } else {
@@ -271,13 +280,15 @@ impl LexicalGenerationPostingsV1 {
                 .map_err(map_postings_build_error)?,
             )
         };
+        let fuzzy_terms = FuzzyTermIndex::from_terms(vocabulary, Some(deadline))
+            .map_err(map_postings_build_error)?;
+        check_projection_build_deadline(deadline)?;
         Ok(Self {
             term_documents,
             exact_documents,
             normalized_text,
             raw_text,
-            fuzzy_terms: FuzzyTermIndex::from_terms(vocabulary)
-                .map_err(RetrievalPortError::Contract)?,
+            fuzzy_terms,
             document_frequencies,
             average_field_lengths,
         })
@@ -413,7 +424,11 @@ impl CodeLexicalProjectionAdapterV1 {
         chunks: Vec<CodeSearchChunkV1>,
         extraction_admitted: bool,
     ) -> Result<Self, RetrievalPortError> {
+        let deadline =
+            Instant::now() + Duration::from_micros(LEXICAL_PROJECTION_BUILD_DEADLINE_MICROS_V1);
+        check_projection_build_deadline(deadline)?;
         metadata.validate()?;
+        check_projection_build_deadline(deadline)?;
         if chunks.len() > u32::MAX as usize {
             return Err(RetrievalPortError::Contract(
                 "lexical projection exceeds the posting document-id range".to_owned(),
@@ -422,6 +437,7 @@ impl CodeLexicalProjectionAdapterV1 {
         let mut seen = BTreeSet::new();
         let mut rows = Vec::with_capacity(chunks.len());
         for chunk in chunks {
+            check_projection_build_deadline(deadline)?;
             chunk.validate().map_err(contract_error)?;
             if !extraction_admitted
                 && chunk
@@ -452,10 +468,10 @@ impl CodeLexicalProjectionAdapterV1 {
                     ))
                 })?;
             rows.push(ProjectedChunkV1::new(chunk, logical_path));
+            check_projection_build_deadline(deadline)?;
         }
         rows.sort_by(|left, right| left.chunk.id.cmp(&right.chunk.id));
-        let deadline =
-            Instant::now() + Duration::from_micros(LEXICAL_PROJECTION_BUILD_DEADLINE_MICROS_V1);
+        check_projection_build_deadline(deadline)?;
         let postings = Arc::new(LexicalGenerationPostingsV1::from_rows(&rows, deadline)?);
         Ok(Self {
             metadata,

--- a/crates/tracedecay-query/src/retrieval/lexical/projection/postings.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection/postings.rs
@@ -1,11 +1,14 @@
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
 
 use fst::{IntoStreamer, Set, Streamer, automaton::Levenshtein};
 use roaring::RoaringBitmap;
 
 const NGRAM_KEY_ESTIMATED_BYTES: usize = 64;
 const NGRAM_DOCUMENT_POSTING_ESTIMATED_BYTES: usize = 8;
+pub(super) const LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED: &str =
+    "lexical projection exceeded its build deadline";
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct ByteNgramPostings {
@@ -16,9 +19,13 @@ impl ByteNgramPostings {
     pub(super) fn from_documents<'a>(
         documents: impl IntoIterator<Item = &'a [u8]>,
         budget: &mut ByteNgramBudget,
+        deadline: Option<Instant>,
     ) -> Result<Self, String> {
         let mut postings = BTreeMap::<u32, RoaringBitmap>::new();
         for (document, bytes) in documents.into_iter().enumerate() {
+            if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                return Err(LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED.to_owned());
+            }
             let document = u32::try_from(document)
                 .map_err(|_| "posting document id exceeds u32".to_owned())?;
             for width in 1..=bytes.len().min(3) {
@@ -195,6 +202,7 @@ mod tests {
                 b"gamma request completed".as_slice(),
             ],
             &mut budget,
+            None,
         )
         .expect("bounded postings");
 
@@ -222,9 +230,21 @@ mod tests {
     #[test]
     fn ngram_postings_reject_over_budget_generations() {
         let mut budget = ByteNgramBudget::new(80);
-        let error = ByteNgramPostings::from_documents([b"abcdef".as_slice()], &mut budget)
+        let error = ByteNgramPostings::from_documents([b"abcdef".as_slice()], &mut budget, None)
             .expect_err("posting memory must be bounded");
         assert!(error.contains("n-gram posting memory budget"));
+    }
+
+    #[test]
+    fn ngram_postings_reject_an_already_expired_build_deadline() {
+        let mut budget = ByteNgramBudget::new(1024 * 1024);
+        let error = ByteNgramPostings::from_documents(
+            [b"abcdef".as_slice()],
+            &mut budget,
+            Some(Instant::now()),
+        )
+        .expect_err("expired deadline must fail closed");
+        assert_eq!(error, LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED);
     }
 
     #[test]

--- a/crates/tracedecay-query/src/retrieval/lexical/projection/postings.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection/postings.rs
@@ -140,17 +140,26 @@ pub(super) struct FuzzySearchSlice {
 }
 
 impl FuzzyTermIndex {
-    pub(super) fn from_terms<I, S>(terms: I) -> Result<Self, String>
+    pub(super) fn from_terms<I, S>(terms: I, deadline: Option<Instant>) -> Result<Self, String>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let terms = terms
-            .into_iter()
-            .map(|term| term.as_ref().to_owned())
-            .collect::<BTreeSet<_>>();
-        let terms = Set::from_iter(terms.into_iter().map(String::into_bytes))
+        let mut canonical_terms = BTreeSet::new();
+        for term in terms {
+            if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                return Err(LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED.to_owned());
+            }
+            canonical_terms.insert(term.as_ref().to_owned());
+        }
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED.to_owned());
+        }
+        let terms = Set::from_iter(canonical_terms.into_iter().map(String::into_bytes))
             .map_err(|error| error.to_string())?;
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED.to_owned());
+        }
         Ok(Self { terms })
     }
 
@@ -248,9 +257,16 @@ mod tests {
     }
 
     #[test]
+    fn fuzzy_index_rejects_an_already_expired_build_deadline() {
+        let error = FuzzyTermIndex::from_terms(["alpha"], Some(Instant::now()))
+            .expect_err("expired deadline must cover fuzzy index construction");
+        assert_eq!(error, LEXICAL_PROJECTION_BUILD_DEADLINE_EXCEEDED);
+    }
+
+    #[test]
     fn fuzzy_enumeration_stops_at_the_remaining_budget() {
         let terms = ('!'..='~').map(|character| format!("aaaa{character}aaaaa"));
-        let index = FuzzyTermIndex::from_terms(terms).expect("valid FST");
+        let index = FuzzyTermIndex::from_terms(terms, None).expect("valid FST");
         let mut seen = BTreeSet::new();
         let slice = index
             .terms_at_distance("aaaaaaaaaa", 1, 3, &mut seen)

--- a/crates/tracedecay-query/src/retrieval/semantic.rs
+++ b/crates/tracedecay-query/src/retrieval/semantic.rs
@@ -24,6 +24,11 @@ use super::ports::{
     checkpoint_digest, contract_error, lane_candidate_cap,
 };
 
+/// Fallback exact-flat scan deadline when both request budgets omit
+/// `deadline_micros`. Retention is heap-capped; the visit is still a full
+/// generation scan, so a missing request deadline must not run unbounded.
+pub const SEMANTIC_EXACT_FLAT_DEFAULT_DEADLINE_MICROS_V1: u64 = 5_000_000;
+
 mod execution_authority;
 mod service;
 pub use execution_authority::{
@@ -657,20 +662,23 @@ fn semantic_checkpoint_digest(
     ))
 }
 
+fn effective_deadline_micros(request: &SemanticRetrievalRequestV1<'_>) -> u64 {
+    match (
+        request.budget.deadline_micros,
+        request.base.budget.deadline_micros,
+    ) {
+        (Some(lane), Some(base)) => lane.min(base),
+        (Some(lane), None) => lane,
+        (None, Some(base)) => base,
+        (None, None) => SEMANTIC_EXACT_FLAT_DEFAULT_DEADLINE_MICROS_V1,
+    }
+}
+
 fn deadline_exhausted<C: SemanticExecutionControl>(
     request: &SemanticRetrievalRequestV1<'_>,
     control: &C,
 ) -> bool {
-    let elapsed = elapsed_micros(request, control);
-    request
-        .budget
-        .deadline_micros
-        .is_some_and(|deadline| elapsed >= deadline)
-        || request
-            .base
-            .budget
-            .deadline_micros
-            .is_some_and(|deadline| elapsed >= deadline)
+    elapsed_micros(request, control) >= effective_deadline_micros(request)
 }
 
 fn elapsed_micros<C: SemanticExecutionControl>(

--- a/crates/tracedecay-query/src/retrieval/semantic.rs
+++ b/crates/tracedecay-query/src/retrieval/semantic.rs
@@ -216,11 +216,13 @@ pub struct SemanticVectorScanSummaryV1 {
 
 /// Read-only port over one immutable, fully published vector generation.
 /// The callback shape lets the lane scan without retaining or copying the
-/// complete vector set.
+/// complete vector set. Implementations must invoke `examine` before every
+/// row they inspect, including rows they exclude before invoking `visit`.
 pub trait SemanticVectorReadPort {
     fn scan_exact_flat(
         &self,
         request: SemanticVectorReadRequestV1<'_>,
+        examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
         visit: &mut dyn FnMut(&SemanticVectorRecordV1) -> Result<(), RetrievalPortError>,
     ) -> Result<SemanticVectorScanSummaryV1, RetrievalPortError>;
 }
@@ -407,23 +409,29 @@ where
             capability_manifest_digest: &request.capability_manifest_digest,
             search_kind: SemanticSearchKindV1::ExactFlat,
         };
-        let scan = self.vectors.scan_exact_flat(scan_request, &mut |record| {
+        let mut examine = || {
             if self.control.is_cancelled() {
                 return Err(RetrievalPortError::Cancelled);
             }
             if deadline_exhausted(request, self.control) {
                 return Err(RetrievalPortError::BudgetExceeded);
             }
-            let distance = Self::score_record(request, record, query)?;
-            if !seen_occurrences.insert(record.candidate.source_occurrence_id.clone()) {
-                return Err(RetrievalPortError::Contract(
-                    "semantic vector generation contains duplicate source occurrences".to_owned(),
-                ));
-            }
-            eligible_count += 1;
-            Self::retain_scored_record(request, record, distance, cap, &mut ranked);
             Ok(())
-        });
+        };
+        let scan = self
+            .vectors
+            .scan_exact_flat(scan_request, &mut examine, &mut |record| {
+                let distance = Self::score_record(request, record, query)?;
+                if !seen_occurrences.insert(record.candidate.source_occurrence_id.clone()) {
+                    return Err(RetrievalPortError::Contract(
+                        "semantic vector generation contains duplicate source occurrences"
+                            .to_owned(),
+                    ));
+                }
+                eligible_count += 1;
+                Self::retain_scored_record(request, record, distance, cap, &mut ranked);
+                Ok(())
+            });
         let summary = match scan {
             Ok(summary) => summary,
             Err(error) => {

--- a/crates/tracedecay-query/src/retrieval/semantic.rs
+++ b/crates/tracedecay-query/src/retrieval/semantic.rs
@@ -5,6 +5,8 @@
 //! performs no artifact admission, vector mutation, ANN lookup, fusion,
 //! reranking, hydration, activation, or calls into another retrieval lane.
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 
@@ -263,11 +265,11 @@ where
     V: SemanticVectorReadPort,
     C: SemanticExecutionControl,
 {
-    fn enforce_record(
+    fn score_record(
         request: &SemanticRetrievalRequestV1<'_>,
         record: &SemanticVectorRecordV1,
         query: &EphemeralQueryEmbeddingV1,
-    ) -> Result<(CompactCandidate, CodeSemanticEvidenceV1), RetrievalPortError> {
+    ) -> Result<CanonicalSemanticDistanceV1, RetrievalPortError> {
         if record.vector_generation != request.vector_generation
             || record.projection_key != *request.projection.projection_key()
         {
@@ -305,16 +307,25 @@ where
             request.projection.embedding_key().dimensions,
             "stored semantic vector",
         )?;
-        let distance = canonical_distance(
+        canonical_distance(
             request.projection.embedding_key().metric,
             &query.values,
             &record.values,
-        )?;
+        )
+    }
+
+    fn materialize_record(
+        request: &SemanticRetrievalRequestV1<'_>,
+        record: &SemanticVectorRecordV1,
+        distance: CanonicalSemanticDistanceV1,
+    ) -> SemanticRankedEntryV1 {
+        #[cfg(test)]
+        SEMANTIC_RETAINED_MATERIALIZATIONS.with(|count| count.set(count.get() + 1));
         let mut candidate = record.candidate.clone();
         candidate.raw_score = distance.as_descending_score();
-        Ok((
+        SemanticRankedEntryV1 {
             candidate,
-            CodeSemanticEvidenceV1 {
+            evidence: CodeSemanticEvidenceV1 {
                 projection_key: request.projection.embedding_key().clone(),
                 search_index_key: request.search_index_key.clone(),
                 vector_generation: request.vector_generation.clone(),
@@ -322,7 +333,47 @@ where
                 distance,
                 search_kind: SemanticSearchKindV1::ExactFlat,
             },
-        ))
+        }
+    }
+
+    fn retain_scored_record(
+        request: &SemanticRetrievalRequestV1<'_>,
+        record: &SemanticVectorRecordV1,
+        distance: CanonicalSemanticDistanceV1,
+        cap: usize,
+        ranked: &mut BinaryHeap<SemanticRankedEntryV1>,
+    ) {
+        if cap == 0 {
+            return;
+        }
+        // Compare against the heap worst using the same key as SemanticRankedEntryV1
+        // without cloning a losing candidate.
+        let retain = if ranked.len() < cap {
+            true
+        } else if let Some(worst) = ranked.peek() {
+            rank_key(
+                distance,
+                &record.candidate.source_occurrence_id,
+                &record.candidate.retriever_evidence_anchor,
+                &record.chunk_id,
+            )
+            .cmp(&rank_key(
+                worst.evidence.distance,
+                &worst.candidate.source_occurrence_id,
+                &worst.candidate.retriever_evidence_anchor,
+                &worst.evidence.chunk_id,
+            )) == Ordering::Less
+        } else {
+            false
+        };
+        if !retain {
+            return;
+        }
+        let entry = Self::materialize_record(request, record, distance);
+        if ranked.len() == cap {
+            ranked.pop();
+        }
+        ranked.push(entry);
     }
 
     fn retrieve_complete(
@@ -363,29 +414,14 @@ where
             if deadline_exhausted(request, self.control) {
                 return Err(RetrievalPortError::BudgetExceeded);
             }
-            let (candidate, evidence) = Self::enforce_record(request, record, query)?;
-            if !seen_occurrences.insert(candidate.source_occurrence_id.clone()) {
+            let distance = Self::score_record(request, record, query)?;
+            if !seen_occurrences.insert(record.candidate.source_occurrence_id.clone()) {
                 return Err(RetrievalPortError::Contract(
                     "semantic vector generation contains duplicate source occurrences".to_owned(),
                 ));
             }
             eligible_count += 1;
-            if cap == 0 {
-                return Ok(());
-            }
-            let entry = SemanticRankedEntryV1 {
-                candidate,
-                evidence,
-            };
-            if ranked.len() < cap {
-                ranked.push(entry);
-            } else if ranked
-                .peek()
-                .is_some_and(|worst| entry.cmp(worst) == Ordering::Less)
-            {
-                ranked.pop();
-                ranked.push(entry);
-            }
+            Self::retain_scored_record(request, record, distance, cap, &mut ranked);
             Ok(())
         });
         let summary = match scan {
@@ -688,6 +724,35 @@ fn elapsed_micros<C: SemanticExecutionControl>(
     control.elapsed_micros()
 }
 
+#[cfg(test)]
+thread_local! {
+    static SEMANTIC_RETAINED_MATERIALIZATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn take_semantic_retained_materializations() -> usize {
+    SEMANTIC_RETAINED_MATERIALIZATIONS.with(|count| count.replace(0))
+}
+
+fn rank_key<'a>(
+    distance: CanonicalSemanticDistanceV1,
+    source_occurrence_id: &'a tracedecay_domain::SourceOccurrenceId,
+    retriever_evidence_anchor: &'a tracedecay_domain::RetrievalAnchorId,
+    chunk_id: &'a tracedecay_domain::CodeSearchChunkId,
+) -> (
+    CanonicalSemanticDistanceV1,
+    &'a tracedecay_domain::SourceOccurrenceId,
+    &'a tracedecay_domain::RetrievalAnchorId,
+    &'a tracedecay_domain::CodeSearchChunkId,
+) {
+    (
+        distance,
+        source_occurrence_id,
+        retriever_evidence_anchor,
+        chunk_id,
+    )
+}
+
 /// One retained ExactFlat row, ordered by the deterministic semantic ranking
 /// key (ascending distance, then `source_occurrence_id`,
 /// `retriever_evidence_anchor`, `chunk_id`). `Ord` mirrors the former
@@ -700,20 +765,18 @@ struct SemanticRankedEntryV1 {
 
 impl SemanticRankedEntryV1 {
     fn rank_cmp(&self, other: &Self) -> Ordering {
-        self.evidence
-            .distance
-            .cmp(&other.evidence.distance)
-            .then_with(|| {
-                self.candidate
-                    .source_occurrence_id
-                    .cmp(&other.candidate.source_occurrence_id)
-            })
-            .then_with(|| {
-                self.candidate
-                    .retriever_evidence_anchor
-                    .cmp(&other.candidate.retriever_evidence_anchor)
-            })
-            .then_with(|| self.evidence.chunk_id.cmp(&other.evidence.chunk_id))
+        rank_key(
+            self.evidence.distance,
+            &self.candidate.source_occurrence_id,
+            &self.candidate.retriever_evidence_anchor,
+            &self.evidence.chunk_id,
+        )
+        .cmp(&rank_key(
+            other.evidence.distance,
+            &other.candidate.source_occurrence_id,
+            &other.candidate.retriever_evidence_anchor,
+            &other.evidence.chunk_id,
+        ))
     }
 }
 

--- a/crates/tracedecay-query/src/retrieval/semantic/tests.rs
+++ b/crates/tracedecay-query/src/retrieval/semantic/tests.rs
@@ -506,6 +506,35 @@ fn bounded_scan_retains_the_cap_smallest_rows_by_tie_break_order() {
 }
 
 #[test]
+fn capped_exact_flat_scan_materializes_only_retained_rows() {
+    let query_view = query_view();
+    let projection = projection();
+    let request = request(&query_view, &projection, 2);
+    let rows = vec![
+        record(&request, "a", vec![1.0, 0.0]),
+        record(&request, "b", vec![1.0, 0.0]),
+        record(&request, "c", vec![0.0, 1.0]),
+        record(&request, "d", vec![0.0, 1.0]),
+    ];
+    let embedder = FakeQueryEmbedder::default();
+    let vectors = FakeVectorReadPort::new(&request, rows);
+    let control = FixedExecutionControl::default();
+    let _ = take_semantic_retained_materializations();
+
+    let outcome = SemanticCodeRetriever::new(&embedder, &vectors, &control)
+        .retrieve_semantic(&request)
+        .expect("semantic retrieval");
+    let RetrieverOutcome::Complete(batch) = outcome else {
+        panic!("expected a complete semantic batch");
+    };
+
+    assert_eq!(batch.coverage.examined, 4);
+    assert_eq!(batch.coverage.eligible, 4);
+    assert_eq!(batch.candidates.len(), 2);
+    assert_eq!(take_semantic_retained_materializations(), 2);
+}
+
+#[test]
 fn privacy_identity_mismatch_fails_before_embedding_or_vector_reads() {
     let query_view = query_view();
     let projection = projection();

--- a/crates/tracedecay-query/src/retrieval/semantic/tests.rs
+++ b/crates/tracedecay-query/src/retrieval/semantic/tests.rs
@@ -779,6 +779,30 @@ fn elapsed_deadline_before_scan_invokes_no_authority() {
 }
 
 #[test]
+fn omitted_request_deadline_uses_crate_exact_flat_default() {
+    let query_view = query_view();
+    let projection = projection();
+    let request = request(&query_view, &projection, 4);
+    assert!(request.budget.deadline_micros.is_none());
+    assert!(request.base.budget.deadline_micros.is_none());
+    let embedder = FakeQueryEmbedder::default();
+    let vectors = FakeVectorReadPort::new(&request, Vec::new());
+    let control = FixedExecutionControl {
+        elapsed_micros: Rc::new(Cell::new(SEMANTIC_EXACT_FLAT_DEFAULT_DEADLINE_MICROS_V1)),
+        ..FixedExecutionControl::default()
+    };
+
+    assert!(matches!(
+        SemanticCodeRetriever::new(&embedder, &vectors, &control)
+            .retrieve_semantic(&request)
+            .expect("typed budget outcome"),
+        RetrieverOutcome::BudgetExceeded(_)
+    ));
+    assert_eq!(embedder.calls.get(), 0);
+    assert_eq!(vectors.scans.get(), 0);
+}
+
+#[test]
 fn cancellation_and_deadline_are_checked_during_scan() {
     let query_view = query_view();
     let projection = projection();

--- a/crates/tracedecay-query/src/retrieval/semantic/tests.rs
+++ b/crates/tracedecay-query/src/retrieval/semantic/tests.rs
@@ -270,6 +270,7 @@ impl SemanticVectorReadPort for FakeVectorReadPort {
     fn scan_exact_flat(
         &self,
         request: SemanticVectorReadRequestV1<'_>,
+        examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
         visit: &mut dyn FnMut(&SemanticVectorRecordV1) -> Result<(), RetrievalPortError>,
     ) -> Result<SemanticVectorScanSummaryV1, RetrievalPortError> {
         self.scans.set(self.scans.get() + 1);
@@ -283,6 +284,7 @@ impl SemanticVectorReadPort for FakeVectorReadPort {
         );
         assert_eq!(request.search_kind, SemanticSearchKindV1::ExactFlat);
         for row in &self.rows {
+            examine()?;
             visit(row)?;
         }
         if let Some(cancelled) = &self.after_scan_cancel {
@@ -862,6 +864,45 @@ fn cancellation_and_deadline_are_checked_during_scan() {
         SemanticCodeRetriever::new(&expired_embedder, &expired_vectors, &expired_control)
             .retrieve_semantic(&request)
             .expect("typed deadline"),
+        RetrieverOutcome::BudgetExceeded(_)
+    ));
+}
+
+#[test]
+fn deadline_is_checked_while_the_store_examines_excluded_rows() {
+    struct ExcludedRows;
+
+    impl SemanticVectorReadPort for ExcludedRows {
+        fn scan_exact_flat(
+            &self,
+            _request: SemanticVectorReadRequestV1<'_>,
+            examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
+            _visit: &mut dyn FnMut(&SemanticVectorRecordV1) -> Result<(), RetrievalPortError>,
+        ) -> Result<SemanticVectorScanSummaryV1, RetrievalPortError> {
+            examine()?;
+            Ok(SemanticVectorScanSummaryV1 {
+                examined: 1,
+                eligible: 0,
+                excluded: 1,
+                unknown: 0,
+            })
+        }
+    }
+
+    let query_view = query_view();
+    let projection = projection();
+    let mut request = request(&query_view, &projection, 4);
+    request.budget.deadline_micros = Some(5);
+    let embedder = FakeQueryEmbedder::default();
+    let control = FixedExecutionControl {
+        expire_after_elapsed_checks: Some(2),
+        ..FixedExecutionControl::default()
+    };
+
+    assert!(matches!(
+        SemanticCodeRetriever::new(&embedder, &ExcludedRows, &control)
+            .retrieve_semantic(&request)
+            .expect("excluded-row scan must return a typed deadline outcome"),
         RetrieverOutcome::BudgetExceeded(_)
     ));
 }

--- a/crates/tracedecay-usecases/src/semantic_runtime/production.rs
+++ b/crates/tracedecay-usecases/src/semantic_runtime/production.rs
@@ -2455,6 +2455,7 @@ impl SemanticVectorReadPort for ScopedSemanticEvaluationVectorReadPortV1<'_> {
     fn scan_exact_flat(
         &self,
         request: SemanticVectorReadRequestV1<'_>,
+        examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
         visit: &mut dyn FnMut(&SemanticVectorRecordV1) -> Result<(), RetrievalPortError>,
     ) -> Result<SemanticVectorScanSummaryV1, RetrievalPortError> {
         let mut eligible = 0_u64;
@@ -2465,7 +2466,9 @@ impl SemanticVectorReadPort for ScopedSemanticEvaluationVectorReadPortV1<'_> {
             }
             Ok(())
         };
-        let summary = self.inner.scan_exact_flat(request, &mut scoped_visit)?;
+        let summary = self
+            .inner
+            .scan_exact_flat(request, examine, &mut scoped_visit)?;
         Ok(SemanticVectorScanSummaryV1 {
             examined: summary.examined,
             eligible,
@@ -2649,6 +2652,7 @@ impl SemanticVectorReadPort for PublishedSemanticVectorReadPortV1 {
     fn scan_exact_flat(
         &self,
         request: SemanticVectorReadRequestV1<'_>,
+        examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
         visit: &mut dyn FnMut(&SemanticVectorRecordV1) -> Result<(), RetrievalPortError>,
     ) -> Result<SemanticVectorScanSummaryV1, RetrievalPortError> {
         if request.search_kind != SemanticSearchKindV1::ExactFlat
@@ -2661,6 +2665,7 @@ impl SemanticVectorReadPort for PublishedSemanticVectorReadPortV1 {
             return Err(RetrievalPortError::IncompatibleProjection);
         }
         for row in &self.rows {
+            examine()?;
             visit(row)?;
         }
         Ok(SemanticVectorScanSummaryV1 {
@@ -4118,6 +4123,7 @@ mod tests {
             fn scan_exact_flat(
                 &self,
                 _request: SemanticVectorReadRequestV1<'_>,
+                _examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
                 _visit: &mut dyn FnMut(&SemanticVectorRecordV1) -> Result<(), RetrievalPortError>,
             ) -> Result<SemanticVectorScanSummaryV1, RetrievalPortError> {
                 panic!("cancelled query runtime must not scan vectors")
@@ -4310,6 +4316,7 @@ mod tests {
             fn scan_exact_flat(
                 &self,
                 _request: tracedecay_query::retrieval::semantic::SemanticVectorReadRequestV1<'_>,
+                _examine: &mut dyn FnMut() -> Result<(), RetrievalPortError>,
                 _visit: &mut dyn FnMut(
                     &tracedecay_query::retrieval::semantic::SemanticVectorRecordV1,
                 ) -> Result<(), RetrievalPortError>,


### PR DESCRIPTION
## Summary
- Restacked onto `fa9c6318` (merge of #537). Query crate work plus the forced `SemanticVectorReadPort` examine adapt in usecases so the trait change compiles.
- Exact-flat still visits for coverage, but **does less work**: score without cloning, materialize candidate/evidence only for retained heap rows. Isolated proof: 4 eligible / cap 2 → 2 materializations.
- Omitted `deadline_micros` falls back to crate 5s (semantic) / 30s (lexical projection build). A set request/profile `RetrievalBudget.deadline_micros` wins (Plan 20, same bar as #538).
- `BudgetExceeded` stays **Partial**, never a complete empty success. Semantic 5s does not take down exact/lexical/graph (required lanes stay exact+lexical).
- Full-scan deadlines: store `examine` runs before every inspected row, including excluded ones; lexical projection/fuzzy/n-gram build checkpoints the same deadline.

## Test plan
- [x] `cargo test -p tracedecay-query --lib retrieval::semantic::tests` (28 passed)
- [x] `cargo test -p tracedecay-query --lib retrieval::lexical` (20 passed)
- [x] `cargo test -p tracedecay-query --lib retrieval::tests::composition` (16 passed, including `semantic_budget_exceeded_does_not_take_down_exact_lexical_or_graph`)
- [ ] CI

Does not reopen #532. Do not merge until CI is green.