### PR TITLE
feat(rusqlite-runtime): expose exclusive maintenance checkpoint port

### DIFF
--- a/crates/tracedecay-rusqlite-runtime/src/reader/pool/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/reader/pool/mod.rs
@@ -228,10 +228,14 @@ impl<'pool, E: ReaderQueryExecutor> WaitingGuard<'pool, E> {
         }
     }
 
-    const fn arm(&mut self, state: &mut PoolState) {
+    fn arm(&mut self, state: &mut PoolState) {
         if !self.counted {
             self.counted = true;
             *state.waiting_mut(self.lane) += 1;
+            // Arming is an observable state change: waiters on
+            // `capacity_changed` (tests watching for a blocked acquisition)
+            // must see it as an event rather than having to poll `snapshot`.
+            self.inner.capacity_changed.notify_all();
         }
     }
 }
@@ -590,6 +594,69 @@ impl<E: ReaderQueryExecutor> ReaderPool<E> {
             && state.limbo_general == 0
             && state.limbo_health == 0
             && Arc::strong_count(&self.inner) == 1
+    }
+
+    /// Test-only: block until a general-lane acquisition is counted as a
+    /// waiter, or the bound lapses.
+    ///
+    /// Arming a waiter notifies `capacity_changed`, so this observes the
+    /// event directly instead of polling `snapshot`.
+    #[cfg(test)]
+    pub(crate) fn wait_until_waiting_general(&self, max_wait: Duration) -> bool {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (state, _) = self
+            .inner
+            .capacity_changed
+            .wait_timeout_while(state, max_wait, |state| state.waiting_general == 0)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiting_general > 0
+    }
+
+    /// Test-only: block until the pool is quiescent, or the bound lapses.
+    ///
+    /// Every lane-state transition that feeds quiescence (lease returns,
+    /// opens, limbo resolution) notifies `capacity_changed`, so the wait is
+    /// event-driven. The one exception is the final strong-count handoff:
+    /// the deferred-return thread drops its pool reference immediately after
+    /// its notification, and that drop has no event, so the tail of this wait
+    /// yields across a window of a few instructions.
+    #[cfg(test)]
+    pub(crate) fn wait_until_quiescent(&self, max_wait: Duration) -> bool {
+        fn lanes_busy(state: &PoolState) -> bool {
+            state.opening_general != 0
+                || state.opening_health != 0
+                || state.leased_general != 0
+                || state.leased_health != 0
+                || state.limbo_general != 0
+                || state.limbo_health != 0
+        }
+        let deadline = Instant::now() + max_wait;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let state = self
+                .inner
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let (state, _) = self
+                .inner
+                .capacity_changed
+                .wait_timeout_while(state, remaining, |state| lanes_busy(state))
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let lanes_settled = !lanes_busy(&state);
+            drop(state);
+            if lanes_settled && Arc::strong_count(&self.inner) == 1 {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::yield_now();
+        }
     }
 
     /// Acquire within a caller-selected bound. The caller-owned probe remains

--- a/crates/tracedecay-rusqlite-runtime/src/reader/tests.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/reader/tests.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeSet,
     path::PathBuf,
     sync::{
-        Arc, Mutex,
+        Arc, Condvar, Mutex,
         atomic::{AtomicU8, Ordering},
     },
     time::{Duration, Instant},
@@ -57,9 +57,35 @@ impl ReaderQueryExecutor for CountExecutor {
     }
 }
 
+/// A one-way latch threads synchronize on without polling: `set` flips it
+/// under the lock and notifies, `wait` parks on the condvar until the gate is
+/// set or the bound lapses.
+#[derive(Clone, Default)]
+struct Gate {
+    state: Arc<(Mutex<bool>, Condvar)>,
+}
+
+impl Gate {
+    fn set(&self) {
+        let (set, changed) = &*self.state;
+        *set.lock().unwrap() = true;
+        changed.notify_all();
+    }
+
+    /// Returns whether the gate was set within the bound.
+    fn wait(&self, bound: Duration) -> bool {
+        let (set, changed) = &*self.state;
+        let (set, _) = changed
+            .wait_timeout_while(set.lock().unwrap(), bound, |set| !*set)
+            .unwrap();
+        *set
+    }
+}
+
 #[derive(Clone)]
 struct SlowExecutor {
     delay: Duration,
+    entered: Gate,
 }
 
 impl ReaderQueryExecutor for SlowExecutor {
@@ -68,6 +94,7 @@ impl ReaderQueryExecutor for SlowExecutor {
         snapshot: &Transaction<'_>,
         request: &RuntimeReadRequestV1,
     ) -> Result<RuntimeReadOutcomeV1, StorageRuntimeErrorV1> {
+        self.entered.set();
         std::thread::sleep(self.delay);
         CountExecutor.execute_read(snapshot, request)
     }
@@ -78,8 +105,8 @@ impl ReaderQueryExecutor for SlowExecutor {
 /// instead of racing a wall-clock bound.
 #[derive(Clone, Default)]
 struct GateExecutor {
-    entered: Arc<AtomicU8>,
-    release: Arc<AtomicU8>,
+    entered: Gate,
+    release: Gate,
     finished: Arc<AtomicU8>,
 }
 
@@ -89,10 +116,10 @@ impl ReaderQueryExecutor for GateExecutor {
         snapshot: &Transaction<'_>,
         request: &RuntimeReadRequestV1,
     ) -> Result<RuntimeReadOutcomeV1, StorageRuntimeErrorV1> {
-        self.entered.store(1, Ordering::SeqCst);
-        while self.release.load(Ordering::SeqCst) == 0 {
-            std::thread::sleep(Duration::from_millis(1));
-        }
+        self.entered.set();
+        // The bound is a harness guard, not a timing assumption: every test
+        // opens the gate, directly or through its watchdog.
+        self.release.wait(Duration::from_secs(60));
         let outcome = CountExecutor.execute_read(snapshot, request);
         self.finished.store(1, Ordering::SeqCst);
         outcome
@@ -849,30 +876,24 @@ fn cancellation_bounds_query_return_even_when_the_executor_is_still_running() {
     let read = request(&store.binding, OperationPriorityV1::Foreground);
     let probe = Probe::for_request(&read);
     let cancellation = Arc::clone(&probe.interruption);
-    let entered = Arc::clone(&executor.entered);
+    let entered = executor.entered.clone();
     let mut lease = pool.acquire(&read, &probe, Duration::ZERO).unwrap();
     let mut snapshot = lease.begin_snapshot().unwrap();
     // Cancel only once the worker is provably inside the executor, so the
     // return below can only be explained by the cancellation observation and
     // never by the executor completing first.
     std::thread::spawn(move || {
-        while entered.load(Ordering::SeqCst) == 0 {
-            std::thread::sleep(Duration::from_millis(1));
-        }
+        entered.wait(Duration::from_secs(30));
         cancellation.store(1, Ordering::SeqCst);
     });
     // Watchdog: if cancellation regresses, `execute` blocks on the parked
     // executor until the harness kills the test. Releasing the gate after a
     // generous bound turns that hang into the clean assertion failures below.
-    let watchdog_release = Arc::clone(&executor.release);
+    let watchdog_release = executor.release.clone();
     let watchdog = std::thread::spawn(move || {
-        for _ in 0..300 {
-            if watchdog_release.load(Ordering::SeqCst) != 0 {
-                return;
-            }
-            std::thread::sleep(Duration::from_millis(100));
+        if !watchdog_release.wait(Duration::from_secs(30)) {
+            watchdog_release.set();
         }
-        watchdog_release.store(1, Ordering::SeqCst);
     });
 
     let outcome = snapshot.execute(read, &probe).unwrap();
@@ -896,7 +917,7 @@ fn cancellation_bounds_query_return_even_when_the_executor_is_still_running() {
         0,
         "snapshot and lease teardown must not wait for the abandoned executor"
     );
-    executor.release.store(1, Ordering::SeqCst);
+    executor.release.set();
     watchdog.join().unwrap();
 }
 
@@ -1145,15 +1166,11 @@ fn a_blocked_acquisition_is_reported_as_a_waiter_and_released() {
         })
     };
 
-    let deadline = Instant::now() + Duration::from_secs(2);
-    while Instant::now() < deadline && pool.snapshot().waiting_general == 0 {
-        std::thread::sleep(Duration::from_millis(5));
-    }
-    assert_eq!(
-        pool.snapshot().waiting_general,
-        1,
+    assert!(
+        pool.wait_until_waiting_general(Duration::from_secs(2)),
         "an acquisition blocked on a full lane must be visible as a waiter"
     );
+    assert_eq!(pool.snapshot().waiting_general, 1);
     assert_eq!(pool.snapshot().waiting_health, 0);
 
     // The waiter gives up on its own bound; the count must not leak.
@@ -1176,14 +1193,12 @@ fn a_blocked_acquisition_is_reported_as_a_waiter_and_released() {
 #[test]
 fn a_deferred_snapshot_end_is_counted_replaceable_and_bounded() {
     let store = TestStore::new();
-    let pool = ReaderPool::start(
-        store.locator(),
-        two_reader_budget(),
-        SlowExecutor {
-            delay: Duration::from_millis(400),
-        },
-    )
-    .unwrap();
+    let executor = SlowExecutor {
+        delay: Duration::from_millis(400),
+        entered: Gate::default(),
+    };
+    let entered = executor.entered.clone();
+    let pool = ReaderPool::start(store.locator(), two_reader_budget(), executor).unwrap();
 
     let read = request(&store.binding, OperationPriorityV1::Foreground);
     let probe = Probe::for_request(&read);
@@ -1191,8 +1206,11 @@ fn a_deferred_snapshot_end_is_counted_replaceable_and_bounded() {
     let mut lease = pool.acquire(&read, &probe, Duration::from_secs(2)).unwrap();
     {
         let mut snapshot = lease.begin_snapshot().unwrap();
+        // Cancel only once the worker is provably inside the executor's
+        // delay, so the cancellation always lands with most of the delay
+        // still ahead of the snapshot end.
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(30));
+            entered.wait(Duration::from_secs(30));
             cancel.store(1, Ordering::SeqCst);
         });
         // The probe releases the caller while the worker is still inside the
@@ -1231,17 +1249,13 @@ fn a_deferred_snapshot_end_is_counted_replaceable_and_bounded() {
     drop(second);
 
     // The deferred return is bounded, so the limbo always resolves.
-    let deadline = Instant::now() + Duration::from_secs(3);
-    while Instant::now() < deadline && !pool.is_quiescent() {
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    let settled = pool.snapshot();
-    assert_eq!(
-        settled.limbo_general, 0,
-        "the limbo worker was never reclaimed or replaced"
-    );
     assert!(
-        pool.is_quiescent(),
+        pool.wait_until_quiescent(Duration::from_secs(3)),
         "the pool must reach quiescence once the deferred end resolves"
+    );
+    assert_eq!(
+        pool.snapshot().limbo_general,
+        0,
+        "the limbo worker was never reclaimed or replaced"
     );
 }

--- a/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
@@ -506,6 +506,10 @@ impl RepositoryRuntimePhysicalAttachment {
     /// Crate-private: public callers use [`Self::run_maintenance_checkpoint`],
     /// which validates permit and admission-stage authority first. Admission is
     /// not reopened; that exclusive window is intentional.
+    ///
+    /// Test modules in this crate call this wrapper; lib clippy does not see
+    /// those `#[cfg(test)]` uses.
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn begin_maintenance_drain(&self) -> Result<(), RepositoryDispatchError> {
         let mut state = self.lock_state();
         Self::begin_maintenance_drain_locked(&mut state)

--- a/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
@@ -16,8 +16,8 @@ use tracedecay_store::{
 };
 
 use crate::{
-    CheckpointOutcome, CheckpointRequest, ExistingWriterLocator, OnlineBackupReceipt,
-    PersistentWriter, RuntimeWriteAuthority, WriterStartError, WriterState,
+    CheckpointOutcome, CheckpointRequest, ExistingWriterLocator, MaintenanceCheckpointRequest,
+    OnlineBackupReceipt, PersistentWriter, RuntimeWriteAuthority, WriterStartError, WriterState,
     connection::{OpenedDatabaseFile, OpenedDatabaseFileError},
     exact_sql::{ExactSqlError, ExactSqlHandle},
     reader::{
@@ -497,6 +497,59 @@ impl RepositoryRuntimePhysicalAttachment {
             .map_err(|error| RepositoryDispatchError::Writer(error.to_string()))
     }
 
+    /// Close admission and move the retained writer to `Draining` so an
+    /// exclusive maintenance checkpoint can run. Unlike [`Self::drain`], the
+    /// writer is neither taken nor joined: its checkpoint handle stays live
+    /// for [`Self::run_maintenance_checkpoint`]. Idempotent while draining.
+    pub fn begin_maintenance_drain(&self) -> Result<(), RepositoryDispatchError> {
+        let mut state = self.lock_state();
+        Self::begin_maintenance_drain_locked(&mut state)
+    }
+
+    fn begin_maintenance_drain_locked(
+        state: &mut RepositoryRuntimePhysicalState,
+    ) -> Result<(), RepositoryDispatchError> {
+        if state.closed {
+            return Err(RepositoryDispatchError::Closed);
+        }
+        let Some(writer) = state.writer.as_ref() else {
+            return Err(RepositoryDispatchError::Closed);
+        };
+        writer.begin_drain();
+        if let Some(readers) = &state.readers {
+            readers.begin_drain();
+        }
+        state.admission_open = false;
+        Ok(())
+    }
+
+    /// Run an exclusive WAL RESTART/TRUNCATE checkpoint through the retained
+    /// writer. Maintenance runs after admission has closed, so this does not
+    /// require `admission_open`; a still-`Ready` writer is moved to
+    /// `Draining` first. PASSIVE checkpoints stay on [`Self::run_checkpoint`].
+    pub async fn run_maintenance_checkpoint(
+        &self,
+        request: MaintenanceCheckpointRequest,
+        authority: Arc<dyn RuntimeWriteAuthority>,
+    ) -> Result<CheckpointOutcome, RepositoryDispatchError> {
+        let checkpoint = {
+            let mut state = self.lock_state();
+            Self::begin_maintenance_drain_locked(&mut state)?;
+            state
+                .writer
+                .as_ref()
+                .ok_or(RepositoryDispatchError::Closed)?
+                .checkpoint_handle()
+        };
+        let ticket = checkpoint
+            .trigger_maintenance_authorized(request, authority)
+            .map_err(|error| RepositoryDispatchError::Writer(error.to_string()))?;
+        ticket
+            .wait()
+            .await
+            .map_err(|error| RepositoryDispatchError::Writer(error.to_string()))
+    }
+
     pub async fn snapshot_to(
         &self,
         destination: PathBuf,
@@ -780,9 +833,25 @@ mod tests {
     use tracedecay_domain::LocatorDigest;
     use tracedecay_store::{AdmissionConfigV1, StoreIncarnationV1};
 
-    use crate::exact_sql::{ExactSqlError, ExactSqlStatement, ExactSqlValue};
+    use crate::{
+        CheckpointBlockers, CheckpointKind, MaintenanceCheckpointMode, RuntimeWriteAuthorityError,
+        RuntimeWriteAuthorityStage,
+        exact_sql::{ExactSqlError, ExactSqlStatement, ExactSqlValue},
+        maintenance::{ExclusiveMaintenancePermit, MaintenanceOwnerId},
+    };
 
     use super::*;
+
+    struct UnrestrictedAuthority;
+
+    impl RuntimeWriteAuthority for UnrestrictedAuthority {
+        fn verify(
+            &self,
+            _stage: RuntimeWriteAuthorityStage,
+        ) -> Result<(), RuntimeWriteAuthorityError> {
+            Ok(())
+        }
+    }
 
     fn binding() -> StoreRuntimeBindingV1 {
         serde_json::from_value(serde_json::json!({
@@ -1009,6 +1078,237 @@ mod tests {
                 ))
                 .unwrap_err(),
             ExactSqlError::WriterUnavailable
+        );
+
+        attachment.drain().unwrap();
+        attachment.close_and_join().unwrap();
+    }
+
+    fn attach_wal_database(directory: &TempDir) -> RepositoryRuntimePhysicalAttachment {
+        let path = directory.path().join("maintenance.sqlite3");
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        let journal_mode: String = connection
+            .query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal_mode, "wal");
+        drop(connection);
+        let path = path.canonicalize().unwrap();
+        let binding = binding();
+        RepositoryPhysicalAttachmentFactory
+            .attach(
+                binding.clone(),
+                locator(&binding),
+                path,
+                AdmissionConfigV1::default(),
+            )
+            .unwrap()
+    }
+
+    fn maintenance_request(
+        attachment: &RepositoryRuntimePhysicalAttachment,
+        mode: MaintenanceCheckpointMode,
+    ) -> MaintenanceCheckpointRequest {
+        let permit = ExclusiveMaintenancePermit::issue(
+            MaintenanceOwnerId::new(1).unwrap(),
+            attachment.binding(),
+        );
+        MaintenanceCheckpointRequest::new(mode, permit, CheckpointBlockers::default())
+    }
+
+    #[test]
+    fn maintenance_port_reports_closed_without_a_writer_or_after_close() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("reader-only.sqlite3");
+        create_identity_database(&path, "reader-only");
+        let path = path.canonicalize().unwrap();
+        let binding = binding();
+        let read_only = RepositoryPhysicalAttachmentFactory
+            .attach_read_only(
+                binding.clone(),
+                locator(&binding),
+                path,
+                AdmissionConfigV1::default(),
+            )
+            .unwrap();
+        assert!(matches!(
+            read_only.begin_maintenance_drain(),
+            Err(RepositoryDispatchError::Closed)
+        ));
+        let request = maintenance_request(&read_only, MaintenanceCheckpointMode::Truncate);
+        let error = runtime
+            .block_on(
+                read_only.run_maintenance_checkpoint(request, Arc::new(UnrestrictedAuthority)),
+            )
+            .unwrap_err();
+        assert!(matches!(error, RepositoryDispatchError::Closed));
+        read_only.drain().unwrap();
+        read_only.close_and_join().unwrap();
+
+        let writable = attach_wal_database(&directory);
+        writable.drain().unwrap();
+        writable.close_and_join().unwrap();
+        assert!(matches!(
+            writable.begin_maintenance_drain(),
+            Err(RepositoryDispatchError::Closed)
+        ));
+        let request = maintenance_request(&writable, MaintenanceCheckpointMode::Truncate);
+        let error = runtime
+            .block_on(writable.run_maintenance_checkpoint(request, Arc::new(UnrestrictedAuthority)))
+            .unwrap_err();
+        assert!(matches!(error, RepositoryDispatchError::Closed));
+    }
+
+    #[test]
+    fn maintenance_drain_keeps_writer_attached_and_closes_admission() {
+        let directory = TempDir::new().unwrap();
+        let attachment = attach_wal_database(&directory);
+        let handle = attachment.exact_sql_handle().unwrap();
+        handle
+            .execute_batch("CREATE TABLE maintenance_probe (value INTEGER NOT NULL)".to_owned())
+            .unwrap();
+
+        attachment.begin_maintenance_drain().unwrap();
+        attachment.begin_maintenance_drain().unwrap();
+        {
+            let state = attachment.lock_state();
+            assert!(!state.admission_open);
+            assert!(!state.closed);
+            let writer = state.writer.as_ref().expect("writer stays attached");
+            assert_eq!(writer.state(), WriterState::Draining);
+            assert!(state.readers.is_some());
+        }
+        assert!(attachment.snapshot().writer_present);
+        let admission_error = match attachment.exact_sql_handle() {
+            Err(error) => error,
+            Ok(_) => panic!("maintenance drain must close exact-SQL admission"),
+        };
+        assert_eq!(admission_error, ExactSqlError::WriterUnavailable);
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let outcome = runtime
+            .block_on(attachment.run_maintenance_checkpoint(
+                maintenance_request(&attachment, MaintenanceCheckpointMode::Restart),
+                Arc::new(UnrestrictedAuthority),
+            ))
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            CheckpointOutcome::Complete {
+                kind: CheckpointKind::Restart,
+                ..
+            }
+        ));
+
+        attachment.drain().unwrap();
+        attachment.close_and_join().unwrap();
+        {
+            let state = attachment.lock_state();
+            assert!(state.closed);
+            assert!(state.writer.is_none());
+            assert!(state.readers.is_none());
+        }
+    }
+
+    #[test]
+    fn maintenance_truncate_is_typed_pending_while_pinned_then_reclaims_wal() {
+        let directory = TempDir::new().unwrap();
+        let attachment = attach_wal_database(&directory);
+        let handle = attachment.exact_sql_handle().unwrap();
+        handle
+            .execute_batch("CREATE TABLE maintenance_probe (value INTEGER NOT NULL)".to_owned())
+            .unwrap();
+
+        // Pin an independent read snapshot at the current WAL mark, then
+        // append frames the checkpoint cannot backfill while it lives.
+        let (database_path, wal_path) = {
+            let state = attachment.lock_state();
+            (
+                state.database_path.clone(),
+                PathBuf::from(format!("{}-wal", state.database_path.display())),
+            )
+        };
+        let mut pinned = rusqlite::Connection::open(&database_path).unwrap();
+        let pinned_snapshot = pinned.transaction().unwrap();
+        let pinned_rows: i64 = pinned_snapshot
+            .query_row("SELECT COUNT(*) FROM maintenance_probe", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(pinned_rows, 0);
+        for value in 0..8_i64 {
+            handle
+                .execute(statement(
+                    "INSERT INTO maintenance_probe (value) VALUES (?)",
+                    vec![ExactSqlValue::Integer(value)],
+                ))
+                .unwrap();
+        }
+        let pinned_wal_bytes = fs::metadata(&wal_path).unwrap().len();
+        assert!(
+            pinned_wal_bytes > 0,
+            "maintenance truncate must start with committed frames pending in WAL"
+        );
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let outcome = runtime
+            .block_on(attachment.run_maintenance_checkpoint(
+                maintenance_request(&attachment, MaintenanceCheckpointMode::Truncate),
+                Arc::new(UnrestrictedAuthority),
+            ))
+            .unwrap();
+        let report = match outcome {
+            CheckpointOutcome::Pending {
+                kind: CheckpointKind::Truncate,
+                report,
+                ..
+            } => report,
+            other => panic!("a pinned WAL truncate must be typed Pending, got {other:?}"),
+        };
+        assert!(
+            report.busy,
+            "a truncate blocked by a pinned reader must report busy"
+        );
+        assert!(
+            report.checkpointed_frames < report.log_frames,
+            "pinned frames must stay unbackfilled: {} of {}",
+            report.checkpointed_frames,
+            report.log_frames
+        );
+        assert_eq!(
+            fs::metadata(&wal_path).unwrap().len(),
+            pinned_wal_bytes,
+            "a busy truncate must not report reclaim the WAL file disproves"
+        );
+
+        drop(pinned_snapshot);
+        drop(pinned);
+        let outcome = runtime
+            .block_on(attachment.run_maintenance_checkpoint(
+                maintenance_request(&attachment, MaintenanceCheckpointMode::Truncate),
+                Arc::new(UnrestrictedAuthority),
+            ))
+            .unwrap();
+        let report = match outcome {
+            CheckpointOutcome::Complete {
+                kind: CheckpointKind::Truncate,
+                report,
+                ..
+            } => report,
+            other => panic!("a released WAL truncate must complete, got {other:?}"),
+        };
+        assert!(!report.busy);
+        assert_eq!(report.checkpointed_frames, report.log_frames);
+        assert_eq!(
+            fs::metadata(&wal_path).unwrap().len(),
+            0,
+            "an exclusive TRUNCATE checkpoint must leave a zero-length WAL"
         );
 
         attachment.drain().unwrap();

--- a/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
@@ -16,8 +16,9 @@ use tracedecay_store::{
 };
 
 use crate::{
-    CheckpointOutcome, CheckpointRequest, ExistingWriterLocator, MaintenanceCheckpointRequest,
-    OnlineBackupReceipt, PersistentWriter, RuntimeWriteAuthority, WriterStartError, WriterState,
+    CheckpointControlError, CheckpointOutcome, CheckpointRequest, ExistingWriterLocator,
+    MaintenanceCheckpointRequest, OnlineBackupReceipt, PersistentWriter, RuntimeWriteAuthority,
+    RuntimeWriteAuthorityStage, WriterStartError, WriterState,
     connection::{OpenedDatabaseFile, OpenedDatabaseFileError},
     exact_sql::{ExactSqlError, ExactSqlHandle},
     reader::{
@@ -527,6 +528,11 @@ impl RepositoryRuntimePhysicalAttachment {
     /// writer. Maintenance runs after admission has closed, so this does not
     /// require `admission_open`; a still-`Ready` writer is moved to
     /// `Draining` first. PASSIVE checkpoints stay on [`Self::run_checkpoint`].
+    ///
+    /// The permit binding and admission-stage authority are validated before
+    /// any lifecycle transition: draining is irreversible, so a misrouted
+    /// permit or revoked authority must leave admission open and the writer
+    /// `Ready`.
     pub async fn run_maintenance_checkpoint(
         &self,
         request: MaintenanceCheckpointRequest,
@@ -534,6 +540,24 @@ impl RepositoryRuntimePhysicalAttachment {
     ) -> Result<CheckpointOutcome, RepositoryDispatchError> {
         let checkpoint = {
             let mut state = self.lock_state();
+            if state.closed || state.writer.is_none() {
+                return Err(RepositoryDispatchError::Closed);
+            }
+            if request.permit().binding() != &state.binding {
+                return Err(RepositoryDispatchError::Checkpoint(
+                    CheckpointControlError::BindingMismatch,
+                ));
+            }
+            if authority
+                .verify(RuntimeWriteAuthorityStage::BeforeAdmission)
+                .is_err()
+            {
+                return Err(RepositoryDispatchError::Checkpoint(
+                    CheckpointControlError::AuthorityDenied {
+                        stage: RuntimeWriteAuthorityStage::BeforeAdmission,
+                    },
+                ));
+            }
             Self::begin_maintenance_drain_locked(&mut state)?;
             state
                 .writer
@@ -543,11 +567,11 @@ impl RepositoryRuntimePhysicalAttachment {
         };
         let ticket = checkpoint
             .trigger_maintenance_authorized(request, authority)
-            .map_err(|error| RepositoryDispatchError::Writer(error.to_string()))?;
+            .map_err(RepositoryDispatchError::Checkpoint)?;
         ticket
             .wait()
             .await
-            .map_err(|error| RepositoryDispatchError::Writer(error.to_string()))
+            .map_err(RepositoryDispatchError::Checkpoint)
     }
 
     pub async fn snapshot_to(
@@ -731,6 +755,7 @@ impl Drop for RepositoryRuntimePhysicalAttachment {
 #[derive(Debug)]
 pub enum RepositoryDispatchError {
     Closed,
+    Checkpoint(CheckpointControlError),
     Reader(ReaderAcquireError),
     ReaderWorker(String),
     Writer(String),
@@ -740,6 +765,12 @@ impl fmt::Display for RepositoryDispatchError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Closed => formatter.write_str("repository runtime is closed"),
+            Self::Checkpoint(error) => {
+                write!(
+                    formatter,
+                    "repository maintenance checkpoint failed: {error}"
+                )
+            }
             Self::Reader(error) => write!(formatter, "repository read failed: {error}"),
             Self::ReaderWorker(error) => write!(formatter, "repository snapshot failed: {error}"),
             Self::Writer(error) => write!(formatter, "repository write failed: {error}"),
@@ -750,6 +781,7 @@ impl fmt::Display for RepositoryDispatchError {
 impl Error for RepositoryDispatchError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            Self::Checkpoint(error) => Some(error),
             Self::Reader(error) => Some(error),
             Self::Closed | Self::ReaderWorker(_) | Self::Writer(_) => None,
         }
@@ -835,7 +867,6 @@ mod tests {
 
     use crate::{
         CheckpointBlockers, CheckpointKind, MaintenanceCheckpointMode, RuntimeWriteAuthorityError,
-        RuntimeWriteAuthorityStage,
         exact_sql::{ExactSqlError, ExactSqlStatement, ExactSqlValue},
         maintenance::{ExclusiveMaintenancePermit, MaintenanceOwnerId},
     };
@@ -850,6 +881,19 @@ mod tests {
             _stage: RuntimeWriteAuthorityStage,
         ) -> Result<(), RuntimeWriteAuthorityError> {
             Ok(())
+        }
+    }
+
+    struct DeniedAuthority;
+
+    impl RuntimeWriteAuthority for DeniedAuthority {
+        fn verify(
+            &self,
+            stage: RuntimeWriteAuthorityStage,
+        ) -> Result<(), RuntimeWriteAuthorityError> {
+            Err(RuntimeWriteAuthorityError::denied(format!(
+                "maintenance authority denied at {stage:?}"
+            )))
         }
     }
 
@@ -1113,6 +1157,138 @@ mod tests {
             attachment.binding(),
         );
         MaintenanceCheckpointRequest::new(mode, permit, CheckpointBlockers::default())
+    }
+
+    fn foreign_binding() -> StoreRuntimeBindingV1 {
+        serde_json::from_value(serde_json::json!({
+            "shard_id": {
+                "brain_id": "brain.repository-lifecycle",
+                "profile_id": "profile.repository-lifecycle",
+                "scope": {
+                    "kind": "project",
+                    "project_id": "project.other-shard"
+                }
+            },
+            "incarnation": 4,
+            "authority_epoch": 12
+        }))
+        .unwrap()
+    }
+
+    fn assert_admission_open_and_writer_ready(attachment: &RepositoryRuntimePhysicalAttachment) {
+        let state = attachment.lock_state();
+        assert!(state.admission_open, "admission must stay open");
+        assert!(!state.closed);
+        assert_eq!(
+            state
+                .writer
+                .as_ref()
+                .expect("writer stays attached")
+                .state(),
+            WriterState::Ready,
+            "writer must stay Ready"
+        );
+        assert!(state.readers.is_some());
+    }
+
+    #[test]
+    fn maintenance_checkpoint_rejects_foreign_permit_before_draining() {
+        let directory = TempDir::new().unwrap();
+        let attachment = attach_wal_database(&directory);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let foreign_permit = ExclusiveMaintenancePermit::issue(
+            MaintenanceOwnerId::new(1).unwrap(),
+            foreign_binding(),
+        );
+        let request = MaintenanceCheckpointRequest::new(
+            MaintenanceCheckpointMode::Truncate,
+            foreign_permit,
+            CheckpointBlockers::default(),
+        );
+        let error = runtime
+            .block_on(
+                attachment.run_maintenance_checkpoint(request, Arc::new(UnrestrictedAuthority)),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RepositoryDispatchError::Checkpoint(CheckpointControlError::BindingMismatch)
+        ));
+
+        assert_admission_open_and_writer_ready(&attachment);
+        attachment
+            .exact_sql_handle()
+            .expect("a rejected foreign permit must not close exact-SQL admission");
+        attachment.drain().unwrap();
+        attachment.close_and_join().unwrap();
+    }
+
+    #[test]
+    fn maintenance_checkpoint_denied_authority_never_drains() {
+        let directory = TempDir::new().unwrap();
+        let attachment = attach_wal_database(&directory);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let error = runtime
+            .block_on(attachment.run_maintenance_checkpoint(
+                maintenance_request(&attachment, MaintenanceCheckpointMode::Truncate),
+                Arc::new(DeniedAuthority),
+            ))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RepositoryDispatchError::Checkpoint(CheckpointControlError::AuthorityDenied {
+                stage: RuntimeWriteAuthorityStage::BeforeAdmission,
+            })
+        ));
+
+        assert_admission_open_and_writer_ready(&attachment);
+        attachment
+            .exact_sql_handle()
+            .expect("a denied authority must not close exact-SQL admission");
+        attachment.drain().unwrap();
+        attachment.close_and_join().unwrap();
+    }
+
+    #[test]
+    fn maintenance_checkpoint_preserves_typed_blocked_failure() {
+        let directory = TempDir::new().unwrap();
+        let attachment = attach_wal_database(&directory);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+
+        let permit = ExclusiveMaintenancePermit::issue(
+            MaintenanceOwnerId::new(1).unwrap(),
+            attachment.binding(),
+        );
+        let blockers = CheckpointBlockers {
+            blockers: Vec::new(),
+            omitted: 1,
+        };
+        let request = MaintenanceCheckpointRequest::new(
+            MaintenanceCheckpointMode::Truncate,
+            permit,
+            blockers.clone(),
+        );
+        let error = runtime
+            .block_on(
+                attachment.run_maintenance_checkpoint(request, Arc::new(UnrestrictedAuthority)),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RepositoryDispatchError::Checkpoint(CheckpointControlError::Blocked(ref actual))
+                if *actual == blockers
+        ));
+
+        attachment.drain().unwrap();
+        attachment.close_and_join().unwrap();
     }
 
     #[test]

--- a/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
@@ -535,9 +535,10 @@ impl RepositoryRuntimePhysicalAttachment {
     /// Admission is not reopened after Truncate — the exclusive window lasts
     /// until `drain` + `close_and_join`.
     ///
-    /// The permit binding and admission-stage authority are validated before
-    /// any lifecycle transition: draining is irreversible, so a misrouted
-    /// permit or revoked authority must leave admission open and the writer
+    /// The permit binding, admission-stage authority, and request-local
+    /// snapshot blockers are validated before any lifecycle transition:
+    /// draining is irreversible, so a misrouted permit, revoked authority, or
+    /// stale inventory (`Blocked`) must leave admission open and the writer
     /// `Ready`.
     pub async fn run_maintenance_checkpoint(
         &self,
@@ -562,6 +563,11 @@ impl RepositoryRuntimePhysicalAttachment {
                     CheckpointControlError::AuthorityDenied {
                         stage: RuntimeWriteAuthorityStage::BeforeAdmission,
                     },
+                ));
+            }
+            if !request.blockers().is_clear() {
+                return Err(RepositoryDispatchError::Checkpoint(
+                    CheckpointControlError::Blocked(request.blockers().clone()),
                 ));
             }
             Self::begin_maintenance_drain_locked(&mut state)?;
@@ -1293,6 +1299,10 @@ mod tests {
                 if *actual == blockers
         ));
 
+        assert_admission_open_and_writer_ready(&attachment);
+        attachment
+            .exact_sql_handle()
+            .expect("a blocked inventory must not close exact-SQL admission");
         attachment.drain().unwrap();
         attachment.close_and_join().unwrap();
     }

--- a/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/attachment.rs
@@ -502,7 +502,11 @@ impl RepositoryRuntimePhysicalAttachment {
     /// exclusive maintenance checkpoint can run. Unlike [`Self::drain`], the
     /// writer is neither taken nor joined: its checkpoint handle stays live
     /// for [`Self::run_maintenance_checkpoint`]. Idempotent while draining.
-    pub fn begin_maintenance_drain(&self) -> Result<(), RepositoryDispatchError> {
+    ///
+    /// Crate-private: public callers use [`Self::run_maintenance_checkpoint`],
+    /// which validates permit and admission-stage authority first. Admission is
+    /// not reopened; that exclusive window is intentional.
+    pub(crate) fn begin_maintenance_drain(&self) -> Result<(), RepositoryDispatchError> {
         let mut state = self.lock_state();
         Self::begin_maintenance_drain_locked(&mut state)
     }
@@ -528,6 +532,8 @@ impl RepositoryRuntimePhysicalAttachment {
     /// writer. Maintenance runs after admission has closed, so this does not
     /// require `admission_open`; a still-`Ready` writer is moved to
     /// `Draining` first. PASSIVE checkpoints stay on [`Self::run_checkpoint`].
+    /// Admission is not reopened after Truncate — the exclusive window lasts
+    /// until `drain` + `close_and_join`.
     ///
     /// The permit binding and admission-stage authority are validated before
     /// any lifecycle transition: draining is irreversible, so a misrouted

--- a/crates/tracedecay-rusqlite-runtime/src/writer.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer.rs
@@ -940,6 +940,24 @@ impl PersistentWriter {
         self.join_worker()
     }
 
+    /// Drain, shut down, and join the worker, then report the settled
+    /// `(state, telemetry)` pair.
+    ///
+    /// Joining the worker is the event that settles a fault: after the join,
+    /// every admitted operation has been completed or released and the final
+    /// telemetry is visible, so callers observing a fault need no polling
+    /// loop. Hidden because it is a test observation seam, not part of the
+    /// writer contract — integration tests cannot reach `pub(crate)`.
+    #[doc(hidden)]
+    pub fn shutdown_and_join_snapshot(
+        mut self,
+    ) -> Result<(WriterState, WriterTelemetrySnapshot), WriterActorError> {
+        self.begin_drain();
+        self.request_shutdown();
+        self.join_worker()?;
+        Ok((self.state(), self.telemetry_snapshot()))
+    }
+
     fn request_shutdown(&mut self) {
         self.shutdown_requested.store(true, Ordering::Release);
         if let Some(sender) = self.shutdown_sender.take() {

--- a/crates/tracedecay-rusqlite-runtime/src/writer.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer.rs
@@ -201,6 +201,10 @@ impl MaintenanceCheckpointRequest {
         self.mode
     }
 
+    pub fn permit(&self) -> &ExclusiveMaintenancePermit {
+        &self.permit
+    }
+
     pub fn blockers(&self) -> &CheckpointBlockers {
         &self.blockers
     }

--- a/crates/tracedecay-rusqlite-runtime/src/writer.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer.rs
@@ -940,24 +940,6 @@ impl PersistentWriter {
         self.join_worker()
     }
 
-    /// Drain, shut down, and join the worker, then report the settled
-    /// `(state, telemetry)` pair.
-    ///
-    /// Joining the worker is the event that settles a fault: after the join,
-    /// every admitted operation has been completed or released and the final
-    /// telemetry is visible, so callers observing a fault need no polling
-    /// loop. Hidden because it is a test observation seam, not part of the
-    /// writer contract — integration tests cannot reach `pub(crate)`.
-    #[doc(hidden)]
-    pub fn shutdown_and_join_snapshot(
-        mut self,
-    ) -> Result<(WriterState, WriterTelemetrySnapshot), WriterActorError> {
-        self.begin_drain();
-        self.request_shutdown();
-        self.join_worker()?;
-        Ok((self.state(), self.telemetry_snapshot()))
-    }
-
     fn request_shutdown(&mut self) {
         self.shutdown_requested.store(true, Ordering::Release);
         if let Some(sender) = self.shutdown_sender.take() {

--- a/crates/tracedecay-rusqlite-runtime/tests/multi_root_scope_set.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/multi_root_scope_set.rs
@@ -1,10 +1,6 @@
-mod common;
-
 use std::collections::BTreeSet;
 use std::fmt;
 use std::path::PathBuf;
-
-use common::fixture_abs_root;
 
 use rusqlite::{Connection, Savepoint};
 use tempfile::TempDir;

--- a/crates/tracedecay-rusqlite-runtime/tests/runtime_actor/faults.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/runtime_actor/faults.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use tracedecay_rusqlite_runtime::{WriterActorError, WriterState};
 use tracedecay_store::{
     AdmissionConfigV1, CorruptionClassV1, OperationPriorityV1, RuntimeSubmitOutcomeV1,
@@ -129,26 +127,16 @@ fn executor_panic_faults_the_actor_and_releases_the_pending_request() {
         Err(WriterActorError::ReplyDropped)
     ));
 
-    let deadline = Instant::now() + Duration::from_secs(1);
-    while Instant::now() < deadline {
-        let telemetry = writer.telemetry_snapshot();
-        if writer.state() == WriterState::Faulted
-            && telemetry.queue.queued_operations == 0
-            && telemetry.error_events >= 1
-            && telemetry.operations.admitted_operations == telemetry.operations.completed_operations
-        {
-            break;
-        }
-        std::thread::yield_now();
-    }
-    assert_eq!(writer.state(), WriterState::Faulted);
-    let telemetry = writer.telemetry_snapshot();
+    // Joining the worker is the fault-settlement event: once the actor
+    // thread has exited, the queue has been released and the final state and
+    // telemetry are visible, so nothing here needs to poll.
+    let (state, telemetry) = writer.shutdown_and_join_snapshot().unwrap();
+    assert_eq!(state, WriterState::Faulted);
     assert_eq!(telemetry.queue.queued_operations, 0);
     assert_eq!(
         telemetry.operations.admitted_operations,
         telemetry.operations.completed_operations
     );
     assert_eq!(telemetry.error_events, 1);
-    writer.shutdown_and_join().unwrap();
     assert_eq!(marker_count(&database), 0);
 }

--- a/crates/tracedecay-rusqlite-runtime/tests/runtime_actor/faults.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/runtime_actor/faults.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use tracedecay_rusqlite_runtime::{WriterActorError, WriterState};
 use tracedecay_store::{
     AdmissionConfigV1, CorruptionClassV1, OperationPriorityV1, RuntimeSubmitOutcomeV1,
@@ -127,16 +129,26 @@ fn executor_panic_faults_the_actor_and_releases_the_pending_request() {
         Err(WriterActorError::ReplyDropped)
     ));
 
-    // Joining the worker is the fault-settlement event: once the actor
-    // thread has exited, the queue has been released and the final state and
-    // telemetry are visible, so nothing here needs to poll.
-    let (state, telemetry) = writer.shutdown_and_join_snapshot().unwrap();
-    assert_eq!(state, WriterState::Faulted);
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while Instant::now() < deadline {
+        let telemetry = writer.telemetry_snapshot();
+        if writer.state() == WriterState::Faulted
+            && telemetry.queue.queued_operations == 0
+            && telemetry.error_events >= 1
+            && telemetry.operations.admitted_operations == telemetry.operations.completed_operations
+        {
+            break;
+        }
+        std::thread::yield_now();
+    }
+    assert_eq!(writer.state(), WriterState::Faulted);
+    let telemetry = writer.telemetry_snapshot();
     assert_eq!(telemetry.queue.queued_operations, 0);
     assert_eq!(
         telemetry.operations.admitted_operations,
         telemetry.operations.completed_operations
     );
     assert_eq!(telemetry.error_events, 1);
+    writer.shutdown_and_join().unwrap();
     assert_eq!(marker_count(&database), 0);
 }

--- a/crates/tracedecay-rusqlite-runtime/tests/work_attempt_storage.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/work_attempt_storage.rs
@@ -752,7 +752,7 @@ fn attempt_with_effect(
         id::<ProjectId>("project.attempt.storage"),
         id::<RepositoryId>("repository.attempt.storage"),
         id::<WorktreeId>("worktree.attempt.storage"),
-        "/tmp/attempt-storage".to_owned(),
+        fixture_abs_root("/tmp/attempt-storage"),
         Some(id::<RefId>("refs/heads/attempt-storage")),
         id::<CommitId>("0123456789abcdef0123456789abcdef01234567"),
         "Execute the admitted provider step.".to_owned(),

--- a/crates/tracedecay-rusqlite-runtime/tests/work_placement_storage.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/work_placement_storage.rs
@@ -148,7 +148,7 @@ fn an_unplaced_run_has_no_row_and_no_holder() {
         None
     );
     assert_eq!(
-        store.storage().target_holder(&authority, ROOT).unwrap(),
+        store.storage().target_holder(&authority, &ROOT).unwrap(),
         None
     );
 }
@@ -157,7 +157,7 @@ fn an_unplaced_run_has_no_row_and_no_holder() {
 fn the_first_admission_inserts_and_a_racing_first_admission_conflicts() {
     let store = RegisteredWorkStore::start("placement-first");
     let authority = authority("actor.placement.first");
-    let placement = admitted("run.a", ROOT);
+    let placement = admitted("run.a", &ROOT);
     store
         .storage()
         .publish_placement(&authority, None, &placement)
@@ -170,7 +170,7 @@ fn the_first_admission_inserts_and_a_racing_first_admission_conflicts() {
         Some(placement.clone())
     );
     assert_eq!(
-        store.storage().target_holder(&authority, ROOT).unwrap(),
+        store.storage().target_holder(&authority, &ROOT).unwrap(),
         Some(identity("run.a"))
     );
     assert_eq!(
@@ -188,7 +188,7 @@ fn the_database_refuses_a_second_holder_of_the_same_managed_root() {
     let authority = authority("actor.placement.exclusive");
     store
         .storage()
-        .publish_placement(&authority, None, &admitted("run.a", ROOT))
+        .publish_placement(&authority, None, &admitted("run.a", &ROOT))
         .unwrap();
 
     // A different run naming the same root is refused by the exclusivity index
@@ -196,7 +196,7 @@ fn the_database_refuses_a_second_holder_of_the_same_managed_root() {
     assert_eq!(
         store
             .storage()
-            .publish_placement(&authority, None, &admitted("run.b", ROOT))
+            .publish_placement(&authority, None, &admitted("run.b", &ROOT))
             .expect_err("a held root is exclusive"),
         WorkPlacementStorageError::AuthorityConflict
     );
@@ -218,7 +218,7 @@ fn the_database_refuses_a_second_holder_of_the_same_managed_root() {
 fn a_released_placement_frees_its_root_and_a_quarantined_one_does_not() {
     let store = RegisteredWorkStore::start("placement-release");
     let authority = authority("actor.placement.release");
-    let placement = admitted("run.a", ROOT);
+    let placement = admitted("run.a", &ROOT);
     store
         .storage()
         .publish_placement(&authority, None, &placement)
@@ -240,13 +240,13 @@ fn a_released_placement_frees_its_root_and_a_quarantined_one_does_not() {
         .unwrap();
     // Quarantine retains the bytes, so the root is still held.
     assert_eq!(
-        store.storage().target_holder(&authority, ROOT).unwrap(),
+        store.storage().target_holder(&authority, &ROOT).unwrap(),
         Some(identity("run.a"))
     );
     assert_eq!(
         store
             .storage()
-            .publish_placement(&authority, None, &admitted("run.b", ROOT))
+            .publish_placement(&authority, None, &admitted("run.b", &ROOT))
             .expect_err("a quarantined root is still held"),
         WorkPlacementStorageError::AuthorityConflict
     );
@@ -260,13 +260,13 @@ fn a_released_placement_frees_its_root_and_a_quarantined_one_does_not() {
         .unwrap();
     assert_eq!(released.state(), WorkPlacementStateV1::Released);
     assert_eq!(
-        store.storage().target_holder(&authority, ROOT).unwrap(),
+        store.storage().target_holder(&authority, &ROOT).unwrap(),
         None
     );
     // Only now can another run take it.
     store
         .storage()
-        .publish_placement(&authority, None, &admitted("run.b", ROOT))
+        .publish_placement(&authority, None, &admitted("run.b", &ROOT))
         .unwrap();
 }
 
@@ -275,7 +275,7 @@ fn a_stale_version_conflicts_and_rows_survive_a_restart_per_authority() {
     let store = RegisteredWorkStore::start("placement-isolation");
     let mine = authority("actor.placement.mine");
     let peer = authority("actor.placement.peer");
-    let placement = admitted("run.a", ROOT);
+    let placement = admitted("run.a", &ROOT);
     store
         .storage()
         .publish_placement(&mine, None, &placement)
@@ -290,10 +290,10 @@ fn a_stale_version_conflicts_and_rows_survive_a_restart_per_authority() {
     );
 
     // Another actor holds nothing here, and the same root is free for it.
-    assert_eq!(store.storage().target_holder(&peer, ROOT).unwrap(), None);
+    assert_eq!(store.storage().target_holder(&peer, &ROOT).unwrap(), None);
     store
         .storage()
-        .publish_placement(&peer, None, &admitted("run.a", ROOT))
+        .publish_placement(&peer, None, &admitted("run.a", &ROOT))
         .unwrap();
 
     let restarted = store.restart("placement-isolation");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This is the daemon-lane WAL Truncate seam. `RepositoryRuntimePhysicalAttachment` previously forwarded only PASSIVE checkpoints (`run_checkpoint` via `trigger_authorized`), while the exclusive RESTART/TRUNCATE path (`CheckpointHandle::trigger_maintenance_authorized`) requires `WriterState::Draining` — and the only attachment-level drain, `drain()`, takes and joins the writer, leaving nothing to checkpoint through. Runtime-core could not wire crate-only.

Changes in `crates/tracedecay-rusqlite-runtime` only:

- `RepositoryRuntimePhysicalAttachment::begin_maintenance_drain()` — closes admission and moves the retained writer `Ready → Draining` (`PersistentWriter::begin_drain`) plus a reader-pool maintenance drain, without taking or joining the writer. Idempotent; `Closed` when closed or writer-less.
- `RepositoryRuntimePhysicalAttachment::run_maintenance_checkpoint(MaintenanceCheckpointRequest, Arc<dyn RuntimeWriteAuthority>)` — does not require `admission_open` (maintenance runs after admission closes) and performs the maintenance drain first if the writer is still `Ready`. Forwards through `trigger_maintenance_authorized` and awaits the ticket.
- Pre-drain validation (review fix): the permit binding and admission-stage authority (`RuntimeWriteAuthorityStage::BeforeAdmission`, same stage `CheckpointHandle` verifies) are checked before any lifecycle transition. A foreign-shard permit or revoked authority returns a typed error and leaves admission open and the writer `Ready` — draining is irreversible, so misrouted requests must not tear down the attachment. `MaintenanceCheckpointRequest` gained a `permit()` accessor for this.
- Typed failures (review fix): `RepositoryDispatchError::Checkpoint(CheckpointControlError)` preserves `Blocked`/`Busy`/`BindingMismatch`/`AuthorityDenied`/`Unavailable` from trigger and wait instead of collapsing them into `Writer(String)`; `Display`/`source` carry the typed error. `RepositoryDispatchError` is only referenced inside this crate, so the new variant breaks no downstream matches.

Busy/incomplete is typed, not success (Plan 38 §6 measured reclaim): the port returns the writer's `CheckpointOutcome` verbatim — `Complete` is only produced when the frame report is complete (`checkpointed_frames == log_frames` and not busy); a pinned/busy TRUNCATE surfaces as `CheckpointOutcome::Pending` with the busy frame report. No second checkpoint engine, no outcome flattening.

Unchanged: PASSIVE `run_checkpoint`, `drain()` (still joins the writer), `close_and_join()`. `Database::checkpoint` TRUNCATE is deliberately not implemented here — runtime-core wires that after this lands.

## Tests (isolated, this crate)

`cargo test -p tracedecay-rusqlite-runtime --lib -- repository::attachment::tests writer::tests::checkpoint` — 15 passed, 0 failed, on the restacked base 8fa116bd (#539 merge). Clippy and fmt clean on the crate.

- `maintenance_port_reports_closed_without_a_writer_or_after_close` — read-only attachment and post-close attachment both yield `RepositoryDispatchError::Closed` from both new methods.
- `maintenance_drain_keeps_writer_attached_and_closes_admission` — after `begin_maintenance_drain` (called twice for idempotency) the writer is still attached in `Draining`, exact-SQL admission is closed, an exclusive RESTART through the port returns `Complete`, and the existing `drain()` + `close_and_join()` lifecycle still succeeds afterwards.
- `maintenance_checkpoint_rejects_foreign_permit_before_draining` — a wrong-shard permit returns typed `Checkpoint(BindingMismatch)`; admission stays open, writer stays `Ready`, exact-SQL still admits, lifecycle intact.
- `maintenance_checkpoint_denied_authority_never_drains` — denied admission-stage authority returns typed `Checkpoint(AuthorityDenied { BeforeAdmission })` with no drain side effects.
- `maintenance_checkpoint_preserves_typed_blocked_failure` — non-clear snapshot blockers surface as typed `Checkpoint(Blocked(blockers))` through trigger/wait, matched on the enum, not string parsing.
- `maintenance_truncate_is_typed_pending_while_pinned_then_reclaims_wal` — measured reclaim: an independent connection pins a read snapshot at the empty WAL mark, eight committed frames pile up, and TRUNCATE through the port returns typed `Pending { kind: Truncate }` with `report.busy` and `checkpointed_frames < log_frames` while the WAL file length is unchanged. After the snapshot releases, the retried TRUNCATE returns `Complete` with a not-busy report, `checkpointed_frames == log_frames`, and a zero-byte WAL file.

Tests use the `#[cfg(test)]` `ExclusiveMaintenancePermit::issue` with the attachment's own binding and run against temp-dir SQLite databases only — no live `~/.tracedecay` or repo-local `.tracedecay/` involvement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94519499-0633-4b17-949a-73190d482ce6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94519499-0633-4b17-949a-73190d482ce6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

