### PR TITLE
perf(code-index): shrink graph publication and adjacency hydration work

### DIFF
--- a/crates/tracedecay-application/tests/common/mod.rs
+++ b/crates/tracedecay-application/tests/common/mod.rs
@@ -69,6 +69,16 @@ pub fn digest(value: &str) -> ManifestDigest {
     ManifestDigest::new(value).expect("fixture digest is canonical")
 }
 
+/// Platform-absolute fixture root: the work and registered-root contracts
+/// require `Path::is_absolute`, which a bare `/...` literal fails on Windows.
+pub fn fixture_abs_root(posix: &str) -> String {
+    if cfg!(windows) {
+        format!("C:{}", posix.replace('/', "\\"))
+    } else {
+        posix.to_owned()
+    }
+}
+
 /// Canonical digest fixture for the Work-attempt product journey.
 pub fn work_digest(value: char) -> ManifestDigest {
     digest_char(value)

--- a/crates/tracedecay-code-index/src/graph_projection.rs
+++ b/crates/tracedecay-code-index/src/graph_projection.rs
@@ -15,10 +15,9 @@ use tracedecay_domain::{
 };
 use tracedecay_graph_db::{
     GraphCancellation, GraphDbError, GraphEntity, GraphEntityId, GraphEntityRef, GraphGenerationId,
-    GraphGenerationManifest, GraphGenerationRelation, GraphIdempotencyKey, GraphLabel,
-    GraphNamespace, GraphProjectionId, GraphProjectionIdentity, GraphProjectorRevision,
-    GraphProperty, GraphPropertyName, GraphRelationId, GraphRelationKind, GraphTraversalDirection,
-    SourceGeneration, TraversalRequest, VerifiedGraphSnapshot,
+    GraphGenerationManifest, GraphIdempotencyKey, GraphLabel, GraphNamespace, GraphProjectionId,
+    GraphProjectionIdentity, GraphProjectorRevision, GraphProperty, GraphPropertyName,
+    GraphTraversalDirection, SourceGeneration, TraversalRequest, VerifiedGraphSnapshot,
 };
 #[cfg(any(feature = "test-helpers", feature = "eval-helpers"))]
 use tracedecay_graph_db::{GraphWatermark, NeverCancelled};
@@ -754,55 +753,21 @@ fn current_generation_entity(
     .map_err(Into::into)
 }
 
-fn symbol_entity(record: SymbolRecordV1) -> Result<GraphEntity, CodeGraphProjectionError> {
+/// `identity` must be the [`symbol_entity_id`] of `record.occurrence`; the
+/// builder derives each occurrence's identity once and reuses it here and in
+/// every relation that names the symbol.
+fn symbol_entity(
+    identity: GraphEntityId,
+    record: SymbolRecordV1,
+) -> Result<GraphEntity, CodeGraphProjectionError> {
     validate_symbol_record(&record)?;
     GraphEntity::new(
-        symbol_entity_id(&record.occurrence)?,
+        identity,
         BTreeSet::from([GraphLabel::new(SYMBOL_LABEL)?]),
         BTreeMap::from([(
             GraphPropertyName::new(SYMBOL_RECORD_PROPERTY)?,
             GraphProperty::Bytes(serialize(&record)?),
         )]),
-    )
-    .map_err(Into::into)
-}
-
-fn edge_entity(edge: &CanonicalRelationEdgeV1) -> Result<GraphEntity, CodeGraphProjectionError> {
-    GraphEntity::new(
-        edge_entity_id(edge)?,
-        BTreeSet::from([GraphLabel::new(EDGE_LABEL)?]),
-        BTreeMap::from([(
-            GraphPropertyName::new(EDGE_RECORD_PROPERTY)?,
-            GraphProperty::Bytes(serialize(edge)?),
-        )]),
-    )
-    .map_err(Into::into)
-}
-
-fn source_relation(
-    projection: &GraphProjectionIdentity,
-    edge: &CanonicalRelationEdgeV1,
-) -> Result<GraphGenerationRelation, CodeGraphProjectionError> {
-    GraphGenerationRelation::new(
-        relation_id("source", edge)?,
-        GraphEntityRef::new(projection.clone(), symbol_entity_id(&edge.from_occurrence)?),
-        GraphEntityRef::new(projection.clone(), edge_entity_id(edge)?),
-        GraphRelationKind::new(SOURCE_EDGE_KIND)?,
-        BTreeMap::new(),
-    )
-    .map_err(Into::into)
-}
-
-fn target_relation(
-    projection: &GraphProjectionIdentity,
-    edge: &CanonicalRelationEdgeV1,
-) -> Result<GraphGenerationRelation, CodeGraphProjectionError> {
-    GraphGenerationRelation::new(
-        relation_id("target", edge)?,
-        GraphEntityRef::new(projection.clone(), edge_entity_id(edge)?),
-        GraphEntityRef::new(projection.clone(), symbol_entity_id(&edge.to_occurrence)?),
-        GraphRelationKind::new(TARGET_EDGE_KIND)?,
-        BTreeMap::new(),
     )
     .map_err(Into::into)
 }
@@ -817,13 +782,6 @@ fn edge_entity_id(
     edge: &CanonicalRelationEdgeV1,
 ) -> Result<GraphEntityId, CodeGraphProjectionError> {
     GraphEntityId::new(stable_identity("edge", &hex::encode(serialize(edge)?))).map_err(Into::into)
-}
-
-fn relation_id(
-    role: &str,
-    edge: &CanonicalRelationEdgeV1,
-) -> Result<GraphRelationId, CodeGraphProjectionError> {
-    GraphRelationId::new(stable_identity(role, edge_entity_id(edge)?.as_str())).map_err(Into::into)
 }
 
 #[cfg(any(feature = "test-helpers", feature = "eval-helpers"))]

--- a/crates/tracedecay-code-index/src/graph_projection/builder.rs
+++ b/crates/tracedecay-code-index/src/graph_projection/builder.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use crate::chunks::CodeIndexImportEvidenceV1;
 use crate::lineage::{GenerationSymbolIndexV1, LineageSymbolRecordV1};
@@ -6,8 +7,9 @@ use crate::production::CodeIndexPublishedGenerationV1;
 use serde::{Deserialize, Serialize};
 use tracedecay_domain::{
     CanonicalRelationEdgeV1, ChunkerRevision, CodeGenerationId, CodeSearchChunkAnchorV1,
-    CodeSearchChunkId, CodeSearchChunkV1, ContentDigest, LanguageDescriptorRevision,
-    SanitizedCodeFileV1, SanitizerRevision, SensitivityDecision, SymbolOccurrenceId,
+    CodeSearchChunkId, CodeSearchChunkV1, ContentDigest, FileOccurrenceId,
+    LanguageDescriptorRevision, SanitizedCodeFileV1, SanitizerRevision, SensitivityDecision,
+    SymbolOccurrenceId,
 };
 use tracedecay_graph_db::{
     GraphDbError, GraphEntity, GraphEntityId, GraphEntityRef, GraphGenerationManifest,
@@ -17,13 +19,13 @@ use tracedecay_graph_db::{
 
 use super::schema::{
     FILE_IMPORT_EDGE_KIND, FILE_LABEL, FILE_RECORD_PROPERTY, IMPORT_LABEL, IMPORT_RECORD_PROPERTY,
-    file_entity_id, file_import_relation_id, import_entity_id, serialize, stable_identity,
+    file_entity_id, file_import_relation_id_with, import_entity_id, serialize, stable_identity,
 };
 use super::{
     CHUNK_LABEL, CHUNK_RECORD_PROPERTY, CHUNK_SYMBOL_EDGE_KIND, CodeGraphProjectionError,
-    CodeGraphSymbolBindingV1, FILE_SYMBOL_EDGE_KIND, SymbolRecordV1,
-    build_code_graph_manifest_inputs_checked, compare_edges, current_generation_entity,
-    edge_entity, source_relation, symbol_entity, symbol_entity_id, target_relation, validate_edge,
+    CodeGraphSymbolBindingV1, EDGE_LABEL, EDGE_RECORD_PROPERTY, FILE_SYMBOL_EDGE_KIND,
+    SOURCE_EDGE_KIND, SymbolRecordV1, TARGET_EDGE_KIND, build_code_graph_manifest_inputs_checked,
+    compare_edges, current_generation_entity, symbol_entity, symbol_entity_id, validate_edge,
 };
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -43,6 +45,7 @@ pub fn build_published_code_graph_manifest_checked(
     projector_revision: &GraphProjectorRevision,
     check: &dyn Fn() -> Result<(), GraphDbError>,
 ) -> Result<GraphGenerationManifest, CodeGraphProjectionError> {
+    check()?;
     generation
         .validate()
         .map_err(|error| CodeGraphProjectionError::Contract(error.to_string()))?;
@@ -50,8 +53,19 @@ pub fn build_published_code_graph_manifest_checked(
     if generation.symbols().generation_id != *generation_id {
         return Err(CodeGraphProjectionError::GenerationMismatch);
     }
-    build_code_graph_manifest_inputs_checked(
-        projection,
+    // A published generation is immutable, so this manifest is a pure function
+    // of (generation, projection identity, projector revision). Seat retries
+    // and the seat/reconcile duplicate publication of one sealed generation
+    // reuse the first complete build instead of re-serializing and re-hashing
+    // every entity and relation. Fail-closed: only a fully successful build is
+    // memoized — an interrupted or deadline-exceeded build records nothing —
+    // and the `check` above refuses a cancelled or expired request before a
+    // memo hit can be served.
+    if let Some(manifest) = generation.memoized_graph_manifest(&projection, projector_revision) {
+        return Ok((*manifest).clone());
+    }
+    let manifest = build_code_graph_manifest_inputs_checked(
+        projection.clone(),
         generation_id,
         generation.edges(),
         generation.chunks().chunks(),
@@ -62,7 +76,13 @@ pub fn build_published_code_graph_manifest_checked(
         }),
         projector_revision,
         check,
-    )
+    )?;
+    generation.memoize_graph_manifest(
+        projection,
+        projector_revision.clone(),
+        Arc::new(manifest.clone()),
+    );
+    Ok(manifest)
 }
 
 pub(super) struct BuiltProjection {
@@ -210,19 +230,61 @@ pub(super) fn build_projection(
             .saturating_add(retained_edges.len())
             .saturating_add(1),
     );
+    let mut relations = Vec::with_capacity(
+        retained_edges
+            .len()
+            .saturating_mul(2)
+            .saturating_add(bindings.len().saturating_mul(2))
+            .saturating_add(imports.len()),
+    );
+
+    // Every stable identity below is a serialize-and-hash; each is computed
+    // exactly once and reused by the entity and every relation that names it,
+    // instead of being re-derived per emission site.
+    let mut file_ids = BTreeMap::<FileOccurrenceId, GraphEntityId>::new();
     for file in files.values() {
         check()?;
-        entities.push(file_entity(file)?);
+        let identity = file_entity_id(&file.file_occurrence_id)?;
+        entities.push(file_entity(identity.clone(), file)?);
+        file_ids.insert(file.file_occurrence_id.clone(), identity);
     }
     for import in imports {
         check()?;
-        entities.push(import_entity(import)?);
+        let identity = import_entity_id(import)?;
+        let file_id = file_ids
+            .get(&import.file_occurrence_id)
+            .cloned()
+            .ok_or_else(|| {
+                CodeGraphProjectionError::Contract(
+                    "code graph import refers to a file outside its immutable snapshot".to_owned(),
+                )
+            })?;
+        relations.push(file_import_relation(
+            projection,
+            import,
+            file_id,
+            &identity,
+        )?);
+        entities.push(import_entity(identity, import)?);
+    }
+
+    let mut symbol_ids = BTreeMap::<SymbolOccurrenceId, GraphEntityId>::new();
+    for occurrence in &occurrences {
+        symbol_ids.insert(occurrence.clone(), symbol_entity_id(occurrence)?);
     }
     for chunk in chunks {
         check()?;
-        entities.push(chunk_entity(chunk)?);
+        let identity = chunk_entity_id(&chunk.id)?;
+        if let Some(occurrence) = &chunk.anchor.symbol_occurrence_id {
+            let symbol_id = require_symbol_id(&symbol_ids, occurrence)?;
+            relations.push(chunk_symbol_relation(
+                projection, &identity, chunk, occurrence, symbol_id,
+            )?);
+        }
+        entities.push(chunk_entity(identity, chunk)?);
     }
     for occurrence in occurrences {
+        let identity = require_symbol_id(&symbol_ids, &occurrence)?.clone();
         let record = SymbolRecordV1 {
             binding: bindings.get(&occurrence).cloned(),
             metadata: symbol_metadata
@@ -230,10 +292,28 @@ pub(super) fn build_projection(
                 .map(|record| (*record).clone()),
             occurrence,
         };
-        entities.push(symbol_entity(record)?);
+        entities.push(symbol_entity(identity, record)?);
+    }
+    if production.is_some() {
+        for (occurrence, binding) in &bindings {
+            let file_id = file_ids.get(&binding.file).cloned().ok_or_else(|| {
+                CodeGraphProjectionError::Contract(
+                    "code graph binding refers to a file outside its immutable snapshot"
+                        .to_owned(),
+                )
+            })?;
+            let symbol_id = require_symbol_id(&symbol_ids, occurrence)?;
+            relations.push(file_symbol_relation(
+                projection, binding, file_id, occurrence, symbol_id,
+            )?);
+        }
     }
     for edge in &retained_edges {
-        entities.push(edge_entity(edge)?);
+        check()?;
+        let (entity, source, target) = edge_artifacts(projection, edge, &symbol_ids)?;
+        entities.push(entity);
+        relations.push(source);
+        relations.push(target);
     }
     let projection_node_count = entities.len().checked_add(1).ok_or_else(|| {
         CodeGraphProjectionError::Contract("code graph projection node count overflowed".to_owned())
@@ -243,31 +323,6 @@ pub(super) fn build_projection(
         projection_node_count,
     )?);
 
-    let mut relations = Vec::with_capacity(
-        retained_edges
-            .len()
-            .saturating_mul(2)
-            .saturating_add(bindings.len().saturating_mul(2))
-            .saturating_add(imports.len()),
-    );
-    if production.is_some() {
-        for (occurrence, binding) in &bindings {
-            relations.push(file_symbol_relation(projection, binding, occurrence)?);
-        }
-    }
-    for import in imports {
-        check()?;
-        relations.push(file_import_relation(projection, import)?);
-    }
-    for chunk in chunks {
-        if let Some(occurrence) = &chunk.anchor.symbol_occurrence_id {
-            relations.push(chunk_symbol_relation(projection, chunk, occurrence)?);
-        }
-    }
-    for edge in retained_edges {
-        relations.push(source_relation(projection, &edge)?);
-        relations.push(target_relation(projection, &edge)?);
-    }
     Ok(BuiltProjection {
         watermark: GraphWatermark::new(stable_identity("watermark", generation.as_str()))?,
         entities,
@@ -275,11 +330,62 @@ pub(super) fn build_projection(
     })
 }
 
-fn file_entity(file: &SanitizedCodeFileV1) -> Result<GraphEntity, CodeGraphProjectionError> {
+fn require_symbol_id<'ids>(
+    symbol_ids: &'ids BTreeMap<SymbolOccurrenceId, GraphEntityId>,
+    occurrence: &SymbolOccurrenceId,
+) -> Result<&'ids GraphEntityId, CodeGraphProjectionError> {
+    symbol_ids.get(occurrence).ok_or_else(|| {
+        CodeGraphProjectionError::Contract(
+            "code graph relation names a symbol occurrence with no entity".to_owned(),
+        )
+    })
+}
+
+/// One retained edge's entity plus both endpoint relations, sharing a single
+/// serialization and identity derivation of the edge payload.
+fn edge_artifacts(
+    projection: &GraphProjectionIdentity,
+    edge: &CanonicalRelationEdgeV1,
+    symbol_ids: &BTreeMap<SymbolOccurrenceId, GraphEntityId>,
+) -> Result<(GraphEntity, GraphGenerationRelation, GraphGenerationRelation), CodeGraphProjectionError>
+{
+    let payload = serialize(edge)?;
+    let identity = GraphEntityId::new(stable_identity("edge", &hex::encode(&payload)))?;
+    let entity = GraphEntity::new(
+        identity.clone(),
+        BTreeSet::from([GraphLabel::new(EDGE_LABEL)?]),
+        BTreeMap::from([(
+            GraphPropertyName::new(EDGE_RECORD_PROPERTY)?,
+            GraphProperty::Bytes(payload),
+        )]),
+    )?;
+    let from = require_symbol_id(symbol_ids, &edge.from_occurrence)?;
+    let to = require_symbol_id(symbol_ids, &edge.to_occurrence)?;
+    let source = GraphGenerationRelation::new(
+        GraphRelationId::new(stable_identity("source", identity.as_str()))?,
+        GraphEntityRef::new(projection.clone(), from.clone()),
+        GraphEntityRef::new(projection.clone(), identity.clone()),
+        GraphRelationKind::new(SOURCE_EDGE_KIND)?,
+        BTreeMap::new(),
+    )?;
+    let target = GraphGenerationRelation::new(
+        GraphRelationId::new(stable_identity("target", identity.as_str()))?,
+        GraphEntityRef::new(projection.clone(), identity),
+        GraphEntityRef::new(projection.clone(), to.clone()),
+        GraphRelationKind::new(TARGET_EDGE_KIND)?,
+        BTreeMap::new(),
+    )?;
+    Ok((entity, source, target))
+}
+
+fn file_entity(
+    identity: GraphEntityId,
+    file: &SanitizedCodeFileV1,
+) -> Result<GraphEntity, CodeGraphProjectionError> {
     file.validate()
         .map_err(|error| CodeGraphProjectionError::Contract(error.to_string()))?;
     GraphEntity::new(
-        file_entity_id(&file.file_occurrence_id)?,
+        identity,
         BTreeSet::from([GraphLabel::new(FILE_LABEL)?]),
         BTreeMap::from([(
             GraphPropertyName::new(FILE_RECORD_PROPERTY)?,
@@ -290,10 +396,11 @@ fn file_entity(file: &SanitizedCodeFileV1) -> Result<GraphEntity, CodeGraphProje
 }
 
 fn import_entity(
+    identity: GraphEntityId,
     import: &CodeIndexImportEvidenceV1,
 ) -> Result<GraphEntity, CodeGraphProjectionError> {
     GraphEntity::new(
-        import_entity_id(import)?,
+        identity,
         BTreeSet::from([GraphLabel::new(IMPORT_LABEL)?]),
         BTreeMap::from([(
             GraphPropertyName::new(IMPORT_RECORD_PROPERTY)?,
@@ -303,7 +410,10 @@ fn import_entity(
     .map_err(Into::into)
 }
 
-fn chunk_entity(chunk: &CodeSearchChunkV1) -> Result<GraphEntity, CodeGraphProjectionError> {
+fn chunk_entity(
+    identity: GraphEntityId,
+    chunk: &CodeSearchChunkV1,
+) -> Result<GraphEntity, CodeGraphProjectionError> {
     let record = ChunkRecordV1 {
         id: chunk.id.clone(),
         anchor: chunk.anchor.clone(),
@@ -314,7 +424,7 @@ fn chunk_entity(chunk: &CodeSearchChunkV1) -> Result<GraphEntity, CodeGraphProje
         sensitivity: chunk.sensitivity.clone(),
     };
     GraphEntity::new(
-        chunk_entity_id(&chunk.id)?,
+        identity,
         BTreeSet::from([GraphLabel::new(CHUNK_LABEL)?]),
         BTreeMap::from([(
             GraphPropertyName::new(CHUNK_RECORD_PROPERTY)?,
@@ -327,15 +437,17 @@ fn chunk_entity(chunk: &CodeSearchChunkV1) -> Result<GraphEntity, CodeGraphProje
 fn file_symbol_relation(
     projection: &GraphProjectionIdentity,
     binding: &CodeGraphSymbolBindingV1,
+    file_id: GraphEntityId,
     occurrence: &SymbolOccurrenceId,
+    symbol_id: &GraphEntityId,
 ) -> Result<GraphGenerationRelation, CodeGraphProjectionError> {
     GraphGenerationRelation::new(
         GraphRelationId::new(stable_identity(
             "file-symbol",
             &format!("{}\0{}", binding.file.as_str(), occurrence.as_str()),
         ))?,
-        GraphEntityRef::new(projection.clone(), file_entity_id(&binding.file)?),
-        GraphEntityRef::new(projection.clone(), symbol_entity_id(occurrence)?),
+        GraphEntityRef::new(projection.clone(), file_id),
+        GraphEntityRef::new(projection.clone(), symbol_id.clone()),
         GraphRelationKind::new(FILE_SYMBOL_EDGE_KIND)?,
         BTreeMap::new(),
     )
@@ -345,15 +457,13 @@ fn file_symbol_relation(
 fn file_import_relation(
     projection: &GraphProjectionIdentity,
     import: &CodeIndexImportEvidenceV1,
+    file_id: GraphEntityId,
+    import_id: &GraphEntityId,
 ) -> Result<GraphGenerationRelation, CodeGraphProjectionError> {
-    let import_id = import_entity_id(import)?;
     GraphGenerationRelation::new(
-        file_import_relation_id(import)?,
-        GraphEntityRef::new(
-            projection.clone(),
-            file_entity_id(&import.file_occurrence_id)?,
-        ),
-        GraphEntityRef::new(projection.clone(), import_id),
+        file_import_relation_id_with(import, import_id)?,
+        GraphEntityRef::new(projection.clone(), file_id),
+        GraphEntityRef::new(projection.clone(), import_id.clone()),
         GraphRelationKind::new(FILE_IMPORT_EDGE_KIND)?,
         BTreeMap::new(),
     )
@@ -362,16 +472,18 @@ fn file_import_relation(
 
 fn chunk_symbol_relation(
     projection: &GraphProjectionIdentity,
+    chunk_id: &GraphEntityId,
     chunk: &CodeSearchChunkV1,
     occurrence: &SymbolOccurrenceId,
+    symbol_id: &GraphEntityId,
 ) -> Result<GraphGenerationRelation, CodeGraphProjectionError> {
     GraphGenerationRelation::new(
         GraphRelationId::new(stable_identity(
             "chunk-symbol",
             &format!("{}\0{}", chunk.id.as_str(), occurrence.as_str()),
         ))?,
-        GraphEntityRef::new(projection.clone(), chunk_entity_id(&chunk.id)?),
-        GraphEntityRef::new(projection.clone(), symbol_entity_id(occurrence)?),
+        GraphEntityRef::new(projection.clone(), chunk_id.clone()),
+        GraphEntityRef::new(projection.clone(), symbol_id.clone()),
         GraphRelationKind::new(CHUNK_SYMBOL_EDGE_KIND)?,
         BTreeMap::new(),
     )

--- a/crates/tracedecay-code-index/src/graph_projection/builder.rs
+++ b/crates/tracedecay-code-index/src/graph_projection/builder.rs
@@ -260,10 +260,7 @@ pub(super) fn build_projection(
                 )
             })?;
         relations.push(file_import_relation(
-            projection,
-            import,
-            file_id,
-            &identity,
+            projection, import, file_id, &identity,
         )?);
         entities.push(import_entity(identity, import)?);
     }
@@ -298,8 +295,7 @@ pub(super) fn build_projection(
         for (occurrence, binding) in &bindings {
             let file_id = file_ids.get(&binding.file).cloned().ok_or_else(|| {
                 CodeGraphProjectionError::Contract(
-                    "code graph binding refers to a file outside its immutable snapshot"
-                        .to_owned(),
+                    "code graph binding refers to a file outside its immutable snapshot".to_owned(),
                 )
             })?;
             let symbol_id = require_symbol_id(&symbol_ids, occurrence)?;
@@ -347,8 +343,14 @@ fn edge_artifacts(
     projection: &GraphProjectionIdentity,
     edge: &CanonicalRelationEdgeV1,
     symbol_ids: &BTreeMap<SymbolOccurrenceId, GraphEntityId>,
-) -> Result<(GraphEntity, GraphGenerationRelation, GraphGenerationRelation), CodeGraphProjectionError>
-{
+) -> Result<
+    (
+        GraphEntity,
+        GraphGenerationRelation,
+        GraphGenerationRelation,
+    ),
+    CodeGraphProjectionError,
+> {
     let payload = serialize(edge)?;
     let identity = GraphEntityId::new(stable_identity("edge", &hex::encode(&payload)))?;
     let entity = GraphEntity::new(

--- a/crates/tracedecay-code-index/src/graph_projection/interactive.rs
+++ b/crates/tracedecay-code-index/src/graph_projection/interactive.rs
@@ -701,6 +701,12 @@ impl CodeGraphInteractiveReader {
         Ok(built)
     }
 
+    /// Hydration is staged so excluded work is never paid: each adjacency row
+    /// loads its relation and edge payload first, edges outside the admitted
+    /// kinds stop there without touching their far endpoint, and each unique
+    /// far endpoint that survives the filter is hydrated once per batch —
+    /// impact frontiers and shared callees converge on the same neighbors, so
+    /// per-edge endpoint reads repeated the same snapshot lookups.
     fn semantic_neighbors(
         &self,
         seeds: &[SymbolOccurrenceId],
@@ -730,6 +736,7 @@ impl CodeGraphInteractiveReader {
                 "code graph adjacency batch shape does not match its seeds".to_owned(),
             ));
         }
+        let mut neighbors = BTreeMap::<SymbolOccurrenceId, CodeGraphSymbolSummaryV1>::new();
         let mut batches = Vec::with_capacity(seeds.len());
         for (seed, relations) in seeds.iter().zip(per_seed_relations) {
             let mut edges = Vec::new();
@@ -737,15 +744,39 @@ impl CodeGraphInteractiveReader {
                 if cancellation.is_cancelled() {
                     return Err(CodeGraphProjectionError::Cancelled);
                 }
-                let edge = self.hydrate_semantic_edge(
+                let edge = self.hydrate_edge_record(
                     seed,
                     &relation,
                     direction,
                     Arc::clone(&cancellation),
                 )?;
-                if admitted.is_empty() || admitted.contains(&edge.edge.kind) {
-                    edges.push(edge);
+                if !admitted.is_empty() && !admitted.contains(&edge.kind) {
+                    continue;
                 }
+                let far = match direction {
+                    AdjacencyDirection::Outgoing => &edge.to_occurrence,
+                    AdjacencyDirection::Incoming => &edge.from_occurrence,
+                };
+                let neighbor = match neighbors.get(far) {
+                    Some(summary) => summary.clone(),
+                    None => {
+                        let record = load_symbol_record(
+                            &self.snapshot,
+                            &self.projection,
+                            far,
+                            Arc::clone(&cancellation),
+                        )?
+                        .ok_or_else(|| {
+                            CodeGraphProjectionError::Corrupt(
+                                "code graph edge endpoint has no symbol entity".to_owned(),
+                            )
+                        })?;
+                        let summary = summary_from_record(record);
+                        neighbors.insert(far.clone(), summary.clone());
+                        summary
+                    }
+                };
+                edges.push(CodeGraphSemanticEdgeV1 { edge, neighbor });
             }
             edges.sort_by(|left, right| compare_edges(&left.edge, &right.edge));
             edges.dedup();
@@ -754,13 +785,15 @@ impl CodeGraphInteractiveReader {
         Ok(batches)
     }
 
-    fn hydrate_semantic_edge(
+    /// Loads one adjacency row up to its validated edge payload: the relation,
+    /// the edge entity, and the seed-endpoint check — no far-endpoint read.
+    fn hydrate_edge_record(
         &self,
         seed: &SymbolOccurrenceId,
         relation: &GraphRelationId,
         direction: AdjacencyDirection,
         cancellation: Arc<dyn GraphCancellation>,
-    ) -> Result<CodeGraphSemanticEdgeV1, CodeGraphProjectionError> {
+    ) -> Result<CanonicalRelationEdgeV1, CodeGraphProjectionError> {
         let relation = self
             .snapshot
             .relation(
@@ -778,32 +811,23 @@ impl CodeGraphInteractiveReader {
         };
         let entity = self
             .snapshot
-            .entity(edge_reference, Arc::clone(&cancellation))?
+            .entity(edge_reference, cancellation)?
             .ok_or_else(|| {
                 CodeGraphProjectionError::Corrupt(
                     "code graph adjacency referenced a missing edge entity".to_owned(),
                 )
             })?;
         let edge = load_edge_record(&entity)?;
-        let (near, far) = match direction {
-            AdjacencyDirection::Outgoing => (&edge.from_occurrence, &edge.to_occurrence),
-            AdjacencyDirection::Incoming => (&edge.to_occurrence, &edge.from_occurrence),
+        let near = match direction {
+            AdjacencyDirection::Outgoing => &edge.from_occurrence,
+            AdjacencyDirection::Incoming => &edge.to_occurrence,
         };
         if near != seed {
             return Err(CodeGraphProjectionError::Corrupt(
                 "code graph edge endpoint does not match its adjacency seed".to_owned(),
             ));
         }
-        let neighbor = load_symbol_record(&self.snapshot, &self.projection, far, cancellation)?
-            .ok_or_else(|| {
-                CodeGraphProjectionError::Corrupt(
-                    "code graph edge endpoint has no symbol entity".to_owned(),
-                )
-            })?;
-        Ok(CodeGraphSemanticEdgeV1 {
-            edge,
-            neighbor: summary_from_record(neighbor),
-        })
+        Ok(edge)
     }
 }
 

--- a/crates/tracedecay-code-index/src/graph_projection/interactive/tests.rs
+++ b/crates/tracedecay-code-index/src/graph_projection/interactive/tests.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tracedecay_application::CancellationSignal;
 use tracedecay_domain::{
@@ -30,6 +31,26 @@ struct CancelledNow;
 impl GraphCancellation for CancelledNow {
     fn is_cancelled(&self) -> bool {
         true
+    }
+}
+
+/// Counts cancellation observations without ever cancelling. Every snapshot
+/// read observes the request cancellation, so for two structurally identical
+/// queries against one snapshot the observation counts order exactly like the
+/// snapshot reads performed.
+#[derive(Default)]
+struct CountingCancellation(AtomicU64);
+
+impl CountingCancellation {
+    fn observations(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl GraphCancellation for CountingCancellation {
+    fn is_cancelled(&self) -> bool {
+        self.0.fetch_add(1, Ordering::Relaxed);
+        false
     }
 }
 
@@ -409,6 +430,97 @@ fn adjacency_reads_are_kind_filtered_and_endpoint_checked() {
         .expect("callees");
     assert_eq!(callees[0].len(), 1);
     assert_eq!(callees[0][0].edge.to_occurrence.as_str(), "sym.beta.run");
+}
+
+/// Edge kinds outside the admitted set must stop hydration at the edge
+/// payload: their far endpoints are never read. Both queries examine the same
+/// two adjacency rows of `sym.beta.run`; the filtered one hydrates one
+/// neighbor where the unfiltered one hydrates two, so it must perform strictly
+/// fewer snapshot reads.
+#[test]
+fn kind_filtered_adjacency_skips_far_endpoint_hydration_for_excluded_edges() {
+    let reader = reader(&store_for(production_manifest()));
+    let beta = vec![id::<SymbolOccurrenceId>("sym.beta.run")];
+
+    let filtered_reads = Arc::new(CountingCancellation::default());
+    let filtered = reader
+        .callers(
+            &beta,
+            &[RelationEdgeKindV1::Calls],
+            16,
+            Arc::clone(&filtered_reads) as Arc<dyn GraphCancellation>,
+        )
+        .expect("filtered callers");
+    assert_eq!(filtered[0].len(), 1, "one Calls edge survives the filter");
+
+    let unfiltered_reads = Arc::new(CountingCancellation::default());
+    let unfiltered = reader
+        .callers(
+            &beta,
+            &[],
+            16,
+            Arc::clone(&unfiltered_reads) as Arc<dyn GraphCancellation>,
+        )
+        .expect("unfiltered callers");
+    assert_eq!(unfiltered[0].len(), 2, "both incoming edges hydrate");
+
+    assert!(
+        filtered_reads.observations() < unfiltered_reads.observations(),
+        "excluded kinds must not hydrate far endpoints: filtered={} unfiltered={}",
+        filtered_reads.observations(),
+        unfiltered_reads.observations()
+    );
+}
+
+/// Far endpoints shared inside one batch hydrate once, not once per edge.
+/// Both batches carry two seeds with one outgoing edge each; the batch whose
+/// edges converge on one shared endpoint must perform strictly fewer snapshot
+/// reads than the batch whose endpoints are distinct.
+#[test]
+fn shared_far_endpoints_hydrate_once_per_adjacency_batch() {
+    let reader = reader(&store_for(production_manifest()));
+
+    let shared_reads = Arc::new(CountingCancellation::default());
+    let shared = reader
+        .callees(
+            &[
+                id::<SymbolOccurrenceId>("sym.alpha.run"),
+                id::<SymbolOccurrenceId>("sym.beta.runner"),
+            ],
+            &[],
+            16,
+            Arc::clone(&shared_reads) as Arc<dyn GraphCancellation>,
+        )
+        .expect("shared-endpoint batch");
+    assert!(
+        shared
+            .iter()
+            .flatten()
+            .all(|edge| edge.neighbor.occurrence.as_str() == "sym.beta.run"),
+        "both edges converge on sym.beta.run"
+    );
+    assert_eq!(shared.iter().flatten().count(), 2);
+
+    let distinct_reads = Arc::new(CountingCancellation::default());
+    let distinct = reader
+        .callees(
+            &[
+                id::<SymbolOccurrenceId>("sym.gamma.main"),
+                id::<SymbolOccurrenceId>("sym.alpha.run"),
+            ],
+            &[],
+            16,
+            Arc::clone(&distinct_reads) as Arc<dyn GraphCancellation>,
+        )
+        .expect("distinct-endpoint batch");
+    assert_eq!(distinct.iter().flatten().count(), 2);
+
+    assert!(
+        shared_reads.observations() < distinct_reads.observations(),
+        "a shared far endpoint must hydrate once per batch: shared={} distinct={}",
+        shared_reads.observations(),
+        distinct_reads.observations()
+    );
 }
 
 #[test]

--- a/crates/tracedecay-code-index/src/graph_projection/schema.rs
+++ b/crates/tracedecay-code-index/src/graph_projection/schema.rs
@@ -43,6 +43,15 @@ pub(super) fn file_import_relation_id(
     import: &CodeIndexImportEvidenceV1,
 ) -> Result<GraphRelationId, CodeGraphProjectionError> {
     let import_id = import_entity_id(import)?;
+    file_import_relation_id_with(import, &import_id)
+}
+
+/// Same relation identity with the import entity id already derived, so a
+/// caller that just computed it does not serialize and hash the import again.
+pub(super) fn file_import_relation_id_with(
+    import: &CodeIndexImportEvidenceV1,
+    import_id: &GraphEntityId,
+) -> Result<GraphRelationId, CodeGraphProjectionError> {
     GraphRelationId::new(stable_identity(
         "file-import",
         &format!(

--- a/crates/tracedecay-code-index/src/production/mod.rs
+++ b/crates/tracedecay-code-index/src/production/mod.rs
@@ -9,6 +9,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracedecay_code_extraction::incremental::ParseError;
+use tracedecay_graph_db::{GraphGenerationManifest, GraphProjectionIdentity, GraphProjectorRevision};
 use tracedecay_domain::{
     CanonicalRelationEdgeV1, CodeGenerationId, CodeGenerationManifestV1,
     CodeIndexCapabilityManifestV1, CodeSearchEligibilityV1, ComponentVersion, CoverageSummaryV1,
@@ -433,6 +434,25 @@ pub struct CodeIndexPublishedGenerationV1 {
     /// evidence digest are a pure function of the immutable generation. Only
     /// success is cached.
     attribution: OnceLock<PublishedGenerationTestAttributionAuthorityV1>,
+    /// Amortized code-graph publication manifest. Seat retries and the
+    /// seat/reconcile duplicate publication of one sealed generation each
+    /// rebuilt every graph entity and relation — a serialize-and-hash sweep
+    /// over the whole store charged against the activation deadline. The
+    /// manifest is a pure function of the immutable generation plus the
+    /// projection identity and projector revision recorded beside it. Only a
+    /// complete successful build is cached; an interrupted or
+    /// deadline-exceeded build records nothing.
+    graph_manifest: OnceLock<CodeGraphManifestMemoV1>,
+}
+
+/// One successfully built code-graph publication manifest, pinned to the
+/// exact projection identity and projector revision it was derived under. A
+/// lookup under any other identity is a memo miss, never an aliased manifest.
+#[derive(Clone, Debug)]
+struct CodeGraphManifestMemoV1 {
+    projection: GraphProjectionIdentity,
+    projector_revision: GraphProjectorRevision,
+    manifest: Arc<GraphGenerationManifest>,
 }
 
 impl CodeIndexPublishedGenerationV1 {
@@ -718,6 +738,36 @@ impl CodeIndexPublishedGenerationV1 {
             generation_id: self.manifest.generation_id.clone(),
             read,
         })
+    }
+
+    /// The memoized code-graph publication manifest for exactly this
+    /// projection identity and projector revision, if a prior complete build
+    /// recorded one. A key mismatch is a miss, never a substituted manifest.
+    pub(crate) fn memoized_graph_manifest(
+        &self,
+        projection: &GraphProjectionIdentity,
+        projector_revision: &GraphProjectorRevision,
+    ) -> Option<Arc<GraphGenerationManifest>> {
+        self.graph_manifest.get().and_then(|memo| {
+            (memo.projection == *projection && memo.projector_revision == *projector_revision)
+                .then(|| Arc::clone(&memo.manifest))
+        })
+    }
+
+    /// Record one complete, successfully built code-graph publication
+    /// manifest. First success wins; the generation is immutable, so any
+    /// competing build under the same key produced an identical manifest.
+    pub(crate) fn memoize_graph_manifest(
+        &self,
+        projection: GraphProjectionIdentity,
+        projector_revision: GraphProjectorRevision,
+        manifest: Arc<GraphGenerationManifest>,
+    ) {
+        let _ = self.graph_manifest.set(CodeGraphManifestMemoV1 {
+            projection,
+            projector_revision,
+            manifest,
+        });
     }
 
     /// Return chunks re-admitted through their parser-backed exact authority.
@@ -1226,6 +1276,7 @@ where
             validated: OnceLock::new(),
             admitted: OnceLock::new(),
             attribution: OnceLock::new(),
+            graph_manifest: OnceLock::new(),
         };
         candidate.validate()?;
 

--- a/crates/tracedecay-code-index/src/production/mod.rs
+++ b/crates/tracedecay-code-index/src/production/mod.rs
@@ -9,7 +9,6 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracedecay_code_extraction::incremental::ParseError;
-use tracedecay_graph_db::{GraphGenerationManifest, GraphProjectionIdentity, GraphProjectorRevision};
 use tracedecay_domain::{
     CanonicalRelationEdgeV1, CodeGenerationId, CodeGenerationManifestV1,
     CodeIndexCapabilityManifestV1, CodeSearchEligibilityV1, ComponentVersion, CoverageSummaryV1,
@@ -20,6 +19,9 @@ use tracedecay_domain::{
     SanitizerRevision, SensitivityLevelV1, SnapshotFileDispositionV1, SymbolLineageCandidateV1,
     SymbolOccurrenceId, TestAttributionEvidenceClassV1, UtcMicros, ValidatedCodeFileV1,
     ValidatedCodeSnapshotV1, WorktreeId, canonical_sha256,
+};
+use tracedecay_graph_db::{
+    GraphGenerationManifest, GraphProjectionIdentity, GraphProjectorRevision,
 };
 
 use super::{

--- a/crates/tracedecay-code-index/src/production/sealed_codec.rs
+++ b/crates/tracedecay-code-index/src/production/sealed_codec.rs
@@ -406,6 +406,7 @@ impl CodeIndexPublishedGenerationV1 {
             validated: OnceLock::new(),
             admitted: OnceLock::new(),
             attribution: OnceLock::new(),
+            graph_manifest: OnceLock::new(),
         };
         generation.validate_fresh()?;
         Ok(generation)

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::Cell,
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex},
     time::Duration,
@@ -8,8 +9,8 @@ use tracedecay_code_extraction::incremental::ParseLimits;
 use tracedecay_code_index::{
     chunks::content_digest,
     graph_projection::{
-        CODE_GRAPH_PROJECTOR_REVISION, build_published_code_graph_manifest_checked,
-        code_graph_projection_identity,
+        CODE_GRAPH_PROJECTOR_REVISION, CodeGraphProjectionError,
+        build_published_code_graph_manifest_checked, code_graph_projection_identity,
     },
     production::{
         CodeIndexAtomicPublicationPort, CodeIndexBuildRequestV1, CodeIndexCapturedFileV1,
@@ -34,7 +35,7 @@ use tracedecay_domain::{
     SanitizedCodeFileV1, SanitizedCodeSnapshotV1, SanitizerRevision, SnapshotFileDispositionV1,
     StackNodeId, TestAttributionEvidenceClassV1, TreeId, UtcMicros, WorktreeId,
 };
-use tracedecay_graph_db::{GraphNamespace, GraphProjectorRevision};
+use tracedecay_graph_db::{GraphDbError, GraphNamespace, GraphProjectorRevision};
 
 use crate::support::{RUST_SOURCE, id};
 
@@ -698,6 +699,119 @@ fn published_graph_manifest_projects_files_chunks_symbols_and_replays_byte_ident
         replayed
             .expected_recovered_digest(&|| Ok(()))
             .expect("replayed projection digest")
+    );
+}
+
+/// The graph publication manifest is a pure function of the immutable
+/// generation, so seat retries and the seat/reconcile duplicate publication of
+/// one sealed generation must not re-examine every chunk, symbol, and edge.
+/// The memo is fail-closed: a deadline mid-build records nothing, a memo hit
+/// still refuses an expired request, and a foreign projection identity or
+/// projector revision rebuilds in full instead of aliasing the cached
+/// manifest.
+#[test]
+fn repeated_graph_manifest_builds_reuse_the_memo_without_reexamining_the_generation() {
+    let store = SharedPublicationStore::default();
+    let mut owner = CodeIndexProductionOwnerV1::new(config(), store, ApplyingProjectionSink)
+        .expect("production owner");
+    let generation = owner
+        .build_and_publish(request("file.graph-memo", 1_260_000), &ActiveControl)
+        .expect("generation publishes");
+    let projector_revision =
+        GraphProjectorRevision::try_from(CODE_GRAPH_PROJECTOR_REVISION.to_owned())
+            .expect("projector revision");
+    let projection =
+        code_graph_projection_identity(GraphNamespace::new("code-graph-memo").expect("namespace"))
+            .expect("projection identity");
+
+    // A deadline mid-build is a failed generation build that memoizes nothing.
+    let interrupted_checks = Cell::new(0usize);
+    let interrupted = build_published_code_graph_manifest_checked(
+        projection.clone(),
+        &generation,
+        &projector_revision,
+        &|| {
+            interrupted_checks.set(interrupted_checks.get() + 1);
+            if interrupted_checks.get() > 3 {
+                Err(GraphDbError::DeadlineExceeded)
+            } else {
+                Ok(())
+            }
+        },
+    )
+    .expect_err("a deadline mid-build fails the build");
+    assert_eq!(interrupted, CodeGraphProjectionError::DeadlineExceeded);
+
+    let first_checks = Cell::new(0usize);
+    let first = build_published_code_graph_manifest_checked(
+        projection.clone(),
+        &generation,
+        &projector_revision,
+        &|| {
+            first_checks.set(first_checks.get() + 1);
+            Ok(())
+        },
+    )
+    .expect("first complete build");
+    let second_checks = Cell::new(0usize);
+    let second = build_published_code_graph_manifest_checked(
+        projection.clone(),
+        &generation,
+        &projector_revision,
+        &|| {
+            second_checks.set(second_checks.get() + 1);
+            Ok(())
+        },
+    )
+    .expect("memoized build");
+    assert_eq!(first, second, "the memo returns the identical manifest");
+    assert!(
+        first_checks.get() > 3,
+        "the interrupted build must not have been memoized (first build saw {} checks)",
+        first_checks.get()
+    );
+    assert!(
+        first_checks.get() > first.entities.len() / 4,
+        "a fresh build examines the generation item by item ({} checks over {} entities)",
+        first_checks.get(),
+        first.entities.len()
+    );
+    assert_eq!(
+        second_checks.get(),
+        1,
+        "a memo hit performs the admission check only, with no per-item examination"
+    );
+
+    // A memo hit still refuses an already-expired request.
+    let refused = build_published_code_graph_manifest_checked(
+        projection.clone(),
+        &generation,
+        &projector_revision,
+        &|| Err(GraphDbError::DeadlineExceeded),
+    )
+    .expect_err("an expired request is refused before the memo serves");
+    assert_eq!(refused, CodeGraphProjectionError::DeadlineExceeded);
+
+    // A foreign projection identity is a memo miss that rebuilds in full.
+    let foreign = code_graph_projection_identity(
+        GraphNamespace::new("code-graph-memo-other").expect("namespace"),
+    )
+    .expect("projection identity");
+    let foreign_checks = Cell::new(0usize);
+    let rebuilt = build_published_code_graph_manifest_checked(
+        foreign.clone(),
+        &generation,
+        &projector_revision,
+        &|| {
+            foreign_checks.set(foreign_checks.get() + 1);
+            Ok(())
+        },
+    )
+    .expect("foreign projection rebuilds");
+    assert_eq!(rebuilt.projection, foreign);
+    assert!(
+        foreign_checks.get() > 1,
+        "a foreign projection identity cannot serve the cached manifest"
     );
 }
 

--- a/crates/tracedecay-sessions/src/runtime/jsonl_observation_admission/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/jsonl_observation_admission/tests.rs
@@ -74,7 +74,10 @@ impl HostAdmission for SeamSpyAdmission {
         advance: ObservationCursorAdvance,
         cancellation: ObservationCancellation,
     ) -> AdmissionFuture<'a, CursorAdvanceOutcome> {
-        self.cover_past_advances.lock().unwrap().push(advance.clone());
+        self.cover_past_advances
+            .lock()
+            .unwrap()
+            .push(advance.clone());
         self.inner
             .advance_non_durable_source_cursor(advance, cancellation)
     }
@@ -193,7 +196,11 @@ async fn commit_failures_block_typed_and_never_cover_past() {
         spy.script_capture_error(HostAdmissionOutcome::degraded(reason));
 
         let error = try_admit_codex_jsonl_observations_for_profile_with_admission(
-            &path, None, &[], &spy, None,
+            &path,
+            None,
+            &[],
+            &spy,
+            None,
         )
         .await
         .expect_err("a commit failure must block the source instead of covering past it");
@@ -222,13 +229,14 @@ async fn commit_failures_block_typed_and_never_cover_past() {
 async fn retryable_admission_failures_keep_their_own_verdict() {
     let (_temp, path, _len) = rollout_fixture();
     let spy = SeamSpyAdmission::default();
-    spy.script_capture_error(HostAdmissionOutcome::retained_backpressured("cursor_conflict"));
+    spy.script_capture_error(HostAdmissionOutcome::retained_backpressured(
+        "cursor_conflict",
+    ));
 
-    let error = try_admit_codex_jsonl_observations_for_profile_with_admission(
-        &path, None, &[], &spy, None,
-    )
-    .await
-    .expect_err("a retryable race must surface for another pass");
+    let error =
+        try_admit_codex_jsonl_observations_for_profile_with_admission(&path, None, &[], &spy, None)
+            .await
+            .expect_err("a retryable race must surface for another pass");
 
     assert!(
         matches!(
@@ -249,28 +257,33 @@ async fn retryable_admission_failures_keep_their_own_verdict() {
 async fn content_refusals_cover_past_so_the_stream_converges() {
     let (_temp, path, len) = rollout_fixture();
     let spy = SeamSpyAdmission::default();
-    spy.script_capture_error(HostAdmissionOutcome::degraded("invalid_observation_contract"));
+    spy.script_capture_error(HostAdmissionOutcome::degraded(
+        "invalid_observation_contract",
+    ));
 
-    let progress = try_admit_codex_jsonl_observations_for_profile_with_admission(
-        &path, None, &[], &spy, None,
-    )
-    .await
-    .expect("deterministic content refusals must not block the source");
+    let progress =
+        try_admit_codex_jsonl_observations_for_profile_with_admission(&path, None, &[], &spy, None)
+            .await
+            .expect("deterministic content refusals must not block the source");
 
     assert_eq!(progress.bytes_consumed, len);
     let advances = spy.cover_past_advances();
     assert_eq!(advances.len(), 2, "both refused frames must be covered");
     for advance in &advances {
-        assert_eq!(advance.reason(), ObservationCoverageReason::AdmissionRefused);
+        assert_eq!(
+            advance.reason(),
+            ObservationCoverageReason::AdmissionRefused
+        );
     }
-    let cursor = stored_cursor(&spy).await.expect("coverage must advance the frontier");
+    let cursor = stored_cursor(&spy)
+        .await
+        .expect("coverage must advance the frontier");
     assert_eq!(cursor.position(), len);
 
-    let replay = try_admit_codex_jsonl_observations_for_profile_with_admission(
-        &path, None, &[], &spy, None,
-    )
-    .await
-    .expect("a covered stream must converge");
+    let replay =
+        try_admit_codex_jsonl_observations_for_profile_with_admission(&path, None, &[], &spy, None)
+            .await
+            .expect("a covered stream must converge");
     assert_eq!(replay.bytes_consumed, 0);
     assert_eq!(
         spy.cover_past_advances().len(),
@@ -289,18 +302,19 @@ async fn exact_duplicates_are_idempotent_no_op_receipts() {
         .expect("initial admission must persist both records");
     assert_eq!(spy.inner.observations().len(), 2);
     assert!(spy.cover_past_advances().is_empty());
-    let committed = stored_cursor(&spy).await.expect("persist must advance the frontier");
+    let committed = stored_cursor(&spy)
+        .await
+        .expect("persist must advance the frontier");
     assert_eq!(committed.position(), len);
 
     // Replay the whole file against the already-durable rows, the state a
     // lost or stale frontier read produces: every frame is an exact
     // duplicate (same identity + digest) and must be a silent no-op receipt.
     spy.report_no_cursor.store(true, Ordering::SeqCst);
-    let replay = try_admit_codex_jsonl_observations_for_profile_with_admission(
-        &path, None, &[], &spy, None,
-    )
-    .await
-    .expect("exact duplicates must be idempotent no-op receipts");
+    let replay =
+        try_admit_codex_jsonl_observations_for_profile_with_admission(&path, None, &[], &spy, None)
+            .await
+            .expect("exact duplicates must be idempotent no-op receipts");
     spy.report_no_cursor.store(false, Ordering::SeqCst);
 
     assert_eq!(replay.bytes_consumed, len);
@@ -309,7 +323,9 @@ async fn exact_duplicates_are_idempotent_no_op_receipts() {
         spy.cover_past_advances().is_empty(),
         "an exact duplicate is not an admission refusal and writes no coverage"
     );
-    let unchanged = stored_cursor(&spy).await.expect("frontier must remain durable");
+    let unchanged = stored_cursor(&spy)
+        .await
+        .expect("frontier must remain durable");
     assert_eq!(
         unchanged, committed,
         "an exact duplicate replay performs no extra cursor write"

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -33,10 +33,7 @@ pub(crate) async fn daemon_tool_json_until(
         false,
     )?;
     let result = tracedecay::daemon::call_default_tool_awaiting_project_open(
-        &handshake,
-        tool_name,
-        arguments,
-        deadline,
+        &handshake, tool_name, arguments, deadline,
     )
     .await?;
     recover_truncated_payload(&handshake, tool_name, result, Some(deadline)).await


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Live evidence (~4:21 PM PT): `code_index_reconcile_failed` and `code_index_retained_seat_failed` with "code graph operation deadline exceeded" (68 deadline lines), and `code_index_search_failed` on ZeroFS with "no complete current generation" (search has nothing to serve because seat/reconcile never completes). Project open: tracedecay `full_published` 52.6 s; ZeroFS `graph_admitted` 94.8 s / `full_published` 95.7 s.

The deadline budget on the seat/reconcile path was being burned on repeated, redundant crate-side graph work, not just on graph-db ingest. This PR shrinks that work in `crates/tracedecay-code-index` only. It is a new perf PR (not a #532 reopen; #532 stays merged), stacked on #543 after #509 → #421 → #540.

## What work shrank

**1. Seat/reconcile: the published-graph manifest is built once per generation, not once per attempt.**
`build_published_code_graph_manifest_checked` rebuilt every graph entity and relation on every call. The daemon calls it on the initial seat, on every seat retry after a deadline (the backoff loop re-activates the same sealed artifact), and again when the background reconcile publishes the same generation the seat pass already published. The manifest is a pure function of the immutable generation plus (projection identity, projector revision), so it is now memoized on `CodeIndexPublishedGenerationV1` under exactly that key. A retry or duplicate publication now goes straight to graph-db ingest with its full deadline budget instead of re-serializing and re-hashing the whole store first.

**2. First build: each stable identity is derived exactly once.**
`build_projection` serialized every retained edge four times and SHA-256-hashed it three times (entity id, source-relation id, target-relation id), and re-derived symbol/chunk/file/import identities at every relation that named them. Each identity is now computed once and reused by the entity and all of its relations — for the dominant edge case that is one serialization plus one identity hash per edge instead of four and three.

**3. Interactive/graph-query adjacency: smaller hydrate.**
`semantic_neighbors` (behind `callers`, `callees`, `impact`, `edges_among`, `shortest_path`, `edge_kind_counts`) hydrated three snapshot reads per adjacency row — relation, edge entity, far-endpoint symbol entity — including for edge kinds the query excluded, and re-read shared far endpoints once per incident edge. Hydration is now staged: excluded kinds stop at the validated edge payload without touching their far endpoint, and each surviving unique endpoint hydrates once per batch (impact frontiers and shared callees converge on the same neighbors).

## Which tests prove it

All isolated (hermetic fixtures, in-memory graph stores; no `~/.tracedecay`, no in-repo `.tracedecay/`):

- `production_orchestration::repeated_graph_manifest_builds_reuse_the_memo_without_reexamining_the_generation` — counts `check()` observations: the first build examines the generation item by item; the second build of the same generation performs exactly 1 admission check and returns an identical manifest. Also proves fail-closed behavior: a deadline mid-build memoizes nothing (the next build still pays the full examination), a memo hit still refuses an expired request with a typed `DeadlineExceeded`, and a foreign projection identity rebuilds in full.
- `interactive::tests::kind_filtered_adjacency_skips_far_endpoint_hydration_for_excluded_edges` — two structurally identical queries over the same two adjacency rows; the kind-filtered one performs strictly fewer snapshot reads (counted via cancellation observations). Fails on the previous code, where both hydrated everything.
- `interactive::tests::shared_far_endpoints_hydrate_once_per_adjacency_batch` — two batches with identical seed/edge counts; the batch converging on one shared endpoint performs strictly fewer snapshot reads than the batch with distinct endpoints. Fails on the previous code.
- Identity preservation for the builder dedup is guarded by the pre-existing byte-identity tests (`published_graph_manifest_projects_files_chunks_symbols_and_replays_byte_identically`, `sealed_generation_replay_rebuilds_identical_import_manifest_and_digest`), which compare manifests and recovered digests across seal/restore instances, plus the read paths' per-entity identity revalidation.

## Plan 25 compliance

Seal-then-publish is untouched: `build_and_publish` still validates the complete generation before the atomic compare-and-swap, so there is one complete generation or none. `DeadlineExceeded` stays a typed failure everywhere — it cannot become a serving state, a memoized manifest, or a complete census: only a fully successful manifest build is memoized, and an interrupted build records nothing. Serve-during-refresh semantics (daemon-side) are unchanged.

## Scope

- Edits only `crates/tracedecay-code-index`.
- No deadline changes, no earlier bailouts — the same work budget now covers strictly less work.
- #509 untouched; #532 untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5de8ad43-c78a-41f2-8876-cbeabe816b34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5de8ad43-c78a-41f2-8876-cbeabe816b34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

