### PR TITLE
test(rusqlite-runtime): fake clock for long-lease renewal

### DIFF
--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs
@@ -116,6 +116,46 @@ fn sqlite_busy_or_locked(error: &rusqlite::Error) -> bool {
     )
 }
 
+/// Clock behind every transaction lease deadline: idle, absolute, renewal.
+///
+/// Production reads the monotonic wall clock. Tests may freeze and advance a
+/// writer-thread-local fake instead, so lease renewal is provable without
+/// sleeping through real lease periods.
+#[cfg(not(test))]
+fn lease_now() -> Instant {
+    Instant::now()
+}
+
+#[cfg(test)]
+use lease_clock::lease_now;
+
+#[cfg(test)]
+pub(crate) mod lease_clock {
+    use std::{
+        cell::Cell,
+        time::{Duration, Instant},
+    };
+
+    thread_local! {
+        static FAKE_LEASE_NOW: Cell<Option<Instant>> = const { Cell::new(None) };
+    }
+
+    /// Real monotonic time until [`advance`] freezes this thread's clock.
+    pub(crate) fn lease_now() -> Instant {
+        FAKE_LEASE_NOW.with(Cell::get).unwrap_or_else(Instant::now)
+    }
+
+    /// Freezes this thread's lease clock `by` past its current reading.
+    ///
+    /// Only code already running on the writer thread — in practice an
+    /// [`super::ExactSqlWriteAuthority`] verification — can move the clock
+    /// the transaction loop reads.
+    pub(crate) fn advance(by: Duration) {
+        let advanced = lease_now() + by;
+        FAKE_LEASE_NOW.with(|fake| fake.set(Some(advanced)));
+    }
+}
+
 pub(crate) enum TransactionCommand {
     Attach {
         attachment: ExactSqlAttachment,
@@ -332,14 +372,14 @@ fn run_transaction(
 ) -> TransactionCompletion {
     let mut attachments = Vec::new();
     let mut previous_attachment_limit = None;
-    let mut idle_deadline = Instant::now() + EXACT_SQL_TRANSACTION_IDLE_LIMIT;
-    let mut transaction_deadline = Instant::now() + EXACT_SQL_TRANSACTION_LIMIT;
+    let mut idle_deadline = lease_now() + EXACT_SQL_TRANSACTION_IDLE_LIMIT;
+    let mut transaction_deadline = lease_now() + EXACT_SQL_TRANSACTION_LIMIT;
     loop {
         if shutdown_requested.load(Ordering::Acquire) {
             let _ = transaction.rollback();
             return TransactionCompletion::abandoned(attachments, previous_attachment_limit);
         }
-        let now = Instant::now();
+        let now = lease_now();
         if now >= idle_deadline || now >= transaction_deadline {
             expired.store(true, Ordering::Release);
             let _ = transaction.rollback();
@@ -358,7 +398,7 @@ fn run_transaction(
         };
         match command {
             TransactionCommand::Attach { attachment, reply } => {
-                if Instant::now() >= transaction_deadline {
+                if lease_now() >= transaction_deadline {
                     expired.store(true, Ordering::Release);
                     let _ = transaction.rollback();
                     let _ = reply.send(Err(ExactSqlError::TransactionExpired));
@@ -420,7 +460,7 @@ fn run_transaction(
                             );
                         }
                         let _ = reply.send(Ok(()));
-                        idle_deadline = Instant::now() + EXACT_SQL_TRANSACTION_IDLE_LIMIT;
+                        idle_deadline = lease_now() + EXACT_SQL_TRANSACTION_IDLE_LIMIT;
                     }
                     Err(error) => {
                         let _ = transaction.rollback();
@@ -437,7 +477,7 @@ fn run_transaction(
                 execution_policy,
                 reply,
             } => {
-                if Instant::now() >= transaction_deadline {
+                if lease_now() >= transaction_deadline {
                     expired.store(true, Ordering::Release);
                     let _ = transaction.rollback();
                     let _ = reply.send(Err(ExactSqlError::TransactionExpired));
@@ -517,7 +557,7 @@ fn run_transaction(
                     );
                 }
                 if execution_policy == ExecutionPolicy::Bounded
-                    && Instant::now() >= transaction_deadline
+                    && lease_now() >= transaction_deadline
                 {
                     expired.store(true, Ordering::Release);
                     let _ = transaction.rollback();
@@ -536,7 +576,7 @@ fn run_transaction(
                 let succeeded = result.is_ok();
                 let _ = reply.send(result);
                 if succeeded {
-                    let renewed_at = Instant::now();
+                    let renewed_at = lease_now();
                     idle_deadline = renewed_at + EXACT_SQL_TRANSACTION_IDLE_LIMIT;
                     // A long-lease transaction earns its next lease by
                     // committing progress: full-index replacement writes far
@@ -549,7 +589,7 @@ fn run_transaction(
                 }
             }
             TransactionCommand::Commit { reply } => {
-                if Instant::now() >= transaction_deadline {
+                if lease_now() >= transaction_deadline {
                     expired.store(true, Ordering::Release);
                     let _ = transaction.rollback();
                     let _ = reply.send(Err(ExactSqlError::TransactionExpired));

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/authority.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/authority.rs
@@ -172,19 +172,20 @@ fn long_lease_transaction_renews_its_lease_after_successful_bounded_steps() {
     let base = ExactSqlHandle::attach(&fixture.writer, &fixture.readers).unwrap();
     base.execute_batch("CREATE TABLE lease_probe (value INTEGER)".to_owned())
         .unwrap();
+    let authority = Arc::new(LeaseClockAdvancingAuthority {
+        step: EXACT_SQL_TRANSACTION_LIMIT / 4,
+        execute_checks: AtomicUsize::new(0),
+    });
     let channel = ExactSqlHandle::attach(&fixture.writer, &fixture.readers)
         .unwrap()
-        .with_write_authority(Arc::new(AtomicWriteAuthority(Arc::new(AtomicBool::new(
-            true,
-        )))))
+        .with_write_authority(authority.clone())
         .unwrap();
     let transaction = channel.begin_authorized_long_lease_immediate().unwrap();
-    let started = Instant::now();
 
-    // Five bounded steps, each well inside a single lease, must together
-    // outlive the absolute transaction limit so success proves renewal.
+    // Five bounded steps, each preceded by a quarter-limit advance of the
+    // writer's fake lease clock, must together outlive the absolute
+    // transaction limit so success proves renewal.
     for value in 0..5 {
-        std::thread::sleep(EXACT_SQL_TRANSACTION_LIMIT / 4);
         transaction
             .execute(statement(
                 "INSERT INTO lease_probe VALUES (?)",
@@ -192,7 +193,7 @@ fn long_lease_transaction_renews_its_lease_after_successful_bounded_steps() {
             ))
             .unwrap();
     }
-    assert!(started.elapsed() > EXACT_SQL_TRANSACTION_LIMIT);
+    assert!(authority.fake_elapsed() > EXACT_SQL_TRANSACTION_LIMIT);
     transaction.commit().unwrap();
 
     let rows = base

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/mod.rs
@@ -30,6 +30,37 @@ impl ExactSqlWriteAuthority for AtomicWriteAuthority {
     }
 }
 
+/// Drives the writer thread's fake lease clock from inside the lease it
+/// probes: authority verification is the only test code that runs on the
+/// writer thread. `run_transaction` verifies with `Execute` intent exactly
+/// twice per bounded step — before and after execution — so every even check
+/// is the pre-step hook.
+struct LeaseClockAdvancingAuthority {
+    step: Duration,
+    execute_checks: AtomicUsize,
+}
+
+impl LeaseClockAdvancingAuthority {
+    fn fake_elapsed(&self) -> Duration {
+        let steps = self.execute_checks.load(Ordering::Acquire).div_ceil(2);
+        self.step * u32::try_from(steps).unwrap()
+    }
+}
+
+impl ExactSqlWriteAuthority for LeaseClockAdvancingAuthority {
+    fn verify(&self, intent: ExactSqlWriteIntent) -> Result<(), ExactSqlError> {
+        if intent == ExactSqlWriteIntent::Execute
+            && self
+                .execute_checks
+                .fetch_add(1, Ordering::AcqRel)
+                .is_multiple_of(2)
+        {
+            command::lease_clock::advance(self.step);
+        }
+        Ok(())
+    }
+}
+
 struct SlowSchemaAuthority {
     execute_batch_checks: AtomicUsize,
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
build-perf conversion, based on #421 / `codex/tracedecay-total-redesign-plan`. No wire changes.

Converts `long_lease_transaction_renews_its_lease_after_successful_bounded_steps` from five real `std::thread::sleep(EXACT_SQL_TRANSACTION_LIMIT / 4)` waits (~5s of wall clock) to a fake lease clock, and stays entirely inside `crates/tracedecay-rusqlite-runtime`.

- `run_transaction` in `src/exact_sql/command.rs` now reads its idle/absolute/renewal lease deadlines through a crate-private `lease_now()`: `Instant::now()` in production, and under `#[cfg(test)]` a writer-thread-local fake `Instant` that tests can freeze and advance. Production durations and the busy-retry path are unchanged; nothing moves to tokio time.
- The test drives the fake clock from a `LeaseClockAdvancingAuthority`: authority verification is the only test code that runs on the writer thread, and `run_transaction` verifies with `Execute` intent exactly twice per bounded step, so the pre-step check advances the clock by `EXACT_SQL_TRANSACTION_LIMIT / 4` before each of the 5 INSERTs.
- Renewal is proved without wall clock: the accumulated fake advance (5 × limit/4) exceeds `EXACT_SQL_TRANSACTION_LIMIT`, the commit succeeds, and `count(*) == 5`. No `Instant::now().elapsed()` assertion remains.
- Falsifiability checked by mutation: with the long-lease renewal branch disabled, the test fails with `TransactionExpired` in 0.01s.

Verification: `cargo fmt -p tracedecay-rusqlite-runtime --check` clean; `cargo test -p tracedecay-rusqlite-runtime --lib exact_sql::tests::authority` — 11 passed; full `exact_sql::tests` group — 56 passed in ~4s (the other real-time lease/transaction tests are untouched and still pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58a2963a-5dc6-49cf-a43f-8a6bd07ed418?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58a2963a-5dc6-49cf-a43f-8a6bd07ed418&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

