### PR TITLE
test: Phase 1 named wait-converts (publish handle, paused grace, FIFO provider)

### DIFF
--- a/src/daemon/code_index_scheduler/ignored_dependencies_tests.rs
+++ b/src/daemon/code_index_scheduler/ignored_dependencies_tests.rs
@@ -717,15 +717,20 @@ async fn duplicate_concurrent_ignored_dependency_requests_publish_one_generation
     let right = right.expect("second duplicate admission");
 
     assert_eq!(left.generation_id, right.generation_id);
-    let publication = tokio::time::timeout(Duration::from_secs(5), publications.recv())
-        .await
-        .expect("one generation publication")
-        .expect("publication channel");
+    // Serving publication happens-before every admission return: the owner
+    // broadcasts before returning, and coalesced followers settle only from
+    // the owner's finished flight. Both admissions above have returned, so
+    // the receiver subscribed before the join already holds every publication
+    // these requests could produce — read it without a wall-clock bound.
+    let publication = publications
+        .try_recv()
+        .expect("one generation publication is sealed before admission returns");
     assert_eq!(publication.generation_id, left.generation_id);
     assert!(
-        tokio::time::timeout(Duration::from_millis(200), publications.recv())
-            .await
-            .is_err(),
+        matches!(
+            publications.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ),
         "duplicate in-flight requests coalesce instead of publishing twice"
     );
     registry.shutdown().await;

--- a/src/daemon/service/invocation/work_attempt_exec/tests.rs
+++ b/src/daemon/service/invocation/work_attempt_exec/tests.rs
@@ -1084,6 +1084,9 @@ fn overflow_classification_names_the_channel_and_yields_to_cancellation() {
 
 /// A provider that traps `SIGINT` and keeps running forces the full ladder:
 /// the graceful rung is delivered, ignored, and then escalated to a kill.
+/// The fake provider parks on a writerless FIFO instead of a sleep loop:
+/// the group `SIGINT` kills the blocked `cat`, the trap records the rung,
+/// and the loop parks again with no polling until the group kill lands.
 /// This test spends the real `CANCELLATION_GRACE` window on purpose — a
 /// virtual clock would let the grace expire without proving the child
 /// actually survived it.
@@ -1094,12 +1097,14 @@ async fn a_provider_that_ignores_interrupt_is_escalated_to_a_kill_on_the_record(
     let root = directory.path();
     let started_marker = root.join("started");
     let interrupted_marker = root.join("interrupted");
+    let blocker = root.join("blocker");
     let executable = fake_executable(
         root,
         "stubborn-provider",
         &format!(
-            "#!/bin/sh\ntrap \"printf x >> {interrupted}\" INT\nprintf x > {started}\ni=0\nwhile [ $i -lt 300 ]; do sleep 1; i=$((i+1)); done\n",
+            "#!/bin/sh\ntrap \"printf x >> {interrupted}\" INT\nmkfifo {blocker}\nprintf x > {started}\nwhile :; do cat {blocker}; done\n",
             interrupted = interrupted_marker.display(),
+            blocker = blocker.display(),
             started = started_marker.display(),
         ),
     );

--- a/src/daemon_client/controlled_invocation_tests.rs
+++ b/src/daemon_client/controlled_invocation_tests.rs
@@ -435,7 +435,7 @@ async fn remote_effect_deadline_requests_daemon_cancel_and_awaits_settlement() {
     server.await.expect("server task");
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn remote_effect_without_authoritative_settlement_returns_reset_required() {
     const REQUEST_ID: &str = "request.remote-effect-no-settlement";
     let (client, admitted, server) =
@@ -450,7 +450,9 @@ async fn remote_effect_without_authoritative_settlement_returns_reset_required()
     let deadline = deadline_after(Duration::from_secs(10));
 
     // The unsettled server never answers, so the join bound must outlive the
-    // full authoritative response grace.
+    // full authoritative response grace. The paused clock auto-advances that
+    // grace only while every task is idle on loopback I/O that will never
+    // arrive, so the join is virtual instead of a real 30s wait.
     let response = tokio::time::timeout(
         crate::daemon::DAEMON_TOOL_RESPONSE_GRACE + Duration::from_secs(1),
         client.invoke_controlled(
@@ -469,7 +471,7 @@ async fn remote_effect_without_authoritative_settlement_returns_reset_required()
     server.abort();
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn remote_effect_cancel_delivery_failure_returns_reset_required() {
     const REQUEST_ID: &str = "request.remote-effect-cancel-delivery-failure";
     let (client, admitted, server) =
@@ -483,6 +485,8 @@ async fn remote_effect_cancel_delivery_failure_returns_reset_required() {
     });
     let deadline = deadline_after(Duration::from_secs(10));
 
+    // The paused clock virtualizes the full response grace; see the
+    // no-settlement test above.
     let response = tokio::time::timeout(
         crate::daemon::DAEMON_TOOL_RESPONSE_GRACE + Duration::from_secs(1),
         client.invoke_controlled(
@@ -501,10 +505,13 @@ async fn remote_effect_cancel_delivery_failure_returns_reset_required() {
     server.abort();
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn indeterminate_effect_discards_connection_before_next_invocation() {
     const FIRST_ID: &str = "request.remote-effect-reset-state";
     const SECOND_ID: &str = "request.remote-after-effect-reset";
+    // The paused clock virtualizes the response grace the first invocation
+    // must exhaust before it settles as an indeterminate effect; the
+    // choreography itself still runs over real loopback connections.
     let (client, admitted, server) = reset_then_reconnect_client(FIRST_ID, SECOND_ID).await;
     let cancellation =
         CancellationSignal::active("cancel.remote-effect-reset-state").expect("cancellation");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supersedes [#570](https://github.com/ScriptedAlchemy/tracedecay/pull/570), which GitHub auto-closed when a remount briefly force-pushed the branch to the bare #421 tip, and which GitHub refuses to reopen (the closed PR is frozen at that empty head; `gh pr reopen` is also denied for this token). Same branch, same base, same three commits (`e5a858ac5`, `73a12e2db`, `fbdbadb39`, parented on `4e9804ed4`).

**Integration note:** the content of these three commits is already reachable from the #421 tip — `fe7a8248a` (inside `e298b1132`) swept in this branch's earlier revision `fc6bd1bd4` during the #564 integration. The three test files are byte-identical between this head and the tip, so merging this PR records the lane in #421 history without changing any file content.

## The three wait-converts

1. **`src/daemon/code_index_scheduler/ignored_dependencies_tests.rs` — `duplicate_concurrent_ignored_dependency_requests_publish_one_generation`**
   Replaced the 5s `recv` timeout and the 200ms negative-wait with deterministic reads of the pre-subscribed publication receiver. The serving publication is broadcast before `index_verified_ignored_dependency` returns (owner publishes before `Ok`; coalesced followers settle only from the owner's finished flight), so after the `tokio::join!` both admissions happen-after the publish: `try_recv` reads it and `try_recv → Empty` asserts coalescing, with no wall-clock window.

2. **`src/daemon_client/controlled_invocation_tests.rs` — the three `DAEMON_TOOL_RESPONSE_GRACE` (30s) tests**
   `remote_effect_without_authoritative_settlement_returns_reset_required`, `remote_effect_cancel_delivery_failure_returns_reset_required`, and `indeterminate_effect_discards_connection_before_next_invocation` now run `start_paused = true`. Every wait on this path is tokio time (`sleep(remaining)`, the 250ms cancel-delivery bound, the grace `timeout`, the 5s liveness poll in `next_daemon_response_line`). tokio 1.53's paused park only auto-advances when the zero-timeout I/O poll delivered no wake-ups (`did_wake` gating), so the real loopback choreography still runs on I/O readiness and the clock jumps only while every task is parked on I/O that will never arrive — the grace becomes virtual instead of a real 30s wait per test.

3. **`src/daemon/service/invocation/work_attempt_exec/tests.rs` — stubborn-provider kill**
   The fake provider parks on a writerless FIFO (`mkfifo` + `while :; do cat blocker; done`) instead of a 300-iteration `sleep 1` loop. The ladder's group `SIGINT` (`killpg`) kills the blocked `cat`, the trap records the graceful rung, and the loop parks again with zero polling until the group kill. The real `CANCELLATION_GRACE` window is still spent on purpose, as the test documents — the convert removes the sleeping `/bin/sh`, not the measured grace.

## Verification

Isolated verify on the builder (converted tests + clippy on the touched crate only; no full-repo gate) against the `e298b1132` tree — the exact post-merge content. Results follow in a PR update once the run completes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a227081e-9c09-4a98-aa79-b3085ae5f6a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a227081e-9c09-4a98-aa79-b3085ae5f6a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

