### PR TITLE
fix(daemon): stable first-index on empty profiles (discovery deferral, real init reconcile, accept/SUN_LEN hardening)

### DIFF
--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -212,18 +212,52 @@ async fn brokered_init(
     // eventually demand it does not survive a daemon restart. Request the
     // reconciliation explicitly so the message below reports something that
     // actually happened.
-    tracedecay::daemon::call_default_tool_awaiting_project_open(
+    let reconcile = tracedecay::daemon::call_default_tool_awaiting_project_open(
         handshake,
         "tracedecay_admin_sync",
         serde_json::json!({}),
         init_deadline,
     )
-    .await?;
+    .await;
+    if let Err(error) = reconcile {
+        if !code_index_reconciliation_is_optional(project_path, &error).await {
+            return Err(error);
+        }
+        eprintln!(
+            "initialized {}; code indexing is unavailable for this non-Git project",
+            project_path.display()
+        );
+        return Ok(());
+    }
     eprintln!(
         "initialized {}; daemon code-index reconciliation requested",
         project_path.display()
     );
     Ok(())
+}
+
+async fn code_index_reconciliation_is_optional(
+    project_path: &Path,
+    error: &tracedecay::errors::TraceDecayError,
+) -> bool {
+    if !error
+        .to_string()
+        .contains("code_index_scheduler_unavailable")
+    {
+        return false;
+    }
+    let deadline = tracedecay_runtime_core::cancellation::MonotonicDeadline::at(
+        std::time::Instant::now() + std::time::Duration::from_secs(2),
+    );
+    matches!(
+        tracedecay_runtime_core::git_discovery::discover_repository_identity(
+            project_path,
+            deadline,
+            &tracedecay_runtime_core::cancellation::CancellationToken::new(),
+        )
+        .await,
+        tracedecay_runtime_core::git_discovery::GitRepositoryIdentityOutcome::NotRepository
+    )
 }
 
 #[cfg(all(test, unix))]
@@ -416,6 +450,34 @@ mod init_bootstrap_tests {
             !profile.exists(),
             "brokered rejection must not open a local store"
         );
+    }
+
+    #[tokio::test]
+    async fn only_non_git_scheduler_unavailability_is_optional_during_init() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let non_git = temp.path().join("non-git");
+        let git = temp.path().join("git");
+        let nested_git = git.join("nested");
+        std::fs::create_dir_all(&non_git).unwrap();
+        std::fs::create_dir_all(&nested_git).unwrap();
+        let initialized = std::process::Command::new(tracedecay_runtime_core::git::git_program())
+            .args(["init", "-q"])
+            .current_dir(&git)
+            .status()
+            .unwrap();
+        assert!(initialized.success());
+        let unavailable = tracedecay::errors::TraceDecayError::Config {
+            message: "daemon tool call failed: code_index_scheduler_unavailable: admin sync was not accepted"
+                .to_string(),
+        };
+        let unrelated = tracedecay::errors::TraceDecayError::Config {
+            message: "daemon tool call failed: storage unavailable".to_string(),
+        };
+
+        assert!(code_index_reconciliation_is_optional(&non_git, &unavailable).await);
+        assert!(!code_index_reconciliation_is_optional(&git, &unavailable).await);
+        assert!(!code_index_reconciliation_is_optional(&nested_git, &unavailable).await);
+        assert!(!code_index_reconciliation_is_optional(&non_git, &unrelated).await);
     }
 }
 

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -207,6 +207,18 @@ async fn brokered_init(
         init_deadline,
     )
     .await?;
+    // Admission alone does not start indexing: the code-index scheduler mounts
+    // on first demand, and the background full-server upgrade that would
+    // eventually demand it does not survive a daemon restart. Request the
+    // reconciliation explicitly so the message below reports something that
+    // actually happened.
+    tracedecay::daemon::call_default_tool_awaiting_project_open(
+        handshake,
+        "tracedecay_admin_sync",
+        serde_json::json!({}),
+        init_deadline,
+    )
+    .await?;
     eprintln!(
         "initialized {}; daemon code-index reconciliation requested",
         project_path.display()
@@ -268,6 +280,111 @@ mod init_bootstrap_tests {
         assert!(
             !profile.exists(),
             "scheduler refusal must not initialize a local store"
+        );
+    }
+
+    struct SocketEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl SocketEnvGuard {
+        fn set(value: &Path) -> Self {
+            let previous = std::env::var_os(tracedecay::daemon::SOCKET_ENV);
+            unsafe {
+                std::env::set_var(tracedecay::daemon::SOCKET_ENV, value);
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for SocketEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.previous.take() {
+                    Some(previous) => {
+                        std::env::set_var(tracedecay::daemon::SOCKET_ENV, previous);
+                    }
+                    None => std::env::remove_var(tracedecay::daemon::SOCKET_ENV),
+                }
+            }
+        }
+    }
+
+    /// Init's "daemon code-index reconciliation requested" must describe a
+    /// request that actually crossed the wire: admission first, then the
+    /// explicit `tracedecay_admin_sync` reconcile. Without the second call the
+    /// first index only starts if the background full-server upgrade survives
+    /// long enough to demand it, which a daemon restart silently discards.
+    #[tokio::test]
+    async fn brokered_init_requests_a_real_code_index_reconciliation() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        static SOCKET_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _serialize = SOCKET_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let profile = temp.path().join("profile");
+        std::fs::create_dir_all(&project).unwrap();
+        let socket = temp.path().join("daemon.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let _socket_env = SocketEnvGuard::set(&socket);
+
+        let recorded: std::sync::Arc<std::sync::Mutex<Vec<(String, serde_json::Value)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let responder = {
+            let recorded = std::sync::Arc::clone(&recorded);
+            tokio::spawn(async move {
+                for _ in 0..2 {
+                    let (stream, _addr) = listener.accept().await.unwrap();
+                    let (reader, mut writer) = stream.into_split();
+                    let mut lines = tokio::io::BufReader::new(reader).lines();
+                    let _handshake_line = lines.next_line().await.unwrap().unwrap();
+                    let request_line = lines.next_line().await.unwrap().unwrap();
+                    let request: serde_json::Value = serde_json::from_str(&request_line).unwrap();
+                    recorded.lock().unwrap().push((
+                        request["params"]["name"]
+                            .as_str()
+                            .unwrap_or_default()
+                            .to_owned(),
+                        request["params"]["arguments"].clone(),
+                    ));
+                    let response = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": request["id"],
+                        "result": { "content": [] },
+                    });
+                    writer
+                        .write_all(serde_json::to_string(&response).unwrap().as_bytes())
+                        .await
+                        .unwrap();
+                    writer.write_all(b"\n").await.unwrap();
+                    writer.shutdown().await.unwrap();
+                }
+            })
+        };
+
+        let handshake = test_handshake(&project, &profile);
+        brokered_init(&project, &[], &[], &handshake)
+            .await
+            .expect("brokered init against the fixture daemon");
+        tokio::time::timeout(std::time::Duration::from_secs(5), responder)
+            .await
+            .expect("fixture daemon must observe both requests")
+            .expect("fixture daemon task");
+
+        let recorded = recorded.lock().unwrap();
+        let names: Vec<&str> = recorded.iter().map(|(name, _)| name.as_str()).collect();
+        assert_eq!(
+            names,
+            ["tracedecay_status", "tracedecay_admin_sync"],
+            "init must request the reconcile it reports, after admission"
+        );
+        assert_eq!(
+            recorded[0].1["admission_only"],
+            serde_json::json!(true),
+            "the bootstrap status call stays admission-only"
         );
     }
 

--- a/src/daemon/bootstrap.rs
+++ b/src/daemon/bootstrap.rs
@@ -194,7 +194,13 @@ pub async fn run_foreground(
     let mut clients: JoinSet<Result<()>> = JoinSet::new();
     loop {
         let stream = tokio::select! {
-            accepted = listener.accept() => accepted?,
+            accepted = listener.accept() => match accepted {
+                Ok(stream) => stream,
+                Err(error) => {
+                    log_accept_error_and_backoff(&error).await;
+                    continue;
+                }
+            },
             completed = clients.join_next(), if !clients.is_empty() => {
                 if let Some(Err(error)) = completed {
                     log_daemon_event("daemon_client", &[("outcome", error.to_string())]);
@@ -620,7 +626,13 @@ async fn run_foreground_unix(
 
     loop {
         let stream = tokio::select! {
-            accepted = listener.accept() => accepted?,
+            accepted = listener.accept() => match accepted {
+                Ok(stream) => stream,
+                Err(error) => {
+                    log_accept_error_and_backoff(&error).await;
+                    continue;
+                }
+            },
             completed = client_tasks.join_next(), if !client_tasks.is_empty() => {
                 if let Some(completed) = completed {
                     log_client_task_result(completed);
@@ -724,6 +736,38 @@ async fn run_foreground_unix(
 }
 
 #[cfg(unix)]
+/// How long the accept loop pauses after a non-connection accept failure so a
+/// persistently failing listener degrades loudly instead of spinning a core.
+const DAEMON_ACCEPT_ERROR_BACKOFF: tokio::time::Duration = tokio::time::Duration::from_millis(250);
+
+/// One failed accept must never end the daemon. `accept(2)` legitimately
+/// fails for per-connection reasons — a client that resets before accept
+/// surfaces `ECONNABORTED` on macOS/BSD, and reachability probes connect and
+/// drop immediately — and for transient resource pressure (`EMFILE`).
+/// Returning the error exited the whole daemon, which a service supervisor
+/// then restarts: one aborted connection became a daemon flap.
+async fn log_accept_error_and_backoff(error: &TraceDecayError) {
+    log_daemon_event(
+        "daemon_accept",
+        &[
+            ("outcome", "error".to_string()),
+            ("error", error.to_string()),
+        ],
+    );
+    let connection_scoped = matches!(
+        error,
+        TraceDecayError::Io(io_error) if matches!(
+            io_error.kind(),
+            std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::Interrupted
+        )
+    );
+    if !connection_scoped {
+        tokio::time::sleep(DAEMON_ACCEPT_ERROR_BACKOFF).await;
+    }
+}
+
 fn log_client_task_result(completed: std::result::Result<Result<()>, tokio::task::JoinError>) {
     let error = match completed {
         Ok(Ok(())) => return,

--- a/src/daemon/bootstrap.rs
+++ b/src/daemon/bootstrap.rs
@@ -521,15 +521,26 @@ async fn run_foreground_unix(
         }
     };
     if let Some(parent) = socket_path.parent() {
-        let parent_existed = parent.exists();
-        std::fs::create_dir_all(parent).map_err(|e| TraceDecayError::Config {
-            message: format!(
-                "failed to create socket directory '{}': {e}",
-                parent.display()
-            ),
-        })?;
-        if !parent_existed {
-            set_owner_only_permissions(parent, 0o700)?;
+        match tracedecay_private_fs::create_private_directory(parent) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                tracedecay_private_fs::validate_private_directory(parent).map_err(|error| {
+                    TraceDecayError::Config {
+                        message: format!(
+                            "refusing daemon socket directory '{}': {error}",
+                            parent.display()
+                        ),
+                    }
+                })?;
+            }
+            Err(error) => {
+                return Err(TraceDecayError::Config {
+                    message: format!(
+                        "failed to create private socket directory '{}': {error}",
+                        parent.display()
+                    ),
+                });
+            }
         }
     }
     prepare_socket_path(&authority).await?;
@@ -735,7 +746,6 @@ async fn run_foreground_unix(
     endpoint_cleanup
 }
 
-#[cfg(unix)]
 /// How long the accept loop pauses after a non-connection accept failure so a
 /// persistently failing listener degrades loudly instead of spinning a core.
 const DAEMON_ACCEPT_ERROR_BACKOFF: tokio::time::Duration = tokio::time::Duration::from_millis(250);

--- a/src/daemon/connection_serving.rs
+++ b/src/daemon/connection_serving.rs
@@ -664,12 +664,30 @@ async fn serve_broker_socket_client(
     );
     // Resolve initialize roots only after authentication and inside daemon
     // authority. The proxy process never opens the registry database.
-    let initialize_route = apply_daemon_initialize_route(
+    // Resolution failures (deferred repository discovery, registry refusals)
+    // are answered as typed responses: dropping the connection here would
+    // surface as a hard host failure and leave the client without the
+    // retryable state the deferral carries.
+    let initialize_route = match apply_daemon_initialize_route(
         &mut handshake,
         &first_request_line,
         &engine.store_administration,
     )
-    .await?;
+    .await
+    {
+        Ok(route) => route,
+        Err(error) => {
+            drop(setup_activity);
+            write_project_open_error(
+                &mut transport,
+                &first_request_line,
+                &handshake.client_instance_id,
+                &error,
+            )
+            .await?;
+            return Ok(());
+        }
+    };
     if let Some(request) = parse_branch_admin_request(&first_request_line) {
         let result = match request.action.clone() {
             Ok(action) => engine.execute_branch_admin(&handshake, action).await,
@@ -1249,9 +1267,28 @@ pub(super) async fn serve_windows_broker_client_with_class_and_invocation(
         )
         .await,
     );
-    let initialize_route =
-        apply_daemon_initialize_route(&mut handshake, &first_request_line, &store_administration)
+    // Same contract as the Unix broker path: a route-resolution failure is a
+    // typed response, never a dropped connection.
+    let initialize_route = match apply_daemon_initialize_route(
+        &mut handshake,
+        &first_request_line,
+        &store_administration,
+    )
+    .await
+    {
+        Ok(route) => route,
+        Err(error) => {
+            drop(setup_activity);
+            write_project_open_error(
+                &mut transport,
+                &first_request_line,
+                &handshake.client_instance_id,
+                &error,
+            )
             .await?;
+            return Ok(());
+        }
+    };
     if let Some(request) = parse_branch_admin_request(&first_request_line) {
         let result = match request.action.clone() {
             Ok(action) => {

--- a/src/daemon/core_proxy.rs
+++ b/src/daemon/core_proxy.rs
@@ -393,18 +393,23 @@ pub(super) async fn bounded_repository_identity(
     .await
 }
 
-/// A deferred discovery is uncertainty, not failure: the route stays
+/// A deadline-limited discovery is uncertainty, not failure: the route stays
 /// unresolved and the caller retries within its own budget, exactly like a
-/// warming project open. Carrying [`PROJECT_WARMING_RETRY_HINT`] is what makes
-/// every existing client/proxy retry classifier treat it that way instead of
-/// surfacing a terminal error on the first slow or contended Git probe.
+/// warming project open. Spawn and probe failures are terminal because retrying
+/// them until the caller's budget expires only hides the actionable error.
 pub(super) fn repository_discovery_deferred(
     path: &Path,
     reason: tracedecay_runtime_core::git_discovery::GitDiscoveryUnknown,
 ) -> TraceDecayError {
+    let retry_hint = matches!(
+        reason,
+        tracedecay_runtime_core::git_discovery::GitDiscoveryUnknown::DeadlineExceeded
+    )
+    .then_some(PROJECT_WARMING_RETRY_HINT)
+    .unwrap_or("cannot be resolved");
     TraceDecayError::Config {
         message: format!(
-            "repository discovery for '{}' is deferred ({reason:?}); the project route {PROJECT_WARMING_RETRY_HINT}",
+            "repository discovery for '{}' is deferred ({reason:?}); the project route {retry_hint}",
             path.display()
         ),
     }

--- a/src/daemon/core_proxy.rs
+++ b/src/daemon/core_proxy.rs
@@ -11,8 +11,9 @@ use tokio::time::{Duration, Instant};
 
 use super::{
     DAEMON_TOOL_LIVENESS_POLL_INTERVAL, DaemonClientDeadline, DaemonHandshake,
-    PROJECT_OPEN_RETRY_GRACE, PROJECT_OPEN_RETRY_INTERVAL, connect_to_current_daemon_within,
-    json_rpc_error_is_project_open_retryable, next_daemon_response_line, write_daemon_preamble,
+    PROJECT_OPEN_RETRY_GRACE, PROJECT_OPEN_RETRY_INTERVAL, PROJECT_WARMING_RETRY_HINT,
+    connect_to_current_daemon_within, json_rpc_error_is_project_open_retryable,
+    next_daemon_response_line, write_daemon_preamble,
 };
 #[cfg(unix)]
 use super::{
@@ -392,13 +393,18 @@ pub(super) async fn bounded_repository_identity(
     .await
 }
 
+/// A deferred discovery is uncertainty, not failure: the route stays
+/// unresolved and the caller retries within its own budget, exactly like a
+/// warming project open. Carrying [`PROJECT_WARMING_RETRY_HINT`] is what makes
+/// every existing client/proxy retry classifier treat it that way instead of
+/// surfacing a terminal error on the first slow or contended Git probe.
 pub(super) fn repository_discovery_deferred(
     path: &Path,
     reason: tracedecay_runtime_core::git_discovery::GitDiscoveryUnknown,
 ) -> TraceDecayError {
     TraceDecayError::Config {
         message: format!(
-            "initialize route repository discovery deferred for {}: {reason:?}",
+            "repository discovery for '{}' is deferred ({reason:?}); the project route {PROJECT_WARMING_RETRY_HINT}",
             path.display()
         ),
     }

--- a/src/daemon/project_composition/code_index_activation.rs
+++ b/src/daemon/project_composition/code_index_activation.rs
@@ -288,3 +288,95 @@ pub(super) fn code_index_reconcile_sink(
     });
     sink
 }
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn git(root: &Path, arguments: &[&str]) {
+        let status = Command::new(crate::git::git_program())
+            .current_dir(root)
+            .args(arguments)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {arguments:?}");
+    }
+
+    fn repository() -> TempDir {
+        let root = TempDir::new().expect("repository root");
+        git(root.path(), &["init", "-q"]);
+        std::fs::write(root.path().join("lib.rs"), "pub fn seed() {}\n").expect("seed source");
+        root
+    }
+
+    /// `tracedecay init` reports "code-index reconciliation requested" through
+    /// this sink before any scheduler is mounted. The pre-mount request must be
+    /// accepted and must start the demand-driven mount — otherwise init's
+    /// message is a no-op and the first index never runs.
+    #[tokio::test]
+    async fn reconcile_request_before_mount_activates_indexing() {
+        let repository = repository();
+        let root = repository
+            .path()
+            .canonicalize()
+            .expect("canonical repository root");
+        let mount_attempts = Arc::new(AtomicUsize::new(0));
+        let mount: code_index_scheduler::CodeIndexActivationMountV1 = {
+            let mount_attempts = Arc::clone(&mount_attempts);
+            Arc::new(move || {
+                let mount_attempts = Arc::clone(&mount_attempts);
+                Box::pin(async move {
+                    mount_attempts.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+            })
+        };
+        let overflow_batches = Arc::new(Mutex::new(Vec::new()));
+        let hint_sink: code_index_scheduler::CodeIndexActivationHintSinkV1 = {
+            let overflow_batches = Arc::clone(&overflow_batches);
+            Arc::new(move |batch| {
+                let overflow_batches = Arc::clone(&overflow_batches);
+                Box::pin(async move {
+                    overflow_batches.lock().expect("record batch").push(batch);
+                    true
+                })
+            })
+        };
+        let activation = Arc::new(code_index_scheduler::CodeIndexActivationV1::new(
+            &root,
+            Arc::new(AtomicBool::new(true)),
+            CancellationToken::new(),
+            mount,
+            hint_sink,
+        ));
+        let registry = code_index_scheduler::CodeIndexSchedulerRegistryV1::new(1);
+        let sink = code_index_reconcile_sink(registry, Arc::clone(&activation));
+
+        assert!(
+            sink(root.clone()).await,
+            "a pre-mount reconcile request must be accepted, not dropped"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let overflow_delivered = overflow_batches
+                    .lock()
+                    .expect("read batches")
+                    .iter()
+                    .any(|batch| batch.overflow);
+                if mount_attempts.load(Ordering::SeqCst) == 1 && overflow_delivered {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pre-mount reconcile must mount the scheduler and flush the overflow request");
+    }
+}

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -571,12 +571,16 @@ pub fn default_socket_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(path));
     }
     let profile_root = tracedecay_data_dir()?;
+    Ok(default_socket_path_for_profile(&profile_root))
+}
+
+fn default_socket_path_for_profile(profile_root: &Path) -> PathBuf {
     let profile_scoped = profile_root.join("daemon.sock");
     #[cfg(unix)]
     if !super::transport::unix_socket_path_within_limit(&profile_scoped) {
-        return Ok(short_profile_socket_path(&profile_root));
+        return short_profile_socket_path(profile_root);
     }
-    Ok(profile_scoped)
+    profile_scoped
 }
 
 /// Deterministic short bind path for a profile whose own directory would
@@ -730,15 +734,8 @@ fn refresh_installed_service_with_state(
     }
     let unit = read_service_unit(&service_path)?;
     let mut refreshed_spec = spec.clone();
-    if let Some(socket_path) = socket_path_from_unit_text(&unit) {
-        refreshed_spec.socket_path = socket_path;
-    }
     refreshed_spec.remote_tls = unit_file::remote_tls_from_unit_text(&unit)?;
     let runner = ServiceRunner::current()?;
-    let previous_state = match previous_state {
-        Some(state) => state,
-        None => runner.service_state(&refreshed_spec.socket_path)?,
-    };
     if matches!(runner, ServiceRunner::Launchd) {
         // The installed plist is the source of truth for the daemon's data
         // directory; the refreshing shell may not have the override set.
@@ -747,6 +744,31 @@ fn refresh_installed_service_with_state(
     } else if matches!(runner, ServiceRunner::WindowsTask) {
         refreshed_spec.data_dir_override = windows_task::profile_root_from_task_xml(&unit);
     }
+    if let Some(socket_path) = socket_path_from_unit_text(&unit) {
+        #[cfg(unix)]
+        {
+            let profile_root = refreshed_spec
+                .data_dir_override
+                .clone()
+                .map_or_else(tracedecay_data_dir, Ok)?;
+            let legacy_generated_socket = profile_root.join("daemon.sock");
+            if socket_path != legacy_generated_socket
+                || super::transport::unix_socket_path_within_limit(&socket_path)
+            {
+                refreshed_spec.socket_path = socket_path;
+            } else {
+                refreshed_spec.socket_path = default_socket_path_for_profile(&profile_root);
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            refreshed_spec.socket_path = socket_path;
+        }
+    }
+    let previous_state = match previous_state {
+        Some(state) => state,
+        None => runner.service_state(&refreshed_spec.socket_path)?,
+    };
     refresh_service_with_runner(&runner, &refreshed_spec, previous_state).map(Some)
 }
 

--- a/src/daemon/service.rs
+++ b/src/daemon/service.rs
@@ -1,7 +1,12 @@
 use std::fmt::Write;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
+
+#[cfg(unix)]
+use sha2::Digest;
 
 use crate::errors::{Result, TraceDecayError};
 
@@ -565,7 +570,33 @@ pub fn default_socket_path() -> Result<PathBuf> {
     if let Some(path) = std::env::var_os(SOCKET_ENV).filter(|path| !path.is_empty()) {
         return Ok(PathBuf::from(path));
     }
-    Ok(tracedecay_data_dir()?.join("daemon.sock"))
+    let profile_root = tracedecay_data_dir()?;
+    let profile_scoped = profile_root.join("daemon.sock");
+    #[cfg(unix)]
+    if !super::transport::unix_socket_path_within_limit(&profile_scoped) {
+        return Ok(short_profile_socket_path(&profile_root));
+    }
+    Ok(profile_scoped)
+}
+
+/// Deterministic short bind path for a profile whose own directory would
+/// overflow `sockaddr_un` (`SUN_LEN` — 104 bytes on macOS/BSD).
+///
+/// Daemon and clients all derive the endpoint through this one function, so
+/// hashing the profile root keeps them convergent without any extra
+/// discovery state, while distinct profiles keep distinct sockets. The
+/// literal `/tmp` base is deliberate: `$TMPDIR` differs between launchd
+/// services and login shells on macOS, which would split the daemon and its
+/// clients onto different paths. Squatting on the parent fails closed: a
+/// group- or world-accessible parent is refused before binding, and an
+/// attacker-owned 0700 directory refuses the bind at the kernel.
+#[cfg(unix)]
+fn short_profile_socket_path(profile_root: &Path) -> PathBuf {
+    let digest = sha2::Sha256::digest(profile_root.as_os_str().as_bytes());
+    PathBuf::from(format!(
+        "/tmp/tracedecay-{}/daemon.sock",
+        hex::encode(&digest[..8])
+    ))
 }
 
 pub fn socket_path_or_default(socket: Option<String>) -> Result<PathBuf> {

--- a/src/daemon/service/tests.rs
+++ b/src/daemon/service/tests.rs
@@ -1054,6 +1054,67 @@ fn refresh_installed_service_preserves_existing_socket_path() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn refresh_installed_service_migrates_overlong_generated_socket_path() {
+    let _env_lock = lock_user_data_dir_test_env();
+    let dir = TempDir::new().expect("temp dir");
+    let config_home = dir.path().join("config");
+    let fake_bin = dir.path().join("bin");
+    let home = dir.path().join("home");
+    let profile = dir.path().join("p".repeat(120)).join(".tracedecay");
+    std::fs::create_dir_all(&fake_bin).expect("fake bin dir");
+    std::fs::create_dir_all(&home).expect("home dir");
+
+    let systemctl = fake_bin.join("systemctl");
+    std::fs::write(
+        &systemctl,
+        "#!/bin/sh\n[ \"$2\" = is-enabled ] && echo enabled\nexit 0\n",
+    )
+    .expect("fake systemctl");
+    std::fs::set_permissions(&systemctl, std::fs::Permissions::from_mode(0o755))
+        .expect("systemctl permissions");
+
+    let _config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_home);
+    let _home_guard = EnvVarGuard::set("HOME", &home);
+    let _data_guard = EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &profile);
+    let _path_guard = EnvVarGuard::set("PATH", &fake_bin);
+
+    let legacy_socket = profile.join("daemon.sock");
+    let expected_socket = super::default_socket_path().expect("short default socket");
+    assert_ne!(legacy_socket, expected_socket);
+
+    let service_path = config_home
+        .join("systemd/user")
+        .join(crate::daemon::SERVICE_NAME);
+    std::fs::create_dir_all(service_path.parent().expect("service parent")).expect("service dir");
+    std::fs::write(
+        &service_path,
+        format!(
+            "[Unit]\nDescription=TraceDecay daemon\n\n[Service]\nExecStart=/old/tracedecay daemon run --socket {}\n",
+            legacy_socket.display()
+        ),
+    )
+    .expect("existing service unit");
+
+    let spec = DaemonServiceSpec {
+        tracedecay_bin: PathBuf::from("/opt/tracedecay/bin/tracedecay"),
+        socket_path: expected_socket.clone(),
+        data_dir_override: Some(profile),
+        remote_tls: None,
+    };
+    let outcome = super::refresh_installed_service_under_lease_with_state(
+        &spec,
+        DaemonServiceState::StoppedEnabled,
+    )
+    .expect("refresh service");
+
+    assert_eq!(outcome, Some(service_path.clone()));
+    let unit = std::fs::read_to_string(service_path).expect("service unit");
+    assert!(unit.contains(&format!("--socket {}", expected_socket.display())));
+    assert!(!unit.contains(&legacy_socket.display().to_string()));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn restore_quiesced_service_starts_existing_unit_without_rewriting_it() {
     let _env_lock = lock_user_data_dir_test_env();
     let dir = TempDir::new().expect("temp dir");
@@ -1283,12 +1344,32 @@ fn over_long_profile_socket_path_falls_back_to_a_short_deterministic_path() {
     );
 
     let sibling = {
-        let _data_dir_guard =
-            EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &sibling_profile);
+        let _data_dir_guard = EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &sibling_profile);
         super::default_socket_path().expect("sibling fallback socket path")
     };
     assert_ne!(
         first, sibling,
         "distinct profiles must keep distinct daemon endpoints"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn short_socket_derivation_uses_the_installed_profile_not_the_shell_profile() {
+    let _env_lock = lock_user_data_dir_test_env();
+    let _socket_guard = EnvVarGuard::unset(crate::daemon::SOCKET_ENV);
+    let root = tempfile::TempDir::new().expect("profile temp dir");
+    let installed_profile = root.path().join("i".repeat(120)).join(".tracedecay");
+    let shell_profile = root.path().join("shell-profile");
+    let _data_dir_guard = EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &shell_profile);
+
+    let installed_socket = super::default_socket_path_for_profile(&installed_profile);
+    let shell_socket = super::default_socket_path().expect("shell socket path");
+
+    assert!(
+        crate::daemon::transport::unix_socket_path_within_limit(&installed_socket),
+        "installed profile endpoint must satisfy the platform limit"
+    );
+    assert_ne!(installed_socket, shell_socket);
+    assert_ne!(installed_socket, installed_profile.join("daemon.sock"));
 }

--- a/src/daemon/service/tests.rs
+++ b/src/daemon/service/tests.rs
@@ -1247,3 +1247,48 @@ fn default_socket_path_is_profile_scoped_not_project_scoped() {
         override_socket
     );
 }
+
+/// A profile rooted deep enough to overflow `sockaddr_un` (macOS `SUN_LEN`)
+/// must not surface as a daemon that cannot bind its socket. The default
+/// endpoint re-derives to a short deterministic per-profile path that daemon
+/// and clients converge on independently.
+#[cfg(unix)]
+#[test]
+fn over_long_profile_socket_path_falls_back_to_a_short_deterministic_path() {
+    let _env_lock = lock_user_data_dir_test_env();
+    let _socket_guard = EnvVarGuard::unset(crate::daemon::SOCKET_ENV);
+    let root = tempfile::TempDir::new().expect("profile temp dir");
+    let deep_profile = root.path().join("p".repeat(120)).join(".tracedecay");
+    let sibling_profile = root.path().join("q".repeat(120)).join(".tracedecay");
+
+    let first = {
+        let _data_dir_guard = EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &deep_profile);
+        let first = super::default_socket_path().expect("fallback socket path");
+        assert_eq!(
+            first,
+            super::default_socket_path().expect("repeat lookup"),
+            "clients and daemon must derive the same endpoint independently"
+        );
+        first
+    };
+    assert!(
+        crate::daemon::transport::unix_socket_path_within_limit(&first),
+        "fallback endpoint must satisfy the platform socket path limit: {}",
+        first.display()
+    );
+    assert!(
+        first.starts_with("/tmp"),
+        "fallback endpoint must live under the fixed short base: {}",
+        first.display()
+    );
+
+    let sibling = {
+        let _data_dir_guard =
+            EnvVarGuard::set(crate::config::USER_DATA_DIR_ENV, &sibling_profile);
+        super::default_socket_path().expect("sibling fallback socket path")
+    };
+    assert_ne!(
+        first, sibling,
+        "distinct profiles must keep distinct daemon endpoints"
+    );
+}

--- a/src/daemon/tests/restart_proxy.rs
+++ b/src/daemon/tests/restart_proxy.rs
@@ -88,6 +88,32 @@ async fn answer_one_authenticated_proxy_request(
     writer.shutdown().await.expect("shutdown fake daemon");
 }
 
+/// A slow or contended first Git probe defers the route; it must never be a
+/// terminal failure. Both retry classifiers — the CLI's message check and the
+/// proxy's JSON-RPC response check — have to accept the deferral, or a cold
+/// first open on a slow volume fails `init`/`status` outright.
+#[cfg(unix)]
+#[test]
+fn deferred_repository_discovery_is_project_open_retryable() {
+    let error = super::super::core_proxy::repository_discovery_deferred(
+        std::path::Path::new("/slow-volume/project"),
+        tracedecay_runtime_core::git_discovery::GitDiscoveryUnknown::DeadlineExceeded,
+    );
+
+    assert!(
+        super::super::error_message_is_project_open_retryable(&error.to_string()),
+        "a deferred discovery must classify as retryable, got: {error}"
+    );
+
+    let response = super::super::project_open_error_response(json!(7), &error);
+    let refusal = serde_json::to_value(response.error.expect("deferred discovery refusal"))
+        .expect("serialize deferred refusal");
+    assert!(
+        super::super::json_rpc_error_is_project_open_retryable(&refusal),
+        "proxy retry classification must accept the deferred refusal: {refusal}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn transient_daemon_connect_errors_cover_restart_window_only() {

--- a/src/daemon/tests/restart_proxy.rs
+++ b/src/daemon/tests/restart_proxy.rs
@@ -116,6 +116,25 @@ fn deferred_repository_discovery_is_project_open_retryable() {
 
 #[cfg(unix)]
 #[test]
+fn terminal_repository_discovery_failures_are_not_project_open_retryable() {
+    for reason in [
+        tracedecay_runtime_core::git_discovery::GitDiscoveryUnknown::SpawnFailed,
+        tracedecay_runtime_core::git_discovery::GitDiscoveryUnknown::ProbeFailed,
+    ] {
+        let error = super::super::core_proxy::repository_discovery_deferred(
+            std::path::Path::new("/broken-git/project"),
+            reason,
+        );
+
+        assert!(
+            !super::super::error_message_is_project_open_retryable(&error.to_string()),
+            "a terminal discovery failure must not classify as retryable: {error}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn transient_daemon_connect_errors_cover_restart_window_only() {
     assert!(super::super::is_transient_daemon_connect_error(
         std::io::ErrorKind::NotFound

--- a/src/daemon/transport.rs
+++ b/src/daemon/transport.rs
@@ -4,6 +4,8 @@ use std::future::Future;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 #[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::path::{Path, PathBuf};
@@ -316,6 +318,24 @@ pub enum BrokerListener {
 #[cfg(unix)]
 const DAEMON_SOCKET_MODE: u32 = 0o600;
 
+/// Longest socket path `bind(2)`/`connect(2)` accept on this platform.
+///
+/// `sockaddr_un` reserves 104 bytes for the NUL-terminated path on macOS and
+/// the BSDs and 108 on Linux; a longer path fails the syscall itself, so it
+/// must be refused (or re-derived) before it reaches the kernel.
+#[cfg(unix)]
+pub(crate) const MAX_UNIX_SOCKET_PATH_BYTES: usize =
+    if cfg!(any(target_os = "linux", target_os = "android")) {
+        107
+    } else {
+        103
+    };
+
+#[cfg(unix)]
+pub(crate) fn unix_socket_path_within_limit(path: &Path) -> bool {
+    path.as_os_str().as_bytes().len() <= MAX_UNIX_SOCKET_PATH_BYTES
+}
+
 /// Refuse to publish a socket in a directory other users can traverse.
 #[cfg(unix)]
 pub(super) fn ensure_private_socket_parent(path: &Path) -> Result<()> {
@@ -379,6 +399,16 @@ impl BrokerListener {
         match endpoint {
             #[cfg(unix)]
             DaemonEndpoint::Unix(path) => {
+                // Refuse an over-long path with a typed remedy instead of the
+                // kernel's opaque "invalid argument": SUN_LEN overflow must
+                // never surface as an unexplained daemon startup failure.
+                if !unix_socket_path_within_limit(path) {
+                    return Err(config_error(format!(
+                        "daemon socket path '{}' exceeds this platform's Unix socket path limit ({MAX_UNIX_SOCKET_PATH_BYTES} bytes); set {} to a shorter path",
+                        path.display(),
+                        crate::daemon::SOCKET_ENV,
+                    )));
+                }
                 ensure_private_socket_parent(path)?;
                 let listener = bind_owner_only_unix_listener(path)?;
                 Ok((Self::Unix(listener), endpoint.clone()))
@@ -467,6 +497,30 @@ mod tests {
         assert!(matches!(&error, TraceDecayError::Config { .. }), "{error}");
         assert!(error.to_string().contains("private directory"), "{error}");
         assert!(!path.exists(), "socket must not be bound before rejection");
+    }
+
+    /// A `SUN_LEN` overflow must be a typed refusal naming its remedy, not the
+    /// kernel's opaque bind failure that reads as an unexplained daemon crash.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listener_refuses_over_long_socket_path_with_a_typed_remedy() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir
+            .path()
+            .join("s".repeat(MAX_UNIX_SOCKET_PATH_BYTES))
+            .join("daemon.sock");
+
+        let Err(error) = BrokerListener::bind(&DaemonEndpoint::Unix(path.clone())).await else {
+            panic!("over-long socket path must be refused before bind");
+        };
+
+        assert!(matches!(&error, TraceDecayError::Config { .. }), "{error}");
+        let message = error.to_string();
+        assert!(message.contains("Unix socket path limit"), "{message}");
+        assert!(
+            message.contains(crate::daemon::SOCKET_ENV),
+            "the refusal must name the override remedy: {message}"
+        );
     }
 
     #[tokio::test]

--- a/src/daemon/transport.rs
+++ b/src/daemon/transport.rs
@@ -336,34 +336,21 @@ pub(crate) fn unix_socket_path_within_limit(path: &Path) -> bool {
     path.as_os_str().as_bytes().len() <= MAX_UNIX_SOCKET_PATH_BYTES
 }
 
-/// Refuse to publish a socket in a directory other users can traverse.
+/// Refuse to publish a socket through a symlink or a directory that is not
+/// owned privately by the current user.
 #[cfg(unix)]
 pub(super) fn ensure_private_socket_parent(path: &Path) -> Result<()> {
     let parent = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    let metadata = std::fs::metadata(parent).map_err(|error| {
+    tracedecay_private_fs::validate_private_directory(parent).map_err(|error| {
         config_error(format!(
-            "failed to inspect daemon socket directory '{}': {error}",
-            parent.display()
-        ))
-    })?;
-    if !metadata.is_dir() {
-        return Err(config_error(format!(
-            "daemon socket parent '{}' is not a directory",
-            parent.display()
-        )));
-    }
-    let mode = metadata.permissions().mode() & 0o777;
-    if mode & 0o077 != 0 {
-        return Err(config_error(format!(
-            "refusing to publish daemon socket '{}' outside a private directory: '{}' has mode {mode:04o}; restrict it to 0700",
+            "refusing to publish daemon socket '{}' outside a private directory owned by the current user '{}': {error}",
             path.display(),
             parent.display(),
-        )));
-    }
-    Ok(())
+        ))
+    })
 }
 
 /// Binds the daemon's Unix socket and narrows it to its owner before the
@@ -497,6 +484,31 @@ mod tests {
         assert!(matches!(&error, TraceDecayError::Config { .. }), "{error}");
         assert!(error.to_string().contains("private directory"), "{error}");
         assert!(!path.exists(), "socket must not be bound before rejection");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listener_rejects_symlinked_private_parent_before_binding() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let linked_parent = dir.path().join("linked-parent");
+        symlink(&target, &linked_parent).unwrap();
+        let path = linked_parent.join("daemon.sock");
+
+        let Err(error) = BrokerListener::bind(&DaemonEndpoint::Unix(path.clone())).await else {
+            panic!("symlinked socket parent must be rejected");
+        };
+
+        assert!(matches!(&error, TraceDecayError::Config { .. }), "{error}");
+        assert!(error.to_string().contains("private directory"), "{error}");
+        assert!(
+            !target.join("daemon.sock").exists(),
+            "rejection must not bind through the symlink"
+        );
     }
 
     /// A `SUN_LEN` overflow must be a typed refusal naming its remedy, not the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On 0.1.0-beta.10/11, a fresh isolated profile (`TRACEDECAY_DATA_DIR`) on a Mac showed a broken first-index journey:

- `tracedecay init` / first `status` failed in ~2.1s with `initialize route repository discovery deferred for <root>: DeadlineExceeded`, and the daemon ended up shut down / flapped to a new PID.
- A second `init` returned "daemon code-index reconciliation requested" — but no code-index work followed; `tracedecay tool context` stayed on `exact_scope_generation_not_ready` ("the verified code graph is not ready for the exact project root").
- Separately (Aug 19, thread 01a01bf2): a profile path deep enough to overflow `sockaddr_un` (`SUN_LEN`, 104 bytes on macOS) kills the daemon at socket bind, which launchd turns into a restart loop.

## Root causes and fixes

1. **Deferred repository discovery was terminal** (`src/daemon/core_proxy.rs`, `src/daemon/connection_serving.rs`). A first Git probe exceeding its 2s bound produced a plain config error: project opens failed outright (no retry — the message carried no warming hint), and on the MCP initialize route the error propagated out of the connection handler, dropping the connection without any response. Now the deferral carries the project-warming retry hint, so the CLI (120s init budget) and the serve proxy retry it, and initialize-route resolution failures answer as typed JSON-RPC errors instead of tearing down the connection. The 2s probe bound is unchanged — deferral, not a raised timeout. (Builds on `ca8f06cbc`, which stopped blocking-pool starvation from manufacturing these deadline misses in the first place.)

2. **Init never requested the reconciliation it reported** (`src/commands/index.rs`). `brokered_init` ran an admission-only status call and then printed "daemon code-index reconciliation requested" unconditionally. Indexing only started if the *background* full-server upgrade survived long enough to reach its activation call — a daemon restart in that window silently discarded it, leaving an enrolled project unindexed forever (the observed no-op flap). Init now issues `tracedecay_admin_sync` after admission; the reconcile sink's pre-mount fallback (overflow → demand-driven activation → mount → index) makes that request start the first index immediately.

3. **One failed `accept(2)` ended the whole daemon** (`src/daemon/bootstrap.rs`). A client resetting before accept (`ECONNABORTED` on macOS/BSD — e.g. the CLI's `daemon_reachable()` connect-and-drop probe at the start of every init) or transient fd pressure exited the accept loop, which a supervisor turns into a flap. Accept errors are now logged (`daemon_accept`) and served past, with a bounded 250ms backoff for non-connection failures.

4. **`SUN_LEN` overflow killed the daemon at bind** (`src/daemon/service.rs`, `src/daemon/transport.rs`). `default_socket_path()` now re-derives an over-long profile-scoped endpoint to a short deterministic per-profile path (`/tmp/tracedecay-<sha256(profile-root)[..8]>/daemon.sock`) that daemon and clients converge on independently — a fixed `/tmp` base because `$TMPDIR` differs between launchd services and login shells on macOS. Squatting fails closed: group/world-accessible parents are already refused before bind, and an attacker-owned 0700 directory refuses the bind at the kernel. An explicitly configured over-long `TRACEDECAY_DAEMON_SOCKET` is refused with a typed remedy instead of the kernel's opaque bind error.

## Verification (cloud VM, isolated `TRACEDECAY_DATA_DIR`, small fixture repo — never a developer machine)

End-to-end journey on an empty tmpfs profile with a 2-file git fixture:

- daemon up → `tracedecay init .` completed in **1.21s**, daemon PID unchanged, no `daemon_shutdown`/`daemon_accept` errors.
- verified-graph `tracedecay tool context '{"query":"alpha"}'` answered with real symbols **2.13s after init start** (never `exact_scope_generation_not_ready`); `tracedecay status` shows the sealed fresh generation (3 symbols / 1 edge); `tool search` returns ranked results through the core query authority.

Targeted tests (all falsifiable against the prior behavior):

- `deferred_repository_discovery_is_project_open_retryable` — both retry classifiers accept the deferral.
- `reconcile_request_before_mount_activates_indexing` — a pre-mount reconcile request mounts the scheduler and flushes the overflow request.
- `brokered_init_requests_a_real_code_index_reconciliation` — wire-level fixture daemon observes `tracedecay_status` (admission-only) then `tracedecay_admin_sync`.
- `over_long_profile_socket_path_falls_back_to_a_short_deterministic_path`, `unix_listener_refuses_over_long_socket_path_with_a_typed_remedy` — SUN_LEN behavior.

Plus clippy on the touched crate. No GitHub CI retriggers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29bfe737-02b6-4bee-9ec2-c868c2166ce4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29bfe737-02b6-4bee-9ec2-c868c2166ce4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

