### PR TITLE
perf(cli): skip install health checks for inspections

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1246,6 +1246,7 @@ async fn dispatch_knowledge_command(command: Commands) -> tracedecay::errors::Re
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CommandStartupPolicy {
     Full,
+    SkipAgentInstallCheck,
     SkipAll,
 }
 
@@ -1290,6 +1291,25 @@ impl CommandStartupPolicy {
             | Commands::Projects { .. }
             | Commands::Daemon { .. }
             | Commands::Serve { .. } => Self::SkipAll,
+            // Inspection-only commands retain ordinary startup maintenance but
+            // do not need the unrelated agent-install health check.
+            Commands::Memory { .. }
+            | Commands::Sessions {
+                action:
+                    SessionsAction::Search(_)
+                    | SessionsAction::Refresh {
+                        action: SessionsRefreshAction::Status(_),
+                    },
+            }
+            | Commands::Branch {
+                action:
+                    BranchAction::List { .. }
+                    | BranchAction::Autotrack {
+                        action: BranchAutotrackAction::Status { .. },
+                    },
+            }
+            | Commands::Channel { channel: None }
+            | Commands::Gitignore { action: None, .. } => Self::SkipAgentInstallCheck,
             _ => Self::Full,
         }
     }

--- a/src/startup_tests.rs
+++ b/src/startup_tests.rs
@@ -8,8 +8,16 @@ use super::{
     validate_host_bundle_options,
 };
 use clap::Parser;
+use std::iter;
 use std::path::PathBuf;
 use tracedecay::user_config::UserConfig;
+
+fn parse_command(args: &[&str]) -> Commands {
+    Cli::try_parse_from(iter::once("tracedecay").chain(args.iter().copied()))
+        .expect("command must parse")
+        .command
+        .expect("subcommand must be present")
+}
 
 /// `wipe` destroys deployed state, so it takes the same `--yes` acceptance as
 /// the lifecycle mutations. Without it a scripted wipe had to feed `go!`
@@ -379,6 +387,54 @@ fn first_class_git_reads_skip_network_and_agent_startup_maintenance() {
 
     assert!(should_skip_startup_maintenance(&command));
     assert!(should_skip_agent_install_check(&command));
+}
+
+#[test]
+fn nested_inspection_commands_skip_agent_install_check() {
+    let commands = [
+        &["memory", "status"][..],
+        &["sessions", "search", "needle"][..],
+        &[
+            "sessions",
+            "refresh",
+            "status",
+            "--project-id",
+            "project-123",
+            "--session-id",
+            "session-123",
+            "--provider",
+            "claude",
+            "--source",
+            "1",
+            "--target",
+            "2",
+            "--handle",
+            "refresh-123",
+        ][..],
+        &["branch", "list"][..],
+        &["branch", "autotrack", "status"][..],
+        &["channel"][..],
+        &["gitignore"][..],
+    ];
+
+    for args in commands {
+        let command = parse_command(args);
+        assert!(
+            should_skip_agent_install_check(&command),
+            "{args:?} must not run the unrelated agent-install check"
+        );
+    }
+}
+
+#[test]
+fn nested_mutating_commands_keep_agent_install_check() {
+    for args in [&["channel", "beta"][..], &["gitignore", "on"][..]] {
+        let command = parse_command(args);
+        assert!(
+            !should_skip_agent_install_check(&command),
+            "{args:?} must retain the agent-install check"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- skip the read-only Claude install-health check for nested inspection commands
- retain ordinary startup maintenance for those commands
- keep mutating channel, gitignore, branch, and session actions on the full policy

## Verification

- exact nested inspection policy test
- exact nested mutation control test
- binary tests Clippy with warnings denied

The earlier implicit-repair concern was removed directly from the redesign branch. This PR now contains only the narrower read-only startup optimization.