### PR TITLE
fix(daemon): skip redundant graph activation

### DIFF
--- a/src/daemon/code_index_scheduler/registry.rs
+++ b/src/daemon/code_index_scheduler/registry.rs
@@ -2301,7 +2301,7 @@ impl CodeIndexSchedulerRegistryV1 {
                     (result, latest, replay_binding)
                 })
                 .await;
-                let install_generation = match &result {
+                let replace_serving_generation = match &result {
                     Ok((Ok(CodeIndexReconcileOutcomeV1::Noop(_)), Some(latest), Some(_))) => {
                         let serving = worker_serving_generation
                             .read()
@@ -2319,7 +2319,7 @@ impl CodeIndexSchedulerRegistryV1 {
                 // the persistent graph again, so daemon shutdown cancelled the
                 // duplicate projection and then conflicted while closing the
                 // still-running graph reconciliation owner.
-                if install_generation
+                if replace_serving_generation
                     && let Ok((Ok(_), Some(latest), Some(replay_binding))) = &result
                 {
                     let activation = worker_graph_activation
@@ -2351,7 +2351,7 @@ impl CodeIndexSchedulerRegistryV1 {
                         result = Ok((Err(error), None, None));
                     }
                 }
-                if install_generation && let Ok((Ok(_), Some(latest), _)) = &result {
+                if let Ok((Ok(_), Some(latest), _)) = &result {
                     let scheduler = Arc::clone(&worker_scheduler);
                     let serving_generation = Arc::clone(&worker_serving_generation);
                     let serving_generation_epoch = Arc::clone(&worker_serving_generation_epoch);
@@ -2366,12 +2366,17 @@ impl CodeIndexSchedulerRegistryV1 {
                                     .to_owned(),
                             ));
                         }
-                        let mut serving = serving_generation
-                            .write()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner);
-                        *serving = Some(latest.clone());
-                        serving_generation_epoch.fetch_add(1, Ordering::AcqRel);
-                        drop(serving);
+                        if replace_serving_generation {
+                            let mut serving = serving_generation
+                                .write()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            *serving = Some(latest.clone());
+                            serving_generation_epoch.fetch_add(1, Ordering::AcqRel);
+                        }
+                        // Semantic admission is independently retryable. A
+                        // prior attempt may have lost bounded queue capacity,
+                        // so an unchanged reconcile must offer the already-
+                        // serving generation again without reinstalling it.
                         let _ = scheduler.schedule_semantic_generation(latest.generation());
                         Ok::<_, CodeIndexSchedulerErrorV1>(())
                     })

--- a/src/daemon/code_index_scheduler/registry.rs
+++ b/src/daemon/code_index_scheduler/registry.rs
@@ -2301,7 +2301,27 @@ impl CodeIndexSchedulerRegistryV1 {
                     (result, latest, replay_binding)
                 })
                 .await;
-                if let Ok((Ok(_), Some(latest), Some(replay_binding))) = &result {
+                let install_generation = match &result {
+                    Ok((Ok(CodeIndexReconcileOutcomeV1::Noop(_)), Some(latest), Some(_))) => {
+                        let serving = worker_serving_generation
+                            .read()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        serving.as_ref().is_none_or(|serving| {
+                            serving.generation().manifest().generation_id
+                                != latest.generation().manifest().generation_id
+                        })
+                    }
+                    Ok((Ok(_), Some(_), Some(_))) => true,
+                    _ => false,
+                };
+                // An unchanged reconcile over the exact serving generation has
+                // no graph effect to install. Replaying activation here opened
+                // the persistent graph again, so daemon shutdown cancelled the
+                // duplicate projection and then conflicted while closing the
+                // still-running graph reconciliation owner.
+                if install_generation
+                    && let Ok((Ok(_), Some(latest), Some(replay_binding))) = &result
+                {
                     let activation = worker_graph_activation
                         .activate(
                             &worker_project_id,
@@ -2331,7 +2351,7 @@ impl CodeIndexSchedulerRegistryV1 {
                         result = Ok((Err(error), None, None));
                     }
                 }
-                if let Ok((Ok(_), Some(latest), _)) = &result {
+                if install_generation && let Ok((Ok(_), Some(latest), _)) = &result {
                     let scheduler = Arc::clone(&worker_scheduler);
                     let serving_generation = Arc::clone(&worker_serving_generation);
                     let serving_generation_epoch = Arc::clone(&worker_serving_generation_epoch);

--- a/src/daemon/code_index_scheduler/tests.rs
+++ b/src/daemon/code_index_scheduler/tests.rs
@@ -63,6 +63,7 @@ use tracedecay_query::retrieval::rerank::{
     LocalRerankInputV1, LocalRerankPermitV1, RerankExecutionControlV1,
 };
 
+mod noop_reconcile_tests;
 mod semantic_schedule_order_tests;
 
 struct GitFixture {

--- a/src/daemon/code_index_scheduler/tests/noop_reconcile_tests.rs
+++ b/src/daemon/code_index_scheduler/tests/noop_reconcile_tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use tracedecay_code_index::production::CodeIndexPublishedGenerationV1;
+use tracedecay_usecases::semantic_runtime::SavedCodeGenerationScheduleHookV1;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unchanged_reconcile_does_not_reactivate_the_serving_generation() {
@@ -56,6 +60,62 @@ async fn unchanged_reconcile_does_not_reactivate_the_serving_generation() {
         registry.latest_generation_id(fixture.path()).await,
         Some(serving_generation),
         "the unchanged reconcile retains the exact serving generation"
+    );
+    registry.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unchanged_reconcile_retries_semantic_admission_for_the_serving_generation() {
+    let fixture = GitFixture::new(ALPHA_LIB_V1);
+    let store = TempDir::new().expect("store root");
+    let accepting = Arc::new(AtomicBool::new(false));
+    let accepted = Arc::new(AtomicUsize::new(0));
+    let semantic_hook = {
+        let accepting = Arc::clone(&accepting);
+        let accepted = Arc::clone(&accepted);
+        Arc::new(move |_: &CodeIndexPublishedGenerationV1| {
+            if accepting.load(Ordering::Acquire) {
+                accepted.fetch_add(1, Ordering::AcqRel);
+                true
+            } else {
+                false
+            }
+        }) as SavedCodeGenerationScheduleHookV1
+    };
+    let registry = CodeIndexSchedulerRegistryV1::with_background_reconcile_permits(1, 1);
+    registry
+        .mount_worktree(
+            test_project_id(),
+            fixture.path(),
+            store.path().to_path_buf(),
+            Some(semantic_hook),
+        )
+        .await
+        .expect("mount");
+    let serving_generation = wait_for_initial_generation(&registry, fixture.path()).await;
+    assert_eq!(
+        accepted.load(Ordering::Acquire),
+        0,
+        "the initial bounded semantic admission is refused"
+    );
+
+    accepting.store(true, Ordering::Release);
+    assert!(
+        registry.notify_hook_overflow(fixture.path()).await,
+        "mounted worktree accepts an unchanged reconcile"
+    );
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while accepted.load(Ordering::Acquire) == 0 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("unchanged reconcile retries semantic admission");
+
+    assert_eq!(
+        registry.latest_generation_id(fixture.path()).await,
+        Some(serving_generation),
+        "semantic retry keeps the exact serving generation"
     );
     registry.shutdown().await;
 }

--- a/src/daemon/code_index_scheduler/tests/noop_reconcile_tests.rs
+++ b/src/daemon/code_index_scheduler/tests/noop_reconcile_tests.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unchanged_reconcile_does_not_reactivate_the_serving_generation() {
+    let fixture = GitFixture::new(ALPHA_LIB_V1);
+    let store = TempDir::new().expect("store root");
+    let registry = CodeIndexSchedulerRegistryV1::with_background_reconcile_permits(1, 1);
+    registry
+        .mount_worktree(
+            test_project_id(),
+            fixture.path(),
+            store.path().to_path_buf(),
+            None,
+        )
+        .await
+        .expect("mount");
+    let serving_generation = wait_for_initial_generation(&registry, fixture.path()).await;
+    let scheduler = registry
+        .scheduler_handle(fixture.path())
+        .await
+        .expect("scheduler handle");
+    let worktree_id = scheduler
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .latest_complete()
+        .expect("sealed generation")
+        .generation()
+        .snapshot()
+        .worktree
+        .clone()
+        .expect("worktree identity");
+    let before_receipts = registry.event_to_ready_receipts().len();
+
+    // Any redundant graph activation now fails. An unchanged reconcile must
+    // still reach its Noop receipt by retaining the already-serving graph.
+    super::super::graph_activation::set_injected_activation_failures(&worktree_id, usize::MAX);
+    assert!(
+        registry.notify_hook_overflow(fixture.path()).await,
+        "mounted worktree accepts an unchanged reconcile"
+    );
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        let receipts = registry.event_to_ready_receipts();
+        if let Some(receipt) = receipts.get(before_receipts) {
+            assert!(receipt.is_noop(), "unchanged reconcile must be a no-op");
+            break;
+        }
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "unchanged reconcile retried graph activation instead of settling"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    super::super::graph_activation::set_injected_activation_failures(&worktree_id, 0);
+    assert_eq!(
+        registry.latest_generation_id(fixture.path()).await,
+        Some(serving_generation),
+        "the unchanged reconcile retains the exact serving generation"
+    );
+    registry.shutdown().await;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Skip persistent graph activation when an unchanged reconcile already matches the exact serving generation.
- Preserve no-op cadence receipts without re-opening graph publication during shutdown.

## Motivation
A second unchanged reconcile after first publication reactivated the same persistent graph. Daemon shutdown then cancelled that duplicate projection (`code_index_reconcile_failed`) and conflicted while closing the still-running memory graph reconciliation owner (`background_task_unfinished`).

## Changes
- Compare no-op reconcile output with the exact serving generation before graph activation and serving-slot replacement.
- Continue activating restored no-op generations when no matching serving generation exists.
- Add a regression that injects an activation failure after first publication and proves an unchanged reconcile settles as `Noop` without reactivation.

## Test plan
- [ ] `cargo nextest run --workspace --no-fail-fast` passes (intentionally not run; targeted verification requested)
- [ ] `cargo clippy` has no new warnings
- [x] Targeted no-op reconcile regression passes under the perf profile
- [ ] Isolated daemon first-index + shutdown journey has no cancelled graph projection or unfinished memory graph reconciliation

## Checklist
- [ ] `CHANGELOG.md` updated (not required for this focused fix)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (no breaking contract change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4902c053-e6f7-464b-aa38-8a8f8eee555f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4902c053-e6f7-464b-aa38-8a8f8eee555f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

