### PR TITLE
fix(agent-hosts): gate receiptless adoption on explicit authority

### DIFF
--- a/crates/tracedecay-agent-hosts/src/agents/cursor.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/cursor.rs
@@ -474,6 +474,30 @@ fn remove_cursor_managed_skill_overlay(install_dir: &Path) {
     std::fs::remove_dir_all(install_dir.join("skills/agent-managed")).ok();
 }
 
+/// Recognize a receiptless Cursor deployment as a prior first-party install.
+///
+/// Pre-receipt releases deployed the plugin bundle without host-bundle v2
+/// receipts, so receipt evidence alone cannot tell those files from an
+/// operator's own. The recognizable provenance is the bundle's own durable
+/// anchor, exactly the evidence the legacy installer trusts before its clean
+/// replace: the plugin directory's `.cursor-plugin/plugin.json` naming
+/// `tracedecay` (plugin components), or the versioned native-extension
+/// directory carrying tracedecay's own `package.json` (the Agent component).
+/// Arbitrary bytes parked at a cataloged deploy path carry neither anchor and
+/// stay refused without the operator's explicit `--yes --adopt`.
+pub(crate) fn receiptless_component_provenance(
+    home: &Path,
+    component: HostBundleComponentV1,
+) -> bool {
+    if component == HostBundleComponentV1::Agent {
+        return matches!(
+            cursor_native_extension_registration(home),
+            HostBundleRegistrationStateV1::Current | HostBundleRegistrationStateV1::Repairable
+        );
+    }
+    cursor_plugin_dir_is_tracedecay(&cursor_plugin_install_dir(home))
+}
+
 /// Sweep retired artifacts only after the current plugin manifest proves the
 /// directory is TraceDecay-owned. Receiptless upgrades call this after their
 /// component-set receipt commits, so a failed cleanup is safely retryable by
@@ -1399,9 +1423,20 @@ mod tests {
                 ),
                 explicit_confirmation,
                 hermes_profile_bindings: 0,
+                explicit_adoption: false,
             },
             operation_id,
         }
+    }
+
+    /// [`cursor_component_request`] carrying the operator's `--yes --adopt`.
+    fn adopting_cursor_component_request(
+        operation: HostBundleLifecycleOpV1,
+        operation_id: [u8; 16],
+    ) -> HostComponentSetExecutionRequestV1 {
+        let mut request = cursor_component_request(operation, operation_id, true);
+        request.lifecycle.explicit_adoption = true;
+        request
     }
 
     #[test]
@@ -1677,6 +1712,184 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A cataloged deploy path proves nothing about ownership: bytes an
+    /// operator parked at the plugin manifest path carry no recognizable
+    /// legacy provenance, so Install and Update refuse them untouched unless
+    /// the operator explicitly adopts. Explicit adoption then takes them
+    /// over, backing the previous bytes up first.
+    #[test]
+    fn cursor_transaction_refuses_unrecognized_receiptless_bytes_without_adoption() {
+        for operation in [
+            HostBundleLifecycleOpV1::Install,
+            HostBundleLifecycleOpV1::Update,
+        ] {
+            let home = TempDir::new().unwrap();
+            let lifecycle = TempDir::new().unwrap();
+            let manifest_path = cursor_plugin_manifest_path(home.path());
+            std::fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+            let operator_bytes = b"my own plugin experiment, not a tracedecay bundle";
+            std::fs::write(&manifest_path, operator_bytes).unwrap();
+
+            let current_bin =
+                super::super::which_tracedecay().unwrap_or_else(|| "tracedecay".to_string());
+            let current = cursor_component_set(&current_bin);
+            let mut writer =
+                HostBundleWriterV1::open_with_lifecycle_root(home.path(), lifecycle.path())
+                    .unwrap();
+
+            let request = cursor_component_request(operation, [71; 16], true);
+            let mut registration = crate::agents::host_component_registration::CatalogHostComponentRegistrationAuthority::new_with_tracedecay_bin(
+                "cursor",
+                home.path(),
+                lifecycle.path(),
+                operation,
+                current_bin.clone(),
+            )
+            .unwrap();
+            let error = HostComponentSetTransactionV1::new(&mut writer)
+                .execute(
+                    &current.component_set,
+                    &request,
+                    &current,
+                    &mut registration,
+                )
+                .expect_err("unrecognized receiptless bytes must refuse without adoption");
+            assert!(
+                matches!(error, HostBundleError::OwnershipConflict(_)),
+                "{operation:?}: {error}"
+            );
+            assert!(
+                error.to_string().contains("--yes --adopt"),
+                "the refusal must name the explicit adoption remedy: {error}"
+            );
+            assert_eq!(
+                std::fs::read(&manifest_path).unwrap(),
+                operator_bytes,
+                "{operation:?} must leave the refused file byte-for-byte untouched"
+            );
+
+            let adopt = adopting_cursor_component_request(operation, [72; 16]);
+            let mut adopting_registration = crate::agents::host_component_registration::CatalogHostComponentRegistrationAuthority::new_with_tracedecay_bin(
+                "cursor",
+                home.path(),
+                lifecycle.path(),
+                operation,
+                current_bin.clone(),
+            )
+            .unwrap();
+            HostComponentSetTransactionV1::new(&mut writer)
+                .execute(
+                    &current.component_set,
+                    &adopt,
+                    &current,
+                    &mut adopting_registration,
+                )
+                .unwrap_or_else(|error| {
+                    panic!("explicit adoption must take the file over: {error}")
+                });
+            let manifest: Value =
+                serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+            assert_eq!(manifest["name"], "tracedecay");
+        }
+    }
+
+    /// The provenance recognizer trusts exactly the durable first-party
+    /// anchors: the plugin directory's own manifest naming tracedecay, and
+    /// tracedecay's versioned native-extension `package.json`. Arbitrary
+    /// bytes at those paths recognize nothing.
+    #[test]
+    fn receiptless_provenance_requires_a_first_party_anchor() {
+        let home = TempDir::new().unwrap();
+        for component in [
+            HostBundleComponentV1::Core,
+            HostBundleComponentV1::ContextMcp,
+            HostBundleComponentV1::Agent,
+        ] {
+            assert!(
+                !receiptless_component_provenance(home.path(), component),
+                "an empty home recognizes no {component:?} provenance"
+            );
+        }
+
+        let manifest_path = cursor_plugin_manifest_path(home.path());
+        std::fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+        std::fs::write(&manifest_path, b"not a tracedecay manifest").unwrap();
+        assert!(!receiptless_component_provenance(
+            home.path(),
+            HostBundleComponentV1::Core
+        ));
+
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec(&json!({ "name": "tracedecay", "version": "0.1.0-beta.4" }))
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(receiptless_component_provenance(
+            home.path(),
+            HostBundleComponentV1::Core
+        ));
+        assert!(receiptless_component_provenance(
+            home.path(),
+            HostBundleComponentV1::ContextMcp
+        ));
+        // The plugin anchor says nothing about the native extension.
+        assert!(!receiptless_component_provenance(
+            home.path(),
+            HostBundleComponentV1::Agent
+        ));
+
+        let extension_dir = home.path().join(cursor_native_extension_relative_dir());
+        std::fs::create_dir_all(&extension_dir).unwrap();
+        std::fs::write(
+            extension_dir.join("package.json"),
+            br#"{"name":"cursor-native","publisher":"tracedecay","main":"./dist/extension.js"}"#,
+        )
+        .unwrap();
+        assert!(receiptless_component_provenance(
+            home.path(),
+            HostBundleComponentV1::Agent
+        ));
+    }
+
+    /// The bounded legacy-inventory sweep removes retired first-party
+    /// artifacts after adoption validated the bundle, and nothing else: a
+    /// user's own files survive, and a directory without the tracedecay
+    /// manifest anchor is never touched.
+    #[test]
+    fn retired_artifact_sweep_is_bounded_and_ownership_gated() {
+        let home = TempDir::new().unwrap();
+        let install_dir = cursor_plugin_install_dir(home.path());
+        write_embedded_plugin(&install_dir, "tracedecay").expect("bundle should deploy");
+        let retired = install_dir.join("rules/tracedecay-memory.mdc");
+        std::fs::write(&retired, RETIRED_CURSOR_MEMORY_RULE_FIXTURE).unwrap();
+        let user_rule = install_dir.join("rules/my-own-notes.mdc");
+        std::fs::write(&user_rule, b"operator notes").unwrap();
+
+        sweep_retired_cursor_plugin_artifacts(home.path()).expect("sweep should succeed");
+        assert!(
+            !retired.exists(),
+            "the retired memory rule must be swept from an owned bundle"
+        );
+        assert!(user_rule.exists(), "user files must survive the sweep");
+
+        // A same-name rule without the tracedecay marker is a user file too.
+        std::fs::write(&retired, b"my own memory rule").unwrap();
+        sweep_retired_cursor_plugin_artifacts(home.path()).expect("sweep should succeed");
+        assert_eq!(std::fs::read(&retired).unwrap(), b"my own memory rule");
+        std::fs::remove_file(&retired).unwrap();
+
+        // Without the manifest anchor the sweep never touches the directory.
+        std::fs::write(
+            install_dir.join(".cursor-plugin/plugin.json"),
+            b"not tracedecay",
+        )
+        .unwrap();
+        std::fs::write(&retired, RETIRED_CURSOR_MEMORY_RULE_FIXTURE).unwrap();
+        sweep_retired_cursor_plugin_artifacts(home.path()).expect("sweep should succeed");
+        assert!(retired.exists(), "an unowned directory must never be swept");
     }
 
     #[test]

--- a/crates/tracedecay-agent-hosts/src/agents/host_bundle_v2.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/host_bundle_v2.rs
@@ -281,6 +281,14 @@ pub struct HostBundleLifecycleRequestV1 {
     /// Hermes has one user-profile binding. Other hosts must pass zero here;
     /// this is not an ambient profile-discovery mechanism.
     pub hermes_profile_bindings: u8,
+    /// Authorization to adopt receiptless observations at this component's
+    /// cataloged deploy paths. True only when the operator explicitly
+    /// confirmed adoption (`--yes --adopt`) or the host adapter recognized
+    /// the receiptless deployment as a prior first-party bundle
+    /// ([`HostComponentSetRegistrationV1::receiptless_component_provenance`]).
+    /// A cataloged deploy path alone never grants this; byte-identical
+    /// staged deploys are adoptable without it.
+    pub adopt_receiptless: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -333,7 +341,12 @@ pub fn plan_lifecycle_mutation(
         let state = observed
             .iter()
             .find(|state| state.relative_path == artifact.relative_path);
-        let action = plan_artifact_action(request.operation, artifact, state)?;
+        let action = plan_artifact_action(
+            request.operation,
+            artifact,
+            state,
+            request.adopt_receiptless,
+        )?;
         mutations.push(HostArtifactMutationV1 {
             relative_path: artifact.relative_path.clone(),
             action,
@@ -414,10 +427,13 @@ pub fn plan_complete_lifecycle_mutation(
             };
             plan.mutations.push(HostArtifactMutationV1 {
                 relative_path: owned.relative_path.clone(),
+                // Receipt-derived removals never adopt; ownership is proven
+                // by the receipt digest or refused.
                 action: plan_artifact_action(
                     HostBundleLifecycleOpV1::Uninstall,
                     &artifact,
                     Some(observed),
+                    false,
                 )?,
             });
         }
@@ -435,6 +451,7 @@ fn plan_artifact_action(
     operation: HostBundleLifecycleOpV1,
     artifact: &HostBundleArtifactV1,
     state: Option<&ObservedHostArtifactV1>,
+    adopt_receiptless: bool,
 ) -> Result<HostArtifactActionV1, HostBundleError> {
     let Some(state) = state else {
         return match operation {
@@ -445,7 +462,9 @@ fn plan_artifact_action(
         };
     };
     match state.kind {
-        ObservedArtifactKindV1::Missing => return plan_artifact_action(operation, artifact, None),
+        ObservedArtifactKindV1::Missing => {
+            return plan_artifact_action(operation, artifact, None, adopt_receiptless);
+        }
         ObservedArtifactKindV1::Symlink | ObservedArtifactKindV1::Directory => {
             return Err(HostBundleError::UnsafeInstallPath);
         }
@@ -453,12 +472,14 @@ fn plan_artifact_action(
     }
     if state.ownership_marker.as_deref() != Some(artifact.ownership_marker.as_str()) {
         // Receiptless artifacts are adoptable only inside the boundary
-        // `adopts_pre_receipt_artifact` defines (`Install`, `Update`, and
-        // `Repair` converging a receiptless cataloged deploy path). Everything
-        // else with a foreign or absent marker conflicts.
-        if !adopts_pre_receipt_artifact(operation, artifact, state) {
+        // `adopts_pre_receipt_artifact` defines: byte-identical staged bytes,
+        // host-recognized legacy provenance, or the operator's explicit
+        // adoption. Everything else with a foreign or absent marker conflicts.
+        if !adopts_pre_receipt_artifact(operation, artifact, state, adopt_receiptless) {
             return Err(HostBundleError::OwnershipConflict(format!(
-                "{}: existing file is not owned by this component (observed ownership marker {}, expected {:?})",
+                "{}: existing file is not owned by this component (observed ownership marker {}, expected {:?}); \
+                 a receiptless file at a cataloged deploy path is adopted only when it matches the staged bytes, \
+                 carries recognizable legacy first-party provenance, or the operator re-runs with `--yes --adopt`",
                 artifact.relative_path,
                 match state.ownership_marker.as_deref() {
                     Some(marker) => format!("{marker:?}"),
@@ -520,43 +541,71 @@ fn plan_artifact_action(
 ///
 /// Pre-v2 installers and pre-activation staging deploy first-party artifacts
 /// without writing a v2 ownership receipt, so their files are
-/// indistinguishable from foreign files by receipt evidence alone. The
-/// adoption boundary:
+/// indistinguishable from foreign files by receipt evidence alone. Sitting at
+/// a cataloged deploy path proves nothing: `cataloged_ownership_marker` is
+/// synthesized from the current manifest, so any bytes an operator placed at
+/// that path would carry it. Adoption therefore requires the cataloged path
+/// AND an explicit authority:
 ///
-/// * `Install`, `Update`, and `Repair` may adopt content at a receiptless
-///   cataloged deploy path. Cataloged artifacts restamp the product version
-///   and binary path on every release, so a live pre-receipt deployment is
-///   never byte-identical to the current catalog; refusing divergent bytes
-///   would wedge such an installation permanently — no lifecycle operation
-///   could ever converge it into receipt ownership. `Uninstall` stays
-///   fail-closed: it must never delete a file whose ownership it cannot
-///   prove;
-/// * the observation must carry the planned component's own cataloged
-///   ownership marker for this exact deploy path, and it must equal the
-///   expected artifact's marker. Observations derived from receipts or from
-///   orphan paths never set it, so they can never reach this branch. Every
-///   cataloged deploy path is a tracedecay-owned artifact location — shared
-///   host config documents are registration surfaces, never catalog
-///   artifacts;
-/// * no receipt may claim the path. A receipt-backed artifact keeps the
-///   unmodified marker equality check, which stays the security boundary.
+/// * byte identity: the observed bytes equal the staged catalog content.
+///   This is the documented hand-over journey for hosts that own their own
+///   activation (Claude Code, Codex): TraceDecay stages the deploy, the host
+///   activates it, and the operator's re-run records exactly the bytes
+///   TraceDecay staged. Paths inside TraceDecay's own staging namespace
+///   ([`HOST_BUNDLE_STAGE_ROOT_RELATIVE`]) extend this to divergent bytes,
+///   because everything there is TraceDecay-staged by construction;
+/// * recognizable legacy provenance: the host adapter inspected the
+///   receiptless deployment and recognized a prior first-party bundle
+///   ([`HostComponentSetRegistrationV1::receiptless_component_provenance`]),
+///   e.g. a Cursor plugin directory whose own manifest names tracedecay.
+///   Live pre-receipt bundles restamp versions and binary paths every
+///   release, so they are never byte-identical — provenance is what lets
+///   `install`/`update-plugin` converge them without wedging;
+/// * explicit operator adoption: `--yes --adopt` claimed the path knowingly.
 ///
-/// Adoption itself never destroys anything: a byte-identical file becomes a
-/// `Noop`, and anything else is backed up before it is replaced.
+/// `Uninstall` never adopts: it must not delete a file whose ownership it
+/// cannot prove. Observations derived from receipts or orphan paths never
+/// carry the cataloged marker, so they can never reach this branch, and a
+/// receipt-backed artifact keeps the unmodified marker equality check as the
+/// security boundary. Adoption itself never destroys anything: byte-identical
+/// files become `Noop`, everything else is backed up before it is replaced.
 fn adopts_pre_receipt_artifact(
     operation: HostBundleLifecycleOpV1,
     artifact: &HostBundleArtifactV1,
     state: &ObservedHostArtifactV1,
+    adopt_receiptless: bool,
 ) -> bool {
     let receiptless_cataloged_path = state.ownership_marker.is_none()
         && state.owned_artifact_digest.is_none()
         && state.cataloged_ownership_marker.as_deref() == Some(artifact.ownership_marker.as_str());
+    if !receiptless_cataloged_path {
+        return false;
+    }
     match operation {
         HostBundleLifecycleOpV1::Install
         | HostBundleLifecycleOpV1::Update
-        | HostBundleLifecycleOpV1::Repair => receiptless_cataloged_path,
+        | HostBundleLifecycleOpV1::Repair => {
+            state.artifact_digest == Some(artifact.artifact_digest)
+                || adopt_receiptless
+                || first_party_staged_deploy_path(&artifact.relative_path)
+        }
         HostBundleLifecycleOpV1::Uninstall => false,
     }
+}
+
+/// Relative prefix of TraceDecay's own host-bundle staging namespace. Hosts
+/// that activate a staged source natively (Kimi's `/plugins install`) deploy
+/// their cataloged artifacts here, inside TraceDecay's private data dir.
+pub const HOST_BUNDLE_STAGE_ROOT_RELATIVE: &str = ".tracedecay/host-bundle-stage";
+
+/// A deploy path inside TraceDecay's own staging namespace is
+/// TraceDecay-staged by construction — it is never host or user config, so a
+/// receiptless divergent file there is a staging left by another TraceDecay
+/// binary version (its render bakes in the binary path), not a foreign claim.
+/// Refusing it would wedge the documented native-activation hand-over
+/// whenever the binary moved between staging and the recording re-run.
+fn first_party_staged_deploy_path(relative_path: &str) -> bool {
+    Path::new(relative_path).starts_with(HOST_BUNDLE_STAGE_ROOT_RELATIVE)
 }
 
 /// Execution-specific input kept separate from the public lifecycle request
@@ -593,6 +642,11 @@ pub struct HostComponentSetLifecycleRequestV1 {
     pub expected_components: Vec<HostBundleComponentV1>,
     pub explicit_confirmation: bool,
     pub hermes_profile_bindings: u8,
+    /// Operator-confirmed authority (`--yes --adopt`) to take ownership of
+    /// receiptless files at cataloged deploy paths even when the host adapter
+    /// recognizes no legacy provenance in them. Distinct from
+    /// `explicit_confirmation`, which only confirms the previewed plan.
+    pub explicit_adoption: bool,
 }
 
 /// One operation id spans every component, registration mutation, receipt,
@@ -789,6 +843,18 @@ pub trait HostComponentSetRegistrationV1 {
         _request: &HostComponentSetExecutionRequestV1,
     ) -> Result<[u8; 32], HostBundleError> {
         Ok(Sha256::digest(b"tracedecay.host-registration.none.v1").into())
+    }
+
+    /// Recognize this host component's receiptless deployment as a prior
+    /// first-party install ("legacy provenance"). Pre-receipt installers
+    /// wrote cataloged deploy paths without v2 receipts, so receipt evidence
+    /// alone cannot tell their files from a user's; a cataloged path alone
+    /// must never be treated as ownership. Implementations inspect durable
+    /// host state (for example a bundle's own manifest naming tracedecay)
+    /// and fail closed: the default recognizes nothing, so adoption then
+    /// requires the operator's explicit `--yes --adopt`.
+    fn receiptless_component_provenance(&self, _component: HostBundleComponentV1) -> bool {
+        false
     }
 
     /// Bounded read-only discovery of third-party extensions that already
@@ -1436,6 +1502,11 @@ pub fn dry_run_host_component_set_lifecycle_with_lifecycle_root_at<
                 expected_component: component.manifest.component,
                 explicit_confirmation: true,
                 hermes_profile_bindings: planning_request.lifecycle.hermes_profile_bindings,
+                adopt_receiptless: component_receiptless_adoption(
+                    &planning_request,
+                    registration,
+                    component.manifest.component,
+                ),
             },
             operation_id: planning_request.operation_id,
         };
@@ -1488,6 +1559,19 @@ pub fn dry_run_host_component_set_lifecycle_with_lifecycle_root_at<
             || !competing_extension_claims.is_empty(),
         competing_extension_claims,
     })
+}
+
+/// Resolve per-component receiptless-adoption authority for a set request:
+/// the operator's explicit `--adopt` or the adapter's recognized legacy
+/// provenance. Preview and confirmed execute both resolve through this, so
+/// their plans agree; provenance drift between them surfaces as the ordinary
+/// plan/`StalePreview` mismatch.
+fn component_receiptless_adoption<R: HostComponentSetRegistrationV1>(
+    request: &HostComponentSetExecutionRequestV1,
+    registration: &R,
+    component: HostBundleComponentV1,
+) -> bool {
+    request.lifecycle.explicit_adoption || registration.receiptless_component_provenance(component)
 }
 
 /// Collect and normalise the adapter's claim discovery so preview, plan
@@ -2741,7 +2825,24 @@ impl HostBundleWriterV1 {
             return Ok(receipt);
         }
 
-        let prepared = self.preflight_component_set(component_set, request, verifier)?;
+        // Resolve receiptless-adoption authority through the same adapter the
+        // preview used, so the replanned mutations match the confirmed plan.
+        let adoption_by_component: BTreeMap<HostBundleComponentV1, bool> = component_set
+            .components
+            .iter()
+            .map(|component| {
+                (
+                    component.manifest.component,
+                    component_receiptless_adoption(
+                        request,
+                        registration,
+                        component.manifest.component,
+                    ),
+                )
+            })
+            .collect();
+        let prepared =
+            self.preflight_component_set(component_set, request, verifier, &adoption_by_component)?;
         // Declare the exact write set before any adapter observes state, so a
         // registration surface that is also one of these artifacts can tell
         // this transaction's own write apart from a foreign edit.
@@ -2898,6 +2999,9 @@ impl HostBundleWriterV1 {
                     .collect(),
                 explicit_confirmation: journal.explicit_confirmation,
                 hermes_profile_bindings: journal.hermes_profile_bindings,
+                // Recovery replays or rolls back the journaled mutations; it
+                // never re-plans, so it can never adopt anything new.
+                explicit_adoption: false,
             },
             operation_id: journal.operation_id,
         };
@@ -2939,6 +3043,7 @@ impl HostBundleWriterV1 {
         component_set: &HostComponentSetV1,
         request: &HostComponentSetExecutionRequestV1,
         verifier: &V,
+        adoption_by_component: &BTreeMap<HostBundleComponentV1, bool>,
     ) -> Result<Vec<PreparedHostComponentSetComponentV1>, HostBundleError> {
         let mut prepared = Vec::with_capacity(component_set.components.len());
         let mut claimed_paths = BTreeMap::new();
@@ -3017,6 +3122,10 @@ impl HostBundleWriterV1 {
                 expected_component: component.manifest.component,
                 explicit_confirmation: request.lifecycle.explicit_confirmation,
                 hermes_profile_bindings: request.lifecycle.hermes_profile_bindings,
+                adopt_receiptless: adoption_by_component
+                    .get(&component.manifest.component)
+                    .copied()
+                    .unwrap_or(false),
             };
             let plan = plan_verified_complete_lifecycle_mutation(
                 &component.manifest,
@@ -3311,6 +3420,9 @@ impl HostBundleWriterV1 {
                     .collect(),
                 explicit_confirmation: true,
                 hermes_profile_bindings: u8::from(journal.host == HostKindV1::Hermes),
+                // Receipt matching compares durable identity; adoption
+                // authority is a planning input and plays no part here.
+                explicit_adoption: false,
             },
             operation_id: journal.operation_id,
         };
@@ -3883,6 +3995,10 @@ impl HostBundleWriterV1 {
                 expected_component: backup.component,
                 explicit_confirmation: true,
                 hermes_profile_bindings: u8::from(backup.host == HostKindV1::Hermes),
+                // The operator explicitly confirmed restoring this exact
+                // named backup, which is adoption authority over the backup's
+                // recorded deploy paths whatever bytes sit there now.
+                adopt_receiptless: true,
             },
             operation_id,
         };
@@ -5032,9 +5148,22 @@ mod tests {
                 expected_component: HostBundleComponentV1::Core,
                 explicit_confirmation: confirmed,
                 hermes_profile_bindings: u8::from(host == HostKindV1::Hermes),
+                adopt_receiptless: false,
             },
             operation_id: [operation_id; 16],
         }
+    }
+
+    /// [`execution`] with operator-confirmed receiptless adoption, the
+    /// `--yes --adopt` shape.
+    fn adopting_execution(
+        host: HostKindV1,
+        operation: HostBundleLifecycleOpV1,
+        operation_id: u8,
+    ) -> HostBundleExecutionRequestV1 {
+        let mut request = execution(host, operation, operation_id, true);
+        request.lifecycle.adopt_receiptless = true;
+        request
     }
 
     fn content(bytes: &[u8]) -> Vec<HostBundleArtifactContentV1> {
@@ -5125,6 +5254,7 @@ mod tests {
                 ],
                 explicit_confirmation: true,
                 hermes_profile_bindings: u8::from(host == HostKindV1::Hermes),
+                explicit_adoption: false,
             },
             operation_id: [operation_id; 16],
         }
@@ -6224,11 +6354,11 @@ mod tests {
 
         std::fs::create_dir_all(root.path().join("plugins")).unwrap();
         std::fs::write(root.path().join("plugins/core.json"), b"external").unwrap();
-        // A file appeared at this cataloged deploy path after the preview was
-        // taken. A fresh preview would adopt it (backing the bytes up first),
-        // so this is genuine preview staleness — the confirmed plan no longer
-        // matches what is observed, and nothing may be overwritten under the
-        // stale plan.
+        // Somebody else owns the bytes on this artifact path, no adoption
+        // authority was granted, and the adapter recognizes no provenance in
+        // them. That is a standing refusal, not preview staleness: retrying
+        // cannot clear it, so it must be reported as the ownership conflict
+        // it is.
         assert!(matches!(
             HostComponentSetTransactionV1::new(&mut writer).execute_confirmed(
                 &component_set,
@@ -6237,7 +6367,7 @@ mod tests {
                 &verifier,
                 &mut registration,
             ),
-            Err(HostBundleError::StalePreview(_))
+            Err(HostBundleError::OwnershipConflict(_))
         ));
         assert_eq!(
             std::fs::read(root.path().join("plugins/core.json")).unwrap(),
@@ -6396,7 +6526,7 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_ops_converge_cataloged_pre_receipt_artifacts() {
+    fn lifecycle_ops_converge_cataloged_pre_receipt_artifacts_only_with_adoption() {
         let bundle = manifest(HostKindV1::KimiCode, b"expected");
         for (operation, operation_id) in [
             (HostBundleLifecycleOpV1::Repair, 20),
@@ -6407,10 +6537,28 @@ mod tests {
             std::fs::create_dir_all(root.path().join("plugins")).unwrap();
             std::fs::write(root.path().join("plugins/tracedecay.json"), b"legacy").unwrap();
             let mut writer = HostBundleWriterV1::open(root.path()).unwrap();
+
+            // Without adoption authority the divergent receiptless file is a
+            // typed conflict and stays byte-for-byte untouched.
+            assert!(matches!(
+                writer.execute(
+                    &bundle,
+                    &execution(HostKindV1::KimiCode, operation, operation_id, true),
+                    &content(b"expected"),
+                    &verifier(&bundle),
+                ),
+                Err(HostBundleError::OwnershipConflict(_))
+            ));
+            assert_eq!(
+                std::fs::read(root.path().join("plugins/tracedecay.json")).unwrap(),
+                b"legacy"
+            );
+
+            // Operator-confirmed adoption converges it and records ownership.
             let receipt = writer
                 .execute(
                     &bundle,
-                    &execution(HostKindV1::KimiCode, operation, operation_id, true),
+                    &adopting_execution(HostKindV1::KimiCode, operation, operation_id),
                     &content(b"expected"),
                     &verifier(&bundle),
                 )
@@ -6552,53 +6700,109 @@ mod tests {
         }
     }
 
+    /// The receiptless-adoption boundary: a cataloged deploy path alone never
+    /// authorizes taking a file over. Divergent bytes are refused without
+    /// adoption authority (recognized legacy provenance or the operator's
+    /// explicit `--adopt`), adopted with backup when that authority is
+    /// present, byte-identical bytes are recorded without authority (the
+    /// staged hand-over journey), and Uninstall never adopts anything.
     #[test]
-    fn lifecycle_ops_adopt_a_receiptless_artifact_carrying_the_expected_ownership_marker() {
+    fn receiptless_adoption_requires_provenance_or_explicit_authority() {
         let bundle = manifest(HostKindV1::KimiCode, b"current");
         let artifact = &bundle.artifacts[0];
         let marker = Some(artifact.ownership_marker.clone());
 
-        // A live pre-receipt deployment is version-stamped, so it is never
-        // byte-identical to the current catalog. Install, Update, and Repair
-        // must all converge it — stale pre-v2 bytes are adopted, but only
-        // after they are backed up.
         for operation in [
             HostBundleLifecycleOpV1::Install,
             HostBundleLifecycleOpV1::Update,
             HostBundleLifecycleOpV1::Repair,
         ] {
+            // Custom or unowned bytes parked at the cataloged path: refused
+            // without adoption authority — the path proves nothing.
+            let refused = plan_artifact_action(
+                operation,
+                artifact,
+                Some(&pre_v2_artifact(artifact, b"pre-v2", marker.clone())),
+                false,
+            )
+            .expect_err("a receiptless divergent file must refuse without adoption authority");
+            assert!(
+                matches!(refused, HostBundleError::OwnershipConflict(_)),
+                "{operation:?}: {refused}"
+            );
+            assert!(
+                refused.to_string().contains("--yes --adopt"),
+                "the refusal must name the explicit adoption remedy: {refused}"
+            );
+
+            // With adoption authority the stale bytes are adopted, but only
+            // after they are backed up.
             assert_eq!(
                 plan_artifact_action(
                     operation,
                     artifact,
                     Some(&pre_v2_artifact(artifact, b"pre-v2", marker.clone())),
+                    true,
                 ),
                 Ok(HostArtifactActionV1::BackupThenReplace),
-                "{operation:?} must adopt a receiptless cataloged deploy path"
+                "{operation:?} must adopt a receiptless cataloged deploy path when authorized"
             );
-            // Pre-v2 bytes that already match the catalog need no mutation.
+            // Bytes identical to the staged catalog are the recorded staged
+            // deploy: adoptable without any extra authority, as a no-op.
             assert_eq!(
                 plan_artifact_action(
                     operation,
                     artifact,
                     Some(&pre_v2_artifact(artifact, b"current", marker.clone())),
+                    false,
                 ),
                 Ok(HostArtifactActionV1::Noop)
             );
         }
 
-        // Uninstall stays fail-closed: it must never delete a file whose
-        // ownership it cannot prove.
+        // Uninstall stays fail-closed even with explicit adoption authority:
+        // it must never delete a file whose ownership it cannot prove.
         assert!(
             matches!(
                 plan_artifact_action(
                     HostBundleLifecycleOpV1::Uninstall,
                     artifact,
                     Some(&pre_v2_artifact(artifact, b"pre-v2", marker.clone())),
+                    true,
                 ),
                 Err(HostBundleError::OwnershipConflict(_))
             ),
             "Uninstall must not adopt an artifact no receipt records"
+        );
+
+        // A deploy path inside TraceDecay's own staging namespace is
+        // TraceDecay-staged by construction, so a divergent staging left by
+        // another binary version converges without extra authority. Kimi's
+        // native activation flow deploys exactly there.
+        assert!(
+            crate::agents::kimi::KIMI_STAGED_PLUGIN_RELATIVE
+                .starts_with(HOST_BUNDLE_STAGE_ROOT_RELATIVE),
+            "the Kimi staged source must live inside the shared staging namespace"
+        );
+        let mut staged_bundle = manifest(HostKindV1::KimiCode, b"current");
+        staged_bundle.artifacts[0].relative_path = format!(
+            "{}/kimi/tracedecay/.kimi-plugin/plugin.json",
+            HOST_BUNDLE_STAGE_ROOT_RELATIVE
+        );
+        let staged_artifact = &staged_bundle.artifacts[0];
+        assert_eq!(
+            plan_artifact_action(
+                HostBundleLifecycleOpV1::Repair,
+                staged_artifact,
+                Some(&pre_v2_artifact(
+                    staged_artifact,
+                    b"staged-by-previous-binary",
+                    Some(staged_artifact.ownership_marker.clone()),
+                )),
+                false,
+            ),
+            Ok(HostArtifactActionV1::BackupThenReplace),
+            "a divergent first-party staging must converge without explicit adoption"
         );
     }
 
@@ -6609,12 +6813,14 @@ mod tests {
         let foreign = expected_ownership_marker(HostKindV1::Hermes, HostBundleComponentV1::Core);
         assert_ne!(foreign, artifact.ownership_marker);
 
-        // A foreign marker on the same deploy path is still a conflict, and
-        // the refusal names the conflicting deploy path.
+        // A foreign marker on the same deploy path is still a conflict even
+        // with explicit adoption authority, and the refusal names the
+        // conflicting deploy path.
         let foreign_conflict = plan_artifact_action(
             HostBundleLifecycleOpV1::Repair,
             artifact,
             Some(&pre_v2_artifact(artifact, b"pre-v2", Some(foreign))),
+            true,
         )
         .expect_err("a foreign marker must refuse");
         assert!(matches!(
@@ -6634,6 +6840,7 @@ mod tests {
                 HostBundleLifecycleOpV1::Repair,
                 artifact,
                 Some(&pre_v2_artifact(artifact, b"pre-v2", None)),
+                true,
             ),
             Err(HostBundleError::OwnershipConflict(_))
         ));
@@ -6647,7 +6854,12 @@ mod tests {
         ));
         claimed.owned_artifact_digest = Some(Sha256::digest(b"pre-v2").into());
         assert!(matches!(
-            plan_artifact_action(HostBundleLifecycleOpV1::Repair, artifact, Some(&claimed)),
+            plan_artifact_action(
+                HostBundleLifecycleOpV1::Repair,
+                artifact,
+                Some(&claimed),
+                true
+            ),
             Err(HostBundleError::OwnershipConflict(_))
         ));
     }
@@ -6703,7 +6915,8 @@ mod tests {
                     plan_artifact_action(
                         HostBundleLifecycleOpV1::Repair,
                         artifact,
-                        Some(&observed)
+                        Some(&observed),
+                        true,
                     )
                     .is_err(),
                     state == HostBundleComponentDoctorStateV1::OwnershipConflict,

--- a/crates/tracedecay-agent-hosts/src/agents/host_bundle_v2.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/host_bundle_v2.rs
@@ -476,16 +476,30 @@ fn plan_artifact_action(
         // host-recognized legacy provenance, or the operator's explicit
         // adoption. Everything else with a foreign or absent marker conflicts.
         if !adopts_pre_receipt_artifact(operation, artifact, state, adopt_receiptless) {
+            let reason = if let Some(marker) = state.ownership_marker.as_deref() {
+                format!(
+                    "a receipt records ownership marker {marker:?}, expected {:?}; uninstall the \
+                     component named by the recorded marker before retrying",
+                    artifact.ownership_marker
+                )
+            } else if state.cataloged_ownership_marker.as_deref()
+                != Some(artifact.ownership_marker.as_str())
+            {
+                format!(
+                    "the observation is neither owned by this component nor a receiptless \
+                     cataloged deploy (expected marker {:?}); move or remove the conflicting \
+                     file before retrying",
+                    artifact.ownership_marker
+                )
+            } else {
+                "a receiptless file at a cataloged deploy path is adopted only when it matches \
+                 the staged bytes, carries recognizable legacy first-party provenance, or the \
+                 operator re-runs with `--yes --adopt`"
+                    .to_string()
+            };
             return Err(HostBundleError::OwnershipConflict(format!(
-                "{}: existing file is not owned by this component (observed ownership marker {}, expected {:?}); \
-                 a receiptless file at a cataloged deploy path is adopted only when it matches the staged bytes, \
-                 carries recognizable legacy first-party provenance, or the operator re-runs with `--yes --adopt`",
+                "{}: existing file is not owned by this component; {reason}",
                 artifact.relative_path,
-                match state.ownership_marker.as_deref() {
-                    Some(marker) => format!("{marker:?}"),
-                    None => "recorded by no receipt".to_string(),
-                },
-                artifact.ownership_marker,
             )));
         }
         return Ok(if state.artifact_digest == Some(artifact.artifact_digest) {
@@ -6833,6 +6847,12 @@ mod tests {
                 .contains(&artifact.relative_path),
             "the conflict must name the contested path: {foreign_conflict}"
         );
+        assert!(
+            foreign_conflict
+                .to_string()
+                .contains("move or remove the conflicting file"),
+            "an uncataloged observation must name a usable recovery: {foreign_conflict}"
+        );
         // So is an absent marker: receipt- and orphan-derived observations
         // never carry one, so they can never be adopted.
         assert!(matches!(
@@ -6853,15 +6873,29 @@ mod tests {
             HostBundleComponentV1::Core,
         ));
         claimed.owned_artifact_digest = Some(Sha256::digest(b"pre-v2").into());
+        let claimed_conflict = plan_artifact_action(
+            HostBundleLifecycleOpV1::Repair,
+            artifact,
+            Some(&claimed),
+            true,
+        )
+        .expect_err("a foreign receipt marker must refuse");
         assert!(matches!(
-            plan_artifact_action(
-                HostBundleLifecycleOpV1::Repair,
-                artifact,
-                Some(&claimed),
-                true
-            ),
-            Err(HostBundleError::OwnershipConflict(_))
+            claimed_conflict,
+            HostBundleError::OwnershipConflict(_)
         ));
+        assert!(
+            claimed_conflict
+                .to_string()
+                .contains("uninstall the component named by the recorded marker"),
+            "a receipt-backed conflict must name the recorded-owner recovery: {claimed_conflict}"
+        );
+        assert!(
+            !claimed_conflict
+                .to_string()
+                .contains("re-runs with `--yes --adopt`"),
+            "receipt-backed conflicts must not advertise a receiptless-only remedy: {claimed_conflict}"
+        );
     }
 
     /// Discovery and planning must agree on the ownership boundary: whenever

--- a/crates/tracedecay-agent-hosts/src/agents/host_component_registration.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/host_component_registration.rs
@@ -1341,6 +1341,21 @@ impl crate::agents::host_bundle_v2::HostComponentSetRegistrationV1
         self.competing_opencode_analyzer_claims(component_set)
     }
 
+    /// Cursor is the one host whose pre-receipt bundles carry a durable
+    /// first-party anchor the adapter can verify; every other integration
+    /// stays fail-closed on the trait default, so receiptless adoption there
+    /// requires the operator's explicit `--yes --adopt`.
+    fn receiptless_component_provenance(
+        &self,
+        component: crate::agents::host_bundle_v2::HostBundleComponentV1,
+    ) -> bool {
+        self.integration.id() == "cursor"
+            && crate::agents::cursor::receiptless_component_provenance(
+                &self.context.home,
+                component,
+            )
+    }
+
     fn confirm_preview(
         &mut self,
         component_set: &crate::agents::host_bundle_v2::HostComponentSetV1,
@@ -1956,6 +1971,7 @@ mod tests {
                     .collect(),
                 explicit_confirmation: true,
                 hermes_profile_bindings: 0,
+                explicit_adoption: false,
             },
             operation_id: [7; 16],
         };

--- a/crates/tracedecay-agent-hosts/src/agents/kiro/tests.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/kiro/tests.rs
@@ -231,6 +231,7 @@ fn kiro_component_request(
             ],
             explicit_confirmation: true,
             hermes_profile_bindings: 0,
+            explicit_adoption: false,
         },
         operation_id,
     }

--- a/src/agent_cmd.rs
+++ b/src/agent_cmd.rs
@@ -156,41 +156,6 @@ pub(crate) async fn handle_host_bundle_component_command(
     Ok(())
 }
 
-/// Refuse a mutation that would claim a file no receipt records unless the
-/// operator confirmed adoption specifically.
-///
-/// `--yes` confirms the plan the preview showed; taking ownership of somebody
-/// else's bytes is a separate decision, so it needs its own `--adopt`. This is
-/// a confirmation gate only: the planner's adoption boundary is unchanged, a
-/// file another owner claims is still refused with a typed ownership conflict,
-/// The caller supplies the transaction's authoritative preview so confirmation
-/// and execution cannot disagree about which paths are being adopted.
-fn require_adoption_confirmation(
-    agent_id: &str,
-    preview: &tracedecay::agents::host_bundle_v2::HostComponentSetLifecyclePreviewV1,
-    options: &crate::cli::HostBundleCliOptions,
-    lifecycle_root: &Path,
-    host: tracedecay::agents::host_bundle_v2::HostKindV1,
-) -> tracedecay::errors::Result<()> {
-    if options.adopt {
-        return Ok(());
-    }
-    let adopted = adopted_relative_paths(preview, lifecycle_root, host);
-    if adopted.is_empty() {
-        return Ok(());
-    }
-    Err(tracedecay::errors::TraceDecayError::Config {
-        message: format!(
-            "agent {agent_id:?} would take ownership of {} file(s) that no TraceDecay receipt \
-             records ({}); the previous bytes are backed up under {}/<operation-id>, but claiming \
-             them is a separate decision — review `--dry-run` and re-run with `--yes --adopt`",
-            adopted.len(),
-            adopted.join(", "),
-            tracedecay::agents::host_bundle_v2::host_bundle_backup_root(lifecycle_root).display()
-        ),
-    })
-}
-
 /// Truthful reason a host component set is unavailable, so a skipped or
 /// refused agent never reads as an empty success.
 fn unsupported_host_component_set_message(agent: &str) -> String {
@@ -430,6 +395,7 @@ fn component_set_request(
     component_set: &tracedecay::agents::host_bundle_registry::VerifiedEmbeddedHostComponentSetV1,
     operation: HostBundleCliOperation,
     explicit_confirmation: bool,
+    explicit_adoption: bool,
 ) -> tracedecay::errors::Result<
     tracedecay::agents::host_bundle_v2::HostComponentSetExecutionRequestV1,
 > {
@@ -455,6 +421,7 @@ fn component_set_request(
                 hermes_profile_bindings: u8::from(
                     host == tracedecay::agents::host_bundle_v2::HostKindV1::Hermes,
                 ),
+                explicit_adoption,
             },
             operation_id,
         },
@@ -569,30 +536,6 @@ fn artifact_disposition(
     }
 }
 
-/// Mutations that would claim an existing file no receipt records.
-fn adopted_relative_paths(
-    preview: &tracedecay::agents::host_bundle_v2::HostComponentSetLifecyclePreviewV1,
-    lifecycle_root: &Path,
-    host: tracedecay::agents::host_bundle_v2::HostKindV1,
-) -> Vec<String> {
-    use tracedecay::agents::host_bundle_v2::HostArtifactActionV1 as Action;
-
-    let mut adopted = Vec::new();
-    for plan in &preview.component_plans {
-        let owned = receipt_owned_paths(lifecycle_root, host, plan.component);
-        for mutation in &plan.mutations {
-            if matches!(mutation.action, Action::BackupThenReplace | Action::Noop)
-                && !owned.contains(&mutation.relative_path)
-            {
-                adopted.push(mutation.relative_path.clone());
-            }
-        }
-    }
-    adopted.sort();
-    adopted.dedup();
-    adopted
-}
-
 fn preview_canonical_component_set(
     agent_id: &str,
     operation: HostBundleCliOperation,
@@ -604,7 +547,7 @@ fn preview_canonical_component_set(
 ) -> tracedecay::errors::Result<
     tracedecay::agents::host_bundle_v2::HostComponentSetLifecyclePreviewV1,
 > {
-    let request = component_set_request(component_set, operation, options.yes)?;
+    let request = component_set_request(component_set, operation, options.yes, options.adopt)?;
     let mut registration = match install_context {
         Some(install) => {
             CatalogHostComponentRegistrationAuthority::new_with_tracedecay_bin_and_dashboard(
@@ -729,6 +672,7 @@ fn apply_canonical_component_set(
         component_set,
         operation,
         options.component.is_none() || options.yes,
+        options.adopt,
     )?;
     let mut writer =
         tracedecay::agents::host_bundle_v2::HostBundleWriterV1::open_with_lifecycle_root(
@@ -778,13 +722,12 @@ fn apply_canonical_component_set(
             &mut registration,
         )
         .map_err(|error| host_bundle_error_for_agent(agent_id, error))?;
-    require_adoption_confirmation(
-        agent_id,
-        &preview,
-        options,
-        lifecycle_root,
-        component_set.component_set.host,
-    )?;
+    // Receiptless-adoption authority is enforced inside the planner: without
+    // `--adopt`, a receiptless file at a cataloged path is adopted only when
+    // the host adapter recognizes legacy first-party provenance in it, and
+    // anything else is refused as a typed ownership conflict naming the
+    // `--yes --adopt` remedy. Reaching this point means every planned
+    // adoption was authorized, so no separate CLI gate re-litigates it.
     // A full default install is otherwise treated as confirmed. A competing
     // third-party claim is exactly the ambiguity that must not be resolved on
     // the operator's behalf, so it demands an explicit `--yes`.
@@ -1195,6 +1138,9 @@ fn feedback_request(
                 hermes_profile_bindings: u8::from(
                     manifest.host == tracedecay::agents::host_bundle_v2::HostKindV1::Hermes,
                 ),
+                // Feedback rollback only ever moves between receipt-owned
+                // Core deployments; it never claims receiptless files.
+                adopt_receiptless: false,
             },
             operation_id,
         },
@@ -3313,9 +3259,10 @@ mod tests {
         );
     }
 
-    /// An explicit component mutation that would claim an unrecorded file is
-    /// refused without `--adopt`, and the refusal names every such path plus
-    /// where the replaced bytes are preserved.
+    /// An explicit component repair that would claim an unrecorded file with
+    /// no recognizable legacy provenance is refused without `--adopt` — even
+    /// at preview time, which stays read-only — and the refusal names the
+    /// contested path plus the explicit adoption remedy.
     #[tokio::test]
     async fn explicit_component_repair_refuses_adoption_without_the_adopt_flag() {
         let _profile = pinned_host_profile();
@@ -3328,8 +3275,9 @@ mod tests {
         )
         .unwrap()
         .unwrap();
-        // A pre-receipt deployment: the cataloged path exists on disk with
-        // foreign bytes and no receipt records it.
+        // A receiptless deployment carrying no recognizable provenance: the
+        // cataloged path exists on disk with foreign bytes and no receipt
+        // records it.
         let adopted =
             &component_set.component_set.components[0].manifest.artifacts[0].relative_path;
         let deployed = home.path().join(adopted);
@@ -3342,7 +3290,7 @@ mod tests {
             adopt: false,
         };
 
-        let preview = super::preview_canonical_component_set(
+        let error = super::preview_canonical_component_set(
             "cursor",
             HostBundleCliOperation::Repair,
             &component_set,
@@ -3351,38 +3299,35 @@ mod tests {
             lifecycle.path(),
             None,
         )
-        .unwrap();
-        let error = super::require_adoption_confirmation(
-            "cursor",
-            &preview,
-            &options,
-            lifecycle.path(),
-            component_set.component_set.host,
-        )
         .unwrap_err()
         .to_string();
 
         assert!(error.contains(adopted.as_str()), "{error}");
         assert!(error.contains("--yes --adopt"), "{error}");
-        assert!(error.contains("backups"), "{error}");
-        assert_eq!(std::fs::read(&deployed).unwrap(), b"pre-receipt");
+        assert_eq!(
+            std::fs::read(&deployed).unwrap(),
+            b"pre-receipt",
+            "the refusing preview is read-only"
+        );
 
         let confirmed = crate::cli::HostBundleCliOptions {
             adopt: true,
             ..options
         };
-        super::require_adoption_confirmation(
+        super::preview_canonical_component_set(
             "cursor",
-            &preview,
+            HostBundleCliOperation::Repair,
+            &component_set,
             &confirmed,
+            home.path(),
             lifecycle.path(),
-            component_set.component_set.host,
+            None,
         )
-        .unwrap();
+        .expect("explicit adoption authority must let the same repair plan");
         assert_eq!(
             std::fs::read(&deployed).unwrap(),
             b"pre-receipt",
-            "the confirmation gate is read-only"
+            "the preview is read-only even with adoption authority"
         );
     }
 
@@ -3508,7 +3453,36 @@ mod tests {
             !retired.exists(),
             "a known retired Cursor artifact must not survive adoption"
         );
-        assert_eq!(std::fs::read(user_file).unwrap(), b"keep me");
+        assert_eq!(std::fs::read(&user_file).unwrap(), b"keep me");
+
+        // A retired rule resurfacing later (e.g. an older release ran again)
+        // is swept by the plain `update-plugin` journey too: the now-current
+        // bundle carries recognizable provenance, so no `--adopt` is needed.
+        std::fs::write(
+            &retired,
+            "<!-- generated by tracedecay from the project fact store; do not edit by hand -->",
+        )
+        .unwrap();
+        super::apply_canonical_component_set(
+            "cursor",
+            HostBundleCliOperation::Update,
+            &component_set,
+            &crate::cli::HostBundleCliOptions {
+                component: None,
+                dry_run: false,
+                yes: true,
+                adopt: false,
+            },
+            home.path(),
+            lifecycle.path(),
+            &ComponentSetApplyContext::with_tracedecay_bin(KIRO_FIXTURE_BIN),
+        )
+        .unwrap();
+        assert!(
+            !retired.exists(),
+            "update-plugin must sweep the retired rule so uninstall can see a clean bundle"
+        );
+        assert_eq!(std::fs::read(&user_file).unwrap(), b"keep me");
     }
 
     #[test]
@@ -4261,7 +4235,8 @@ esac
         // registration authority that fails `verify` after the artifacts are
         // already on disk, which is exactly the state that leaves a journal.
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Install, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
+                .unwrap();
         let mut writer =
             tracedecay::agents::host_bundle_v2::HostBundleWriterV1::open_with_lifecycle_root(
                 home.path(),
@@ -4360,7 +4335,8 @@ esac
         .expect("the packaged Kiro set must install cleanly");
 
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Update, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Update, true, false)
+                .unwrap();
         let mut writer =
             tracedecay::agents::host_bundle_v2::HostBundleWriterV1::open_with_lifecycle_root(
                 home.path(),
@@ -4425,7 +4401,8 @@ esac
             .unwrap()
             .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Install, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
+                .unwrap();
         let mut registration = CatalogHostComponentRegistrationAuthority::new(
             "opencode",
             home.path(),
@@ -4502,7 +4479,7 @@ esac
             // staleness signal, and this test is about the file's content.
             std::fs::create_dir_all(registration_path.parent().unwrap()).unwrap();
             let request =
-                component_set_request(&component_set, HostBundleCliOperation::Install, true)
+                component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
                     .unwrap();
             let mut registration = CatalogHostComponentRegistrationAuthority::new(
                 "opencode",
@@ -4572,7 +4549,8 @@ esac
         .unwrap()
         .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Install, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
+                .unwrap();
         let mut registration = CatalogHostComponentRegistrationAuthority::new(
             "opencode",
             home.path(),
@@ -4656,7 +4634,8 @@ esac
         .unwrap()
         .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Install, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
+                .unwrap();
         let mut registration = CatalogHostComponentRegistrationAuthority::new(
             "opencode",
             home.path(),
@@ -4708,7 +4687,8 @@ esac
         .unwrap()
         .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Repair, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Repair, true, false)
+                .unwrap();
         let mut registration = CatalogHostComponentRegistrationAuthority::new(
             "opencode",
             home.path(),
@@ -4765,7 +4745,8 @@ esac
         .unwrap()
         .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Repair, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Repair, true, false)
+                .unwrap();
         let mut registration = VerifyFailureRegistration {
             inner: CatalogHostComponentRegistrationAuthority::new(
                 "codex",
@@ -5077,7 +5058,7 @@ esac
                 .unwrap()
                 .unwrap_or_else(|| panic!("{agent} must ship a canonical component set"));
             let request =
-                component_set_request(&component_set, HostBundleCliOperation::Install, true)
+                component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
                     .unwrap();
             let registration = CatalogHostComponentRegistrationAuthority::new(
                 agent,
@@ -5627,7 +5608,8 @@ esac
             .unwrap()
             .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Install, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
+                .unwrap();
         let mut registration = CatalogHostComponentRegistrationAuthority::new(
             "kimi",
             home.path(),
@@ -5687,7 +5669,8 @@ esac
             .unwrap()
             .unwrap();
         let request =
-            component_set_request(&component_set, HostBundleCliOperation::Install, true).unwrap();
+            component_set_request(&component_set, HostBundleCliOperation::Install, true, false)
+                .unwrap();
         let mut registration = CatalogHostComponentRegistrationAuthority::new(
             "opencode",
             home.path(),

--- a/src/daemon/git_watch/store_maintenance/vector_retention_tests.rs
+++ b/src/daemon/git_watch/store_maintenance/vector_retention_tests.rs
@@ -11,18 +11,15 @@ use tempfile::TempDir;
 
 use crate::daemon::code_index_scheduler::CodeIndexSchedulerRegistryV1;
 use crate::daemon::code_index_scheduler::semantic_vector_graph::ProjectVectorReadableSources;
-use crate::daemon::maintenance::{
-    SemanticVectorRetentionReadV1, StoreTelemetrySamplingRegistry,
-};
+use crate::daemon::maintenance::{SemanticVectorRetentionReadV1, StoreTelemetrySamplingRegistry};
 use crate::retention::code_index_generations::{
     DurableGenerationIndexEntryV1, DurablePublicationPointerV1, durable_generation_index_digest,
 };
 use crate::tracedecay::TraceDecay;
 
 use super::{
-    VectorRetentionInventoryV1, apply_code_generation_retention,
-    classify_vector_readable_sources, code_index_store_root,
-    resolve_vector_retention_inventory, run_code_generation_retention,
+    VectorRetentionInventoryV1, apply_code_generation_retention, classify_vector_readable_sources,
+    code_index_store_root, resolve_vector_retention_inventory, run_code_generation_retention,
     run_semantic_vector_generation_retention,
 };
 
@@ -98,8 +95,10 @@ fn seed_sealed_generation_store(store_root: &Path, count: usize) {
         std::fs::write(generations_root.join(&file), bytes).expect("write sealed generation");
         sealed.push((generation_id, file, state_digest, size_bytes, sealed_at));
     }
-    let (generation_id, file, state_digest, size_bytes, sealed_at) =
-        sealed.last().expect("at least one sealed generation").clone();
+    let (generation_id, file, state_digest, size_bytes, sealed_at) = sealed
+        .last()
+        .expect("at least one sealed generation")
+        .clone();
     let generation_index = vec![DurableGenerationIndexEntryV1 {
         generation_id: generation_id.clone(),
         snapshot_content_identity: "snapshot.retention-fixture".to_owned(),
@@ -161,8 +160,7 @@ fn fixture_census_shard() -> (
     (
         tracedecay_store::StoreShardIdV1::project(
             tracedecay_domain::BrainId::new("brain.retention-fixture").expect("brain id"),
-            tracedecay_domain::UserProfileId::new("profile.retention-fixture")
-                .expect("profile id"),
+            tracedecay_domain::UserProfileId::new("profile.retention-fixture").expect("profile id"),
             tracedecay_domain::ProjectId::new("project.retention-fixture").expect("project id"),
         ),
         tracedecay_store::SemanticVectorStageCensusRevision::new(1).expect("census revision"),
@@ -409,8 +407,7 @@ async fn unknown_census_still_degrades_to_the_offline_inventory() {
 async fn reset_corrupt_and_denied_vector_authorities_refuse_the_sweep() {
     let fixture = open_unseated_graph_fixture().await;
     let global_db =
-        crate::global_db::tests::harness::RegisteredGlobalDbHarness::open("vector-refusals")
-            .await;
+        crate::global_db::tests::harness::RegisteredGlobalDbHarness::open("vector-refusals").await;
     let scope = tracedecay_application::ResolvedScope::new(
         tracedecay_domain::ProjectId::new("project.retention-fixture").expect("project id"),
         tracedecay_domain::RepositoryId::new("repository.retention-fixture")

--- a/tests/host_bundle_acceptance.rs
+++ b/tests/host_bundle_acceptance.rs
@@ -92,6 +92,7 @@ fn embedded_component_backup_restore_runs_through_the_real_lifecycle_writer() {
                     expected_component: HostBundleComponentV1::Core,
                     explicit_confirmation: true,
                     hermes_profile_bindings: 0,
+                    adopt_receiptless: false,
                 },
                 operation_id: [81; 16],
             },
@@ -323,6 +324,7 @@ fn component_set_dry_run_retains_analyzers_but_refuses_registration_aliases() {
             expected_components: default_components(HostKindV1::OpenCode),
             explicit_confirmation: true,
             hermes_profile_bindings: 0,
+            explicit_adoption: false,
         },
         operation_id: [31; 16],
     };
@@ -619,6 +621,7 @@ fn component_set_dry_run_reports_competing_claims_and_binds_them_to_the_plan() {
             expected_components: default_components(HostKindV1::OpenCode),
             explicit_confirmation: true,
             hermes_profile_bindings: 0,
+            explicit_adoption: false,
         },
         operation_id: [43; 16],
     };
@@ -744,6 +747,7 @@ fn unreadable_host_registration_refuses_instead_of_reporting_no_conflict() {
             expected_components: default_components(HostKindV1::OpenCode),
             explicit_confirmation: true,
             hermes_profile_bindings: 0,
+            explicit_adoption: false,
         },
         operation_id: [44; 16],
     };
@@ -878,6 +882,7 @@ fn embedded_component_sets_complete_lifecycle_for_all_supported_hosts() {
                 // Hermes binds exactly one user TraceDecay profile; other hosts
                 // must pass zero (not an ambient profile-discovery mechanism).
                 hermes_profile_bindings: u8::from(host == HostKindV1::Hermes),
+                explicit_adoption: false,
             },
             operation_id: [operation_id; 16],
         };
@@ -1098,6 +1103,7 @@ fn cursor_core_drift_warns_and_reinstall_converges_with_a_backup() {
             expected_components: vec![HostBundleComponentV1::Core],
             explicit_confirmation: true,
             hermes_profile_bindings: 0,
+            explicit_adoption: false,
         },
         operation_id: [operation_id; 16],
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the two unresolved Codex P1 review comments from [#574](https://github.com/ScriptedAlchemy/tracedecay/pull/574) (merged externally before this commit landed on its branch, so the P1 work continues here as one commit, `bc4d7fb25`):

- P1 [3826034906](https://github.com/ScriptedAlchemy/tracedecay/pull/574#discussion_r3826034906) — receiptless Install/Update require recognizable legacy provenance or explicit adoption. A cataloged deploy path alone never grants ownership: `cataloged_ownership_marker` is synthesized from the current manifest, so path-only inference would let `update-plugin` permanently replace an operator's own file (committed receipts drop their backups). The planner now adopts a receiptless cataloged file only when the bytes are identical to the staged catalog, the path is inside TraceDecay's own `host-bundle-stage` namespace, the host adapter recognizes legacy first-party provenance in a durable anchor, or the operator passed `--yes --adopt`. A custom `~/.config/opencode/plugins/tracedecay.ts` is refused untouched with a typed conflict naming the `--yes --adopt` remedy.
- P1 [3826034908](https://github.com/ScriptedAlchemy/tracedecay/pull/574#discussion_r3826034908) — after validating the old bundle, retired artifacts are swept. Receiptless Cursor adoption removes the bounded legacy inventory (`rules/tracedecay-memory.mdc`, `rules/tracedecay-memory-digest.mdc`, retired skill dirs) after the component-set receipt commits — content-gated and only from a bundle whose own manifest anchor proves tracedecay ownership — on install, `update-plugin`, and repair, so later updates and uninstall see a clean owned bundle. New coverage pins the Update journey and the ownership gating.

The #574 goals stay intact: `update-plugin` restamps the live pre-receipt Cursor bundle to the running binary version through the provenance authority (no flag needed), `install --agent cursor` and `--component core --yes --adopt` take over a no-receipt `plugin.json`, and Codex hook auto-trust plus the byte-identical staged hand-over journeys (Codex, Claude, Kimi) are unregressed.

## Changes

- `crates/tracedecay-agent-hosts/src/agents/host_bundle_v2.rs` — `adopts_pre_receipt_artifact` requires the cataloged path AND an explicit authority (byte identity / first-party stage namespace / adapter-recognized legacy provenance / operator `--yes --adopt`) for Install, Update, and Repair alike; Uninstall never adopts. `HostBundleLifecycleRequestV1.adopt_receiptless` and `HostComponentSetLifecycleRequestV1.explicit_adoption` carry the operator authority; `HostComponentSetRegistrationV1::receiptless_component_provenance` (default fail-closed `false`) carries the adapter's. Preview and confirmed execute resolve adoption through the same adapter so plans agree; the refusal names the contested path and the remedy.
- `crates/tracedecay-agent-hosts/src/agents/cursor.rs` — `receiptless_component_provenance` recognizes exactly the durable first-party anchors (plugin-dir manifest naming `tracedecay`; the versioned native-extension `package.json`); new tests pin the recognizer and the bounded, ownership-gated retired-artifact sweep.
- `crates/tracedecay-agent-hosts/src/agents/host_component_registration.rs` — the catalog registration authority delegates provenance to the Cursor recognizer; every other host stays on the fail-closed default.
- `src/agent_cmd.rs` — `--adopt` threads into the set request (`component_set_request`); the planner is the single adoption boundary, so the CLI preview gate that re-litigated adoptions was deleted with its `adopted_relative_paths` helper (dry-run still labels unrecorded-path mutations `adopt`); the Cursor retired-artifact sweep test now also covers the Update/`update-plugin` journey.

## Test plan

- [x] `cargo test -p tracedecay-agent-hosts --lib` — 720 passed, 0 failed. New/updated: `receiptless_adoption_requires_provenance_or_explicit_authority`, `lifecycle_ops_converge_cataloged_pre_receipt_artifacts_only_with_adoption`, `cursor_transaction_refuses_unrecognized_receiptless_bytes_without_adoption` (Install and Update refuse custom bytes untouched; explicit adopt takes over), `cursor_component_transaction_takes_over_a_pre_receipt_bundle`, `receiptless_provenance_requires_a_first_party_anchor`, `retired_artifact_sweep_is_bounded_and_ownership_gated`, full `agents::codex::` auto-trust suite.
- [x] `cargo test --bin tracedecay -- agent_cmd::` — all adoption/sweep tests pass, including `explicit_component_repair_refuses_adoption_without_the_adopt_flag`, `component_apply_refuses_receiptless_bytes_without_adoption_authority`, `default_component_apply_honors_explicit_adoption_authority`, `cursor_adoption_sweeps_retired_artifacts_and_preserves_user_files` (Install + Update), `kimi_native_activated_retry_tracks_staged_source`. The 6 remaining failures (`codex_native_*`, `codex_core_rollback_*`, `kimi_canonical_*`, `opencode_core_*`) fail identically on the unmodified base in this VM and are unrelated.
- [x] `cargo test --test host_bundle_acceptance` — 18 passed.
- [x] `cargo check --workspace --all-features --profile test` clean; `cargo clippy -p tracedecay-agent-hosts --lib --all-features` no new warnings.
- [ ] Tested manually (not run: no live Mac per task constraints)

## Checklist

- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (none released: the request structs and registration trait are branch-local contracts changed in place)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c18b796f-7091-4585-8335-139d18c4d9a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18b796f-7091-4585-8335-139d18c4d9a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

