### PR TITLE
fix(daemon): preserve exact branch ref identity

### DIFF
--- a/src/daemon/branch_add.rs
+++ b/src/daemon/branch_add.rs
@@ -563,12 +563,13 @@ pub(crate) async fn capture_exact_branch_source(
             ));
         }
     };
-    if snapshot_branch != branch {
+    let expected_reference = format!("refs/heads/{branch}");
+    if snapshot_branch != expected_reference {
         return Err(TraceDecayError::project_route(
             CODE_INDEX_IDENTITY_MISMATCH,
             false,
             format!(
-                "exact Git snapshot is attached to branch '{snapshot_branch}', not requested branch '{branch}'"
+                "exact Git snapshot is attached to branch '{snapshot_branch}', not requested branch '{expected_reference}'"
             ),
         ));
     }
@@ -577,7 +578,7 @@ pub(crate) async fn capture_exact_branch_source(
         repository_id: scope.repository_id.as_str().to_owned(),
         worktree_id: scope.worktree_id.as_str().to_owned(),
         worktree_root: canonical_worktree_root.to_string_lossy().into_owned(),
-        reference: format!("refs/heads/{branch}"),
+        reference: snapshot_branch,
         source_oid,
     })
 }

--- a/src/daemon/pr_autotrack.rs
+++ b/src/daemon/pr_autotrack.rs
@@ -1425,7 +1425,13 @@ fn read_exact_ref(
 ) -> std::result::Result<ExactRefReadV1, ManualBranchActivationError> {
     let output = run_git_with_control(
         repo_root,
-        &["show-ref", "--verify", "--hash", reference],
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            reference,
+        ],
         command_control,
     )
     .map_err(|error| {

--- a/src/daemon/pr_autotrack/tests.rs
+++ b/src/daemon/pr_autotrack/tests.rs
@@ -541,6 +541,22 @@ async fn manual_branch_activates_when_scheduler_is_injected() {
         repo.path(),
         "refs/tracedecay/branch/feature-manual"
     ));
+    let synthetic_branch = crate::branch::current_branch(&activation.worktree)
+        .expect("manual worktree has an attached synthetic branch");
+    let source = crate::daemon::branch_add::capture_exact_branch_source(
+        &graph,
+        &schedulers,
+        repo.path(),
+        &activation.worktree,
+        &synthetic_branch,
+    )
+    .await
+    .expect("synthetic branch source uses exact Git ref identity");
+    assert_eq!(
+        source.reference,
+        "refs/heads/tracedecay/track/feature-manual"
+    );
+    assert_eq!(source.source_oid, activation.head_sha);
     schedulers.shutdown().await;
 }
 


### PR DESCRIPTION
## Summary
- compare native Git snapshots against their canonical `refs/heads/...` identity
- preserve the snapshot ref verbatim in sealed branch provenance
- make absent synthetic refs a normal cleanup state on Git 2.43

## Verification
- `cargo fmt --all -- --check`
- exact `daemon::pr_autotrack::tests::manual_branch_activates_when_scheduler_is_injected` (1 passed)
- exact `daemon::pr_autotrack::tests::manual_artifact_cleanup_accepts_absence_but_refuses_foreign_provenance` (1 passed)
- live beta.14 reproduction: `tracedecay branch add codex/tracedecay-total-redesign-plan` reached the fixed identity boundary and exposed the mismatch before this patch
