### PR TITLE
fix(rusqlite-runtime): move lease_clock test module below production items

### DIFF
--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs
@@ -129,33 +129,6 @@ fn lease_now() -> Instant {
 #[cfg(test)]
 use lease_clock::lease_now;
 
-#[cfg(test)]
-pub(crate) mod lease_clock {
-    use std::{
-        cell::Cell,
-        time::{Duration, Instant},
-    };
-
-    thread_local! {
-        static FAKE_LEASE_NOW: Cell<Option<Instant>> = const { Cell::new(None) };
-    }
-
-    /// Real monotonic time until [`advance`] freezes this thread's clock.
-    pub(crate) fn lease_now() -> Instant {
-        FAKE_LEASE_NOW.with(Cell::get).unwrap_or_else(Instant::now)
-    }
-
-    /// Freezes this thread's lease clock `by` past its current reading.
-    ///
-    /// Only code already running on the writer thread — in practice an
-    /// [`super::ExactSqlWriteAuthority`] verification — can move the clock
-    /// the transaction loop reads.
-    pub(crate) fn advance(by: Duration) {
-        let advanced = lease_now() + by;
-        FAKE_LEASE_NOW.with(|fake| fake.set(Some(advanced)));
-    }
-}
-
 pub(crate) enum TransactionCommand {
     Attach {
         attachment: ExactSqlAttachment,
@@ -699,5 +672,32 @@ impl TransactionCompletion {
             None => {}
         }
         cleanup_error.map_or(Ok(()), Err)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod lease_clock {
+    use std::{
+        cell::Cell,
+        time::{Duration, Instant},
+    };
+
+    thread_local! {
+        static FAKE_LEASE_NOW: Cell<Option<Instant>> = const { Cell::new(None) };
+    }
+
+    /// Real monotonic time until [`advance`] freezes this thread's clock.
+    pub(crate) fn lease_now() -> Instant {
+        FAKE_LEASE_NOW.with(Cell::get).unwrap_or_else(Instant::now)
+    }
+
+    /// Freezes this thread's lease clock `by` past its current reading.
+    ///
+    /// Only code already running on the writer thread — in practice an
+    /// [`super::ExactSqlWriteAuthority`] verification — can move the clock
+    /// the transaction loop reads.
+    pub(crate) fn advance(by: Duration) {
+        let advanced = lease_now() + by;
+        FAKE_LEASE_NOW.with(|fake| fake.set(Some(advanced)));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Repairs the inherited Clippy `items_after_test_module` failure from #604 job 96951258179 (which #604 does not itself cause — the offending file is untouched by #604).
- One-file move only: relocates `#[cfg(test)] pub(crate) mod lease_clock` in `crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs` from before the production items (`TransactionCommand`, `run_writer_command`, `run_transaction`, `TransactionCompletion`) to the end of the file, after `TransactionCompletion::finish`.
- No `#[allow(...)]`/`#[expect(...)]` attributes added; no behavior change; no Stage0b / #604 files touched.

## Motivation

`cargo clippy -p tracedecay-rusqlite-runtime --lib --tests -- -D warnings` on the current `codex/tracedecay-total-redesign-plan` tip (2be2b9478, merge #603) fails:

```
error: items after a test module
   --> crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs:133:1
```

This blocks #604 CI even though #604 never modifies this file.

## Changes

- `crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs`: `mod lease_clock` moved verbatim to end of file. `#[cfg(not(test))] fn lease_now()` and `#[cfg(test)] use lease_clock::lease_now;` stay above the production items.

## Test plan

- [x] RED captured before edit: `clippy::items_after_test_module` at `command.rs:133:1`, exit 101
- [x] `cargo clippy -p tracedecay-rusqlite-runtime --lib --tests -- -D warnings` passes after the move
- [x] `cargo test -p tracedecay-rusqlite-runtime --lib exact_sql` — 58 passed, 0 failed
- [x] `cargo fmt -p tracedecay-rusqlite-runtime -- --check` clean
- [x] `npm run lint:commit -- --from origin/codex/tracedecay-total-redesign-plan --to HEAD` passes

## Checklist

- [ ] `CHANGELOG.md` updated (not applicable: lint-only test-module reordering, no behavior change)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be0119d2-a1d5-4593-bb5e-6224b924dcfc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be0119d2-a1d5-4593-bb5e-6224b924dcfc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

