### PR TITLE
fix(release): validate semantic feature owner

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -137,6 +137,7 @@ jobs:
           python3 .release-automation/scripts/test-build-mcpb.py
           python3 .release-automation/scripts/test-resolve-installed-binary.py
           python3 .release-automation/scripts/test-check-packaged-mcp-stdio.py
+          python3 .release-automation/scripts/test-check-distribution-feature-wiring.py
           python3 .release-automation/scripts/test-resolve-release-source-profile.py
           python3 .release-automation/scripts/test-package-release-archive.py
           python3 .release-automation/scripts/test-prepare-release-runtime.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,7 @@ jobs:
           python3 .release-automation/scripts/test-build-mcpb.py
           python3 .release-automation/scripts/test-resolve-installed-binary.py
           python3 .release-automation/scripts/test-check-packaged-mcp-stdio.py
+          python3 .release-automation/scripts/test-check-distribution-feature-wiring.py
           python3 .release-automation/scripts/test-resolve-release-source-profile.py
           python3 .release-automation/scripts/test-package-release-archive.py
           python3 .release-automation/scripts/test-prepare-release-runtime.py

--- a/scripts/check-distribution-acceptance.sh
+++ b/scripts/check-distribution-acceptance.sh
@@ -199,98 +199,13 @@ assert_code_extraction_assets() {
 verify_feature_wiring() {
   local source_manifest=$1
   local packaged_manifest=$2
-  python3 - "$source_manifest" "$packaged_manifest" <<'PY'
-import sys
-import tomllib
-from pathlib import Path
-
-REQUIRED = {
-    "full",
-    "token-counting",
-    "semantic-fastembed",
-    "test-transport",
-}
-
-
-def load(path: str) -> dict:
-    with Path(path).open("rb") as handle:
-        return tomllib.load(handle)
-
-
-def optional_dependencies(manifest: dict) -> set[str]:
-    names: set[str] = set()
-
-    def collect(table: object) -> None:
-        if not isinstance(table, dict):
-            return
-        dependencies = table.get("dependencies")
-        if isinstance(dependencies, dict):
-            for name, spec in dependencies.items():
-                if isinstance(spec, dict) and spec.get("optional") is True:
-                    names.add(name)
-
-    collect(manifest)
-    for target in manifest.get("target", {}).values():
-        collect(target)
-    return names
-
-
-source = load(sys.argv[1])
-packaged = load(sys.argv[2])
-source_features = source.get("features", {})
-packaged_features = packaged.get("features", {})
-
-missing = sorted(REQUIRED - source_features.keys())
-if missing:
-    raise SystemExit(
-        "distribution acceptance: source manifest is missing required features: "
-        + ", ".join(missing)
-    )
-if source_features != packaged_features:
-    raise SystemExit(
-        "distribution acceptance: packaged feature wiring differs from Cargo.toml"
-    )
-
-semantic_members = packaged_features.get("semantic-fastembed")
-required_semantic_members = {
-    "dep:fastembed",
-    "fastembed/ort-download-binaries-rustls-tls",
-}
-if not isinstance(semantic_members, list) or not required_semantic_members.issubset(
-    semantic_members
-):
-    raise SystemExit(
-        "distribution acceptance: semantic-fastembed must enable dep:fastembed "
-        "and fastembed/ort-download-binaries-rustls-tls"
-    )
-fastembed_dependency = packaged.get("dependencies", {}).get("fastembed")
-if (
-    not isinstance(fastembed_dependency, dict)
-    or fastembed_dependency.get("optional") is not True
-    or fastembed_dependency.get("default-features") is not False
-):
-    raise SystemExit(
-        "distribution acceptance: fastembed must remain optional with default features disabled"
-    )
-
-references = {
-    item
-    for members in packaged_features.values()
-    for item in members
-    if isinstance(item, str)
-}
-unwired = sorted(
-    dependency
-    for dependency in optional_dependencies(packaged)
-    if f"dep:{dependency}" not in references
-    and dependency not in packaged_features
-)
-if unwired:
-    raise SystemExit(
-        "distribution acceptance: optional dependencies are not feature-wired: "
-        + ", ".join(unwired)
-    )
-PY
+  local semantic_source_manifest=$3
+  local semantic_packaged_manifest=$4
+  python3 "$repo/scripts/check-distribution-feature-wiring.py" \
+    --root-source "$source_manifest" \
+    --root-packaged "$packaged_manifest" \
+    --semantic-source "$semantic_source_manifest" \
+    --semantic-packaged "$semantic_packaged_manifest"
 }
 
 while (($#)); do
@@ -454,7 +369,11 @@ catalog_package=${package_dirs[tracedecay-tool-catalog]}
 
 assert_required_assets "$root_package"
 assert_code_extraction_assets "$code_extraction_package"
-verify_feature_wiring "$repo/Cargo.toml" "$root_package/Cargo.toml"
+verify_feature_wiring \
+  "$repo/Cargo.toml" \
+  "$root_package/Cargo.toml" \
+  "$repo/crates/tracedecay-semantic/Cargo.toml" \
+  "$semantic_package/Cargo.toml"
 
 patch_config="$work/packaged-crates.toml"
 python3 - "$metadata" "$packages" >"$patch_config" <<'PY'

--- a/scripts/check-distribution-feature-wiring.py
+++ b/scripts/check-distribution-feature-wiring.py
@@ -47,7 +47,7 @@ def optional_dependencies(manifest: dict) -> set[str]:
     return names
 
 
-def dependency_names(manifest: dict) -> set[str]:
+def dependency_package_names(manifest: dict) -> set[str]:
     names: set[str] = set()
 
     def collect(table: object) -> None:
@@ -55,7 +55,9 @@ def dependency_names(manifest: dict) -> set[str]:
             return
         dependencies = table.get("dependencies")
         if isinstance(dependencies, dict):
-            names.update(dependencies)
+            for name, spec in dependencies.items():
+                package = spec.get("package") if isinstance(spec, dict) else None
+                names.add(package if isinstance(package, str) else name)
 
     collect(manifest)
     for target in manifest.get("target", {}).values():
@@ -106,7 +108,7 @@ def validate(
             + ", ".join(missing)
         )
     root_semantic_members = root_features.get("semantic-fastembed")
-    if "fastembed" in dependency_names(root_packaged):
+    if "fastembed" in dependency_package_names(root_packaged):
         raise SystemExit(
             "distribution acceptance: root package must not own fastembed"
         )

--- a/scripts/check-distribution-feature-wiring.py
+++ b/scripts/check-distribution-feature-wiring.py
@@ -47,6 +47,22 @@ def optional_dependencies(manifest: dict) -> set[str]:
     return names
 
 
+def dependency_names(manifest: dict) -> set[str]:
+    names: set[str] = set()
+
+    def collect(table: object) -> None:
+        if not isinstance(table, dict):
+            return
+        dependencies = table.get("dependencies")
+        if isinstance(dependencies, dict):
+            names.update(dependencies)
+
+    collect(manifest)
+    for target in manifest.get("target", {}).values():
+        collect(target)
+    return names
+
+
 def require_matching_features(name: str, source: dict, packaged: dict) -> dict:
     source_features = source.get("features", {})
     packaged_features = packaged.get("features", {})
@@ -90,8 +106,13 @@ def validate(
             + ", ".join(missing)
         )
     root_semantic_members = root_features.get("semantic-fastembed")
-    if not isinstance(root_semantic_members, list) or not REQUIRED_ROOT_SEMANTIC_MEMBERS.issubset(
-        root_semantic_members
+    if "fastembed" in dependency_names(root_packaged):
+        raise SystemExit(
+            "distribution acceptance: root package must not own fastembed"
+        )
+    if (
+        not isinstance(root_semantic_members, list)
+        or set(root_semantic_members) != REQUIRED_ROOT_SEMANTIC_MEMBERS
     ):
         raise SystemExit(
             "distribution acceptance: root semantic-fastembed must forward to the "

--- a/scripts/check-distribution-feature-wiring.py
+++ b/scripts/check-distribution-feature-wiring.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Validate source and packaged Cargo feature ownership for distribution builds."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import tomllib
+
+
+REQUIRED_ROOT_FEATURES = {
+    "full",
+    "token-counting",
+    "semantic-fastembed",
+    "test-transport",
+}
+REQUIRED_ROOT_SEMANTIC_MEMBERS = {
+    "tracedecay-semantic/semantic-fastembed",
+    "tracedecay-usecases/semantic-fastembed",
+}
+REQUIRED_SEMANTIC_MEMBERS = {
+    "dep:fastembed",
+    "fastembed/ort-download-binaries-rustls-tls",
+}
+
+
+def load(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def optional_dependencies(manifest: dict) -> set[str]:
+    names: set[str] = set()
+
+    def collect(table: object) -> None:
+        if not isinstance(table, dict):
+            return
+        dependencies = table.get("dependencies")
+        if isinstance(dependencies, dict):
+            for name, spec in dependencies.items():
+                if isinstance(spec, dict) and spec.get("optional") is True:
+                    names.add(name)
+
+    collect(manifest)
+    for target in manifest.get("target", {}).values():
+        collect(target)
+    return names
+
+
+def require_matching_features(name: str, source: dict, packaged: dict) -> dict:
+    source_features = source.get("features", {})
+    packaged_features = packaged.get("features", {})
+    if source_features != packaged_features:
+        raise SystemExit(
+            f"distribution acceptance: packaged {name} feature wiring differs from Cargo.toml"
+        )
+    return packaged_features
+
+
+def require_optional_dependencies_wired(name: str, manifest: dict, features: dict) -> None:
+    references = {
+        item
+        for members in features.values()
+        for item in members
+        if isinstance(item, str)
+    }
+    unwired = sorted(
+        dependency
+        for dependency in optional_dependencies(manifest)
+        if f"dep:{dependency}" not in references and dependency not in features
+    )
+    if unwired:
+        raise SystemExit(
+            f"distribution acceptance: {name} optional dependencies are not feature-wired: "
+            + ", ".join(unwired)
+        )
+
+
+def validate(
+    root_source: dict,
+    root_packaged: dict,
+    semantic_source: dict,
+    semantic_packaged: dict,
+) -> None:
+    root_features = require_matching_features("root", root_source, root_packaged)
+    missing = sorted(REQUIRED_ROOT_FEATURES - root_features.keys())
+    if missing:
+        raise SystemExit(
+            "distribution acceptance: source manifest is missing required features: "
+            + ", ".join(missing)
+        )
+    root_semantic_members = root_features.get("semantic-fastembed")
+    if not isinstance(root_semantic_members, list) or not REQUIRED_ROOT_SEMANTIC_MEMBERS.issubset(
+        root_semantic_members
+    ):
+        raise SystemExit(
+            "distribution acceptance: root semantic-fastembed must forward to the "
+            "semantic and usecases owners"
+        )
+    require_optional_dependencies_wired("root", root_packaged, root_features)
+
+    semantic_features = require_matching_features(
+        "tracedecay-semantic", semantic_source, semantic_packaged
+    )
+    semantic_members = semantic_features.get("semantic-fastembed")
+    if not isinstance(semantic_members, list) or not REQUIRED_SEMANTIC_MEMBERS.issubset(
+        semantic_members
+    ):
+        raise SystemExit(
+            "distribution acceptance: tracedecay-semantic semantic-fastembed must enable "
+            "dep:fastembed and fastembed/ort-download-binaries-rustls-tls"
+        )
+    fastembed_dependency = semantic_packaged.get("dependencies", {}).get("fastembed")
+    if (
+        not isinstance(fastembed_dependency, dict)
+        or fastembed_dependency.get("optional") is not True
+        or fastembed_dependency.get("default-features") is not False
+    ):
+        raise SystemExit(
+            "distribution acceptance: tracedecay-semantic fastembed must remain optional "
+            "with default features disabled"
+        )
+    require_optional_dependencies_wired(
+        "tracedecay-semantic", semantic_packaged, semantic_features
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root-source", type=Path, required=True)
+    parser.add_argument("--root-packaged", type=Path, required=True)
+    parser.add_argument("--semantic-source", type=Path, required=True)
+    parser.add_argument("--semantic-packaged", type=Path, required=True)
+    arguments = parser.parse_args()
+    validate(
+        load(arguments.root_source),
+        load(arguments.root_packaged),
+        load(arguments.semantic_source),
+        load(arguments.semantic_packaged),
+    )
+    print("distribution feature wiring is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-check-distribution-feature-wiring.py
+++ b/scripts/test-check-distribution-feature-wiring.py
@@ -120,6 +120,22 @@ def main() -> int:
     if "root semantic-fastembed must forward" not in root_direct_owner.stderr:
         raise SystemExit("root ownership drift failed for an unexpected reason")
 
+    root_with_shadow_owner = ROOT_MANIFEST.replace(
+        "[dependencies]\n",
+        "[dependencies]\nfastembed = { version = \"=5.17.3\", optional = true }\n",
+    ).replace(
+        'semantic-fastembed = [\n',
+        'semantic-fastembed = [\n    "dep:fastembed",\n',
+    )
+    root_shadow_owner = run_fixture(
+        root_source=root_with_shadow_owner,
+        root_packaged=root_with_shadow_owner,
+    )
+    if root_shadow_owner.returncode == 0:
+        raise SystemExit("root package retaining shadow FastEmbed ownership was accepted")
+    if "root package must not own fastembed" not in root_shadow_owner.stderr:
+        raise SystemExit("root shadow ownership failed for an unexpected reason")
+
     print("distribution feature wiring fixtures passed")
     return 0
 

--- a/scripts/test-check-distribution-feature-wiring.py
+++ b/scripts/test-check-distribution-feature-wiring.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Regression tests for distribution feature ownership validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+VALIDATOR = Path(__file__).with_name("check-distribution-feature-wiring.py")
+
+ROOT_MANIFEST = """[package]
+name = "tracedecay"
+version = "0.1.0-beta.34"
+
+[dependencies]
+tracedecay-semantic = { version = "0.1.0" }
+tracedecay-usecases = { version = "0.1.0" }
+
+[features]
+full = []
+token-counting = []
+test-transport = []
+semantic-fastembed = [
+    "tracedecay-semantic/semantic-fastembed",
+    "tracedecay-usecases/semantic-fastembed",
+]
+"""
+
+SEMANTIC_MANIFEST = """[package]
+name = "tracedecay-semantic"
+version = "0.1.0"
+
+[dependencies]
+fastembed = { version = "=5.17.3", optional = true, default-features = false }
+hf-hub = { version = "0.5", optional = true, default-features = false }
+
+[features]
+semantic-fastembed = [
+    "dep:fastembed",
+    "dep:hf-hub",
+    "fastembed/ort-download-binaries-rustls-tls",
+    "fastembed/hf-hub-rustls-tls",
+]
+"""
+
+
+@dataclass(frozen=True)
+class FixtureResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_fixture(
+    root_source: str = ROOT_MANIFEST,
+    root_packaged: str = ROOT_MANIFEST,
+    semantic_source: str = SEMANTIC_MANIFEST,
+    semantic_packaged: str = SEMANTIC_MANIFEST,
+) -> FixtureResult:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        root = Path(temporary_directory)
+        manifests = {
+            "root-source.toml": root_source,
+            "root-packaged.toml": root_packaged,
+            "semantic-source.toml": semantic_source,
+            "semantic-packaged.toml": semantic_packaged,
+        }
+        for name, contents in manifests.items():
+            root.joinpath(name).write_text(contents, encoding="utf-8")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(VALIDATOR),
+                "--root-source",
+                str(root / "root-source.toml"),
+                "--root-packaged",
+                str(root / "root-packaged.toml"),
+                "--semantic-source",
+                str(root / "semantic-source.toml"),
+                "--semantic-packaged",
+                str(root / "semantic-packaged.toml"),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return FixtureResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def main() -> int:
+    extracted_owner = run_fixture()
+    if extracted_owner.returncode != 0:
+        raise SystemExit(extracted_owner.stderr)
+
+    semantic_without_runtime = SEMANTIC_MANIFEST.replace(
+        '    "fastembed/ort-download-binaries-rustls-tls",\n', ""
+    )
+    missing_runtime = run_fixture(
+        semantic_source=semantic_without_runtime,
+        semantic_packaged=semantic_without_runtime,
+    )
+    if missing_runtime.returncode == 0:
+        raise SystemExit("semantic owner without the bundled ORT feature was accepted")
+    if "tracedecay-semantic semantic-fastembed must enable" not in missing_runtime.stderr:
+        raise SystemExit("missing semantic runtime failed for an unexpected reason")
+
+    root_with_direct_owner = ROOT_MANIFEST.replace(
+        '    "tracedecay-semantic/semantic-fastembed",\n', '    "dep:fastembed",\n'
+    )
+    root_direct_owner = run_fixture(
+        root_source=root_with_direct_owner,
+        root_packaged=root_with_direct_owner,
+    )
+    if root_direct_owner.returncode == 0:
+        raise SystemExit("root package reclaiming FastEmbed ownership was accepted")
+    if "root semantic-fastembed must forward" not in root_direct_owner.stderr:
+        raise SystemExit("root ownership drift failed for an unexpected reason")
+
+    print("distribution feature wiring fixtures passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-check-distribution-feature-wiring.py
+++ b/scripts/test-check-distribution-feature-wiring.py
@@ -136,6 +136,22 @@ def main() -> int:
     if "root package must not own fastembed" not in root_shadow_owner.stderr:
         raise SystemExit("root shadow ownership failed for an unexpected reason")
 
+    root_with_aliased_shadow_owner = ROOT_MANIFEST.replace(
+        "[dependencies]\n",
+        "[dependencies]\nfastembed-shadow = { package = \"fastembed\", version = \"=5.17.3\", optional = true }\n",
+    ).replace(
+        "[features]\n",
+        '[features]\nshadow-fastembed = ["dep:fastembed-shadow"]\n',
+    )
+    root_aliased_shadow_owner = run_fixture(
+        root_source=root_with_aliased_shadow_owner,
+        root_packaged=root_with_aliased_shadow_owner,
+    )
+    if root_aliased_shadow_owner.returncode == 0:
+        raise SystemExit("renamed root FastEmbed dependency was accepted")
+    if "root package must not own fastembed" not in root_aliased_shadow_owner.stderr:
+        raise SystemExit("renamed root ownership failed for an unexpected reason")
+
     print("distribution feature wiring fixtures passed")
     return 0
 


### PR DESCRIPTION
## Summary

- fixes beta.34 distribution acceptance after FastEmbed ownership moved from the root crate to `tracedecay-semantic`
- validates root feature forwarding and the semantic crate's direct FastEmbed/ORT ownership against Cargo's normalized packaged manifests
- adds a fast fixture regression to beta and stable release harness validation

## Root cause

The release gate still required the root `semantic-fastembed` feature to contain `dep:fastembed` and inspected a root dependency that no longer exists. The root correctly forwards to `tracedecay-semantic/semantic-fastembed`; that crate owns the optional dependency and ORT feature.

Observed RED: beta.34 aarch64 Linux release job 96948387454 failed distribution acceptance with `semantic-fastembed must enable dep:fastembed and fastembed/ort-download-binaries-rustls-tls` after all-feature compilation and packaging succeeded.

## Verification

- `python3 scripts/test-check-distribution-feature-wiring.py`
- validator passes against Cargo's actual `cargo package --workspace --exclude-lockfile` normalized root and semantic manifests
- `python3 -m py_compile` for both scripts
- `bash -n scripts/check-distribution-acceptance.sh`
- `shellcheck scripts/check-distribution-acceptance.sh`
- `actionlint .github/workflows/release.yml .github/workflows/release-beta.yml`
- `git diff --check`
- commitlint for the new commit

This PR targets #421 and does not merge #421 into master.
