### PR TITLE
fix(release): validate exact published prerelease

### DIFF
--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -5,9 +5,9 @@ usage() {
   cat <<'EOF'
 Usage: scripts/check-release-drift.sh [--repo PATH] [--release-version VERSION]
 
-Fails when Cargo.toml differs from the latest non-prerelease GitHub release
-tag. That state means a release automation version bump reached master without
-the GitHub tag/release completing.
+Fails when Cargo.toml differs from its published GitHub release. Stable
+versions are compared with the latest non-prerelease release; prerelease
+versions require their exact published prerelease tag.
 EOF
 }
 
@@ -52,17 +52,33 @@ if [[ -z "$release_version" ]]; then
   if [[ -n "${GITHUB_TOKEN:-}" ]]; then
     curl_args+=(-H "Authorization: Bearer $GITHUB_TOKEN")
   fi
-  release_version="$(curl "${curl_args[@]}" \
-    https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest \
-    | python3 -c '
+  release_endpoint="https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest"
+  expected_prerelease=false
+  if [[ "$local_version" == *-* ]]; then
+    release_endpoint="https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/tags/v${local_version}"
+    expected_prerelease=true
+  fi
+  if ! release_response="$(curl "${curl_args[@]}" "$release_endpoint")"; then
+    echo "release drift detected: no published GitHub release v$local_version" >&2
+    exit 1
+  fi
+  release_version="$(python3 - "$local_version" "$expected_prerelease" "$release_response" <<'PY'
 import json
 import sys
 
-tag = json.load(sys.stdin).get("tag_name")
+local_version, expected_prerelease, payload = sys.argv[1:]
+release = json.loads(payload)
+tag = release.get("tag_name")
 if not isinstance(tag, str) or not tag:
-    raise SystemExit("latest GitHub release response has no tag_name")
+    raise SystemExit("GitHub release response has no tag_name")
+if expected_prerelease == "true":
+    if tag != f"v{local_version}":
+        raise SystemExit(f"GitHub prerelease tag mismatch: expected v{local_version}, got {tag}")
+    if release.get("draft") is not False or release.get("prerelease") is not True:
+        raise SystemExit(f"GitHub prerelease v{local_version} is not published")
 print(tag)
-')"
+PY
+)"
 fi
 
 release_version="${release_version#v}"

--- a/tests/release_drift_check_test.sh
+++ b/tests/release_drift_check_test.sh
@@ -30,14 +30,52 @@ cat >"$fake_bin/curl" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-[[ "$*" == *"https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest"* ]]
-printf '%s\n' '{"tag_name":"v0.0.33"}'
+case "$*" in
+  *"https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest"*)
+    printf '%s\n' '{"tag_name":"v0.0.33","draft":false,"prerelease":false}'
+    ;;
+  *"https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/tags/v0.1.0-beta.34"*)
+    case "${FAKE_RELEASE_STATE:-published}" in
+      draft)
+        printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":true,"prerelease":true}'
+        ;;
+      stable)
+        printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":false,"prerelease":false}'
+        ;;
+      published)
+        printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":false,"prerelease":true}'
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected GitHub release endpoint: $*" >&2
+    exit 1
+    ;;
+esac
 SH
 chmod +x "$fake_bin/curl"
 
 gate_run env PATH="$fake_bin:$PATH" "$SCRIPT" --repo "$same_repo"
 gate_expect_success "GitHub release lookup"
 gate_output_contains "GitHub release lookup" "release versions are aligned: 0.0.33"
+
+prerelease_repo="$(write_repo 0.1.0-beta.34)"
+gate_run env PATH="$fake_bin:$PATH" "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_success "published prerelease lookup"
+gate_output_contains "published prerelease lookup" \
+  "release versions are aligned: 0.1.0-beta.34"
+
+gate_run env FAKE_RELEASE_STATE=draft PATH="$fake_bin:$PATH" \
+  "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_status "draft prerelease" 1
+gate_output_contains "draft prerelease" \
+  "GitHub prerelease v0.1.0-beta.34 is not published"
+
+gate_run env FAKE_RELEASE_STATE=stable PATH="$fake_bin:$PATH" \
+  "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_status "release with wrong channel" 1
+gate_output_contains "release with wrong channel" \
+  "GitHub prerelease v0.1.0-beta.34 is not published"
 
 ahead_repo="$(write_repo 0.0.34)"
 gate_run "$SCRIPT" --repo "$ahead_repo" --release-version v0.0.33


### PR DESCRIPTION
## Outcome

The release-drift gate now compares prerelease checkouts with their exact published GitHub prerelease instead of GitHub’s latest stable release. This removes the false beta.34-versus-v0.0.74 failure without weakening stable release drift detection.

This is the top layer of the gate-repair stack:

1. #607 fixes the rusqlite-runtime all-target Clippy ordering error.
2. #609 fixes every verified graph publication bench manifest conversion found by Clippy/Hawk.
3. This PR fixes the prerelease drift gate.

Once this exact head is green, it can merge down through #609 and #607 into #421. It must not merge into master.

## TDD evidence

RED: the published prerelease fixture exited 1 because the guard queried `/releases/latest` and compared `0.1.0-beta.34` with stable `v0.0.33`.

GREEN:
- `bash tests/release_drift_check_test.sh`
- live `scripts/check-release-drift.sh` against published `v0.1.0-beta.34`
- `bash -n scripts/check-release-drift.sh tests/release_drift_check_test.sh`
- `shellcheck scripts/check-release-drift.sh`
- `shellcheck -e SC1091 tests/release_drift_check_test.sh`
- `git diff --check`

The behavioral fixture also proves draft prereleases and exact-tag releases marked as non-prerelease fail closed.