### PR TITLE
fix(graph-db): wrap bench manifests for verified publish

### DIFF
--- a/crates/tracedecay-graph-db/benches/support/mismatch.rs
+++ b/crates/tracedecay-graph-db/benches/support/mismatch.rs
@@ -81,7 +81,7 @@ impl ExactMismatchReplay {
                 &mut mismatch,
                 &publish_context,
                 &key,
-                Some(manifest.clone()),
+                Some(manifest.clone().into()),
             )
             .expect_err("the exact recovered-digest mismatch must reject publication");
         assert!(
@@ -136,7 +136,7 @@ impl ExactMismatchReplay {
                 &mut self.graph.authority,
                 &context,
                 &self.key,
-                Some(self.manifest),
+                Some(self.manifest.into()),
             )
             .expect("exact mismatch replay reopens and verifies");
         assert_eq!(commit.head.key, self.key);

--- a/crates/tracedecay-graph-db/benches/support/mod.rs
+++ b/crates/tracedecay-graph-db/benches/support/mod.rs
@@ -259,7 +259,7 @@ impl PersistentBenchmarkGraph {
                 &mut self.authority,
                 &publish_context,
                 &key,
-                Some(manifest),
+                Some(manifest.into()),
             )
             .expect("benchmark generation publishes and verifies");
         drop(completion);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clean replacement for #609. Wraps the graph-db bench support manifests (`Some(manifest)` → `Some(manifest.into())`) so the bench harness compiles against the verified-publish signature change. Same type wrap as the already-reviewed isolate, scoped to exactly two files:

- `crates/tracedecay-graph-db/benches/support/mod.rs` (line 262): `Some(manifest)` → `Some(manifest.into())`
- `crates/tracedecay-graph-db/benches/support/mismatch.rs` (lines 84, 139): `Some(manifest.clone())` → `Some(manifest.clone().into())`; `Some(self.manifest)` → `Some(self.manifest.into())`

No `#[allow]`, no `tracedecay-code-index` bench changes, no rusqlite changes.

## Why replace #609

The head of #609 (`5305f6f6d474adf31ecd55a6c7eb1f0d61791160`) has the #607 commit `b2163041ace6fdbedd0f8dce0dc7eff10a7061da` as an ancestor. Merging it would historically merge #607 while reverting its tree and would break the later #607 restack. This PR is built directly on the exact 421 tip with no `b216` ancestry:

- Base: `2be2b9478959213924f797ba206766a219d987cc` (exact `codex/tracedecay-total-redesign-plan` tip)
- Commits: `91428631d86b5b00458a81e9cab743d5f4c33de5` → `c14bbf09a364f4ab1e49071aa4d1dfa77e5e312f` (head)
- Proof: `git merge-base --is-ancestor b2163041ace6fdbedd0f8dce0dc7eff10a7061da c14bbf09a` exits **1** (not an ancestor)

## Verification (on head c14bbf09)

- `cargo clippy -p tracedecay-graph-db --all-targets --all-features -- -D warnings` → exit 0 (benches compiled; criterion in the build graph, non-vacuous)
- `cargo fmt --check -p tracedecay-graph-db` → exit 0
- `npm run lint:commit -- --from 2be2b9478 --to HEAD` → exit 0
- 3-dot diff vs `2be2b9478` is exactly the two graph-db bench support files (3 insertions, 3 deletions)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26f4e983-f148-4116-bbcc-214bc44864c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26f4e983-f148-4116-bbcc-214bc44864c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

