### PR TITLE
fix(tests): satisfy workspace Clippy gates

### DIFF
--- a/crates/tracedecay-code-index/benches/support/git.rs
+++ b/crates/tracedecay-code-index/benches/support/git.rs
@@ -250,7 +250,7 @@ impl PersistentGitGraph {
                 &mut self.authority,
                 &publish_context,
                 &key,
-                Some(manifest),
+                Some(manifest.into()),
             )
             .expect("benchmark generation publishes and verifies");
         self.latest_head = Some(commit.head);

--- a/crates/tracedecay-graph-db/benches/support/mismatch.rs
+++ b/crates/tracedecay-graph-db/benches/support/mismatch.rs
@@ -81,7 +81,7 @@ impl ExactMismatchReplay {
                 &mut mismatch,
                 &publish_context,
                 &key,
-                Some(manifest.clone()),
+                Some(manifest.clone().into()),
             )
             .expect_err("the exact recovered-digest mismatch must reject publication");
         assert!(
@@ -136,7 +136,7 @@ impl ExactMismatchReplay {
                 &mut self.graph.authority,
                 &context,
                 &self.key,
-                Some(self.manifest),
+                Some(self.manifest.into()),
             )
             .expect("exact mismatch replay reopens and verifies");
         assert_eq!(commit.head.key, self.key);

--- a/crates/tracedecay-graph-db/benches/support/mod.rs
+++ b/crates/tracedecay-graph-db/benches/support/mod.rs
@@ -259,7 +259,7 @@ impl PersistentBenchmarkGraph {
                 &mut self.authority,
                 &publish_context,
                 &key,
-                Some(manifest),
+                Some(manifest.into()),
             )
             .expect("benchmark generation publishes and verifies");
         drop(completion);

--- a/crates/tracedecay-runtime-core/src/db/connection/memory_graph_reconciliation.rs
+++ b/crates/tracedecay-runtime-core/src/db/connection/memory_graph_reconciliation.rs
@@ -1108,7 +1108,10 @@ mod tests {
         })
         .await;
 
-        tokio::time::advance(AUTOMATIC_RETRY_BASE - Duration::from_millis(1)).await;
+        let just_before_retry = AUTOMATIC_RETRY_BASE
+            .checked_sub(Duration::from_millis(1))
+            .expect("automatic retry base exceeds one millisecond");
+        tokio::time::advance(just_before_retry).await;
         for _ in 0..64 {
             tokio::task::yield_now().await;
         }

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/command.rs
@@ -129,33 +129,6 @@ fn lease_now() -> Instant {
 #[cfg(test)]
 use lease_clock::lease_now;
 
-#[cfg(test)]
-pub(crate) mod lease_clock {
-    use std::{
-        cell::Cell,
-        time::{Duration, Instant},
-    };
-
-    thread_local! {
-        static FAKE_LEASE_NOW: Cell<Option<Instant>> = const { Cell::new(None) };
-    }
-
-    /// Real monotonic time until [`advance`] freezes this thread's clock.
-    pub(crate) fn lease_now() -> Instant {
-        FAKE_LEASE_NOW.with(Cell::get).unwrap_or_else(Instant::now)
-    }
-
-    /// Freezes this thread's lease clock `by` past its current reading.
-    ///
-    /// Only code already running on the writer thread — in practice an
-    /// [`super::ExactSqlWriteAuthority`] verification — can move the clock
-    /// the transaction loop reads.
-    pub(crate) fn advance(by: Duration) {
-        let advanced = lease_now() + by;
-        FAKE_LEASE_NOW.with(|fake| fake.set(Some(advanced)));
-    }
-}
-
 pub(crate) enum TransactionCommand {
     Attach {
         attachment: ExactSqlAttachment,
@@ -699,5 +672,32 @@ impl TransactionCompletion {
             None => {}
         }
         cleanup_error.map_or(Ok(()), Err)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod lease_clock {
+    use std::{
+        cell::Cell,
+        time::{Duration, Instant},
+    };
+
+    thread_local! {
+        static FAKE_LEASE_NOW: Cell<Option<Instant>> = const { Cell::new(None) };
+    }
+
+    /// Real monotonic time until [`advance`] freezes this thread's clock.
+    pub(crate) fn lease_now() -> Instant {
+        FAKE_LEASE_NOW.with(Cell::get).unwrap_or_else(Instant::now)
+    }
+
+    /// Freezes this thread's lease clock `by` past its current reading.
+    ///
+    /// Only code already running on the writer thread — in practice an
+    /// [`super::ExactSqlWriteAuthority`] verification — can move the clock
+    /// the transaction loop reads.
+    pub(crate) fn advance(by: Duration) {
+        let advanced = lease_now() + by;
+        FAKE_LEASE_NOW.with(|fake| fake.set(Some(advanced)));
     }
 }

--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -5,9 +5,9 @@ usage() {
   cat <<'EOF'
 Usage: scripts/check-release-drift.sh [--repo PATH] [--release-version VERSION]
 
-Fails when Cargo.toml differs from the latest non-prerelease GitHub release
-tag. That state means a release automation version bump reached master without
-the GitHub tag/release completing.
+Fails when Cargo.toml differs from its published GitHub release. Stable
+versions are compared with the latest non-prerelease release; prerelease
+versions require their exact published prerelease tag.
 EOF
 }
 
@@ -52,17 +52,33 @@ if [[ -z "$release_version" ]]; then
   if [[ -n "${GITHUB_TOKEN:-}" ]]; then
     curl_args+=(-H "Authorization: Bearer $GITHUB_TOKEN")
   fi
-  release_version="$(curl "${curl_args[@]}" \
-    https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest \
-    | python3 -c '
+  release_endpoint="https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest"
+  expected_prerelease=false
+  if [[ "$local_version" == *-* ]]; then
+    release_endpoint="https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/tags/v${local_version}"
+    expected_prerelease=true
+  fi
+  if ! release_response="$(curl "${curl_args[@]}" "$release_endpoint")"; then
+    echo "release drift detected: no published GitHub release v$local_version" >&2
+    exit 1
+  fi
+  release_version="$(python3 - "$local_version" "$expected_prerelease" "$release_response" <<'PY'
 import json
 import sys
 
-tag = json.load(sys.stdin).get("tag_name")
+local_version, expected_prerelease, payload = sys.argv[1:]
+release = json.loads(payload)
+tag = release.get("tag_name")
 if not isinstance(tag, str) or not tag:
-    raise SystemExit("latest GitHub release response has no tag_name")
+    raise SystemExit("GitHub release response has no tag_name")
+if expected_prerelease == "true":
+    if tag != f"v{local_version}":
+        raise SystemExit(f"GitHub prerelease tag mismatch: expected v{local_version}, got {tag}")
+    if release.get("draft") is not False or release.get("prerelease") is not True:
+        raise SystemExit(f"GitHub prerelease v{local_version} is not published")
 print(tag)
-')"
+PY
+)"
 fi
 
 release_version="${release_version#v}"

--- a/scripts/check-release-drift.sh
+++ b/scripts/check-release-drift.sh
@@ -62,12 +62,12 @@ if [[ -z "$release_version" ]]; then
     echo "release drift detected: no published GitHub release v$local_version" >&2
     exit 1
   fi
-  release_version="$(python3 - "$local_version" "$expected_prerelease" "$release_response" <<'PY'
+  release_version="$(python3 -c '
 import json
 import sys
 
-local_version, expected_prerelease, payload = sys.argv[1:]
-release = json.loads(payload)
+local_version, expected_prerelease = sys.argv[1:]
+release = json.load(sys.stdin)
 tag = release.get("tag_name")
 if not isinstance(tag, str) or not tag:
     raise SystemExit("GitHub release response has no tag_name")
@@ -77,8 +77,7 @@ if expected_prerelease == "true":
     if release.get("draft") is not False or release.get("prerelease") is not True:
         raise SystemExit(f"GitHub prerelease v{local_version} is not published")
 print(tag)
-PY
-)"
+' "$local_version" "$expected_prerelease" <<<"$release_response")"
 fi
 
 release_version="${release_version#v}"

--- a/src/daemon/tests/ownership.rs
+++ b/src/daemon/tests/ownership.rs
@@ -213,7 +213,7 @@ async fn cold_project_shutdown_joins_every_production_graph_holder() {
     release_cold_commit
         .send(())
         .expect("release cold mount during shutdown");
-    let shutdown = tokio::time::timeout(std::time::Duration::from_secs(60), shutdown)
+    let shutdown = tokio::time::timeout(std::time::Duration::from_mins(1), shutdown)
         .await
         .expect("daemon shutdown deadline")
         .expect("daemon shutdown task");

--- a/src/startup_tests.rs
+++ b/src/startup_tests.rs
@@ -651,15 +651,13 @@ fn agent_install_health_check_is_selective() {
     }));
     assert!(should_skip_agent_install_check(&Commands::Doctor));
 
-    for (label, args) in [("init", &["tracedecay", "init", "."][..])] {
-        let cli = Cli::try_parse_from(args)
-            .unwrap_or_else(|error| panic!("{label} entrypoint must parse: {error}"));
-        let command = cli.command.expect("entrypoint command");
-        assert!(
-            !should_skip_agent_install_check(&command),
-            "{label} should retain the read-only install health check"
-        );
-    }
+    let cli = Cli::try_parse_from(["tracedecay", "init", "."])
+        .unwrap_or_else(|error| panic!("init entrypoint must parse: {error}"));
+    let command = cli.command.expect("entrypoint command");
+    assert!(
+        !should_skip_agent_install_check(&command),
+        "init should retain the read-only install health check"
+    );
 
     for (label, args) in [
         ("status", &["tracedecay", "status", "--json"][..]),

--- a/tests/release_drift_check_test.sh
+++ b/tests/release_drift_check_test.sh
@@ -30,14 +30,52 @@ cat >"$fake_bin/curl" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
-[[ "$*" == *"https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest"* ]]
-printf '%s\n' '{"tag_name":"v0.0.33"}'
+case "$*" in
+  *"https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/latest"*)
+    printf '%s\n' '{"tag_name":"v0.0.33","draft":false,"prerelease":false}'
+    ;;
+  *"https://api.github.com/repos/ScriptedAlchemy/tracedecay/releases/tags/v0.1.0-beta.34"*)
+    case "${FAKE_RELEASE_STATE:-published}" in
+      draft)
+        printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":true,"prerelease":true}'
+        ;;
+      stable)
+        printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":false,"prerelease":false}'
+        ;;
+      published)
+        printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":false,"prerelease":true}'
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected GitHub release endpoint: $*" >&2
+    exit 1
+    ;;
+esac
 SH
 chmod +x "$fake_bin/curl"
 
 gate_run env PATH="$fake_bin:$PATH" "$SCRIPT" --repo "$same_repo"
 gate_expect_success "GitHub release lookup"
 gate_output_contains "GitHub release lookup" "release versions are aligned: 0.0.33"
+
+prerelease_repo="$(write_repo 0.1.0-beta.34)"
+gate_run env PATH="$fake_bin:$PATH" "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_success "published prerelease lookup"
+gate_output_contains "published prerelease lookup" \
+  "release versions are aligned: 0.1.0-beta.34"
+
+gate_run env FAKE_RELEASE_STATE=draft PATH="$fake_bin:$PATH" \
+  "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_status "draft prerelease" 1
+gate_output_contains "draft prerelease" \
+  "GitHub prerelease v0.1.0-beta.34 is not published"
+
+gate_run env FAKE_RELEASE_STATE=stable PATH="$fake_bin:$PATH" \
+  "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_status "release with wrong channel" 1
+gate_output_contains "release with wrong channel" \
+  "GitHub prerelease v0.1.0-beta.34 is not published"
 
 ahead_repo="$(write_repo 0.0.34)"
 gate_run "$SCRIPT" --repo "$ahead_repo" --release-version v0.0.33

--- a/tests/release_drift_check_test.sh
+++ b/tests/release_drift_check_test.sh
@@ -42,6 +42,18 @@ case "$*" in
       stable)
         printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":false,"prerelease":false}'
         ;;
+      large)
+        python3 - <<'PY'
+import json
+
+print(json.dumps({
+    "tag_name": "v0.1.0-beta.34",
+    "draft": False,
+    "prerelease": True,
+    "body": "x" * 200_000,
+}))
+PY
+        ;;
       published)
         printf '%s\n' '{"tag_name":"v0.1.0-beta.34","draft":false,"prerelease":true}'
         ;;
@@ -63,6 +75,12 @@ prerelease_repo="$(write_repo 0.1.0-beta.34)"
 gate_run env PATH="$fake_bin:$PATH" "$SCRIPT" --repo "$prerelease_repo"
 gate_expect_success "published prerelease lookup"
 gate_output_contains "published prerelease lookup" \
+  "release versions are aligned: 0.1.0-beta.34"
+
+gate_run env FAKE_RELEASE_STATE=large PATH="$fake_bin:$PATH" \
+  "$SCRIPT" --repo "$prerelease_repo"
+gate_expect_success "published prerelease with large metadata"
+gate_output_contains "published prerelease with large metadata" \
   "release versions are aligned: 0.1.0-beta.34"
 
 gate_run env FAKE_RELEASE_STATE=draft PATH="$fake_bin:$PATH" \


### PR DESCRIPTION
## Summary

- make the paused-time retry boundary use checked duration subtraction
- express the daemon shutdown deadline in canonical minute units
- remove a single-element startup-test loop without changing its assertion

## Evidence

RED was the hosted full-workspace Clippy job on #607 (job 96967227169):
- `clippy::unchecked_time_subtraction` in runtime-core
- `clippy::duration_suboptimal_units` in daemon ownership tests
- `clippy::single_element_loop` in startup tests (revealed after the first two fixes)

GREEN on exact commit `5c34626e9`:
- `cargo +1.97.1 fmt --check -- ...` — pass
- `TRACEDECAY_SKIP_DASHBOARD_BUILD=1 cargo +1.97.1 clippy -p tracedecay-runtime-core --lib --tests --locked -- -D warnings` — pass
- `TRACEDECAY_SKIP_DASHBOARD_BUILD=1 cargo +1.97.1 clippy -p tracedecay --lib --tests --locked -- -D warnings` — pass
- retry regression — 1 passed, 0 failed
- startup inspection regression — 1 passed, 0 failed

This PR targets #421 only. It must not be merged into master.
