### PR TITLE
fix(benches): wrap manifests for verified graph publish

### DIFF
--- a/crates/tracedecay-code-index/benches/support/git.rs
+++ b/crates/tracedecay-code-index/benches/support/git.rs
@@ -250,7 +250,7 @@ impl PersistentGitGraph {
                 &mut self.authority,
                 &publish_context,
                 &key,
-                Some(manifest),
+                Some(manifest.into()),
             )
             .expect("benchmark generation publishes and verifies");
         self.latest_head = Some(commit.head);

--- a/crates/tracedecay-graph-db/benches/support/mismatch.rs
+++ b/crates/tracedecay-graph-db/benches/support/mismatch.rs
@@ -81,7 +81,7 @@ impl ExactMismatchReplay {
                 &mut mismatch,
                 &publish_context,
                 &key,
-                Some(manifest.clone()),
+                Some(manifest.clone().into()),
             )
             .expect_err("the exact recovered-digest mismatch must reject publication");
         assert!(
@@ -136,7 +136,7 @@ impl ExactMismatchReplay {
                 &mut self.graph.authority,
                 &context,
                 &self.key,
-                Some(self.manifest),
+                Some(self.manifest.into()),
             )
             .expect("exact mismatch replay reopens and verifies");
         assert_eq!(commit.head.key, self.key);

--- a/crates/tracedecay-graph-db/benches/support/mod.rs
+++ b/crates/tracedecay-graph-db/benches/support/mod.rs
@@ -259,7 +259,7 @@ impl PersistentBenchmarkGraph {
                 &mut self.authority,
                 &publish_context,
                 &key,
-                Some(manifest),
+                Some(manifest.into()),
             )
             .expect("benchmark generation publishes and verifies");
         drop(completion);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remounts the graph-db bench isolate directly onto exact 421 (`codex/tracedecay-total-redesign-plan` @ `2be2b9478959213924f797ba206766a219d987cc`), replacing contaminated [#612](https://github.com/ScriptedAlchemy/tracedecay/pull/612).
- Head is the known-good, previously Mac-approved SHA `9c16732d6dce7c5c1f4ff3f1727ad925f0613f19` (parent chain `9c16732` → `4c9c06a6` → `f191c77d` → `2be2b947`), pushed as a new ref with no force-push.
- Does NOT include any #615 workspace clippy-time-tests changes.

## Motivation

[#612](https://github.com/ScriptedAlchemy/tracedecay/pull/612) was remounted off 421 onto #615 (`codex/fix-workspace-clippy-time-tests`), so its head `52413b34` has #615 in its ancestry and its 3-dot diff vs 421 picked up clippy-time-tests files (`memory_graph_reconciliation.rs`, `src/daemon/tests/ownership.rs`, `src/startup_tests.rs`). That voided the Mac approval of `9c16732d`. This PR restores the exact approved isolate on the exact approved base.

## Changes

3-dot diff `2be2b9478...9c16732d` is exactly:

- `crates/tracedecay-graph-db/benches/support/mod.rs`
- `crates/tracedecay-graph-db/benches/support/mismatch.rs`
- `crates/tracedecay-code-index/benches/support/git.rs`

Isolation proofs on this head:

- `git merge-base --is-ancestor b2163041ace6fdbedd0f8dce0dc7eff10a7061da HEAD` → exit 1 (not an ancestor)
- `git merge-base --is-ancestor 5c34626e932f08d47823fc5b88c38502f2d1e66a HEAD` → exit 1 (not an ancestor, no #615 contamination)

## Test plan

- [x] Head SHA `9c16732d` is byte-identical to the previously Mac-approved isolate (no new commits)
- [x] 3-dot vs base contains only the three bench support files above
- [ ] `cargo clippy -p tracedecay-graph-db --all-targets --all-features -- -D warnings`

## Checklist

- [x] No secrets, credentials, or `.env` files included
- [x] No breaking changes
- [x] `CHANGELOG.md` unchanged (bench-support-only fix, no version bump)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6ad070e-0f6d-4218-8914-15f285bf09db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6ad070e-0f6d-4218-8914-15f285bf09db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

