### PR TITLE
test(automation): closed-stdout fixture is Disconnected

### DIFF
--- a/tests/automation_runner_test/backend.rs
+++ b/tests/automation_runner_test/backend.rs
@@ -225,7 +225,7 @@ fn classifies_backend_failures_for_retry_policy() {
         ),
         (
             "config error: codex app-server closed stdout before completing",
-            AgentTaskFailureClass::Unavailable,
+            AgentTaskFailureClass::Disconnected,
             true,
         ),
         (
@@ -269,7 +269,7 @@ fn failure_disposition_heals_stale_recorded_retryability() {
 
     assert_eq!(
         disposition.classification,
-        Some(AgentTaskFailureClass::Unavailable)
+        Some(AgentTaskFailureClass::Disconnected)
     );
     assert_eq!(disposition.retryable, Some(true));
     assert!(!disposition.is_non_retryable());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixture PR C3: updates exactly two stale expected states in `tests/automation_runner_test/backend.rs` from `AgentTaskFailureClass::Unavailable` to `AgentTaskFailureClass::Disconnected` for the closed-stdout message (`config error: codex app-server closed stdout before completing`). Production has classified closed stdout as `Disconnected` since b392635; only the test expectations were stale.

- Site 1: classification table row in `classifies_backend_failures_for_retry_policy` — `Unavailable` → `Disconnected`, `retryable` stays `true`.
- Site 2: `failure_disposition_heals_stale_recorded_retryability` — `Some(Unavailable)` → `Some(Disconnected)`.

The `codex was not found` `Unavailable` row is untouched. No production edits; one file only.

## RED/GREEN proof (non-vacuous)

On the unmodified floor `3ac2a798a1af388d0ac5513c72de8385f8641f51`, both tests fail:

```
test backend::classifies_backend_failures_for_retry_policy ... FAILED
  left: Disconnected / right: Unavailable  (message: config error: codex app-server closed stdout before completing)
test backend::failure_disposition_heals_stale_recorded_retryability ... FAILED
  left: Some(Disconnected) / right: Some(Unavailable)
```

After the two replacements:

```
test backend::failure_disposition_heals_stale_recorded_retryability ... ok
test backend::classifies_backend_failures_for_retry_policy ... ok
test result: ok. 2 passed; 0 failed
```

## Base

Single commit stacked directly on `3ac2a798a1af388d0ac5513c72de8385f8641f51` (current `codex/tracedecay-total-redesign-plan` tip), 0 behind.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f8831c7-0ed9-4ab9-8d56-cff3144c5c03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f8831c7-0ed9-4ab9-8d56-cff3144c5c03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

