### PR TITLE
test(host-admission): expect accepted-for-replay committed ingress

### DIFF
--- a/src/host_admission_test.rs
+++ b/src/host_admission_test.rs
@@ -20,7 +20,8 @@ use tracedecay_store::{ObservationPersistOutcome, ObservationReplayRequest, Obse
 
 use tracedecay_usecases::host_admission::*;
 use tracedecay_usecases::observation::{
-    CaptureObservationOutcome, CaptureObservationRequest, ObservationCancellation,
+    CaptureObservationOutcome, CaptureObservationRequest, ExternalSourceProjectionStateV1,
+    ObservationCancellation,
 };
 
 fn initialize_repository(path: &Path) {
@@ -168,10 +169,17 @@ async fn host_ingress_binds_provenance_to_authoritative_project_and_replays_stab
         ))
         .await
         .unwrap();
+    // Host ingress commits the observation durably but leaves the
+    // external-source projection queued, so the truthful outcome is
+    // `AcceptedForReplay` carrying the underlying committed persist outcome
+    // with a `Pending` projection state — never a fake immediate persist.
     let (initial_attachment, initial_generation) = match initial {
-        CaptureObservationOutcome::Persisted { outcome, .. }
-            if matches!(*outcome, ObservationPersistOutcome::Committed(_)) =>
-        {
+        CaptureObservationOutcome::AcceptedForReplay {
+            projection_state,
+            outcome,
+            ..
+        } if matches!(*outcome, ObservationPersistOutcome::Committed(_)) => {
+            assert_eq!(projection_state, ExternalSourceProjectionStateV1::Pending);
             let ObservationPersistOutcome::Committed(receipt) = *outcome else {
                 unreachable!("guard matched committed persist outcome");
             };
@@ -180,7 +188,9 @@ async fn host_ingress_binds_provenance_to_authoritative_project_and_replays_stab
                 receipt.projection_generation().clone(),
             )
         }
-        other => panic!("expected committed project observation, got {other:?}"),
+        other => {
+            panic!("expected committed project observation accepted for replay, got {other:?}")
+        }
     };
     let initial_provenance = initial_attachment.provenance().unwrap();
     assert_eq!(initial_provenance.capture().project_id(), Some(&project_id));
@@ -204,16 +214,22 @@ async fn host_ingress_binds_provenance_to_authoritative_project_and_replays_stab
         ))
         .await
         .unwrap();
+    // The replay is an exact duplicate of the committed observation, and the
+    // queued external-source projection is still pending, so it too arrives as
+    // `AcceptedForReplay` around the underlying `ExactDuplicate` outcome.
     let replay_attachment = match replay {
-        CaptureObservationOutcome::Persisted { outcome, .. }
-            if matches!(*outcome, ObservationPersistOutcome::ExactDuplicate(_)) =>
-        {
+        CaptureObservationOutcome::AcceptedForReplay {
+            projection_state,
+            outcome,
+            ..
+        } if matches!(*outcome, ObservationPersistOutcome::ExactDuplicate(_)) => {
+            assert_eq!(projection_state, ExternalSourceProjectionStateV1::Pending);
             let ObservationPersistOutcome::ExactDuplicate(receipt) = *outcome else {
                 unreachable!("guard matched exact duplicate persist outcome");
             };
             receipt.repository_provenance_attachment().clone()
         }
-        other => panic!("expected exact duplicate replay, got {other:?}"),
+        other => panic!("expected exact duplicate replay accepted for replay, got {other:?}"),
     };
     assert_eq!(replay_attachment, initial_attachment);
 
@@ -255,15 +271,20 @@ async fn host_ingress_binds_provenance_to_authoritative_project_and_replays_stab
         .await
         .unwrap();
     let profile_attachment = match profile {
-        CaptureObservationOutcome::Persisted { outcome, .. }
-            if matches!(*outcome, ObservationPersistOutcome::Committed(_)) =>
-        {
+        CaptureObservationOutcome::AcceptedForReplay {
+            projection_state,
+            outcome,
+            ..
+        } if matches!(*outcome, ObservationPersistOutcome::Committed(_)) => {
+            assert_eq!(projection_state, ExternalSourceProjectionStateV1::Pending);
             let ObservationPersistOutcome::Committed(receipt) = *outcome else {
                 unreachable!("guard matched committed persist outcome");
             };
             receipt.repository_provenance_attachment().clone()
         }
-        other => panic!("expected committed profile observation, got {other:?}"),
+        other => {
+            panic!("expected committed profile observation accepted for replay, got {other:?}")
+        }
     };
     assert!(matches!(
         profile_attachment.availability(),
@@ -334,8 +355,11 @@ async fn registered_profile_runtime_is_required_and_mismatch_never_falls_back() 
     .unwrap();
     assert!(matches!(
         authoritative,
-        CaptureObservationOutcome::Persisted { outcome, .. }
-            if matches!(*outcome, ObservationPersistOutcome::Committed(_))
+        CaptureObservationOutcome::AcceptedForReplay {
+            projection_state: ExternalSourceProjectionStateV1::Pending,
+            outcome,
+            ..
+        } if matches!(*outcome, ObservationPersistOutcome::Committed(_))
     ));
 
     let mismatch = HostAdmissionFacade::new(HostAdmissionAuthorities::for_profile(
@@ -495,8 +519,11 @@ async fn registered_project_runtime_is_exact_and_revocation_never_falls_back() {
     .unwrap();
     assert!(matches!(
         committed,
-        CaptureObservationOutcome::Persisted { outcome, .. }
-            if matches!(*outcome, ObservationPersistOutcome::Committed(_))
+        CaptureObservationOutcome::AcceptedForReplay {
+            projection_state: ExternalSourceProjectionStateV1::Pending,
+            outcome,
+            ..
+        } if matches!(*outcome, ObservationPersistOutcome::Committed(_))
     ));
 
     drop(daemon_scope);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# C6: host_admission_test fixture encodes AcceptedForReplay + Committed + truthful Pending

## What

One-file fixture repair: `src/host_admission_test.rs` only. No production host-admission, usecases, or sessions changes. `crates/tracedecay-usecases/src/host_admission_test.rs` untouched.

Host ingress capture commits the observation durably but leaves the external-source projection queued, so production returns `CaptureObservationOutcome::AcceptedForReplay { outcome: Committed, projection_state: ExternalSourceProjectionStateV1::Pending, .. }` — not `Persisted`. The fixture previously asserted `Persisted { Committed }` and failed against production. This PR updates the assertions to encode the truthful contract:

- Initial host ingress (project scope): `AcceptedForReplay` carrying underlying `ObservationPersistOutcome::Committed`, `projection_state` asserted equal to `ExternalSourceProjectionStateV1::Pending`.
- Replay of the same record: `AcceptedForReplay` carrying `ObservationPersistOutcome::ExactDuplicate` (still Pending — the queued projection is untouched by the duplicate), which is what production returns.
- Profile-scope commit and the registered profile/project authority fixtures: same `AcceptedForReplay { Pending, Committed }` shape.

## RED/GREEN receipts (floor `1f4d705d32430f88452398d5b921900356a49c50`, exact #421 tip)

Command: `TMPDIR=<tmpfs> TRACEDECAY_DATA_DIR=target/test-profile/.tracedecay cargo test --lib host_admission_test::`

RED — floor fixture (old `Persisted` expectation), 3 consecutive runs, 3/3 tests FAILED each run:

```
host_admission_test::host_ingress_binds_provenance_to_authoritative_project_and_replays_stably ... FAILED
  panicked at src/host_admission_test.rs:183: expected committed project observation,
  got AcceptedForReplay { ..., projection_state: Pending, outcome: Committed(ObservationCommitReceipt { .. }),
  projection_status: Authoritative(Queued), .. }
host_admission_test::registered_profile_runtime_is_required_and_mismatch_never_falls_back ... FAILED
  panicked at src/host_admission_test.rs:335: assertion failed:
  matches!(authoritative, CaptureObservationOutcome::Persisted { outcome, .. } if Committed)
host_admission_test::registered_project_runtime_is_exact_and_revocation_never_falls_back ... FAILED
  panicked at src/host_admission_test.rs:496: assertion failed:
  matches!(committed, CaptureObservationOutcome::Persisted { outcome, .. } if Committed)
test result: FAILED. 0 passed; 3 failed  (identical across runs 1–3)
```

GREEN — this branch's fixture (AcceptedForReplay + Committed + Pending), 3 consecutive runs:

```
host_admission_test::host_ingress_binds_provenance_to_authoritative_project_and_replays_stably ... ok
host_admission_test::registered_profile_runtime_is_required_and_mismatch_never_falls_back ... ok
host_admission_test::registered_project_runtime_is_exact_and_revocation_never_falls_back ... ok
test result: ok. 3 passed; 0 failed  (identical across runs 1–3)
```

The assertion change alone flips RED to GREEN; production is untouched.

## Reviewer note: one anomaly observed on a prior floor

On the earlier floor `40d72f0cc` (only delta vs. its predecessor: a benchmarks goldens JSON), one build of the old `Persisted` fixture passed repeatedly (4 runs of that binary), implying capture momentarily observed the projection as already applied. On the current floor both fixtures were rebuilt from clean state and behaved deterministically across 3 runs each (RED for `Persisted`, GREEN for `AcceptedForReplay`). Worth keeping an eye on: if the pending-projection read in `finish_capture` can ever race a concurrent drain, this fixture (and the `Persisted` passthrough arm in `capture_observation`) is where it will show up.

## Scope

- Changed paths: `src/host_admission_test.rs` (single commit)
- Base: `codex/tracedecay-total-redesign-plan` at `1f4d705d32430f88452398d5b921900356a49c50` (0 behind)
- No force pushes; no production changes; no self-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34a245ed-0024-4279-9060-185e7d75573c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34a245ed-0024-4279-9060-185e7d75573c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

