### PR TITLE
fix(daemon): alias observability producers per exact store authority

### DIFF
--- a/src/daemon/service/invocation.rs
+++ b/src/daemon/service/invocation.rs
@@ -77,7 +77,7 @@ use tracedecay_tool_catalog::{CapabilityId, EffectClass, SortContractId, UseCase
 
 use super::project_runtime::{
     FeedbackCyclePublicationError, ProjectRuntimeAlreadyRegistered, ProjectRuntimeRegistryError,
-    ProjectRuntimeRegistryV1, RegisteredObservabilityProducerV1,
+    ProjectRuntimeRegistryV1, RegisteredObservabilityProducerV1, StoreObservabilityRegistryV1,
 };
 use crate::agents::context_scout_ports::{
     AdmittedContextScoutHookV1, ContextScoutLifecycleAddressV1,
@@ -290,6 +290,11 @@ pub(crate) struct DaemonInvocationService {
     /// Every per-project component, published together under one lock. See
     /// [`ProjectRuntimeRegistryV1`] for why these are not twelve maps.
     project_runtimes: ProjectRuntimeRegistryV1,
+    /// Observability owners keyed by exact registered-store authority.
+    /// Project roots registered in [`Self::project_runtimes`] hold aliases
+    /// onto these, so linked worktrees share one producer and one
+    /// store-keyed delivery settlement recorder.
+    store_observability: StoreObservabilityRegistryV1,
     operation_events: OperationEventAuthority,
     github_stack_coordinator:
         Arc<tracedecay_usecases::stack_coordinator::DaemonGitHubStackCoordinatorV1>,
@@ -331,6 +336,7 @@ impl DaemonInvocationService {
             authorized_lsp_workspaces: Arc::new(Mutex::new(BTreeMap::new())),
             context_scout_registries: Arc::new(Mutex::new(BTreeMap::new())),
             project_runtimes: ProjectRuntimeRegistryV1::default(),
+            store_observability: StoreObservabilityRegistryV1::default(),
             operation_events: daemon_operation_event_authority(),
             github_stack_coordinator: Arc::new(
                 tracedecay_usecases::stack_coordinator::DaemonGitHubStackCoordinatorV1::default(),

--- a/src/daemon/service/invocation/observability_producer.rs
+++ b/src/daemon/service/invocation/observability_producer.rs
@@ -84,30 +84,48 @@ impl DaemonInvocationService {
                     })
                 },
                 || {
-                    let identity = daemon_observability_producer_identity(
-                        &project_id,
-                        &configuration_revision,
-                        &policy_revision,
-                    )?;
-                    let producer =
-                        tracedecay_usecases::observability::BoundedObservabilityProducerV1::start(
-                            database.clone(),
-                            identity,
-                            DAEMON_OBSERVABILITY_QUEUE_CAPACITY,
-                        )
-                        .map_err(|error| TraceDecayError::Config {
-                            message: format!(
-                                "project observability producer mount failed: {error}"
-                            ),
-                        })?;
-                    RegisteredObservabilityProducerV1::new(
-                        database.clone(),
-                        producer,
+                    // The producer and its store-keyed settlement recorder are
+                    // acquired per exact registered-store authority: a linked
+                    // root of an already-mounted store attaches an alias to
+                    // the incumbent owners instead of starting a second
+                    // recorder for the same store.
+                    self.store_observability.acquire_or_start(
+                        &database,
+                        |incumbent| {
+                            incumbent.authorized_scope_ref == project_id.as_str()
+                                && incumbent.producer_revision
+                                    == DAEMON_OBSERVABILITY_PRODUCER_REVISION
+                                && incumbent.configuration_revision
+                                    == configuration_revision.as_str()
+                                && incumbent.policy_revision == policy_revision.as_str()
+                        },
+                        || TraceDecayError::Config {
+                            message:
+                                "a different observability producer is already mounted for this project store"
+                                    .to_owned(),
+                        },
+                        || {
+                            let identity = daemon_observability_producer_identity(
+                                &project_id,
+                                &configuration_revision,
+                                &policy_revision,
+                            )?;
+                            tracedecay_usecases::observability::BoundedObservabilityProducerV1::start(
+                                database.clone(),
+                                identity,
+                                DAEMON_OBSERVABILITY_QUEUE_CAPACITY,
+                            )
+                            .map_err(|error| TraceDecayError::Config {
+                                message: format!(
+                                    "project observability producer mount failed: {error}"
+                                ),
+                            })
+                        },
                         DAEMON_DELIVERY_SETTLEMENT_QUEUE_CAPACITY,
+                        |error| TraceDecayError::Config {
+                            message: format!("project delivery settlement mount failed: {error}"),
+                        },
                     )
-                    .map_err(|error| TraceDecayError::Config {
-                        message: format!("project delivery settlement mount failed: {error}"),
-                    })
                 },
             )
             .await?;

--- a/src/daemon/service/project_runtime.rs
+++ b/src/daemon/service/project_runtime.rs
@@ -23,7 +23,7 @@ mod observability;
 mod request_snapshot;
 mod shutdown;
 
-pub(crate) use observability::RegisteredObservabilityProducerV1;
+pub(crate) use observability::{RegisteredObservabilityProducerV1, StoreObservabilityRegistryV1};
 pub(crate) use shutdown::ProjectRuntimeRootQuiescenceV1;
 use shutdown::ShutdownState;
 

--- a/src/daemon/service/project_runtime/observability.rs
+++ b/src/daemon/service/project_runtime/observability.rs
@@ -1,11 +1,18 @@
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 
 use tracedecay_usecases::observability::{
     BoundedDeliverySettlementRecorderV1, BoundedObservabilityProducerV1,
     DeliverySettlementAuthorityV1, ObservabilityProducerIdentityV1, WorkOwnerObservationRecoveryV1,
 };
 
-pub(crate) struct RegisteredObservabilityProducerV1 {
+/// The live observability owners for one registered project-session store.
+///
+/// The producer, the delivery settlement recorder, and Work owner-observation
+/// recovery all drain and settle against the registered store itself, so
+/// exactly one of each runs per registered store client no matter how many
+/// project roots (linked worktrees) mount observability for that store.
+struct StoreObservabilityCoreV1 {
     database: crate::global_db::RegisteredGlobalDbLeaseV1,
     producer: Arc<BoundedObservabilityProducerV1>,
     delivery_settlement_authority: Arc<DeliverySettlementAuthorityV1>,
@@ -13,8 +20,8 @@ pub(crate) struct RegisteredObservabilityProducerV1 {
     work_observations: Arc<WorkOwnerObservationRecoveryV1>,
 }
 
-impl RegisteredObservabilityProducerV1 {
-    pub(crate) fn new(
+impl StoreObservabilityCoreV1 {
+    fn start(
         database: crate::global_db::RegisteredGlobalDbLeaseV1,
         producer: BoundedObservabilityProducerV1,
         delivery_capacity: usize,
@@ -45,35 +52,7 @@ impl RegisteredObservabilityProducerV1 {
         })
     }
 
-    pub(crate) fn producer(&self) -> Arc<BoundedObservabilityProducerV1> {
-        Arc::clone(&self.producer)
-    }
-
-    pub(crate) fn database(&self) -> crate::global_db::RegisteredGlobalDbLeaseV1 {
-        self.database.clone()
-    }
-
-    pub(crate) fn delivery_settlement_authority(
-        &self,
-    ) -> Arc<tracedecay_usecases::observability::DeliverySettlementAuthorityV1> {
-        Arc::clone(&self.delivery_settlement_authority)
-    }
-
-    pub(crate) fn delivery_settlement_recorder(&self) -> Arc<BoundedDeliverySettlementRecorderV1> {
-        Arc::clone(&self.delivery_settlements)
-    }
-
-    pub(crate) fn matches(
-        &self,
-        database: &crate::global_db::RegisteredGlobalDbLeaseV1,
-        identity: &ObservabilityProducerIdentityV1,
-    ) -> bool {
-        self.database.shares_client_with(database) && self.producer.identity() == identity
-    }
-
-    pub(crate) async fn shutdown(
-        &self,
-    ) -> Result<(), tracedecay_application::ApplicationContractError> {
+    async fn shutdown(&self) -> Result<(), tracedecay_application::ApplicationContractError> {
         let mut first_error = None;
         if let Err(error) = self.work_observations.shutdown().await {
             tracing::warn!(%error, "registered Work owner-observation recovery was incomplete");
@@ -92,5 +71,162 @@ impl RegisteredObservabilityProducerV1 {
             }
         }
         first_error.map_or(Ok(()), Err)
+    }
+}
+
+/// Whether both leases carry one exact registered-store authority: the same
+/// registered client token for the same store runtime binding and verified
+/// locator. Logical shard ids alone never match: two stores that share a
+/// brain/profile/project id remain distinct authorities.
+fn same_registered_store_authority(
+    incumbent: &crate::global_db::RegisteredGlobalDbLeaseV1,
+    candidate: &crate::global_db::RegisteredGlobalDbLeaseV1,
+) -> bool {
+    incumbent.shares_client_with(candidate)
+        && incumbent.binding() == candidate.binding()
+        && incumbent.verified_locator() == candidate.verified_locator()
+}
+
+struct StoreObservabilityEntryV1 {
+    core: Arc<StoreObservabilityCoreV1>,
+    aliases: usize,
+}
+
+/// Live observability owners keyed by exact registered-store authority.
+///
+/// Project roots are aliases onto one refcounted entry: mounting a linked
+/// root attaches to the incumbent store owners instead of starting a second
+/// producer or settlement recorder, and the last alias to shut down is the
+/// one that drains and closes them.
+#[derive(Clone, Default)]
+pub(crate) struct StoreObservabilityRegistryV1 {
+    entries: Arc<StdMutex<Vec<StoreObservabilityEntryV1>>>,
+}
+
+impl StoreObservabilityRegistryV1 {
+    fn lock_entries(&self) -> MutexGuard<'_, Vec<StoreObservabilityEntryV1>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Attach an alias to the incumbent owners of this exact registered
+    /// store, or start them. An incumbent whose identity the caller does not
+    /// accept refuses the mount instead of running a second store owner.
+    pub(crate) fn acquire_or_start<E>(
+        &self,
+        database: &crate::global_db::RegisteredGlobalDbLeaseV1,
+        accepts_incumbent: impl FnOnce(&ObservabilityProducerIdentityV1) -> bool,
+        refused: impl FnOnce() -> E,
+        start_producer: impl FnOnce() -> Result<BoundedObservabilityProducerV1, E>,
+        delivery_capacity: usize,
+        core_start_failed: impl FnOnce(&'static str) -> E,
+    ) -> Result<RegisteredObservabilityProducerV1, E> {
+        let mut entries = self.lock_entries();
+        if let Some(entry) = entries
+            .iter_mut()
+            .find(|entry| same_registered_store_authority(&entry.core.database, database))
+        {
+            if !accepts_incumbent(entry.core.producer.identity()) {
+                return Err(refused());
+            }
+            entry.aliases += 1;
+            return Ok(RegisteredObservabilityProducerV1::alias(
+                self.clone(),
+                Arc::clone(&entry.core),
+            ));
+        }
+        let producer = start_producer()?;
+        let core = Arc::new(
+            StoreObservabilityCoreV1::start(database.clone(), producer, delivery_capacity)
+                .map_err(core_start_failed)?,
+        );
+        entries.push(StoreObservabilityEntryV1 {
+            core: Arc::clone(&core),
+            aliases: 1,
+        });
+        Ok(RegisteredObservabilityProducerV1::alias(self.clone(), core))
+    }
+}
+
+/// One project root's alias onto its store's observability owners.
+pub(crate) struct RegisteredObservabilityProducerV1 {
+    registry: StoreObservabilityRegistryV1,
+    core: Arc<StoreObservabilityCoreV1>,
+    released: AtomicBool,
+}
+
+impl RegisteredObservabilityProducerV1 {
+    fn alias(registry: StoreObservabilityRegistryV1, core: Arc<StoreObservabilityCoreV1>) -> Self {
+        Self {
+            registry,
+            core,
+            released: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn producer(&self) -> Arc<BoundedObservabilityProducerV1> {
+        Arc::clone(&self.core.producer)
+    }
+
+    pub(crate) fn database(&self) -> crate::global_db::RegisteredGlobalDbLeaseV1 {
+        self.core.database.clone()
+    }
+
+    pub(crate) fn delivery_settlement_authority(
+        &self,
+    ) -> Arc<tracedecay_usecases::observability::DeliverySettlementAuthorityV1> {
+        Arc::clone(&self.core.delivery_settlement_authority)
+    }
+
+    pub(crate) fn delivery_settlement_recorder(&self) -> Arc<BoundedDeliverySettlementRecorderV1> {
+        Arc::clone(&self.core.delivery_settlements)
+    }
+
+    pub(crate) fn matches(
+        &self,
+        database: &crate::global_db::RegisteredGlobalDbLeaseV1,
+        identity: &ObservabilityProducerIdentityV1,
+    ) -> bool {
+        self.core.database.shares_client_with(database) && self.core.producer.identity() == identity
+    }
+
+    /// Releases this alias from its store entry, reporting whether it was the
+    /// last one. Idempotent: shutdown and drop release at most once.
+    fn release(&self) -> bool {
+        if self.released.swap(true, Ordering::AcqRel) {
+            return false;
+        }
+        let mut entries = self.registry.lock_entries();
+        let Some(index) = entries
+            .iter()
+            .position(|entry| Arc::ptr_eq(&entry.core, &self.core))
+        else {
+            return false;
+        };
+        entries[index].aliases -= 1;
+        if entries[index].aliases == 0 {
+            entries.remove(index);
+            return true;
+        }
+        false
+    }
+
+    pub(crate) async fn shutdown(
+        &self,
+    ) -> Result<(), tracedecay_application::ApplicationContractError> {
+        if !self.release() {
+            return Ok(());
+        }
+        self.core.shutdown().await
+    }
+}
+
+impl Drop for RegisteredObservabilityProducerV1 {
+    fn drop(&mut self) {
+        // An alias dropped without shutdown still releases its store entry,
+        // so a later mount starts fresh owners instead of attaching to owners
+        // nobody is left to flush.
+        self.release();
     }
 }

--- a/src/daemon/service/project_runtime/observability_tests.rs
+++ b/src/daemon/service/project_runtime/observability_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,7 +19,7 @@ use tracedecay_usecases::observability::{
 
 use crate::daemon::service::invocation::DaemonInvocationService;
 
-use super::RegisteredObservabilityProducerV1;
+use super::StoreObservabilityRegistryV1;
 
 fn digest(byte: char) -> ManifestDigest {
     ManifestDigest::new(format!("sha256:{}", byte.to_string().repeat(64))).expect("digest")
@@ -186,13 +186,15 @@ async fn a_new_daemon_runtime_restarts_the_project_producer_after_clean_shutdown
 }
 
 #[tokio::test]
-async fn each_producer_lifetime_uses_a_disjoint_ordered_stream() {
+async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down() {
     let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
-    let (_project, project_id, database) = runtime("observability-stream-identity").await;
+    let (_project, project_id, database) = runtime("observability-store-alias").await;
+    let root = PathBuf::from("/project/observability-store-alias");
+    let linked_root = PathBuf::from("/project/observability-store-alias-linked");
     let first_service = DaemonInvocationService::default();
     let first = first_service
         .mount_observability_producer(
-            PathBuf::from("/project/observability-stream-identity"),
+            root.clone(),
             database.clone(),
             project_id.clone(),
             digest('1'),
@@ -202,7 +204,7 @@ async fn each_producer_lifetime_uses_a_disjoint_ordered_stream() {
         .expect("first producer");
     let first_reconciled = first_service
         .mount_observability_producer(
-            PathBuf::from("/project/observability-stream-identity"),
+            root.clone(),
             database.clone(),
             project_id.clone(),
             digest('1'),
@@ -217,7 +219,7 @@ async fn each_producer_lifetime_uses_a_disjoint_ordered_stream() {
     );
     let linked = first_service
         .mount_observability_producer(
-            PathBuf::from("/project/observability-stream-identity-linked"),
+            linked_root.clone(),
             database.clone(),
             project_id.clone(),
             digest('1'),
@@ -225,18 +227,109 @@ async fn each_producer_lifetime_uses_a_disjoint_ordered_stream() {
         )
         .await
         .expect("linked-root producer");
+    // Linked roots are aliases of one store-keyed producer: same Arc, one
+    // ordered boot stream per registered store, never one per root.
+    assert!(Arc::ptr_eq(&first, &linked));
+    assert_eq!(
+        first.identity().process_boot_id,
+        linked.identity().process_boot_id
+    );
+    // The delivery settlement recorder is store-keyed: both roots reach the
+    // exact same recorder rather than running one drain per root.
+    let first_recorder = first_service
+        .delivery_settlement_recorder(Some(&root))
+        .await
+        .expect("first-root recorder");
+    let linked_recorder = first_service
+        .delivery_settlement_recorder(Some(&linked_root))
+        .await
+        .expect("linked-root recorder");
+    assert!(Arc::ptr_eq(&first_recorder, &linked_recorder));
+    // Retaining recorder handles would pin the store spool lock past the
+    // last-alias shutdown below and block the restart from reopening it.
+    drop(first_recorder);
+    drop(linked_recorder);
+    // A root presenting different revisions for the same registered store is
+    // refused, not given a second store owner and not silently aliased.
+    let refused = match first_service
+        .mount_observability_producer(
+            PathBuf::from("/project/observability-store-alias-foreign"),
+            database.clone(),
+            project_id.clone(),
+            digest('9'),
+            digest('2'),
+        )
+        .await
+    {
+        Ok(_) => panic!("mismatched revisions must not mount a second store producer"),
+        Err(error) => error,
+    };
+    assert!(
+        refused.to_string().contains("already mounted"),
+        "unexpected refusal: {refused}"
+    );
     first
-        .try_emit(envelope(&project_id, "stream:first"))
+        .try_emit(envelope(&project_id, "alias:first"))
         .expect("first emission");
     linked
-        .try_emit(envelope(&project_id, "stream:linked"))
+        .try_emit(envelope(&project_id, "alias:linked"))
         .expect("linked emission");
+
+    // Full-upgrade shape for one linked root: quiesce drains that root's
+    // runtime while the other alias keeps the store producer and its boot
+    // stream alive; the remount reattaches to the same live producer.
+    let lsp_registry = Arc::new(tokio::sync::Mutex::new(
+        tracedecay_lsp::LspSessionRegistry::default(),
+    ));
+    let profile_id = database.binding().shard_id.profile_id.clone();
+    let quiescence = first_service
+        .quiesce_project(
+            &lsp_registry,
+            &profile_id,
+            &project_id,
+            &BTreeSet::from([root.clone()]),
+        )
+        .await
+        .expect("quiesce the first root");
+    assert_eq!(
+        linked
+            .try_emit(envelope(&project_id, "alias:after-quiesce"))
+            .expect("surviving alias emission"),
+        ObservabilityEmissionOutcomeV1::Enqueued
+    );
+    drop(quiescence);
+    let remounted = first_service
+        .mount_observability_producer(
+            root.clone(),
+            database.clone(),
+            project_id.clone(),
+            digest('1'),
+            digest('2'),
+        )
+        .await
+        .expect("remounted producer after quiescence");
+    assert!(Arc::ptr_eq(&remounted, &linked));
+    assert_eq!(
+        remounted.identity().process_boot_id,
+        linked.identity().process_boot_id
+    );
+    remounted
+        .try_emit(envelope(&project_id, "alias:remounted"))
+        .expect("remounted emission");
+
+    // The last alias shuts the store producer down.
     first_service.expire_all().await;
+    assert_eq!(
+        linked
+            .try_emit(envelope(&project_id, "alias:after-shutdown"))
+            .expect_err("last alias shutdown closes the store producer"),
+        "observability_producer_closed"
+    );
 
     let restarted_service = DaemonInvocationService::default();
     let restarted = restarted_service
         .mount_observability_producer(
-            PathBuf::from("/project/observability-stream-identity"),
+            root.clone(),
             database.clone(),
             project_id.clone(),
             digest('1'),
@@ -244,20 +337,23 @@ async fn each_producer_lifetime_uses_a_disjoint_ordered_stream() {
         )
         .await
         .expect("restarted producer");
-    let registrations = [&first, &linked, &restarted].map(|producer| {
-        producer
-            .identity()
+    assert!(!Arc::ptr_eq(&first, &restarted));
+    assert_ne!(
+        first.identity().process_boot_id,
+        restarted.identity().process_boot_id
+    );
+    let registration = |identity: &ObservabilityProducerIdentityV1| {
+        identity
             .process_boot_id
             .rsplit(':')
             .next()
             .expect("registration suffix")
             .parse::<u64>()
             .expect("numeric registration suffix")
-    });
-    assert_eq!(registrations[1], registrations[0].saturating_add(1));
-    assert_eq!(registrations[2], registrations[1].saturating_add(1));
+    };
+    assert!(registration(restarted.identity()) > registration(first.identity()));
     restarted
-        .try_emit(envelope(&project_id, "stream:restarted"))
+        .try_emit(envelope(&project_id, "alias:restarted"))
         .expect("restarted emission");
     restarted_service.expire_all().await;
 
@@ -274,24 +370,39 @@ async fn each_producer_lifetime_uses_a_disjoint_ordered_stream() {
         })
         .await
         .expect("query producer streams");
-    assert_eq!(page.events.len(), 3);
-    assert!(page.events.iter().all(|event| event.producer_sequence == 1));
-    let boot_ids = page
-        .events
-        .iter()
-        .map(|event| event.process_boot_id.as_str())
-        .collect::<BTreeSet<_>>();
-    assert_eq!(boot_ids.len(), 3);
+    assert_eq!(page.events.len(), 5);
+    let mut streams: BTreeMap<&str, BTreeSet<u64>> = BTreeMap::new();
+    for event in &page.events {
+        streams
+            .entry(event.process_boot_id.as_str())
+            .or_default()
+            .insert(event.producer_sequence);
+    }
+    // One shared alias stream carries every linked-root emission in order;
+    // the restart after the last-alias shutdown boots a second stream.
+    assert_eq!(streams.len(), 2);
+    assert_eq!(
+        streams
+            .get(first.identity().process_boot_id.as_str())
+            .expect("shared alias stream"),
+        &BTreeSet::from([1, 2, 3, 4])
+    );
+    assert_eq!(
+        streams
+            .get(restarted.identity().process_boot_id.as_str())
+            .expect("restarted stream"),
+        &BTreeSet::from([1])
+    );
     let process_prefix = format!("daemon:{}:", crate::runtime_identity::process_run_id());
     assert!(
-        boot_ids
-            .iter()
+        streams
+            .keys()
             .all(|boot_id| boot_id.starts_with(&process_prefix))
     );
 }
 
 #[tokio::test]
-async fn exact_profile_routing_collapses_linked_roots_without_crossing_profiles() {
+async fn exact_store_routing_collapses_linked_roots_without_crossing_stores() {
     let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
     let profile_a = tempfile::tempdir().expect("profile A");
     let profile_b = tempfile::tempdir().expect("profile B");
@@ -318,19 +429,24 @@ async fn exact_profile_routing_collapses_linked_roots_without_crossing_profiles(
     let database_b = runtime_b
         .project_database_arc()
         .expect("profile B database");
-    let brain_a_id = database_a.binding().shard_id.brain_id.clone();
-    let brain_b_id = database_b.binding().shard_id.brain_id.clone();
-    let profile_a_id = database_a.binding().shard_id.profile_id.clone();
-    let profile_b_id = database_b.binding().shard_id.profile_id.clone();
-    assert_ne!(brain_a_id, brain_b_id);
-    assert_ne!(profile_a_id, profile_b_id);
+    // The test-runtime resolver pins one logical brain/profile identity for
+    // every store, so the two profile stores are distinguished by exactly the
+    // registered-store authority the producer registry keys on: the verified
+    // locator and the registered client token. Logical shard ids alone must
+    // never be treated as the same authority.
+    let brain_id = database_a.binding().shard_id.brain_id.clone();
+    let profile_id = database_a.binding().shard_id.profile_id.clone();
+    assert_eq!(brain_id, database_b.binding().shard_id.brain_id);
+    assert_eq!(profile_id, database_b.binding().shard_id.profile_id);
+    assert!(!database_a.shares_client_with(&database_b));
+    assert_ne!(database_a.verified_locator(), database_b.verified_locator());
     let service = DaemonInvocationService::default();
     let root_a = PathBuf::from("/project/profile-a/shared-observability");
     let linked_a = PathBuf::from("/project/profile-a/shared-observability-linked");
     let root_b = PathBuf::from("/project/profile-b/shared-observability");
     let producer_a = service
         .mount_observability_producer(
-            root_a,
+            root_a.clone(),
             database_a.clone(),
             project_id.clone(),
             digest('1'),
@@ -348,9 +464,20 @@ async fn exact_profile_routing_collapses_linked_roots_without_crossing_profiles(
         )
         .await
         .expect("linked profile A producer");
+    // Linked roots of one exact store alias one producer, and while that is
+    // the only mounted store its exact identity routing resolves it.
+    assert!(Arc::ptr_eq(&producer_a, &linked_producer_a));
+    let routed_a = service
+        .observability_producer_for_brain_profile_project(&brain_id, &profile_id, &project_id)
+        .expect("linked roots resolve one exact profile A store");
+    assert!(Arc::ptr_eq(&routed_a, &producer_a));
+
+    // The same logical identity behind a different registered store must not
+    // alias profile A's producer, even though only the locator and client
+    // token distinguish the two stores.
     let producer_b = service
         .mount_observability_producer(
-            root_b,
+            root_b.clone(),
             database_b,
             project_id.clone(),
             digest('3'),
@@ -358,22 +485,31 @@ async fn exact_profile_routing_collapses_linked_roots_without_crossing_profiles(
         )
         .await
         .expect("profile B producer");
-
-    let routed_a = service
-        .observability_producer_for_brain_profile_project(&brain_a_id, &profile_a_id, &project_id)
-        .expect("linked roots resolve one exact profile A store");
-    assert!(Arc::ptr_eq(&routed_a, &producer_a) || Arc::ptr_eq(&routed_a, &linked_producer_a));
-    let routed_b = service
-        .observability_producer_for_brain_profile_project(&brain_b_id, &profile_b_id, &project_id)
-        .expect("profile B exact producer");
-    assert!(Arc::ptr_eq(&routed_b, &producer_b));
-    assert!(!Arc::ptr_eq(&routed_a, &routed_b));
+    assert!(!Arc::ptr_eq(&producer_a, &producer_b));
+    let recorder_a = service
+        .delivery_settlement_recorder(Some(&root_a))
+        .await
+        .expect("profile A recorder");
+    let recorder_b = service
+        .delivery_settlement_recorder(Some(&root_b))
+        .await
+        .expect("profile B recorder");
+    assert!(!Arc::ptr_eq(&recorder_a, &recorder_b));
+    // With two distinct store authorities mounted under one logical identity,
+    // exact routing refuses to pick either rather than crossing stores.
+    assert!(
+        service
+            .observability_producer_for_brain_profile_project(&brain_id, &profile_id, &project_id)
+            .is_none()
+    );
+    // A foreign identity never routes to a mounted store.
+    let foreign_project = ProjectId::new("project.unmounted-observability").unwrap();
     assert!(
         service
             .observability_producer_for_brain_profile_project(
-                &brain_b_id,
-                &profile_a_id,
-                &project_id,
+                &brain_id,
+                &profile_id,
+                &foreign_project,
             )
             .is_none()
     );
@@ -400,7 +536,15 @@ async fn registered_shutdown_reports_a_blocked_producer_flush() {
         },
     )
     .expect("producer");
-    let registered = RegisteredObservabilityProducerV1::new(database.clone(), producer, 1)
+    let registered = StoreObservabilityRegistryV1::default()
+        .acquire_or_start::<&'static str>(
+            &database,
+            |_| false,
+            || "unexpected incumbent store producer",
+            || Ok(producer),
+            1,
+            |error| error,
+        )
         .expect("registered observability producer");
     let blocker = database
         .begin_write_transaction()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes the production mismatch between the root-keyed `ProjectRuntimeRegistryV1` and the store-keyed `BoundedDeliverySettlementRecorderV1`: mounting a linked worktree root of an already-mounted project-session store failed with `delivery_settlement_recorder_already_running` because each root tried to start its own recorder against the one store spool.
- Observability owners (producer, delivery settlement recorder, Work owner-observation recovery) are now keyed and refcounted by the exact registered-store authority — store runtime binding plus verified locator, witnessed by the registered client token (`shares_client_with`). Project roots hold aliases onto one refcounted entry; the last alias to shut down drains and closes the owners.
- Fences the linked full-upgrade regression: quiescing/retiring one linked root releases only that root's alias, so the surviving root keeps the live producer and its boot stream, and the remounted root reattaches to the same owners instead of booting a duplicate stream.

Supersedes [#631](https://github.com/ScriptedAlchemy/tracedecay/pull/631) (rejected older floor `40d72f0c`; its head `3e3a706ac` is untouched). This branch is a fresh cherry-pick of the same change onto floor `7530ed368d2ae12676d4f1dd547b0bd54813ec41`, which is proven equal to `origin/codex/tracedecay-total-redesign-plan` at creation time; the branch is 0 behind it, no force pushes. No Lane B-relevant path changed between the floors (only an mcp remote-status style fix), and all gates were rerun on this floor.

## Motivation

Production bug (Lane B fence): linked roots that share one registered project-session store must never run the settlement recorder per root, and one root's lifecycle must not tear down owners another root still uses. Busy semantics are preserved and extended to the true key granularity: a mount presenting different configuration/policy revisions for the same registered store is refused (`a different observability producer is already mounted for this project store`), and cross-store aliasing is impossible even when logical brain/profile/project ids collide.

## Changes

- `src/daemon/service/project_runtime/observability.rs` — `StoreObservabilityRegistryV1` (store-authority-keyed, refcounted entries) and `RegisteredObservabilityProducerV1` reworked into a per-root alias whose `shutdown` only drains the shared core on last release; `Drop` releases a leaked alias so later mounts start fresh owners.
- `src/daemon/service/invocation/observability_producer.rs` — `mount_observability_producer` acquires through the store registry inside the existing `register_or_reconcile` build path (production caller: `project_delivery_mount::ensure_project_delivery_settlement` at project open, plus the combined-effect replay mount). Root-level reconcile and its Busy refusal are unchanged.
- `src/daemon/service/invocation.rs` — the service owns the store-keyed registry next to `project_runtimes`.
- `src/daemon/service/project_runtime.rs` — exports the registry.
- `src/daemon/service/project_runtime/observability_tests.rs` — RED→GREEN spec around line ~227 (see below); the blocked-flush test constructs through the registry.

### RED (captured on the clean floor before the fix)

- `linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down` — linked-root mount fails in production code: `project delivery settlement mount failed: delivery_settlement_recorder_already_running` (the fenced bug; also documented pre-existing in `docs/plans/tracedecay-v2/audits/ci-triage-plan-2026-08-14.md` for the predecessor test `each_producer_lifetime_uses_a_disjoint_ordered_stream`).
- `exact_store_routing_collapses_linked_roots_without_crossing_stores` — predecessor `exact_profile_routing_collapses_linked_roots_without_crossing_profiles` was a documented pre-existing failure (test-runtime resolver pins one `brain.test-runtime`/`profile.test-runtime` identity for every store). The test now encodes the negative on the exact store authority itself: same logical ids behind a different verified locator/client token never alias, per-store recorders stay distinct, and `(brain, profile, project)` routing refuses ambiguous multi-store matches instead of crossing stores.

### GREEN (with the fix, rerun on floor `7530ed36`)

- Linked roots return the same `Arc` and boot stream; the store recorder is one shared `Arc` across roots; a mismatched-revision mount on the same store is refused (Busy preserved, not weakened).
- Quiesce of one linked root (production `quiesce_project` caller) keeps the shared producer emitting for the surviving alias; the remount reattaches to the same `Arc`/boot id; `expire_all` (last aliases) closes the producer (`observability_producer_closed`); a new daemon runtime boots a new stream with a strictly newer registration. Persisted page shows exactly 2 boot streams: shared sequences {1,2,3,4} and restarted {1}.

## Test plan

- [x] `cargo test --lib daemon::service::project_runtime::observability_tests` — 5/5 pass on this floor
- [x] `cargo test --lib -- daemon::service::project_runtime daemon::service::invocation::tests` — 107 passed / 10 failed on this floor with the fix vs 105 passed / 12 failed on a clean floor; the 10 remaining failures are identical pre-existing/environmental failures (overlay-filesystem locality verification on this VM plus failures documented in `ci-triage-plan-2026-08-14.md`), i.e. net −2 failures, no new ones
- [x] `cargo clippy -p tracedecay --lib --tests` has no new warnings (rerun on this floor)
- [x] `npm run lint:commit -- --from 7530ed36 --to HEAD` passes
- [ ] Tested manually (not applicable)

## Checklist

- [ ] `CHANGELOG.md` updated (release-please manages the changelog from conventional commits on this repo)
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4966f620-1f07-466f-9ae9-24e45e23b6d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4966f620-1f07-466f-9ae9-24e45e23b6d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

