### PR TITLE
ci(actions): require GitHub-hosted runners

### DIFF
--- a/.github/workflows/sdk-conformance.yml
+++ b/.github/workflows/sdk-conformance.yml
@@ -3,11 +3,7 @@ name: SDK conformance
 on:
   pull_request:
     paths:
-      - ".github/workflows/sdk-conformance.yml"
-      - ".github/workflows/release.yml"
-      - ".github/workflows/release-beta.yml"
-      - ".github/workflows/release-please.yml"
-      - ".github/workflows/release-pr-integrity.yml"
+      - ".github/workflows/**"
       - ".github/release-targets.json"
       - "crates/tracedecay-api/**"
       - "crates/tracedecay-application/**"
@@ -18,6 +14,8 @@ on:
       - "scripts/check-sdk-codegen.sh"
       - "scripts/check-sdk-publish-workflow.py"
       - "scripts/test-check-sdk-publish-workflow.py"
+      - "scripts/check-github-hosted-runners.py"
+      - "scripts/test-check-github-hosted-runners.py"
       - "scripts/package-release-archive.py"
       - "scripts/test-package-release-archive.py"
       - "scripts/plan-release-recovery.py"
@@ -43,6 +41,10 @@ jobs:
         run: |
           python3 scripts/test-check-sdk-publish-workflow.py
           python3 scripts/check-sdk-publish-workflow.py
+      - name: Check GitHub-hosted runner authority
+        run: |
+          python3 scripts/test-check-github-hosted-runners.py
+          python3 scripts/check-github-hosted-runners.py
       - name: Install pinned actionlint
         run: |
           set -euo pipefail

--- a/scripts/check-github-hosted-runners.py
+++ b/scripts/check-github-hosted-runners.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Require every Actions job to resolve to a standard GitHub-hosted runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+STANDARD_GITHUB_HOSTED_RUNNERS = frozenset(
+    {
+        "ubuntu-latest",
+        "ubuntu-24.04",
+        "ubuntu-22.04",
+        "ubuntu-24.04-arm",
+        "ubuntu-22.04-arm",
+        "windows-latest",
+        "windows-2025",
+        "windows-2022",
+        "macos-latest",
+        "macos-15",
+        "macos-15-intel",
+        "macos-14",
+    }
+)
+RELEASE_MATRIX_EXPRESSION = "${{ matrix.runner }}"
+INLINE_MATRIX_EXPRESSION = "${{ fromJSON(matrix.runner) }}"
+RELEASE_WORKFLOWS = frozenset({"release.yml", "release-beta.yml"})
+
+
+class PolicyViolation(ValueError):
+    """A workflow can route work outside the standard GitHub-hosted fleet."""
+
+
+def require_hosted_label(label: object, authority: str) -> None:
+    if not isinstance(label, str) or label not in STANDARD_GITHUB_HOSTED_RUNNERS:
+        raise PolicyViolation(
+            f"{authority} resolves to {label!r}; use a standard GitHub-hosted runner"
+        )
+
+
+def inline_matrix_runners(job: dict[str, Any], authority: str) -> list[str]:
+    strategy = job.get("strategy")
+    matrix = strategy.get("matrix") if isinstance(strategy, dict) else None
+    includes = matrix.get("include") if isinstance(matrix, dict) else None
+    if not isinstance(includes, list) or not includes:
+        raise PolicyViolation(f"{authority} has no auditable inline matrix entries")
+
+    runners: list[str] = []
+    for index, entry in enumerate(includes):
+        encoded = entry.get("runner") if isinstance(entry, dict) else None
+        if not isinstance(encoded, str):
+            raise PolicyViolation(f"{authority} matrix entry {index} has no runner")
+        try:
+            runner = json.loads(encoded)
+        except json.JSONDecodeError as error:
+            raise PolicyViolation(
+                f"{authority} matrix entry {index} is not a JSON runner label"
+            ) from error
+        require_hosted_label(runner, f"{authority} matrix entry {index}")
+        runners.append(runner)
+    return runners
+
+
+def validate_release_manifest(root: Path) -> None:
+    manifest_path = root / ".github/release-targets.json"
+    document = json.loads(manifest_path.read_text(encoding="utf-8"))
+    includes = document.get("include") if isinstance(document, dict) else None
+    if not isinstance(includes, list) or not includes:
+        raise PolicyViolation(".github/release-targets.json has no release targets")
+    for index, entry in enumerate(includes):
+        runner = entry.get("runner") if isinstance(entry, dict) else None
+        require_hosted_label(runner, f"release target {index}")
+
+
+def validate_workflow(path: Path) -> None:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    jobs = document.get("jobs") if isinstance(document, dict) else None
+    if not isinstance(jobs, dict):
+        raise PolicyViolation(f"{path.name} has no jobs mapping")
+
+    for name, job in jobs.items():
+        if not isinstance(job, dict) or "runs-on" not in job:
+            continue
+        runner = job["runs-on"]
+        authority = f"{path.name} job {name!r}"
+        if not isinstance(runner, str):
+            raise PolicyViolation(
+                f"{authority} uses runner labels/groups instead of one hosted label"
+            )
+        if "${{" not in runner:
+            require_hosted_label(runner, authority)
+        elif runner == RELEASE_MATRIX_EXPRESSION and path.name in RELEASE_WORKFLOWS:
+            # The shared release manifest is validated independently.
+            continue
+        elif runner == INLINE_MATRIX_EXPRESSION:
+            inline_matrix_runners(job, authority)
+        else:
+            raise PolicyViolation(
+                f"{authority} uses unaudited dynamic runner expression {runner!r}"
+            )
+
+
+def validate_repository(root: Path) -> None:
+    validate_release_manifest(root)
+    workflow_paths = sorted((root / ".github/workflows").glob("*.y*ml"))
+    if not workflow_paths:
+        raise PolicyViolation("repository has no GitHub Actions workflows")
+    for path in workflow_paths:
+        validate_workflow(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+    )
+    args = parser.parse_args()
+    try:
+        validate_repository(args.root.resolve())
+    except (OSError, json.JSONDecodeError, yaml.YAMLError, PolicyViolation) as error:
+        print(f"GitHub-hosted runner policy violation: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+    print("all Actions jobs use standard GitHub-hosted runners")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-check-github-hosted-runners.py
+++ b/scripts/test-check-github-hosted-runners.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the GitHub-hosted runner policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+POLICY_PATH = ROOT / "scripts/check-github-hosted-runners.py"
+
+
+def load_policy():
+    spec = importlib.util.spec_from_file_location("github_hosted_runner_policy", POLICY_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class GitHubHostedRunnerPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy = load_policy()
+
+    def write_repository(
+        self,
+        root: Path,
+        workflow: str,
+        release_runners: tuple[str, ...] = ("ubuntu-22.04",),
+    ) -> None:
+        workflows = root / ".github/workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text(workflow, encoding="utf-8")
+        (root / ".github/release-targets.json").write_text(
+            json.dumps(
+                {
+                    "include": [
+                        {"name": f"target-{index}", "runner": runner}
+                        for index, runner in enumerate(release_runners)
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def assert_rejected(
+        self,
+        workflow: str,
+        release_runners: tuple[str, ...] = ("ubuntu-22.04",),
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_repository(root, workflow, release_runners)
+            with self.assertRaises(self.policy.PolicyViolation):
+                self.policy.validate_repository(root)
+
+    def test_accepts_current_repository(self) -> None:
+        self.policy.validate_repository(ROOT)
+
+    def test_rejects_explicit_self_hosted_runner(self) -> None:
+        self.assert_rejected(
+            "jobs:\n  test:\n    runs-on: [self-hosted, linux, x64]\n"
+        )
+
+    def test_rejects_custom_runner_label(self) -> None:
+        self.assert_rejected("jobs:\n  test:\n    runs-on: tracedecay-linux-64core\n")
+
+    def test_rejects_runner_group(self) -> None:
+        self.assert_rejected(
+            "jobs:\n  test:\n    runs-on:\n      group: release-runners\n"
+        )
+
+    def test_rejects_custom_runner_from_release_manifest(self) -> None:
+        self.assert_rejected(
+            "jobs:\n  build:\n    runs-on: ${{ matrix.runner }}\n",
+            ("tracedecay-arm64",),
+        )
+
+    def test_rejects_custom_runner_from_inline_matrix(self) -> None:
+        self.assert_rejected(
+            """jobs:
+  test:
+    runs-on: ${{ fromJSON(matrix.runner) }}
+    strategy:
+      matrix:
+        include:
+          - runner: '\"tracedecay-macos\"'
+"""
+        )
+
+    def test_rejects_unbound_dynamic_runner_expression(self) -> None:
+        self.assert_rejected(
+            "jobs:\n  test:\n    runs-on: ${{ inputs.runner }}\n"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Every Actions job is now fail-closed to GitHub's standard hosted runner labels. The current repository already resolves to GitHub-hosted runners; this prevents a future workflow or dynamic release matrix change from routing work to a self-hosted/custom runner.

## Changes

- semantically parse every workflow's `runs-on` authority
- validate dynamic release runners through `.github/release-targets.json`
- validate the CI inline runner matrix after decoding its expression values
- reject self-hosted label arrays, runner groups, custom labels, and unbound dynamic expressions
- run the policy for changes to any workflow or its policy implementation

## Verification

- `python3 scripts/test-check-github-hosted-runners.py` — 7 passed
- `python3 scripts/check-github-hosted-runners.py` — repository accepted
- `actionlint .github/workflows/sdk-conformance.yml` — passed
- `python3 scripts/test-check-sdk-publish-workflow.py` — 18 passed
- `python3 scripts/check-sdk-publish-workflow.py` — passed
- `python3 -m py_compile scripts/check-github-hosted-runners.py scripts/test-check-github-hosted-runners.py` — passed
- `git diff --check` — passed
