### PR TITLE
perf(graph): stop eager replay seal copies

### DIFF
--- a/src/daemon/store_runtime/session_registry/code_graph.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph.rs
@@ -43,9 +43,8 @@ mod sealed_publication_tests;
 mod seals;
 mod semantic_vector;
 use seals::{
-    finalize_project_graph_replay_unlink, install_project_graph_replay_seal_at,
-    lock_project_graph_replay_pool, publish_staged_replay_seal, sealed_digest_from_generation_file,
-    stage_project_graph_replay_seal, stage_project_graph_replay_unlink,
+    finalize_project_graph_replay_unlink, lock_project_graph_replay_pool,
+    sealed_digest_from_generation_file, stage_project_graph_replay_unlink,
 };
 
 const GRAPH_OPERATION_DEADLINE: Duration = Duration::from_secs(30);
@@ -841,18 +840,6 @@ impl RetainedCodeGraphRuntimeV1 {
             .map_err(map_publication_error)?
         {
             GraphPublicationReplayLookupV1::Active(_) => {
-                install_project_graph_replay_seal_at(
-                    &self.generations_root,
-                    &self.replay_root,
-                    &self.sealed_state_digest,
-                    &|| match probe.interruption() {
-                        Some(RuntimeInterruptionV1::Cancelled) => Err(GraphDbError::Cancelled),
-                        Some(RuntimeInterruptionV1::DeadlineExceeded) => {
-                            Err(GraphDbError::DeadlineExceeded)
-                        }
-                        None => Ok(()),
-                    },
-                )?;
                 let head = storage
                     .verified_head(&relational_projection, &context)
                     .map_err(map_publication_error)?;
@@ -873,18 +860,6 @@ impl RetainedCodeGraphRuntimeV1 {
             GraphPublicationReplayLookupV1::Retired(_) => return Err(GraphDbError::Conflict),
             GraphPublicationReplayLookupV1::Missing => {}
         }
-        let staged_seal = stage_project_graph_replay_seal(
-            &self.generations_root,
-            &self.replay_root,
-            &self.sealed_state_digest,
-            &|| match probe.interruption() {
-                Some(RuntimeInterruptionV1::Cancelled) => Err(GraphDbError::Cancelled),
-                Some(RuntimeInterruptionV1::DeadlineExceeded) => {
-                    Err(GraphDbError::DeadlineExceeded)
-                }
-                None => Ok(()),
-            },
-        )?;
         let replay_pool_lock = lock_project_graph_replay_pool(&self.replay_root, &|| match probe
             .interruption()
         {
@@ -892,18 +867,6 @@ impl RetainedCodeGraphRuntimeV1 {
             Some(RuntimeInterruptionV1::DeadlineExceeded) => Err(GraphDbError::DeadlineExceeded),
             None => Ok(()),
         })?;
-        publish_staged_replay_seal(
-            staged_seal,
-            &self.replay_root,
-            &self.sealed_state_digest,
-            &|| match probe.interruption() {
-                Some(RuntimeInterruptionV1::Cancelled) => Err(GraphDbError::Cancelled),
-                Some(RuntimeInterruptionV1::DeadlineExceeded) => {
-                    Err(GraphDbError::DeadlineExceeded)
-                }
-                None => Ok(()),
-            },
-        )?;
         let input = canonical_sha256(&(
             "tracedecay.code-graph-publication-input.v1",
             &source,

--- a/src/daemon/store_runtime/session_registry/code_graph.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph.rs
@@ -764,6 +764,31 @@ impl RetainedCodeGraphRuntimeV1 {
                 tracedecay_code_index::graph_projection::CODE_GRAPH_PROJECTOR_REVISION.to_owned(),
             )?,
         };
+        let verify_durable_source = || {
+            let replay_pool_lock = lock_project_graph_replay_pool(
+                &self.replay_root,
+                &|| match probe.interruption() {
+                    Some(RuntimeInterruptionV1::Cancelled) => Err(GraphDbError::Cancelled),
+                    Some(RuntimeInterruptionV1::DeadlineExceeded) => {
+                        Err(GraphDbError::DeadlineExceeded)
+                    }
+                    None => Ok(()),
+                },
+            )?;
+            super::code_graph_manifest::verify_sealed_generation_source_from_roots(
+                &self.generations_root,
+                &self.replay_root,
+                &self.sealed_state_digest,
+                &|| match probe.interruption() {
+                    Some(RuntimeInterruptionV1::Cancelled) => Err(GraphDbError::Cancelled),
+                    Some(RuntimeInterruptionV1::DeadlineExceeded) => {
+                        Err(GraphDbError::DeadlineExceeded)
+                    }
+                    None => Ok(()),
+                },
+            )?;
+            Ok::<_, GraphDbError>(replay_pool_lock)
+        };
         let mut storage = self
             .project_database
             .graph_publication_storage()
@@ -854,19 +879,14 @@ impl RetainedCodeGraphRuntimeV1 {
                         &relational_projection,
                     );
                 }
+                let _replay_pool_lock = verify_durable_source()?;
                 let publication = publish(&mut storage, &publication_key, Some(manifest))?;
                 return Ok(publication.snapshot);
             }
             GraphPublicationReplayLookupV1::Retired(_) => return Err(GraphDbError::Conflict),
             GraphPublicationReplayLookupV1::Missing => {}
         }
-        let replay_pool_lock = lock_project_graph_replay_pool(&self.replay_root, &|| match probe
-            .interruption()
-        {
-            Some(RuntimeInterruptionV1::Cancelled) => Err(GraphDbError::Cancelled),
-            Some(RuntimeInterruptionV1::DeadlineExceeded) => Err(GraphDbError::DeadlineExceeded),
-            None => Ok(()),
-        })?;
+        let replay_pool_lock = verify_durable_source()?;
         let input = canonical_sha256(&(
             "tracedecay.code-graph-publication-input.v1",
             &source,

--- a/src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs
@@ -13,12 +13,23 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::time::{Duration, Instant};
 
-use tracedecay_domain::ProjectId;
-use tracedecay_graph_db::GraphProjectorRevision;
+use tracedecay_domain::{ProjectId, UtcMicros, canonical_sha256};
+use tracedecay_graph_db::{
+    GraphCancellation, GraphDbError, GraphProjectorRevision, SealedCodeGenerationReplay,
+};
+use tracedecay_store::{
+    GraphGenerationIdV1, GraphProjectionIdV1, GraphProjectionIdentityV1,
+    GraphPublicationIdempotencyKeyV1, GraphPublicationInputDigestV1, GraphPublicationKeyV1,
+    GraphPublicationOperationContextV1, GraphPublicationReplayLookupV1, GraphPublicationStoreV1,
+    GraphReplayAppendOutcomeV1, RetainedGraphStoreLeaseV1, RuntimeCancellationIdV1,
+    RuntimeCancellationIdentityV1, RuntimeDeadlineIdV1, RuntimeDeadlineV1, RuntimeRequestControlV1,
+};
 use tracedecay_usecases::retention::code_index_generations::DurablePublicationPointerV1;
 
 use super::super::DaemonSessionRuntimeRegistryV1;
+use super::{AtomicGraphCancellationV1, GraphPublicationProbeV1, RetainedCodeGraphRuntimeV1};
 use crate::daemon::code_index_scheduler::{
     CodeGraphReplayBindingV1, CodeIndexWorktreeSchedulerV1, SharedCodeIndexBytePoolV1,
     scoped_code_index_store_root,
@@ -36,6 +47,155 @@ fn git(root: &Path, args: &[&str]) {
         "git fixture command failed: {args:?}: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn with_publication_context<T>(
+    label: &str,
+    operation: impl FnOnce(&GraphPublicationOperationContextV1<'_>) -> T,
+) -> T {
+    let cancellation = RuntimeCancellationIdentityV1 {
+        cancellation_id: RuntimeCancellationIdV1::new(format!("{label}-cancellation"))
+            .expect("test cancellation id"),
+        generation: 1,
+    };
+    let deadline = RuntimeDeadlineV1 {
+        deadline_id: RuntimeDeadlineIdV1::new(format!("{label}-deadline"))
+            .expect("test deadline id"),
+    };
+    let request_cancelled = Arc::new(AtomicBool::new(false));
+    let request_cancellation: Arc<dyn GraphCancellation> = Arc::new(
+        AtomicGraphCancellationV1::new(Arc::clone(&request_cancelled)),
+    );
+    let probe = GraphPublicationProbeV1 {
+        request_cancellation,
+        lifecycle_cancelled: Arc::new(AtomicBool::new(false)),
+        deadline_at: Instant::now() + Duration::from_secs(30),
+        cancellation: cancellation.clone(),
+        deadline: deadline.clone(),
+        commit_started: AtomicBool::new(false),
+    };
+    let control = RuntimeRequestControlV1 {
+        requested_at: UtcMicros(crate::tracedecay::current_timestamp()),
+        deadline,
+        cancellation,
+    };
+    let context = GraphPublicationOperationContextV1::new(&control, &probe)
+        .expect("test publication context");
+    operation(&context)
+}
+
+fn publication_replay(
+    runtime: &RetainedCodeGraphRuntimeV1,
+    generation: &tracedecay_code_index::production::CodeIndexPublishedGenerationV1,
+) -> (
+    GraphProjectionIdentityV1,
+    GraphPublicationKeyV1,
+    tracedecay_store::GraphPublicationReplayV1,
+) {
+    let projector_revision = GraphProjectorRevision::try_from(
+        tracedecay_code_index::graph_projection::CODE_GRAPH_PROJECTOR_REVISION.to_owned(),
+    )
+    .expect("projector revision");
+    let projection = tracedecay_code_index::graph_projection::code_graph_projection_identity(
+        runtime.authority.namespace().clone(),
+    )
+    .expect("code graph projection");
+    let manifest =
+        tracedecay_code_index::graph_projection::build_published_code_graph_manifest_checked(
+            projection.clone(),
+            generation,
+            &projector_revision,
+            &|| Ok(()),
+        )
+        .expect("published graph manifest");
+    let relational_projection = GraphProjectionIdentityV1 {
+        shard_id: runtime.authority.binding().shard_id.clone(),
+        namespace: tracedecay_store::GraphNamespaceV1::new(runtime.authority.namespace().as_str())
+            .expect("relational namespace"),
+        projection: GraphProjectionIdV1::new(projection.projection.as_str())
+            .expect("relational projection"),
+    };
+    let idempotency_key = tracedecay_code_index::graph_projection::code_graph_idempotency_key(
+        &runtime.generation_id,
+        &projector_revision,
+    )
+    .expect("publication idempotency key");
+    let publication_key = GraphPublicationKeyV1::new(
+        relational_projection.clone(),
+        GraphGenerationIdV1::new(manifest.generation.as_str()).expect("relational generation"),
+        GraphPublicationIdempotencyKeyV1::new(idempotency_key.as_str())
+            .expect("relational idempotency key"),
+    );
+    let source = SealedCodeGenerationReplay {
+        repository: runtime.repository_id.clone(),
+        generation: runtime.generation_id.clone(),
+        sealed_state_digest: runtime.sealed_state_digest.clone(),
+        projector_revision,
+    };
+    let input = canonical_sha256(&(
+        "tracedecay.code-graph-publication-input.v1",
+        &source,
+        &manifest.generation,
+        &manifest.source_generation,
+        &manifest.watermark,
+    ))
+    .expect("publication input digest");
+    let replay = manifest
+        .relational_sealed_replay(
+            runtime.authority.binding().shard_id.clone(),
+            idempotency_key,
+            GraphPublicationInputDigestV1::new(input.as_str()).expect("publication input digest"),
+            None,
+            source,
+            &|| Ok(()),
+        )
+        .expect("sealed publication replay");
+    (relational_projection, publication_key, replay)
+}
+
+fn assert_unverified_publication_state(
+    runtime: &RetainedCodeGraphRuntimeV1,
+    generation: &tracedecay_code_index::production::CodeIndexPublishedGenerationV1,
+    expected_replay: bool,
+) {
+    let (projection, key, _) = publication_replay(runtime, generation);
+    with_publication_context("inspect-sealed-publication", |context| {
+        let mut storage = runtime
+            .project_database
+            .graph_publication_storage()
+            .expect("graph publication storage");
+        let replay = storage.replay(&key, context).expect("publication replay");
+        if expected_replay {
+            assert!(matches!(replay, GraphPublicationReplayLookupV1::Active(_)));
+        } else {
+            assert!(matches!(replay, GraphPublicationReplayLookupV1::Missing));
+        }
+        assert!(
+            storage
+                .verified_head(&projection, context)
+                .expect("verified graph head")
+                .is_none()
+        );
+    });
+}
+
+fn journal_publication_without_head(
+    runtime: &RetainedCodeGraphRuntimeV1,
+    generation: &tracedecay_code_index::production::CodeIndexPublishedGenerationV1,
+) {
+    let (_, _, replay) = publication_replay(runtime, generation);
+    with_publication_context("journal-sealed-publication", |context| {
+        let mut storage = runtime
+            .project_database
+            .graph_publication_storage()
+            .expect("graph publication storage");
+        assert!(matches!(
+            storage
+                .append_replay(&replay, context)
+                .expect("append sealed publication replay"),
+            GraphReplayAppendOutcomeV1::Appended(_)
+        ));
+    });
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -121,6 +281,13 @@ async fn sealed_generation_publishes_and_republishes_without_eager_replay_payloa
     std::fs::create_dir(&foreign_destination).expect("foreign digest-named directory");
     let sentinel = foreign_destination.join("sentinel");
     std::fs::write(&sentinel, b"foreign replay evidence").expect("foreign replay sentinel");
+    let canonical_seal = scoped_store
+        .join("code-generations-v1")
+        .join(format!("generation-{digest}.json"));
+    let intact_seal = std::fs::read(&canonical_seal).expect("canonical sealed generation");
+    let mut mutated_seal = intact_seal.clone();
+    let mutation_offset = mutated_seal.len() / 2;
+    mutated_seal[mutation_offset] ^= 1;
 
     let runtime = registry
         .retain_code_graph_runtime(
@@ -134,6 +301,54 @@ async fn sealed_generation_publishes_and_republishes_without_eager_replay_payloa
         )
         .await
         .expect("retain code graph runtime");
+
+    std::fs::write(&canonical_seal, &mutated_seal).expect("mutate sealed generation in place");
+    assert!(matches!(
+        runtime.publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false))),
+        Err(GraphDbError::Corrupt { .. })
+    ));
+    assert_unverified_publication_state(&runtime, latest.generation(), false);
+    std::fs::write(&canonical_seal, &intact_seal).expect("restore sealed generation bytes");
+
+    let retained_seal = canonical_seal.with_extension("retained-test-evidence");
+    std::fs::rename(&canonical_seal, &retained_seal).expect("retain original sealed inode");
+    std::fs::write(&canonical_seal, &mutated_seal).expect("replace canonical sealed inode");
+    assert!(matches!(
+        runtime.publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false))),
+        Err(GraphDbError::Corrupt { .. })
+    ));
+    assert_unverified_publication_state(&runtime, latest.generation(), false);
+    std::fs::remove_file(&canonical_seal).expect("remove replacement sealed inode");
+    std::fs::rename(&retained_seal, &canonical_seal).expect("restore original sealed inode");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        std::fs::rename(&canonical_seal, &retained_seal).expect("retain symlink target evidence");
+        symlink(&retained_seal, &canonical_seal).expect("swap canonical seal for symlink");
+        assert!(matches!(
+            runtime
+                .publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false))),
+            Err(GraphDbError::Corrupt { .. })
+        ));
+        assert_unverified_publication_state(&runtime, latest.generation(), false);
+        std::fs::remove_file(&canonical_seal).expect("remove sealed generation symlink");
+        std::fs::rename(&retained_seal, &canonical_seal)
+            .expect("restore sealed generation after symlink refusal");
+    }
+
+    journal_publication_without_head(&runtime, latest.generation());
+    std::fs::write(&canonical_seal, &mutated_seal)
+        .expect("mutate source before active replay completion");
+    assert!(matches!(
+        runtime.publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false))),
+        Err(GraphDbError::Corrupt { .. })
+    ));
+    assert_unverified_publication_state(&runtime, latest.generation(), true);
+    std::fs::write(&canonical_seal, &intact_seal)
+        .expect("restore source before active replay completion");
+
     let snapshot = runtime
         .publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false)))
         .expect("the sealed generation must publish as the verified code graph");

--- a/src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph/sealed_publication_tests.rs
@@ -39,7 +39,7 @@ fn git(root: &Path, args: &[&str]) {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn sealed_generation_publishes_and_republishes_as_the_verified_code_graph() {
+async fn sealed_generation_publishes_and_republishes_without_eager_replay_payload() {
     let temporary = tempfile::tempdir().expect("temporary fixture parent");
     let root = temporary
         .path()
@@ -108,6 +108,19 @@ async fn sealed_generation_publishes_and_republishes_as_the_verified_code_graph(
         .project_memory(project_id.clone(), [canonical_project.clone()])
         .await
         .expect("project graph database");
+    let replay_root = project_database
+        .database_path()
+        .with_extension("graph-replay");
+    tracedecay_runtime_core::storage::PrivateStoreIo::create_private_directory(&replay_root)
+        .expect("private graph replay root");
+    let digest = pointer
+        .state_digest
+        .strip_prefix("sha256:")
+        .expect("sha256 state digest");
+    let foreign_destination = replay_root.join(format!("generation-{digest}.json"));
+    std::fs::create_dir(&foreign_destination).expect("foreign digest-named directory");
+    let sentinel = foreign_destination.join("sentinel");
+    std::fs::write(&sentinel, b"foreign replay evidence").expect("foreign replay sentinel");
 
     let runtime = registry
         .retain_code_graph_runtime(
@@ -135,6 +148,31 @@ async fn sealed_generation_publishes_and_republishes_as_the_verified_code_graph(
     assert_eq!(snapshot.generation(), &expected_generation);
     let head = snapshot.verified_head().clone();
     drop(snapshot);
+    assert_eq!(
+        std::fs::read(&sentinel).expect("foreign replay evidence survives first publication"),
+        b"foreign replay evidence"
+    );
+    let first_publish_payload_bytes = std::fs::read_dir(&replay_root)
+        .expect("read graph replay root after first publication")
+        .map(|entry| entry.expect("graph replay entry"))
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("generation-")
+                && entry
+                    .file_type()
+                    .expect("graph replay entry type")
+                    .is_file()
+        })
+        .map(|entry| {
+            entry
+                .metadata()
+                .expect("graph replay payload metadata")
+                .len()
+        })
+        .sum::<u64>();
+    assert_eq!(first_publish_payload_bytes, 0);
 
     // A retained-seat retry of the same sealed artifact resumes to the same
     // verified head instead of conflicting with its own journaled replay.
@@ -155,4 +193,29 @@ async fn sealed_generation_publishes_and_republishes_as_the_verified_code_graph(
         .expect("a repeated activation must resume the exact publication");
     assert_eq!(resumed.generation(), &expected_generation);
     assert_eq!(resumed.verified_head(), &head);
+    assert_eq!(
+        std::fs::read(&sentinel).expect("foreign replay evidence survives active republish"),
+        b"foreign replay evidence"
+    );
+    let active_republish_payload_bytes = std::fs::read_dir(&replay_root)
+        .expect("read graph replay root after active republish")
+        .map(|entry| entry.expect("graph replay entry"))
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("generation-")
+                && entry
+                    .file_type()
+                    .expect("graph replay entry type")
+                    .is_file()
+        })
+        .map(|entry| {
+            entry
+                .metadata()
+                .expect("graph replay payload metadata")
+                .len()
+        })
+        .sum::<u64>();
+    assert_eq!(active_republish_payload_bytes, 0);
 }

--- a/src/daemon/store_runtime/session_registry/code_graph/seals.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph/seals.rs
@@ -1,26 +1,14 @@
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use sha2::{Digest, Sha256};
-use tracedecay_graph_db::{GraphBudgetKind, GraphDbError, SealedGraphStateDigest};
+use tracedecay_graph_db::{GraphDbError, SealedGraphStateDigest};
 use tracedecay_private_fs::framed_log::{DirectorySyncPolicy, sync_directory};
 
 static STAGED_SEAL_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-
-pub(super) struct StagedReplaySeal {
-    path: PathBuf,
-    file: File,
-    fingerprint: StagedFileFingerprint,
-    existing: Option<ExistingReplaySeal>,
-}
-
-struct ExistingReplaySeal {
-    file: File,
-    fingerprint: StagedFileFingerprint,
-}
 
 pub(super) struct StagedReplayUnlink {
     path: PathBuf,
@@ -52,332 +40,6 @@ pub(super) fn sealed_digest_from_generation_file(
         .and_then(|value| value.strip_suffix(".json"))
         .ok_or_else(|| GraphDbError::invalid("sealed generation filename is invalid"))?;
     SealedGraphStateDigest::try_from(format!("sha256:{digest}"))
-}
-
-pub(super) fn install_project_graph_replay_seal_at(
-    generations_root: &Path,
-    replay_root: &Path,
-    sealed_state_digest: &SealedGraphStateDigest,
-    check: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<(), GraphDbError> {
-    let staged =
-        stage_project_graph_replay_seal(generations_root, replay_root, sealed_state_digest, check)?;
-    let _pool = lock_project_graph_replay_pool(replay_root, check)?;
-    publish_staged_replay_seal(staged, replay_root, sealed_state_digest, check)
-}
-
-/// Pin the exact source inode, copy it into a private create-new staged inode,
-/// and verify the copy without holding either broad filesystem lock.
-pub(super) fn stage_project_graph_replay_seal(
-    generations_root: &Path,
-    replay_root: &Path,
-    sealed_state_digest: &SealedGraphStateDigest,
-    check: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<StagedReplaySeal, GraphDbError> {
-    ensure_replay_root(replay_root)?;
-    let digest = digest_hex(sealed_state_digest)?;
-    let source = generations_root.join(format!("generation-{digest}.json"));
-    let source_store_root = generations_root.parent().ok_or_else(|| {
-        GraphDbError::invalid("code generation replay source has no store authority root")
-    })?;
-    let source_lock = lock_code_generation_store(source_store_root, check)?;
-    let metadata = source.symlink_metadata().map_err(|error| {
-        GraphDbError::unavailable(format!(
-            "code generation replay source is unavailable: {error}"
-        ))
-    })?;
-    if !metadata.file_type().is_file() {
-        return Err(GraphDbError::Corrupt {
-            message: "code generation replay source is not a regular file".to_owned(),
-        });
-    }
-    let admitted_len = metadata.len();
-    if admitted_len > tracedecay_code_index::production::MAX_SEALED_CODE_GENERATION_BYTES_V1 {
-        return Err(GraphDbError::ResetRequired {
-            message: "sealed code generation exceeds the canonical byte limit".to_owned(),
-        });
-    }
-    let mut source_file = File::open(&source).map_err(|error| {
-        GraphDbError::unavailable(format!(
-            "code generation replay source could not be pinned: {error}"
-        ))
-    })?;
-    let sequence = STAGED_SEAL_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let staged = replay_root.join(format!(
-        ".generation-{digest}.stage-{}-{}-{sequence}",
-        std::process::id(),
-        crate::tracedecay::current_timestamp()
-    ));
-    let mut staged_file = OpenOptions::new()
-        .create_new(true)
-        .read(true)
-        .write(true)
-        .open(&staged)
-        .map_err(|error| {
-            GraphDbError::unavailable(format!(
-                "project graph replay staging file could not be created: {error}"
-            ))
-        })?;
-    drop(source_lock);
-    if let Err(error) = copy_and_verify_seal(
-        &mut source_file,
-        &mut staged_file,
-        digest,
-        admitted_len,
-        check,
-    ) {
-        remove_staged(&staged, replay_root)?;
-        return Err(error);
-    }
-    staged_file
-        .sync_all()
-        .map_err(|error| GraphDbError::DurabilityUncertain {
-            message: format!("staged project graph replay seal sync failed: {error}"),
-        })?;
-    let mut permissions = staged_file
-        .metadata()
-        .map_err(|error| GraphDbError::unavailable(error.to_string()))?
-        .permissions();
-    permissions.set_readonly(true);
-    std::fs::set_permissions(&staged, permissions)
-        .map_err(|error| GraphDbError::unavailable(error.to_string()))?;
-    let fingerprint = staged_fingerprint(
-        &staged_file
-            .metadata()
-            .map_err(|error| GraphDbError::unavailable(error.to_string()))?,
-    )?;
-    if !staged_identity_matches(&staged, &staged_file, &fingerprint)? {
-        remove_staged(&staged, replay_root)?;
-        return Err(GraphDbError::Conflict);
-    }
-    let destination = replay_root.join(format!("generation-{digest}.json"));
-    let existing = match pin_existing_replay_seal(&destination, digest, check) {
-        Ok(existing) => existing,
-        Err(error) => {
-            drop(staged_file);
-            remove_staged(&staged, replay_root)?;
-            return Err(error);
-        }
-    };
-    Ok(StagedReplaySeal {
-        path: staged,
-        file: staged_file,
-        fingerprint,
-        existing,
-    })
-}
-
-/// Publish the exact private inode verified by staging while the caller holds
-/// the replay-pool lock. The content-addressed destination is installed with
-/// no-clobber semantics; an existing exact seal is an idempotent replay and a
-/// foreign destination is preserved and rejected.
-pub(super) fn publish_staged_replay_seal(
-    staged: StagedReplaySeal,
-    replay_root: &Path,
-    sealed_state_digest: &SealedGraphStateDigest,
-    check: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<(), GraphDbError> {
-    publish_staged_replay_seal_with_before_install(
-        staged,
-        replay_root,
-        sealed_state_digest,
-        check,
-        &|| Ok(()),
-    )
-}
-
-fn publish_staged_replay_seal_with_before_install(
-    staged: StagedReplaySeal,
-    replay_root: &Path,
-    sealed_state_digest: &SealedGraphStateDigest,
-    check: &dyn Fn() -> Result<(), GraphDbError>,
-    before_install: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<(), GraphDbError> {
-    check()?;
-    let digest = digest_hex(sealed_state_digest)?;
-    let destination = replay_root.join(format!("generation-{digest}.json"));
-    let staged_metadata = staged
-        .path
-        .symlink_metadata()
-        .map_err(|error| GraphDbError::unavailable(error.to_string()))?;
-    if !staged_metadata.file_type().is_file() {
-        return Err(GraphDbError::Corrupt {
-            message: "staged project graph replay seal is not a regular file".to_owned(),
-        });
-    }
-    if !staged_identity_matches(&staged.path, &staged.file, &staged.fingerprint)? {
-        return Err(GraphDbError::Conflict);
-    }
-    before_install()?;
-    check()?;
-    if !staged_identity_matches(&staged.path, &staged.file, &staged.fingerprint)? {
-        return Err(GraphDbError::Conflict);
-    }
-    let StagedReplaySeal {
-        path,
-        file,
-        fingerprint: _,
-        existing,
-    } = staged;
-    match std::fs::hard_link(&path, &destination) {
-        Ok(()) => {
-            check()?;
-            sync_replay_root(replay_root)?;
-            let installed_fingerprint = staged_fingerprint(
-                &file
-                    .metadata()
-                    .map_err(|error| GraphDbError::unavailable(error.to_string()))?,
-            )?;
-            if !staged_identity_matches(&destination, &file, &installed_fingerprint)?
-                || !staged_identity_matches(&path, &file, &installed_fingerprint)?
-            {
-                return Err(GraphDbError::Conflict);
-            }
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            check()?;
-            // Staging pins the destination before the replay-pool lock is
-            // held, so a same-digest peer can install it in between. Re-pin
-            // under the held lock: a digest-exact destination is an
-            // idempotent replay, and only a foreign destination conflicts.
-            let existing = match existing {
-                Some(existing) => existing,
-                None => match pin_existing_replay_seal(&destination, digest, check) {
-                    Ok(Some(existing)) => existing,
-                    Ok(None) => {
-                        drop(file);
-                        remove_staged(&path, replay_root)?;
-                        return Err(GraphDbError::Conflict);
-                    }
-                    Err(error) => {
-                        drop(file);
-                        remove_staged(&path, replay_root)?;
-                        return Err(error);
-                    }
-                },
-            };
-            if !staged_identity_matches(&destination, &existing.file, &existing.fingerprint)? {
-                drop(existing);
-                drop(file);
-                remove_staged(&path, replay_root)?;
-                return Err(GraphDbError::Conflict);
-            }
-        }
-        Err(error) => return Err(GraphDbError::unavailable(error.to_string())),
-    }
-    check()?;
-    if !staged_identity_matches(
-        &path,
-        &file,
-        &staged_fingerprint(
-            &file
-                .metadata()
-                .map_err(|error| GraphDbError::unavailable(error.to_string()))?,
-        )?,
-    )? {
-        return Err(GraphDbError::Conflict);
-    }
-    drop(file);
-    check()?;
-    std::fs::remove_file(&path).map_err(|error| GraphDbError::DurabilityUncertain {
-        message: format!("published replay staging unlink failed: {error}"),
-    })?;
-    sync_replay_root(replay_root)?;
-    Ok(())
-}
-
-fn pin_existing_replay_seal(
-    destination: &Path,
-    expected_digest: &str,
-    check: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<Option<ExistingReplaySeal>, GraphDbError> {
-    let mut file = match File::open(destination) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(GraphDbError::unavailable(error.to_string())),
-    };
-    let metadata = file
-        .metadata()
-        .map_err(|error| GraphDbError::unavailable(error.to_string()))?;
-    if !metadata.file_type().is_file() {
-        return Err(GraphDbError::Corrupt {
-            message: "existing project graph replay seal is not a regular file".to_owned(),
-        });
-    }
-    let fingerprint = staged_fingerprint(&metadata)?;
-    if !staged_identity_matches(destination, &file, &fingerprint)? {
-        return Err(GraphDbError::Conflict);
-    }
-    // The stage/publish journey installs with no-clobber semantics: an exact
-    // seal is an idempotent replay, while a foreign destination is preserved
-    // and rejected as a conflict rather than reported as pool corruption.
-    match verify_seal_file_digest(&mut file, expected_digest, check)? {
-        SealDigestOutcome::Verified => {}
-        SealDigestOutcome::Mismatch => return Err(GraphDbError::Conflict),
-    }
-    if !staged_identity_matches(destination, &file, &fingerprint)? {
-        return Err(GraphDbError::Conflict);
-    }
-    Ok(Some(ExistingReplaySeal { file, fingerprint }))
-}
-
-fn copy_and_verify_seal(
-    source: &mut File,
-    staged: &mut File,
-    expected: &str,
-    admitted_len: u64,
-    check: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<(), GraphDbError> {
-    let mut digest = Sha256::new();
-    let mut buffer = vec![0_u8; 64 * 1024];
-    let mut copied = 0_u64;
-    loop {
-        check()?;
-        let read = source
-            .read(&mut buffer)
-            .map_err(|error| GraphDbError::Corrupt {
-                message: format!("project graph replay source read failed: {error}"),
-            })?;
-        if read == 0 {
-            break;
-        }
-        copied = copied
-            .checked_add(u64::try_from(read).map_err(|_| {
-                GraphDbError::budget_exhausted(
-                    GraphBudgetKind::Write,
-                    tracedecay_code_index::production::MAX_SEALED_CODE_GENERATION_BYTES_V1,
-                )
-            })?)
-            .ok_or_else(|| {
-                GraphDbError::budget_exhausted(
-                    GraphBudgetKind::Write,
-                    tracedecay_code_index::production::MAX_SEALED_CODE_GENERATION_BYTES_V1,
-                )
-            })?;
-        if copied > admitted_len
-            || copied > tracedecay_code_index::production::MAX_SEALED_CODE_GENERATION_BYTES_V1
-        {
-            return Err(GraphDbError::ResetRequired {
-                message: "sealed code generation grew beyond its admitted byte length".to_owned(),
-            });
-        }
-        staged.write_all(&buffer[..read]).map_err(|error| {
-            GraphDbError::unavailable(format!(
-                "project graph replay staging write failed: {error}"
-            ))
-        })?;
-        digest.update(&buffer[..read]);
-    }
-    check()?;
-    if copied != admitted_len {
-        return Err(GraphDbError::Conflict);
-    }
-    if hex::encode(digest.finalize()) != expected {
-        return Err(GraphDbError::Corrupt {
-            message: "project graph replay seal digest does not match its filename".to_owned(),
-        });
-    }
-    Ok(())
 }
 
 fn staged_fingerprint(metadata: &std::fs::Metadata) -> Result<StagedFileFingerprint, GraphDbError> {
@@ -520,7 +182,17 @@ pub(super) fn lock_project_graph_replay_pool(
     replay_root: &Path,
     check: &dyn Fn() -> Result<(), GraphDbError>,
 ) -> Result<crate::retention::code_index_generations::CodeGenerationStoreLockV1, GraphDbError> {
-    ensure_replay_root(replay_root)?;
+    tracedecay_runtime_core::storage::PrivateStoreIo::create_private_directory(replay_root)
+        .map_err(|error| {
+            let message =
+                format!("project graph replay pool is not an owner-private directory: {error}");
+            match error.kind() {
+                std::io::ErrorKind::InvalidInput
+                | std::io::ErrorKind::NotADirectory
+                | std::io::ErrorKind::PermissionDenied => GraphDbError::Corrupt { message },
+                _ => GraphDbError::unavailable(message),
+            }
+        })?;
     lock_code_generation_store(replay_root, check)
 }
 
@@ -539,49 +211,11 @@ fn lock_code_generation_store(
     }
 }
 
-fn ensure_replay_root(replay_root: &Path) -> Result<(), GraphDbError> {
-    let validate_existing = || {
-        tracedecay_private_fs::validate_private_directory(replay_root).map_err(|error| {
-            let message =
-                format!("project graph replay pool is not an owner-private directory: {error}");
-            match error.kind() {
-                std::io::ErrorKind::InvalidInput
-                | std::io::ErrorKind::NotADirectory
-                | std::io::ErrorKind::PermissionDenied => GraphDbError::Corrupt { message },
-                _ => GraphDbError::unavailable(message),
-            }
-        })
-    };
-    match replay_root.symlink_metadata() {
-        Ok(_) => validate_existing(),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            match tracedecay_private_fs::create_private_directory(replay_root) {
-                Ok(()) => Ok(()),
-                Err(create_error) => match replay_root.symlink_metadata() {
-                    Ok(_) => validate_existing(),
-                    Err(_) => Err(GraphDbError::unavailable(create_error.to_string())),
-                },
-            }
-        }
-        Err(error) => Err(GraphDbError::unavailable(error.to_string())),
-    }
-}
-
 fn digest_hex(sealed: &SealedGraphStateDigest) -> Result<&str, GraphDbError> {
     sealed
         .as_str()
         .strip_prefix("sha256:")
         .ok_or_else(|| GraphDbError::invalid("code generation replay digest is not sha256"))
-}
-
-fn remove_staged(staged: &Path, replay_root: &Path) -> Result<(), GraphDbError> {
-    match std::fs::remove_file(staged) {
-        Ok(()) => sync_replay_root(replay_root),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(GraphDbError::DurabilityUncertain {
-            message: format!("failed to remove invalid staged replay seal: {error}"),
-        }),
-    }
 }
 
 fn sync_replay_root(replay_root: &Path) -> Result<(), GraphDbError> {
@@ -604,9 +238,8 @@ pub(super) fn verify_seal_digest(
     }
 }
 
-/// Whether a seal's bytes hash to the digest its filename claims. A mismatch
-/// is a fact about the file, not an error: read paths report it as pool
-/// corruption while publish treats the file as a preserved foreign occupant.
+/// Whether a retained seal's bytes hash to the digest its filename claims. A
+/// mismatch is a fact about the file that read paths report as pool corruption.
 enum SealDigestOutcome {
     Verified,
     Mismatch,
@@ -641,16 +274,14 @@ fn verify_seal_file_digest(
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Barrier};
 
     use sha2::{Digest, Sha256};
     use tempfile::TempDir;
     use tracedecay_graph_db::GraphDbError;
 
     use super::{
-        ensure_replay_root, install_project_graph_replay_seal_at, lock_project_graph_replay_pool,
-        publish_staged_replay_seal, publish_staged_replay_seal_with_before_install,
-        stage_project_graph_replay_seal, verify_seal_digest,
+        finalize_project_graph_replay_unlink, lock_project_graph_replay_pool,
+        stage_project_graph_replay_unlink, verify_seal_digest,
     };
 
     #[cfg(unix)]
@@ -661,7 +292,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let replay_root = temp.path().join("project-replay");
 
-        ensure_replay_root(&replay_root).unwrap();
+        drop(lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap());
 
         assert_eq!(
             replay_root.symlink_metadata().unwrap().permissions().mode() & 0o777,
@@ -676,7 +307,7 @@ mod tests {
         std::fs::write(&replay_root, b"not a directory").unwrap();
 
         assert!(matches!(
-            ensure_replay_root(&replay_root),
+            lock_project_graph_replay_pool(&replay_root, &|| Ok(())),
             Err(GraphDbError::Corrupt { .. })
         ));
     }
@@ -688,12 +319,13 @@ mod tests {
 
         let temp = TempDir::new().unwrap();
         let destination = temp.path().join("private-directory");
-        tracedecay_private_fs::create_private_directory(&destination).unwrap();
+        tracedecay_runtime_core::storage::PrivateStoreIo::create_private_directory(&destination)
+            .unwrap();
         let replay_root = temp.path().join("project-replay");
         symlink(destination, &replay_root).unwrap();
 
         assert!(matches!(
-            ensure_replay_root(&replay_root),
+            lock_project_graph_replay_pool(&replay_root, &|| Ok(())),
             Err(GraphDbError::Corrupt { .. })
         ));
     }
@@ -709,120 +341,13 @@ mod tests {
         std::fs::set_permissions(&replay_root, std::fs::Permissions::from_mode(0o755)).unwrap();
 
         assert!(matches!(
-            ensure_replay_root(&replay_root),
+            lock_project_graph_replay_pool(&replay_root, &|| Ok(())),
             Err(GraphDbError::Corrupt { .. })
         ));
         assert_eq!(
             replay_root.symlink_metadata().unwrap().permissions().mode() & 0o777,
             0o755
         );
-    }
-
-    #[test]
-    fn project_replay_pool_serializes_same_digest_from_distinct_sources() {
-        let temp = TempDir::new().unwrap();
-        let bytes = b"same sealed generation";
-        let digest_hex = hex::encode(Sha256::digest(bytes));
-        let digest =
-            tracedecay_graph_db::SealedGraphStateDigest::try_from(format!("sha256:{digest_hex}"))
-                .unwrap();
-        let replay_root = temp.path().join("project-replay");
-        let mut generation_roots = Vec::new();
-        for source in ["source-a", "source-b"] {
-            let root = temp.path().join(source).join("generations");
-            std::fs::create_dir_all(&root).unwrap();
-            std::fs::write(root.join(format!("generation-{digest_hex}.json")), bytes).unwrap();
-            generation_roots.push(root);
-        }
-        let barrier = Arc::new(Barrier::new(generation_roots.len()));
-        let threads = generation_roots
-            .into_iter()
-            .map(|generation_root| {
-                let barrier = Arc::clone(&barrier);
-                let replay_root = replay_root.clone();
-                let digest = digest.clone();
-                std::thread::spawn(move || {
-                    barrier.wait();
-                    install_project_graph_replay_seal_at(
-                        &generation_root,
-                        &replay_root,
-                        &digest,
-                        &|| Ok(()),
-                    )
-                })
-            })
-            .collect::<Vec<_>>();
-
-        for thread in threads {
-            thread.join().unwrap().unwrap();
-        }
-        assert_eq!(
-            std::fs::read(replay_root.join(format!("generation-{digest_hex}.json"))).unwrap(),
-            bytes
-        );
-    }
-
-    #[test]
-    fn replay_seal_publish_accepts_exact_existing_destination() {
-        let temp = TempDir::new().unwrap();
-        let bytes = b"same sealed generation";
-        let digest_hex = hex::encode(Sha256::digest(bytes));
-        let digest =
-            tracedecay_graph_db::SealedGraphStateDigest::try_from(format!("sha256:{digest_hex}"))
-                .unwrap();
-        let generation_root = temp.path().join("source").join("generations");
-        let replay_root = temp.path().join("project-replay");
-        std::fs::create_dir_all(&generation_root).unwrap();
-        tracedecay_private_fs::create_private_directory(&replay_root).unwrap();
-        std::fs::write(
-            generation_root.join(format!("generation-{digest_hex}.json")),
-            bytes,
-        )
-        .unwrap();
-        let destination = replay_root.join(format!("generation-{digest_hex}.json"));
-        std::fs::write(&destination, bytes).unwrap();
-        let staged =
-            stage_project_graph_replay_seal(&generation_root, &replay_root, &digest, &|| Ok(()))
-                .unwrap();
-        let staged_path = staged.path.clone();
-        let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
-
-        publish_staged_replay_seal(staged, &replay_root, &digest, &|| Ok(())).unwrap();
-
-        assert_eq!(std::fs::read(destination).unwrap(), bytes);
-        assert!(!staged_path.exists());
-    }
-
-    #[test]
-    fn replay_seal_publish_preserves_foreign_existing_destination() {
-        let temp = TempDir::new().unwrap();
-        let bytes = b"sealed generation";
-        let foreign = b"foreign destination";
-        let digest_hex = hex::encode(Sha256::digest(bytes));
-        let digest =
-            tracedecay_graph_db::SealedGraphStateDigest::try_from(format!("sha256:{digest_hex}"))
-                .unwrap();
-        let generation_root = temp.path().join("source").join("generations");
-        let replay_root = temp.path().join("project-replay");
-        std::fs::create_dir_all(&generation_root).unwrap();
-        tracedecay_private_fs::create_private_directory(&replay_root).unwrap();
-        std::fs::write(
-            generation_root.join(format!("generation-{digest_hex}.json")),
-            bytes,
-        )
-        .unwrap();
-        let destination = replay_root.join(format!("generation-{digest_hex}.json"));
-        let staged =
-            stage_project_graph_replay_seal(&generation_root, &replay_root, &digest, &|| Ok(()))
-                .unwrap();
-        std::fs::write(&destination, foreign).unwrap();
-        let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
-
-        assert_eq!(
-            publish_staged_replay_seal(staged, &replay_root, &digest, &|| Ok(())),
-            Err(GraphDbError::Conflict)
-        );
-        assert_eq!(std::fs::read(destination).unwrap(), foreign);
     }
 
     #[test]
@@ -867,113 +392,59 @@ mod tests {
     }
 
     #[test]
-    fn replay_seal_publish_rejects_staged_path_replacement() {
+    fn staged_replay_unlink_preserves_concurrent_canonical_reinstall() {
         let temp = TempDir::new().unwrap();
+        let replay_root = temp.path().join("project-replay");
+        drop(lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap());
         let bytes = b"sealed generation";
         let digest_hex = hex::encode(Sha256::digest(bytes));
         let digest =
             tracedecay_graph_db::SealedGraphStateDigest::try_from(format!("sha256:{digest_hex}"))
                 .unwrap();
-        let generation_root = temp.path().join("source").join("generations");
-        let replay_root = temp.path().join("project-replay");
-        std::fs::create_dir_all(&generation_root).unwrap();
-        std::fs::write(
-            generation_root.join(format!("generation-{digest_hex}.json")),
-            bytes,
-        )
-        .unwrap();
-        let staged =
-            stage_project_graph_replay_seal(&generation_root, &replay_root, &digest, &|| Ok(()))
-                .unwrap();
-        let replacement = staged.path.with_extension("replacement");
-        std::fs::rename(&staged.path, &replacement).unwrap();
-        std::fs::write(&staged.path, bytes).unwrap();
-        let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
+        let canonical = replay_root.join(format!("generation-{digest_hex}.json"));
+        std::fs::write(&canonical, bytes).unwrap();
+        let staged = {
+            let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
+            stage_project_graph_replay_unlink(&replay_root, &digest)
+                .unwrap()
+                .unwrap()
+        };
+        std::fs::write(&canonical, bytes).unwrap();
 
-        assert_eq!(
-            publish_staged_replay_seal(staged, &replay_root, &digest, &|| Ok(())),
-            Err(GraphDbError::Conflict)
-        );
-        assert!(
-            !replay_root
-                .join(format!("generation-{digest_hex}.json"))
-                .exists()
-        );
-    }
+        finalize_project_graph_replay_unlink(staged, &replay_root, &digest, &|| Ok(())).unwrap();
 
-    #[cfg(unix)]
-    #[test]
-    fn replay_seal_publish_rejects_same_inode_same_length_rewrite() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = TempDir::new().unwrap();
-        let bytes = b"sealed generation";
-        let digest_hex = hex::encode(Sha256::digest(bytes));
-        let digest =
-            tracedecay_graph_db::SealedGraphStateDigest::try_from(format!("sha256:{digest_hex}"))
-                .unwrap();
-        let generation_root = temp.path().join("source").join("generations");
-        let replay_root = temp.path().join("project-replay");
-        std::fs::create_dir_all(&generation_root).unwrap();
-        std::fs::write(
-            generation_root.join(format!("generation-{digest_hex}.json")),
-            bytes,
-        )
-        .unwrap();
-        let staged =
-            stage_project_graph_replay_seal(&generation_root, &replay_root, &digest, &|| Ok(()))
-                .unwrap();
-        let before = staged.path.symlink_metadata().unwrap();
-        let mut permissions = before.permissions();
-        permissions.set_mode(permissions.mode() | 0o200);
-        std::fs::set_permissions(&staged.path, permissions).unwrap();
-        std::fs::write(&staged.path, b"rewritten bytes!!").unwrap();
-        assert_eq!(staged.path.symlink_metadata().unwrap().len(), before.len());
-        let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
-
-        assert_eq!(
-            publish_staged_replay_seal(staged, &replay_root, &digest, &|| Ok(())),
-            Err(GraphDbError::Conflict)
-        );
+        assert_eq!(std::fs::read(canonical).unwrap(), bytes);
     }
 
     #[test]
-    fn replay_seal_publish_rejects_path_swap_between_check_and_rename() {
+    fn staged_replay_unlink_replacement_conflicts_without_deleting_evidence() {
         let temp = TempDir::new().unwrap();
+        let replay_root = temp.path().join("project-replay");
+        drop(lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap());
         let bytes = b"sealed generation";
         let digest_hex = hex::encode(Sha256::digest(bytes));
         let digest =
             tracedecay_graph_db::SealedGraphStateDigest::try_from(format!("sha256:{digest_hex}"))
                 .unwrap();
-        let generation_root = temp.path().join("source").join("generations");
-        let replay_root = temp.path().join("project-replay");
-        std::fs::create_dir_all(&generation_root).unwrap();
-        std::fs::write(
-            generation_root.join(format!("generation-{digest_hex}.json")),
-            bytes,
-        )
-        .unwrap();
-        let staged =
-            stage_project_graph_replay_seal(&generation_root, &replay_root, &digest, &|| Ok(()))
-                .unwrap();
+        let canonical = replay_root.join(format!("generation-{digest_hex}.json"));
+        std::fs::write(&canonical, bytes).unwrap();
+        let staged = {
+            let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
+            stage_project_graph_replay_unlink(&replay_root, &digest)
+                .unwrap()
+                .unwrap()
+        };
         let staged_path = staged.path.clone();
-        let retained = staged_path.with_extension("retained");
-        let _pool = lock_project_graph_replay_pool(&replay_root, &|| Ok(())).unwrap();
+        let retained = staged_path.with_extension("retained-evidence");
+        std::fs::rename(&staged_path, &retained).unwrap();
+        std::fs::write(&staged_path, bytes).unwrap();
 
         assert_eq!(
-            publish_staged_replay_seal_with_before_install(
-                staged,
-                &replay_root,
-                &digest,
-                &|| Ok(()),
-                &|| {
-                    std::fs::rename(&staged_path, &retained)
-                        .map_err(|error| GraphDbError::unavailable(error.to_string()))?;
-                    std::fs::write(&staged_path, bytes)
-                        .map_err(|error| GraphDbError::unavailable(error.to_string()))
-                },
-            ),
+            finalize_project_graph_replay_unlink(staged, &replay_root, &digest, &|| Ok(())),
             Err(GraphDbError::Conflict)
         );
+        assert_eq!(std::fs::read(staged_path).unwrap(), bytes);
+        assert_eq!(std::fs::read(retained).unwrap(), bytes);
+        assert!(!canonical.exists());
     }
 }

--- a/src/daemon/store_runtime/session_registry/code_graph/seals.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph/seals.rs
@@ -142,6 +142,14 @@ pub(super) fn stage_project_graph_replay_unlink(
             std::fs::rename(&path, &staged)
                 .map_err(|error| GraphDbError::unavailable(error.to_string()))?;
             sync_replay_root(replay_root)?;
+            // Renaming can legitimately advance ctime. Establish the stable
+            // post-rename fingerprint from the still-open inode, then prove
+            // that the staged path resolves to that exact handle.
+            let fingerprint = staged_fingerprint(
+                &file
+                    .metadata()
+                    .map_err(|error| GraphDbError::unavailable(error.to_string()))?,
+            )?;
             if !staged_identity_matches(&staged, &file, &fingerprint)? {
                 return Err(GraphDbError::Conflict);
             }

--- a/src/daemon/store_runtime/session_registry/code_graph_manifest.rs
+++ b/src/daemon/store_runtime/session_registry/code_graph_manifest.rs
@@ -10,7 +10,7 @@ use tracedecay_domain::{ProjectId, RepositoryId};
 use tracedecay_graph_db::{
     GraphBudgetKind, GraphDbError, GraphGenerationManifest, GraphGenerationManifestProvider,
     GraphNamespace, GraphProjectionId, GraphProjectionIdentity, GraphProjectorRevision,
-    SealedCodeGenerationReplay,
+    SealedCodeGenerationReplay, SealedGraphStateDigest,
 };
 use tracedecay_store::{GraphProjectionIdentityV1, StoreShardIdV1};
 
@@ -232,19 +232,24 @@ fn open_checked_seal_reader<'a>(
 /// which makes recovery from either root equally trustworthy. Typed
 /// interruptions from the caller's probe are transport states and must
 /// surface immediately instead of triggering a second full read.
-fn decode_verified_seal_from_roots(
+fn with_verified_seal_from_roots<T>(
     canonical: &std::path::Path,
     pool: &std::path::Path,
     expected_digest: &str,
     check: &dyn Fn() -> Result<(), GraphDbError>,
-) -> Result<tracedecay_code_index::production::CodeIndexPublishedGenerationV1, GraphDbError> {
+    read: impl Fn(
+        &std::path::Path,
+        &str,
+        &dyn Fn() -> Result<(), GraphDbError>,
+    ) -> Result<T, GraphDbError>,
+) -> Result<T, GraphDbError> {
     let canonical_absent = matches!(
         std::fs::symlink_metadata(canonical),
         Err(ref error) if error.kind() == std::io::ErrorKind::NotFound
     );
     if !canonical_absent {
-        match decode_verified_seal(canonical, expected_digest, check) {
-            Ok(generation) => return Ok(generation),
+        match read(canonical, expected_digest, check) {
+            Ok(value) => return Ok(value),
             Err(error @ (GraphDbError::Cancelled | GraphDbError::DeadlineExceeded)) => {
                 return Err(error);
             }
@@ -253,14 +258,29 @@ fn decode_verified_seal_from_roots(
                 // the pool copy is digest-verified, so recovering there is
                 // sound. A pool failure reports the canonical error, which
                 // names the authoritative copy.
-                return match decode_verified_seal(pool, expected_digest, check) {
-                    Ok(generation) => Ok(generation),
+                return match read(pool, expected_digest, check) {
+                    Ok(value) => Ok(value),
                     Err(_) => Err(canonical_error),
                 };
             }
         }
     }
-    decode_verified_seal(pool, expected_digest, check)
+    read(pool, expected_digest, check)
+}
+
+fn decode_verified_seal_from_roots(
+    canonical: &std::path::Path,
+    pool: &std::path::Path,
+    expected_digest: &str,
+    check: &dyn Fn() -> Result<(), GraphDbError>,
+) -> Result<tracedecay_code_index::production::CodeIndexPublishedGenerationV1, GraphDbError> {
+    with_verified_seal_from_roots(
+        canonical,
+        pool,
+        expected_digest,
+        check,
+        decode_verified_seal,
+    )
 }
 
 fn decode_verified_seal(
@@ -282,6 +302,45 @@ fn decode_verified_seal(
     })?;
     reader.finish(path, &opened_metadata, admitted_len, expected_digest)?;
     Ok(generation)
+}
+
+fn verify_checked_seal(
+    path: &std::path::Path,
+    expected_digest: &str,
+    check: &dyn Fn() -> Result<(), GraphDbError>,
+) -> Result<(), GraphDbError> {
+    let (mut reader, opened_metadata, admitted_len) = open_checked_seal_reader(path, check)?;
+    let copied = std::io::copy(&mut reader, &mut std::io::sink());
+    if let Some(error) = reader.failure.take() {
+        return Err(error);
+    }
+    copied.map_err(|error| GraphDbError::Corrupt {
+        message: format!("sealed code generation checked read failed: {error}"),
+    })?;
+    reader.finish(path, &opened_metadata, admitted_len, expected_digest)
+}
+
+/// Proves that the durable source backing an already-decoded generation still
+/// exists under its canonical-or-retained authority with the exact digest.
+/// This reads and hashes the bounded source without decoding or projecting it.
+pub(super) fn verify_sealed_generation_source_from_roots(
+    generations_root: &std::path::Path,
+    replay_root: &std::path::Path,
+    sealed_state_digest: &SealedGraphStateDigest,
+    check: &dyn Fn() -> Result<(), GraphDbError>,
+) -> Result<(), GraphDbError> {
+    let digest = sealed_state_digest
+        .as_str()
+        .strip_prefix("sha256:")
+        .ok_or_else(|| GraphDbError::invalid("sealed state digest is not sha256"))?;
+    let seal_file = format!("generation-{digest}.json");
+    with_verified_seal_from_roots(
+        &generations_root.join(&seal_file),
+        &replay_root.join(&seal_file),
+        digest,
+        check,
+        verify_checked_seal,
+    )
 }
 
 #[derive(Clone)]
@@ -445,25 +504,9 @@ mod tests {
     };
 
     use super::{
-        DaemonCodeGraphManifestProviderV1, SEAL_READ_CHECK_BYTES, open_checked_seal_reader,
-        validate_sealed_generation_metadata,
+        DaemonCodeGraphManifestProviderV1, SEAL_READ_CHECK_BYTES,
+        validate_sealed_generation_metadata, verify_checked_seal,
     };
-
-    fn verify_seal_stream(
-        path: &std::path::Path,
-        expected_digest: &str,
-        check: &dyn Fn() -> Result<(), GraphDbError>,
-    ) -> Result<(), GraphDbError> {
-        let (mut reader, opened_metadata, admitted_len) = open_checked_seal_reader(path, check)?;
-        let copied = std::io::copy(&mut reader, &mut std::io::sink());
-        if let Some(error) = reader.failure.take() {
-            return Err(error);
-        }
-        copied.map_err(|error| GraphDbError::Corrupt {
-            message: format!("sealed code generation test read failed: {error}"),
-        })?;
-        reader.finish(path, &opened_metadata, admitted_len, expected_digest)
-    }
 
     fn fixture(
         generations_root: std::path::PathBuf,
@@ -623,7 +666,7 @@ mod tests {
         std::fs::write(&path, bytes).unwrap();
         let checks = AtomicUsize::new(0);
 
-        let error = verify_seal_stream(&path, &digest, &|| {
+        let error = verify_checked_seal(&path, &digest, &|| {
             if checks.fetch_add(1, Ordering::SeqCst) == 1 {
                 let mut file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
                 file.seek(SeekFrom::Start(SEAL_READ_CHECK_BYTES as u64))
@@ -680,7 +723,7 @@ mod tests {
         let checks = AtomicUsize::new(0);
 
         assert_eq!(
-            verify_seal_stream(&path, &digest, &|| {
+            verify_checked_seal(&path, &digest, &|| {
                 if checks.fetch_add(1, Ordering::SeqCst) >= 2 {
                     Err(GraphDbError::DeadlineExceeded)
                 } else {


### PR DESCRIPTION
## Summary

- remove the publish-side generation JSON copy into the graph replay pool
- publish initial and active generations from the already-decoded in-hand manifest while writing zero generation payload bytes into the pool
- before Missing journaling or unverified Active completion, verify the canonical-or-pool durable source is a regular stable inode with bounded length and the exact sealed digest
- reuse the canonical CheckedSealReader authority under replay-pool serialization without decoding or restoring the eager copy
- preserve Stage0b retirement unlink/finalize durability, private-root validation, and pending-predecessor hydration fencing
- correct staged-unlink identity capture after rename so reinstall/replacement races retain the new canonical evidence

## Behavioral evidence

- source-binding RED on old dccb baseline: exact production journey matched 1 and failed 0/1 after a same-length post-load mutation was wrongly accepted; exit 101; log SHA-256 a0309c5c5f1c0c57cce26e3930a3dcfaa5d9f798bd0243be1a4e1e231213c23c
- source-binding GREEN on the fix: exact production journey passed 1/1 with 2782 filtered; log SHA-256 856d70355fda51dc1723e7d5075f54c2fdd46e4c2de1e35a8990bb66b89fd983
- that journey now proves same-length mutation, inode replacement, and symlink swap each return typed Corrupt with no replay/head; intact publication and Active republish leave zero replay-pool payload bytes
- initial zero-copy RED/GREEN: eager code rejected a foreign digest-named directory 0/1; fixed publication preserves its sentinel and passes 1/1
- staged unlink races passed 2/2; log SHA-256 ce98bbd084cfb34409d51b416207ae22b05f8475f426f1364790c533f57683aa
- replay provider/manifest regressions passed 6/6; log SHA-256 1ae133396ab4d38078874aa74dba17ec84a597ad16a47c03a83d8c344273db10
- graph-db sealed digest/reopen regressions passed 3/3; log SHA-256 5cdd23dd3a1c6351cbdd872f877078fce04ee9b84b00213595008a5a11662e57
- Stage0b retention/release regressions passed 8/8; log SHA-256 3732a630324a52582ab6303f7dec2f8cba48cebf8bd375a6f00c9a15a4d91ab2
- direct rustfmt check, diff-check, and commitlint passed on the final four-path diff

The current #421 floor changed no owned graph blobs before the normal merge, so the exact behavioral result remains byte-applicable. Root Clippy and Hawk were not rerun under the shared build-slot instruction.