### PR TITLE
fix(global-db): enforce retention scope authority

### DIFF
--- a/crates/tracedecay-global-db/src/registered.rs
+++ b/crates/tracedecay-global-db/src/registered.rs
@@ -5,10 +5,10 @@ use std::sync::{Arc, OnceLock};
 
 use tracedecay_runtime_core::{
     db::{
-        Database, DatabaseEngineReadConnection, DatabaseEngineReadSnapshot, DatabaseOwnerErrorV1,
-        DatabaseOwnerRetirementReservationV1, DatabaseOwnerV1, DatabaseOwnerWeakLeaseIssuerErrorV1,
-        DatabaseOwnerWeakLeaseIssuerV1, DatabaseRuntimeClientV1, DatabaseStorageTelemetryHandle,
-        DatabaseWriteTransaction,
+        Database, DatabaseAuthority, DatabaseEngineReadConnection, DatabaseEngineReadSnapshot,
+        DatabaseOwnerErrorV1, DatabaseOwnerRetirementReservationV1, DatabaseOwnerV1,
+        DatabaseOwnerWeakLeaseIssuerErrorV1, DatabaseOwnerWeakLeaseIssuerV1,
+        DatabaseRuntimeClientV1, DatabaseStorageTelemetryHandle, DatabaseWriteTransaction,
         engine::{Executor, IntoParams, QueryExecutor, Rows},
     },
     errors::TraceDecayError,
@@ -752,6 +752,9 @@ impl RegisteredGlobalDb {
                 "registered database client is read-only",
             ));
         }
+        self.database
+            .write_authority()?
+            .require_active_write_scope("open registered global database writer")?;
         Ok(RegisteredGlobalDbWriterConnection {
             database: &self.database,
         })
@@ -760,11 +763,16 @@ impl RegisteredGlobalDb {
     pub async fn begin_write_transaction(
         &self,
     ) -> tracedecay_runtime_core::errors::Result<RegisteredGlobalDbWriteTransaction<'_>> {
+        let authority = self.database.write_authority()?;
+        authority.require_active_write_scope("begin registered global database transaction")?;
         let transaction = self
             .database
             .begin_write_transaction("begin registered global database transaction")
             .await?;
-        Ok(RegisteredGlobalDbWriteTransaction { transaction })
+        Ok(RegisteredGlobalDbWriteTransaction {
+            transaction,
+            authority,
+        })
     }
 
     pub fn binding(&self) -> &tracedecay_store::StoreRuntimeBindingV1 {
@@ -972,6 +980,11 @@ impl RegisteredGlobalDb {
     ) -> tracedecay_runtime_core::errors::Result<
         super::observation::retention::ObservationRetentionReport,
     > {
+        if matches!(mode, super::observation::retention::RetentionMode::Apply) {
+            self.database
+                .write_authority()?
+                .require_active_write_scope("run registered observation retention")?;
+        }
         super::observation::retention::run_observation_retention(
             &self.database,
             generation,
@@ -1036,6 +1049,7 @@ impl RegisteredGlobalDbWriterConnection<'_> {
 
 pub struct RegisteredGlobalDbWriteTransaction<'a> {
     transaction: DatabaseWriteTransaction<'a>,
+    authority: DatabaseAuthority,
 }
 
 impl QueryExecutor for RegisteredGlobalDbWriteTransaction<'_> {
@@ -1158,6 +1172,20 @@ impl RegisteredGlobalDbWriteTransaction<'_> {
     }
 
     pub async fn commit(self) -> tracedecay_runtime_core::db::engine::Result<()> {
+        if let Err(error) = self
+            .authority
+            .require_active_write_scope("commit registered global database transaction")
+        {
+            let rollback = self.transaction.rollback().await;
+            return match rollback {
+                Ok(()) => Err(engine_error(error)),
+                Err(rollback_error) => Err(
+                    tracedecay_runtime_core::db::engine::Error::invalid_operation(format!(
+                        "{error}; rollback after authority loss failed: {rollback_error}"
+                    )),
+                ),
+            };
+        }
         self.transaction.commit().await.map_err(engine_error)
     }
 

--- a/crates/tracedecay-global-db/src/tests/harness.rs
+++ b/crates/tracedecay-global-db/src/tests/harness.rs
@@ -1201,10 +1201,6 @@ async fn open_registered_test_database_with(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let authority = tracedecay_runtime_core::db::DatabaseAuthority::acquire_test(
-        path,
-        "open registered global-db test runtime",
-    )?;
     // The exact test-runtime resolver refuses `Initialize` for a store that is
     // already on disk (and `Existing` for one that is not). Fixtures reach this
     // helper both ways — a fresh profile root, and a shard some earlier stage of
@@ -1214,25 +1210,39 @@ async fn open_registered_test_database_with(
     } else {
         tracedecay_runtime_core::db::TestDatabaseRuntimeMode::Initialize
     };
-    let fixture = tracedecay_runtime_core::db::Database::publish_registered_test_runtime_with_retirement_control(
-        path, &authority, mode, scope,
-    )
-    .await?;
-    let (database_owner, _runtime, _retirement) = fixture.into_parts();
-    let database = RegisteredGlobalDbOwnerV1::admit_and_attach(database_owner).await?;
-    // The physical fixture is already opened in the mode requested above.
-    // Issuance preserves that capability; neither test branch manufactures a
-    // second raw authority after publication.
-    let registered = match write_authority {
-        RegisteredTestWriteAuthority::Fixture | RegisteredTestWriteAuthority::DaemonScoped => {
-            database.issue_lease().map_err(|failure| {
-                tracedecay_runtime_core::errors::TraceDecayError::Database {
-                    operation: "issue registered global-db test database lease".to_owned(),
-                    message: format!("{failure:?}"),
-                }
-            })?
+    let fixture = match write_authority {
+        RegisteredTestWriteAuthority::Fixture => {
+            let authority = tracedecay_runtime_core::db::DatabaseAuthority::acquire_test(
+                path,
+                "open registered global-db test runtime",
+            )?;
+            tracedecay_runtime_core::db::Database::publish_registered_test_runtime_with_retirement_control(
+                path, &authority, mode, scope,
+            )
+            .await?
+        }
+        RegisteredTestWriteAuthority::DaemonScoped => {
+            let authority = tracedecay_runtime_core::db::DatabaseAuthority::for_owned_runtime(
+                path,
+                "open registered global-db daemon-scoped test runtime",
+            )?;
+            tracedecay_runtime_core::db::Database::publish_registered_daemon_test_runtime_with_retirement_control(
+                path, &authority, mode, scope,
+            )
+            .await?
         }
     };
+    let (database_owner, _runtime, _retirement) = fixture.into_parts();
+    let database = RegisteredGlobalDbOwnerV1::admit_and_attach(database_owner).await?;
+    // The physical fixture is already opened with the requested authority.
+    // Issuance preserves that capability; neither branch manufactures a
+    // second raw authority after publication.
+    let registered = database.issue_lease().map_err(|failure| {
+        tracedecay_runtime_core::errors::TraceDecayError::Database {
+            operation: "issue registered global-db test database lease".to_owned(),
+            message: format!("{failure:?}"),
+        }
+    })?;
     Ok((registered, database))
 }
 

--- a/crates/tracedecay-runtime-core/src/db/connection/test_runtime.rs
+++ b/crates/tracedecay-runtime-core/src/db/connection/test_runtime.rs
@@ -421,7 +421,32 @@ impl Database {
                 operation: "publish registered test runtime".to_owned(),
             });
         }
-        Self::publish_registered_test_runtime_with_retirement_control_inner(
+        Self::publish_registered_fixture_with_retirement_control(
+            db_path, authority, mode, None, scope,
+        )
+        .await
+    }
+
+    /// Publishes a registered fixture under the active daemon authority whose
+    /// scope the test controls. This stays separate from the unconditional
+    /// Test-authority publisher so a fixture cannot silently bypass actor-time
+    /// scope revocation.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-helpers", feature = "test-transport"))]
+    pub async fn publish_registered_daemon_test_runtime_with_retirement_control(
+        db_path: &Path,
+        authority: &DatabaseAuthority,
+        mode: TestDatabaseRuntimeMode,
+        scope: TestDatabaseRuntimeScope,
+    ) -> Result<RegisteredTestRuntimeFixtureV1> {
+        if authority.role() != super::DatabaseAuthorityRole::Daemon {
+            return Err(TraceDecayError::Database {
+                message: "daemon-scoped registered test runtime requires explicit daemon authority"
+                    .to_owned(),
+                operation: "publish daemon-scoped registered test runtime".to_owned(),
+            });
+        }
+        Self::publish_registered_fixture_with_retirement_control(
             db_path, authority, mode, None, scope,
         )
         .await
@@ -462,6 +487,20 @@ impl Database {
                 operation: "publish registered test runtime".to_owned(),
             });
         }
+        Self::publish_registered_fixture_with_retirement_control(
+            db_path, authority, mode, identity, scope,
+        )
+        .await
+    }
+
+    #[cfg(any(test, feature = "test-helpers", feature = "test-transport"))]
+    async fn publish_registered_fixture_with_retirement_control(
+        db_path: &Path,
+        authority: &DatabaseAuthority,
+        mode: TestDatabaseRuntimeMode,
+        identity: Option<TestRuntimeProfileIdentityV1>,
+        scope: TestDatabaseRuntimeScope,
+    ) -> Result<RegisteredTestRuntimeFixtureV1> {
         let publication = Self::publish_fixture_runtime_publication(
             db_path,
             authority,
@@ -854,6 +893,74 @@ mod tests {
                 identity.profile_id().clone(),
             )
         );
+    }
+
+    #[tokio::test]
+    async fn daemon_scoped_registered_fixture_requires_exact_daemon_authority() {
+        let root = tempfile::tempdir().expect("daemon-scoped fixture root");
+        let _scope = crate::db::enter_daemon_database_scope(
+            root.path(),
+            1,
+            "daemon-scoped-registered-fixture",
+        )
+        .expect("enter daemon database scope");
+        let path = root.path().join("sessions.db");
+        let authority = DatabaseAuthority::for_owned_runtime(
+            &path,
+            "daemon-scoped registered fixture authority",
+        )
+        .expect("acquire daemon fixture authority");
+
+        let fixture = Database::publish_registered_daemon_test_runtime_with_retirement_control(
+            &path,
+            &authority,
+            TestDatabaseRuntimeMode::Initialize,
+            TestDatabaseRuntimeScope::ProfileSessions,
+        )
+        .await
+        .expect("publish daemon-scoped registered fixture");
+        let (owner, _runtime, _retirement) = fixture.into_parts();
+        let database = owner.issue_lease().expect("issue daemon-scoped client");
+        assert_eq!(
+            database
+                .write_authority()
+                .expect("daemon-scoped write authority")
+                .role(),
+            crate::db::DatabaseAuthorityRole::Daemon
+        );
+
+        let invalid_path = root.path().join("invalid.db");
+        let invalid = DatabaseAuthority::acquire_test(
+            &invalid_path,
+            "invalid daemon-scoped registered fixture authority",
+        )
+        .expect("acquire explicit test authority");
+        let error = match Database::publish_registered_daemon_test_runtime_with_retirement_control(
+            &invalid_path,
+            &invalid,
+            TestDatabaseRuntimeMode::Initialize,
+            TestDatabaseRuntimeScope::ProfileSessions,
+        )
+        .await
+        {
+            Ok(_) => panic!("Test authority published a daemon-scoped fixture"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("explicit daemon authority"));
+
+        let foreign_path = root.path().join("foreign.db");
+        let error = match Database::publish_registered_daemon_test_runtime_with_retirement_control(
+            &foreign_path,
+            &authority,
+            TestDatabaseRuntimeMode::Initialize,
+            TestDatabaseRuntimeScope::ProfileSessions,
+        )
+        .await
+        {
+            Ok(_) => panic!("foreign daemon authority published another fixture"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("different database"));
     }
 
     #[test]

--- a/crates/tracedecay-runtime-core/src/db/connection/test_runtime.rs
+++ b/crates/tracedecay-runtime-core/src/db/connection/test_runtime.rs
@@ -439,6 +439,41 @@ impl Database {
         mode: TestDatabaseRuntimeMode,
         scope: TestDatabaseRuntimeScope,
     ) -> Result<RegisteredTestRuntimeFixtureV1> {
+        Self::publish_registered_daemon_fixture_with_retirement_control(
+            db_path, authority, mode, None, scope,
+        )
+        .await
+    }
+
+    /// Publishes the same daemon-scoped fixture under identity already minted
+    /// by the production profile authority.
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-helpers", feature = "test-transport"))]
+    pub async fn publish_registered_daemon_test_runtime_with_retirement_control_for_profile_identity(
+        db_path: &Path,
+        authority: &DatabaseAuthority,
+        mode: TestDatabaseRuntimeMode,
+        identity: TestRuntimeProfileIdentityV1,
+        scope: TestDatabaseRuntimeScope,
+    ) -> Result<RegisteredTestRuntimeFixtureV1> {
+        Self::publish_registered_daemon_fixture_with_retirement_control(
+            db_path,
+            authority,
+            mode,
+            Some(identity),
+            scope,
+        )
+        .await
+    }
+
+    #[cfg(any(test, feature = "test-helpers", feature = "test-transport"))]
+    async fn publish_registered_daemon_fixture_with_retirement_control(
+        db_path: &Path,
+        authority: &DatabaseAuthority,
+        mode: TestDatabaseRuntimeMode,
+        identity: Option<TestRuntimeProfileIdentityV1>,
+        scope: TestDatabaseRuntimeScope,
+    ) -> Result<RegisteredTestRuntimeFixtureV1> {
         if authority.role() != super::DatabaseAuthorityRole::Daemon {
             return Err(TraceDecayError::Database {
                 message: "daemon-scoped registered test runtime requires explicit daemon authority"
@@ -447,7 +482,7 @@ impl Database {
             });
         }
         Self::publish_registered_fixture_with_retirement_control(
-            db_path, authority, mode, None, scope,
+            db_path, authority, mode, identity, scope,
         )
         .await
     }
@@ -910,15 +945,20 @@ mod tests {
             "daemon-scoped registered fixture authority",
         )
         .expect("acquire daemon fixture authority");
+        let identity = TestRuntimeProfileIdentityV1::new(
+            BrainId::new("brain.daemon-scoped-fixture").expect("fixture brain identity"),
+            UserProfileId::new("profile.daemon-scoped-fixture").expect("fixture profile identity"),
+        );
 
-        let fixture = Database::publish_registered_daemon_test_runtime_with_retirement_control(
-            &path,
-            &authority,
-            TestDatabaseRuntimeMode::Initialize,
-            TestDatabaseRuntimeScope::ProfileSessions,
-        )
-        .await
-        .expect("publish daemon-scoped registered fixture");
+        let fixture = Database::publish_registered_daemon_test_runtime_with_retirement_control_for_profile_identity(
+                &path,
+                &authority,
+                TestDatabaseRuntimeMode::Initialize,
+                identity.clone(),
+                TestDatabaseRuntimeScope::ProfileSessions,
+            )
+            .await
+            .expect("publish daemon-scoped registered fixture");
         let (owner, _runtime, _retirement) = fixture.into_parts();
         let database = owner.issue_lease().expect("issue daemon-scoped client");
         assert_eq!(
@@ -927,6 +967,13 @@ mod tests {
                 .expect("daemon-scoped write authority")
                 .role(),
             crate::db::DatabaseAuthorityRole::Daemon
+        );
+        assert_eq!(
+            database.registered_binding().shard_id,
+            StoreShardIdV1::profile_sessions(
+                identity.brain_id().clone(),
+                identity.profile_id().clone(),
+            )
         );
 
         let invalid_path = root.path().join("invalid.db");


### PR DESCRIPTION
## Summary

- Fail-closed daemon-scope authority on the registered global DB write path: revoked or unknown scope refuses at writer open, `begin_write_transaction`, retention `Apply` (DryRun stays read-only/ungated), and `commit` — commit-time authority loss rolls back and surfaces both errors if the rollback also fails. Both trait commits route through the checked inherent `commit`; per-statement re-checks in runtime-core close the held-connection gap.
- Test fixtures now use real daemon authority against temp-dir-isolated profile roots (`daemon_scoped_registered_fixture_requires_exact_daemon_authority`); no operator data touched.

## Verification (isolated worktree at 258983ed3, target-dir isolated)

- `cargo test -p tracedecay-global-db`: 394 passed / 4 failed vs 386 / 12 on the integration tip `bb372f6bd` — fixes 8 of the 12 pre-existing daemon-scope-revocation failures, zero new failures. All 17 `configuration::store` tests green.
- Residual 4 failures are byte-identical on the baseline and deterministic solo: retirement lease accounting, weak graph-proxy binding, sealed legacy-schema installer, remount writer-lock contention — pre-existing, separate lanes.
- `cargo test -p tracedecay-runtime-core`: fully green (672+ lib tests, all aux suites).
- `cargo clippy -p tracedecay-global-db -p tracedecay-runtime-core --all-targets -- -D warnings`: clean.