### PR TITLE
test(automation): remove post-commit gate via sync fault injection

### DIFF
--- a/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
@@ -20,84 +20,6 @@ use super::managed_skill_validation::{
     validate_managed_skill, validate_managed_skill_update, validate_skill_id,
 };
 
-#[cfg(test)]
-#[derive(Clone)]
-pub(super) struct PostCommitUsageSyncTestGate {
-    // Scopes the gate to one test's skill store so concurrent tests touching
-    // other stores neither trip the gate nor wake its owner spuriously.
-    profile_root: PathBuf,
-    entered: std::sync::Arc<tokio::sync::Notify>,
-    release: std::sync::Arc<tokio::sync::Notify>,
-}
-
-#[cfg(test)]
-static POST_COMMIT_USAGE_SYNC_TEST_GATE: std::sync::Mutex<Option<PostCommitUsageSyncTestGate>> =
-    std::sync::Mutex::new(None);
-
-#[cfg(test)]
-static POST_COMMIT_USAGE_SYNC_TEST_SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-#[cfg(test)]
-pub(super) struct PostCommitUsageSyncTestGuard {
-    gate: PostCommitUsageSyncTestGate,
-    _serial: std::sync::MutexGuard<'static, ()>,
-}
-
-#[cfg(test)]
-impl PostCommitUsageSyncTestGuard {
-    pub(super) async fn entered(&self) {
-        self.gate.entered.notified().await;
-    }
-}
-
-#[cfg(test)]
-impl Drop for PostCommitUsageSyncTestGuard {
-    fn drop(&mut self) {
-        self.gate.release.notify_waiters();
-        let mut active = POST_COMMIT_USAGE_SYNC_TEST_GATE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *active = None;
-    }
-}
-
-#[cfg(test)]
-pub(super) fn install_post_commit_usage_sync_test_gate(
-    profile_root: &Path,
-) -> PostCommitUsageSyncTestGuard {
-    let serial = POST_COMMIT_USAGE_SYNC_TEST_SERIAL
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let gate = PostCommitUsageSyncTestGate {
-        profile_root: profile_root.to_path_buf(),
-        entered: std::sync::Arc::new(tokio::sync::Notify::new()),
-        release: std::sync::Arc::new(tokio::sync::Notify::new()),
-    };
-    let mut active = POST_COMMIT_USAGE_SYNC_TEST_GATE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    assert!(active.replace(gate.clone()).is_none());
-    drop(active);
-    PostCommitUsageSyncTestGuard {
-        gate,
-        _serial: serial,
-    }
-}
-
-#[cfg(test)]
-async fn wait_for_post_commit_usage_sync_test_gate(profile_root: &Path) {
-    let gate = POST_COMMIT_USAGE_SYNC_TEST_GATE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .clone();
-    if let Some(gate) = gate
-        && gate.profile_root == profile_root
-    {
-        gate.entered.notify_one();
-        gate.release.notified().await;
-    }
-}
-
 pub fn managed_skill_root(profile_root: &Path) -> PathBuf {
     profile_root.join("agent_managed").join("skills")
 }
@@ -421,8 +343,6 @@ pub async fn apply_managed_skill_consolidation(
     revisions.push(&source);
     persist_skill_transaction_unlocked(profile_root, &revisions)?;
     drop(lock);
-    #[cfg(test)]
-    wait_for_post_commit_usage_sync_test_gate(profile_root).await;
     for skill in &revisions {
         if let Err(error) = super::skill_usage::sync_skill_usage_metadata(profile_root, skill).await
         {
@@ -780,8 +700,6 @@ fn apply_managed_skill_update_fields(
 }
 
 async fn record_skill_patch_best_effort(profile_root: &Path, skill: &ManagedSkill, target: &str) {
-    #[cfg(test)]
-    wait_for_post_commit_usage_sync_test_gate(profile_root).await;
     if let Err(error) = super::skill_usage::record_skill_usage_event(
         profile_root,
         super::skill_usage::SkillUsageEvent {

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -252,9 +252,9 @@ pub(super) fn applied_consolidation_record(
 mod tests {
     use super::super::super::managed_skills::{
         ManagedSkillDraft, ManagedSkillProvenance, ManagedSupportFile, apply_managed_skill_update,
-        create_managed_skill, default_managed_skill_targets,
-        install_post_commit_usage_sync_test_gate, load_managed_skill,
+        create_managed_skill, default_managed_skill_targets, load_managed_skill,
     };
+    use super::super::super::skill_usage::skill_usage_ledger_path;
     use super::super::skill_proposal_action;
     use super::*;
 
@@ -783,8 +783,18 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn archive_persists_tombstone_before_postcommit_usage_sync_can_be_cancelled() {
+    /// Replaces the usage ledger file with a directory so every post-commit
+    /// usage sync fails at its real filesystem boundary. The typed tombstone
+    /// must then come from the commit transaction alone.
+    fn break_usage_sync(profile_root: &Path) {
+        let ledger_path = skill_usage_ledger_path(profile_root);
+        std::fs::remove_file(&ledger_path).unwrap();
+        std::fs::create_dir(&ledger_path).unwrap();
+        assert!(ledger_path.is_dir());
+    }
+
+    #[tokio::test]
+    async fn archive_commit_durably_carries_tombstone_despite_usage_sync_failure() {
         let profile = tempfile::tempdir().unwrap();
         let skills = persisted_consolidation_fixture(profile.path()).await;
         let proposal = json!({
@@ -794,15 +804,17 @@ mod tests {
             "reason": "duplicate guidance"
         });
         let archive = skill_archive_from_proposal(&proposal, &skills).unwrap();
-        let gate = install_post_commit_usage_sync_test_gate(profile.path());
-        let profile_root = profile.path().to_path_buf();
-        let archive_for_task = archive.clone();
-        let task =
-            tokio::spawn(
-                async move { apply_skill_archive(&profile_root, &archive_for_task).await },
-            );
+        break_usage_sync(profile.path());
 
-        gate.entered().await;
+        let archived = apply_skill_archive(profile.path(), &archive)
+            .await
+            .expect("committed archive must succeed despite best-effort sync failure");
+
+        assert_eq!(archived.metadata.state, ManagedSkillState::Archived);
+        assert_eq!(
+            archived.metadata.archived_reason.as_deref(),
+            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
+        );
         let committed = load_managed_skill(profile.path(), "workflow-b")
             .await
             .unwrap();
@@ -810,23 +822,18 @@ mod tests {
         assert_eq!(
             committed.metadata.archived_reason.as_deref(),
             Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE),
-            "the archive commit must durably carry its typed tombstone before usage sync"
+            "the archive commit must durably carry its typed tombstone even when \
+             post-commit usage sync never succeeds"
         );
-        task.abort();
-        assert!(task.await.unwrap_err().is_cancelled());
-        assert_eq!(
-            load_managed_skill(profile.path(), "workflow-b")
-                .await
-                .unwrap()
-                .metadata
-                .archived_reason
-                .as_deref(),
-            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
+        assert!(
+            skill_usage_ledger_path(profile.path()).is_dir(),
+            "usage sync must not have replaced the broken ledger, so the \
+             tombstone cannot have come from the sync phase"
         );
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn merge_persists_tombstone_before_postcommit_usage_sync_can_be_cancelled() {
+    #[tokio::test]
+    async fn merge_commit_durably_carries_tombstone_despite_usage_sync_failure() {
         let profile = tempfile::tempdir().unwrap();
         let skills = persisted_consolidation_fixture(profile.path()).await;
         let proposal = json!({
@@ -838,21 +845,18 @@ mod tests {
             "reason": "duplicate guidance"
         });
         let merge = skill_merge_from_proposal(&proposal, &skills).unwrap();
-        let gate = install_post_commit_usage_sync_test_gate(profile.path());
-        let profile_root = profile.path().to_path_buf();
-        let merge_for_task = merge.clone();
-        let task =
-            tokio::spawn(async move { apply_skill_merge(&profile_root, &merge_for_task).await });
+        break_usage_sync(profile.path());
 
-        gate.entered().await;
+        let (source, _target) = apply_skill_merge(profile.path(), &merge)
+            .await
+            .expect("committed merge must succeed despite best-effort sync failure");
+
+        assert_eq!(source.metadata.state, ManagedSkillState::Archived);
+        assert_eq!(source.metadata.absorbed_into.as_deref(), Some("workflow-a"));
         let committed_source = load_managed_skill(profile.path(), "workflow-b")
             .await
             .unwrap();
-        assert_eq!(
-            committed_source.metadata.state,
-            ManagedSkillState::Archived,
-            "the cancellation gate must run after the merge commit"
-        );
+        assert_eq!(committed_source.metadata.state, ManagedSkillState::Archived);
         assert_eq!(
             committed_source.metadata.absorbed_into.as_deref(),
             Some("workflow-a")
@@ -860,18 +864,13 @@ mod tests {
         assert_eq!(
             committed_source.metadata.archived_reason.as_deref(),
             Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE),
-            "the merge commit must durably carry its typed tombstone before usage sync"
+            "the merge commit must durably carry its typed tombstone even when \
+             post-commit usage sync never succeeds"
         );
-        task.abort();
-        assert!(task.await.unwrap_err().is_cancelled());
-        assert_eq!(
-            load_managed_skill(profile.path(), "workflow-b")
-                .await
-                .unwrap()
-                .metadata
-                .archived_reason
-                .as_deref(),
-            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
+        assert!(
+            skill_usage_ledger_path(profile.path()).is_dir(),
+            "usage sync must not have replaced the broken ledger, so the \
+             tombstone cannot have come from the sync phase"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up addressing both Codex review findings on #638.

**Finding 1 (P1, `managed_skills.rs`): remove the test-only gate from production flow.** The `#[cfg(test)]` post-commit synchronization gate (gate struct, statics, guard, and the two `wait_for_post_commit_usage_sync_test_gate` calls woven into `apply_managed_skill_consolidation` and `record_skill_patch_best_effort`) is deleted entirely. Production function bodies now carry no test-only synchronization points. The tombstone-durability tests instead observe the commit/sync boundary through a real seam: they replace the skill-usage ledger file with a directory (the same filesystem fault-injection pattern as the existing `committed_change_survives_usage_ledger_failure` test), so every post-commit usage sync fails at its genuine filesystem boundary. The tests then assert the archive/merge still returns `Ok`, the committed revision durably carries `SKILL_OVERLAP_REMOVAL_TOMBSTONE` (plus `absorbed_into` for merges), and the ledger path is still the broken directory — proving the tombstone came from the single crash-recoverable commit transaction, not from the sync phase. No exception to the no-test-hooks rule was needed.

**Finding 2 (P2): fail when the gated task exits before reaching the hook.** Moot by construction after the rework: there is no gate and no spawned task, so nothing can hang or pass vacuously waiting on a hook. The tests await the operation directly and `expect(...)` its result, so an early death surfaces immediately. Demonstrated by temporarily injecting `return Err(config_error("injected: task died before commit"))` at the top of `apply_skill_archive`: the test failed fast in 0.01s with `committed archive must succeed despite best-effort sync failure: Config { message: "injected: task died before commit" }` (no hang), after which the injection was removed and the suite re-verified green.

## Verification

CARGO_TARGET_DIR scoped to the lane worktree, after merging `origin/codex/tracedecay-total-redesign-plan` (fast-forward to `fddb6d5c4`):

- `cargo test -p tracedecay-automation` — 57 passed; 0 failed
- `cargo test -p tracedecay-agent-hosts --lib automation::` — 340 passed; 0 failed (388 filtered out)
- `cargo test -p tracedecay-agent-hosts --lib durably_carries_tombstone_despite_usage_sync_failure` — 2 passed; 0 failed (non-vacuity check on the reworked tests)
- `cargo test -p tracedecay --features test-transport --test automation_runner_test skill_writer_consolidation` — 1 passed; 0 failed (184 filtered out)
- `cargo clippy -p tracedecay-automation -p tracedecay-agent-hosts --all-targets -- -D warnings` — clean