### PR TITLE
fix(daemon): preserve linked-root observability policy

### DIFF
--- a/crates/tracedecay-usecases/src/observability/delivery_recorder.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_recorder.rs
@@ -8,10 +8,10 @@ use tokio::time::{MissedTickBehavior, interval, timeout};
 use tracedecay_application::ApplicationContractError;
 use tracedecay_domain::DeliverySettlementV1;
 
-use super::DeliverySettlementAuthorityV1;
 use super::delivery_spool::{
     DeliveryRecorderSourceReceiptV1, DeliveryRecorderSpoolError, DeliveryRecorderSpoolV1,
 };
+use super::{DeliverySettlementAuthorityV1, ObservabilityProducerIdentityV1};
 
 const RECORDER_RUNNING: u8 = 0;
 const RECORDER_STOPPING: u8 = 1;
@@ -48,12 +48,13 @@ enum RecorderControl {
 /// pressure therefore delays SQLite work without erasing delivery evidence;
 /// transient failures remain replayable across process restart.
 pub struct BoundedDeliverySettlementRecorderV1 {
+    identity: ObservabilityProducerIdentityV1,
     wake: mpsc::Sender<()>,
     control: mpsc::Sender<RecorderControl>,
     state: Arc<AtomicU8>,
-    admission: Mutex<()>,
+    admission: Arc<Mutex<()>>,
     spool: Arc<DeliveryRecorderSpoolV1>,
-    worker: Mutex<Option<JoinHandle<()>>>,
+    worker: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl BoundedDeliverySettlementRecorderV1 {
@@ -75,19 +76,45 @@ impl BoundedDeliverySettlementRecorderV1 {
         let worker_state = Arc::clone(&state);
         let worker_spool = Arc::clone(&spool);
         let worker = runtime.spawn(run_recorder(
-            authority,
+            Arc::clone(&authority),
             worker_spool,
             wake_rx,
             control_rx,
             worker_state,
         ));
         Ok(Self {
+            identity: authority.identity().clone(),
             wake,
             control,
             state,
-            admission: Mutex::new(()),
+            admission: Arc::new(Mutex::new(())),
             spool,
-            worker: Mutex::new(Some(worker)),
+            worker: Arc::new(Mutex::new(Some(worker))),
+        })
+    }
+
+    /// Attach one linked root's policy-specific admission frontend to this
+    /// recorder's existing spool, wake lane, lifecycle, and worker.
+    pub fn alias_with_policy_identity(
+        &self,
+        identity: ObservabilityProducerIdentityV1,
+    ) -> Result<Self, &'static str> {
+        identity.validate()?;
+        if identity.authorized_scope_ref != self.identity.authorized_scope_ref
+            || identity.process_boot_id != self.identity.process_boot_id
+            || identity.producer_revision != self.identity.producer_revision
+            || identity.configuration_revision != self.identity.configuration_revision
+        {
+            return Err("delivery_settlement_recorder_alias_identity");
+        }
+        Ok(Self {
+            identity,
+            wake: self.wake.clone(),
+            control: self.control.clone(),
+            state: Arc::clone(&self.state),
+            admission: Arc::clone(&self.admission),
+            spool: Arc::clone(&self.spool),
+            worker: Arc::clone(&self.worker),
         })
     }
 
@@ -96,8 +123,8 @@ impl BoundedDeliverySettlementRecorderV1 {
         settlement: DeliverySettlementV1,
     ) -> Result<DeliverySettlementRecordOutcomeV1, &'static str> {
         settlement.validate()?;
-        let receipt =
-            DeliveryRecorderSourceReceiptV1::new(settlement).map_err(map_spool_admission_error)?;
+        let receipt = DeliveryRecorderSourceReceiptV1::new(settlement, self.identity.clone())
+            .map_err(map_spool_admission_error)?;
         let _admission = self
             .admission
             .lock()
@@ -242,8 +269,16 @@ async fn drain_once(
     let mut acknowledged = 0_usize;
     for receipt in receipts {
         let result = async {
-            authority.begin(&receipt.settlement.attempt).await?;
-            authority.settle(&receipt.settlement).await?;
+            let receipt_authority = authority
+                .alias_with_policy_identity(
+                    receipt
+                        .emission_identity
+                        .clone()
+                        .unwrap_or_else(|| authority.identity().clone()),
+                )
+                .map_err(|error| ApplicationContractError::Domain(error.to_owned()))?;
+            receipt_authority.begin(&receipt.settlement.attempt).await?;
+            receipt_authority.settle(&receipt.settlement).await?;
             spool
                 .acknowledge(receipt.receipt_id)
                 .map_err(|error| ApplicationContractError::Domain(error.to_string()))?;

--- a/crates/tracedecay-usecases/src/observability/delivery_recorder.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_recorder.rs
@@ -269,14 +269,11 @@ async fn drain_once(
     let mut acknowledged = 0_usize;
     for receipt in receipts {
         let result = async {
-            let receipt_authority = authority
-                .alias_with_policy_identity(
-                    receipt
-                        .emission_identity
-                        .clone()
-                        .unwrap_or_else(|| authority.identity().clone()),
-                )
-                .map_err(|error| ApplicationContractError::Domain(error.to_owned()))?;
+            let receipt_authority = match receipt.emission_identity.as_ref() {
+                Some(identity) => authority.alias_for_durable_replay(identity),
+                None => authority.alias_with_policy_identity(authority.identity().clone()),
+            }
+            .map_err(|error| ApplicationContractError::Domain(error.to_owned()))?;
             receipt_authority.begin(&receipt.settlement.attempt).await?;
             receipt_authority.settle(&receipt.settlement).await?;
             spool
@@ -328,5 +325,102 @@ const fn map_spool_admission_error(error: DeliveryRecorderSpoolError) -> &'stati
         DeliveryRecorderSpoolError::LockPoisoned => {
             "delivery_settlement_recorder_spool_lock_poisoned"
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracedecay_domain::{
+        DeliveryChannelIdentityV1, DeliveryEventClassV1, DeliverySettlementAttemptV1,
+        DeliverySettlementOutcomeV1, DeliverySurfaceFamilyV1, ProjectId, UtcMicros,
+        canonical_sha256,
+    };
+
+    use super::super::BoundedObservabilityProducerV1;
+    use super::*;
+
+    fn legacy_receipt_id(settlement: &DeliverySettlementV1) -> [u8; 16] {
+        let digest =
+            canonical_sha256(&("tracedecay.delivery-recorder-source-receipt.v1", settlement))
+                .expect("legacy receipt digest");
+        let hex = digest
+            .as_str()
+            .strip_prefix("sha256:")
+            .expect("canonical digest prefix");
+        let mut receipt_id = [0_u8; 16];
+        for (index, slot) in receipt_id.iter_mut().enumerate() {
+            let offset = index * 2;
+            *slot = u8::from_str_radix(&hex[offset..offset + 2], 16).expect("canonical digest hex");
+        }
+        receipt_id
+    }
+
+    #[tokio::test]
+    async fn legacy_v1_receipt_replays_through_current_process_identity() {
+        let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
+        let project = tempfile::tempdir().expect("project");
+        let project_id = ProjectId::new("project.delivery.legacy-replay").expect("project id");
+        let runtime = tracedecay_global_db::tests::harness::RegisteredGlobalDbTestRuntime::project(
+            tracedecay_runtime_core::storage::default_profile_root().expect("profile root"),
+            project.path(),
+            project_id.clone(),
+        )
+        .await
+        .expect("registered runtime");
+        let db = runtime.project_database_arc().expect("project database");
+        let identity = ObservabilityProducerIdentityV1 {
+            authorized_scope_ref: project_id.as_str().to_owned(),
+            process_boot_id: "boot:delivery-legacy-replay".to_owned(),
+            producer_revision: "delivery-legacy-replay-producer.v1".to_owned(),
+            configuration_revision: "delivery-legacy-replay-config.v1".to_owned(),
+            policy_revision: "delivery-legacy-replay-policy.v1".to_owned(),
+        };
+        let producer = Arc::new(
+            BoundedObservabilityProducerV1::start(db.clone(), identity.clone(), 8)
+                .expect("producer"),
+        );
+        let authority = Arc::new(
+            DeliverySettlementAuthorityV1::new(db, Arc::clone(&producer), identity)
+                .expect("settlement authority"),
+        );
+        let settlement = DeliverySettlementV1 {
+            attempt: DeliverySettlementAttemptV1 {
+                owner_event_id: "work:delivery-legacy-replay".to_owned(),
+                event_class: DeliveryEventClassV1::OperationTerminal,
+                channel: DeliveryChannelIdentityV1 {
+                    surface: DeliverySurfaceFamilyV1::Mcp,
+                    channel_ref: "mcp:delivery-legacy-replay".to_owned(),
+                },
+                work_attempt: None,
+                eligible: 1,
+                valid_at: UtcMicros(100),
+                attempted_at: UtcMicros(110),
+            },
+            outcome: DeliverySettlementOutcomeV1::Delivered,
+            settled_at: UtcMicros(120),
+            drop_reason: None,
+        };
+        let spool = DeliveryRecorderSpoolV1::open(authority.spool_root()).expect("spool");
+        spool
+            .append(&DeliveryRecorderSourceReceiptV1 {
+                receipt_id: legacy_receipt_id(&settlement),
+                settlement,
+                emission_identity: None,
+            })
+            .expect("append legacy receipt");
+        let mut summary = DeliverySettlementRecorderSummaryV1::default();
+
+        assert_eq!(
+            drain_once(authority.as_ref(), &spool, &mut summary).await,
+            1
+        );
+        assert_eq!(summary.settled, 1);
+        assert_eq!(spool.len().expect("pending receipts"), 0);
+
+        drop(spool);
+        drop(authority);
+        let producer = Arc::try_unwrap(producer)
+            .unwrap_or_else(|_| panic!("authority must release producer after replay"));
+        producer.shutdown().await.expect("flush producer");
     }
 }

--- a/crates/tracedecay-usecases/src/observability/delivery_settlement.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_settlement.rs
@@ -74,6 +74,16 @@ impl DeliverySettlementAuthorityV1 {
         Self::new(self.db.clone(), producer, identity)
     }
 
+    /// Replay one authenticated durable receipt through the current process
+    /// owner while retaining the policy selected when the receipt was admitted.
+    pub(super) fn alias_for_durable_replay(
+        &self,
+        admitted_identity: &ObservabilityProducerIdentityV1,
+    ) -> Result<Self, &'static str> {
+        let identity = durable_replay_identity(&self.identity, admitted_identity)?;
+        self.alias_with_policy_identity(identity)
+    }
+
     pub async fn begin(
         &self,
         attempt: &DeliverySettlementAttemptV1,
@@ -182,6 +192,21 @@ impl DeliverySettlementAuthorityV1 {
     }
 }
 
+fn durable_replay_identity(
+    current_identity: &ObservabilityProducerIdentityV1,
+    admitted_identity: &ObservabilityProducerIdentityV1,
+) -> Result<ObservabilityProducerIdentityV1, &'static str> {
+    current_identity.validate()?;
+    admitted_identity.validate()?;
+    if admitted_identity.authorized_scope_ref != current_identity.authorized_scope_ref {
+        return Err("delivery_settlement_replay_scope");
+    }
+    Ok(ObservabilityProducerIdentityV1 {
+        policy_revision: admitted_identity.policy_revision.clone(),
+        ..current_identity.clone()
+    })
+}
+
 const fn surface_name(surface: tracedecay_domain::DeliverySurfaceFamilyV1) -> &'static str {
     match surface {
         tracedecay_domain::DeliverySurfaceFamilyV1::Hook => "hook",
@@ -190,5 +215,48 @@ const fn surface_name(surface: tracedecay_domain::DeliverySurfaceFamilyV1) -> &'
         tracedecay_domain::DeliverySurfaceFamilyV1::Dashboard => "dashboard",
         tracedecay_domain::DeliverySurfaceFamilyV1::Cli => "cli",
         tracedecay_domain::DeliverySurfaceFamilyV1::Other => "other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity(scope: &str, boot: &str, policy: &str) -> ObservabilityProducerIdentityV1 {
+        ObservabilityProducerIdentityV1 {
+            authorized_scope_ref: scope.to_owned(),
+            process_boot_id: boot.to_owned(),
+            producer_revision: format!("producer:{boot}"),
+            configuration_revision: format!("config:{boot}"),
+            policy_revision: policy.to_owned(),
+        }
+    }
+
+    #[test]
+    fn durable_replay_identity_uses_current_process_and_admitted_policy() {
+        let current = identity("project.delivery", "boot:new", "policy:new-core");
+        let admitted = identity("project.delivery", "boot:old", "policy:linked-b");
+
+        let replay = durable_replay_identity(&current, &admitted).expect("durable replay identity");
+
+        assert_eq!(replay.authorized_scope_ref, current.authorized_scope_ref);
+        assert_eq!(replay.process_boot_id, current.process_boot_id);
+        assert_eq!(replay.producer_revision, current.producer_revision);
+        assert_eq!(
+            replay.configuration_revision,
+            current.configuration_revision
+        );
+        assert_eq!(replay.policy_revision, admitted.policy_revision);
+    }
+
+    #[test]
+    fn durable_replay_identity_refuses_foreign_scope() {
+        let current = identity("project.delivery", "boot:new", "policy:new-core");
+        let foreign = identity("project.foreign", "boot:old", "policy:linked-b");
+
+        assert_eq!(
+            durable_replay_identity(&current, &foreign),
+            Err("delivery_settlement_replay_scope")
+        );
     }
 }

--- a/crates/tracedecay-usecases/src/observability/delivery_settlement.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_settlement.rs
@@ -60,6 +60,20 @@ impl DeliverySettlementAuthorityV1 {
         })
     }
 
+    pub const fn identity(&self) -> &ObservabilityProducerIdentityV1 {
+        &self.identity
+    }
+
+    /// Retain this store authority while selecting one linked root's policy
+    /// identity for the resulting observability envelope.
+    pub fn alias_with_policy_identity(
+        &self,
+        identity: ObservabilityProducerIdentityV1,
+    ) -> Result<Self, &'static str> {
+        let producer = Arc::new(self.producer.alias_with_policy_identity(identity.clone())?);
+        Self::new(self.db.clone(), producer, identity)
+    }
+
     pub async fn begin(
         &self,
         attempt: &DeliverySettlementAttemptV1,

--- a/crates/tracedecay-usecases/src/observability/delivery_spool.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_spool.rs
@@ -11,6 +11,8 @@ use tracedecay_private_fs::framed_log::{
     DirectorySyncPolicy, atomic_write, read_bounded, sync_directory, validate_regular_or_missing,
 };
 
+use super::ObservabilityProducerIdentityV1;
+
 const MAX_PENDING_RECEIPTS: usize = 16_384;
 const MAX_RECEIPT_BYTES: usize = 8 * 1024;
 const RECEIPT_SUFFIX: &str = ".delivery.v1.json";
@@ -22,16 +24,28 @@ const DIRECTORY_POLICY: DirectorySyncPolicy = DirectorySyncPolicy::Strict;
 pub(super) struct DeliveryRecorderSourceReceiptV1 {
     pub receipt_id: [u8; 16],
     pub settlement: DeliverySettlementV1,
+    /// Exact linked-root emission identity selected at admission. Receipts
+    /// written before policy-specific frontends omit this and replay through
+    /// the recorder's store-core identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emission_identity: Option<ObservabilityProducerIdentityV1>,
 }
 
 impl DeliveryRecorderSourceReceiptV1 {
-    pub fn new(settlement: DeliverySettlementV1) -> Result<Self, DeliveryRecorderSpoolError> {
+    pub fn new(
+        settlement: DeliverySettlementV1,
+        emission_identity: ObservabilityProducerIdentityV1,
+    ) -> Result<Self, DeliveryRecorderSpoolError> {
         settlement
             .validate()
             .map_err(|_| DeliveryRecorderSpoolError::InvalidReceipt)?;
+        emission_identity
+            .validate()
+            .map_err(|_| DeliveryRecorderSpoolError::InvalidReceipt)?;
         let digest = canonical_sha256(&(
-            "tracedecay.delivery-recorder-source-receipt.v1",
+            "tracedecay.delivery-recorder-source-receipt.v2",
             &settlement,
+            &emission_identity,
         ))
         .map_err(|_| DeliveryRecorderSpoolError::InvalidReceipt)?;
         let hex = digest
@@ -43,6 +57,7 @@ impl DeliveryRecorderSourceReceiptV1 {
         Ok(Self {
             receipt_id,
             settlement,
+            emission_identity: Some(emission_identity),
         })
     }
 
@@ -50,12 +65,33 @@ impl DeliveryRecorderSourceReceiptV1 {
         if self.receipt_id == [0; 16] {
             return Err(DeliveryRecorderSpoolError::InvalidReceipt);
         }
-        let expected = Self::new(self.settlement.clone())?;
-        if expected.receipt_id != self.receipt_id {
+        self.settlement
+            .validate()
+            .map_err(|_| DeliveryRecorderSpoolError::InvalidReceipt)?;
+        let expected_receipt_id = if let Some(emission_identity) = &self.emission_identity {
+            Self::new(self.settlement.clone(), emission_identity.clone())?.receipt_id
+        } else {
+            legacy_receipt_id(&self.settlement)?
+        };
+        if expected_receipt_id != self.receipt_id {
             return Err(DeliveryRecorderSpoolError::InvalidReceipt);
         }
         Ok(())
     }
+}
+
+fn legacy_receipt_id(
+    settlement: &DeliverySettlementV1,
+) -> Result<[u8; 16], DeliveryRecorderSpoolError> {
+    let digest = canonical_sha256(&("tracedecay.delivery-recorder-source-receipt.v1", settlement))
+        .map_err(|_| DeliveryRecorderSpoolError::InvalidReceipt)?;
+    let hex = digest
+        .as_str()
+        .strip_prefix("sha256:")
+        .ok_or(DeliveryRecorderSpoolError::InvalidReceipt)?;
+    let mut receipt_id = [0_u8; 16];
+    decode_hex_prefix(hex, &mut receipt_id)?;
+    Ok(receipt_id)
 }
 
 #[derive(Debug, Error, Eq, PartialEq)]

--- a/crates/tracedecay-usecases/src/observability/delivery_spool.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_spool.rs
@@ -362,3 +362,59 @@ fn decode_nibble(byte: u8) -> Result<u8, DeliveryRecorderSpoolError> {
         _ => Err(DeliveryRecorderSpoolError::InvalidReceipt),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tracedecay_domain::{
+        DeliveryChannelIdentityV1, DeliveryEventClassV1, DeliverySettlementAttemptV1,
+        DeliverySettlementOutcomeV1, DeliverySurfaceFamilyV1, UtcMicros,
+    };
+
+    use super::*;
+
+    fn settlement() -> DeliverySettlementV1 {
+        DeliverySettlementV1 {
+            attempt: DeliverySettlementAttemptV1 {
+                owner_event_id: "work:delivery-spool:test".to_owned(),
+                event_class: DeliveryEventClassV1::OperationTerminal,
+                channel: DeliveryChannelIdentityV1 {
+                    surface: DeliverySurfaceFamilyV1::Mcp,
+                    channel_ref: "mcp:delivery-spool:test".to_owned(),
+                },
+                work_attempt: None,
+                eligible: 1,
+                valid_at: UtcMicros(100),
+                attempted_at: UtcMicros(110),
+            },
+            outcome: DeliverySettlementOutcomeV1::Delivered,
+            settled_at: UtcMicros(120),
+            drop_reason: None,
+        }
+    }
+
+    fn identity() -> ObservabilityProducerIdentityV1 {
+        ObservabilityProducerIdentityV1 {
+            authorized_scope_ref: "project.delivery-spool".to_owned(),
+            process_boot_id: "boot:delivery-spool".to_owned(),
+            producer_revision: "delivery-spool-producer.v1".to_owned(),
+            configuration_revision: "delivery-spool-config.v1".to_owned(),
+            policy_revision: "delivery-spool-policy.v1".to_owned(),
+        }
+    }
+
+    #[test]
+    fn v2_receipt_refuses_tampered_emission_identity() {
+        let mut receipt =
+            DeliveryRecorderSourceReceiptV1::new(settlement(), identity()).expect("v2 receipt");
+        receipt
+            .emission_identity
+            .as_mut()
+            .expect("v2 emission identity")
+            .policy_revision = "delivery-spool-tampered-policy.v1".to_owned();
+
+        assert_eq!(
+            receipt.validate(),
+            Err(DeliveryRecorderSpoolError::InvalidReceipt)
+        );
+    }
+}

--- a/crates/tracedecay-usecases/src/observability/producer.rs
+++ b/crates/tracedecay-usecases/src/observability/producer.rs
@@ -143,6 +143,7 @@ struct QueuedObservation {
 struct QueuedOwnerFact {
     json: String,
     durable_claimed: bool,
+    emission_identity: ObservabilityProducerIdentityV1,
 }
 
 struct ProducerWorkerState {
@@ -174,9 +175,9 @@ pub struct BoundedObservabilityProducerV1 {
     next_sequence: Arc<AtomicU64>,
     state: Arc<AtomicU8>,
     deadlines: ObservabilityProducerDeadlinesV1,
-    emission_lock: Mutex<()>,
+    emission_lock: Arc<Mutex<()>>,
     durable_emission_lock: Arc<AsyncMutex<()>>,
-    worker: Mutex<Option<JoinHandle<()>>>,
+    worker: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl BoundedObservabilityProducerV1 {
@@ -244,9 +245,45 @@ impl BoundedObservabilityProducerV1 {
             next_sequence,
             state,
             deadlines,
-            emission_lock: Mutex::new(()),
+            emission_lock: Arc::new(Mutex::new(())),
             durable_emission_lock,
-            worker: Mutex::new(Some(worker)),
+            worker: Arc::new(Mutex::new(Some(worker))),
+        })
+    }
+
+    /// Attach a policy-specific emission frontend to this producer's shared
+    /// queue, sequence, lifecycle, and worker.
+    ///
+    /// Linked worktrees share one registered project-session store owner but
+    /// retain distinct policy provenance. Every backend authority must match;
+    /// only the policy stamped at admission may differ.
+    pub fn alias_with_policy_identity(
+        &self,
+        identity: ObservabilityProducerIdentityV1,
+    ) -> Result<Self, &'static str> {
+        identity.validate()?;
+        if identity.authorized_scope_ref != self.identity.authorized_scope_ref
+            || identity.process_boot_id != self.identity.process_boot_id
+            || identity.producer_revision != self.identity.producer_revision
+            || identity.configuration_revision != self.identity.configuration_revision
+        {
+            return Err("observability_producer_alias_identity");
+        }
+        Ok(Self {
+            db: self.db.clone(),
+            identity,
+            data: self.data.clone(),
+            control: self.control.clone(),
+            pending_dropped: Arc::clone(&self.pending_dropped),
+            total_dropped: Arc::clone(&self.total_dropped),
+            first_missing_sequence: Arc::clone(&self.first_missing_sequence),
+            last_missing_sequence: Arc::clone(&self.last_missing_sequence),
+            next_sequence: Arc::clone(&self.next_sequence),
+            state: Arc::clone(&self.state),
+            deadlines: self.deadlines,
+            emission_lock: Arc::clone(&self.emission_lock),
+            durable_emission_lock: Arc::clone(&self.durable_emission_lock),
+            worker: Arc::clone(&self.worker),
         })
     }
 
@@ -809,7 +846,7 @@ async fn record_queued(
         } else {
             claim_and_settle_durable(
                 db,
-                identity,
+                &owner_fact.emission_identity,
                 next_sequence,
                 observation.envelope,
                 owner_fact.json,

--- a/crates/tracedecay-usecases/src/observability/producer.rs
+++ b/crates/tracedecay-usecases/src/observability/producer.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 use std::time::Duration;
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex as AsyncMutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, sleep_until, timeout, timeout_at};
@@ -36,7 +37,7 @@ const ROLLUP_BACKLOG_REBUILD_INTERVAL: Duration = Duration::from_secs(1);
 const ROLLUP_IDLE_RETRY_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const TELEMETRY_DROP_EVENT_KIND: &str = "telemetry.drop.observed.v1";
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ObservabilityProducerIdentityV1 {
     pub authorized_scope_ref: String,
     pub process_boot_id: String,
@@ -46,7 +47,7 @@ pub struct ObservabilityProducerIdentityV1 {
 }
 
 impl ObservabilityProducerIdentityV1 {
-    fn validate(&self) -> Result<(), &'static str> {
+    pub(super) fn validate(&self) -> Result<(), &'static str> {
         for value in [
             self.authorized_scope_ref.as_str(),
             self.process_boot_id.as_str(),
@@ -116,16 +117,17 @@ enum ProducerControl {
     },
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct DropRange {
+    identity: ObservabilityProducerIdentityV1,
     first: u64,
     last: u64,
     count: u64,
 }
 
 impl DropRange {
-    fn merge(&mut self, other: Self) -> bool {
-        if self.last.saturating_add(1) != other.first {
+    fn merge(&mut self, other: &Self) -> bool {
+        if self.identity != other.identity || self.last.saturating_add(1) != other.first {
             return false;
         }
         self.last = other.last;
@@ -136,7 +138,7 @@ impl DropRange {
 
 struct QueuedObservation {
     envelope: ObservabilityEnvelopeV1,
-    carried_drop: Option<DropRange>,
+    carried_drops: Vec<DropRange>,
     owner_fact: Option<QueuedOwnerFact>,
 }
 
@@ -147,10 +149,8 @@ struct QueuedOwnerFact {
 }
 
 struct ProducerWorkerState {
-    pending_dropped: Arc<AtomicU64>,
+    pending_drops: Arc<Mutex<Vec<DropRange>>>,
     total_dropped: Arc<AtomicU64>,
-    first_missing_sequence: Arc<AtomicU64>,
-    last_missing_sequence: Arc<AtomicU64>,
     next_sequence: Arc<AtomicU64>,
     lifecycle: Arc<AtomicU8>,
     durable_emission_lock: Arc<AsyncMutex<()>>,
@@ -168,10 +168,8 @@ pub struct BoundedObservabilityProducerV1 {
     identity: ObservabilityProducerIdentityV1,
     data: mpsc::Sender<QueuedObservation>,
     control: mpsc::Sender<ProducerControl>,
-    pending_dropped: Arc<AtomicU64>,
+    pending_drops: Arc<Mutex<Vec<DropRange>>>,
     total_dropped: Arc<AtomicU64>,
-    first_missing_sequence: Arc<AtomicU64>,
-    last_missing_sequence: Arc<AtomicU64>,
     next_sequence: Arc<AtomicU64>,
     state: Arc<AtomicU8>,
     deadlines: ObservabilityProducerDeadlinesV1,
@@ -208,10 +206,8 @@ impl BoundedObservabilityProducerV1 {
         let (data, data_rx) = mpsc::channel(capacity);
         // The control lane remains writable when every data slot is occupied.
         let (control, control_rx) = mpsc::channel(1);
-        let pending_dropped = Arc::new(AtomicU64::new(0));
+        let pending_drops = Arc::new(Mutex::new(Vec::new()));
         let total_dropped = Arc::new(AtomicU64::new(0));
-        let first_missing_sequence = Arc::new(AtomicU64::new(0));
-        let last_missing_sequence = Arc::new(AtomicU64::new(0));
         let next_sequence = Arc::new(AtomicU64::new(1));
         let state = Arc::new(AtomicU8::new(PRODUCER_RUNNING));
         let durable_emission_lock = Arc::new(AsyncMutex::new(()));
@@ -223,10 +219,8 @@ impl BoundedObservabilityProducerV1 {
             data_rx,
             control_rx,
             ProducerWorkerState {
-                pending_dropped: Arc::clone(&pending_dropped),
+                pending_drops: Arc::clone(&pending_drops),
                 total_dropped: Arc::clone(&total_dropped),
-                first_missing_sequence: Arc::clone(&first_missing_sequence),
-                last_missing_sequence: Arc::clone(&last_missing_sequence),
                 next_sequence: Arc::clone(&next_sequence),
                 lifecycle: Arc::clone(&state),
                 durable_emission_lock: Arc::clone(&durable_emission_lock),
@@ -238,10 +232,8 @@ impl BoundedObservabilityProducerV1 {
             identity,
             data,
             control,
-            pending_dropped,
+            pending_drops,
             total_dropped,
-            first_missing_sequence,
-            last_missing_sequence,
             next_sequence,
             state,
             deadlines,
@@ -274,10 +266,8 @@ impl BoundedObservabilityProducerV1 {
             identity,
             data: self.data.clone(),
             control: self.control.clone(),
-            pending_dropped: Arc::clone(&self.pending_dropped),
+            pending_drops: Arc::clone(&self.pending_drops),
             total_dropped: Arc::clone(&self.total_dropped),
-            first_missing_sequence: Arc::clone(&self.first_missing_sequence),
-            last_missing_sequence: Arc::clone(&self.last_missing_sequence),
             next_sequence: Arc::clone(&self.next_sequence),
             state: Arc::clone(&self.state),
             deadlines: self.deadlines,
@@ -353,46 +343,57 @@ impl BoundedObservabilityProducerV1 {
         let sequence = envelope.producer_sequence;
         match self.data.try_reserve() {
             Ok(permit) => {
-                let carried_drops = self.pending_dropped.swap(0, Ordering::AcqRel);
-                let carried_drop = (carried_drops > 0).then(|| {
-                    let first = self.first_missing_sequence.swap(0, Ordering::AcqRel);
-                    let last = self.last_missing_sequence.swap(0, Ordering::AcqRel);
-                    DropRange {
-                        first,
-                        last,
-                        count: carried_drops,
-                    }
-                });
-                if carried_drops > 0 {
-                    envelope.dropped_count = envelope.dropped_count.saturating_add(carried_drops);
+                let carried_drops = {
+                    let mut pending = self
+                        .pending_drops
+                        .lock()
+                        .map_err(|_| "observability_producer_lock_poisoned")?;
+                    std::mem::take(&mut *pending)
+                };
+                let carried_drop_count = carried_drops
+                    .iter()
+                    .fold(0_u64, |count, range| count.saturating_add(range.count));
+                if carried_drop_count > 0 {
+                    envelope.dropped_count =
+                        envelope.dropped_count.saturating_add(carried_drop_count);
                     envelope.coverage = CoverageStateV1::Partial;
                 }
                 permit.send(QueuedObservation {
                     envelope,
-                    carried_drop,
+                    carried_drops,
                     owner_fact,
                 });
                 Ok(ObservabilityEmissionOutcomeV1::Enqueued)
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
-                self.record_capacity_drop(sequence);
+                self.record_capacity_drop(sequence)?;
                 Ok(ObservabilityEmissionOutcomeV1::DroppedAtCapacity)
             }
             Err(mpsc::error::TrySendError::Closed(_)) => Err("observability_producer_closed"),
         }
     }
 
-    fn record_capacity_drop(&self, sequence: u64) {
-        self.pending_dropped.fetch_add(1, Ordering::AcqRel);
+    fn record_capacity_drop(&self, sequence: u64) -> Result<(), &'static str> {
+        let mut pending = self
+            .pending_drops
+            .lock()
+            .map_err(|_| "observability_producer_lock_poisoned")?;
+        if let Some(range) = pending
+            .iter_mut()
+            .find(|range| range.identity == self.identity)
+        {
+            range.last = sequence;
+            range.count = range.count.saturating_add(1);
+        } else {
+            pending.push(DropRange {
+                identity: self.identity.clone(),
+                first: sequence,
+                last: sequence,
+                count: 1,
+            });
+        }
         self.total_dropped.fetch_add(1, Ordering::AcqRel);
-        let _ = self.first_missing_sequence.compare_exchange(
-            0,
-            sequence,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        );
-        self.last_missing_sequence
-            .store(sequence, Ordering::Release);
+        Ok(())
     }
 
     pub async fn shutdown(
@@ -612,7 +613,6 @@ async fn run_worker(
                 let persisted_before = progress.persisted;
                 record_queued(
                     &db,
-                    &identity,
                     &state.durable_emission_lock,
                     &state.next_sequence,
                     observation,
@@ -671,7 +671,7 @@ fn should_wake_rollup_now(
 }
 
 fn observation_dirties_rollup(observation: &QueuedObservation) -> bool {
-    observation.carried_drop.is_some()
+    !observation.carried_drops.is_empty()
         || observation.envelope.event_kind == TELEMETRY_DROP_EVENT_KIND
         || EXECUTION_TOPOLOGY_EVENT_KINDS_V1.contains(&observation.envelope.event_kind.as_str())
 }
@@ -696,8 +696,12 @@ async fn settle_worker(
     if discard_pending {
         let mut ranges = Vec::new();
         while let Ok(observation) = data.try_recv() {
-            if observation
-                .owner_fact
+            let QueuedObservation {
+                envelope,
+                carried_drops,
+                owner_fact,
+            } = observation;
+            if owner_fact
                 .as_ref()
                 .is_some_and(|owner| owner.durable_claimed)
             {
@@ -705,29 +709,40 @@ async fn settle_worker(
                 // producer; cancellation never relabels them as loss.
                 continue;
             }
-            if let Some(carried_drop) = observation.carried_drop {
+            for carried_drop in carried_drops {
                 push_drop_range(&mut ranges, carried_drop);
             }
-            let sequence = if observation.owner_fact.is_some() {
+            let emission_identity = owner_fact
+                .as_ref()
+                .map(|owner| owner.emission_identity.clone())
+                .unwrap_or_else(|| identity_from_envelope(&envelope));
+            let sequence = if owner_fact.is_some() {
                 state.next_sequence.fetch_add(1, Ordering::AcqRel)
             } else {
-                observation.envelope.producer_sequence
+                envelope.producer_sequence
             };
             state.total_dropped.fetch_add(1, Ordering::AcqRel);
             push_drop_range(
                 &mut ranges,
                 DropRange {
+                    identity: emission_identity,
                     first: sequence,
                     last: sequence,
                     count: 1,
                 },
             );
         }
-        if let Some(pending) = take_pending_drop(state) {
-            push_drop_range(&mut ranges, pending);
+        match take_pending_drops(state) {
+            Ok(pending) => {
+                for range in pending {
+                    push_drop_range(&mut ranges, range);
+                }
+            }
+            Err(error) if progress.first_error.is_none() => progress.first_error = Some(error),
+            Err(_) => {}
         }
         for range in ranges {
-            let drop_envelope = telemetry_drop_envelope(identity, range, false);
+            let drop_envelope = telemetry_drop_envelope(range, false);
             record(
                 db,
                 drop_envelope,
@@ -741,7 +756,6 @@ async fn settle_worker(
         while let Some(observation) = data.recv().await {
             record_queued(
                 db,
-                identity,
                 &state.durable_emission_lock,
                 &state.next_sequence,
                 observation,
@@ -759,11 +773,19 @@ async fn settle_worker(
             state.deadlines.persistence,
         )
         .await;
-        let pending = take_pending_drop(state);
-        let had_pending = pending.is_some();
-        if let Some(pending) = pending {
+        let pending = match take_pending_drops(state) {
+            Ok(pending) => pending,
+            Err(error) => {
+                if progress.first_error.is_none() {
+                    progress.first_error = Some(error);
+                }
+                Vec::new()
+            }
+        };
+        let had_pending = !pending.is_empty();
+        for pending in pending {
             let closes_cleanly = clean_shutdown_observed && progress.first_error.is_none();
-            let drop_envelope = telemetry_drop_envelope(identity, pending, closes_cleanly);
+            let drop_envelope = telemetry_drop_envelope(pending, closes_cleanly);
             record(
                 db,
                 drop_envelope,
@@ -778,8 +800,8 @@ async fn settle_worker(
             // TelemetryDrop is Plan 26's reserved terminal carrier. A zero
             // lower bound seals this sequence without asserting a drop.
             let zero_terminal = telemetry_drop_envelope(
-                identity,
                 DropRange {
+                    identity: identity.clone(),
                     first: sequence,
                     last: sequence,
                     count: 0,
@@ -806,17 +828,17 @@ async fn settle_worker(
     state.total_dropped.load(Ordering::Acquire)
 }
 
-fn take_pending_drop(state: &ProducerWorkerState) -> Option<DropRange> {
-    let count = state.pending_dropped.swap(0, Ordering::AcqRel);
-    (count > 0).then(|| DropRange {
-        first: state.first_missing_sequence.swap(0, Ordering::AcqRel),
-        last: state.last_missing_sequence.swap(0, Ordering::AcqRel),
-        count,
-    })
+fn take_pending_drops(
+    state: &ProducerWorkerState,
+) -> Result<Vec<DropRange>, ApplicationContractError> {
+    let mut pending = state.pending_drops.lock().map_err(|_| {
+        ApplicationContractError::Domain("observability_producer_lock_poisoned".to_owned())
+    })?;
+    Ok(std::mem::take(&mut *pending))
 }
 
 fn push_drop_range(ranges: &mut Vec<DropRange>, range: DropRange) {
-    if ranges.last_mut().is_some_and(|last| last.merge(range)) {
+    if ranges.last_mut().is_some_and(|last| last.merge(&range)) {
         return;
     }
     ranges.push(range);
@@ -824,7 +846,6 @@ fn push_drop_range(ranges: &mut Vec<DropRange>, range: DropRange) {
 
 async fn record_queued(
     db: &RegisteredGlobalDb,
-    identity: &ObservabilityProducerIdentityV1,
     durable_emission_lock: &AsyncMutex<()>,
     next_sequence: &AtomicU64,
     observation: QueuedObservation,
@@ -857,8 +878,8 @@ async fn record_queued(
         }
         return;
     }
-    if let Some(range) = observation.carried_drop {
-        let drop_envelope = telemetry_drop_envelope(identity, range, false);
+    for range in observation.carried_drops {
+        let drop_envelope = telemetry_drop_envelope(range, false);
         record(
             db,
             drop_envelope,
@@ -876,6 +897,16 @@ async fn record_queued(
         persistence_deadline,
     )
     .await;
+}
+
+fn identity_from_envelope(envelope: &ObservabilityEnvelopeV1) -> ObservabilityProducerIdentityV1 {
+    ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: envelope.scope_ref.clone(),
+        process_boot_id: envelope.process_boot_id.clone(),
+        producer_revision: envelope.producer_revision.clone(),
+        configuration_revision: envelope.configuration_revision.clone(),
+        policy_revision: envelope.policy_revision.clone(),
+    }
 }
 
 fn prepare_delivery_with_identity(
@@ -925,10 +956,10 @@ async fn record(
 }
 
 fn telemetry_drop_envelope(
-    identity: &ObservabilityProducerIdentityV1,
     range: DropRange,
     clean_shutdown_observed: bool,
 ) -> ObservabilityEnvelopeV1 {
+    let identity = &range.identity;
     let first_missing = range.first.max(1);
     let last_missing = range.last.max(first_missing);
     let observed_at = now_micros().0;

--- a/crates/tracedecay-usecases/src/observability/producer/outbox.rs
+++ b/crates/tracedecay-usecases/src/observability/producer/outbox.rs
@@ -55,7 +55,7 @@ impl BoundedObservabilityProducerV1 {
     ) -> Result<ObservabilityEmissionOutcomeV1, &'static str> {
         match self.data.try_send(QueuedObservation {
             envelope,
-            carried_drop: None,
+            carried_drops: Vec::new(),
             owner_fact: Some(QueuedOwnerFact {
                 json: owner_fact_json,
                 durable_claimed: false,
@@ -65,7 +65,7 @@ impl BoundedObservabilityProducerV1 {
             Ok(()) => Ok(ObservabilityEmissionOutcomeV1::Enqueued),
             Err(mpsc::error::TrySendError::Full(_)) => {
                 let sequence = self.next_sequence.fetch_add(1, Ordering::AcqRel);
-                self.record_capacity_drop(sequence);
+                self.record_capacity_drop(sequence)?;
                 Ok(ObservabilityEmissionOutcomeV1::DroppedAtCapacity)
             }
             Err(mpsc::error::TrySendError::Closed(_)) => Err("observability_producer_closed"),
@@ -164,7 +164,7 @@ impl BoundedObservabilityProducerV1 {
                 Some(permit) => {
                     permit.send(QueuedObservation {
                         envelope: delivery,
-                        carried_drop: None,
+                        carried_drops: Vec::new(),
                         owner_fact: Some(QueuedOwnerFact {
                             json: owner_fact_json,
                             durable_claimed: true,

--- a/crates/tracedecay-usecases/src/observability/producer/outbox.rs
+++ b/crates/tracedecay-usecases/src/observability/producer/outbox.rs
@@ -59,6 +59,7 @@ impl BoundedObservabilityProducerV1 {
             owner_fact: Some(QueuedOwnerFact {
                 json: owner_fact_json,
                 durable_claimed: false,
+                emission_identity: self.identity.clone(),
             }),
         }) {
             Ok(()) => Ok(ObservabilityEmissionOutcomeV1::Enqueued),
@@ -167,6 +168,7 @@ impl BoundedObservabilityProducerV1 {
                         owner_fact: Some(QueuedOwnerFact {
                             json: owner_fact_json,
                             durable_claimed: true,
+                            emission_identity: self.identity.clone(),
                         }),
                     });
                     Ok(ObservabilityOwnerEmissionOutcomeV1::Enqueued)

--- a/crates/tracedecay-usecases/tests/delivery_settlement_observability.rs
+++ b/crates/tracedecay-usecases/tests/delivery_settlement_observability.rs
@@ -263,19 +263,29 @@ async fn recorder_replays_retained_receipt_after_transient_db_failure_and_restar
     .await
     .expect("registered runtime");
     let db = runtime.project_database_arc().expect("project database");
-    let identity = ObservabilityProducerIdentityV1 {
+    let core_identity = ObservabilityProducerIdentityV1 {
         authorized_scope_ref: project_id.as_str().to_owned(),
         process_boot_id: "boot:delivery-restart".to_owned(),
         producer_revision: "delivery-restart-producer.v1".to_owned(),
         configuration_revision: "delivery-restart-config.v1".to_owned(),
-        policy_revision: "delivery-restart-policy.v1".to_owned(),
+        policy_revision: "delivery-restart-core-policy.v1".to_owned(),
+    };
+    let linked_identity = ObservabilityProducerIdentityV1 {
+        policy_revision: "delivery-restart-linked-policy.v1".to_owned(),
+        ..core_identity.clone()
     };
     let producer = Arc::new(
-        BoundedObservabilityProducerV1::start(db.clone(), identity.clone(), 8).expect("producer"),
+        BoundedObservabilityProducerV1::start(db.clone(), core_identity.clone(), 8)
+            .expect("producer"),
     );
     let authority = Arc::new(
-        DeliverySettlementAuthorityV1::new(db.clone(), Arc::clone(&producer), identity)
+        DeliverySettlementAuthorityV1::new(db.clone(), Arc::clone(&producer), core_identity)
             .expect("settlement authority"),
+    );
+    let linked_authority = Arc::new(
+        authority
+            .alias_with_policy_identity(linked_identity)
+            .expect("linked settlement authority"),
     );
     let transaction = db
         .begin_write_transaction()
@@ -293,8 +303,8 @@ async fn recorder_replays_retained_receipt_after_transient_db_failure_and_restar
         .expect("install failure trigger");
     transaction.commit().await.expect("commit failure trigger");
 
-    let recorder =
-        BoundedDeliverySettlementRecorderV1::start(Arc::clone(&authority), 1).expect("recorder");
+    let recorder = BoundedDeliverySettlementRecorderV1::start(Arc::clone(&linked_authority), 1)
+        .expect("recorder");
     let terminal = DeliverySettlementV1 {
         attempt: attempt(),
         outcome: DeliverySettlementOutcomeV1::Delivered,
@@ -311,6 +321,13 @@ async fn recorder_replays_retained_receipt_after_transient_db_failure_and_restar
     assert_eq!(failed.settled, 0);
     assert_eq!(failed.retained, 1);
     drop(recorder);
+    drop(linked_authority);
+    drop(authority);
+    let producer = match Arc::try_unwrap(producer) {
+        Ok(producer) => producer,
+        Err(_) => panic!("recorder must release old producer after shutdown"),
+    };
+    producer.shutdown().await.expect("stop old producer");
 
     let transaction = db
         .begin_write_transaction()
@@ -325,8 +342,27 @@ async fn recorder_replays_retained_receipt_after_transient_db_failure_and_restar
         .expect("remove failure trigger");
     transaction.commit().await.expect("commit recovery");
 
-    let restarted =
-        BoundedDeliverySettlementRecorderV1::start(Arc::clone(&authority), 1).expect("restart");
+    let restarted_identity = ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: project_id.as_str().to_owned(),
+        process_boot_id: "boot:delivery-restarted".to_owned(),
+        producer_revision: "delivery-restarted-producer.v2".to_owned(),
+        configuration_revision: "delivery-restarted-config.v2".to_owned(),
+        policy_revision: "delivery-restarted-core-policy.v2".to_owned(),
+    };
+    let producer = Arc::new(
+        BoundedObservabilityProducerV1::start(db.clone(), restarted_identity.clone(), 8)
+            .expect("restarted producer"),
+    );
+    let authority = Arc::new(
+        DeliverySettlementAuthorityV1::new(
+            db.clone(),
+            Arc::clone(&producer),
+            restarted_identity.clone(),
+        )
+        .expect("restarted settlement authority"),
+    );
+    let restarted = BoundedDeliverySettlementRecorderV1::start(Arc::clone(&authority), 1)
+        .expect("restart recorder");
     let recovered = restarted.shutdown().await.expect("restart replay");
     assert_eq!(recovered.settled, 1);
     assert_eq!(recovered.retained, 0);
@@ -343,4 +379,34 @@ async fn recorder_replays_retained_receipt_after_transient_db_failure_and_restar
         Err(_) => panic!("recorder must release producer after restart"),
     };
     producer.shutdown().await.expect("flush producer");
+    let page = RegisteredObservabilityPortV1::new(db.as_ref())
+        .query(ObservabilityQueryV1 {
+            authorized_scope_ref: project_id.as_str().to_owned(),
+            event_kinds: vec!["work.delivery_fanout.observed.v1".to_owned()],
+            horizon: ObservabilityHorizonV1 {
+                since_micros: 0,
+                until_micros: i64::MAX,
+            },
+            after_watermark: None,
+            limit: 8,
+        })
+        .await
+        .expect("restarted settlement observation query");
+    assert_eq!(page.events.len(), 1);
+    assert_eq!(
+        page.events[0].policy_revision,
+        "delivery-restart-linked-policy.v1"
+    );
+    assert_eq!(
+        page.events[0].process_boot_id,
+        restarted_identity.process_boot_id
+    );
+    assert_eq!(
+        page.events[0].producer_revision,
+        restarted_identity.producer_revision
+    );
+    assert_eq!(
+        page.events[0].configuration_revision,
+        restarted_identity.configuration_revision
+    );
 }

--- a/src/daemon/project_delivery_mount.rs
+++ b/src/daemon/project_delivery_mount.rs
@@ -28,6 +28,7 @@ pub(super) async fn ensure_project_delivery_settlement(
             session_db,
             scope.project_id.clone(),
             access.configuration_digest.clone(),
+            access.configuration_provenance_digest.clone(),
             configuration_policy_digest.clone(),
         )
         .await

--- a/src/daemon/scheduler/combined_effect.rs
+++ b/src/daemon/scheduler/combined_effect.rs
@@ -1056,6 +1056,7 @@ mod tests {
         project_id: ProjectId,
         configuration_revision_id: tracedecay_domain::configuration::ConfigurationRevisionId,
         configuration_digest: ManifestDigest,
+        configuration_provenance_digest: ManifestDigest,
     }
 
     impl CombinedAdmissionFixture {
@@ -1154,6 +1155,7 @@ mod tests {
                 project_id,
                 configuration_revision_id,
                 configuration_digest: access.configuration_digest,
+                configuration_provenance_digest: access.configuration_provenance_digest,
             }
         }
 
@@ -1178,6 +1180,7 @@ mod tests {
                     session_db.clone(),
                     self.project_id.clone(),
                     self.configuration_digest.clone(),
+                    self.configuration_provenance_digest.clone(),
                     policy_digest,
                 )
                 .await

--- a/src/daemon/service/invocation/observability_producer.rs
+++ b/src/daemon/service/invocation/observability_producer.rs
@@ -38,11 +38,13 @@ fn registered_observability_producer_matches_mount(
     database: &crate::global_db::RegisteredGlobalDbLeaseV1,
     project_id: &ProjectId,
     configuration_revision: &ManifestDigest,
+    configuration_provenance_revision: &ManifestDigest,
     policy_revision: &ManifestDigest,
 ) -> bool {
     let incumbent = registered.producer();
     registered.matches(
         database,
+        configuration_provenance_revision,
         &tracedecay_usecases::observability::ObservabilityProducerIdentityV1 {
             authorized_scope_ref: project_id.as_str().to_owned(),
             process_boot_id: incumbent.identity().process_boot_id.clone(),
@@ -60,6 +62,7 @@ impl DaemonInvocationService {
         database: crate::global_db::RegisteredGlobalDbLeaseV1,
         project_id: ProjectId,
         configuration_revision: ManifestDigest,
+        configuration_provenance_revision: ManifestDigest,
         policy_revision: ManifestDigest,
     ) -> Result<
         Arc<tracedecay_usecases::observability::BoundedObservabilityProducerV1>,
@@ -74,6 +77,7 @@ impl DaemonInvocationService {
                         &database,
                         &project_id,
                         &configuration_revision,
+                        &configuration_provenance_revision,
                         &policy_revision,
                     )
                     .then_some(())
@@ -91,6 +95,7 @@ impl DaemonInvocationService {
                     // recorder for the same store.
                     self.store_observability.acquire_or_start(
                         &database,
+                        &configuration_provenance_revision,
                         |incumbent| {
                             incumbent.authorized_scope_ref == project_id.as_str()
                                 && incumbent.producer_revision

--- a/src/daemon/service/invocation/tests/mod.rs
+++ b/src/daemon/service/invocation/tests/mod.rs
@@ -76,14 +76,25 @@ pub(in crate::daemon) async fn mount_test_work_observability(
     scope: &ResolvedScope,
     configuration_digest: &ManifestDigest,
 ) -> ManifestDigest {
-    let policy_digest =
-        ManifestDigest::new(format!("sha256:{}", "e".repeat(64))).expect("policy digest");
+    let configuration_provenance_digest = tracedecay_domain::canonical_sha256(&(
+        "tracedecay.test.work-observability-provenance.v1",
+        configuration_digest,
+    ))
+    .expect("configuration provenance digest");
+    let policy_digest = tracedecay_domain::canonical_sha256(&(
+        "tracedecay.daemon.configuration-policy.v1",
+        &scope.scope_digest,
+        configuration_digest,
+        &configuration_provenance_digest,
+    ))
+    .expect("policy digest");
     service
         .mount_observability_producer(
             project_root.to_path_buf(),
             database,
             scope.project_id.clone(),
             configuration_digest.clone(),
+            configuration_provenance_digest,
             policy_digest.clone(),
         )
         .await

--- a/src/daemon/service/project_runtime/observability.rs
+++ b/src/daemon/service/project_runtime/observability.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 
 use tracedecay_application::ApplicationContractError;
+use tracedecay_domain::ManifestDigest;
 use tracedecay_usecases::observability::{
     BoundedDeliverySettlementRecorderV1, BoundedObservabilityProducerV1,
     DeliverySettlementAuthorityV1, ObservabilityProducerIdentityV1, WorkOwnerObservationRecoveryV1,
@@ -15,6 +16,10 @@ use tracedecay_usecases::observability::{
 /// project roots (linked worktrees) mount observability for that store.
 struct StoreObservabilityCoreV1 {
     database: crate::global_db::RegisteredGlobalDbLeaseV1,
+    // Canonical configuration resolution provenance is store-wide. Exact
+    // digest equality proves that linked-root policy differences come only
+    // from their scopes; a different provenance must not reuse this owner.
+    configuration_provenance_revision: ManifestDigest,
     producer: Arc<BoundedObservabilityProducerV1>,
     delivery_settlement_authority: Arc<DeliverySettlementAuthorityV1>,
     delivery_settlements: Arc<BoundedDeliverySettlementRecorderV1>,
@@ -24,6 +29,7 @@ struct StoreObservabilityCoreV1 {
 impl StoreObservabilityCoreV1 {
     fn start(
         database: crate::global_db::RegisteredGlobalDbLeaseV1,
+        configuration_provenance_revision: ManifestDigest,
         producer: BoundedObservabilityProducerV1,
         delivery_capacity: usize,
     ) -> Result<Self, &'static str> {
@@ -46,6 +52,7 @@ impl StoreObservabilityCoreV1 {
         )?);
         Ok(Self {
             database,
+            configuration_provenance_revision,
             producer,
             delivery_settlement_authority,
             delivery_settlements,
@@ -128,8 +135,11 @@ impl StoreObservabilityRegistryV1 {
     pub(crate) fn acquire_or_start<E>(
         &self,
         database: &crate::global_db::RegisteredGlobalDbLeaseV1,
+        configuration_provenance_revision: &ManifestDigest,
         accepts_incumbent: impl FnOnce(&ObservabilityProducerIdentityV1) -> bool,
-        alias_identity: impl FnOnce(&ObservabilityProducerIdentityV1) -> ObservabilityProducerIdentityV1,
+        emission_identity: impl FnOnce(
+            &ObservabilityProducerIdentityV1,
+        ) -> ObservabilityProducerIdentityV1,
         refused: impl FnOnce() -> E,
         start_producer: impl FnOnce() -> Result<BoundedObservabilityProducerV1, E>,
         delivery_capacity: usize,
@@ -142,17 +152,24 @@ impl StoreObservabilityRegistryV1 {
         {
             match &mut entry.state {
                 StoreObservabilityStateV1::Active { core, aliases } => {
-                    if !accepts_incumbent(core.producer.identity()) {
+                    if core.configuration_provenance_revision != *configuration_provenance_revision
+                        || !accepts_incumbent(core.producer.identity())
+                    {
                         return Err(refused());
                     }
-                    let mount_identity = alias_identity(core.producer.identity());
+                    let emission_identity = emission_identity(core.producer.identity());
+                    let producer = Arc::new(
+                        core.producer
+                            .alias_with_policy_identity(emission_identity)
+                            .map_err(&unavailable)?,
+                    );
                     *aliases = aliases.checked_add(1).ok_or_else(|| {
                         unavailable("store_observability_alias_capacity_exhausted")
                     })?;
                     return Ok(RegisteredObservabilityProducerV1::alias(
                         self.clone(),
                         Arc::clone(core),
-                        mount_identity,
+                        producer,
                     ));
                 }
                 StoreObservabilityStateV1::Stopping { .. } => {
@@ -164,10 +181,14 @@ impl StoreObservabilityRegistryV1 {
             }
         }
         let producer = start_producer()?;
-        let mount_identity = alias_identity(producer.identity());
         let core = Arc::new(
-            StoreObservabilityCoreV1::start(database.clone(), producer, delivery_capacity)
-                .map_err(&unavailable)?,
+            StoreObservabilityCoreV1::start(
+                database.clone(),
+                configuration_provenance_revision.clone(),
+                producer,
+                delivery_capacity,
+            )
+            .map_err(&unavailable)?,
         );
         entries.push(StoreObservabilityEntryV1 {
             database: database.clone(),
@@ -178,8 +199,8 @@ impl StoreObservabilityRegistryV1 {
         });
         Ok(RegisteredObservabilityProducerV1::alias(
             self.clone(),
-            core,
-            mount_identity,
+            Arc::clone(&core),
+            Arc::clone(&core.producer),
         ))
     }
 
@@ -264,7 +285,7 @@ impl StoreObservabilityRegistryV1 {
 pub(crate) struct RegisteredObservabilityProducerV1 {
     registry: StoreObservabilityRegistryV1,
     core: Arc<StoreObservabilityCoreV1>,
-    mount_identity: ObservabilityProducerIdentityV1,
+    producer: Arc<BoundedObservabilityProducerV1>,
     released: AtomicBool,
 }
 
@@ -272,18 +293,18 @@ impl RegisteredObservabilityProducerV1 {
     fn alias(
         registry: StoreObservabilityRegistryV1,
         core: Arc<StoreObservabilityCoreV1>,
-        mount_identity: ObservabilityProducerIdentityV1,
+        producer: Arc<BoundedObservabilityProducerV1>,
     ) -> Self {
         Self {
             registry,
             core,
-            mount_identity,
+            producer,
             released: AtomicBool::new(false),
         }
     }
 
     pub(crate) fn producer(&self) -> Arc<BoundedObservabilityProducerV1> {
-        Arc::clone(&self.core.producer)
+        Arc::clone(&self.producer)
     }
 
     pub(crate) fn database(&self) -> crate::global_db::RegisteredGlobalDbLeaseV1 {
@@ -303,10 +324,12 @@ impl RegisteredObservabilityProducerV1 {
     pub(crate) fn matches(
         &self,
         database: &crate::global_db::RegisteredGlobalDbLeaseV1,
+        configuration_provenance_revision: &ManifestDigest,
         identity: &ObservabilityProducerIdentityV1,
     ) -> bool {
         same_registered_store_authority(&self.core.database, database)
-            && self.mount_identity == *identity
+            && self.core.configuration_provenance_revision == *configuration_provenance_revision
+            && *self.producer.identity() == *identity
     }
 
     /// Releases this alias from its store entry, reporting whether it was the

--- a/src/daemon/service/project_runtime/observability.rs
+++ b/src/daemon/service/project_runtime/observability.rs
@@ -163,14 +163,17 @@ impl StoreObservabilityRegistryV1 {
                             .alias_with_policy_identity(emission_identity)
                             .map_err(&unavailable)?,
                     );
-                    *aliases = aliases.checked_add(1).ok_or_else(|| {
+                    let next_aliases = aliases.checked_add(1).ok_or_else(|| {
                         unavailable("store_observability_alias_capacity_exhausted")
                     })?;
-                    return Ok(RegisteredObservabilityProducerV1::alias(
+                    let registered = RegisteredObservabilityProducerV1::alias(
                         self.clone(),
                         Arc::clone(core),
                         producer,
-                    ));
+                    )
+                    .map_err(&unavailable)?;
+                    *aliases = next_aliases;
+                    return Ok(registered);
                 }
                 StoreObservabilityStateV1::Stopping { .. } => {
                     return Err(unavailable("store_observability_retiring"));
@@ -190,6 +193,12 @@ impl StoreObservabilityRegistryV1 {
             )
             .map_err(&unavailable)?,
         );
+        let registered = RegisteredObservabilityProducerV1::alias(
+            self.clone(),
+            Arc::clone(&core),
+            Arc::clone(&core.producer),
+        )
+        .map_err(&unavailable)?;
         entries.push(StoreObservabilityEntryV1 {
             database: database.clone(),
             state: StoreObservabilityStateV1::Active {
@@ -197,11 +206,7 @@ impl StoreObservabilityRegistryV1 {
                 aliases: 1,
             },
         });
-        Ok(RegisteredObservabilityProducerV1::alias(
-            self.clone(),
-            Arc::clone(&core),
-            Arc::clone(&core.producer),
-        ))
+        Ok(registered)
     }
 
     fn begin_retirement(
@@ -286,6 +291,8 @@ pub(crate) struct RegisteredObservabilityProducerV1 {
     registry: StoreObservabilityRegistryV1,
     core: Arc<StoreObservabilityCoreV1>,
     producer: Arc<BoundedObservabilityProducerV1>,
+    delivery_settlement_authority: Arc<DeliverySettlementAuthorityV1>,
+    delivery_settlements: Arc<BoundedDeliverySettlementRecorderV1>,
     released: AtomicBool,
 }
 
@@ -294,13 +301,24 @@ impl RegisteredObservabilityProducerV1 {
         registry: StoreObservabilityRegistryV1,
         core: Arc<StoreObservabilityCoreV1>,
         producer: Arc<BoundedObservabilityProducerV1>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, &'static str> {
+        let emission_identity = producer.identity().clone();
+        let delivery_settlement_authority = Arc::new(
+            core.delivery_settlement_authority
+                .alias_with_policy_identity(emission_identity.clone())?,
+        );
+        let delivery_settlements = Arc::new(
+            core.delivery_settlements
+                .alias_with_policy_identity(emission_identity)?,
+        );
+        Ok(Self {
             registry,
             core,
             producer,
+            delivery_settlement_authority,
+            delivery_settlements,
             released: AtomicBool::new(false),
-        }
+        })
     }
 
     pub(crate) fn producer(&self) -> Arc<BoundedObservabilityProducerV1> {
@@ -314,11 +332,11 @@ impl RegisteredObservabilityProducerV1 {
     pub(crate) fn delivery_settlement_authority(
         &self,
     ) -> Arc<tracedecay_usecases::observability::DeliverySettlementAuthorityV1> {
-        Arc::clone(&self.core.delivery_settlement_authority)
+        Arc::clone(&self.delivery_settlement_authority)
     }
 
     pub(crate) fn delivery_settlement_recorder(&self) -> Arc<BoundedDeliverySettlementRecorderV1> {
-        Arc::clone(&self.core.delivery_settlements)
+        Arc::clone(&self.delivery_settlements)
     }
 
     pub(crate) fn matches(

--- a/src/daemon/service/project_runtime/observability_tests.rs
+++ b/src/daemon/service/project_runtime/observability_tests.rs
@@ -8,14 +8,16 @@ use tracedecay_application::{
     ObservabilityHorizonV1, ObservabilityQueryPort, ObservabilityQueryV1,
 };
 use tracedecay_domain::{
-    CoverageStateV1, ManifestDigest, ObservabilityEnvelopeV1, ObservabilityPayloadV1,
-    ObservabilityRetentionClassV1, ObservabilityTerminalResultV1, ProjectId, RepositoryId,
-    RetrievalQueryObservedV1, WorktreeId, canonical_sha256,
+    CoverageStateV1, DeliveryChannelIdentityV1, DeliveryEventClassV1, DeliverySettlementAttemptV1,
+    DeliverySettlementOutcomeV1, DeliverySettlementV1, DeliverySurfaceFamilyV1, ManifestDigest,
+    ObservabilityEnvelopeV1, ObservabilityPayloadV1, ObservabilityRetentionClassV1,
+    ObservabilityTerminalResultV1, ProjectId, RepositoryId, RetrievalQueryObservedV1, UtcMicros,
+    WorktreeId, canonical_sha256,
 };
 use tracedecay_usecases::observability::{
-    BoundedObservabilityProducerV1, ObservabilityEmissionOutcomeV1,
-    ObservabilityProducerDeadlinesV1, ObservabilityProducerIdentityV1,
-    RegisteredObservabilityPortV1,
+    BoundedObservabilityProducerV1, DeliverySettlementRecordOutcomeV1,
+    ObservabilityEmissionOutcomeV1, ObservabilityProducerDeadlinesV1,
+    ObservabilityProducerIdentityV1, RegisteredObservabilityPortV1,
 };
 
 use crate::daemon::service::invocation::DaemonInvocationService;
@@ -319,8 +321,8 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
         .await
         .expect("reconciled linked-root producer");
     assert!(Arc::ptr_eq(&linked, &linked_reconciled));
-    // The delivery settlement recorder is store-keyed: both roots reach the
-    // exact same recorder rather than running one drain per root.
+    // Each root keeps its policy-specific admission frontend while both
+    // frontends share the exact store recorder backend and drain worker.
     let first_recorder = first_service
         .delivery_settlement_recorder(Some(&root))
         .await
@@ -329,7 +331,29 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
         .delivery_settlement_recorder(Some(&linked_root))
         .await
         .expect("linked-root recorder");
-    assert!(Arc::ptr_eq(&first_recorder, &linked_recorder));
+    assert!(!Arc::ptr_eq(&first_recorder, &linked_recorder));
+    assert_eq!(
+        linked_recorder
+            .try_record(DeliverySettlementV1 {
+                attempt: DeliverySettlementAttemptV1 {
+                    owner_event_id: "linked:settlement:b".to_owned(),
+                    event_class: DeliveryEventClassV1::OperationTerminal,
+                    channel: DeliveryChannelIdentityV1 {
+                        surface: DeliverySurfaceFamilyV1::Lsp,
+                        channel_ref: "lsp:linked-root-b".to_owned(),
+                    },
+                    work_attempt: None,
+                    eligible: 1,
+                    valid_at: UtcMicros(20),
+                    attempted_at: UtcMicros(21),
+                },
+                outcome: DeliverySettlementOutcomeV1::Delivered,
+                settled_at: UtcMicros(22),
+                drop_reason: None,
+            })
+            .expect("record linked-root B settlement"),
+        DeliverySettlementRecordOutcomeV1::Enqueued
+    );
     // Retaining recorder handles would pin the store spool lock past the
     // last-alias shutdown below and block the restart from reopening it.
     drop(first_recorder);
@@ -498,6 +522,27 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
         persisted_policies.get("alias:linked").copied(),
         Some(linked_policy_revision.as_str()),
         "the linked-root frontend must stamp its own policy provenance"
+    );
+    let delivery_page = RegisteredObservabilityPortV1::new(&database)
+        .query(ObservabilityQueryV1 {
+            authorized_scope_ref: project_id.as_str().to_owned(),
+            event_kinds: vec!["work.delivery_fanout.observed.v1".to_owned()],
+            horizon: ObservabilityHorizonV1 {
+                since_micros: 0,
+                until_micros: i64::MAX,
+            },
+            after_watermark: None,
+            limit: 8,
+        })
+        .await
+        .expect("query linked-root settlement");
+    let [delivery] = delivery_page.events.as_slice() else {
+        panic!("one linked-root delivery settlement observation is required");
+    };
+    assert_eq!(
+        delivery.policy_revision,
+        linked_policy_revision.as_str(),
+        "the root-selected delivery recorder must retain root B's policy"
     );
     let mut streams: BTreeMap<&str, BTreeSet<u64>> = BTreeMap::new();
     for event in &page.events {
@@ -913,6 +958,130 @@ async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finis
         )
         .expect("one replacement after both aliases release");
     replacement.shutdown().await.expect("replacement shutdown");
+}
+
+#[tokio::test]
+async fn adjacent_linked_alias_capacity_drops_retain_distinct_policy_carriers() {
+    let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
+    let (_project, project_id, database, _runtime) =
+        runtime("observability-linked-capacity-drops").await;
+    let blocker = database
+        .begin_write_transaction()
+        .await
+        .expect("hold registered writer");
+    let registry = StoreObservabilityRegistryV1::default();
+    let configuration_provenance_revision = digest('0');
+    let policy_a = digest('a');
+    let policy_b = digest('b');
+    let producer = BoundedObservabilityProducerV1::start(
+        database.clone(),
+        ObservabilityProducerIdentityV1 {
+            authorized_scope_ref: project_id.as_str().to_owned(),
+            process_boot_id: "daemon:linked-capacity-drops".to_owned(),
+            producer_revision: "producer.v1".to_owned(),
+            configuration_revision: digest('c').as_str().to_owned(),
+            policy_revision: policy_a.as_str().to_owned(),
+        },
+        1,
+    )
+    .expect("producer");
+    let first = registry
+        .acquire_or_start::<&'static str>(
+            &database,
+            &configuration_provenance_revision,
+            |_| false,
+            ObservabilityProducerIdentityV1::clone,
+            || "unexpected incumbent store producer",
+            || Ok(producer),
+            1,
+            |error| error,
+        )
+        .expect("first alias");
+    let linked = registry
+        .acquire_or_start::<&'static str>(
+            &database,
+            &configuration_provenance_revision,
+            |_| true,
+            |incumbent| {
+                let mut identity = incumbent.clone();
+                identity.policy_revision = policy_b.as_str().to_owned();
+                identity
+            },
+            || "unexpected incumbent refusal",
+            || Err("must not start a second producer"),
+            1,
+            |error| error,
+        )
+        .expect("linked alias");
+    let first_producer = first.producer();
+    let linked_producer = linked.producer();
+
+    let mut index = 0_u64;
+    let first_missing_sequence = loop {
+        let outcome = first_producer
+            .try_emit(envelope(&project_id, &format!("capacity:alias-a:{index}")))
+            .expect("bounded alias A emission");
+        index = index.saturating_add(1);
+        if outcome == ObservabilityEmissionOutcomeV1::DroppedAtCapacity {
+            break index;
+        }
+        assert!(index < 1_024, "writer pressure must fill the bounded queue");
+    };
+    assert_eq!(
+        linked_producer
+            .try_emit(envelope(&project_id, "capacity:alias-b"))
+            .expect("adjacent bounded alias B emission"),
+        ObservabilityEmissionOutcomeV1::DroppedAtCapacity
+    );
+
+    blocker.commit().await.expect("release registered writer");
+    first.shutdown().await.expect("release first alias");
+    linked.shutdown().await.expect("drain last alias");
+
+    let page = RegisteredObservabilityPortV1::new(&database)
+        .query(ObservabilityQueryV1 {
+            authorized_scope_ref: project_id.as_str().to_owned(),
+            event_kinds: vec!["telemetry.drop.observed.v1".to_owned()],
+            horizon: ObservabilityHorizonV1 {
+                since_micros: 0,
+                until_micros: i64::MAX,
+            },
+            after_watermark: None,
+            limit: 8,
+        })
+        .await
+        .expect("query linked-root capacity drops");
+    let dropped: BTreeMap<&str, (u64, u64, u64)> = page
+        .events
+        .iter()
+        .filter_map(|event| {
+            let ObservabilityPayloadV1::TelemetryDrop(drop) = &event.payload else {
+                return None;
+            };
+            (drop.proved_drop_lower_bound > 0).then_some((
+                event.policy_revision.as_str(),
+                (
+                    drop.first_missing_sequence,
+                    drop.last_missing_sequence,
+                    drop.proved_drop_lower_bound,
+                ),
+            ))
+        })
+        .collect();
+    assert_eq!(
+        dropped,
+        BTreeMap::from([
+            (
+                policy_a.as_str(),
+                (first_missing_sequence, first_missing_sequence, 1),
+            ),
+            (
+                policy_b.as_str(),
+                (first_missing_sequence + 1, first_missing_sequence + 1, 1),
+            ),
+        ]),
+        "adjacent alias losses must not coalesce or inherit core A's policy"
+    );
 }
 
 #[tokio::test]

--- a/src/daemon/service/project_runtime/observability_tests.rs
+++ b/src/daemon/service/project_runtime/observability_tests.rs
@@ -10,7 +10,7 @@ use tracedecay_application::{
 use tracedecay_domain::{
     CoverageStateV1, ManifestDigest, ObservabilityEnvelopeV1, ObservabilityPayloadV1,
     ObservabilityRetentionClassV1, ObservabilityTerminalResultV1, ProjectId, RepositoryId,
-    RetrievalQueryObservedV1, WorktreeId,
+    RetrievalQueryObservedV1, WorktreeId, canonical_sha256,
 };
 use tracedecay_usecases::observability::{
     BoundedObservabilityProducerV1, ObservabilityEmissionOutcomeV1,
@@ -101,6 +101,7 @@ async fn project_runtime_reuses_one_producer_and_shutdown_flushes_it() {
             database.clone(),
             project_id.clone(),
             digest('a'),
+            digest('0'),
             digest('b'),
         )
         .await
@@ -111,6 +112,7 @@ async fn project_runtime_reuses_one_producer_and_shutdown_flushes_it() {
             database.clone(),
             project_id.clone(),
             digest('a'),
+            digest('0'),
             digest('b'),
         )
         .await
@@ -159,6 +161,7 @@ async fn a_new_daemon_runtime_restarts_the_project_producer_after_clean_shutdown
             database.clone(),
             project_id.clone(),
             digest('c'),
+            digest('0'),
             digest('d'),
         )
         .await
@@ -172,6 +175,7 @@ async fn a_new_daemon_runtime_restarts_the_project_producer_after_clean_shutdown
             database.clone(),
             project_id.clone(),
             digest('c'),
+            digest('0'),
             digest('d'),
         )
         .await
@@ -228,6 +232,20 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
     )
     .expect("linked scope");
     assert_ne!(root_scope.scope_digest, linked_scope.scope_digest);
+    let configuration_revision = digest('1');
+    let configuration_provenance_revision = digest('2');
+    let policy_revision = |scope: &tracedecay_application::ResolvedScope| {
+        canonical_sha256(&(
+            "tracedecay.daemon.configuration-policy.v1",
+            &scope.scope_digest,
+            &configuration_revision,
+            &configuration_provenance_revision,
+        ))
+        .expect("scope-derived configuration policy")
+    };
+    let root_policy_revision = policy_revision(&root_scope);
+    let linked_policy_revision = policy_revision(&linked_scope);
+    assert_ne!(root_policy_revision, linked_policy_revision);
     let root = PathBuf::from("/project/observability-store-alias");
     let linked_root = PathBuf::from("/project/observability-store-alias-linked");
     let first_service = DaemonInvocationService::default();
@@ -236,8 +254,9 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
             root.clone(),
             database.clone(),
             project_id.clone(),
-            digest('1'),
-            root_scope.scope_digest.clone(),
+            configuration_revision.clone(),
+            configuration_provenance_revision.clone(),
+            root_policy_revision.clone(),
         )
         .await
         .expect("first producer");
@@ -246,8 +265,9 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
             root.clone(),
             database.clone(),
             project_id.clone(),
-            digest('1'),
-            root_scope.scope_digest.clone(),
+            configuration_revision.clone(),
+            configuration_provenance_revision.clone(),
+            root_policy_revision.clone(),
         )
         .await
         .expect("reconciled first producer");
@@ -261,17 +281,26 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
             linked_root.clone(),
             linked_database.clone(),
             project_id.clone(),
-            digest('1'),
-            linked_scope.scope_digest.clone(),
+            configuration_revision.clone(),
+            configuration_provenance_revision.clone(),
+            linked_policy_revision.clone(),
         )
         .await
         .expect("linked-root producer");
-    // Linked roots are aliases of one store-keyed producer: same Arc, one
-    // ordered boot stream per registered store, never one per root.
-    assert!(Arc::ptr_eq(&first, &linked));
+    // Linked roots have distinct policy-stamping frontends over one ordered
+    // store backend and boot stream.
+    assert!(!Arc::ptr_eq(&first, &linked));
     assert_eq!(
         first.identity().process_boot_id,
         linked.identity().process_boot_id
+    );
+    assert_eq!(
+        first.identity().policy_revision,
+        root_policy_revision.as_str()
+    );
+    assert_eq!(
+        linked.identity().policy_revision,
+        linked_policy_revision.as_str()
     );
     let linked_reconciled = first_service
         .mount_observability_producer(
@@ -280,8 +309,9 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
                 .issue_project_database_lease_for_test()
                 .expect("fresh reconciled linked-root database client"),
             project_id.clone(),
-            digest('1'),
-            linked_scope.scope_digest.clone(),
+            configuration_revision.clone(),
+            configuration_provenance_revision.clone(),
+            linked_policy_revision.clone(),
         )
         .await
         .expect("reconciled linked-root producer");
@@ -309,7 +339,8 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
             database.clone(),
             project_id.clone(),
             digest('9'),
-            root_scope.scope_digest.clone(),
+            configuration_provenance_revision.clone(),
+            root_policy_revision.clone(),
         )
         .await
     {
@@ -319,6 +350,32 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
     assert!(
         refused.to_string().contains("already mounted"),
         "unexpected refusal: {refused}"
+    );
+    let foreign_provenance_revision = digest('8');
+    let foreign_policy_revision = canonical_sha256(&(
+        "tracedecay.daemon.configuration-policy.v1",
+        &linked_scope.scope_digest,
+        &configuration_revision,
+        &foreign_provenance_revision,
+    ))
+    .expect("foreign-provenance configuration policy");
+    let refused = match first_service
+        .mount_observability_producer(
+            PathBuf::from("/project/observability-store-alias-foreign-provenance"),
+            database.clone(),
+            project_id.clone(),
+            configuration_revision.clone(),
+            foreign_provenance_revision,
+            foreign_policy_revision,
+        )
+        .await
+    {
+        Ok(_) => panic!("foreign provenance must not alias the store producer"),
+        Err(error) => error,
+    };
+    assert!(
+        refused.to_string().contains("already mounted"),
+        "unexpected provenance refusal: {refused}"
     );
     first
         .try_emit(envelope(&project_id, "alias:first"))
@@ -355,12 +412,13 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
             root.clone(),
             database.clone(),
             project_id.clone(),
-            digest('1'),
-            root_scope.scope_digest.clone(),
+            configuration_revision.clone(),
+            configuration_provenance_revision.clone(),
+            root_policy_revision.clone(),
         )
         .await
         .expect("remounted producer after quiescence");
-    assert!(Arc::ptr_eq(&remounted, &linked));
+    assert!(!Arc::ptr_eq(&remounted, &linked));
     assert_eq!(
         remounted.identity().process_boot_id,
         linked.identity().process_boot_id
@@ -384,8 +442,9 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
             root.clone(),
             database.clone(),
             project_id.clone(),
-            digest('1'),
-            root_scope.scope_digest.clone(),
+            configuration_revision.clone(),
+            configuration_provenance_revision.clone(),
+            root_policy_revision.clone(),
         )
         .await
         .expect("restarted producer");
@@ -423,6 +482,20 @@ async fn linked_roots_alias_one_store_producer_until_the_last_alias_shuts_down()
         .await
         .expect("query producer streams");
     assert_eq!(page.events.len(), 5);
+    let persisted_policies: BTreeMap<&str, &str> = page
+        .events
+        .iter()
+        .map(|event| (event.event_id.as_str(), event.policy_revision.as_str()))
+        .collect();
+    assert_eq!(
+        persisted_policies.get("alias:first").copied(),
+        Some(root_policy_revision.as_str())
+    );
+    assert_eq!(
+        persisted_policies.get("alias:linked").copied(),
+        Some(linked_policy_revision.as_str()),
+        "the linked-root frontend must stamp its own policy provenance"
+    );
     let mut streams: BTreeMap<&str, BTreeSet<u64>> = BTreeMap::new();
     for event in &page.events {
         streams
@@ -516,6 +589,7 @@ async fn exact_store_routing_collapses_linked_roots_without_crossing_stores() {
             database_a.clone(),
             project_id.clone(),
             digest('1'),
+            digest('0'),
             digest('2'),
         )
         .await
@@ -526,13 +600,18 @@ async fn exact_store_routing_collapses_linked_roots_without_crossing_stores() {
             database_a,
             project_id.clone(),
             digest('1'),
+            digest('0'),
             digest('2'),
         )
         .await
         .expect("linked profile A producer");
-    // Linked roots of one exact store alias one producer, and while that is
+    // Linked roots of one exact store alias one backend, and while that is
     // the only mounted store its exact identity routing resolves it.
-    assert!(Arc::ptr_eq(&producer_a, &linked_producer_a));
+    assert!(!Arc::ptr_eq(&producer_a, &linked_producer_a));
+    assert_eq!(
+        producer_a.identity().process_boot_id,
+        linked_producer_a.identity().process_boot_id
+    );
     let routed_a = service
         .observability_producer_for_brain_profile_project(&brain_id, &profile_id, &project_id)
         .expect("linked roots resolve one exact profile A store");
@@ -547,6 +626,7 @@ async fn exact_store_routing_collapses_linked_roots_without_crossing_stores() {
             database_b,
             project_id.clone(),
             digest('3'),
+            digest('0'),
             digest('4'),
         )
         .await
@@ -595,6 +675,7 @@ async fn last_alias_shutdown_keeps_the_store_retiring_until_drain_finishes() {
             database.clone(),
             project_id.clone(),
             digest('3'),
+            digest('0'),
             digest('4'),
         )
         .await
@@ -647,6 +728,7 @@ async fn last_alias_shutdown_keeps_the_store_retiring_until_drain_finishes() {
             database.clone(),
             project_id.clone(),
             digest('3'),
+            digest('0'),
             digest('5'),
         )
         .await
@@ -669,10 +751,163 @@ async fn last_alias_shutdown_keeps_the_store_retiring_until_drain_finishes() {
         .expect("clean project quiescence");
     drop(quiescence);
     service
-        .mount_observability_producer(linked_root, database, project_id, digest('3'), digest('5'))
+        .mount_observability_producer(
+            linked_root,
+            database,
+            project_id,
+            digest('3'),
+            digest('0'),
+            digest('5'),
+        )
         .await
         .expect("one replacement mounts after retirement");
     service.expire_all().await;
+}
+
+#[tokio::test]
+async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finishes() {
+    let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
+    let (_project, project_id, database) = runtime("observability-retiring-two-aliases").await;
+    let registry = StoreObservabilityRegistryV1::default();
+    let configuration_provenance_revision = digest('0');
+    let producer = BoundedObservabilityProducerV1::start(
+        database.clone(),
+        ObservabilityProducerIdentityV1 {
+            authorized_scope_ref: project_id.as_str().to_owned(),
+            process_boot_id: "daemon:retiring-two-aliases".to_owned(),
+            producer_revision: "producer.v1".to_owned(),
+            configuration_revision: digest('6').as_str().to_owned(),
+            policy_revision: digest('7').as_str().to_owned(),
+        },
+        1,
+    )
+    .expect("producer");
+    let first = registry
+        .acquire_or_start::<&'static str>(
+            &database,
+            &configuration_provenance_revision,
+            |_| false,
+            ObservabilityProducerIdentityV1::clone,
+            || "unexpected incumbent store producer",
+            || Ok(producer),
+            1,
+            |error| error,
+        )
+        .expect("first alias");
+    let linked = registry
+        .acquire_or_start::<&'static str>(
+            &database,
+            &configuration_provenance_revision,
+            |_| true,
+            |incumbent| {
+                let mut identity = incumbent.clone();
+                identity.policy_revision = digest('8').as_str().to_owned();
+                identity
+            },
+            || "unexpected incumbent refusal",
+            || Err("must not start a second producer"),
+            1,
+            |error| error,
+        )
+        .expect("linked alias");
+    let first_producer = first.producer();
+    let producer = linked.producer();
+    assert!(!Arc::ptr_eq(&first_producer, &producer));
+    assert_eq!(
+        first_producer.identity().process_boot_id,
+        producer.identity().process_boot_id
+    );
+
+    let blocker = database
+        .begin_write_transaction()
+        .await
+        .expect("hold registered writer");
+    producer
+        .try_emit(envelope(&project_id, "retiring:two-aliases:blocked"))
+        .expect("enqueue blocked event");
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let first = Arc::new(first);
+    let linked = Arc::new(linked);
+    let first_barrier = Arc::clone(&barrier);
+    let first_release = tokio::spawn(async move {
+        first_barrier.wait().await;
+        first.shutdown().await
+    });
+    let linked_barrier = Arc::clone(&barrier);
+    let linked_release = tokio::spawn(async move {
+        linked_barrier.wait().await;
+        linked.shutdown().await
+    });
+    barrier.wait().await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        let mut probe = 0_u64;
+        loop {
+            match producer.try_emit(envelope(
+                &project_id,
+                &format!("retiring:two-aliases:probe:{probe}"),
+            )) {
+                Err("observability_producer_closed") => break,
+                Err(error) => panic!("unexpected producer state: {error}"),
+                Ok(_) => {
+                    probe += 1;
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    })
+    .await
+    .expect("concurrent last release reaches the producer");
+
+    let retiring = registry.acquire_or_start::<&'static str>(
+        &database,
+        &configuration_provenance_revision,
+        |_| true,
+        ObservabilityProducerIdentityV1::clone,
+        || "unexpected incumbent refusal",
+        || panic!("retiring store must not start an overlapping producer"),
+        1,
+        |error| error,
+    );
+    assert!(matches!(retiring, Err("store_observability_retiring")));
+    blocker.commit().await.expect("release registered writer");
+    tokio::time::timeout(Duration::from_secs(3), async {
+        first_release
+            .await
+            .expect("first release task")
+            .expect("first alias release");
+        linked_release
+            .await
+            .expect("linked release task")
+            .expect("linked alias release");
+    })
+    .await
+    .expect("concurrent owner retirement completes");
+
+    let replacement = registry
+        .acquire_or_start::<&'static str>(
+            &database,
+            &configuration_provenance_revision,
+            |_| false,
+            ObservabilityProducerIdentityV1::clone,
+            || "unexpected incumbent store producer",
+            || {
+                BoundedObservabilityProducerV1::start(
+                    database.clone(),
+                    ObservabilityProducerIdentityV1 {
+                        authorized_scope_ref: project_id.as_str().to_owned(),
+                        process_boot_id: "daemon:retiring-two-aliases-replacement".to_owned(),
+                        producer_revision: "producer.v1".to_owned(),
+                        configuration_revision: digest('6').as_str().to_owned(),
+                        policy_revision: digest('7').as_str().to_owned(),
+                    },
+                    1,
+                )
+            },
+            1,
+            |error| error,
+        )
+        .expect("one replacement after both aliases release");
+    replacement.shutdown().await.expect("replacement shutdown");
 }
 
 #[tokio::test]
@@ -695,6 +930,7 @@ async fn dropped_last_alias_keeps_the_store_retiring_until_owners_release() {
     let registered = registry
         .acquire_or_start::<&'static str>(
             &database,
+            &digest('0'),
             |_| false,
             ObservabilityProducerIdentityV1::clone,
             || "unexpected incumbent store producer",
@@ -715,6 +951,7 @@ async fn dropped_last_alias_keeps_the_store_retiring_until_owners_release() {
 
     let retiring = registry.acquire_or_start::<&'static str>(
         &database,
+        &digest('0'),
         |_| true,
         ObservabilityProducerIdentityV1::clone,
         || "unexpected incumbent refusal",
@@ -741,6 +978,7 @@ async fn dropped_last_alias_keeps_the_store_retiring_until_owners_release() {
         loop {
             let attempt = registry.acquire_or_start::<&'static str>(
                 &database,
+                &digest('0'),
                 |_| true,
                 ObservabilityProducerIdentityV1::clone,
                 || "unexpected incumbent refusal",
@@ -796,6 +1034,7 @@ async fn registered_shutdown_reports_a_blocked_producer_flush() {
     let registered = registry
         .acquire_or_start::<&'static str>(
             &database,
+            &digest('0'),
             |_| false,
             ObservabilityProducerIdentityV1::clone,
             || "unexpected incumbent store producer",
@@ -829,6 +1068,7 @@ async fn registered_shutdown_reports_a_blocked_producer_flush() {
     let observed_start = Arc::clone(&start_called);
     let failed = registry.acquire_or_start::<&'static str>(
         &database,
+        &digest('0'),
         |_| true,
         ObservabilityProducerIdentityV1::clone,
         || "unexpected incumbent refusal",

--- a/src/daemon/service/project_runtime/observability_tests.rs
+++ b/src/daemon/service/project_runtime/observability_tests.rs
@@ -771,7 +771,8 @@ async fn last_alias_shutdown_keeps_the_store_retiring_until_drain_finishes() {
 #[tokio::test]
 async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finishes() {
     let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
-    let (_project, project_id, database) = runtime("observability-retiring-two-aliases").await;
+    let (_project, project_id, database, _runtime) =
+        runtime("observability-retiring-two-aliases").await;
     let registry = StoreObservabilityRegistryV1::default();
     let configuration_provenance_revision = digest('0');
     let producer = BoundedObservabilityProducerV1::start(

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -132,6 +132,7 @@ pub async fn dashboard_automation_authority_for_test(
             project_database,
             project_id.clone(),
             configuration.snapshot.effective_behavior_digest,
+            configuration.snapshot.resolution_provenance_digest,
             configuration_policy_digest,
         )
         .await?;


### PR DESCRIPTION
## Why

Merged #634 correctly retained one observability owner per exact registered store, but its linked-root alias stored a second mount identity without using it for emission. The shared producer overwrote B events with A policy, and same-configuration mounts with changed configuration provenance silently aliased.

## Fix

- give each linked root a real policy-stamping frontend over one shared queue, sequence, lifecycle, locks, and worker
- retain canonical configuration provenance on the store owner and refuse a different provenance before alias construction
- preserve exact-store/configuration safety and Active/Stopping/Failed retirement semantics
- cover durable B-policy persistence, provenance refusal, and concurrent two-alias last-release/remount behavior

## Evidence

- RED on 496bd52e: exact linked-root test ran 1 and failed because the B marker persisted A policy
- GREEN on this branch: exact linked-root test ran 1, passed
- GREEN on this branch: exact concurrent two-alias retirement test ran 1, passed
- repeated both exact tests after merging merged-#634 floor 8b11a11b: 1 passed each
- standalone rustfmt check, git diff --check, and commitlint pass

Corrective diff is exactly nine paths over 8b11a11b.