### PR TITLE
fix(storage): keep schema installation authority-bound

### DIFF
--- a/crates/tracedecay-global-db/src/schema_stages.rs
+++ b/crates/tracedecay-global-db/src/schema_stages.rs
@@ -522,7 +522,7 @@ pub async fn ensure_registered_schema_for_admission(
     let is_fresh = configuration_fresh.is_some();
     let force_exhaustive = !authority_invariant_triggers_intact(installation).await?;
     let transaction = installation
-        .begin_immediate()
+        .begin_atomic_schema_transaction()
         .await
         .map_err(|error| global_db_operation_error(OPERATION, error))?;
 

--- a/crates/tracedecay-runtime-core/src/ports.rs
+++ b/crates/tracedecay-runtime-core/src/ports.rs
@@ -30,9 +30,7 @@ pub mod registered_schema {
     use std::pin::Pin;
     use std::sync::OnceLock;
 
-    use crate::db::engine::{
-        Connection, Executor, QueryExecutor, Transaction, TransactionBehavior,
-    };
+    use crate::db::engine::{Connection, Executor, QueryExecutor, Transaction};
     use crate::errors::{Result, TraceDecayError};
     use tracedecay_store::StoreRuntimeBindingV1;
 
@@ -47,9 +45,10 @@ pub mod registered_schema {
         connection: Connection,
     }
 
-    /// An immediate schema-installation transaction tied to its initializing
+    /// An atomic schema-installation transaction tied to its initializing
     /// capability. The lifetime keeps the authorized installation connection
-    /// alive through commit, rollback, or drop.
+    /// alive through commit, rollback, or drop, while long-running batches
+    /// continuously revalidate the same write authority.
     pub struct RegisteredSchemaInstallationTransactionV1<'a> {
         transaction: Transaction,
         _installation: &'a RegisteredSchemaInstallationV1,
@@ -90,13 +89,17 @@ pub mod registered_schema {
             self.connection.execute_batch(sql).await
         }
 
-        /// Begins the only ordinary write transaction available to a
-        /// registered-schema installer.
-        pub async fn begin_immediate(
+        /// Begins the authority-bound transaction used for one atomic schema
+        /// installation.
+        ///
+        /// The long lease renews only when bounded work makes progress.
+        /// Shutdown, idleness, and authority revocation remain cancellation
+        /// conditions; this does not widen any statement or lease timeout.
+        pub async fn begin_atomic_schema_transaction(
             &self,
         ) -> crate::db::engine::Result<RegisteredSchemaInstallationTransactionV1<'_>> {
             self.connection
-                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .authorized_long_lease_transaction()
                 .await
                 .map(|transaction| RegisteredSchemaInstallationTransactionV1 {
                     transaction,
@@ -169,7 +172,9 @@ pub mod registered_schema {
         }
 
         pub async fn execute_batch(&self, sql: &str) -> crate::db::engine::Result<()> {
-            self.transaction.execute_batch(sql).await
+            self.transaction
+                .execute_authority_revalidated_batch(sql)
+                .await
         }
 
         pub async fn commit(self) -> crate::db::engine::Result<()> {
@@ -297,7 +302,32 @@ pub mod registered_schema {
 
     #[cfg(test)]
     mod tests {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use tracedecay_rusqlite_runtime::exact_sql::{
+            ExactSqlError, ExactSqlWriteAuthority, ExactSqlWriteIntent,
+        };
+
         use super::*;
+
+        struct CountingSchemaAuthority {
+            batch_checks: AtomicUsize,
+        }
+
+        impl ExactSqlWriteAuthority for CountingSchemaAuthority {
+            fn verify(
+                &self,
+                intent: ExactSqlWriteIntent,
+            ) -> std::result::Result<(), ExactSqlError> {
+                if intent == ExactSqlWriteIntent::ExecuteBatch {
+                    self.batch_checks.fetch_add(1, Ordering::AcqRel);
+                }
+                Ok(())
+            }
+        }
 
         #[test]
         fn installer_signature_borrows_only_the_sealed_installation_capability() {
@@ -326,6 +356,53 @@ pub mod registered_schema {
                 rendered.contains("no registered global/session schema installer is registered"),
                 "unexpected fail-closed message: {rendered}"
             );
+        }
+
+        #[tokio::test]
+        async fn registered_schema_transaction_revalidates_authority_during_atomic_batch() {
+            let directory = tempfile::tempdir().unwrap();
+            let authority = Arc::new(CountingSchemaAuthority {
+                batch_checks: AtomicUsize::new(0),
+            });
+            let connection = crate::db::engine::TestConnection::open_with_write_authority(
+                &directory.path().join("registered-schema.sqlite3"),
+                authority.clone(),
+            );
+            let installation =
+                RegisteredSchemaInstallationV1::from_authorized_connection((*connection).clone());
+            let transaction = installation
+                .begin_atomic_schema_transaction()
+                .await
+                .unwrap();
+
+            transaction
+                .execute_batch(
+                    "CREATE TABLE registered_schema_authority_probe (value INTEGER NOT NULL);
+                     WITH RECURSIVE values_to_install(value) AS (
+                         VALUES(1)
+                         UNION ALL
+                         SELECT value + 1 FROM values_to_install WHERE value < 10000
+                     )
+                     INSERT INTO registered_schema_authority_probe
+                     SELECT value FROM values_to_install;",
+                )
+                .await
+                .unwrap();
+            transaction.commit().await.unwrap();
+
+            assert!(
+                authority.batch_checks.load(Ordering::Acquire) > 2,
+                "schema authority must be revalidated while one atomic batch makes progress"
+            );
+            let mut rows = connection
+                .query("SELECT COUNT(*) FROM registered_schema_authority_probe", ())
+                .await
+                .unwrap();
+            assert_eq!(
+                rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+                10000
+            );
+            assert!(rows.next().await.unwrap().is_none());
         }
     }
 }


### PR DESCRIPTION
## Outcome

Fresh profile/session schema installation now uses the existing authority-bound long-lease transaction and continuously revalidates write authority while each DDL batch makes progress. The installation remains one atomic admission transaction: commit, rollback, shutdown cancellation, authority revocation, and fail-closed behavior are preserved. No lease or statement timeout changed, and the transaction was not split.

Exact base: `d13a0135320919295910572fac86457c26dbbe26`
Exact head: `bcdbf824e6af211b66369c6299568543f3c475cf`

Changed paths:
- `crates/tracedecay-runtime-core/src/ports.rs`
- `crates/tracedecay-global-db/src/schema_stages.rs`

## TDD evidence

RED (before production change):
- `registered_schema_transaction_revalidates_authority_during_atomic_batch`: 0 passed, 1 failed, 672 filtered. The real 10,000-row DDL batch committed, but the authority was checked only at its boundaries rather than during progress.

GREEN:
- same exact runtime-core regression: 1 passed, 0 failed, 672 filtered
- `long_lease_transaction_renews_its_lease_after_successful_bounded_steps`: 1 passed, 0 failed, 289 filtered
- `authority_revalidated_batch_has_no_guessed_deadline_and_rechecks_authority`: 1 passed, 0 failed, 289 filtered
- `cargo clippy -p tracedecay-runtime-core -p tracedecay-global-db --lib --tests --locked -- -D warnings`
- rustfmt, `git diff --check`, and exact commitlint

This addresses the fresh-enrollment schema lease failure without masking the measured beta.33 swap/starvation pressure by inflating timeouts.