### PR TITLE
fix(agent-hosts): bind overlap tombstones to exact pairs

### DIFF
--- a/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
@@ -741,6 +741,7 @@ mod transaction_tests {
     use super::*;
     use std::sync::{Arc, Barrier};
     use std::time::Duration;
+    use tracedecay_automation::run_labels::SKILL_OVERLAP_REMOVAL_TOMBSTONE;
 
     fn skill(id: &str, body: &str) -> ManagedSkill {
         ManagedSkillDraft {
@@ -776,6 +777,7 @@ mod transaction_tests {
         next_a.body_markdown = "# A\nnew".to_string();
         next_a.refresh_checksum();
         let mut next_b = original_b.clone();
+        next_b.metadata.archived_reason = Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE.to_string());
         next_b.set_state(ManagedSkillState::Archived);
         let root = managed_skill_root(profile);
         let nonce = 7;
@@ -799,6 +801,10 @@ mod transaction_tests {
         let loaded_b = load_managed_skill(profile, "skill-b").await.unwrap();
         assert_eq!(loaded_a.body_markdown, "# A\nnew");
         assert_eq!(loaded_b.metadata.state, ManagedSkillState::Archived);
+        assert_eq!(
+            loaded_b.metadata.archived_reason.as_deref(),
+            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
+        );
         assert!(!root.join(SKILL_TRANSACTION_JOURNAL).exists());
         assert!(
             journal
@@ -857,6 +863,75 @@ mod transaction_tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("source and target must differ"));
+    }
+
+    #[tokio::test]
+    async fn archive_authority_rejects_the_reserved_overlap_tombstone() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path();
+        let original = skill("unrelated-archive", "# Unrelated archive");
+        save_managed_skill(profile, &original).await.unwrap();
+
+        let error = apply_managed_skill_archive(
+            profile,
+            &original.metadata.id,
+            &original.metadata.checksum,
+            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE.to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("reserved skill-overlap tombstone")
+        );
+        assert_eq!(
+            load_managed_skill(profile, &original.metadata.id)
+                .await
+                .unwrap(),
+            original
+        );
+    }
+
+    #[tokio::test]
+    async fn consolidation_authority_rejects_the_reserved_overlap_tombstone() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path();
+        let target = skill("unrelated-target", "# Unrelated target");
+        let source = skill("unrelated-source", "# Unrelated source");
+        save_managed_skill(profile, &target).await.unwrap();
+        save_managed_skill(profile, &source).await.unwrap();
+
+        let error = apply_managed_skill_consolidation(
+            profile,
+            Some(&target.metadata.id),
+            Some(&target.metadata.checksum),
+            None,
+            &source.metadata.id,
+            &source.metadata.checksum,
+            SKILL_OVERLAP_REMOVAL_TOMBSTONE,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("reserved skill-overlap tombstone")
+        );
+        assert_eq!(
+            load_managed_skill(profile, &target.metadata.id)
+                .await
+                .unwrap(),
+            target
+        );
+        assert_eq!(
+            load_managed_skill(profile, &source.metadata.id)
+                .await
+                .unwrap(),
+            source
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
@@ -469,6 +469,24 @@ fn validate_autonomous_consolidation_skill(skill: &ManagedSkill, checksum: &str)
     Ok(())
 }
 
+fn validate_overlap_partner(skill: &ManagedSkill, checksum: &str) -> Result<()> {
+    let id = &skill.metadata.id;
+    if skill.metadata.checksum != checksum {
+        return Err(config_error(format!(
+            "base_checksum for managed skill id '{id}' is stale"
+        )));
+    }
+    if skill.metadata.pinned {
+        return Err(config_error(format!(
+            "managed skill '{id}' is pinned and exempt from consolidation"
+        )));
+    }
+    if skill.metadata.state != ManagedSkillState::Active {
+        return Err(config_error(format!("managed skill '{id}' is not active")));
+    }
+    Ok(())
+}
+
 pub fn managed_skill_dir(profile_root: &Path, id: &str) -> Result<PathBuf> {
     validate_skill_id(id)?;
     Ok(managed_skill_root(profile_root).join(id))
@@ -730,7 +748,7 @@ pub(crate) async fn apply_managed_skill_overlap_archive(
     let source = load_managed_skill_unlocked(profile_root, source_id)?;
     validate_autonomous_consolidation_skill(&source, source_checksum)?;
     let overlap = load_managed_skill_unlocked(profile_root, overlap_id)?;
-    validate_autonomous_consolidation_skill(&overlap, overlap_checksum)?;
+    validate_overlap_partner(&overlap, overlap_checksum)?;
     validate_detected_skill_overlap_pair(&source, &overlap)?;
     let skill = apply_managed_skill_archive_unlocked(
         profile_root,

--- a/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
@@ -7,6 +7,7 @@ use super::config_error;
 use crate::errors::Result;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use tracedecay_automation::run_labels::SKILL_OVERLAP_REMOVAL_TOMBSTONE;
 use tracedecay_private_fs::framed_log::DirectorySyncPolicy;
 
 pub use super::managed_skill_model::{
@@ -32,6 +33,20 @@ pub struct SkillConsolidationResult {
     pub target_after_checksum: Option<String>,
     pub source_before_checksum: String,
     pub source_after_checksum: String,
+}
+
+enum SkillConsolidationKind<'a> {
+    General(&'a str),
+    DetectedOverlap,
+}
+
+impl SkillConsolidationKind<'_> {
+    fn archived_reason(&self) -> &str {
+        match self {
+            Self::General(reason) => reason,
+            Self::DetectedOverlap => SKILL_OVERLAP_REMOVAL_TOMBSTONE,
+        }
+    }
 }
 
 struct SkillStoreLock(File);
@@ -306,6 +321,48 @@ pub async fn apply_managed_skill_consolidation(
     source_checksum: &str,
     reason: &str,
 ) -> Result<SkillConsolidationResult> {
+    reject_reserved_overlap_tombstone(Some(reason))?;
+    apply_managed_skill_consolidation_kind(
+        profile_root,
+        target_id,
+        target_checksum,
+        target_update,
+        source_id,
+        source_checksum,
+        SkillConsolidationKind::General(reason),
+    )
+    .await
+}
+
+pub(crate) async fn apply_managed_skill_overlap_consolidation(
+    profile_root: &Path,
+    target_id: &str,
+    target_checksum: &str,
+    target_update: Option<ManagedSkillUpdate>,
+    source_id: &str,
+    source_checksum: &str,
+) -> Result<SkillConsolidationResult> {
+    apply_managed_skill_consolidation_kind(
+        profile_root,
+        Some(target_id),
+        Some(target_checksum),
+        target_update,
+        source_id,
+        source_checksum,
+        SkillConsolidationKind::DetectedOverlap,
+    )
+    .await
+}
+
+async fn apply_managed_skill_consolidation_kind(
+    profile_root: &Path,
+    target_id: Option<&str>,
+    target_checksum: Option<&str>,
+    target_update: Option<ManagedSkillUpdate>,
+    source_id: &str,
+    source_checksum: &str,
+    kind: SkillConsolidationKind<'_>,
+) -> Result<SkillConsolidationResult> {
     if target_id == Some(source_id) {
         return Err(config_error(
             "managed skill consolidation source and target must differ",
@@ -329,6 +386,13 @@ pub async fn apply_managed_skill_consolidation(
         None => None,
     };
 
+    if matches!(&kind, SkillConsolidationKind::DetectedOverlap) {
+        let target = target
+            .as_ref()
+            .ok_or_else(|| config_error("skill-overlap consolidation requires an exact target"))?;
+        validate_detected_skill_overlap_pair(target, &source)?;
+    }
+
     if let (Some(target), Some(update)) = (&mut target, target_update)
         && apply_managed_skill_update_fields(target, update)?
     {
@@ -337,7 +401,7 @@ pub async fn apply_managed_skill_consolidation(
     }
 
     source.metadata.absorbed_into = target_id.map(ToOwned::to_owned);
-    source.metadata.archived_reason = Some(reason.to_string());
+    source.metadata.archived_reason = Some(kind.archived_reason().to_string());
     source.set_state(ManagedSkillState::Archived);
     let mut revisions: Vec<&ManagedSkill> = target.iter().collect();
     revisions.push(&source);
@@ -360,6 +424,24 @@ pub async fn apply_managed_skill_consolidation(
         target,
         source,
     })
+}
+
+fn validate_detected_skill_overlap_pair(first: &ManagedSkill, second: &ManagedSkill) -> Result<()> {
+    let skills = [first.clone(), second.clone()];
+    let detected = super::skill_usage::skill_overlap_candidates(&skills, 1)
+        .into_iter()
+        .any(|candidate| {
+            (candidate.skill_a == first.metadata.id && candidate.skill_b == second.metadata.id)
+                || (candidate.skill_a == second.metadata.id
+                    && candidate.skill_b == first.metadata.id)
+        });
+    if !detected {
+        return Err(config_error(format!(
+            "managed skills '{}' and '{}' are not a detected overlap candidate pair",
+            first.metadata.id, second.metadata.id
+        )));
+    }
+    Ok(())
 }
 
 fn validate_autonomous_consolidation_skill(skill: &ManagedSkill, checksum: &str) -> Result<()> {
@@ -624,11 +706,50 @@ pub async fn apply_managed_skill_archive(
     base_checksum: &str,
     reason: Option<String>,
 ) -> Result<ManagedSkill> {
+    reject_reserved_overlap_tombstone(reason.as_deref())?;
     let lock = lock_skill_store_async(profile_root).await?;
     let skill = apply_managed_skill_archive_unlocked(profile_root, id, base_checksum, reason)?;
     drop(lock);
     record_skill_patch_best_effort(profile_root, &skill, "automatic_archive").await;
     Ok(skill)
+}
+
+pub(crate) async fn apply_managed_skill_overlap_archive(
+    profile_root: &Path,
+    source_id: &str,
+    source_checksum: &str,
+    overlap_id: &str,
+    overlap_checksum: &str,
+) -> Result<ManagedSkill> {
+    if source_id == overlap_id {
+        return Err(config_error(
+            "skill-overlap archive source and partner must differ",
+        ));
+    }
+    let lock = lock_skill_store_async(profile_root).await?;
+    let source = load_managed_skill_unlocked(profile_root, source_id)?;
+    validate_autonomous_consolidation_skill(&source, source_checksum)?;
+    let overlap = load_managed_skill_unlocked(profile_root, overlap_id)?;
+    validate_autonomous_consolidation_skill(&overlap, overlap_checksum)?;
+    validate_detected_skill_overlap_pair(&source, &overlap)?;
+    let skill = apply_managed_skill_archive_unlocked(
+        profile_root,
+        source_id,
+        source_checksum,
+        Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE.to_string()),
+    )?;
+    drop(lock);
+    record_skill_patch_best_effort(profile_root, &skill, "automatic_archive").await;
+    Ok(skill)
+}
+
+fn reject_reserved_overlap_tombstone(reason: Option<&str>) -> Result<()> {
+    if reason == Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE) {
+        return Err(config_error(
+            "reserved skill-overlap tombstone requires exact overlap authority",
+        ));
+    }
+    Ok(())
 }
 
 fn apply_managed_skill_archive_unlocked(
@@ -741,7 +862,6 @@ mod transaction_tests {
     use super::*;
     use std::sync::{Arc, Barrier};
     use std::time::Duration;
-    use tracedecay_automation::run_labels::SKILL_OVERLAP_REMOVAL_TOMBSTONE;
 
     fn skill(id: &str, body: &str) -> ManagedSkill {
         ManagedSkillDraft {
@@ -925,6 +1045,44 @@ mod transaction_tests {
                 .await
                 .unwrap(),
             target
+        );
+        assert_eq!(
+            load_managed_skill(profile, &source.metadata.id)
+                .await
+                .unwrap(),
+            source
+        );
+    }
+
+    #[tokio::test]
+    async fn overlap_archive_authority_rejects_an_unrelated_exact_pair() {
+        let temp = tempfile::tempdir().unwrap();
+        let profile = temp.path();
+        let source = skill(
+            "rust-errors",
+            "# Rust errors\nModel failures with typed enums and explicit conversions.",
+        );
+        let partner = skill(
+            "dashboard-layout",
+            "# Dashboard layout\nAlign responsive cards with accessible navigation.",
+        );
+        save_managed_skill(profile, &source).await.unwrap();
+        save_managed_skill(profile, &partner).await.unwrap();
+
+        let error = apply_managed_skill_overlap_archive(
+            profile,
+            &source.metadata.id,
+            &source.metadata.checksum,
+            &partner.metadata.id,
+            &partner.metadata.checksum,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("not a detected overlap candidate pair")
         );
         assert_eq!(
             load_managed_skill(profile, &source.metadata.id)

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -375,6 +375,32 @@ mod tests {
         skills[id].metadata.checksum.clone()
     }
 
+    #[cfg(unix)]
+    fn replace_usage_ledger_with_blocking_fifo(
+        profile_root: &Path,
+    ) -> (std::fs::File, std::path::PathBuf) {
+        let ledger_path = skill_usage_ledger_path(profile_root);
+        match std::fs::remove_file(&ledger_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("remove usage ledger before FIFO replacement: {error}"),
+        }
+        assert!(
+            std::process::Command::new("mkfifo")
+                .arg(&ledger_path)
+                .status()
+                .expect("run mkfifo")
+                .success(),
+            "the production usage-ledger read must block on a real FIFO"
+        );
+        let control = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&ledger_path)
+            .expect("open FIFO control handle without blocking");
+        (control, ledger_path)
+    }
+
     #[test]
     fn archive_proposals_validate_ids_checksums_and_exemptions() {
         let skills = consolidation_fixture();
@@ -783,18 +809,54 @@ mod tests {
         );
     }
 
-    /// Replaces the usage ledger file with a directory so every post-commit
-    /// usage sync fails at its real filesystem boundary. The typed tombstone
-    /// must then come from the commit transaction alone.
-    fn break_usage_sync(profile_root: &Path) {
-        let ledger_path = skill_usage_ledger_path(profile_root);
-        std::fs::remove_file(&ledger_path).unwrap();
-        std::fs::create_dir(&ledger_path).unwrap();
-        assert!(ledger_path.is_dir());
+    #[tokio::test]
+    async fn archive_refuses_a_changed_exact_overlap_partner() {
+        let profile = tempfile::tempdir().unwrap();
+        let skills = persisted_consolidation_fixture(profile.path()).await;
+        let archive = skill_archive_from_proposal(
+            &json!({
+                "action": "archive",
+                "id": "workflow-b",
+                "base_checksum": checksum(&skills, "workflow-b"),
+                "reason": "duplicate guidance"
+            }),
+            &skills,
+        )
+        .unwrap();
+        apply_managed_skill_update(
+            profile.path(),
+            "workflow-a",
+            &checksum(&skills, "workflow-a"),
+            ManagedSkillUpdate {
+                body_markdown: Some(
+                    "Model library failures with explicit error enums and no automation guidance."
+                        .to_string(),
+                ),
+                ..ManagedSkillUpdate::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = apply_skill_archive(profile.path(), &archive)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("base_checksum for managed skill id 'workflow-a' is stale")
+        );
+        let source = load_managed_skill(profile.path(), "workflow-b")
+            .await
+            .unwrap();
+        assert_eq!(source.metadata.state, ManagedSkillState::Active);
+        assert_eq!(source.metadata.archived_reason, None);
     }
 
-    #[tokio::test]
-    async fn archive_commit_durably_carries_tombstone_despite_usage_sync_failure() {
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn archive_persists_tombstone_before_postcommit_usage_sync_can_be_cancelled() {
         let profile = tempfile::tempdir().unwrap();
         let skills = persisted_consolidation_fixture(profile.path()).await;
         let proposal = json!({
@@ -804,36 +866,63 @@ mod tests {
             "reason": "duplicate guidance"
         });
         let archive = skill_archive_from_proposal(&proposal, &skills).unwrap();
-        break_usage_sync(profile.path());
+        let (fifo_control, ledger_path) = replace_usage_ledger_with_blocking_fifo(profile.path());
+        let profile_root = profile.path().to_path_buf();
+        let archive_for_task = archive.clone();
+        let mut task =
+            tokio::spawn(
+                async move { apply_skill_archive(&profile_root, &archive_for_task).await },
+            );
 
-        let archived = apply_skill_archive(profile.path(), &archive)
-            .await
-            .expect("committed archive must succeed despite best-effort sync failure");
-
-        assert_eq!(archived.metadata.state, ManagedSkillState::Archived);
-        assert_eq!(
-            archived.metadata.archived_reason.as_deref(),
-            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
-        );
-        let committed = load_managed_skill(profile.path(), "workflow-b")
-            .await
-            .unwrap();
+        let committed = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                tokio::select! {
+                    result = &mut task => {
+                        panic!("archive exited before its committed revision was observable: {result:?}");
+                    }
+                    loaded = load_managed_skill(profile.path(), "workflow-b") => {
+                        let loaded = loaded.expect("load archive candidate through the production store");
+                        if loaded.metadata.state == ManagedSkillState::Archived {
+                            break loaded;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("archive commit becomes observable before usage sync completes");
         assert_eq!(committed.metadata.state, ManagedSkillState::Archived);
         assert_eq!(
             committed.metadata.archived_reason.as_deref(),
             Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE),
-            "the archive commit must durably carry its typed tombstone even when \
-             post-commit usage sync never succeeds"
+            "the archive commit must durably carry its typed tombstone before \
+             post-commit usage sync completes"
         );
+        task.abort();
+        drop(fifo_control);
         assert!(
-            skill_usage_ledger_path(profile.path()).is_dir(),
-            "usage sync must not have replaced the broken ledger, so the \
-             tombstone cannot have come from the sync phase"
+            tokio::time::timeout(std::time::Duration::from_secs(2), &mut task)
+                .await
+                .expect("cancelled archive task joins")
+                .unwrap_err()
+                .is_cancelled()
+        );
+        std::fs::remove_file(ledger_path).expect("remove usage-ledger FIFO");
+        assert_eq!(
+            load_managed_skill(profile.path(), "workflow-b")
+                .await
+                .unwrap()
+                .metadata
+                .archived_reason
+                .as_deref(),
+            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
         );
     }
 
-    #[tokio::test]
-    async fn merge_commit_durably_carries_tombstone_despite_usage_sync_failure() {
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn merge_persists_tombstone_before_postcommit_usage_sync_can_be_cancelled() {
         let profile = tempfile::tempdir().unwrap();
         let skills = persisted_consolidation_fixture(profile.path()).await;
         let proposal = json!({
@@ -845,18 +934,36 @@ mod tests {
             "reason": "duplicate guidance"
         });
         let merge = skill_merge_from_proposal(&proposal, &skills).unwrap();
-        break_usage_sync(profile.path());
+        let (fifo_control, ledger_path) = replace_usage_ledger_with_blocking_fifo(profile.path());
+        let profile_root = profile.path().to_path_buf();
+        let merge_for_task = merge.clone();
+        let mut task =
+            tokio::spawn(async move { apply_skill_merge(&profile_root, &merge_for_task).await });
 
-        let (source, _target) = apply_skill_merge(profile.path(), &merge)
+        let committed_source =
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                loop {
+                    tokio::select! {
+                        result = &mut task => {
+                            panic!("merge exited before its committed source was observable: {result:?}");
+                        }
+                        loaded = load_managed_skill(profile.path(), "workflow-b") => {
+                            let loaded = loaded.expect("load merge source through the production store");
+                            if loaded.metadata.state == ManagedSkillState::Archived {
+                                break loaded;
+                            }
+                            tokio::task::yield_now().await;
+                        }
+                    }
+                }
+            })
             .await
-            .expect("committed merge must succeed despite best-effort sync failure");
-
-        assert_eq!(source.metadata.state, ManagedSkillState::Archived);
-        assert_eq!(source.metadata.absorbed_into.as_deref(), Some("workflow-a"));
-        let committed_source = load_managed_skill(profile.path(), "workflow-b")
-            .await
-            .unwrap();
-        assert_eq!(committed_source.metadata.state, ManagedSkillState::Archived);
+            .expect("merge commit becomes observable before usage sync completes");
+        assert_eq!(
+            committed_source.metadata.state,
+            ManagedSkillState::Archived,
+            "the cancellation gate must run after the merge commit"
+        );
         assert_eq!(
             committed_source.metadata.absorbed_into.as_deref(),
             Some("workflow-a")
@@ -864,13 +971,27 @@ mod tests {
         assert_eq!(
             committed_source.metadata.archived_reason.as_deref(),
             Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE),
-            "the merge commit must durably carry its typed tombstone even when \
-             post-commit usage sync never succeeds"
+            "the merge commit must durably carry its typed tombstone before \
+             post-commit usage sync completes"
         );
+        task.abort();
+        drop(fifo_control);
         assert!(
-            skill_usage_ledger_path(profile.path()).is_dir(),
-            "usage sync must not have replaced the broken ledger, so the \
-             tombstone cannot have come from the sync phase"
+            tokio::time::timeout(std::time::Duration::from_secs(2), &mut task)
+                .await
+                .expect("cancelled merge task joins")
+                .unwrap_err()
+                .is_cancelled()
+        );
+        std::fs::remove_file(ledger_path).expect("remove usage-ledger FIFO");
+        assert_eq!(
+            load_managed_skill(profile.path(), "workflow-b")
+                .await
+                .unwrap()
+                .metadata
+                .archived_reason
+                .as_deref(),
+            Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
         );
     }
 

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -285,6 +285,7 @@ mod tests {
         ManagedSkillDraft, ManagedSkillProvenance, ManagedSupportFile, apply_managed_skill_update,
         create_managed_skill, default_managed_skill_targets, load_managed_skill,
     };
+    #[cfg(unix)]
     use super::super::super::skill_usage::skill_usage_ledger_path;
     use super::super::skill_proposal_action;
     use super::*;

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -410,7 +410,7 @@ mod tests {
     #[cfg(unix)]
     fn replace_usage_ledger_with_blocking_fifo(
         profile_root: &Path,
-    ) -> (std::fs::File, std::path::PathBuf) {
+    ) -> (std::thread::JoinHandle<std::fs::File>, std::path::PathBuf) {
         let ledger_path = skill_usage_ledger_path(profile_root);
         match std::fs::remove_file(&ledger_path) {
             Ok(()) => {}
@@ -425,12 +425,28 @@ mod tests {
                 .success(),
             "the production usage-ledger read must block on a real FIFO"
         );
-        let control = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&ledger_path)
-            .expect("open FIFO control handle without blocking");
-        (control, ledger_path)
+        let writer_path = ledger_path.clone();
+        let writer = std::thread::spawn(move || {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .open(writer_path)
+                .expect("open FIFO writer after the production reader arrives")
+        });
+        (writer, ledger_path)
+    }
+
+    #[cfg(unix)]
+    async fn await_usage_ledger_reader(
+        writer: std::thread::JoinHandle<std::fs::File>,
+    ) -> std::fs::File {
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !writer.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("production usage-ledger reader opens the FIFO");
+        writer.join().expect("FIFO writer thread joins")
     }
 
     #[test]
@@ -900,7 +916,7 @@ mod tests {
             "reason": "duplicate guidance"
         });
         let archive = skill_archive_from_proposal(&proposal, &skills).unwrap();
-        let (fifo_control, ledger_path) = replace_usage_ledger_with_blocking_fifo(profile.path());
+        let (fifo_writer, ledger_path) = replace_usage_ledger_with_blocking_fifo(profile.path());
         let profile_root = profile.path().to_path_buf();
         let archive_for_task = archive.clone();
         let mut task =
@@ -933,8 +949,13 @@ mod tests {
             "the archive commit must durably carry its typed tombstone before \
              post-commit usage sync completes"
         );
+        let fifo_writer = await_usage_ledger_reader(fifo_writer).await;
+        assert!(
+            !task.is_finished(),
+            "archive remains blocked at the production usage-ledger read"
+        );
         task.abort();
-        drop(fifo_control);
+        drop(fifo_writer);
         assert!(
             tokio::time::timeout(std::time::Duration::from_secs(2), &mut task)
                 .await
@@ -968,7 +989,7 @@ mod tests {
             "reason": "duplicate guidance"
         });
         let merge = skill_merge_from_proposal(&proposal, &skills).unwrap();
-        let (fifo_control, ledger_path) = replace_usage_ledger_with_blocking_fifo(profile.path());
+        let (fifo_writer, ledger_path) = replace_usage_ledger_with_blocking_fifo(profile.path());
         let profile_root = profile.path().to_path_buf();
         let merge_for_task = merge.clone();
         let mut task =
@@ -1008,8 +1029,13 @@ mod tests {
             "the merge commit must durably carry its typed tombstone before \
              post-commit usage sync completes"
         );
+        let fifo_writer = await_usage_ledger_reader(fifo_writer).await;
+        assert!(
+            !task.is_finished(),
+            "merge remains blocked at the production usage-ledger read"
+        );
         task.abort();
-        drop(fifo_control);
+        drop(fifo_writer);
         assert!(
             tokio::time::timeout(std::time::Duration::from_secs(2), &mut task)
                 .await

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -6,7 +6,8 @@ use tracedecay_automation::run_labels::SKILL_OVERLAP_REMOVAL_TOMBSTONE;
 
 use super::super::managed_skills::{
     ManagedSkill, ManagedSkillSource, ManagedSkillState, ManagedSkillUpdate,
-    apply_managed_skill_archive, apply_managed_skill_consolidation, preview_managed_skill_update,
+    apply_managed_skill_overlap_archive, apply_managed_skill_overlap_consolidation,
+    preview_managed_skill_update,
 };
 use super::super::skill_usage::{DEFAULT_SKILL_OVERLAP_LIMIT, skill_overlap_candidates};
 use super::{
@@ -19,6 +20,8 @@ use crate::errors::Result;
 pub(super) struct SkillArchiveProposal {
     pub(super) skill_id: String,
     pub(super) base_checksum: String,
+    pub(super) overlap_skill_id: String,
+    pub(super) overlap_base_checksum: String,
 }
 
 #[derive(Debug, Clone)]
@@ -66,20 +69,35 @@ fn required_consolidation_reason(value: Option<&Value>) -> std::result::Result<S
     Ok(reason)
 }
 
-fn is_detected_overlap_candidate(
+fn is_detected_overlap_pair(
     existing_skills: &BTreeMap<String, ManagedSkill>,
-    skill_id: &str,
-    paired_skill_id: Option<&str>,
+    first_skill_id: &str,
+    second_skill_id: &str,
 ) -> bool {
     let skills = existing_skills.values().cloned().collect::<Vec<_>>();
     skill_overlap_candidates(&skills, DEFAULT_SKILL_OVERLAP_LIMIT)
         .iter()
-        .any(|candidate| match paired_skill_id {
-            Some(paired_skill_id) => {
-                (candidate.skill_a == skill_id && candidate.skill_b == paired_skill_id)
-                    || (candidate.skill_a == paired_skill_id && candidate.skill_b == skill_id)
+        .any(|candidate| {
+            (candidate.skill_a == first_skill_id && candidate.skill_b == second_skill_id)
+                || (candidate.skill_a == second_skill_id && candidate.skill_b == first_skill_id)
+        })
+}
+
+fn detected_overlap_partner(
+    existing_skills: &BTreeMap<String, ManagedSkill>,
+    skill_id: &str,
+) -> Option<String> {
+    let skills = existing_skills.values().cloned().collect::<Vec<_>>();
+    skill_overlap_candidates(&skills, DEFAULT_SKILL_OVERLAP_LIMIT)
+        .into_iter()
+        .find_map(|candidate| {
+            if candidate.skill_a == skill_id {
+                Some(candidate.skill_b)
+            } else if candidate.skill_b == skill_id {
+                Some(candidate.skill_a)
+            } else {
+                None
             }
-            None => candidate.skill_a == skill_id || candidate.skill_b == skill_id,
         })
 }
 
@@ -94,14 +112,27 @@ pub(super) fn skill_archive_from_proposal(
     let base_checksum = required_proposal_string(object.get("base_checksum"), "base_checksum")?;
     required_consolidation_reason(object.get("reason"))?;
     consolidation_guard(existing_skills, &id, &base_checksum, "archive")?;
-    if !is_detected_overlap_candidate(existing_skills, &id, None) {
-        return Err(format!(
-            "managed skill '{id}' is not a detected overlap candidate"
-        ));
-    }
+    let overlap_skill_id = detected_overlap_partner(existing_skills, &id)
+        .ok_or_else(|| format!("managed skill '{id}' is not a detected overlap candidate"))?;
+    let overlap_base_checksum = existing_skills
+        .get(&overlap_skill_id)
+        .ok_or_else(|| {
+            format!("detected overlap partner managed skill id '{overlap_skill_id}' does not exist")
+        })?
+        .metadata
+        .checksum
+        .clone();
+    consolidation_guard(
+        existing_skills,
+        &overlap_skill_id,
+        &overlap_base_checksum,
+        "archive overlap partner",
+    )?;
     Ok(SkillArchiveProposal {
         skill_id: id,
         base_checksum,
+        overlap_skill_id,
+        overlap_base_checksum,
     })
 }
 
@@ -129,7 +160,7 @@ pub(super) fn skill_merge_from_proposal(
         &source_base_checksum,
         "merge source",
     )?;
-    if !is_detected_overlap_candidate(existing_skills, &target_skill_id, Some(&source_skill_id)) {
+    if !is_detected_overlap_pair(existing_skills, &target_skill_id, &source_skill_id) {
         return Err(format!(
             "managed skills '{target_skill_id}' and '{source_skill_id}' are not a detected overlap candidate pair"
         ));
@@ -175,11 +206,12 @@ pub(super) async fn apply_skill_archive(
     profile_root: &Path,
     archive: &SkillArchiveProposal,
 ) -> Result<ManagedSkill> {
-    apply_managed_skill_archive(
+    apply_managed_skill_overlap_archive(
         profile_root,
         &archive.skill_id,
         &archive.base_checksum,
-        Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE.to_string()),
+        &archive.overlap_skill_id,
+        &archive.overlap_base_checksum,
     )
     .await
 }
@@ -191,14 +223,13 @@ pub(super) async fn apply_skill_merge(
     profile_root: &Path,
     merge: &SkillMergeProposal,
 ) -> Result<(ManagedSkill, Option<ManagedSkill>)> {
-    let result = apply_managed_skill_consolidation(
+    let result = apply_managed_skill_overlap_consolidation(
         profile_root,
-        Some(&merge.target_skill_id),
-        Some(&merge.base_checksum),
+        &merge.target_skill_id,
+        &merge.base_checksum,
         merge.update.clone(),
         &merge.source_skill_id,
         &merge.source_base_checksum,
-        SKILL_OVERLAP_REMOVAL_TOMBSTONE,
     )
     .await?;
     Ok((result.source, result.target))
@@ -414,6 +445,8 @@ mod tests {
             &skills,
         ));
         assert_eq!(valid.skill_id, "workflow-a");
+        assert_eq!(valid.overlap_skill_id, "workflow-b");
+        assert_eq!(valid.overlap_base_checksum, checksum(&skills, "workflow-b"));
 
         assert_err_eq(
             skill_archive_from_proposal(

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -61,6 +61,30 @@ fn consolidation_guard<'a>(
     Ok(skill)
 }
 
+fn overlap_partner_guard<'a>(
+    existing_skills: &'a BTreeMap<String, ManagedSkill>,
+    id: &str,
+    base_checksum: &str,
+) -> std::result::Result<&'a ManagedSkill, String> {
+    let skill = existing_skills
+        .get(id)
+        .ok_or_else(|| format!("archive overlap partner managed skill id '{id}' does not exist"))?;
+    if base_checksum != skill.metadata.checksum {
+        return Err(format!(
+            "base_checksum for managed skill id '{id}' is stale"
+        ));
+    }
+    if skill.metadata.pinned {
+        return Err(format!(
+            "managed skill '{id}' is pinned and exempt from consolidation"
+        ));
+    }
+    if skill.metadata.state != ManagedSkillState::Active {
+        return Err(format!("managed skill '{id}' is not active"));
+    }
+    Ok(skill)
+}
+
 fn required_consolidation_reason(value: Option<&Value>) -> std::result::Result<String, String> {
     let reason = required_proposal_string(value, "reason")?;
     if reason == SKILL_OVERLAP_REMOVAL_TOMBSTONE {
@@ -122,12 +146,7 @@ pub(super) fn skill_archive_from_proposal(
         .metadata
         .checksum
         .clone();
-    consolidation_guard(
-        existing_skills,
-        &overlap_skill_id,
-        &overlap_base_checksum,
-        "archive overlap partner",
-    )?;
+    overlap_partner_guard(existing_skills, &overlap_skill_id, &overlap_base_checksum)?;
     Ok(SkillArchiveProposal {
         skill_id: id,
         base_checksum,
@@ -403,6 +422,28 @@ mod tests {
         .collect()
     }
 
+    async fn persisted_archive_fixture_with_authored_partner(
+        profile_root: &Path,
+        partner_source: ManagedSkillSource,
+    ) -> BTreeMap<String, ManagedSkill> {
+        let partner =
+            create_managed_skill(profile_root, fixture_draft("workflow-a", partner_source))
+                .await
+                .unwrap();
+        let source = create_managed_skill(
+            profile_root,
+            fixture_draft("workflow-b", ManagedSkillSource::AutomationRun),
+        )
+        .await
+        .unwrap();
+        [
+            (partner.metadata.id.clone(), partner),
+            (source.metadata.id.clone(), source),
+        ]
+        .into_iter()
+        .collect()
+    }
+
     fn checksum(skills: &BTreeMap<String, ManagedSkill>, id: &str) -> String {
         skills[id].metadata.checksum.clone()
     }
@@ -555,6 +596,26 @@ mod tests {
             ),
             "managed skill 'archived-skill' is already archived",
         );
+    }
+
+    #[test]
+    fn archive_still_requires_an_automation_owned_source() {
+        let skills = consolidation_fixture();
+
+        for id in ["user-skill", "imported-skill"] {
+            assert_err_eq(
+                skill_archive_from_proposal(
+                    &json!({
+                        "action": "archive",
+                        "id": id,
+                        "base_checksum": checksum(&skills, id),
+                        "reason": "duplicate guidance"
+                    }),
+                    &skills,
+                ),
+                &format!("managed skill '{id}' is not automation-owned"),
+            );
+        }
     }
 
     #[test]
@@ -902,6 +963,42 @@ mod tests {
             .unwrap();
         assert_eq!(source.metadata.state, ManagedSkillState::Active);
         assert_eq!(source.metadata.archived_reason, None);
+    }
+
+    #[tokio::test]
+    async fn archive_accepts_user_and_import_authored_overlap_partners() {
+        for partner_source in [ManagedSkillSource::User, ManagedSkillSource::Import] {
+            let profile = tempfile::tempdir().unwrap();
+            let skills =
+                persisted_archive_fixture_with_authored_partner(profile.path(), partner_source)
+                    .await;
+            let partner_before = skills["workflow-a"].clone();
+            let archive = skill_archive_from_proposal(
+                &json!({
+                    "action": "archive",
+                    "id": "workflow-b",
+                    "base_checksum": checksum(&skills, "workflow-b"),
+                    "reason": "duplicate guidance"
+                }),
+                &skills,
+            )
+            .unwrap();
+
+            let archived = apply_skill_archive(profile.path(), &archive).await.unwrap();
+            let partner = load_managed_skill(profile.path(), "workflow-a")
+                .await
+                .unwrap();
+
+            assert_eq!(archived.metadata.state, ManagedSkillState::Archived);
+            assert_eq!(
+                archived.metadata.archived_reason.as_deref(),
+                Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
+            );
+            assert_eq!(partner, partner_before);
+            assert_eq!(partner.metadata.state, ManagedSkillState::Active);
+            assert_eq!(partner.metadata.provenance.source, partner_source);
+            assert!(!partner.metadata.pinned);
+        }
     }
 
     #[cfg(unix)]

--- a/tests/automation_runner_test/skill_writer_consolidation.rs
+++ b/tests/automation_runner_test/skill_writer_consolidation.rs
@@ -172,12 +172,9 @@ async fn skill_writer_runner_auto_applies_safe_consolidations() {
         archived_source.metadata.absorbed_into.as_deref(),
         Some("automation-run-review")
     );
-    assert!(
-        archived_source
-            .metadata
-            .archived_reason
-            .as_deref()
-            .is_some_and(|reason| reason.contains("overlap"))
+    assert_eq!(
+        archived_source.metadata.archived_reason.as_deref(),
+        Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
     );
     let updated_target = load_managed_skill(&profile_root, "automation-run-review")
         .await


### PR DESCRIPTION
## Summary

- reserve the canonical skill-overlap tombstone for typed overlap archive/merge authorities
- retain and atomically revalidate the exact archive partner and both checksums under the skill-store lock
- prove archive/merge tombstone durability across real FIFO-backed post-commit cancellation and require exact runner label equality

## Verification

- mutation RED: reserved-label authority, 0 passed / 2 failed as intended
- mutation RED: changed exact archive partner, 0 passed / 1 failed as intended
- final-head narrow gates: reserved-label 2/2; stale partner 1/1; unrelated pair 1/1; cancellation 2/2 plus five bounded reruns; runner 1/1
- `cargo test -p tracedecay-agent-hosts -p tracedecay-automation` (732 + 3 + 57 passed)
- `cargo clippy -p tracedecay-agent-hosts -p tracedecay-automation --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run lint:commit -- --from e62a29fc6598a77d073ec8411df44b8d8ef84a96 --to HEAD`
