### PR TITLE
refactor(automation): single skill-overlap validation authority

### DIFF
--- a/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/managed_skills.rs
@@ -426,16 +426,11 @@ async fn apply_managed_skill_consolidation_kind(
     })
 }
 
+/// Typed-error adapter over the single pairwise overlap authority in
+/// `skill_usage`; proposal parsing runs the same predicate, so the two layers
+/// cannot disagree about whether a pair is a detected overlap.
 fn validate_detected_skill_overlap_pair(first: &ManagedSkill, second: &ManagedSkill) -> Result<()> {
-    let skills = [first.clone(), second.clone()];
-    let detected = super::skill_usage::skill_overlap_candidates(&skills, 1)
-        .into_iter()
-        .any(|candidate| {
-            (candidate.skill_a == first.metadata.id && candidate.skill_b == second.metadata.id)
-                || (candidate.skill_a == second.metadata.id
-                    && candidate.skill_b == first.metadata.id)
-        });
-    if !detected {
+    if !super::skill_usage::detected_skill_overlap_pair(first, second) {
         return Err(config_error(format!(
             "managed skills '{}' and '{}' are not a detected overlap candidate pair",
             first.metadata.id, second.metadata.id

--- a/crates/tracedecay-agent-hosts/src/automation/skill_usage.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_usage.rs
@@ -18,7 +18,8 @@ pub use analytics::ingest_analytics_events;
 pub use analytics::ingest_project_analytics_events;
 pub use overlap::{
     DEFAULT_SKILL_OVERLAP_LIMIT, SKILL_OVERLAP_CONTENT_THRESHOLD, SKILL_OVERLAP_TITLE_THRESHOLD,
-    SkillOverlapCandidate, skill_overlap_candidates,
+    SkillOverlapCandidate, detected_skill_overlap_pair, detected_skill_overlap_partner,
+    skill_overlap_candidates,
 };
 pub use recommendations::{skill_improvement_recommendations, stale_skill_recommendations};
 

--- a/crates/tracedecay-agent-hosts/src/automation/skill_usage/overlap.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_usage/overlap.rs
@@ -1,7 +1,15 @@
-//! Pairwise overlap detection between managed skills, used by the
-//! `skill_writer` evidence bundle to surface consolidation candidates
-//! (Hermes curator parity). Detection is purely lexical (token Jaccard on
-//! normalized titles and bodies) and deterministic; it never mutates skills.
+//! Pairwise overlap detection between managed skills (Hermes curator
+//! parity). Detection is purely lexical (token Jaccard on normalized titles
+//! and bodies) and deterministic; it never mutates skills.
+//!
+//! This module is the single skill-overlap authority. Validation — at
+//! proposal parse time and again at lifecycle apply time — goes through
+//! [`detected_skill_overlap_pair`], which judges exactly one pair and is
+//! therefore order-independent and stable: whether two skills validate can
+//! never depend on unrelated skills crowding a ranked list. The ranked
+//! [`skill_overlap_candidates`] list is a bounded discovery surface for the
+//! `skill_writer` evidence bundle only, computed pair-by-pair from the same
+//! predicate; it is never a validation authority.
 
 use serde::{Deserialize, Serialize};
 
@@ -33,25 +41,60 @@ pub struct SkillOverlapCandidate {
     pub reason: String,
 }
 
+/// Order-independent pairwise overlap predicate: the single validation
+/// authority shared by proposal parsing and lifecycle application. The
+/// decision depends only on the two skills — their consolidation eligibility
+/// and the lexical thresholds — never on how a pair ranks against unrelated
+/// skills.
+pub fn detected_skill_overlap_pair(first: &ManagedSkill, second: &ManagedSkill) -> bool {
+    detected_overlap(first, second).is_some()
+}
+
+/// The strongest detected overlap partner for `skill` among `others`, judged
+/// per pair by the same authority as [`detected_skill_overlap_pair`]. Unlike
+/// the ranked discovery list this is never truncated, so a partner cannot be
+/// crowded out by unrelated higher-scoring pairs. Score ties break to the
+/// lexicographically smaller partner id for determinism.
+pub fn detected_skill_overlap_partner<'a, I>(
+    skill: &ManagedSkill,
+    others: I,
+) -> Option<&'a ManagedSkill>
+where
+    I: IntoIterator<Item = &'a ManagedSkill>,
+{
+    let mut best: Option<(f64, &'a ManagedSkill)> = None;
+    for other in others {
+        let Some(candidate) = detected_overlap(skill, other) else {
+            continue;
+        };
+        let replace =
+            best.as_ref().is_none_or(
+                |(score, current)| match candidate.score.partial_cmp(score) {
+                    Some(std::cmp::Ordering::Greater) => true,
+                    Some(std::cmp::Ordering::Equal) => other.metadata.id < current.metadata.id,
+                    _ => false,
+                },
+            );
+        if replace {
+            best = Some((candidate.score, other));
+        }
+    }
+    best.map(|(_, partner)| partner)
+}
+
 /// Computes the top overlapping managed-skill pairs above the lexical
-/// thresholds. Archived and disabled skills are ignored; pairs where either
-/// skill is pinned are skipped entirely (pinned skills are exempt from
-/// consolidation, matching the Hermes curator).
+/// thresholds, pair-by-pair through the same predicate that backs
+/// [`detected_skill_overlap_pair`]. This ranked, truncated view exists to
+/// bound the `skill_writer` evidence bundle; validation must use the pairwise
+/// authority instead.
 pub fn skill_overlap_candidates(
     skills: &[ManagedSkill],
     limit: usize,
 ) -> Vec<SkillOverlapCandidate> {
-    let eligible: Vec<&ManagedSkill> = skills
-        .iter()
-        .filter(|skill| matches!(skill.metadata.state, ManagedSkillState::Active))
-        .collect();
     let mut candidates = Vec::new();
-    for (index, a) in eligible.iter().enumerate() {
-        for b in eligible.iter().skip(index + 1) {
-            if a.metadata.pinned || b.metadata.pinned {
-                continue;
-            }
-            if let Some(candidate) = overlap_candidate(a, b) {
+    for (index, a) in skills.iter().enumerate() {
+        for b in skills.iter().skip(index + 1) {
+            if let Some(candidate) = detected_overlap(a, b) {
                 candidates.push(candidate);
             }
         }
@@ -65,6 +108,19 @@ pub fn skill_overlap_candidates(
     });
     candidates.truncate(limit);
     candidates
+}
+
+/// Consolidation eligibility: archived and disabled skills are out of scope
+/// and pinned skills are exempt, matching the Hermes curator.
+fn overlap_eligible(skill: &ManagedSkill) -> bool {
+    matches!(skill.metadata.state, ManagedSkillState::Active) && !skill.metadata.pinned
+}
+
+fn detected_overlap(a: &ManagedSkill, b: &ManagedSkill) -> Option<SkillOverlapCandidate> {
+    if a.metadata.id == b.metadata.id || !overlap_eligible(a) || !overlap_eligible(b) {
+        return None;
+    }
+    overlap_candidate(a, b)
 }
 
 fn overlap_candidate(a: &ManagedSkill, b: &ManagedSkill) -> Option<SkillOverlapCandidate> {
@@ -221,5 +277,63 @@ mod tests {
         );
         let candidates = skill_overlap_candidates(&[a, b, c], 1);
         assert_eq!(candidates.len(), 1);
+    }
+
+    #[test]
+    fn pair_authority_is_order_independent() {
+        let (a, b) = overlapping_pair();
+        let unrelated = unrelated_skill();
+
+        assert!(detected_skill_overlap_pair(&a, &b));
+        assert!(detected_skill_overlap_pair(&b, &a));
+        assert!(!detected_skill_overlap_pair(&a, &unrelated));
+        assert!(!detected_skill_overlap_pair(&unrelated, &a));
+        assert!(
+            !detected_skill_overlap_pair(&a, &a),
+            "a skill must never be its own overlap partner"
+        );
+    }
+
+    #[test]
+    fn pair_authority_rejects_pinned_and_inactive_skills() {
+        let (mut a, mut b) = overlapping_pair();
+        a.set_pinned(true);
+        assert!(!detected_skill_overlap_pair(&a, &b));
+        a.set_pinned(false);
+        b.set_state(ManagedSkillState::Archived);
+        assert!(!detected_skill_overlap_pair(&a, &b));
+        b.set_state(ManagedSkillState::Disabled);
+        assert!(!detected_skill_overlap_pair(&a, &b));
+    }
+
+    #[test]
+    fn partner_discovery_prefers_the_strongest_pair() {
+        let (a, twin) = overlapping_pair();
+        let weaker = skill(
+            "automation-outcome-notes",
+            "Automation outcome notes",
+            "Review automation run ledgers after automatic changes apply.",
+            "Check run ledger counts, then escalate repeated regressions to the owning workflow for review.",
+        );
+        let twin_score = detected_overlap(&a, &twin)
+            .expect("premise: the twin must be a detected pair")
+            .score;
+        let weaker_score = detected_overlap(&a, &weaker)
+            .expect("premise: the weaker skill must also be a detected pair")
+            .score;
+        assert!(
+            twin_score > weaker_score,
+            "premise: the twin ({twin_score}) must outscore the weaker pair ({weaker_score})"
+        );
+        let unrelated = unrelated_skill();
+        let skills = [weaker, twin.clone(), unrelated.clone()];
+
+        let partner =
+            detected_skill_overlap_partner(&a, &skills).expect("a detected partner exists");
+        assert_eq!(partner.metadata.id, twin.metadata.id);
+        assert!(
+            detected_skill_overlap_partner(&unrelated, &skills[..2]).is_none(),
+            "a skill without any pairwise overlap has no partner"
+        );
     }
 }

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -9,7 +9,7 @@ use super::super::managed_skills::{
     apply_managed_skill_overlap_archive, apply_managed_skill_overlap_consolidation,
     preview_managed_skill_update,
 };
-use super::super::skill_usage::{DEFAULT_SKILL_OVERLAP_LIMIT, skill_overlap_candidates};
+use super::super::skill_usage::{detected_skill_overlap_pair, detected_skill_overlap_partner};
 use super::{
     SkillProposalAction, optional_proposal_string, optional_proposal_targets,
     required_proposal_string, support_files_from_proposal,
@@ -61,68 +61,12 @@ fn consolidation_guard<'a>(
     Ok(skill)
 }
 
-fn overlap_partner_guard<'a>(
-    existing_skills: &'a BTreeMap<String, ManagedSkill>,
-    id: &str,
-    base_checksum: &str,
-) -> std::result::Result<&'a ManagedSkill, String> {
-    let skill = existing_skills
-        .get(id)
-        .ok_or_else(|| format!("archive overlap partner managed skill id '{id}' does not exist"))?;
-    if base_checksum != skill.metadata.checksum {
-        return Err(format!(
-            "base_checksum for managed skill id '{id}' is stale"
-        ));
-    }
-    if skill.metadata.pinned {
-        return Err(format!(
-            "managed skill '{id}' is pinned and exempt from consolidation"
-        ));
-    }
-    if skill.metadata.state != ManagedSkillState::Active {
-        return Err(format!("managed skill '{id}' is not active"));
-    }
-    Ok(skill)
-}
-
 fn required_consolidation_reason(value: Option<&Value>) -> std::result::Result<String, String> {
     let reason = required_proposal_string(value, "reason")?;
     if reason == SKILL_OVERLAP_REMOVAL_TOMBSTONE {
         return Err("reason must not reuse the reserved skill-overlap tombstone label".to_string());
     }
     Ok(reason)
-}
-
-fn is_detected_overlap_pair(
-    existing_skills: &BTreeMap<String, ManagedSkill>,
-    first_skill_id: &str,
-    second_skill_id: &str,
-) -> bool {
-    let skills = existing_skills.values().cloned().collect::<Vec<_>>();
-    skill_overlap_candidates(&skills, DEFAULT_SKILL_OVERLAP_LIMIT)
-        .iter()
-        .any(|candidate| {
-            (candidate.skill_a == first_skill_id && candidate.skill_b == second_skill_id)
-                || (candidate.skill_a == second_skill_id && candidate.skill_b == first_skill_id)
-        })
-}
-
-fn detected_overlap_partner(
-    existing_skills: &BTreeMap<String, ManagedSkill>,
-    skill_id: &str,
-) -> Option<String> {
-    let skills = existing_skills.values().cloned().collect::<Vec<_>>();
-    skill_overlap_candidates(&skills, DEFAULT_SKILL_OVERLAP_LIMIT)
-        .into_iter()
-        .find_map(|candidate| {
-            if candidate.skill_a == skill_id {
-                Some(candidate.skill_b)
-            } else if candidate.skill_b == skill_id {
-                Some(candidate.skill_a)
-            } else {
-                None
-            }
-        })
 }
 
 pub(super) fn skill_archive_from_proposal(
@@ -135,23 +79,19 @@ pub(super) fn skill_archive_from_proposal(
     let id = required_proposal_string(object.get("id"), "id")?;
     let base_checksum = required_proposal_string(object.get("base_checksum"), "base_checksum")?;
     required_consolidation_reason(object.get("reason"))?;
-    consolidation_guard(existing_skills, &id, &base_checksum, "archive")?;
-    let overlap_skill_id = detected_overlap_partner(existing_skills, &id)
+    let skill = consolidation_guard(existing_skills, &id, &base_checksum, "archive")?;
+    // Partner discovery scans every skill pairwise under the single overlap
+    // authority, so a partner cannot be crowded out of a ranked candidate
+    // list. A discovered partner is active and unpinned by that authority;
+    // its checksum is captured here so the apply layer re-fences the exact
+    // partner revision against the store under its lock.
+    let partner = detected_skill_overlap_partner(skill, existing_skills.values())
         .ok_or_else(|| format!("managed skill '{id}' is not a detected overlap candidate"))?;
-    let overlap_base_checksum = existing_skills
-        .get(&overlap_skill_id)
-        .ok_or_else(|| {
-            format!("detected overlap partner managed skill id '{overlap_skill_id}' does not exist")
-        })?
-        .metadata
-        .checksum
-        .clone();
-    overlap_partner_guard(existing_skills, &overlap_skill_id, &overlap_base_checksum)?;
     Ok(SkillArchiveProposal {
         skill_id: id,
         base_checksum,
-        overlap_skill_id,
-        overlap_base_checksum,
+        overlap_skill_id: partner.metadata.id.clone(),
+        overlap_base_checksum: partner.metadata.checksum.clone(),
     })
 }
 
@@ -173,13 +113,13 @@ pub(super) fn skill_merge_from_proposal(
         return Err("merge proposal source_skill_id must differ from id".to_string());
     }
     let target = consolidation_guard(existing_skills, &target_skill_id, &base_checksum, "merge")?;
-    consolidation_guard(
+    let source = consolidation_guard(
         existing_skills,
         &source_skill_id,
         &source_base_checksum,
         "merge source",
     )?;
-    if !is_detected_overlap_pair(existing_skills, &target_skill_id, &source_skill_id) {
+    if !detected_skill_overlap_pair(target, source) {
         return Err(format!(
             "managed skills '{target_skill_id}' and '{source_skill_id}' are not a detected overlap candidate pair"
         ));
@@ -306,6 +246,7 @@ mod tests {
     };
     #[cfg(unix)]
     use super::super::super::skill_usage::skill_usage_ledger_path;
+    use super::super::super::skill_usage::{DEFAULT_SKILL_OVERLAP_LIMIT, skill_overlap_candidates};
     use super::super::skill_proposal_action;
     use super::*;
 
@@ -380,6 +321,47 @@ mod tests {
             .unwrap_or_else(|err| panic!("overlapping skill should materialize: {err}"));
         skill.set_state(ManagedSkillState::Active);
         skill
+    }
+
+    fn crowding_cluster_skill(id: &str) -> ManagedSkill {
+        let mut draft = fixture_draft(id, ManagedSkillSource::AutomationRun);
+        draft.title = "Automation ledger triage".to_string();
+        draft.summary = "Triage automation ledger regressions immediately.".to_string();
+        draft.body_markdown =
+            "Inspect ledger deltas, replay failing runs, and quarantine flaky proposals."
+                .to_string();
+        let mut skill = draft
+            .materialize()
+            .unwrap_or_else(|err| panic!("cluster skill should materialize: {err}"));
+        skill.set_state(ManagedSkillState::Active);
+        skill
+    }
+
+    fn moderately_overlapping_migration_pair() -> (ManagedSkill, ManagedSkill) {
+        let build = |id: &str, title: &str, body: &str| {
+            let mut draft = fixture_draft(id, ManagedSkillSource::AutomationRun);
+            draft.title = title.to_string();
+            draft.summary =
+                "Verify migration journals before deploying schema changes.".to_string();
+            draft.body_markdown = body.to_string();
+            let mut skill = draft
+                .materialize()
+                .unwrap_or_else(|err| panic!("migration skill should materialize: {err}"));
+            skill.set_state(ManagedSkillState::Active);
+            skill
+        };
+        (
+            build(
+                "migration-verification",
+                "Database migration verification",
+                "Check migration journals, verify rollback steps, and confirm schema versions before deployment.",
+            ),
+            build(
+                "migration-rehearsal",
+                "Database migration rehearsal",
+                "Check migration journals, verify rollback steps, and rehearse recovery drills after deployment.",
+            ),
+        )
     }
 
     fn consolidation_fixture() -> BTreeMap<String, ManagedSkill> {
@@ -772,6 +754,77 @@ mod tests {
             ),
             "managed skills 'workflow-a' and 'rust-error-handling' are not a detected overlap candidate pair",
         );
+    }
+
+    #[test]
+    fn consolidation_validates_pairs_crowded_out_of_the_ranked_discovery_list() {
+        let mut skills = BTreeMap::new();
+        for id in ["cluster-a", "cluster-b", "cluster-c", "cluster-d"] {
+            let skill = crowding_cluster_skill(id);
+            skills.insert(skill.metadata.id.clone(), skill);
+        }
+        let (verification, rehearsal) = moderately_overlapping_migration_pair();
+        skills.insert(verification.metadata.id.clone(), verification);
+        skills.insert(rehearsal.metadata.id.clone(), rehearsal);
+
+        // Premise: the identical cluster skills produce six maximal-score
+        // pairs, saturating the ranked discovery list and crowding out the
+        // lower-scoring (but detected) migration pair.
+        let ranked = skill_overlap_candidates(
+            &skills.values().cloned().collect::<Vec<_>>(),
+            DEFAULT_SKILL_OVERLAP_LIMIT,
+        );
+        assert_eq!(ranked.len(), DEFAULT_SKILL_OVERLAP_LIMIT);
+        assert!(
+            ranked.iter().all(|candidate| {
+                candidate.skill_a.starts_with("cluster-")
+                    && candidate.skill_b.starts_with("cluster-")
+            }),
+            "premise: cluster pairs must crowd the migration pair out of the ranked list"
+        );
+
+        // Validation is pairwise, so the crowded-out pair still merges …
+        let merge = assert_ok(skill_merge_from_proposal(
+            &json!({
+                "action": "merge",
+                "id": "migration-verification",
+                "base_checksum": checksum(&skills, "migration-verification"),
+                "source_skill_id": "migration-rehearsal",
+                "source_base_checksum": checksum(&skills, "migration-rehearsal"),
+                "reason": "duplicate migration guidance"
+            }),
+            &skills,
+        ));
+        assert_eq!(merge.source_skill_id, "migration-rehearsal");
+
+        // … and archive partner discovery still resolves the true pairwise
+        // partner instead of failing or drifting to an unrelated cluster skill.
+        let archive = assert_ok(skill_archive_from_proposal(
+            &json!({
+                "action": "archive",
+                "id": "migration-rehearsal",
+                "base_checksum": checksum(&skills, "migration-rehearsal"),
+                "reason": "duplicate migration guidance"
+            }),
+            &skills,
+        ));
+        assert_eq!(archive.overlap_skill_id, "migration-verification");
+        assert_eq!(
+            archive.overlap_base_checksum,
+            checksum(&skills, "migration-verification")
+        );
+
+        // Equal-scoring partners resolve deterministically.
+        let cluster_archive = assert_ok(skill_archive_from_proposal(
+            &json!({
+                "action": "archive",
+                "id": "cluster-d",
+                "base_checksum": checksum(&skills, "cluster-d"),
+                "reason": "duplicate cluster guidance"
+            }),
+            &skills,
+        ));
+        assert_eq!(cluster_archive.overlap_skill_id, "cluster-a");
     }
 
     #[test]

--- a/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/skill_writer/consolidation.rs
@@ -1043,9 +1043,13 @@ mod tests {
                 .unwrap();
 
             assert_eq!(archived.metadata.state, ManagedSkillState::Archived);
+            // Independently spelled pin of the persisted tombstone: skills
+            // archived by earlier releases durably carry this exact string,
+            // so constant drift must fail here instead of silently
+            // re-labeling the on-disk format.
             assert_eq!(
                 archived.metadata.archived_reason.as_deref(),
-                Some(SKILL_OVERLAP_REMOVAL_TOMBSTONE)
+                Some("skill_overlap_removal_tombstone")
             );
             assert_eq!(partner, partner_before);
             assert_eq!(partner.metadata.state, ManagedSkillState::Active);

--- a/crates/tracedecay-automation/src/run_labels.rs
+++ b/crates/tracedecay-automation/src/run_labels.rs
@@ -55,21 +55,4 @@ mod tests {
             }
         }
     }
-
-    #[test]
-    fn labels_pin_their_exact_wire_values() {
-        assert_eq!(AUTOMATION_DISABLED, "automation_disabled");
-        assert_eq!(
-            SESSION_EVIDENCE_BUDGET_EXHAUSTED,
-            "session_evidence_budget_exhausted"
-        );
-        assert_eq!(
-            SESSION_EVIDENCE_BUDGET_SUPPRESSED,
-            "session_evidence_budget_suppressed"
-        );
-        assert_eq!(
-            SKILL_OVERLAP_REMOVAL_TOMBSTONE,
-            "skill_overlap_removal_tombstone"
-        );
-    }
 }


### PR DESCRIPTION
## Findings addressed

### D1 (medium): duplicated and semantically divergent overlap validation

The proposal layer validated overlap through the ranked top-N candidate list computed over the entire skill map (`skill_overlap_candidates(&skills, DEFAULT_SKILL_OVERLAP_LIMIT)`), while the apply layer re-checked the same pair pairwise with limit 1. A pair could rank below top-N at proposal time yet pass pairwise at apply time, so whether a proposal validated depended on unrelated skills crowding the list. `overlap_partner_guard` also duplicated `validate_overlap_partner` check-for-check with a different error type, and `is_detected_overlap_pair` / `detected_overlap_partner` each cloned the full skill map and recomputed the O(n²) candidate set per proposal.

**Semantic decision:** the pairwise check is the single validation authority — it is order-independent and per-pair stable, and it already matched the stricter of the two prior predicates (every ranked candidate satisfies it, so nothing that previously validated at apply time is rejected). The ranked top-N list survives only as the bounded discovery surface for the skill_writer evidence bundle.

Changes:

- `skill_usage/overlap.rs`: new `detected_skill_overlap_pair` (single pairwise authority: consolidation eligibility + lexical thresholds) and `detected_skill_overlap_partner` (strongest pairwise partner, never truncated, deterministic tie-break). `skill_overlap_candidates` is reimplemented pair-by-pair on the same internal predicate, so discovery and validation cannot drift.
- `managed_skills.rs`: `validate_detected_skill_overlap_pair` is now a thin typed-error adapter over the authority (same error message, no more two-element clone-and-rank).
- `skill_writer/consolidation.rs`: merge validation calls `detected_skill_overlap_pair` on the two guarded skills; archive partner discovery calls `detected_skill_overlap_partner` over the map values. `is_detected_overlap_pair`, `detected_overlap_partner`, and `overlap_partner_guard` are deleted. The proposal-layer partner guard was vacuous by construction — the partner checksum was read from the same map entry it was compared against, and discovery already guarantees an active, unpinned partner — so `validate_overlap_partner` in `managed_skills.rs` remains the one partner guard with one (typed) error mapping, enforced at apply time where the store is re-read under lock (covered by `archive_refuses_a_changed_exact_overlap_partner`).
- Per-batch candidate-set recomputation: none is needed anymore. Merge validation is a single pairwise comparison and archive discovery is one linear scan per proposal, so the full-map O(n²) recompute (twice per archive, once per merge) is gone entirely, and validation always sees the current in-batch skill map state rather than a stale precomputed set.

No behavioral weakening: non-overlapping proposals are still rejected at both layers (`consolidation_proposals_require_a_detected_overlap`), and the reserved-tombstone-label spoofing rejection is untouched at both layers.

New regression coverage:

- `consolidation_validates_pairs_crowded_out_of_the_ranked_discovery_list`: six maximal-score cluster pairs saturate the ranked list (premise asserted), yet the crowded-out pair still merges and archives with the correct partner — this fails on the old ranked-membership semantics.
- `pair_authority_is_order_independent`, `pair_authority_rejects_pinned_and_inactive_skills`, `partner_discovery_prefers_the_strongest_pair` in `overlap.rs`.

### Minor: tautological `labels_pin_their_exact_wire_values`

The test asserted each constant against a copy of its own definition literal. Deleted it, kept the pairwise-distinctness test, and pinned the one label this subsystem persists where it is falsifiable: `archive_accepts_user_and_import_authored_overlap_partners` now asserts the durably persisted `archived_reason` equals the independently spelled literal `"skill_overlap_removal_tombstone"`, so constant drift breaks against the on-disk format. (`AUTOMATION_DISABLED` is already behaviorally pinned by the daemon scheduler ledger test; the budget labels are owned by `tracedecay-domain`, outside this change's file ownership.)

## Receipts

- `cargo test -p tracedecay-agent-hosts --lib automation::` — 350 passed, 0 failed
- `cargo test -p tracedecay-automation` — 56 passed, 0 failed (57 minus the deleted tautology)
- `cargo test -p tracedecay --features test-transport --test automation_runner_test skill_writer_consolidation` — 1 passed, 0 failed
- Named runs of the 4 new tests: 3 + 1 passed (non-zero counts confirmed)
- `cargo clippy -p tracedecay-agent-hosts -p tracedecay-automation --all-targets -- -D warnings` — clean
- `cargo fmt` on touched files