### PR TITLE
refactor(daemon): split observability core from alias handles

### DIFF
--- a/crates/tracedecay-usecases/src/observability/delivery_recorder.rs
+++ b/crates/tracedecay-usecases/src/observability/delivery_recorder.rs
@@ -40,6 +40,26 @@ enum RecorderControl {
     },
 }
 
+/// Store-owner state shared by every linked root's admission frontend: the
+/// spool, wake lane, lifecycle, and worker exist exactly once per started
+/// recorder. Frontends are cheap identity carriers over one `Arc` of this
+/// core, so aliasing is handle construction and shutdown drains the one
+/// worker no matter which frontend drives it.
+struct DeliverySettlementRecorderCoreV1 {
+    /// The founding owner identity every alias must match on the
+    /// store-authority fields; frontends stamp their own policy revision.
+    identity: ObservabilityProducerIdentityV1,
+    wake: mpsc::Sender<()>,
+    control: mpsc::Sender<RecorderControl>,
+    // `state` and `spool` stay `Arc` because the spawned worker shares them.
+    // The worker must not hold the core itself: the wake sender lives in the
+    // core, so a worker-held core could never observe channel closure.
+    state: Arc<AtomicU8>,
+    spool: Arc<DeliveryRecorderSpoolV1>,
+    admission: Mutex<()>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
 /// Bounded, daemon-owned durable write-behind lane for post-delivery receipts.
 ///
 /// Surface adapters offer only outcomes they observed at a real write, flush,
@@ -48,13 +68,10 @@ enum RecorderControl {
 /// pressure therefore delays SQLite work without erasing delivery evidence;
 /// transient failures remain replayable across process restart.
 pub struct BoundedDeliverySettlementRecorderV1 {
+    core: Arc<DeliverySettlementRecorderCoreV1>,
+    /// The identity stamped on receipts admitted through this frontend. It
+    /// differs from the core owner identity only in policy provenance.
     identity: ObservabilityProducerIdentityV1,
-    wake: mpsc::Sender<()>,
-    control: mpsc::Sender<RecorderControl>,
-    state: Arc<AtomicU8>,
-    admission: Arc<Mutex<()>>,
-    spool: Arc<DeliveryRecorderSpoolV1>,
-    worker: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl BoundedDeliverySettlementRecorderV1 {
@@ -75,6 +92,7 @@ impl BoundedDeliverySettlementRecorderV1 {
         let state = Arc::new(AtomicU8::new(RECORDER_RUNNING));
         let worker_state = Arc::clone(&state);
         let worker_spool = Arc::clone(&spool);
+        let identity = authority.identity().clone();
         let worker = runtime.spawn(run_recorder(
             Arc::clone(&authority),
             worker_spool,
@@ -82,39 +100,31 @@ impl BoundedDeliverySettlementRecorderV1 {
             control_rx,
             worker_state,
         ));
-        Ok(Self {
-            identity: authority.identity().clone(),
+        let core = Arc::new(DeliverySettlementRecorderCoreV1 {
+            identity: identity.clone(),
             wake,
             control,
             state,
-            admission: Arc::new(Mutex::new(())),
             spool,
-            worker: Arc::new(Mutex::new(Some(worker))),
-        })
+            admission: Mutex::new(()),
+            worker: Mutex::new(Some(worker)),
+        });
+        Ok(Self { core, identity })
     }
 
     /// Attach one linked root's policy-specific admission frontend to this
-    /// recorder's existing spool, wake lane, lifecycle, and worker.
+    /// recorder's shared core: one spool, wake lane, lifecycle, and worker.
     pub fn alias_with_policy_identity(
         &self,
         identity: ObservabilityProducerIdentityV1,
     ) -> Result<Self, &'static str> {
         identity.validate()?;
-        if identity.authorized_scope_ref != self.identity.authorized_scope_ref
-            || identity.process_boot_id != self.identity.process_boot_id
-            || identity.producer_revision != self.identity.producer_revision
-            || identity.configuration_revision != self.identity.configuration_revision
-        {
+        if !identity.is_policy_alias_of(&self.core.identity) {
             return Err("delivery_settlement_recorder_alias_identity");
         }
         Ok(Self {
+            core: Arc::clone(&self.core),
             identity,
-            wake: self.wake.clone(),
-            control: self.control.clone(),
-            state: Arc::clone(&self.state),
-            admission: Arc::clone(&self.admission),
-            spool: Arc::clone(&self.spool),
-            worker: Arc::clone(&self.worker),
         })
     }
 
@@ -126,13 +136,14 @@ impl BoundedDeliverySettlementRecorderV1 {
         let receipt = DeliveryRecorderSourceReceiptV1::new(settlement, self.identity.clone())
             .map_err(map_spool_admission_error)?;
         let _admission = self
+            .core
             .admission
             .lock()
             .map_err(|_| "delivery_settlement_recorder_lock_poisoned")?;
-        if self.state.load(Ordering::Acquire) != RECORDER_RUNNING {
+        if self.core.state.load(Ordering::Acquire) != RECORDER_RUNNING {
             return Err("delivery_settlement_recorder_closed");
         }
-        match self.spool.append(&receipt) {
+        match self.core.spool.append(&receipt) {
             Ok(_) => {}
             Err(DeliveryRecorderSpoolError::Full) => {
                 return Ok(DeliverySettlementRecordOutcomeV1::DroppedAtCapacity);
@@ -141,7 +152,7 @@ impl BoundedDeliverySettlementRecorderV1 {
         }
         // A full wake queue is safe: the durable receipt is already visible to
         // the active worker's bounded scan and periodic restart replay.
-        match self.wake.try_send(()) {
+        match self.core.wake.try_send(()) {
             Ok(()) | Err(mpsc::error::TrySendError::Full(())) => {
                 Ok(DeliverySettlementRecordOutcomeV1::Enqueued)
             }
@@ -152,6 +163,16 @@ impl BoundedDeliverySettlementRecorderV1 {
     }
 
     pub async fn shutdown(
+        &self,
+    ) -> Result<DeliverySettlementRecorderSummaryV1, ApplicationContractError> {
+        self.core.shutdown().await
+    }
+}
+
+impl DeliverySettlementRecorderCoreV1 {
+    /// Shutdown lives only on the core: any frontend may drive it, and the
+    /// lifecycle compare-and-swap admits exactly one drain.
+    async fn shutdown(
         &self,
     ) -> Result<DeliverySettlementRecorderSummaryV1, ApplicationContractError> {
         {

--- a/crates/tracedecay-usecases/src/observability/producer.rs
+++ b/crates/tracedecay-usecases/src/observability/producer.rs
@@ -61,6 +61,16 @@ impl ObservabilityProducerIdentityV1 {
         }
         Ok(())
     }
+
+    /// The one store-owner alias gate: a policy-stamping frontend must match
+    /// its owner on every store-authority field. Only the policy revision a
+    /// linked root selects for its own emissions may differ.
+    pub(super) fn is_policy_alias_of(&self, owner: &Self) -> bool {
+        self.authorized_scope_ref == owner.authorized_scope_ref
+            && self.process_boot_id == owner.process_boot_id
+            && self.producer_revision == owner.producer_revision
+            && self.configuration_revision == owner.configuration_revision
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -163,19 +173,38 @@ struct ProducerWorkerProgress {
     rollup_frontier_initialized: bool,
 }
 
-pub struct BoundedObservabilityProducerV1 {
+/// Store-owner state shared by every policy-stamping frontend: the bounded
+/// queue, the worker, the sequence allocator, and the lifecycle exist exactly
+/// once per started producer. Frontends are cheap identity carriers over one
+/// `Arc` of this core, so aliasing is handle construction and shutdown drains
+/// the one worker no matter which frontend drives it.
+struct ObservabilityProducerCoreV1 {
     db: RegisteredGlobalDbLeaseV1,
+    /// The founding owner identity. Every alias must match it on the
+    /// store-authority fields (`is_policy_alias_of`); frontends stamp their
+    /// own policy revision at admission.
     identity: ObservabilityProducerIdentityV1,
     data: mpsc::Sender<QueuedObservation>,
     control: mpsc::Sender<ProducerControl>,
+    // The next five stay `Arc` because the spawned worker shares them. The
+    // worker must not hold the core itself: the queue senders live in the
+    // core, so a worker-held core would keep its own channels open and the
+    // worker could never wind down when every frontend is dropped.
     pending_drops: Arc<Mutex<Vec<DropRange>>>,
     total_dropped: Arc<AtomicU64>,
     next_sequence: Arc<AtomicU64>,
     state: Arc<AtomicU8>,
-    deadlines: ObservabilityProducerDeadlinesV1,
-    emission_lock: Arc<Mutex<()>>,
     durable_emission_lock: Arc<AsyncMutex<()>>,
-    worker: Arc<Mutex<Option<JoinHandle<()>>>>,
+    deadlines: ObservabilityProducerDeadlinesV1,
+    emission_lock: Mutex<()>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+pub struct BoundedObservabilityProducerV1 {
+    core: Arc<ObservabilityProducerCoreV1>,
+    /// The identity this frontend stamps on admitted envelopes. It differs
+    /// from the core owner identity only in policy provenance.
+    identity: ObservabilityProducerIdentityV1,
 }
 
 impl BoundedObservabilityProducerV1 {
@@ -227,53 +256,40 @@ impl BoundedObservabilityProducerV1 {
                 deadlines,
             },
         ));
-        Ok(Self {
+        let core = Arc::new(ObservabilityProducerCoreV1 {
             db,
-            identity,
+            identity: identity.clone(),
             data,
             control,
             pending_drops,
             total_dropped,
             next_sequence,
             state,
-            deadlines,
-            emission_lock: Arc::new(Mutex::new(())),
             durable_emission_lock,
-            worker: Arc::new(Mutex::new(Some(worker))),
-        })
+            deadlines,
+            emission_lock: Mutex::new(()),
+            worker: Mutex::new(Some(worker)),
+        });
+        Ok(Self { core, identity })
     }
 
     /// Attach a policy-specific emission frontend to this producer's shared
-    /// queue, sequence, lifecycle, and worker.
+    /// core: one queue, sequence, lifecycle, and worker.
     ///
     /// Linked worktrees share one registered project-session store owner but
-    /// retain distinct policy provenance. Every backend authority must match;
-    /// only the policy stamped at admission may differ.
+    /// retain distinct policy provenance. Every store-authority field must
+    /// match the owner; only the policy stamped at admission may differ.
     pub fn alias_with_policy_identity(
         &self,
         identity: ObservabilityProducerIdentityV1,
     ) -> Result<Self, &'static str> {
         identity.validate()?;
-        if identity.authorized_scope_ref != self.identity.authorized_scope_ref
-            || identity.process_boot_id != self.identity.process_boot_id
-            || identity.producer_revision != self.identity.producer_revision
-            || identity.configuration_revision != self.identity.configuration_revision
-        {
+        if !identity.is_policy_alias_of(&self.core.identity) {
             return Err("observability_producer_alias_identity");
         }
         Ok(Self {
-            db: self.db.clone(),
+            core: Arc::clone(&self.core),
             identity,
-            data: self.data.clone(),
-            control: self.control.clone(),
-            pending_drops: Arc::clone(&self.pending_drops),
-            total_dropped: Arc::clone(&self.total_dropped),
-            next_sequence: Arc::clone(&self.next_sequence),
-            state: Arc::clone(&self.state),
-            deadlines: self.deadlines,
-            emission_lock: Arc::clone(&self.emission_lock),
-            durable_emission_lock: Arc::clone(&self.durable_emission_lock),
-            worker: Arc::clone(&self.worker),
         })
     }
 
@@ -286,12 +302,12 @@ impl BoundedObservabilityProducerV1 {
         &self.identity
     }
 
-    pub const fn persistence_deadline(&self) -> Duration {
-        self.deadlines.persistence
+    pub fn persistence_deadline(&self) -> Duration {
+        self.core.deadlines.persistence
     }
 
     fn validate_admission(&self, envelope: &ObservabilityEnvelopeV1) -> Result<(), &'static str> {
-        if self.state.load(Ordering::Acquire) != PRODUCER_RUNNING {
+        if self.core.state.load(Ordering::Acquire) != PRODUCER_RUNNING {
             return Err("observability_producer_closed");
         }
         if envelope.scope_ref != self.identity.authorized_scope_ref {
@@ -326,11 +342,12 @@ impl BoundedObservabilityProducerV1 {
         envelope: ObservabilityEnvelopeV1,
     ) -> Result<ObservabilityEmissionOutcomeV1, &'static str> {
         let _emission_guard = self
+            .core
             .emission_lock
             .lock()
             .map_err(|_| "observability_producer_lock_poisoned")?;
         self.validate_admission(&envelope)?;
-        let sequence = self.next_sequence.fetch_add(1, Ordering::AcqRel);
+        let sequence = self.core.next_sequence.fetch_add(1, Ordering::AcqRel);
         let envelope = self.prepare_delivery(envelope, sequence, false)?;
         self.offer_prepared(envelope, None)
     }
@@ -341,10 +358,11 @@ impl BoundedObservabilityProducerV1 {
         owner_fact: Option<QueuedOwnerFact>,
     ) -> Result<ObservabilityEmissionOutcomeV1, &'static str> {
         let sequence = envelope.producer_sequence;
-        match self.data.try_reserve() {
+        match self.core.data.try_reserve() {
             Ok(permit) => {
                 let carried_drops = {
                     let mut pending = self
+                        .core
                         .pending_drops
                         .lock()
                         .map_err(|_| "observability_producer_lock_poisoned")?;
@@ -375,6 +393,7 @@ impl BoundedObservabilityProducerV1 {
 
     fn record_capacity_drop(&self, sequence: u64) -> Result<(), &'static str> {
         let mut pending = self
+            .core
             .pending_drops
             .lock()
             .map_err(|_| "observability_producer_lock_poisoned")?;
@@ -392,20 +411,24 @@ impl BoundedObservabilityProducerV1 {
                 count: 1,
             });
         }
-        self.total_dropped.fetch_add(1, Ordering::AcqRel);
+        self.core.total_dropped.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
 
     pub async fn shutdown(
         &self,
     ) -> Result<ObservabilityProducerSummaryV1, ApplicationContractError> {
-        self.stop(false).await
+        self.core.stop(false).await
     }
 
     pub async fn cancel(&self) -> Result<ObservabilityProducerSummaryV1, ApplicationContractError> {
-        self.stop(true).await
+        self.core.stop(true).await
     }
+}
 
+impl ObservabilityProducerCoreV1 {
+    /// Shutdown lives only on the core: any frontend may drive it, and the
+    /// lifecycle compare-and-swap admits exactly one drain.
     async fn stop(
         &self,
         cancelled: bool,

--- a/crates/tracedecay-usecases/src/observability/producer/outbox.rs
+++ b/crates/tracedecay-usecases/src/observability/producer/outbox.rs
@@ -9,6 +9,7 @@ impl BoundedObservabilityProducerV1 {
         envelope: ObservabilityEnvelopeV1,
     ) -> Result<ObservabilityEmissionOutcomeV1, &'static str> {
         let _emission_guard = self
+            .core
             .emission_lock
             .lock()
             .map_err(|_| "observability_producer_lock_poisoned")?;
@@ -29,6 +30,7 @@ impl BoundedObservabilityProducerV1 {
             return Err("observability_owner_batch_bounds");
         }
         let _emission_guard = self
+            .core
             .emission_lock
             .lock()
             .map_err(|_| "observability_producer_lock_poisoned")?;
@@ -53,7 +55,7 @@ impl BoundedObservabilityProducerV1 {
         envelope: ObservabilityEnvelopeV1,
         owner_fact_json: String,
     ) -> Result<ObservabilityEmissionOutcomeV1, &'static str> {
-        match self.data.try_send(QueuedObservation {
+        match self.core.data.try_send(QueuedObservation {
             envelope,
             carried_drops: Vec::new(),
             owner_fact: Some(QueuedOwnerFact {
@@ -64,7 +66,7 @@ impl BoundedObservabilityProducerV1 {
         }) {
             Ok(()) => Ok(ObservabilityEmissionOutcomeV1::Enqueued),
             Err(mpsc::error::TrySendError::Full(_)) => {
-                let sequence = self.next_sequence.fetch_add(1, Ordering::AcqRel);
+                let sequence = self.core.next_sequence.fetch_add(1, Ordering::AcqRel);
                 self.record_capacity_drop(sequence)?;
                 Ok(ObservabilityEmissionOutcomeV1::DroppedAtCapacity)
             }
@@ -79,7 +81,7 @@ impl BoundedObservabilityProducerV1 {
         envelope: ObservabilityEnvelopeV1,
     ) -> Result<ObservabilityOwnerEmissionOutcomeV1, ApplicationContractError> {
         timeout(
-            self.deadlines.persistence,
+            self.core.deadlines.persistence,
             self.emit_owner_fact_unbounded(envelope),
         )
         .await
@@ -99,7 +101,7 @@ impl BoundedObservabilityProducerV1 {
                 "observability_owner_batch_bounds".to_owned(),
             ));
         }
-        timeout(self.deadlines.persistence, async {
+        timeout(self.core.deadlines.persistence, async {
             let mut outcomes = Vec::with_capacity(envelopes.len());
             for envelope in envelopes {
                 outcomes.push(self.emit_owner_fact_unbounded(envelope).await?);
@@ -116,7 +118,7 @@ impl BoundedObservabilityProducerV1 {
         &self,
         envelope: ObservabilityEnvelopeV1,
     ) -> Result<ObservabilityOwnerEmissionOutcomeV1, ApplicationContractError> {
-        let _durable_guard = self.durable_emission_lock.lock().await;
+        let _durable_guard = self.core.durable_emission_lock.lock().await;
         self.validate_admission(&envelope)
             .map_err(|error| ApplicationContractError::Domain(error.to_owned()))?;
         let owner_fact_json = normalized_owner_fact_json(&envelope).map_err(|error| {
@@ -126,6 +128,7 @@ impl BoundedObservabilityProducerV1 {
         })?;
         let owner_event_id = envelope.idempotency_key.clone();
         if let Some(existing) = self
+            .core
             .db
             .observability_emission_claim(
                 &self.identity.authorized_scope_ref,
@@ -138,9 +141,9 @@ impl BoundedObservabilityProducerV1 {
             return Ok(replay_owner_claim(existing));
         }
 
-        let permit = self.data.try_reserve().ok();
+        let permit = self.core.data.try_reserve().ok();
         let delayed = permit.is_none();
-        let sequence = self.next_sequence.fetch_add(1, Ordering::AcqRel);
+        let sequence = self.core.next_sequence.fetch_add(1, Ordering::AcqRel);
         let delivery = self
             .prepare_delivery(envelope, sequence, delayed)
             .map_err(|error| ApplicationContractError::Domain(error.to_owned()))?;
@@ -150,6 +153,7 @@ impl BoundedObservabilityProducerV1 {
             ))
         })?;
         let claim = self
+            .core
             .db
             .claim_observability_emission(
                 &self.identity.authorized_scope_ref,

--- a/src/daemon/service/invocation.rs
+++ b/src/daemon/service/invocation.rs
@@ -77,7 +77,8 @@ use tracedecay_tool_catalog::{CapabilityId, EffectClass, SortContractId, UseCase
 
 use super::project_runtime::{
     FeedbackCyclePublicationError, ProjectRuntimeAlreadyRegistered, ProjectRuntimeRegistryError,
-    ProjectRuntimeRegistryV1, RegisteredObservabilityProducerV1, StoreObservabilityRegistryV1,
+    ProjectRuntimeRegistryV1, RegisteredObservabilityProducerV1, StoreObservabilityMountErrorV1,
+    StoreObservabilityMountV1, StoreObservabilityRegistryV1,
 };
 use crate::agents::context_scout_ports::{
     AdmittedContextScoutHookV1, ContextScoutLifecycleAddressV1,

--- a/src/daemon/service/invocation/observability_producer.rs
+++ b/src/daemon/service/invocation/observability_producer.rs
@@ -11,14 +11,12 @@ fn daemon_observability_producer_identity(
     project_id: &ProjectId,
     configuration_revision: &ManifestDigest,
     policy_revision: &ManifestDigest,
-) -> Result<tracedecay_usecases::observability::ObservabilityProducerIdentityV1, TraceDecayError> {
+) -> Result<tracedecay_usecases::observability::ObservabilityProducerIdentityV1, &'static str> {
     let registration = NEXT_DAEMON_OBSERVABILITY_PRODUCER_REGISTRATION
         .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
             current.checked_add(1)
         })
-        .map_err(|_| TraceDecayError::Config {
-            message: "daemon observability producer registrations are exhausted".to_owned(),
-        })?;
+        .map_err(|_| "daemon_observability_producer_registrations_exhausted")?;
     Ok(
         tracedecay_usecases::observability::ObservabilityProducerIdentityV1 {
             authorized_scope_ref: project_id.as_str().to_owned(),
@@ -93,52 +91,52 @@ impl DaemonInvocationService {
                     // root of an already-mounted store attaches an alias to
                     // the incumbent owners instead of starting a second
                     // recorder for the same store.
-                    self.store_observability.acquire_or_start(
-                        &database,
-                        &configuration_provenance_revision,
-                        |incumbent| {
-                            incumbent.authorized_scope_ref == project_id.as_str()
-                                && incumbent.producer_revision
-                                    == DAEMON_OBSERVABILITY_PRODUCER_REVISION
-                                && incumbent.configuration_revision
-                                    == configuration_revision.as_str()
-                        },
-                        |incumbent| {
-                            tracedecay_usecases::observability::ObservabilityProducerIdentityV1 {
+                    self.store_observability
+                        .acquire_or_start(
+                            &database,
+                            &StoreObservabilityMountV1 {
+                                configuration_provenance_revision:
+                                    configuration_provenance_revision.clone(),
                                 authorized_scope_ref: project_id.as_str().to_owned(),
-                                process_boot_id: incumbent.process_boot_id.clone(),
-                                producer_revision: DAEMON_OBSERVABILITY_PRODUCER_REVISION.to_owned(),
-                                configuration_revision: configuration_revision.as_str().to_owned(),
-                                policy_revision: policy_revision.as_str().to_owned(),
-                            }
-                        },
-                        || TraceDecayError::Config {
-                            message:
-                                "a different observability producer is already mounted for this project store"
+                                producer_revision: DAEMON_OBSERVABILITY_PRODUCER_REVISION
                                     .to_owned(),
-                        },
-                        || {
-                            let identity = daemon_observability_producer_identity(
-                                &project_id,
-                                &configuration_revision,
-                                &policy_revision,
-                            )?;
-                            tracedecay_usecases::observability::BoundedObservabilityProducerV1::start(
-                                database.clone(),
-                                identity,
-                                DAEMON_OBSERVABILITY_QUEUE_CAPACITY,
-                            )
-                            .map_err(|error| TraceDecayError::Config {
-                                message: format!(
-                                    "project observability producer mount failed: {error}"
-                                ),
-                            })
-                        },
-                        DAEMON_DELIVERY_SETTLEMENT_QUEUE_CAPACITY,
-                        |error| TraceDecayError::Config {
-                            message: format!("project observability owner mount failed: {error}"),
-                        },
-                    )
+                                configuration_revision: configuration_revision
+                                    .as_str()
+                                    .to_owned(),
+                                policy_revision: policy_revision.as_str().to_owned(),
+                                delivery_capacity: DAEMON_DELIVERY_SETTLEMENT_QUEUE_CAPACITY,
+                            },
+                            || {
+                                let identity = daemon_observability_producer_identity(
+                                    &project_id,
+                                    &configuration_revision,
+                                    &policy_revision,
+                                )
+                                .map_err(StoreObservabilityMountErrorV1::Unavailable)?;
+                                tracedecay_usecases::observability::BoundedObservabilityProducerV1::start(
+                                    database.clone(),
+                                    identity,
+                                    DAEMON_OBSERVABILITY_QUEUE_CAPACITY,
+                                )
+                                .map_err(StoreObservabilityMountErrorV1::Unavailable)
+                            },
+                        )
+                        .map_err(|error| match error {
+                            StoreObservabilityMountErrorV1::Busy => TraceDecayError::Config {
+                                message:
+                                    "a different observability producer is already mounted for this project store"
+                                        .to_owned(),
+                            },
+                            error @ (StoreObservabilityMountErrorV1::Retiring
+                            | StoreObservabilityMountErrorV1::ShutdownFailed
+                            | StoreObservabilityMountErrorV1::Unavailable(_)) => {
+                                TraceDecayError::Config {
+                                    message: format!(
+                                        "project observability owner mount failed: {error}"
+                                    ),
+                                }
+                            }
+                        })
                 },
             )
             .await?;

--- a/src/daemon/service/project_runtime.rs
+++ b/src/daemon/service/project_runtime.rs
@@ -23,7 +23,10 @@ mod observability;
 mod request_snapshot;
 mod shutdown;
 
-pub(crate) use observability::{RegisteredObservabilityProducerV1, StoreObservabilityRegistryV1};
+pub(crate) use observability::{
+    RegisteredObservabilityProducerV1, StoreObservabilityMountErrorV1, StoreObservabilityMountV1,
+    StoreObservabilityRegistryV1,
+};
 pub(crate) use shutdown::ProjectRuntimeRootQuiescenceV1;
 use shutdown::ShutdownState;
 

--- a/src/daemon/service/project_runtime/observability.rs
+++ b/src/daemon/service/project_runtime/observability.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::fmt;
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 
 use tracedecay_application::ApplicationContractError;
@@ -98,6 +98,10 @@ fn same_registered_store_authority(
 enum StoreObservabilityStateV1 {
     Active {
         core: Arc<StoreObservabilityCoreV1>,
+        /// Live alias handles onto this owner. Each
+        /// [`RegisteredObservabilityProducerV1`] surrenders its single
+        /// release token exactly once — by explicit shutdown or by drop —
+        /// so this registry-owned count is the one refcount authority.
         aliases: usize,
     },
     Stopping {
@@ -109,6 +113,49 @@ enum StoreObservabilityStateV1 {
 struct StoreObservabilityEntryV1 {
     database: crate::global_db::RegisteredGlobalDbLeaseV1,
     state: StoreObservabilityStateV1,
+}
+
+/// One project root's request to mount observability for an exact registered
+/// store. An incumbent owner must carry the same configuration provenance and
+/// match every store-authority identity field; `policy_revision` is this
+/// root's own provenance, stamped by the resulting alias frontend rather than
+/// compared against the incumbent.
+pub(crate) struct StoreObservabilityMountV1 {
+    pub(crate) configuration_provenance_revision: ManifestDigest,
+    pub(crate) authorized_scope_ref: String,
+    pub(crate) producer_revision: String,
+    pub(crate) configuration_revision: String,
+    pub(crate) policy_revision: String,
+    pub(crate) delivery_capacity: usize,
+}
+
+/// Why observability could not be mounted for a registered store.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StoreObservabilityMountErrorV1 {
+    /// A live owner for this exact store carries a different configuration
+    /// provenance or identity. The mount is refused rather than silently
+    /// aliased or given a second store owner.
+    Busy,
+    /// The last alias is draining. Replacement owners are refused until the
+    /// drain finishes and the store entry retires.
+    Retiring,
+    /// The last owner shutdown failed and is remembered: mounting again
+    /// could overlap a worker whose drain never completed.
+    ShutdownFailed,
+    /// Registry or owner-start infrastructure was unavailable.
+    Unavailable(&'static str),
+}
+
+impl fmt::Display for StoreObservabilityMountErrorV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let code = match self {
+            Self::Busy => "store_observability_busy",
+            Self::Retiring => "store_observability_retiring",
+            Self::ShutdownFailed => "store_observability_shutdown_failed",
+            Self::Unavailable(reason) => reason,
+        };
+        formatter.write_str(code)
+    }
 }
 
 /// Live observability owners keyed by exact registered-store authority.
@@ -130,85 +177,98 @@ impl StoreObservabilityRegistryV1 {
     }
 
     /// Attach an alias to the incumbent owners of this exact registered
-    /// store, or start them. An incumbent whose identity the caller does not
-    /// accept refuses the mount instead of running a second store owner.
-    pub(crate) fn acquire_or_start<E>(
+    /// store, or start them via `start_producer`. An incumbent that does not
+    /// match the mount's store-authority fields refuses the mount instead of
+    /// running a second store owner.
+    pub(crate) fn acquire_or_start(
         &self,
         database: &crate::global_db::RegisteredGlobalDbLeaseV1,
-        configuration_provenance_revision: &ManifestDigest,
-        accepts_incumbent: impl FnOnce(&ObservabilityProducerIdentityV1) -> bool,
-        emission_identity: impl FnOnce(
-            &ObservabilityProducerIdentityV1,
-        ) -> ObservabilityProducerIdentityV1,
-        refused: impl FnOnce() -> E,
-        start_producer: impl FnOnce() -> Result<BoundedObservabilityProducerV1, E>,
-        delivery_capacity: usize,
-        unavailable: impl Fn(&'static str) -> E,
-    ) -> Result<RegisteredObservabilityProducerV1, E> {
-        let mut entries = self.lock_entries().map_err(&unavailable)?;
+        mount: &StoreObservabilityMountV1,
+        start_producer: impl FnOnce() -> Result<
+            BoundedObservabilityProducerV1,
+            StoreObservabilityMountErrorV1,
+        >,
+    ) -> Result<RegisteredObservabilityProducerV1, StoreObservabilityMountErrorV1> {
+        let mut entries = self
+            .lock_entries()
+            .map_err(StoreObservabilityMountErrorV1::Unavailable)?;
         if let Some(entry) = entries
             .iter_mut()
             .find(|entry| same_registered_store_authority(&entry.database, database))
         {
-            match &mut entry.state {
+            return match &mut entry.state {
                 StoreObservabilityStateV1::Active { core, aliases } => {
-                    if core.configuration_provenance_revision != *configuration_provenance_revision
-                        || !accepts_incumbent(core.producer.identity())
+                    let incumbent = core.producer.identity();
+                    if core.configuration_provenance_revision
+                        != mount.configuration_provenance_revision
+                        || incumbent.authorized_scope_ref != mount.authorized_scope_ref
+                        || incumbent.producer_revision != mount.producer_revision
+                        || incumbent.configuration_revision != mount.configuration_revision
                     {
-                        return Err(refused());
+                        return Err(StoreObservabilityMountErrorV1::Busy);
                     }
-                    let emission_identity = emission_identity(core.producer.identity());
+                    // The alias joins the incumbent's boot stream and stamps
+                    // this root's own policy provenance.
+                    let emission_identity = ObservabilityProducerIdentityV1 {
+                        authorized_scope_ref: mount.authorized_scope_ref.clone(),
+                        process_boot_id: incumbent.process_boot_id.clone(),
+                        producer_revision: mount.producer_revision.clone(),
+                        configuration_revision: mount.configuration_revision.clone(),
+                        policy_revision: mount.policy_revision.clone(),
+                    };
+                    let next_aliases = aliases.checked_add(1).ok_or(
+                        StoreObservabilityMountErrorV1::Unavailable(
+                            "store_observability_alias_capacity_exhausted",
+                        ),
+                    )?;
                     let producer = Arc::new(
                         core.producer
                             .alias_with_policy_identity(emission_identity)
-                            .map_err(&unavailable)?,
+                            .map_err(StoreObservabilityMountErrorV1::Unavailable)?,
                     );
-                    let next_aliases = aliases.checked_add(1).ok_or_else(|| {
-                        unavailable("store_observability_alias_capacity_exhausted")
-                    })?;
                     let registered = RegisteredObservabilityProducerV1::alias(
                         self.clone(),
                         Arc::clone(core),
                         producer,
                     )
-                    .map_err(&unavailable)?;
+                    .map_err(StoreObservabilityMountErrorV1::Unavailable)?;
                     *aliases = next_aliases;
-                    return Ok(registered);
+                    Ok(registered)
                 }
                 StoreObservabilityStateV1::Stopping { .. } => {
-                    return Err(unavailable("store_observability_retiring"));
+                    Err(StoreObservabilityMountErrorV1::Retiring)
                 }
                 StoreObservabilityStateV1::Failed => {
-                    return Err(unavailable("store_observability_shutdown_failed"));
+                    Err(StoreObservabilityMountErrorV1::ShutdownFailed)
                 }
-            }
+            };
         }
         let producer = start_producer()?;
         let core = Arc::new(
             StoreObservabilityCoreV1::start(
                 database.clone(),
-                configuration_provenance_revision.clone(),
+                mount.configuration_provenance_revision.clone(),
                 producer,
-                delivery_capacity,
+                mount.delivery_capacity,
             )
-            .map_err(&unavailable)?,
+            .map_err(StoreObservabilityMountErrorV1::Unavailable)?,
         );
         let registered = RegisteredObservabilityProducerV1::alias(
             self.clone(),
             Arc::clone(&core),
             Arc::clone(&core.producer),
         )
-        .map_err(&unavailable)?;
+        .map_err(StoreObservabilityMountErrorV1::Unavailable)?;
         entries.push(StoreObservabilityEntryV1 {
             database: database.clone(),
-            state: StoreObservabilityStateV1::Active {
-                core: Arc::clone(&core),
-                aliases: 1,
-            },
+            state: StoreObservabilityStateV1::Active { core, aliases: 1 },
         });
         Ok(registered)
     }
 
+    /// Surrenders one alias release. Reports whether it was the last one, in
+    /// which case the entry is now `Stopping` and the caller must drain the
+    /// core and then finish the retirement.
     fn begin_retirement(
         &self,
         core: &Arc<StoreObservabilityCoreV1>,
@@ -255,10 +315,13 @@ impl StoreObservabilityRegistryV1 {
         Ok(true)
     }
 
+    /// Settles a `Stopping` entry: a releasable retirement removes it so a
+    /// fresh owner may mount; a genuine shutdown failure is remembered as
+    /// `Failed` and refuses all future mounts.
     fn finish_retirement(
         &self,
         core: &Arc<StoreObservabilityCoreV1>,
-        succeeded: bool,
+        releasable: bool,
     ) -> Result<(), ApplicationContractError> {
         let mut entries =
             self.lock_entries()
@@ -277,7 +340,7 @@ impl StoreObservabilityRegistryV1 {
                 field: "store_observability_retiring_owner",
             });
         };
-        if succeeded {
+        if releasable {
             entries.remove(index);
         } else {
             entries[index].state = StoreObservabilityStateV1::Failed;
@@ -293,7 +356,11 @@ pub(crate) struct RegisteredObservabilityProducerV1 {
     producer: Arc<BoundedObservabilityProducerV1>,
     delivery_settlement_authority: Arc<DeliverySettlementAuthorityV1>,
     delivery_settlements: Arc<BoundedDeliverySettlementRecorderV1>,
-    released: AtomicBool,
+    /// The single release token: `Some` exactly while this alias is counted
+    /// by its store entry. It is taken once — by the consuming [`Self::shutdown`]
+    /// or by drop — so the registry's alias count is derived from exactly one
+    /// release per handle, with no separate released flag to keep consistent.
+    release: Option<Arc<StoreObservabilityCoreV1>>,
 }
 
 impl RegisteredObservabilityProducerV1 {
@@ -313,11 +380,11 @@ impl RegisteredObservabilityProducerV1 {
         );
         Ok(Self {
             registry,
+            release: Some(Arc::clone(&core)),
             core,
             producer,
             delivery_settlement_authority,
             delivery_settlements,
-            released: AtomicBool::new(false),
         })
     }
 
@@ -350,21 +417,22 @@ impl RegisteredObservabilityProducerV1 {
             && *self.producer.identity() == *identity
     }
 
-    /// Releases this alias from its store entry, reporting whether it was the
-    /// last one. Idempotent: shutdown and drop release at most once.
-    fn begin_retirement(&self) -> Result<bool, ApplicationContractError> {
-        if self.released.swap(true, Ordering::AcqRel) {
-            return Ok(false);
-        }
-        self.registry.begin_retirement(&self.core)
-    }
-
-    pub(crate) async fn shutdown(&self) -> Result<(), ApplicationContractError> {
-        if !self.begin_retirement()? {
+    /// Releases this alias; the last release drains and closes the store
+    /// owners. Consuming the handle is what makes the release single-shot:
+    /// the token taken here is the same one drop would take.
+    pub(crate) async fn shutdown(mut self) -> Result<(), ApplicationContractError> {
+        let Some(core) = self.release.take() else {
+            // Unreachable for an owned handle: only drop takes the token
+            // otherwise. Releasing twice is an idempotent no-op by contract.
+            return Ok(());
+        };
+        let registry = self.registry.clone();
+        drop(self);
+        if !registry.begin_retirement(&core)? {
             return Ok(());
         }
-        let result = self.core.shutdown().await;
-        let retirement = self.registry.finish_retirement(&self.core, result.is_ok());
+        let result = core.shutdown().await;
+        let retirement = registry.finish_retirement(&core, result.is_ok());
         match result {
             Ok(()) => retirement,
             Err(error) => {
@@ -382,7 +450,10 @@ impl RegisteredObservabilityProducerV1 {
 
 impl Drop for RegisteredObservabilityProducerV1 {
     fn drop(&mut self) {
-        let is_last = match self.begin_retirement() {
+        let Some(core) = self.release.take() else {
+            return;
+        };
+        let is_last = match self.registry.begin_retirement(&core) {
             Ok(is_last) => is_last,
             Err(error) => {
                 tracing::warn!(%error, "observability alias release was incomplete");
@@ -392,22 +463,32 @@ impl Drop for RegisteredObservabilityProducerV1 {
         if !is_last {
             return;
         }
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            if let Err(error) = self.registry.finish_retirement(&self.core, false) {
-                tracing::warn!(%error, "observability owner failure could not be retained");
+        match tokio::runtime::Handle::try_current() {
+            Ok(runtime) => {
+                let registry = self.registry.clone();
+                runtime.spawn(async move {
+                    let result = core.shutdown().await;
+                    if let Err(error) = &result {
+                        tracing::warn!(%error, "dropped observability owner shutdown was incomplete");
+                    }
+                    if let Err(error) = registry.finish_retirement(&core, result.is_ok()) {
+                        tracing::warn!(%error, "dropped observability retirement was incomplete");
+                    }
+                });
             }
-            return;
-        };
-        let registry = self.registry.clone();
-        let core = Arc::clone(&self.core);
-        runtime.spawn(async move {
-            let result = core.shutdown().await;
-            if let Err(error) = &result {
-                tracing::warn!(%error, "dropped observability owner shutdown was incomplete");
+            Err(_) => {
+                // A drop without a runtime is a teardown accident, not a
+                // shutdown failure: release the store entry instead of
+                // poisoning it so a future daemon runtime can mount fresh
+                // owners. The owner workers settle on their own runtime as
+                // their queues close when the core drops.
+                tracing::warn!(
+                    "observability owners dropped without a runtime; released without an awaited drain"
+                );
+                if let Err(error) = self.registry.finish_retirement(&core, true) {
+                    tracing::warn!(%error, "dropped observability retirement was incomplete");
+                }
             }
-            if let Err(error) = registry.finish_retirement(&core, result.is_ok()) {
-                tracing::warn!(%error, "dropped observability retirement was incomplete");
-            }
-        });
+        }
     }
 }

--- a/src/daemon/service/project_runtime/observability_tests.rs
+++ b/src/daemon/service/project_runtime/observability_tests.rs
@@ -22,10 +22,28 @@ use tracedecay_usecases::observability::{
 
 use crate::daemon::service::invocation::DaemonInvocationService;
 
-use super::StoreObservabilityRegistryV1;
+use super::{
+    StoreObservabilityMountErrorV1, StoreObservabilityMountV1, StoreObservabilityRegistryV1,
+};
 
 fn digest(byte: char) -> ManifestDigest {
     ManifestDigest::new(format!("sha256:{}", byte.to_string().repeat(64))).expect("digest")
+}
+
+/// A registry mount request whose store-authority fields match `identity`,
+/// stamping that identity's policy revision for the mounting root.
+fn store_mount(
+    configuration_provenance_revision: &ManifestDigest,
+    identity: &ObservabilityProducerIdentityV1,
+) -> StoreObservabilityMountV1 {
+    StoreObservabilityMountV1 {
+        configuration_provenance_revision: configuration_provenance_revision.clone(),
+        authorized_scope_ref: identity.authorized_scope_ref.clone(),
+        producer_revision: identity.producer_revision.clone(),
+        configuration_revision: identity.configuration_revision.clone(),
+        policy_revision: identity.policy_revision.clone(),
+        delivery_capacity: 1,
+    }
 }
 
 fn envelope(scope: &ProjectId, event: &str) -> ObservabilityEnvelopeV1 {
@@ -820,44 +838,35 @@ async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finis
         runtime("observability-retiring-two-aliases").await;
     let registry = StoreObservabilityRegistryV1::default();
     let configuration_provenance_revision = digest('0');
-    let producer = BoundedObservabilityProducerV1::start(
-        database.clone(),
-        ObservabilityProducerIdentityV1 {
-            authorized_scope_ref: project_id.as_str().to_owned(),
-            process_boot_id: "daemon:retiring-two-aliases".to_owned(),
-            producer_revision: "producer.v1".to_owned(),
-            configuration_revision: digest('6').as_str().to_owned(),
-            policy_revision: digest('7').as_str().to_owned(),
-        },
-        1,
-    )
-    .expect("producer");
+    let identity = ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: project_id.as_str().to_owned(),
+        process_boot_id: "daemon:retiring-two-aliases".to_owned(),
+        producer_revision: "producer.v1".to_owned(),
+        configuration_revision: digest('6').as_str().to_owned(),
+        policy_revision: digest('7').as_str().to_owned(),
+    };
+    let producer = BoundedObservabilityProducerV1::start(database.clone(), identity.clone(), 1)
+        .expect("producer");
     let first = registry
-        .acquire_or_start::<&'static str>(
+        .acquire_or_start(
             &database,
-            &configuration_provenance_revision,
-            |_| false,
-            ObservabilityProducerIdentityV1::clone,
-            || "unexpected incumbent store producer",
+            &store_mount(&configuration_provenance_revision, &identity),
             || Ok(producer),
-            1,
-            |error| error,
         )
         .expect("first alias");
+    let linked_identity = ObservabilityProducerIdentityV1 {
+        policy_revision: digest('8').as_str().to_owned(),
+        ..identity.clone()
+    };
     let linked = registry
-        .acquire_or_start::<&'static str>(
+        .acquire_or_start(
             &database,
-            &configuration_provenance_revision,
-            |_| true,
-            |incumbent| {
-                let mut identity = incumbent.clone();
-                identity.policy_revision = digest('8').as_str().to_owned();
-                identity
+            &store_mount(&configuration_provenance_revision, &linked_identity),
+            || {
+                Err(StoreObservabilityMountErrorV1::Unavailable(
+                    "must not start a second producer",
+                ))
             },
-            || "unexpected incumbent refusal",
-            || Err("must not start a second producer"),
-            1,
-            |error| error,
         )
         .expect("linked alias");
     let first_producer = first.producer();
@@ -876,8 +885,6 @@ async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finis
         .try_emit(envelope(&project_id, "retiring:two-aliases:blocked"))
         .expect("enqueue blocked event");
     let barrier = Arc::new(tokio::sync::Barrier::new(3));
-    let first = Arc::new(first);
-    let linked = Arc::new(linked);
     let first_barrier = Arc::clone(&barrier);
     let first_release = tokio::spawn(async move {
         first_barrier.wait().await;
@@ -908,17 +915,15 @@ async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finis
     .await
     .expect("concurrent last release reaches the producer");
 
-    let retiring = registry.acquire_or_start::<&'static str>(
+    let retiring = registry.acquire_or_start(
         &database,
-        &configuration_provenance_revision,
-        |_| true,
-        ObservabilityProducerIdentityV1::clone,
-        || "unexpected incumbent refusal",
+        &store_mount(&configuration_provenance_revision, &identity),
         || panic!("retiring store must not start an overlapping producer"),
-        1,
-        |error| error,
     );
-    assert!(matches!(retiring, Err("store_observability_retiring")));
+    assert!(matches!(
+        retiring,
+        Err(StoreObservabilityMountErrorV1::Retiring)
+    ));
     blocker.commit().await.expect("release registered writer");
     tokio::time::timeout(Duration::from_secs(3), async {
         first_release
@@ -933,29 +938,16 @@ async fn concurrent_two_alias_release_keeps_the_store_retiring_until_drain_finis
     .await
     .expect("concurrent owner retirement completes");
 
+    let replacement_identity = ObservabilityProducerIdentityV1 {
+        process_boot_id: "daemon:retiring-two-aliases-replacement".to_owned(),
+        ..identity.clone()
+    };
+    let replacement_mount = store_mount(&configuration_provenance_revision, &replacement_identity);
     let replacement = registry
-        .acquire_or_start::<&'static str>(
-            &database,
-            &configuration_provenance_revision,
-            |_| false,
-            ObservabilityProducerIdentityV1::clone,
-            || "unexpected incumbent store producer",
-            || {
-                BoundedObservabilityProducerV1::start(
-                    database.clone(),
-                    ObservabilityProducerIdentityV1 {
-                        authorized_scope_ref: project_id.as_str().to_owned(),
-                        process_boot_id: "daemon:retiring-two-aliases-replacement".to_owned(),
-                        producer_revision: "producer.v1".to_owned(),
-                        configuration_revision: digest('6').as_str().to_owned(),
-                        policy_revision: digest('7').as_str().to_owned(),
-                    },
-                    1,
-                )
-            },
-            1,
-            |error| error,
-        )
+        .acquire_or_start(&database, &replacement_mount, || {
+            BoundedObservabilityProducerV1::start(database.clone(), replacement_identity, 1)
+                .map_err(StoreObservabilityMountErrorV1::Unavailable)
+        })
         .expect("one replacement after both aliases release");
     replacement.shutdown().await.expect("replacement shutdown");
 }
@@ -973,44 +965,35 @@ async fn adjacent_linked_alias_capacity_drops_retain_distinct_policy_carriers() 
     let configuration_provenance_revision = digest('0');
     let policy_a = digest('a');
     let policy_b = digest('b');
-    let producer = BoundedObservabilityProducerV1::start(
-        database.clone(),
-        ObservabilityProducerIdentityV1 {
-            authorized_scope_ref: project_id.as_str().to_owned(),
-            process_boot_id: "daemon:linked-capacity-drops".to_owned(),
-            producer_revision: "producer.v1".to_owned(),
-            configuration_revision: digest('c').as_str().to_owned(),
-            policy_revision: policy_a.as_str().to_owned(),
-        },
-        1,
-    )
-    .expect("producer");
+    let identity = ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: project_id.as_str().to_owned(),
+        process_boot_id: "daemon:linked-capacity-drops".to_owned(),
+        producer_revision: "producer.v1".to_owned(),
+        configuration_revision: digest('c').as_str().to_owned(),
+        policy_revision: policy_a.as_str().to_owned(),
+    };
+    let producer = BoundedObservabilityProducerV1::start(database.clone(), identity.clone(), 1)
+        .expect("producer");
     let first = registry
-        .acquire_or_start::<&'static str>(
+        .acquire_or_start(
             &database,
-            &configuration_provenance_revision,
-            |_| false,
-            ObservabilityProducerIdentityV1::clone,
-            || "unexpected incumbent store producer",
+            &store_mount(&configuration_provenance_revision, &identity),
             || Ok(producer),
-            1,
-            |error| error,
         )
         .expect("first alias");
+    let linked_identity = ObservabilityProducerIdentityV1 {
+        policy_revision: policy_b.as_str().to_owned(),
+        ..identity.clone()
+    };
     let linked = registry
-        .acquire_or_start::<&'static str>(
+        .acquire_or_start(
             &database,
-            &configuration_provenance_revision,
-            |_| true,
-            |incumbent| {
-                let mut identity = incumbent.clone();
-                identity.policy_revision = policy_b.as_str().to_owned();
-                identity
+            &store_mount(&configuration_provenance_revision, &linked_identity),
+            || {
+                Err(StoreObservabilityMountErrorV1::Unavailable(
+                    "must not start a second producer",
+                ))
             },
-            || "unexpected incumbent refusal",
-            || Err("must not start a second producer"),
-            1,
-            |error| error,
         )
         .expect("linked alias");
     let first_producer = first.producer();
@@ -1089,29 +1072,19 @@ async fn dropped_last_alias_keeps_the_store_retiring_until_owners_release() {
     let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
     let (_project, project_id, database, _runtime) = runtime("observability-retiring-drop").await;
     let registry = StoreObservabilityRegistryV1::default();
-    let producer = BoundedObservabilityProducerV1::start(
-        database.clone(),
-        ObservabilityProducerIdentityV1 {
-            authorized_scope_ref: project_id.as_str().to_owned(),
-            process_boot_id: "daemon:retiring-drop".to_owned(),
-            producer_revision: "producer.v1".to_owned(),
-            configuration_revision: digest('6').as_str().to_owned(),
-            policy_revision: digest('7').as_str().to_owned(),
-        },
-        1,
-    )
-    .expect("producer");
+    let identity = ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: project_id.as_str().to_owned(),
+        process_boot_id: "daemon:retiring-drop".to_owned(),
+        producer_revision: "producer.v1".to_owned(),
+        configuration_revision: digest('6').as_str().to_owned(),
+        policy_revision: digest('7').as_str().to_owned(),
+    };
+    let producer = BoundedObservabilityProducerV1::start(database.clone(), identity.clone(), 1)
+        .expect("producer");
     let registered = registry
-        .acquire_or_start::<&'static str>(
-            &database,
-            &digest('0'),
-            |_| false,
-            ObservabilityProducerIdentityV1::clone,
-            || "unexpected incumbent store producer",
-            || Ok(producer),
-            1,
-            |error| error,
-        )
+        .acquire_or_start(&database, &store_mount(&digest('0'), &identity), || {
+            Ok(producer)
+        })
         .expect("registered observability producer");
     let blocker = database
         .begin_write_transaction()
@@ -1123,58 +1096,39 @@ async fn dropped_last_alias_keeps_the_store_retiring_until_owners_release() {
         .expect("enqueue blocked event");
     drop(registered);
 
-    let retiring = registry.acquire_or_start::<&'static str>(
-        &database,
-        &digest('0'),
-        |_| true,
-        ObservabilityProducerIdentityV1::clone,
-        || "unexpected incumbent refusal",
-        || {
-            BoundedObservabilityProducerV1::start(
-                database.clone(),
-                ObservabilityProducerIdentityV1 {
-                    authorized_scope_ref: project_id.as_str().to_owned(),
-                    process_boot_id: "daemon:retiring-drop-overlap".to_owned(),
-                    producer_revision: "producer.v1".to_owned(),
-                    configuration_revision: digest('6').as_str().to_owned(),
-                    policy_revision: digest('7').as_str().to_owned(),
-                },
-                1,
-            )
-        },
-        1,
-        |error| error,
-    );
-    assert!(matches!(retiring, Err("store_observability_retiring")));
+    let overlap_identity = ObservabilityProducerIdentityV1 {
+        process_boot_id: "daemon:retiring-drop-overlap".to_owned(),
+        ..identity.clone()
+    };
+    let overlap_mount = store_mount(&digest('0'), &overlap_identity);
+    let retiring = registry.acquire_or_start(&database, &overlap_mount, || {
+        BoundedObservabilityProducerV1::start(database.clone(), overlap_identity.clone(), 1)
+            .map_err(StoreObservabilityMountErrorV1::Unavailable)
+    });
+    assert!(matches!(
+        retiring,
+        Err(StoreObservabilityMountErrorV1::Retiring)
+    ));
     blocker.commit().await.expect("release registered writer");
 
+    let replacement_identity = ObservabilityProducerIdentityV1 {
+        process_boot_id: "daemon:retiring-drop-replacement".to_owned(),
+        ..identity.clone()
+    };
+    let replacement_mount = store_mount(&digest('0'), &replacement_identity);
     let replacement = tokio::time::timeout(Duration::from_secs(3), async {
         loop {
-            let attempt = registry.acquire_or_start::<&'static str>(
-                &database,
-                &digest('0'),
-                |_| true,
-                ObservabilityProducerIdentityV1::clone,
-                || "unexpected incumbent refusal",
-                || {
-                    BoundedObservabilityProducerV1::start(
-                        database.clone(),
-                        ObservabilityProducerIdentityV1 {
-                            authorized_scope_ref: project_id.as_str().to_owned(),
-                            process_boot_id: "daemon:retiring-drop-replacement".to_owned(),
-                            producer_revision: "producer.v1".to_owned(),
-                            configuration_revision: digest('6').as_str().to_owned(),
-                            policy_revision: digest('7').as_str().to_owned(),
-                        },
-                        1,
-                    )
-                },
-                1,
-                |error| error,
-            );
+            let attempt = registry.acquire_or_start(&database, &replacement_mount, || {
+                BoundedObservabilityProducerV1::start(
+                    database.clone(),
+                    replacement_identity.clone(),
+                    1,
+                )
+                .map_err(StoreObservabilityMountErrorV1::Unavailable)
+            });
             match attempt {
                 Ok(replacement) => break replacement,
-                Err("store_observability_retiring") => tokio::task::yield_now().await,
+                Err(StoreObservabilityMountErrorV1::Retiring) => tokio::task::yield_now().await,
                 Err(error) => panic!("unexpected replacement result: {error}"),
             }
         }
@@ -1189,15 +1143,16 @@ async fn registered_shutdown_reports_a_blocked_producer_flush() {
     let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
     let (_project, project_id, database, _runtime) =
         runtime("observability-shutdown-failure").await;
+    let identity = ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: project_id.as_str().to_owned(),
+        process_boot_id: "daemon:shutdown-failure".to_owned(),
+        producer_revision: "producer.v1".to_owned(),
+        configuration_revision: digest('e').as_str().to_owned(),
+        policy_revision: digest('f').as_str().to_owned(),
+    };
     let producer = BoundedObservabilityProducerV1::start_with_deadlines(
         database.clone(),
-        ObservabilityProducerIdentityV1 {
-            authorized_scope_ref: project_id.as_str().to_owned(),
-            process_boot_id: "daemon:shutdown-failure".to_owned(),
-            producer_revision: "producer.v1".to_owned(),
-            configuration_revision: digest('e').as_str().to_owned(),
-            policy_revision: digest('f').as_str().to_owned(),
-        },
+        identity.clone(),
         1,
         ObservabilityProducerDeadlinesV1 {
             persistence: Duration::from_millis(50),
@@ -1207,16 +1162,9 @@ async fn registered_shutdown_reports_a_blocked_producer_flush() {
     .expect("producer");
     let registry = StoreObservabilityRegistryV1::default();
     let registered = registry
-        .acquire_or_start::<&'static str>(
-            &database,
-            &digest('0'),
-            |_| false,
-            ObservabilityProducerIdentityV1::clone,
-            || "unexpected incumbent store producer",
-            || Ok(producer),
-            1,
-            |error| error,
-        )
+        .acquire_or_start(&database, &store_mount(&digest('0'), &identity), || {
+            Ok(producer)
+        })
         .expect("registered observability producer");
     let blocker = database
         .begin_write_transaction()
@@ -1241,29 +1189,19 @@ async fn registered_shutdown_reports_a_blocked_producer_flush() {
     );
     let start_called = Arc::new(AtomicBool::new(false));
     let observed_start = Arc::clone(&start_called);
-    let failed = registry.acquire_or_start::<&'static str>(
-        &database,
-        &digest('0'),
-        |_| true,
-        ObservabilityProducerIdentityV1::clone,
-        || "unexpected incumbent refusal",
-        || {
-            observed_start.store(true, Ordering::Release);
-            BoundedObservabilityProducerV1::start(
-                database.clone(),
-                ObservabilityProducerIdentityV1 {
-                    authorized_scope_ref: project_id.as_str().to_owned(),
-                    process_boot_id: "daemon:shutdown-failure-replacement".to_owned(),
-                    producer_revision: "producer.v1".to_owned(),
-                    configuration_revision: digest('e').as_str().to_owned(),
-                    policy_revision: digest('f').as_str().to_owned(),
-                },
-                1,
-            )
-        },
-        1,
-        |error| error,
-    );
-    assert!(matches!(failed, Err("store_observability_shutdown_failed")));
+    let replacement_identity = ObservabilityProducerIdentityV1 {
+        process_boot_id: "daemon:shutdown-failure-replacement".to_owned(),
+        ..identity.clone()
+    };
+    let replacement_mount = store_mount(&digest('0'), &replacement_identity);
+    let failed = registry.acquire_or_start(&database, &replacement_mount, || {
+        observed_start.store(true, Ordering::Release);
+        BoundedObservabilityProducerV1::start(database.clone(), replacement_identity.clone(), 1)
+            .map_err(StoreObservabilityMountErrorV1::Unavailable)
+    });
+    assert!(matches!(
+        failed,
+        Err(StoreObservabilityMountErrorV1::ShutdownFailed)
+    ));
     assert!(!start_called.load(Ordering::Acquire));
 }


### PR DESCRIPTION
## Findings addressed

Audit finding M5 (major, three parts) plus one minor, in the store-authority observability aliasing introduced by #634/#642.

### M5(a) — owner/alias ambiguity in the usecases owners
`BoundedObservabilityProducerV1` and `BoundedDeliverySettlementRecorderV1` were simultaneously owners (holding the worker `JoinHandle`, able to shut down) and aliases (sharing it), forcing `worker`, `admission`, and `emission_lock` behind `Arc<Mutex<…>>` and hand-cloning ~10 fields in each `alias_with_policy_identity`, with one 4-field identity gate duplicated verbatim in both.

- `crates/tracedecay-usecases/src/observability/producer.rs`: new private `ObservabilityProducerCoreV1` owns the queue senders, worker handle, sequence allocator, lifecycle, and locks (now plain `Mutex`); `BoundedObservabilityProducerV1` is `{ core: Arc<Core>, identity }`. `alias_with_policy_identity` is gate + `Arc::clone` + identity. Shutdown (`stop`) lives only on the core.
- `crates/tracedecay-usecases/src/observability/delivery_recorder.rs`: same split into `DeliverySettlementRecorderCoreV1`; the handle carries only the admission identity.
- The duplicated gates collapse into one `ObservabilityProducerIdentityV1::is_policy_alias_of` (store-authority fields must match; only per-root policy may differ); both callers keep their typed error labels.
- `producer/outbox.rs`: owner-fact admission paths route through the core fields.

### M5(b) — eight-parameter, five-closure `acquire_or_start`
`StoreObservabilityRegistryV1::acquire_or_start` (`src/daemon/service/project_runtime/observability.rs`) now takes the database, a concrete `StoreObservabilityMountV1` (provenance + store-authority identity fields + the mounting root's policy revision + delivery capacity), and one lazy producer-start closure, returning a concrete `StoreObservabilityMountErrorV1` (`Busy`/`Retiring`/`ShutdownFailed`/`Unavailable`). The single production caller (`src/daemon/service/invocation/observability_producer.rs`) does its policy mapping inline: `Busy` → the "already mounted" refusal, everything else → the typed owner-mount failure message. Active/Stopping/Failed semantics are unchanged — mounts during Stopping are refused with `store_observability_retiring`, Failed is remembered, and the entry stays present until the drain finishes (guarded by `last_alias_shutdown_keeps_the_store_retiring_until_drain_finishes`).

### M5(c) — hand-rolled refcount layered on Arc
The `aliases: usize` count plus per-handle `released: AtomicBool` were two counts kept consistent by hand. The registry-owned count is now the single authority, derived from exactly one release per handle: `RegisteredObservabilityProducerV1::shutdown` consumes the handle (`mut self`) and takes the same `release: Option<Arc<StoreObservabilityCoreV1>>` token that `Drop` would take, so no flag exists to drift from the count.

### Minor — drop-context poisoning
`Drop for RegisteredObservabilityProducerV1` used to mark the store entry `Failed` (permanently refusing all future mounts) whenever no tokio runtime was available at drop time. A runtime-less last-alias drop now releases the store entry without poisoning (the owner workers settle on their own runtime as the core's queues close); `Failed` is reserved for a genuine shutdown failure.

## Receipts

- `cargo test --lib daemon::service::project_runtime::observability_tests` — **9 passed, 0 failed** (all semantic assertions unmodified; only the renamed registry API call sites and the owned-`shutdown` signature were adapted).
- `cargo test --lib daemon::service::invocation::tests` — 79 passed, 8 failed; the failure set is **byte-identical to the base tip** (`ef34f73e5`) baseline run: `dispatch_tests::feedback_handles_fail_closed_without_an_owner`, `dispatch_tests::multi_root_payloads_are_not_served_by_the_per_project_service`, `lsp_lease_tests::rejected_lsp_open_does_not_initialize_analyzer_or_mint_session_access`, `lsp_tests::lsp_detach_after_unacknowledged_outbound_records_disconnected_drop`, `lsp_tests::lsp_disconnect_expiry_settles_unacknowledged_outbound_as_dropped`, `project_lifecycle_tests::recovery_quiescence_retires_only_the_selected_projects_lsp_owners`, `types_tests::hook_orchestration_backpressures_without_waiting`, `types_tests::superseded_blocking_work_is_joined_before_its_receipt_terminal`.
- `cargo test -p tracedecay-usecases --lib observability` — **70 passed, 0 failed**.
- `cargo clippy -p tracedecay-usecases --lib --tests -- -D warnings` — clean.
- `cargo clippy -p tracedecay --lib --tests -- -D warnings` — the only errors are pre-existing in `src/daemon/code_index_scheduler*` (active peer lane, untouched); no diagnostics in any file touched here.
- `cargo fmt` applied to all touched files.

Net delta: +460 / −391 across 8 files (usecases split +118/−70; daemon registry, caller, and tests +342/−321).