### PR TITLE
fix(daemon): keep runtimeless drops retiring until the drain confirms

### DIFF
--- a/src/daemon/service/project_runtime/observability.rs
+++ b/src/daemon/service/project_runtime/observability.rs
@@ -95,6 +95,19 @@ fn same_registered_store_authority(
         && incumbent.verified_locator() == candidate.verified_locator()
 }
 
+/// How a `Stopping` entry's drain is progressing. Only a confirmed drain may
+/// settle the retirement: a mount frontend obtained from the owner can
+/// outlive every alias handle, so the entry must keep refusing mounts until
+/// the core is actually closed.
+#[derive(Clone, Copy)]
+enum StoreObservabilityDrainV1 {
+    /// A retiring caller is awaiting the core drain or has spawned it.
+    InFlight,
+    /// The last alias was dropped without a tokio runtime, so nothing could
+    /// run the drain. The next mount attempt on a live runtime starts it.
+    Deferred,
+}
+
 enum StoreObservabilityStateV1 {
     Active {
         core: Arc<StoreObservabilityCoreV1>,
@@ -106,6 +119,7 @@ enum StoreObservabilityStateV1 {
     },
     Stopping {
         core: Arc<StoreObservabilityCoreV1>,
+        drain: StoreObservabilityDrainV1,
     },
     Failed,
 }
@@ -235,7 +249,17 @@ impl StoreObservabilityRegistryV1 {
                     *aliases = next_aliases;
                     Ok(registered)
                 }
-                StoreObservabilityStateV1::Stopping { .. } => {
+                StoreObservabilityStateV1::Stopping { core, drain } => {
+                    // A deferred drain (the last alias was dropped without a
+                    // runtime) starts now that a caller with a live runtime
+                    // has arrived. The mount is still refused: only the
+                    // confirmed drain may vacate the entry.
+                    if matches!(drain, StoreObservabilityDrainV1::Deferred)
+                        && let Ok(runtime) = tokio::runtime::Handle::try_current()
+                    {
+                        *drain = StoreObservabilityDrainV1::InFlight;
+                        self.spawn_retirement_drain(&runtime, Arc::clone(core));
+                    }
                     Err(StoreObservabilityMountErrorV1::Retiring)
                 }
                 StoreObservabilityStateV1::Failed => {
@@ -267,11 +291,14 @@ impl StoreObservabilityRegistryV1 {
     }
 
     /// Surrenders one alias release. Reports whether it was the last one, in
-    /// which case the entry is now `Stopping` and the caller must drain the
-    /// core and then finish the retirement.
+    /// which case the entry is now `Stopping` with the given drain progress:
+    /// an `InFlight` caller must drain the core and finish the retirement; a
+    /// `Deferred` retirement waits for the next mount attempt on a live
+    /// runtime to start the drain.
     fn begin_retirement(
         &self,
         core: &Arc<StoreObservabilityCoreV1>,
+        drain: StoreObservabilityDrainV1,
     ) -> Result<bool, ApplicationContractError> {
         let mut entries =
             self.lock_entries()
@@ -311,8 +338,28 @@ impl StoreObservabilityRegistryV1 {
         }
         entry.state = StoreObservabilityStateV1::Stopping {
             core: Arc::clone(core),
+            drain,
         };
         Ok(true)
+    }
+
+    /// Runs the core drain in the background and settles the retirement with
+    /// the drain's confirmed outcome.
+    fn spawn_retirement_drain(
+        &self,
+        runtime: &tokio::runtime::Handle,
+        core: Arc<StoreObservabilityCoreV1>,
+    ) {
+        let registry = self.clone();
+        runtime.spawn(async move {
+            let result = core.shutdown().await;
+            if let Err(error) = &result {
+                tracing::warn!(%error, "background observability owner drain was incomplete");
+            }
+            if let Err(error) = registry.finish_retirement(&core, result.is_ok()) {
+                tracing::warn!(%error, "background observability retirement was incomplete");
+            }
+        });
     }
 
     /// Settles a `Stopping` entry: a releasable retirement removes it so a
@@ -332,7 +379,7 @@ impl StoreObservabilityRegistryV1 {
             same_registered_store_authority(&entry.database, &core.database)
                 && matches!(
                     &entry.state,
-                    StoreObservabilityStateV1::Stopping { core: incumbent }
+                    StoreObservabilityStateV1::Stopping { core: incumbent, .. }
                         if Arc::ptr_eq(incumbent, core)
                 )
         }) else {
@@ -428,7 +475,7 @@ impl RegisteredObservabilityProducerV1 {
         };
         let registry = self.registry.clone();
         drop(self);
-        if !registry.begin_retirement(&core)? {
+        if !registry.begin_retirement(&core, StoreObservabilityDrainV1::InFlight)? {
             return Ok(());
         }
         let result = core.shutdown().await;
@@ -453,7 +500,19 @@ impl Drop for RegisteredObservabilityProducerV1 {
         let Some(core) = self.release.take() else {
             return;
         };
-        let is_last = match self.registry.begin_retirement(&core) {
+        // A drop without a runtime cannot await the drain, and retained
+        // mount frontends may still hold the shared producer core open, so
+        // inability to drain is never a confirmed close. The entry stays
+        // retiring — refusing replacement mounts that would start a
+        // duplicate producer — until the deferred drain, started by the next
+        // mount attempt on a live runtime, confirms the close.
+        let runtime = tokio::runtime::Handle::try_current().ok();
+        let drain = if runtime.is_some() {
+            StoreObservabilityDrainV1::InFlight
+        } else {
+            StoreObservabilityDrainV1::Deferred
+        };
+        let is_last = match self.registry.begin_retirement(&core, drain) {
             Ok(is_last) => is_last,
             Err(error) => {
                 tracing::warn!(%error, "observability alias release was incomplete");
@@ -463,32 +522,12 @@ impl Drop for RegisteredObservabilityProducerV1 {
         if !is_last {
             return;
         }
-        match tokio::runtime::Handle::try_current() {
-            Ok(runtime) => {
-                let registry = self.registry.clone();
-                runtime.spawn(async move {
-                    let result = core.shutdown().await;
-                    if let Err(error) = &result {
-                        tracing::warn!(%error, "dropped observability owner shutdown was incomplete");
-                    }
-                    if let Err(error) = registry.finish_retirement(&core, result.is_ok()) {
-                        tracing::warn!(%error, "dropped observability retirement was incomplete");
-                    }
-                });
-            }
-            Err(_) => {
-                // A drop without a runtime is a teardown accident, not a
-                // shutdown failure: release the store entry instead of
-                // poisoning it so a future daemon runtime can mount fresh
-                // owners. The owner workers settle on their own runtime as
-                // their queues close when the core drops.
-                tracing::warn!(
-                    "observability owners dropped without a runtime; released without an awaited drain"
-                );
-                if let Err(error) = self.registry.finish_retirement(&core, true) {
-                    tracing::warn!(%error, "dropped observability retirement was incomplete");
-                }
-            }
+        match runtime {
+            Some(runtime) => self.registry.spawn_retirement_drain(&runtime, core),
+            None => tracing::warn!(
+                "observability owners dropped without a runtime; the store stays \
+                 retiring until a deferred drain confirms the close"
+            ),
         }
     }
 }

--- a/src/daemon/service/project_runtime/observability_tests.rs
+++ b/src/daemon/service/project_runtime/observability_tests.rs
@@ -1139,6 +1139,89 @@ async fn dropped_last_alias_keeps_the_store_retiring_until_owners_release() {
 }
 
 #[tokio::test]
+async fn runtimeless_last_alias_drop_keeps_the_store_retiring_until_the_drain_confirms() {
+    let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
+    let (_project, project_id, database, _runtime) =
+        runtime("observability-runtimeless-drop").await;
+    let registry = StoreObservabilityRegistryV1::default();
+    let identity = ObservabilityProducerIdentityV1 {
+        authorized_scope_ref: project_id.as_str().to_owned(),
+        process_boot_id: "daemon:runtimeless-drop".to_owned(),
+        producer_revision: "producer.v1".to_owned(),
+        configuration_revision: digest('6').as_str().to_owned(),
+        policy_revision: digest('7').as_str().to_owned(),
+    };
+    let producer = BoundedObservabilityProducerV1::start(database.clone(), identity.clone(), 8)
+        .expect("producer");
+    let registered = registry
+        .acquire_or_start(&database, &store_mount(&digest('0'), &identity), || {
+            Ok(producer)
+        })
+        .expect("registered observability producer");
+    // Owners that record through the mounted producer retain frontends past
+    // the alias handle's lifetime; this one keeps the shared core open.
+    let retained = registered.producer();
+    std::thread::spawn(move || drop(registered))
+        .join()
+        .expect("drop the last alias handle outside any tokio runtime");
+    assert_eq!(
+        retained
+            .try_emit(envelope(&project_id, "runtimeless:retained"))
+            .expect("retained frontend still emits through the open core"),
+        ObservabilityEmissionOutcomeV1::Enqueued
+    );
+
+    // The store entry must stay retiring: the drain never ran, so vacating
+    // it would let a second producer start while the first still writes.
+    let overlap_identity = ObservabilityProducerIdentityV1 {
+        process_boot_id: "daemon:runtimeless-drop-overlap".to_owned(),
+        ..identity.clone()
+    };
+    let overlap_mount = store_mount(&digest('0'), &overlap_identity);
+    let refused = registry.acquire_or_start(&database, &overlap_mount, || {
+        panic!("a runtimeless drop must not vacate the store entry into a duplicate producer")
+    });
+    assert!(matches!(
+        refused,
+        Err(StoreObservabilityMountErrorV1::Retiring)
+    ));
+
+    // That refused mount ran on a live runtime, so the deferred drain is now
+    // in flight; only its confirmed close releases the store entry.
+    let replacement_identity = ObservabilityProducerIdentityV1 {
+        process_boot_id: "daemon:runtimeless-drop-replacement".to_owned(),
+        ..identity.clone()
+    };
+    let replacement_mount = store_mount(&digest('0'), &replacement_identity);
+    let replacement = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            let attempt = registry.acquire_or_start(&database, &replacement_mount, || {
+                BoundedObservabilityProducerV1::start(
+                    database.clone(),
+                    replacement_identity.clone(),
+                    1,
+                )
+                .map_err(StoreObservabilityMountErrorV1::Unavailable)
+            });
+            match attempt {
+                Ok(replacement) => break replacement,
+                Err(StoreObservabilityMountErrorV1::Retiring) => tokio::task::yield_now().await,
+                Err(error) => panic!("unexpected replacement result: {error}"),
+            }
+        }
+    })
+    .await
+    .expect("deferred drain confirms and releases the store");
+    assert_eq!(
+        retained
+            .try_emit(envelope(&project_id, "runtimeless:after-drain"))
+            .expect_err("the confirmed drain closes the retained frontend"),
+        "observability_producer_closed"
+    );
+    replacement.shutdown().await.expect("replacement shutdown");
+}
+
+#[tokio::test]
 async fn registered_shutdown_reports_a_blocked_producer_flush() {
     let _pin = tracedecay_runtime_core::config::PinnedUserDataDir::new();
     let (_project, project_id, database, _runtime) =


### PR DESCRIPTION
## Summary

Resolves the unresolved Codex P2 finding on #650: **"Keep runtimeless drops retiring until the owner closes."**

The runtimeless-drop path shipped in #650 called `finish_retirement(&core, true)` when the last alias handle was dropped outside a tokio runtime — treating inability-to-await as a successful retirement. That vacated the exact-store entry while a retained producer frontend (from `RegisteredObservabilityProducerV1::producer()`) still held the shared producer core open, so the next mount could start a **second producer for the same store** while the first still accepted and wrote events — exactly the duplicate-producer bug the store-authority registry exists to prevent.

## Fix (`src/daemon/service/project_runtime/observability.rs`)

- New `StoreObservabilityDrainV1 { InFlight, Deferred }` on the `Stopping` state records whether the core drain is actually running.
- `Drop for RegisteredObservabilityProducerV1` without a runtime now begins retirement as `Deferred` and **never** settles it: the entry stays `Stopping`, refusing all mounts, and only warns.
- `acquire_or_start` hitting a `Deferred` retirement on a live runtime flips it to `InFlight` (under the registry lock, exactly once) and spawns the real `core.shutdown()` drain — the mount itself is still refused with `Retiring`.
- Only the confirmed drain outcome settles the entry via `finish_retirement`: success vacates it, failure is remembered as `Failed`. Explicit `shutdown()` and runtime-present drops are unchanged (`InFlight`, shared `spawn_retirement_drain`).

## Regression test (RED on pre-fix code)

`runtimeless_last_alias_drop_keeps_the_store_retiring_until_the_drain_confirms`: mounts a producer, retains the frontend from `producer()`, drops the last alias handle on a `std::thread` (no tokio runtime), proves the retained frontend still enqueues, then attempts an overlap mount whose start closure panics if reached.

On the pre-fix code (`baa5cb8d9`) the test **fails** with:

```
panicked at src/daemon/service/project_runtime/observability_tests.rs:1182:9:
a runtimeless drop must not vacate the store entry into a duplicate producer
```

i.e. the vacated entry let the registry invoke the start closure for a duplicate producer while the retained frontend was still live. Post-fix the overlap mount is refused `Retiring`, the deferred drain then confirms (retained frontend observes `observability_producer_closed`), and a replacement mounts and shuts down cleanly.

## Receipts

- `cargo test --lib daemon::service::project_runtime::observability_tests` — 10 passed, 0 failed (includes the new test)
- `cargo test -p tracedecay-usecases --lib observability` — 70 passed, 0 failed
- `cargo clippy -p tracedecay --lib --tests -- -D warnings` — no diagnostics in touched files; remaining errors are pre-existing in `src/daemon/code_index_scheduler*` (peer lane, unchanged here)
- `cargo fmt` clean on touched files