### PR TITLE
test(query): bind artifact regressions to behavior

### DIFF
--- a/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/builder.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/builder.rs
@@ -2589,33 +2589,6 @@ mod tests {
     }
 
     #[test]
-    fn document_integrity_queries_seek_document_leading_indexes() {
-        let connection = Connection::open_in_memory().expect("open artifact database");
-        create_schema(&connection).expect("create artifact schema");
-
-        for (query, expected_index) in [
-            (DOCUMENT_TERM_POSTINGS_QUERY, "term_postings_by_document"),
-            (DOCUMENT_EXACT_POSTINGS_QUERY, "exact_postings_by_document"),
-            (DOCUMENT_NGRAM_POSTINGS_QUERY, "ngram_postings_by_document"),
-        ] {
-            let plan = explain_document_integrity_query(&connection, query);
-            assert!(
-                plan.iter()
-                    .any(|detail| { detail.contains("SEARCH") && detail.contains(expected_index) }),
-                "document integrity query must seek {expected_index}, got {plan:?}"
-            );
-            assert!(
-                plan.iter().all(|detail| !detail.contains("SCAN")),
-                "document integrity query must not scan its generation, got {plan:?}"
-            );
-            assert!(
-                plan.iter().all(|detail| !detail.contains("TEMP B-TREE")),
-                "document integrity query must not sort its generation, got {plan:?}"
-            );
-        }
-    }
-
-    #[test]
     fn one_document_integrity_row_does_not_visit_unrelated_generation_rows() {
         let mut connection = Connection::open_in_memory().expect("open artifact database");
         create_schema(&connection).expect("create artifact schema");
@@ -2733,18 +2706,6 @@ mod tests {
         assert_eq!(state.section_row_count, 0);
         assert_eq!(state.completed_rows, 0);
         assert_eq!(state.section_last_key, None);
-    }
-
-    fn explain_document_integrity_query(connection: &Connection, query: &str) -> Vec<String> {
-        let mut statement = connection
-            .prepare(&format!("EXPLAIN QUERY PLAN {query}"))
-            .expect("prepare document integrity query plan");
-        let mut rows = statement.query([0i64]).expect("query plan");
-        let mut details = Vec::new();
-        while let Some(row) = rows.next().expect("read query plan") {
-            details.push(row.get(3).expect("query plan detail"));
-        }
-        details
     }
 
     #[test]

--- a/crates/tracedecay-query/tests/search_quality_suite/candidate_producers.rs
+++ b/crates/tracedecay-query/tests/search_quality_suite/candidate_producers.rs
@@ -195,6 +195,27 @@ impl CodeIndexExecutionControlV1 for CancelAtObservation {
     }
 }
 
+#[derive(Default)]
+struct CancelAfterAcceptedPage {
+    page_accepted: std::sync::atomic::AtomicBool,
+}
+
+impl CancelAfterAcceptedPage {
+    fn mark_page_accepted(&self) {
+        self.page_accepted.store(true, Ordering::SeqCst);
+    }
+}
+
+impl CodeIndexExecutionControlV1 for CancelAfterAcceptedPage {
+    fn is_cancelled(&self) -> bool {
+        self.page_accepted.load(Ordering::SeqCst)
+    }
+
+    fn is_deadline_exceeded(&self) -> bool {
+        false
+    }
+}
+
 /// A bounded work budget that exhausts after a fixed number of deadline
 /// observations, mirroring the production activations that failed with
 /// "the read port exceeded its bounded work budget".
@@ -2039,39 +2060,43 @@ fn disk_artifact_same_source_instance_resumes_after_accepted_page_failure() {
     let metadata = fixture.metadata.clone();
     let control = ArtifactControl { cancelled: false };
     let directory = tempfile::tempdir().expect("artifact tempdir");
-    let mut resumed_after_acceptance = false;
-    for cancellation_observation in 3..=256 {
-        let artifact_path = directory
-            .path()
-            .join(format!("same-source-{cancellation_observation}.sqlite"));
-        let mut builder = CodeLexicalArtifactBuilderV1::create(&artifact_path, metadata.clone())
-            .expect("create artifact");
-        let mut source = fixture.open_source(1);
-        let cancellation = CancelAtObservation::new(cancellation_observation);
-        match builder.rebuild_and_finalize(&mut source, &cancellation) {
-            Err(CodeLexicalArtifactErrorV1::Interrupted(_)) => {}
-            Ok(_) => break,
-            Err(error) => panic!("interrupted seal replay must stay typed: {error:?}"),
-        }
-        if source.cursor().next_page_ordinal() == 0 {
-            continue;
-        }
-        // The failure landed after page acceptance: the SAME instance must
-        // resume and seal.
-        resumed_after_acceptance = true;
-        let verified = builder.rebuild_and_finalize(&mut source, &control).expect(
-            "the same source instance must resume after an accepted-page failure \
-             instead of terminally blocking on the page-zero precondition",
-        );
-        assert_eq!(verified.total_chunks(), source_receipt.total_chunks());
-        let (rows, _) = staged_row_cardinality(&artifact_path);
-        assert_eq!(rows, source_receipt.total_chunks());
-        break;
-    }
-    assert!(
-        resumed_after_acceptance,
-        "the cancellation sweep must observe at least one failure after page acceptance"
+    let artifact_path = directory.path().join("same-source.sqlite");
+    let mut builder =
+        CodeLexicalArtifactBuilderV1::create(&artifact_path, metadata).expect("create artifact");
+    let mut source = fixture.open_source(1);
+    let cancellation = CancelAfterAcceptedPage::default();
+
+    let first_page = source
+        .next_page_if(&cancellation, |page| {
+            builder.append_page(page, &cancellation)?;
+            cancellation.mark_page_accepted();
+            Ok::<(), CodeLexicalArtifactErrorV1>(())
+        })
+        .expect("stage the first verified page")
+        .expect("admit the first verified page");
+    assert!(matches!(
+        first_page,
+        VerifiedSealedLexicalPageReadV1::Page(_)
+    ));
+    assert_eq!(source.cursor().next_page_ordinal(), 1);
+
+    assert!(matches!(
+        builder.rebuild_and_finalize(&mut source, &cancellation),
+        Err(CodeLexicalArtifactErrorV1::Interrupted(
+            CodeIndexInterruptionV1::Cancelled
+        ))
+    ));
+    assert_eq!(source.cursor().next_page_ordinal(), 1);
+
+    // The failure landed after page acceptance: the SAME instance must
+    // resume and seal.
+    let verified = builder.rebuild_and_finalize(&mut source, &control).expect(
+        "the same source instance must resume after an accepted-page failure \
+         instead of terminally blocking on the page-zero precondition",
     );
+    assert_eq!(verified.total_chunks(), source_receipt.total_chunks());
+    let (rows, _) = staged_row_cardinality(&artifact_path);
+    assert_eq!(rows, source_receipt.total_chunks());
 }
 
 /// A test authority that denies a configured set of literal byte strings and


### PR DESCRIPTION
## Summary

- remove the SQLite `EXPLAIN QUERY PLAN` wording/index-name assertion from the document-integrity regression
- retain direct `StatementStatus::FullscanStep == 0` and `Sort == 0` behavioral evidence across 2,048 unrelated rows
- replace the arbitrary checkpoint-count cancellation sweep with an event-driven control armed immediately after the first page is accepted
- prove cancellation leaves the same source cursor at page 1 and that the same instance resumes and seals exactly once

## Review follow-up

Addresses both delayed comments on #654:
- https://github.com/ScriptedAlchemy/tracedecay/pull/654#discussion_r3836775657
- https://github.com/ScriptedAlchemy/tracedecay/pull/654#discussion_r3836775659

Production code and artifact format are unchanged.

## Verification

- exact `one_document_integrity_row_does_not_visit_unrelated_generation_rows`: 1 passed
- exact `disk_artifact_same_source_instance_resumes_after_accepted_page_failure`: 1 passed
- `cargo clippy -p tracedecay-query --lib --tests --locked -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
