### PR TITLE
fix(query): use stable Windows file identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5978,6 +5978,7 @@ dependencies = [
  "tracedecay-domain",
  "tracedecay-graph-db",
  "tracedecay-private-fs",
+ "tracedecay-runtime-core",
  "tracedecay-temporal-query",
  "zeroize",
 ]

--- a/crates/tracedecay-query/Cargo.toml
+++ b/crates/tracedecay-query/Cargo.toml
@@ -26,6 +26,9 @@ tracedecay-private-fs = { path = "../tracedecay-private-fs", version = "0.1.0" }
 tracedecay-temporal-query = { path = "../tracedecay-temporal-query", version = "0.1.0" }
 zeroize = "1.9.0"
 
+[target.'cfg(windows)'.dependencies]
+tracedecay-runtime-core = { path = "../tracedecay-runtime-core", version = "0.1.0" }
+
 [features]
 # Explicit opt-in (same policy as `test-transport` on the runtime crate):
 # exposes `*_for_test` constructors to dependent crates' test builds only.

--- a/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/builder.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/builder.rs
@@ -319,9 +319,7 @@ struct StableArtifactFileIdentityV1 {
     #[cfg(windows)]
     volume_serial_number: u32,
     #[cfg(windows)]
-    file_index_high: u32,
-    #[cfg(windows)]
-    file_index_low: u32,
+    file_index: u64,
 }
 
 pub struct CodeLexicalArtifactBuilderV1 {
@@ -770,11 +768,11 @@ fn open_bound_builder_connection(
 fn stable_file_identity(
     file: &File,
 ) -> Result<StableArtifactFileIdentityV1, CodeLexicalArtifactErrorV1> {
-    let metadata = file.metadata().map_err(private_staging_error)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
 
+        let metadata = file.metadata().map_err(private_staging_error)?;
         Ok(StableArtifactFileIdentityV1 {
             device: metadata.dev(),
             inode: metadata.ino(),
@@ -782,12 +780,12 @@ fn stable_file_identity(
     }
     #[cfg(windows)]
     {
-        use std::os::windows::fs::MetadataExt;
+        let information = tracedecay_runtime_core::windows_file::information(file)
+            .map_err(private_staging_error)?;
 
         Ok(StableArtifactFileIdentityV1 {
-            volume_serial_number: metadata.volume_serial_number(),
-            file_index_high: metadata.file_index_high(),
-            file_index_low: metadata.file_index_low(),
+            volume_serial_number: information.volume_serial_number,
+            file_index: information.file_index,
         })
     }
 }

--- a/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/reader.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/reader.rs
@@ -1440,29 +1440,14 @@ fn verify_named_path_identity(path: &Path, file: &File) -> Result<(), CodeLexica
 
     #[cfg(windows)]
     {
-        use std::os::windows::fs::MetadataExt;
-
-        let named_volume = named.volume_serial_number().ok_or_else(|| {
-            CodeLexicalArtifactErrorV1::Incompatible(
-                "artifact filesystem does not expose a stable volume identity".to_owned(),
-            )
-        })?;
-        let opened_volume = opened.volume_serial_number().ok_or_else(|| {
-            CodeLexicalArtifactErrorV1::Incompatible(
-                "opened artifact does not expose a stable volume identity".to_owned(),
-            )
-        })?;
-        let named_index = named.file_index().ok_or_else(|| {
-            CodeLexicalArtifactErrorV1::Incompatible(
-                "artifact filesystem does not expose a stable file identity".to_owned(),
-            )
-        })?;
-        let opened_index = opened.file_index().ok_or_else(|| {
-            CodeLexicalArtifactErrorV1::Incompatible(
-                "opened artifact does not expose a stable file identity".to_owned(),
-            )
-        })?;
-        if named_volume != opened_volume || named_index != opened_index {
+        let named_file = File::open(path).map_err(map_artifact_file_error)?;
+        let named_identity = tracedecay_runtime_core::windows_file::information(&named_file)
+            .map_err(map_artifact_file_error)?;
+        let opened_identity = tracedecay_runtime_core::windows_file::information(file)
+            .map_err(map_artifact_file_error)?;
+        if named_identity.volume_serial_number != opened_identity.volume_serial_number
+            || named_identity.file_index != opened_identity.file_index
+        {
             return Err(CodeLexicalArtifactErrorV1::Corrupt(
                 "artifact path was atomically replaced while opening".to_owned(),
             ));


### PR DESCRIPTION
Fix the inherited Windows build failure introduced by lexical artifact file binding.

- replace unstable `std::os::windows::fs::MetadataExt` file identity calls with the existing `GetFileInformationByHandle` authority
- preserve exact volume + file-index binding for staging and content-addressed readers
- keep the runtime-core dependency Windows-only

Evidence:
- hosted RED on PR #653: E0658/E0308/E0599 in builder.rs and reader.rs
- `cargo check -p tracedecay-query --target x86_64-pc-windows-gnu --locked` GREEN
- three exact native file replacement/mutation regressions GREEN
- `cargo clippy -p tracedecay-query --lib --tests --locked -- -D warnings` GREEN
- rustfmt and diff-check GREEN