### PR TITLE
fix(code-index): preserve active warmup snapshots

### DIFF
--- a/src/daemon/code_index_scheduler/registry.rs
+++ b/src/daemon/code_index_scheduler/registry.rs
@@ -37,6 +37,8 @@ use super::{
 #[cfg(test)]
 use super::{CodeIndexBytePoolStatsV1, CodeIndexCadenceReadModelV1};
 
+#[cfg(test)]
+mod cold_read_wake_tests;
 mod ignored_dependencies;
 mod lsp_projection;
 #[cfg(test)]
@@ -3421,12 +3423,13 @@ impl CodeIndexSchedulerRegistryV1 {
         let project_root = project_root.canonicalize().ok()?;
         // Clone the per-worktree handle under a short map lock, then drop the
         // registry guard before checking the mounted route.
-        let (scheduler, serving_generation, wake, pending_wake) = {
+        let (scheduler, serving_generation, hints, wake, pending_wake) = {
             let mounted = self.mounted.lock().await;
             let worktree = mounted.get(&project_root)?;
             (
                 Arc::clone(&worktree.scheduler),
                 Arc::clone(&worktree.serving_generation),
+                Arc::clone(&worktree.hints),
                 Arc::clone(&worktree.wake),
                 Arc::clone(&worktree.pending_wake),
             )
@@ -3496,7 +3499,13 @@ impl CodeIndexSchedulerRegistryV1 {
                 .micros
                 == 0
             {
-                scheduler.request_background_reconcile();
+                // A cold read carries no source-change evidence. Preserve any
+                // snapshot the retained owner is already reconstructing and
+                // keep one follow-up authoritative scan pending instead.
+                hints
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .overflow();
                 Self::note_wake(
                     &pending_wake,
                     &wake,
@@ -3842,7 +3851,7 @@ impl CodeIndexSchedulerRegistryV1 {
         } else {
             None
         };
-        let (scheduler, serving_generation, wake, pending_wake) = {
+        let (scheduler, serving_generation, hints, wake, pending_wake) = {
             let Ok(mounted) = self.mounted.try_lock() else {
                 return false;
             };
@@ -3859,6 +3868,7 @@ impl CodeIndexSchedulerRegistryV1 {
                 matched = Some((
                     Arc::clone(&worktree.scheduler),
                     Arc::clone(&worktree.serving_generation),
+                    Arc::clone(&worktree.hints),
                     Arc::clone(&worktree.wake),
                     Arc::clone(&worktree.pending_wake),
                 ));
@@ -3914,7 +3924,13 @@ impl CodeIndexSchedulerRegistryV1 {
             // apply: a reconcile is the only thing that can ever make this scope
             // answerable, and no other caller on this path will ask for it.
             if nothing_servable {
-                scheduler.request_background_reconcile();
+                // This admission observed no source mutation, so it may not
+                // supersede an in-flight authoritative snapshot. The retained
+                // overflow plus pending wake guarantees a follow-up pass.
+                hints
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .overflow();
             } else if !scheduler.request_fresh_for_query_background() {
                 return false;
             }

--- a/src/daemon/code_index_scheduler/registry/cold_read_wake_tests.rs
+++ b/src/daemon/code_index_scheduler/registry/cold_read_wake_tests.rs
@@ -1,0 +1,134 @@
+//! Cold-read wake behavior while the retained code-index owner is active.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use tempfile::TempDir;
+use tracedecay_application::ResolvedScope;
+
+use super::super::{DaemonCodeIndexControlV1, ReconcilePassGuard};
+use super::CodeIndexSchedulerRegistryV1;
+use crate::code_index::production::CodeIndexExecutionControlV1;
+
+#[tokio::test]
+async fn cold_read_wakes_do_not_cancel_an_in_flight_reconcile_snapshot() {
+    let fixture = TempDir::new().expect("fixture root");
+    let project = fixture.path().join("project");
+    fs::create_dir_all(project.join("src")).expect("create source root");
+    fs::write(project.join("src/main.rs"), "fn main() {}\n").expect("write source");
+    run_git_in(&project, &["init", "-q", "-b", "main"]);
+    run_git_in(&project, &["add", "."]);
+    run_git_in(&project, &["commit", "-qm", "fixture"]);
+
+    let project_id =
+        tracedecay_domain::ProjectId::new("project.cold-read-wake").expect("project identity");
+    let registry = CodeIndexSchedulerRegistryV1::with_background_reconcile_permits(1, 1);
+    let admission = registry
+        .background_reconcile_admission()
+        .acquire_owned()
+        .await
+        .expect("hold background worker at its dequeue point");
+    registry
+        .mount_worktree(
+            project_id.clone(),
+            &project,
+            fixture.path().join("store"),
+            None,
+        )
+        .await
+        .expect("mount scheduler");
+    let canonical_project = project.canonicalize().expect("canonical project");
+
+    let (scope, epoch, shutting_down, reconcile_in_progress) = {
+        let mounted = registry.mounted.lock().await;
+        let worktree = mounted.get(&canonical_project).expect("mounted worktree");
+        let reference = worktree
+            .scheduler
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .identity()
+            .head_ref()
+            .cloned()
+            .expect("branch reference");
+        (
+            ResolvedScope::new(
+                project_id,
+                worktree.repository_id.clone(),
+                worktree.worktree_id.clone(),
+                Some(reference),
+            )
+            .expect("resolved scope"),
+            Arc::clone(&worktree.epoch),
+            Arc::clone(&worktree.shutting_down),
+            Arc::clone(&worktree.reconcile_in_progress),
+        )
+    };
+    registry.clear_pending_wake_for_scope(&scope).await;
+    let reconcile_pass = ReconcilePassGuard::enter(&reconcile_in_progress);
+
+    let latest_control =
+        DaemonCodeIndexControlV1::new(Arc::clone(&epoch), Arc::clone(&shutting_down));
+    assert!(
+        registry.latest_complete_fresh(&project).await.is_none(),
+        "a cold read must stay unavailable until the retained owner publishes"
+    );
+    assert!(
+        !latest_control.is_cancelled(),
+        "a cold latest-generation read may wake the owner but must not supersede its snapshot"
+    );
+    assert_ne!(
+        registry
+            .pending_wake_micros_for_scope(&scope)
+            .await
+            .expect("mounted worktree"),
+        0,
+        "the non-invalidating read must retain one authoritative follow-up wake"
+    );
+
+    registry.clear_pending_wake_for_scope(&scope).await;
+    let query_control =
+        DaemonCodeIndexControlV1::new(Arc::clone(&epoch), Arc::clone(&shutting_down));
+    assert!(
+        registry.request_query_background_reconcile(&scope).await,
+        "a cold query still records one follow-up wake"
+    );
+    assert!(
+        !query_control.is_cancelled(),
+        "a cold search may wake the owner but must not supersede its snapshot"
+    );
+
+    let invalidation_control = DaemonCodeIndexControlV1::new(epoch, shutting_down);
+    assert!(
+        registry
+            .notify_hook_paths(&project, &["src/main.rs".to_owned()])
+            .await,
+        "a real source hint reaches the mounted scheduler"
+    );
+    assert!(
+        invalidation_control.is_cancelled(),
+        "source-change evidence must still supersede the in-flight snapshot"
+    );
+
+    drop(reconcile_pass);
+    drop(admission);
+    registry.shutdown().await;
+}
+
+fn run_git_in(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", "TraceDecay Test")
+        .env("GIT_AUTHOR_EMAIL", "test@tracedecay.invalid")
+        .env("GIT_COMMITTER_NAME", "TraceDecay Test")
+        .env("GIT_COMMITTER_EMAIL", "test@tracedecay.invalid")
+        .output()
+        .expect("git command should run");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/src/daemon/code_index_scheduler/registry/cold_read_wake_tests.rs
+++ b/src/daemon/code_index_scheduler/registry/cold_read_wake_tests.rs
@@ -41,7 +41,7 @@ async fn cold_read_wakes_do_not_cancel_an_in_flight_reconcile_snapshot() {
         .expect("mount scheduler");
     let canonical_project = project.canonicalize().expect("canonical project");
 
-    let (scope, epoch, shutting_down, reconcile_in_progress) = {
+    let (scope, scheduler, hints, epoch, shutting_down, reconcile_in_progress) = {
         let mounted = registry.mounted.lock().await;
         let worktree = mounted.get(&canonical_project).expect("mounted worktree");
         let reference = worktree
@@ -60,6 +60,8 @@ async fn cold_read_wakes_do_not_cancel_an_in_flight_reconcile_snapshot() {
                 Some(reference),
             )
             .expect("resolved scope"),
+            Arc::clone(&worktree.scheduler),
+            Arc::clone(&worktree.hints),
             Arc::clone(&worktree.epoch),
             Arc::clone(&worktree.shutting_down),
             Arc::clone(&worktree.reconcile_in_progress),
@@ -86,8 +88,20 @@ async fn cold_read_wakes_do_not_cancel_an_in_flight_reconcile_snapshot() {
         0,
         "the non-invalidating read must retain one authoritative follow-up wake"
     );
+    assert_eq!(
+        scheduler
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pending_hint_count(),
+        None,
+        "the cold latest-generation wake must require an authoritative overflow reconcile"
+    );
 
     registry.clear_pending_wake_for_scope(&scope).await;
+    hints
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
     let query_control =
         DaemonCodeIndexControlV1::new(Arc::clone(&epoch), Arc::clone(&shutting_down));
     assert!(
@@ -97,6 +111,14 @@ async fn cold_read_wakes_do_not_cancel_an_in_flight_reconcile_snapshot() {
     assert!(
         !query_control.is_cancelled(),
         "a cold search may wake the owner but must not supersede its snapshot"
+    );
+    assert_eq!(
+        scheduler
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pending_hint_count(),
+        None,
+        "the cold query wake must require an authoritative overflow reconcile"
     );
 
     let invalidation_control = DaemonCodeIndexControlV1::new(epoch, shutting_down);


### PR DESCRIPTION
## Summary
- keep cold latest-generation reads and cold search admissions fail-fast while retaining one authoritative follow-up wake
- stop those read-only wake requests from advancing the scheduler epoch and cancelling the retained owner already rebuilding or activating the same snapshot
- preserve real hook-path invalidation: source-change evidence still advances the epoch and cancels superseded work

## Dogfood evidence
Fresh beta.36 enrollment completed in 1.94s, then the isolated daemon remained cold for more than 30 minutes, reached roughly 5 GiB RSS, and repeatedly logged `code_index_retained_seat_failed ... the read port was cancelled`. Retry intervals grew through the configured 30s, 60s, 120s, and 240s backoff to the 10-minute ceiling while one-minute automation reads continued and no tracked source file changed.

The exact code path was: the worker claimed its pending wake and entered a retained reconcile or activation pass; with nothing serving, a cold read observed an empty pending slot, called `request_background_reconcile`, and advanced the same epoch captured by the active production control.

## TDD
RED on base `3850d8eaa6d0178716ca994f4e92f8e62f7a46ab`:
- exact regression ran 1 test and failed at `a cold latest-generation read may wake the owner but must not supersede its snapshot`

GREEN on `de87992e3`:
- exact regression: 1 passed / 0 failed / 2,804 filtered
- asserts both cold-read entry points retain a follow-up wake without cancelling the captured control
- negative control delivers a real production hook path and proves that source invalidation still cancels the snapshot

Independent review follow-up on final head `4f2d79acf3cc44ac161aebe075a72bec0787d288`:
- mutation RED 1: remove the latest-generation `overflow()` only; exact test failed 0/1 with `Some(0)` instead of authoritative `None`
- mutation RED 2: restore that path and remove the cold-query `overflow()` only; exact test failed 0/1 at the second independent assertion
- restored exact GREEN: 1 passed / 0 failed / 2,804 filtered
- root Clippy for lib and tests with `--no-deps --locked -D warnings`: GREEN
- `cargo fmt --all --check`, `git diff --check`, and commitlint: GREEN

Not counted as green: the older neighboring `search_requests_one_background_reconcile_when_nothing_is_servable` test missed its unchanged 5-second initial-generation fixture bound before reaching the modified branch, both before and after stopping the dogfood daemon. This PR does not change that pre-publication path.

## Scope
Exactly two paths:
- `src/daemon/code_index_scheduler/registry.rs`
- `src/daemon/code_index_scheduler/registry/cold_read_wake_tests.rs`
