### PR TITLE
fix(update): quiesce daemon before dogfood refresh

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -622,14 +622,10 @@ async fn dispatch_command(command: Commands) -> tracedecay::errors::Result<()> {
             lifecycle_lease_token,
             previous_daemon_state,
         } => {
-            let lifecycle_lease = tracedecay::lifecycle_lease::acquire_exclusive_or_inherited(
-                "post-update",
-                lifecycle_lease_token.as_deref(),
-            )?;
-            update_cmd::run_post_update_tasks(
+            update_cmd::run_post_update_command(
                 no_heal,
                 no_reinstall,
-                &lifecycle_lease,
+                lifecycle_lease_token.as_deref(),
                 previous_daemon_state,
             )
             .await?;

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -385,6 +385,40 @@ where
     }
 }
 
+fn prepare_post_update_window(
+    lifecycle_lease_token: Option<&str>,
+    previous_daemon_state: Option<tracedecay::daemon::DaemonServiceState>,
+) -> tracedecay::errors::Result<(
+    tracedecay::lifecycle_lease::LifecycleLease,
+    Option<tracedecay::daemon::DaemonServiceState>,
+)> {
+    prepare_post_update_window_with(
+        lifecycle_lease_token,
+        previous_daemon_state,
+        |token| {
+            tracedecay::lifecycle_lease::acquire_exclusive_or_inherited("post-update", Some(token))
+        },
+        || begin_update_window("post-update"),
+    )
+}
+
+fn prepare_post_update_window_with<Lease, AcquireInherited, BeginDirect>(
+    lifecycle_lease_token: Option<&str>,
+    previous_daemon_state: Option<tracedecay::daemon::DaemonServiceState>,
+    acquire_inherited: AcquireInherited,
+    begin_direct: BeginDirect,
+) -> tracedecay::errors::Result<(Lease, Option<tracedecay::daemon::DaemonServiceState>)>
+where
+    AcquireInherited: FnOnce(&str) -> tracedecay::errors::Result<Lease>,
+    BeginDirect:
+        FnOnce() -> tracedecay::errors::Result<(tracedecay::daemon::DaemonServiceState, Lease)>,
+{
+    match lifecycle_lease_token {
+        Some(token) => acquire_inherited(token).map(|lease| (lease, previous_daemon_state)),
+        None => begin_direct().map(|(previous_state, lease)| (lease, Some(previous_state))),
+    }
+}
+
 fn restore_after_update_window(
     previous_state: tracedecay::daemon::DaemonServiceState,
     result: tracedecay::errors::Result<()>,
@@ -638,7 +672,24 @@ async fn reinstall_tracked_agents_with_lease(
     partition_reinstall_results(results)
 }
 
-pub(crate) async fn run_post_update_tasks(
+pub(crate) async fn run_post_update_command(
+    no_heal: bool,
+    no_reinstall: bool,
+    lifecycle_lease_token: Option<&str>,
+    previous_daemon_state: Option<tracedecay::daemon::DaemonServiceState>,
+) -> tracedecay::errors::Result<()> {
+    let (lifecycle_lease, previous_daemon_state) =
+        prepare_post_update_window(lifecycle_lease_token, previous_daemon_state)?;
+    run_post_update_tasks(
+        no_heal,
+        no_reinstall,
+        &lifecycle_lease,
+        previous_daemon_state,
+    )
+    .await
+}
+
+async fn run_post_update_tasks(
     no_heal: bool,
     no_reinstall: bool,
     lifecycle_lease: &tracedecay::lifecycle_lease::LifecycleLease,
@@ -783,8 +834,8 @@ mod tests {
         PostUpdateExecution, RefreshPolicy, ReinstallOutcome, begin_update_window_with,
         current_tracedecay_exe_from, finish_post_update_execution_with, finish_update_flow_with,
         normalize_bin_path, partition_reinstall_results, post_update_binary,
-        post_update_binary_from, prepare_post_update_lease, resolve_previous_daemon_state,
-        restart_daemon_service_with, run_install_then_refresh,
+        post_update_binary_from, prepare_post_update_lease, prepare_post_update_window_with,
+        resolve_previous_daemon_state, restart_daemon_service_with, run_install_then_refresh,
     };
     use tempfile::TempDir;
     use tracedecay::upgrade::UpgradeOutcome;
@@ -915,6 +966,63 @@ mod tests {
                 .contains("lifecycle lease busy")
         );
         assert_eq!(order.into_inner(), ["quiesce", "acquire", "restore"]);
+    }
+
+    #[test]
+    fn tokenless_post_update_restores_daemon_when_exclusive_lease_is_busy() {
+        let order = RefCell::new(Vec::new());
+        let result = prepare_post_update_window_with(
+            None,
+            None,
+            |_| panic!("tokenless post-update must not use inherited acquisition"),
+            || {
+                begin_update_window_with(
+                    || {
+                        order.borrow_mut().push("quiesce");
+                        Ok(tracedecay::daemon::DaemonServiceState::RunningEnabled)
+                    },
+                    || -> tracedecay::errors::Result<()> {
+                        assert_eq!(order.borrow().as_slice(), ["quiesce"]);
+                        order.borrow_mut().push("acquire");
+                        Err(config_err("lifecycle lease busy"))
+                    },
+                    |state| {
+                        assert_eq!(
+                            state,
+                            tracedecay::daemon::DaemonServiceState::RunningEnabled
+                        );
+                        order.borrow_mut().push("restore");
+                        Ok(())
+                    },
+                )
+            },
+        );
+
+        assert!(
+            result
+                .expect_err("busy lifecycle lease should fail")
+                .to_string()
+                .contains("lifecycle lease busy")
+        );
+        assert_eq!(order.into_inner(), ["quiesce", "acquire", "restore"]);
+    }
+
+    #[test]
+    fn inherited_post_update_uses_parent_token_and_state_without_direct_window() {
+        let previous_state = tracedecay::daemon::DaemonServiceState::RunningDisabled;
+        let (lease, inherited_state) = prepare_post_update_window_with(
+            Some("live-parent-token"),
+            Some(previous_state),
+            |token| {
+                assert_eq!(token, "live-parent-token");
+                Ok("inherited lease")
+            },
+            || panic!("inherited post-update must not open a second update window"),
+        )
+        .expect("inherited post-update window");
+
+        assert_eq!(lease, "inherited lease");
+        assert_eq!(inherited_state, Some(previous_state));
     }
 
     #[test]

--- a/tests/dogfood_command_test.sh
+++ b/tests/dogfood_command_test.sh
@@ -48,4 +48,14 @@ grep -Fxq -- '--version' "$log"
 
 grep -Fq 'dogfood = "run --quiet --release --bin tracedecay -- dogfood"' "$repo_root/.cargo/config.toml"
 
+post_update_dispatch=$(
+  sed -n '/Commands::PostUpdate {/,/Commands::Channel { channel }/p' "$repo_root/src/main.rs"
+)
+if grep -Fq 'acquire_exclusive_or_inherited' <<<"$post_update_dispatch"; then
+  printf '%s\n' \
+    'tokenless post-update acquires the exclusive lifecycle lease before quiescing the daemon' >&2
+  exit 1
+fi
+grep -Fq 'update_cmd::run_post_update_command(' <<<"$post_update_dispatch"
+
 echo "dogfood command contract passed"


### PR DESCRIPTION
## Summary

- make tokenless post-update quiesce the managed daemon before acquiring the exclusive lifecycle lease
- preserve the inherited-token handoff used by update and upgrade
- add regression coverage for dogfood dispatch ordering and daemon restoration when lease acquisition fails

## Why

cargo dogfood installs the source-built binary and invokes post-update directly. With a managed daemon already running, post-update attempted exclusive lease acquisition before stopping the daemon that held the shared lease, so activation failed after the binary copy.

## TDD evidence

- RED: the dogfood contract failed on the original dispatch with tokenless post-update acquires the exclusive lifecycle lease before quiescing the daemon
- GREEN: the identical dogfood contract passed after routing tokenless post-update through the existing lifecycle update window

## Tests

- bash tests/dogfood_command_test.sh
- cargo test --bin tracedecay post_update -- --test-threads=1
- cargo test -p tracedecay-runtime-core post_update_child_must_present_the_live_parent_token -- --test-threads=1
- cargo test -p tracedecay-runtime-core post_update_child_rejects_a_stale_owner_token_from_a_dead_process -- --test-threads=1
- cargo test --test update_health_pass_test -- --test-threads=1
- rustfmt --edition 2024 --check src/main.rs src/update_cmd.rs
- git diff --check
- npm run lint:commit -- --from origin/master --to HEAD