### PR TITLE
refactor(features): centralize language tier membership

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,12 +253,15 @@ token-counting = ["tracedecay-agent-hosts/token-counting", "tracedecay-dashboard
 # has it, and a build that indexes code but not its docs is not a shippable
 # tier. Its grammar lives in the (monolithic) large bundle, so `lite` now links
 # that bundle — the compile-weight cost of making docs unconditional.
-lite = ["tracedecay-code-index/lite", "lang-markdown"]
+lite = ["tracedecay-code-index/lite"]
 
-medium = ["lang-dart", "lang-pascal", "lang-php", "lang-ruby", "lang-bash", "lang-protobuf", "lang-powershell", "lang-nix", "lang-vbnet"]
-full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-wgsl", "lang-hlsl", "lang-metal", "lang-markdown", "lang-r", "lang-sql", "lang-julia", "lang-haskell", "lang-ocaml", "lang-clojure", "lang-erlang", "lang-elixir", "lang-fsharp", "lang-quint", "lang-toml", "lang-lean"]
+medium = ["tracedecay-code-index/medium"]
+full = ["tracedecay-code-index/full"]
 
-# Language features backed by the bundled tree-sitter grammar crate.
+# These aliases are intentionally repeated at the binary boundary: Cargo
+# cannot expose a dependency feature as a caller-selectable local feature.
+# Tier membership remains owned by tracedecay-code-extraction and reaches this
+# package through the aggregate forwards above.
 lang-dart = ["tracedecay-code-index/lang-dart"]
 lang-pascal = ["tracedecay-code-index/lang-pascal"]
 lang-php = ["tracedecay-code-index/lang-php"]

--- a/crates/tracedecay-code-index/Cargo.toml
+++ b/crates/tracedecay-code-index/Cargo.toml
@@ -37,12 +37,16 @@ default = [
     "full",
 ]
 # Markdown is admitted by every tier, not just `full` — see the note on the
-# extraction crate's `lite` feature.
+# extraction crate's `lite` feature. The local alias keeps this crate's
+# Markdown-specific tests aligned with the forwarded extraction tier.
 lite = ["tracedecay-code-extraction/lite", "lang-markdown"]
-medium = ["lang-dart", "lang-pascal", "lang-php", "lang-ruby", "lang-bash", "lang-protobuf", "lang-powershell", "lang-nix", "lang-vbnet"]
-full = ["medium", "lang-lua", "lang-zig", "lang-objc", "lang-perl", "lang-batch", "lang-fortran", "lang-cobol", "lang-msbasic2", "lang-gwbasic", "lang-qbasic", "lang-dockerfile", "lang-glsl", "lang-wgsl", "lang-hlsl", "lang-metal", "lang-markdown", "lang-r", "lang-sql", "lang-julia", "lang-haskell", "lang-ocaml", "lang-clojure", "lang-erlang", "lang-elixir", "lang-fsharp", "lang-quint", "lang-toml", "lang-lean"]
+medium = ["tracedecay-code-extraction/medium"]
+full = ["tracedecay-code-extraction/full", "lang-markdown"]
 test-helpers = ["tracedecay-graph-db/test-helpers"]
 eval-helpers = ["tracedecay-graph-db/eval-helpers"]
+# Cargo requires these aliases at this public package boundary so downstream
+# crates can still select one language at a time. The extraction crate owns
+# which aliases each aggregate tier enables.
 lang-dart = ["tracedecay-code-extraction/lang-dart"]
 lang-pascal = ["tracedecay-code-extraction/lang-pascal"]
 lang-php = ["tracedecay-code-extraction/lang-php"]

--- a/crates/tracedecay-rusqlite-runtime/src/writer/transaction.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer/transaction.rs
@@ -50,6 +50,7 @@ struct Processed {
 }
 
 #[hotpath::measure]
+#[allow(clippy::too_many_arguments)]
 pub(super) fn process_batch(
     connection: &mut Connection,
     binding: &StoreRuntimeBindingV1,

--- a/scripts/check-distribution-acceptance.sh
+++ b/scripts/check-distribution-acceptance.sh
@@ -199,11 +199,19 @@ assert_code_extraction_assets() {
 verify_feature_wiring() {
   local source_manifest=$1
   local packaged_manifest=$2
-  local semantic_source_manifest=$3
-  local semantic_packaged_manifest=$4
+  local code_index_source_manifest=$3
+  local code_index_packaged_manifest=$4
+  local extraction_source_manifest=$5
+  local extraction_packaged_manifest=$6
+  local semantic_source_manifest=$7
+  local semantic_packaged_manifest=$8
   python3 "$repo/scripts/check-distribution-feature-wiring.py" \
     --root-source "$source_manifest" \
     --root-packaged "$packaged_manifest" \
+    --code-index-source "$code_index_source_manifest" \
+    --code-index-packaged "$code_index_packaged_manifest" \
+    --extraction-source "$extraction_source_manifest" \
+    --extraction-packaged "$extraction_packaged_manifest" \
     --semantic-source "$semantic_source_manifest" \
     --semantic-packaged "$semantic_packaged_manifest"
 }
@@ -354,6 +362,7 @@ for required_package in \
   tracedecay-api \
   tracedecay-tool-catalog \
   tracedecay-lsp \
+  tracedecay-code-index \
   tracedecay-code-extraction \
   tracedecay-query \
   tracedecay-semantic; do
@@ -362,6 +371,7 @@ for required_package in \
 done
 root_package=${package_dirs[tracedecay]}
 lsp_package=${package_dirs[tracedecay-lsp]}
+code_index_package=${package_dirs[tracedecay-code-index]}
 code_extraction_package=${package_dirs[tracedecay-code-extraction]}
 query_package=${package_dirs[tracedecay-query]}
 semantic_package=${package_dirs[tracedecay-semantic]}
@@ -372,6 +382,10 @@ assert_code_extraction_assets "$code_extraction_package"
 verify_feature_wiring \
   "$repo/Cargo.toml" \
   "$root_package/Cargo.toml" \
+  "$repo/crates/tracedecay-code-index/Cargo.toml" \
+  "$code_index_package/Cargo.toml" \
+  "$repo/crates/tracedecay-code-extraction/Cargo.toml" \
+  "$code_extraction_package/Cargo.toml" \
   "$repo/crates/tracedecay-semantic/Cargo.toml" \
   "$semantic_package/Cargo.toml"
 

--- a/scripts/check-distribution-acceptance.sh
+++ b/scripts/check-distribution-acceptance.sh
@@ -205,6 +205,7 @@ verify_feature_wiring() {
   local extraction_packaged_manifest=$6
   local semantic_source_manifest=$7
   local semantic_packaged_manifest=$8
+  local cargo_config=$9
   python3 "$repo/scripts/check-distribution-feature-wiring.py" \
     --root-source "$source_manifest" \
     --root-packaged "$packaged_manifest" \
@@ -213,7 +214,10 @@ verify_feature_wiring() {
     --extraction-source "$extraction_source_manifest" \
     --extraction-packaged "$extraction_packaged_manifest" \
     --semantic-source "$semantic_source_manifest" \
-    --semantic-packaged "$semantic_packaged_manifest"
+    --semantic-packaged "$semantic_packaged_manifest" \
+    --check-extraction-manifest "$extraction_packaged_manifest" \
+    --cargo-config "$cargo_config" \
+    --offline
 }
 
 while (($#)); do
@@ -379,15 +383,6 @@ catalog_package=${package_dirs[tracedecay-tool-catalog]}
 
 assert_required_assets "$root_package"
 assert_code_extraction_assets "$code_extraction_package"
-verify_feature_wiring \
-  "$repo/Cargo.toml" \
-  "$root_package/Cargo.toml" \
-  "$repo/crates/tracedecay-code-index/Cargo.toml" \
-  "$code_index_package/Cargo.toml" \
-  "$repo/crates/tracedecay-code-extraction/Cargo.toml" \
-  "$code_extraction_package/Cargo.toml" \
-  "$repo/crates/tracedecay-semantic/Cargo.toml" \
-  "$semantic_package/Cargo.toml"
 
 patch_config="$work/packaged-crates.toml"
 python3 - "$metadata" "$packages" >"$patch_config" <<'PY'
@@ -406,6 +401,17 @@ for package in sorted(metadata["packages"], key=lambda value: value["name"]):
     path = packages / f'{package["name"]}-{package["version"]}'
     print(f'{json.dumps(package["name"])} = {{ path = {json.dumps(str(path))} }}')
 PY
+
+verify_feature_wiring \
+  "$repo/Cargo.toml" \
+  "$root_package/Cargo.toml" \
+  "$repo/crates/tracedecay-code-index/Cargo.toml" \
+  "$code_index_package/Cargo.toml" \
+  "$repo/crates/tracedecay-code-extraction/Cargo.toml" \
+  "$code_extraction_package/Cargo.toml" \
+  "$repo/crates/tracedecay-semantic/Cargo.toml" \
+  "$semantic_package/Cargo.toml" \
+  "$patch_config"
 
 echo "distribution acceptance: testing packaged patched Rust grammar"
 cargo nextest run \

--- a/scripts/check-distribution-feature-wiring.py
+++ b/scripts/check-distribution-feature-wiring.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import subprocess
 import tomllib
 
 
@@ -153,6 +154,54 @@ def require_tier_forwarding(
             )
 
 
+def require_isolated_language_features_compile(
+    manifest_path: Path,
+    authority_features: set[str],
+    cargo_config: Path | None,
+    offline: bool,
+) -> None:
+    manifest = load(manifest_path)
+    package_name = manifest.get("package", {}).get("name")
+    if not isinstance(package_name, str):
+        raise SystemExit(
+            "distribution acceptance: extraction build manifest has no package name"
+        )
+
+    build_features = language_feature_names(manifest.get("features", {}))
+    if build_features != authority_features:
+        raise SystemExit(
+            "distribution acceptance: extraction build manifest language features "
+            "differ from the packaged authority"
+        )
+
+    for feature in sorted(authority_features):
+        command = [
+            "cargo",
+            "check",
+            "--manifest-path",
+            str(manifest_path),
+            "--package",
+            package_name,
+            "--lib",
+            "--no-default-features",
+            "--features",
+            feature,
+        ]
+        if cargo_config is not None:
+            command.extend(["--config", str(cargo_config)])
+        if offline:
+            command.append("--offline")
+        completed = subprocess.run(
+            command, check=False, capture_output=True, text=True
+        )
+        if completed.returncode != 0:
+            details = completed.stderr.strip() or completed.stdout.strip()
+            raise SystemExit(
+                f"distribution acceptance: {feature} does not compile in isolation"
+                + (f"\n{details}" if details else "")
+            )
+
+
 def validate(
     root_source: dict,
     root_packaged: dict,
@@ -250,17 +299,28 @@ def main() -> int:
     parser.add_argument("--extraction-packaged", type=Path, required=True)
     parser.add_argument("--semantic-source", type=Path, required=True)
     parser.add_argument("--semantic-packaged", type=Path, required=True)
+    parser.add_argument("--check-extraction-manifest", type=Path)
+    parser.add_argument("--cargo-config", type=Path)
+    parser.add_argument("--offline", action="store_true")
     arguments = parser.parse_args()
+    extraction_packaged = load(arguments.extraction_packaged)
     validate(
         load(arguments.root_source),
         load(arguments.root_packaged),
         load(arguments.code_index_source),
         load(arguments.code_index_packaged),
         load(arguments.extraction_source),
-        load(arguments.extraction_packaged),
+        extraction_packaged,
         load(arguments.semantic_source),
         load(arguments.semantic_packaged),
     )
+    if arguments.check_extraction_manifest is not None:
+        require_isolated_language_features_compile(
+            arguments.check_extraction_manifest,
+            language_feature_names(extraction_packaged.get("features", {})),
+            arguments.cargo_config,
+            arguments.offline,
+        )
     print("distribution feature wiring is valid")
     return 0
 

--- a/scripts/check-distribution-feature-wiring.py
+++ b/scripts/check-distribution-feature-wiring.py
@@ -22,6 +22,12 @@ REQUIRED_SEMANTIC_MEMBERS = {
     "dep:fastembed",
     "fastembed/ort-download-binaries-rustls-tls",
 }
+LANGUAGE_TIERS = ("lite", "medium", "full")
+CODE_INDEX_LOCAL_TIER_MEMBERS = {
+    "lite": {"lang-markdown"},
+    "medium": set(),
+    "full": {"lang-markdown"},
+}
 
 
 def load(path: Path) -> dict:
@@ -94,9 +100,66 @@ def require_optional_dependencies_wired(name: str, manifest: dict, features: dic
         )
 
 
+def language_feature_names(features: dict) -> set[str]:
+    return {name for name in features if name.startswith("lang-")}
+
+
+def require_language_forwarding(
+    name: str,
+    features: dict,
+    authority_features: set[str],
+    dependency: str,
+) -> None:
+    actual_features = language_feature_names(features)
+    if actual_features != authority_features:
+        missing = sorted(authority_features - actual_features)
+        extra = sorted(actual_features - authority_features)
+        details = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if extra:
+            details.append("extra " + ", ".join(extra))
+        raise SystemExit(
+            f"distribution acceptance: {name} language features differ from "
+            "tracedecay-code-extraction: " + "; ".join(details)
+        )
+
+    for feature in sorted(authority_features):
+        expected = [f"{dependency}/{feature}"]
+        if features.get(feature) != expected:
+            raise SystemExit(
+                f"distribution acceptance: {name} {feature} must forward exactly to "
+                f"{expected[0]}"
+            )
+
+
+def require_tier_forwarding(
+    name: str,
+    features: dict,
+    dependency: str,
+    local_members: dict[str, set[str]],
+) -> None:
+    for tier in LANGUAGE_TIERS:
+        expected = {f"{dependency}/{tier}", *local_members.get(tier, set())}
+        members = features.get(tier)
+        if (
+            not isinstance(members, list)
+            or len(members) != len(expected)
+            or set(members) != expected
+        ):
+            raise SystemExit(
+                f"distribution acceptance: {name} {tier} must forward only to "
+                + ", ".join(sorted(expected))
+            )
+
+
 def validate(
     root_source: dict,
     root_packaged: dict,
+    code_index_source: dict,
+    code_index_packaged: dict,
+    extraction_source: dict,
+    extraction_packaged: dict,
     semantic_source: dict,
     semantic_packaged: dict,
 ) -> None:
@@ -121,6 +184,35 @@ def validate(
             "semantic and usecases owners"
         )
     require_optional_dependencies_wired("root", root_packaged, root_features)
+
+    code_index_features = require_matching_features(
+        "tracedecay-code-index", code_index_source, code_index_packaged
+    )
+    extraction_features = require_matching_features(
+        "tracedecay-code-extraction", extraction_source, extraction_packaged
+    )
+    language_features = language_feature_names(extraction_features)
+    require_language_forwarding(
+        "root", root_features, language_features, "tracedecay-code-index"
+    )
+    require_language_forwarding(
+        "code-index",
+        code_index_features,
+        language_features,
+        "tracedecay-code-extraction",
+    )
+    require_tier_forwarding(
+        "root", root_features, "tracedecay-code-index", {}
+    )
+    require_tier_forwarding(
+        "code-index",
+        code_index_features,
+        "tracedecay-code-extraction",
+        CODE_INDEX_LOCAL_TIER_MEMBERS,
+    )
+    require_optional_dependencies_wired(
+        "tracedecay-code-extraction", extraction_packaged, extraction_features
+    )
 
     semantic_features = require_matching_features(
         "tracedecay-semantic", semantic_source, semantic_packaged
@@ -152,12 +244,20 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root-source", type=Path, required=True)
     parser.add_argument("--root-packaged", type=Path, required=True)
+    parser.add_argument("--code-index-source", type=Path, required=True)
+    parser.add_argument("--code-index-packaged", type=Path, required=True)
+    parser.add_argument("--extraction-source", type=Path, required=True)
+    parser.add_argument("--extraction-packaged", type=Path, required=True)
     parser.add_argument("--semantic-source", type=Path, required=True)
     parser.add_argument("--semantic-packaged", type=Path, required=True)
     arguments = parser.parse_args()
     validate(
         load(arguments.root_source),
         load(arguments.root_packaged),
+        load(arguments.code_index_source),
+        load(arguments.code_index_packaged),
+        load(arguments.extraction_source),
+        load(arguments.extraction_packaged),
         load(arguments.semantic_source),
         load(arguments.semantic_packaged),
     )

--- a/scripts/test-check-distribution-feature-wiring.py
+++ b/scripts/test-check-distribution-feature-wiring.py
@@ -62,6 +62,48 @@ lang-dart = []
 lang-markdown = []
 """
 
+EXTRACTION_BUILD_MANIFEST = """[package]
+name = "tracedecay-code-extraction"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = []
+lang-dart = ["dep:dart-grammar"]
+lang-markdown = ["dep:markdown-grammar"]
+
+[dependencies]
+dart-grammar = { path = "dart-grammar", optional = true }
+markdown-grammar = { path = "markdown-grammar", optional = true }
+"""
+
+EXTRACTION_BUILD_LIB = """#[cfg(feature = "lang-dart")]
+pub fn dart() -> dart_grammar::Language {
+    dart_grammar::language()
+}
+
+#[cfg(feature = "lang-markdown")]
+pub fn markdown() -> markdown_grammar::Language {
+    markdown_grammar::language()
+}
+"""
+
+GRAMMAR_MANIFEST = """[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "lib.rs"
+"""
+
+GRAMMAR_LIB = """pub struct Language;
+
+pub fn language() -> Language {
+    Language
+}
+"""
+
 SEMANTIC_MANIFEST = """[package]
 name = "tracedecay-semantic"
 version = "0.1.0"
@@ -96,6 +138,7 @@ def run_fixture(
     extraction_packaged: str = EXTRACTION_MANIFEST,
     semantic_source: str = SEMANTIC_MANIFEST,
     semantic_packaged: str = SEMANTIC_MANIFEST,
+    extraction_build_manifest: str | None = None,
 ) -> FixtureResult:
     with tempfile.TemporaryDirectory() as temporary_directory:
         root = Path(temporary_directory)
@@ -111,27 +154,49 @@ def run_fixture(
         }
         for name, contents in manifests.items():
             root.joinpath(name).write_text(contents, encoding="utf-8")
+        command = [
+            sys.executable,
+            str(VALIDATOR),
+            "--root-source",
+            str(root / "root-source.toml"),
+            "--root-packaged",
+            str(root / "root-packaged.toml"),
+            "--code-index-source",
+            str(root / "code-index-source.toml"),
+            "--code-index-packaged",
+            str(root / "code-index-packaged.toml"),
+            "--extraction-source",
+            str(root / "extraction-source.toml"),
+            "--extraction-packaged",
+            str(root / "extraction-packaged.toml"),
+            "--semantic-source",
+            str(root / "semantic-source.toml"),
+            "--semantic-packaged",
+            str(root / "semantic-packaged.toml"),
+        ]
+        if extraction_build_manifest is not None:
+            extraction = root / "extraction-build"
+            extraction.joinpath("src").mkdir(parents=True)
+            extraction.joinpath("Cargo.toml").write_text(
+                extraction_build_manifest, encoding="utf-8"
+            )
+            extraction.joinpath("src/lib.rs").write_text(
+                EXTRACTION_BUILD_LIB, encoding="utf-8"
+            )
+            for grammar in ("dart-grammar", "markdown-grammar"):
+                dependency = extraction / grammar
+                dependency.mkdir()
+                dependency.joinpath("Cargo.toml").write_text(
+                    GRAMMAR_MANIFEST.format(name=grammar), encoding="utf-8"
+                )
+                dependency.joinpath("lib.rs").write_text(
+                    GRAMMAR_LIB, encoding="utf-8"
+                )
+            command.extend(
+                ["--check-extraction-manifest", str(extraction / "Cargo.toml")]
+            )
         completed = subprocess.run(
-            [
-                sys.executable,
-                str(VALIDATOR),
-                "--root-source",
-                str(root / "root-source.toml"),
-                "--root-packaged",
-                str(root / "root-packaged.toml"),
-                "--code-index-source",
-                str(root / "code-index-source.toml"),
-                "--code-index-packaged",
-                str(root / "code-index-packaged.toml"),
-                "--extraction-source",
-                str(root / "extraction-source.toml"),
-                "--extraction-packaged",
-                str(root / "extraction-packaged.toml"),
-                "--semantic-source",
-                str(root / "semantic-source.toml"),
-                "--semantic-packaged",
-                str(root / "semantic-packaged.toml"),
-            ],
+            command,
             check=False,
             capture_output=True,
             text=True,
@@ -236,6 +301,24 @@ def main() -> int:
         raise SystemExit("renamed root FastEmbed dependency was accepted")
     if "root package must not own fastembed" not in root_aliased_shadow_owner.stderr:
         raise SystemExit("renamed root ownership failed for an unexpected reason")
+
+    isolated_languages = run_fixture(
+        extraction_build_manifest=EXTRACTION_BUILD_MANIFEST
+    )
+    if isolated_languages.returncode != 0:
+        raise SystemExit(isolated_languages.stderr)
+
+    extraction_with_miswired_language = EXTRACTION_BUILD_MANIFEST.replace(
+        'lang-dart = ["dep:dart-grammar"]',
+        'lang-dart = ["dep:markdown-grammar"]',
+    )
+    miswired_language = run_fixture(
+        extraction_build_manifest=extraction_with_miswired_language
+    )
+    if miswired_language.returncode == 0:
+        raise SystemExit("miswired isolated extraction language was accepted")
+    if "lang-dart does not compile in isolation" not in miswired_language.stderr:
+        raise SystemExit("miswired extraction language failed for an unexpected reason")
 
     print("distribution feature wiring fixtures passed")
     return 0

--- a/scripts/test-check-distribution-feature-wiring.py
+++ b/scripts/test-check-distribution-feature-wiring.py
@@ -17,17 +17,49 @@ name = "tracedecay"
 version = "0.1.0-beta.34"
 
 [dependencies]
+tracedecay-code-index = { version = "0.1.0" }
 tracedecay-semantic = { version = "0.1.0" }
 tracedecay-usecases = { version = "0.1.0" }
 
 [features]
-full = []
+lite = ["tracedecay-code-index/lite"]
+medium = ["tracedecay-code-index/medium"]
+full = ["tracedecay-code-index/full"]
+lang-dart = ["tracedecay-code-index/lang-dart"]
+lang-markdown = ["tracedecay-code-index/lang-markdown"]
 token-counting = []
 test-transport = []
 semantic-fastembed = [
     "tracedecay-semantic/semantic-fastembed",
     "tracedecay-usecases/semantic-fastembed",
 ]
+"""
+
+CODE_INDEX_MANIFEST = """[package]
+name = "tracedecay-code-index"
+version = "0.1.0"
+
+[dependencies]
+tracedecay-code-extraction = { version = "0.1.0" }
+
+[features]
+lite = ["tracedecay-code-extraction/lite", "lang-markdown"]
+medium = ["tracedecay-code-extraction/medium"]
+full = ["tracedecay-code-extraction/full", "lang-markdown"]
+lang-dart = ["tracedecay-code-extraction/lang-dart"]
+lang-markdown = ["tracedecay-code-extraction/lang-markdown"]
+"""
+
+EXTRACTION_MANIFEST = """[package]
+name = "tracedecay-code-extraction"
+version = "0.1.0"
+
+[features]
+lite = ["lang-markdown"]
+medium = ["lang-dart"]
+full = ["medium", "lang-markdown"]
+lang-dart = []
+lang-markdown = []
 """
 
 SEMANTIC_MANIFEST = """[package]
@@ -58,6 +90,10 @@ class FixtureResult:
 def run_fixture(
     root_source: str = ROOT_MANIFEST,
     root_packaged: str = ROOT_MANIFEST,
+    code_index_source: str = CODE_INDEX_MANIFEST,
+    code_index_packaged: str = CODE_INDEX_MANIFEST,
+    extraction_source: str = EXTRACTION_MANIFEST,
+    extraction_packaged: str = EXTRACTION_MANIFEST,
     semantic_source: str = SEMANTIC_MANIFEST,
     semantic_packaged: str = SEMANTIC_MANIFEST,
 ) -> FixtureResult:
@@ -66,6 +102,10 @@ def run_fixture(
         manifests = {
             "root-source.toml": root_source,
             "root-packaged.toml": root_packaged,
+            "code-index-source.toml": code_index_source,
+            "code-index-packaged.toml": code_index_packaged,
+            "extraction-source.toml": extraction_source,
+            "extraction-packaged.toml": extraction_packaged,
             "semantic-source.toml": semantic_source,
             "semantic-packaged.toml": semantic_packaged,
         }
@@ -79,6 +119,14 @@ def run_fixture(
                 str(root / "root-source.toml"),
                 "--root-packaged",
                 str(root / "root-packaged.toml"),
+                "--code-index-source",
+                str(root / "code-index-source.toml"),
+                "--code-index-packaged",
+                str(root / "code-index-packaged.toml"),
+                "--extraction-source",
+                str(root / "extraction-source.toml"),
+                "--extraction-packaged",
+                str(root / "extraction-packaged.toml"),
                 "--semantic-source",
                 str(root / "semantic-source.toml"),
                 "--semantic-packaged",
@@ -95,6 +143,43 @@ def main() -> int:
     extracted_owner = run_fixture()
     if extracted_owner.returncode != 0:
         raise SystemExit(extracted_owner.stderr)
+
+    root_with_local_tier_members = ROOT_MANIFEST.replace(
+        'full = ["tracedecay-code-index/full"]',
+        'full = ["tracedecay-code-index/full", "lang-markdown"]',
+    )
+    duplicated_tier = run_fixture(
+        root_source=root_with_local_tier_members,
+        root_packaged=root_with_local_tier_members,
+    )
+    if duplicated_tier.returncode == 0:
+        raise SystemExit("root package duplicating extraction tier membership was accepted")
+    if "root full must forward only" not in duplicated_tier.stderr:
+        raise SystemExit("duplicated tier membership failed for an unexpected reason")
+
+    code_index_with_missing_alias = CODE_INDEX_MANIFEST.replace(
+        'lang-dart = ["tracedecay-code-extraction/lang-dart"]\n', ""
+    )
+    missing_alias = run_fixture(
+        code_index_source=code_index_with_missing_alias,
+        code_index_packaged=code_index_with_missing_alias,
+    )
+    if missing_alias.returncode == 0:
+        raise SystemExit("code-index package missing a language alias was accepted")
+    if "code-index language features differ" not in missing_alias.stderr:
+        raise SystemExit("missing language alias failed for an unexpected reason")
+
+    extraction_with_new_language = EXTRACTION_MANIFEST.replace(
+        "lang-markdown = []\n", "lang-markdown = []\nlang-rustdoc = []\n"
+    )
+    unforwarded_language = run_fixture(
+        extraction_source=extraction_with_new_language,
+        extraction_packaged=extraction_with_new_language,
+    )
+    if unforwarded_language.returncode == 0:
+        raise SystemExit("new extraction language without public aliases was accepted")
+    if "root language features differ" not in unforwarded_language.stderr:
+        raise SystemExit("unforwarded language failed for an unexpected reason")
 
     semantic_without_runtime = SEMANTIC_MANIFEST.replace(
         '    "fastembed/ort-download-binaries-rustls-tls",\n', ""


### PR DESCRIPTION
## Summary

- make `tracedecay-code-extraction` the single owner of `lite`/`medium`/`full` language membership and forward those aggregate tiers through code-index and the root package
- retain every individual `lang-*` alias at each Cargo package boundary, including code-index's local Markdown gate, so downstream CLI opt-ins remain unchanged
- extend distribution acceptance to compare packaged root/index/extraction feature tables and dynamically reject missing, extra, or miswired language aliases without a hard-coded count

The caller manifests now contain 8 aggregate tier-member references instead of 80. Cargo still requires the individual aliases at each public package boundary; the new validator documents and protects that necessary duplication.

## Audit

- checked all `lang-*` consumers in root, code-index, code-extraction, search-eval, tests, and docs
- checked production/default/all-feature release workflows and packaged-crate acceptance
- validated the packaged dashboard plus Claude, Codex, Cursor, and Kimi host manifests; all consume the same production binary feature profile
- confirmed `hotpath*` remains absent from the production feature graph

## Verification

- `python3 scripts/test-check-distribution-feature-wiring.py`
- `python3 scripts/test-resolve-release-source-profile.py`
- dynamic Cargo resolution comparison across all 41 discovered tier/production/individual-language scenarios (identical language and grammar dependency resolution)
- `python3 scripts/check-production-feature-profile.py --repo <clean-archive>`
- packaged root, code-index, and code-extraction manifests validated with `check-distribution-feature-wiring.py`
- packaged dashboard and Claude/Codex/Cursor/Kimi manifests validated
- `cargo check -p tracedecay-code-index --no-default-features --features full` in a clean offline archive
- representative individual checks for built-in WGSL, standalone HLSL, medium-bundle Dart, and large-bundle Pascal
- exact non-vacuous `languages::tests::markdown_is_admitted_with_stable_section_spans`: 1 passed
- `npm run build` in `dashboard/`
- `npm run lint:commit -- --from HEAD^ --to HEAD`
