### PR TITLE
fix(daemon): stop capping how many projects can enrol

### DIFF
--- a/crates/tracedecay-graph-db/src/registry.rs
+++ b/crates/tracedecay-graph-db/src/registry.rs
@@ -1894,6 +1894,16 @@ fn rollback_retiring_under_lock(
     Ok(())
 }
 
+/// Reclaims one idle owner so `opening` can take its slot.
+///
+/// A candidate must be `Ready` *and* unleased, and a mounted project never is:
+/// the daemon holds its `GraphDbOwnerAttachmentV1` for as long as the project
+/// stays mounted, so `is_unleased()` stays false and the search below cannot
+/// select it. In practice that means this reclaims nothing for live projects
+/// and the caller's `max_open` behaves as a population ceiling rather than a
+/// working-set one. Making it a true LRU needs a way to hibernate an idle
+/// project's owner and remount it on next access; until that exists, the
+/// ceilings are sized as runaway guards instead.
 fn reserve_capacity_eviction(
     state: &mut RegistryState,
     max_open: usize,

--- a/src/daemon/store_runtime/session_registry.rs
+++ b/src/daemon/store_runtime/session_registry.rs
@@ -55,8 +55,25 @@ use retained_hook_tasks::RetainedHookTasks;
 pub(crate) use code_graph::RetainedCodeGraphRuntimeV1;
 pub(crate) use profile_memory::open_user_memory_db;
 
-const MAX_RETAINED_PROJECT_RUNTIME_OWNERS: usize = 8;
-const MAX_RETAINED_REMOTE_NODE_OWNERS: usize = 8;
+/// Sanity ceilings on concurrently mounted owners, not a bound on how many
+/// projects a profile may enrol.
+///
+/// These were 8, which is where enrolment actually stopped: a profile with
+/// four projects was refused, and once the budget was exhausted even a
+/// read-only `projects list` failed. Nothing about 8 was derived — the working
+/// set of a developer with a few dozen checkouts is far above it.
+///
+/// Sizing is honest about what does and does not bound this today. File
+/// descriptors are not the constraint (the process ceiling is ~1M here and a
+/// mount holds a handful). Resident memory *is* the constraint, and it is
+/// currently ungoverned for these owners: no resident-memory gate covers a
+/// mounted project runtime, and `reserve_capacity_eviction` cannot reclaim one
+/// (see the note there), so a ceiling this high means residency grows with the
+/// number of projects actually touched. That is the deliberate trade — a
+/// refusal at 4 projects was the worse failure — and the real fix is idle
+/// project hibernation, which is follow-up work.
+const MAX_RETAINED_PROJECT_RUNTIME_OWNERS: usize = 4_096;
+const MAX_RETAINED_REMOTE_NODE_OWNERS: usize = 4_096;
 
 struct SessionGraphOwnerV1 {
     graph: GraphDbOwnerAttachmentV1,

--- a/src/daemon/store_runtime/session_registry/mounts.rs
+++ b/src/daemon/store_runtime/session_registry/mounts.rs
@@ -101,7 +101,14 @@ impl DaemonSessionRuntimeRegistryV1 {
         let graph_manifest_provider =
             Arc::new(super::code_graph_manifest::DaemonCodeGraphManifestProviderV1::default());
         let graph_registry = GraphDbRegistry::new_with_manifest_provider(
-            GraphDbRegistryConfig { max_open: 8 },
+            // Two graph owners per mounted project (its project shard and its
+            // session-relation shard) plus up to two profile-wide owners, so
+            // the previous 8 admitted exactly three projects before refusing
+            // the fourth. Sized here as a runaway guard well above any real
+            // working set rather than as a population bound; see
+            // MAX_RETAINED_PROJECT_RUNTIME_OWNERS for what actually bounds
+            // residency today.
+            GraphDbRegistryConfig { max_open: 8_192 },
             graph_manifest_provider.clone(),
         )
         .map_err(|error| {


### PR DESCRIPTION
## What this fixes

Enrolling five projects into one profile, the first three succeeded and the fourth failed:

```
Error: config error: daemon tool call failed: config error: database error:
graph capacity budget exhausted (limit 8) (operation: open session relation graph owner)
```

Worse, once the budget was exhausted a plain read-only `tracedecay projects list` failed with the same error — exhausting it takes the whole profile down for ordinary reads, not just for new enrolment.

## Why 8 meant three projects

A mounted project pins **two** graph owners (its project shard and its session-relation shard), and up to **two** more are profile-wide. `2 + 2×3 = 8` — exactly the observed cliff.

An experiment separated the two candidate causes: `tracedecay init` run **12 times against the same project** never exhausted the budget. So this is not a per-call leak; capacity is consumed per distinct project.

## Why raising the ceiling is the fix available today

`reserve_capacity_eviction` requires a candidate that is `Ready` **and** unleased. A mounted project holds its `GraphDbOwnerAttachmentV1` for the life of the mount, so `is_unleased()` never becomes true and the candidate search cannot select it. LRU eviction is effectively dead code for live projects, which is why `max_open` behaved as a *population* bound rather than a working-set one. That is now documented at the function itself, where a reader would otherwise reasonably assume eviction works.

## Sizing, stated honestly

- File descriptors are **not** the constraint (process ceiling is ~1M here; a mount holds a handful).
- Resident memory **is** the constraint, and it is **currently ungoverned** for these owners — no resident-memory gate covers a mounted project runtime.

So this trades a hard refusal at four projects for residency that grows with the number of projects actually touched. That trade is deliberate and the comments say so. **This is not "unbounded" enrolment** — genuine elasticity needs idle-project hibernation (a cross-cutting lifecycle change across `session_registry.rs`, `mounts.rs`, `code_graph.rs`, `memory_runtime.rs`), which is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)