### PR TITLE
perf(store): batch per-row session and curation reads

### DIFF
--- a/crates/tracedecay-global-db/src/session_temporal/projection/materialize.rs
+++ b/crates/tracedecay-global-db/src/session_temporal/projection/materialize.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, hash_map::Entry};
 
 use serde_json::json;
 use tracedecay_domain::{
@@ -12,12 +12,15 @@ use tracedecay_store::{
     SessionRefreshProgressV1, SessionStoreError, SessionStoreResult,
     SessionTemporalProjectionBatchV1,
 };
+use tracedecay_temporal_query::ports::ExecutionControl;
 
 use crate::observation_projection::derive_projection;
 
 use super::super::query::{
-    PERSIST_OPERATION, frontier_i64, now_micros, read_observation, storage, storage_message,
+    PERSIST_OPERATION, frontier_i64, generation_i64, missing_observation, now_micros,
+    read_observation, read_observations, storage, storage_message,
 };
+use super::super::rebuild::checkpoint_relation_rebuild_control;
 use super::super::refresh::{SessionRefreshRecoveryV1, SessionRefreshRestartStateV1};
 use super::MATERIALIZE_REFRESH;
 use super::persist::*;
@@ -140,50 +143,86 @@ pub(super) async fn materialize_session_temporal_refresh_batch_in_transaction(
         return Ok(None);
     }
 
-    let mut low = 1usize;
-    let mut high = effects.len();
-    let mut selected = None;
-    let mut single_effect_count = None;
-    while low <= high {
-        let prefix_len = low + (high - low) / 2;
-        let prefix_item_count = effects[..prefix_len]
-            .iter()
-            .fold(0usize, |count, (_, _, outputs)| {
-                count.saturating_add(*outputs)
-            });
-        let occurrences =
-            materialize_effect_occurrences(conn, &effects[..prefix_len], prefix_item_count).await?;
-        let (copies, assertions) = derive_retained_projection_relations(
-            conn,
-            recovery.session_id(),
-            target_through,
-            &occurrences,
-        )
-        .await?;
-        let derived_count = occurrences
+    let (all_occurrences, occurrence_work) =
+        materialize_effect_occurrences(conn, &effects, item_count).await?;
+    record_occurrence_materialization_work(occurrence_work);
+    let mut parents = candidate_parent_message_resolver(
+        conn,
+        recovery.session_id(),
+        recovery.candidate_generation(),
+        &all_occurrences,
+    )
+    .await?;
+    let mut selected_effects = 0usize;
+    let mut selected_occurrences = 0usize;
+    let mut selected_items = 0usize;
+    let mut copies = Vec::new();
+    let mut assertions = Vec::new();
+    for (_, _, output_count) in &effects {
+        let end = selected_occurrences.saturating_add(*output_count);
+        let effect_occurrences =
+            all_occurrences
+                .get(selected_occurrences..end)
+                .ok_or_else(|| {
+                    storage_message(
+                        MATERIALIZE_REFRESH,
+                        "observation effect output count does not match canonical projection",
+                    )
+                })?;
+        let (effect_copies, effect_assertions, relation_work) =
+            derive_retained_projection_relations(
+                conn,
+                recovery.session_id(),
+                effect_occurrences,
+                &parents,
+            )
+            .await?;
+        record_relation_derivation_work(relation_work);
+        let effect_items = effect_occurrences
             .len()
-            .saturating_add(copies.len())
-            .saturating_add(assertions.len());
-        if derived_count <= MAX_SESSION_TEMPORAL_PROJECTION_BATCH_ITEMS {
-            selected = Some((prefix_len, occurrences, copies, assertions));
-            low = prefix_len.saturating_add(1);
-        } else {
-            if prefix_len == 1 {
-                single_effect_count = Some(derived_count);
+            .saturating_add(effect_copies.len())
+            .saturating_add(effect_assertions.len());
+        if selected_items.saturating_add(effect_items) > MAX_SESSION_TEMPORAL_PROJECTION_BATCH_ITEMS
+        {
+            if selected_effects == 0 {
+                return Err(SessionStoreError::BatchLimitExceeded {
+                    field: "session temporal derived observation effect records",
+                    count: effect_items,
+                    max: MAX_SESSION_TEMPORAL_PROJECTION_BATCH_ITEMS,
+                });
             }
-            high = prefix_len.saturating_sub(1);
+            has_more = true;
+            break;
+        }
+        selected_items += effect_items;
+        selected_occurrences = end;
+        selected_effects += 1;
+        copies.extend(effect_copies);
+        assertions.extend(effect_assertions);
+        for occurrence in effect_occurrences {
+            if let Some(message_id) = occurrence.message_id.as_ref() {
+                parents.register(message_id.as_str(), occurrence.occurrence_id.as_str());
+            }
         }
     }
-    let Some((prefix_len, occurrences, copies, assertions)) = selected else {
+    if selected_effects == 0 {
         return Err(SessionStoreError::BatchLimitExceeded {
             field: "session temporal derived observation effect records",
-            count: single_effect_count
-                .unwrap_or(MAX_SESSION_TEMPORAL_PROJECTION_BATCH_ITEMS.saturating_add(1)),
+            count: MAX_SESSION_TEMPORAL_PROJECTION_BATCH_ITEMS.saturating_add(1),
             max: MAX_SESSION_TEMPORAL_PROJECTION_BATCH_ITEMS,
         });
-    };
-    if prefix_len < effects.len() {
-        effects.truncate(prefix_len);
+    }
+    let occurrences = all_occurrences
+        .get(..selected_occurrences)
+        .ok_or_else(|| {
+            storage_message(
+                MATERIALIZE_REFRESH,
+                "selected observation effects exceed materialized occurrences",
+            )
+        })?
+        .to_vec();
+    if selected_effects < effects.len() {
+        effects.truncate(selected_effects);
         has_more = true;
     }
     let source_through = if has_more {
@@ -241,38 +280,68 @@ pub(super) async fn materialize_effect_occurrences(
     conn: &impl QueryExecutor,
     effects: &[(tracedecay_domain::CanonicalObservationIdV1, u64, usize)],
     item_count: usize,
-) -> SessionStoreResult<Vec<MessageOccurrenceRecordV1>> {
+) -> SessionStoreResult<(
+    Vec<MessageOccurrenceRecordV1>,
+    OccurrenceMaterializationWork,
+)> {
     let mut occurrences = Vec::with_capacity(item_count);
+    let mut work = OccurrenceMaterializationWork::default();
+    // One chunked prefetch for the whole effect set instead of one probe per
+    // effect. The loop below still walks `effects` in order, so both the emitted
+    // occurrence order and the first error raised are unchanged.
+    let observation_ids = effects
+        .iter()
+        .map(|(observation_id, _, _)| observation_id.clone())
+        .collect::<Vec<_>>();
+    let observations = read_observations(conn, &observation_ids).await?;
     for (observation_id, _, output_count) in effects {
-        let (_, observation) = read_observation(conn, observation_id).await?;
+        let (_, observation) = observations
+            .get(observation_id.as_str())
+            .ok_or_else(|| missing_observation(observation_id))?;
         // One derivation per observation, reused across all of its outputs.
         let projection =
-            derive_projection(&observation).map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
-        for output_ordinal in 0..*output_count {
-            occurrences.push(
-                canonical_occurrence(
-                    conn,
-                    &observation,
-                    &projection,
-                    u32::try_from(output_ordinal)
-                        .map_err(|error| storage(MATERIALIZE_REFRESH, error))?,
-                )
-                .await?,
-            );
+            derive_projection(observation).map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+        let outputs = projection.messages().collect::<Vec<_>>();
+        if outputs.len() != *output_count {
+            return Err(storage_message(
+                MATERIALIZE_REFRESH,
+                "canonical observation effect output authority disagrees with its projection",
+            ));
+        }
+        let envelope: CanonicalObservationEnvelopeV1 =
+            observation_envelope_from_payload(observation.payload())
+                .map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+        work.envelope_parses = work.envelope_parses.saturating_add(1);
+        for output in outputs {
+            occurrences.push(canonical_occurrence(conn, observation, &envelope, output).await?);
         }
     }
-    Ok(occurrences)
+    Ok((occurrences, work))
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct OccurrenceMaterializationWork {
+    pub(super) envelope_parses: u64,
+}
+
+#[inline(always)]
+fn record_occurrence_materialization_work(work: OccurrenceMaterializationWork) {
+    #[cfg(feature = "hotpath")]
+    hotpath::gauge!("session_temporal.occurrence_materialization.envelope_parses")
+        .inc(work.envelope_parses);
+    #[cfg(not(feature = "hotpath"))]
+    let _ = work;
 }
 
 pub(super) fn derived_temporal_assertion_id(
-    occurrence_id: &MessageOccurrenceIdV1,
+    subject_anchor_id: &tracedecay_domain::RetrievalAnchorId,
     kind: TemporalAssertionKindV1,
     object_anchor_id: &tracedecay_domain::RetrievalAnchorId,
 ) -> String {
     digest_bytes(
         format!(
             "session-temporal-assertion-v1\0{}\0{}\0{}",
-            occurrence_id.as_str(),
+            subject_anchor_id.as_str(),
             kind.as_str(),
             object_anchor_id.as_str()
         )
@@ -374,26 +443,43 @@ pub(super) async fn canonical_copy_proof_for_retained(
 pub(super) async fn derive_retained_projection_relations(
     conn: &impl QueryExecutor,
     session_id: &SessionId,
-    source_frontier: u64,
     occurrences: &[MessageOccurrenceRecordV1],
-) -> SessionStoreResult<(Vec<LogicalCopyRecordV1>, Vec<TemporalAssertionRecordV1>)> {
-    let parents = canonical_parent_message_resolver(
-        conn,
-        session_id.as_str(),
-        source_frontier,
-        MATERIALIZE_REFRESH,
-    )
-    .await?;
-
+    parents: &ParentMessageResolver,
+) -> SessionStoreResult<(
+    Vec<LogicalCopyRecordV1>,
+    Vec<TemporalAssertionRecordV1>,
+    RelationDerivationWork,
+)> {
     let mut copies = BTreeMap::<(String, String), LogicalCopyRecordV1>::new();
     let mut assertions = BTreeMap::<String, TemporalAssertionRecordV1>::new();
     let mut seen_copy_keys = BTreeSet::new();
+    let mut seen_assertion_anchors = BTreeSet::new();
+
+    // Occurrences routinely share a source observation, so the chunked prefetch
+    // both collapses the repeats and drops the per-occurrence round trip. The
+    // loop order, and therefore the first error raised, is unchanged.
+    let observation_ids = occurrences
+        .iter()
+        .map(|occurrence| occurrence.source_observation_id.clone())
+        .collect::<Vec<_>>();
+    let observations = read_observations(conn, &observation_ids).await?;
+    let mut envelopes = HashMap::with_capacity(observations.len());
+    let mut work = RelationDerivationWork::default();
 
     for occurrence in occurrences {
-        let (_, observation) = read_observation(conn, &occurrence.source_observation_id).await?;
-        let envelope: CanonicalObservationEnvelopeV1 =
-            observation_envelope_from_payload(observation.payload())
-                .map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+        let envelope = match envelopes.entry(occurrence.source_observation_id.as_str().to_owned()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let (_, observation) = observations
+                    .get(occurrence.source_observation_id.as_str())
+                    .ok_or_else(|| missing_observation(&occurrence.source_observation_id))?;
+                let envelope: CanonicalObservationEnvelopeV1 =
+                    observation_envelope_from_payload(observation.payload())
+                        .map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+                work.envelope_parses = work.envelope_parses.saturating_add(1);
+                entry.insert(envelope)
+            }
+        };
         // A parent-message relation is conversation threading, not evidence of a
         // copy: Claude's `parentUuid`, and every other producer of
         // `parent_message_id`, points at the message this one *replies to*. Only
@@ -442,6 +528,9 @@ pub(super) async fn derive_retained_projection_relations(
             }
         }
 
+        if !seen_assertion_anchors.insert(occurrence.retrieval_anchor_id.as_str()) {
+            continue;
+        }
         let mut anchor_rows = conn
             .query(
                 "SELECT anchor_json FROM retrieval_anchors WHERE anchor_id = ?1",
@@ -473,8 +562,11 @@ pub(super) async fn derive_retained_projection_relations(
             let Some(kind) = assertion_kind_for_relation(lineage.relation()) else {
                 continue;
             };
-            let assertion_id =
-                derived_temporal_assertion_id(&occurrence.occurrence_id, kind, lineage.anchor_id());
+            let assertion_id = derived_temporal_assertion_id(
+                &occurrence.retrieval_anchor_id,
+                kind,
+                lineage.anchor_id(),
+            );
             let assertion: TemporalAssertionRecordV1 = serde_json::from_value(json!({
                 "assertion_id": assertion_id,
                 "kind": kind.as_str(),
@@ -497,27 +589,124 @@ pub(super) async fn derive_retained_projection_relations(
     Ok((
         copies.into_values().collect(),
         assertions.into_values().collect(),
+        work,
     ))
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct RelationDerivationWork {
+    pub(super) envelope_parses: u64,
+}
+
+#[inline(always)]
+fn record_relation_derivation_work(work: RelationDerivationWork) {
+    #[cfg(feature = "hotpath")]
+    hotpath::gauge!("session_temporal.relation_derivation.envelope_parses")
+        .inc(work.envelope_parses);
+    #[cfg(not(feature = "hotpath"))]
+    let _ = work;
+}
+
+#[hotpath::measure]
+async fn candidate_parent_message_resolver(
+    conn: &impl QueryExecutor,
+    session_id: &SessionId,
+    generation: tracedecay_domain::SessionProjectionGenerationV1,
+    occurrences: &[MessageOccurrenceRecordV1],
+) -> SessionStoreResult<ParentMessageResolver> {
+    let message_ids = occurrences
+        .iter()
+        .filter_map(|occurrence| occurrence.message_id.as_ref())
+        .map(|message_id| message_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut resolver = ParentMessageResolver::default();
+    if message_ids.is_empty() {
+        return Ok(resolver);
+    }
+    let encoded_ids =
+        serde_json::to_string(&message_ids).map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+    record_parent_resolver_probe();
+    let mut rows = conn
+        .query(
+            "SELECT requested.value,
+                    (
+                        SELECT occurrence.occurrence_id
+                        FROM session_occurrences AS occurrence
+                        JOIN session_temporal_observation_effects AS effect
+                          ON effect.observation_id = occurrence.source_observation_id
+                         AND effect.session_id = occurrence.session_id
+                        WHERE occurrence.session_id = ?1
+                          AND occurrence.generation = ?2
+                          AND occurrence.message_id = requested.value
+                        ORDER BY effect.observation_sequence,
+                                 occurrence.projection_output_ordinal,
+                                 occurrence.occurrence_id
+                        LIMIT 1
+                    )
+             FROM json_each(?3) AS requested
+             ORDER BY requested.value",
+            params![
+                session_id.as_str(),
+                generation_i64(generation, MATERIALIZE_REFRESH)?,
+                encoded_ids.as_str(),
+            ],
+        )
+        .await
+        .map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| storage(MATERIALIZE_REFRESH, error))?
+    {
+        let message_id: String = row
+            .get(0)
+            .map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+        let occurrence_id: Option<String> = row
+            .get(1)
+            .map_err(|error| storage(MATERIALIZE_REFRESH, error))?;
+        let Some(occurrence_id) = occurrence_id else {
+            continue;
+        };
+        record_parent_resolver_row(
+            u64::try_from(message_id.len().saturating_add(occurrence_id.len()))
+                .map_err(|error| storage(MATERIALIZE_REFRESH, error))?,
+        );
+        resolver.register(&message_id, &occurrence_id);
+    }
+    Ok(resolver)
+}
+
+#[hotpath::measure]
 pub async fn canonical_parent_message_resolver(
     conn: &impl QueryExecutor,
     session_id: &str,
     source_frontier: u64,
     operation: &'static str,
+    control: Option<&ExecutionControl>,
+    retain_canonical_outputs: bool,
 ) -> SessionStoreResult<ParentMessageResolver> {
     let mut resolver = ParentMessageResolver::default();
     let frontier = frontier_i64(source_frontier, operation)?;
     let mut after_sequence = 0_i64;
     loop {
+        if let Some(control) = control {
+            checkpoint_relation_rebuild_control(control)?;
+        }
+        record_parent_resolver_probe();
         let mut rows = conn
             .query(
                 "WITH page AS (
-                     SELECT sequence, observation_json
-                     FROM observations
-                     WHERE sequence > ?1 AND sequence <= ?2
-                     ORDER BY sequence
-                     LIMIT ?3
+                     SELECT effect.observation_sequence AS sequence,
+                            observation.observation_json
+                     FROM session_temporal_observation_effects AS effect
+                     JOIN observations AS observation
+                       ON observation.observation_id = effect.observation_id
+                     WHERE effect.session_id = ?1
+                       AND effect.observation_sequence > ?2
+                       AND effect.observation_sequence <= ?3
+                       AND effect.output_count > 0
+                     ORDER BY effect.observation_sequence
+                     LIMIT ?4
                  ),
                  bounded AS (
                      SELECT sequence, observation_json,
@@ -528,9 +717,10 @@ pub async fn canonical_parent_message_resolver(
                  )
                  SELECT sequence, observation_json
                  FROM bounded
-                 WHERE cumulative_bytes <= ?4 OR page_row = 1
+                 WHERE cumulative_bytes <= ?5 OR page_row = 1
                  ORDER BY sequence",
                 params![
+                    session_id,
                     after_sequence,
                     frontier,
                     PARENT_RESOLVER_PAGE_SIZE,
@@ -545,6 +735,9 @@ pub async fn canonical_parent_message_resolver(
             .await
             .map_err(|error| storage(operation, error))?
         {
+            if let Some(control) = control {
+                checkpoint_relation_rebuild_control(control)?;
+            }
             let sequence: i64 = row.get(0).map_err(|error| storage(operation, error))?;
             if sequence <= after_sequence {
                 return Err(storage_message(
@@ -553,8 +746,19 @@ pub async fn canonical_parent_message_resolver(
                 ));
             }
             let encoded: String = row.get(1).map_err(|error| storage(operation, error))?;
+            record_parent_resolver_row(
+                u64::try_from(encoded.len()).map_err(|error| storage(operation, error))?,
+            );
             let observation: tracedecay_domain::DurableObservationV1 =
                 serde_json::from_str(&encoded).map_err(|error| storage(operation, error))?;
+            let envelope = if retain_canonical_outputs {
+                Some(
+                    observation_envelope_from_payload(observation.payload())
+                        .map_err(|error| storage(operation, error))?,
+                )
+            } else {
+                None
+            };
             let projection =
                 derive_projection(&observation).map_err(|error| storage(operation, error))?;
             for output in projection
@@ -566,6 +770,16 @@ pub async fn canonical_parent_message_resolver(
                     tracedecay_domain::ProjectionOutputOrdinalV1::new(output.output_ordinal()),
                 );
                 resolver.register(&output.message().message_id, occurrence_id.as_str());
+                if let Some(envelope) = envelope.as_ref() {
+                    resolver.canonical_outputs.push((
+                        occurrence_id.as_str().to_owned(),
+                        envelope
+                            .relations()
+                            .parent_message_id()
+                            .filter(|parent| parent.as_str() == output.message().message_id)
+                            .map(|parent| parent.as_str().to_owned()),
+                    ));
+                }
             }
             after_sequence = sequence;
             page_count += 1;
@@ -579,28 +793,50 @@ pub async fn canonical_parent_message_resolver(
     Ok(resolver)
 }
 
+#[inline(always)]
+fn record_parent_resolver_probe() {
+    #[cfg(feature = "hotpath")]
+    hotpath::gauge!("session_temporal.parent_resolver.query_probes").inc(1_u64);
+}
+
+#[inline(always)]
+fn record_parent_resolver_row(bytes: u64) {
+    #[cfg(feature = "hotpath")]
+    {
+        hotpath::gauge!("session_temporal.parent_resolver.rows").inc(1_u64);
+        hotpath::gauge!("session_temporal.parent_resolver.row_payload_bytes").inc(bytes);
+    }
+    #[cfg(not(feature = "hotpath"))]
+    let _ = bytes;
+}
+
 impl ParentMessageResolver {
     pub(in crate::session_temporal) fn register(&mut self, message_id: &str, occurrence_id: &str) {
         self.occurrences
             .entry(message_id.to_owned())
-            .or_default()
-            .insert(occurrence_id.to_owned());
+            .and_modify(|resolution| {
+                resolution.occurrences.insert(occurrence_id.to_owned());
+            })
+            .or_insert_with(|| ParentMessageResolution {
+                selected: occurrence_id.to_owned(),
+                occurrences: BTreeSet::from([occurrence_id.to_owned()]),
+            });
     }
 
     pub(in crate::session_temporal) fn reject_ambiguity(
         &self,
         operation: &'static str,
     ) -> SessionStoreResult<()> {
-        if let Some((message_id, occurrences)) = self
+        if let Some((message_id, resolution)) = self
             .occurrences
             .iter()
-            .find(|(_, occurrences)| occurrences.len() > 1)
+            .find(|(_, resolution)| resolution.occurrences.len() > 1)
         {
             return Err(storage_message(
                 operation,
                 format!(
                     "session-scoped message id {message_id} resolves to {} occurrences",
-                    occurrences.len()
+                    resolution.occurrences.len()
                 ),
             ));
         }
@@ -610,12 +846,22 @@ impl ParentMessageResolver {
     pub(in crate::session_temporal) fn resolve(&self, message_id: &str) -> Option<&str> {
         self.occurrences
             .get(message_id)
-            .and_then(|occurrences| occurrences.first())
-            .map(String::as_str)
+            .map(|resolution| resolution.selected.as_str())
+    }
+
+    pub(in crate::session_temporal) fn canonical_outputs(&self) -> &[(String, Option<String>)] {
+        &self.canonical_outputs
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ParentMessageResolver {
-    occurrences: BTreeMap<String, BTreeSet<String>>,
+    occurrences: BTreeMap<String, ParentMessageResolution>,
+    canonical_outputs: Vec<(String, Option<String>)>,
+}
+
+#[derive(Debug)]
+struct ParentMessageResolution {
+    selected: String,
+    occurrences: BTreeSet<String>,
 }

--- a/crates/tracedecay-global-db/src/session_temporal/retrieval.rs
+++ b/crates/tracedecay-global-db/src/session_temporal/retrieval.rs
@@ -1,4 +1,13 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
+
+/// `(session_id, generation, provider)` -> the `(state, frozen_watermarks_json)`
+/// rows the join produced for that participant key.
+type FrozenParticipantGenerations = HashMap<(String, i64, String), Vec<(String, String)>>;
+
+/// The largest participant batch one frozen-generation read binds. Each entry
+/// contributes three variables plus the shared project key, so this stays clear of
+/// `SQLite`'s default statement-variable ceiling.
+const FROZEN_PARTICIPANT_BATCH: usize = 300;
 
 use tracedecay_runtime_core::db::{
     DatabaseEngineReadSnapshot,
@@ -789,6 +798,12 @@ impl<'a> GlobalDbTemporalReadPort<'a> {
             .authorized_root()
             .ok_or(TemporalPortError::UnauthorizedSnapshot)?
             .project_key();
+        // The per-participant frozen-generation probe is resolved from one chunked
+        // batch instead of one statement per participant. The batch is filled
+        // lazily, at the exact point the first participant would have issued its
+        // own query, so an unauthorized or unconvertible participant ahead of it
+        // still short-circuits before any read happens.
+        let mut frozen_generations: Option<FrozenParticipantGenerations> = None;
         for participant in snapshot.participant_manifest().entries() {
             control.checkpoint()?;
             if !participant.is_authorized_for_snapshot()
@@ -800,58 +815,36 @@ impl<'a> GlobalDbTemporalReadPort<'a> {
             }
             let generation = i64::try_from(participant.generation())
                 .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
-            let mut rows = self
-                .read
-                .query(
-                    "SELECT generation.state, generation.frozen_watermarks_json
-                     FROM session_temporal_generations AS generation
-                     JOIN sessions AS source
-                       ON source.session_id = generation.session_id
-                      AND source.provider = ?3
-                      AND source.project_key = ?4
-                     WHERE generation.session_id = ?1
-                       AND generation.generation = ?2
-                     LIMIT 2",
-                    params![
-                        participant.session_id().as_str(),
-                        generation,
-                        participant.source_id(),
-                        project_key
-                    ],
+            let batch = match &frozen_generations {
+                Some(batch) => batch,
+                None => frozen_generations.insert(
+                    self.read_frozen_participant_generations(snapshot, project_key)
+                        .await?,
+                ),
+            };
+            let matched = batch
+                .get(&(
+                    participant.session_id().as_str().to_owned(),
+                    generation,
+                    participant.source_id().to_owned(),
+                ))
+                .map_or(&[][..], Vec::as_slice);
+            let (state, encoded) = matched.first().ok_or_else(|| {
+                read_message(
+                    SNAPSHOT_OPERATION,
+                    "frozen participant generation is missing",
                 )
-                .await
-                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
-            let row = rows
-                .next()
-                .await
-                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?
-                .ok_or_else(|| {
-                    read_message(
-                        SNAPSHOT_OPERATION,
-                        "frozen participant generation is missing",
-                    )
-                })?;
-            let state: String = row
-                .get(0)
-                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
-            let encoded: String = row
-                .get(1)
-                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
-            if rows
-                .next()
-                .await
-                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?
-                .is_some()
-            {
+            })?;
+            if matched.len() > 1 {
                 return Err(read_message(
                     SNAPSHOT_OPERATION,
                     "frozen participant generation is not unique",
                 ));
             }
-            let frozen: FrozenWatermarksWire = serde_json::from_str(&encoded)
+            let frozen: FrozenWatermarksWire = serde_json::from_str(encoded)
                 .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
             let watermarks = participant.watermarks();
-            if state != "active"
+            if state.as_str() != "active"
                 || frozen.active_generation > watermarks.generation
                 || frozen.source_frontier != watermarks.source
                 || frozen.projection_frontier != watermarks.projection
@@ -865,6 +858,103 @@ impl<'a> GlobalDbTemporalReadPort<'a> {
             }
         }
         control.checkpoint()
+    }
+
+    /// Reads every participant's frozen generation row in chunked batches.
+    ///
+    /// `session_temporal_generations` is keyed by `(session_id, generation)` and
+    /// `sessions` by `(provider, session_id)`, so the inner join yields at most one
+    /// row per `(session_id, generation, provider)` — the same row the replaced
+    /// per-participant `LIMIT 2` probe would have returned. Rows are still kept in
+    /// a vector per key so a schema that ever admitted a duplicate raises the same
+    /// "not unique" error the probe did.
+    async fn read_frozen_participant_generations(
+        &self,
+        snapshot: &TemporalExecutionSnapshot,
+        project_key: &str,
+    ) -> Result<FrozenParticipantGenerations, TemporalPortError> {
+        let mut keys = Vec::new();
+        let mut seen = HashSet::new();
+        for participant in snapshot.participant_manifest().entries() {
+            // Participants whose generation does not fit an `i64` are skipped here;
+            // the validation loop still raises their conversion error in place.
+            let Ok(generation) = i64::try_from(participant.generation()) else {
+                continue;
+            };
+            let key = (
+                participant.session_id().as_str().to_owned(),
+                generation,
+                participant.source_id().to_owned(),
+            );
+            if seen.insert(key.clone()) {
+                keys.push(key);
+            }
+        }
+        let mut batch = FrozenParticipantGenerations::new();
+        if keys.is_empty() {
+            return Ok(batch);
+        }
+        for chunk in keys.chunks(FROZEN_PARTICIPANT_BATCH) {
+            let mut values = Vec::with_capacity(chunk.len() * 3 + 1);
+            values.push(Value::Text(project_key.to_owned()));
+            let predicate = chunk
+                .iter()
+                .enumerate()
+                .map(|(offset, (session_id, generation, provider))| {
+                    values.push(Value::Text(session_id.clone()));
+                    values.push(Value::Integer(*generation));
+                    values.push(Value::Text(provider.clone()));
+                    let base = offset * 3 + 2;
+                    format!(
+                        "(generation.session_id = ?{base} AND generation.generation = ?{} \
+                         AND source.provider = ?{})",
+                        base + 1,
+                        base + 2,
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            let sql = format!(
+                "SELECT generation.session_id, generation.generation, source.provider,
+                        generation.state, generation.frozen_watermarks_json
+                 FROM session_temporal_generations AS generation
+                 JOIN sessions AS source
+                   ON source.session_id = generation.session_id
+                  AND source.project_key = ?1
+                 WHERE {predicate}"
+            );
+            let mut rows = self
+                .read
+                .query(&sql, values)
+                .await
+                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?
+            {
+                let session_id: String = row
+                    .get(0)
+                    .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
+                let generation: i64 = row
+                    .get(1)
+                    .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
+                let provider: String = row
+                    .get(2)
+                    .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
+                let state: String = row
+                    .get(3)
+                    .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
+                let encoded: String = row
+                    .get(4)
+                    .map_err(|error| read_error(SNAPSHOT_OPERATION, error))?;
+                batch
+                    .entry((session_id, generation, provider))
+                    .or_default()
+                    .push((state, encoded));
+            }
+        }
+        Ok(batch)
     }
 
     async fn produce_candidates(

--- a/crates/tracedecay-runtime-core/src/background_cpu.rs
+++ b/crates/tracedecay-runtime-core/src/background_cpu.rs
@@ -1,0 +1,461 @@
+//! Process-wide weighted admission for background CPU work.
+//!
+//! The authority counts active CPU units rather than owning an executor. Code
+//! indexing, semantic native threads, and session preparation can therefore
+//! use their existing execution substrates while sharing one hard process
+//! ceiling. FIFO waiter order prevents a continuously busy class from starving
+//! another class, and RAII releases capacity on success, cancellation, or
+//! unwind.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+#[derive(Debug)]
+struct BackgroundCpuWaiterV1 {
+    units: usize,
+}
+
+#[derive(Default)]
+struct BackgroundCpuStateV1 {
+    active_units: usize,
+    waiters: VecDeque<Arc<BackgroundCpuWaiterV1>>,
+}
+
+/// One process-wide background CPU budget shared across subsystems.
+pub struct ProcessBackgroundCpuV1 {
+    width: NonZeroUsize,
+    state: Mutex<BackgroundCpuStateV1>,
+    available: Condvar,
+}
+
+impl fmt::Debug for ProcessBackgroundCpuV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessBackgroundCpuV1")
+            .field("width", &self.width)
+            .field("active_units", &self.active_units())
+            .finish_non_exhaustive()
+    }
+}
+
+thread_local! {
+    static BACKGROUND_CPU_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static BACKGROUND_CPU_UNITS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct BackgroundCpuScopeV1;
+
+impl BackgroundCpuScopeV1 {
+    fn enter() -> Self {
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+struct YieldedBackgroundCpuV1<'a> {
+    authority: &'a Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+    depth: usize,
+}
+
+impl Drop for YieldedBackgroundCpuV1<'_> {
+    fn drop(&mut self) {
+        self.authority.admit_units(self.units);
+        BACKGROUND_CPU_UNITS.with(|units| units.set(self.units));
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(self.depth));
+    }
+}
+
+impl Drop for BackgroundCpuScopeV1 {
+    fn drop(&mut self) {
+        BACKGROUND_CPU_DEPTH.with(|depth| {
+            let remaining = depth.get().saturating_sub(1);
+            depth.set(remaining);
+            if remaining == 0 {
+                BACKGROUND_CPU_UNITS.with(|units| units.set(0));
+            }
+        });
+    }
+}
+
+impl ProcessBackgroundCpuV1 {
+    fn new(width: NonZeroUsize) -> Self {
+        Self {
+            width,
+            state: Mutex::new(BackgroundCpuStateV1::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> NonZeroUsize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn active_units(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_units
+    }
+
+    #[must_use]
+    pub fn waiting_work_units(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        waiting_units(&state)
+    }
+
+    /// Acquire one CPU unit, waiting in FIFO order when the process budget is
+    /// full. The returned guard must remain alive for the active work unit.
+    pub fn acquire(self: &Arc<Self>) -> BackgroundCpuPermitV1 {
+        self.acquire_units(1)
+    }
+
+    /// Acquire one CPU unit only when no earlier waiter exists and capacity is
+    /// immediately available.
+    pub fn try_acquire(self: &Arc<Self>) -> Option<BackgroundCpuPermitV1> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.waiters.is_empty() || state.active_units >= self.width.get() {
+            return None;
+        }
+        state.active_units += 1;
+        record_state(&state, self.width);
+        Some(BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units: 1,
+        })
+    }
+
+    /// Run one active work unit under the process budget. Nested work on the
+    /// same thread reuses a sufficient parent admission instead of waiting on
+    /// itself.
+    pub fn with_permit<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        self.with_permits(1, operation)
+    }
+
+    /// Run a weighted work unit, clamped to the entire process width. Semantic
+    /// inference uses its native intra-op thread count as the weight; ordinary
+    /// index/session preparation uses one.
+    pub fn with_permits<R>(
+        self: &Arc<Self>,
+        requested_units: usize,
+        operation: impl FnOnce() -> R,
+    ) -> R {
+        let units = requested_units.max(1).min(self.width.get());
+        let active_units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if active_units >= units {
+            return operation();
+        }
+        if active_units > 0 {
+            let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+            self.release(active_units);
+            BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+            BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+            let _restore = YieldedBackgroundCpuV1 {
+                authority: self,
+                units: active_units,
+                depth,
+            };
+            let _permit = self.acquire_units(units);
+            let _scope = BackgroundCpuScopeV1::enter();
+            BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+            return operation();
+        }
+        let _permit = self.acquire_units(units);
+        let _scope = BackgroundCpuScopeV1::enter();
+        BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+        operation()
+    }
+
+    /// Temporarily yield the caller's active units while a nested executor
+    /// fans out independently admitted leaf work. This prevents a parent
+    /// Rayon worker from holding capacity while it waits for child workers,
+    /// including a full-width weighted child. Capacity is reacquired before
+    /// the parent resumes, including during unwind.
+    pub fn with_yielded_permits<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        let units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if units == 0 {
+            return operation();
+        }
+        let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+        self.release(units);
+        BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+        BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+        let _restore = YieldedBackgroundCpuV1 {
+            authority: self,
+            units,
+            depth,
+        };
+        operation()
+    }
+
+    fn acquire_units(self: &Arc<Self>, units: usize) -> BackgroundCpuPermitV1 {
+        self.admit_units(units);
+        BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units,
+        }
+    }
+
+    fn admit_units(&self, units: usize) {
+        let waiter = Arc::new(BackgroundCpuWaiterV1 { units });
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiters.push_back(Arc::clone(&waiter));
+        record_state(&state, self.width);
+        loop {
+            let is_front = state
+                .waiters
+                .front()
+                .is_some_and(|front| Arc::ptr_eq(front, &waiter));
+            if is_front && state.active_units.saturating_add(waiter.units) <= self.width.get() {
+                state.waiters.pop_front();
+                state.active_units += waiter.units;
+                record_state(&state, self.width);
+                self.available.notify_all();
+                return;
+            }
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn release(&self, units: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(state.active_units >= units);
+        state.active_units = state.active_units.saturating_sub(units);
+        record_state(&state, self.width);
+        self.available.notify_all();
+    }
+}
+
+fn record_state(state: &BackgroundCpuStateV1, width: NonZeroUsize) {
+    hotpath::gauge!("runtime_core.background_cpu.width").set(width.get());
+    hotpath::gauge!("runtime_core.background_cpu.active_units").set(state.active_units);
+    hotpath::gauge!("runtime_core.background_cpu.waiting_work_units").set(waiting_units(state));
+}
+
+fn waiting_units(state: &BackgroundCpuStateV1) -> usize {
+    state
+        .waiters
+        .iter()
+        .fold(0usize, |total, waiter| total.saturating_add(waiter.units))
+}
+
+/// RAII ownership of active CPU capacity. Dropping it is cancellation-safe and
+/// releases the exact acquired weight.
+pub struct BackgroundCpuPermitV1 {
+    authority: Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+}
+
+impl fmt::Debug for BackgroundCpuPermitV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackgroundCpuPermitV1")
+            .field("units", &self.units)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for BackgroundCpuPermitV1 {
+    fn drop(&mut self) {
+        self.authority.release(self.units);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BackgroundCpuInstallErrorV1 {
+    #[error(
+        "background CPU authority is already installed at width {installed_width}, not requested width {requested_width}"
+    )]
+    ConflictingWidth {
+        installed_width: usize,
+        requested_width: usize,
+    },
+    #[error("background CPU authority installation did not settle")]
+    InstallationDidNotSettle,
+}
+
+static PROCESS_BACKGROUND_CPU: OnceLock<Arc<ProcessBackgroundCpuV1>> = OnceLock::new();
+
+/// Install or idempotently reuse the one process background CPU authority.
+pub fn install_process_background_cpu(
+    width: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if let Some(installed) = PROCESS_BACKGROUND_CPU.get() {
+        return compare_installed_width(installed, width);
+    }
+    let requested = Arc::new(ProcessBackgroundCpuV1::new(width));
+    match PROCESS_BACKGROUND_CPU.set(Arc::clone(&requested)) {
+        Ok(()) => Ok(requested),
+        Err(_) => PROCESS_BACKGROUND_CPU.get().map_or_else(
+            || Err(BackgroundCpuInstallErrorV1::InstallationDidNotSettle),
+            |installed| compare_installed_width(installed, width),
+        ),
+    }
+}
+
+fn compare_installed_width(
+    installed: &Arc<ProcessBackgroundCpuV1>,
+    requested: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if installed.width == requested {
+        Ok(Arc::clone(installed))
+    } else {
+        Err(BackgroundCpuInstallErrorV1::ConflictingWidth {
+            installed_width: installed.width.get(),
+            requested_width: requested.get(),
+        })
+    }
+}
+
+/// Installed process authority, or `None` before daemon worker-plan admission.
+#[must_use]
+pub fn process_background_cpu() -> Option<Arc<ProcessBackgroundCpuV1>> {
+    PROCESS_BACKGROUND_CPU.get().map(Arc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn combined_classes_never_exceed_width_and_both_progress() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let index_completed = Arc::new(AtomicUsize::new(0));
+        let session_completed = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(17));
+        let mut workers = Vec::new();
+        for ordinal in 0..16 {
+            let authority = Arc::clone(&authority);
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let index_completed = Arc::clone(&index_completed);
+            let session_completed = Arc::clone(&session_completed);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                authority.with_permit(|| {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if ordinal % 2 == 0 {
+                        index_completed.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        session_completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }));
+        }
+        start.wait();
+        for worker in workers {
+            worker.join().expect("background worker");
+        }
+
+        assert!(maximum.load(Ordering::SeqCst) <= 4);
+        assert_eq!(index_completed.load(Ordering::SeqCst), 8);
+        assert_eq!(session_completed.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn waiting_demand_sums_weighted_work_units() {
+        let state = BackgroundCpuStateV1 {
+            active_units: 4,
+            waiters: VecDeque::from([
+                Arc::new(BackgroundCpuWaiterV1 { units: 4 }),
+                Arc::new(BackgroundCpuWaiterV1 { units: 1 }),
+            ]),
+        };
+
+        assert_eq!(waiting_units(&state), 5);
+    }
+
+    #[test]
+    fn weighted_units_and_nested_work_share_one_width() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permits(4, || {
+            assert_eq!(authority.active_units(), 4);
+            authority.with_permit(|| assert_eq!(authority.active_units(), 4));
+        });
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn nested_executor_yields_parent_units_and_reacquires_them() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_yielded_permits(|| {
+                assert_eq!(authority.active_units(), 0);
+                authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            });
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn panic_and_cancellation_drop_release_every_unit() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(2).expect("nonzero width"),
+        ));
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permits(2, || panic!("injected background panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let nested_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permit(|| {
+                authority.with_yielded_permits(|| panic!("injected nested executor panic"));
+            });
+        }));
+        assert!(nested_panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let cancelled = authority.acquire();
+        assert_eq!(authority.active_units(), 1);
+        drop(cancelled);
+        assert_eq!(authority.active_units(), 0);
+        assert!(authority.try_acquire().is_some());
+    }
+}

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -76,6 +76,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod background_cpu;
 pub mod branch;
 pub mod branch_meta;
 pub mod cancellation;

--- a/crates/tracedecay-runtime-core/src/store/memory/curation/apply.rs
+++ b/crates/tracedecay-runtime-core/src/store/memory/curation/apply.rs
@@ -398,14 +398,13 @@ pub(super) async fn load_commit_events_tx(
                 .or_insert((fact_id, event_json, sequence));
         }
     }
+    // Replay order is the receipt's own order, never storage order. Callers assert
+    // a strictly increasing `event_sequence` over this vector precisely to catch a
+    // receipt whose ids were reordered; re-sorting the batch rows by
+    // `event_sequence` would manufacture the canonical order that check exists to
+    // find missing, so the receipt is walked as written and each id is looked up.
     let mut events = Vec::with_capacity(event_ids.len());
-    let mut red_storage_order = stored.iter().collect::<Vec<_>>();
-    red_storage_order.sort_by_key(|(_, (_, _, sequence))| *sequence);
-    let red_ids = red_storage_order
-        .into_iter()
-        .map(|(event_id, _)| FactEventId::new(event_id.clone()).expect("red event id"))
-        .collect::<Vec<_>>();
-    for event_id in &red_ids {
+    for event_id in event_ids {
         let (stored_fact_id, event_json, sequence) =
             stored.get(event_id.as_str()).ok_or_else(|| {
                 storage_message(

--- a/crates/tracedecay-runtime-core/src/store/memory/curation/apply.rs
+++ b/crates/tracedecay-runtime-core/src/store/memory/curation/apply.rs
@@ -1,6 +1,6 @@
 //! Canonical tag curation and fact merge commands.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use serde_json::Value;
 use tracedecay_domain::{
@@ -16,7 +16,7 @@ use tracedecay_store::{
 };
 
 use crate::db::DatabaseMemoryTransaction as Transaction;
-use crate::db::engine::params;
+use crate::db::engine::{params, params_from_iter};
 
 use super::super::crud::{
     add_project_memory_fact_tx, commit_batch_tx, remove_project_memory_fact_tx, sanitize_payload,
@@ -338,40 +338,84 @@ async fn verify_curation_replay_events_tx(
     Ok(())
 }
 
-async fn load_commit_events_tx(
+/// The largest `event_id IN (...)` batch one curation commit-receipt event load
+/// binds, kept clear of `SQLite`'s default variable ceiling.
+const COMMIT_EVENT_BATCH: usize = 500;
+
+/// Reads every canonical event a commit receipt names in chunked `IN (...)`
+/// batches instead of one probe per event id.
+///
+/// The returned vector stays in `committed_event_ids()` order: callers destructure
+/// it positionally and assert a strictly increasing `event_sequence`, so the batch
+/// rows are collected into a lookup and then replayed against the receipt's own
+/// ordering rather than the order `SQLite` happens to return them in.
+pub(super) async fn load_commit_events_tx(
     transaction: &Transaction<'_>,
     owner: &OwnerKey,
     receipt: &FactCommitReceipt,
 ) -> FactStoreResult<Vec<(i64, FactLineageEventV1)>> {
-    let mut events = Vec::with_capacity(receipt.committed_event_ids().len());
-    for event_id in receipt.committed_event_ids() {
+    let event_ids = receipt.committed_event_ids();
+    if event_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    // `event_id -> (stored fact_id, event_json, event_sequence)`. The per-event
+    // probe this replaces bound `LIMIT 1` with no `ORDER BY`; the table's only
+    // uniqueness is `(event_id, fact_id, owner_kind, project_id)`, so the lowest
+    // `event_sequence` wins here to keep the choice deterministic.
+    let mut stored: HashMap<String, (String, String, i64)> =
+        HashMap::with_capacity(event_ids.len());
+    for chunk in event_ids.chunks(COMMIT_EVENT_BATCH) {
+        let placeholders = (3..=chunk.len() + 2)
+            .map(|index| format!("?{index}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT event_id, fact_id, event_json, event_sequence
+             FROM memory_v2_lineage_events
+             WHERE owner_kind = ?1 AND project_id = ?2
+               AND event_id IN ({placeholders})
+             ORDER BY event_sequence"
+        );
+        let mut bindings = Vec::with_capacity(chunk.len() + 2);
+        bindings.push(owner.kind);
+        bindings.push(owner.project_id.as_str());
+        bindings.extend(chunk.iter().map(FactEventId::as_str));
         let mut rows = transaction
-            .query(
-                "SELECT fact_id, event_json, event_sequence
-                 FROM memory_v2_lineage_events
-                 WHERE owner_kind = ?1 AND project_id = ?2 AND event_id = ?3
-                 LIMIT 1",
-                params![owner.kind, owner.project_id.as_str(), event_id.as_str()],
-            )
+            .query(&sql, params_from_iter(bindings))
             .await
             .map_err(|error| storage_error(PROJECT_MEMORY_WRITE_OPERATION, error))?;
-        let row = rows
+        while let Some(row) = rows
             .next()
             .await
             .map_err(|error| storage_error(PROJECT_MEMORY_WRITE_OPERATION, error))?
-            .ok_or_else(|| {
+        {
+            let event_id = row_string(&row, 0, PROJECT_MEMORY_WRITE_OPERATION)?;
+            let fact_id = row_string(&row, 1, PROJECT_MEMORY_WRITE_OPERATION)?;
+            let event_json = row_string(&row, 2, PROJECT_MEMORY_WRITE_OPERATION)?;
+            let sequence = row_i64(&row, 3, PROJECT_MEMORY_WRITE_OPERATION)?;
+            stored
+                .entry(event_id)
+                .or_insert((fact_id, event_json, sequence));
+        }
+    }
+    let mut events = Vec::with_capacity(event_ids.len());
+    let mut red_storage_order = stored.iter().collect::<Vec<_>>();
+    red_storage_order.sort_by_key(|(_, (_, _, sequence))| *sequence);
+    let red_ids = red_storage_order
+        .into_iter()
+        .map(|(event_id, _)| FactEventId::new(event_id.clone()).expect("red event id"))
+        .collect::<Vec<_>>();
+    for event_id in &red_ids {
+        let (stored_fact_id, event_json, sequence) =
+            stored.get(event_id.as_str()).ok_or_else(|| {
                 storage_message(
                     PROJECT_MEMORY_WRITE_OPERATION,
                     "curation receipt references a missing canonical event",
                 )
             })?;
-        let stored_fact_id = FactId::new(row_string(&row, 0, PROJECT_MEMORY_WRITE_OPERATION)?)?;
-        let event = serde_json::from_str::<FactLineageEventV1>(&row_string(
-            &row,
-            1,
-            PROJECT_MEMORY_WRITE_OPERATION,
-        )?)
-        .map_err(|error| storage_error(PROJECT_MEMORY_WRITE_OPERATION, error))?;
+        let stored_fact_id = FactId::new(stored_fact_id.clone())?;
+        let event = serde_json::from_str::<FactLineageEventV1>(event_json)
+            .map_err(|error| storage_error(PROJECT_MEMORY_WRITE_OPERATION, error))?;
         if event.event_id() != event_id
             || event.fact_id() != &stored_fact_id
             || event.fact_id() != receipt.fact_id()
@@ -382,7 +426,7 @@ async fn load_commit_events_tx(
                 "curation receipt event does not match canonical storage",
             ));
         }
-        events.push((row_i64(&row, 2, PROJECT_MEMORY_WRITE_OPERATION)?, event));
+        events.push((*sequence, event));
     }
     Ok(events)
 }

--- a/crates/tracedecay-runtime-core/src/store/memory/curation/tests.rs
+++ b/crates/tracedecay-runtime-core/src/store/memory/curation/tests.rs
@@ -32,6 +32,7 @@ use crate::store::memory::{DatabaseFactStore, FactWriteControl};
 
 use super::apply::{apply_project_memory_fact_curation_tx, curation_receipt_from_value};
 
+mod commit_event_batch_tests;
 mod duplicate_identity_tests;
 mod graph_source_tests;
 mod replay_conflict_tests;

--- a/crates/tracedecay-runtime-core/src/store/memory/curation/tests/commit_event_batch_tests.rs
+++ b/crates/tracedecay-runtime-core/src/store/memory/curation/tests/commit_event_batch_tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+use crate::store::memory::curation::apply::load_commit_events_tx;
+
+/// Enough synthetic lineage events to force `load_commit_events_tx` past a single
+/// `COMMIT_EVENT_BATCH` chunk and past the historical 999-variable `SQLite`
+/// statement ceiling, so an unchunked `IN (?, ?, ...)` build would be visible here.
+const BATCHED_EVENT_COUNT: usize = 1_100;
+
+/// The batched read must hand every event back in the receipt's own order, not in
+/// the `event_sequence` order `SQLite` returns rows in. Callers destructure the
+/// result positionally and reject a non-increasing sequence run, so storage order
+/// would silently launder a corrupt receipt.
+#[tokio::test]
+async fn commit_event_load_preserves_receipt_order_across_chunks() {
+    let fixture = Fixture::new("commit-event-batch-order").await;
+    let fact = fixture.seed("commit-event-batch-subject", 10).await;
+    let key = OwnerKey::new(&fixture.owner).expect("owner key");
+    let seed_event = lineage_events_for_fact(&fixture.db, &fixture.owner, &fact)
+        .await
+        .into_iter()
+        .next()
+        .expect("seeded lineage event");
+
+    let transaction = fixture
+        .db
+        .begin_memory_write_transaction(PROJECT_MEMORY_WRITE_OPERATION)
+        .await
+        .expect("begin commit-event batch transaction");
+
+    // `event_sequence` is AUTOINCREMENT, so insertion order is ascending storage
+    // order. Only `occurred_at` varies, which is enough to derive a distinct
+    // `event_id` per row.
+    let mut storage_order = Vec::with_capacity(BATCHED_EVENT_COUNT);
+    for offset in 0..BATCHED_EVENT_COUNT {
+        let event = FactLineageEventV1::new(
+            fact.clone(),
+            fixture.owner.clone(),
+            seed_event.kind().clone(),
+            UtcMicros(1_000_000 + i64::try_from(offset).expect("offset fits i64")),
+            seed_event.actor_id().cloned(),
+        )
+        .expect("synthetic lineage event");
+        transaction
+            .execute(
+                "INSERT INTO memory_v2_lineage_events(
+                    event_id, fact_id, owner_kind, project_id,
+                    event_json, occurred_at, recorded_at
+                 ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    event.event_id().as_str(),
+                    event.fact_id().as_str(),
+                    key.kind,
+                    key.project_id.as_str(),
+                    serde_json::to_string(&event).expect("serialize synthetic event"),
+                    event.occurred_at().0,
+                    event.occurred_at().0,
+                ],
+            )
+            .await
+            .expect("insert synthetic lineage event");
+        storage_order.push(event.event_id().clone());
+    }
+
+    let requested = storage_order
+        .iter()
+        .rev()
+        .cloned()
+        .collect::<Vec<FactEventId>>();
+    let receipt = FactCommitReceipt::new(
+        fact.clone(),
+        fixture.owner.clone(),
+        requested.clone(),
+        requested.last().expect("requested tail").clone(),
+        None,
+    )
+    .expect("commit receipt over the synthetic events");
+
+    let loaded = load_commit_events_tx(&transaction, &key, &receipt)
+        .await
+        .expect("load batched commit events");
+    transaction
+        .rollback()
+        .await
+        .expect("roll back commit-event batch transaction");
+
+    // Every requested event came back: no chunk was dropped and no oversized
+    // statement was refused.
+    assert_eq!(loaded.len(), BATCHED_EVENT_COUNT);
+    assert_eq!(
+        loaded
+            .iter()
+            .map(|(_, event)| event.event_id().clone())
+            .collect::<Vec<_>>(),
+        requested,
+    );
+    // Storage order is the failure mode to rule out: the sequences must descend
+    // because the receipt asked for them reversed.
+    let sequences = loaded
+        .iter()
+        .map(|(sequence, _)| *sequence)
+        .collect::<Vec<_>>();
+    assert!(
+        sequences.windows(2).all(|pair| pair[0] > pair[1]),
+        "batched read returned storage order instead of receipt order: {sequences:?}",
+    );
+}

--- a/crates/tracedecay-runtime-core/src/store/memory/curation/tests/commit_event_batch_tests.rs
+++ b/crates/tracedecay-runtime-core/src/store/memory/curation/tests/commit_event_batch_tests.rs
@@ -105,3 +105,79 @@ async fn commit_event_load_preserves_receipt_order_across_chunks() {
         "batched read returned storage order instead of receipt order: {sequences:?}",
     );
 }
+
+/// A durable receipt holding the correct event ids in a noncanonical order, with
+/// `last_event_id` and `replay_event_id` retargeted to the new tail, is entirely
+/// self-consistent: it deserializes, keeps its event count, and keeps its
+/// `active_assertion_id`. The sibling reversal asserted in `tests.rs` is refused at
+/// deserialization because it leaves the old tail behind, so it never reaches the
+/// replay verifier at all. This one does, and the only check left to catch it is the
+/// verifier's strictly increasing `event_sequence` run over `load_commit_events_tx`.
+/// Re-sorting the batched rows by `event_sequence` would hand that verifier canonical
+/// order whatever the receipt said, laundering the tamper into a successful replay.
+#[tokio::test]
+async fn replay_rejects_a_self_consistent_reordered_commit_event_receipt() {
+    let fixture = Fixture::new("commit-event-reordered-receipt").await;
+    let normalized = fixture.seed("reordered-commit-subject", 10).await;
+    let evidence = fixture.seed("reordered-commit-evidence", 20).await;
+    let operation_id = provenance_id("fixture.normalize.reordered-commit-events");
+    let request = normalize_request(
+        &fixture.db,
+        &fixture.owner,
+        operation_id.as_str(),
+        None,
+        &normalized,
+        vec!["cache-policy".to_owned(), "canonical-tag".to_owned()],
+        vec![evidence],
+        0.9,
+    )
+    .await;
+    let store = DatabaseFactStore::new(&fixture.db);
+    let committed = store
+        .apply_project_memory_fact_curation(request.clone(), &fixture.control)
+        .await
+        .expect("commit normalized tags");
+
+    // Two canonical events, so receipt order and storage order can disagree at all.
+    let commit = primary_commit(&committed.operation_effects()[0]);
+    assert_eq!(commit.committed_event_ids().len(), 2);
+    let reordered_tail = commit.committed_event_ids()[0].clone();
+
+    let receipts = operation_receipts(&fixture.db, &fixture.owner, &operation_id).await;
+    let mut reordered = receipts[0].receipt.clone();
+    reordered["operation_effects"][0]["commit"]["committed_event_ids"]
+        .as_array_mut()
+        .expect("committed event array")
+        .reverse();
+    reordered["operation_effects"][0]["commit"]["last_event_id"] = json!(reordered_tail.as_str());
+    reordered["replay_event_id"] = json!(reordered_tail.as_str());
+    assert!(
+        curation_receipt_from_value(&reordered).is_ok(),
+        "the tampered receipt must stay self-consistent, or it is refused before the \
+         canonical sequence check and proves nothing",
+    );
+    rebind_curation_operation_receipt(
+        &fixture.db,
+        &fixture.owner,
+        &operation_id,
+        &reordered_tail,
+        &reordered,
+    )
+    .await;
+    let before_events = lineage_events_for_fact(&fixture.db, &fixture.owner, &normalized).await;
+
+    assert!(
+        matches!(
+            store
+                .apply_project_memory_fact_curation(request, &fixture.control)
+                .await,
+            Err(FactStoreError::Storage { .. })
+        ),
+        "reordered commit receipt replayed successfully instead of failing the canonical \
+         projection-history check",
+    );
+    assert_eq!(
+        lineage_events_for_fact(&fixture.db, &fixture.owner, &normalized).await,
+        before_events
+    );
+}


### PR DESCRIPTION
Three N+1 read sites, each re-verified as still present before the change.

| site | problem |
|---|---|
| `session_temporal/projection/materialize.rs` | one `read_observation` per effect, in three separate loops |
| `session_temporal/retrieval.rs` | a `session_temporal_generations JOIN sessions` query **per participant** |
| `runtime-core/store/memory/curation/apply.rs` | one query per committed event id |

Each now reads its whole set in chunked batches, following the existing `REFERENCED_ANCHOR_BATCH` pattern already used for the equivalent fix in `memory/crud/commit.rs`.

A batched `IN (…)` does not preserve input order, so results are re-mapped where the caller depends on ordering, and the empty-set case is handled explicitly rather than building degenerate SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)