### PR TITLE
fix(build): restore APIs the extraction merges made private

### DIFF
--- a/crates/tracedecay-agent-hosts/src/hooks/analytics/readiness.rs
+++ b/crates/tracedecay-agent-hosts/src/hooks/analytics/readiness.rs
@@ -179,6 +179,32 @@ pub struct HookCompletedReadinessDistributions {
     pub(crate) disposition_values_folded_to_unknown: u64,
 }
 
+impl HookCompletedReadinessDistributions {
+    /// Readiness counters read by the root-crate observation benchmark. The
+    /// struct moved into this crate, so its `pub(crate)` fields are no longer
+    /// reachable from there; these expose exactly the five it folds.
+    pub fn source_event(&self) -> &str {
+        &self.source_event
+    }
+
+    pub fn input_rows_received(&self) -> u64 {
+        self.input_rows_received
+    }
+
+    pub fn input_rows_processed(&self) -> u64 {
+        self.input_rows_processed
+    }
+
+    pub fn input_rows_dropped_at_cap(&self) -> u64 {
+        self.input_rows_dropped_at_cap
+    }
+
+    pub fn events_considered(&self) -> u64 {
+        self.events_considered
+    }
+}
+
+
 #[derive(Default)]
 struct MutableNumericSummary {
     present_count: u64,

--- a/crates/tracedecay-cli/src/startup_tests.rs
+++ b/crates/tracedecay-cli/src/startup_tests.rs
@@ -1,7 +1,7 @@
 use super::{
     AnalyticsAction, Cli, CommandFamily, Commands, DAEMON_CPU_THREADS_ENV,
     DEFAULT_MAX_DAEMON_CPU_THREADS, DaemonAction, GitAction, GitProjectArgs, HostBundleCliOptions,
-    HostBundleComponentArg, MAX_ASYNC_WORKER_THREADS, MAX_BLOCKING_THREADS, PackageHookAction,
+    HostBundleComponentArg, MAX_ASYNC_WORKER_THREADS, PackageHookAction,
     ProfileStorageAction, RAYON_NUM_THREADS_ENV, ScoopPackageHookAction, StderrTracingDefault,
     async_worker_threads, daemon_cpu_threads_from, is_daemon_run, is_full_component_set_adoption,
     is_local_install_command, should_skip_agent_install_check, should_skip_startup_maintenance,
@@ -254,7 +254,9 @@ fn unrelated_and_uninstall_commands_reject_adoption() {
 fn async_runtime_bounds_parallel_allocators() {
     assert!((1..=MAX_ASYNC_WORKER_THREADS).contains(&async_worker_threads()));
     assert_eq!(MAX_ASYNC_WORKER_THREADS, 16);
-    assert_eq!(MAX_BLOCKING_THREADS, 32);
+    // The blocking pool is no longer a flat constant: `blocking_thread_limit_tests`
+    // covers `tokio_blocking_thread_limit_from`, which derives the width from the
+    // installed indexing workers plus a serving reserve.
 }
 
 #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -191,7 +191,7 @@ pub(crate) mod privacy_remediation;
 pub(crate) mod project_open_owners;
 #[cfg(feature = "test-transport")]
 pub(crate) use dashboard_configuration_test_runtime::{
-    dashboard_configuration_runtime_for_test, register_dashboard_test_retained_runtime,
+    dashboard_configuration_authorities_for_test, register_dashboard_test_retained_runtime,
 };
 pub(crate) mod query_authority_provider;
 #[cfg(any(test, feature = "test-transport"))]
@@ -247,7 +247,7 @@ use invocation_executor::{
     unavailable_root_generation,
 };
 mod invocation_state;
-use invocation_state::DaemonInvocationState;
+pub(crate) use invocation_state::DaemonInvocationState;
 pub(crate) mod lcm_authority;
 mod lsp_sessions;
 mod request_cancellation;

--- a/src/daemon/invocation_state.rs
+++ b/src/daemon/invocation_state.rs
@@ -26,7 +26,7 @@ mod project_invocation;
 /// session remains daemon-owned across client connections until it is detached
 /// or expires.
 #[derive(Clone)]
-pub(super) struct DaemonInvocationState {
+pub(crate) struct DaemonInvocationState {
     pub(super) lsp_session_registry: Arc<tokio::sync::Mutex<LspSessionRegistry>>,
     pub(super) service: DaemonInvocationService,
     pub(super) github_credential_lifecycle:
@@ -76,6 +76,32 @@ impl Default for DaemonInvocationState {
 impl DaemonInvocationState {
     pub(super) fn invocation_service(&self) -> DaemonInvocationService {
         self.service.clone()
+    }
+
+    /// Mount the profile-owned background-worker plan before any projectless
+    /// session or host-admission work can start. The exact ProfileSessions
+    /// shard is the persisted user-profile authority; project configuration
+    /// must never win this process-wide installation by opening first.
+    pub(crate) async fn install_profile_worker_plan(
+        &self,
+        database: crate::global_db::RegisteredGlobalDbLeaseV1,
+        profile_id: &tracedecay_domain::configuration::UserProfileId,
+    ) -> Result<tracedecay_domain::configuration::CodeIndexWorkerStatusV1> {
+        let configured = crate::config::read_or_initialize_profile_code_index_worker_selection(
+            database, profile_id,
+        )
+        .await?;
+        let resident_memory = self.code_index_schedulers.process_resident_memory();
+        let resident_snapshot = resident_memory.snapshot();
+        tracedecay_code_index::parallelism::install_worker_plan(
+            configured,
+            resident_snapshot
+                .limit_bytes
+                .saturating_sub(resident_snapshot.used_bytes),
+        )
+        .map_err(|error| TraceDecayError::Config {
+            message: format!("code-index worker plan refused: {error}"),
+        })
     }
 
     pub(super) async fn retire_remote_deleted_project(

--- a/src/sessions/claude_observation_benchmark/baseline.rs
+++ b/src/sessions/claude_observation_benchmark/baseline.rs
@@ -266,7 +266,7 @@ pub(super) fn validate_hook_telemetry_readiness() {
     );
     assert_eq!(readiness.unavailable_measurements.len(), 1);
     assert_eq!(
-        readiness.readiness_distributions.source_event,
+        readiness.readiness_distributions.source_event(),
         "hook_completed"
     );
     assert_eq!(
@@ -274,13 +274,13 @@ pub(super) fn validate_hook_telemetry_readiness() {
             .expect("serialize empty readiness distributions")["collection_status"],
         "no_samples"
     );
-    assert_eq!(readiness.readiness_distributions.input_rows_received, 0);
-    assert_eq!(readiness.readiness_distributions.input_rows_processed, 0);
+    assert_eq!(readiness.readiness_distributions.input_rows_received(), 0);
+    assert_eq!(readiness.readiness_distributions.input_rows_processed(), 0);
     assert_eq!(
-        readiness.readiness_distributions.input_rows_dropped_at_cap,
+        readiness.readiness_distributions.input_rows_dropped_at_cap(),
         0
     );
-    assert_eq!(readiness.readiness_distributions.events_considered, 0);
+    assert_eq!(readiness.readiness_distributions.events_considered(), 0);
     assert_eq!(
         readiness.canonical_contract["latency_semantics"]["host_ipc_rtt"]["event_field"],
         "daemon_rtt_us"


### PR DESCRIPTION
`cargo check --workspace --all-targets` did not compile after the CLI (#669) and hooks (#668) crate extractions merged. Both moved code out of the root crate and left consumers behind.

| symbol | breakage |
|---|---|
| `DaemonInvocationState` | private, and the re-export could not raise it — root-crate tests could no longer name it |
| `install_profile_worker_plan` | `pub(super)`, so unreachable from `src/host_admission_test.rs` outside `crate::daemon` |
| `HookCompletedReadinessDistributions` | moved into `tracedecay-agent-hosts`; its `pub(crate)` counters became unreachable from the root-crate observation benchmark |
| `CodeIndexSchedulerRegistryV1::resident_memory` | accessor gone while callers still used it |
| `MAX_BLOCKING_THREADS` | replaced by the dynamic `tokio_blocking_thread_limit()`, but its `== 32` assertion stayed behind |

Five readiness counters are exposed as accessors rather than `pub` fields — widening the fields leaked several `pub(crate)` field *types* out of the crate (E0446), which would have been a much larger API change than the benchmark needs.

The stale `MAX_BLOCKING_THREADS` assertion is dropped rather than pinned to a new number: `blocking_thread_limit_tests` already covers `tokio_blocking_thread_limit_from`, which derives the width from installed indexing workers plus a serving reserve.

After this, `cargo check --workspace --all-targets --locked` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)