### PR TITLE
docs(memory): describe the current retrieval and trust model

### DIFF
--- a/docs/RETRIEVAL-QUALITY-EVAL.md
+++ b/docs/RETRIEVAL-QUALITY-EVAL.md
@@ -1,269 +1,308 @@
 # Holographic Memory — Retrieval & Entity Quality Evaluation
 
-Task `t_3d566784` ("Evaluate retrieval and entity quality"). This document maps the
-current recall pipeline, then reports **empirically measured** quality risks gathered by
-driving the real `tracedecay` binary (`target/debug/tracedecay tool fact_store`) against a
-throwaway fixture project, and proposes concrete follow-ups.
+This document maps the current project-memory recall pipeline (candidate
+generation, scoring, fusion) and the entity extractor that feeds it, then
+records which of the previously-identified quality risks still hold against
+the current implementation.
 
-All evidence below is reproducible: every query/probe/reason result was produced by the
-actual shipped binary against a freshly-initialized temp project (temp `HOME`, temp project
-dir — the shared repo `.tracedecay/` was never touched). Per-signal scores (`fts_score`,
-`jaccard_score`, `holographic_score`, `trust_score`) come straight from the `why` field the
-search handler emits.
-
----
-
-> **Status: historical — code layer superseded.** Every `retrieval.rs:NNN` /
-> `entities.rs:NNN` / `encoding.rs:NNN` / `migrations.rs:NNN` / `trust.rs:NNN`
-> anchor below was written against a single-crate `src/memory/` layout that no
-> longer exists. The retrieval pipeline was rewritten and split into
-> `crates/tracedecay-runtime-core/src/store/memory/{candidates.rs,scoring.rs,search.rs}`
-> (async, transaction-based, `project_memory_*`-prefixed functions) reading
-> `memory_v2_*` tables (`crates/tracedecay-runtime-core/src/db/migrations.rs`),
-> not the `memory_facts`/`memory_entities` tables this document cites. Verified
-> directly against the current source: **Risk A is resolved** —
-> `crates/tracedecay-runtime-core/src/memory/entities.rs` now extracts single
-> capitalized proper nouns and strips inflected leading verbs
-> (`is_non_entity_leading_word` matches "Prefers"/"Uses"/etc., not just exact
-> base forms), with code comments explicitly citing "Risk A" as the motivation.
-> The 0.40/0.30/0.30 fusion weights and the `(sim+1)/2` holographic floor
-> (Risks C/D) still exist verbatim in
-> `crates/tracedecay-runtime-core/src/store/memory/scoring.rs`, but scoring also
-> gained a `usage_boost` term from `retrieval_count` not described here, and
-> candidate FTS queries now add prefix-wildcarding for tokens ≥4 chars
-> (`crates/tracedecay-runtime-core/src/store/memory/candidates.rs`), which
-> likely changes Risk B's conclusion. The specific line citations throughout
-> this document are stale and unresolvable; re-verify each remaining risk
-> against the current module layout before acting on it rather than trusting
-> the numbers below.
-
-## 1. Current retrieval pipeline (with code references)
-
-`FactRetriever::search` (`src/memory/retrieval.rs:36`) fuses four recall channels and one
-ranking function:
-
-1. **Candidate generation** — three channels are unioned:
-   - FTS5 BM25 (`fts_candidates`, `retrieval.rs:328-398`). Score is `1/(1+|bm25|)`
-     (`retrieval.rs:391-395`); query is an OR of quoted tokens (`build_fts_query`,
-     `retrieval.rs:608-620`). FTS table uses the **default `unicode61` tokenizer with no
-     stemmer** (`src/db/migrations.rs:1136-1139`).
-   - Entity match (`entity_candidates`, `retrieval.rs:400-483`): a fact is a candidate if any
-     extracted entity exactly equals, or `LIKE %term%`-matches, the whole normalized query or
-     any query token (`retrieval.rs:428-429`).
-   - Trust-bucketed baseline scan (`MemoryStore::list_facts`, limit·10).
-
-2. **Recall gate** — if the query has tokens, a candidate survives only if it is in the FTS
-   set **or** shares ≥1 token (len≥2) with the fact's content+tags+entities
-   (`token_overlap > 0`, `retrieval.rs:81-87`). *No stopword list* is applied to these tokens.
-
-3. **Per-candidate scoring** (`retrieval.rs:102-128`) computes four signals:
-   - `fts_score` (from step 1),
-   - `jaccard_score` — token-set Jaccard vs query (`retrieval.rs:675-688`),
-   - `holographic_score` — FHRR-2048 binding similarity (`holographic_score_with`,
-     `retrieval.rs:590-605`),
-   - `trust_score` (stored) and `temporal_decay` (`retrieval.rs:712-719`).
-
-4. **Fusion** (`combined_score`, `retrieval.rs:698-710`):
-   ```
-   relevance = 0.40·fts + 0.30·jaccard + 0.30·holographic   (weights retrieval.rs:19-21)
-   score     = relevance · trust · temporal_decay
-   ```
-   Sorted by score, tie-broken by `updated_at` (`retrieval.rs:130-136`).
-
-5. **Entity-graph modes** bypass fusion entirely:
-   - `probe` / `reason` (`retrieval.rs:149-283`) return fact ids from entity joins and score
-     them with `results_for_fact_ids` (`retrieval.rs:557-584`), which sets
-     `score = trust_score`, `holographic_score = 1.0`, `fts/jaccard = 0.0` — i.e. **ranked by
-     trust alone, no query-relevance signal**.
-
-### Entity extraction (`src/memory/entities.rs`)
-`extract_entities` (`entities.rs:13-39`) captures five shapes:
-- quoted spans (`"..."` / `'...'`),
-- `aka`/`also known as` aliases (`entities.rs:64-105`),
-- code tokens that look like file paths, `::` Rust symbols, or `tracedecay_`/`tracedecay_` tool
-  names (`entities.rs:107-119, 217-238`),
-- **multi-word capitalized sequences** — requires **≥2 consecutive capitalized words**
-  (`extract_capitalized_names` / `push_capitalized_sequence`, `entities.rs:121-151`),
-- minus a leading-verb exclusion list matched **by exact string**
-  (`is_non_entity_leading_word`, `entities.rs:153-171`).
-
-The `memory_entities` table carries **no score, weight, frequency, or salience column**
-(`migrations.rs:1072-1079`) — entities are binary matchers used only for candidate
-generation, never scored into the ranking.
-
-### Holographic encoding (`src/memory/encoding.rs`)
-`encode_fact` (`encoding.rs:36-66`) binds content + each entity under fixed roles and
-averages. Atoms are **deterministic SHA-256 hashes of the literal token text**
-(`deterministic_coefficients`, `encoding.rs:85-110`) — there is **no semantic model**, so
-"install" and "installing" are as unrelated as "install" and "xylophone".
+The retrieval pipeline described here lives in
+`crates/tracedecay-runtime-core/src/store/memory/{candidates.rs,scoring.rs,search.rs}`
+— async, transaction-scoped, `project_memory_*`-prefixed functions operating
+over the `memory_v2_*` SQLite tables
+(`crates/tracedecay-runtime-core/src/db/memory_v2/schema/`). This is a full
+rewrite of an earlier single-crate `src/memory/{retrieval.rs,store.rs}`
+pipeline; none of that module layout exists anymore, and this document no
+longer cites it.
 
 ---
 
-## 2. Measured quality risks (with evidence)
+## 1. Current retrieval pipeline
 
-Fixture facts (8, controlled `trust`, category), with the entities the extractor actually
-produced:
+### Candidate generation
 
-| # | content | trust | extracted entities |
-|---|---------|-------|--------------------|
-| F1 | Acme Corp uses Postgres for its primary database | 0.5 | `["Acme Corp"]` |
-| F2 | The backend standardized on Postgres in 2023 | 0.5 | `[]` |
-| F3 | Prefers Tokio for async runtime | 0.5 | `["Prefers Tokio"]` |
-| F4 | Use pnpm for installing dependencies in this monorepo | 0.9 | `[]` |
-| F5 | Use npm to install packages | 0.3 | `[]` |
-| F6 | Always back up the database nightly before deploy | 1.0 | `[]` (aged 730 days) |
-| F7 | Database backups run via pg_dump every night | 0.3 | `[]` |
-| F8 | The deploy runs on Kubernetes with three replicas | 0.5 | `[]` |
+`project_memory_search_candidates_tx` (in `candidates.rs`) unions three SQL
+channels, each capped at `SEARCH_CANDIDATE_ARM_LIMIT` (1,000) rows:
 
-### RISK A — Entity extraction is brittle; the entity-graph retrieval modes are largely blind to it
-- The genuine entity in F3 is **Tokio**, but the extractor produced the noisy phrase
-  **`"Prefers Tokio"`** because the leading-verb filter matches `Prefer` exactly but not
-  `Prefers` (`entities.rs:153-171`). Result: `probe("Tokio")` → **EMPTY**; only the bogus
-  `probe("Prefers Tokio")` → `[F3]` returns the fact. No user/agent would query that phrase.
-- Single-token proper nouns (Postgres, Tokio, Kubernetes, npm, database) are **never**
-  extracted (the ≥2-capitalized-word rule, `entities.rs:147`, drops them), so `probe`/`reason`
-  cannot reach them. `reason(["database"])` → **EMPTY** against the 8-fact corpus, then
-  returned a fact only after `database` was supplied as an **explicit** entity.
-- `reason` is a strict entity-join with `HAVING COUNT(DISTINCT entity) = N`
-  (`retrieval.rs:223-267`); it returns nothing unless every query concept was captured as an
-  entity at write time. For a corpus where most facts have zero extracted entities, the entire
-  multi-entity reasoning path is inert.
+1. **FTS5 BM25** — `project_memory_fts_candidates_tx` queries the
+   `memory_v2_assertion_payloads_fts` virtual table (SQLite FTS5, default
+   `unicode61` tokenizer, **no stemmer configured**) joined through
+   `memory_v2_current_facts` / `memory_v2_facts` / `memory_v2_assertion_payloads`,
+   filtered by owner, trust floor, and optional category. The FTS index only
+   covers fact **content** (not tags or entities).
 
-### RISK B — No stemming/morphology across FTS, Jaccard, and holographic atoms
-- Query `database backup` vs facts F6 ("back **up** the **database**") and F7 ("database
-  **backups**"): the token `backup` matches **neither** `backups` nor `back up`. All three
-  candidate facts tied at `fts_score = 0.699` (only `database` matched). Query `install
-  dependencies` could not prefer F4 ("**installing** dependencies") over F5 ("**install**
-  packages") on the morphologically-related word.
-- Root cause is shared by all three signals: FTS5 default tokenizer (`migrations.rs:1136`),
-  the `tokenize`/`tokenize_text` helpers (`retrieval.rs:622`, `encoding.rs:112`), and the
-  SHA-256 atom keys (`encoding.rs:31,85`) all key on the exact surface string.
+   The query text is built by `project_memory_fts_query`: every query token is
+   quoted, and — **not documented in earlier versions of this doc** — any
+   token with 4 or more characters gets a trailing `*`, turning it into an
+   FTS5 prefix query; all tokens are OR'd together. A query token like
+   `install` therefore prefix-matches `installing`/`installs` in the index,
+   even though FTS5 itself is not stemming.
 
-### RISK C — Trust is a hard multiplicative gate that buries relevant low-trust facts
-Final score is `relevance · trust · decay`. In `search("database backup")`:
+2. **Entity match** — `project_memory_entity_candidates_tx` tokenizes the
+   query text and also adds the whole normalized/lowercased query string as
+   one more term, then matches each term against every fact's `$.entities`
+   JSON array (extracted via `json_each`) with either an exact
+   case-insensitive match or a `LIKE '%term%'` broadening (escaped for SQL
+   wildcards). No stopword list is applied to these terms.
 
-| rank | fact | relevance* | trust | decay | **score** |
-|------|------|-----------|-------|-------|-----------|
-| 1 | F1 Acme/Postgres (**off-topic**) | 0.4815 | 0.50 | 1.00 | **0.2408** |
-| 2 | F7 Database backups/pg_dump (**on-topic**) | 0.4935 | 0.30 | 1.00 | 0.1480 |
-| 3 | F6 back up the database nightly (**on-topic**) | 0.4881 | 1.00 | 0.25 | 0.1221 |
+3. **Newest-facts baseline** — `project_memory_newest_candidates_tx`: every
+   trust/category-eligible fact, ordered by `updated_at DESC`, capped at the
+   arm limit. This ensures a query with no lexical/entity match at all still
+   has a bounded pool of recent facts to rank (they will usually fail the
+   recall gate below unless the query has no tokens).
 
-\* recomputed from the binary's own per-signal scores: `0.40·fts + 0.30·jaccard + 0.30·holo`
-(F1: 0.40·0.699+0.30·0.111+0.30·0.562=0.4815; F7: 0.4935; F6: 0.4881) — these reproduce the
-emitted `score` exactly, confirming **relevance was actually F7 ≈ F6 > F1**, yet the
-off-topic F1 ranked first purely on `trust × decay`. A fact needs `trust ≥ 0.62` to match a
-`trust = 0.3` peer of equal relevance — the default floor is 0.3 (`DEFAULT_MIN_TRUST`,
-`trust.rs:10`) and new facts start at 0.5 (`DEFAULT_TRUST`, `trust.rs:9`), so freshly-learned
-facts are systematically disadvantaged against entrenched medium-trust ones.
+4. **Graph-assist expansion** (new since the rewrite, not present in the old
+   pipeline) — `project_memory_graph_assist` in `search.rs`: when the memory
+   graph runtime is mounted, it expands the FTS/entity candidate roots with
+   facts related through the code/entity graph
+   (`super::graph::project_memory_graph`), and reports coverage as
+   `ProjectMemoryFactSearchGraphCoverageV1::{Complete, Degraded, NotMounted}`
+   on the result page. If the graph is unavailable, missing, or over budget,
+   search degrades gracefully to the SQL-only candidate set rather than
+   failing.
 
-### RISK D — The holographic signal is decorative
-Two compounding effects make the 0.30 holographic weight nearly meaningless for ordering:
-1. **Floor at 0.5**: `holographic_score_with` returns `midpoint(sim, 1.0).clamp(0,1)`
-   (`retrieval.rs:604`) = `(sim+1)/2`, so even unrelated content scores ≈0.5 and a perfect
-   match scores 1.0 — the usable band is [0.5, 1.0].
-2. **Recall gate already filters lexically**: candidates only reach scoring if they share a
-   token with the query (`retrieval.rs:81-87`), so holographic only re-orders an
-   already-lexically-tied set. Across the `database backup` candidates, holographic ranged
-   0.562–0.588 (weighted swing ≈ 0.008) — too small to change order against a 0.2 trust gap.
-The unrelated query `butterfly migration` correctly returned nothing — but only because the
-lexical gate rejected it; the holographic channel alone would have surfaced everything at ~0.5.
+### Recall gate
 
-### RISK E — `probe`/`reason` ignore query relevance
-`results_for_fact_ids` (`retrieval.rs:557-584`) sets `holographic_score = 1.0` and
-`score = trust_score`. Any fact sharing an entity with the probe is returned ordered by trust
-alone — a high-trust fact that merely co-occurs with the entity outranks the directly
-on-topic one. These modes also do not apply the temporal or relevance signals, so stale
-high-trust facts dominate.
+Ranking (`project_memory_rank_facts_tx` in `search.rs`, `Search` arm) drops a
+candidate if the query has tokens and it scored **zero on both** the FTS
+component and the Jaccard component — i.e. it needs at least a partial BM25
+match (with coverage) or a shared token to survive. There is still no
+stopword list applied here.
 
-### RISK F — Stale entities / supersession are report-only
-Adding `Use pnpm instead of npm` after `Use npm to install packages` correctly emitted
-`diff: possible_conflict` (similarity 0.9997, `diff.rs:86-100`) — but **both facts coexist**
-and both remain reachable; nothing is deprecated, merged, or re-ranked. There is no
-entity-level `updated_at`/salience and no supersession flag on `memory_facts`
-(`migrations.rs:1050-1070`), so `probe`/`reason` entity joins return the superseded fact
-indefinitely. The aged F6 (730 days, `temporal_decay` ≈ 0.25) still surfaced in `deploy` and
-`database backup` results.
+### Per-candidate scoring
 
-### RISK G — Entity candidate broadening is noisy and unnormalized
-`entity_candidates` LIKE-matches the **whole normalized query string** and each raw query
-token (no stopword removal) against `normalized_name` (`retrieval.rs:409-432`). Common query
-words (`use`, `for`, `the`) become LIKE patterns that can match unrelated entity substrings,
-and the whole-query match favors coincidental exact-string entities over conceptual ones. The
-added candidates are then scored only through the lexical/holographic channels, which (per
-Risk B/D) add little discrimination.
+`project_memory_search_scores` (in `search.rs`, backed by `scoring.rs`)
+computes:
 
----
+- **`fts`** = `project_memory_fts_component(normalized_bm25, coverage)` =
+  `normalized_bm25 * (0.5 + 0.5 * coverage)`.
+  - `normalized_bm25` comes from `project_memory_normalize_fts5_ranks`:
+    SQLite's `bm25()` rank (negative; lower is a better match) is negated and
+    floored at 0, then divided by the **maximum** relevance across the
+    candidate set for that query — a max-relative normalization. This
+    replaces the collection-size-dependent `1/(1+|bm25|)` formula from the
+    pre-rewrite pipeline.
+  - `coverage` = `project_memory_term_coverage`: the fraction of query tokens
+    present in the fact's token set, where a match is either exact or (for
+    query tokens of 4+ characters) a prefix match against a fact token — the
+    same prefix-tolerance the FTS query itself uses.
+- **`jaccard`** = `project_memory_jaccard`, the exact Jaccard similarity
+  between `project_memory_tokens(query)` and `project_memory_fact_tokens(fact)`
+  (fact tokens are content + tags + entities, tokenized identically).
+- **`holographic`** = `project_memory_holographic_score`: FHRR-2048 binding of
+  content + normalized entities via `HolographicEncoder`
+  (`crates/tracedecay-runtime-core/src/memory/encoding.rs`, unchanged in
+  spirit from the pre-rewrite code) — every token still becomes a
+  deterministic SHA-256-derived coefficient vector; there is no semantic
+  embedding model. The raw FHRR similarity is rescaled with
+  `midpoint(sim, 1.0)` (i.e. `(sim + 1) / 2`), so the usable band is still
+  `[0, 1]` with an unrelated-content floor near 0.5.
+- **`trust`** = the fact's persisted `trust_score` (a `Confidence` in
+  `[0, 1]`; see the companion `TRUST-DECAY-SEMANTICS.md` for how it changes).
+- **`temporal_decay`** = `project_memory_temporal_decay` — unchanged formula
+  (see the trust-decay doc): `0.5^(age_days / 365)`, clamped to `[0.10, 1.0]`.
+- **`retrieval_count`** = the fact's stored retrieval counter, feeding the new
+  usage-boost term below.
 
-## 3. Proposed follow-ups (≥3, prioritized)
+### Fusion
 
-### F1 — Add a retrieval-ranking eval scenario family (highest value, lowest risk)
-The existing `tests/memory_suite/memory_eval_test.rs` + `evals/memory/scenarios/*.json` harness covers **hygiene
-contracts only** (secrets, transient, supersession, dedup). It has **no ranking-quality
-scenarios**. Add scenarios that assert ordering, e.g. `memory-ranking-trust-bias.json`:
-seed an on-topic low-trust fact and an off-topic high-trust fact sharing one token, assert
-`search()` ranks the on-topic fact first. Extend the harness with a ranking assertion kind
-(`Assertion::SearchRank { query, top_fact_source, min_rank_gap }`) that calls
-`tracedecay tool fact_store --args {action:search}` and checks the returned order — this is
-the same subprocess path the harness already uses. This pins Risks A–E as regression tests.
+`project_memory_combined_score` (in `scoring.rs`):
 
-### F2 — Re-balance fusion: gate trust, don't multiply it
-Replace the hard `relevance · trust` product (`retrieval.rs:709`) with a trust **gate +
-gentle nudge**, e.g. `score = relevance · (0.5 + 0.5·trust) · decay` (or min-trust filter
-then mild boost). This keeps low-trust exclusion (via `DEFAULT_MIN_TRUST`) while stopping
-trust from burying equally-relevant fresher facts. Pair with normalizing the FTS score to a
-stable [0,1] range (the current `1/(1+|bm25|)` is collection-size-dependent). Add unit tests
-on `combined_score` (`retrieval.rs:698`) covering the trust-bias case from Risk C.
+```text
+relevance   = 0.40 * fts + 0.30 * jaccard + 0.30 * holographic
+usage_boost = 1.0 + min(0.02 * ln(1 + retrieval_count), 0.50)
+score       = relevance * trust * temporal_decay * usage_boost
+```
 
-### F3 — Fix entity extraction coverage and the brittle verb list
-- Extend `extract_capitalized_names` to also capture **single high-salience capitalized
-  tokens** (e.g. recognized tech/project names), or lower the ≥2-word threshold for
-  capitalized tokens that are not sentence-initial — so Postgres/Tokio/Kubernetes become
-  entities.
-- Make `is_non_entity_leading_word` (`entities.rs:153`) stem-/prefix-match (accept `prefer`,
-  `prefers`, `preferred`, `preferring`, `using`, `uses`) so phrase capture like
-  `"Prefers Tokio"` does not swallow the real entity.
-- Extract the **head noun** of a captured phrase as an additional entity (so `"Prefers
-  Tokio"` also yields `"Tokio"`). Add unit tests in `entities.rs` for each.
+The `0.40 / 0.30 / 0.30` fusion weights are unchanged from the pre-rewrite
+pipeline. **`usage_boost` is new and was not described in earlier versions of
+this document**: the more often a fact has previously been retrieved
+(`retrieval_count`, incremented on every successful search hit — see
+`project_memory_update_retrieval_projection_tx`), the more its score is
+nudged upward, on a `ln(1 + n)` curve capped so the multiplier never exceeds
+`1.5×` (`RETRIEVAL_REINFORCEMENT_CAP = 0.50`, weight
+`RETRIEVAL_REINFORCEMENT_WEIGHT = 0.02`). In practice the cap is reached only
+at an unrealistically large retrieval count; for ordinary usage the boost is
+a small, smoothly-increasing nudge, not a hard step.
 
-### F4 — Make the holographic signal earn its weight
-Either (a) remove the `(sim+1)/2` floor (`retrieval.rs:604`) and let raw FHRR similarity
-(≈[-1,1], rescaled to [0,1] without midpoint compression) discriminate, or (b) if the floor
-is needed to avoid negatives, drop the holographic weight from 0.30 toward 0.10–0.15 until a
-real embedding model replaces the SHA-256 atom keys (which currently make the channel a
-deterministic lexical hash, not a semantic signal — see `encoding.rs:85`). Add a test that
-two semantically-similar-but-lexically-different facts score higher than two
-lexically-similar-but-semantically-unrelated ones; until that passes, the channel is
-decorative (Risk D).
+The final score is stored as millionths and clamped at
+`MAX_PROJECT_MEMORY_SEARCH_SCORE_MILLIONTHS = 1_500_000` (i.e. 1.5), which is
+exactly the ceiling the formula can reach (`relevance = 1, trust = 1,
+decay = 1, usage_boost = 1.5`).
 
-### F5 — Add morphology to the lexical channels
-Configure FTS5 with the `porter` stemmer (`tokenize='porter'` or a unicode61+stemmer config,
-`migrations.rs:1136`) and apply the same stemming in `tokenize`/`tokenize_text`
-(`retrieval.rs:622`, `encoding.rs:112`) so `install`/`installing`/`installs` and
-`backup`/`backups`/`back up` collapse. Risk B. Guard with tests.
+Hits are ordered by score descending, tie-broken by `updated_at` then fact id
+(`rank_and_seek`), with a resumable cursor
+(`ProjectMemoryFactSearchCursorV1`) for pagination. Each hit also carries a
+human-readable `why` string with every raw component
+(`fts=…, coverage=…, jaccard=…, holographic=…, trust=…, temporal_decay=…,
+retrieval_count=…`).
 
-### F6 — Persist supersession so entity joins can skip stale facts
-When `add_fact` classifies `PossibleConflict`, offer to mark the older fact superseded (a
-`superseded_by`/`deprecated` flag on `memory_facts`) and have `probe`/`reason`/`search`
-exclude or down-rank superseded facts. Today the signal is purely advisory (Risk F).
+### Entity-graph modes bypass fusion entirely
 
----
+`Probe`, `Related`, and `Reason` queries resolve candidate fact ids from
+`project_memory_exact_entity_candidates_tx` (an **exact** normalized-entity
+match only — no `LIKE` broadening in these modes) and then score every
+surviving fact as `score = trust`, `holographic = 1.0`, `fts = jaccard = 0`.
+These modes still carry **no query-relevance signal** — a fact is ranked by
+trust alone once it matches the requested entity/entities, same as the
+pre-rewrite pipeline.
 
-## 4. Reproducing this evaluation
+## 2. Entity extraction (`crates/tracedecay-runtime-core/src/memory/entities.rs`)
 
-The evidence above was produced with the shipped binary against an ephemeral fixture (no
-cargo, no repo-DB mutation). Minimal reproduction:
+`extract_entities` combines five sources, in document order, de-duplicated
+case-insensitively:
+
+- quoted spans (`"…"` / `'…'`, with apostrophe-as-delimiter suppressed
+  between two alphanumeric characters so possessives/contractions don't pair
+  into a giant span),
+- `aka` / `a.k.a.` / `also known as` aliases,
+- code-like tokens: file paths, `::`-qualified Rust symbols, `tracedecay_*`
+  tool names, and `snake_case`/`camelCase` identifiers,
+- multi-word capitalized phrases, and
+- **single-token capitalized proper nouns** (e.g. `Postgres`, `Tokio`,
+  `Kubernetes`, `Database`), filtered by a sentence-function-word stoplist
+  (`is_common_sentence_word`: articles, pronouns, auxiliaries, etc.).
+
+Every candidate is additionally shape-checked (`is_valid_entity`): at most 80
+characters, at most 6 words, and — for anything that isn't a single trusted
+code token — every word must be a clean identifier-ish token (no stray
+sentence punctuation).
+
+### Risk A — resolved
+
+An earlier version of this document flagged entity extraction as brittle
+because (1) the leading-verb exclusion list matched only exact base forms
+(`Prefer`, not `Prefers`), so `"Prefers Tokio for async runtime"` was captured
+verbatim as the noisy entity `"Prefers Tokio"` instead of `"Tokio"`, and (2)
+single capitalized tokens were never extracted at all (only ≥2-word
+capitalized sequences), so `probe("Tokio")` / `probe("Postgres")` could never
+reach a fact that only mentioned the bare noun.
+
+Both are fixed in the current `entities.rs`:
+
+- `is_non_entity_leading_word` now matches every common inflection of the
+  ~14 leading verbs (`add/adds/added/adding`, `prefer/prefers/preferred/
+  preferring`, `use/uses/used/using`, etc.), case-insensitively, not just the
+  base form. `"Prefers Tokio"` now strips the leading verb and yields
+  `"Tokio"` (plus the remainder phrase `"Prefers Tokio"` itself no longer
+  survives verbatim).
+- `push_capitalized_sequence` / `push_single_capitalized` now also emit a
+  bare single capitalized token as its own entity (still filtered by
+  `is_common_sentence_word`), so `Postgres`, `Tokio`, `Kubernetes`, and
+  `Database` are all extractable as entities in their own right, not only as
+  part of a ≥2-word phrase.
+
+Both fixes are covered by unit tests in `entities.rs` itself — notably
+`leading_verbs_match_across_inflections`,
+`leading_verb_no_longer_swallows_following_entity`,
+`single_capitalized_proper_nouns_are_extracted`, and
+`verb_led_multiword_phrase_exposes_head_noun` — and the code comments
+explicitly cite "Risk A" as the motivation for the change.
+
+## 3. Remaining considerations
+
+The rest of the original risk list still describes real architectural
+properties of the current pipeline, verified against the source above. The
+**specific fixture measurements** from the original evaluation run (exact
+score tables against an 8-fact corpus) are not reproduced here: the scoring
+formula changed enough — coverage-weighted and max-normalized BM25, plus the
+new `usage_boost` term — that those old numbers would not replay verbatim
+against the current code. Re-run the reproduction steps in §4 with the
+current binary before citing exact scores again.
+
+- **No stemming/morphology across FTS, Jaccard, and holographic atoms.**
+  FTS5 still uses the default `unicode61` tokenizer with no stemmer;
+  `project_memory_tokens` / the holographic tokenizer still key on the exact
+  lowercased surface string. The new prefix-wildcarding and coverage-prefix
+  matching (§1) now cover the common case of one token being a literal prefix
+  of another (`install` → `installing`), but not compound/word-order
+  differences (`backup` vs. `back up`) or non-suffix inflection.
+- **Trust remains a hard multiplicative gate.** `score = relevance * trust *
+  temporal_decay * usage_boost` — a low-trust, on-topic fact still needs a
+  proportionally larger relevance or usage-count advantage to outrank a
+  higher-trust, less-relevant peer.
+- **The holographic signal is still a lexical hash, not a semantic
+  embedding.** Atoms are still deterministic SHA-256 hashes of literal token
+  text (`crates/tracedecay-runtime-core/src/memory/encoding.rs`), with the
+  same `(sim + 1) / 2` floor. It remains a narrow re-ranking signal on top of
+  an already lexically-filtered candidate set, not an independent semantic
+  channel.
+- **`Probe` / `Related` / `Reason` still ignore query relevance** and rank
+  purely by trust once a fact matches the requested entity/entities (§1).
+- **Cross-fact duplicate/supersession detection is still separate from
+  retrieval.** `add_fact`'s conflict classification
+  (`store/memory/crud/add.rs`) still only reports a signal
+  (e.g. `possible_conflict`) at write time; nothing marks an older fact
+  superseded automatically, and `search`/`probe`/`reason` do not consult
+  supersession state. A dedicated memory-curation review/apply flow now
+  exists (`store/memory/curation/{review.rs,apply.rs}`) that can act on
+  near-duplicate/contradiction signals, but it is a distinct
+  operator-or-automation step, not something the retrieval path applies
+  implicitly.
+- **Entity-candidate broadening is still unnormalized.**
+  `project_memory_entity_candidates_tx` still `LIKE`-matches every raw query
+  token (no stopword removal) against each fact's entity list, so common
+  words can still match unrelated entity substrings.
+
+## 4. Proposed follow-ups
+
+### Add a retrieval-ranking eval scenario family
+Cover the trust-vs-relevance tradeoff and the entity-graph modes with
+regression scenarios (seed an on-topic low-trust fact and an off-topic
+high-trust fact sharing one token; assert ordering) exercised through the
+`fact_store_search`/`fact_store_probe`/`fact_store_reason` MCP tools (or their
+CLI equivalents), the same way the existing memory eval harness already
+drives the shipped binary for hygiene contracts.
+
+### Re-balance fusion: gate trust, don't multiply it
+Replace the hard `relevance * trust` product in
+`project_memory_combined_score` with a trust **gate + gentle nudge** (e.g.
+`relevance * (0.5 + 0.5 * trust)`), keeping the `DEFAULT_MIN_TRUST` floor as
+the hard exclusion while stopping trust from burying an equally-relevant
+fresher fact. Add unit tests on `project_memory_combined_score` covering that
+tradeoff explicitly (the existing tests in `scoring.rs` cover the ceiling and
+the shipped BM25/coverage math, but not a trust-vs-relevance ordering case).
+
+### Make the holographic signal earn its weight
+Either drop the `(sim + 1) / 2` floor in favor of a rescale that doesn't
+compress unrelated content toward 0.5, or reduce the holographic weight until
+a real embedding model replaces the SHA-256 atom keys in
+`HolographicEncoder`. Add a test asserting two semantically-similar-but-
+lexically-different facts score above two lexically-similar-but-unrelated
+ones; until it passes, the channel is decorative for ordering purposes.
+
+### Add morphology to the lexical channels
+Configure `memory_v2_assertion_payloads_fts` with a stemming tokenizer (e.g.
+`porter`) and apply the same stemming in `project_memory_tokens` and the
+holographic tokenizer, so `install`/`installing`/`installs` and
+`backup`/`backups`/`back up` collapse consistently rather than relying on the
+narrower prefix-wildcard heuristic.
+
+### Wire supersession into retrieval
+When the memory-curation flow marks a fact superseded/merged, have
+`search`/`probe`/`reason`/`related` exclude or down-rank the superseded fact
+by default, so a stale duplicate stops surfacing indefinitely once curation
+has acted on it.
+
+## 5. Reproducing this evaluation
+
+The tool surface changed along with the retrieval rewrite: memory operations
+are now separate MCP tools (`fact_store_add`, `fact_store_search`,
+`fact_store_probe`, `fact_store_reason`, …) rather than one `fact_store` tool
+with an `action` field, and the CLI's `tracedecay tool <name> --args '<json>'`
+dispatches any of them by name (short or `tracedecay_`-prefixed). A
+reproduction along the same lines as before now looks like:
 
 ```bash
-BIN=target/debug/tracedecay
-HOME=$(mktemp -d) PROJ=$(mktemp -d); mkdir -p $PROJ/src
-echo 'pub fn m(){}' > $PROJ/src/lib.rs
-cd $PROJ
-HOME=$HOME TRACEDECAY_GLOBAL_DB=$HOME/.tracedecay/global.db $BIN init
-HOME=$HOME TRACEDECAY_GLOBAL_DB=$HOME/.tracedecay/global.db $BIN tool fact_store --args \
-  '{"action":"add","content":"Database backups run via pg_dump every night","category":"project","trust":0.3}'
-HOME=$HOME TRACEDECAY_GLOBAL_DB=$HOME/.tracedecay/global.db $BIN tool fact_store --args \
-  '{"action":"add","content":"Acme Corp uses Postgres for its primary database","category":"general","trust":0.5}'
-HOME=$HOME TRACEDECAY_GLOBAL_DB=$HOME/.tracedecay/global.db $BIN tool fact_store --args \
-  '{"action":"search","query":"database backup","limit":5}'
-# observe the off-topic Postgres fact (trust 0.5) outrank the on-topic backups fact (trust 0.3)
+tracedecay tool fact_store_add --args \
+  '{"content":"Database backups run via pg_dump every night","category":"project","trust":0.3}'
+tracedecay tool fact_store_add --args \
+  '{"content":"Acme Corp uses Postgres for its primary database","category":"general","trust":0.5}'
+tracedecay tool fact_store_search --args '{"query":"database backup","limit":5}'
 ```
+
+Run against a scratch project (a temporary `HOME` and an initialized project
+directory, as before) so the reproduction never touches a real `.tracedecay/`
+store. The exact commands above have not been re-executed as part of this
+rewrite — treat them as a starting point to reproduce and re-measure the
+"Remaining considerations" in §3 against the current binary, not as verified
+output.

--- a/docs/TRUST-DECAY-SEMANTICS.md
+++ b/docs/TRUST-DECAY-SEMANTICS.md
@@ -1,246 +1,181 @@
 # Trust & Temporal-Decay Semantics — Current Behavior
 
-Status: factual audit of the `master` branch as of this writing. Every claim is
-backed by a `file:line` reference so it can be re-verified.
+This document describes how a project-memory fact's persisted trust score
+changes, and how temporal decay affects search ranking, against the current
+`crates/tracedecay-runtime-core` implementation.
 
-> **Update: code layer superseded.** Every `src/memory/{retrieval,store,trust}.rs`,
-> `src/db/migrations.rs`, `src/mcp/tools/handlers/memory.rs`, `src/tracedecay.rs`,
-> and `src/dashboard/{memory_api,mod}.rs` reference below is from a single-crate
-> layout that predates the current workspace split; those exact paths and line
-> numbers no longer resolve. Verified directly against the current source: the
-> policy conclusion still holds — `crates/tracedecay-runtime-core/src/memory/trust.rs`
-> still has no time-based aging function (only `clamp_trust`/feedback deltas:
-> `HELPFUL_DELTA = 0.05`, `UNHELPFUL_DELTA = -0.10`, `DEFAULT_TRUST = 0.5`,
-> `DEFAULT_MIN_TRUST = 0.3`), and the dynamic 365-day half-life / 0.10 floor
-> ranking decay now lives in `project_memory_temporal_decay` in
-> `crates/tracedecay-runtime-core/src/store/memory/scoring.rs` with the same
-> formula. The persisted store moved to `memory_v2_current_facts` /
-> `memory_v2_facts` tables (not `memory_facts`), and the retrieval/store logic
-> that used to live in `retrieval.rs`/`store.rs` is now split across
-> `crates/tracedecay-runtime-core/src/store/memory/{search.rs,candidates.rs,scoring.rs,crud/}`.
-> The specific `file:line` citations throughout §1–§8 have not been
-> individually re-verified against this new layout and should be treated as
-> historical, not authoritative.
+An earlier version of this document was written against a single-crate
+`src/memory/{retrieval,store,trust}.rs` layout, a `src/db/migrations.rs`
+schema, and MCP/dashboard modules under `src/mcp` / `src/dashboard` — none of
+which exist anymore. The relevant logic is now split across
+`crates/tracedecay-runtime-core/src/memory/trust.rs` (trust constants and
+bucketing), `crates/tracedecay-runtime-core/src/store/memory/scoring.rs`
+(the ranking-time decay formula), `crates/tracedecay-runtime-core/src/store/
+memory/crud/{commands.rs,feedback.rs,lineage.rs}` (the writers of trust),
+and the `memory_v2_*` tables in
+`crates/tracedecay-runtime-core/src/db/memory_v2/schema/`. The policy
+conclusion this document previously reached still holds, and is restated
+below against the current code.
 
 ## TL;DR
 
-- The stored `memory_facts.trust_score` **never decays**. It changes only via
-  explicit feedback, an explicit trust set on add/edit, or a manual MCP trust
-  bump. There is no scheduler, no background sweep, no maintenance pass, and no
-  retrieval-time write that ages trust.
+- The persisted `trust_score` (on `memory_v2_current_facts`) **never decays
+  on its own**. It only changes through an explicit writer: adding a fact
+  with an explicit trust value, updating a fact's trust via an edit, or
+  applying helpful/unhelpful feedback. There is no scheduler, no background
+  sweep, and no retrieval-time write that ages the stored value.
 - Temporal decay of *ranking* is applied **only at retrieval time**, computed
-  dynamically from `updated_at` by `retrieval.rs::temporal_decay_factor`
-  (365-day half-life, floored at 0.10). It is **never persisted**.
-- There is now **one** decay function, not two. The former
-  `trust.rs::temporal_decay(current_trust, age_days)` dead routine (persisted-score aging
-  routine, 180-day exponential pull toward 0.5) was **removed** in favor of
-  dynamic-only decay (policy decision in §8 — Option 1, adopted). Its unit test
-  (`tests/memory_test.rs:262`) was removed with it. Only
-  `retrieval.rs::temporal_decay_factor` remains.
-- Operators **can** now see *why* a trust value is what it is. The
-  `memory_feedback_events` audit table, which used to be write-only, is now
-  readable via `TraceDecay::fact_trust_history(fact_id)`, the MCP fact `get`
-  `trust_history` field, and
-  `GET /api/plugins/holographic/fact/{fact_id}/trust-history` (landed via Q6;
-  see §5). (Historical: at audit time the table was write-only — only `store.rs`
-  inserted; no SELECT/read path existed.)
-- The storage audit (`docs/archive/MEMORY-STORAGE-GROWTH-AUDIT.md` §7) was corrected:
-  it now states that *only* `retrieval.rs::temporal_decay_factor` affects
-  ranking, that the stored `trust_score` never decays, and that
-  `trust.rs::temporal_decay` has been removed.
+  dynamically from a fact's `updated_at` by `project_memory_temporal_decay`
+  in `scoring.rs` — a 365-day half-life, floored at 0.10. It is **never
+  persisted** back to the fact.
+- Trust changes are event-sourced: every mutation to `trust_score` is
+  recorded as a `FactLineageEventKindV1::TrustChanged` event in the fact's
+  lineage, and `memory_v2_current_facts.trust_score` is a materialized
+  projection replayed from that lineage, not a value written imperatively in
+  place.
+- Feedback history is append-only and readable, not write-only: every
+  helpful/unhelpful action is recorded in `memory_v2_feedback_history` (a
+  table whose schema forbids `UPDATE`/`DELETE` outside redaction), and is
+  exposed back through the fact-store MCP surface (`fact_store_get` returns
+  trust history alongside the current score) and the dashboard API.
 
 ---
 
-## 1. The data model (`memory_facts`)
+## 1. The data model
 
-Relevant columns (from `src/db/migrations.rs:1050` / live `.tracedecay/tracedecay.db`):
+The persisted trust value and its supporting counters live on
+`memory_v2_current_facts` (schema in
+`crates/tracedecay-runtime-core/src/db/memory_v2/schema/baseline.rs`), keyed
+by `(fact_id, owner_kind, project_id)`:
 
 | column | meaning | who writes it |
 |---|---|---|
-| `trust_score` REAL default 0.5 | the *persisted* per-fact trust, clamped to [0,1] | feedback, add/edit trust set, manual MCP bump |
-| `created_at` | write origin time | INSERT |
-| `updated_at` | **last mutation time** — the input to the ranking decay factor | create, edit, feedback (all writes); **not** reads |
-| `last_retrieved_at` | last probe/list scan | `record_fact_retrievals` (`store.rs:772`) |
-| `last_recalled_at` | last time a recall search *returned* the fact | `record_fact_recalls` (`store.rs:798`) |
-| `retrieval_count` / `access_count` | scan count vs. returned-count | the two record_* helpers above |
-| `helpful_count` / `unhelpful_count` / `last_feedback_at` | feedback tallies | `record_feedback_event` (`store.rs:870`) |
+| `trust_score` | persisted per-fact trust, `CHECK`-constrained to `[0, 1]` (or `NULL`) | replayed from lineage events on every commit (see §2) |
+| `updated_at` | last mutation time — the input to the ranking decay factor | every commit that touches this fact (create, edit, feedback, curation) |
+| `retrieval_count` / `access_count` | scan count vs. returned-count | `project_memory_update_retrieval_projection_tx`, on every search/probe/reason/related hit |
+| `last_retrieved_at` / `last_recalled_at` | last scan / last time a search actually returned the fact | the same retrieval-projection update |
+| `helpful_count` / `unhelpful_count` / `last_feedback_at` | feedback tallies | `project_memory_update_feedback_projection_tx`, on every feedback event |
 
-There is **no "confidence" concept for memory facts**. The word `confidence` in
-this codebase belongs exclusively to the *code-graph reference resolver*
-(`src/resolution/resolver.rs`, `ResolvedReference.confidence` in
-`src/types.rs:612` — values 0.65–0.95). It has no relationship to memory trust.
+`trust_score` is not written directly by an `UPDATE trust_score = …`
+statement in the write path. Instead, every fact mutation appends one or more
+`FactLineageEventKindV1` events (`AssertionRecorded`, `TrustChanged`,
+`Curated`, `PayloadAccessChanged`) to the fact's lineage, and
+`publish_current_projection` (in `store/memory/crud/lineage.rs`) replays the
+whole lineage into an in-memory `Projection`, then upserts the resulting
+`trust_score`/`updated_at`/etc. into `memory_v2_current_facts` in one
+`INSERT … ON CONFLICT DO UPDATE`. Only a `TrustChanged` event can move
+`trust_score`; the event carries `previous`/`current` and is rejected by
+construction if they're equal.
+
+There is still no separate "confidence" concept for memory facts distinct
+from trust; trust is represented by the shared `Confidence` domain type
+(`[0, 1]`), the same type used for the query filter's `min_trust`.
 
 ## 2. What can change `trust_score`
 
-Exhaustive list of writers (verified by grepping every `trust_score =` / clamp):
+The complete, current set of writers:
 
-1. **Create** — `store.rs:175`: `clamp_trust(request.trust.unwrap_or(default_trust))`.
-2. **Edit** — `store.rs:425,439`: `request.trust.map_or(existing, clamp_trust)`; re-written on every `update_fact`.
-3. **Feedback** — `store.rs:860–888`: `apply_feedback(old, action)` → `+0.05` (helpful) / `−0.10` (unhelpful), clamped (`trust.rs:5,6,16`). Also bumps `updated_at`, `last_feedback_at`, and the helpful/unhelpful tallies, and appends a `memory_feedback_events` row.
-4. **Manual MCP trust bump** — `src/mcp/tools/handlers/memory.rs:148`: `(existing.trust_score + delta).clamp(0,1)` computed from a `trust_delta` arg, then written via the edit path.
+1. **Create** (`fact_store_add`) — a fact is always created at
+   `DEFAULT_TRUST = 0.5` first; if the caller supplied a different explicit
+   trust value, an immediate `TrustChanged { previous: 0.5, current: <requested> }`
+   event is appended in the same commit (`store/memory/crud/project.rs`).
+2. **Update** (`fact_store_update`) — the update patch
+   (`ProjectMemoryFactUpdatePatchV1`) can carry an absolute `trust: Option<Confidence>`
+   alongside content/category/tags/entities/metadata; when present, it emits
+   a `TrustChanged` event with the new absolute value (not a delta).
+3. **Feedback** (`fact_feedback`) — `project_memory_feedback_delta` maps
+   `Helpful → +0.05` / `Unhelpful → −0.10`; the new trust is
+   `(old_trust + delta).clamp(0.0, 1.0)`, recorded as a `TrustChanged` event,
+   and also bumps `helpful_count`/`unhelpful_count`/`last_feedback_at` via
+   `project_memory_update_feedback_projection_tx` and appends a row to
+   `memory_v2_feedback_history`. These deltas match the constants in
+   `crates/tracedecay-runtime-core/src/memory/trust.rs`
+   (`HELPFUL_DELTA = 0.05`, `UNHELPFUL_DELTA = -0.10`).
 
-That is the **complete** set. None of these is time-driven; none runs on a
-schedule.
+That is the complete set — there is no separate "manual trust bump" tool with
+its own delta argument anymore; an absolute trust set now goes through the
+same update patch as any other field edit. None of the above is time-driven;
+none runs on a schedule.
 
 ## 3. Where temporal decay is actually applied: retrieval, dynamically
 
-The only live decay is in recall ranking (`src/memory/retrieval.rs`):
-
-```text
-score = relevance * trust_score * temporal_decay_factor(updated_at)   # retrieval.rs:709
-        \__ fts*0.40 + jaccard*0.30 + holographic*0.30 __/  (weights: retrieval.rs:705)
-```
+The only live decay is in recall ranking, in
+`crates/tracedecay-runtime-core/src/store/memory/scoring.rs`:
 
 ```rust
-// retrieval.rs:712 — THE ONLY DECAY THAT RUNS
-fn temporal_decay_factor(updated_at: i64) -> f64 {
-    if updated_at <= 0 { return 1.0; }                 // unknown age → no penalty
-    let age_days = (now - updated_at).max(0) as f64 / 86_400.0;
-    0.5_f64.powf(age_days / 365.0).clamp(0.10, 1.0)    // 365-day half-life, floor 0.10
+pub(super) fn project_memory_temporal_decay(updated_at: UtcMicros, now: UtcMicros) -> f64 {
+    if updated_at.0 <= 0 {
+        return 1.0;
+    }
+    let age_micros = now.0.saturating_sub(updated_at.0).max(0) as f64;
+    let age_days = age_micros / 86_400_000_000.0;
+    0.5_f64.powf(age_days / 365.0).clamp(0.10, 1.0)
 }
 ```
 
-Properties:
-- **When:** computed per candidate, inside `recall()` scoring (`retrieval.rs:103–128`). Pure read; no DB write.
-- **Keyed on `updated_at`** (last *write*), **not** on last access. Reads bump only `last_retrieved_at` / `last_recalled_at` (`store.rs:773,800`), so a frequently-read-but-never-edited fact *still* decays in ranking.
-- **Bounds:** any fact loses half its ranking weight every 365 days since its last write, bottoming at 0.10×. Facts never fall fully out of ranking on age alone; the `DEFAULT_MIN_TRUST = 0.3` *recall floor* (`retrieval.rs:245,261,…`) is a separate filter applied to the stored `trust_score`, not to the decay factor.
-- **Visible?** Yes, per-result: the `why` string emitted with every `FactSearchResult` includes `temporal_decay=0.xxx` (`retrieval.rs:124–126`). So a caller can see the dynamic factor that ranked a result.
-- **Persistent?** No. Nothing writes the decayed value back. `trust_score` on disk is the raw, never-aged value.
+Properties (unchanged from the pre-rewrite formula):
 
-## 4. The former aging function `trust.rs::temporal_decay` — removed
+- **When:** computed per candidate, during ranking in
+  `project_memory_search_scores` (`store/memory/search.rs`). Pure function of
+  `updated_at` and the current time; no DB write.
+- **Keyed on `updated_at`** (last *write*), not on last access. Reads only
+  bump `last_retrieved_at` / `last_recalled_at`, so a frequently-searched but
+  never-edited fact still decays in ranking exactly as fast as an
+  never-searched one.
+- **Bounds:** a fact loses half its ranking weight every 365 days since its
+  last write, bottoming out at `0.10×`. Age alone never fully excludes a
+  fact from ranking; the `DEFAULT_MIN_TRUST = 0.3` recall floor
+  (`memory/trust.rs`) is a separate filter applied to the *stored*
+  `trust_score`, unrelated to the decay factor.
+- **Visible?** Yes, per result: every hit's `why` string includes
+  `temporal_decay=0.xxx` alongside the other raw scoring components (see
+  `RETRIEVAL-QUALITY-EVAL.md` §1).
+- **Persistent?** No. Nothing writes the decayed value back; `trust_score` on
+  disk is always the raw, never-aged value.
 
-The persisted-score aging routine that previously lived in `trust.rs` has been
-**deleted** (policy decision: dynamic-only decay — §8 Option 1, adopted). This
-resolved the "two decay functions, two policies, two constants, one name"
-confusion this audit originally flagged. `src/memory/trust.rs` now contains only
-`clamp_trust`, `apply_feedback`, and the bucket/distribution helpers.
+There is only one decay function in the current codebase — no second,
+persisted-trust-aging routine exists alongside it.
 
-For the historical record: the removed `temporal_decay(current_trust, age_days)`
-had **zero production callers** — only the now-removed `tests/memory_test.rs:262`
-asserted it. Had it been called it would have rewritten the *persisted*
-`trust_score` toward `DEFAULT_TRUST = 0.5` (180-day exponential time-constant) —
-a fundamentally different policy from the live retrieval factor (365-day
-half-life multiplier that never touches the stored value, and only ever
-*reduces* ranking weight).
+## 4. Semantic model (condensed)
 
-## 5. Visibility / explainability ("can an operator understand why trust changed?")
-
-- **Retrieval-time decay:** visible per result via the `why` field (`retrieval.rs:124`). ✓
-- **Feedback-driven trust changes:** an append-only audit row is written to
-  `memory_feedback_events` (old_trust → new_trust, delta, action, source, note,
-  timestamp) on every feedback event (`store.rs:890–905`). ✓ *recorded* —
-- …and **now readable**. Q6 landed a read path across three surfaces:
-  `TraceDecay::fact_trust_history(fact_id)` → ordered history
-  (`src/tracedecay.rs:3625` / `src/memory/store.rs:858`); the MCP fact `get`
-  action returns a `trust_history` field (`src/mcp/tools/handlers/memory.rs:260`);
-  and `GET /api/plugins/holographic/fact/{fact_id}/trust-history`
-  (`src/dashboard/memory_api.rs:205`, `src/dashboard/mod.rs:271`). ✓ *surfaced*
-  (Historical: at audit time there was no read path — no dashboard endpoint, no
-  MCP field, no store SELECT — so an operator had to run raw SQL.)
-- **Explanation for the *current* trust value:** the MCP fact `get` action now
-  returns `trust_history` alongside the scalar `trust_score`, so a caller can
-  see how it got there. ✓
-
-## 6. Semantic model (current behavior, condensed)
-
-```
-                     ┌──────────────── memory_facts ────────────────┐
-  add/edit trust ──► │ trust_score   (clamped [0,1], NEVER decays)  │
-  feedback ±0.05/±0.1│ updated_at    (advanced on EVERY write only) │ ──► recall() ──► rank
-  manual MCP bump    │ last_*_at     (read-side counters)           │        rank = relevance
-                     └──────────────────────────────────────────────┘               × trust_score
-                                                                               × decay_factor(updated_at)
-   (no scheduler)    trust.rs::temporal_decay = REMOVED (was dead code)   decay_factor = 0.5^(age_days/365) ∈ [0.10,1]
+```text
+                   ┌───────────── memory_v2_current_facts ─────────────┐
+ add (explicit) ──►│ trust_score    (Confidence [0,1], never decays)   │
+ update (absolute) │ updated_at     (advanced on every commit only)    │──► search/probe/reason
+ feedback ±0.05/.10│ retrieval/access/helpful/unhelpful counters       │        ranking:
+                   └────────────────────────────────────────────────────┘   relevance × trust_score
+                                                                              × temporal_decay(updated_at)
+   (no scheduler ages trust_score)                    temporal_decay = 0.5^(age_days/365), floor 0.10
 ```
 
-Answers to the task's framing ("automatic / maintenance / retrieval / not at all"):
-- **Automatic (scheduler):** no.
-- **Explicit maintenance pass:** no. `hygiene.rs` is secret/transient *content* detection only; it never touches `trust_score`.
-- **At retrieval time:** **yes, ranking only** — `temporal_decay_factor`, dynamic, not persisted.
-- **Persisted trust decay:** **no**. The function that would have done it (`trust.rs::temporal_decay`) has been removed; no scheduler ages persisted trust.
+Answers to the recurring framing question ("automatic / maintenance /
+retrieval / not at all"):
 
-## 7. Problems this audit flagged (and their status)
+- **Automatic (scheduler):** no. Nothing periodically touches `trust_score`.
+- **Explicit maintenance pass:** the memory-curation review/apply flow
+  (`store/memory/curation/{review.rs,apply.rs}`) can record `Curated` lineage
+  events (contradiction/merge dispositions) but does not itself age or reset
+  trust; only add/update/feedback move `trust_score`.
+- **At retrieval time:** yes, ranking only — `project_memory_temporal_decay`,
+  dynamic, never persisted.
+- **Persisted trust decay:** no. No writer in the current codebase ages a
+  fact's stored `trust_score` based on elapsed time.
 
-1. **Stated vs. real behavior diverge — RESOLVED.** The module doc (`trust.rs:1`)
-   used to advertise "aging" and the storage audit used to credit the former
-   former `trust.rs::temporal_decay` with affecting scoring. Both are now corrected and
-   the dead function is gone; a reader no longer believes persisted trust ages.
-2. **Two functions, one name, incompatible policies — RESOLVED.** The 180-day
-   pull-to-0.5 routine was deleted; only the 365-day multiplicative ranking
-   penalty (`temporal_decay_factor`) remains, so intent is unambiguous.
-3. **Unobservable trust history — RESOLVED (Q6 landed).** The audit data is now
-   reachable through `fact_trust_history` (store + MCP `get` field + dashboard
-   route), so "why did this fact's trust change?" is answerable without SQL.
-4. **Untestable end-to-end — PARTIALLY RESOLVED.** With persisted aging gone by
-   design, the remaining invariant to assert is "stored `trust_score` is
-   unchanged by a `now` advance, while `temporal_decay_factor` moves ranking" —
-   the integration test proposed in §8 item 6 still has no home.
+## 5. Visibility / explainability
 
-## 8. Recommendations (API / scheduler / migration / docs)
-
-Pick **one** of two coherent policies and make it the single source of truth; do
-not leave both half-implemented.
-
-### A. Decide the policy — DECIDED: Option 1 (dynamic-only), adopted
-
-- **Option 1 — keep decay dynamic (ranking-only) — ADOPTED.** The dead
-  `trust.rs::temporal_decay` and its unit test were removed; the misleading doc
-  claims were corrected; `updated_at` stays the clock. No migration.
-- **Option 2 — also age persisted trust on a schedule — NOT taken.** If genuine
-  "forgetting" becomes a product ask later, wire a renamed
-  `apply_persisted_trust_aging` into a real job and persist the result
-  (scheduler + migration below). Until then it is explicitly out of scope.
-
-### B. Concrete changes (ranked; do regardless of A/Option)
-
-1. **Docs — fix the inaccuracy (DONE).** The storage audit
-   (`docs/archive/MEMORY-STORAGE-GROWTH-AUDIT.md` §7) now reads: only
-   `retrieval.rs::temporal_decay_factor` (365-day half-life, floor 0.10, keyed
-   on `updated_at`) affects ranking; the stored `trust_score` never decays;
-   `trust.rs::temporal_decay` has been removed. The `trust.rs:1` module doc no
-   longer mentions "aging".
-2. **Eliminate the name collision / dead code (DONE).** `trust.rs::temporal_decay`
-   and its unit test were deleted (Option 1). No unused aging function sits next
-   to the live decay factor anymore.
-3. **Explainability API — DONE (Q6).** A read path for `memory_feedback_events`
-   landed: `TraceDecay::fact_trust_history(fact_id)` → ordered history, exposed
-   as a dashboard endpoint
-   (`GET /api/plugins/holographic/fact/{fact_id}/trust-history`) and an MCP field
-   (`trust_history`) on fact `get`. The existing audit table now answers "why is
-   trust X?".
-4. **Scheduler (only if Option 2).** A periodic `tokio` task (e.g. daily,
-   alongside the existing startup catch-up spawn in `mcp/server.rs`) that, in a
-   single transaction, applies `apply_persisted_trust_aging` to facts whose
-   `updated_at` is older than the period, stamping a new `updated_at`/
-   `last_feedback_at`-style watermark to avoid double-application. Must be
-   idempotent and log every change to `memory_feedback_events` with
-   `source='decay'` so the audit trail (now readable via item 3) explains it.
-5. **Migration (only if Option 2).** Add a watermark column, e.g.
-   `trust_decayed_at INTEGER` (default = `created_at`/`updated_at`), seeded in a
-   one-shot migration in `src/db/migrations.rs`, so the scheduler can compute
-   "age since last aging" deterministically and survive restarts. No schema
-   change needed for Option 1.
-6. **Make it testable (OPEN — Option 1 branch).** Add an integration test in
-   `tests/memory_test.rs` asserting that `trust_score` is byte-identical
-   before/after a simulated `now` advance and that `temporal_decay_factor` moves
-   the ranking as expected (the Option 1(a) branch). The Option 2 branch is
-   moot since Option 2 was not taken. A test that the explainability API
-   (item 3) returns the expected history is covered by the Q6 read-API tests
-   (`tests/dashboard_api_test/api.rs` exercises `/trust-history`; MCP `get`
-   `trust_history` is exercised in the memory-handler tests). This names
-   implemented coverage, not a successful aggregate dashboard-suite run.
-
-### Acceptance-criteria check
-
-- **When is decay applied today?** Ranking only, at recall time, dynamically via
-  `retrieval.rs::temporal_decay_factor(updated_at)`; never on a schedule, never
-  to persisted `trust_score`. (§3, §6)
-- **Is it visible/persistent?** The ranking factor is visible per result (`why`
-  field) and **not** persisted. The persisted `trust_score` never decays. The
-  feedback audit trail is recorded and **now readable** via the Q6 read API
-  (store method, MCP `get` field, dashboard route). (§3, §5)
-- **What changes are required to make it explicit & testable?** The doc
-  inaccuracy, the dead-code/name-collision, and the feedback-history read API
-  (Q6) are DONE; remaining work is the Option-1 integration test
-  (§8 item 6, OPEN). The scheduler + watermark migration apply only under
-  Option 2, which was not adopted. (§8)
+- **Retrieval-time decay** is visible per result via the `why` field on every
+  search hit.
+- **Feedback-driven trust changes** are recorded append-only in
+  `memory_v2_feedback_history` (old trust → new trust, delta, action, source
+  label, note, timestamp). The table's schema forbids `DELETE` and restricts
+  `UPDATE` to detail redaction only (`memory_v2_feedback_history_no_delete`,
+  `memory_v2_feedback_history_only_redaction` triggers in
+  `db/memory_v2/schema/final_authority.rs`), so the audit trail cannot be
+  rewritten or dropped through normal writes.
+- **That history is readable, not write-only.** It is exposed through the
+  fact-store query surface (the `fact_store_get` fact-store MCP tool returns
+  trust history alongside the current score) and through the dashboard API
+  (`crates/tracedecay-dashboard-api/src/memory_api.rs`, documented there as
+  `GET /api/plugins/holographic/fact/{fact_id}` for full fact detail and
+  `GET /api/plugins/holographic/fact/{fact_id}/trust-history` for the
+  append-only history specifically).


### PR DESCRIPTION
## What changed

Rewrites the bodies of `docs/RETRIEVAL-QUALITY-EVAL.md` and `docs/TRUST-DECAY-SEMANTICS.md`, which described a single-crate `src/memory/{retrieval,store}.rs` layout that was fully rewritten into `crates/tracedecay-runtime-core/src/store/memory/{candidates.rs,scoring.rs,search.rs}` (async, `project_memory_*`-prefixed, `memory_v2_*` tables). The temporary "Status: historical" banners added in an earlier pass are removed now that the bodies themselves are accurate.

Verified directly against the current source before writing (no invented `file:line` anchors — locations are described by file/function/table name in prose):

- **Risk A is resolved**, not merely stale. `crates/tracedecay-runtime-core/src/memory/entities.rs` now strips inflected leading verbs (`is_non_entity_leading_word` matches `Prefers`/`Uses`/etc., not just exact base forms) and extracts single capitalized proper nouns (`Postgres`, `Tokio`, `Kubernetes`, `Database`) that used to require a ≥2-word phrase. Both are covered by dedicated unit tests in `entities.rs`, which the doc now cites by name.
- **Two previously-undocumented behaviors** are now described: FTS5 prefix-wildcarding for query tokens ≥4 chars (`project_memory_fts_query`), and a retrieval-count `usage_boost` term in `project_memory_combined_score` (capped at 1.5x via `ln(1+n)`).
- The trust constants (`HELPFUL_DELTA = 0.05`, `UNHELPFUL_DELTA = -0.10`, `DEFAULT_TRUST = 0.5`, `DEFAULT_MIN_TRUST = 0.3`) and the 365-day half-life / 0.10-floor decay formula are confirmed unchanged, now sourced to `memory/trust.rs` and `store/memory/scoring.rs::project_memory_temporal_decay`.
- Trust is now event-sourced: every `trust_score` mutation is a `FactLineageEventKindV1::TrustChanged` event replayed into `memory_v2_current_facts`, not an in-place `UPDATE`. There is no longer a separate "manual trust-delta bump" MCP action — an absolute trust set is just one field of the general fact-update patch.

## What I found that pushes back on the brief

- The task brief described this as two purely documentation-only fixes on top of an otherwise-intact pipeline. In practice large parts of both documents needed a full rewrite: the FTS score normalization changed from a `1/(1+|bm25|)` formula to a max-relative normalization plus a coverage multiplier, the recall gate's shape changed slightly, and a new graph-assist candidate-expansion channel was added that has no analog in the old pipeline at all. None of this was called out in the task description, so I documented it as new/changed behavior rather than silently reusing the old framing.
- I could not re-run the original fixture-based empirical measurement (the exact score tables in the old `RETRIEVAL-QUALITY-EVAL.md` §2) because the scoring formula changed enough that the old numbers would not replay verbatim, and re-running it would require rebuilding the CLI from this exact worktree — out of scope for a docs-only change. I kept the qualitative risk conclusions that are still true per the source (no stemming, trust-as-hard-gate, decorative holographic signal, probe/reason ignoring relevance) but explicitly flagged the old numeric table as retired rather than re-publishing stale numbers under a new banner.
- The old TRUST-DECAY-SEMANTICS doc described a "manual MCP trust bump" tool with its own `trust_delta` argument, distinct from the edit path. That tool no longer exists as a separate concept — the current `ProjectMemoryFactUpdatePatchV1` just carries an optional absolute `trust` field alongside content/tags/etc. I documented the current (merged) shape rather than preserving the old distinction.

## Scope

Docs only — no `.rs`/`.ts`/workflow files touched (verified via `git diff --stat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)