### PR TITLE
test(writer): pin the batch-to-frame coalescing ratio

### DIFF
--- a/crates/tracedecay-runtime-core/src/background_cpu.rs
+++ b/crates/tracedecay-runtime-core/src/background_cpu.rs
@@ -1,0 +1,461 @@
+//! Process-wide weighted admission for background CPU work.
+//!
+//! The authority counts active CPU units rather than owning an executor. Code
+//! indexing, semantic native threads, and session preparation can therefore
+//! use their existing execution substrates while sharing one hard process
+//! ceiling. FIFO waiter order prevents a continuously busy class from starving
+//! another class, and RAII releases capacity on success, cancellation, or
+//! unwind.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+#[derive(Debug)]
+struct BackgroundCpuWaiterV1 {
+    units: usize,
+}
+
+#[derive(Default)]
+struct BackgroundCpuStateV1 {
+    active_units: usize,
+    waiters: VecDeque<Arc<BackgroundCpuWaiterV1>>,
+}
+
+/// One process-wide background CPU budget shared across subsystems.
+pub struct ProcessBackgroundCpuV1 {
+    width: NonZeroUsize,
+    state: Mutex<BackgroundCpuStateV1>,
+    available: Condvar,
+}
+
+impl fmt::Debug for ProcessBackgroundCpuV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessBackgroundCpuV1")
+            .field("width", &self.width)
+            .field("active_units", &self.active_units())
+            .finish_non_exhaustive()
+    }
+}
+
+thread_local! {
+    static BACKGROUND_CPU_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static BACKGROUND_CPU_UNITS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct BackgroundCpuScopeV1;
+
+impl BackgroundCpuScopeV1 {
+    fn enter() -> Self {
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+struct YieldedBackgroundCpuV1<'a> {
+    authority: &'a Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+    depth: usize,
+}
+
+impl Drop for YieldedBackgroundCpuV1<'_> {
+    fn drop(&mut self) {
+        self.authority.admit_units(self.units);
+        BACKGROUND_CPU_UNITS.with(|units| units.set(self.units));
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(self.depth));
+    }
+}
+
+impl Drop for BackgroundCpuScopeV1 {
+    fn drop(&mut self) {
+        BACKGROUND_CPU_DEPTH.with(|depth| {
+            let remaining = depth.get().saturating_sub(1);
+            depth.set(remaining);
+            if remaining == 0 {
+                BACKGROUND_CPU_UNITS.with(|units| units.set(0));
+            }
+        });
+    }
+}
+
+impl ProcessBackgroundCpuV1 {
+    fn new(width: NonZeroUsize) -> Self {
+        Self {
+            width,
+            state: Mutex::new(BackgroundCpuStateV1::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> NonZeroUsize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn active_units(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_units
+    }
+
+    #[must_use]
+    pub fn waiting_work_units(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        waiting_units(&state)
+    }
+
+    /// Acquire one CPU unit, waiting in FIFO order when the process budget is
+    /// full. The returned guard must remain alive for the active work unit.
+    pub fn acquire(self: &Arc<Self>) -> BackgroundCpuPermitV1 {
+        self.acquire_units(1)
+    }
+
+    /// Acquire one CPU unit only when no earlier waiter exists and capacity is
+    /// immediately available.
+    pub fn try_acquire(self: &Arc<Self>) -> Option<BackgroundCpuPermitV1> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.waiters.is_empty() || state.active_units >= self.width.get() {
+            return None;
+        }
+        state.active_units += 1;
+        record_state(&state, self.width);
+        Some(BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units: 1,
+        })
+    }
+
+    /// Run one active work unit under the process budget. Nested work on the
+    /// same thread reuses a sufficient parent admission instead of waiting on
+    /// itself.
+    pub fn with_permit<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        self.with_permits(1, operation)
+    }
+
+    /// Run a weighted work unit, clamped to the entire process width. Semantic
+    /// inference uses its native intra-op thread count as the weight; ordinary
+    /// index/session preparation uses one.
+    pub fn with_permits<R>(
+        self: &Arc<Self>,
+        requested_units: usize,
+        operation: impl FnOnce() -> R,
+    ) -> R {
+        let units = requested_units.max(1).min(self.width.get());
+        let active_units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if active_units >= units {
+            return operation();
+        }
+        if active_units > 0 {
+            let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+            self.release(active_units);
+            BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+            BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+            let _restore = YieldedBackgroundCpuV1 {
+                authority: self,
+                units: active_units,
+                depth,
+            };
+            let _permit = self.acquire_units(units);
+            let _scope = BackgroundCpuScopeV1::enter();
+            BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+            return operation();
+        }
+        let _permit = self.acquire_units(units);
+        let _scope = BackgroundCpuScopeV1::enter();
+        BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+        operation()
+    }
+
+    /// Temporarily yield the caller's active units while a nested executor
+    /// fans out independently admitted leaf work. This prevents a parent
+    /// Rayon worker from holding capacity while it waits for child workers,
+    /// including a full-width weighted child. Capacity is reacquired before
+    /// the parent resumes, including during unwind.
+    pub fn with_yielded_permits<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        let units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if units == 0 {
+            return operation();
+        }
+        let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+        self.release(units);
+        BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+        BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+        let _restore = YieldedBackgroundCpuV1 {
+            authority: self,
+            units,
+            depth,
+        };
+        operation()
+    }
+
+    fn acquire_units(self: &Arc<Self>, units: usize) -> BackgroundCpuPermitV1 {
+        self.admit_units(units);
+        BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units,
+        }
+    }
+
+    fn admit_units(&self, units: usize) {
+        let waiter = Arc::new(BackgroundCpuWaiterV1 { units });
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiters.push_back(Arc::clone(&waiter));
+        record_state(&state, self.width);
+        loop {
+            let is_front = state
+                .waiters
+                .front()
+                .is_some_and(|front| Arc::ptr_eq(front, &waiter));
+            if is_front && state.active_units.saturating_add(waiter.units) <= self.width.get() {
+                state.waiters.pop_front();
+                state.active_units += waiter.units;
+                record_state(&state, self.width);
+                self.available.notify_all();
+                return;
+            }
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn release(&self, units: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(state.active_units >= units);
+        state.active_units = state.active_units.saturating_sub(units);
+        record_state(&state, self.width);
+        self.available.notify_all();
+    }
+}
+
+fn record_state(state: &BackgroundCpuStateV1, width: NonZeroUsize) {
+    hotpath::gauge!("runtime_core.background_cpu.width").set(width.get());
+    hotpath::gauge!("runtime_core.background_cpu.active_units").set(state.active_units);
+    hotpath::gauge!("runtime_core.background_cpu.waiting_work_units").set(waiting_units(state));
+}
+
+fn waiting_units(state: &BackgroundCpuStateV1) -> usize {
+    state
+        .waiters
+        .iter()
+        .fold(0usize, |total, waiter| total.saturating_add(waiter.units))
+}
+
+/// RAII ownership of active CPU capacity. Dropping it is cancellation-safe and
+/// releases the exact acquired weight.
+pub struct BackgroundCpuPermitV1 {
+    authority: Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+}
+
+impl fmt::Debug for BackgroundCpuPermitV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackgroundCpuPermitV1")
+            .field("units", &self.units)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for BackgroundCpuPermitV1 {
+    fn drop(&mut self) {
+        self.authority.release(self.units);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BackgroundCpuInstallErrorV1 {
+    #[error(
+        "background CPU authority is already installed at width {installed_width}, not requested width {requested_width}"
+    )]
+    ConflictingWidth {
+        installed_width: usize,
+        requested_width: usize,
+    },
+    #[error("background CPU authority installation did not settle")]
+    InstallationDidNotSettle,
+}
+
+static PROCESS_BACKGROUND_CPU: OnceLock<Arc<ProcessBackgroundCpuV1>> = OnceLock::new();
+
+/// Install or idempotently reuse the one process background CPU authority.
+pub fn install_process_background_cpu(
+    width: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if let Some(installed) = PROCESS_BACKGROUND_CPU.get() {
+        return compare_installed_width(installed, width);
+    }
+    let requested = Arc::new(ProcessBackgroundCpuV1::new(width));
+    match PROCESS_BACKGROUND_CPU.set(Arc::clone(&requested)) {
+        Ok(()) => Ok(requested),
+        Err(_) => PROCESS_BACKGROUND_CPU.get().map_or_else(
+            || Err(BackgroundCpuInstallErrorV1::InstallationDidNotSettle),
+            |installed| compare_installed_width(installed, width),
+        ),
+    }
+}
+
+fn compare_installed_width(
+    installed: &Arc<ProcessBackgroundCpuV1>,
+    requested: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if installed.width == requested {
+        Ok(Arc::clone(installed))
+    } else {
+        Err(BackgroundCpuInstallErrorV1::ConflictingWidth {
+            installed_width: installed.width.get(),
+            requested_width: requested.get(),
+        })
+    }
+}
+
+/// Installed process authority, or `None` before daemon worker-plan admission.
+#[must_use]
+pub fn process_background_cpu() -> Option<Arc<ProcessBackgroundCpuV1>> {
+    PROCESS_BACKGROUND_CPU.get().map(Arc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn combined_classes_never_exceed_width_and_both_progress() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let index_completed = Arc::new(AtomicUsize::new(0));
+        let session_completed = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(17));
+        let mut workers = Vec::new();
+        for ordinal in 0..16 {
+            let authority = Arc::clone(&authority);
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let index_completed = Arc::clone(&index_completed);
+            let session_completed = Arc::clone(&session_completed);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                authority.with_permit(|| {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if ordinal % 2 == 0 {
+                        index_completed.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        session_completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }));
+        }
+        start.wait();
+        for worker in workers {
+            worker.join().expect("background worker");
+        }
+
+        assert!(maximum.load(Ordering::SeqCst) <= 4);
+        assert_eq!(index_completed.load(Ordering::SeqCst), 8);
+        assert_eq!(session_completed.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn waiting_demand_sums_weighted_work_units() {
+        let state = BackgroundCpuStateV1 {
+            active_units: 4,
+            waiters: VecDeque::from([
+                Arc::new(BackgroundCpuWaiterV1 { units: 4 }),
+                Arc::new(BackgroundCpuWaiterV1 { units: 1 }),
+            ]),
+        };
+
+        assert_eq!(waiting_units(&state), 5);
+    }
+
+    #[test]
+    fn weighted_units_and_nested_work_share_one_width() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permits(4, || {
+            assert_eq!(authority.active_units(), 4);
+            authority.with_permit(|| assert_eq!(authority.active_units(), 4));
+        });
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn nested_executor_yields_parent_units_and_reacquires_them() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_yielded_permits(|| {
+                assert_eq!(authority.active_units(), 0);
+                authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            });
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn panic_and_cancellation_drop_release_every_unit() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(2).expect("nonzero width"),
+        ));
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permits(2, || panic!("injected background panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let nested_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permit(|| {
+                authority.with_yielded_permits(|| panic!("injected nested executor panic"));
+            });
+        }));
+        assert!(nested_panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let cancelled = authority.acquire();
+        assert_eq!(authority.active_units(), 1);
+        drop(cancelled);
+        assert_eq!(authority.active_units(), 0);
+        assert!(authority.try_acquire().is_some());
+    }
+}

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -76,6 +76,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod background_cpu;
 pub mod branch;
 pub mod branch_meta;
 pub mod cancellation;

--- a/crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs
@@ -937,3 +937,204 @@ mod auxiliary_scheduling_tests {
         assert!(connection.is_autocommit());
     }
 }
+
+/// Regression cover for writer transaction amplification.
+///
+/// The measured session-ingest profile showed 26,382 `submit_authorized` calls
+/// settling as 26,380 durable transactions — an effective batch size of 1.0,
+/// so the writer paid one `BEGIN IMMEDIATE`/`COMMIT` pair per frame. The
+/// coalescing itself lives in [`build_batches`], and nothing in this crate
+/// pinned its ratio: every existing assertion sits above the writer, in the
+/// stores that decide how many requests to submit. Those stores can stay fixed
+/// while this function silently regresses to one batch per request.
+///
+/// These assert on a count — batches produced for a known request count —
+/// because the timings this work came from swing double digits run to run on
+/// identical input, so an elapsed-time assertion here would prove nothing.
+#[cfg(test)]
+mod batch_coalescing_tests {
+    use std::sync::Arc;
+
+    use tracedecay_store::{
+        AdmissionConfigV1, BatchBudgetV1, RuntimeCancellationIdentityV1, RuntimeDeadlineV1,
+        RuntimeInterruptionV1, RuntimeRequestProbeV1, RuntimeSubmitRequestV1,
+    };
+
+    use crate::{
+        admission::{Admission, Capacity, Limits},
+        test_support::{metadata, request},
+        writer::UnrestrictedRuntimeWriteAuthority,
+    };
+
+    use super::{AcceptedRequest, ExecutionBatch, build_batches};
+
+    /// A probe that never interrupts, so batch shape is decided only by the
+    /// budget and by `requires_isolated_commit`.
+    struct BatchProbe {
+        cancellation: RuntimeCancellationIdentityV1,
+        deadline: RuntimeDeadlineV1,
+        isolated: bool,
+    }
+
+    impl BatchProbe {
+        fn new(request: &RuntimeSubmitRequestV1, isolated: bool) -> Self {
+            Self {
+                cancellation: request.control().cancellation.clone(),
+                deadline: request.control().deadline.clone(),
+                isolated,
+            }
+        }
+    }
+
+    impl RuntimeRequestProbeV1 for BatchProbe {
+        fn cancellation_identity(&self) -> &RuntimeCancellationIdentityV1 {
+            &self.cancellation
+        }
+
+        fn deadline_identity(&self) -> &RuntimeDeadlineV1 {
+            &self.deadline
+        }
+
+        fn interruption(&self) -> Option<RuntimeInterruptionV1> {
+            None
+        }
+
+        fn try_begin_commit(&self) -> bool {
+            true
+        }
+
+        fn requires_isolated_commit(&self) -> bool {
+            self.isolated
+        }
+    }
+
+    fn config(max_operations: u32) -> AdmissionConfigV1 {
+        let defaults = AdmissionConfigV1::default();
+        AdmissionConfigV1 {
+            foreground_batch: BatchBudgetV1 {
+                max_operations,
+                max_bytes: u64::MAX,
+                ..defaults.foreground_batch
+            },
+            background_batch: BatchBudgetV1 {
+                max_operations,
+                max_bytes: u64::MAX,
+                ..defaults.background_batch
+            },
+            ..defaults
+        }
+    }
+
+    /// Builds `count` mutually compatible foreground requests, the shape one
+    /// scan batch submits.
+    fn compatible_requests(count: usize, isolate_last: bool) -> Vec<AcceptedRequest> {
+        let admission = Admission::new(
+            Limits::new(
+                Capacity {
+                    operations: u32::try_from(count).unwrap() + 8,
+                    bytes: u64::MAX,
+                },
+                Capacity {
+                    operations: 1,
+                    bytes: u64::MAX,
+                },
+                u64::MAX,
+                u64::MAX,
+            )
+            .unwrap(),
+        );
+        (0..count)
+            .map(|index| {
+                let submit = Arc::new(request(metadata(
+                    &format!("operation.batch.ratio.{index}"),
+                    &format!("key.batch.ratio.{index}"),
+                    'a',
+                )));
+                let permit = admission.reserve(&submit.envelope().metadata).unwrap();
+                let isolated = isolate_last && index + 1 == count;
+                let (reply, _response) = tokio::sync::oneshot::channel();
+                AcceptedRequest::new(
+                    Arc::clone(&submit),
+                    Arc::new(BatchProbe::new(&submit, isolated)),
+                    Arc::new(UnrestrictedRuntimeWriteAuthority),
+                    reply,
+                    permit,
+                )
+            })
+            .collect()
+    }
+
+    fn frames(batches: &[ExecutionBatch]) -> usize {
+        batches.iter().map(|batch| batch.items.len()).sum()
+    }
+
+    #[test]
+    fn one_scan_batch_of_compatible_writes_opens_one_transaction() {
+        const REQUESTS: usize = 256;
+
+        let batches = build_batches(compatible_requests(REQUESTS, false), &config(512));
+
+        assert_eq!(
+            frames(&batches),
+            REQUESTS,
+            "coalescing must not drop or duplicate a request"
+        );
+        assert_eq!(
+            batches.len(),
+            1,
+            "a budget-fitting scan batch must open one durable transaction: \
+             batches={} frames={REQUESTS} ratio={:.4} batches/frame (target <= 1.0)",
+            batches.len(),
+            batches.len() as f64 / REQUESTS as f64,
+        );
+    }
+
+    #[test]
+    fn batch_count_is_bounded_by_the_budget_not_by_the_request_count() {
+        const REQUESTS: usize = 256;
+        const MAX_OPERATIONS: u32 = 64;
+        const EXPECTED: usize = REQUESTS / MAX_OPERATIONS as usize;
+
+        let batches = build_batches(
+            compatible_requests(REQUESTS, false),
+            &config(MAX_OPERATIONS),
+        );
+
+        assert_eq!(frames(&batches), REQUESTS);
+        assert_eq!(
+            batches.len(),
+            EXPECTED,
+            "batch count must track the operation budget, not the request count: \
+             batches={} frames={REQUESTS} budget={MAX_OPERATIONS}",
+            batches.len(),
+        );
+        assert!(
+            batches
+                .iter()
+                .all(|batch| batch.items.len() <= MAX_OPERATIONS as usize),
+            "no batch may exceed its operation budget"
+        );
+    }
+
+    /// Widening the transaction window must not silently swallow a request that
+    /// asked to commit alone.
+    #[test]
+    fn an_isolated_commit_still_gets_its_own_transaction() {
+        const REQUESTS: usize = 8;
+
+        let batches = build_batches(compatible_requests(REQUESTS, true), &config(512));
+
+        assert_eq!(frames(&batches), REQUESTS);
+        assert_eq!(
+            batches.len(),
+            2,
+            "an isolated-commit request must split the batch: batches={}",
+            batches.len(),
+        );
+        assert_eq!(
+            batches.last().expect("isolated batch").items.len(),
+            1,
+            "the isolated-commit request must not share its transaction"
+        );
+    }
+}


### PR DESCRIPTION
## Current-state finding: the 14:1 ratio was already fixed, twice

I was sent to cut writer transaction amplification from a measured 26,382
`submit_authorized` calls settling as 26,380 durable transactions for 1,878
persisted frames. **I did not reimplement that fix, because it already
exists — in two independent places.** Both landed after the binary those
numbers were measured on.

1. **Upstream, in the stores.** `persist_observations` submits one writer
   request per scan batch instead of one per frame
   (`crates/tracedecay-sessions/src/runtime/jsonl_observation_admission.rs`,
   `MAX_CAPTURE_WINDOW = 256`). This is already regression-covered at two
   layers, both asserting on transaction counts rather than time:
   - `tracedecay-global-db`: `persist_observations_opens_one_writer_transaction_for_the_batch`
   - `tracedecay-usecases`: `persist_observations_opens_one_writer_transaction_for_the_batch`,
     paired with `n_persist_observation_calls_open_n_writer_transactions` as
     its negative control.

2. **In the writer worker.** A peer's local commit `perf(writer): coalesce
   compatible queued writes` adds a dwell window so the queue accumulates
   compatible arrivals before the worker drains it. Without it, `build_batches`
   had nothing to coalesce: a sequential submitter awaits each settle before
   submitting again, so the queue was empty at every wake and the average
   batch was exactly 1.0 — which is precisely the measured 26,382:26,380.
   **That commit is not in this PR and I did not cherry-pick it.**

So the honest answer to "is problem 1 already fixed?" is **yes**. The
remaining ratio is set by the batch budget, not by the frame count.

### What this PR actually adds

One gap survived both fixes: **`build_batches` itself has no assertion in
this crate.** It is the pure function that groups queued requests into
transactions, and every existing assertion sits *above* it — constraining how
many requests get submitted, not how they get grouped. The stores can stay
correct and the dwell window can keep filling the queue while this function
silently regresses to one batch per request, and nothing currently fails.

Three tests, all asserting on counts:

- `one_scan_batch_of_compatible_writes_opens_one_transaction` — 256 compatible
  foreground requests under a 512-operation budget must produce exactly 1
  batch. Ratio `0.0039` batches/frame.
- `batch_count_is_bounded_by_the_budget_not_by_the_request_count` — 256
  requests under a 64-operation budget must produce exactly 4 batches, and no
  batch may exceed its budget.
- `an_isolated_commit_still_gets_its_own_transaction` — durability guard, see
  below.

**No timing assertions.** The profile this work came from swings ~12% run to
run on identical input, so an elapsed-time assertion would prove nothing. The
failure messages quote the ratio so a regression reports the number directly.

## Durability argument

**This PR widens no transaction window and changes no production code.** It is
test-only against `crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs`.
Durability semantics are therefore unchanged by construction — there is no
at-least-once coverage to lose, no commit order to perturb, and no write lock
held for one additional instruction.

On the coalescing that *does* exist, the two properties that matter are already
structural rather than incidental, and the third test pins one of them:

- **The write lock covers only the commit.** `process_batch` takes
  `BEGIN IMMEDIATE` and then does all per-request work inside savepoints on an
  already-open transaction. No parse and no I/O wait happens between the lock
  being taken and the commit — the dwell window that accumulates requests runs
  *before* the transaction begins, not inside it.
- **A request that asked to commit alone still does.** `build_batches` splits
  the batch on `requires_isolated_commit()`. Widening a window must never
  quietly absorb such a request, so
  `an_isolated_commit_still_gets_its_own_transaction` asserts the split
  survives.
- **Batch failure is not silently shared.** Already handled and already
  covered: `settle_authority_denied` gives the members that did *not* lose
  authority a retryable `Faulted` rather than blaming them for a peer's
  revocation.

## Problem 2: the `begin_immediate` tail is not lock contention — diagnosis, no fix

I was asked to stop and report rather than guess if this needed a design
change. It does. Reporting.

The symptom: `rusqlite.begin_immediate` has a **mean of 10.65 ms against a p95
of 82 µs** — ~130x — across 4,900 calls. That shape says nearly every call is
instant and a handful block enormously. The natural reading is that
`BEGIN IMMEDIATE` is fighting for SQLite's write lock.

**That reading is wrong, and the metric name is what makes it look right.**

**Evidence chain:**

1. `rusqlite.begin_immediate` is emitted from exactly one place —
   `crates/tracedecay-rusqlite-runtime/src/exact_sql/mod.rs:427`. It is **not**
   the writer's transaction begin; the writer emits `rusqlite.writer.begin`
   from `writer/transaction.rs`. This is why its 4,900 calls never reconciled
   with `process_batch`'s 26,380 — they are different paths.

2. The measured span is not a SQLite statement. `begin_transaction`
   (`exact_sql/mod.rs:466`) does `try_send(WriterCommand::BeginTransaction)`
   onto the writer actor's exact-SQL channel and then **blocks on
   `response.recv()`**. The span therefore includes the full wait for the
   writer worker thread to get around to the command.

3. The worker deliberately deprioritises that command.
   `select_auxiliary_work` returns `None` whenever product writes are queued
   and `prefer_auxiliary` is false. In the main loop, `prefer_auxiliary` is
   reset to `true` only *after* `queue.drain_fair()` has been fully processed
   — every batch from `build_batches`, with `run_scheduled_checkpoint`
   interleaved between them.

4. So an exact-SQL `BeginTransaction` arriving mid-drain waits for the entire
   remaining drain plus its interleaved checkpoints. When the worker is idle it
   is served immediately — that is the 82 µs p95.

5. It compounds: `run_writer_command` executes `run_transaction(...)`
   **inline on the worker thread** (`exact_sql/command.rs:186-228`), driven by
   the caller over a `sync_channel(1)`. The writer actor is occupied for the
   whole lifetime of an exact-SQL transaction, blocked waiting on the caller's
   next statement. Product writes and exact-SQL transactions mutually exclude
   each other on one actor.

**Consequences for how this should be read:**

- `rusqlite.begin_immediate` is **actor-queue scheduling latency**, not lock
  acquisition. Its mean is a fairness property of the writer worker. Treating
  it as I/O or as SQLite contention will send the next person down the wrong
  path, which is roughly what its name invites.
- **Widening the writer's transaction window makes this metric worse, not
  better** — a longer drain is a longer wait for the exact-SQL command behind
  it. That is a direct argument against "fix the tail by batching harder".
- The peer's dwell window does **not** worsen it: `dwell_for_batch` returns
  immediately on any non-`Write` wake, so an arriving exact-SQL command ends
  the dwell rather than waiting it out. Good design, worth preserving.

**Why I did not fix it.** Every available option is a design change, not a
local edit: give exact-SQL its own write connection (changes the single-writer
invariant), make the drain yield to auxiliary work between batches (changes
fairness and starvation guarantees), or split the metric into queue-wait vs
actual `BEGIN` (honest, but a contract change to the profile everyone is
reading). Picking one of those unbriefed is exactly the guessing I was told to
avoid.

**Cheapest useful next step**, if someone wants it: split the
`rusqlite.begin_immediate` span into `rusqlite.exact_sql.queue_wait` and
`rusqlite.exact_sql.begin`. That alone converts "24.3% of measured total,
cause unknown" into two numbers with obvious owners, and costs no behaviour
change. I have not done it here because it changes a metric others are
currently comparing against.

## Carried commit

This branch carries `fix(runtime-core): commit the missing background CPU
module` (`origin/claude/fix-missing-background-cpu`, PR #676). The base branch
does not compile without it — `crates/tracedecay-sessions/src/observation.rs`
imports `tracedecay_runtime_core::background_cpu`, whose module file was never
`git add`ed as part of `perf(observation): batch admission and preparation`. It
is purely additive. If #676 merges first this will fold away cleanly.

## Merge-order note

`crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs` is also heavily
modified by the peer's unpushed `perf(writer): coalesce compatible queued
writes` (+803 lines in that file). **Expect a textual conflict there.** It is
additive on both sides — my tests are a new `batch_coalescing_tests` module at
the end of the file and touch nothing the dwell work touches. Resolving by
keeping both modules is correct. Landing the peer's commit first is the lower
friction order.

## Verification

Per-crate only; no workspace build or workspace clippy.

- `cargo check -p tracedecay-rusqlite-runtime --all-targets --locked` — clean
- `cargo check -p tracedecay-rusqlite-runtime --all-targets --locked --features hotpath` — clean
- `cargo clippy -p tracedecay-rusqlite-runtime --all-targets --locked` — no warnings
- `cargo test -p tracedecay-rusqlite-runtime --lib writer::` — 33 passed, 0 failed

hotpath remains off by default.
