### PR TITLE
fix(writer): read the configured WAL budget

### DIFF
--- a/crates/tracedecay-rusqlite-runtime/src/writer/tests/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer/tests/mod.rs
@@ -19,15 +19,16 @@ use tracedecay_store::{
     RepositoryWritePayloadV1, RetrievalAnchorDispositionRecordV1, RuntimeCancellationIdentityV1,
     RuntimeDeadlineV1, RuntimeInterruptionV1, RuntimeRequestProbeV1, RuntimeSubmitOutcomeV1,
     RuntimeSubmitRequestV1, StorageRuntimeErrorV1, StoreCommitReceiptV1, StoreRuntimeBindingV1,
-    VerifiedStoreLocatorV1,
+    VerifiedStoreLocatorV1, WAL_HARD_LIMIT_BYTES, WAL_SOFT_LIMIT_BYTES, WalBudgetV1,
 };
 
 use super::*;
 use crate::{
     checkpoint::{
-        CheckpointBlockers, CheckpointDecision, CheckpointInterruption, CheckpointKind,
-        CheckpointMode, CheckpointOutcome, CheckpointPressure, CheckpointReport, CheckpointResult,
-        MaintenanceCheckpointMode, WalPressure, WalSample,
+        CheckpointBlockers, CheckpointConfig, CheckpointDecision, CheckpointInterruption,
+        CheckpointKind, CheckpointMode, CheckpointOutcome, CheckpointPressure,
+        CheckpointReport, CheckpointResult, MaintenanceCheckpointMode, WalPressure,
+        WalSample,
     },
     maintenance::{ExclusiveMaintenancePermit, MaintenanceOwnerId},
     test_support::{binding, metadata, request, scope},
@@ -451,6 +452,29 @@ fn start(
     .unwrap()
 }
 
+fn start_with_admission(
+    database: &TestDatabase,
+    request: &RuntimeSubmitRequestV1,
+    applied: Arc<AtomicU64>,
+    admission: AdmissionConfigV1,
+) -> PersistentWriter {
+    let binding = binding(&request.envelope().metadata);
+    let locator = VerifiedStoreLocatorV1::new(
+        binding.shard_id.clone(),
+        binding.incarnation,
+        LocatorDigest::new(format!("sha256:{}", "d".repeat(64))).unwrap(),
+    );
+    PersistentWriter::start_with_persistence(
+        ExistingWriterLocator::new(binding, locator, database.0.clone()).unwrap(),
+        admission,
+        Box::new(TestPersistence {
+            applied,
+            sequence: 0,
+        }),
+    )
+    .unwrap()
+}
+
 fn start_with_persistence(
     database: &TestDatabase,
     request: &RuntimeSubmitRequestV1,
@@ -611,3 +635,105 @@ mod authority;
 mod backup;
 mod checkpoint;
 mod interruption;
+
+/// The operator's configured WAL budget must reach the checkpoint controller.
+///
+/// `actor_commits_before_reply_and_releases_admission` pins the default: one
+/// small write leaves the WAL below the 32 MiB soft limit, so the scheduled
+/// checkpoint reports `BelowSoft`. Configuring a one-byte soft limit must flip
+/// that same observation - any non-empty WAL is now over pressure, so a PASSIVE
+/// checkpoint has to run. Asserts the published decision, never a duration or a
+/// WAL byte count.
+#[test]
+fn scheduled_checkpoint_honors_the_configured_wal_budget() {
+    let database = TestDatabase::new();
+    let request = request(metadata("operation.wal.budget", "key.wal.budget", 'w'));
+    let admission = AdmissionConfigV1 {
+        wal: WalBudgetV1 {
+            soft_limit_bytes: 1,
+            hard_limit_bytes: 2,
+        },
+        ..AdmissionConfigV1::default()
+    };
+    admission
+        .validate()
+        .expect("a one-byte soft limit is an admissible operator configuration");
+    let writer = start_with_admission(&database, &request, Arc::new(AtomicU64::new(0)), admission);
+    let checkpoint = writer.checkpoint_handle();
+    let mut checkpoint_status = checkpoint.status_subscription();
+    let probe = Arc::new(Probe::new(&request, None));
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let outcome = runtime.block_on(writer.submit(request, probe)).unwrap();
+    assert!(matches!(outcome, RuntimeSubmitOutcomeV1::Committed { .. }));
+    runtime
+        .block_on(checkpoint_status.changed())
+        .expect("writer publishes a scheduled WAL sample");
+
+    let latest = checkpoint_status.borrow().latest.clone();
+    assert!(
+        !matches!(latest, Some(CheckpointOutcome::BelowSoft { .. })),
+        "configured soft limit never reached the controller; got {latest:?}"
+    );
+    assert!(
+        matches!(
+            latest,
+            Some(
+                CheckpointOutcome::Complete {
+                    kind: CheckpointKind::Passive,
+                    ..
+                } | CheckpointOutcome::Pending {
+                    kind: CheckpointKind::Passive,
+                    ..
+                }
+            )
+        ),
+        "expected a scheduled PASSIVE checkpoint; got {latest:?}"
+    );
+    writer.shutdown_and_join().unwrap();
+}
+
+/// Honouring the configured budget must not be able to weaken durability.
+///
+/// `AdmissionConfigV1::validate` caps the soft and hard limits at exactly the
+/// values `CheckpointConfig::default()` used to hardcode, so every admissible
+/// budget is at or below the previous thresholds: the writer can only reach a
+/// checkpoint sooner than it did before, never later. Anything above the
+/// ceilings is rejected before a writer can start.
+#[test]
+fn no_admissible_wal_budget_relaxes_the_previous_checkpoint_thresholds() {
+    let previous = CheckpointConfig::default();
+
+    let ceiling = AdmissionConfigV1 {
+        wal: WalBudgetV1 {
+            soft_limit_bytes: WAL_SOFT_LIMIT_BYTES,
+            hard_limit_bytes: WAL_HARD_LIMIT_BYTES,
+        },
+        ..AdmissionConfigV1::default()
+    };
+    ceiling.validate().expect("the ceilings are admissible");
+    assert_eq!(ceiling.wal.soft_limit_bytes, previous.soft_wal_bytes);
+    assert_eq!(ceiling.wal.hard_limit_bytes, previous.hard_wal_bytes);
+
+    for budget in [
+        WalBudgetV1 {
+            soft_limit_bytes: WAL_SOFT_LIMIT_BYTES + 1,
+            hard_limit_bytes: WAL_HARD_LIMIT_BYTES,
+        },
+        WalBudgetV1 {
+            soft_limit_bytes: WAL_SOFT_LIMIT_BYTES,
+            hard_limit_bytes: WAL_HARD_LIMIT_BYTES + 1,
+        },
+    ] {
+        let over = AdmissionConfigV1 {
+            wal: budget,
+            ..AdmissionConfigV1::default()
+        };
+        assert!(
+            over.validate().is_err(),
+            "a budget above the contract ceiling must never reach a writer"
+        );
+    }
+}

--- a/crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs
@@ -180,9 +180,21 @@ impl Worker {
             }
             None => None,
         };
+        // The checkpoint thresholds are the operator's admitted WAL budget, not
+        // this crate's defaults. `PersistentWriter::start_with_persistence` has
+        // already run `AdmissionConfigV1::validate`, which caps the soft limit
+        // at `WAL_SOFT_LIMIT_BYTES` and the hard limit at `WAL_HARD_LIMIT_BYTES`
+        // -- the two values `CheckpointConfig::default()` hardcodes. A
+        // configured budget can therefore only lower a threshold, never raise
+        // one, so honouring it can only checkpoint more often than before.
+        // `WriterCheckpointController::new` re-validates and fails startup
+        // closed rather than trusting the value.
         let mut checkpoint = match WriterCheckpointController::new(
             RusqliteCheckpointDriver::new(connection),
-            CheckpointConfig::default(),
+            CheckpointConfig {
+                soft_wal_bytes: self.config.wal.soft_limit_bytes,
+                hard_wal_bytes: self.config.wal.hard_limit_bytes,
+            },
         ) {
             Ok(checkpoint) => checkpoint,
             Err(_) => return self.fail_start(WriterStartError::CheckpointSetupFailed),


### PR DESCRIPTION
Scoped down after discovering a peer session had already committed (locally, unpushed) against both findings. This PR is **only the gap those commits leave**.

## What the peer commits actually do

| Peer commit | Claim | Reality |
| --- | --- | --- |
| `d15c99737 perf(connection): bound retained WAL files` | Finding A (`journal_size_limit`) | **Fully fixes it.** Not duplicated here. |
| `9f4671f99 fix(checkpoint): honor configured WAL budget` | Finding B | **Does not fix it.** Adds the adapter, never plugs it in. |

`9f4671f99` touches exactly two files (`checkpoint/types.rs`, `checkpoint/tests.rs`). It adds `impl From<&WalBudgetV1> for CheckpointConfig` and re-derives the crate defaults from the store contract constants. It does **not** touch the writer. Verified at the peer's own tip:

```
$ git grep -n "CheckpointConfig::default()\|CheckpointConfig::from" 9f4671f99 -- crates/tracedecay-rusqlite-runtime/src | grep -v checkpoint/tests.rs
9f4671f99:crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs:185:            CheckpointConfig::default(),

$ git grep -n "CheckpointConfig::from" 9f4671f99 -- crates/tracedecay-rusqlite-runtime/src
9f4671f99:crates/tracedecay-rusqlite-runtime/src/checkpoint/tests.rs:190:    let config = CheckpointConfig::from(&budget);
```

The new `From` impl has exactly one caller and it is a test. The single non-test construction site still passes `CheckpointConfig::default()`, so the operator's configured budget still never reaches the checkpoint controller. **This PR is that one line** (plus its proof).

## Verified vs. taken on faith

**Verified by reading code and running it:**

- Finding A was real on the base branch: `rg journal_size_limit` returns 0 matches on `origin/cursor/simplify-pr421-hot-paths`.
- `apply_pragmas` in `connection/mod.rs` is genuinely the single shared path for every WAL database this codebase opens. Every other non-test `Connection::open` is the lexical projection artifact (`tracedecay-query/.../artifact/{reader,builder}.rs`), which never sets `journal_mode=WAL` — it is served read-only and built in rollback-journal mode, so `journal_size_limit` is inert there. The peer's fix on Writer + Maintenance is therefore complete coverage, not a single-path fix.
- Finding B was real and remains real: `CheckpointConfig::default()` at `writer/worker/mod.rs:185` was the only non-test construction site, while `Worker.config: AdmissionConfigV1` — carrying the operator's `wal` budget — was already in scope on the same struct.
- The revert is a clean, complete revert: `git diff 88b3d0e7b^ ab57c7c58 -- crates/tracedecay-rusqlite-runtime/` is empty.

**Taken on faith:** nothing load-bearing. The peer commits are local-only and were read, not cherry-picked; if `9f4671f99` is amended before it lands, the gap analysis above should be re-checked.

## The prior revert, and why it does not block this

`88b3d0e7b fix(rusqlite-runtime): skip scheduled WAL sample below soft` made the writer skip the real `sample_wal()` when an *extrapolation* (`last_wal_bytes + batch.bytes + soft/32`) stayed below the soft limit. `ab57c7c58 revert(rusqlite-runtime): keep WAL pressure authoritative` backed it out 15 minutes later.

That estimate was unsound in a specific, unbounded way. `batch.bytes` is the admission-payload size, not the WAL frames SQLite appends. Those diverge in the dangerous direction: WAL frames are whole pages, so many small operations badly under-count; index churn, page splits, and the `auto_vacuum = INCREMENTAL` pointer-map writes this runtime enables append frames that the payload does not represent at all. Because `last_wal_bytes` was only re-synced from a real sample *when the code decided to sample*, an under-counting estimate was self-reinforcing — it never sampled, so it never corrected — and the fixed `soft/32` slack is a constant, not a bound on the error. The WAL could cross the soft limit, and in principle the hard limit, unobserved. Hence "keep WAL pressure authoritative": pressure must come from a measurement, never an extrapolation.

**That reasoning does not block this change**, because the two are on different axes. The revert was about *whether* the controller measures WAL pressure. This PR changes only *which threshold* the measured pressure is compared against. Every `sample_wal()` call stays exactly where it is; no estimate is introduced.

## Durability

Strictly safe by construction, and asserted. `AdmissionConfigV1::validate` caps `soft_limit_bytes` at `WAL_SOFT_LIMIT_BYTES` (32 MiB) and `hard_limit_bytes` at `WAL_HARD_LIMIT_BYTES` (256 MiB) — precisely the values `CheckpointConfig::default()` hardcoded. So an admissible budget can only *lower* a threshold: the writer can reach a checkpoint sooner than before, never later, and the WAL cannot grow past today's bound. `WriterCheckpointController::new` re-validates and fails startup closed rather than trusting the value. `no_admissible_wal_budget_relaxes_the_previous_checkpoint_thresholds` pins this.

## Should the flat 32 MiB scale with database size?

**No — and the "flatness" framing measures the wrong axis.** The budget is already scaled, to the right quantity. From `tracedecay-store/src/runtime/operation.rs`:

```
DEFAULT_GLOBAL_QUEUE_BYTES     =  64 MiB
WAL_SOFT_LIMIT_BYTES           =  32 MiB   (half the standard global queue)
WORKSTATION_GLOBAL_QUEUE_BYTES = 256 MiB
WAL_HARD_LIMIT_BYTES           = 256 MiB   (exactly the workstation global queue)
```

The hard limit equals the largest volume of write traffic the runtime will ever admit at once — the invariant is "one full global-queue drain must fit in the WAL." That is what actually governs how fast the WAL grows between checkpoints.

Database size is the wrong driver. Every real cost of a large WAL scales with WAL *frames*, not database bytes: crash-recovery replay, the reader `-shm` wal-index size and scan cost, and checkpoint copy work. A 10 GiB database does not make a 400 MiB WAL cheaper to replay — it makes recovery slower on exactly the deployment that can least afford it. Scaling by database size would also undo the peer's `journal_size_limit` fix (the retained WAL file would grow with the database, reintroducing the standing on-disk cost) and would breach the 256 MiB hard ceiling for any database past a couple of GiB under any sane ratio.

So the constant is unchanged and the ceiling is kept. The defect was never the number; it was that the number the operator configured was never read.

## RED / GREEN

RED — with `soft_limit_bytes: 1` configured, a 12 KiB WAL is still classified below-soft, because the controller is comparing against the hardcoded 32 MiB:

```
running 1 test
test writer::tests::scheduled_checkpoint_honors_the_configured_wal_budget ... FAILED

---- writer::tests::scheduled_checkpoint_honors_the_configured_wal_budget stdout ----
thread '...' panicked at crates/tracedecay-rusqlite-runtime/src/writer/tests/mod.rs:675:5:
configured soft limit never reached the controller; got Some(BelowSoft { wal: CheckpointWal { frames: 3, bytes: 12392 } })

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 299 filtered out
```

GREEN:

```
running 2 tests
test writer::tests::no_admissible_wal_budget_relaxes_the_previous_checkpoint_thresholds ... ok
test writer::tests::scheduled_checkpoint_honors_the_configured_wal_budget ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 299 filtered out; finished in 0.01s
```

Full crate suite:

```
test result: ok. 301 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.14s
```

Neither test asserts on elapsed time or on a WAL byte count. The discriminator is the published `CheckpointOutcome` variant, and it depends only on the WAL being non-empty after a committed write — guaranteed here because `wal_autocheckpoint = 0` and nothing else checkpoints. The test blocks on the status watch channel rather than sleeping. The `BelowSoft` baseline it inverts is already pinned by the pre-existing `actor_commits_before_reply_and_releases_admission`.

Builds (per-crate only, as briefed): `cargo check -p tracedecay-store --all-targets --locked` and `cargo check -p tracedecay-rusqlite-runtime --all-targets --locked` both clean.

## Deliberately not fixed

- **Finding A.** Already fixed by `d15c99737`. I had implemented it independently first and converged on the identical design — same `RETAINED_WAL_BYTES = WAL_SOFT_LIMIT_BYTES`, same Writer + Maintenance lanes, same `apply_pragmas` site — then dropped my commit rather than ship a duplicate that would conflict. The value is pinned from both sides: lower truncates into the sub-soft band the controller deliberately reuses, converting reclaim into per-commit file extension; higher makes the transient over-soft band permanent.
- **The peer's now-dead `From<&WalBudgetV1> for CheckpointConfig`.** I deliberately did *not* add my own copy — two identical trait impls landing together is `E0119`, a hard compile error. This PR constructs the config inline at the one call site. When `9f4671f99` lands, swapping that literal for `CheckpointConfig::from(&self.config.wal)` is a one-line cleanup, not a conflict. Both orderings compile.
- **`GlobalQueueProfileV1::ExplicitWorkstation` and the WAL budget.** The workstation profile raises the global queue to 256 MiB while the WAL soft limit stays capped at 32 MiB, so a workstation can admit 8x the soft limit in a single drain. That may be intentional (it is what the 256 MiB hard limit absorbs), but the coupling is undocumented. Out of scope here; worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
