### PR TITLE
fix(build): land the batching commit's unpushed consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6143,6 +6143,7 @@ dependencies = [
  "tracedecay-code-extraction",
  "tracedecay-domain",
  "tracedecay-graph-db",
+ "tracedecay-runtime-core",
  "tracedecay-rusqlite-runtime",
  "tracedecay-store",
  "tree-sitter",

--- a/crates/tracedecay-code-index/Cargo.toml
+++ b/crates/tracedecay-code-index/Cargo.toml
@@ -16,6 +16,7 @@ hotpath = [
     "tracedecay-application/hotpath",
     "tracedecay-code-extraction/hotpath",
     "tracedecay-graph-db/hotpath",
+    "tracedecay-runtime-core/hotpath",
 ]
 hotpath-alloc = [
     "hotpath",
@@ -23,6 +24,7 @@ hotpath-alloc = [
     "tracedecay-application/hotpath-alloc",
     "tracedecay-code-extraction/hotpath-alloc",
     "tracedecay-graph-db/hotpath-alloc",
+    "tracedecay-runtime-core/hotpath-alloc",
 ]
 hotpath-cpu = [
     "hotpath",
@@ -30,6 +32,7 @@ hotpath-cpu = [
     "tracedecay-application/hotpath-cpu",
     "tracedecay-code-extraction/hotpath-cpu",
     "tracedecay-graph-db/hotpath-cpu",
+    "tracedecay-runtime-core/hotpath-cpu",
 ]
 default = [
     "lite",
@@ -100,6 +103,7 @@ tracedecay-application = { path = "../tracedecay-application", version = "0.1.0"
 tracedecay-code-extraction = { path = "../tracedecay-code-extraction", version = "0.1.0", default-features = false }
 tracedecay-domain = { path = "../tracedecay-domain", version = "0.1.0" }
 tracedecay-graph-db = { path = "../tracedecay-graph-db", version = "0.1.0" }
+tracedecay-runtime-core = { path = "../tracedecay-runtime-core", version = "0.1.0" }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/tracedecay-code-index/src/chunks.rs
+++ b/crates/tracedecay-code-index/src/chunks.rs
@@ -147,8 +147,10 @@ where
     if chunks.len() < PARALLEL_CHUNK_THRESHOLD {
         return chunks.iter().map(operation).collect();
     }
-    let results: Vec<Result<T, ChunkingFailureV1>> =
-        chunks.par_iter().map(operation).collect::<Vec<_>>();
+    let results: Vec<Result<T, ChunkingFailureV1>> = chunks
+        .par_iter()
+        .map(|chunk| crate::parallelism::with_background_cpu_permit(|| operation(chunk)))
+        .collect::<Vec<_>>();
     results.into_iter().collect()
 }
 
@@ -168,7 +170,11 @@ where
     let failure = chunks
         .par_iter()
         .enumerate()
-        .filter_map(|(index, chunk)| operation(chunk).err().map(|error| (index, error)))
+        .filter_map(|(index, chunk)| {
+            crate::parallelism::with_background_cpu_permit(|| operation(chunk))
+                .err()
+                .map(|error| (index, error))
+        })
         .min_by_key(|(index, _)| *index);
     match failure {
         Some((_, error)) => Err(error),
@@ -261,7 +267,7 @@ impl ExactExtractionAuthorityV1 {
         }
         let admitted = chunks
             .into_par_iter()
-            .map(|chunk| self.admit(chunk))
+            .map(|chunk| crate::parallelism::with_background_cpu_permit(|| self.admit(chunk)))
             .collect::<Vec<_>>();
         admitted.into_iter().collect()
     }
@@ -1963,10 +1969,12 @@ fn emit_windows(
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
+    use std::time::Duration;
 
     use super::*;
     use tracedecay_domain::{
@@ -1985,8 +1993,70 @@ mod tests {
     };
     use crate::intake::{CodeIndexIntake, SanitizedCodeIntake};
     use crate::languages::{LanguageRegistry, StaticLanguageRegistry};
+    use tracedecay_runtime_core::background_cpu::{
+        install_process_background_cpu, process_background_cpu,
+    };
 
     struct AlwaysCancelled;
+
+    #[test]
+    fn nested_chunk_fanout_admits_stolen_workers_without_exceeding_width() {
+        assert!(
+            process_background_cpu().is_none(),
+            "no test may install a shadow background CPU authority"
+        );
+        let _preview = crate::parallelism::preview_worker_plan(
+            tracedecay_domain::configuration::CodeIndexWorkerSelectionV1::Automatic,
+            20 * crate::parallelism::INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+        );
+        assert!(
+            process_background_cpu().is_none(),
+            "worker-plan preview must not install background CPU authority"
+        );
+        let authority =
+            install_process_background_cpu(NonZeroUsize::new(2).expect("nonzero background width"))
+                .expect("background CPU authority");
+        let fixture = chunk_source("pub fn shared_cpu_fixture() {}\n")
+            .chunks
+            .into_iter()
+            .next()
+            .expect("fixture chunk");
+        let chunks = vec![fixture; PARALLEL_CHUNK_THRESHOLD * 2];
+        let active = AtomicUsize::new(0);
+        let maximum = AtomicUsize::new(0);
+        let parent_completed = AtomicUsize::new(0);
+        let stolen_completed = AtomicUsize::new(0);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("nested Rayon pool");
+
+        let mapped = pool
+            .install(|| {
+                crate::parallelism::with_background_cpu_permit(|| {
+                    let parent = rayon::current_thread_index().expect("parent Rayon worker");
+                    map_chunks_ordered(&chunks, |_| {
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        maximum.fetch_max(current, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(5));
+                        if rayon::current_thread_index() == Some(parent) {
+                            parent_completed.fetch_add(1, Ordering::SeqCst);
+                        } else {
+                            stolen_completed.fetch_add(1, Ordering::SeqCst);
+                        }
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    })
+                })
+            })
+            .expect("nested chunk fan-out");
+
+        assert_eq!(mapped.len(), chunks.len());
+        assert_eq!(maximum.load(Ordering::SeqCst), authority.width().get());
+        assert!(parent_completed.load(Ordering::SeqCst) > 0);
+        assert!(stolen_completed.load(Ordering::SeqCst) > 0);
+        assert_eq!(authority.active_units(), 0);
+    }
 
     impl ExtractionCancellation for AlwaysCancelled {
         fn is_cancelled(&self) -> bool {

--- a/crates/tracedecay-code-index/src/hotpath_observe.rs
+++ b/crates/tracedecay-code-index/src/hotpath_observe.rs
@@ -8,6 +8,8 @@
 
 #[cfg(test)]
 use std::cell::Cell;
+#[cfg(not(test))]
+use std::marker::PhantomData;
 #[cfg(feature = "hotpath")]
 use std::sync::atomic::AtomicU64;
 #[cfg(any(feature = "hotpath", test))]
@@ -139,6 +141,9 @@ impl WorkerBusyGuard {
         #[cfg(test)]
         self.coordinating.set(true);
         WorkerPoolCoordinationGuard {
+            #[cfg(not(test))]
+            _worker: PhantomData,
+            #[cfg(test)]
             worker: self,
             #[cfg(feature = "hotpath")]
             started: Instant::now(),
@@ -162,6 +167,9 @@ impl Drop for WorkerBusyGuard {
 }
 
 pub(crate) struct WorkerPoolCoordinationGuard<'a> {
+    #[cfg(not(test))]
+    _worker: PhantomData<&'a WorkerBusyGuard>,
+    #[cfg(test)]
     worker: &'a WorkerBusyGuard,
     #[cfg(feature = "hotpath")]
     started: Instant,
@@ -178,8 +186,6 @@ impl Drop for WorkerPoolCoordinationGuard<'_> {
         }
         #[cfg(test)]
         self.worker.coordinating.set(false);
-        #[cfg(not(any(feature = "hotpath", test)))]
-        let _ = self.worker;
     }
 }
 

--- a/crates/tracedecay-code-index/src/parallelism.rs
+++ b/crates/tracedecay-code-index/src/parallelism.rs
@@ -1,157 +1,509 @@
-//! Indexing parallelism: bounded race to idle with serving capacity reserved.
+//! Process-wide code-index worker policy and its dedicated Rayon pool.
 //!
-//! Indexing is a batch job with a finish line, but each concurrent parser and
-//! artifact builder retains substantially more than its source bytes. Running
-//! at every non-serving core multiplied that transient state to 90 workers on
-//! a 96-core host and forced the daemon into swap. The shared pool therefore
-//! races to idle within a memory-safe default ceiling while preserving the
-//! barrier-free pipeline. See `docs/SERVING-PATH-PERFORMANCE.md` Principle 2.
-//!
-//! Interactive latency is protected by a *reservation*, not by throttling:
-//! the indexing pool is sized to `min(total_cores - reserve, 8)`, so the
-//! daemon's request runtime always has runnable CPU and parser memory cannot
-//! scale with a large host's full logical-core count. The reserve is deliberately small
-//! (`max(2, cores/16)`) because serving work is latency-bound, not
-//! throughput-bound — a handful of cores answers reads at full speed.
-//!
-//! Everything here is sizing policy only. It never changes what is computed,
-//! so generation bytes and digests are identical at any width.
+//! Automatic sizing races small machines at full width and reserves half of a
+//! larger host for serving. A conservative per-worker resident budget then
+//! caps that CPU target. Exact profile or environment selections are never
+//! silently narrowed: an unsafe count is a typed startup refusal.
 
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::sync::{
     Mutex, OnceLock,
     atomic::{AtomicUsize, Ordering},
 };
 
-/// Floor on the serving reservation. Two cores keep the tokio request
-/// workers and the store's blocking pool runnable on any host.
-const MIN_SERVING_RESERVED_CORES: usize = 2;
+use tracedecay_domain::configuration::{
+    CodeIndexWorkerLimitingReasonV1, CodeIndexWorkerSelectionV1, CodeIndexWorkerStatusV1,
+};
+use tracedecay_runtime_core::background_cpu::{
+    BackgroundCpuInstallErrorV1, install_process_background_cpu, process_background_cpu,
+};
 
-/// Fraction of a large host handed to serving: `cores / 16` (6 of 96).
-const SERVING_RESERVE_DIVISOR: usize = 16;
-
-/// Default ceiling for concurrent parse/artifact workers. Each worker can hold
-/// source, syntax trees, extraction rows, chunks, and graph edges at once, so
-/// machine-width fan-out is a memory multiplier rather than a free speedup.
-const DEFAULT_MAX_INDEXING_WORKERS: usize = 8;
-
-/// Operator override for the indexing width, for hosts where memory rather
-/// than CPU is the binding constraint (each worker holds a tree-sitter
-/// parser). Values below 1 are ignored; the daemon's canonical CPU-thread
-/// ceiling remains an upper bound.
+/// Operator override for the indexing width. It has higher precedence than
+/// the profile setting and must be a positive `u16`.
 const INDEXING_WORKERS_ENV: &str = "TRACEDECAY_INDEX_WORKERS";
 
-/// Daemon-owned upper bound for this dedicated pool. Zero means the process is
-/// a one-shot caller and has not installed a daemon CPU budget.
-static DAEMON_WORKER_CEILING: AtomicUsize = AtomicUsize::new(0);
-/// Serializes the one-time ceiling/width decision. Reads after initialization
-/// use the atomic fast path and never take this lock.
-static PARALLELISM_CONFIGURATION_GATE: Mutex<()> = Mutex::new(());
-/// Zero means the process has not fixed its indexing width yet.
-static CONFIGURED_INDEXING_WORKERS: AtomicUsize = AtomicUsize::new(0);
+/// Conservative V1 scratch-RSS admission per active parser/artifact worker.
+///
+/// One worker may simultaneously build a tree-sitter syntax tree, extraction
+/// rows, chunks, and graph edges. The scheduler reserves `effective_workers *
+/// this value` around every production build. Source snapshot retention is
+/// measured and charged separately, so `memory_safe_workers` truthfully
+/// describes this modeled worker scratch only. Measured profiling may revise
+/// this versioned budget, but configuration must never choose it merely to
+/// reach a preferred width on one host.
+pub const INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1: u64 = 128 * 1024 * 1024;
+
+/// Memory deliberately left outside worker scratch admission for retained
+/// source snapshots and the process's other canonical resident components.
+/// The larger of this floor and 25% of currently available authority is held
+/// back before `memory_safe_workers` is derived.
+const INDEX_NON_WORKER_MEMORY_HEADROOM_BYTES_V1: u64 = 512 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DaemonWorkerCeilingInstallError {
-    PoolAlreadyInitialized { workers: usize },
-    ConflictingCeiling { existing: usize, requested: usize },
+struct CodeIndexWorkerPlanV1 {
+    configured: CodeIndexWorkerSelectionV1,
+    environment_override_workers: Option<u16>,
+    requested_workers: usize,
+    effective_workers: usize,
+    available_logical_cpus: usize,
+    memory_safe_workers: usize,
+    memory_headroom_bytes: u64,
+    limiting_reason: CodeIndexWorkerLimitingReasonV1,
+    reservation_bytes: u64,
 }
 
-impl fmt::Display for DaemonWorkerCeilingInstallError {
+impl CodeIndexWorkerPlanV1 {
+    fn status(self) -> CodeIndexWorkerStatusV1 {
+        CodeIndexWorkerStatusV1 {
+            configured: self.configured,
+            environment_override_workers: self.environment_override_workers,
+            effective_workers: saturating_u16(self.effective_workers),
+            available_logical_cpus: saturating_u16(self.available_logical_cpus),
+            memory_safe_workers: saturating_u16(self.memory_safe_workers),
+            limiting_reason: self.limiting_reason,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CodeIndexWorkerPlanErrorV1 {
+    MalformedEnvironment {
+        value: String,
+    },
+    NonUnicodeEnvironment,
+    NoMemorySafeWorker {
+        available_bytes: u64,
+    },
+    InvalidExactWorkerCount {
+        workers: u16,
+    },
+    ExplicitWidthExceedsLogicalCpus {
+        requested_workers: usize,
+        available_logical_cpus: usize,
+    },
+    ExplicitWidthExceedsMemorySafe {
+        requested_workers: usize,
+        memory_safe_workers: usize,
+    },
+}
+
+impl fmt::Display for CodeIndexWorkerPlanErrorV1 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::PoolAlreadyInitialized { workers } => write!(
+            Self::MalformedEnvironment { value } => write!(
                 formatter,
-                "indexing pool width was already initialized at {workers} workers"
+                "{INDEXING_WORKERS_ENV} must be a positive integer no greater than {}, got {value:?}",
+                u16::MAX
             ),
-            Self::ConflictingCeiling {
-                existing,
-                requested,
+            Self::NonUnicodeEnvironment => {
+                write!(formatter, "{INDEXING_WORKERS_ENV} must be valid Unicode")
+            }
+            Self::NoMemorySafeWorker { available_bytes } => write!(
+                formatter,
+                "code-index worker admission needs {INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1} scratch bytes after non-worker headroom, but only {available_bytes} total bytes are available"
+            ),
+            Self::InvalidExactWorkerCount { workers } => write!(
+                formatter,
+                "exact code-index worker count must be positive, got {workers}"
+            ),
+            Self::ExplicitWidthExceedsLogicalCpus {
+                requested_workers,
+                available_logical_cpus,
             } => write!(
                 formatter,
-                "daemon worker ceiling is already {existing}, not requested {requested}"
+                "explicit code-index width {requested_workers} exceeds the {available_logical_cpus} available logical CPUs"
+            ),
+            Self::ExplicitWidthExceedsMemorySafe {
+                requested_workers,
+                memory_safe_workers,
+            } => write!(
+                formatter,
+                "explicit code-index width {requested_workers} exceeds the memory-safe width {memory_safe_workers}"
             ),
         }
     }
 }
 
-/// Cores held back from indexing so interactive requests never wait for a
-/// free CPU. Never reserves the whole machine.
-#[must_use]
-pub fn serving_reserved_cores(total_cores: usize) -> usize {
-    let total = total_cores.max(1);
-    let reserve = MIN_SERVING_RESERVED_CORES.max(total / SERVING_RESERVE_DIVISOR);
-    reserve.min(total.saturating_sub(1))
+impl std::error::Error for CodeIndexWorkerPlanErrorV1 {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CodeIndexWorkerPlanInstallErrorV1 {
+    Invalid(CodeIndexWorkerPlanErrorV1),
+    PoolBuild {
+        message: String,
+    },
+    BackgroundCpu(BackgroundCpuInstallErrorV1),
+    ConflictingPlan {
+        existing: CodeIndexWorkerStatusV1,
+        requested: CodeIndexWorkerStatusV1,
+    },
 }
 
-/// Indexing width for a host with `total_cores` logical CPUs.
+impl fmt::Display for CodeIndexWorkerPlanInstallErrorV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(error) => error.fmt(formatter),
+            Self::PoolBuild { message } => {
+                write!(
+                    formatter,
+                    "code-index worker pool could not start: {message}"
+                )
+            }
+            Self::BackgroundCpu(error) => error.fmt(formatter),
+            Self::ConflictingPlan {
+                existing,
+                requested,
+            } => write!(
+                formatter,
+                "code-index worker plan is already installed as {existing:?}, not requested {requested:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CodeIndexWorkerPlanInstallErrorV1 {}
+
+impl From<CodeIndexWorkerPlanErrorV1> for CodeIndexWorkerPlanInstallErrorV1 {
+    fn from(error: CodeIndexWorkerPlanErrorV1) -> Self {
+        Self::Invalid(error)
+    }
+}
+
+struct InstalledCodeIndexWorkerRuntimeV1 {
+    plan: CodeIndexWorkerPlanV1,
+    pool: rayon::ThreadPool,
+}
+
+static WORKER_RUNTIME: OnceLock<InstalledCodeIndexWorkerRuntimeV1> = OnceLock::new();
+static WORKER_RUNTIME_INSTALL: Mutex<()> = Mutex::new(());
+
+/// Automatic CPU target: use every logical CPU through eight, then floor half.
 #[must_use]
 pub fn indexing_worker_target(total_cores: usize) -> usize {
     let total = total_cores.max(1);
-    total
-        .saturating_sub(serving_reserved_cores(total))
-        .clamp(1, DEFAULT_MAX_INDEXING_WORKERS)
+    if total <= 8 { total } else { total / 2 }
+}
+
+#[must_use]
+fn memory_safe_worker_count(available_bytes: u64) -> usize {
+    usize::try_from(
+        worker_memory_budget_bytes(available_bytes) / INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+    )
+    .unwrap_or(usize::MAX)
+}
+
+#[must_use]
+fn worker_memory_headroom_bytes(available_bytes: u64) -> u64 {
+    INDEX_NON_WORKER_MEMORY_HEADROOM_BYTES_V1
+        .max(available_bytes / 4)
+        .min(available_bytes)
+}
+
+#[must_use]
+fn worker_memory_budget_bytes(available_bytes: u64) -> u64 {
+    available_bytes.saturating_sub(worker_memory_headroom_bytes(available_bytes))
+}
+
+#[must_use]
+pub fn worker_reservation_bytes(workers: usize) -> u64 {
+    u64::try_from(workers)
+        .unwrap_or(u64::MAX)
+        .saturating_mul(INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1)
 }
 
 fn detected_cores() -> usize {
     std::thread::available_parallelism().map_or(1, usize::from)
 }
 
-fn honor_daemon_worker_ceiling(requested: usize, daemon_ceiling: Option<usize>) -> usize {
-    daemon_ceiling.map_or(requested, |ceiling| requested.min(ceiling.max(1)))
+fn saturating_u16(value: usize) -> u16 {
+    u16::try_from(value).unwrap_or(u16::MAX)
 }
 
-/// Installs the daemon's canonical CPU-thread ceiling before the indexing pool
-/// is first used. Repeating the same value before width initialization is
-/// idempotent; a conflicting second owner or late installation is refused.
-pub fn install_daemon_worker_ceiling(
-    threads: usize,
-) -> Result<(), DaemonWorkerCeilingInstallError> {
-    let _configuration = PARALLELISM_CONFIGURATION_GATE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let threads = threads.max(1);
-    let workers = CONFIGURED_INDEXING_WORKERS.load(Ordering::Acquire);
-    if workers != 0 {
-        return Err(DaemonWorkerCeilingInstallError::PoolAlreadyInitialized { workers });
+fn worker_plan_from(
+    configured: CodeIndexWorkerSelectionV1,
+    available_logical_cpus: usize,
+    available_memory_bytes: u64,
+    environment_override: Option<&str>,
+) -> Result<CodeIndexWorkerPlanV1, CodeIndexWorkerPlanErrorV1> {
+    let environment_override_workers = parse_environment_override(environment_override)?;
+    let available_logical_cpus = available_logical_cpus.max(1);
+    let (requested_workers, explicit, mut limiting_reason) =
+        if let Some(workers) = environment_override_workers {
+            (
+                usize::from(workers),
+                true,
+                CodeIndexWorkerLimitingReasonV1::EnvironmentOverride,
+            )
+        } else {
+            match configured {
+                CodeIndexWorkerSelectionV1::Automatic => (
+                    indexing_worker_target(available_logical_cpus),
+                    false,
+                    if available_logical_cpus <= 8 {
+                        CodeIndexWorkerLimitingReasonV1::AutomaticAllCores
+                    } else {
+                        CodeIndexWorkerLimitingReasonV1::AutomaticHalfCores
+                    },
+                ),
+                CodeIndexWorkerSelectionV1::Exact { workers } if workers > 0 => (
+                    usize::from(workers),
+                    true,
+                    CodeIndexWorkerLimitingReasonV1::ConfiguredExact,
+                ),
+                CodeIndexWorkerSelectionV1::Exact { workers } => {
+                    return Err(CodeIndexWorkerPlanErrorV1::InvalidExactWorkerCount { workers });
+                }
+            }
+        };
+    let memory_safe_workers = memory_safe_worker_count(available_memory_bytes);
+    if memory_safe_workers == 0 {
+        return Err(CodeIndexWorkerPlanErrorV1::NoMemorySafeWorker {
+            available_bytes: available_memory_bytes,
+        });
     }
-    match DAEMON_WORKER_CEILING.compare_exchange(0, threads, Ordering::AcqRel, Ordering::Acquire) {
-        Ok(_) => Ok(()),
-        Err(existing) if existing == threads => Ok(()),
-        Err(existing) => Err(DaemonWorkerCeilingInstallError::ConflictingCeiling {
-            existing,
-            requested: threads,
-        }),
+    if explicit && requested_workers > available_logical_cpus {
+        return Err(
+            CodeIndexWorkerPlanErrorV1::ExplicitWidthExceedsLogicalCpus {
+                requested_workers,
+                available_logical_cpus,
+            },
+        );
+    }
+    if explicit && requested_workers > memory_safe_workers {
+        return Err(CodeIndexWorkerPlanErrorV1::ExplicitWidthExceedsMemorySafe {
+            requested_workers,
+            memory_safe_workers,
+        });
+    }
+    let effective_workers = requested_workers.min(memory_safe_workers);
+    if effective_workers < requested_workers {
+        limiting_reason = CodeIndexWorkerLimitingReasonV1::ResidentMemory;
+    }
+    Ok(CodeIndexWorkerPlanV1 {
+        configured,
+        environment_override_workers,
+        requested_workers,
+        effective_workers,
+        available_logical_cpus,
+        memory_safe_workers,
+        memory_headroom_bytes: worker_memory_headroom_bytes(available_memory_bytes),
+        limiting_reason,
+        reservation_bytes: worker_reservation_bytes(effective_workers),
+    })
+}
+
+fn parse_environment_override(
+    environment_override: Option<&str>,
+) -> Result<Option<u16>, CodeIndexWorkerPlanErrorV1> {
+    environment_override
+        .map(|raw| {
+            raw.trim()
+                .parse::<u16>()
+                .ok()
+                .filter(|workers| *workers > 0)
+                .ok_or_else(|| CodeIndexWorkerPlanErrorV1::MalformedEnvironment {
+                    value: raw.to_owned(),
+                })
+        })
+        .transpose()
+}
+
+fn environment_override_value() -> Result<Option<String>, CodeIndexWorkerPlanErrorV1> {
+    match std::env::var(INDEXING_WORKERS_ENV) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(CodeIndexWorkerPlanErrorV1::NonUnicodeEnvironment)
+        }
     }
 }
 
-/// Host width: the operator override if set, otherwise the reservation
-/// target, then clamped to the daemon's canonical ceiling when installed.
-/// Fixed for the life of the process; this is what the pool is built at.
-fn configured_indexing_workers() -> usize {
-    let configured = CONFIGURED_INDEXING_WORKERS.load(Ordering::Acquire);
-    if configured != 0 {
-        return configured;
+/// Preview the worker status without constructing a pool or installing any
+/// process authority. `available_memory_bytes` must come from the caller's
+/// canonical resident-memory authority (`limit - used`), never a second
+/// estimator. Environment precedence and every typed refusal are identical to
+/// [`install_worker_plan`].
+pub fn preview_worker_plan(
+    configured: CodeIndexWorkerSelectionV1,
+    available_memory_bytes: u64,
+) -> Result<CodeIndexWorkerStatusV1, CodeIndexWorkerPlanErrorV1> {
+    let environment_override = environment_override_value()?;
+    preview_worker_plan_from(
+        configured,
+        detected_cores(),
+        available_memory_bytes,
+        environment_override.as_deref(),
+    )
+}
+
+fn preview_worker_plan_from(
+    configured: CodeIndexWorkerSelectionV1,
+    available_logical_cpus: usize,
+    available_memory_bytes: u64,
+    environment_override: Option<&str>,
+) -> Result<CodeIndexWorkerStatusV1, CodeIndexWorkerPlanErrorV1> {
+    worker_plan_from(
+        configured,
+        available_logical_cpus,
+        available_memory_bytes,
+        environment_override,
+    )
+    .map(CodeIndexWorkerPlanV1::status)
+}
+
+fn compare_installed_plan(
+    existing: &CodeIndexWorkerPlanV1,
+    requested: &CodeIndexWorkerPlanV1,
+) -> Result<(), CodeIndexWorkerPlanInstallErrorV1> {
+    if existing == requested {
+        Ok(())
+    } else {
+        Err(CodeIndexWorkerPlanInstallErrorV1::ConflictingPlan {
+            existing: existing.status(),
+            requested: requested.status(),
+        })
     }
-    let _configuration = PARALLELISM_CONFIGURATION_GATE
+}
+
+fn record_plan(plan: CodeIndexWorkerPlanV1) {
+    hotpath::gauge!("code_index_workers_requested").set(plan.requested_workers);
+    hotpath::gauge!("code_index_workers_effective").set(plan.effective_workers);
+    hotpath::gauge!("code_index_workers_memory_safe").set(plan.memory_safe_workers);
+    hotpath::gauge!("code_index_workers_memory_headroom_bytes")
+        .set(plan.memory_headroom_bytes as f64);
+    hotpath::gauge!("code_index_workers_limiting_reason").set(match plan.limiting_reason {
+        CodeIndexWorkerLimitingReasonV1::AutomaticAllCores => 1,
+        CodeIndexWorkerLimitingReasonV1::AutomaticHalfCores => 2,
+        CodeIndexWorkerLimitingReasonV1::ResidentMemory => 3,
+        CodeIndexWorkerLimitingReasonV1::ConfiguredExact => 4,
+        CodeIndexWorkerLimitingReasonV1::EnvironmentOverride => 5,
+    });
+    hotpath::gauge!("code_index_workers_reservation_bytes").set(plan.reservation_bytes as f64);
+}
+
+/// Install the process-resident plan before the first code-index build.
+/// Repeating the byte-identical plan is idempotent; a second owner asking for
+/// a different process-wide pool is refused.
+pub fn install_worker_plan(
+    configured: CodeIndexWorkerSelectionV1,
+    available_memory_bytes: u64,
+) -> Result<CodeIndexWorkerStatusV1, CodeIndexWorkerPlanInstallErrorV1> {
+    // Planning and pool construction are one initialization transaction. This
+    // prevents concurrent registrars from constructing duplicate large pools
+    // from different instantaneous memory snapshots before the OnceLock wins.
+    let _installation = WORKER_RUNTIME_INSTALL
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let configured = CONFIGURED_INDEXING_WORKERS.load(Ordering::Acquire);
-    if configured != 0 {
-        return configured;
+    let environment_override = environment_override_value()?;
+    let environment_override_workers = parse_environment_override(environment_override.as_deref())?;
+    if let Some(installed) = WORKER_RUNTIME.get()
+        && installed.plan.configured == configured
+        && installed.plan.environment_override_workers == environment_override_workers
+    {
+        record_plan(installed.plan);
+        return Ok(installed.plan.status());
     }
-    let requested = std::env::var(INDEXING_WORKERS_ENV)
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|workers| *workers >= 1)
-        .unwrap_or_else(|| indexing_worker_target(detected_cores()));
-    let daemon_ceiling = match DAEMON_WORKER_CEILING.load(Ordering::Acquire) {
-        0 => None,
-        ceiling => Some(ceiling),
-    };
-    let configured = honor_daemon_worker_ceiling(requested, daemon_ceiling);
-    CONFIGURED_INDEXING_WORKERS.store(configured, Ordering::Release);
-    configured
+    let requested = worker_plan_from(
+        configured,
+        detected_cores(),
+        available_memory_bytes,
+        environment_override.as_deref(),
+    )?;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(requested.effective_workers)
+        .thread_name(|index| format!("tracedecay-index-{index}"))
+        .build()
+        .map_err(|error| CodeIndexWorkerPlanInstallErrorV1::PoolBuild {
+            message: error.to_string(),
+        })?;
+    install_process_background_cpu(
+        NonZeroUsize::new(requested.effective_workers).unwrap_or(NonZeroUsize::MIN),
+    )
+    .map_err(CodeIndexWorkerPlanInstallErrorV1::BackgroundCpu)?;
+    match WORKER_RUNTIME.set(InstalledCodeIndexWorkerRuntimeV1 {
+        plan: requested,
+        pool,
+    }) {
+        Ok(()) => {
+            record_plan(requested);
+            Ok(requested.status())
+        }
+        Err(_) => {
+            let Some(existing) = WORKER_RUNTIME.get() else {
+                return Err(CodeIndexWorkerPlanInstallErrorV1::PoolBuild {
+                    message: "worker runtime installation did not settle".to_owned(),
+                });
+            };
+            compare_installed_plan(&existing.plan, &requested)?;
+            record_plan(existing.plan);
+            Ok(existing.plan.status())
+        }
+    }
 }
+
+/// Canonical runtime status for configuration/dashboard projection.
+#[must_use]
+pub fn installed_worker_status() -> Option<CodeIndexWorkerStatusV1> {
+    WORKER_RUNTIME.get().map(|runtime| runtime.plan.status())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CodeIndexParallelismErrorV1 {
+    PoolBuild {
+        message: String,
+    },
+    BackgroundCpuNotInstalled,
+    /// A per-item unit fanned out on the indexing pool panicked. Per-file work
+    /// runs over arbitrary user source, so a malformed input must be contained
+    /// to its own unit and named, never allowed to unwind out of the pool and
+    /// take an entire generation with it.
+    WorkerPanic {
+        index: usize,
+        message: String,
+    },
+}
+
+impl CodeIndexParallelismErrorV1 {
+    /// Recover the panic message from a caught unwind payload, falling back to
+    /// a stable label when the payload is not a string.
+    #[must_use]
+    pub fn from_panic_payload(index: usize, payload: &(dyn std::any::Any + Send)) -> Self {
+        let message = payload
+            .downcast_ref::<&'static str>()
+            .map(|text| (*text).to_owned())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "non-string panic payload".to_owned());
+        Self::WorkerPanic { index, message }
+    }
+}
+
+impl fmt::Display for CodeIndexParallelismErrorV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PoolBuild { message } => {
+                write!(
+                    formatter,
+                    "code-index worker pool is unavailable: {message}"
+                )
+            }
+            Self::BackgroundCpuNotInstalled => {
+                write!(
+                    formatter,
+                    "process background CPU authority is not installed"
+                )
+            }
+            Self::WorkerPanic { index, message } => {
+                write!(
+                    formatter,
+                    "code-index worker unit {index} panicked: {message}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CodeIndexParallelismErrorV1 {}
 
 /// 0 means "use the configured host width".
 static FORCED_WORKERS: AtomicUsize = AtomicUsize::new(0);
@@ -161,7 +513,10 @@ static FORCED_WORKERS: AtomicUsize = AtomicUsize::new(0);
 #[must_use]
 pub fn indexing_workers() -> usize {
     match FORCED_WORKERS.load(Ordering::Relaxed) {
-        0 => configured_indexing_workers(),
+        0 => WORKER_RUNTIME.get().map_or_else(
+            || indexing_worker_target(detected_cores()),
+            |runtime| runtime.plan.effective_workers,
+        ),
         forced => forced,
     }
 }
@@ -184,96 +539,265 @@ pub fn clear_forced_indexing_workers_for_test() {
     FORCED_WORKERS.store(0, Ordering::Relaxed);
 }
 
-/// The process-wide indexing pool. Always built, even at width 1: the pool
-/// is what CONFINES indexing to its reservation. Without it, the nested
-/// chunk-level `par_iter` sweeps would land on rayon's global pool, which is
-/// sized to every logical CPU — the reservation would leak exactly where the
-/// work is heaviest.
-fn indexing_pool() -> Option<&'static rayon::ThreadPool> {
-    static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
-    POOL.get_or_init(|| {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(configured_indexing_workers())
-            .thread_name(|index| format!("tracedecay-index-{index}"))
-            .build()
-            .ok()
-    })
-    .as_ref()
+/// Run one active work unit under the process background CPU authority.
+/// Standalone callers without an installed daemon plan run directly.
+pub fn with_background_cpu_permits<R>(requested_units: usize, operation: impl FnOnce() -> R) -> R {
+    if let Some(authority) = process_background_cpu() {
+        return authority.with_permits(requested_units, operation);
+    }
+    operation()
 }
 
-/// Run `operation` on the reserved-width indexing pool.
+/// One-unit convenience for ordinary index/session preparation work.
+pub fn with_background_cpu_permit<R>(operation: impl FnOnce() -> R) -> R {
+    with_background_cpu_permits(1, operation)
+}
+
+/// Run `operation` on the configured indexing pool.
 ///
-/// Nested calls (chunking fanning out inside a per-file extraction) stay on
-/// the same pool, so the reservation holds for the whole pipeline rather than
-/// being multiplied by pipeline depth. Falls back to running inline only if
-/// the pool could not be built at all.
+/// CPU admission happens inside each active parallel work unit through
+/// [`with_background_cpu_permit`] or [`with_background_cpu_permits`], allowing
+/// indexing, semantic inference, and session preparation to share idle width.
+/// A standalone caller without registration gets a scoped automatic pool.
 #[hotpath::measure]
-pub fn install<R, F>(operation: F) -> R
+pub fn install<R, F>(operation: F) -> Result<R, CodeIndexParallelismErrorV1>
 where
     F: FnOnce() -> R + Send,
     R: Send,
 {
     hotpath::gauge!("code_index_worker_count").set(indexing_workers());
-    match indexing_pool() {
-        Some(pool) => pool.install(operation),
-        None => operation(),
+    if let Some(runtime) = WORKER_RUNTIME.get() {
+        let authority = process_background_cpu()
+            .ok_or(CodeIndexParallelismErrorV1::BackgroundCpuNotInstalled)?;
+        return Ok(authority.with_yielded_permits(|| runtime.pool.install(operation)));
     }
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(indexing_worker_target(detected_cores()))
+        .thread_name(|index| format!("tracedecay-index-standalone-{index}"))
+        .build()
+        .map_err(|error| CodeIndexParallelismErrorV1::PoolBuild {
+            message: error.to_string(),
+        })?;
+    Ok(pool.install(operation))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracedecay_domain::configuration::CodeIndexWorkerSelectionV1;
 
     #[test]
-    fn reservation_scales_with_the_host_but_never_takes_it_all() {
-        assert_eq!(serving_reserved_cores(1), 0);
-        assert_eq!(serving_reserved_cores(2), 1);
-        assert_eq!(serving_reserved_cores(4), 2);
-        assert_eq!(serving_reserved_cores(16), 2);
-        assert_eq!(serving_reserved_cores(96), 6);
-        assert_eq!(serving_reserved_cores(128), 8);
-    }
-
-    #[test]
-    fn indexing_stays_within_the_default_memory_safe_width() {
+    fn automatic_width_uses_small_hosts_and_half_of_large_hosts() {
         assert_eq!(indexing_worker_target(1), 1);
-        assert_eq!(indexing_worker_target(2), 1);
-        assert_eq!(indexing_worker_target(4), 2);
-        assert_eq!(indexing_worker_target(16), 8);
-        assert_eq!(indexing_worker_target(96), 8);
-        assert_eq!(indexing_worker_target(128), 8);
+        assert_eq!(indexing_worker_target(4), 4);
+        assert_eq!(indexing_worker_target(8), 8);
+        assert_eq!(indexing_worker_target(20), 10);
+        assert_eq!(indexing_worker_target(128), 64);
     }
 
     #[test]
-    fn daemon_ceiling_clamps_requested_width() {
-        assert_eq!(honor_daemon_worker_ceiling(8, None), 8);
-        assert_eq!(honor_daemon_worker_ceiling(90, Some(16)), 16);
-        assert_eq!(honor_daemon_worker_ceiling(8, Some(16)), 8);
-        assert_eq!(honor_daemon_worker_ceiling(8, Some(4)), 4);
+    fn exact_selection_uses_the_configured_core_count() {
+        let plan = worker_plan_from(
+            CodeIndexWorkerSelectionV1::Exact { workers: 7 },
+            8,
+            32 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+            None,
+        )
+        .expect("exact selection");
+
+        assert_eq!(plan.requested_workers, 7);
+        assert_eq!(plan.effective_workers, 7);
+        assert_eq!(
+            plan.limiting_reason,
+            CodeIndexWorkerLimitingReasonV1::ConfiguredExact
+        );
     }
 
     #[test]
-    fn every_host_keeps_at_least_one_indexing_worker_and_one_reserved_core() {
-        for cores in 1..=512usize {
-            let workers = indexing_worker_target(cores);
-            assert!(workers >= 1, "cores={cores} left no indexing worker");
-            assert!(workers <= cores, "cores={cores} oversubscribed");
-            assert!(
-                workers <= DEFAULT_MAX_INDEXING_WORKERS,
-                "cores={cores} exceeded the default memory-safe width"
-            );
-            if cores > 1 {
-                assert!(
-                    serving_reserved_cores(cores) >= 1,
-                    "cores={cores} reserved nothing for serving"
-                );
+    fn exact_selection_cannot_oversubscribe_logical_cpus() {
+        assert_eq!(
+            worker_plan_from(
+                CodeIndexWorkerSelectionV1::Exact { workers: 17 },
+                8,
+                32 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+                None,
+            ),
+            Err(
+                CodeIndexWorkerPlanErrorV1::ExplicitWidthExceedsLogicalCpus {
+                    requested_workers: 17,
+                    available_logical_cpus: 8,
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn zero_exact_selection_is_a_typed_refusal() {
+        assert_eq!(
+            worker_plan_from(
+                CodeIndexWorkerSelectionV1::Exact { workers: 0 },
+                8,
+                8 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+                None,
+            ),
+            Err(CodeIndexWorkerPlanErrorV1::InvalidExactWorkerCount { workers: 0 })
+        );
+    }
+
+    #[test]
+    fn environment_override_has_highest_precedence() {
+        let plan = worker_plan_from(
+            CodeIndexWorkerSelectionV1::Exact { workers: 3 },
+            128,
+            64 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+            Some("11"),
+        )
+        .expect("environment override");
+
+        assert_eq!(plan.requested_workers, 11);
+        assert_eq!(plan.effective_workers, 11);
+        assert_eq!(plan.environment_override_workers, Some(11));
+        assert_eq!(
+            plan.limiting_reason,
+            CodeIndexWorkerLimitingReasonV1::EnvironmentOverride
+        );
+    }
+
+    #[test]
+    fn malformed_environment_override_is_a_typed_refusal() {
+        assert!(matches!(
+            worker_plan_from(
+                CodeIndexWorkerSelectionV1::Automatic,
+                8,
+                8 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+                Some("many"),
+            ),
+            Err(CodeIndexWorkerPlanErrorV1::MalformedEnvironment { .. })
+        ));
+        assert!(matches!(
+            worker_plan_from(
+                CodeIndexWorkerSelectionV1::Automatic,
+                8,
+                8 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+                Some("0"),
+            ),
+            Err(CodeIndexWorkerPlanErrorV1::MalformedEnvironment { .. })
+        ));
+    }
+
+    #[test]
+    fn automatic_width_is_capped_by_the_resident_budget() {
+        let plan = worker_plan_from(
+            CodeIndexWorkerSelectionV1::Automatic,
+            128,
+            12 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+            None,
+        )
+        .expect("memory-capped automatic selection");
+
+        assert_eq!(plan.requested_workers, 64);
+        assert_eq!(plan.memory_safe_workers, 8);
+        assert_eq!(plan.effective_workers, 8);
+        assert_eq!(
+            plan.limiting_reason,
+            CodeIndexWorkerLimitingReasonV1::ResidentMemory
+        );
+    }
+
+    #[test]
+    fn default_authority_preserves_source_and_component_headroom() {
+        let available = 6 * 1024 * 1024 * 1024;
+        let plan = worker_plan_from(CodeIndexWorkerSelectionV1::Automatic, 96, available, None)
+            .expect("default-memory automatic selection");
+
+        assert_eq!(plan.requested_workers, 48);
+        assert_eq!(plan.memory_safe_workers, 36);
+        assert_eq!(plan.effective_workers, 36);
+        assert_eq!(plan.memory_headroom_bytes, 1536 * 1024 * 1024);
+        assert_eq!(
+            plan.reservation_bytes + plan.memory_headroom_bytes,
+            available
+        );
+    }
+
+    #[test]
+    fn explicit_width_above_the_resident_budget_is_refused() {
+        let error = worker_plan_from(
+            CodeIndexWorkerSelectionV1::Exact { workers: 9 },
+            128,
+            12 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+            None,
+        )
+        .expect_err("unsafe exact width must be refused");
+
+        assert_eq!(
+            error,
+            CodeIndexWorkerPlanErrorV1::ExplicitWidthExceedsMemorySafe {
+                requested_workers: 9,
+                memory_safe_workers: 8,
             }
-        }
+        );
     }
 
     #[test]
-    fn install_runs_the_operation_exactly_once() {
-        let value = install(|| 7_usize);
-        assert_eq!(value, 7);
+    fn worker_reservation_scales_linearly_with_the_documented_rss_budget() {
+        assert_eq!(
+            worker_reservation_bytes(1),
+            INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1
+        );
+        assert_eq!(
+            worker_reservation_bytes(16),
+            16 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1
+        );
+        assert_eq!(memory_safe_worker_count(6 * 1024 * 1024 * 1024), 36);
+        assert_eq!(
+            worker_memory_headroom_bytes(6 * 1024 * 1024 * 1024),
+            1536 * 1024 * 1024
+        );
+        assert_eq!(
+            worker_memory_budget_bytes(6 * 1024 * 1024 * 1024)
+                + worker_memory_headroom_bytes(6 * 1024 * 1024 * 1024),
+            6 * 1024 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn plan_identity_accepts_repetition_and_refuses_conflict() {
+        let plan = worker_plan_from(
+            CodeIndexWorkerSelectionV1::Automatic,
+            20,
+            20 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+            None,
+        )
+        .expect("automatic plan");
+
+        assert_eq!(compare_installed_plan(&plan, &plan), Ok(()));
+        let conflicting = worker_plan_from(
+            CodeIndexWorkerSelectionV1::Exact { workers: 4 },
+            20,
+            20 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1,
+            None,
+        )
+        .expect("exact plan");
+        assert!(matches!(
+            compare_installed_plan(&plan, &conflicting),
+            Err(CodeIndexWorkerPlanInstallErrorV1::ConflictingPlan { .. })
+        ));
+    }
+
+    #[test]
+    fn preview_matches_install_derivation_without_installing_runtime() {
+        let runtime_before = installed_worker_status();
+        let available = 20 * INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1;
+        let preview =
+            preview_worker_plan_from(CodeIndexWorkerSelectionV1::Automatic, 20, available, None)
+                .expect("worker-plan preview");
+        let installation_derivation =
+            worker_plan_from(CodeIndexWorkerSelectionV1::Automatic, 20, available, None)
+                .expect("worker-plan installation derivation")
+                .status();
+
+        assert_eq!(preview, installation_derivation);
+        assert_eq!(installed_worker_status(), runtime_before);
     }
 }

--- a/crates/tracedecay-code-index/src/production/mod.rs
+++ b/crates/tracedecay-code-index/src/production/mod.rs
@@ -288,12 +288,19 @@ const MAX_PHYSICAL_CODE_ARTIFACTS: usize = 1_024;
 /// tradeoff for having no barrier. Cancellation still short-circuits, because
 /// every per-file closure checkpoints the execution control first and
 /// returns immediately once the reconcile is cancelled.
+///
+/// Per-unit work parses arbitrary user source, so a panic in one unit is
+/// contained here and converted into that unit's typed
+/// [`crate::parallelism::CodeIndexParallelismErrorV1::WorkerPanic`]. Letting
+/// it unwind out of the pool instead aborted the whole fan-out and surfaced in
+/// the daemon only as an opaque `JoinError`, so a single malformed file took
+/// down every other file's work in the same generation.
 #[hotpath::measure]
 fn collect_bounded_ordered<T, R, E, F>(items: &[T], operation: F) -> Result<Vec<R>, E>
 where
     T: Sync,
     R: Send,
-    E: Send,
+    E: From<crate::parallelism::CodeIndexParallelismErrorV1> + Send,
     F: Fn(&T, &crate::hotpath_observe::WorkerBusyGuard) -> Result<R, E> + Sync,
 {
     let queue = crate::hotpath_observe::PendingWorkQueue::new(items.len());
@@ -302,16 +309,32 @@ where
     // what keeps the nested chunk-level fan-out inside the reservation
     // instead of spilling onto rayon's global (all-cores) pool.
     crate::parallelism::install(|| {
-        let run = |item| {
-            let worker = queue.start_worker();
-            operation(item, &worker)
+        let run = |(index, item): (usize, &T)| -> Result<R, E> {
+            crate::parallelism::with_background_cpu_permit(|| {
+                let worker = queue.start_worker();
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| operation(item, &worker)))
+                    .unwrap_or_else(|payload| {
+                        Err(E::from(
+                            crate::parallelism::CodeIndexParallelismErrorV1::from_panic_payload(
+                                index, &*payload,
+                            ),
+                        ))
+                    })
+            })
         };
         if items.len() < 2 || crate::parallelism::indexing_workers() < 2 {
-            return items.iter().map(&run).collect();
+            return items.iter().enumerate().map(&run).collect();
         }
-        let results: Vec<Result<R, E>> = items.par_iter().map(&run).collect::<Vec<Result<R, E>>>();
+        // Collecting every unit's result before short-circuiting keeps the
+        // reported failure the lowest-index one, panic or not.
+        let results: Vec<Result<R, E>> = items
+            .par_iter()
+            .enumerate()
+            .map(&run)
+            .collect::<Vec<Result<R, E>>>();
         results.into_iter().collect()
     })
+    .map_err(E::from)?
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -1108,6 +1131,8 @@ pub enum CodeIndexProductionErrorV1 {
     Publication(#[from] CodeIndexPublicationStoreErrorV1),
     #[error("code-index contract failed: {0}")]
     Contract(String),
+    #[error("code-index parallel worker runtime failed: {0}")]
+    Parallelism(#[from] crate::parallelism::CodeIndexParallelismErrorV1),
 }
 
 /// Production owner for one repository and one atomic publication authority.

--- a/crates/tracedecay-code-index/src/production/worker_tests.rs
+++ b/crates/tracedecay-code-index/src/production/worker_tests.rs
@@ -3,6 +3,18 @@ use std::sync::{Arc, Mutex};
 
 use super::*;
 
+#[derive(Debug, PartialEq, Eq)]
+enum WorkerTestError {
+    Mapping(usize),
+    Parallelism(crate::parallelism::CodeIndexParallelismErrorV1),
+}
+
+impl From<crate::parallelism::CodeIndexParallelismErrorV1> for WorkerTestError {
+    fn from(error: crate::parallelism::CodeIndexParallelismErrorV1) -> Self {
+        Self::Parallelism(error)
+    }
+}
+
 #[test]
 fn cloned_arc_lookup_releases_the_mutex_before_downstream_work() {
     let state = Mutex::new(Some(Arc::new(7_u8)));
@@ -37,8 +49,9 @@ fn prior_sealed_generation_is_rejected_before_manifest_decode() {
 fn parallel_collection_preserves_input_order() {
     let items = (0..1_024_usize).collect::<Vec<_>>();
 
-    let values = collect_bounded_ordered(&items, |item, _worker| Ok::<_, ()>(*item * 2))
-        .expect("infallible mapping");
+    let values =
+        collect_bounded_ordered(&items, |item, _worker| Ok::<_, WorkerTestError>(*item * 2))
+            .expect("infallible mapping");
 
     assert_eq!(values.len(), items.len());
     assert!(
@@ -58,7 +71,7 @@ fn parallel_collection_returns_the_lowest_index_failure() {
     let error = collect_bounded_ordered(&items, |item, _worker| {
         visited.fetch_add(1, Ordering::Relaxed);
         if *item == 2 || *item == 200 {
-            Err(*item)
+            Err(WorkerTestError::Mapping(*item))
         } else {
             Ok(*item)
         }
@@ -66,7 +79,8 @@ fn parallel_collection_returns_the_lowest_index_failure() {
     .expect_err("the mapping fails");
 
     assert_eq!(
-        error, 2,
+        error,
+        WorkerTestError::Mapping(2),
         "the reported failure must be the sequential one, not the first to finish"
     );
     assert!(visited.load(Ordering::Relaxed) > 0);
@@ -75,16 +89,74 @@ fn parallel_collection_returns_the_lowest_index_failure() {
 #[test]
 fn parallel_and_sequential_collection_agree() {
     let items = (0..2_048_usize).collect::<Vec<_>>();
-    let sequential_operation = |item: &usize| Ok::<_, ()>(item.wrapping_mul(2_654_435_761));
+    let sequential_operation =
+        |item: &usize| Ok::<_, WorkerTestError>(item.wrapping_mul(2_654_435_761));
     let parallel_operation = |item: &usize, _worker: &crate::hotpath_observe::WorkerBusyGuard| {
-        Ok::<_, ()>(item.wrapping_mul(2_654_435_761))
+        Ok::<_, WorkerTestError>(item.wrapping_mul(2_654_435_761))
     };
 
     let sequential = items
         .iter()
         .map(sequential_operation)
-        .collect::<Result<Vec<_>, ()>>();
+        .collect::<Result<Vec<_>, WorkerTestError>>();
     let parallel = collect_bounded_ordered(&items, parallel_operation);
 
     assert_eq!(sequential, parallel);
+}
+
+/// One malformed source file must not take the whole generation down with it.
+/// A panicking per-file unit is contained and reported as that unit's typed
+/// failure; every other file still runs to completion.
+#[test]
+fn parallel_collection_contains_a_panicking_unit_without_poisoning_the_rest() {
+    let completed = AtomicUsize::new(0);
+    let items = (0..256_usize).collect::<Vec<_>>();
+
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let outcome = collect_bounded_ordered(&items, |item, _worker| {
+        assert_ne!(*item, 200, "synthetic per-file panic");
+        completed.fetch_add(1, Ordering::Relaxed);
+        Ok::<_, WorkerTestError>(*item)
+    });
+    std::panic::set_hook(previous_hook);
+
+    let error = outcome.expect_err("a panicking unit must surface as a failure");
+    assert_eq!(
+        error,
+        WorkerTestError::Parallelism(
+            crate::parallelism::CodeIndexParallelismErrorV1::WorkerPanic {
+                index: 200,
+                message: "synthetic per-file panic".to_owned(),
+            }
+        ),
+        "the panic must be reported as that unit's typed failure"
+    );
+    assert_eq!(
+        completed.load(Ordering::Relaxed),
+        items.len() - 1,
+        "every non-panicking unit must still complete"
+    );
+}
+
+/// A panic in a later unit must not mask an ordinary failure in an earlier
+/// one: reported failure stays the lowest-index one, panic or not.
+#[test]
+fn parallel_collection_reports_the_lowest_index_failure_across_panics() {
+    let items = (0..256_usize).collect::<Vec<_>>();
+
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let error = collect_bounded_ordered(&items, |item, _worker| {
+        assert_ne!(*item, 200, "synthetic per-file panic");
+        if *item == 2 {
+            Err(WorkerTestError::Mapping(*item))
+        } else {
+            Ok(*item)
+        }
+    })
+    .expect_err("the mapping fails");
+    std::panic::set_hook(previous_hook);
+
+    assert_eq!(error, WorkerTestError::Mapping(2));
 }

--- a/crates/tracedecay-runtime-core/src/background_cpu.rs
+++ b/crates/tracedecay-runtime-core/src/background_cpu.rs
@@ -1,0 +1,461 @@
+//! Process-wide weighted admission for background CPU work.
+//!
+//! The authority counts active CPU units rather than owning an executor. Code
+//! indexing, semantic native threads, and session preparation can therefore
+//! use their existing execution substrates while sharing one hard process
+//! ceiling. FIFO waiter order prevents a continuously busy class from starving
+//! another class, and RAII releases capacity on success, cancellation, or
+//! unwind.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+#[derive(Debug)]
+struct BackgroundCpuWaiterV1 {
+    units: usize,
+}
+
+#[derive(Default)]
+struct BackgroundCpuStateV1 {
+    active_units: usize,
+    waiters: VecDeque<Arc<BackgroundCpuWaiterV1>>,
+}
+
+/// One process-wide background CPU budget shared across subsystems.
+pub struct ProcessBackgroundCpuV1 {
+    width: NonZeroUsize,
+    state: Mutex<BackgroundCpuStateV1>,
+    available: Condvar,
+}
+
+impl fmt::Debug for ProcessBackgroundCpuV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessBackgroundCpuV1")
+            .field("width", &self.width)
+            .field("active_units", &self.active_units())
+            .finish_non_exhaustive()
+    }
+}
+
+thread_local! {
+    static BACKGROUND_CPU_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static BACKGROUND_CPU_UNITS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct BackgroundCpuScopeV1;
+
+impl BackgroundCpuScopeV1 {
+    fn enter() -> Self {
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+struct YieldedBackgroundCpuV1<'a> {
+    authority: &'a Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+    depth: usize,
+}
+
+impl Drop for YieldedBackgroundCpuV1<'_> {
+    fn drop(&mut self) {
+        self.authority.admit_units(self.units);
+        BACKGROUND_CPU_UNITS.with(|units| units.set(self.units));
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(self.depth));
+    }
+}
+
+impl Drop for BackgroundCpuScopeV1 {
+    fn drop(&mut self) {
+        BACKGROUND_CPU_DEPTH.with(|depth| {
+            let remaining = depth.get().saturating_sub(1);
+            depth.set(remaining);
+            if remaining == 0 {
+                BACKGROUND_CPU_UNITS.with(|units| units.set(0));
+            }
+        });
+    }
+}
+
+impl ProcessBackgroundCpuV1 {
+    fn new(width: NonZeroUsize) -> Self {
+        Self {
+            width,
+            state: Mutex::new(BackgroundCpuStateV1::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> NonZeroUsize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn active_units(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_units
+    }
+
+    #[must_use]
+    pub fn waiting_work_units(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        waiting_units(&state)
+    }
+
+    /// Acquire one CPU unit, waiting in FIFO order when the process budget is
+    /// full. The returned guard must remain alive for the active work unit.
+    pub fn acquire(self: &Arc<Self>) -> BackgroundCpuPermitV1 {
+        self.acquire_units(1)
+    }
+
+    /// Acquire one CPU unit only when no earlier waiter exists and capacity is
+    /// immediately available.
+    pub fn try_acquire(self: &Arc<Self>) -> Option<BackgroundCpuPermitV1> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.waiters.is_empty() || state.active_units >= self.width.get() {
+            return None;
+        }
+        state.active_units += 1;
+        record_state(&state, self.width);
+        Some(BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units: 1,
+        })
+    }
+
+    /// Run one active work unit under the process budget. Nested work on the
+    /// same thread reuses a sufficient parent admission instead of waiting on
+    /// itself.
+    pub fn with_permit<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        self.with_permits(1, operation)
+    }
+
+    /// Run a weighted work unit, clamped to the entire process width. Semantic
+    /// inference uses its native intra-op thread count as the weight; ordinary
+    /// index/session preparation uses one.
+    pub fn with_permits<R>(
+        self: &Arc<Self>,
+        requested_units: usize,
+        operation: impl FnOnce() -> R,
+    ) -> R {
+        let units = requested_units.max(1).min(self.width.get());
+        let active_units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if active_units >= units {
+            return operation();
+        }
+        if active_units > 0 {
+            let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+            self.release(active_units);
+            BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+            BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+            let _restore = YieldedBackgroundCpuV1 {
+                authority: self,
+                units: active_units,
+                depth,
+            };
+            let _permit = self.acquire_units(units);
+            let _scope = BackgroundCpuScopeV1::enter();
+            BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+            return operation();
+        }
+        let _permit = self.acquire_units(units);
+        let _scope = BackgroundCpuScopeV1::enter();
+        BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+        operation()
+    }
+
+    /// Temporarily yield the caller's active units while a nested executor
+    /// fans out independently admitted leaf work. This prevents a parent
+    /// Rayon worker from holding capacity while it waits for child workers,
+    /// including a full-width weighted child. Capacity is reacquired before
+    /// the parent resumes, including during unwind.
+    pub fn with_yielded_permits<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        let units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if units == 0 {
+            return operation();
+        }
+        let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+        self.release(units);
+        BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+        BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+        let _restore = YieldedBackgroundCpuV1 {
+            authority: self,
+            units,
+            depth,
+        };
+        operation()
+    }
+
+    fn acquire_units(self: &Arc<Self>, units: usize) -> BackgroundCpuPermitV1 {
+        self.admit_units(units);
+        BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units,
+        }
+    }
+
+    fn admit_units(&self, units: usize) {
+        let waiter = Arc::new(BackgroundCpuWaiterV1 { units });
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiters.push_back(Arc::clone(&waiter));
+        record_state(&state, self.width);
+        loop {
+            let is_front = state
+                .waiters
+                .front()
+                .is_some_and(|front| Arc::ptr_eq(front, &waiter));
+            if is_front && state.active_units.saturating_add(waiter.units) <= self.width.get() {
+                state.waiters.pop_front();
+                state.active_units += waiter.units;
+                record_state(&state, self.width);
+                self.available.notify_all();
+                return;
+            }
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn release(&self, units: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(state.active_units >= units);
+        state.active_units = state.active_units.saturating_sub(units);
+        record_state(&state, self.width);
+        self.available.notify_all();
+    }
+}
+
+fn record_state(state: &BackgroundCpuStateV1, width: NonZeroUsize) {
+    hotpath::gauge!("runtime_core.background_cpu.width").set(width.get());
+    hotpath::gauge!("runtime_core.background_cpu.active_units").set(state.active_units);
+    hotpath::gauge!("runtime_core.background_cpu.waiting_work_units").set(waiting_units(state));
+}
+
+fn waiting_units(state: &BackgroundCpuStateV1) -> usize {
+    state
+        .waiters
+        .iter()
+        .fold(0usize, |total, waiter| total.saturating_add(waiter.units))
+}
+
+/// RAII ownership of active CPU capacity. Dropping it is cancellation-safe and
+/// releases the exact acquired weight.
+pub struct BackgroundCpuPermitV1 {
+    authority: Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+}
+
+impl fmt::Debug for BackgroundCpuPermitV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackgroundCpuPermitV1")
+            .field("units", &self.units)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for BackgroundCpuPermitV1 {
+    fn drop(&mut self) {
+        self.authority.release(self.units);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BackgroundCpuInstallErrorV1 {
+    #[error(
+        "background CPU authority is already installed at width {installed_width}, not requested width {requested_width}"
+    )]
+    ConflictingWidth {
+        installed_width: usize,
+        requested_width: usize,
+    },
+    #[error("background CPU authority installation did not settle")]
+    InstallationDidNotSettle,
+}
+
+static PROCESS_BACKGROUND_CPU: OnceLock<Arc<ProcessBackgroundCpuV1>> = OnceLock::new();
+
+/// Install or idempotently reuse the one process background CPU authority.
+pub fn install_process_background_cpu(
+    width: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if let Some(installed) = PROCESS_BACKGROUND_CPU.get() {
+        return compare_installed_width(installed, width);
+    }
+    let requested = Arc::new(ProcessBackgroundCpuV1::new(width));
+    match PROCESS_BACKGROUND_CPU.set(Arc::clone(&requested)) {
+        Ok(()) => Ok(requested),
+        Err(_) => PROCESS_BACKGROUND_CPU.get().map_or_else(
+            || Err(BackgroundCpuInstallErrorV1::InstallationDidNotSettle),
+            |installed| compare_installed_width(installed, width),
+        ),
+    }
+}
+
+fn compare_installed_width(
+    installed: &Arc<ProcessBackgroundCpuV1>,
+    requested: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if installed.width == requested {
+        Ok(Arc::clone(installed))
+    } else {
+        Err(BackgroundCpuInstallErrorV1::ConflictingWidth {
+            installed_width: installed.width.get(),
+            requested_width: requested.get(),
+        })
+    }
+}
+
+/// Installed process authority, or `None` before daemon worker-plan admission.
+#[must_use]
+pub fn process_background_cpu() -> Option<Arc<ProcessBackgroundCpuV1>> {
+    PROCESS_BACKGROUND_CPU.get().map(Arc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn combined_classes_never_exceed_width_and_both_progress() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let index_completed = Arc::new(AtomicUsize::new(0));
+        let session_completed = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(17));
+        let mut workers = Vec::new();
+        for ordinal in 0..16 {
+            let authority = Arc::clone(&authority);
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let index_completed = Arc::clone(&index_completed);
+            let session_completed = Arc::clone(&session_completed);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                authority.with_permit(|| {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if ordinal % 2 == 0 {
+                        index_completed.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        session_completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }));
+        }
+        start.wait();
+        for worker in workers {
+            worker.join().expect("background worker");
+        }
+
+        assert!(maximum.load(Ordering::SeqCst) <= 4);
+        assert_eq!(index_completed.load(Ordering::SeqCst), 8);
+        assert_eq!(session_completed.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn waiting_demand_sums_weighted_work_units() {
+        let state = BackgroundCpuStateV1 {
+            active_units: 4,
+            waiters: VecDeque::from([
+                Arc::new(BackgroundCpuWaiterV1 { units: 4 }),
+                Arc::new(BackgroundCpuWaiterV1 { units: 1 }),
+            ]),
+        };
+
+        assert_eq!(waiting_units(&state), 5);
+    }
+
+    #[test]
+    fn weighted_units_and_nested_work_share_one_width() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permits(4, || {
+            assert_eq!(authority.active_units(), 4);
+            authority.with_permit(|| assert_eq!(authority.active_units(), 4));
+        });
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn nested_executor_yields_parent_units_and_reacquires_them() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_yielded_permits(|| {
+                assert_eq!(authority.active_units(), 0);
+                authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            });
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn panic_and_cancellation_drop_release_every_unit() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(2).expect("nonzero width"),
+        ));
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permits(2, || panic!("injected background panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let nested_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permit(|| {
+                authority.with_yielded_permits(|| panic!("injected nested executor panic"));
+            });
+        }));
+        assert!(nested_panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let cancelled = authority.acquire();
+        assert_eq!(authority.active_units(), 1);
+        drop(cancelled);
+        assert_eq!(authority.active_units(), 0);
+        assert!(authority.try_acquire().is_some());
+    }
+}

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -76,6 +76,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod background_cpu;
 pub mod branch;
 pub mod branch_meta;
 pub mod cancellation;

--- a/crates/tracedecay-sessions/src/runtime/cline_like.rs
+++ b/crates/tracedecay-sessions/src/runtime/cline_like.rs
@@ -1414,6 +1414,7 @@ mod observation_tests {
                     status: HostAdmissionStatus::Unavailable,
                     retryable: true,
                     reason_code: Some("authority_unavailable"),
+                    recovery: None,
                 },
             );
             assert!(matches!(

--- a/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
@@ -531,6 +531,11 @@ pub fn classify_claude_observation_failure(
             crate::observation::ObservationApplicationError::BatchContainsNonDurable => {
                 permanent("observation_batch_non_durable")
             }
+            // The worker went away before reaching a verdict, so nothing was
+            // decided about the payload. Re-running the same input can succeed.
+            crate::observation::ObservationApplicationError::BatchWorkerStopped => {
+                unavailable("observation_batch_worker_stopped")
+            }
         },
         Ingest::MissingParsedRecord => permanent("observation_parsed_record_missing"),
         Ingest::InvalidFrameState => permanent("observation_frame_state_invalid"),

--- a/crates/tracedecay-sessions/src/runtime/ingest/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/tests.rs
@@ -234,6 +234,7 @@ fn still_mounting_admission_failures_keep_the_admission_retryability() {
             status: crate::admission::HostAdmissionStatus::Unavailable,
             retryable: true,
             reason_code: Some("authority_write_failed"),
+            recovery: None,
         },
     );
 
@@ -254,6 +255,7 @@ fn permanent_admission_failures_still_classify_permanent() {
             status: crate::admission::HostAdmissionStatus::Degraded,
             retryable: false,
             reason_code: Some("invalid_observation_contract"),
+            recovery: None,
         },
     );
 

--- a/crates/tracedecay-sessions/src/runtime/kiro.rs
+++ b/crates/tracedecay-sessions/src/runtime/kiro.rs
@@ -1332,6 +1332,7 @@ mod observation_tests {
                 status: HostAdmissionStatus::Unavailable,
                 retryable: true,
                 reason_code: Some("authority_unavailable"),
+                recovery: None,
             },
         );
         assert!(matches!(


### PR DESCRIPTION
## Merge this first — it supersedes #676

`cursor/simplify-pr421-hot-paths` does not compile. `perf(observation): batch admission and preparation` landed changes whose consumers and one whole file were never `git add`ed, so the work exists only in one local working tree. Every branch cut from the pushed head fails **before its own code is built** — that is currently every open PR and every agent working against this branch.

Four separate breakages, all the same root cause:

| Missing | Referenced by |
|---|---|
| `crates/tracedecay-runtime-core/src/background_cpu.rs` (whole file + `mod` line) | `observation.rs` import |
| `ObservationApplicationError::BatchWorkerStopped` arm | `runtime/ingest/failure.rs:517` |
| `HostAdmissionOutcome.recovery` field | `kiro.rs`, `cline_like.rs`, `ingest/tests.rs` ×2 |
| `CodeIndexWorkerPlanInstallErrorV1`, `worker_reservation_bytes`, `installed_worker_status`, `with_background_cpu_permit` | `src/daemon/code_index_scheduler.rs` |

The last one is a ~694-added/170-removed-line delta in `crates/tracedecay-code-index/src/parallelism.rs` — the in-flight worker-planning work. It is carried here as its original commit rather than reconstructed.

## One judgement call, flagged for the author

`BatchWorkerStopped` needed a classification and none was written. It is classified **retryable / `Unavailable`** with reason code `observation_batch_worker_stopped`: a worker that went away before reaching a verdict decided nothing about the payload, so re-running the same input can succeed. Classifying it `permanent` would silently drop observations on a transient worker fault. If the author intended different semantics, this is the line to change.

## Verification

`cargo check -p tracedecay-sessions --all-targets` clean. `Cargo.lock` is updated because the carried commit adds dependencies.

Two agents independently hit these and reported rather than repairing, which is how the scope got established rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)