### PR TITLE
perf(codex): decide rollout scope before the frame is decoded

### DIFF
--- a/crates/tracedecay-runtime-core/src/background_cpu.rs
+++ b/crates/tracedecay-runtime-core/src/background_cpu.rs
@@ -1,0 +1,461 @@
+//! Process-wide weighted admission for background CPU work.
+//!
+//! The authority counts active CPU units rather than owning an executor. Code
+//! indexing, semantic native threads, and session preparation can therefore
+//! use their existing execution substrates while sharing one hard process
+//! ceiling. FIFO waiter order prevents a continuously busy class from starving
+//! another class, and RAII releases capacity on success, cancellation, or
+//! unwind.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+#[derive(Debug)]
+struct BackgroundCpuWaiterV1 {
+    units: usize,
+}
+
+#[derive(Default)]
+struct BackgroundCpuStateV1 {
+    active_units: usize,
+    waiters: VecDeque<Arc<BackgroundCpuWaiterV1>>,
+}
+
+/// One process-wide background CPU budget shared across subsystems.
+pub struct ProcessBackgroundCpuV1 {
+    width: NonZeroUsize,
+    state: Mutex<BackgroundCpuStateV1>,
+    available: Condvar,
+}
+
+impl fmt::Debug for ProcessBackgroundCpuV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessBackgroundCpuV1")
+            .field("width", &self.width)
+            .field("active_units", &self.active_units())
+            .finish_non_exhaustive()
+    }
+}
+
+thread_local! {
+    static BACKGROUND_CPU_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static BACKGROUND_CPU_UNITS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct BackgroundCpuScopeV1;
+
+impl BackgroundCpuScopeV1 {
+    fn enter() -> Self {
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+struct YieldedBackgroundCpuV1<'a> {
+    authority: &'a Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+    depth: usize,
+}
+
+impl Drop for YieldedBackgroundCpuV1<'_> {
+    fn drop(&mut self) {
+        self.authority.admit_units(self.units);
+        BACKGROUND_CPU_UNITS.with(|units| units.set(self.units));
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(self.depth));
+    }
+}
+
+impl Drop for BackgroundCpuScopeV1 {
+    fn drop(&mut self) {
+        BACKGROUND_CPU_DEPTH.with(|depth| {
+            let remaining = depth.get().saturating_sub(1);
+            depth.set(remaining);
+            if remaining == 0 {
+                BACKGROUND_CPU_UNITS.with(|units| units.set(0));
+            }
+        });
+    }
+}
+
+impl ProcessBackgroundCpuV1 {
+    fn new(width: NonZeroUsize) -> Self {
+        Self {
+            width,
+            state: Mutex::new(BackgroundCpuStateV1::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> NonZeroUsize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn active_units(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_units
+    }
+
+    #[must_use]
+    pub fn waiting_work_units(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        waiting_units(&state)
+    }
+
+    /// Acquire one CPU unit, waiting in FIFO order when the process budget is
+    /// full. The returned guard must remain alive for the active work unit.
+    pub fn acquire(self: &Arc<Self>) -> BackgroundCpuPermitV1 {
+        self.acquire_units(1)
+    }
+
+    /// Acquire one CPU unit only when no earlier waiter exists and capacity is
+    /// immediately available.
+    pub fn try_acquire(self: &Arc<Self>) -> Option<BackgroundCpuPermitV1> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.waiters.is_empty() || state.active_units >= self.width.get() {
+            return None;
+        }
+        state.active_units += 1;
+        record_state(&state, self.width);
+        Some(BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units: 1,
+        })
+    }
+
+    /// Run one active work unit under the process budget. Nested work on the
+    /// same thread reuses a sufficient parent admission instead of waiting on
+    /// itself.
+    pub fn with_permit<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        self.with_permits(1, operation)
+    }
+
+    /// Run a weighted work unit, clamped to the entire process width. Semantic
+    /// inference uses its native intra-op thread count as the weight; ordinary
+    /// index/session preparation uses one.
+    pub fn with_permits<R>(
+        self: &Arc<Self>,
+        requested_units: usize,
+        operation: impl FnOnce() -> R,
+    ) -> R {
+        let units = requested_units.max(1).min(self.width.get());
+        let active_units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if active_units >= units {
+            return operation();
+        }
+        if active_units > 0 {
+            let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+            self.release(active_units);
+            BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+            BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+            let _restore = YieldedBackgroundCpuV1 {
+                authority: self,
+                units: active_units,
+                depth,
+            };
+            let _permit = self.acquire_units(units);
+            let _scope = BackgroundCpuScopeV1::enter();
+            BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+            return operation();
+        }
+        let _permit = self.acquire_units(units);
+        let _scope = BackgroundCpuScopeV1::enter();
+        BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+        operation()
+    }
+
+    /// Temporarily yield the caller's active units while a nested executor
+    /// fans out independently admitted leaf work. This prevents a parent
+    /// Rayon worker from holding capacity while it waits for child workers,
+    /// including a full-width weighted child. Capacity is reacquired before
+    /// the parent resumes, including during unwind.
+    pub fn with_yielded_permits<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        let units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if units == 0 {
+            return operation();
+        }
+        let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+        self.release(units);
+        BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+        BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+        let _restore = YieldedBackgroundCpuV1 {
+            authority: self,
+            units,
+            depth,
+        };
+        operation()
+    }
+
+    fn acquire_units(self: &Arc<Self>, units: usize) -> BackgroundCpuPermitV1 {
+        self.admit_units(units);
+        BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units,
+        }
+    }
+
+    fn admit_units(&self, units: usize) {
+        let waiter = Arc::new(BackgroundCpuWaiterV1 { units });
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiters.push_back(Arc::clone(&waiter));
+        record_state(&state, self.width);
+        loop {
+            let is_front = state
+                .waiters
+                .front()
+                .is_some_and(|front| Arc::ptr_eq(front, &waiter));
+            if is_front && state.active_units.saturating_add(waiter.units) <= self.width.get() {
+                state.waiters.pop_front();
+                state.active_units += waiter.units;
+                record_state(&state, self.width);
+                self.available.notify_all();
+                return;
+            }
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn release(&self, units: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(state.active_units >= units);
+        state.active_units = state.active_units.saturating_sub(units);
+        record_state(&state, self.width);
+        self.available.notify_all();
+    }
+}
+
+fn record_state(state: &BackgroundCpuStateV1, width: NonZeroUsize) {
+    hotpath::gauge!("runtime_core.background_cpu.width").set(width.get());
+    hotpath::gauge!("runtime_core.background_cpu.active_units").set(state.active_units);
+    hotpath::gauge!("runtime_core.background_cpu.waiting_work_units").set(waiting_units(state));
+}
+
+fn waiting_units(state: &BackgroundCpuStateV1) -> usize {
+    state
+        .waiters
+        .iter()
+        .fold(0usize, |total, waiter| total.saturating_add(waiter.units))
+}
+
+/// RAII ownership of active CPU capacity. Dropping it is cancellation-safe and
+/// releases the exact acquired weight.
+pub struct BackgroundCpuPermitV1 {
+    authority: Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+}
+
+impl fmt::Debug for BackgroundCpuPermitV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackgroundCpuPermitV1")
+            .field("units", &self.units)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for BackgroundCpuPermitV1 {
+    fn drop(&mut self) {
+        self.authority.release(self.units);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BackgroundCpuInstallErrorV1 {
+    #[error(
+        "background CPU authority is already installed at width {installed_width}, not requested width {requested_width}"
+    )]
+    ConflictingWidth {
+        installed_width: usize,
+        requested_width: usize,
+    },
+    #[error("background CPU authority installation did not settle")]
+    InstallationDidNotSettle,
+}
+
+static PROCESS_BACKGROUND_CPU: OnceLock<Arc<ProcessBackgroundCpuV1>> = OnceLock::new();
+
+/// Install or idempotently reuse the one process background CPU authority.
+pub fn install_process_background_cpu(
+    width: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if let Some(installed) = PROCESS_BACKGROUND_CPU.get() {
+        return compare_installed_width(installed, width);
+    }
+    let requested = Arc::new(ProcessBackgroundCpuV1::new(width));
+    match PROCESS_BACKGROUND_CPU.set(Arc::clone(&requested)) {
+        Ok(()) => Ok(requested),
+        Err(_) => PROCESS_BACKGROUND_CPU.get().map_or_else(
+            || Err(BackgroundCpuInstallErrorV1::InstallationDidNotSettle),
+            |installed| compare_installed_width(installed, width),
+        ),
+    }
+}
+
+fn compare_installed_width(
+    installed: &Arc<ProcessBackgroundCpuV1>,
+    requested: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if installed.width == requested {
+        Ok(Arc::clone(installed))
+    } else {
+        Err(BackgroundCpuInstallErrorV1::ConflictingWidth {
+            installed_width: installed.width.get(),
+            requested_width: requested.get(),
+        })
+    }
+}
+
+/// Installed process authority, or `None` before daemon worker-plan admission.
+#[must_use]
+pub fn process_background_cpu() -> Option<Arc<ProcessBackgroundCpuV1>> {
+    PROCESS_BACKGROUND_CPU.get().map(Arc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn combined_classes_never_exceed_width_and_both_progress() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let index_completed = Arc::new(AtomicUsize::new(0));
+        let session_completed = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(17));
+        let mut workers = Vec::new();
+        for ordinal in 0..16 {
+            let authority = Arc::clone(&authority);
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let index_completed = Arc::clone(&index_completed);
+            let session_completed = Arc::clone(&session_completed);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                authority.with_permit(|| {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if ordinal % 2 == 0 {
+                        index_completed.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        session_completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }));
+        }
+        start.wait();
+        for worker in workers {
+            worker.join().expect("background worker");
+        }
+
+        assert!(maximum.load(Ordering::SeqCst) <= 4);
+        assert_eq!(index_completed.load(Ordering::SeqCst), 8);
+        assert_eq!(session_completed.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn waiting_demand_sums_weighted_work_units() {
+        let state = BackgroundCpuStateV1 {
+            active_units: 4,
+            waiters: VecDeque::from([
+                Arc::new(BackgroundCpuWaiterV1 { units: 4 }),
+                Arc::new(BackgroundCpuWaiterV1 { units: 1 }),
+            ]),
+        };
+
+        assert_eq!(waiting_units(&state), 5);
+    }
+
+    #[test]
+    fn weighted_units_and_nested_work_share_one_width() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permits(4, || {
+            assert_eq!(authority.active_units(), 4);
+            authority.with_permit(|| assert_eq!(authority.active_units(), 4));
+        });
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn nested_executor_yields_parent_units_and_reacquires_them() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_yielded_permits(|| {
+                assert_eq!(authority.active_units(), 0);
+                authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            });
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn panic_and_cancellation_drop_release_every_unit() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(2).expect("nonzero width"),
+        ));
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permits(2, || panic!("injected background panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let nested_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permit(|| {
+                authority.with_yielded_permits(|| panic!("injected nested executor panic"));
+            });
+        }));
+        assert!(nested_panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let cancelled = authority.acquire();
+        assert_eq!(authority.active_units(), 1);
+        drop(cancelled);
+        assert_eq!(authority.active_units(), 0);
+        assert!(authority.try_acquire().is_some());
+    }
+}

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -76,6 +76,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod background_cpu;
 pub mod branch;
 pub mod branch_meta;
 pub mod cancellation;

--- a/crates/tracedecay-sessions/src/runtime/codex.rs
+++ b/crates/tracedecay-sessions/src/runtime/codex.rs
@@ -50,6 +50,7 @@ mod goals;
 mod meta;
 mod observation;
 mod records;
+mod scope_probe;
 #[cfg(test)]
 mod tests;
 

--- a/crates/tracedecay-sessions/src/runtime/codex/observation.rs
+++ b/crates/tracedecay-sessions/src/runtime/codex/observation.rs
@@ -18,6 +18,7 @@ use tracedecay_store::observation::ObservationCoverageReason;
 use super::PROVIDER;
 use super::context::CodexContextState;
 use super::meta::session_meta_with_provenance;
+use super::scope_probe::{CodexFrameScopeProbeV1, probe_codex_frame};
 use crate::admission::HostAdmission;
 use crate::host_ports::unregistered_admission;
 use crate::observation::ObservationCancellation;
@@ -40,6 +41,9 @@ pub struct CodexJsonlAdmissionProgress {
     pub frames_decoded: u64,
     pub frames_accepted: u64,
     pub frames_skipped: u64,
+    /// Of `frames_skipped`, the frames refused from their raw bytes before any
+    /// decode. Every one is a rollout record this scope never owned.
+    pub frames_rejected_before_decode: u64,
     pub frames_refused: u64,
     pub frames_persisted: u64,
 }
@@ -277,6 +281,19 @@ async fn try_admit_codex_jsonl_observations(
             }
         },
         |context_state, bytes, range, _| {
+            // Scope is settled before the frame is decoded whenever it can be.
+            // A frame that cannot move the session cwd inherits the verdict the
+            // current cwd already carries, so when that verdict is "out of
+            // scope" the authoritative check below would reach it again after
+            // building and walking the frame's whole value tree. Proving the
+            // frame inert costs a tokenize; the parse it replaces does not.
+            if !scope_matcher.accepts(context_state.cwd.as_deref())
+                && probe_codex_frame(bytes, range) == CodexFrameScopeProbeV1::Inert
+            {
+                return Ok(JsonlFrameAdmission::non_durable_before_decode(
+                    ObservationCoverageReason::OutOfScope,
+                ));
+            }
             let mut stable_record_id = None;
             let mut non_durable_reason = None;
             let parsed = parse_normalized_observation_record_v1(
@@ -326,6 +343,7 @@ async fn try_admit_codex_jsonl_observations(
         frames_decoded: progress.frames_decoded,
         frames_accepted: progress.frames_accepted,
         frames_skipped: progress.frames_skipped,
+        frames_rejected_before_decode: progress.frames_rejected_before_decode,
         frames_refused: progress.frames_refused,
         frames_persisted: progress.frames_persisted,
     })

--- a/crates/tracedecay-sessions/src/runtime/codex/scope_probe.rs
+++ b/crates/tracedecay-sessions/src/runtime/codex/scope_probe.rs
@@ -1,0 +1,348 @@
+//! Pre-decode scope probe for Codex rollout frames.
+//!
+//! A rollout discovered under one project scope is usually owned by a
+//! *different* project: the profile sweep hands every `~/.codex/sessions`
+//! rollout to a scope that rejects nearly all of it. Those frames were read,
+//! decoded into a `serde_json::Value` tree, and walked twice by the structural
+//! validator before anything consulted their scope, because the scope test
+//! lives inside the normalizer the parser calls last.
+//!
+//! The scope of a Codex frame is not a property of the frame: it is a property
+//! of the session cwd the frame is observed under. Only two record kinds can
+//! move that cwd, and [`session_meta_from_record`] and
+//! [`turn_context_from_record`] both gate on exactly one thing — the top-level
+//! `type` string. Every other frame leaves the cwd exactly as it found it, so
+//! the verdict for such a frame is already decided before it is decoded.
+//!
+//! [`probe_codex_frame`] proves that property by tokenizing the frame and
+//! discarding it, allocating nothing but the `type` value itself. It answers
+//! [`CodexFrameScopeProbeV1::Inert`] only when it can also prove the frame
+//! would clear every structural gate the authoritative parser applies before
+//! reaching the normalizer, so an early rejection can never claim a different
+//! coverage reason than the parser would have recorded.
+//!
+//! [`session_meta_from_record`]: super::meta::session_meta_from_record
+//! [`turn_context_from_record`]: super::meta::turn_context_from_record
+
+use std::cell::Cell;
+
+use serde::de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde_json::Value;
+use tracedecay_domain::ObservationSourceRangeV1;
+use tracedecay_runtime_core::privacy::ParseLimits;
+
+/// The top-level `type` values that let a Codex record move the session cwd.
+const SESSION_META_TYPE: &str = "session_meta";
+const TURN_CONTEXT_TYPE: &str = "turn_context";
+
+/// What a raw Codex frame can be proved to be without decoding it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CodexFrameScopeProbeV1 {
+    /// The frame is a JSON object within every structural limit the
+    /// authoritative parser enforces, and its top-level `type` is neither
+    /// `session_meta` nor `turn_context`. Such a frame cannot change the
+    /// session cwd, so the scope verdict computed from the current cwd is the
+    /// verdict the authoritative parser would reach for it.
+    Inert,
+    /// Nothing was proved. The frame may carry context, or it violates a gate
+    /// whose own coverage reason the authoritative parser owns. Decode it.
+    Undecided,
+}
+
+/// Prove — or fail to prove — that `record` cannot move the session cwd.
+///
+/// `range` is the frame's file-byte range. Codex admits every rollout frame in
+/// the [`FileBytes`] ordering domain, which is the domain whose range/length
+/// agreement the authoritative parser checks, so that check is replicated here
+/// rather than assumed.
+///
+/// [`FileBytes`]: tracedecay_domain::ObservationOrderingDomainV1::FileBytes
+pub(super) fn probe_codex_frame(
+    record: &[u8],
+    range: ObservationSourceRangeV1,
+) -> CodexFrameScopeProbeV1 {
+    let limits = ParseLimits::default_policy();
+    // The three frame gates the authoritative parser applies before it decodes
+    // anything. Each one has its own coverage reason, so failing any of them
+    // must reach the parser rather than be answered here.
+    if record.is_empty() || record.len() > limits.record_bytes {
+        return CodexFrameScopeProbeV1::Undecided;
+    }
+    if u64::try_from(record.len()).ok() != Some(range.end().saturating_sub(range.start())) {
+        return CodexFrameScopeProbeV1::Undecided;
+    }
+
+    let budget = Cell::new(Budget {
+        values: 0,
+        value_limit: limits.values,
+        depth_limit: limits.depth,
+    });
+    let mut deserializer = serde_json::Deserializer::from_slice(record);
+    let Ok(top_level_type) = (RootSeed { budget: &budget }).deserialize(&mut deserializer) else {
+        return CodexFrameScopeProbeV1::Undecided;
+    };
+    // `serde_json::from_slice` rejects trailing content after the value; a
+    // probe that did not would call a frame inert that the parser calls
+    // malformed.
+    if deserializer.end().is_err() {
+        return CodexFrameScopeProbeV1::Undecided;
+    }
+    match top_level_type {
+        TopLevelType::SessionMeta | TopLevelType::TurnContext => CodexFrameScopeProbeV1::Undecided,
+        TopLevelType::Other => CodexFrameScopeProbeV1::Inert,
+    }
+}
+
+/// The top-level `type` of one record, reduced to the only distinction that
+/// changes scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TopLevelType {
+    SessionMeta,
+    TurnContext,
+    /// Absent, not a string, or any other string. Both context classifiers
+    /// read this field with `Value::as_str`, so a non-string `type` is as
+    /// inert as a missing one.
+    Other,
+}
+
+impl TopLevelType {
+    fn classify(value: &str) -> Self {
+        match value {
+            SESSION_META_TYPE => Self::SessionMeta,
+            TURN_CONTEXT_TYPE => Self::TurnContext,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// The structural budget the authoritative validator enforces, tracked while
+/// the frame is skipped rather than after it is materialized.
+///
+/// The count can exceed the validator's own for one input shape: duplicate
+/// object keys collapse in a `serde_json::Value` map and are counted once
+/// there, while a streaming walk sees both. That direction is safe — it can
+/// only turn `Inert` into `Undecided`, which costs a decode and changes no
+/// verdict.
+#[derive(Clone, Copy)]
+struct Budget {
+    values: usize,
+    value_limit: usize,
+    depth_limit: usize,
+}
+
+/// Charge one value at `depth`, failing the walk when either limit is passed.
+///
+/// Both limits are reported as a plain deserialize error because every probe
+/// failure has the same meaning: the authoritative parser decides.
+fn charge<E: de::Error>(budget: &Cell<Budget>, depth: usize) -> Result<(), E> {
+    let mut current = budget.get();
+    current.values = current.values.saturating_add(1);
+    if current.values > current.value_limit || depth > current.depth_limit {
+        return Err(de::Error::custom("codex frame exceeds a structural limit"));
+    }
+    budget.set(current);
+    Ok(())
+}
+
+/// Charge an already-materialized subtree, matching the validator's traversal.
+///
+/// Only the `type` value is materialized, and only so its string form can be
+/// read the same way the context classifiers read it.
+fn charge_value<E: de::Error>(budget: &Cell<Budget>, value: &Value, depth: usize) -> Result<(), E> {
+    let mut stack = vec![(value, depth)];
+    while let Some((current, current_depth)) = stack.pop() {
+        charge::<E>(budget, current_depth)?;
+        match current {
+            Value::Object(fields) => stack.extend(
+                fields
+                    .values()
+                    .map(|child| (child, current_depth.saturating_add(1))),
+            ),
+            Value::Array(items) => stack.extend(
+                items
+                    .iter()
+                    .map(|child| (child, current_depth.saturating_add(1))),
+            ),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// The root of one frame: an object, or nothing this probe can speak for.
+struct RootSeed<'budget> {
+    budget: &'budget Cell<Budget>,
+}
+
+impl<'de> DeserializeSeed<'de> for RootSeed<'_> {
+    type Value = TopLevelType;
+
+    fn deserialize<D: de::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_map(RootVisitor {
+            budget: self.budget,
+        })
+    }
+}
+
+struct RootVisitor<'budget> {
+    budget: &'budget Cell<Budget>,
+}
+
+impl<'de> Visitor<'de> for RootVisitor<'_> {
+    type Value = TopLevelType;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a Codex rollout record object")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        charge::<A::Error>(self.budget, 1)?;
+        // A duplicated `type` resolves to its last occurrence, the same way a
+        // `serde_json::Value` map does.
+        let mut top_level_type = TopLevelType::Other;
+        while let Some(is_type) = map.next_key_seed(RootKeySeed)? {
+            if is_type {
+                let value: Value = map.next_value()?;
+                charge_value::<A::Error>(self.budget, &value, 2)?;
+                top_level_type = value
+                    .as_str()
+                    .map_or(TopLevelType::Other, TopLevelType::classify);
+            } else {
+                map.next_value_seed(CountingSeed {
+                    depth: 2,
+                    budget: self.budget,
+                })?;
+            }
+        }
+        Ok(top_level_type)
+    }
+}
+
+/// A root key, reduced to whether it is `type`, so no key is ever allocated.
+struct RootKeySeed;
+
+impl<'de> DeserializeSeed<'de> for RootKeySeed {
+    type Value = bool;
+
+    fn deserialize<D: de::Deserializer<'de>>(self, deserializer: D) -> Result<bool, D::Error> {
+        deserializer.deserialize_str(RootKeyVisitor)
+    }
+}
+
+struct RootKeyVisitor;
+
+impl Visitor<'_> for RootKeyVisitor {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a record field name")
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<bool, E> {
+        Ok(value == "type")
+    }
+}
+
+/// One value that is counted and discarded rather than built.
+#[derive(Clone, Copy)]
+struct CountingSeed<'budget> {
+    depth: usize,
+    budget: &'budget Cell<Budget>,
+}
+
+impl<'de> DeserializeSeed<'de> for CountingSeed<'_> {
+    type Value = ();
+
+    fn deserialize<D: de::Deserializer<'de>>(self, deserializer: D) -> Result<(), D::Error> {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for CountingSeed<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("any JSON value")
+    }
+
+    fn visit_bool<E: de::Error>(self, _: bool) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_i64<E: de::Error>(self, _: i64) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_i128<E: de::Error>(self, _: i128) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_u64<E: de::Error>(self, _: u64) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_u128<E: de::Error>(self, _: u128) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_f64<E: de::Error>(self, _: f64) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_str<E: de::Error>(self, _: &str) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_bytes<E: de::Error>(self, _: &[u8]) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<(), E> {
+        charge(self.budget, self.depth)
+    }
+
+    fn visit_some<D: de::Deserializer<'de>>(self, deserializer: D) -> Result<(), D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_newtype_struct<D: de::Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<(), D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+        charge::<A::Error>(self.budget, self.depth)?;
+        let element = CountingSeed {
+            depth: self.depth.saturating_add(1),
+            budget: self.budget,
+        };
+        while seq.next_element_seed(element)?.is_some() {}
+        Ok(())
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+        charge::<A::Error>(self.budget, self.depth)?;
+        let value = CountingSeed {
+            depth: self.depth.saturating_add(1),
+            budget: self.budget,
+        };
+        // Keys are not values: the structural validator walks a decoded map's
+        // values only, so counting a key here would diverge from it.
+        while map.next_key::<IgnoredAny>()?.is_some() {
+            map.next_value_seed(value)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tracedecay-sessions/src/runtime/codex/scope_probe/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/codex/scope_probe/tests.rs
@@ -1,0 +1,248 @@
+//! Differential cover for the pre-decode scope probe.
+//!
+//! The probe is only allowed to answer `Inert` when the authoritative pipeline
+//! would have reached the same verdict after decoding, so the tests here do not
+//! restate the probe's rules — they run the real parser and the real context
+//! classifiers over the same bytes and require the two to agree.
+
+use serde_json::{Value, json};
+use tracedecay_domain::{ObservationOrderingDomainV1, ObservationSourceRangeV1};
+use tracedecay_runtime_core::privacy::{
+    ObservationRecordParseErrorV1, parse_normalized_observation_record_v1,
+};
+
+use super::{CodexFrameScopeProbeV1, probe_codex_frame};
+use crate::runtime::codex::{session_meta_from_record, turn_context_from_record};
+
+/// The frame's own file-byte range. A byte range is always non-empty, so the
+/// empty-frame fixture is given the smallest legal range and is rejected on its
+/// emptiness rather than on its range — the same order the parser uses.
+fn range_for(record: &[u8]) -> ObservationSourceRangeV1 {
+    ObservationSourceRangeV1::new(0, u64::try_from(record.len()).unwrap().max(1)).unwrap()
+}
+
+fn probe(record: &str) -> CodexFrameScopeProbeV1 {
+    probe_codex_frame(record.as_bytes(), range_for(record.as_bytes()))
+}
+
+/// What the authoritative pipeline does with one frame, observed through the
+/// real parser rather than restated.
+struct Authoritative {
+    /// The parser cleared every gate it applies before the normalizer runs, so
+    /// the frame's disposition is the normalizer's to decide.
+    reached_normalizer: bool,
+    /// One of the two classifiers that can move the session cwd claimed it.
+    may_move_cwd: bool,
+}
+
+fn authoritative(record: &str) -> Authoritative {
+    let bytes = record.as_bytes();
+    let mut reached_normalizer = false;
+    let mut may_move_cwd = false;
+    let _ = parse_normalized_observation_record_v1(
+        bytes,
+        range_for(bytes),
+        ObservationOrderingDomainV1::FileBytes,
+        |native: Value| {
+            reached_normalizer = true;
+            may_move_cwd = session_meta_from_record(&native, std::path::Path::new("rollout.jsonl"))
+                .is_some()
+                || turn_context_from_record(&native).is_some();
+            // The normalizer's own product is irrelevant here; only whether it
+            // ran, and what it would have concluded about the cwd.
+            Err(ObservationRecordParseErrorV1::NormalizationFailed)
+        },
+    );
+    Authoritative {
+        reached_normalizer,
+        may_move_cwd,
+    }
+}
+
+fn nested_arrays(depth: usize) -> String {
+    let mut record = String::from("{\"type\":\"event_msg\",\"payload\":");
+    record.push_str(&"[".repeat(depth));
+    record.push_str(&"]".repeat(depth));
+    record.push('}');
+    record
+}
+
+/// Every frame the probe is asked about, spanning the shapes a rollout really
+/// carries plus the encodings a cheaper probe would get wrong.
+fn corpus() -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "event message",
+            json!({
+                "timestamp": "2026-01-01T00:00:01.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "hello"}
+            })
+            .to_string(),
+        ),
+        (
+            "response item with nested content",
+            json!({
+                "timestamp": "2026-01-01T00:00:02.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "a\nb\t\"c\""}]
+                }
+            })
+            .to_string(),
+        ),
+        (
+            "session meta",
+            json!({
+                "type": "session_meta",
+                "payload": {"id": "s", "cwd": "/tmp/workspace"}
+            })
+            .to_string(),
+        ),
+        (
+            "turn context",
+            json!({"type": "turn_context", "payload": {"cwd": "/tmp/workspace"}}).to_string(),
+        ),
+        (
+            "type escaped as unicode",
+            r#"{"type":"session_\u006deta","payload":{"cwd":"/tmp/workspace","id":"s"}}"#
+                .to_string(),
+        ),
+        (
+            "turn context type escaped as unicode",
+            r#"{"type":"turn_\u0063ontext","payload":{"cwd":"/tmp/workspace"}}"#.to_string(),
+        ),
+        (
+            "duplicate type keys resolving to a context record",
+            r#"{"type":"event_msg","type":"turn_context","payload":{"cwd":"/tmp/w"}}"#.to_string(),
+        ),
+        (
+            "context type name appearing only in payload text",
+            json!({
+                "type": "event_msg",
+                "payload": {"message": "the session_meta and turn_context lines"}
+            })
+            .to_string(),
+        ),
+        ("missing type", json!({"payload": {"a": 1}}).to_string()),
+        (
+            "non string type",
+            json!({"type": 7, "payload": {}}).to_string(),
+        ),
+        (
+            "object type",
+            json!({"type": {"nested": "session_meta"}, "payload": {}}).to_string(),
+        ),
+        ("non object top level", "[1,2,3]".to_string()),
+        ("malformed", r#"{"type":"event_msg","#.to_string()),
+        ("empty", String::new()),
+        (
+            "trailing content",
+            r#"{"type":"event_msg"} {"type":"turn_context"}"#.to_string(),
+        ),
+        ("within the depth limit", nested_arrays(90)),
+        ("past the depth limit", nested_arrays(120)),
+        (
+            "past the value limit",
+            format!(
+                "{{\"type\":\"event_msg\",\"payload\":[{}]}}",
+                vec!["0"; 60_000].join(",")
+            ),
+        ),
+    ]
+}
+
+/// The load-bearing claim: `Inert` is never asserted over a frame the
+/// authoritative pipeline would have treated differently.
+///
+/// A frame is safe to reject before decoding only when the parser would have
+/// handed it to the normalizer at all (otherwise the parser owns a different
+/// coverage reason) and the normalizer would have left the session cwd alone
+/// (otherwise the scope verdict could change under it).
+#[test]
+fn inert_is_claimed_only_where_the_authoritative_pipeline_agrees() {
+    for (name, record) in corpus() {
+        if probe(&record) != CodexFrameScopeProbeV1::Inert {
+            continue;
+        }
+        let observed = authoritative(&record);
+        assert!(
+            observed.reached_normalizer,
+            "{name}: probe claimed inert for a frame the parser rejects before the normalizer"
+        );
+        assert!(
+            !observed.may_move_cwd,
+            "{name}: probe claimed inert for a frame that can move the session cwd"
+        );
+    }
+}
+
+/// The probe has to be worth having: the frame shapes that dominate a rollout
+/// must actually reach the fast path.
+#[test]
+fn ordinary_rollout_frames_are_proved_inert() {
+    for name in [
+        "event message",
+        "response item with nested content",
+        "context type name appearing only in payload text",
+        "missing type",
+        "non string type",
+        "object type",
+        "within the depth limit",
+    ] {
+        let record = corpus()
+            .into_iter()
+            .find_map(|(candidate, record)| (candidate == name).then_some(record))
+            .unwrap();
+        assert_eq!(
+            probe(&record),
+            CodexFrameScopeProbeV1::Inert,
+            "{name}: an ordinary frame must not pay for a decode"
+        );
+    }
+}
+
+/// Anything that can carry context, or that the parser reports under its own
+/// coverage reason, must fall through to the parser.
+#[test]
+fn context_and_gate_failures_stay_undecided() {
+    for name in [
+        "session meta",
+        "turn context",
+        "type escaped as unicode",
+        "turn context type escaped as unicode",
+        "duplicate type keys resolving to a context record",
+        "non object top level",
+        "malformed",
+        "empty",
+        "trailing content",
+        "past the depth limit",
+        "past the value limit",
+    ] {
+        let record = corpus()
+            .into_iter()
+            .find_map(|(candidate, record)| (candidate == name).then_some(record))
+            .unwrap();
+        assert_eq!(
+            probe(&record),
+            CodexFrameScopeProbeV1::Undecided,
+            "{name}: the authoritative parser must own this verdict"
+        );
+    }
+}
+
+/// A frame whose byte range disagrees with its length is a parser gate with its
+/// own coverage reason, not a scope question.
+#[test]
+fn a_range_length_mismatch_stays_undecided() {
+    let record = json!({"type": "event_msg", "payload": {}}).to_string();
+    let bytes = record.as_bytes();
+    let mismatched =
+        ObservationSourceRangeV1::new(0, u64::try_from(bytes.len()).unwrap() + 1).unwrap();
+    assert_eq!(
+        probe_codex_frame(bytes, mismatched),
+        CodexFrameScopeProbeV1::Undecided
+    );
+}

--- a/crates/tracedecay-sessions/src/runtime/jsonl_observation_admission.rs
+++ b/crates/tracedecay-sessions/src/runtime/jsonl_observation_admission.rs
@@ -96,7 +96,13 @@ pub(super) enum JsonlFrameAdmission {
         parsed_record: ParsedObservationRecordV1,
         native_record_id: ObservationId,
     },
-    NonDurable(ObservationCoverageReason),
+    NonDurable {
+        reason: ObservationCoverageReason,
+        /// The verdict was reached from the frame's raw bytes, without
+        /// decoding it. Kept because the cost of a skipped frame is not the
+        /// skip: it is whether the frame was parsed first.
+        before_decode: bool,
+    },
 }
 
 impl JsonlFrameAdmission {
@@ -111,7 +117,22 @@ impl JsonlFrameAdmission {
     }
 
     pub(super) fn non_durable(reason: ObservationCoverageReason) -> Self {
-        Self::NonDurable(reason)
+        Self::NonDurable {
+            reason,
+            before_decode: false,
+        }
+    }
+
+    /// A frame refused from its raw bytes alone.
+    ///
+    /// A normalizer may only answer this when it can prove the decoded frame
+    /// would have carried the same reason, because the coverage row this
+    /// writes is indistinguishable from the one the decoded path writes.
+    pub(super) fn non_durable_before_decode(reason: ObservationCoverageReason) -> Self {
+        Self::NonDurable {
+            reason,
+            before_decode: true,
+        }
     }
 }
 
@@ -122,6 +143,10 @@ pub(super) struct JsonlObservationAdmissionProgress {
     pub frames_decoded: u64,
     pub frames_accepted: u64,
     pub frames_skipped: u64,
+    /// Of `frames_skipped`, how many were refused from their raw bytes before
+    /// being decoded. The aggregate cannot separate a skip that cost a decode
+    /// and two structural walks from one that cost a tokenize.
+    pub frames_rejected_before_decode: u64,
     pub frames_refused: u64,
     pub frames_persisted: u64,
     pub io: crate::runtime::source::JsonlIoAccounting,
@@ -646,12 +671,19 @@ pub(super) async fn admit_jsonl_observations<State>(
                                 }
                             }
                         }
-                        JsonlFrameAdmission::NonDurable(reason) => {
+                        JsonlFrameAdmission::NonDurable {
+                            reason,
+                            before_decode,
+                        } => {
                             active
                                 .advance_coverage(expected_cursor, checkpoint, reason, None)
                                 .await?;
                             crate::runtime::pipeline_metrics::record_frame_skipped(reason);
                             progress.frames_skipped = progress.frames_skipped.saturating_add(1);
+                            if before_decode {
+                                progress.frames_rejected_before_decode =
+                                    progress.frames_rejected_before_decode.saturating_add(1);
+                            }
                         }
                     }
                 }
@@ -729,7 +761,10 @@ pub(super) async fn admit_jsonl_observations<State>(
                     parsed_record,
                     native_record_id,
                 } => (parsed_record, native_record_id),
-                JsonlFrameAdmission::NonDurable(reason) => {
+                JsonlFrameAdmission::NonDurable {
+                    reason,
+                    before_decode,
+                } => {
                     flush_pending(
                         &active,
                         &mut expected_cursor,
@@ -748,6 +783,10 @@ pub(super) async fn admit_jsonl_observations<State>(
                         .await?;
                     crate::runtime::pipeline_metrics::record_frame_skipped(reason);
                     progress.frames_skipped = progress.frames_skipped.saturating_add(1);
+                    if before_decode {
+                        progress.frames_rejected_before_decode =
+                            progress.frames_rejected_before_decode.saturating_add(1);
+                    }
                     continue;
                 }
             };
@@ -824,6 +863,7 @@ pub(super) async fn admit_jsonl_observations<State>(
         progress.frames_decoded,
         progress.frames_accepted,
         progress.frames_skipped,
+        progress.frames_rejected_before_decode,
         progress.frames_refused,
         progress.frames_persisted,
     );

--- a/crates/tracedecay-sessions/src/runtime/jsonl_observation_admission/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/jsonl_observation_admission/tests.rs
@@ -185,12 +185,19 @@ fn write_rollout(path: &Path, cwd: &Path) -> u64 {
 }
 
 fn rollout_fixture() -> (tempfile::TempDir, PathBuf, u64) {
+    let (temp, path, len, _cwd) = rollout_fixture_with_cwd();
+    (temp, path, len)
+}
+
+/// The same rollout, plus the working directory its records are recorded under,
+/// so a test can put that directory inside or outside the admitting scope.
+fn rollout_fixture_with_cwd() -> (tempfile::TempDir, PathBuf, u64, PathBuf) {
     let temp = tempfile::tempdir().unwrap();
     let cwd = temp.path().join("workspace");
     std::fs::create_dir_all(&cwd).unwrap();
     let path = temp.path().join("rollout.jsonl");
     let len = write_rollout(&path, &cwd);
-    (temp, path, len)
+    (temp, path, len, cwd)
 }
 
 async fn stored_cursor(spy: &SeamSpyAdmission) -> Option<ObservationSourceCursorV1> {
@@ -365,5 +372,68 @@ async fn exact_duplicates_are_idempotent_no_op_receipts() {
     assert_eq!(
         unchanged, committed,
         "an exact duplicate replay performs no extra cursor write"
+    );
+}
+
+/// A rollout owned by a registered project is not the profile pass's to ingest,
+/// and the profile pass sees far more of those than of its own.
+///
+/// Scope is a property of the session cwd, not of the frame: only a
+/// `session_meta` or `turn_context` line can move that cwd, so every other
+/// frame inherits a verdict that is already settled. This asserts the seam acts
+/// on that — the message frame is refused from its bytes, while the session
+/// meta, which *can* move the cwd, is still decoded before it is judged.
+#[tokio::test]
+async fn out_of_scope_frames_are_refused_before_they_are_decoded() {
+    let (_temp, path, _len, cwd) = rollout_fixture_with_cwd();
+    let spy = SeamSpyAdmission::default();
+
+    let progress = try_admit_codex_jsonl_observations_for_profile_with_admission(
+        &path,
+        None,
+        std::slice::from_ref(&cwd),
+        &spy,
+        None,
+    )
+    .await
+    .expect("an out-of-scope rollout is covered, not failed");
+
+    assert!(
+        spy.inner.observations().is_empty(),
+        "a rollout a registered project owns must persist nothing here"
+    );
+    assert_eq!(progress.frames_decoded, 2);
+    assert_eq!(progress.frames_skipped, 2);
+    assert_eq!(progress.frames_persisted, 0);
+    assert_eq!(
+        progress.frames_rejected_before_decode, 1,
+        "the frame that cannot move the cwd must not be parsed to learn it is out of scope"
+    );
+    assert!(
+        spy.cover_past_advances()
+            .iter()
+            .all(|advance| advance.reason() == ObservationCoverageReason::OutOfScope),
+        "moving the verdict earlier must not change the coverage reason it writes"
+    );
+}
+
+/// The counterpart: a rollout no registered project owns still admits in full,
+/// and pays no early rejection.
+#[tokio::test]
+async fn in_scope_frames_still_admit_in_full() {
+    let (_temp, path, _len, _cwd) = rollout_fixture_with_cwd();
+    let spy = SeamSpyAdmission::default();
+
+    let progress =
+        try_admit_codex_jsonl_observations_for_profile_with_admission(&path, None, &[], &spy, None)
+            .await
+            .expect("a profile-owned rollout must admit");
+
+    assert_eq!(spy.inner.observations().len(), 2);
+    assert_eq!(progress.frames_persisted, 2);
+    assert_eq!(progress.frames_skipped, 0);
+    assert_eq!(
+        progress.frames_rejected_before_decode, 0,
+        "nothing in scope may be refused before it is decoded"
     );
 }

--- a/crates/tracedecay-sessions/src/runtime/pipeline_metrics.rs
+++ b/crates/tracedecay-sessions/src/runtime/pipeline_metrics.rs
@@ -198,11 +198,18 @@ pub(crate) fn record_frame_skipped(reason: ObservationCoverageReason) {
     );
 }
 
+/// One admission batch, counted at the seam that owns the decode boundary.
+///
+/// `frames_rejected_before_decode` is the half of `frames_skipped` that never
+/// paid for a parse. Without it the skip split says how much work is discarded
+/// but not how much of it was avoided, so a change that moves a verdict earlier
+/// is indistinguishable from one that does nothing.
 #[inline(always)]
 pub(crate) fn record_admission_progress(
     frames_decoded: u64,
     frames_accepted: u64,
     frames_skipped: u64,
+    frames_rejected_before_decode: u64,
     frames_refused: u64,
     frames_persisted: u64,
 ) {
@@ -211,12 +218,17 @@ pub(crate) fn record_admission_progress(
         add("sessions.jsonl.frames.decoded", frames_decoded);
         add("sessions.jsonl.frames.accepted", frames_accepted);
         add("sessions.jsonl.frames.skipped", frames_skipped);
+        add(
+            "sessions.jsonl.frames.skipped.before_decode",
+            frames_rejected_before_decode,
+        );
         add("sessions.jsonl.frames.refused", frames_refused);
         add("sessions.jsonl.frames.persisted", frames_persisted);
     }
     #[cfg(not(feature = "hotpath"))]
     let _ = (
         frames_decoded,
+        frames_rejected_before_decode,
         frames_accepted,
         frames_skipped,
         frames_refused,


### PR DESCRIPTION
Of 1,905 frames a hotpath-instrumented ingest run skipped, **1,886 (99%) were skipped as `out_of_scope`**. Each was read, decoded into a `serde_json::Value` tree, and walked by the structural validator *before* anything consulted its scope — the scope test lives inside the normalizer that `parse_normalized_observation_record_v1` calls last. This moves that decision ahead of the decode.

The set of admitted frames, and the coverage reason written for every skipped one, is unchanged. That is the claim to review; the speedup is not.

## Where the 1,886 come from

`ObservationCoverageReason::OutOfScope` reaches `record_frame_skipped` from exactly one place: the normalizer closure in `crates/tracedecay-sessions/src/runtime/codex/observation.rs`. The other `admit_jsonl_observations` callers (vibe, kimi, cursor) never construct it, and `skipped_reason()` only produces `BlankFrame`/`OversizedFrame`. So the whole 99% is Codex rollout admission: a scope is handed every rollout under a profile or project sweep, and owns almost none of them.

## Equivalence argument

**Claim.** For a frame `F` observed under context state with cwd `C`, if
1. `!scope_matcher.accepts(C)`, and
2. `probe_codex_frame(F) == Inert`,

then rejecting `F` as `OutOfScope` before decoding is *identical* — same disposition, same coverage reason — to what the existing path produces after decoding.

**Proof.** The existing path, for each frame, is:

```
observe_context_record(&native, ..)      // may move the cwd
if !scope_matcher.accepts(state.cwd) -> OutOfScope
```

reached only after `parse_normalized_observation_record_v1` clears, in order: `validate_record_frame` (empty / over `MAX_OBSERVATION_RECORD_BYTES` / range-length mismatch), `serde_json::from_slice::<Value>`, `is_object`, and `validate_structure` (depth ≤ 96, values ≤ 50,000). Failing any of those returns before `non_durable_reason` is ever set, so the frame is covered as `MalformedFrame` — a *different* reason. An early check therefore has to prove both halves.

*Half one — the cwd cannot move.* `observe_context_record` mutates `self.cwd` only via `session_meta_from_record` or `turn_context_from_record`, and both return `None` unless the record's **top-level `type`** is the string `"session_meta"` / `"turn_context"` (`crates/tracedecay-sessions/src/runtime/codex/meta.rs:67,148`). Nothing else in either function is reached first. `Inert` is returned only when the probe has deserialized that exact field and found neither value, so `observe_context_record` returns `false` and the post-state cwd is `C`. The late check then evaluates `!accepts(C)`, which is premise 1. Same verdict.

*Half two — no earlier gate would have fired.* The probe replicates `validate_record_frame` literally (emptiness, byte cap, `range.end() - range.start()` against `record.len()`; Codex admits only in the `FileBytes` domain, which is the domain that check applies to), runs the same `serde_json` tokenizer over the same bytes, requires the top level to be a map, calls `Deserializer::end()` so trailing content is rejected the way `from_slice` rejects it, and charges the same depth/value budget `validate_structure` charges. Any failure yields `Undecided`, never `Inert`.

**Why the `type` field is read, not scanned.** `Value::as_str()` returns the *decoded* string, so `{"type":"session_meta"}` **is** a `session_meta` record. A raw-substring scan for `session_meta` would call that frame inert and wrongly skip it. The probe deserializes the field through serde, so it decodes escapes identically. Both escaped encodings are in the test corpus and both come back `Undecided`.

**Where the probe is deliberately imprecise, and in which direction.** A `serde_json::Value` map collapses duplicate keys; a streaming walk sees both. So the probe's value count can *exceed* the validator's, pushing a frame over the budget that the validator would have accepted. That turns `Inert` into `Undecided` — it costs a decode and changes no verdict. It can never turn `Undecided` into `Inert`. Duplicate `type` keys resolve last-wins in both, matching the map.

`Undecided` is always safe: the frame takes the existing path byte-for-byte.

## Falsifiability

Both tests assert on counters, never on elapsed time.

- `inert_is_claimed_only_where_the_authoritative_pipeline_agrees` is differential: for every fixture the probe calls `Inert`, it runs the **real** `parse_normalized_observation_record_v1` and the **real** context classifiers over the same bytes and requires the parser to have reached the normalizer and the classifiers to disclaim the cwd. It does not restate the probe's rules.
- `out_of_scope_frames_are_refused_before_they_are_decoded` runs a real profile admission whose cwd is owned by a registered root. The `session_meta` line *can* move the cwd, so it must still be decoded; the message line cannot, so it must not be. The test pins `frames_rejected_before_decode == 1` and asserts every coverage advance still carries `OutOfScope`.
- `in_scope_frames_still_admit_in_full` is the counterpart: nothing in scope may be refused early.

RED was demonstrated two ways — neutering the fast path (the counter goes to 0, and `frames_decoded`/`frames_skipped`/`frames_persisted` stay put, so it is the parse assertion that fires), and making the probe unsound by always answering `Inert` (caught in three places, including "probe claimed inert for a frame that can move the session cwd"). Verbatim output is in the agent report.

## Counter, not a shadow metric

`frames_rejected_before_decode` rides the existing `JsonlObservationAdmissionProgress` → `CodexJsonlAdmissionProgress` production data flow and is emitted as `sessions.jsonl.frames.skipped.before_decode` through the existing hotpath authority. `record_frame_skipped`'s own doc comment already asked for this split: it notes that the aggregate cannot tell a blank line's decode from an out-of-scope frame's full parse. No new metrics authority, no test-only port. hotpath stays off by default.

## Verification

- `cargo check -p tracedecay-sessions --all-targets --locked` — no new errors (see caveat)
- `cargo check -p tracedecay-sessions --all-targets --locked --features hotpath` — clean
- `cargo clippy -p tracedecay-sessions --all-targets --locked` — clean
- `cargo test -p tracedecay-sessions --locked --lib` — 659 passed, 0 failed

## Two things a reviewer should know

**This branch carries a cherry-pick.** `origin/claude/fix-missing-background-cpu` (#676) is included because the base does not compile without it. When #676 merges, the duplicate resolves cleanly.

**The base has three further pre-existing compile errors**, unrelated to this change and untouched by it, reported rather than repaired:
- `runtime/ingest/failure.rs:517` — match on `ObservationApplicationError` does not cover `BatchWorkerStopped` (fires for lib and lib test)
- `runtime/kiro.rs:1331`, `runtime/cline_like.rs:1413`, `runtime/ingest/tests.rs:233,253` — `HostAdmissionOutcome` initializers missing the new `recovery` field

They look like the tail of `64dbb4bf1 perf(observation): batch admission and preparation`. Confirmed pre-existing by stashing this work and re-running: identical error set. They were patched in the working tree only, to let this crate build for verification, and reverted before committing — this branch contains none of them. After reverting, `cargo check` returns exactly the base's error set, so this change adds zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
