### PR TITLE
perf(ledger): store commit sequence, not the receipt

### DIFF
--- a/crates/tracedecay-rusqlite-runtime/src/ledger.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/ledger.rs
@@ -8,6 +8,7 @@ mod commit;
 mod error;
 mod idempotency;
 mod inbox;
+mod migrate;
 mod outbox;
 mod schema;
 mod sqlite;

--- a/crates/tracedecay-rusqlite-runtime/src/ledger/commit.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/ledger/commit.rs
@@ -6,7 +6,7 @@ use tracedecay_store::{
 
 use super::{
     LedgerDisposition, LedgerError, checkpoint, idempotency, inbox, outbox,
-    sqlite::{LedgerTransaction, Submission, encode_json},
+    sqlite::{LedgerTransaction, Submission},
 };
 
 enum RuntimeBookkeeping<'a> {
@@ -73,9 +73,8 @@ fn record_with_bookkeeping(
         commit_sequence: checkpoint.watermark.commit_sequence,
         committed_at: metadata.admitted_at,
     };
-    let receipt_json = encode_json(&receipt, "original_receipt_json")?;
     checkpoint::persist(transaction, &submission, &checkpoint, &receipt)?;
-    idempotency::insert(transaction, &submission, &receipt, &receipt_json)?;
+    idempotency::insert(transaction, &submission, &receipt)?;
     match bookkeeping {
         RuntimeBookkeeping::None => {}
         RuntimeBookkeeping::Outbox(entry) => {

--- a/crates/tracedecay-rusqlite-runtime/src/ledger/idempotency.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/ledger/idempotency.rs
@@ -1,7 +1,9 @@
 use rusqlite::{Row, params};
+use tracedecay_domain::UtcMicros;
 use tracedecay_store::{
-    CommandDigestV1, DurabilityClassV1, IdempotencyIdentityV1, RuntimeTransactionScopeV1,
-    StoreCommitReceiptV1, StoreIdempotencyKeyV1, StoreOperationIdV1, StoreRuntimeBindingV1,
+    CommandDigestV1, CommitSequenceV1, DurabilityClassV1, IdempotencyIdentityV1,
+    RuntimeTransactionScopeV1, StoreCommitReceiptV1, StoreIdempotencyKeyV1, StoreOperationIdV1,
+    StoreRuntimeBindingV1,
 };
 
 use super::{
@@ -11,7 +13,7 @@ use super::{
 
 const IDEMPOTENCY_TABLE: &str = "td_runtime_writer_idempotency_v1";
 const SELECT_IDEMPOTENCY: &str = r#"
-SELECT request_digest, original_receipt_json, transaction_scope_json,
+SELECT request_digest, commit_sequence, transaction_scope_json,
        operation_id, durability_json, committed_at_micros
 FROM td_runtime_writer_idempotency_v1
 WHERE shard_json = ?1 AND incarnation = ?2 AND authority_epoch = ?3
@@ -20,7 +22,7 @@ WHERE shard_json = ?1 AND incarnation = ?2 AND authority_epoch = ?3
 const INSERT_IDEMPOTENCY: &str = r#"
 INSERT OR IGNORE INTO td_runtime_writer_idempotency_v1 (
     shard_json, incarnation, authority_epoch, idempotency_key, request_digest,
-    original_receipt_json, transaction_scope_json, operation_id, durability_json,
+    commit_sequence, transaction_scope_json, operation_id, durability_json,
     committed_at_micros
 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
 "#;
@@ -83,8 +85,8 @@ pub(super) fn insert(
     transaction: &impl LedgerTransaction,
     submission: &Submission<'_>,
     receipt: &StoreCommitReceiptV1,
-    receipt_json: &str,
 ) -> Result<(), LedgerError> {
+    let commit_sequence = sqlite_u64(receipt.commit_sequence.0, "commit sequence")?;
     let changed = transaction.execute(
         INSERT_IDEMPOTENCY,
         params![
@@ -93,7 +95,7 @@ pub(super) fn insert(
             submission.authority_epoch_sql,
             submission.metadata.idempotency.key.as_str(),
             submission.metadata.idempotency.command_digest.as_str(),
-            receipt_json,
+            commit_sequence,
             &submission.transaction_scope_json,
             submission.metadata.operation_id.as_str(),
             &submission.durability_json,
@@ -133,6 +135,19 @@ fn load(
     Ok(Some(record))
 }
 
+/// Rebuilds the durable receipt from the row's own columns.
+///
+/// Six of the seven receipt fields are columns of this table. Four of them
+/// (shard, incarnation, authority epoch, idempotency key) form the primary key
+/// this row was just matched on, so they are the caller's own arguments by
+/// construction. The remaining `commit_sequence` is the one value the receipt
+/// ever carried that nothing else recorded, which is why it is now a column of
+/// its own rather than 587 bytes of re-encoded JSON per row.
+///
+/// The equality checks this used to run against the encoded receipt are gone
+/// because they are now unrepresentable: there is no second copy left to
+/// disagree. The cross-column checks that still compare independent values,
+/// the transaction scope against the binding and the durability, are kept.
 fn decode_row(
     row: &Row<'_>,
     binding: &StoreRuntimeBindingV1,
@@ -143,11 +158,7 @@ fn decode_row(
             table: IDEMPOTENCY_TABLE,
             field: "request_digest",
         })?;
-    let receipt: StoreCommitReceiptV1 = decode_json(
-        &row.get::<_, String>(1)?,
-        IDEMPOTENCY_TABLE,
-        "original_receipt_json",
-    )?;
+    let commit_sequence = decode_commit_sequence(row.get(1)?)?;
     let transaction_scope: RuntimeTransactionScopeV1 = decode_json(
         &row.get::<_, String>(2)?,
         IDEMPOTENCY_TABLE,
@@ -164,18 +175,21 @@ fn decode_row(
         "durability_json",
     )?;
     let committed_at_micros: i64 = row.get(5)?;
-    let receipt_binding = StoreRuntimeBindingV1::new(
-        receipt.shard_id.clone(),
-        receipt.incarnation,
-        receipt.authority_epoch,
-    );
+
+    let receipt = StoreCommitReceiptV1 {
+        operation_id,
+        idempotency: IdempotencyIdentityV1 {
+            key: key.clone(),
+            command_digest: request_digest.clone(),
+        },
+        shard_id: binding.shard_id.clone(),
+        incarnation: binding.incarnation,
+        authority_epoch: binding.authority_epoch,
+        commit_sequence,
+        committed_at: UtcMicros(committed_at_micros),
+    };
     if receipt.validate().is_err()
-        || receipt_binding != *binding
-        || receipt.idempotency.key != *key
-        || receipt.idempotency.command_digest != request_digest
-        || receipt.operation_id != operation_id
-        || receipt.committed_at.0 != committed_at_micros
-        || transaction_scope.compatibility.binding != receipt_binding
+        || transaction_scope.compatibility.binding != *binding
         || transaction_scope.compatibility.durability != durability
     {
         return Err(LedgerError::Corrupt {
@@ -189,4 +203,20 @@ fn decode_row(
         transaction_scope,
         durability,
     })
+}
+
+/// A sequence is only ever written from a validated positive `u64`, so anything
+/// else in this column is a corrupt store rather than a representable state.
+fn decode_commit_sequence(raw: i64) -> Result<CommitSequenceV1, LedgerError> {
+    let raw = u64::try_from(raw).map_err(|_| LedgerError::Corrupt {
+        table: IDEMPOTENCY_TABLE,
+        field: "commit_sequence",
+    })?;
+    if raw == 0 {
+        return Err(LedgerError::Corrupt {
+            table: IDEMPOTENCY_TABLE,
+            field: "commit_sequence",
+        });
+    }
+    Ok(CommitSequenceV1(raw))
 }

--- a/crates/tracedecay-rusqlite-runtime/src/ledger/migrate.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/ledger/migrate.rs
@@ -1,0 +1,510 @@
+//! In-place upgrade of the writer idempotency ledger to its narrow shape.
+//!
+//! The ledger shards carry no `PRAGMA user_version`: they are created lazily by
+//! [`super::schema::initialize_schema`] inside whatever transaction the writer
+//! already holds, and they share their file with 200-odd unrelated tables whose
+//! own versioning does not cover them. Claiming that file-global pragma for the
+//! ledger would let a stamp disagree with the shape it claims to describe.
+//!
+//! So the shape *is* the version. The presence of the `original_receipt_json`
+//! column is the old shape and its absence is the new one. That predicate is
+//! read from `pragma_table_info`, which is derived from the same schema record
+//! the queries compile against, so it cannot drift from what is actually there.
+//!
+//! # Why the rewrite loses nothing
+//!
+//! `original_receipt_json` held a serialized [`StoreCommitReceiptV1`]. That type
+//! is `deny_unknown_fields` over exactly seven fields, and six of them are
+//! already columns of this table — `operation_id`, `idempotency.key`,
+//! `idempotency.command_digest`, `shard_id`, `incarnation`, `authority_epoch`,
+//! and `committed_at` map onto `operation_id`, `idempotency_key`,
+//! `request_digest`, `shard_json`, `incarnation`, `authority_epoch`, and
+//! `committed_at_micros`. `super::idempotency::decode_row` already *required*
+//! every one of those equalities and failed closed otherwise, so the encoded
+//! receipt was never authority for anything except its `commit_sequence`.
+//! Carrying that one integer across is therefore a lossless projection.
+//!
+//! # Why an interruption is safe
+//!
+//! The rewrite runs entirely inside the caller's transaction. SQLite makes DDL
+//! transactional, so a crash, a kill, or a rolled-back savepoint leaves the old
+//! table exactly as it was — including its column set, which is the version.
+//! The next open re-reads the predicate, still sees the old shape, and retries.
+//! There is no half-migrated state to detect because there is no state outside
+//! the transaction to disagree with.
+//!
+//! # Why a concurrent writer is safe
+//!
+//! One writer actor owns one shard, and SQLite serializes writers across
+//! processes besides. A racing process either waits for the exclusive lock and
+//! then observes the new shape, or is refused with `SQLITE_BUSY` and rolls back
+//! having changed nothing.
+//!
+//! # Why an unmigratable row stops the migration
+//!
+//! A receipt whose `commit_sequence` is not a positive integer is already fatal:
+//! today `decode_row` answers [`LedgerError::Corrupt`] the moment that key is
+//! looked up. The preflight below raises the same error class before touching
+//! anything, so the transaction rolls back and the store is left byte-identical
+//! at its old shape. Dropping such a row instead would silently shrink the set
+//! of submissions the ledger can recognise, which is the one outcome that could
+//! admit a duplicate write.
+
+use super::{LedgerError, sqlite::LedgerTransaction};
+
+const IDEMPOTENCY_TABLE: &str = "td_runtime_writer_idempotency_v1";
+
+/// True while the table still carries the encoded receipt column.
+const DETECT_LEGACY_SHAPE: &str = r#"
+SELECT count(*)
+FROM pragma_table_info('td_runtime_writer_idempotency_v1')
+WHERE name = 'original_receipt_json'
+"#;
+
+/// Counts rows whose encoded receipt cannot yield a usable commit sequence.
+///
+/// `typeof` is checked explicitly because SQLite orders text above every
+/// integer, so a `'garbage' > 0` comparison would otherwise pass.
+const COUNT_UNMIGRATABLE: &str = r#"
+SELECT count(*)
+FROM td_runtime_writer_idempotency_v1
+WHERE typeof(json_extract(original_receipt_json, '$.commit_sequence')) <> 'integer'
+   OR json_extract(original_receipt_json, '$.commit_sequence') <= 0
+"#;
+
+/// The narrow shape, built beside the old table so the swap is one rename.
+const CREATE_NARROW: &str = r#"
+CREATE TABLE td_runtime_writer_idempotency_migrate_v1 (
+    shard_json TEXT NOT NULL,
+    incarnation INTEGER NOT NULL CHECK (incarnation > 0),
+    authority_epoch INTEGER NOT NULL CHECK (authority_epoch > 0),
+    idempotency_key TEXT NOT NULL,
+    request_digest TEXT NOT NULL,
+    commit_sequence INTEGER NOT NULL CHECK (commit_sequence > 0),
+    transaction_scope_json TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    durability_json TEXT NOT NULL,
+    committed_at_micros INTEGER NOT NULL,
+    PRIMARY KEY (shard_json, incarnation, authority_epoch, idempotency_key)
+) WITHOUT ROWID
+"#;
+
+/// Projects every legacy row onto the narrow shape. `NOT NULL` and the `CHECK`
+/// stay as a backstop under the preflight, so a row the preflight somehow missed
+/// aborts the transaction rather than landing unreadable.
+const COPY_ROWS: &str = r#"
+INSERT INTO td_runtime_writer_idempotency_migrate_v1 (
+    shard_json, incarnation, authority_epoch, idempotency_key, request_digest,
+    commit_sequence, transaction_scope_json, operation_id, durability_json,
+    committed_at_micros
+)
+SELECT shard_json, incarnation, authority_epoch, idempotency_key, request_digest,
+       json_extract(original_receipt_json, '$.commit_sequence'),
+       transaction_scope_json, operation_id, durability_json, committed_at_micros
+FROM td_runtime_writer_idempotency_v1
+"#;
+
+const DROP_LEGACY: &str = "DROP TABLE td_runtime_writer_idempotency_v1";
+const RENAME_NARROW: &str = "ALTER TABLE td_runtime_writer_idempotency_migrate_v1
+     RENAME TO td_runtime_writer_idempotency_v1";
+const COUNT_LEGACY: &str = "SELECT count(*) FROM td_runtime_writer_idempotency_v1";
+const COUNT_NARROW: &str = "SELECT count(*) FROM td_runtime_writer_idempotency_migrate_v1";
+
+/// Upgrades the idempotency ledger in the caller's transaction when it is still
+/// at the legacy shape, and does nothing otherwise.
+pub(super) fn upgrade_idempotency_shape(
+    transaction: &impl LedgerTransaction,
+) -> Result<(), LedgerError> {
+    if count(transaction, DETECT_LEGACY_SHAPE)? == 0 {
+        return Ok(());
+    }
+
+    if count(transaction, COUNT_UNMIGRATABLE)? != 0 {
+        return Err(LedgerError::Corrupt {
+            table: IDEMPOTENCY_TABLE,
+            field: "original receipt commit sequence",
+        });
+    }
+
+    let legacy_rows = count(transaction, COUNT_LEGACY)?;
+    transaction.execute_batch(CREATE_NARROW)?;
+    transaction.execute(COPY_ROWS, [])?;
+
+    // Every legacy row must have landed. A short copy would silently forget
+    // submissions the ledger is supposed to recognise, so it fails closed.
+    if count(transaction, COUNT_NARROW)? != legacy_rows {
+        return Err(LedgerError::Corrupt {
+            table: IDEMPOTENCY_TABLE,
+            field: "migrated row count",
+        });
+    }
+
+    transaction.execute_batch(DROP_LEGACY)?;
+    transaction.execute_batch(RENAME_NARROW)?;
+    Ok(())
+}
+
+fn count(transaction: &impl LedgerTransaction, sql: &str) -> Result<i64, LedgerError> {
+    let mut statement = transaction.prepare(sql)?;
+    let mut rows = statement.query([])?;
+    let row = rows.next()?.ok_or(LedgerError::Corrupt {
+        table: IDEMPOTENCY_TABLE,
+        field: "schema probe",
+    })?;
+    Ok(row.get(0)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+    use tracedecay_store::{StoreCommitReceiptV1, StoreOperationMetadataV1};
+
+    use crate::{
+        ledger::{
+            LedgerDisposition, LedgerError, initialize_schema, lookup_receipt, record_commit,
+            sqlite::{BindingKey, encode_json},
+        },
+        test_support::{binding, metadata, scope},
+    };
+
+    /// The exact shape every existing store carries today, reproduced verbatim
+    /// so the migration tests start from a real pre-migration table rather than
+    /// from something the new code could have written.
+    const LEGACY_IDEMPOTENCY_DDL: &str = r#"
+CREATE TABLE td_runtime_writer_idempotency_v1 (
+    shard_json TEXT NOT NULL,
+    incarnation INTEGER NOT NULL CHECK (incarnation > 0),
+    authority_epoch INTEGER NOT NULL CHECK (authority_epoch > 0),
+    idempotency_key TEXT NOT NULL,
+    request_digest TEXT NOT NULL,
+    original_receipt_json TEXT NOT NULL,
+    transaction_scope_json TEXT NOT NULL,
+    operation_id TEXT NOT NULL,
+    durability_json TEXT NOT NULL,
+    committed_at_micros INTEGER NOT NULL,
+    PRIMARY KEY (shard_json, incarnation, authority_epoch, idempotency_key)
+) WITHOUT ROWID;
+"#;
+
+    const INSERT_LEGACY: &str = "INSERT INTO td_runtime_writer_idempotency_v1 (
+         shard_json, incarnation, authority_epoch, idempotency_key, request_digest,
+         original_receipt_json, transaction_scope_json, operation_id, durability_json,
+         committed_at_micros
+     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
+
+    fn legacy_receipt(metadata: &StoreOperationMetadataV1, sequence: u64) -> StoreCommitReceiptV1 {
+        serde_json::from_value(serde_json::json!({
+            "operation_id": metadata.operation_id,
+            "idempotency": metadata.idempotency,
+            "shard_id": metadata.shard_id,
+            "incarnation": metadata.incarnation,
+            "authority_epoch": metadata.authority_epoch,
+            "commit_sequence": sequence,
+            "committed_at": metadata.admitted_at,
+        }))
+        .unwrap()
+    }
+
+    /// Writes one authentic legacy row. The receipt is encoded by the same
+    /// serializer production used, so the row is byte-for-byte what a store
+    /// written before this change holds.
+    fn insert_legacy(
+        connection: &Connection,
+        metadata: &StoreOperationMetadataV1,
+        sequence: u64,
+        receipt_json_override: Option<&str>,
+    ) -> StoreCommitReceiptV1 {
+        let receipt = legacy_receipt(metadata, sequence);
+        let scope = scope(metadata);
+        let binding_key = BindingKey::from_parts(&metadata.shard_id, metadata.incarnation).unwrap();
+        let receipt_json = receipt_json_override
+            .map(str::to_owned)
+            .unwrap_or_else(|| serde_json::to_string(&receipt).unwrap());
+        connection
+            .execute(
+                INSERT_LEGACY,
+                rusqlite::params![
+                    &binding_key.shard_json,
+                    binding_key.incarnation_sql,
+                    i64::try_from(metadata.authority_epoch.get()).unwrap(),
+                    metadata.idempotency.key.as_str(),
+                    metadata.idempotency.command_digest.as_str(),
+                    receipt_json,
+                    encode_json(&scope, "transaction_scope_json").unwrap(),
+                    metadata.operation_id.as_str(),
+                    encode_json(&metadata.durability, "durability_json").unwrap(),
+                    metadata.admitted_at.0,
+                ],
+            )
+            .unwrap();
+        receipt
+    }
+
+    fn seed_legacy(
+        connection: &Connection,
+        metadata: &StoreOperationMetadataV1,
+        sequence: u64,
+        receipt_json_override: Option<&str>,
+    ) -> StoreCommitReceiptV1 {
+        connection.execute_batch(LEGACY_IDEMPOTENCY_DDL).unwrap();
+        insert_legacy(connection, metadata, sequence, receipt_json_override)
+    }
+
+    fn has_column(connection: &Connection, column: &str) -> bool {
+        connection
+            .query_row(
+                "SELECT count(*) FROM pragma_table_info('td_runtime_writer_idempotency_v1')
+                 WHERE name = ?1",
+                [column],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+            > 0
+    }
+
+    fn row_count(connection: &Connection) -> i64 {
+        connection
+            .query_row(
+                "SELECT count(*) FROM td_runtime_writer_idempotency_v1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn migration_preserves_the_exact_receipt_a_legacy_store_recorded() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let metadata = metadata("operation.legacy", "key.legacy", 'a');
+        let binding = binding(&metadata);
+        let expected = seed_legacy(&connection, &metadata, 4_242, None);
+        assert!(has_column(&connection, "original_receipt_json"));
+
+        let transaction = connection.transaction().unwrap();
+        initialize_schema(&transaction).unwrap();
+        transaction.commit().unwrap();
+
+        assert!(!has_column(&connection, "original_receipt_json"));
+        assert!(has_column(&connection, "commit_sequence"));
+        assert_eq!(row_count(&connection), 1);
+
+        let transaction = connection.transaction().unwrap();
+        let found = lookup_receipt(&transaction, &binding, &metadata.idempotency)
+            .unwrap()
+            .expect("migrated row must still answer the original lookup");
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn a_migrated_duplicate_still_replays_instead_of_committing_again() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let original = metadata("operation.legacy", "key.dup", 'a');
+        let expected = seed_legacy(&connection, &original, 7, None);
+
+        let transaction = connection.transaction().unwrap();
+        initialize_schema(&transaction).unwrap();
+
+        // Same key, same digest, different operation id: a retry.
+        let replay = metadata("operation.retry", "key.dup", 'a');
+        assert!(matches!(
+            record_commit(&transaction, &replay, &scope(&replay), None).unwrap(),
+            LedgerDisposition::Replay(found) if found == expected
+        ));
+        // Same key, different digest: a conflict, never a second commit.
+        let conflict = metadata("operation.other", "key.dup", 'b');
+        assert!(matches!(
+            record_commit(&transaction, &conflict, &scope(&conflict), None).unwrap(),
+            LedgerDisposition::Conflict(found) if found == expected
+        ));
+        transaction.commit().unwrap();
+
+        // Neither submission added a row.
+        assert_eq!(row_count(&connection), 1);
+    }
+
+    #[test]
+    fn an_interrupted_migration_leaves_the_legacy_store_untouched_and_retries() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let metadata = metadata("operation.legacy", "key.interrupt", 'a');
+        let binding = binding(&metadata);
+        let expected = seed_legacy(&connection, &metadata, 99, None);
+
+        // A migration that never reaches its commit.
+        let transaction = connection.transaction().unwrap();
+        initialize_schema(&transaction).unwrap();
+        assert!(!has_column(&transaction, "original_receipt_json"));
+        transaction.rollback().unwrap();
+
+        // The shape is the version, so rolling back restores both.
+        assert!(has_column(&connection, "original_receipt_json"));
+        assert!(!has_column(&connection, "commit_sequence"));
+        assert_eq!(row_count(&connection), 1);
+
+        // The next open migrates cleanly and the row is still answerable.
+        let transaction = connection.transaction().unwrap();
+        initialize_schema(&transaction).unwrap();
+        transaction.commit().unwrap();
+        assert!(!has_column(&connection, "original_receipt_json"));
+
+        let transaction = connection.transaction().unwrap();
+        let found = lookup_receipt(&transaction, &binding, &metadata.idempotency)
+            .unwrap()
+            .expect("row survives an interrupted migration");
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn an_unmigratable_receipt_fails_closed_without_dropping_the_row() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let metadata = metadata("operation.legacy", "key.corrupt", 'a');
+        // A receipt whose commit sequence is text. SQLite orders text above
+        // every integer, so a bare `> 0` guard would have let this through.
+        seed_legacy(
+            &connection,
+            &metadata,
+            1,
+            Some(r#"{"commit_sequence":"not-a-number"}"#),
+        );
+
+        let transaction = connection.transaction().unwrap();
+        assert!(matches!(
+            initialize_schema(&transaction),
+            Err(LedgerError::Corrupt { .. })
+        ));
+        transaction.rollback().unwrap();
+
+        // The store is left exactly as it was: nothing dropped, nothing rewritten.
+        assert!(has_column(&connection, "original_receipt_json"));
+        assert_eq!(row_count(&connection), 1);
+    }
+
+    #[test]
+    fn migrating_an_already_narrow_store_is_a_no_op() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        let metadata = metadata("operation.fresh", "key.fresh", 'a');
+        let binding = binding(&metadata);
+
+        let transaction = connection.transaction().unwrap();
+        initialize_schema(&transaction).unwrap();
+        let receipt = match record_commit(&transaction, &metadata, &scope(&metadata), None).unwrap()
+        {
+            LedgerDisposition::Committed(receipt) => receipt,
+            other => panic!("expected commit, got {other:?}"),
+        };
+        transaction.commit().unwrap();
+
+        // Re-initialising repeatedly must not disturb a narrow store.
+        for _ in 0..3 {
+            let transaction = connection.transaction().unwrap();
+            initialize_schema(&transaction).unwrap();
+            transaction.commit().unwrap();
+        }
+        assert_eq!(row_count(&connection), 1);
+
+        let transaction = connection.transaction().unwrap();
+        assert_eq!(
+            lookup_receipt(&transaction, &binding, &metadata.idempotency).unwrap(),
+            Some(receipt)
+        );
+    }
+
+    /// A binary from before this change reads `original_receipt_json`. Against a
+    /// migrated store that column does not exist, so its statement fails to
+    /// prepare. The point of pinning it is the *direction* of the failure: the
+    /// old binary is refused, never told "no such row", so it can never mistake
+    /// a shape it cannot read for an absent record and admit a duplicate write.
+    #[test]
+    fn an_older_binary_is_refused_by_a_migrated_store_rather_than_misreading_it() {
+        const LEGACY_SELECT: &str = "SELECT request_digest, original_receipt_json,
+                 transaction_scope_json, operation_id, durability_json, committed_at_micros
+             FROM td_runtime_writer_idempotency_v1
+             WHERE shard_json = ?1 AND incarnation = ?2 AND authority_epoch = ?3
+               AND idempotency_key = ?4";
+
+        let mut connection = Connection::open_in_memory().unwrap();
+        let metadata = metadata("operation.downgrade", "key.downgrade", 'a');
+        seed_legacy(&connection, &metadata, 5, None);
+        // The legacy statement is valid against the legacy store.
+        connection.prepare(LEGACY_SELECT).unwrap();
+
+        let transaction = connection.transaction().unwrap();
+        initialize_schema(&transaction).unwrap();
+        transaction.commit().unwrap();
+
+        let error = connection
+            .prepare(LEGACY_SELECT)
+            .expect_err("a pre-migration binary must be refused, not answered");
+        assert!(
+            error.to_string().contains("original_receipt_json"),
+            "expected a missing-column refusal, got {error}"
+        );
+    }
+
+    /// Falsifiable size claim, measured as on-disk pages over the same rows at
+    /// the two shapes. A legacy row averages ~1,486 bytes and so exceeds the
+    /// 1,002-byte `maxLocal` of a 4 KiB index b-tree page, spilling one overflow
+    /// page each; the narrow row fits and spills none.
+    #[test]
+    fn the_narrow_shape_removes_the_per_row_overflow_page() {
+        let directory = tempfile::tempdir().unwrap();
+        let rows = 500_usize;
+        let legacy_path = directory.path().join("legacy.db");
+        let narrow_path = directory.path().join("narrow.db");
+
+        let cases = [(&legacy_path, true), (&narrow_path, false)];
+        for (path, legacy) in cases {
+            let mut connection = Connection::open(path).unwrap();
+            if legacy {
+                connection.execute_batch(LEGACY_IDEMPOTENCY_DDL).unwrap();
+            } else {
+                let transaction = connection.transaction().unwrap();
+                initialize_schema(&transaction).unwrap();
+                transaction.commit().unwrap();
+            }
+            let transaction = connection.transaction().unwrap();
+            for index in 0..rows {
+                let metadata = metadata(
+                    &format!("operation.host-observation.{index:064x}"),
+                    &format!("host.{index:064x}"),
+                    'a',
+                );
+                if legacy {
+                    insert_legacy(
+                        &transaction,
+                        &metadata,
+                        u64::try_from(index + 1).unwrap(),
+                        None,
+                    );
+                } else {
+                    record_commit(&transaction, &metadata, &scope(&metadata), None).unwrap();
+                }
+            }
+            transaction.commit().unwrap();
+            connection.execute_batch("VACUUM").unwrap();
+        }
+
+        let bytes = |path: &std::path::Path| -> i64 {
+            let connection = Connection::open(path).unwrap();
+            let pages: i64 = connection
+                .query_row("PRAGMA page_count", [], |row| row.get(0))
+                .unwrap();
+            let size: i64 = connection
+                .query_row("PRAGMA page_size", [], |row| row.get(0))
+                .unwrap();
+            pages * size
+        };
+        let legacy_bytes = bytes(&legacy_path);
+        let narrow_bytes = bytes(&narrow_path);
+        println!(
+            "rows={rows} legacy_bytes={legacy_bytes} narrow_bytes={narrow_bytes} \
+             saved={} reduction={}%",
+            legacy_bytes - narrow_bytes,
+            (legacy_bytes - narrow_bytes) * 100 / legacy_bytes
+        );
+        assert!(
+            narrow_bytes * 2 < legacy_bytes,
+            "narrow shape must more than halve the ledger: \
+             legacy={legacy_bytes} narrow={narrow_bytes}"
+        );
+    }
+}

--- a/crates/tracedecay-rusqlite-runtime/src/ledger/schema.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/ledger/schema.rs
@@ -1,4 +1,4 @@
-use super::{LedgerError, sqlite::LedgerTransaction};
+use super::{LedgerError, migrate, sqlite::LedgerTransaction};
 
 const LEDGER_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS td_runtime_writer_checkpoint_v1 (
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS td_runtime_writer_idempotency_v1 (
     authority_epoch INTEGER NOT NULL CHECK (authority_epoch > 0),
     idempotency_key TEXT NOT NULL,
     request_digest TEXT NOT NULL,
-    original_receipt_json TEXT NOT NULL,
+    commit_sequence INTEGER NOT NULL CHECK (commit_sequence > 0),
     transaction_scope_json TEXT NOT NULL,
     operation_id TEXT NOT NULL,
     durability_json TEXT NOT NULL,
@@ -100,5 +100,9 @@ ON td_runtime_writer_inbox_v1 (target_shard_json, effect_id);
 
 pub(crate) fn initialize_schema(transaction: &impl LedgerTransaction) -> Result<(), LedgerError> {
     transaction.execute_batch(LEDGER_SCHEMA)?;
+    // `CREATE TABLE IF NOT EXISTS` is a no-op against a store that already
+    // holds the pre-narrowing idempotency shape, so the upgrade runs after it
+    // and in the same transaction.
+    migrate::upgrade_idempotency_shape(transaction)?;
     Ok(())
 }

--- a/crates/tracedecay-rusqlite-runtime/src/ledger/tests.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/ledger/tests.rs
@@ -85,7 +85,7 @@ fn malformed_canonical_json_fails_closed() {
     transaction.commit().unwrap();
     connection
         .execute(
-            "UPDATE td_runtime_writer_idempotency_v1 SET original_receipt_json = '{}'",
+            "UPDATE td_runtime_writer_idempotency_v1 SET transaction_scope_json = '{}'",
             [],
         )
         .unwrap();

--- a/crates/tracedecay-rusqlite-runtime/tests/runtime_actor/faults.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/runtime_actor/faults.rs
@@ -75,7 +75,7 @@ fn binding_mismatches_are_typed_and_corrupt_replay_faults_closed() {
     database
         .connect()
         .execute(
-            "UPDATE td_runtime_writer_idempotency_v1 SET original_receipt_json = '{}'",
+            "UPDATE td_runtime_writer_idempotency_v1 SET transaction_scope_json = '{}'",
             [],
         )
         .unwrap();


### PR DESCRIPTION
## What

`td_runtime_writer_idempotency_v1` replaces its 587-byte `original_receipt_json`
column with a `commit_sequence` integer, and gains a transactional in-place
upgrade so existing stores move to the narrow shape.

## Why the receipt is reconstructible

This is the load-bearing claim, so it is argued twice — structurally and
empirically.

**Structurally.** `StoreCommitReceiptV1` is `#[serde(deny_unknown_fields)]` over
exactly seven fields. Six were already columns of this same row:

| receipt field | column |
| --- | --- |
| `operation_id` | `operation_id` |
| `idempotency.key` | `idempotency_key` |
| `idempotency.command_digest` | `request_digest` |
| `shard_id` | `shard_json` |
| `incarnation` | `incarnation` |
| `authority_epoch` | `authority_epoch` |
| `committed_at` | `committed_at_micros` |
| `commit_sequence` | **nothing** |

`decode_row` already *required* every one of those equalities and answered
`LedgerError::Corrupt` otherwise, so the encoded receipt was never authority for
anything except `commit_sequence`. The reconstruction is that same check run
backwards. Four of the six — shard, incarnation, authority epoch, idempotency
key — are the primary key the row was matched on, so they are the caller's own
arguments by construction.

**Empirically.** Every real row on this machine was rebuilt byte-for-byte from
the six columns plus the sequence:

```
proj_099ef1e4af1c6508/sessions.db: rows=24558 reconstruct_mismatches=0 unexpected_key_shape=0
proj_7b2798f1d4448b5d/sessions.db: rows=40003 reconstruct_mismatches=0 unexpected_key_shape=0
proj_a5b3d7e3ebe14ca7/sessions.db: rows=94313 reconstruct_mismatches=0 unexpected_key_shape=0
.tracedecay/user-sessions.db:      rows=65634 reconstruct_mismatches=0 unexpected_key_shape=0

TOTAL rows scanned:            224508
byte-exact reconstruct FAILED: 0
receipts with unexpected keys: 0
RESULT: commit_sequence is the ONLY field not already a column.
```

## Why the row was spilling

`maxLocal` for an index b-tree at 4 KiB pages is `((4096-12)*64/255)-23 = 1002`
bytes. Measured payloads, and the projection after the change:

```
BEFORE (payload incl. record header)          AFTER (projected)
proj_099ef1e4af1c6508  avg=1486 max=1493      min=895 avg=899 max=902  over_maxlocal=0
proj_7b2798f1d4448b5d  avg=1478 max=1493      min=895 avg=895 max=902  over_maxlocal=0
proj_a5b3d7e3ebe14ca7  avg=1485 max=1493      min=895 avg=898 max=902  over_maxlocal=0
user-sessions          avg=1372 max=1382      min=821 avg=823 max=828  over_maxlocal=0
```

Every one of the 224,508 rows was over `maxLocal` before and none is after. The
`dbstat` page census showed overflow pages exactly 1:1 with rows in all four
stores (24,558 / 40,003 / 94,313 / 65,634), each holding ~1,005 bytes in a
4,096-byte page — 688 MB of pure slack.

Note the remaining headroom is ~100 bytes, and the largest remaining column is
`transaction_scope_json` at 456 bytes, which re-encodes the binding and
durability this row already carries. Normalising it (and `shard_json`) is the
obvious follow-up, but it is a separate change and this one has to land first.

## Why the migration is safe

The ledger shards sit at `user_version = 0`, outside the schema framework, and
share their file with ~207 unrelated tables. Claiming that file-global pragma
for the ledger would let a stamp disagree with the shape it describes, so
**the shape is the version**: the presence of `original_receipt_json` is the old
one, read from `pragma_table_info`, which is derived from the same schema record
the queries compile against and therefore cannot drift from what is there.

- **Interrupted migration.** The rewrite runs entirely inside the writer's
  existing transaction, and SQLite DDL is transactional. A crash rolls back to
  the old table *including its column set*, so the next open re-detects the old
  shape and retries. There is no state outside the transaction that could
  disagree with it, so there is no half-migrated state to detect.
- **Concurrent access.** One writer actor owns one shard, and SQLite serializes
  writers across processes. A racing process either waits for the exclusive lock
  and observes the new shape, or is refused `SQLITE_BUSY` having changed nothing.
- **Older binary afterwards.** Its `SELECT` names `original_receipt_json`, which
  no longer exists, so the statement fails to *prepare*. The direction matters:
  it is refused, never told "no such row", so it cannot mistake an unreadable
  shape for an absent record and admit a duplicate. Pinned by
  `an_older_binary_is_refused_by_a_migrated_store_rather_than_misreading_it`.
  This is forward-only, consistent with the framework's own stance that a store
  at an unexpected shape "is refused at open".
- **Unmigratable row.** A commit sequence that is not a positive integer aborts
  the migration with the same `Corrupt` class that reading that row already
  raised, leaving the store byte-identical at the old shape. `typeof` is checked
  explicitly because SQLite orders text above every integer, so a bare `> 0`
  would have let `"not-a-number"` through. Dropping such a row instead would
  silently shrink the set of submissions the ledger recognises — the one outcome
  that could admit a duplicate write.
- **Row count is verified** after the copy; a short copy fails closed.
- No view, trigger, or index depends on the table (checked against a real
  store), so the `DROP`/`RENAME` swap has no dependents.

## Measured, on a copy of a real 94,366-row store

The exact statements the migration runs, applied to a copy of a live store:

```
--- before ---
  rows=94366
  ledger_bytes=442458112 overflow_pages=94366
  db_bytes=1604157440
--- migrating ---
  unmigratable_rows=0
--- after ---
  rows=94366
  ledger_bytes=96649216 overflow_pages=0
  db_bytes=1239306240

--- receipt equivalence over the whole real store ---
  expected receipts: 94366
  rebuilt receipts:  94366
  RESULT: every receipt round-trips byte-for-byte through the migration.
```

Ledger 442,458,112 → 96,649,216 bytes (**78.2%**, 345,808,896 saved), overflow
pages 94,366 → 0, whole store down 22.7%, every receipt unchanged.

## RED / GREEN

RED, with the migration neutered to an early `Ok(())` (the "row-width fix with
no migration mechanism" state):

```
running 6 tests
test ledger::migrate::tests::an_unmigratable_receipt_fails_closed_without_dropping_the_row ... FAILED
test ledger::migrate::tests::an_interrupted_migration_leaves_the_legacy_store_untouched_and_retries ... FAILED
test ledger::migrate::tests::a_migrated_duplicate_still_replays_instead_of_committing_again ... FAILED
test ledger::migrate::tests::migrating_an_already_narrow_store_is_a_no_op ... ok
test ledger::migrate::tests::migration_preserves_the_exact_receipt_a_legacy_store_recorded ... FAILED
test ledger::migrate::tests::the_narrow_shape_removes_the_per_row_overflow_page ... ok

---- a_migrated_duplicate_still_replays_instead_of_committing_again stdout ----
called `Result::unwrap()` on an `Err` value: Sqlite(SqlInputError { ...
  msg: "no such column: commit_sequence", ... })

---- migration_preserves_the_exact_receipt_a_legacy_store_recorded stdout ----
assertion failed: !has_column(&connection, "original_receipt_json")

---- an_interrupted_migration_leaves_the_legacy_store_untouched_and_retries stdout ----
assertion failed: !has_column(&transaction, "original_receipt_json")

---- an_unmigratable_receipt_fails_closed_without_dropping_the_row stdout ----
assertion failed: matches!(initialize_schema(&transaction), Err(LedgerError::Corrupt { .. }))

test result: FAILED. 2 passed; 4 failed; 0 ignored; 0 measured; 299 filtered out
```

That third failure is itself the shape-mismatch evidence: a mismatch is a hard
SQL refusal, never a silent miss.

GREEN:

```
running 12 tests
test repository::fact::tests::fact_executor_does_not_claim_replay_without_writer_ledger ... ok
test ledger::tests::commit_uses_one_replay_and_conflict_disposition ... ok
test ledger::tests::malformed_canonical_json_fails_closed ... ok
test ledger::migrate::tests::migrating_an_already_narrow_store_is_a_no_op ... ok
test ledger::migrate::tests::an_unmigratable_receipt_fails_closed_without_dropping_the_row ... ok
test ledger::migrate::tests::an_older_binary_is_refused_by_a_migrated_store_rather_than_misreading_it ... ok
test ledger::tests::ledger_records_share_the_callers_transaction_boundary ... ok
test ledger::migrate::tests::migration_preserves_the_exact_receipt_a_legacy_store_recorded ... ok
test ledger::migrate::tests::a_migrated_duplicate_still_replays_instead_of_committing_again ... ok
test ledger::tests::runtime_effect_payloads_persist_inbox_and_ack_bookkeeping ... ok
test ledger::migrate::tests::an_interrupted_migration_leaves_the_legacy_store_untouched_and_retries ... ok
rows=500 legacy_bytes=2314240 narrow_bytes=466944 saved=1847296 reduction=79%
test ledger::migrate::tests::the_narrow_shape_removes_the_per_row_overflow_page ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 294 filtered out; finished in 0.12s
```

The migration tests start from `LEGACY_IDEMPOTENCY_DDL`, the pre-change table
definition reproduced verbatim, with receipts encoded by the same serializer
production used — a real pre-migration shape, not something the new code could
have written.

Duplicate-admission behaviour is covered directly:
`a_migrated_duplicate_still_replays_instead_of_committing_again` seeds a legacy
row, migrates, then asserts a same-key/same-digest retry still `Replay`s the
original receipt, a same-key/different-digest submission still `Conflict`s, and
that neither added a row.

Full crate suite: 440 tests across 20 binaries, all passing. No assertion
anywhere is on elapsed time.

## Checks

```
cargo check -p tracedecay-rusqlite-runtime --all-targets --locked   # clean
cargo clippy -p tracedecay-rusqlite-runtime --all-targets --locked  # no warnings
cargo test -p tracedecay-rusqlite-runtime --locked                  # all pass
```

Per-crate only, as requested.

## Relationship to the pruning rule

`perf(ledger): prune superseded idempotency records` is not on this base branch.
The two are complementary and near-disjoint — prune deletes unreachable rows,
this narrows the rows that remain. On merge the only textual overlaps are two
adjacent lines in `commit.rs` (prune inserts a `prune_superseded` call directly
above the `idempotency::insert` call whose `receipt_json` argument this removes)
and separate test functions in `tests.rs`; the migration tests were deliberately
placed in `migrate.rs` to keep `tests.rs` conflict-free. Nothing in this change
touches `prune.rs`'s `DELETE`, which selects on `shard_json` and
`authority_epoch` only.

## Scope deviation

- `tests.rs::malformed_canonical_json_fails_closed` and
  `tests/runtime_actor/faults.rs` both corrupted `original_receipt_json` to
  assert fail-closed behaviour. That column no longer exists, so both were
  retargeted to `transaction_scope_json`, which is still an encoded column, to
  preserve each test's intent.
- `commit.rs` no longer encodes the receipt to JSON, so its now-unused
  `encode_json` import was dropped.
- Not done, deliberately: `transaction_scope_json` and `shard_json`
  normalisation (the further ~20%), and any change to
  `td_runtime_writer_checkpoint_v1`, which holds one row per shard/incarnation
  and is not a size problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
