### PR TITLE
fix(cli): honest dashboard reuse reporting + init -p/--path

### DIFF
--- a/crates/tracedecay-cli/src/cli.rs
+++ b/crates/tracedecay-cli/src/cli.rs
@@ -191,6 +191,13 @@ pub enum Commands {
     Init {
         /// Project path (default: current directory)
         path: Option<String>,
+        /// Project path, as an explicit flag. Equivalent to the positional
+        /// PATH argument above; accepted for consistency with `-p`/`--path`
+        /// on other project-scoped commands (e.g. `dashboard`, `gitignore`,
+        /// `bench`). Conflicts with the positional PATH — pass one or the
+        /// other, not both.
+        #[arg(short = 'p', long = "path", value_name = "PATH", conflicts_with = "path")]
+        path_flag: Option<String>,
         /// Folders to skip during indexing (can be repeated)
         #[arg(long = "skip-folder", num_args = 1..)]
         skip_folders: Vec<String>,

--- a/crates/tracedecay-cli/src/cli/parse_tests.rs
+++ b/crates/tracedecay-cli/src/cli/parse_tests.rs
@@ -716,6 +716,62 @@ fn branch_autotrack_enable_parses_poll_secs_and_path() {
 }
 
 #[test]
+fn init_accepts_short_and_long_path_flag_like_dashboard_does() {
+    // `-p, --path` is documented (see TOP_LEVEL_AFTER_HELP) and already works
+    // on `dashboard`, `gitignore`, and `bench`; `init` previously only took
+    // PATH positionally and rejected `-p`/`--path` outright.
+    let short = Cli::try_parse_from(["tracedecay", "init", "-p", "/tmp/project"])
+        .expect("init -p PATH should parse");
+    assert!(matches!(
+        short.command,
+        Some(Commands::Init {
+            path: None,
+            path_flag,
+            ..
+        }) if path_flag.as_deref() == Some("/tmp/project")
+    ));
+
+    let long = Cli::try_parse_from(["tracedecay", "init", "--path", "/tmp/project"])
+        .expect("init --path PATH should parse");
+    assert!(matches!(
+        long.command,
+        Some(Commands::Init {
+            path: None,
+            path_flag,
+            ..
+        }) if path_flag.as_deref() == Some("/tmp/project")
+    ));
+
+    // The positional form keeps working unchanged.
+    let positional = Cli::try_parse_from(["tracedecay", "init", "/tmp/project"])
+        .expect("init PATH should still parse positionally");
+    assert!(matches!(
+        positional.command,
+        Some(Commands::Init {
+            path,
+            path_flag: None,
+            ..
+        }) if path.as_deref() == Some("/tmp/project")
+    ));
+
+    // Supplying both the positional PATH and `-p`/`--path` is refused rather
+    // than silently picking one — clap's `conflicts_with` rejects it.
+    // `Cli` does not derive `Debug`, so match directly instead of
+    // `.expect_err(...)` (which requires the `Ok` type to be `Debug`).
+    let conflict = match Cli::try_parse_from([
+        "tracedecay",
+        "init",
+        "/tmp/project",
+        "--path",
+        "/tmp/other",
+    ]) {
+        Ok(_) => panic!("init PATH and --path together should be rejected as a conflict"),
+        Err(error) => error,
+    };
+    assert_eq!(conflict.kind(), ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn init_and_sync_parse_runtime_skip_and_include_folders() {
     let init = Cli::try_parse_from([
         "tracedecay",
@@ -732,6 +788,7 @@ fn init_and_sync_parse_runtime_skip_and_include_folders() {
         init.command,
         Some(Commands::Init {
             path,
+            path_flag: None,
             skip_folders,
             include_folders,
             adopt_project: None,

--- a/crates/tracedecay-cli/src/dashboard_start_tests.rs
+++ b/crates/tracedecay-cli/src/dashboard_start_tests.rs
@@ -1,0 +1,158 @@
+//! RED/GREEN coverage for `tracedecay dashboard`'s handling of the daemon's
+//! process-wide dashboard singleton (see `src/mcp/tools/handlers/dashboard.rs`).
+//!
+//! These fabricate the `tracedecay_dashboard` tool response directly instead
+//! of spinning up a real daemon, so the assertions are on the reported
+//! URL/status/exit behavior — never on timing — and can be pasted verbatim
+//! as RED/GREEN evidence.
+//!
+//! The fixtures mirror the exact reproduction that motivated this fix: a
+//! second `tracedecay dashboard --path /fast/projects/mold --port 7400`
+//! call against a daemon already serving `/fast/projects/react-router` on
+//! port 7399.
+
+use std::path::Path;
+
+use super::{DashboardStartOutcome, interpret_dashboard_start_response};
+
+fn mold_request() -> (&'static Path, &'static str, u16) {
+    (Path::new("/fast/projects/mold"), "127.0.0.1", 7400)
+}
+
+#[test]
+fn started_response_is_reported_as_started() {
+    let result = serde_json::json!({
+        "status": "started",
+        "url": "http://127.0.0.1:7400/",
+        "host": "127.0.0.1",
+        "port": 7400,
+        "project_root": "/fast/projects/mold",
+    });
+    let (project_path, host, port) = mold_request();
+
+    let outcome = interpret_dashboard_start_response(&result, project_path, host, port)
+        .expect("a `started` response must be interpretable");
+
+    assert_eq!(
+        outcome,
+        DashboardStartOutcome::Started {
+            url: "http://127.0.0.1:7400/".to_string(),
+        }
+    );
+}
+
+#[test]
+fn already_running_response_matching_the_request_is_a_truthful_no_op() {
+    // Same host, same port, same project as what was requested: genuinely
+    // idempotent, not a conflict.
+    let result = serde_json::json!({
+        "status": "already_running",
+        "url": "http://127.0.0.1:7400/",
+        "host": "127.0.0.1",
+        "port": 7400,
+        "project_root": "/fast/projects/mold",
+        "requested_host": "127.0.0.1",
+        "requested_port": 7400,
+        "requested_project_root": "/fast/projects/mold",
+        "matches_request": true,
+    });
+    let (project_path, host, port) = mold_request();
+
+    let outcome = interpret_dashboard_start_response(&result, project_path, host, port)
+        .expect("a matching already_running response must be interpretable");
+
+    assert_eq!(
+        outcome,
+        DashboardStartOutcome::AlreadyServingRequest {
+            url: "http://127.0.0.1:7400/".to_string(),
+            project_root: "/fast/projects/mold".to_string(),
+        }
+    );
+}
+
+/// RED (pre-fix behavior, reconstructed here): the CLI printed
+///   "tracedecay dashboard listening on http://127.0.0.1:7399/"
+///   "Serving project /fast/projects/mold"
+/// and exited 0 — the URL was real, but the "Serving project mold" line was
+/// false (react-router's store was still the one being served) and the
+/// explicitly requested port 7400 was silently discarded with no error.
+///
+/// GREEN (this test, post-fix): the exact same daemon response must be
+/// reported as a `Conflict`, never as success, and the resulting message
+/// must name the ACTUAL project/URL being served (react-router / 7399) and
+/// say plainly that the requested port and project were not started.
+#[test]
+fn already_running_response_for_a_different_project_is_reported_as_a_conflict_not_a_falsehood() {
+    let result = serde_json::json!({
+        "status": "already_running",
+        "url": "http://127.0.0.1:7399/",
+        "host": "127.0.0.1",
+        "port": 7399,
+        "project_root": "/fast/projects/react-router",
+        "requested_host": "127.0.0.1",
+        "requested_port": 7400,
+        "requested_project_root": "/fast/projects/mold",
+        "matches_request": false,
+    });
+    let (project_path, host, port) = mold_request();
+
+    let outcome = interpret_dashboard_start_response(&result, project_path, host, port)
+        .expect("an already_running response must still be interpretable, not an Err");
+
+    let DashboardStartOutcome::Conflict { message } = outcome else {
+        panic!("expected a Conflict outcome for a mismatched already_running response, got {outcome:?}");
+    };
+
+    // The message must name the truth (react-router at 7399)...
+    assert!(
+        message.contains("react-router"),
+        "conflict message must name the project actually being served: {message}"
+    );
+    assert!(
+        message.contains("7399"),
+        "conflict message must name the URL/port actually reachable: {message}"
+    );
+    // ...and must not claim the requested port/project were honored.
+    assert!(
+        message.contains("7400") && message.contains("mold"),
+        "conflict message must name the requested host/port/project that were NOT started: {message}"
+    );
+    assert!(
+        message.contains("NOT started") || message.contains("were not"),
+        "conflict message must say plainly that the request was not fulfilled: {message}"
+    );
+}
+
+#[test]
+fn stopping_status_mismatched_with_the_request_is_also_a_conflict() {
+    let result = serde_json::json!({
+        "status": "stopping",
+        "url": "http://127.0.0.1:7399/",
+        "host": "127.0.0.1",
+        "port": 7399,
+        "project_root": "/fast/projects/react-router",
+        "matches_request": false,
+    });
+    let (project_path, host, port) = mold_request();
+
+    let outcome = interpret_dashboard_start_response(&result, project_path, host, port)
+        .expect("a stopping-status response must still be interpretable");
+
+    let DashboardStartOutcome::Conflict { message } = outcome else {
+        panic!("expected a Conflict outcome while the prior dashboard is shutting down, got {outcome:?}");
+    };
+    assert!(
+        message.contains("shutting down"),
+        "conflict message should reflect the in-progress shutdown: {message}"
+    );
+}
+
+#[test]
+fn a_response_missing_url_is_an_error_not_a_silent_success() {
+    let result = serde_json::json!({ "status": "started" });
+    let (project_path, host, port) = mold_request();
+
+    let error = interpret_dashboard_start_response(&result, project_path, host, port)
+        .expect_err("a response with no URL must not be treated as success");
+    assert!(error.to_string().contains("omitted URL"));
+}

--- a/crates/tracedecay-cli/src/main.rs
+++ b/crates/tracedecay-cli/src/main.rs
@@ -715,11 +715,15 @@ async fn dispatch_project_command(
     match command {
         Commands::Init {
             path,
+            path_flag,
             skip_folders,
             include_folders,
             adopt_project,
             fresh,
         } => {
+            // `clap` refuses `-p`/`--path` together with the positional PATH
+            // (`conflicts_with`), so at most one of these is ever `Some`.
+            let path = path.or(path_flag);
             commands::handle_init(
                 path,
                 skip_folders,
@@ -838,20 +842,27 @@ async fn dispatch_runtime_command(command: Commands) -> tracedecay::errors::Resu
                 }),
             )
             .await?;
-            let url = result
-                .get("url")
-                .and_then(serde_json::Value::as_str)
-                .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
-                    message: "daemon dashboard response omitted URL".to_string(),
-                })?;
-            println!("tracedecay dashboard listening on {url}");
-            eprintln!("Serving project {}", project_path.display());
-            if open {
-                match open::that(url) {
-                    Ok(()) => eprintln!("Opened dashboard in default browser: {url}"),
-                    Err(error) => {
-                        eprintln!("Warning: could not open browser for {url}: {error}")
-                    }
+            match interpret_dashboard_start_response(&result, &project_path, &host, port)? {
+                DashboardStartOutcome::Started { url } => {
+                    println!("tracedecay dashboard listening on {url}");
+                    eprintln!("Serving project {}", project_path.display());
+                    report_dashboard_browser_open(&url, open);
+                }
+                DashboardStartOutcome::AlreadyServingRequest { url, project_root } => {
+                    // Exactly what was requested is already being served:
+                    // a truthful no-op, not a conflict.
+                    println!("tracedecay dashboard already listening on {url}");
+                    eprintln!("Serving project {project_root}");
+                    report_dashboard_browser_open(&url, open);
+                }
+                DashboardStartOutcome::Conflict { message } => {
+                    // The daemon runs at most one dashboard per process
+                    // (`src/mcp/tools/handlers/dashboard.rs`); this call found
+                    // one already up (or shutting down) that is serving
+                    // something other than what was requested. Fail loudly
+                    // instead of claiming the requested host/port/project
+                    // were honored — they were never started.
+                    return Err(tracedecay::errors::TraceDecayError::Config { message });
                 }
             }
         }
@@ -1462,5 +1473,101 @@ fn is_local_install_command(command: &Commands) -> bool {
     matches!(command, Commands::Install { local: true, .. })
 }
 
+/// What actually happened after a `tracedecay dashboard` `start` request.
+///
+/// The `tracedecay_dashboard` MCP tool runs at most one dashboard per daemon
+/// process (`src/mcp/tools/handlers/dashboard.rs`): a second `start` finds
+/// the first instance already up (or mid-shutdown) instead of binding the
+/// newly requested host/port for the newly requested project. That reuse is
+/// intentional, but the CLI must never claim the requested host/port/project
+/// were honored when they were not — hence three distinct outcomes instead
+/// of a single always-successful "listening on {url}" message.
+#[derive(Debug, PartialEq, Eq)]
+enum DashboardStartOutcome {
+    /// A fresh dashboard was bound for exactly the requested host/port/project.
+    Started { url: String },
+    /// A dashboard was already running (or shutting down) but it is already
+    /// serving exactly the requested host/port/project: a truthful no-op.
+    AlreadyServingRequest { url: String, project_root: String },
+    /// A dashboard was already running (or shutting down) serving something
+    /// OTHER than what was requested. The requested host/port/project were
+    /// never started; `message` explains the truth to the user.
+    Conflict { message: String },
+}
+
+/// Turns the raw `tracedecay_dashboard` tool response into one of the three
+/// outcomes above, without printing anything or touching the network/browser
+/// — kept pure so the reporting logic is unit-testable against fabricated
+/// daemon responses instead of only against a live daemon.
+fn interpret_dashboard_start_response(
+    result: &serde_json::Value,
+    requested_project_path: &std::path::Path,
+    requested_host: &str,
+    requested_port: u16,
+) -> tracedecay::errors::Result<DashboardStartOutcome> {
+    let url = result
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| tracedecay::errors::TraceDecayError::Config {
+            message: "daemon dashboard response omitted URL".to_string(),
+        })?
+        .to_string();
+    let status = result
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("started");
+
+    if status == "started" {
+        return Ok(DashboardStartOutcome::Started { url });
+    }
+
+    let actual_project = result
+        .get("project_root")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown project>")
+        .to_string();
+    let matches_request = result
+        .get("matches_request")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    if matches_request {
+        return Ok(DashboardStartOutcome::AlreadyServingRequest {
+            url,
+            project_root: actual_project,
+        });
+    }
+
+    let state_word = if status == "stopping" {
+        "is shutting down"
+    } else {
+        "is already running"
+    };
+    Ok(DashboardStartOutcome::Conflict {
+        message: format!(
+            "a tracedecay dashboard for this daemon process {state_word} at {url}, serving project {actual_project}. Only one dashboard runs per daemon process, so the requested host/port ({requested_host}:{requested_port}) and project ({}) were NOT started. Stop the running dashboard first with `tracedecay tool tracedecay_dashboard --args '{{\"action\":\"stop\"}}'`, then retry, or connect to the dashboard already running at the URL above.",
+            requested_project_path.display()
+        ),
+    })
+}
+
+/// Best-effort browser open for a dashboard URL that is genuinely reachable
+/// (either freshly started or already running exactly as requested). Never
+/// called for a `Conflict` outcome — opening a browser to a URL serving a
+/// different project than the one the user asked for would compound the
+/// original falsehood.
+fn report_dashboard_browser_open(url: &str, open: bool) {
+    if !open {
+        return;
+    }
+    match open::that(url) {
+        Ok(()) => eprintln!("Opened dashboard in default browser: {url}"),
+        Err(error) => eprintln!("Warning: could not open browser for {url}: {error}"),
+    }
+}
+
 #[cfg(test)]
 mod startup_tests;
+
+#[cfg(test)]
+mod dashboard_start_tests;

--- a/crates/tracedecay-cli/src/startup_tests.rs
+++ b/crates/tracedecay-cli/src/startup_tests.rs
@@ -309,6 +309,7 @@ fn representative_commands_route_to_their_dispatch_family() {
         (
             Commands::Init {
                 path: None,
+                path_flag: None,
                 skip_folders: Vec::new(),
                 include_folders: Vec::new(),
                 adopt_project: None,

--- a/crates/tracedecay-runtime-core/src/background_cpu.rs
+++ b/crates/tracedecay-runtime-core/src/background_cpu.rs
@@ -1,0 +1,461 @@
+//! Process-wide weighted admission for background CPU work.
+//!
+//! The authority counts active CPU units rather than owning an executor. Code
+//! indexing, semantic native threads, and session preparation can therefore
+//! use their existing execution substrates while sharing one hard process
+//! ceiling. FIFO waiter order prevents a continuously busy class from starving
+//! another class, and RAII releases capacity on success, cancellation, or
+//! unwind.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+#[derive(Debug)]
+struct BackgroundCpuWaiterV1 {
+    units: usize,
+}
+
+#[derive(Default)]
+struct BackgroundCpuStateV1 {
+    active_units: usize,
+    waiters: VecDeque<Arc<BackgroundCpuWaiterV1>>,
+}
+
+/// One process-wide background CPU budget shared across subsystems.
+pub struct ProcessBackgroundCpuV1 {
+    width: NonZeroUsize,
+    state: Mutex<BackgroundCpuStateV1>,
+    available: Condvar,
+}
+
+impl fmt::Debug for ProcessBackgroundCpuV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessBackgroundCpuV1")
+            .field("width", &self.width)
+            .field("active_units", &self.active_units())
+            .finish_non_exhaustive()
+    }
+}
+
+thread_local! {
+    static BACKGROUND_CPU_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static BACKGROUND_CPU_UNITS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct BackgroundCpuScopeV1;
+
+impl BackgroundCpuScopeV1 {
+    fn enter() -> Self {
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+struct YieldedBackgroundCpuV1<'a> {
+    authority: &'a Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+    depth: usize,
+}
+
+impl Drop for YieldedBackgroundCpuV1<'_> {
+    fn drop(&mut self) {
+        self.authority.admit_units(self.units);
+        BACKGROUND_CPU_UNITS.with(|units| units.set(self.units));
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(self.depth));
+    }
+}
+
+impl Drop for BackgroundCpuScopeV1 {
+    fn drop(&mut self) {
+        BACKGROUND_CPU_DEPTH.with(|depth| {
+            let remaining = depth.get().saturating_sub(1);
+            depth.set(remaining);
+            if remaining == 0 {
+                BACKGROUND_CPU_UNITS.with(|units| units.set(0));
+            }
+        });
+    }
+}
+
+impl ProcessBackgroundCpuV1 {
+    fn new(width: NonZeroUsize) -> Self {
+        Self {
+            width,
+            state: Mutex::new(BackgroundCpuStateV1::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> NonZeroUsize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn active_units(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_units
+    }
+
+    #[must_use]
+    pub fn waiting_work_units(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        waiting_units(&state)
+    }
+
+    /// Acquire one CPU unit, waiting in FIFO order when the process budget is
+    /// full. The returned guard must remain alive for the active work unit.
+    pub fn acquire(self: &Arc<Self>) -> BackgroundCpuPermitV1 {
+        self.acquire_units(1)
+    }
+
+    /// Acquire one CPU unit only when no earlier waiter exists and capacity is
+    /// immediately available.
+    pub fn try_acquire(self: &Arc<Self>) -> Option<BackgroundCpuPermitV1> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.waiters.is_empty() || state.active_units >= self.width.get() {
+            return None;
+        }
+        state.active_units += 1;
+        record_state(&state, self.width);
+        Some(BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units: 1,
+        })
+    }
+
+    /// Run one active work unit under the process budget. Nested work on the
+    /// same thread reuses a sufficient parent admission instead of waiting on
+    /// itself.
+    pub fn with_permit<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        self.with_permits(1, operation)
+    }
+
+    /// Run a weighted work unit, clamped to the entire process width. Semantic
+    /// inference uses its native intra-op thread count as the weight; ordinary
+    /// index/session preparation uses one.
+    pub fn with_permits<R>(
+        self: &Arc<Self>,
+        requested_units: usize,
+        operation: impl FnOnce() -> R,
+    ) -> R {
+        let units = requested_units.max(1).min(self.width.get());
+        let active_units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if active_units >= units {
+            return operation();
+        }
+        if active_units > 0 {
+            let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+            self.release(active_units);
+            BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+            BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+            let _restore = YieldedBackgroundCpuV1 {
+                authority: self,
+                units: active_units,
+                depth,
+            };
+            let _permit = self.acquire_units(units);
+            let _scope = BackgroundCpuScopeV1::enter();
+            BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+            return operation();
+        }
+        let _permit = self.acquire_units(units);
+        let _scope = BackgroundCpuScopeV1::enter();
+        BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+        operation()
+    }
+
+    /// Temporarily yield the caller's active units while a nested executor
+    /// fans out independently admitted leaf work. This prevents a parent
+    /// Rayon worker from holding capacity while it waits for child workers,
+    /// including a full-width weighted child. Capacity is reacquired before
+    /// the parent resumes, including during unwind.
+    pub fn with_yielded_permits<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        let units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if units == 0 {
+            return operation();
+        }
+        let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+        self.release(units);
+        BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+        BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+        let _restore = YieldedBackgroundCpuV1 {
+            authority: self,
+            units,
+            depth,
+        };
+        operation()
+    }
+
+    fn acquire_units(self: &Arc<Self>, units: usize) -> BackgroundCpuPermitV1 {
+        self.admit_units(units);
+        BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units,
+        }
+    }
+
+    fn admit_units(&self, units: usize) {
+        let waiter = Arc::new(BackgroundCpuWaiterV1 { units });
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiters.push_back(Arc::clone(&waiter));
+        record_state(&state, self.width);
+        loop {
+            let is_front = state
+                .waiters
+                .front()
+                .is_some_and(|front| Arc::ptr_eq(front, &waiter));
+            if is_front && state.active_units.saturating_add(waiter.units) <= self.width.get() {
+                state.waiters.pop_front();
+                state.active_units += waiter.units;
+                record_state(&state, self.width);
+                self.available.notify_all();
+                return;
+            }
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn release(&self, units: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(state.active_units >= units);
+        state.active_units = state.active_units.saturating_sub(units);
+        record_state(&state, self.width);
+        self.available.notify_all();
+    }
+}
+
+fn record_state(state: &BackgroundCpuStateV1, width: NonZeroUsize) {
+    hotpath::gauge!("runtime_core.background_cpu.width").set(width.get());
+    hotpath::gauge!("runtime_core.background_cpu.active_units").set(state.active_units);
+    hotpath::gauge!("runtime_core.background_cpu.waiting_work_units").set(waiting_units(state));
+}
+
+fn waiting_units(state: &BackgroundCpuStateV1) -> usize {
+    state
+        .waiters
+        .iter()
+        .fold(0usize, |total, waiter| total.saturating_add(waiter.units))
+}
+
+/// RAII ownership of active CPU capacity. Dropping it is cancellation-safe and
+/// releases the exact acquired weight.
+pub struct BackgroundCpuPermitV1 {
+    authority: Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+}
+
+impl fmt::Debug for BackgroundCpuPermitV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackgroundCpuPermitV1")
+            .field("units", &self.units)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for BackgroundCpuPermitV1 {
+    fn drop(&mut self) {
+        self.authority.release(self.units);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BackgroundCpuInstallErrorV1 {
+    #[error(
+        "background CPU authority is already installed at width {installed_width}, not requested width {requested_width}"
+    )]
+    ConflictingWidth {
+        installed_width: usize,
+        requested_width: usize,
+    },
+    #[error("background CPU authority installation did not settle")]
+    InstallationDidNotSettle,
+}
+
+static PROCESS_BACKGROUND_CPU: OnceLock<Arc<ProcessBackgroundCpuV1>> = OnceLock::new();
+
+/// Install or idempotently reuse the one process background CPU authority.
+pub fn install_process_background_cpu(
+    width: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if let Some(installed) = PROCESS_BACKGROUND_CPU.get() {
+        return compare_installed_width(installed, width);
+    }
+    let requested = Arc::new(ProcessBackgroundCpuV1::new(width));
+    match PROCESS_BACKGROUND_CPU.set(Arc::clone(&requested)) {
+        Ok(()) => Ok(requested),
+        Err(_) => PROCESS_BACKGROUND_CPU.get().map_or_else(
+            || Err(BackgroundCpuInstallErrorV1::InstallationDidNotSettle),
+            |installed| compare_installed_width(installed, width),
+        ),
+    }
+}
+
+fn compare_installed_width(
+    installed: &Arc<ProcessBackgroundCpuV1>,
+    requested: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if installed.width == requested {
+        Ok(Arc::clone(installed))
+    } else {
+        Err(BackgroundCpuInstallErrorV1::ConflictingWidth {
+            installed_width: installed.width.get(),
+            requested_width: requested.get(),
+        })
+    }
+}
+
+/// Installed process authority, or `None` before daemon worker-plan admission.
+#[must_use]
+pub fn process_background_cpu() -> Option<Arc<ProcessBackgroundCpuV1>> {
+    PROCESS_BACKGROUND_CPU.get().map(Arc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn combined_classes_never_exceed_width_and_both_progress() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let index_completed = Arc::new(AtomicUsize::new(0));
+        let session_completed = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(17));
+        let mut workers = Vec::new();
+        for ordinal in 0..16 {
+            let authority = Arc::clone(&authority);
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let index_completed = Arc::clone(&index_completed);
+            let session_completed = Arc::clone(&session_completed);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                authority.with_permit(|| {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if ordinal % 2 == 0 {
+                        index_completed.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        session_completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }));
+        }
+        start.wait();
+        for worker in workers {
+            worker.join().expect("background worker");
+        }
+
+        assert!(maximum.load(Ordering::SeqCst) <= 4);
+        assert_eq!(index_completed.load(Ordering::SeqCst), 8);
+        assert_eq!(session_completed.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn waiting_demand_sums_weighted_work_units() {
+        let state = BackgroundCpuStateV1 {
+            active_units: 4,
+            waiters: VecDeque::from([
+                Arc::new(BackgroundCpuWaiterV1 { units: 4 }),
+                Arc::new(BackgroundCpuWaiterV1 { units: 1 }),
+            ]),
+        };
+
+        assert_eq!(waiting_units(&state), 5);
+    }
+
+    #[test]
+    fn weighted_units_and_nested_work_share_one_width() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permits(4, || {
+            assert_eq!(authority.active_units(), 4);
+            authority.with_permit(|| assert_eq!(authority.active_units(), 4));
+        });
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn nested_executor_yields_parent_units_and_reacquires_them() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_yielded_permits(|| {
+                assert_eq!(authority.active_units(), 0);
+                authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            });
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn panic_and_cancellation_drop_release_every_unit() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(2).expect("nonzero width"),
+        ));
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permits(2, || panic!("injected background panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let nested_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permit(|| {
+                authority.with_yielded_permits(|| panic!("injected nested executor panic"));
+            });
+        }));
+        assert!(nested_panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let cancelled = authority.acquire();
+        assert_eq!(authority.active_units(), 1);
+        drop(cancelled);
+        assert_eq!(authority.active_units(), 0);
+        assert!(authority.try_acquire().is_some());
+    }
+}

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -76,6 +76,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod background_cpu;
 pub mod branch;
 pub mod branch_meta;
 pub mod cancellation;

--- a/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
@@ -531,6 +531,14 @@ pub fn classify_claude_observation_failure(
             crate::observation::ObservationApplicationError::BatchContainsNonDurable => {
                 permanent("observation_batch_non_durable")
             }
+            // The batch worker went away before the batch completed, so this
+            // pass never reached a verdict about the observation itself. That
+            // is a missing runtime, not backpressure and not bad data: the
+            // same input succeeds once a worker is running again, so it is
+            // retryable and reported as unavailable rather than contended.
+            crate::observation::ObservationApplicationError::BatchWorkerStopped => {
+                unavailable("observation_batch_worker_stopped")
+            }
         },
         Ingest::MissingParsedRecord => permanent("observation_parsed_record_missing"),
         Ingest::InvalidFrameState => permanent("observation_frame_state_invalid"),

--- a/src/host_admission.rs
+++ b/src/host_admission.rs
@@ -1117,6 +1117,7 @@ const fn registered_authority_unavailable_outcome() -> HostAdmissionOutcome {
         status: HostAdmissionStatus::Unavailable,
         retryable: true,
         reason_code: Some("registered_authority_unavailable"),
+        recovery: None,
     }
 }
 

--- a/src/host_admission/integration_test_support.rs
+++ b/src/host_admission/integration_test_support.rs
@@ -290,6 +290,7 @@ impl HostAdmissionTestRuntimeV1 {
             status: HostAdmissionStatus::Unavailable,
             retryable: false,
             reason_code: Some("project_authority_unbound"),
+            recovery: None,
         })?;
         self.facade()
             .get_source_cursor(

--- a/src/mcp/tools/handlers/dashboard.rs
+++ b/src/mcp/tools/handlers/dashboard.rs
@@ -361,6 +361,15 @@ fn dashboard_configuration_unavailable(
 /// Internal handle for a managed dashboard instance.
 struct RunningDashboard {
     url: String,
+    /// Host the running instance actually bound. Recorded so a later `start`
+    /// call that finds this instance already up can truthfully report what
+    /// is really being served instead of echoing back the new caller's
+    /// request as if it had been honored.
+    host: String,
+    /// Port the running instance actually bound.
+    port: u16,
+    /// Canonicalized project root the running instance is actually serving.
+    project_root: PathBuf,
     shutdown: Option<tokio::sync::oneshot::Sender<()>>,
     task: tokio::task::JoinHandle<Result<()>>,
     completed: Arc<tokio::sync::Notify>,
@@ -548,6 +557,20 @@ pub(super) async fn handle_dashboard(
                 .and_then(serde_json::Value::as_u64)
                 .and_then(|p| u16::try_from(p).ok())
                 .unwrap_or(DEFAULT_PORT);
+            // Canonicalized ahead of the reuse check (not just the fresh-start
+            // path below) so a caller that finds an already-running instance
+            // can be told truthfully whether that instance is actually
+            // serving what was requested, instead of the response silently
+            // echoing the request back as if it had been honored.
+            let requested_root =
+                cg.project_root()
+                    .canonicalize()
+                    .map_err(|error| TraceDecayError::Config {
+                        message: format!(
+                            "dashboard project root '{}' is unavailable: {error}",
+                            cg.project_root().display()
+                        ),
+                    })?;
 
             let manager = get_manager();
             let mut guard = manager.lock().await;
@@ -558,12 +581,22 @@ pub(super) async fn handle_dashboard(
                 } else {
                     "stopping"
                 };
+                let matches_request = handle.host == host
+                    && handle.port == port
+                    && handle.project_root == requested_root;
                 return Ok(dashboard_tool_result(
                     cg,
                     &args,
                     &json!({
                         "status": status,
-                        "url": handle.url
+                        "url": handle.url,
+                        "host": handle.host,
+                        "port": handle.port,
+                        "project_root": handle.project_root.display().to_string(),
+                        "requested_host": host,
+                        "requested_port": port,
+                        "requested_project_root": requested_root.display().to_string(),
+                        "matches_request": matches_request,
                     }),
                 ));
             }
@@ -606,15 +639,6 @@ pub(super) async fn handle_dashboard(
                         retained_graph.project_root().display()
                     ),
                 })?;
-            let requested_root =
-                cg.project_root()
-                    .canonicalize()
-                    .map_err(|error| TraceDecayError::Config {
-                        message: format!(
-                            "dashboard project root '{}' is unavailable: {error}",
-                            cg.project_root().display()
-                        ),
-                    })?;
             if retained_root != requested_root {
                 return Err(TraceDecayError::project_route(
                     "project_route_unavailable",
@@ -751,6 +775,9 @@ pub(super) async fn handle_dashboard(
 
             *guard = Some(RunningDashboard {
                 url: url.clone(),
+                host: host.clone(),
+                port: addr.port(),
+                project_root: requested_root.clone(),
                 shutdown: Some(shutdown_tx),
                 task,
                 completed,
@@ -763,7 +790,8 @@ pub(super) async fn handle_dashboard(
                     "status": "started",
                     "url": url,
                     "host": host,
-                    "port": addr.port()
+                    "port": addr.port(),
+                    "project_root": requested_root.display().to_string(),
                 }),
             ))
         }

--- a/src/mcp/tools/handlers/dashboard/tests.rs
+++ b/src/mcp/tools/handlers/dashboard/tests.rs
@@ -15,6 +15,9 @@ async fn shutdown_deadline_aborts_joins_and_clears_dashboard_task() {
     });
     *manager = Some(RunningDashboard {
         url: "http://127.0.0.1:0/".to_owned(),
+        host: "127.0.0.1".to_owned(),
+        port: 0,
+        project_root: std::path::PathBuf::from("/tmp"),
         shutdown: Some(shutdown),
         task,
         completed,


### PR DESCRIPTION
## Summary

Fixes two CLI defects on `tracedecay-cli`.

### Defect 1 — `tracedecay dashboard --port <N>` (root cause + fix)

**Root cause, established by reading the code, not assumed:** the
`tracedecay_dashboard` MCP tool runs *at most one dashboard per daemon
process* (`src/mcp/tools/handlers/dashboard.rs`, `DASHBOARD_MANAGER`, a
process-wide `OnceLock<Mutex<Option<RunningDashboard>>>`). This reuse is
**documented and intentional** ("Idempotent: returns the existing URL if
already running for this process"), not a bug. The CLI's daemon is a single
long-lived process shared across every `tracedecay dashboard` invocation for
the profile, so a second `dashboard --port 7400 --path mold` call finds the
first dashboard (react-router, port 7399) still up and reuses it.

**What was genuinely wrong:** the CLI ignored the daemon's `status` field
and always printed as if the request had been honored — `"Serving project
{requested_path}"` was printed even when the reachable server was actually
serving a *different* project, and the daemon never even reported which
project the reused instance was actually serving, so there was no way for
the CLI to detect or report the mismatch. The requested `--port` was
silently discarded with no warning and exit code 0.

**Fix:**
- `src/mcp/tools/handlers/dashboard.rs`: `RunningDashboard` now records
  `host`, `port`, and the canonicalized `project_root` it is actually
  serving. The `start` reuse path (`already_running`/`stopping`) now returns
  those actual values plus a `matches_request` bool (computed by comparing
  the running instance's host/port/project against what was just requested).
- `crates/tracedecay-cli/src/main.rs`: `tracedecay dashboard` now branches
  on the daemon's response:
  - `started` → unchanged success path.
  - already running **and** it happens to match the request exactly → a
    truthful no-op ("dashboard already listening on ...").
  - already running (or shutting down) **and it does not match** → the CLI
    now **errors** (`process::exit(1)`) with a message naming the actual
    project/URL being served and stating plainly that the requested
    host/port/project were **not** started, with a working next step
    (`tracedecay tool tracedecay_dashboard --args '{"action":"stop"}'`).

I did not turn the process-wide single-dashboard-per-daemon design into a
multi-dashboard registry (keyed by project/port) — the code already has a
dedicated single-instance shutdown/task-completion lifecycle
(`shutdown_dashboard_until`, `DASHBOARD_MANAGER`) that a multi-instance
registry would need to redesign, which is well past "a small change" and
risks colliding with concurrent hot-path work already in flight on this
branch. Erroring loudly and truthfully on a genuine conflict, while keeping
matching requests a real no-op, satisfies "never told a falsehood" without
that redesign.

`--port 0` ("pick a free port") is untouched for the fresh-start path; it
was already handled correctly by `bind_dashboard`, and continues to be.

### Defect 2 — `tracedecay init -p <path>`

`Init`'s `path` field was a *bare positional* (`path: Option<String>`, no
`#[arg(...)]`), unlike `dashboard`/`gitignore`/`bench`, which declare
`#[arg(short, long)] path: Option<String>` and so accept `-p`/`--path`. Top
level `--help` documents `--path` as one of the general ways to target
another project, so this was a real, if small, inconsistency.

Resolution: added `-p`/`--path` as an explicit flag (`path_flag`) alongside
the existing positional `path`, `conflicts_with` the positional so passing
both is a parse error rather than a silent pick. `tracedecay init /repo`
keeps working exactly as documented in `INIT_AFTER_HELP`.

## Real defect vs. intended behavior

| Symptom | Verdict |
|---|---|
| Second `dashboard` call reuses the first daemon-wide instance instead of binding a new port | **Intended** (single dashboard per daemon process, documented) |
| CLI prints "Serving project X" for a request that was never honored | **Defect** — fixed |
| Explicit `--port` silently discarded with no warning/error | **Defect** — fixed (now a loud, truthful error when it actually conflicts) |
| `tracedecay init -p <path>` rejected | **Defect** — fixed |

## Tests (RED/GREEN)

- `crates/tracedecay-cli/src/dashboard_start_tests.rs` (new): fabricates the
  exact `tracedecay_dashboard` tool response from the reported repro
  (react-router already running on 7399, `mold --port 7400` requested) and
  asserts the CLI's pure response-interpretation function
  (`interpret_dashboard_start_response`) returns a `Conflict` naming the
  *actual* project/port and saying the requested ones were not started —
  never a silent `Started`. Also covers the exactly-matching no-op case, the
  `stopping` status, and the missing-URL-is-an-error case.
- `crates/tracedecay-cli/src/cli/parse_tests.rs`
  (`init_accepts_short_and_long_path_flag_like_dashboard_does`): asserts
  `-p`/`--path` and the positional PATH all parse, and that supplying both
  together is a parse-time `ArgumentConflict`, not a silent pick.

GREEN, pasted verbatim (`cargo test -p tracedecay-cli --locked` filtered to
the new tests, both against the fixed code):

```
running 5 tests
test dashboard_start_tests::a_response_missing_url_is_an_error_not_a_silent_success ... ok
test dashboard_start_tests::already_running_response_for_a_different_project_is_reported_as_a_conflict_not_a_falsehood ... ok
test dashboard_start_tests::already_running_response_matching_the_request_is_a_truthful_no_op ... ok
test dashboard_start_tests::started_response_is_reported_as_started ... ok
test dashboard_start_tests::stopping_status_mismatched_with_the_request_is_also_a_conflict ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 294 filtered out

test cli::parse_tests::init_accepts_short_and_long_path_flag_like_dashboard_does ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 298 filtered out
```

RED (the exact scenario reconstructed as evidence, not a hypothetical):
`already_running_response_for_a_different_project_is_reported_as_a_conflict_not_a_falsehood`
fabricates the daemon's real pre-fix response shape — `status:
"already_running"`, `url: "http://127.0.0.1:7399/"` (react-router, already
running) — for a request targeting mold on port 7400. Before this fix the
CLI had no `matches_request`/`project_root` fields to check and no
`Conflict` outcome at all: it unconditionally printed
`"tracedecay dashboard listening on {url}"` (the real, reachable URL) and
`"Serving project {requested_path}"` (false — react-router, not mold, was
being served) and returned `Ok(())` — exit 0. The test's assertions
(`message.contains("react-router")`, `.contains("7399")`,
`.contains("7400") && .contains("mold")`,
`.contains("NOT started") || .contains("were not")`) are only satisfiable
by the fixed `Conflict` path; the pre-fix code path had no `message` to
even inspect.

Full `cargo test -p tracedecay-cli --locked --bin tracedecay` on the fixed
tree: **291 passed** (including the 6 new tests above), **8 failed** — all
in `agent_cmd::tests::{codex,opencode,kimi}_*`, `tool_command::tests::
successful_tool_result_exits_zero`, and `startup_tests::
agent_install_health_check_is_selective`. None touch dashboard or init;
they reference `host_component_registration.rs` filesystem/receipt
plumbing for Codex/OpenCode/Kimi lifecycle, a subsystem this PR never
touches. Re-running the exact same command against a stash of every
defect-fix file (keeping only the three build-unblocker commits) reproduces
the identical 291/8 split with the identical 8 test names — proving these
failures pre-exist on this branch and are unaffected by this change.

## Scope deviation

This branch (`cursor/simplify-pr421-hot-paths`) does not compile at the
commit I branched from — confirmed by reproducing every failure below on a
clean `git stash` of my diff, i.e. none of it is caused by my change:

1. `tracedecay-sessions`: unresolved `tracedecay_runtime_core::background_cpu`
   import. Already fixed, unmodified, on sibling branch
   `claude/perf-graph-publication-batching` (commit `1d591191e`) — cherry-picked.
2. `tracedecay-sessions`: non-exhaustive match on
   `ObservationApplicationError::BatchWorkerStopped`. Already fixed,
   unmodified, on sibling branch `local/verify-stack` (commit `bfba3221e`) —
   cherry-picked.
3. Root `tracedecay` crate: two `HostAdmissionOutcome { .. }` struct
   literals (`src/host_admission.rs`,
   `src/host_admission/integration_test_support.rs`) were missing the
   `recovery` field added to the struct by an in-flight refactor. No existing
   fix found on any branch, so I added `recovery: None` at both sites myself
   (the same value every other constructor in the codebase uses for a
   non-recovery outcome).

None of these three touch dashboard or init behavior; they exist solely to
make this branch — and this PR's own diff — actually compile so its tests
can run. I made no other changes outside the two assigned CLI defects and
these three minimal, additive build-unblockers.
