### PR TITLE
perf(semantic): reserve per-session bytes, not process budget

### DIFF
--- a/crates/tracedecay-semantic/src/fastembed_adapter.rs
+++ b/crates/tracedecay-semantic/src/fastembed_adapter.rs
@@ -176,7 +176,40 @@ struct VerifiedEmbeddingArtifactV1 {
     max_batch_bytes: u32,
     max_threads: u32,
     resident_byte_ceiling: u64,
+    /// What ONE warmed session is expected to retain, derived from the
+    /// artifact's own declared member lengths.
+    ///
+    /// This is deliberately NOT `resident_byte_ceiling`. The ceiling is the
+    /// whole *process* semantic budget; charging it per session makes the
+    /// first session reserve the entire budget, so the pool's memory check
+    /// refuses every subsequent session and embedding silently collapses to
+    /// one session on every host. The reservation must therefore be a
+    /// per-session estimate, bounded above by the ceiling.
+    resident_bytes_estimate: u64,
     load_deadline_ms: u64,
+}
+
+/// Headroom over the artifact's declared member bytes for ORT arena,
+/// activations, and allocator slack.
+///
+/// Deliberately generous: under-reserving would let the pool admit sessions
+/// the machine cannot hold, which is a worse failure than embedding narrow.
+const RESIDENT_ESTIMATE_HEADROOM_NUMERATOR: u64 = 5;
+const RESIDENT_ESTIMATE_HEADROOM_DENOMINATOR: u64 = 4;
+
+/// Per-session resident estimate from declared member lengths, clamped into
+/// `1..=ceiling`. A zero or unknown length falls back to the ceiling, which
+/// preserves exactly the previous conservative behaviour for any artifact
+/// that does not declare its sizes.
+fn resident_bytes_estimate_for(member_bytes: u64, resident_byte_ceiling: u64) -> u64 {
+    if member_bytes == 0 {
+        return resident_byte_ceiling;
+    }
+    member_bytes
+        .saturating_mul(RESIDENT_ESTIMATE_HEADROOM_NUMERATOR)
+        .checked_div(RESIDENT_ESTIMATE_HEADROOM_DENOMINATOR)
+        .unwrap_or(resident_byte_ceiling)
+        .clamp(1, resident_byte_ceiling.max(1))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -246,6 +279,12 @@ impl VerifiedEmbeddingArtifactV1 {
 
     pub fn resident_byte_ceiling(&self) -> u64 {
         self.resident_byte_ceiling
+    }
+
+    /// What one warmed session is expected to retain. Always `<=`
+    /// [`Self::resident_byte_ceiling`], which the pool still enforces.
+    pub fn resident_bytes_estimate(&self) -> u64 {
+        self.resident_bytes_estimate.min(self.resident_byte_ceiling)
     }
 
     pub fn load_deadline_ms(&self) -> u64 {
@@ -402,6 +441,8 @@ impl AdmittedProjectionArtifactV1 {
         let model_file = member_path(artifact, ArtifactMemberRoleV1::Model)?;
         let tokenizer_file = member_path(artifact, ArtifactMemberRoleV1::Tokenizer)?;
         let config_file = member_path(artifact, ArtifactMemberRoleV1::Config)?;
+        let declared_member_bytes = member_byte_length(artifact, ArtifactMemberRoleV1::Model)
+            .saturating_add(member_byte_length(artifact, ArtifactMemberRoleV1::Tokenizer));
         Ok(Self {
             runtime_artifact: VerifiedEmbeddingArtifactV1 {
                 projection: projection.clone(),
@@ -417,6 +458,10 @@ impl AdmittedProjectionArtifactV1 {
                 ),
                 max_threads: payload.resource_ceiling.max_threads,
                 resident_byte_ceiling: payload.resource_ceiling.max_resident_bytes,
+                resident_bytes_estimate: resident_bytes_estimate_for(
+                    declared_member_bytes,
+                    payload.resource_ceiling.max_resident_bytes,
+                ),
                 load_deadline_ms: payload.resource_ceiling.load_deadline_ms,
             },
         })
@@ -488,6 +533,10 @@ impl AdmittedProjectionArtifactV1 {
                 ),
                 max_threads: resources.max_threads,
                 resident_byte_ceiling: resources.max_resident_bytes,
+                resident_bytes_estimate: resident_bytes_estimate_for(
+                    model_member.length.saturating_add(tokenizer.length),
+                    resources.max_resident_bytes,
+                ),
                 load_deadline_ms: resources.load_deadline_ms,
             },
         })
@@ -583,6 +632,10 @@ impl AdmittedProjectionArtifactV1 {
 
     pub fn resident_byte_ceiling(&self) -> u64 {
         self.runtime_artifact.resident_byte_ceiling()
+    }
+
+    pub fn resident_bytes_estimate(&self) -> u64 {
+        self.runtime_artifact.resident_bytes_estimate()
     }
 
     pub fn load_deadline_ms(&self) -> u64 {
@@ -719,6 +772,15 @@ fn member_path(
         .package_member(role)
         .map(|member| member.path.clone())
         .ok_or(ProjectionArtifactPinV1::ManifestIdentity)
+}
+
+/// Declared byte length of one manifest member, or 0 when the role is absent.
+/// A 0 total makes the resident estimate fall back to the ceiling.
+fn member_byte_length(artifact: &AdmittedArtifactV1, role: ArtifactMemberRoleV1) -> u64 {
+    artifact
+        .manifest()
+        .package_member(role)
+        .map_or(0, |member| member.byte_length)
 }
 
 /// One typed embedding vector. Dimensions, metric, and normalization are
@@ -1003,7 +1065,7 @@ impl EmbeddingRuntime for FastEmbedEmbeddingRuntime {
     type Session = UnavailableEmbeddingSession;
 
     fn resident_bytes_reservation(&self, authority: &AdmittedProjectionArtifactV1) -> u64 {
-        authority.resident_byte_ceiling()
+        authority.resident_bytes_estimate()
     }
 
     fn verify_artifact_compatibility(
@@ -1032,7 +1094,7 @@ impl EmbeddingRuntime for FastEmbedEmbeddingRuntime {
     type Session = FastEmbedEmbeddingSession;
 
     fn resident_bytes_reservation(&self, authority: &AdmittedProjectionArtifactV1) -> u64 {
-        authority.resident_byte_ceiling()
+        authority.resident_bytes_estimate()
     }
 
     fn verify_artifact_compatibility(
@@ -1119,7 +1181,7 @@ impl EmbeddingSession for FastEmbedEmbeddingSession {
     }
 
     fn resident_bytes_estimate(&self) -> u64 {
-        self.authority.resident_byte_ceiling()
+        self.authority.resident_bytes_estimate()
     }
 
     #[hotpath::measure]
@@ -1624,6 +1686,86 @@ mod tests {
         id(&format!("sha256:{}", byte.to_string().repeat(64)))
     }
 
+    /// A session must be charged what one session retains, not the whole
+    /// process budget.
+    ///
+    /// Charging the ceiling per session is self-defeating: the first session
+    /// reserves the entire budget, so the pool's memory check refuses every
+    /// later acquisition and embedding collapses to one session on every
+    /// host, whatever the CPU width arithmetic asked for.
+    #[test]
+    fn resident_estimate_admits_more_than_one_session_under_the_process_ceiling() {
+        const CEILING: u64 = 2 * 1024 * 1024 * 1024;
+        // The shipped default code model plus its tokenizer.
+        const MEMBER_BYTES: u64 = 612 * 1024 * 1024 + 2 * 1024 * 1024;
+
+        let estimate = resident_bytes_estimate_for(MEMBER_BYTES, CEILING);
+        assert!(
+            estimate < CEILING,
+            "a single session must not reserve the whole process budget"
+        );
+        assert!(
+            estimate >= MEMBER_BYTES,
+            "the estimate must still cover the artifact's own declared bytes"
+        );
+        assert!(
+            CEILING / estimate >= 2,
+            "the default ceiling must admit at least the two concurrent \
+             sessions the host width arithmetic derives"
+        );
+    }
+
+    /// End-to-end over the real admission path: a production-scale artifact
+    /// must not charge one session the whole process budget.
+    ///
+    /// Before the reservation was split from the ceiling, the descriptor
+    /// reported the full `max_resident_bytes` for every session, so the
+    /// pool's `resident_bytes + reserved > memory_ceiling` check refused the
+    /// second acquisition and `RuntimeChunkVectorEncoderV1::ensure_sessions`
+    /// silently broke out of its loop at one session.
+    #[test]
+    fn production_scale_artifact_admits_the_derived_session_width() {
+        const CEILING: u64 = 2 * 1024 * 1024 * 1024;
+        const MODEL_BYTES: u64 = 612 * 1024 * 1024;
+        const TOKENIZER_BYTES: u64 = 2 * 1024 * 1024;
+
+        let artifact = crate::session_pool::test_support::admitted_artifact_sized(
+            MODEL_BYTES,
+            TOKENIZER_BYTES,
+            CEILING,
+        );
+        let projection = crate::session_pool::test_support::projection_for(&artifact)
+            .admit()
+            .expect("production-scale fixture projection");
+        let authority = AdmittedProjectionArtifactV1::admit(&artifact, &projection)
+            .expect("production-scale fixture admits");
+
+        let reserved = authority.resident_bytes_estimate();
+        assert!(
+            reserved <= authority.resident_byte_ceiling(),
+            "a per-session reservation may never exceed the process ceiling"
+        );
+        // The pool admits while `resident_bytes + reserved <= ceiling`.
+        let admitted = (1..=8).take_while(|n| reserved.saturating_mul(*n) <= CEILING).count();
+        assert!(
+            admitted >= 2,
+            "the process ceiling must admit at least the two sessions the host \
+             width arithmetic derives, but only {admitted} fit at {reserved} bytes each"
+        );
+    }
+
+    #[test]
+    fn resident_estimate_never_exceeds_the_ceiling_and_survives_unknown_sizes() {
+        const CEILING: u64 = 4096;
+        // An artifact that declares no lengths keeps the previous
+        // conservative behaviour rather than under-reserving.
+        assert_eq!(resident_bytes_estimate_for(0, CEILING), CEILING);
+        // A model larger than the ceiling still clamps to it; the pool's own
+        // `reserved_bytes > resident_byte_ceiling` check then refuses it.
+        assert_eq!(resident_bytes_estimate_for(u64::MAX, CEILING), CEILING);
+        assert!(resident_bytes_estimate_for(1024, CEILING) <= CEILING);
+    }
+
     fn authority(dimensions: u32) -> AdmittedProjectionArtifactV1 {
         authority_with(
             dimensions,
@@ -1676,6 +1818,7 @@ mod tests {
                 max_batch_bytes: 16 * 1024,
                 max_threads: 4,
                 resident_byte_ceiling: 64 * 1024 * 1024,
+                resident_bytes_estimate: 8 * 1024 * 1024,
                 load_deadline_ms: 30_000,
             },
         }

--- a/crates/tracedecay-semantic/src/lib.rs
+++ b/crates/tracedecay-semantic/src/lib.rs
@@ -987,14 +987,20 @@ where
         runtime: Arc<SemanticRuntimeService<R>>,
         progress: Arc<SemanticRuntimeScheduleCancellationV1>,
     ) -> Self {
+        let width = embedding_parallelism::embedding_session_width(
+            embedding_parallelism::DEFAULT_INTRA_THREADS,
+            u32::MAX,
+        );
+        // The width the host arithmetic asks for. Compare against
+        // `semantic_embed_sessions_held` to see what the pool actually
+        // granted; the two diverging is the only symptom pool pressure has on
+        // this path, because acquisition here never blocks.
+        hotpath::gauge!("semantic_embed_session_width").set(width);
         Self {
             runtime,
             progress,
             sessions: Vec::new(),
-            width: embedding_parallelism::embedding_session_width(
-                embedding_parallelism::DEFAULT_INTRA_THREADS,
-                u32::MAX,
-            ),
+            width,
             completed_units: 0,
         }
     }
@@ -1010,9 +1016,20 @@ where
             match self.runtime.acquire() {
                 Ok(session) => self.sessions.push(session),
                 Err(error) if self.sessions.is_empty() => return Err(error.to_string()),
-                Err(_) => break,
+                // The pool refused, so embedding narrows rather than failing.
+                // This is the ONLY way pool pressure reaches the projection
+                // path: acquisition here is non-blocking, so no caller ever
+                // waits and `semantic.session_pool.wait` can never record it.
+                // Counting the refusal is therefore the only way a narrowed
+                // run is distinguishable from a deliberately narrow host.
+                Err(_) => {
+                    hotpath::gauge!("semantic_embed_session_shortfall").inc(1);
+                    break;
+                }
             }
         }
+        hotpath::gauge!("semantic_embed_sessions_wanted").set(wanted);
+        hotpath::gauge!("semantic_embed_sessions_held").set(self.sessions.len());
         Ok(self.sessions.len())
     }
 }
@@ -1056,14 +1073,19 @@ where
             "semantic projection authority does not match its inference batch identity".to_owned(),
         );
     }
-    let batch = BoundedSanitizedTextBatchV1::try_new(
-        chunks
-            .iter()
-            .map(|chunk| chunk.sanitized_text.as_str().to_owned())
-            .collect(),
-        max_texts,
-        max_bytes,
-    )
+    // The one copy between canonical chunks and tensor input: every chunk's
+    // sanitized text is cloned into an owned String. Timed separately so it
+    // cannot hide inside `semantic.embed.infer`.
+    let batch = hotpath::measure_block!("semantic.embed.batch_assembly", {
+        BoundedSanitizedTextBatchV1::try_new(
+            chunks
+                .iter()
+                .map(|chunk| chunk.sanitized_text.as_str().to_owned())
+                .collect(),
+            max_texts,
+            max_bytes,
+        )
+    })
     .map_err(|error| error.to_string())?;
     let vectors = session
         .embed_batch(&batch, progress)
@@ -1071,13 +1093,18 @@ where
     if vectors.len() != chunks.len() {
         return Err("semantic projector returned an unexpected vector batch size".to_owned());
     }
-    let encoded = vectors
-        .into_iter()
-        .map(|vector| {
-            vector.validate().map_err(|error| error.to_string())?;
-            Ok(vector.values)
-        })
-        .collect::<Result<Vec<_>, String>>()?;
+    // Per-vector dimension/finite validation plus the move out of the
+    // adapter's vector type. Also timed separately: a regression here would
+    // otherwise be read as slower inference.
+    let encoded = hotpath::measure_block!("semantic.embed.vector_writeback", {
+        vectors
+            .into_iter()
+            .map(|vector| {
+                vector.validate().map_err(|error| error.to_string())?;
+                Ok(vector.values)
+            })
+            .collect::<Result<Vec<_>, String>>()
+    })?;
     Ok((encoded, chunks.len() as u64))
 }
 
@@ -1147,6 +1174,10 @@ where
         }
         let sessions = self.ensure_sessions(groups.len())?;
         if sessions <= 1 || groups.len() == 1 {
+            // One stripe. Counted so a run that never widens is visible as a
+            // count rather than inferred from the absence of parallel spans.
+            hotpath::gauge!("semantic_embed_sequential_dispatch").inc(1);
+            hotpath::gauge!("semantic_embed_encode_stripes").set(1_usize);
             let progress = Arc::clone(&self.progress);
             let mut encoded = Vec::with_capacity(groups.len());
             let mut units = 0u64;
@@ -1167,6 +1198,7 @@ where
 
         let stripe_len = groups.len().div_ceil(sessions);
         let stripes = groups.chunks(stripe_len).collect::<Vec<_>>();
+        hotpath::gauge!("semantic_embed_encode_stripes").set(stripes.len());
         let progress = Arc::clone(&self.progress);
         let mut stripe_results: Vec<EncodedStripeResultV1> = embedding_parallelism::install(|| {
             use rayon::prelude::*;

--- a/crates/tracedecay-semantic/src/session_pool.rs
+++ b/crates/tracedecay-semantic/src/session_pool.rs
@@ -863,6 +863,17 @@ pub mod test_support {
     }
 
     pub fn admitted_artifact() -> AdmittedArtifactV1 {
+        admitted_artifact_sized(5, 9, 64 * 1024 * 1024)
+    }
+
+    /// Same fixture with caller-chosen member sizes and process ceiling, so a
+    /// test can reproduce production-scale resident arithmetic (a ~600 MB
+    /// model under a 2 GiB process budget) without a real artifact.
+    pub fn admitted_artifact_sized(
+        model_bytes: u64,
+        tokenizer_bytes: u64,
+        max_resident_bytes: u64,
+    ) -> AdmittedArtifactV1 {
         let model_digest = Sha256DigestHex::of_bytes(b"model");
         let tokenizer_digest = Sha256DigestHex::of_bytes(b"tokenizer");
         let config_digest = Sha256DigestHex::of_bytes(b"config");
@@ -878,7 +889,7 @@ pub mod test_support {
                 spdx_license: "MIT".to_owned(),
                 model_member: ArtifactMemberPinV1 {
                     digest: model_digest.clone(),
-                    byte_length: 5,
+                    byte_length: model_bytes,
                 },
                 tokenizer_digest: tokenizer_digest.clone(),
                 config_digest: config_digest.clone(),
@@ -889,13 +900,13 @@ pub mod test_support {
                         role: ArtifactMemberRoleV1::Model,
                         path: "model.onnx".to_owned(),
                         digest: model_digest,
-                        byte_length: 5,
+                        byte_length: model_bytes,
                     },
                     ArtifactPackageMemberV1 {
                         role: ArtifactMemberRoleV1::Tokenizer,
                         path: "tokenizer.json".to_owned(),
                         digest: tokenizer_digest,
-                        byte_length: 9,
+                        byte_length: tokenizer_bytes,
                     },
                     ArtifactPackageMemberV1 {
                         role: ArtifactMemberRoleV1::Config,
@@ -947,9 +958,9 @@ pub mod test_support {
                 },
                 device: DeviceClassV1::Cpu,
                 resource_ceiling: ResourceCeilingV1 {
-                    max_model_bytes: 1024,
-                    max_tokenizer_bytes: 1024,
-                    max_resident_bytes: 64 * 1024 * 1024,
+                    max_model_bytes: model_bytes.max(1024),
+                    max_tokenizer_bytes: tokenizer_bytes.max(1024),
+                    max_resident_bytes,
                     max_threads: 4,
                     max_batch_size: 8,
                     max_sequence_length: 512,


### PR DESCRIPTION
## The infer-vs-wait split: 100% infer, 0% wait — by construction, not by measurement

**`semantic.session_pool.wait` can never fire for embedding.** Its only
`measure_block!` sits inside `SessionPool::acquire_blocking`, and every call
site of `acquire_blocking` is inside `session_pool.rs`'s own `#[cfg(test)]`
module. The projection path acquires through `RuntimeChunkVectorEncoderV1::
ensure_sessions` → `SemanticRuntimeService::acquire` → the **non-blocking**
`SessionPool::acquire`. No embedding caller ever waits.

So the split could not have been read off the existing labels. Pool pressure
reaches this path only through `ensure_sessions`' `Err(_) => break` arm, which
silently narrows the width and, until this PR, incremented nothing.

Everything below follows from that.

## What the width actually is

The premise I was given was `96 / 4 = 24 → capped to 16 → ~64 cores busy`.
That is wrong, and the host disagrees.

`embedding_session_width_for` divides `indexing_worker_target(total_cores)`,
not `total_cores`. Measured live on this 96-core host via the hotpath MCP
`gauges` surface:

```
code_index_worker_count = 8   (last_value, 1340 logs)
```

`indexing_worker_target(96)` = 8 (the parser-memory ceiling), so
`embedding_session_width(4, …)` = `8 / 4` = **2 sessions**, not 16 — a
derived ceiling of ~8 cores, not ~64. The crate's own test already asserts
this (`embedding_session_width_for(96, 4, 64) == 2`).

## The bug: one session reserves the entire process budget

`VerifiedEmbeddingArtifactV1` set `resident_byte_ceiling = resources.
max_resident_bytes` (2 GiB, the *process* semantic budget) at both production
construction sites, and both `resident_bytes_reservation` impls returned that
ceiling as the *per-session* reservation.

In `acquire_verified` the pool admits while
`resident_bytes + reserved <= memory_ceiling_bytes`:

| session | resident before | reserved | projected | admitted |
|---|---|---|---|---|
| 1 | 0 | 2 GiB | 2 GiB | yes |
| 2 | 2 GiB | 2 GiB | 4 GiB | **MemoryCeilingExceeded** |

`ensure_sessions(2)` therefore returned 1, hit `Err(_) => break`, and
embedding ran at **1 session × 4 intra-op threads ≈ 4 of 96 cores** — half
even the derived width, on every host, regardless of configuration. The rayon
striping in `encode_batches` is unreachable in production, because
`sessions <= 1` always takes the sequential branch.

## Falsifiable RED/GREEN evidence (counters, not elapsed time)

`production_scale_artifact_admits_the_derived_session_width` drives the real
`AdmittedProjectionArtifactV1::admit` path with a production-scale artifact
(612 MiB model + 2 MiB tokenizer under a 2 GiB ceiling) and counts how many
sessions the pool's own admission arithmetic accepts.

**RED** — reservation restored to the pre-fix `resident_byte_ceiling()`:

```
panicked at fastembed_adapter.rs:1750:
the process ceiling must admit at least the two sessions the host width
arithmetic derives, but only 1 fit at 2147483648 bytes each
test result: FAILED. 0 passed; 1 failed
```

**GREEN** — per-session estimate:

```
test production_scale_artifact_admits_the_derived_session_width ... ok
test resident_estimate_admits_more_than_one_session_under_the_process_ceiling ... ok
test resident_estimate_never_exceeds_the_ceiling_and_survives_unknown_sizes ... ok
test result: ok. 170 passed; 0 failed   (full tracedecay-semantic lib suite)
```

The failure message *is* the measurement: `1 fit at 2147483648 bytes each`.

## The fix, and why it does not exceed the memory budget

The reservation is now derived from the artifact's own declared member
lengths (`model + tokenizer`, ×5/4 headroom for ORT arena and activations),
clamped to `resident_byte_ceiling`, which the pool still enforces unchanged.
An artifact that declares no lengths falls back to the ceiling, preserving the
previous conservative behaviour exactly.

At production scale that is ~768 MiB per session, so the unchanged 2 GiB
budget admits **2** sessions — exactly the width the CPU arithmetic already
derived, and within the pool's `ResidentSessionLimit` (`max_sessions =
embedding_pool_sessions` = width + 1 = 3). **No ceiling, no width formula, and
no concurrency knob was raised.** The 96-core machine still uses ~8 cores for
embedding, not 64; that ceiling is memory, and it is respected.

## Instrumentation added for the genuinely unmeasured steps

- `semantic_embed_session_width` / `_sessions_wanted` / `_sessions_held` /
  `_session_shortfall` — the shortfall counter is the only signal that a run
  narrowed, since no wait can occur.
- `semantic_embed_encode_stripes` / `_sequential_dispatch` — dispatch shape
  actually taken.
- `semantic.embed.batch_assembly` — the one copy from canonical chunks into
  owned tensor input.
- `semantic.embed.vector_writeback` — per-vector validation and move out of
  the adapter type.

Tokenisation is not separately instrumented: FastEmbed's `embed()` tokenises
and infers in one call, so splitting it would mean changing how the model is
invoked. Model *fetch* was out of scope and is untouched.

## Batch size: measured, and deliberately not changed

`inference_batch_size` = `max_batch_size` = 32; projection pages are 512
chunks (`MAX_SEMANTIC_VECTOR_STAGE_CHUNKS_PER_BATCH`). Groups reach 32 only
when singleton-file runs coalesce; a multi-chunk file flushes the singleton
run and emits its own group, so real corpora produce many sub-32 batches.

That is a real inefficiency, but **it is not a free lever**: `projector.rs`
states group membership *is* projection identity — regrouping changes tensor
shapes, therefore vector bytes, therefore every `output_digest` and the
generation manifest digest. Enlarging batches means a full re-embed, which is
a separate decision. Reporting it, not taking it.

## Verification

```
cargo check -p tracedecay-semantic --all-targets --locked
cargo check -p tracedecay-semantic --all-targets --locked --features hotpath
cargo check -p tracedecay-semantic --all-targets --locked --features semantic-fastembed,hotpath
cargo test  -p tracedecay-semantic --lib      # 170 passed
```

No workspace build, no workspace clippy. Sizing only: vector bytes and
generation digests are unchanged, which the crate's existing width-equivalence
tests continue to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
