### PR TITLE
docs(perf): diagnose the tokio async-worker skew

### DIFF
--- a/docs/SERVING-PATH-PERFORMANCE.md
+++ b/docs/SERVING-PATH-PERFORMANCE.md
@@ -199,6 +199,10 @@ have no finish line, so they stay paced:
   them defer or shrink a slice while agents are actively querying. Results
   are identical; only pacing changes.
 
+The historical half of the session-refresh sweep does none of this today; see
+"Open breach: historical transcript ingest violates Principle 2" below for the
+measurement and for why the answer is not a wider or narrower worker pool.
+
 ### 3. Hash where data is born, never where it is served
 
 Content digests (payload references, canonical record digests) are computed
@@ -339,6 +343,87 @@ box: the reserved slice, not a slower indexer, is what holds the line.
 cost, not indexing interference. Peak daemon RSS on this host is ~13.6GB with
 no indexing at all, well over the 6GB gate budget — a live, separate breach
 of Principle 5 that this measurement did not introduce.
+
+## Open breach: historical transcript ingest violates Principle 2
+
+Principle 2 says long CPU slices "run in `spawn_blocking` chunks, never on the
+request runtime's workers for unbounded stretches", and names projection
+refresh as an open-ended sweep that must stay paced. Measurement contradicts
+both for the *historical* half of that sweep.
+
+Reproduce with `scripts/profile-tokio-worker-balance.sh`, which reads Hotpath's
+metrics server and needs no product code change. The numbers below are one
+60-second window on a 96-core host, `--profile perf`, features
+`production,hotpath,hotpath-mcp`, `--cfg tokio_unstable`, against an isolated
+profile root under `/tmp` with one registered 3,114-file corpus:
+
+```
+window 60.0s   workers 16   blocking threads 8 (7 idle)
+async pool busy 91.92s = 1.53 cores   steals 14
+
+ wrk    busy_ms   share%      polls    us/poll   steals     parks
+  14      61824    67.26       6926     8926.4        2     13084
+  12      13398    14.58      10979     1220.3        2     21509
+   6       8814     9.59       7343     1200.3        2     15314
+  15       5892     6.41       9293      634.0        4     17940
+  10       1990     2.16       3452      576.5        4      6424
+   (workers 0-5, 7-9, 11, 13 ran zero polls)
+
+top-2 busy share  81.84%
+workers with any busy time  5/16
+
+in-poll execution by labelled future (excludes every .await):
+   cores    poll_s     polls    us/poll  label
+    1.49     89.68     35648     2515.7  session_temporal_refresh.history
+```
+
+`total_poll_duration_ns` is wall time strictly inside `Future::poll`, so an
+`.await` cannot contribute to it. One label therefore accounts for 89.68s of
+the pool's 91.92s of busy time — **97.6% of everything the request runtime's
+async workers did was synchronous execution belonging to
+`session_temporal_refresh.history`**, at 2.5ms per poll and a worst-worker
+occupancy of 8.9ms per poll. A 325-second run of the same scenario shows the
+same shape: 5 of 16 workers carry 98.5% of busy time, the reserved indexing
+pool consumes 4.22 CPU-seconds over the whole run, and cumulative steal counts
+stay in single digits.
+
+### The skew is a symptom; do not resize the pool
+
+The concentration is not a scheduling defect and it is not fixed by changing
+`async_worker_threads()`. `session_history_refresh` runs as exactly two
+long-lived tasks — one project-scoped ingestor and one profile-scoped one — so
+runnable async concurrency is 2, not 16. Work-stealing has nothing to steal
+(14 steals in 60s), and no pool width redistributes a slice that a worker is
+already inside: a poll is not preemptible until it returns.
+
+The width is in fact why the breach has not surfaced as a latency regression.
+Eleven of sixteen workers ran zero polls in the sampled minute, so an arriving
+request always finds a parked worker rather than queueing behind a 9ms poll.
+Narrowing the pool to "match" the observed concurrency would delete exactly
+that headroom and convert a benign skew into a real tail. The measurement to
+watch is microseconds per poll, not busy share.
+
+### Where the fix has to land
+
+The cost is CPU placement, not balance: this work belongs off the request
+runtime, in the same sense the indexing pool already is. Fixing it means
+restructuring the ingest pass, not adding a yield — the pass is an async
+pipeline whose synchronous slices sit *between* store awaits, so a yield point
+redistributes the slices across workers without moving a single cycle off the
+serving pool, and `spawn_blocking` cannot wrap the pass as a whole because it
+is a future, not a closure. The work has to be batched into blocking chunks at
+a boundary that owns its data.
+
+Leaf attribution is not yet pinned down, and the obvious instrument cannot pin
+it: Tokio names async worker threads and blocking-pool threads with the same
+`thread_name_fn`, so `perf --comms` cannot separate the two pools. Under that
+combined thread-name family the largest single product symbol during ingest is
+`privacy::rules::contains_ignore_ascii_case` (5.16% of whole-process cycles,
+~7.4% for the privacy-detector family), which is a plausible in-poll leaf
+because redaction is pure CPU over transcript text — but the SQLite parser
+symbols in the same family belong to `ReadSnapshot::query`, which already uses
+`spawn_blocking` and is correctly placed. Naming the exact leaf needs a
+`#[hotpath::measure]` inside the pass or `HOTPATH_FOCUS`, not a thread filter.
 
 ## Open breach: the vector-generation store violates Principle 5
 

--- a/scripts/lib/tokio_worker_balance.py
+++ b/scripts/lib/tokio_worker_balance.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Tokio async-worker balance analysis from Hotpath's metrics server.
+
+Answers one question with falsifiable numbers: is the daemon's Tokio worker
+pool skewed because a few tasks execute long *synchronous* slices inside
+`poll()`, or is it merely idle because the async side has little to do?
+
+Two independent signals are combined, both taken from the already-present
+Hotpath instrumentation (no product code changes are required):
+
+* ``GET /tokio_runtime`` -- Tokio's own per-worker counters. ``busy_duration``
+  minus ``park`` time is what the worker was *not* parked for;
+  ``poll_count`` divides it into per-poll occupancy. Microseconds per poll is
+  the discriminator: single-digit microseconds is a healthy async poll, and
+  milliseconds means the worker ran synchronous work inside one poll and could
+  not be preempted.
+* ``GET /futures`` -- Hotpath's labelled-future poll accounting.
+  ``total_poll_duration_ns`` is wall time strictly *inside* ``Future::poll``,
+  so it excludes every ``.await``. Divided by the sample window it reads as
+  "cores of synchronous execution this label pinned to the async pool".
+
+Both are deltas between two samples, never lifetime totals, so a long-lived
+daemon and a fresh one are comparable.
+
+This module is deliberately dependency-free (stdlib only) and importable, so
+``--self-test`` can exercise the arithmetic over fixtures with no daemon.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+__all__ = [
+    "WorkerDelta",
+    "FutureDelta",
+    "BalanceReport",
+    "fetch_json",
+    "worker_deltas",
+    "future_deltas",
+    "build_report",
+    "render_report",
+]
+
+
+@dataclass(frozen=True)
+class WorkerDelta:
+    """One Tokio worker's counters between two samples."""
+
+    index: int
+    busy_ms: int
+    polls: int
+    steals: int
+    parks: int
+
+    @property
+    def us_per_poll(self) -> float:
+        return (self.busy_ms * 1000.0 / self.polls) if self.polls else 0.0
+
+
+@dataclass(frozen=True)
+class FutureDelta:
+    """One labelled future's in-poll execution between two samples."""
+
+    label: str
+    source: str
+    poll_ns: int
+    polls: int
+
+    @property
+    def us_per_poll(self) -> float:
+        return (self.poll_ns / 1000.0 / self.polls) if self.polls else 0.0
+
+    def cores(self, window_secs: float) -> float:
+        return (self.poll_ns / 1e9 / window_secs) if window_secs > 0 else 0.0
+
+
+@dataclass
+class BalanceReport:
+    window_secs: float
+    workers: list[WorkerDelta] = field(default_factory=list)
+    futures: list[FutureDelta] = field(default_factory=list)
+    num_workers: int = 0
+    blocking_threads: int | None = None
+    idle_blocking_threads: int | None = None
+
+    @property
+    def total_busy_ms(self) -> int:
+        return sum(w.busy_ms for w in self.workers)
+
+    @property
+    def busy_cores(self) -> float:
+        if self.window_secs <= 0:
+            return 0.0
+        return self.total_busy_ms / 1000.0 / self.window_secs
+
+    def busy_share(self, worker: WorkerDelta) -> float:
+        total = self.total_busy_ms
+        return (100.0 * worker.busy_ms / total) if total else 0.0
+
+    def top_share(self, count: int) -> float:
+        total = self.total_busy_ms
+        if not total:
+            return 0.0
+        ranked = sorted(self.workers, key=lambda w: -w.busy_ms)[:count]
+        return 100.0 * sum(w.busy_ms for w in ranked) / total
+
+    @property
+    def active_workers(self) -> int:
+        return sum(1 for w in self.workers if w.busy_ms > 0)
+
+    @property
+    def total_steals(self) -> int:
+        return sum(w.steals for w in self.workers)
+
+    def worst_us_per_poll(self) -> float:
+        """Highest per-poll occupancy among workers that did real work.
+
+        Workers with a handful of polls are excluded: one slow poll on an
+        otherwise idle worker is noise, not a funnel.
+        """
+        candidates = [w for w in self.workers if w.polls >= 100]
+        return max((w.us_per_poll for w in candidates), default=0.0)
+
+
+def fetch_json(host: str, port: int, path: str, timeout: float = 5.0) -> Any:
+    """GET one Hotpath metrics route. Returns None when it is not served."""
+    url = f"http://{host}:{port}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return json.loads(response.read().decode())
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+        return None
+
+
+def _rows(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        payload = payload.get("data", [])
+    if not isinstance(payload, list):
+        return []
+    return [row for row in payload if isinstance(row, dict)]
+
+
+def worker_deltas(before: Any, after: Any) -> list[WorkerDelta]:
+    """Per-worker counter deltas between two ``/tokio_runtime`` snapshots."""
+    if not isinstance(before, dict) or not isinstance(after, dict):
+        return []
+    first = {w["index"]: w for w in _rows(before.get("workers"))}
+    deltas = []
+    for row in _rows(after.get("workers")):
+        prior = first.get(row["index"])
+        if prior is None:
+            continue
+        deltas.append(
+            WorkerDelta(
+                index=row["index"],
+                busy_ms=row["busy_duration_ms"] - prior["busy_duration_ms"],
+                polls=(row.get("poll_count") or 0) - (prior.get("poll_count") or 0),
+                steals=(row.get("steal_count") or 0) - (prior.get("steal_count") or 0),
+                parks=row["park_count"] - prior["park_count"],
+            )
+        )
+    deltas.sort(key=lambda w: -w.busy_ms)
+    return deltas
+
+
+def future_deltas(before: Any, after: Any) -> list[FutureDelta]:
+    """Per-label in-poll deltas between two ``/futures`` snapshots."""
+    first = {row["id"]: row for row in _rows(before) if "id" in row}
+    deltas = []
+    for row in _rows(after):
+        prior = first.get(row.get("id"))
+        if prior is None:
+            continue
+        deltas.append(
+            FutureDelta(
+                label=row.get("label") or row.get("source", "?"),
+                source=row.get("source", "?"),
+                poll_ns=row["total_poll_duration_ns"] - prior["total_poll_duration_ns"],
+                polls=row["total_polls"] - prior["total_polls"],
+            )
+        )
+    deltas.sort(key=lambda f: -f.poll_ns)
+    return deltas
+
+
+def build_report(
+    window_secs: float,
+    runtime_before: Any,
+    runtime_after: Any,
+    futures_before: Any,
+    futures_after: Any,
+) -> BalanceReport:
+    after = runtime_after if isinstance(runtime_after, dict) else {}
+    return BalanceReport(
+        window_secs=window_secs,
+        workers=worker_deltas(runtime_before, runtime_after),
+        futures=future_deltas(futures_before, futures_after),
+        num_workers=after.get("num_workers", 0),
+        blocking_threads=after.get("num_blocking_threads"),
+        idle_blocking_threads=after.get("num_idle_blocking_threads"),
+    )
+
+
+def render_report(report: BalanceReport, future_limit: int = 8) -> str:
+    out: list[str] = []
+    out.append(
+        f"window {report.window_secs:.1f}s   workers {report.num_workers}   "
+        f"blocking threads {report.blocking_threads} "
+        f"({report.idle_blocking_threads} idle)"
+    )
+    out.append(
+        f"async pool busy {report.total_busy_ms / 1000.0:.2f}s "
+        f"= {report.busy_cores:.2f} cores   steals {report.total_steals}"
+    )
+    out.append("")
+    out.append(
+        f"{'wrk':>4} {'busy_ms':>10} {'share%':>8} {'polls':>10} "
+        f"{'us/poll':>10} {'steals':>8} {'parks':>9}"
+    )
+    for worker in report.workers:
+        out.append(
+            f"{worker.index:>4} {worker.busy_ms:>10} "
+            f"{report.busy_share(worker):>8.2f} {worker.polls:>10} "
+            f"{worker.us_per_poll:>10.1f} {worker.steals:>8} {worker.parks:>9}"
+        )
+    out.append("")
+    out.append(f"top-1 busy share  {report.top_share(1):.2f}%")
+    out.append(f"top-2 busy share  {report.top_share(2):.2f}%")
+    out.append(f"workers with any busy time  {report.active_workers}/{len(report.workers)}")
+    out.append(f"worst us/poll (>=100 polls) {report.worst_us_per_poll():.1f}")
+    out.append("")
+    out.append("in-poll execution by labelled future (excludes every .await):")
+    out.append(f"{'cores':>8} {'poll_s':>9} {'polls':>9} {'us/poll':>10}  label")
+    for entry in report.futures[:future_limit]:
+        if entry.poll_ns <= 0:
+            continue
+        out.append(
+            f"{entry.cores(report.window_secs):>8.2f} {entry.poll_ns / 1e9:>9.2f} "
+            f"{entry.polls:>9} {entry.us_per_poll:>10.1f}  {entry.label}"
+        )
+    return "\n".join(out)
+
+
+def check_thresholds(
+    report: BalanceReport,
+    max_top2_share: float | None,
+    max_us_per_poll: float | None,
+) -> list[str]:
+    """Return one message per breached threshold; empty means the gate passed."""
+    failures: list[str] = []
+    if max_top2_share is not None:
+        share = report.top_share(2)
+        if share > max_top2_share:
+            failures.append(
+                f"top-2 worker busy share {share:.2f}% exceeds {max_top2_share:.2f}%"
+            )
+    if max_us_per_poll is not None:
+        worst = report.worst_us_per_poll()
+        if worst > max_us_per_poll:
+            failures.append(
+                f"worst worker occupancy {worst:.1f} us/poll exceeds "
+                f"{max_us_per_poll:.1f} us/poll"
+            )
+    return failures
+
+
+# --------------------------------------------------------------------------
+# Self-test: exercise the arithmetic over fixtures, with no daemon involved.
+# --------------------------------------------------------------------------
+
+
+def _runtime_fixture(busy: Iterable[int], polls: Iterable[int]) -> dict[str, Any]:
+    workers = [
+        {
+            "index": index,
+            "park_count": 10 * index,
+            "busy_duration_ms": busy_ms,
+            "poll_count": poll_count,
+            "steal_count": 0,
+        }
+        for index, (busy_ms, poll_count) in enumerate(zip(busy, polls))
+    ]
+    return {
+        "num_workers": len(workers),
+        "num_blocking_threads": 6,
+        "num_idle_blocking_threads": 6,
+        "workers": workers,
+    }
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(name: str, condition: bool) -> None:
+        if not condition:
+            failures.append(name)
+
+    zero = _runtime_fixture([0, 0, 0, 0], [0, 0, 0, 0])
+    skewed = _runtime_fixture([9000, 900, 50, 0], [9000, 900, 50, 0])
+    report = build_report(10.0, zero, skewed, [], [])
+
+    check("four worker deltas", len(report.workers) == 4)
+    check("busy total", report.total_busy_ms == 9950)
+    check("busy cores", abs(report.busy_cores - 0.995) < 1e-6)
+    check("top1 share", abs(report.top_share(1) - 90.452) < 0.01)
+    check("top2 share", abs(report.top_share(2) - 99.497) < 0.01)
+    check("active workers", report.active_workers == 3)
+    # 9000 ms over 9000 polls is exactly 1000 us per poll.
+    check("us per poll", abs(report.workers[0].us_per_poll - 1000.0) < 1e-6)
+
+    # A worker with very few polls must not set the funnel verdict.
+    noisy = _runtime_fixture([5, 0, 0, 0], [1, 0, 0, 0])
+    noisy_report = build_report(10.0, zero, noisy, [], [])
+    check("low-poll worker ignored", noisy_report.worst_us_per_poll() == 0.0)
+
+    before = [
+        {"id": 1, "label": "a", "source": "s1", "total_polls": 0, "total_poll_duration_ns": 0},
+        {"id": 2, "label": "b", "source": "s2", "total_polls": 0, "total_poll_duration_ns": 0},
+    ]
+    after = [
+        {
+            "id": 1,
+            "label": "a",
+            "source": "s1",
+            "total_polls": 1000,
+            "total_poll_duration_ns": 2_000_000_000,
+        },
+        {
+            "id": 2,
+            "label": "b",
+            "source": "s2",
+            "total_polls": 1000,
+            "total_poll_duration_ns": 1_000_000,
+        },
+    ]
+    futures = future_deltas(before, after)
+    check("futures ranked by poll time", [f.label for f in futures] == ["a", "b"])
+    check("future cores", abs(futures[0].cores(10.0) - 0.2) < 1e-9)
+    check("future us per poll", abs(futures[0].us_per_poll - 2000.0) < 1e-6)
+
+    # Ids absent from the earlier snapshot cannot produce a delta.
+    check("unmatched ids dropped", future_deltas([], after) == [])
+    # Envelope form ({"data": [...]}) must parse the same as a bare list.
+    check("envelope form", len(future_deltas({"data": before}, {"data": after})) == 2)
+
+    check(
+        "threshold gate fails on skew",
+        check_thresholds(report, max_top2_share=60.0, max_us_per_poll=None) != [],
+    )
+    check(
+        "threshold gate passes when balanced",
+        check_thresholds(report, max_top2_share=100.0, max_us_per_poll=None) == [],
+    )
+    check(
+        "threshold gate fails on slow polls",
+        check_thresholds(report, max_top2_share=None, max_us_per_poll=100.0) != [],
+    )
+
+    # A report with no samples must be inert rather than divide by zero.
+    empty = build_report(0.0, None, None, None, None)
+    check("empty report is inert", empty.busy_cores == 0.0 and empty.top_share(2) == 0.0)
+    check("empty renders", "window 0.0s" in render_report(empty))
+
+    if failures:
+        for name in failures:
+            print(f"FAIL {name}")
+        return 1
+    print("tokio_worker_balance self-test: ok")
+    return 0

--- a/scripts/profile-tokio-worker-balance.sh
+++ b/scripts/profile-tokio-worker-balance.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Measure how a running TraceDecay process spreads work across its Tokio
+# async workers, and which labelled futures pin those workers.
+#
+# Reads only Hotpath's metrics server, so it needs no product code change and
+# no restart: build the binary with `hotpath` (see
+# .claude/skills/using-hotpath) and point this at the live port.
+#
+# The two numbers this exists to produce:
+#
+#   * per-worker busy share -- how lopsided the pool is;
+#   * microseconds per poll -- WHY. A healthy async poll is single-digit
+#     microseconds. Milliseconds per poll means a task ran synchronous work
+#     inside one `poll()`, which no amount of work-stealing can rebalance
+#     because the worker is not preemptible until poll returns.
+#
+# Both are deltas across the sample window, so a long-lived daemon and a fresh
+# one are directly comparable. `--futures` attributes the in-poll time to
+# labelled futures; `total_poll_duration_ns` excludes every `.await`, so a
+# label with a high core count is running synchronous work on the async pool.
+#
+# Sample a daemon for 60s:
+#   scripts/profile-tokio-worker-balance.sh --seconds 60
+#
+# Gate a before/after comparison (non-zero exit when breached):
+#   scripts/profile-tokio-worker-balance.sh --seconds 60 \
+#       --max-top2-share 60 --max-us-per-poll 200
+#
+# Hermetic arithmetic tests (no daemon, no cargo):
+#   scripts/profile-tokio-worker-balance.sh --self-test
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd)
+
+usage() {
+  sed -n '2,30p' "$0" >&2
+  exit 2
+}
+
+HOST=127.0.0.1
+PORT=6770
+SECONDS_TO_SAMPLE=60
+JSON_OUT=
+MAX_TOP2=
+MAX_US_PER_POLL=
+SELF_TEST=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host) HOST=${2:?--host needs a value}; shift 2 ;;
+    --port) PORT=${2:?--port needs a value}; shift 2 ;;
+    --seconds) SECONDS_TO_SAMPLE=${2:?--seconds needs a value}; shift 2 ;;
+    --json) JSON_OUT=${2:?--json needs a path}; shift 2 ;;
+    --max-top2-share) MAX_TOP2=${2:?--max-top2-share needs a value}; shift 2 ;;
+    --max-us-per-poll) MAX_US_PER_POLL=${2:?--max-us-per-poll needs a value}; shift 2 ;;
+    --self-test) SELF_TEST=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+PYTHON=${PYTHON:-python3}
+
+if [ "$SELF_TEST" = 1 ]; then
+  exec "$PYTHON" -c "
+import sys
+sys.path.insert(0, '$SCRIPT_DIR/lib')
+import tokio_worker_balance as twb
+raise SystemExit(twb.self_test())
+"
+fi
+
+exec "$PYTHON" - "$HOST" "$PORT" "$SECONDS_TO_SAMPLE" "$JSON_OUT" \
+  "$MAX_TOP2" "$MAX_US_PER_POLL" <<PY
+import json
+import sys
+import time
+
+sys.path.insert(0, "$SCRIPT_DIR/lib")
+import tokio_worker_balance as twb
+
+host, port, seconds, json_out, max_top2, max_us = sys.argv[1:7]
+port = int(port)
+seconds = float(seconds)
+
+runtime_before = twb.fetch_json(host, port, "/tokio_runtime")
+if runtime_before is None:
+    print(
+        f"no Hotpath tokio_runtime metrics at {host}:{port}. Build with the "
+        "'hotpath' feature, register the runtime with hotpath::tokio_runtime!, "
+        "and set HOTPATH_METRICS_PORT.",
+        file=sys.stderr,
+    )
+    raise SystemExit(3)
+futures_before = twb.fetch_json(host, port, "/futures")
+
+started = time.monotonic()
+time.sleep(seconds)
+window = time.monotonic() - started
+
+runtime_after = twb.fetch_json(host, port, "/tokio_runtime")
+futures_after = twb.fetch_json(host, port, "/futures")
+
+report = twb.build_report(
+    window, runtime_before, runtime_after, futures_before, futures_after
+)
+print(twb.render_report(report))
+
+if json_out:
+    with open(json_out, "w") as handle:
+        json.dump(
+            {
+                "window_secs": report.window_secs,
+                "num_workers": report.num_workers,
+                "blocking_threads": report.blocking_threads,
+                "idle_blocking_threads": report.idle_blocking_threads,
+                "busy_cores": report.busy_cores,
+                "top1_share": report.top_share(1),
+                "top2_share": report.top_share(2),
+                "active_workers": report.active_workers,
+                "total_steals": report.total_steals,
+                "worst_us_per_poll": report.worst_us_per_poll(),
+                "workers": [
+                    {
+                        "index": w.index,
+                        "busy_ms": w.busy_ms,
+                        "share_pct": report.busy_share(w),
+                        "polls": w.polls,
+                        "us_per_poll": w.us_per_poll,
+                        "steals": w.steals,
+                        "parks": w.parks,
+                    }
+                    for w in report.workers
+                ],
+                "futures": [
+                    {
+                        "label": f.label,
+                        "source": f.source,
+                        "poll_seconds": f.poll_ns / 1e9,
+                        "cores": f.cores(report.window_secs),
+                        "polls": f.polls,
+                        "us_per_poll": f.us_per_poll,
+                    }
+                    for f in report.futures
+                    if f.poll_ns > 0
+                ],
+            },
+            handle,
+            indent=2,
+        )
+    print(f"\nwrote {json_out}")
+
+failures = twb.check_thresholds(
+    report,
+    float(max_top2) if max_top2 else None,
+    float(max_us) if max_us else None,
+)
+if failures:
+    print("")
+    for failure in failures:
+        print(f"THRESHOLD BREACHED: {failure}")
+    raise SystemExit(1)
+PY


### PR DESCRIPTION
## Outcome: diagnosis, no production change

The reported "2 of 16 tokio workers carry ~90% of busy time" is real and
reproducible. Its cause is **not** a scheduling or width problem, and the two
obvious fixes for a scheduling problem — resizing the pool, or adding yield
points — would both make things worse or do nothing. No production behaviour is
changed here.

What lands instead: a self-tested profiler that turns Hotpath's already-present
metrics into the falsifiable numbers, and the measured breach recorded against
the doc that currently claims the opposite.

## What the hot workers are running

`session_temporal_refresh.history` — the historical transcript-ingest pass
driven by the session-refresh scheduler
(`src/daemon/session_temporal_refresh_scheduler/worker.rs:53`).

Hotpath's `total_poll_duration_ns` is wall time **strictly inside
`Future::poll`**, so an `.await` cannot contribute to it. Across three
independent 60s windows that one label accounts for **96.7–97.6% of everything
the async pool did**.

## Why it concentrates

Exactly two long-lived tasks — one project-scoped ingestor and one
profile-scoped one (`run_session_temporal_refresh_scheduler`, `call_count: 2`).
Runnable async concurrency is 2, not 16. Work-stealing has nothing to steal
(14–23 steals per 60s window), and no pool width redistributes a slice a worker
is already inside: a poll is not preemptible until it returns.

Ruling out the other candidates from the brief:

- **Blocking work on async workers** — yes, this is it, but not at a store
  boundary. SQLite already runs on dedicated reader/writer OS threads
  (`reader/worker.rs`, `writer.rs`), and `ReadSnapshot::query` already uses
  `spawn_blocking`. The synchronous slices sit in the ingest pass itself,
  between store awaits.
- **A single `select!`/actor funnel** — no. Lock waits are nanoseconds across
  7,324 instrumented mutexes and 2 rw-locks.
- **Oversubscription** — no. 16 workers on 96 usable cores, `nproc` 96, no
  cgroup CPU limit.

## Is 16 workers the right width?

Yes, and it should not be touched. The width is *why* this breach has not
surfaced as a latency regression: **11 of 16 workers ran zero polls** in each
sampled minute, so an arriving request always finds a parked worker instead of
queueing behind a 56ms poll. Narrowing the pool to "match" observed concurrency
would delete exactly that headroom and convert a benign skew into a real tail.

The number to watch is microseconds per poll, not busy share.

## Evidence

96-core host, `--profile perf`, features `production,hotpath,hotpath-mcp`,
`--cfg tokio_unstable`, isolated profile root under `/tmp` (the user's
`~/.tracedecay` is never touched), one registered 3,114-file corpus. Three
independent daemon runs.

**Run 1 — 325s, whole daemon lifetime.** 5 of 16 workers carry 98.5% of busy
time; 5 workers completely idle; cumulative steals 0–9; the reserved indexing
pool consumes 4.22 CPU-seconds over the entire run.

**Run 2 — 60s window, via the profiler added here:**

```
window 60.0s   workers 16   blocking threads 8 (7 idle)
async pool busy 91.92s = 1.53 cores   steals 14

 wrk    busy_ms   share%      polls    us/poll   steals     parks
  14      61824    67.26       6926     8926.4        2     13084
  12      13398    14.58      10979     1220.3        2     21509
   6       8814     9.59       7343     1200.3        2     15314
  15       5892     6.41       9293      634.0        4     17940
  10       1990     2.16       3452      576.5        4      6424
  (workers 0-5, 7-9, 11, 13: zero polls)

top-1 busy share  67.26%
top-2 busy share  81.84%
workers with any busy time  5/16
worst us/poll (>=100 polls) 8926.4

in-poll execution by labelled future (excludes every .await):
   cores    poll_s     polls    us/poll  label
    1.49     89.68     35648     2515.7  session_temporal_refresh.history
```

89.68s of the pool's 91.92s busy time — **97.6%** — is synchronous execution
under one label.

**Run 3 — same scenario, with the profiler's threshold gate armed:**

```
window 60.0s   workers 16   blocking threads 6 (5 idle)
async pool busy 86.88s = 1.45 cores   steals 23

 wrk    busy_ms   share%      polls    us/poll   steals     parks
  12      50969    58.67        910    56009.9        1      1533
  14      11860    13.65       7595     1561.6        5     15223
   0       9393    10.81       6612     1420.6        8     12881
   9       8743    10.06       6881     1270.6        5     12851
  10       5913     6.81       3770     1568.4        4      7487
  (11 workers: zero polls)

top-2 busy share  72.32%
worst us/poll (>=100 polls) 56009.9

   cores    poll_s     polls    us/poll  label
    1.40     84.03     23884     3518.3  session_temporal_refresh.history

THRESHOLD BREACHED: top-2 worker busy share 72.32% exceeds 60.00%
THRESHOLD BREACHED: worst worker occupancy 56009.9 us/poll exceeds 200.0 us/poll
```

Exit status 1. **A single poll held a worker for 56 milliseconds.**

Supporting function timing from the same scenario (inclusive, so awaits are
included — these locate the pass, they do not measure occupancy):

```
    509.73 s        2   254.86 s  run_session_temporal_refresh_scheduler
    509.21 s        4   127.30 s  session_history_refresh
    188.78 s        4    47.19 s  ingest::project_provider::run_codex
     44.31 s    16386     2.70 ms  jsonl_observation_admission::admit_jsonl_observations
```

## Where a fix has to land, and why none is in this PR

The cost is CPU **placement**, not balance. This work belongs off the request
runtime the way indexing already is.

- A **yield point** redistributes the slices across workers without moving a
  single cycle off the serving pool. It would improve the busy-share metric and
  fix nothing — precisely the cosmetic rebalance the brief warns against.
- **`spawn_blocking` cannot wrap the pass**, because the pass is a future with
  interleaved store awaits, not a closure. A real fix has to batch the
  synchronous work into blocking chunks at a boundary that owns its data, which
  is a restructure of the ingest pipeline and its cancellation/cursor handling.
  That is not something I can land and prove in one session on a path this
  privacy- and cursor-sensitive, so it is scoped rather than guessed at.

Leaf attribution is left open, and the obvious instrument cannot close it:
Tokio names async worker threads and blocking-pool threads with the same
`thread_name_fn`, so `perf --comms` cannot separate the two pools. Under that
combined family the largest single product symbol during ingest is
`privacy::rules::contains_ignore_ascii_case` (5.16% of whole-process cycles,
~7.4% for the privacy-detector family) — a plausible in-poll leaf, since
redaction is pure CPU over transcript text. But SQLite parser symbols in the
same family belong to `ReadSnapshot::query`, which is correctly placed on
`spawn_blocking`. Naming the exact leaf needs a `#[hotpath::measure]` inside the
pass or `HOTPATH_FOCUS`, not a thread filter. This is written down in the doc so
the follow-up starts from the obstacle rather than rediscovering it.

## Scope of the measurement

All three runs start from a **cold, isolated profile**, so the ingest is doing a
full historical catch-up. That is a real workload (fresh install, wipe, new
profile) and the code path is identical when warm — warm passes carry fewer
bytes, not a different structure. The steady-state magnitude is not measured
here.

## What lands

- `scripts/profile-tokio-worker-balance.sh` + `scripts/lib/tokio_worker_balance.py`
  — reads only Hotpath's metrics HTTP routes, so no product code change and no
  restart. `--max-top2-share` / `--max-us-per-poll` make it a before/after gate.
  Dependency-free stdlib Python; `--self-test` covers the arithmetic over
  fixtures with no daemon.
- `docs/SERVING-PATH-PERFORMANCE.md` — an "Open breach" section following the
  existing pattern, plus a pointer from Principle 2, which currently asserts the
  invariant this measurement contradicts.

## Verification

```
$ ./scripts/profile-tokio-worker-balance.sh --self-test
tokio_worker_balance self-test: ok

$ ./scripts/profile-tokio-worker-balance.sh --port 59999 --seconds 1; echo $?
no Hotpath tokio_runtime metrics at 127.0.0.1:59999. ...
3
```

`npx commitlint --from origin/cursor/simplify-pr421-hot-paths --to HEAD` — 0
problems. No Rust source is touched, so there is no crate to rebuild; the
`production,hotpath,hotpath-mcp` binary that produced every number above built
clean.

## Note on the base branch

`origin/cursor/simplify-pr421-hot-paths` does not currently compile: commit
`64dbb4bf1` references `tracedecay_runtime_core::background_cpu`, but that
module is not in the tree (it exists uncommitted in the shared checkout). The
measurements were taken at `434f4d492`, the last building ancestor; these two
commits are then rebased onto the branch head and touch only `scripts/` and
`docs/`, so they neither depend on nor conflict with that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
