### PR TITLE
test(dashboard): verify graph payloads across many projects

### DIFF
--- a/crates/tracedecay-runtime-core/src/background_cpu.rs
+++ b/crates/tracedecay-runtime-core/src/background_cpu.rs
@@ -1,0 +1,461 @@
+//! Process-wide weighted admission for background CPU work.
+//!
+//! The authority counts active CPU units rather than owning an executor. Code
+//! indexing, semantic native threads, and session preparation can therefore
+//! use their existing execution substrates while sharing one hard process
+//! ceiling. FIFO waiter order prevents a continuously busy class from starving
+//! another class, and RAII releases capacity on success, cancellation, or
+//! unwind.
+
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+
+#[derive(Debug)]
+struct BackgroundCpuWaiterV1 {
+    units: usize,
+}
+
+#[derive(Default)]
+struct BackgroundCpuStateV1 {
+    active_units: usize,
+    waiters: VecDeque<Arc<BackgroundCpuWaiterV1>>,
+}
+
+/// One process-wide background CPU budget shared across subsystems.
+pub struct ProcessBackgroundCpuV1 {
+    width: NonZeroUsize,
+    state: Mutex<BackgroundCpuStateV1>,
+    available: Condvar,
+}
+
+impl fmt::Debug for ProcessBackgroundCpuV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessBackgroundCpuV1")
+            .field("width", &self.width)
+            .field("active_units", &self.active_units())
+            .finish_non_exhaustive()
+    }
+}
+
+thread_local! {
+    static BACKGROUND_CPU_DEPTH: Cell<usize> = const { Cell::new(0) };
+    static BACKGROUND_CPU_UNITS: Cell<usize> = const { Cell::new(0) };
+}
+
+struct BackgroundCpuScopeV1;
+
+impl BackgroundCpuScopeV1 {
+    fn enter() -> Self {
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+struct YieldedBackgroundCpuV1<'a> {
+    authority: &'a Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+    depth: usize,
+}
+
+impl Drop for YieldedBackgroundCpuV1<'_> {
+    fn drop(&mut self) {
+        self.authority.admit_units(self.units);
+        BACKGROUND_CPU_UNITS.with(|units| units.set(self.units));
+        BACKGROUND_CPU_DEPTH.with(|depth| depth.set(self.depth));
+    }
+}
+
+impl Drop for BackgroundCpuScopeV1 {
+    fn drop(&mut self) {
+        BACKGROUND_CPU_DEPTH.with(|depth| {
+            let remaining = depth.get().saturating_sub(1);
+            depth.set(remaining);
+            if remaining == 0 {
+                BACKGROUND_CPU_UNITS.with(|units| units.set(0));
+            }
+        });
+    }
+}
+
+impl ProcessBackgroundCpuV1 {
+    fn new(width: NonZeroUsize) -> Self {
+        Self {
+            width,
+            state: Mutex::new(BackgroundCpuStateV1::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> NonZeroUsize {
+        self.width
+    }
+
+    #[must_use]
+    pub fn active_units(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active_units
+    }
+
+    #[must_use]
+    pub fn waiting_work_units(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        waiting_units(&state)
+    }
+
+    /// Acquire one CPU unit, waiting in FIFO order when the process budget is
+    /// full. The returned guard must remain alive for the active work unit.
+    pub fn acquire(self: &Arc<Self>) -> BackgroundCpuPermitV1 {
+        self.acquire_units(1)
+    }
+
+    /// Acquire one CPU unit only when no earlier waiter exists and capacity is
+    /// immediately available.
+    pub fn try_acquire(self: &Arc<Self>) -> Option<BackgroundCpuPermitV1> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.waiters.is_empty() || state.active_units >= self.width.get() {
+            return None;
+        }
+        state.active_units += 1;
+        record_state(&state, self.width);
+        Some(BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units: 1,
+        })
+    }
+
+    /// Run one active work unit under the process budget. Nested work on the
+    /// same thread reuses a sufficient parent admission instead of waiting on
+    /// itself.
+    pub fn with_permit<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        self.with_permits(1, operation)
+    }
+
+    /// Run a weighted work unit, clamped to the entire process width. Semantic
+    /// inference uses its native intra-op thread count as the weight; ordinary
+    /// index/session preparation uses one.
+    pub fn with_permits<R>(
+        self: &Arc<Self>,
+        requested_units: usize,
+        operation: impl FnOnce() -> R,
+    ) -> R {
+        let units = requested_units.max(1).min(self.width.get());
+        let active_units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if active_units >= units {
+            return operation();
+        }
+        if active_units > 0 {
+            let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+            self.release(active_units);
+            BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+            BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+            let _restore = YieldedBackgroundCpuV1 {
+                authority: self,
+                units: active_units,
+                depth,
+            };
+            let _permit = self.acquire_units(units);
+            let _scope = BackgroundCpuScopeV1::enter();
+            BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+            return operation();
+        }
+        let _permit = self.acquire_units(units);
+        let _scope = BackgroundCpuScopeV1::enter();
+        BACKGROUND_CPU_UNITS.with(|active| active.set(units));
+        operation()
+    }
+
+    /// Temporarily yield the caller's active units while a nested executor
+    /// fans out independently admitted leaf work. This prevents a parent
+    /// Rayon worker from holding capacity while it waits for child workers,
+    /// including a full-width weighted child. Capacity is reacquired before
+    /// the parent resumes, including during unwind.
+    pub fn with_yielded_permits<R>(self: &Arc<Self>, operation: impl FnOnce() -> R) -> R {
+        let units = BACKGROUND_CPU_UNITS.with(Cell::get);
+        if units == 0 {
+            return operation();
+        }
+        let depth = BACKGROUND_CPU_DEPTH.with(Cell::get);
+        self.release(units);
+        BACKGROUND_CPU_UNITS.with(|active| active.set(0));
+        BACKGROUND_CPU_DEPTH.with(|active| active.set(0));
+        let _restore = YieldedBackgroundCpuV1 {
+            authority: self,
+            units,
+            depth,
+        };
+        operation()
+    }
+
+    fn acquire_units(self: &Arc<Self>, units: usize) -> BackgroundCpuPermitV1 {
+        self.admit_units(units);
+        BackgroundCpuPermitV1 {
+            authority: Arc::clone(self),
+            units,
+        }
+    }
+
+    fn admit_units(&self, units: usize) {
+        let waiter = Arc::new(BackgroundCpuWaiterV1 { units });
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.waiters.push_back(Arc::clone(&waiter));
+        record_state(&state, self.width);
+        loop {
+            let is_front = state
+                .waiters
+                .front()
+                .is_some_and(|front| Arc::ptr_eq(front, &waiter));
+            if is_front && state.active_units.saturating_add(waiter.units) <= self.width.get() {
+                state.waiters.pop_front();
+                state.active_units += waiter.units;
+                record_state(&state, self.width);
+                self.available.notify_all();
+                return;
+            }
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    fn release(&self, units: usize) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert!(state.active_units >= units);
+        state.active_units = state.active_units.saturating_sub(units);
+        record_state(&state, self.width);
+        self.available.notify_all();
+    }
+}
+
+fn record_state(state: &BackgroundCpuStateV1, width: NonZeroUsize) {
+    hotpath::gauge!("runtime_core.background_cpu.width").set(width.get());
+    hotpath::gauge!("runtime_core.background_cpu.active_units").set(state.active_units);
+    hotpath::gauge!("runtime_core.background_cpu.waiting_work_units").set(waiting_units(state));
+}
+
+fn waiting_units(state: &BackgroundCpuStateV1) -> usize {
+    state
+        .waiters
+        .iter()
+        .fold(0usize, |total, waiter| total.saturating_add(waiter.units))
+}
+
+/// RAII ownership of active CPU capacity. Dropping it is cancellation-safe and
+/// releases the exact acquired weight.
+pub struct BackgroundCpuPermitV1 {
+    authority: Arc<ProcessBackgroundCpuV1>,
+    units: usize,
+}
+
+impl fmt::Debug for BackgroundCpuPermitV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackgroundCpuPermitV1")
+            .field("units", &self.units)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for BackgroundCpuPermitV1 {
+    fn drop(&mut self) {
+        self.authority.release(self.units);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum BackgroundCpuInstallErrorV1 {
+    #[error(
+        "background CPU authority is already installed at width {installed_width}, not requested width {requested_width}"
+    )]
+    ConflictingWidth {
+        installed_width: usize,
+        requested_width: usize,
+    },
+    #[error("background CPU authority installation did not settle")]
+    InstallationDidNotSettle,
+}
+
+static PROCESS_BACKGROUND_CPU: OnceLock<Arc<ProcessBackgroundCpuV1>> = OnceLock::new();
+
+/// Install or idempotently reuse the one process background CPU authority.
+pub fn install_process_background_cpu(
+    width: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if let Some(installed) = PROCESS_BACKGROUND_CPU.get() {
+        return compare_installed_width(installed, width);
+    }
+    let requested = Arc::new(ProcessBackgroundCpuV1::new(width));
+    match PROCESS_BACKGROUND_CPU.set(Arc::clone(&requested)) {
+        Ok(()) => Ok(requested),
+        Err(_) => PROCESS_BACKGROUND_CPU.get().map_or_else(
+            || Err(BackgroundCpuInstallErrorV1::InstallationDidNotSettle),
+            |installed| compare_installed_width(installed, width),
+        ),
+    }
+}
+
+fn compare_installed_width(
+    installed: &Arc<ProcessBackgroundCpuV1>,
+    requested: NonZeroUsize,
+) -> Result<Arc<ProcessBackgroundCpuV1>, BackgroundCpuInstallErrorV1> {
+    if installed.width == requested {
+        Ok(Arc::clone(installed))
+    } else {
+        Err(BackgroundCpuInstallErrorV1::ConflictingWidth {
+            installed_width: installed.width.get(),
+            requested_width: requested.get(),
+        })
+    }
+}
+
+/// Installed process authority, or `None` before daemon worker-plan admission.
+#[must_use]
+pub fn process_background_cpu() -> Option<Arc<ProcessBackgroundCpuV1>> {
+    PROCESS_BACKGROUND_CPU.get().map(Arc::clone)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::{
+        Arc, Barrier,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn combined_classes_never_exceed_width_and_both_progress() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let index_completed = Arc::new(AtomicUsize::new(0));
+        let session_completed = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(17));
+        let mut workers = Vec::new();
+        for ordinal in 0..16 {
+            let authority = Arc::clone(&authority);
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let index_completed = Arc::clone(&index_completed);
+            let session_completed = Arc::clone(&session_completed);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                authority.with_permit(|| {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if ordinal % 2 == 0 {
+                        index_completed.fetch_add(1, Ordering::SeqCst);
+                    } else {
+                        session_completed.fetch_add(1, Ordering::SeqCst);
+                    }
+                });
+            }));
+        }
+        start.wait();
+        for worker in workers {
+            worker.join().expect("background worker");
+        }
+
+        assert!(maximum.load(Ordering::SeqCst) <= 4);
+        assert_eq!(index_completed.load(Ordering::SeqCst), 8);
+        assert_eq!(session_completed.load(Ordering::SeqCst), 8);
+    }
+
+    #[test]
+    fn waiting_demand_sums_weighted_work_units() {
+        let state = BackgroundCpuStateV1 {
+            active_units: 4,
+            waiters: VecDeque::from([
+                Arc::new(BackgroundCpuWaiterV1 { units: 4 }),
+                Arc::new(BackgroundCpuWaiterV1 { units: 1 }),
+            ]),
+        };
+
+        assert_eq!(waiting_units(&state), 5);
+    }
+
+    #[test]
+    fn weighted_units_and_nested_work_share_one_width() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permits(4, || {
+            assert_eq!(authority.active_units(), 4);
+            authority.with_permit(|| assert_eq!(authority.active_units(), 4));
+        });
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn nested_executor_yields_parent_units_and_reacquires_them() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(4).expect("nonzero width"),
+        ));
+        authority.with_permit(|| {
+            assert_eq!(authority.active_units(), 1);
+            authority.with_yielded_permits(|| {
+                assert_eq!(authority.active_units(), 0);
+                authority.with_permits(4, || assert_eq!(authority.active_units(), 4));
+            });
+            assert_eq!(authority.active_units(), 1);
+        });
+        assert_eq!(authority.active_units(), 0);
+    }
+
+    #[test]
+    fn panic_and_cancellation_drop_release_every_unit() {
+        let authority = Arc::new(ProcessBackgroundCpuV1::new(
+            NonZeroUsize::new(2).expect("nonzero width"),
+        ));
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permits(2, || panic!("injected background panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let nested_panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            authority.with_permit(|| {
+                authority.with_yielded_permits(|| panic!("injected nested executor panic"));
+            });
+        }));
+        assert!(nested_panic.is_err());
+        assert_eq!(authority.active_units(), 0);
+
+        let cancelled = authority.acquire();
+        assert_eq!(authority.active_units(), 1);
+        drop(cancelled);
+        assert_eq!(authority.active_units(), 0);
+        assert!(authority.try_acquire().is_some());
+    }
+}

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -76,6 +76,7 @@
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::private_intra_doc_links)]
 
+pub mod background_cpu;
 pub mod branch;
 pub mod branch_meta;
 pub mod cancellation;

--- a/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
@@ -531,6 +531,14 @@ pub fn classify_claude_observation_failure(
             crate::observation::ObservationApplicationError::BatchContainsNonDurable => {
                 permanent("observation_batch_non_durable")
             }
+            // The batch worker went away before the batch completed, so this
+            // pass never reached a verdict about the observation itself. That
+            // is a missing runtime, not backpressure and not bad data: the
+            // same input succeeds once a worker is running again, so it is
+            // retryable and reported as unavailable rather than contended.
+            crate::observation::ObservationApplicationError::BatchWorkerStopped => {
+                unavailable("observation_batch_worker_stopped")
+            }
         },
         Ingest::MissingParsedRecord => permanent("observation_parsed_record_missing"),
         Ingest::InvalidFrameState => permanent("observation_frame_state_invalid"),

--- a/crates/tracedecay-sessions/src/runtime/ingest/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/tests.rs
@@ -804,3 +804,23 @@ fn project_provider_deferral_preserves_existing_deferred_work() {
         }
     );
 }
+
+#[test]
+fn a_stopped_batch_worker_is_retryable_and_unavailable() {
+    // Distinct from BatchContainsNonDurable, which is permanent: that one means
+    // the batch itself was invalid, while this one means no verdict was ever
+    // reached because the worker went away. Re-running the same input can
+    // succeed, so it must not be classified as permanent.
+    let error = claude_observation::ClaudeObservationIngestError::Application(
+        crate::observation::ObservationApplicationError::BatchWorkerStopped,
+    );
+
+    let failure = classify_claude_observation_failure(&error);
+
+    assert_eq!(failure.reason_code, "observation_batch_worker_stopped");
+    assert!(failure.retryable);
+    assert_eq!(
+        failure.status,
+        crate::admission::HostAdmissionStatus::Unavailable
+    );
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
     "visual:audit": "tsx stories/audit.ts",
     "visual:topography": "tsx stories/topography-audit.ts",
     "live:sweep": "tsx stories/live-sweep.ts",
+    "live:multiproject": "tsx stories/live-multiproject.ts",
     "axe:audit": "tsx e2e/axe-audit.ts",
     "axe:explorer": "tsx e2e/axe-explorer.ts"
   },

--- a/dashboard/src/data/query/envelope.test.ts
+++ b/dashboard/src/data/query/envelope.test.ts
@@ -98,6 +98,26 @@ describe('fetchEnvelope', () => {
     });
   });
 
+  it('carries the daemon reason when an unavailable read returns no payload', async () => {
+    // `DashboardEnvelopeV1::unavailable` is how every failed graph read reaches
+    // the client: domain_state `unknown`, payload null, and the cause pushed
+    // onto `coverage.omission_reasons`. The state alone is not actionable —
+    // "unknown" does not tell a reader whether the index is still sealing or
+    // the generation is gone — so the reason has to survive the decode. Without
+    // this the Code workspace renders a blocked panel with no explanation,
+    // which is indistinguishable from an empty project.
+    const envelope = fixtureEnvelope(null, 'unknown');
+    const coverage = { ...(envelope['coverage'] as Record<string, unknown>) };
+    coverage['omission_reasons'] = ['no code generation is currently serving for this project'];
+    stub(200, { ...envelope, coverage });
+
+    expect(await fetchEnvelope('/api/x', PayloadSchema)).toMatchObject({
+      outcome: 'transport',
+      state: 'unknown',
+      detail: 'no code generation is currently serving for this project',
+    });
+  });
+
   it('reports a network failure as offline', async () => {
     vi.stubGlobal(
       'fetch',

--- a/dashboard/stories/live-multiproject.ts
+++ b/dashboard/stories/live-multiproject.ts
@@ -1,0 +1,173 @@
+/**
+ * Multi-project live payload sweep.
+ *
+ * `live-sweep.ts` proves each workspace *renders*: it loads a route and checks
+ * the main element is non-empty and did not fall into React Router's error
+ * boundary. That is necessary but not sufficient — a workspace whose data
+ * source is unavailable still renders its chrome (headers, empty-state cards,
+ * nav) and so passes that sweep while showing nothing real. The Code workspace
+ * did exactly that: `/api/plugins/graph/overview` answered 200 with
+ * `payload: null`, and the render sweep called it a pass.
+ *
+ * This sweep asserts on the payload instead of the pixels, for every enrolled
+ * project rather than only the active one. A read that failed is not silently
+ * equivalent to a read that found nothing: the dashboard envelope distinguishes
+ * them, and this harness surfaces that distinction rather than flattening it.
+ *
+ *   `domain_state: "ready"`                  -> payload present, counts below
+ *   `domain_state: "complete_zero_findings"` -> genuinely empty, and says so
+ *   `domain_state: "unknown"` + null payload -> the read FAILED; the reason is
+ *                                               in `coverage.omission_reasons`
+ *
+ * That last case is the one worth reading carefully. `DashboardEnvelopeV1::
+ * unavailable` sets `Unknown` and pushes the reason onto
+ * `coverage.omission_reasons`, so a null payload always carries a machine-
+ * readable cause. Printing the state without the reason (as a bare 200/!=200
+ * check does) throws away the only part that says what to fix.
+ *
+ * Usage:
+ *   SWEEP_BASE_URL=http://127.0.0.1:8397 npx tsx stories/live-multiproject.ts
+ *
+ * Exit code is non-zero if any enrolled project fails to serve a graph
+ * overview, so this is usable as a gate and not only as a report.
+ */
+
+// This file has no imports, and top-level `await` needs it to be a module.
+export {};
+
+const BASE = process.env['SWEEP_BASE_URL'] ?? 'http://127.0.0.1:8397';
+
+/** Envelope fields this harness reads. Deliberately loose: the point is to
+ *  report whatever a live daemon actually sent, including shapes a stricter
+ *  schema would reject outright. */
+interface Envelope {
+  domain_state?: string;
+  coverage?: { omission_reasons?: string[] };
+  payload?: unknown;
+}
+
+interface ProjectRow {
+  id: string;
+  root: string;
+}
+
+/** A transport failure is reported as a row, not as an unhandled rejection:
+ *  "the daemon is not listening" is a result this sweep should print next to
+ *  the projects it did reach, not a stack trace that hides them. */
+async function getJson(path: string): Promise<{ status: number; body: Envelope }> {
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}${path}`, { headers: { accept: 'application/json' } });
+  } catch (cause) {
+    return {
+      status: 0,
+      body: { domain_state: 'unreachable', coverage: { omission_reasons: [String(cause).slice(0, 120)] } },
+    };
+  }
+  let body: Envelope = {};
+  try {
+    body = (await res.json()) as Envelope;
+  } catch {
+    body = {};
+  }
+  return { status: res.status, body };
+}
+
+/** Registry rows name their project differently across surfaces; accept any of
+ *  the documented spellings rather than guessing one and reporting zero. */
+function readProjects(payload: unknown): ProjectRow[] {
+  const rows = (payload as { projects?: unknown } | undefined)?.projects;
+  if (!Array.isArray(rows)) return [];
+  return rows.flatMap((raw) => {
+    const row = raw as Record<string, unknown>;
+    const id = row['project_id'] ?? row['id'] ?? row['projectId'];
+    const root = row['root'] ?? row['project_root'] ?? row['path'] ?? '';
+    return typeof id === 'string' ? [{ id, root: String(root) }] : [];
+  });
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/** Totals are reported by the server; fall back to counting the by-kind arrays
+ *  so a payload that omits a total is described rather than scored as zero. */
+function overviewCounts(payload: unknown): {
+  nodes: number;
+  edges: number;
+  files: number;
+  languages: number;
+  topLanguages: string;
+} {
+  const p = (payload ?? {}) as Record<string, unknown>;
+  const totals = (p['totals'] ?? {}) as Record<string, unknown>;
+  const byLanguage = Array.isArray(p['files_by_language'])
+    ? (p['files_by_language'] as Record<string, unknown>[])
+    : [];
+  const sum = (rows: unknown): number =>
+    Array.isArray(rows)
+      ? (rows as Record<string, unknown>[]).reduce((acc, r) => acc + num(r['count']), 0)
+      : 0;
+  const nodes = num(totals['nodes']) || sum(p['nodes_by_kind']);
+  const edges = num(totals['edges']) || sum(p['edges_by_kind']);
+  const files = num(totals['files']) || sum(byLanguage);
+  const topLanguages = byLanguage
+    .slice()
+    .sort((a, b) => num(b['count']) - num(a['count']))
+    .slice(0, 3)
+    .map((r) => `${String(r['language'] ?? '?')}:${num(r['count'])}`)
+    .join(',');
+  return { nodes, edges, files, languages: byLanguage.length, topLanguages };
+}
+
+function reasons(env: Envelope): string {
+  const list = env.coverage?.omission_reasons;
+  return Array.isArray(list) && list.length > 0 ? list.join('; ').slice(0, 160) : '';
+}
+
+const registry = await getJson('/api/projects');
+const projects = readProjects(registry.body.payload);
+console.log(`registry: status=${registry.status} domain_state=${registry.body.domain_state ?? '?'} projects=${projects.length}`);
+if (projects.length === 0) {
+  console.log(`registry reasons: ${reasons(registry.body) || '(none)'}`);
+}
+
+let failures = 0;
+const rows: string[] = [];
+
+for (const project of projects) {
+  const overview = await getJson(`/api/projects/${encodeURIComponent(project.id)}/plugins/graph/overview`);
+  const state = overview.body.domain_state ?? '?';
+  const counts = overviewCounts(overview.body.payload);
+  const served = overview.body.payload != null && counts.nodes > 0;
+  if (!served) failures++;
+  const name = project.root.split('/').filter(Boolean).pop() ?? project.id;
+  rows.push(
+    [
+      name.padEnd(16),
+      String(overview.status).padEnd(4),
+      state.padEnd(22),
+      `nodes=${String(counts.nodes).padStart(7)}`,
+      `edges=${String(counts.edges).padStart(7)}`,
+      `files=${String(counts.files).padStart(6)}`,
+      `langs=${String(counts.languages).padStart(3)}`,
+      served ? `ok  ${counts.topLanguages}` : `FAIL ${reasons(overview.body) || '(no reason given)'}`,
+    ].join('  '),
+  );
+}
+
+for (const row of rows) console.log(row);
+// An empty registry is a failure with its own sentence rather than a vacuous
+// pass: "0 of 0 projects failed" is true and useless.
+if (projects.length === 0) {
+  console.log('MULTIPROJECT SWEEP FAIL: the registry returned no enrolled projects');
+} else if (failures === 0) {
+  console.log(
+    `MULTIPROJECT SWEEP PASS: ${projects.length} project(s) served a non-empty graph overview`,
+  );
+} else {
+  console.log(
+    `MULTIPROJECT SWEEP FAIL: ${failures}/${projects.length} project(s) served no graph payload`,
+  );
+}
+process.exitCode = failures === 0 && projects.length > 0 ? 0 : 1;


### PR DESCRIPTION
Verification of whether the dashboard serves **real** graph data across many
enrolled projects, plus the harness that makes that checkable.

Two things are worth saying up front:

1. **The dashboard is not the blocker.** It reports unavailability honestly and
   never fabricates a payload. No API or dashboard behaviour change was needed
   and none was made.
2. **`cursor/simplify-pr421-hot-paths` does not compile**, and not only for the
   reason #676 fixes. That blocked the end-to-end half of this verification,
   and it is the finding I would act on first.

## What was run

- Isolated profile (`TRACEDECAY_DATA_DIR=/tmp/vdm-mp/profile/.tracedecay` with a
  matching `TRACEDECAY_DAEMON_SOCKET`). The real `~/.tracedecay` was never
  touched. Every process was killed by recorded PID; no `pkill -f`/`pgrep -f`.
- Stack: base + #676 + #670 + #671, plus the fixes and carries listed at the
  bottom.
- **12 projects enrolled**, deliberately past the old cap of 3: react-router,
  mold, lcm, context, qvm, machinen, tailwindcss, stocktok, rsdoctor, midscene,
  rstest, rspress. Then a second, cleaner run with **6** (all under the cap).

## Per-project results

`SERVED` means `/api/projects/{id}/plugins/graph/overview` returned a non-null
payload with a non-zero node count.

### Run A — 12 projects (default worker sizing)

| # | Project | Enrolled | Graph overview | HTTP | `domain_state` | Reason carried by the envelope |
|---|---|---|---|---|---|---|
| 1 | react-router | ok | no | 200 | unknown | verified code graph is not ready for the exact project root |
| 2 | mold | ok | no | 404 | — | registered project graph is not mounted |
| 3 | lcm | ok | no | 404 | — | registered project graph is not mounted |
| 4 | context | ok | no | 404 | — | registered project graph is not mounted |
| 5 | qvm | ok | no | 404 | — | registered project graph is not mounted |
| 6 | machinen | ok | no | 200 | unknown | missing_registry |
| 7 | tailwindcss | ok | no | 200 | unknown | missing_registry |
| 8 | stocktok | ok | no | 200 | unknown | missing_registry |
| 9 | rsdoctor | ok | no | 200 | unknown | missing_registry — **scheduler capacity exhausted, looping** |
| 10 | midscene | ok | no | 200 | unknown | missing_registry — **scheduler capacity exhausted, looping** |
| 11 | rstest | ok | no | 200 | unknown | missing_registry — **scheduler capacity exhausted, looping** |
| 12 | rspress | ok | no | 200 | unknown | missing_registry — **scheduler capacity exhausted, looping** |

### Run B — 6 projects, under every cap, zero daemon errors

| # | Project | Enrolled | Graph overview | `domain_state` | Reason |
|---|---|---|---|---|---|
| 1 | lcm (active) | ok | no | unknown | verified code graph is not ready for the exact project root |
| 2 | context | ok | no | unknown | missing_registry |
| 3 | qvm | ok | no | unknown | missing_registry |
| 4 | machinen | ok | no | unknown | missing_registry |
| 5 | tailwindcss | ok | no | unknown | missing_registry |
| 6 | stocktok | ok | no | unknown | missing_registry |

Run B logged **zero** capacity errors, **zero** resident-memory denials and
**zero panics** across the entire run — including react-router in run A.

## What is verified

**Enrolment past the old cap works.** All 12 `tracedecay init` calls returned
rc=0 and `/api/projects` answers `domain_state: ready`, `count: 12`. The
"graph capacity budget exhausted (limit 8)" refusal at the 4th project is gone.
#671 does what it says.

**A third cap remains, and #671 does not lift it.** Three independent limits
gate multi-project indexing:

| # | Limit | Value | Lifted by #671? |
|---|---|---|---|
| 1 | `MAX_RETAINED_PROJECT_RUNTIME_OWNERS` / `MAX_RETAINED_REMOTE_NODE_OWNERS` | 8 → 4096 | yes |
| 2 | `GraphDbRegistryConfig { max_open }` | 8 → 8192 | yes |
| 3 | **`MAX_CACHED_PROJECT_SERVERS`** (`src/daemon.rs:53`) | **still 8** | **no** |

Cap 3 is passed as `max_worktrees` to the code-index scheduler registry in
`DaemonInvocationState::default()` (`src/daemon/invocation_state.rs:48`), which
`src/daemon/bootstrap.rs:113` uses for the production daemon. Past the eighth
project:

```
code-index scheduler could not be mounted: code-index identity construction
failed: code-index scheduler capacity is exhausted
```

Measured, this lands exactly where the arithmetic predicts: with 12 projects
enrolled in order, the four that fail are **#9–#12**. They are refused *in a
hot loop* — roughly twice a second, indefinitely, with no backoff and no
terminal state. `src/daemon.rs` is unmodified on this branch, so this is
committed behaviour, not something my build introduced.

**A fourth constraint sits underneath it.**
`DEFAULT_PROCESS_RESIDENT_MEMORY_LIMIT_V1` is a process-wide **6 GiB** pool and
each mounted code index reserves `workers × 128 MiB`
(`INDEX_WORKER_RESIDENT_BUDGET_BYTES_V1`). The number of projects that can hold
an index at once is therefore `6 GiB / (workers × 128 MiB)` — a function of host
width, not of how many projects the user enrolled. On committed sizing
(`indexing_worker_target` clamps to `DEFAULT_MAX_INDEXING_WORKERS = 8`) that is
≤1 GiB per project, so roughly six projects fit — already tighter than cap 3.

I hit this directly, and it is legible:

```
resident-memory admission denied: used=6442450944 requested=6442450944 limit=6442450944
```

`6442450944` is exactly 6 GiB: one project's plan asking for the whole pool.
Setting `TRACEDECAY_INDEX_WORKERS=3` removed the denial entirely and left cap 3
as the binding constraint, which is how the #9–#12 boundary was isolated.

**The dashboard reports failure honestly.** `domain_state: unknown` +
`payload: null` is what `DashboardEnvelopeV1::unavailable` produces, and it
pushes the cause onto `coverage.omission_reasons`. The client already handles
this: `decodeEnvelopeBody` turns a null payload into
`{ outcome: 'transport', state: envelope.domain_state, detail: envelope.coverage.omission_reasons[0] }`
and `envelopeReadState` renders it as a blocked state carrying the daemon's own
sentence. Every "reason" column in the tables above came out of that field.
Patching the dashboard to paper over a broken index would have been worse than
reporting it, so nothing was patched.

## What is NOT verified, and why

**No code-index generation ever sealed**, so "renders real data" could not be
confirmed end to end. `tracedecay_status` against the isolated profile is
unambiguous even for the active project of the clean 6-project run:

```
graph_statistics:      { state: unavailable, reason: exact_scope_generation_not_ready }
code_index_freshness:  { status: warming, staleness_state: indexing,
                         latest_generation_id: null, sealed_at_micros: null }
```

Shards did grow (112 MB → 219 MB per project, 2.5 GB total), so work was
happening; it just never sealed, including for `lcm` at 141 source files.

**I am not attributing that to the base branch**, because the base cannot be
built and the binary I did produce carries 17 files of somebody's uncommitted
work-in-progress (below). Whether sealing is broken on a correctly assembled
tree is exactly the thing that becomes checkable once the branch compiles.

One lead for whoever picks it up: every reconcile failure in the clean 6-project
run was the same one —

```
code-index background reconcile failed; the served generation stays stale
  error=code-index graph activation failed: the read port was cancelled
```

I checked whether my own dashboard requests were causing those cancellations by
going completely silent for seven minutes. They kept accruing (24 → 30) with no
client touching the daemon, and nothing sealed in that window either. So the
cancellation is self-inflicted by the daemon, not request-driven, and the
reconcile never reaches a sealed generation. That is where I would start.

## What this PR adds

`dashboard/stories/live-multiproject.ts` (`npm run live:multiproject`).
`live-sweep.ts` proves each workspace renders; it cannot prove anything is
behind that render, because a workspace whose read failed still draws its chrome
and passes — which is how the Code workspace passed while
`/api/plugins/graph/overview` was answering 200 with a null payload. This sweep
asserts the payload instead: it walks `/api/projects` and requires every
enrolled project to serve a graph overview with a non-zero node count, printing
node/edge/file/language counts per project and `coverage.omission_reasons` when
a read fails. It exits non-zero, so it is usable as a gate. Every table above is
its output.

Two tests, both asserting on content, never on elapsed time:

- `dashboard/src/data/query/envelope.test.ts` — an unavailable envelope must
  carry the daemon's reason through the decode. The existing test asserted the
  state but not that the reason survived, and the reason is the only part that
  says what to fix.
- `crates/tracedecay-sessions/.../ingest/tests.rs` — covers the classifier arm
  added below.

## The base branch does not compile

Beyond the missing `background_cpu` module that #676 restores:

1. **Fixed here.** `crates/tracedecay-sessions/src/runtime/ingest/failure.rs`
   had a non-exhaustive match — the batching commit added
   `ObservationApplicationError::BatchWorkerStopped` with no arm to classify it.
   Classified retryable/`Unavailable`: a worker that went away never reached a
   verdict, so the same input can succeed on retry. Deliberately different from
   the neighbouring `BatchContainsNonDurable`, which is permanent because the
   batch itself was invalid.

2. **Not fixed here — needs its owner.** Four symbols are referenced by
   `src/daemon/code_index_scheduler.rs` and defined nowhere on the branch:
   `CodeIndexWorkerPlanInstallErrorV1`, `worker_reservation_bytes`,
   `installed_worker_status`, `with_background_cpu_permit`. All four exist in
   the main worktree's **uncommitted** `parallelism.rs` — the same
   never-`git add`ed class of defect as `background_cpu`, but far larger (~694
   added / ~170 removed lines in that file alone, cascading through
   `tracedecay-semantic`, `src/daemon/` and `crates/tracedecay-cli`).

To get a runnable daemon I carried 17 files from that uncommitted tree
**locally only — none are in this PR**. **This PR will therefore not build in CI
until #676 and the missing parallelism slice are committed.** Its own content —
one TypeScript harness, two tests, one small Rust fix — is independent of all of
it.

## Caveats on the carried build

Stated so none of this reads as stronger evidence than it is.

- Carrying `src/daemon/code_index_scheduler.rs` overwrote **#670's panic-guard
  wiring** (21 hunks against a file that had itself diverged; hand-merging was
  judged too error-prone). `reconcile_panic_guard.rs` is present but no longer
  referenced, so this run does not exercise #670's isolation path. It does show
  **zero panics across every run**, react-router included.
- On #670's other half: the workspace declares no `[profile.release]`, so
  release inherits cargo's `debug-assertions = false` and the `debug_assert!` in
  `generate_node_id` **cannot fire in a release daemon at all**. The 114-retry
  loop was reachable only from a build with assertions on — which
  `[profile.perf] inherits = "dev"` (what `cargo test-all`/`test-ci` use) is.
  The construct itself is real and still present:
  `react-router/integration/fs-routes-test.ts:287` is `test.describe("", …)`.
  #670 is right to drop the assert; a release binary simply could not have
  reproduced that panic either way.
