### PR TITLE
test(exact-sql): pin begin_immediate vs write_lock span split

### DIFF
--- a/crates/tracedecay-agent-hosts/src/hooks/analytics/readiness.rs
+++ b/crates/tracedecay-agent-hosts/src/hooks/analytics/readiness.rs
@@ -178,6 +178,31 @@ pub struct HookCompletedReadinessDistributions {
     pub(crate) rows_folded_to_other_host: u64,
     pub(crate) disposition_values_folded_to_unknown: u64,
 }
+impl HookCompletedReadinessDistributions {
+    /// Readiness counters the root-crate observation benchmark folds. The
+    /// struct moved into this crate, so its `pub(crate)` fields are no longer
+    /// reachable from there; these expose exactly the five it reads.
+    pub fn source_event(&self) -> &str {
+        &self.source_event
+    }
+
+    pub fn input_rows_received(&self) -> u64 {
+        self.input_rows_received
+    }
+
+    pub fn input_rows_processed(&self) -> u64 {
+        self.input_rows_processed
+    }
+
+    pub fn input_rows_dropped_at_cap(&self) -> u64 {
+        self.input_rows_dropped_at_cap
+    }
+
+    pub fn events_considered(&self) -> u64 {
+        self.events_considered
+    }
+}
+
 
 #[derive(Default)]
 struct MutableNumericSummary {

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/hotpath_spans.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/hotpath_spans.rs
@@ -1,0 +1,104 @@
+//! Falsifiable proof that the exact-SQL "begin" measurements are two
+//! genuinely distinct Hotpath spans, not one metric wearing two names.
+//!
+//! `rusqlite.exact_sql.begin_immediate` (caller side, `ExactSqlHandle::begin_immediate`
+//! in `exact_sql/mod.rs`) times the whole round trip: dispatching
+//! `BeginTransaction` to the writer thread, waiting on the reply channel, and
+//! the lock acquisition the worker performs before it replies.
+//! `rusqlite.exact_sql.write_lock` (`command::begin_transaction_with_busy_retry`)
+//! times only the worker-side busy-retry loop that actually takes SQLite's
+//! write lock. Collapsing them into one label — which is what
+//! `rusqlite.begin_immediate` used to do before they were split — sums a
+//! channel wait and a lock wait into a population whose mean and p95 describe
+//! neither.
+//!
+//! This only asserts that both span *names* were recorded at least once and
+//! that the names differ; it never asserts on elapsed time, because Hotpath's
+//! own timings swing double digits in percent run over run on shared CI
+//! hardware, so a duration threshold here would be flaky by construction.
+//! Only compiled when this crate's `hotpath` feature is enabled: without it,
+//! `hotpath::measure_block!` is a no-op and there is no report to inspect.
+
+use super::*;
+
+#[test]
+fn begin_immediate_and_write_lock_are_distinct_spans() {
+    // Ambient `HOTPATH_OUTPUT_FORMAT`/`HOTPATH_OUTPUT_PATH` env vars would
+    // silently override the explicit `.format(..)`/`.output_path(..)` below.
+    // SAFETY: this process may run other tests concurrently, but none of them
+    // read or write these two specific variables (grep confirms the crate's
+    // only other env-var test, `remote_client_proxy`, lives in a different
+    // crate and touches unrelated proxy variables), so this mutation cannot
+    // race with another test's observation of the same keys.
+    unsafe {
+        std::env::remove_var("HOTPATH_OUTPUT_FORMAT");
+        std::env::remove_var("HOTPATH_OUTPUT_PATH");
+    }
+
+    let report_dir = TempDir::new().unwrap();
+    let report_path = report_dir.path().join("exact-sql-begin-spans.json");
+
+    let guard = hotpath::HotpathGuardBuilder::new("exact_sql_begin_span_split_test")
+        .format(hotpath::Format::Json)
+        .output_path(&report_path)
+        .build();
+
+    let fixture = fixture('a', 'a');
+    let channel = ExactSqlHandle::attach(&fixture.writer, &fixture.readers).unwrap();
+    channel
+        .execute_batch("CREATE TABLE hotpath_begin_spans (value INTEGER NOT NULL)".to_owned())
+        .unwrap();
+    // `begin_immediate` records the caller round trip; the worker it
+    // dispatches to records `write_lock` for the same call, on its own
+    // thread, before replying.
+    let transaction = channel.begin_immediate().unwrap();
+    transaction
+        .execute(statement(
+            "INSERT INTO hotpath_begin_spans VALUES (?)",
+            vec![ExactSqlValue::Integer(1)],
+        ))
+        .unwrap();
+    transaction.commit().unwrap();
+
+    // Guard::drop flushes the accumulated registry to `report_path`.
+    drop(guard);
+
+    let report_text = std::fs::read_to_string(&report_path)
+        .expect("hotpath guard must write its report to output_path on drop");
+    let report: serde_json::Value =
+        serde_json::from_str(&report_text).expect("hotpath report must be valid JSON");
+    let functions = report["functions_timing"]["data"]
+        .as_array()
+        .expect("functions_timing.data must be present in a timing report");
+
+    let calls_for = |name: &str| -> Option<u64> {
+        functions
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .and_then(|entry| entry["calls"].as_u64())
+    };
+
+    let begin_immediate_calls = calls_for("rusqlite.exact_sql.begin_immediate");
+    let write_lock_calls = calls_for("rusqlite.exact_sql.write_lock");
+
+    // Real output, pasted verbatim in the PR description this test backs.
+    eprintln!(
+        "exact-sql begin span report: begin_immediate={begin_immediate_calls:?} calls, \
+         write_lock={write_lock_calls:?} calls\nfull report: {report_text}"
+    );
+
+    assert!(
+        begin_immediate_calls.unwrap_or(0) >= 1,
+        "expected rusqlite.exact_sql.begin_immediate to be recorded at least once; \
+         full report: {report_text}"
+    );
+    assert!(
+        write_lock_calls.unwrap_or(0) >= 1,
+        "expected rusqlite.exact_sql.write_lock to be recorded at least once; \
+         full report: {report_text}"
+    );
+    assert_ne!(
+        "rusqlite.exact_sql.begin_immediate", "rusqlite.exact_sql.write_lock",
+        "the caller round trip and the worker lock acquisition must stay distinct span names"
+    );
+}

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/mod.rs
@@ -186,6 +186,8 @@ fn statement(sql: &str, params: Vec<ExactSqlValue>) -> ExactSqlStatement {
 mod authority;
 mod dispatch;
 mod guard;
+#[cfg(feature = "hotpath")]
+mod hotpath_spans;
 mod lease;
 mod limits;
 mod pragma;

--- a/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
@@ -539,6 +539,8 @@ pub fn classify_claude_observation_failure(
             crate::observation::ObservationApplicationError::BatchContainsNonDurable => {
                 permanent("observation_batch_non_durable")
             }
+            // The worker went away before reaching a verdict, so nothing was
+            // decided about the payload. Re-running the same input can succeed.
             crate::observation::ObservationApplicationError::BatchWorkerStopped => {
                 unavailable("observation_batch_worker_stopped")
             }

--- a/src/sessions/claude_observation_benchmark/baseline.rs
+++ b/src/sessions/claude_observation_benchmark/baseline.rs
@@ -265,14 +265,22 @@ pub(super) fn validate_hook_telemetry_readiness() {
             .any(|measurement| measurement.metric == "daemon_processing_duration_distribution")
     );
     assert_eq!(readiness.unavailable_measurements.len(), 1);
-    let readiness_distributions = serde_json::to_value(&readiness.readiness_distributions)
-        .expect("serialize empty readiness distributions");
-    assert_eq!(readiness_distributions["source_event"], "hook_completed");
-    assert_eq!(readiness_distributions["collection_status"], "no_samples");
-    assert_eq!(readiness_distributions["input_rows_received"], 0);
-    assert_eq!(readiness_distributions["input_rows_processed"], 0);
-    assert_eq!(readiness_distributions["input_rows_dropped_at_cap"], 0);
-    assert_eq!(readiness_distributions["events_considered"], 0);
+    assert_eq!(
+        readiness.readiness_distributions.source_event(),
+        "hook_completed"
+    );
+    assert_eq!(
+        serde_json::to_value(&readiness.readiness_distributions)
+            .expect("serialize empty readiness distributions")["collection_status"],
+        "no_samples"
+    );
+    assert_eq!(readiness.readiness_distributions.input_rows_received(), 0);
+    assert_eq!(readiness.readiness_distributions.input_rows_processed(), 0);
+    assert_eq!(
+        readiness.readiness_distributions.input_rows_dropped_at_cap(),
+        0
+    );
+    assert_eq!(readiness.readiness_distributions.events_considered(), 0);
     assert_eq!(
         readiness.canonical_contract["latency_semantics"]["host_ipc_rtt"]["event_field"],
         "daemon_rtt_us"


### PR DESCRIPTION
Carries PR #688 (`origin/claude/base-build-fixes-v2`, cherry-picked as
`885760263`) so this branch compiles; noted per the task instructions.

## Premise check — the span was already split before this PR

The task described `rusqlite.begin_immediate` as one span at
`exact_sql/mod.rs` around line 427 mixing a channel wait with SQLite's
`BEGIN IMMEDIATE`, mean 10.65 ms vs p95 82 µs. Verifying against current
`origin/cursor/simplify-pr421-hot-paths`, that premise is **stale**: commit
`8bb12ad98` (`perf(exact-sql): separate dispatch and lock timing`),
already merged into this base branch via PR #663, did exactly the split
the task asked for, before this PR was opened:

- `rusqlite.exact_sql.begin_immediate` (`exact_sql/mod.rs`, `begin_immediate`)
  — the **caller-side round trip**: `try_send` the `BeginTransaction`
  command, then block on `response.recv()`. This does include the worker's
  own lock-acquisition time, by design, since long-running work already
  queued on the worker (vacuum, WAL truncation, a long-lease transaction)
  should show up here as begin latency even when SQLite itself was never
  contended.
- `rusqlite.exact_sql.write_lock` (`exact_sql/command.rs`,
  `begin_transaction_with_busy_retry`) — the **worker-side lock
  acquisition alone**: the busy-retry loop around
  `Transaction::new_unchecked`, measured on the worker thread inside
  `run_writer_command`, with no channel wait folded in.

Both are already documented with doc comments explaining exactly this
split and why the two are kept apart (see `exact_sql/mod.rs:427-435` and
`exact_sql/command.rs:57-63`). The bare `rusqlite.begin_immediate` name
now appears exactly once, unrelated to exact-SQL: in
`writer/worker/mod.rs`'s `run_incremental_vacuum`, a maintenance path that
opens its own transaction directly on the already-dequeued worker thread
— no caller-side channel wait to fold in there, so it needed no split.

The ordinary write-batch path (`writer/transaction.rs::process_batch`)
was already separately instrumented: `queue_wait_micros` is computed at
the dequeue boundary and reported via `record_writer_batch`, while
`rusqlite.writer.begin` measures only the transaction open on the writer
thread.

**What I actually did**, since the instrumentation itself pre-dated this
PR: added the falsifiable test the task asked for, proving the split
holds and stays distinct, plus verified all of the above by reading the
call sites rather than trusting the doc comments.

## Change

`crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/hotpath_spans.rs`
(new, `#[cfg(feature = "hotpath")]`-gated module registered from
`tests/mod.rs`): builds a real `HotpathGuardBuilder` writing a JSON
report to a temp file, drives one real `begin_immediate()` /
`execute()` / `commit()` through a real writer thread via the crate's
existing `fixture()`/`ExactSqlHandle::attach` test harness, drops the
guard to flush the report, then asserts from the parsed JSON:

- `rusqlite.exact_sql.begin_immediate` was recorded with `calls >= 1`
- `rusqlite.exact_sql.write_lock` was recorded with `calls >= 1`
- the two label strings are literally distinct (`assert_ne!`)

No elapsed-time assertion anywhere — only `calls` counts from the report,
per the requirement that these timings swing ~12% run to run.

## Instrumentation-only, confirmed

No edits to `select_auxiliary_work`, `prefer_auxiliary`, `drain_fair`, or
any writer scheduling code — `git diff` against
`writer/worker/mod.rs` is empty. The only files touched are the new test
module and its registration in `tests/mod.rs`.

## Verified vs. taken on faith

Verified by reading the code directly (not inferred from doc comments):
- `begin_immediate` really does `try_send` + blocking `response.recv()`
  on the caller thread (`exact_sql/mod.rs::begin_transaction`).
- `begin_transaction_with_busy_retry` really does run on the worker
  thread, inside `run_writer_command`'s `WriterCommand::BeginTransaction`
  arm, with no channel wait of its own.
- `git log --oneline -- exact_sql/mod.rs` and `git merge-base
  --is-ancestor 8bb12ad98 origin/cursor/simplify-pr421-hot-paths` confirm
  the split predates this branch's HEAD.

Taken on faith: the hotpath crate's own internal aggregation (`0.24.0`,
vendored dependency) correctly attributes cross-thread `measure_block!`
calls to one shared registry keyed by label — I did not read hotpath's
internals byte-for-byte, only enough to find the JSON report schema
(`functions_timing.data[].{name, calls}`) and confirm `HotpathGuardBuilder`
panics only if a second guard is built concurrently (none of this crate's
other tests build one).

## Metric-name/shape change to flag

This is **not new** to this PR — commit `8bb12ad98` (already merged via
PR #663) already renamed the exact-SQL caller round trip from
`rusqlite.begin_immediate` to `rusqlite.exact_sql.begin_immediate` and
introduced `rusqlite.exact_sql.write_lock` as a new, separate label. Any
historical profiling comparison keyed on the old bare
`rusqlite.begin_immediate` name for the exact-SQL path will not line up
against reports taken after that commit — flagging this explicitly since
that commit's own message didn't call it out. The bare
`rusqlite.begin_immediate` name that still exists today refers only to
the unrelated incremental-vacuum maintenance path and was not touched by
either commit.

## Test output (verbatim)

```
running 1 test
[hotpath - error] 127.0.0.1:6770 busy (Address already in use (os error 98)), skipping metrics server start. Use HOTPATH_METRICS_PORT to change the port.
exact-sql begin span report: begin_immediate=Some(1) calls, write_lock=Some(1) calls
full report: {"type":"hotpath_report","functions_timing":{"profiling_mode":"timing","time_elapsed":"14.62 ms","total_elapsed_ns":14617603,"description":"Execution duration of functions.","caller_name":"exact_sql_begin_span_split_test","percentiles":[95.0],"data":[{"id":8,"name":"exact_sql_begin_span_split_test","calls":1,"sampled_calls":1,"avg":"14.13 ms","p95":"14.13 ms","total":"14.13 ms","percent_total":"100.00%"},{"id":3,"name":"rusqlite.writer.exact_sql","calls":2,"sampled_calls":2,"avg":"1.08 ms","p95":"1.99 ms","total":"2.17 ms","percent_total":"15.33%"},{"id":2,"name":"tracedecay_rusqlite_runtime::exact_sql::command::run_writer_command","calls":2,"sampled_calls":2,"avg":"1.08 ms","p95":"1.98 ms","total":"2.16 ms","percent_total":"15.31%"},{"id":7,"name":"rusqlite.exact_sql.begin_immediate","calls":1,"sampled_calls":1,"avg":"35.94 µs","p95":"35.97 µs","total":"35.94 µs","percent_total":"0.25%"},{"id":5,"name":"tracedecay_rusqlite_runtime::exact_sql::execute_statement","calls":1,"sampled_calls":1,"avg":"32.71 µs","p95":"32.72 µs","total":"32.71 µs","percent_total":"0.23%"},{"id":1,"name":"rusqlite.writer.drain_ingress","calls":5,"sampled_calls":5,"avg":"3.58 µs","p95":"14.50 µs","total":"17.92 µs","percent_total":"0.13%"},{"id":6,"name":"rusqlite.commit","calls":1,"sampled_calls":1,"avg":"15.54 µs","p95":"15.54 µs","total":"15.54 µs","percent_total":"0.11%"},{"id":4,"name":"rusqlite.exact_sql.write_lock","calls":1,"sampled_calls":1,"avg":"7.98 µs","p95":"7.98 µs","total":"7.98 µs","percent_total":"0.06%"}]}, ... }

test exact_sql::tests::hotpath_spans::begin_immediate_and_write_lock_are_distinct_spans ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 325 filtered out; finished in 0.02s
```

Full-suite confirmation (both configurations, per-crate only):

```
$ cargo check -p tracedecay-rusqlite-runtime --all-targets --locked
    Finished `dev` profile [optimized + debuginfo] target(s)

$ cargo check -p tracedecay-rusqlite-runtime --all-targets --features hotpath --locked
    Finished `dev` profile [optimized + debuginfo] target(s)

$ cargo test -p tracedecay-rusqlite-runtime --features hotpath --lib
test result: ok. 326 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.94s

$ cargo test -p tracedecay-rusqlite-runtime --lib   # default features, rerun for a clean pass
test result: ok. 325 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 11.09s
```

One transient failure was seen on a first default-build run, under
concurrent CPU load from other agents on this shared machine:
`exact_sql::tests::transaction::immediate_begin_retries_sqlite_busy_until_lock_releases`
(a pre-existing SQLite-busy-timing race, unrelated to this change — the
new test module doesn't exist at all in a build without the `hotpath`
feature). It passed both in isolation and on a clean rerun of the full
suite; not investigated further as out of scope for an instrumentation-only
change.

## SCOPE DEVIATION

None. Only the new `hotpath_spans.rs` test module and its one-line
registration in `tests/mod.rs` were added. No writer scheduling,
`select_auxiliary_work`, `prefer_auxiliary`, or `drain_fair` code was
touched, and no production instrumentation was renamed by this PR (that
rename already happened in `8bb12ad98`, which this branch already
carries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
