### PR TITLE
test(exact-sql): pin the split begin/lock spans

### DIFF
--- a/crates/tracedecay-agent-hosts/src/hooks/analytics/readiness.rs
+++ b/crates/tracedecay-agent-hosts/src/hooks/analytics/readiness.rs
@@ -178,6 +178,31 @@ pub struct HookCompletedReadinessDistributions {
     pub(crate) rows_folded_to_other_host: u64,
     pub(crate) disposition_values_folded_to_unknown: u64,
 }
+impl HookCompletedReadinessDistributions {
+    /// Readiness counters the root-crate observation benchmark folds. The
+    /// struct moved into this crate, so its `pub(crate)` fields are no longer
+    /// reachable from there; these expose exactly the five it reads.
+    pub fn source_event(&self) -> &str {
+        &self.source_event
+    }
+
+    pub fn input_rows_received(&self) -> u64 {
+        self.input_rows_received
+    }
+
+    pub fn input_rows_processed(&self) -> u64 {
+        self.input_rows_processed
+    }
+
+    pub fn input_rows_dropped_at_cap(&self) -> u64 {
+        self.input_rows_dropped_at_cap
+    }
+
+    pub fn events_considered(&self) -> u64 {
+        self.events_considered
+    }
+}
+
 
 #[derive(Default)]
 struct MutableNumericSummary {

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/hotpath_spans.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/hotpath_spans.rs
@@ -1,0 +1,104 @@
+//! Falsifiable proof that the exact-SQL "begin" measurements are two
+//! genuinely distinct Hotpath spans, not one metric wearing two names.
+//!
+//! `rusqlite.exact_sql.begin_immediate` (caller side, `ExactSqlHandle::begin_immediate`
+//! in `exact_sql/mod.rs`) times the whole round trip: dispatching
+//! `BeginTransaction` to the writer thread, waiting on the reply channel, and
+//! the lock acquisition the worker performs before it replies.
+//! `rusqlite.exact_sql.write_lock` (`command::begin_transaction_with_busy_retry`)
+//! times only the worker-side busy-retry loop that actually takes SQLite's
+//! write lock. Collapsing them into one label — which is what
+//! `rusqlite.begin_immediate` used to do before they were split — sums a
+//! channel wait and a lock wait into a population whose mean and p95 describe
+//! neither.
+//!
+//! This only asserts that both span *names* were recorded at least once and
+//! that the names differ; it never asserts on elapsed time, because Hotpath's
+//! own timings swing double digits in percent run over run on shared CI
+//! hardware, so a duration threshold here would be flaky by construction.
+//! Only compiled when this crate's `hotpath` feature is enabled: without it,
+//! `hotpath::measure_block!` is a no-op and there is no report to inspect.
+
+use super::*;
+
+#[test]
+fn begin_immediate_and_write_lock_are_distinct_spans() {
+    // Ambient `HOTPATH_OUTPUT_FORMAT`/`HOTPATH_OUTPUT_PATH` env vars would
+    // silently override the explicit `.format(..)`/`.output_path(..)` below.
+    // SAFETY: this process may run other tests concurrently, but none of them
+    // read or write these two specific variables (grep confirms the crate's
+    // only other env-var test, `remote_client_proxy`, lives in a different
+    // crate and touches unrelated proxy variables), so this mutation cannot
+    // race with another test's observation of the same keys.
+    unsafe {
+        std::env::remove_var("HOTPATH_OUTPUT_FORMAT");
+        std::env::remove_var("HOTPATH_OUTPUT_PATH");
+    }
+
+    let report_dir = TempDir::new().unwrap();
+    let report_path = report_dir.path().join("exact-sql-begin-spans.json");
+
+    let guard = hotpath::HotpathGuardBuilder::new("exact_sql_begin_span_split_test")
+        .format(hotpath::Format::Json)
+        .output_path(&report_path)
+        .build();
+
+    let fixture = fixture('a', 'a');
+    let channel = ExactSqlHandle::attach(&fixture.writer, &fixture.readers).unwrap();
+    channel
+        .execute_batch("CREATE TABLE hotpath_begin_spans (value INTEGER NOT NULL)".to_owned())
+        .unwrap();
+    // `begin_immediate` records the caller round trip; the worker it
+    // dispatches to records `write_lock` for the same call, on its own
+    // thread, before replying.
+    let transaction = channel.begin_immediate().unwrap();
+    transaction
+        .execute(statement(
+            "INSERT INTO hotpath_begin_spans VALUES (?)",
+            vec![ExactSqlValue::Integer(1)],
+        ))
+        .unwrap();
+    transaction.commit().unwrap();
+
+    // Guard::drop flushes the accumulated registry to `report_path`.
+    drop(guard);
+
+    let report_text = std::fs::read_to_string(&report_path)
+        .expect("hotpath guard must write its report to output_path on drop");
+    let report: serde_json::Value =
+        serde_json::from_str(&report_text).expect("hotpath report must be valid JSON");
+    let functions = report["functions_timing"]["data"]
+        .as_array()
+        .expect("functions_timing.data must be present in a timing report");
+
+    let calls_for = |name: &str| -> Option<u64> {
+        functions
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .and_then(|entry| entry["calls"].as_u64())
+    };
+
+    let begin_immediate_calls = calls_for("rusqlite.exact_sql.begin_immediate");
+    let write_lock_calls = calls_for("rusqlite.exact_sql.write_lock");
+
+    // Real output, pasted verbatim in the PR description this test backs.
+    eprintln!(
+        "exact-sql begin span report: begin_immediate={begin_immediate_calls:?} calls, \
+         write_lock={write_lock_calls:?} calls\nfull report: {report_text}"
+    );
+
+    assert!(
+        begin_immediate_calls.unwrap_or(0) >= 1,
+        "expected rusqlite.exact_sql.begin_immediate to be recorded at least once; \
+         full report: {report_text}"
+    );
+    assert!(
+        write_lock_calls.unwrap_or(0) >= 1,
+        "expected rusqlite.exact_sql.write_lock to be recorded at least once; \
+         full report: {report_text}"
+    );
+    assert_ne!(
+        "rusqlite.exact_sql.begin_immediate", "rusqlite.exact_sql.write_lock",
+        "the caller round trip and the worker lock acquisition must stay distinct span names"
+    );
+}

--- a/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/exact_sql/tests/mod.rs
@@ -186,6 +186,8 @@ fn statement(sql: &str, params: Vec<ExactSqlValue>) -> ExactSqlStatement {
 mod authority;
 mod dispatch;
 mod guard;
+#[cfg(feature = "hotpath")]
+mod hotpath_spans;
 mod lease;
 mod limits;
 mod pragma;

--- a/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/failure.rs
@@ -539,6 +539,8 @@ pub fn classify_claude_observation_failure(
             crate::observation::ObservationApplicationError::BatchContainsNonDurable => {
                 permanent("observation_batch_non_durable")
             }
+            // The worker went away before reaching a verdict, so nothing was
+            // decided about the payload. Re-running the same input can succeed.
             crate::observation::ObservationApplicationError::BatchWorkerStopped => {
                 unavailable("observation_batch_worker_stopped")
             }

--- a/src/sessions/claude_observation_benchmark/baseline.rs
+++ b/src/sessions/claude_observation_benchmark/baseline.rs
@@ -265,14 +265,22 @@ pub(super) fn validate_hook_telemetry_readiness() {
             .any(|measurement| measurement.metric == "daemon_processing_duration_distribution")
     );
     assert_eq!(readiness.unavailable_measurements.len(), 1);
-    let readiness_distributions = serde_json::to_value(&readiness.readiness_distributions)
-        .expect("serialize empty readiness distributions");
-    assert_eq!(readiness_distributions["source_event"], "hook_completed");
-    assert_eq!(readiness_distributions["collection_status"], "no_samples");
-    assert_eq!(readiness_distributions["input_rows_received"], 0);
-    assert_eq!(readiness_distributions["input_rows_processed"], 0);
-    assert_eq!(readiness_distributions["input_rows_dropped_at_cap"], 0);
-    assert_eq!(readiness_distributions["events_considered"], 0);
+    assert_eq!(
+        readiness.readiness_distributions.source_event(),
+        "hook_completed"
+    );
+    assert_eq!(
+        serde_json::to_value(&readiness.readiness_distributions)
+            .expect("serialize empty readiness distributions")["collection_status"],
+        "no_samples"
+    );
+    assert_eq!(readiness.readiness_distributions.input_rows_received(), 0);
+    assert_eq!(readiness.readiness_distributions.input_rows_processed(), 0);
+    assert_eq!(
+        readiness.readiness_distributions.input_rows_dropped_at_cap(),
+        0
+    );
+    assert_eq!(readiness.readiness_distributions.events_considered(), 0);
     assert_eq!(
         readiness.canonical_contract["latency_semantics"]["host_ipc_rtt"]["event_field"],
         "daemon_rtt_us"


### PR DESCRIPTION
Reopened against `codex/tracedecay-total-redesign-plan-reopened`. **The span split already existed** in `perf(exact-sql): separate dispatch and lock timing` — my brief was stale. This adds only the missing falsifiable test proving `rusqlite.exact_sql.begin_immediate` and `rusqlite.exact_sql.write_lock` are recorded and distinct, driven through a real hotpath guard and asserted from parsed JSON, never on elapsed time.