### PR TITLE
fix(clippy): clear the workspace clippy failures on #707

### DIFF
--- a/crates/tracedecay-global-db/src/session_temporal/projection/tests.rs
+++ b/crates/tracedecay-global-db/src/session_temporal/projection/tests.rs
@@ -542,7 +542,7 @@ async fn multi_output_projection_reuses_source_derivation_and_activates_shared_a
         counted.query_count(),
         batch.occurrences().len()
     );
-    drop(counted);
+    // `counted` holds no Drop impl, so dropping it only extends its borrows.
     drop(transaction);
 
     store

--- a/crates/tracedecay-graph-db/src/registry/publication.rs
+++ b/crates/tracedecay-graph-db/src/registry/publication.rs
@@ -29,6 +29,21 @@ use crate::{
     GraphProjectionIdentity, GraphReplayCollectionOutcome, VerifiedGraphCommit,
 };
 
+/// The three publication mode choices `publish_verified_inner` varies on.
+///
+/// Grouped because passing them positionally put the function at 8 arguments,
+/// and three adjacent bools at a call site read as noise: `false, true` says
+/// nothing about which knob is which.
+struct GraphPublishModeV1 {
+    /// A manifest supplied by the caller instead of one derived from replay.
+    supplied_manifest: Option<Arc<GraphGenerationManifest>>,
+    /// Reopen metadata rather than treating the existing handle as current.
+    reopen_metadata: bool,
+    /// This call writes a durable staging page, so it retries across the
+    /// boundary to prove the exact commit rather than assuming it landed.
+    durable_stage_boundary: bool,
+}
+
 impl GraphDbRegistry {
     #[hotpath::measure(label = "graph_db.replay_pool.retire", impl_type = "GraphDbRegistry")]
     pub fn retire_one_code_generation_replay(
@@ -410,9 +425,11 @@ impl GraphDbRegistry {
             authority,
             context,
             publication_key,
-            supplied_manifest,
-            false,
-            false,
+            GraphPublishModeV1 {
+                supplied_manifest,
+                reopen_metadata: false,
+                durable_stage_boundary: false,
+            },
         )
     }
 
@@ -434,9 +451,11 @@ impl GraphDbRegistry {
             authority,
             context,
             publication_key,
-            supplied_manifest,
-            false,
-            true,
+            GraphPublishModeV1 {
+                supplied_manifest,
+                reopen_metadata: false,
+                durable_stage_boundary: true,
+            },
         )
     }
 
@@ -458,9 +477,11 @@ impl GraphDbRegistry {
             authority,
             context,
             publication_key,
-            None,
-            false,
-            false,
+            GraphPublishModeV1 {
+                supplied_manifest: None,
+                reopen_metadata: false,
+                durable_stage_boundary: false,
+            },
         )
     }
 
@@ -477,11 +498,14 @@ impl GraphDbRegistry {
             authority,
             context,
             publication_key,
-            None,
-            true,
-            false,
+            GraphPublishModeV1 {
+                supplied_manifest: None,
+                reopen_metadata: true,
+                durable_stage_boundary: false,
+            },
         )
     }
+
 
     #[hotpath::measure(label = "graph_db.generation.publish", impl_type = "GraphDbRegistry")]
     fn publish_verified_inner(
@@ -490,10 +514,13 @@ impl GraphDbRegistry {
         authority: &mut dyn GraphPublicationStoreV1,
         context: &GraphPublicationOperationContextV1<'_>,
         publication_key: &GraphPublicationKeyV1,
-        supplied_manifest: Option<Arc<GraphGenerationManifest>>,
-        reopen_metadata: bool,
-        durable_stage_boundary: bool,
+        mode: GraphPublishModeV1,
     ) -> Result<VerifiedGraphCommit, GraphDbError> {
+        let GraphPublishModeV1 {
+            supplied_manifest,
+            reopen_metadata,
+            durable_stage_boundary,
+        } = mode;
         operation.check(self, context)?;
         operation.require_publication_binding(publication_key)?;
         let database = operation.database().clone();

--- a/crates/tracedecay-graph-db/src/registry/publication.rs
+++ b/crates/tracedecay-graph-db/src/registry/publication.rs
@@ -506,7 +506,6 @@ impl GraphDbRegistry {
         )
     }
 
-
     #[hotpath::measure(label = "graph_db.generation.publish", impl_type = "GraphDbRegistry")]
     fn publish_verified_inner(
         &self,

--- a/crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/writer/worker/mod.rs
@@ -1612,10 +1612,12 @@ mod auxiliary_scheduling_tests {
     /// validated, reported in telemetry, and never obeyed.
     #[test]
     fn writer_checkpoint_policy_is_the_configured_wal_budget() {
-        let mut admission = tracedecay_store::AdmissionConfigV1::default();
-        admission.wal = tracedecay_store::WalBudgetV1 {
-            soft_limit_bytes: 4 * 1024 * 1024,
-            hard_limit_bytes: 64 * 1024 * 1024,
+        let admission = tracedecay_store::AdmissionConfigV1 {
+            wal: tracedecay_store::WalBudgetV1 {
+                soft_limit_bytes: 4 * 1024 * 1024,
+                hard_limit_bytes: 64 * 1024 * 1024,
+            },
+            ..Default::default()
         };
         admission
             .validate()

--- a/crates/tracedecay-sessions/src/runtime/codex/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/codex/tests.rs
@@ -1005,13 +1005,15 @@ mod recent_first_discovery_tests {
 
     #[test]
     fn indexed_replay_starts_at_the_acknowledged_btree_position() {
-        let mut index = CodexReplayIndex::default();
-        index.complete = true;
-        index.frontier = CodexDiscoveryFrontier::complete(CodexCorpusEpoch {
-            high: 1,
-            low: 2,
-            files: 8192,
-        });
+        let mut index = CodexReplayIndex {
+            complete: true,
+            frontier: CodexDiscoveryFrontier::complete(CodexCorpusEpoch {
+                high: 1,
+                low: 2,
+                files: 8192,
+            }),
+            ..Default::default()
+        };
         for value in 0..8192 {
             index.paths.insert(CodexIndexedPath {
                 root_order: 0,
@@ -1041,13 +1043,15 @@ mod recent_first_discovery_tests {
 
     #[test]
     fn indexed_replay_preserves_recent_sessions_before_archive() {
-        let mut index = CodexReplayIndex::default();
-        index.complete = true;
-        index.frontier = CodexDiscoveryFrontier::complete(CodexCorpusEpoch {
-            high: 1,
-            low: 2,
-            files: 3,
-        });
+        let mut index = CodexReplayIndex {
+            complete: true,
+            frontier: CodexDiscoveryFrontier::complete(CodexCorpusEpoch {
+                high: 1,
+                low: 2,
+                files: 3,
+            }),
+            ..Default::default()
+        };
         let newest = CodexIndexedPath {
             root_order: 0,
             path: PathBuf::from("/sessions/2026/08/24/rollout-new.jsonl"),

--- a/crates/tracedecay-sessions/src/runtime/lcm/gc/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/lcm/gc/tests.rs
@@ -1695,8 +1695,14 @@ async fn pending_delete_drain_batches_mixed_metadata_presence() -> Result<(), St
         .await
         .map_err(|err| err.to_string())?;
 
-    assert_eq!(drain.outcomes.preserved.refs, *std::slice::from_ref(&live_ref));
-    assert_eq!(drain.outcomes.removed.refs, *std::slice::from_ref(&dead_ref));
+    assert_eq!(
+        drain.outcomes.preserved.refs,
+        *std::slice::from_ref(&live_ref)
+    );
+    assert_eq!(
+        drain.outcomes.removed.refs,
+        *std::slice::from_ref(&dead_ref)
+    );
     assert!(dir.join(&live_ref).is_file(), "live payload was unlinked");
     assert!(!dir.join(&dead_ref).exists(), "dead payload survived");
     Ok(())

--- a/crates/tracedecay-sessions/src/runtime/lcm/gc/tests.rs
+++ b/crates/tracedecay-sessions/src/runtime/lcm/gc/tests.rs
@@ -1695,8 +1695,8 @@ async fn pending_delete_drain_batches_mixed_metadata_presence() -> Result<(), St
         .await
         .map_err(|err| err.to_string())?;
 
-    assert_eq!(drain.outcomes.preserved.refs, [live_ref.clone()]);
-    assert_eq!(drain.outcomes.removed.refs, [dead_ref.clone()]);
+    assert_eq!(drain.outcomes.preserved.refs, *std::slice::from_ref(&live_ref));
+    assert_eq!(drain.outcomes.removed.refs, *std::slice::from_ref(&dead_ref));
     assert!(dir.join(&live_ref).is_file(), "live payload was unlinked");
     assert!(!dir.join(&dead_ref).exists(), "dead payload survived");
     Ok(())

--- a/crates/tracedecay-sessions/src/runtime/lcm/query.rs
+++ b/crates/tracedecay-sessions/src/runtime/lcm/query.rs
@@ -1048,7 +1048,7 @@ mod tests {
         )
         .await
         .expect("session schema");
-        schema::ensure_lcm_schema(&*conn).await.expect("LCM schema");
+        schema::ensure_lcm_schema(&conn).await.expect("LCM schema");
         conn.execute(
             "INSERT INTO sessions(provider, session_id, project_key, project_path)
              VALUES ('cursor', 'session-a', '/p', '/p')",

--- a/src/daemon/bootstrap.rs
+++ b/src/daemon/bootstrap.rs
@@ -769,7 +769,7 @@ async fn run_foreground_unix(
 }
 
 /// Install the daemon-wide worker authority from the profile's exact
-/// ProfileSessions configuration before publishing a transport endpoint.
+/// `ProfileSessions` configuration before publishing a transport endpoint.
 /// Account-deletion-only boots return before this point and never start
 /// projectless capture work.
 async fn install_profile_worker_plan(

--- a/src/daemon/code_index_scheduler.rs
+++ b/src/daemon/code_index_scheduler.rs
@@ -567,7 +567,7 @@ impl DaemonCodeIndexPublicationStoreV1 {
     fn state_digest_file(path: &Path) -> Result<String, CodeIndexPublicationStoreErrorV1> {
         let mut file = File::open(path).map_err(Self::unavailable)?;
         let mut hasher = Sha256::new();
-        let mut buffer = [0_u8; DURABLE_GENERATION_IO_CHUNK_BYTES_V1];
+        let mut buffer = vec![0_u8; DURABLE_GENERATION_IO_CHUNK_BYTES_V1];
         loop {
             let read = file.read(&mut buffer).map_err(Self::unavailable)?;
             if read == 0 {
@@ -591,8 +591,8 @@ impl DaemonCodeIndexPublicationStoreV1 {
         }
         let mut left = File::open(left).map_err(Self::unavailable)?;
         let mut right = File::open(right).map_err(Self::unavailable)?;
-        let mut left_buffer = [0_u8; DURABLE_GENERATION_IO_CHUNK_BYTES_V1];
-        let mut right_buffer = [0_u8; DURABLE_GENERATION_IO_CHUNK_BYTES_V1];
+        let mut left_buffer = vec![0_u8; DURABLE_GENERATION_IO_CHUNK_BYTES_V1];
+        let mut right_buffer = vec![0_u8; DURABLE_GENERATION_IO_CHUNK_BYTES_V1];
         loop {
             let left_read = left.read(&mut left_buffer).map_err(Self::unavailable)?;
             if left_read == 0 {

--- a/src/daemon/code_index_scheduler/tests.rs
+++ b/src/daemon/code_index_scheduler/tests.rs
@@ -9144,10 +9144,10 @@ async fn resident_memory_graph_refusal_seats_text_serving_without_graph() {
 
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     let latest = loop {
-        if let Some(latest) = registry.latest_complete_serving_for_scope(&scope).await {
-            if latest.query_owners_are_warm() {
-                break latest;
-            }
+        if let Some(latest) = registry.latest_complete_serving_for_scope(&scope).await
+            && latest.query_owners_are_warm()
+        {
+            break latest;
         }
         assert!(
             std::time::Instant::now() <= deadline,

--- a/src/daemon/database_owner_registry.rs
+++ b/src/daemon/database_owner_registry.rs
@@ -9,6 +9,9 @@ use super::*;
 /// evicted to stay within the registry's capacity bound.
 pub(super) type BoundRouteInsertionV1<Server> = (Server, bool, Vec<(ProjectServerKey, Server)>);
 
+/// One retired owner and the project servers that were mounted under it.
+pub(super) type RetiredOwnerServersV1<Server> = (StoreOwnerKey, Vec<(ProjectServerKey, Server)>);
+
 // Fields are `pub(super)` so `branch_admin` can read `server` directly.
 pub(super) struct DatabaseOwnerEntry<Server> {
     pub(super) server: Server,
@@ -285,14 +288,14 @@ impl<Server> DatabaseOwnerRegistry<Server> {
     pub(super) fn retire_lru_ready_under_graph_pressure<F>(
         &mut self,
         mut is_leased: F,
-    ) -> std::result::Result<Option<(StoreOwnerKey, Vec<(ProjectServerKey, Server)>)>, ()>
+    ) -> std::result::Result<Option<RetiredOwnerServersV1<Server>>, ()>
     where
         F: FnMut(&Server) -> bool,
     {
         let owners = self
             .servers
-            .iter()
-            .map(|(key, _)| key.owner.clone())
+            .keys()
+            .map(|key| key.owner.clone())
             .collect::<std::collections::HashSet<_>>();
         let evict = owners
             .into_iter()

--- a/src/daemon/invocation_state.rs
+++ b/src/daemon/invocation_state.rs
@@ -79,7 +79,7 @@ impl DaemonInvocationState {
     }
 
     /// Mount the profile-owned background-worker plan before any projectless
-    /// session or host-admission work can start. The exact ProfileSessions
+    /// session or host-admission work can start. The exact `ProfileSessions`
     /// shard is the persisted user-profile authority; project configuration
     /// must never win this process-wide installation by opening first.
     pub(crate) async fn install_profile_worker_plan(

--- a/src/daemon/session_temporal_refresh_scheduler/worker.rs
+++ b/src/daemon/session_temporal_refresh_scheduler/worker.rs
@@ -25,7 +25,7 @@ use crate::store::{
     GlobalDbSessionTemporalStore, SessionRefreshRecoveryV1, SessionRefreshRestartStateV1,
 };
 
-const HISTORY_IDLE_RECHECK_INTERVAL: Duration = Duration::from_secs(60);
+const HISTORY_IDLE_RECHECK_INTERVAL: Duration = Duration::from_mins(1);
 
 #[hotpath::measure]
 pub(super) async fn run_session_temporal_refresh_scheduler(

--- a/src/mcp/tools/handlers/dashboard.rs
+++ b/src/mcp/tools/handlers/dashboard.rs
@@ -84,7 +84,7 @@ pub(crate) fn compose_dashboard_profile_code_index_worker_settings(
 impl DashboardProfileCodeIndexWorkerSettingsPort
     for DashboardProfileCodeIndexWorkerSettingsAdapter
 {
-    fn read<'a>(&'a self) -> DashboardCodeIndexWorkerSettingsFuture<'a> {
+    fn read(&self) -> DashboardCodeIndexWorkerSettingsFuture<'_> {
         let database = self.database.clone();
         let profile_id = self.profile_id.clone();
         Box::pin(async move {
@@ -98,12 +98,12 @@ impl DashboardProfileCodeIndexWorkerSettingsPort
         })
     }
 
-    fn commit<'a>(
-        &'a self,
+    fn commit(
+        &self,
         selection: CodeIndexWorkerSelectionV1,
         expected_revision: ConfigurationRevisionId,
         idempotency_key: ConfigurationIdempotencyKey,
-    ) -> DashboardCodeIndexWorkerSettingsCommitFuture<'a> {
+    ) -> DashboardCodeIndexWorkerSettingsCommitFuture<'_> {
         let database = self.database.clone();
         let profile_id = self.profile_id.clone();
         let project_root = self.project_root.clone();


### PR DESCRIPTION
## What this fixes

`Clippy` has been failing on #707 continuously — it failed on `e2430e639`, was not re-attempted while the light 8-check gate ran, and reproduced identically when the wide run fanned out again on `fac184df5`. Roughly ten commits landed in between without it being addressed, because the intervening runs never executed it.

Reproduced locally with the exact CI command (`cargo clippy --workspace --all-targets --locked -- -D warnings`) in an isolated worktree, so nothing touched the shared checkout's in-progress files.

## The one that needed a judgement call

`publish_verified_inner` was at 8 arguments (7 allowed), with three of them a manifest option plus two adjacent bools. Rather than raise the threshold or `#[allow]` it, the three mode choices are grouped into `GraphPublishModeV1`. That also fixes the readability problem the lint is pointing at: `..., false, true)` at a call site said nothing about which knob was which, and the four call sites now name each field.

## The rest

| site | lint |
|---|---|
| `writer/worker/mod.rs` | field reassign after `Default::default()` (the WAL-budget test) |
| `codex/tests.rs` ×2 | same, on `CodexReplayIndex` |
| `lcm/gc/tests.rs` ×2 | redundant `clone()` to build a slice — uses `slice::from_ref` |
| `lcm/query.rs` | redundant deref |
| `session_temporal/projection/tests.rs` | `drop()` on a type with no `Drop` impl |
| `database_owner_registry.rs` | complex return type named; `.iter().map(\|(k,_)\|…)` → `.keys()` |
| `code_index_scheduler/tests.rs` | collapsible nested `if` |
| `dashboard.rs` ×2 | needless explicit lifetimes |
| `bootstrap.rs`, `invocation_state.rs` | doc identifiers missing backticks |
| `session_temporal_refresh_scheduler/worker.rs` | `from_secs(60)` → `from_mins(1)` |

No `#[allow]` was added anywhere.

## Verification

`cargo clippy --workspace --all-targets --locked -- -D warnings` — **clean**.

**Note:** `Hawk`, `Dashboard` and `Build Windows tests` also fail on the same wide run and are **not** addressed here. They are separate failures needing their own fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)