### PR TITLE
fix(ci): unbreak Hawk and match its documented advisory intent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,13 @@ jobs:
           printf '%s\n' '<!doctype html><title>hawk</title>' > dashboard/app-dist/index.html
 
       - name: Hawk
+        # Reports, does not gate. The job header above states Hawk is not a
+        # required check until the workspace is clean under `-D warnings`, but
+        # the step hard-failed anyway, so Hawk showed as a red required check
+        # while the workspace carries ~9k visibility findings. Keep `-D
+        # warnings` so the report stays honest, and drop the gate until the
+        # backlog is burned down and this line can be removed.
+        continue-on-error: true
         run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
 
   fmt:

--- a/tests/mcp_suite/mcp_dashboard_tool_test.rs
+++ b/tests/mcp_suite/mcp_dashboard_tool_test.rs
@@ -10,6 +10,8 @@ use std::time::Duration;
 use crate::common::http_agent;
 use serde_json::json;
 #[cfg(feature = "test-transport")]
+use serde_json::Value;
+#[cfg(feature = "test-transport")]
 use std::sync::Arc;
 use tempfile::TempDir;
 #[cfg(feature = "test-transport")]

--- a/tests/mcp_suite/mcp_dashboard_tool_test.rs
+++ b/tests/mcp_suite/mcp_dashboard_tool_test.rs
@@ -12,8 +12,6 @@ use crate::common::http_agent;
 use serde_json::Value;
 use serde_json::json;
 #[cfg(feature = "test-transport")]
-use serde_json::Value;
-#[cfg(feature = "test-transport")]
 use std::sync::Arc;
 use tempfile::TempDir;
 #[cfg(feature = "test-transport")]


### PR DESCRIPTION
## Two separate problems, one job

**1. Hawk never got to lint.** It died at compile:

```
error[E0425]: cannot find type `Value` in this scope
   --> tests/mcp_suite/mcp_dashboard_tool_test.rs:120:18
```

`mcp_dashboard_tool_test.rs` uses `serde_json::Value` inside a `#[cfg(feature = "test-transport")]` test but only imports `json`. **Hawk builds that target with `--all-features`; the ordinary gates do not** — same rot class as the earlier `test-transport` breakage, where a target nothing routinely builds is free to stop compiling. Fixed with a matching gated import, following the file's existing pattern.

**2. With that fixed, Hawk runs — and reports 9,032 findings.** So the job would have gone on failing regardless of the import.

```
hawk::unnecessary_public:               7069
hawk::unnecessary_restricted_visibility: 1280
hawk::dead_public:                       683
```

The job's own header already says what should happen here:

> Additive visibility lint. **Not a required check yet** — introduce Hawk, then promote once the workspace is clean under `-D warnings`.

But the step ran `-D warnings` with no `continue-on-error`, so it hard-failed and surfaced as a red check. The intent and the implementation disagreed; this makes them agree.

`-D warnings` is deliberately kept so the report stays honest and the backlog stays visible. Only the gate is dropped, with a comment saying to remove that line once the backlog is burned down.

## What this does not do

It does not fix 9,032 visibility findings, and it is not an attempt to hide them. If you would rather Hawk stay gating, the alternative is a baseline file or a per-crate ratchet — say so and I will do that instead.

## Verification

`cargo +1.97.1 hawk check --target-dir target/hawk -D warnings` now completes and produces its report instead of failing to build. `cargo check --tests --features test-transport --locked` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)