### PR TITLE
fix(automation): keep a vanished job lock contended instead of stale

### DIFF
--- a/crates/tracedecay-agent-hosts/src/automation/scheduler.rs
+++ b/crates/tracedecay-agent-hosts/src/automation/scheduler.rs
@@ -725,9 +725,31 @@ async fn lock_is_stale(path: &Path, stale_after_secs: Option<u64>, now_secs: i64
         }
     }
     let Some(created_at) = lock_created_at(path).await? else {
-        return Ok(true);
+        // `lock_created_at` yields no timestamp when the lock vanished after
+        // the contender's `create_new` failed (the holder finished and
+        // released mid-check) or when no mtime is readable. Treating that as
+        // stale let the contender "reclaim" a released lock and run a second
+        // time (the Windows double-execution flake). Report stale only for a
+        // provably old on-disk lock; a vanished lock stays contended.
+        return Ok(lock_mtime_elapsed_secs(path, now_secs)
+            .await
+            .is_some_and(|elapsed| elapsed >= stale_after_secs));
     };
     Ok(elapsed_secs(created_at, now_secs) >= stale_after_secs)
+}
+
+/// Seconds since the lock file was last modified, or `None` when the file or
+/// its timestamps cannot be read (treated as not stale by the caller).
+async fn lock_mtime_elapsed_secs(path: &Path, now_secs: i64) -> Option<u64> {
+    let metadata = tokio::fs::symlink_metadata(path).await.ok()?;
+    let modified = metadata.modified().ok()?;
+    let modified_secs: i64 = modified
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs()
+        .try_into()
+        .ok()?;
+    Some(elapsed_secs(modified_secs, now_secs))
 }
 
 async fn lock_pid(path: &Path) -> Result<Option<u32>> {

--- a/tests/automation_runner_test/scheduler.rs
+++ b/tests/automation_runner_test/scheduler.rs
@@ -847,6 +847,72 @@ async fn task_lock_reclaims_stale_dead_pid_lock_file() {
 }
 
 #[tokio::test]
+async fn task_lock_does_not_steal_fresh_empty_lock_file() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let temp = tempdir().unwrap();
+    let lock_dir = temp.path().join("automation_locks");
+    std::fs::create_dir_all(&lock_dir).unwrap();
+    let lock_path = lock_dir.join("memory_curator.lock");
+    // A concurrent winner has created the lock file but not yet written its
+    // payload: the file exists and is empty. It must not be treated as stale.
+    std::fs::write(&lock_path, b"").unwrap();
+    let now_secs = i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    )
+    .unwrap();
+
+    let lock = AutomationTaskLock::try_acquire(
+        temp.path(),
+        AgentTaskKind::MemoryCurator,
+        Some(3600),
+        now_secs,
+    )
+    .await
+    .unwrap();
+
+    assert!(lock.is_none());
+    assert!(lock_path.exists());
+}
+
+#[tokio::test]
+async fn task_lock_reclaims_empty_lock_file_older_than_stale_window() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let temp = tempdir().unwrap();
+    let lock_dir = temp.path().join("automation_locks");
+    std::fs::create_dir_all(&lock_dir).unwrap();
+    let lock_path = lock_dir.join("skill_writer.lock");
+    // An empty lock whose mtime is far outside the stale window is a crash
+    // leftover and stays reclaimable.
+    std::fs::write(&lock_path, b"").unwrap();
+    let now_secs = i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    )
+    .unwrap()
+        + 7200;
+
+    let lock = AutomationTaskLock::try_acquire(
+        temp.path(),
+        AgentTaskKind::SkillWriter,
+        Some(3600),
+        now_secs,
+    )
+    .await
+    .unwrap();
+
+    assert!(lock.is_some());
+    drop(lock);
+    assert!(!lock_path.exists());
+}
+
+#[tokio::test]
 async fn task_lock_keeps_live_pid_lock_file() {
     let temp = tempdir().unwrap();
     let lock_dir = temp.path().join("automation_locks");


### PR DESCRIPTION
## The Windows double-execution flake

`jobs::concurrent_manual_job_triggers_do_not_double_execute` flaked on the 2026-08-04 master run (Test Windows shard 2): `backend.calls` was 2, and nextest is configured fail-on-flaky.

**Race:** a manual trigger loses the `create_new` race; the winner finishes the job and releases (deletes) the lock before the loser's staleness reads complete. `lock_created_at` then finds no file, `lock_is_stale` returned `true` for the missing timestamp, and the loser "reclaimed" the just-released lock and ran the job a second time. Windows' slower file I/O widens the window (the test's backend also blocks the runtime for 200ms, so the loser's checks resume exactly when the winner is finishing).

**Fix:** a lock with no readable creation timestamp is aged by its on-disk mtime and reported stale only when provably older than the stale window; a vanished lock stays contended. Crash recovery is preserved: dead-pid locks with payload age by `created_at` as before, and an empty crash leftover ages by mtime — both pinned by new regression tests (`task_lock_does_not_steal_fresh_empty_lock_file`, `task_lock_reclaims_empty_lock_file_older_than_stale_window`).

**Verification:** full `automation_runner_test` suite 154/154 locally; scoped clippy `-D warnings` clean on both changed targets; `cargo fmt --check` clean.

**Note for #707:** `crates/tracedecay-agent-hosts/src/automation/scheduler.rs` on the V2 branch has the same `create_new` + stale-reclaim pattern and needs the same port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2BarcJk3iuv77aJQwHvnx