### PR TITLE
ci(hotpath): experimental performance-diff workflows

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -1,0 +1,48 @@
+# Experimental companion to hotpath-profile.yml: posts the head-vs-base
+# profiling diff as a PR comment via hotpath-utils profile-pr.
+name: hotpath-comment
+
+on:
+  workflow_run:
+    workflows: ["hotpath-profile"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: profile-metrics
+          path: /tmp/metrics/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Install hotpath-utils 0.24.0
+        run: cargo install hotpath --version 0.24.0 --locked --features utils --bin hotpath-utils
+
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pr=$(cat /tmp/metrics/pr_number.txt)
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "no PR context (manual run); skipping comment"; exit 0
+          fi
+          export GITHUB_BASE_REF=$(cat /tmp/metrics/base_ref.txt)
+          export GITHUB_HEAD_REF=$(cat /tmp/metrics/head_ref.txt)
+          hotpath-utils profile-pr \
+            --head-metrics /tmp/metrics/head_timing.json \
+            --base-metrics /tmp/metrics/base_timing.json \
+            --github-token "$GH_TOKEN" \
+            --pr-number "$pr" \
+            --benchmark-id "mcp-smoke-timing"

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -1,0 +1,64 @@
+# Experimental: hotpath performance CI (https://hotpath.rs/github_ci).
+# Manually triggered while the workload is the bounded MCP conformance
+# smoke; swap in a daemon-free indexing benchmark before enabling on
+# pull_request. Pinned to hotpath 0.24.0 like the workspace.
+name: hotpath-profile
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Create metrics directory
+        run: mkdir -p /tmp/metrics
+
+      - name: Head profile (timing)
+        env:
+          HOTPATH_OUTPUT_FORMAT: json
+          HOTPATH_OUTPUT_PATH: /tmp/metrics/head_timing.json
+          HOTPATH_REPORT: functions-timing
+        run: |
+          cargo build --locked -p tracedecay-cli --bin tracedecay \
+            --no-default-features --features production,hotpath
+          TRACEDECAY_BIN=target/debug/tracedecay scripts/mcp-conformance-smoke.sh
+
+      - name: Checkout base
+        run: git checkout ${{ github.event.pull_request.base.sha || 'origin/master' }}
+
+      - name: Base profile (timing)
+        env:
+          HOTPATH_OUTPUT_FORMAT: json
+          HOTPATH_OUTPUT_PATH: /tmp/metrics/base_timing.json
+          HOTPATH_REPORT: functions-timing
+        run: |
+          cargo build --locked -p tracedecay-cli --bin tracedecay \
+            --no-default-features --features production,hotpath
+          TRACEDECAY_BIN=target/debug/tracedecay scripts/mcp-conformance-smoke.sh
+
+      - name: Save PR metadata
+        run: |
+          echo '${{ github.event.pull_request.number }}' > /tmp/metrics/pr_number.txt
+          echo '${{ github.base_ref }}' > /tmp/metrics/base_ref.txt
+          echo '${{ github.head_ref }}' > /tmp/metrics/head_ref.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: profile-metrics
+          path: /tmp/metrics/
+          retention-days: 1


### PR DESCRIPTION
Adds hotpath's official two-workflow performance CI pattern ([docs](https://hotpath.rs/github_ci)):

- **hotpath-profile** — `workflow_dispatch`-gated (zero cost until triggered): builds the `production,hotpath` binary and profiles the bounded MCP conformance smoke on head and base, uploading JSON metrics.
- **hotpath-comment** — fork-safe companion with `pull-requests: write`; installs `hotpath-utils` pinned to the workspace's **0.24.0** and posts the head-vs-base diff via `profile-pr` (skips cleanly on manual runs with no PR context).

Same two files are already on the #707 branch (`58b007bb10`), so landing this on master makes the eventual reconciliation a no-op for these paths. Upgrade path before enabling on `pull_request`: swap the profiled workload for a daemon-free indexing benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2BarcJk3iuv77aJQwHvnx