### PR TITLE
ci(hotpath): enable pull_request profiling with availability guards

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
       - uses: actions/download-artifact@v4
         with:
           name: profile-metrics
@@ -26,18 +23,42 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      # The profile job succeeds without metrics when a side predates the
+      # benchmark binary; a comparison comment needs both sides and a PR.
+      - name: Check for a comparable profile
+        id: comparable
+        run: |
+          pr=$(cat /tmp/metrics/pr_number.txt || true)
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "no PR context (manual run); skipping comment"
+          elif [ ! -s /tmp/metrics/head_timing.json ] || \
+               [ ! -s /tmp/metrics/base_timing.json ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "head or base has no profile" \
+                 "(head available: $(cat /tmp/metrics/head_bench_available.txt || echo '?')," \
+                 "base available: $(cat /tmp/metrics/base_bench_available.txt || echo '?'));" \
+                 "skipping comment"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.comparable.outputs.available == 'true'
+      - uses: Swatinem/rust-cache@v2
+        if: steps.comparable.outputs.available == 'true'
+
       - name: Install hotpath-utils 0.24.0
+        if: steps.comparable.outputs.available == 'true'
         run: cargo install hotpath --version 0.24.0 --locked --features utils --bin hotpath-utils
 
       - name: Post PR comment
+        if: steps.comparable.outputs.available == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           pr=$(cat /tmp/metrics/pr_number.txt)
-          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
-            echo "no PR context (manual run); skipping comment"; exit 0
-          fi
           export GITHUB_BASE_REF=$(cat /tmp/metrics/base_ref.txt)
           export GITHUB_HEAD_REF=$(cat /tmp/metrics/head_ref.txt)
           hotpath-utils profile-pr \
@@ -45,4 +66,4 @@ jobs:
             --base-metrics /tmp/metrics/base_timing.json \
             --github-token "$GH_TOKEN" \
             --pr-number "$pr" \
-            --benchmark-id "mcp-smoke-timing"
+            --benchmark-id "index-bench-timing"

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -1,14 +1,45 @@
 # Experimental: hotpath performance CI (https://hotpath.rs/github_ci).
-# Manually triggered while the workload is the bounded MCP conformance
-# smoke; swap in a daemon-free indexing benchmark before enabling on
-# pull_request. Pinned to hotpath 0.24.0 like the workspace.
+# Runs on every pull request. Pinned to hotpath 0.24.0 like the workspace.
+#
+# The profiled workload is `tracedecay-index-bench` (see
+# `benchmark_data/index-bench/README.md`): a daemon-free, socket-free,
+# deterministic indexing run over a committed fixture corpus. Head and base
+# index the same bytes in the same order, so a timing delta is attributable
+# to the diff rather than to the corpus, the clock, or the network.
+#
+# The benchmark binary does not exist on every commit line yet. Each side is
+# profiled only if its checkout carries the binary: a PR whose head predates
+# the benchmark skips profiling entirely, and a PR whose base predates it
+# uploads a head-only profile with no comparison. Both degradations are
+# recorded in the artifact rather than failing the job, so the trigger can
+# stay on pull_request while the benchmark propagates to every base.
 name: hotpath-profile
 
 on:
+  pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: hotpath-profile-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
+
+env:
+  # The workload budget. A run that overruns it is measuring something other
+  # than the diff and its numbers are not comparable.
+  INDEX_BENCH_TIMEOUT_SECONDS: "180"
+  # Both sides index this copy, taken from the head checkout before the base
+  # checkout replaces the working tree. Pinning the corpus is what makes the
+  # delta attributable to the code: if base carried its own older corpus,
+  # a fixture edit would read as a performance change.
+  TRACEDECAY_INDEX_BENCH_CORPUS: /tmp/index-bench-corpus
+  # Hotpath binds a localhost metrics server by default; the benchmark turns
+  # it off itself, and this makes that explicit at the job boundary too.
+  HOTPATH_METRICS_SERVER_OFF: "1"
+  # The file whose presence marks a checkout as carrying the benchmark.
+  INDEX_BENCH_SOURCE: crates/tracedecay-query/src/bin/tracedecay_index_bench.rs
 
 jobs:
   profile:
@@ -21,41 +52,96 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - name: Create metrics directory
         run: mkdir -p /tmp/metrics
 
+      - name: Detect benchmark at head
+        id: head_bench
+        run: |
+          if [ -f "${INDEX_BENCH_SOURCE}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::head does not carry tracedecay-index-bench;" \
+                 "hotpath profiling is not applicable to this PR line yet"
+          fi
+
+      # Taken from head so the base profile below indexes the same bytes.
+      - name: Pin the benchmark corpus
+        if: steps.head_bench.outputs.available == 'true'
+        run: |
+          cp -r benchmark_data/index-bench/corpus "${TRACEDECAY_INDEX_BENCH_CORPUS}"
+          find "${TRACEDECAY_INDEX_BENCH_CORPUS}" -type f | wc -l
+
       - name: Head profile (timing)
+        if: steps.head_bench.outputs.available == 'true'
         env:
           HOTPATH_OUTPUT_FORMAT: json
           HOTPATH_OUTPUT_PATH: /tmp/metrics/head_timing.json
           HOTPATH_REPORT: functions-timing
         run: |
-          cargo build --locked -p tracedecay-cli --bin tracedecay \
+          cargo build --locked -p tracedecay-query --bin tracedecay-index-bench \
             --no-default-features --features production,hotpath
-          TRACEDECAY_BIN=target/debug/tracedecay scripts/mcp-conformance-smoke.sh
+          timeout "${INDEX_BENCH_TIMEOUT_SECONDS}" \
+            target/debug/tracedecay-index-bench | tee /tmp/metrics/head_workload.json
 
       - name: Checkout base
+        if: steps.head_bench.outputs.available == 'true'
         run: git checkout ${{ github.event.pull_request.base.sha || 'origin/master' }}
 
+      # A base that predates the benchmark has no comparable profile; the
+      # head-only artifact says so instead of a red job saying nothing.
+      - name: Detect benchmark at base
+        id: base_bench
+        if: steps.head_bench.outputs.available == 'true'
+        run: |
+          if [ -f "${INDEX_BENCH_SOURCE}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::base does not carry tracedecay-index-bench;" \
+                 "uploading a head-only profile with no comparison"
+          fi
+
       - name: Base profile (timing)
+        if: steps.base_bench.outputs.available == 'true'
         env:
           HOTPATH_OUTPUT_FORMAT: json
           HOTPATH_OUTPUT_PATH: /tmp/metrics/base_timing.json
           HOTPATH_REPORT: functions-timing
         run: |
-          cargo build --locked -p tracedecay-cli --bin tracedecay \
+          cargo build --locked -p tracedecay-query --bin tracedecay-index-bench \
             --no-default-features --features production,hotpath
-          TRACEDECAY_BIN=target/debug/tracedecay scripts/mcp-conformance-smoke.sh
+          timeout "${INDEX_BENCH_TIMEOUT_SECONDS}" \
+            target/debug/tracedecay-index-bench | tee /tmp/metrics/base_workload.json
+
+      # A timing delta only means something if both sides indexed the same
+      # bytes. The sealed state digest is a function of the admitted corpus
+      # and the extraction output, so an unequal digest says the comparison
+      # is invalid - either the corpus moved or the diff changed sealed
+      # output, and both need a human before any number is believed.
+      - name: Compare workload identity
+        if: steps.base_bench.outputs.available == 'true'
+        run: |
+          head_digest=$(jq -r .sealed_state_digest /tmp/metrics/head_workload.json)
+          base_digest=$(jq -r .sealed_state_digest /tmp/metrics/base_workload.json)
+          echo "head sealed state digest: ${head_digest}"
+          echo "base sealed state digest: ${base_digest}"
+          if [ "${head_digest}" != "${base_digest}" ]; then
+            echo "::warning::sealed state digest differs between head and base;" \
+                 "the timing comparison covers different indexing output"
+          fi
+          jq -r '"head peak RSS bytes: \(.peak_rss_bytes)"' /tmp/metrics/head_workload.json
+          jq -r '"base peak RSS bytes: \(.peak_rss_bytes)"' /tmp/metrics/base_workload.json
 
       - name: Save PR metadata
         run: |
           echo '${{ github.event.pull_request.number }}' > /tmp/metrics/pr_number.txt
           echo '${{ github.base_ref }}' > /tmp/metrics/base_ref.txt
           echo '${{ github.head_ref }}' > /tmp/metrics/head_ref.txt
+          echo '${{ steps.head_bench.outputs.available }}' > /tmp/metrics/head_bench_available.txt
+          echo '${{ steps.base_bench.outputs.available }}' > /tmp/metrics/base_bench_available.txt
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Promotes the hotpath performance CI from \`workflow_dispatch\`-only to running on every pull request, without waiting for the benchmark binary to reach every commit line.

## Why now

The profiled workload (\`tracedecay-index-bench\`) lives in \`crates/tracedecay-query\`, which only exists on the #707 redesign line — master cannot build it until #707 merges. Rather than leaving the trigger manual until then, each side of the comparison is now guarded by an availability probe:

- **head predates the benchmark** → profiling skipped entirely, job green in seconds (this PR itself exercises that path).
- **base predates the benchmark** (e.g. #707 vs master) → head-only profile uploaded, notice emitted, no red job.
- **both sides carry it** (every PR after #707 merges) → full head-vs-base timing diff + sealed-state-digest identity check, PR comment via \`hotpath-utils profile-pr\`.

The comment workflow (which always runs from master) now checks for a comparable pair before installing tooling, and skips with an explanatory log instead of failing on missing metrics.

Also adds a per-PR concurrency group with cancel-in-progress so force-pushes don't stack 45-minute jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPdGeG8tU25R3QSh5dE7XW