### PR TITLE
fix(daemon): allow init from linked worktrees

### DIFF
--- a/crates/tracedecay-cli/tests/core_cli_suite/tool_daemon_test.rs
+++ b/crates/tracedecay-cli/tests/core_cli_suite/tool_daemon_test.rs
@@ -284,6 +284,83 @@ fn git(project: &Path, args: &[&str]) {
     );
 }
 
+#[test]
+fn daemon_first_init_enrolls_a_clean_profile_from_a_linked_worktree() {
+    let home = TempDir::new().unwrap();
+    let repository = TempDir::new().unwrap();
+    let home_path = canonical_existing_path(home.path());
+    let primary = repository.path().join("primary");
+    let linked = repository.path().join("linked");
+    std::fs::create_dir_all(primary.join("src")).unwrap();
+    git(&primary, &["init", "-b", "main"]);
+    std::fs::write(
+        primary.join("src/lib.rs"),
+        "pub fn daemon_first_init_fixture() {}\n",
+    )
+    .unwrap();
+    git(&primary, &["add", "."]);
+    git(
+        &primary,
+        &[
+            "-c",
+            "user.name=TraceDecay Tests",
+            "-c",
+            "user.email=tests@tracedecay.local",
+            "commit",
+            "-m",
+            "seed linked worktree fixture",
+        ],
+    );
+    let linked_arg = linked.to_string_lossy().into_owned();
+    git(
+        &primary,
+        &["worktree", "add", "-b", "linked-init", &linked_arg],
+    );
+    let linked = canonical_existing_path(&linked);
+
+    // Match the production dogfood journey exactly: the profile is empty,
+    // daemon authority starts first, then the public CLI initializes the
+    // checkout through that already-running daemon.
+    let _daemon = spawn_tracedecay_daemon(&home_path);
+    let initialized = run_command_with_timeout(
+        {
+            let mut command = tracedecay_command_with_home(&home_path);
+            command.arg("init").current_dir(&linked);
+            command
+        },
+        CLI_ROUNDTRIP_TIMEOUT,
+    );
+    assert!(
+        initialized.status.success(),
+        "daemon-first init from a linked worktree must enroll the authenticated profile\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&initialized.stdout),
+        String::from_utf8_lossy(&initialized.stderr)
+    );
+    let init_stderr = String::from_utf8_lossy(&initialized.stderr);
+    assert!(
+        init_stderr.contains("daemon code-index reconciliation requested"),
+        "successful init must request the daemon-owned scheduler: {init_stderr}"
+    );
+
+    let linked_arg = linked.to_string_lossy().into_owned();
+    let status = run_command_with_timeout(
+        {
+            let mut command = tracedecay_command_with_home(&home_path);
+            command
+                .args(["tool", "--project", &linked_arg, "status", "--json"])
+                .current_dir(&linked);
+            command
+        },
+        CLI_ROUNDTRIP_TIMEOUT,
+    );
+    assert!(
+        status.status.success(),
+        "the initialized linked worktree must remain enrolled for a normal daemon call\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&status.stdout),
+        String::from_utf8_lossy(&status.stderr)
+    );
+}
+
 fn tool_status_server_tool_calls(home: &Path, project: &Path) -> u64 {
     let project_arg = project.to_string_lossy().to_string();
     let output = tracedecay_command_with_home(home)

--- a/crates/tracedecay/src/daemon/project_open_orchestration.rs
+++ b/crates/tracedecay/src/daemon/project_open_orchestration.rs
@@ -216,13 +216,15 @@ pub(super) async fn ensure_registered_project_route(
         if durable_enrollment_resolves_existing_store(store_administration, &project_path) {
             return Ok(());
         }
-        let owns_repository_identity =
-            tracedecay_runtime_core::project_registry::primary_checkout_root(
-                &project_path,
-                repository_common_dir.as_deref(),
-            )
-            .is_none();
-        if allow_init && requested_path_is_repository_root && owns_repository_identity {
+        // Explicit initialization is valid from the root of any checkout,
+        // including a linked worktree. The first-touch resolver binds the
+        // identity through the shared Git common directory, and registration
+        // pins the canonical project root to the primary checkout. Requiring
+        // this path to own that repository identity makes daemon-first init
+        // impossible from the linked worktrees used by normal development and
+        // CI, even though the authenticated profile remains the sole store
+        // authority.
+        if allow_init && requested_path_is_repository_root {
             return Ok(());
         }
         return Err(unenrolled_project_route_error(&project_path));

--- a/crates/tracedecay/src/daemon/tests/bootstrap.rs
+++ b/crates/tracedecay/src/daemon/tests/bootstrap.rs
@@ -1635,7 +1635,7 @@ async fn unenrolled_leaf_is_rejected_from_cache_and_direct_open() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn linked_worktree_root_is_not_admitted_as_first_touch_project() {
+async fn linked_worktree_root_is_admitted_for_explicit_first_touch_init() {
     let home = TempDir::new().expect("isolated home");
     let root = home.path().canonicalize().expect("canonical home");
     let primary = root.join("primary");
@@ -1668,22 +1668,20 @@ async fn linked_worktree_root_is_not_admitted_as_first_touch_project() {
         ..test_handshake_defaults()
     };
 
-    let error = match engine.project_server(&handshake).await {
-        Ok(_) => panic!("linked worktree must not claim first-touch project authority"),
-        Err(error) => error,
-    };
-
-    assert_missing_enrollment_admission(&error);
+    engine
+        .ensure_registered_project_route(&linked, handshake.allow_init)
+        .await
+        .expect("explicit init must admit a linked worktree repository root");
     assert_eq!(
         engine
             .project_open_attempts
             .load(std::sync::atomic::Ordering::Relaxed),
         0,
-        "linked first-touch rejection must precede project opening"
+        "admission alone must not start project opening"
     );
     assert!(
         !linked.join(".tracedecay").exists(),
-        "rejection must not write linked-worktree project state"
+        "admission must not write linked-worktree project state"
     );
 }
 


### PR DESCRIPTION
## Summary

- allow explicit first-touch `init` from the root of a linked Git worktree
- keep unenrolled leaf-directory and ambient-path admission guards intact
- add both a daemon admission test and a public CLI integration test

## Why

The PR #707 dogfood checkout is itself a linked worktree. With a clean profile, daemon-first startup creates a circular bootstrap:

1. `init` needs the daemon-owned scheduler
2. the running daemon rejects the linked worktree until it is enrolled by `init`

Repository identity is already canonicalized through the shared Git common directory, so an explicit `allow_init` request at a checkout root can safely proceed.

## Verification

Tested against PR #707 head `c9b360aabea2e69602967e858d85b9404721c9dd`:

- `cargo test -p tracedecay linked_worktree_root_is_admitted_for_explicit_first_touch_init -- --nocapture`
- `cargo test -p tracedecay-cli daemon_first_init_enrolls_a_clean_profile_from_a_linked_worktree -- --nocapture`
- `git diff --check upstream/pr/707...HEAD`

The base branch currently has unrelated red CI; the focused tests above pass on the exact base head.

Supports ScriptedAlchemy/tracedecay#707.