### PR TITLE
test(dogfood): make process harness portable

### DIFF
--- a/scripts/ci-pr-dogfood-smoke.sh
+++ b/scripts/ci-pr-dogfood-smoke.sh
@@ -10,6 +10,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_PATH="$REPO_ROOT/scripts/ci-pr-dogfood-smoke.sh"
 DAEMON_HARNESS="$REPO_ROOT/scripts/with-isolated-tracedecay-daemon.sh"
 OUTPUT_VALIDATOR="$REPO_ROOT/scripts/check-pr-dogfood-output.py"
+PROCESS_HELPER="$REPO_ROOT/scripts/lib/portable_process.py"
 WORK_DIR=""
 
 cleanup() {
@@ -22,10 +23,10 @@ cleanup() {
 }
 
 elapsed_ms() {
-  local started_ns="$1"
-  local finished_ns
-  finished_ns="$(date +%s%N)"
-  printf '%s\n' "$(((finished_ns - started_ns) / 1000000))"
+  local started_ms="$1"
+  local finished_ms
+  finished_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
+  printf '%s\n' "$((finished_ms - started_ms))"
 }
 
 run_timed() {
@@ -34,12 +35,13 @@ run_timed() {
   local stdout_path="$3"
   local stderr_path="$4"
   shift 4
-  local started_ns status duration_ms
-  started_ns="$(date +%s%N)"
+  local started_ms status duration_ms
+  started_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
   status=0
-  timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" "$@" \
+  python3 -S "$PROCESS_HELPER" run \
+    --timeout "$timeout_seconds" --kill-after 5 -- "$@" \
     >"$stdout_path" 2>"$stderr_path" || status=$?
-  duration_ms="$(elapsed_ms "$started_ns")"
+  duration_ms="$(elapsed_ms "$started_ms")"
   cat "$stdout_path"
   if [[ -s "$stderr_path" ]]; then
     cat "$stderr_path" >&2
@@ -74,31 +76,31 @@ run_smoke() {
 
   run_timed status 60 "$output_dir/status.json" "$output_dir/status.stderr" \
     "$binary" status --json "$project_root"
-  python3 "$OUTPUT_VALIDATOR" --kind status --input "$output_dir/status.json"
+  python3 -S "$OUTPUT_VALIDATOR" --kind status --input "$output_dir/status.json"
 
   run_timed context 90 "$output_dir/context.json" "$output_dir/context.stderr" \
     "$binary" tool context --project "$project_root" \
       --task "Locate the TraceDecay CLI entry point and report available evidence." \
       --format json
-  python3 "$OUTPUT_VALIDATOR" --kind context --input "$output_dir/context.json"
+  python3 -S "$OUTPUT_VALIDATOR" --kind context --input "$output_dir/context.json"
 
   run_timed pr_context 90 "$output_dir/pr-context.json" "$output_dir/pr-context.stderr" \
     "$binary" tool pr_context --project "$project_root" \
       --base-ref "$base_ref" --head-ref "$head_ref" --format json
-  python3 "$OUTPUT_VALIDATOR" --kind pr_context \
+  python3 -S "$OUTPUT_VALIDATOR" --kind pr_context \
     --input "$output_dir/pr-context.json" \
     --base-oid "$base_oid" --head-oid "$head_oid" --merge-base "$merge_base"
 
   run_timed runtime_status 60 "$output_dir/runtime-status.json" \
     "$output_dir/runtime-status.stderr" \
     "$binary" status --json --runtime "$project_root"
-  python3 "$OUTPUT_VALIDATOR" --kind status --input "$output_dir/runtime-status.json"
+  python3 -S "$OUTPUT_VALIDATOR" --kind status --input "$output_dir/runtime-status.json"
 
   echo "tracedecay_ci_dogfood outcome=complete"
 }
 
 main() {
-  local binary project_root base_ref head_ref checked_out_oid head_oid started_ns status
+  local binary project_root base_ref head_ref checked_out_oid head_oid started_ms status
   binary="${TRACEDECAY_BIN:-$REPO_ROOT/target/debug/tracedecay}"
   project_root="${TRACEDECAY_DOGFOOD_PROJECT:-$REPO_ROOT}"
   base_ref="${TRACEDECAY_DOGFOOD_BASE_REF:-}"
@@ -116,6 +118,14 @@ main() {
     echo "error: TRACEDECAY_DOGFOOD_BASE_REF is required" >&2
     return 2
   }
+  command -v python3 >/dev/null 2>&1 || {
+    echo "error: python3 is required for portable process control" >&2
+    return 2
+  }
+  [[ -f "$PROCESS_HELPER" ]] || {
+    echo "error: portable process helper is missing: $PROCESS_HELPER" >&2
+    return 2
+  }
   git -C "$project_root" rev-parse --verify "$base_ref^{commit}" >/dev/null
   git -C "$project_root" rev-parse --verify "$head_ref^{commit}" >/dev/null
   checked_out_oid="$(git -C "$project_root" rev-parse HEAD)"
@@ -125,13 +135,13 @@ main() {
     return 2
   fi
 
-  binary="$(readlink -f "$binary")"
+  binary="$(python3 -S "$PROCESS_HELPER" realpath "$binary")"
   project_root="$(cd "$project_root" && pwd)"
   WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tracedecay-pr-dogfood.XXXXXX")"
   mkdir -p "$WORK_DIR/home" "$WORK_DIR/output"
   trap cleanup EXIT
 
-  started_ns="$(date +%s%N)"
+  started_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
   status=0
   HOME="$WORK_DIR/home" \
     XDG_DATA_HOME="$WORK_DIR/home/.local/share" \
@@ -141,7 +151,7 @@ main() {
       --lifecycle-label "TraceDecay PR dogfood daemon" -- \
       "$SCRIPT_PATH" --run "$project_root" "$base_ref" "$head_ref" \
       "$WORK_DIR/output" || status=$?
-  echo "tracedecay_ci_timing phase=total_journey elapsed_ms=$(elapsed_ms "$started_ns") status=$status"
+  echo "tracedecay_ci_timing phase=total_journey elapsed_ms=$(elapsed_ms "$started_ms") status=$status"
   return "$status"
 }
 

--- a/scripts/lib/portable_process.py
+++ b/scripts/lib/portable_process.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Portable Unix process controls for TraceDecay shell harnesses.
+
+Only Python's standard library is used so the same process-tree and timeout
+semantics are available on Linux and macOS without GNU coreutils or util-linux.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import math
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+
+
+def _positive_seconds(value: str) -> float:
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return seconds
+
+
+def _positive_pid(value: str) -> int:
+    pid = int(value)
+    if pid <= 0:
+        raise argparse.ArgumentTypeError("must be a positive process ID")
+    return pid
+
+
+def _command_after_separator(command: Sequence[str]) -> list[str]:
+    result = list(command)
+    if result[:1] == ["--"]:
+        result.pop(0)
+    if not result:
+        raise ValueError("a command is required after --")
+    return result
+
+
+def _group_alive(pid: int) -> bool:
+    try:
+        os.killpg(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _signal_group(pid: int, sig: signal.Signals) -> None:
+    try:
+        os.killpg(pid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def _stop_group(pid: int, grace_seconds: float) -> bool:
+    """Stop a process group, returning True when SIGKILL was required."""
+
+    if not _group_alive(pid):
+        return False
+
+    _signal_group(pid, signal.SIGTERM)
+    deadline = time.monotonic() + grace_seconds
+    while _group_alive(pid) and time.monotonic() < deadline:
+        time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+
+    forced = _group_alive(pid)
+    if forced:
+        _signal_group(pid, signal.SIGKILL)
+    return forced
+
+
+def _return_code(status: int) -> int:
+    return status if status >= 0 else 128 + abs(status)
+
+
+def command_exec_session(args: argparse.Namespace) -> int:
+    command = _command_after_separator(args.command)
+    try:
+        os.setsid()
+    except PermissionError:
+        # A process that is already its own process-group leader cannot call
+        # setsid(), but its negative PID still addresses the owned group.
+        if os.getpgrp() != os.getpid():
+            raise
+    os.execvp(command[0], command)
+    return 127
+
+
+def command_run(args: argparse.Namespace) -> int:
+    command = _command_after_separator(args.command)
+    process = subprocess.Popen(command, start_new_session=True)
+    interrupted_by: int | None = None
+
+    def handle_signal(signum: int, _frame: object) -> None:
+        nonlocal interrupted_by
+        interrupted_by = signum
+
+    previous_handlers = {
+        sig: signal.signal(sig, handle_signal)
+        for sig in (signal.SIGINT, signal.SIGTERM)
+    }
+    deadline = time.monotonic() + args.timeout
+    timed_out = False
+    try:
+        while process.poll() is None:
+            if interrupted_by is not None:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            try:
+                process.wait(timeout=min(0.1, remaining))
+            except subprocess.TimeoutExpired:
+                pass
+
+        if timed_out or interrupted_by is not None:
+            _stop_group(process.pid, args.kill_after)
+        elif _group_alive(process.pid):
+            # The leader may have exited after launching background work.
+            # A bounded smoke phase owns and cleans its entire process group.
+            _stop_group(process.pid, args.kill_after)
+
+        try:
+            status = process.wait(timeout=args.kill_after)
+        except subprocess.TimeoutExpired:
+            _signal_group(process.pid, signal.SIGKILL)
+            status = process.wait()
+
+        if interrupted_by is not None:
+            return 128 + interrupted_by
+        if timed_out:
+            return 124
+        return _return_code(status)
+    finally:
+        for sig, handler in previous_handlers.items():
+            signal.signal(sig, handler)
+
+
+def command_group_alive(args: argparse.Namespace) -> int:
+    return 0 if _group_alive(args.pid) else 1
+
+
+def command_stop_group(args: argparse.Namespace) -> int:
+    return 2 if _stop_group(args.pid, args.grace) else 0
+
+
+def command_wait_unix_socket(args: argparse.Namespace) -> int:
+    deadline = time.monotonic() + args.timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(args.pid, 0)
+        except ProcessLookupError:
+            print(
+                "error: tracedecay daemon exited before becoming ready", file=sys.stderr
+            )
+            return 1
+        except PermissionError:
+            pass
+
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(min(0.25, max(0.01, deadline - time.monotonic())))
+        try:
+            client.connect(args.path)
+        except OSError:
+            time.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
+        else:
+            return 0
+        finally:
+            client.close()
+
+    print(
+        f"error: tracedecay daemon did not become ready within {args.timeout:g} seconds",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def command_monotonic_ms(_args: argparse.Namespace) -> int:
+    print(time.monotonic_ns() // 1_000_000)
+    return 0
+
+
+def command_realpath(args: argparse.Namespace) -> int:
+    try:
+        print(Path(args.path).resolve(strict=True))
+    except (FileNotFoundError, OSError) as error:
+        detail = error.strerror if getattr(error, "strerror", None) else str(error)
+        print(f"error: cannot resolve path '{args.path}': {detail}", file=sys.stderr)
+        return errno.ENOENT
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="action", required=True)
+
+    exec_session = subparsers.add_parser("exec-session")
+    exec_session.add_argument("command", nargs=argparse.REMAINDER)
+    exec_session.set_defaults(func=command_exec_session)
+
+    run = subparsers.add_parser("run")
+    run.add_argument("--timeout", required=True, type=_positive_seconds)
+    run.add_argument("--kill-after", required=True, type=_positive_seconds)
+    run.add_argument("command", nargs=argparse.REMAINDER)
+    run.set_defaults(func=command_run)
+
+    group_alive = subparsers.add_parser("group-alive")
+    group_alive.add_argument("--pid", required=True, type=_positive_pid)
+    group_alive.set_defaults(func=command_group_alive)
+
+    stop_group = subparsers.add_parser("stop-group")
+    stop_group.add_argument("--pid", required=True, type=_positive_pid)
+    stop_group.add_argument("--grace", required=True, type=_positive_seconds)
+    stop_group.set_defaults(func=command_stop_group)
+
+    wait_socket = subparsers.add_parser("wait-unix-socket")
+    wait_socket.add_argument("--path", required=True)
+    wait_socket.add_argument("--pid", required=True, type=_positive_pid)
+    wait_socket.add_argument("--timeout", required=True, type=_positive_seconds)
+    wait_socket.set_defaults(func=command_wait_unix_socket)
+
+    monotonic_ms = subparsers.add_parser("monotonic-ms")
+    monotonic_ms.set_defaults(func=command_monotonic_ms)
+
+    realpath = subparsers.add_parser("realpath")
+    realpath.add_argument("path")
+    realpath.set_defaults(func=command_realpath)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        return args.func(args)
+    except (ValueError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 127 if getattr(error, "errno", None) == errno.ENOENT else 126
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-pr-dogfood-portability.py
+++ b/scripts/test-pr-dogfood-portability.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the portable PR dogfood process harness."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+HELPER = ROOT / "scripts/lib/portable_process.py"
+DAEMON_HARNESS = ROOT / "scripts/with-isolated-tracedecay-daemon.sh"
+DOGFOOD_SCRIPT = ROOT / "scripts/ci-pr-dogfood-smoke.sh"
+
+
+def helper(*args: str, timeout: float = 10) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-S", str(HELPER), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+class PortableProcessTests(unittest.TestCase):
+    def test_run_preserves_output_and_exit_status(self) -> None:
+        completed = helper(
+            "run",
+            "--timeout",
+            "2",
+            "--kill-after",
+            "0.2",
+            "--",
+            sys.executable,
+            "-S",
+            "-c",
+            "import sys; print('phase stdout'); print('phase stderr', file=sys.stderr); sys.exit(7)",
+        )
+        self.assertEqual(completed.returncode, 7)
+        self.assertEqual(completed.stdout, "phase stdout\n")
+        self.assertEqual(completed.stderr, "phase stderr\n")
+
+    def test_timeout_returns_124_and_kills_the_process_tree(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="portable-timeout-") as tmp:
+            survived = Path(tmp) / "descendant-survived"
+            descendant = textwrap.dedent(
+                f"""
+                import pathlib, signal, time
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                time.sleep(0.8)
+                pathlib.Path({str(survived)!r}).write_text("survived", encoding="utf-8")
+                """
+            )
+            parent = textwrap.dedent(
+                f"""
+                import signal, subprocess, sys, time
+                subprocess.Popen([sys.executable, "-S", "-c", {descendant!r}])
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                time.sleep(10)
+                """
+            )
+            started = time.monotonic()
+            completed = helper(
+                "run",
+                "--timeout",
+                "0.15",
+                "--kill-after",
+                "0.15",
+                "--",
+                sys.executable,
+                "-S",
+                "-c",
+                parent,
+                timeout=3,
+            )
+            elapsed = time.monotonic() - started
+            self.assertEqual(completed.returncode, 124, completed.stderr)
+            self.assertLess(elapsed, 1.5)
+            time.sleep(0.7)
+            self.assertFalse(survived.exists(), "timed-out descendant escaped cleanup")
+
+    def test_successful_command_cannot_leave_background_work(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="portable-background-") as tmp:
+            survived = Path(tmp) / "background-survived"
+            descendant = textwrap.dedent(
+                f"""
+                import pathlib, signal, time
+                signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                time.sleep(0.6)
+                pathlib.Path({str(survived)!r}).write_text("survived", encoding="utf-8")
+                """
+            )
+            parent = (
+                "import subprocess, sys; "
+                f"subprocess.Popen([sys.executable, '-S', '-c', {descendant!r}])"
+            )
+            completed = helper(
+                "run",
+                "--timeout",
+                "2",
+                "--kill-after",
+                "0.1",
+                "--",
+                sys.executable,
+                "-S",
+                "-c",
+                parent,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            time.sleep(0.6)
+            self.assertFalse(survived.exists(), "background descendant escaped cleanup")
+
+    def test_monotonic_clock_and_realpath_are_portable(self) -> None:
+        first = helper("monotonic-ms")
+        second = helper("monotonic-ms")
+        self.assertEqual(first.returncode, 0)
+        self.assertGreaterEqual(int(second.stdout), int(first.stdout))
+
+        resolved = helper("realpath", str(HELPER.parent / ".." / "lib" / HELPER.name))
+        self.assertEqual(resolved.returncode, 0)
+        self.assertEqual(Path(resolved.stdout.strip()), HELPER.resolve())
+
+    def test_missing_command_has_bounded_error_output(self) -> None:
+        completed = helper(
+            "run",
+            "--timeout",
+            "1",
+            "--kill-after",
+            "0.1",
+            "--",
+            "/definitely/not/a/command",
+        )
+        self.assertEqual(completed.returncode, 127)
+        self.assertIn("No such file or directory", completed.stderr)
+        self.assertNotIn("Traceback", completed.stderr)
+
+
+class IsolatedDaemonHarnessTests(unittest.TestCase):
+    def make_fake_daemon(self, directory: Path) -> Path:
+        daemon = directory / "fake-tracedecay"
+        daemon.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import os
+                from pathlib import Path
+                import signal
+                import socket
+                import subprocess
+                import sys
+                import time
+
+                socket_path = sys.argv[sys.argv.index("--socket") + 1]
+                print("fake daemon boot", flush=True)
+                if os.environ.get("FAKE_DAEMON_NO_SOCKET") == "1":
+                    time.sleep(30)
+                    raise SystemExit(0)
+
+                term_marker = os.environ.get("FAKE_DESCENDANT_TERM_MARKER")
+                ready_marker = os.environ.get("FAKE_DESCENDANT_READY_MARKER")
+                survived_marker = os.environ.get("FAKE_DESCENDANT_SURVIVED_MARKER")
+                if term_marker and ready_marker and survived_marker:
+                    child = '''
+                from pathlib import Path
+                import os, signal, time
+                def on_term(_signum, _frame):
+                    Path(os.environ["FAKE_DESCENDANT_TERM_MARKER"]).write_text("term", encoding="utf-8")
+                signal.signal(signal.SIGTERM, on_term)
+                Path(os.environ["FAKE_DESCENDANT_READY_MARKER"]).write_text("ready", encoding="utf-8")
+                time.sleep(1.5)
+                Path(os.environ["FAKE_DESCENDANT_SURVIVED_MARKER"]).write_text("survived", encoding="utf-8")
+                '''
+                    subprocess.Popen([sys.executable, "-S", "-c", child])
+                    deadline = time.monotonic() + 2
+                    while not Path(ready_marker).exists() and time.monotonic() < deadline:
+                        time.sleep(0.01)
+                    if not Path(ready_marker).exists():
+                        raise RuntimeError("fake daemon descendant did not start")
+
+                listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                listener.bind(socket_path)
+                listener.listen()
+                signal.signal(signal.SIGTERM, lambda _signum, _frame: sys.exit(0))
+                while True:
+                    listener.accept()[0].close()
+                """
+            ),
+            encoding="utf-8",
+        )
+        daemon.chmod(0o755)
+        return daemon
+
+    def test_harness_waits_for_readiness_forwards_output_and_cleans_tree(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="daemon-harness-") as tmp:
+            tmp_path = Path(tmp)
+            daemon = self.make_fake_daemon(tmp_path)
+            term_marker = tmp_path / "descendant-term"
+            ready_marker = tmp_path / "descendant-ready"
+            survived_marker = tmp_path / "descendant-survived"
+            env = os.environ.copy()
+            env["FAKE_DESCENDANT_TERM_MARKER"] = str(term_marker)
+            env["FAKE_DESCENDANT_READY_MARKER"] = str(ready_marker)
+            env["FAKE_DESCENDANT_SURVIVED_MARKER"] = str(survived_marker)
+            completed = subprocess.run(
+                [
+                    str(DAEMON_HARNESS),
+                    "--bin",
+                    str(daemon),
+                    "--ready-timeout",
+                    "2",
+                    "--stop-timeout",
+                    "1",
+                    "--lifecycle-label",
+                    "fake daemon",
+                    "--",
+                    sys.executable,
+                    "-S",
+                    "-c",
+                    "import os; assert os.path.exists(os.environ['TRACEDECAY_DAEMON_SOCKET']); print('smoke command output')",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=6,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("== starting fake daemon", completed.stdout)
+            self.assertIn("smoke command output", completed.stdout)
+            self.assertIn("== stopping fake daemon", completed.stderr)
+            self.assertTrue(
+                term_marker.exists(), "descendant did not receive group TERM"
+            )
+            time.sleep(0.6)
+            self.assertFalse(
+                survived_marker.exists(), "daemon descendant escaped group KILL"
+            )
+
+    def test_readiness_timeout_is_bounded_and_surfaces_daemon_output(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="daemon-not-ready-") as tmp:
+            daemon = self.make_fake_daemon(Path(tmp))
+            env = os.environ.copy()
+            env["FAKE_DAEMON_NO_SOCKET"] = "1"
+            started = time.monotonic()
+            completed = subprocess.run(
+                [
+                    str(DAEMON_HARNESS),
+                    "--bin",
+                    str(daemon),
+                    "--ready-timeout",
+                    "1",
+                    "--stop-timeout",
+                    "1",
+                    "--",
+                    sys.executable,
+                    "-S",
+                    "-c",
+                    "raise SystemExit('command must not run')",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=5,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertLess(time.monotonic() - started, 4)
+            self.assertIn("did not become ready within 1 seconds", completed.stderr)
+            self.assertIn("fake daemon boot", completed.stderr)
+            self.assertNotIn("command must not run", completed.stderr)
+
+    def test_shell_drivers_do_not_require_gnu_or_linux_only_commands(self) -> None:
+        forbidden = ("setsid", "timeout --", "readlink -f", "date +%s%N")
+        for script in (DAEMON_HARNESS, DOGFOOD_SCRIPT):
+            source = script.read_text(encoding="utf-8")
+            for token in forbidden:
+                self.assertNotIn(token, source, f"{script.name} still requires {token}")
+            syntax = subprocess.run(
+                ["bash", "-n", str(script)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(syntax.returncode, 0, syntax.stderr)
+
+
+class DogfoodJourneyOutputTests(unittest.TestCase):
+    def test_run_mode_emits_validated_phase_output_and_timings(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dogfood-output-") as tmp:
+            tmp_path = Path(tmp)
+            project = tmp_path / "project"
+            output = tmp_path / "output"
+            project.mkdir()
+            output.mkdir()
+            subprocess.run(["git", "init", "-q", str(project)], check=True)
+            hooks = tmp_path / "empty-hooks"
+            hooks.mkdir()
+            subprocess.run(
+                ["git", "-C", str(project), "config", "core.hooksPath", str(hooks)],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(project), "config", "user.name", "Dogfood Test"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(project),
+                    "config",
+                    "user.email",
+                    "dogfood@example.invalid",
+                ],
+                check=True,
+            )
+            tracked = project / "fixture.txt"
+            tracked.write_text("base\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(project), "add", "fixture.txt"], check=True
+            )
+            subprocess.run(
+                ["git", "-C", str(project), "commit", "-qm", "base"], check=True
+            )
+            base_oid = subprocess.check_output(
+                ["git", "-C", str(project), "rev-parse", "HEAD"], text=True
+            ).strip()
+            tracked.write_text("head\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(project), "commit", "-qam", "head"], check=True
+            )
+            head_oid = subprocess.check_output(
+                ["git", "-C", str(project), "rev-parse", "HEAD"], text=True
+            ).strip()
+
+            fake_binary = tmp_path / "fake-tracedecay"
+            fake_binary.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    if [[ "${1:-}" == "--version" ]]; then
+                      echo "tracedecay fake-test"
+                    elif [[ "${1:-}" == "init" ]]; then
+                      :
+                    elif [[ "${1:-}" == "status" ]]; then
+                      echo '{"status":"ready"}'
+                    elif [[ "${1:-} ${2:-}" == "tool context" ]]; then
+                      echo '{"coverage":{"state":"complete"}}'
+                    elif [[ "${1:-} ${2:-}" == "tool pr_context" ]]; then
+                      project=""
+                      base=""
+                      head=""
+                      shift 2
+                      while (($#)); do
+                        case "$1" in
+                          --project) project="$2"; shift 2 ;;
+                          --base-ref) base="$2"; shift 2 ;;
+                          --head-ref) head="$2"; shift 2 ;;
+                          *) shift ;;
+                        esac
+                      done
+                      base_oid="$(git -C "$project" rev-parse "$base^{commit}")"
+                      head_oid="$(git -C "$project" rev-parse "$head^{commit}")"
+                      merge_base="$(git -C "$project" merge-base "$base" "$head")"
+                      printf '{"base_oid":"%s","head_oid":"%s","merge_base":"%s","files_changed":1,"changes":[{"path":"fixture.txt","status":"modified"}],"analysis_coverage":{"complete":true}}\\n' \\
+                        "$base_oid" "$head_oid" "$merge_base"
+                    else
+                      echo "unexpected fake TraceDecay arguments: $*" >&2
+                      exit 2
+                    fi
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_binary.chmod(0o755)
+            env = os.environ.copy()
+            env["TRACEDECAY_BIN"] = str(fake_binary)
+            completed = subprocess.run(
+                [
+                    str(DOGFOOD_SCRIPT),
+                    "--run",
+                    str(project),
+                    base_oid,
+                    head_oid,
+                    str(output),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=10,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(completed.stderr, "")
+            for phase in ("init", "status", "context", "pr_context", "runtime_status"):
+                self.assertRegex(
+                    completed.stdout,
+                    rf"tracedecay_ci_timing phase={phase} elapsed_ms=\d+ status=0",
+                )
+            self.assertIn(
+                "TraceDecay PR dogfood pr_context output is valid", completed.stdout
+            )
+            self.assertIn("tracedecay_ci_dogfood outcome=complete", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/with-isolated-tracedecay-daemon.sh
+++ b/scripts/with-isolated-tracedecay-daemon.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROCESS_HELPER="$SCRIPT_DIR/lib/portable_process.py"
+
 usage() {
   cat >&2 <<'EOF'
 Usage:
@@ -86,8 +89,8 @@ command -v python3 >/dev/null 2>&1 || {
   echo "error: python3 is required for the bounded daemon socket probe" >&2
   exit 2
 }
-command -v setsid >/dev/null 2>&1 || {
-  echo "error: setsid is required for bounded daemon process-group cleanup" >&2
+[[ -f "$PROCESS_HELPER" ]] || {
+  echo "error: portable process helper is missing: $PROCESS_HELPER" >&2
   exit 2
 }
 
@@ -112,23 +115,20 @@ print_daemon_log() {
 }
 
 daemon_group_alive() {
-  [[ -n "$daemon_pid" ]] && kill -0 -- "-$daemon_pid" 2>/dev/null
+  [[ -n "$daemon_pid" ]] &&
+    python3 -S "$PROCESS_HELPER" group-alive --pid "$daemon_pid" >/dev/null 2>&1
 }
 
 stop_daemon() {
-  local deadline
+  local stop_status=0
 
   [[ -n "$daemon_pid" ]] || return 0
   if daemon_group_alive; then
     [[ -z "$lifecycle_label" ]] || echo "== stopping $lifecycle_label" >&2
-    kill -TERM -- "-$daemon_pid" 2>/dev/null || true
-    deadline=$((SECONDS + stop_timeout))
-    while daemon_group_alive && ((SECONDS < deadline)); do
-      sleep 0.1
-    done
-    if daemon_group_alive; then
+    python3 -S "$PROCESS_HELPER" stop-group \
+      --pid "$daemon_pid" --grace "$stop_timeout" || stop_status=$?
+    if ((stop_status == 2)); then
       [[ -z "$lifecycle_label" ]] || echo "== force stopping $lifecycle_label" >&2
-      kill -KILL -- "-$daemon_pid" 2>/dev/null || true
     fi
   fi
   wait "$daemon_pid" 2>/dev/null || true
@@ -151,45 +151,22 @@ trap 'exit 143' TERM
 
 [[ -z "$lifecycle_label" ]] || echo "== starting $lifecycle_label"
 if [[ "$daemon_mode" == "bin" ]]; then
-  setsid "$daemon_value" daemon run --socket "$TRACEDECAY_DAEMON_SOCKET" \
+  python3 -S "$PROCESS_HELPER" exec-session -- \
+    "$daemon_value" daemon run --socket "$TRACEDECAY_DAEMON_SOCKET" \
     >"$daemon_log" 2>&1 &
 else
   (
     cd "$daemon_value"
-    exec setsid cargo run -- daemon run --socket "$TRACEDECAY_DAEMON_SOCKET"
+    exec python3 -S "$PROCESS_HELPER" exec-session -- \
+      cargo run -- daemon run --socket "$TRACEDECAY_DAEMON_SOCKET"
   ) >"$daemon_log" 2>&1 &
 fi
 daemon_pid=$!
 
-if ! python3 - "$TRACEDECAY_DAEMON_SOCKET" "$daemon_pid" "$ready_timeout" <<'PY'
-import os
-import socket
-import sys
-import time
-
-socket_path, daemon_pid, timeout = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-deadline = time.monotonic() + timeout
-while time.monotonic() < deadline:
-    try:
-        os.kill(daemon_pid, 0)
-    except ProcessLookupError:
-        print("error: tracedecay daemon exited before becoming ready", file=sys.stderr)
-        raise SystemExit(1)
-
-    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    client.settimeout(min(0.25, max(0.01, deadline - time.monotonic())))
-    try:
-        client.connect(socket_path)
-    except (FileNotFoundError, ConnectionRefusedError, socket.timeout, OSError):
-        time.sleep(min(0.1, max(0.0, deadline - time.monotonic())))
-    else:
-        raise SystemExit(0)
-    finally:
-        client.close()
-
-print(f"error: tracedecay daemon did not become ready within {timeout} seconds", file=sys.stderr)
-raise SystemExit(1)
-PY
+if ! python3 -S "$PROCESS_HELPER" wait-unix-socket \
+  --path "$TRACEDECAY_DAEMON_SOCKET" \
+  --pid "$daemon_pid" \
+  --timeout "$ready_timeout"
 then
   exit 1
 fi


### PR DESCRIPTION
## Summary

- replace Linux/GNU-only process control in the PR #707 dogfood harness with a Python standard-library helper
- provide portable process-session launch, bounded timeout, process-group cleanup, socket readiness, realpath, and monotonic timing
- add focused portability and process-tree tests

## Why

The dogfood workflow currently depends on `setsid`, GNU `timeout`, `readlink -f`, and `date +%s%N`. Those assumptions prevent the same checked-out-PR journey from running locally on macOS, where PR #707 needs independent beta coverage.

## Verification

Tested against PR #707 head `c9b360aabea2e69602967e858d85b9404721c9dd`:

- 9 portable-process tests pass
- 6 existing dogfood output-contract tests pass
- `bash -n` passes for both shell entry points
- `shellcheck -e SC2329` passes (SC2329 is excluded because trap callbacks are intentionally indirect)
- `ruff check` passes
- the real macOS PR checkout dogfood journey passes in 4.147 seconds with bounded daemon cleanup

This change only makes the harness portable; it intentionally does not tighten the existing warming/partial-graph acceptance contract.

The base branch currently has unrelated red CI; the focused checks above pass on the exact base head.

Supports ScriptedAlchemy/tracedecay#707.