### PR TITLE
fix(ci): enforce graph-ready PR dogfood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     name: PR checkout dogfood
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:
@@ -82,8 +82,10 @@ jobs:
       - name: Build checked-out TraceDecay CLI
         run: cargo build -p tracedecay-cli --bin tracedecay --locked
 
-      - name: Test dogfood output validation
-        run: python3 scripts/test-check-pr-dogfood-output.py
+      - name: Test dogfood harnesses
+        run: |
+          python3 scripts/test-check-pr-dogfood-output.py
+          python3 scripts/test-pr-dogfood-portability.py
 
       - name: Initialize checkout and exercise CLI tools
         run: scripts/ci-pr-dogfood-smoke.sh

--- a/scripts/check-pr-dogfood-output.py
+++ b/scripts/check-pr-dogfood-output.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import sys
 from typing import Any
 
 
 TRANSIENT_GRAPH_REASONS = frozenset({"code-graph-unavailable", "code-graph-stale"})
+PR_CONTEXT_MAX_SYMBOLS = 500
 
 
 def require_object(value: Any, label: str) -> dict[str, Any]:
@@ -16,15 +18,57 @@ def require_object(value: Any, label: str) -> dict[str, Any]:
     return value
 
 
-def validate_status(value: dict[str, Any]) -> None:
+def require_nonnegative_integer(value: dict[str, Any], key: str, label: str) -> int:
+    result = value.get(key)
+    if isinstance(result, bool) or not isinstance(result, int) or result < 0:
+        raise ValueError(f"{label} {key} must be a non-negative integer")
+    return result
+
+
+def validate_status(value: dict[str, Any], *, strict: bool = False) -> None:
     if not value:
         raise ValueError("status output must not be empty")
+    if not strict:
+        return
+
+    freshness = value.get("code_index_freshness")
+    if not isinstance(freshness, dict) or freshness.get("status") != "current":
+        raise ValueError("strict status requires current code-index freshness")
+    worktree = freshness.get("worktree")
+    if not isinstance(worktree, dict):
+        raise ValueError("strict status requires typed worktree freshness")
+    if worktree.get("coverage") != "complete":
+        raise ValueError("strict status requires complete text-index coverage")
+    if worktree.get("staleness_state") != "fresh":
+        raise ValueError("strict status requires a fresh text-index generation")
+    if not worktree.get("latest_generation_id"):
+        raise ValueError("strict status requires a current text-index generation")
+
+    graph = value.get("graph_statistics")
+    if not isinstance(graph, dict):
+        raise ValueError("strict status requires typed graph statistics")
+    if graph.get("state") != "observed":
+        reason = graph.get("reason", "unknown")
+        raise ValueError(f"strict status requires an observed graph; reason={reason}")
 
 
-def validate_context(value: dict[str, Any]) -> None:
+def validate_context(value: dict[str, Any], *, strict: bool = False) -> None:
     coverage = value.get("coverage")
     if not isinstance(coverage, dict) or not coverage:
         raise ValueError("context must return typed retrieval coverage")
+    if not strict:
+        return
+
+    if coverage.get("lexical") != "complete":
+        raise ValueError("strict context requires complete lexical coverage")
+    if coverage.get("graph") != "complete":
+        raise ValueError("strict context requires complete graph symbol evidence coverage")
+    if not isinstance(value.get("search_matches"), list) or not value["search_matches"]:
+        raise ValueError("strict context requires lexical search evidence")
+    if not isinstance(value.get("symbols"), list) or not value["symbols"]:
+        raise ValueError("strict context requires graph symbol evidence")
+    if value.get("verified_graph_evidence") is not None:
+        raise ValueError("strict context cannot contain unavailable verified graph evidence")
 
 
 def validate_pr_context(
@@ -33,6 +77,7 @@ def validate_pr_context(
     expected_base_oid: str,
     expected_head_oid: str,
     expected_merge_base: str,
+    strict: bool = False,
 ) -> None:
     expected_oids = {
         "base_oid": expected_base_oid,
@@ -54,6 +99,62 @@ def validate_pr_context(
         raise ValueError("pr_context must return typed analysis coverage")
 
     graph = value.get("verified_graph_evidence")
+    if strict:
+        if value.get("status") == "partial" or graph is not None:
+            raise ValueError("strict pr_context rejects unavailable graph evidence")
+
+        graph_generation = value.get("graph_generation")
+        if not isinstance(graph_generation, str) or not graph_generation.strip():
+            raise ValueError("strict pr_context requires a valid graph generation")
+
+        symbol_page = value.get("symbol_page")
+        if not isinstance(symbol_page, dict):
+            raise ValueError("strict pr_context requires typed symbol-page metadata")
+        limit = require_nonnegative_integer(symbol_page, "limit", "symbol_page")
+        returned = require_nonnegative_integer(symbol_page, "returned", "symbol_page")
+        if limit < 1 or limit > PR_CONTEXT_MAX_SYMBOLS or returned > limit:
+            raise ValueError("strict pr_context requires a valid bounded symbol page")
+        has_more = symbol_page.get("has_more")
+        page_complete = symbol_page.get("complete")
+        continuation_available = symbol_page.get("continuation_available")
+        if not all(
+            isinstance(item, bool)
+            for item in (has_more, page_complete, continuation_available)
+        ):
+            raise ValueError("strict pr_context requires typed symbol-page state")
+        if symbol_page.get("selection") != "stable_prefix":
+            raise ValueError("strict pr_context requires stable-prefix symbol selection")
+        if page_complete != (not has_more) or continuation_available != has_more:
+            raise ValueError("strict pr_context symbol-page state is inconsistent")
+        next_cursor = value.get("next_cursor")
+        if has_more and (not isinstance(next_cursor, str) or not next_cursor):
+            raise ValueError("strict pr_context bounded symbol page requires a cursor")
+        if not has_more and next_cursor is not None:
+            raise ValueError("strict pr_context complete symbol page cannot have a cursor")
+
+        integer_coverage_fields = (
+            "seed_symbols_analyzed",
+            "symbols_returned",
+            "impact_nodes_admitted",
+            "impact_nodes_returned",
+            "direct_call_edges_admitted",
+            "impact_bytes_admitted",
+        )
+        coverage_counts = {
+            key: require_nonnegative_integer(coverage, key, "analysis_coverage")
+            for key in integer_coverage_fields
+        }
+        symbols_complete = coverage.get("symbols_complete")
+        impact_partial = coverage.get("impact_partial")
+        if not isinstance(symbols_complete, bool) or not isinstance(impact_partial, bool):
+            raise ValueError("strict pr_context requires typed bounded analysis coverage")
+        if (
+            coverage_counts["seed_symbols_analyzed"] != returned
+            or coverage_counts["symbols_returned"] != returned
+            or symbols_complete != page_complete
+            or coverage["complete"] != (symbols_complete and not impact_partial)
+        ):
+            raise ValueError("strict pr_context bounded analysis coverage is inconsistent")
     if graph is None:
         if value.get("status") == "partial":
             raise ValueError("partial pr_context requires typed graph evidence")
@@ -70,20 +171,21 @@ def validate_pr_context(
         raise ValueError("partial pr_context graph evidence must remain retryable")
 
 
-def main() -> int:
+def run() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--kind", choices=("status", "context", "pr_context"), required=True)
     parser.add_argument("--input", type=Path, required=True)
     parser.add_argument("--base-oid")
     parser.add_argument("--head-oid")
     parser.add_argument("--merge-base")
+    parser.add_argument("--strict", action="store_true")
     args = parser.parse_args()
 
     value = require_object(json.loads(args.input.read_text(encoding="utf-8")), args.kind)
     if args.kind == "status":
-        validate_status(value)
+        validate_status(value, strict=args.strict)
     elif args.kind == "context":
-        validate_context(value)
+        validate_context(value, strict=args.strict)
     else:
         if not all((args.base_oid, args.head_oid, args.merge_base)):
             parser.error("pr_context validation requires --base-oid, --head-oid, and --merge-base")
@@ -92,9 +194,18 @@ def main() -> int:
             expected_base_oid=args.base_oid,
             expected_head_oid=args.head_oid,
             expected_merge_base=args.merge_base,
+            strict=args.strict,
         )
     print(f"TraceDecay PR dogfood {args.kind} output is valid")
     return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+        print(f"error: TraceDecay PR dogfood validation failed: {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/ci-pr-dogfood-smoke.sh
+++ b/scripts/ci-pr-dogfood-smoke.sh
@@ -29,6 +29,17 @@ elapsed_ms() {
   printf '%s\n' "$((finished_ms - started_ms))"
 }
 
+print_compact_file() {
+  local label="$1"
+  local path="$2"
+  echo "----- $label (last 16 KiB) -----" >&2
+  if [[ -s "$path" ]]; then
+    tail -c 16384 "$path" >&2 || true
+  else
+    echo "(no output captured)" >&2
+  fi
+}
+
 run_timed() {
   local label="$1"
   local timeout_seconds="$2"
@@ -42,15 +53,122 @@ run_timed() {
     --timeout "$timeout_seconds" --kill-after 5 -- "$@" \
     >"$stdout_path" 2>"$stderr_path" || status=$?
   duration_ms="$(elapsed_ms "$started_ms")"
+  echo "tracedecay_ci_timing phase=$label elapsed_ms=$duration_ms status=$status"
+  if ((status != 0)); then
+    echo "error: TraceDecay PR dogfood phase '$label' failed" >&2
+    print_compact_file "$label stdout" "$stdout_path"
+    print_compact_file "$label stderr" "$stderr_path"
+    return "$status"
+  fi
   cat "$stdout_path"
   if [[ -s "$stderr_path" ]]; then
     cat "$stderr_path" >&2
   fi
-  echo "tracedecay_ci_timing phase=$label elapsed_ms=$duration_ms status=$status"
+}
+
+run_validation() {
+  local label="$1"
+  local input_path="$2"
+  shift 2
+  local stdout_path="${input_path}.validation.stdout"
+  local stderr_path="${input_path}.validation.stderr"
+  local status=0
+  python3 -S "$OUTPUT_VALIDATOR" "$@" --input "$input_path" \
+    >"$stdout_path" 2>"$stderr_path" || status=$?
   if ((status != 0)); then
-    echo "error: TraceDecay PR dogfood phase '$label' failed" >&2
+    echo "error: TraceDecay PR dogfood '$label' validation failed" >&2
+    print_compact_file "$label output" "$input_path"
+    print_compact_file "$label validator" "$stderr_path"
     return "$status"
   fi
+  cat "$stdout_path"
+  if [[ -s "$stderr_path" ]]; then
+    cat "$stderr_path" >&2
+  fi
+}
+
+wait_for_strict_readiness() {
+  local project_root="$1"
+  local output_dir="$2"
+  local binary="$3"
+  local timeout_seconds="${TRACEDECAY_DOGFOOD_READINESS_TIMEOUT:-600}"
+  local poll_interval="${TRACEDECAY_DOGFOOD_READINESS_POLL_INTERVAL:-5}"
+  local timeout_ms started_ms deadline_ms now_ms remaining_ms probe_timeout
+  local attempts=0 command_status validation_status duration_ms
+
+  timeout_ms="$(python3 -S -c '
+import math, sys
+try:
+    value = float(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+if not math.isfinite(value) or value <= 0:
+    raise SystemExit(1)
+print(max(1, int(value * 1000)))
+' "$timeout_seconds")" || {
+    echo "error: TRACEDECAY_DOGFOOD_READINESS_TIMEOUT must be greater than zero" >&2
+    return 2
+  }
+  python3 -S -c '
+import math, sys
+try:
+    value = float(sys.argv[1])
+except ValueError:
+    raise SystemExit(1)
+raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)
+' "$poll_interval" || {
+    echo "error: TRACEDECAY_DOGFOOD_READINESS_POLL_INTERVAL must be greater than zero" >&2
+    return 2
+  }
+
+  started_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
+  deadline_ms="$((started_ms + timeout_ms))"
+  : >"$output_dir/status.validation.stderr"
+  while :; do
+    now_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
+    remaining_ms="$((deadline_ms - now_ms))"
+    ((remaining_ms > 0)) || break
+    probe_timeout="$(python3 -S -c 'import sys; print(min(60.0, max(0.05, int(sys.argv[1]) / 1000)))' "$remaining_ms")"
+    attempts="$((attempts + 1))"
+    : >"$output_dir/status.validation.stdout"
+    : >"$output_dir/status.validation.stderr"
+    command_status=0
+    python3 -S "$PROCESS_HELPER" run \
+      --timeout "$probe_timeout" --kill-after 5 -- \
+      "$binary" status --json "$project_root" \
+      >"$output_dir/status.json" 2>"$output_dir/status.stderr" || command_status=$?
+    validation_status=1
+    if ((command_status == 0)); then
+      validation_status=0
+      python3 -S "$OUTPUT_VALIDATOR" --kind status --strict \
+        --input "$output_dir/status.json" \
+        >"$output_dir/status.validation.stdout" \
+        2>"$output_dir/status.validation.stderr" || validation_status=$?
+    fi
+    if ((command_status == 0 && validation_status == 0)); then
+      duration_ms="$(elapsed_ms "$started_ms")"
+      cat "$output_dir/status.json"
+      [[ ! -s "$output_dir/status.stderr" ]] || cat "$output_dir/status.stderr" >&2
+      cat "$output_dir/status.validation.stdout"
+      echo "tracedecay_ci_timing phase=status elapsed_ms=$duration_ms status=0"
+      echo "tracedecay_ci_readiness attempts=$attempts elapsed_ms=$duration_ms"
+      return 0
+    fi
+
+    now_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
+    remaining_ms="$((deadline_ms - now_ms))"
+    ((remaining_ms > 0)) || break
+    python3 -S -c 'import sys, time; time.sleep(min(float(sys.argv[1]), int(sys.argv[2]) / 1000))' \
+      "$poll_interval" "$remaining_ms"
+  done
+
+  duration_ms="$(elapsed_ms "$started_ms")"
+  echo "tracedecay_ci_timing phase=status elapsed_ms=$duration_ms status=1"
+  echo "error: TraceDecay PR dogfood did not reach strict index readiness within ${timeout_seconds}s" >&2
+  print_compact_file "last status output" "$output_dir/status.json"
+  print_compact_file "last status stderr" "$output_dir/status.stderr"
+  print_compact_file "last status validator" "$output_dir/status.validation.stderr"
+  return 1
 }
 
 run_smoke() {
@@ -74,27 +192,24 @@ run_smoke() {
       "$binary" init
   )
 
-  run_timed status 60 "$output_dir/status.json" "$output_dir/status.stderr" \
-    "$binary" status --json "$project_root"
-  python3 -S "$OUTPUT_VALIDATOR" --kind status --input "$output_dir/status.json"
+  wait_for_strict_readiness "$project_root" "$output_dir" "$binary"
 
   run_timed context 90 "$output_dir/context.json" "$output_dir/context.stderr" \
     "$binary" tool context --project "$project_root" \
       --task "Locate the TraceDecay CLI entry point and report available evidence." \
       --format json
-  python3 -S "$OUTPUT_VALIDATOR" --kind context --input "$output_dir/context.json"
+  run_validation context "$output_dir/context.json" --kind context --strict
 
   run_timed pr_context 90 "$output_dir/pr-context.json" "$output_dir/pr-context.stderr" \
     "$binary" tool pr_context --project "$project_root" \
       --base-ref "$base_ref" --head-ref "$head_ref" --format json
-  python3 -S "$OUTPUT_VALIDATOR" --kind pr_context \
-    --input "$output_dir/pr-context.json" \
+  run_validation pr_context "$output_dir/pr-context.json" --kind pr_context --strict \
     --base-oid "$base_oid" --head-oid "$head_oid" --merge-base "$merge_base"
 
   run_timed runtime_status 60 "$output_dir/runtime-status.json" \
     "$output_dir/runtime-status.stderr" \
     "$binary" status --json --runtime "$project_root"
-  python3 -S "$OUTPUT_VALIDATOR" --kind status --input "$output_dir/runtime-status.json"
+  run_validation runtime_status "$output_dir/runtime-status.json" --kind status
 
   echo "tracedecay_ci_dogfood outcome=complete"
 }

--- a/scripts/test-check-pr-dogfood-output.py
+++ b/scripts/test-check-pr-dogfood-output.py
@@ -31,7 +31,27 @@ class PrDogfoodOutputTests(unittest.TestCase):
             "merge_base": "merge-base-oid",
             "files_changed": 1,
             "changes": [{"path": "src/lib.rs", "status": "modified"}],
-            "analysis_coverage": {"complete": False},
+            "graph_generation": None,
+            "next_cursor": None,
+            "symbol_page": {
+                "limit": 200,
+                "returned": 0,
+                "has_more": False,
+                "complete": False,
+                "selection": "unavailable",
+                "continuation_available": False,
+            },
+            "analysis_coverage": {
+                "seed_symbols_analyzed": 0,
+                "symbols_returned": 0,
+                "symbols_complete": False,
+                "impact_nodes_admitted": 0,
+                "impact_nodes_returned": 0,
+                "direct_call_edges_admitted": 0,
+                "impact_bytes_admitted": 0,
+                "impact_partial": True,
+                "complete": False,
+            },
             "verified_graph_evidence": {
                 "status": "unavailable",
                 "reason_code": "code-graph-unavailable",
@@ -47,6 +67,15 @@ class PrDogfoodOutputTests(unittest.TestCase):
             expected_merge_base="merge-base-oid",
         )
 
+    def validate_strict(self, payload: dict[str, object]) -> None:
+        self.checker.validate_pr_context(
+            payload,
+            expected_base_oid="base-oid",
+            expected_head_oid="head-oid",
+            expected_merge_base="merge-base-oid",
+            strict=True,
+        )
+
     def test_accepts_exact_partial_warmup_evidence(self) -> None:
         self.validate(self.payload)
 
@@ -55,6 +84,36 @@ class PrDogfoodOutputTests(unittest.TestCase):
         del self.payload["verified_graph_evidence"]
         self.payload["analysis_coverage"] = {"complete": True}
         self.validate(self.payload)
+
+    def test_strict_accepts_graph_ready_bounded_prefix_with_more_symbols(self) -> None:
+        del self.payload["status"]
+        del self.payload["verified_graph_evidence"]
+        self.payload["graph_generation"] = "code-graph:sha256:ready-generation"
+        self.payload["next_cursor"] = "pr-context.cursor.next"
+        self.payload["symbol_page"] = {
+            "limit": 500,
+            "returned": 500,
+            "has_more": True,
+            "complete": False,
+            "selection": "stable_prefix",
+            "continuation_available": True,
+        }
+        self.payload["analysis_coverage"] = {
+            "seed_symbols_analyzed": 500,
+            "symbols_returned": 500,
+            "symbols_complete": False,
+            "impact_nodes_admitted": 700,
+            "impact_nodes_returned": 700,
+            "direct_call_edges_admitted": 900,
+            "impact_bytes_admitted": 65536,
+            "impact_partial": True,
+            "complete": False,
+        }
+        self.validate_strict(self.payload)
+
+    def test_strict_rejects_partial_graph_unavailability(self) -> None:
+        with self.assertRaisesRegex(ValueError, "strict.*unavailable graph"):
+            self.validate_strict(self.payload)
 
     def test_rejects_evidence_for_a_different_head(self) -> None:
         self.payload["head_oid"] = "wrong-head"
@@ -79,6 +138,103 @@ class PrDogfoodOutputTests(unittest.TestCase):
         del self.payload["verified_graph_evidence"]
         with self.assertRaisesRegex(ValueError, "graph evidence"):
             self.validate(self.payload)
+
+
+class StrictReadinessOutputTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.checker = load_checker()
+
+    def test_strict_status_accepts_current_text_and_observed_graph(self) -> None:
+        self.checker.validate_status(
+            {
+                "code_index_freshness": {
+                    "status": "current",
+                    "worktree": {
+                        "coverage": "complete",
+                        "staleness_state": "fresh",
+                        "latest_generation_id": "generation.ready",
+                    },
+                },
+                "graph_statistics": {
+                    "state": "observed",
+                    "generation_id": "generation.ready",
+                    "symbol_count": 12,
+                    "edge_count": 9,
+                },
+            },
+            strict=True,
+        )
+
+    def test_strict_status_rejects_live_exact_scope_graph_degradation(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exact_scope_generation_not_ready"):
+            self.checker.validate_status(
+                {
+                    "code_index_freshness": {
+                        "status": "current",
+                        "worktree": {
+                            "coverage": "complete",
+                            "staleness_state": "fresh",
+                            "latest_generation_id": "generation.text-only",
+                        },
+                    },
+                    "graph_statistics": {
+                        "state": "unavailable",
+                        "reason": "exact_scope_generation_not_ready",
+                    },
+                },
+                strict=True,
+            )
+
+    def test_structural_status_still_accepts_degraded_typed_output(self) -> None:
+        self.checker.validate_status(
+            {
+                "graph_statistics": {
+                    "state": "unavailable",
+                    "reason": "exact_scope_generation_not_ready",
+                }
+            }
+        )
+
+    def test_strict_context_accepts_lexical_and_graph_symbol_evidence(self) -> None:
+        self.checker.validate_context(
+            {
+                "coverage": {
+                    "exact": "complete",
+                    "lexical": "complete",
+                    "graph": "complete",
+                    "semantic": {"status": "unavailable", "reason": "disabled"},
+                    "recall": "partial",
+                },
+                "search_matches": [{"file": "src/main.rs"}],
+                "symbols": [{"node_id": "symbol:main"}],
+            },
+            strict=True,
+        )
+
+    def test_strict_context_rejects_lexical_only_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "graph symbol evidence"):
+            self.checker.validate_context(
+                {
+                    "coverage": {
+                        "exact": "complete",
+                        "lexical": "complete",
+                        "graph": {
+                            "status": "unavailable",
+                            "reason": "verified_code_graph_not_ready",
+                        },
+                        "semantic": {"status": "unavailable", "reason": "warming"},
+                        "recall": "partial",
+                    },
+                    "search_matches": [{"file": "src/main.rs"}],
+                    "symbols": [],
+                    "verified_graph_evidence": {
+                        "status": "unavailable",
+                        "reason_code": "verified-code-graph-read-unavailable",
+                        "retryable": True,
+                    },
+                },
+                strict=True,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test-pr-dogfood-portability.py
+++ b/scripts/test-pr-dogfood-portability.py
@@ -29,6 +29,50 @@ def helper(*args: str, timeout: float = 10) -> subprocess.CompletedProcess[str]:
     )
 
 
+def make_two_commit_project(directory: Path) -> tuple[Path, str, str]:
+    project = directory / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q", str(project)], check=True)
+    hooks = directory / "empty-hooks"
+    hooks.mkdir()
+    subprocess.run(
+        ["git", "-C", str(project), "config", "core.hooksPath", str(hooks)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(project), "config", "user.name", "Dogfood Test"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "config",
+            "user.email",
+            "dogfood@example.invalid",
+        ],
+        check=True,
+    )
+    tracked = project / "fixture.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(project), "add", "fixture.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(project), "commit", "-qm", "base"], check=True
+    )
+    base_oid = subprocess.check_output(
+        ["git", "-C", str(project), "rev-parse", "HEAD"], text=True
+    ).strip()
+    tracked.write_text("head\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(project), "commit", "-qam", "head"], check=True
+    )
+    head_oid = subprocess.check_output(
+        ["git", "-C", str(project), "rev-parse", "HEAD"], text=True
+    ).strip()
+    return project, base_oid, head_oid
+
+
 class PortableProcessTests(unittest.TestCase):
     def test_run_preserves_output_and_exit_status(self) -> None:
         completed = helper(
@@ -169,9 +213,10 @@ class IsolatedDaemonHarnessTests(unittest.TestCase):
                 if term_marker and ready_marker and survived_marker:
                     child = '''
                 from pathlib import Path
-                import os, signal, time
+                import os, signal, sys, time
                 def on_term(_signum, _frame):
                     Path(os.environ["FAKE_DESCENDANT_TERM_MARKER"]).write_text("term", encoding="utf-8")
+                    raise SystemExit(0)
                 signal.signal(signal.SIGTERM, on_term)
                 Path(os.environ["FAKE_DESCENDANT_READY_MARKER"]).write_text("ready", encoding="utf-8")
                 time.sleep(1.5)
@@ -187,7 +232,10 @@ class IsolatedDaemonHarnessTests(unittest.TestCase):
                 listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 listener.bind(socket_path)
                 listener.listen()
-                signal.signal(signal.SIGTERM, lambda _signum, _frame: sys.exit(0))
+                if os.environ.get("FAKE_DAEMON_IGNORE_TERM") == "1":
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                else:
+                    signal.signal(signal.SIGTERM, lambda _signum, _frame: sys.exit(0))
                 while True:
                     listener.accept()[0].close()
                 """
@@ -208,6 +256,8 @@ class IsolatedDaemonHarnessTests(unittest.TestCase):
             env["FAKE_DESCENDANT_TERM_MARKER"] = str(term_marker)
             env["FAKE_DESCENDANT_READY_MARKER"] = str(ready_marker)
             env["FAKE_DESCENDANT_SURVIVED_MARKER"] = str(survived_marker)
+            profile_path_marker = tmp_path / "profile-path"
+            env["FAKE_PROFILE_PATH_MARKER"] = str(profile_path_marker)
             completed = subprocess.run(
                 [
                     str(DAEMON_HARNESS),
@@ -223,7 +273,7 @@ class IsolatedDaemonHarnessTests(unittest.TestCase):
                     sys.executable,
                     "-S",
                     "-c",
-                    "import os; assert os.path.exists(os.environ['TRACEDECAY_DAEMON_SOCKET']); print('smoke command output')",
+                    "import os, pathlib; assert os.path.exists(os.environ['TRACEDECAY_DAEMON_SOCKET']); pathlib.Path(os.environ['FAKE_PROFILE_PATH_MARKER']).write_text(os.environ['TRACEDECAY_DATA_DIR'], encoding='utf-8'); print('smoke command output')",
                 ],
                 check=False,
                 capture_output=True,
@@ -242,6 +292,66 @@ class IsolatedDaemonHarnessTests(unittest.TestCase):
             self.assertFalse(
                 survived_marker.exists(), "daemon descendant escaped group KILL"
             )
+            profile_path = Path(profile_path_marker.read_text(encoding="utf-8"))
+            self.assertFalse(profile_path.exists(), "isolated profile was retained")
+
+    def test_graceful_cleanup_preserves_command_failure_status(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="daemon-graceful-") as tmp:
+            daemon = self.make_fake_daemon(Path(tmp))
+            completed = subprocess.run(
+                [
+                    str(DAEMON_HARNESS),
+                    "--bin",
+                    str(daemon),
+                    "--ready-timeout",
+                    "2",
+                    "--stop-timeout",
+                    "1",
+                    "--",
+                    sys.executable,
+                    "-S",
+                    "-c",
+                    "raise SystemExit(7)",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            self.assertEqual(completed.returncode, 7, completed.stderr)
+
+    def test_forced_cleanup_fails_an_otherwise_green_command(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="daemon-forced-") as tmp:
+            daemon = self.make_fake_daemon(Path(tmp))
+            env = os.environ.copy()
+            env["FAKE_DAEMON_IGNORE_TERM"] = "1"
+            completed = subprocess.run(
+                [
+                    str(DAEMON_HARNESS),
+                    "--bin",
+                    str(daemon),
+                    "--ready-timeout",
+                    "2",
+                    "--stop-timeout",
+                    "1",
+                    "--lifecycle-label",
+                    "fake daemon",
+                    "--",
+                    sys.executable,
+                    "-S",
+                    "-c",
+                    "print('green command')",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=6,
+            )
+            self.assertEqual(completed.returncode, 2, completed.stderr)
+            self.assertIn("green command", completed.stdout)
+            self.assertIn("== force stopping fake daemon", completed.stderr)
+            self.assertIn("fake daemon boot", completed.stderr)
 
     def test_readiness_timeout_is_bounded_and_surfaces_daemon_output(self) -> None:
         with tempfile.TemporaryDirectory(prefix="daemon-not-ready-") as tmp:
@@ -292,53 +402,12 @@ class IsolatedDaemonHarnessTests(unittest.TestCase):
 
 
 class DogfoodJourneyOutputTests(unittest.TestCase):
-    def test_run_mode_emits_validated_phase_output_and_timings(self) -> None:
+    def test_run_mode_polls_until_strict_readiness_then_validates_journey(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dogfood-output-") as tmp:
             tmp_path = Path(tmp)
-            project = tmp_path / "project"
             output = tmp_path / "output"
-            project.mkdir()
             output.mkdir()
-            subprocess.run(["git", "init", "-q", str(project)], check=True)
-            hooks = tmp_path / "empty-hooks"
-            hooks.mkdir()
-            subprocess.run(
-                ["git", "-C", str(project), "config", "core.hooksPath", str(hooks)],
-                check=True,
-            )
-            subprocess.run(
-                ["git", "-C", str(project), "config", "user.name", "Dogfood Test"],
-                check=True,
-            )
-            subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(project),
-                    "config",
-                    "user.email",
-                    "dogfood@example.invalid",
-                ],
-                check=True,
-            )
-            tracked = project / "fixture.txt"
-            tracked.write_text("base\n", encoding="utf-8")
-            subprocess.run(
-                ["git", "-C", str(project), "add", "fixture.txt"], check=True
-            )
-            subprocess.run(
-                ["git", "-C", str(project), "commit", "-qm", "base"], check=True
-            )
-            base_oid = subprocess.check_output(
-                ["git", "-C", str(project), "rev-parse", "HEAD"], text=True
-            ).strip()
-            tracked.write_text("head\n", encoding="utf-8")
-            subprocess.run(
-                ["git", "-C", str(project), "commit", "-qam", "head"], check=True
-            )
-            head_oid = subprocess.check_output(
-                ["git", "-C", str(project), "rev-parse", "HEAD"], text=True
-            ).strip()
+            project, base_oid, head_oid = make_two_commit_project(tmp_path)
 
             fake_binary = tmp_path / "fake-tracedecay"
             fake_binary.write_text(
@@ -351,9 +420,19 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
                     elif [[ "${1:-}" == "init" ]]; then
                       :
                     elif [[ "${1:-}" == "status" ]]; then
-                      echo '{"status":"ready"}'
+                      count=0
+                      if [[ -f "$FAKE_STATUS_COUNTER" ]]; then
+                        count="$(cat "$FAKE_STATUS_COUNTER")"
+                      fi
+                      count="$((count + 1))"
+                      echo "$count" >"$FAKE_STATUS_COUNTER"
+                      if [[ "${FAKE_NEVER_READY:-0}" == "1" || "$count" -lt 3 ]]; then
+                        echo '{"code_index_freshness":{"status":"current","worktree":{"coverage":"complete","staleness_state":"fresh","latest_generation_id":"generation.text-only"}},"graph_statistics":{"state":"unavailable","reason":"exact_scope_generation_not_ready"}}'
+                      else
+                        echo '{"code_index_freshness":{"status":"current","worktree":{"coverage":"complete","staleness_state":"fresh","latest_generation_id":"generation.ready"}},"graph_statistics":{"state":"observed","generation_id":"generation.ready","symbol_count":2,"edge_count":1}}'
+                      fi
                     elif [[ "${1:-} ${2:-}" == "tool context" ]]; then
-                      echo '{"coverage":{"state":"complete"}}'
+                      echo '{"coverage":{"exact":"complete","lexical":"complete","graph":"complete","semantic":{"status":"unavailable","reason":"disabled"},"recall":"partial"},"search_matches":[{"file":"src/main.rs"}],"symbols":[{"node_id":"symbol:main"}]}'
                     elif [[ "${1:-} ${2:-}" == "tool pr_context" ]]; then
                       project=""
                       base=""
@@ -370,7 +449,7 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
                       base_oid="$(git -C "$project" rev-parse "$base^{commit}")"
                       head_oid="$(git -C "$project" rev-parse "$head^{commit}")"
                       merge_base="$(git -C "$project" merge-base "$base" "$head")"
-                      printf '{"base_oid":"%s","head_oid":"%s","merge_base":"%s","files_changed":1,"changes":[{"path":"fixture.txt","status":"modified"}],"analysis_coverage":{"complete":true}}\\n' \\
+                      printf '{"base_oid":"%s","head_oid":"%s","merge_base":"%s","graph_generation":"code-graph:sha256:ready-generation","files_changed":1,"changes":[{"path":"fixture.txt","status":"modified"}],"next_cursor":"pr-context.cursor.next","symbol_page":{"limit":1,"returned":1,"has_more":true,"complete":false,"selection":"stable_prefix","continuation_available":true},"analysis_coverage":{"seed_symbols_analyzed":1,"symbols_returned":1,"symbols_complete":false,"impact_nodes_admitted":2,"impact_nodes_returned":2,"direct_call_edges_admitted":1,"impact_bytes_admitted":256,"impact_partial":false,"complete":false}}\\n' \\
                         "$base_oid" "$head_oid" "$merge_base"
                     else
                       echo "unexpected fake TraceDecay arguments: $*" >&2
@@ -383,6 +462,10 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
             fake_binary.chmod(0o755)
             env = os.environ.copy()
             env["TRACEDECAY_BIN"] = str(fake_binary)
+            status_counter = tmp_path / "status-counter"
+            env["FAKE_STATUS_COUNTER"] = str(status_counter)
+            env["TRACEDECAY_DOGFOOD_READINESS_TIMEOUT"] = "1"
+            env["TRACEDECAY_DOGFOOD_READINESS_POLL_INTERVAL"] = "0.05"
             completed = subprocess.run(
                 [
                     str(DOGFOOD_SCRIPT),
@@ -408,7 +491,71 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
             self.assertIn(
                 "TraceDecay PR dogfood pr_context output is valid", completed.stdout
             )
+            self.assertIn("tracedecay_ci_readiness attempts=3", completed.stdout)
+            self.assertEqual(status_counter.read_text(encoding="utf-8").strip(), "4")
             self.assertIn("tracedecay_ci_dogfood outcome=complete", completed.stdout)
+
+    def test_run_mode_bounds_never_ready_graph_and_surfaces_last_reason(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="dogfood-not-ready-") as tmp:
+            tmp_path = Path(tmp)
+            output = tmp_path / "output"
+            output.mkdir()
+            project, base_oid, head_oid = make_two_commit_project(tmp_path)
+
+            status_counter = tmp_path / "status-counter"
+            fake_binary = tmp_path / "fake-tracedecay"
+            fake_binary.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    if [[ "${1:-}" == "--version" ]]; then
+                      echo "tracedecay fake-test"
+                    elif [[ "${1:-}" == "init" ]]; then
+                      :
+                    elif [[ "${1:-}" == "status" ]]; then
+                      count=0
+                      [[ ! -f "$FAKE_STATUS_COUNTER" ]] || count="$(cat "$FAKE_STATUS_COUNTER")"
+                      echo "$((count + 1))" >"$FAKE_STATUS_COUNTER"
+                      echo '{"code_index_freshness":{"status":"current","worktree":{"coverage":"complete","staleness_state":"fresh","latest_generation_id":"generation.text-only"}},"graph_statistics":{"state":"unavailable","reason":"exact_scope_generation_not_ready"}}'
+                    else
+                      echo "journey advanced before graph readiness" >&2
+                      exit 2
+                    fi
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_binary.chmod(0o755)
+            env = os.environ.copy()
+            env["TRACEDECAY_BIN"] = str(fake_binary)
+            env["FAKE_STATUS_COUNTER"] = str(status_counter)
+            env["TRACEDECAY_DOGFOOD_READINESS_TIMEOUT"] = "0.3"
+            env["TRACEDECAY_DOGFOOD_READINESS_POLL_INTERVAL"] = "0.05"
+            started = time.monotonic()
+            completed = subprocess.run(
+                [
+                    str(DOGFOOD_SCRIPT),
+                    "--run",
+                    str(project),
+                    base_oid,
+                    head_oid,
+                    str(output),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=5,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertLess(time.monotonic() - started, 3)
+            self.assertGreaterEqual(
+                int(status_counter.read_text(encoding="utf-8").strip()), 2
+            )
+            self.assertIn("exact_scope_generation_not_ready", completed.stderr)
+            self.assertNotIn("Traceback", completed.stderr)
+            self.assertNotIn("tracedecay_ci_dogfood outcome=complete", completed.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/with-isolated-tracedecay-daemon.sh
+++ b/scripts/with-isolated-tracedecay-daemon.sh
@@ -108,7 +108,7 @@ mkdir -p "$TRACEDECAY_DATA_DIR"
 print_daemon_log() {
   echo "----- tracedecay daemon log -----" >&2
   if [[ -s "$daemon_log" ]]; then
-    cat "$daemon_log" >&2 || true
+    tail -c 16384 "$daemon_log" >&2 || true
   else
     echo "(no daemon output captured)" >&2
   fi
@@ -132,14 +132,18 @@ stop_daemon() {
     fi
   fi
   wait "$daemon_pid" 2>/dev/null || true
+  return "$stop_status"
 }
 
 cleanup() {
-  local status=$?
+  local status=$? stop_status=0
 
   trap - EXIT INT TERM
-  stop_daemon
-  if ((status != 0)); then
+  stop_daemon || stop_status=$?
+  if ((status == 0 && stop_status != 0)); then
+    status="$stop_status"
+  fi
+  if ((status != 0 || stop_status != 0)); then
     print_daemon_log
   fi
   rm -rf "$run_dir"


### PR DESCRIPTION
## Summary

- add opt-in strict validation for graph-ready status, context, and PR context
- poll within a bounded deadline instead of accepting the first warming status response
- fail on forced daemon termination and retain compact failure diagnostics
- run the portable process-harness tests in CI and give cold builds a 45-minute job budget

## Why

The PR checkout smoke currently validates response shape, so text-only fallback and partial graph evidence can still end with `outcome=complete`. Strict mode preserves the existing structural contract while making the dogfood journey fail with the actual readiness reason.

Large PRs remain valid when graph-backed analysis returns a stable bounded prefix; strict mode does not require exhaustive pagination.

## Verification

- validator suite: 13 passed
- portability/process suite: 12 passed
- Bash syntax, Ruff, ShellCheck, and changed-workflow actionlint pass
- merged with the two companion test-only branches and reran both script suites

This intentionally makes unresolved graph readiness or SIGKILL cleanup visible to CI.

Supports ScriptedAlchemy/tracedecay#707.