### PR TITLE
ci: satisfy hotpath workflow lint

### DIFF
--- a/.github/workflows/hotpath-comment.yml
+++ b/.github/workflows/hotpath-comment.yml
@@ -59,8 +59,10 @@ jobs:
         run: |
           set -euo pipefail
           pr=$(cat /tmp/metrics/pr_number.txt)
-          export GITHUB_BASE_REF=$(cat /tmp/metrics/base_ref.txt)
-          export GITHUB_HEAD_REF=$(cat /tmp/metrics/head_ref.txt)
+          GITHUB_BASE_REF=$(cat /tmp/metrics/base_ref.txt)
+          export GITHUB_BASE_REF
+          GITHUB_HEAD_REF=$(cat /tmp/metrics/head_ref.txt)
+          export GITHUB_HEAD_REF
           hotpath-utils profile-pr \
             --head-metrics /tmp/metrics/head_timing.json \
             --base-metrics /tmp/metrics/base_timing.json \

--- a/.github/workflows/hotpath-profile.yml
+++ b/.github/workflows/hotpath-profile.yml
@@ -152,10 +152,12 @@ jobs:
           jq -r '"base peak RSS bytes: \(.peak_rss_bytes)"' /tmp/metrics/base_workload.json
 
       - name: Save PR metadata
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           echo '${{ github.event.pull_request.number }}' > /tmp/metrics/pr_number.txt
           echo '${{ github.base_ref }}' > /tmp/metrics/base_ref.txt
-          echo '${{ github.head_ref }}' > /tmp/metrics/head_ref.txt
+          printf '%s\n' "$HEAD_REF" > /tmp/metrics/head_ref.txt
           echo '${{ steps.head_bench.outputs.available }}' > /tmp/metrics/head_bench_available.txt
           echo '${{ steps.base_bench.outputs.available }}' > /tmp/metrics/base_bench_available.txt
 


### PR DESCRIPTION
## Summary

- separate command substitution from exported variables so shell failures stay visible
- pass the PR head ref through an environment variable before shell interpolation
- preserve the existing hotpath workflow behavior

## Why

The two hotpath workflows contained actionlint and ShellCheck violations that could hide failed substitutions and interpolate GitHub input directly inside shell source.

## Verification

- actionlint passes for all 10 workflow files
- aggregate Rustfmt and diff checks pass
- branch scope audit: one commit, two workflow files, clean worktree

Supports ScriptedAlchemy/tracedecay#707.