### PR TITLE
fix(dogfood): ignore zombie-only process groups on macOS

### DIFF
--- a/scripts/lib/portable_process.py
+++ b/scripts/lib/portable_process.py
@@ -49,7 +49,10 @@ def _group_alive(pid: int) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
-        return True
+        # Some BSD kernels return EPERM for a group whose only remaining
+        # member is a zombie.  Permission confirms that the group exists,
+        # not that it still contains work capable of running.
+        pass
     return _group_has_runnable_member(pid)
 
 

--- a/scripts/test-pr-dogfood-portability.py
+++ b/scripts/test-pr-dogfood-portability.py
@@ -233,6 +233,8 @@ class PortableProcessTests(unittest.TestCase):
         finally:
             holder.kill()
             holder.wait()
+            if holder.stdout is not None:
+                holder.stdout.close()
 
     def test_missing_command_has_bounded_error_output(self) -> None:
         completed = helper(


### PR DESCRIPTION
## Summary

- let macOS EPERM process-group probes fall through to the existing zombie-aware inspection
- keep live non-zombie process groups classified as running
- close the fixture pipe deterministically

## Why

On BSD/macOS, killpg can return EPERM for a process group containing only zombies. Treating that as unconditional liveness makes bounded dogfood cleanup report a false surviving-process failure.

## Verification

- portable process suite: 13 passed
- dogfood output validator suite: 13 passed
- Python compile and diff checks pass
- branch scope audit: one commit, two script files, clean worktree

Supports ScriptedAlchemy/tracedecay#707.