### PR TITLE
test(rmcp): retain settlement write authority

### DIFF
--- a/crates/tracedecay/src/daemon/broker_stream_transport.rs
+++ b/crates/tracedecay/src/daemon/broker_stream_transport.rs
@@ -490,6 +490,9 @@ mod peer_close_tests {
         producer: Arc<BoundedObservabilityProducerV1>,
         db: tracedecay_global_db::RegisteredGlobalDbLeaseV1,
         project_id: ProjectId,
+        // The lease alone does not own daemon write authority. Keep the test
+        // runtime alive until every asynchronous settlement has drained.
+        _runtime: tracedecay_global_db::tests::harness::RegisteredGlobalDbTestRuntime,
     }
 
     async fn delivery_settlement_fixture() -> DeliverySettlementFixture {
@@ -531,6 +534,7 @@ mod peer_close_tests {
             producer,
             db,
             project_id,
+            _runtime: runtime,
         }
     }
 


### PR DESCRIPTION
## Summary

- retain the registered global-database test runtime for the full broker fixture lifetime
- preserve daemon settlement write authority until asynchronous delivery completes
- leave production transport behavior unchanged

## Why

The fixture kept only the database lease. The registered runtime that owns daemon write scope was dropped before asynchronous settlement, so delivery tests could strand attempts despite exercising valid production behavior.

## Verification

- successful response settlement passes
- peer-disconnect dropped settlement passes
- client-cancellation dropped settlement passes
- aggregate focused suite: 14 passed
- Rustfmt and diff checks pass

Supports ScriptedAlchemy/tracedecay#707.