### PR TITLE
docs(plugin): teach session refresh lifecycle

### DIFF
--- a/plugin/README-cursor.md
+++ b/plugin/README-cursor.md
@@ -237,6 +237,7 @@ per-call review, add the snippet below to `~/.cursor/permissions.json`
     "tracedecay:tracedecay_runtime",
     "tracedecay:tracedecay_search",
     "tracedecay:tracedecay_session_lookup",
+    "tracedecay:tracedecay_session_refresh_status",
     "tracedecay:tracedecay_sessions_for",
     "tracedecay:tracedecay_signature",
     "tracedecay:tracedecay_signature_search",

--- a/plugin/skills/managing-session-context/SKILL.md
+++ b/plugin/skills/managing-session-context/SKILL.md
@@ -82,13 +82,15 @@ before assuming the compacted summary is complete.
 ## Freshness is explicit
 
 Recall never performs catch-up. If a read returns `refresh_required`, get clear
-host or user lifecycle intent before invoking `tracedecay_session_refresh`
-(`action`: `start` / `join` / `resume` / `begin` for the same idempotent
-begin-or-join, then `status` or `cancel` with the returned handle). The CLI
-equivalents are `tracedecay sessions refresh begin`, `status`, and `cancel`,
-using the same selectors and returned handle. Use the authoritative
-selectors provided by the host/runtime; do not reconstruct refresh identity
-from chat text or a filesystem path.
+host or user lifecycle intent before calling `tracedecay_session_refresh_begin`.
+Pass the authoritative scope selectors from the host/runtime, preserve its
+opaque handle, and inspect progress with the read-only
+`tracedecay_session_refresh_status`. Call `tracedecay_session_refresh_cancel`
+only on an explicit cancellation request; only a receipt-backed success proves
+durable cancellation. The compatibility `tracedecay_session_refresh` tool and
+the `tracedecay sessions refresh begin|status|cancel` CLI expose the same
+lifecycle. Never reconstruct refresh identity from chat text or a filesystem
+path.
 
 ## LCM status and diagnosis
 
@@ -108,8 +110,11 @@ chat content.
 
 ## Guardrails
 
-- Every callable LCM tool in this workflow is read-only. Grep/status may touch
-  access counters, but no tool here compacts, repairs, cleans, or applies state.
+- Recall and inspection tools in this workflow, including refresh status, are
+  read-only; grep/status may touch access counters. Refresh begin and cancel
+  are lifecycle mutations, require clear intent, and cancellation is proven
+  only by receipt-backed success. Neither path compacts, repairs, cleans, or
+  applies maintenance state.
 - When a read supports `provider`, use an exact provider for provider-local
   evidence or `all` only where its schema permits aggregation.
 - For multi-step recall, dispatch scoped read-only subagents by session id, time
@@ -125,7 +130,7 @@ chat content.
 ## If tools are deferred or MCP fails
 
 - Deferred (names listed without schemas): load once with ToolSearch —
-  `select:tracedecay_message_search,tracedecay_lcm_grep,tracedecay_lcm_load_session,tracedecay_lcm_describe,tracedecay_lcm_expand,tracedecay_lcm_expand_query,tracedecay_lcm_status,tracedecay_sessions_for,tracedecay_workflows,tracedecay_session_refresh,tracedecay_project_search,tracedecay_project_context`
+  `select:tracedecay_message_search,tracedecay_lcm_grep,tracedecay_lcm_load_session,tracedecay_lcm_describe,tracedecay_lcm_expand,tracedecay_lcm_expand_query,tracedecay_lcm_status,tracedecay_sessions_for,tracedecay_workflows,tracedecay_session_refresh,tracedecay_session_refresh_begin,tracedecay_session_refresh_status,tracedecay_session_refresh_cancel,tracedecay_project_search,tracedecay_project_context`
   (one batched call, add only the rungs needed) — then call normally.
 - MCP error/timeout/disconnect: same tool, same args, via shell:
   `tracedecay tool <name>` (see `tracedecay:using-the-cli`). Never


### PR DESCRIPTION
## Summary

- document session refresh begin, status, and cancel as one lifecycle
- keep only read-only status in the zero-confirmation Cursor allowlist
- require explicit mutation intent, opaque handles, and receipt-backed cancellation

## Why

PR #707 splits session refresh into lifecycle tools, but the packaged guidance exposed status without teaching agents how to safely start, track, and cancel the operation.

## Verification

- packaged plugin manifest and skill inventory checks pass
- tool ordering, allowlist, and mutation-guardrail assertions pass
- aggregate Rustfmt and diff checks pass
- branch scope audit: one commit, two documentation files, clean worktree

Supports ScriptedAlchemy/tracedecay#707.