### PR TITLE
fix(index): settle graph-off retained text wakes

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -2779,6 +2779,28 @@ impl CodeIndexSchedulerRegistryV1 {
                 }
                 let scheduler = Arc::clone(&worker_scheduler);
                 let graph_activation_enabled = worker_graph_activation.policy().is_enabled();
+                // A coalesced text-slice wake can outlive the graph-off pass
+                // that drained its final overflow. Do not project that bare
+                // Notify permit as a second refresh: no arrival and no hint
+                // means there is no source work left, while a scheduler-owned
+                // raw overflow still reaches the worker through `None` here.
+                let graph_off_text_is_settled = !graph_activation_enabled
+                    && !worker_pending_wake.has_pending_arrival()
+                    && worker_text_generation
+                        .read()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .as_ref()
+                        .is_some_and(LatestCodeTextGenerationV1::text_serving_is_ready)
+                    && match scheduler.try_lock() {
+                        Ok(scheduler) => scheduler.pending_hint_count() == Some(0),
+                        Err(std::sync::TryLockError::Poisoned(error)) => {
+                            error.into_inner().pending_hint_count() == Some(0)
+                        }
+                        Err(std::sync::TryLockError::WouldBlock) => false,
+                    };
+                if graph_off_text_is_settled {
+                    continue;
+                }
                 // Cover wake claim through failed-arrival restoration so admission
                 // never misreads in-flight owner work as plain unavailability.
                 let _reconcile_pass =
@@ -2999,11 +3021,13 @@ impl CodeIndexSchedulerRegistryV1 {
                         {
                             return Ok(outcome);
                         }
-                        // An empty serving slot must publish the retained
-                        // complete generation before a dirty-tree rebuild.
-                        // Restart remounts otherwise stay warming through the
-                        // successor extract with no seated generation.
-                        if serving_empty
+                        // A graph-enabled empty serving slot must publish the
+                        // retained complete generation before a dirty-tree
+                        // rebuild. Graph-off deliberately leaves this slot
+                        // empty and must instead settle through the retained
+                        // text reconcile below.
+                        if graph_activation_enabled
+                            && serving_empty
                             && text_serving_ready
                             && let Some(outcome) =
                                 scheduler.seat_retained_generation_on_empty_serving()?


### PR DESCRIPTION
## Summary

- bypass full retained-generation seating when native graph activation is disabled
- let graph-off worktrees reconcile through the retained text owner
- drain a stale no-work notification without suppressing real arrivals or raw overflow

## Why

A graph-off worktree could enter an empty full-serving slot, then consume a stale coalesced wake as a second fake refresh. The exact unchanged-source journey consequently reported refreshing instead of fresh.

## Verification

- exact stale-witness regression passes 6 consecutive runs
- all four graph-off scheduler tests pass
- aggregate focused suite: 14 passed
- Rustfmt and diff checks pass

Supports ScriptedAlchemy/tracedecay#707.