### PR TITLE
style(daemon-protocol): restore rustfmt compliance

### DIFF
--- a/crates/tracedecay-daemon-protocol/src/client.rs
+++ b/crates/tracedecay-daemon-protocol/src/client.rs
@@ -1720,11 +1720,8 @@ mod tests {
     }
 
     fn unused_test_endpoint() -> crate::transport::DaemonEndpoint {
-        crate::transport::DaemonEndpoint::loopback(std::net::SocketAddr::from((
-            [127, 0, 0, 1],
-            0,
-        )))
-        .expect("loopback endpoint")
+        crate::transport::DaemonEndpoint::loopback(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+            .expect("loopback endpoint")
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- apply rustfmt to the portable revision-mismatch test helper
- restore workspace formatting checks after the latest #707 update

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- independent scope review: one file, one formatting-only hunk, no findings

Supports #707.