### PR TITLE
fix(retention): defer on replay-pool contention

### DIFF
--- a/crates/tracedecay-code-index-retention/src/code_index_generations.rs
+++ b/crates/tracedecay-code-index-retention/src/code_index_generations.rs
@@ -66,15 +66,17 @@ pub use text_artifacts::{
 };
 
 use generation_transactions::{
-    GENERATION_RECEIPT_STORE, acquire_graph_replay_pool_lock, cleanup_committed_transaction,
-    cleanup_committed_transaction_under_graph_replay_pool_lock, clear_transaction,
-    expose_staged_generations_under_graph_replay_pool_lock, load_transaction,
+    GENERATION_RECEIPT_STORE, acquire_graph_replay_pool_lock_cancellable,
+    cleanup_committed_transaction, cleanup_committed_transaction_under_graph_replay_pool_lock,
+    clear_transaction, expose_staged_generations_under_graph_replay_pool_lock, load_transaction,
     open_file_sha256_hex_cancellable, path_still_names_open_file, persist_transaction,
     receipt_is_durable, regular_file_exists, remove_empty_stage_root, rollback_staged_transaction,
     stage_collectable_generations, transaction_path, write_receipt,
 };
 #[cfg(test)]
-use generation_transactions::{transaction_stage_root, verify_existing_graph_replay_pool_entry};
+use generation_transactions::{
+    acquire_graph_replay_pool_lock, transaction_stage_root, verify_existing_graph_replay_pool_entry,
+};
 use receipt_store::receipt_digest_file_component;
 use scope_roots::is_code_index_scope_hash;
 #[cfg(test)]
@@ -331,6 +333,8 @@ pub enum CodeGenerationRetentionErrorV1 {
     UnsafeState(String),
     #[error("code-generation retention conflict: {0}")]
     Conflict(String),
+    #[error("code-generation retention busy: {0}")]
+    Busy(String),
     #[error("code-generation retention cancelled")]
     Cancelled,
 }
@@ -1012,7 +1016,7 @@ pub fn execute_code_generation_retention_cancellable(
         // pool. Hold the pool lock through durable release publication and
         // committed cleanup so the reconciler cannot race an orphaning unlink.
         let graph_replay_pool_lock = graph_replay_pool_root
-            .map(acquire_graph_replay_pool_lock)
+            .map(|pool_root| acquire_graph_replay_pool_lock_cancellable(pool_root, is_cancelled))
             .transpose()?;
         persist_transaction(store_root, &transaction)?;
 

--- a/crates/tracedecay-code-index-retention/src/code_index_generations/generation_transactions.rs
+++ b/crates/tracedecay-code-index-retention/src/code_index_generations/generation_transactions.rs
@@ -17,7 +17,7 @@ use super::graph_replay_release;
 use super::journal::{
     BoundedJournalSpec, clear_journal, journal_path, load_journal, persist_journal,
 };
-use super::locking::{CodeGenerationStoreLockV1, acquire_code_generation_store_lock};
+use super::locking::{CodeGenerationStoreLockV1, try_acquire_code_generation_store_lock};
 use super::receipt_store;
 use super::receipt_store::ReceiptStoreSpec;
 use super::{
@@ -229,8 +229,33 @@ pub(super) struct GraphReplayPoolLockV1 {
 pub(super) fn acquire_graph_replay_pool_lock(
     pool_root: &Path,
 ) -> Result<GraphReplayPoolLockV1, CodeGenerationRetentionErrorV1> {
+    acquire_graph_replay_pool_lock_cancellable(pool_root, &|| false)
+}
+
+/// Acquire the replay-pool authority without parking on another process's
+/// filesystem lock. Daemon retention already performs an early availability
+/// probe, but a publisher can win the pool after that probe and before the
+/// fully verified plan reaches apply. That race is ordinary contention, not a
+/// reason to retain the daemon writer admission behind a deadline-free flock.
+pub(super) fn acquire_graph_replay_pool_lock_cancellable(
+    pool_root: &Path,
+    is_cancelled: &dyn Fn() -> bool,
+) -> Result<GraphReplayPoolLockV1, CodeGenerationRetentionErrorV1> {
+    if observe_cancel(is_cancelled) {
+        return Err(CodeGenerationRetentionErrorV1::Cancelled);
+    }
     ensure_private_graph_replay_pool_root(pool_root)?;
-    let guard = acquire_code_generation_store_lock(pool_root)?;
+    if observe_cancel(is_cancelled) {
+        return Err(CodeGenerationRetentionErrorV1::Cancelled);
+    }
+    let Some(guard) = try_acquire_code_generation_store_lock(pool_root)? else {
+        return Err(CodeGenerationRetentionErrorV1::Busy(
+            "graph replay pool lock is held".to_owned(),
+        ));
+    };
+    if observe_cancel(is_cancelled) {
+        return Err(CodeGenerationRetentionErrorV1::Cancelled);
+    }
     Ok(GraphReplayPoolLockV1 {
         root: guard.generation_store_root()?.to_path_buf(),
         _guard: guard,
@@ -622,7 +647,7 @@ pub(super) fn withdraw_generations_from_graph_replay_pool(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(storage(error)),
     }
-    let _pool_lock = acquire_code_generation_store_lock(pool_root)?;
+    let _pool_lock = acquire_graph_replay_pool_lock(pool_root)?;
     let generations_root = store_root.join(GENERATIONS_DIRECTORY);
     let mut removed = false;
     for generation in &transaction.receipt.deleted_generations {

--- a/crates/tracedecay/src/daemon/maintenance/generation.rs
+++ b/crates/tracedecay/src/daemon/maintenance/generation.rs
@@ -67,6 +67,9 @@ pub(in crate::daemon) async fn run_project_generation_maintenance(
                 MaintenanceContinuation::CodeGenerationRetention,
             ));
         }
+        CodeGenerationRetentionOutcomeV1::Deferred => {
+            outcome = outcome.combine(MaintenanceTickOutcome::Retry);
+        }
         CodeGenerationRetentionOutcomeV1::Failed => {
             if !cancellation.is_cancelled() {
                 outcome = MaintenanceTickOutcome::Retry;

--- a/crates/tracedecay/src/daemon/store_maintenance/mod.rs
+++ b/crates/tracedecay/src/daemon/store_maintenance/mod.rs
@@ -426,6 +426,7 @@ fn classify_vector_readable_sources(
 pub(in crate::daemon) enum CodeGenerationRetentionOutcomeV1 {
     Complete,
     MoreWork,
+    Deferred,
     Failed,
 }
 
@@ -512,6 +513,32 @@ async fn apply_code_generation_retention(
     vector_inventory: VectorRetentionInventoryV1,
     cancellation: &tracedecay_session_memory::context::CancellationToken,
 ) -> CodeGenerationRetentionOutcomeV1 {
+    apply_code_generation_retention_after_replay_pool_preflight(
+        graph,
+        schedulers,
+        observations,
+        vector_inventory,
+        cancellation,
+        || std::future::ready(()),
+    )
+    .await
+}
+
+async fn apply_code_generation_retention_after_replay_pool_preflight<
+    PostPreflight,
+    PostPreflightFuture,
+>(
+    graph: &TraceDecay,
+    schedulers: &CodeIndexSchedulerRegistryV1,
+    observations: &crate::daemon::maintenance::StoreTelemetrySamplingRegistry,
+    vector_inventory: VectorRetentionInventoryV1,
+    cancellation: &tracedecay_session_memory::context::CancellationToken,
+    post_preflight: PostPreflight,
+) -> CodeGenerationRetentionOutcomeV1
+where
+    PostPreflight: FnOnce() -> PostPreflightFuture,
+    PostPreflightFuture: std::future::Future<Output = ()>,
+{
     use tracedecay_code_index_retention::code_index_generations::{
         CodeGenerationRetentionErrorV1, CodeGenerationRetentionModeV1,
         DEFAULT_SUPERSEDED_GENERATION_FLOOR, execute_code_generation_retention_cancellable,
@@ -567,8 +594,9 @@ async fn apply_code_generation_retention(
         observations.record_graph_replay_release_unhealthy(graph.project_root());
         hotpath::gauge!("daemon.git.maintenance.replay_pool_busy_total").inc(1_u64);
         log_code_generation_retention_degraded("graph_replay_pool_busy");
-        return CodeGenerationRetentionOutcomeV1::Failed;
+        return CodeGenerationRetentionOutcomeV1::Deferred;
     }
+    post_preflight().await;
     // Full digest verification routinely reads several GiB. Run it before
     // entering the graph transaction and preserve the daemon shutdown token
     // through the blocking boundary; the planner checks it after every bounded
@@ -594,6 +622,13 @@ async fn apply_code_generation_retention(
         )) => {
             log_code_generation_retention_degraded("retention_cancelled");
             return CodeGenerationRetentionOutcomeV1::Failed;
+        }
+        Ok(Err(
+            tracedecay_code_index_retention::code_index_generations::CodeGenerationRetentionErrorV1::Busy(_),
+        )) => {
+            hotpath::gauge!("daemon.git.maintenance.replay_pool_busy_total").inc(1_u64);
+            log_code_generation_retention_degraded("graph_replay_pool_busy");
+            return CodeGenerationRetentionOutcomeV1::Deferred;
         }
         Ok(Err(error)) => {
             // The bare label proved undiagnosable on a live profile: without
@@ -905,6 +940,11 @@ async fn apply_code_generation_retention(
         Ok(Err(CodeGenerationRetentionErrorV1::Cancelled)) => {
             log_code_generation_retention_degraded("retention_cancelled");
             CodeGenerationRetentionOutcomeV1::Failed
+        }
+        Ok(Err(CodeGenerationRetentionErrorV1::Busy(_))) => {
+            hotpath::gauge!("daemon.git.maintenance.replay_pool_busy_total").inc(1_u64);
+            log_code_generation_retention_degraded("graph_replay_pool_busy");
+            CodeGenerationRetentionOutcomeV1::Deferred
         }
         Ok(Err(error)) => {
             // Same diagnosability contract as the plan failure above: the

--- a/crates/tracedecay/src/daemon/store_maintenance/vector_retention_tests.rs
+++ b/crates/tracedecay/src/daemon/store_maintenance/vector_retention_tests.rs
@@ -5,6 +5,8 @@
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
@@ -23,8 +25,9 @@ use tracedecay_code_index_runtime::code_index_scheduler::semantic_vector_graph::
 
 use super::{
     CodeGenerationRetentionOutcomeV1, VectorRetentionInventoryV1, apply_code_generation_retention,
-    classify_vector_readable_sources, code_index_store_root, resolve_vector_retention_inventory,
-    run_code_generation_retention, run_semantic_vector_generation_retention,
+    apply_code_generation_retention_after_replay_pool_preflight, classify_vector_readable_sources,
+    code_index_store_root, resolve_vector_retention_inventory, run_code_generation_retention,
+    run_semantic_vector_generation_retention,
 };
 
 const FIXTURE_GENERATION_COUNT: usize = 6;
@@ -43,6 +46,12 @@ struct UnseatedGraphFixture {
 /// live default-off state — with a sealed code-index store that has
 /// collectable superseded generations.
 async fn open_unseated_graph_fixture() -> UnseatedGraphFixture {
+    open_unseated_graph_fixture_with_generation_count(FIXTURE_GENERATION_COUNT).await
+}
+
+async fn open_unseated_graph_fixture_with_generation_count(
+    generation_count: usize,
+) -> UnseatedGraphFixture {
     let pinned_home = tracedecay_runtime_core::config::PinnedUserDataDir::new();
     let project = TempDir::new().expect("isolated project root");
     let graph = TraceDecay::open(project.path())
@@ -57,7 +66,7 @@ async fn open_unseated_graph_fixture() -> UnseatedGraphFixture {
     );
     let layout = graph.hook_store_layout();
     let store_root = code_index_store_root(&layout.data_root, &layout.project_root);
-    seed_sealed_generation_store(&store_root, FIXTURE_GENERATION_COUNT);
+    seed_sealed_generation_store(&store_root, generation_count);
     UnseatedGraphFixture {
         _pinned_home: pinned_home,
         _project: project,
@@ -602,7 +611,7 @@ async fn held_replay_pool_defers_then_backs_off_then_recovers() {
             &fixture.cancellation,
         )
         .await,
-        CodeGenerationRetentionOutcomeV1::Failed,
+        CodeGenerationRetentionOutcomeV1::Deferred,
         "a held replay pool defers the pass without blocking on the holder"
     );
     assert_eq!(
@@ -668,5 +677,136 @@ async fn held_replay_pool_defers_then_backs_off_then_recovers() {
             .observations
             .graph_replay_release_attempt_admitted(&project_root),
         "a served reconcile closes the backoff window"
+    );
+}
+
+/// A pool holder can arrive after the cheap preflight and before the fully
+/// verified plan reaches apply. The authoritative acquisition must still
+/// defer promptly, before any journal or unlink, and return the daemon writer
+/// admission. Once the competing holder leaves, the next bounded pass removes
+/// the only obsolete generation and drains its release evidence.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_preflight_replay_pool_contention_defers_without_retaining_writer() {
+    let fixture = open_unseated_graph_fixture_with_generation_count(2).await;
+    let UnseatedGraphFixture {
+        _pinned_home,
+        _project,
+        graph,
+        store_root,
+        schedulers,
+        observations,
+        cancellation,
+    } = fixture;
+    let graph = Arc::new(graph);
+    let schedulers = Arc::new(schedulers);
+    let observations = Arc::new(observations);
+    let administration = crate::daemon::branch_admin::StoreAdministration::default();
+    let replay_root = graph.db().database_path().with_extension("graph-replay");
+    tracedecay_runtime_core::storage::PrivateStoreIo::create_private_directory(&replay_root)
+        .expect("create owner-private replay pool");
+
+    let preflight_reached = Arc::new(tokio::sync::Notify::new());
+    let resume_retention = Arc::new(tokio::sync::Notify::new());
+    let task_graph = Arc::clone(&graph);
+    let task_schedulers = Arc::clone(&schedulers);
+    let task_observations = Arc::clone(&observations);
+    let task_cancellation = cancellation.clone();
+    let task_administration = administration.clone();
+    let task_preflight_reached = Arc::clone(&preflight_reached);
+    let task_resume_retention = Arc::clone(&resume_retention);
+    let mut retention = tokio::spawn(async move {
+        task_administration
+            .try_with_writer(|| async {
+                apply_code_generation_retention_after_replay_pool_preflight(
+                    task_graph.as_ref(),
+                    task_schedulers.as_ref(),
+                    task_observations.as_ref(),
+                    VectorRetentionInventoryV1::SemanticUnseated,
+                    &task_cancellation,
+                    || async move {
+                        task_preflight_reached.notify_one();
+                        task_resume_retention.notified().await;
+                    },
+                )
+                .await
+            })
+            .await
+    });
+
+    preflight_reached.notified().await;
+    let held_pool = try_acquire_code_generation_store_lock(&replay_root)
+        .expect("probe the replay pool after preflight")
+        .expect("competing publisher acquires the replay pool after preflight");
+    resume_retention.notify_one();
+
+    let outcome = match tokio::time::timeout(Duration::from_secs(2), &mut retention).await {
+        Ok(joined) => joined
+            .expect("post-preflight retention task must not panic")
+            .expect("the test writer admission must be available"),
+        Err(_) => {
+            drop(held_pool);
+            let _ = retention.await;
+            panic!("post-preflight replay-pool contention must defer promptly");
+        }
+    };
+    assert_eq!(outcome, CodeGenerationRetentionOutcomeV1::Deferred);
+    assert_eq!(
+        sealed_generation_files(&store_root).len(),
+        2,
+        "a busy authoritative acquisition must not unlink a generation"
+    );
+    assert_eq!(
+        release_queue_files(&store_root),
+        0,
+        "a busy authoritative acquisition must not publish release evidence"
+    );
+    assert!(
+        !store_root
+            .join(".code-generation-retention-transaction-v1.json")
+            .exists(),
+        "a busy authoritative acquisition must not publish a transaction"
+    );
+    assert!(
+        administration.try_with_writer(|| async {}).await.is_some(),
+        "deferral must return the daemon writer admission while the pool remains held"
+    );
+
+    drop(held_pool);
+    assert_eq!(
+        administration
+            .try_with_writer(|| async {
+                run_code_generation_retention(
+                    graph.as_ref(),
+                    schedulers.as_ref(),
+                    observations.as_ref(),
+                    &cancellation,
+                )
+                .await
+            })
+            .await
+            .expect("the recovered pass acquires writer admission"),
+        CodeGenerationRetentionOutcomeV1::MoreWork,
+        "the next bounded pass removes the final obsolete generation"
+    );
+    assert_eq!(
+        sealed_generation_files(&store_root),
+        BTreeSet::from([active_generation_file(&store_root)]),
+        "the recovered pass converges the generation store to its active head"
+    );
+    assert_eq!(
+        release_queue_files(&store_root),
+        0,
+        "the recovered pass drains the release it publishes"
+    );
+    assert_eq!(
+        run_code_generation_retention(
+            graph.as_ref(),
+            schedulers.as_ref(),
+            observations.as_ref(),
+            &cancellation,
+        )
+        .await,
+        CodeGenerationRetentionOutcomeV1::Complete,
+        "the following metadata-only census confirms convergence"
     );
 }


### PR DESCRIPTION
## Summary

- make the authoritative replay-pool acquisition nonblocking and cancellation-aware
- propagate typed contention as daemon `Deferred` / maintenance retry
- preserve journals and receipts for idempotent recovery when contention occurs during cleanup
- add a synchronized post-preflight race regression

## Why

The existing preflight drops its guard before expensive planning. A publisher can acquire the replay pool afterward, leaving retention blocked indefinitely on `flock` while it still owns daemon writer admission.

Based on #707 commit `e8e30fb323ebdfb53380b682ef6aba5a5c384979`.

## Verification

- graph-replay retention tests: 8 passed
- deterministic post-preflight contention regression: passed
- verifies prompt deferral, no mutation, writer release, and eventual convergence
