### PR TITLE
feat(hotpath): fill sessions ingest/transcript/backfill gaps

### DIFF
--- a/crates/tracedecay-sessions/src/runtime/git_correlation/backfill/bounded.rs
+++ b/crates/tracedecay-sessions/src/runtime/git_correlation/backfill/bounded.rs
@@ -122,6 +122,7 @@ pub struct BoundedBackfillOutcome {
     pub interruption: Option<BoundedBackfillInterruption>,
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.backfill.bounded_page", future = true)]
 pub async fn run_bounded_history_index_page<S>(
     session_store: &S,
     opts: &BackfillOptions,
@@ -409,6 +410,7 @@ pub(super) enum StreamGitEvidenceOutcome {
     Skip(BackfillSkipReason),
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.backfill.stream_evidence", future = true)]
 async fn stream_git_evidence<S: GitCorrelationSessionStore>(
     session_store: &S,
     row: &SessionActivityRow,
@@ -519,6 +521,7 @@ async fn stream_git_evidence<S: GitCorrelationSessionStore>(
     resume_git_evidence(session_store, key, opts, control, stats, committed).await
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.backfill.resume_evidence", future = true)]
 async fn resume_git_evidence<S: GitCorrelationSessionStore>(
     session_store: &S,
     key: GitHistoryProgressKey,
@@ -626,6 +629,7 @@ async fn resume_git_evidence<S: GitCorrelationSessionStore>(
     }
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.backfill.dry_run", future = true)]
 async fn dry_run_native_history(
     project_path: &std::path::Path,
     window_start: i64,
@@ -807,6 +811,7 @@ async fn dry_run_segment(
     Ok(emitted)
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.backfill.frontier_persist", future = true)]
 async fn persist_frontier<S: GitCorrelationSessionStore>(
     session_store: &S,
     candidate: GitHistoryIndexFrontier,

--- a/crates/tracedecay-sessions/src/runtime/git_correlation/backfill/history_progress.rs
+++ b/crates/tracedecay-sessions/src/runtime/git_correlation/backfill/history_progress.rs
@@ -21,6 +21,7 @@ pub(super) const fn initial_reflog_content_chain() -> &'static str {
     INITIAL_REFLOG_CONTENT_CHAIN
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.history_schema", future = true)]
 pub(in super::super) async fn install_final_schema(
     conn: &(impl Executor + ?Sized),
 ) -> Result<(), GitCorrelationError> {
@@ -273,6 +274,7 @@ pub(super) struct GitHistorySeenRow {
     pub oid: String,
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.history_progress_read", future = true)]
 pub(super) async fn read_progress(
     conn: &(impl QueryExecutor + ?Sized),
     key: GitHistoryProgressKey,
@@ -298,6 +300,7 @@ pub(super) async fn read_progress(
         .transpose()
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.history_progress_oldest", future = true)]
 pub(super) async fn read_oldest_progress(
     conn: &(impl QueryExecutor + ?Sized),
 ) -> Result<Option<GitHistoryProgressRow>, GitCorrelationError> {
@@ -324,6 +327,7 @@ pub(super) async fn read_oldest_progress(
 }
 
 /// Inserts a new exact progress row without replacing an existing source seal.
+#[hotpath::measure(label = "sessions.git_correlation.history_progress_insert", future = true)]
 pub(super) async fn insert_progress(
     conn: &(impl Executor + ?Sized),
     progress: &GitHistoryProgressRow,
@@ -355,6 +359,7 @@ pub(super) async fn insert_progress(
 }
 
 /// Advances only mutable cursor fields when both generation and source seal match.
+#[hotpath::measure(label = "sessions.git_correlation.history_progress_cas", future = true)]
 pub(super) async fn compare_and_swap_progress(
     conn: &(impl Executor + ?Sized),
     expected_generation: u64,
@@ -546,6 +551,7 @@ pub(super) async fn read_segment(
 }
 
 /// Inserts a segment or updates only its mutable flags when its sealed shape matches.
+#[hotpath::measure(label = "sessions.git_correlation.history_segment_upsert", future = true)]
 pub(super) async fn upsert_segment(
     conn: &(impl Executor + ?Sized),
     segment: &GitHistorySegmentRow,
@@ -579,6 +585,7 @@ pub(super) async fn upsert_segment(
     Ok(changed == 1)
 }
 
+#[hotpath::measure(label = "sessions.git_correlation.history_pending_page", future = true)]
 pub(super) async fn read_pending_page(
     conn: &(impl QueryExecutor + ?Sized),
     key: GitHistoryProgressKey,

--- a/crates/tracedecay-sessions/src/runtime/hosts/cursor.rs
+++ b/crates/tracedecay-sessions/src/runtime/hosts/cursor.rs
@@ -664,6 +664,7 @@ pub async fn try_ingest_cursor_user_transcript_event_capped_with_registered_root
     .await
 }
 
+#[hotpath::measure(label = "sessions.hosts.cursor.ingest_user_event_capped", future = true)]
 pub async fn try_ingest_cursor_user_transcript_event_capped_with_admission(
     event_json: &str,
     admission: &dyn HostAdmission,
@@ -807,6 +808,7 @@ pub(in crate::runtime) async fn try_ingest_cursor_user_sweep_capped_with_session
     .await
 }
 
+#[hotpath::measure(label = "sessions.hosts.cursor.sweep_admit", future = true)]
 async fn admit_cursor_sweep_observations_with_session_ids(
     source: &CursorSweepSource,
     project_root: &Path,
@@ -995,6 +997,7 @@ impl TranscriptSource for CursorSweepSource {
         "cursor"
     }
 
+    #[hotpath::measure(label = "sessions.hosts.cursor.sweep_discover")]
     fn transcript_paths(&self, project_root: &Path) -> Vec<PathBuf> {
         if let Some(registered_slugs) = &self.user_registered_slugs {
             let Ok(entries) = std::fs::read_dir(&self.cursor_projects_dir) else {
@@ -1314,6 +1317,7 @@ fn parent_dispatch_model_for_subagent(
     None
 }
 
+#[hotpath::measure(label = "sessions.hosts.cursor.dispatch_model_scan")]
 fn dispatch_model_for_agent(path: &Path, agent_id: &str) -> Option<String> {
     let file = File::open(path).ok()?;
     let mut frames = RawJsonlFrameReader::new(BufReader::new(file), MAX_JSONL_RECORD_BYTES);

--- a/crates/tracedecay-sessions/src/runtime/hosts/cursor_composer/ingest.rs
+++ b/crates/tracedecay-sessions/src/runtime/hosts/cursor_composer/ingest.rs
@@ -126,6 +126,7 @@ impl ComposerIngestContext<'_, '_> {
     }
 }
 
+#[hotpath::measure(label = "sessions.hosts.cursor.composer_projection_drain", future = true)]
 async fn drain_composer_projection_queue(
     context: &ComposerIngestContext<'_, '_>,
 ) -> TranscriptIngestResult<crate::runtime::cursor::projection::CursorProjectionDrainStats> {
@@ -163,6 +164,7 @@ struct ComposerCoverageContext<'facade> {
     cancellation: &'facade ObservationCancellation,
 }
 
+#[hotpath::measure(label = "sessions.hosts.cursor.composer_coverage_advance", future = true)]
 async fn advance_composer_coverage(
     context: ComposerCoverageContext<'_>,
     source: ObservationSourceIdentityV1,
@@ -263,6 +265,7 @@ impl CursorComposerSource {
             .await
     }
 
+    #[hotpath::measure(label = "sessions.hosts.cursor.composer_sweep", future = true)]
     async fn ingest_with_context(
         &self,
         context: &ComposerIngestContext<'_, '_>,
@@ -337,6 +340,7 @@ impl CursorComposerSource {
         Ok(outcome.finished(byte_budget.consumed(), byte_budget.deferred()))
     }
 
+    #[hotpath::measure(label = "sessions.hosts.cursor.composer_state_vscdb", future = true)]
     async fn ingest_state_vscdb(
         &self,
         context: &ComposerIngestContext<'_, '_>,
@@ -783,6 +787,7 @@ impl CursorComposerSource {
         }
     }
 
+    #[hotpath::measure(label = "sessions.hosts.cursor.composer_chat_stores", future = true)]
     async fn ingest_chat_store_dbs(
         &self,
         context: &ComposerIngestContext<'_, '_>,
@@ -810,6 +815,7 @@ impl CursorComposerSource {
         }
     }
 
+    #[hotpath::measure(label = "sessions.hosts.cursor.composer_store_db", future = true)]
     async fn ingest_one_store_db(
         &self,
         context: &ComposerIngestContext<'_, '_>,

--- a/crates/tracedecay-sessions/src/runtime/hosts/hermes/ingest.rs
+++ b/crates/tracedecay-sessions/src/runtime/hosts/hermes/ingest.rs
@@ -487,6 +487,7 @@ pub(super) struct HermesProfileSource {
     pub profile: Option<String>,
 }
 
+#[hotpath::measure(label = "sessions.hosts.hermes.discover_profiles")]
 fn all_profile_sources(hermes_homes: &[PathBuf]) -> Vec<HermesProfileSource> {
     let mut out = Vec::new();
     let mut seen = BTreeSet::new();
@@ -518,6 +519,7 @@ fn all_profile_sources(hermes_homes: &[PathBuf]) -> Vec<HermesProfileSource> {
     out
 }
 
+#[hotpath::measure(label = "sessions.hosts.hermes.discover_candidates")]
 fn candidate_state_dbs(hermes_homes: &[PathBuf], project_root: &Path) -> Vec<HermesProfileSource> {
     let mut out = Vec::new();
     let mut seen = BTreeSet::new();

--- a/crates/tracedecay-sessions/src/runtime/ingest/scheduler.rs
+++ b/crates/tracedecay-sessions/src/runtime/ingest/scheduler.rs
@@ -133,6 +133,7 @@ pub(super) fn finish_user_provider_coverage(
     }
 }
 
+#[hotpath::measure(label = "sessions.ingest.frontier_read", future = true)]
 pub(super) async fn read_ingest_frontier<S: TranscriptIngestStore>(
     store: &S,
     key: &str,
@@ -143,6 +144,7 @@ pub(super) async fn read_ingest_frontier<S: TranscriptIngestStore>(
     }
 }
 
+#[hotpath::measure(label = "sessions.ingest.frontier_write", future = true)]
 pub(super) async fn write_ingest_frontier<S: TranscriptIngestStore>(
     store: &S,
     key: &str,
@@ -166,6 +168,7 @@ pub(super) async fn write_ingest_frontier<S: TranscriptIngestStore>(
         .is_ok()
 }
 
+#[hotpath::measure(label = "sessions.ingest.codex_frontier_read", future = true)]
 pub(super) async fn read_codex_discovery_frontier<S: TranscriptIngestStore>(
     store: &S,
 ) -> TranscriptIngestResult<CodexDiscoveryFrontier> {
@@ -178,6 +181,7 @@ pub(super) async fn read_codex_discovery_frontier<S: TranscriptIngestStore>(
     CodexDiscoveryFrontier::from_parse_offsets(stored, epoch)
 }
 
+#[hotpath::measure(label = "sessions.ingest.codex_frontier_write", future = true)]
 pub(super) async fn write_codex_discovery_frontier<S: TranscriptIngestStore>(
     store: &S,
     expected: CodexDiscoveryFrontier,

--- a/crates/tracedecay-sessions/src/runtime/observation/jsonl_observation_admission.rs
+++ b/crates/tracedecay-sessions/src/runtime/observation/jsonl_observation_admission.rs
@@ -839,6 +839,7 @@ struct SharedJsonlBuildOptions {
     cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
+#[hotpath::measure(label = "sessions.observation.jsonl_page_build")]
 fn build_shared_jsonl_page(
     path: PathBuf,
     previous: StoredCursor,
@@ -1043,6 +1044,7 @@ async fn prepare_shared_jsonl_window(
     .await
 }
 
+#[hotpath::measure(label = "sessions.observation.jsonl_window_prepare", future = true)]
 async fn prepare_shared_jsonl_window_with_background_cpu(
     page: &SharedJsonlPage,
     start: usize,
@@ -1223,6 +1225,7 @@ async fn shared_jsonl_page(
     .await
 }
 
+#[hotpath::measure(label = "sessions.observation.jsonl_page_lookup", future = true)]
 async fn shared_jsonl_page_with_cancellation(
     path: &Path,
     previous: StoredCursor,
@@ -1568,6 +1571,7 @@ impl ActiveAdmission<'_> {
         .with_resume_checkpoint(self.file_identity, resume_fingerprint))
     }
 
+    #[hotpath::measure(label = "sessions.observation.jsonl_coverage_advance", future = true)]
     async fn advance_coverage(
         &self,
         expected_cursor: &mut Option<ObservationSourceCursorV1>,
@@ -1760,6 +1764,7 @@ impl ActiveAdmission<'_> {
         }
     }
 
+    #[hotpath::measure(label = "sessions.observation.jsonl_capture", future = true)]
     async fn capture(
         &self,
         expected_cursor: &mut Option<ObservationSourceCursorV1>,
@@ -1778,6 +1783,7 @@ impl ActiveAdmission<'_> {
             .await
     }
 
+    #[hotpath::measure(label = "sessions.observation.jsonl_capture_window", future = true)]
     async fn capture_window(
         &self,
         expected_cursor: &mut Option<ObservationSourceCursorV1>,

--- a/crates/tracedecay-sessions/src/runtime/source.rs
+++ b/crates/tracedecay-sessions/src/runtime/source.rs
@@ -82,6 +82,7 @@ impl HostProviderCoverage {
 pub(super) const CODEX_HISTORY_FRONTIER_KEY: &str = "tracedecay-internal:codex-history-frontier:v2";
 pub(super) const CODEX_HISTORY_EPOCH_KEY: &str = "tracedecay-internal:codex-history-epoch:v2";
 
+#[hotpath::measure(label = "sessions.source.coverage_read", future = true)]
 pub(super) async fn read_host_provider_coverage(
     admission: &dyn HostAdmission,
     scope: &ObservationScopeV1,
@@ -142,6 +143,7 @@ pub(super) async fn persist_codex_history_frontier(
         })
 }
 
+#[hotpath::measure(label = "sessions.source.coverage_persist", future = true)]
 pub(super) async fn persist_host_provider_coverage(
     admission: &(impl HostAdmission + ?Sized),
     scope: &ObservationScopeV1,
@@ -357,6 +359,7 @@ pub struct LoadedTranscriptCursor {
     durable_offset: ParseOffset,
 }
 
+#[hotpath::measure(label = "sessions.source.cursor_load", future = true)]
 pub async fn load_transcript_cursor<S: TranscriptIngestStore>(
     store: &S,
     key: TranscriptCursorKey,
@@ -819,6 +822,7 @@ use jsonl::{
     stream_new_jsonl_raw_strict, stream_new_jsonl_strict, stream_new_jsonl_with_policy,
 };
 
+#[hotpath::measure(label = "sessions.source.preflight_jsonl")]
 pub fn preflight_strict_jsonl(
     provider: &'static str,
     path: &Path,
@@ -859,6 +863,7 @@ pub struct ChangedFile {
 /// with deterministic ids. Idempotent upserts make re-adding unchanged messages
 /// a no-op. Returns `None` when the file cannot be read or is unchanged since
 /// the last run.
+#[hotpath::measure(label = "sessions.source.read_changed")]
 pub fn read_changed_file(path: &Path, prev: StoredCursor, max_bytes: u64) -> Option<ChangedFile> {
     let meta = match std::fs::metadata(path) {
         Ok(meta) => meta,
@@ -892,6 +897,7 @@ pub fn read_changed_file(path: &Path, prev: StoredCursor, max_bytes: u64) -> Opt
 /// own content hash moves or a companion sidecar file's hash moves. The stored
 /// cursor's `position` is a combined hash of both files so a sidecar-only
 /// update (e.g. Cline `ui_messages.json` usage counters) triggers a re-ingest.
+#[hotpath::measure(label = "sessions.source.read_changed_companion")]
 pub fn read_changed_with_companion(
     primary: &Path,
     companion: &Path,

--- a/crates/tracedecay-sessions/src/runtime/store_access/transcript.rs
+++ b/crates/tracedecay-sessions/src/runtime/store_access/transcript.rs
@@ -14,6 +14,7 @@ enum TranscriptWritePolicy {
     ProjectionOnly,
 }
 
+#[hotpath::measure(label = "sessions.transcript.offset_read", future = true)]
 pub async fn get_parse_offset(
     conn: &impl QueryExecutor,
     path: &str,
@@ -123,6 +124,7 @@ pub async fn require_expected_offset(
     }
 }
 
+#[hotpath::measure(label = "sessions.transcript.offset_write", future = true)]
 pub async fn set_parse_offset(
     conn: &impl Executor,
     path: &str,
@@ -156,6 +158,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
             .map_err(|error| TranscriptPersistenceError::storage("begin transcript batch", error))
     }
 
+    #[hotpath::measure(label = "sessions.transcript.session_upsert", future = true)]
     pub async fn upsert_session(&self, session: &SessionRecord) -> bool {
         let Ok(transaction) = self.begin_transcript_transaction().await else {
             return false;
@@ -212,6 +215,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
             .flatten()
     }
 
+    #[hotpath::measure(label = "sessions.transcript.session_read", future = true)]
     pub async fn get_session_result(
         &self,
         provider: &str,
@@ -294,6 +298,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
         })
     }
 
+    #[hotpath::measure(label = "sessions.transcript.message_upsert", future = true)]
     async fn upsert_session_message_in_existing_tx(
         &self,
         conn: &impl Executor,
@@ -418,6 +423,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
         .await
     }
 
+    #[hotpath::measure(label = "sessions.transcript.offset_commit", future = true)]
     pub async fn persist_transcript_offset_result(
         &self,
         parse_offset_path: &str,
@@ -452,6 +458,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
         .map_err(|error| error.to_string())
     }
 
+    #[hotpath::measure(label = "sessions.transcript.batch_persist", future = true)]
     async fn upsert_transcript_batches_inner(
         &self,
         batches: &[TranscriptBatch],
@@ -565,6 +572,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
             .map_err(|error| format!("commit transcript parse offset: {error}"))
     }
 
+    #[hotpath::measure(label = "sessions.transcript.offset_advance", future = true)]
     pub async fn advance_parse_offset_result(
         &self,
         path: &str,
@@ -583,6 +591,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
 
     /// Exact compare-and-set for versioned parse-offset authorities whose
     /// numeric fields are not monotonic transcript positions.
+    #[hotpath::measure(label = "sessions.transcript.offset_replace", future = true)]
     pub async fn replace_parse_offset_result(
         &self,
         path: &str,
@@ -600,6 +609,7 @@ impl<D: SessionRegisteredDb + Sync> SessionStoreAccess<'_, D> {
     /// Atomically compare-and-replace two parse-offset keys. Both expected
     /// values are checked before either write and one transaction owns the
     /// pair through commit.
+    #[hotpath::measure(label = "sessions.transcript.offset_replace_pair", future = true)]
     pub async fn replace_parse_offset_pair_result(
         &self,
         first: (&str, ParseOffset, ParseOffset),

--- a/crates/tracedecay-sessions/src/runtime/workflow/workflow_index.rs
+++ b/crates/tracedecay-sessions/src/runtime/workflow/workflow_index.rs
@@ -101,6 +101,7 @@ impl From<crate::runtime::git_correlation::GitCorrelationError> for WorkflowInde
 /// through the shared `session_schema_migrations` table exactly like
 /// [`crate::runtime::git_correlation::ensure_git_correlation_receipt_schema_in_transaction`],
 /// so both stores register under their own migration name in one table.
+#[hotpath::measure(label = "sessions.workflow_index.ensure_schema", future = true)]
 pub async fn ensure_workflow_index_schema(conn: &impl Executor) -> Result<(), WorkflowIndexError> {
     if schema_version(conn)
         .await
@@ -205,6 +206,7 @@ pub const INGEST_WATERMARK_KEY: &str = "ingest_watermark_mtime";
 /// Reads the ingest watermark (max processed run-file mtime, unix seconds), or
 /// `0` when unset / the schema predates this table. Never errors: a store
 /// without the meta table simply reports no watermark, forcing a full sweep.
+#[hotpath::measure(label = "sessions.workflow_index.watermark_read", future = true)]
 pub async fn read_ingest_watermark(conn: &impl QueryExecutor, key: &str) -> i64 {
     let Ok(mut rows) = conn
         .query(
@@ -225,6 +227,7 @@ pub async fn read_ingest_watermark(conn: &impl QueryExecutor, key: &str) -> i64 
 /// whose transcripts grew (e.g. a `running` run that later `completed`)
 /// overwrites the mutable columns and refreshes `updated_at`. `created_at` is
 /// preserved.
+#[hotpath::measure(label = "sessions.workflow_index.run_upsert", future = true)]
 pub async fn upsert_run(conn: &impl Executor, run: &WorkflowRun) -> Result<(), WorkflowIndexError> {
     if run.run_id.trim().is_empty() {
         return Err(WorkflowIndexError::InvalidArgument(
@@ -266,6 +269,7 @@ pub async fn upsert_run(conn: &impl Executor, run: &WorkflowRun) -> Result<(), W
 
 /// Inserts or updates one agent row (idempotent on `(run_id, agent_label,
 /// agent_id)`).
+#[hotpath::measure(label = "sessions.workflow_index.agent_upsert", future = true)]
 pub async fn upsert_agent(
     conn: &impl Executor,
     agent: &WorkflowAgent,
@@ -414,6 +418,7 @@ where
         self.has_tables(&["workflow_runs", "workflow_agents"]).await
     }
 
+    #[hotpath::measure(label = "sessions.workflow_index.runs_for_session", future = true)]
     pub async fn runs_for_session(
         &self,
         parent_session_id: &str,
@@ -443,6 +448,7 @@ where
         Ok(runs)
     }
 
+    #[hotpath::measure(label = "sessions.workflow_index.run_read", future = true)]
     pub async fn run_for_id(
         &self,
         run_id: &str,
@@ -458,6 +464,7 @@ where
         rows.next().await?.map(|row| row_to_run(&row)).transpose()
     }
 
+    #[hotpath::measure(label = "sessions.workflow_index.agents_for_run", future = true)]
     pub async fn agents_for_run(
         &self,
         run_id: &str,
@@ -532,6 +539,7 @@ where
         rows.next().await?.map(|row| row_to_agent(&row)).transpose()
     }
 
+    #[hotpath::measure(label = "sessions.workflow_index.runs_for_git_scope", future = true)]
     pub async fn runs_for_git_scope(
         &self,
         session_ids: Option<&[(String, String)]>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Gap-fill hotpath coverage in `crates/tracedecay-sessions` only (HP-sessions scope). 42 new `#[hotpath::measure]` sites across 10 files, all on persist / ingest / recall / backfill / IO paths. Purely additive: no existing measure sites, gauges, or program logic were touched (diff is 58 inserted attribute lines, 0 deletions). No `Cargo.toml` changes — the crate's `hotpath` / `hotpath-alloc` / `hotpath-cpu` passthroughs already exist and none of them are reachable from `default` or `production`. Macros no-op without `--features hotpath`.

Rebased onto the current base tip. During the rebase, the base had independently instrumented the four hermes sweep entry points (`sessions.hosts.hermes.ingest_projects` / `ingest_project` / `ingest_user` / `ingest_legacy`); those base labels were kept and this PR's duplicate attributes for the same functions were dropped. This PR still adds the two hermes discovery-walk measures below.

Verified after rebase: `cargo check -p tracedecay-sessions --features hotpath` and `cargo check -p tracedecay-sessions` both pass; no duplicate labels crate-wide; `npm run lint:commit` passes. Base is `codex/tracedecay-total-redesign-plan-reopened` (#707, not merged by this PR).

## New measure sites

| File | Function | New label |
|---|---|---|
| `runtime/store_access/transcript.rs` | `get_parse_offset` (free fn) | `sessions.transcript.offset_read` |
| `runtime/store_access/transcript.rs` | `set_parse_offset` (free fn) | `sessions.transcript.offset_write` |
| `runtime/store_access/transcript.rs` | `upsert_session` | `sessions.transcript.session_upsert` |
| `runtime/store_access/transcript.rs` | `get_session_result` | `sessions.transcript.session_read` |
| `runtime/store_access/transcript.rs` | `upsert_session_message_in_existing_tx` | `sessions.transcript.message_upsert` |
| `runtime/store_access/transcript.rs` | `persist_transcript_offset_result` | `sessions.transcript.offset_commit` |
| `runtime/store_access/transcript.rs` | `upsert_transcript_batches_inner` | `sessions.transcript.batch_persist` |
| `runtime/store_access/transcript.rs` | `advance_parse_offset_result` | `sessions.transcript.offset_advance` |
| `runtime/store_access/transcript.rs` | `replace_parse_offset_result` | `sessions.transcript.offset_replace` |
| `runtime/store_access/transcript.rs` | `replace_parse_offset_pair_result` | `sessions.transcript.offset_replace_pair` |
| `runtime/hosts/hermes/ingest.rs` | `all_profile_sources` | `sessions.hosts.hermes.discover_profiles` |
| `runtime/hosts/hermes/ingest.rs` | `candidate_state_dbs` | `sessions.hosts.hermes.discover_candidates` |
| `runtime/workflow/workflow_index.rs` | `ensure_workflow_index_schema` | `sessions.workflow_index.ensure_schema` |
| `runtime/workflow/workflow_index.rs` | `read_ingest_watermark` | `sessions.workflow_index.watermark_read` |
| `runtime/workflow/workflow_index.rs` | `upsert_run` | `sessions.workflow_index.run_upsert` |
| `runtime/workflow/workflow_index.rs` | `upsert_agent` | `sessions.workflow_index.agent_upsert` |
| `runtime/workflow/workflow_index.rs` | `runs_for_session` | `sessions.workflow_index.runs_for_session` |
| `runtime/workflow/workflow_index.rs` | `run_for_id` | `sessions.workflow_index.run_read` |
| `runtime/workflow/workflow_index.rs` | `agents_for_run` | `sessions.workflow_index.agents_for_run` |
| `runtime/workflow/workflow_index.rs` | `runs_for_git_scope` | `sessions.workflow_index.runs_for_git_scope` |
| `runtime/git_correlation/backfill/history_progress.rs` | `install_final_schema` | `sessions.git_correlation.history_schema` |
| `runtime/git_correlation/backfill/history_progress.rs` | `read_progress` | `sessions.git_correlation.history_progress_read` |
| `runtime/git_correlation/backfill/history_progress.rs` | `read_oldest_progress` | `sessions.git_correlation.history_progress_oldest` |
| `runtime/git_correlation/backfill/history_progress.rs` | `insert_progress` | `sessions.git_correlation.history_progress_insert` |
| `runtime/git_correlation/backfill/history_progress.rs` | `compare_and_swap_progress` | `sessions.git_correlation.history_progress_cas` |
| `runtime/git_correlation/backfill/history_progress.rs` | `upsert_segment` | `sessions.git_correlation.history_segment_upsert` |
| `runtime/git_correlation/backfill/history_progress.rs` | `read_pending_page` | `sessions.git_correlation.history_pending_page` |
| `runtime/git_correlation/backfill/bounded.rs` | `run_bounded_history_index_page` | `sessions.git_correlation.backfill.bounded_page` |
| `runtime/git_correlation/backfill/bounded.rs` | `stream_git_evidence` | `sessions.git_correlation.backfill.stream_evidence` |
| `runtime/git_correlation/backfill/bounded.rs` | `resume_git_evidence` | `sessions.git_correlation.backfill.resume_evidence` |
| `runtime/git_correlation/backfill/bounded.rs` | `dry_run_native_history` | `sessions.git_correlation.backfill.dry_run` |
| `runtime/git_correlation/backfill/bounded.rs` | `persist_frontier` | `sessions.git_correlation.backfill.frontier_persist` |
| `runtime/hosts/cursor_composer/ingest.rs` | `drain_composer_projection_queue` | `sessions.hosts.cursor.composer_projection_drain` |
| `runtime/hosts/cursor_composer/ingest.rs` | `advance_composer_coverage` | `sessions.hosts.cursor.composer_coverage_advance` |
| `runtime/hosts/cursor_composer/ingest.rs` | `ingest_with_context` | `sessions.hosts.cursor.composer_sweep` |
| `runtime/hosts/cursor_composer/ingest.rs` | `ingest_state_vscdb` | `sessions.hosts.cursor.composer_state_vscdb` |
| `runtime/hosts/cursor_composer/ingest.rs` | `ingest_chat_store_dbs` | `sessions.hosts.cursor.composer_chat_stores` |
| `runtime/hosts/cursor_composer/ingest.rs` | `ingest_one_store_db` | `sessions.hosts.cursor.composer_store_db` |
| `runtime/ingest/scheduler.rs` | `read_ingest_frontier` | `sessions.ingest.frontier_read` |
| `runtime/ingest/scheduler.rs` | `write_ingest_frontier` | `sessions.ingest.frontier_write` |
| `runtime/ingest/scheduler.rs` | `read_codex_discovery_frontier` | `sessions.ingest.codex_frontier_read` |
| `runtime/ingest/scheduler.rs` | `write_codex_discovery_frontier` | `sessions.ingest.codex_frontier_write` |
| `runtime/hosts/cursor.rs` (add-missing) | `try_ingest_cursor_user_transcript_event_capped_with_admission` | `sessions.hosts.cursor.ingest_user_event_capped` |
| `runtime/hosts/cursor.rs` (add-missing) | `admit_cursor_sweep_observations_with_session_ids` | `sessions.hosts.cursor.sweep_admit` |
| `runtime/hosts/cursor.rs` (add-missing) | `CursorSweepSource::transcript_paths` | `sessions.hosts.cursor.sweep_discover` |
| `runtime/hosts/cursor.rs` (add-missing) | `dispatch_model_for_agent` | `sessions.hosts.cursor.dispatch_model_scan` |
| `runtime/source.rs` (add-missing) | `load_transcript_cursor` | `sessions.source.cursor_load` |
| `runtime/source.rs` (add-missing) | `read_host_provider_coverage` | `sessions.source.coverage_read` |
| `runtime/source.rs` (add-missing) | `persist_host_provider_coverage` | `sessions.source.coverage_persist` |
| `runtime/source.rs` (add-missing) | `preflight_strict_jsonl` | `sessions.source.preflight_jsonl` |
| `runtime/source.rs` (add-missing) | `read_changed_file` | `sessions.source.read_changed` |
| `runtime/source.rs` (add-missing) | `read_changed_with_companion` | `sessions.source.read_changed_companion` |
| `runtime/observation/jsonl_observation_admission.rs` (add-missing) | `build_shared_jsonl_page` | `sessions.observation.jsonl_page_build` |
| `runtime/observation/jsonl_observation_admission.rs` (add-missing) | `prepare_shared_jsonl_window_with_background_cpu` | `sessions.observation.jsonl_window_prepare` |
| `runtime/observation/jsonl_observation_admission.rs` (add-missing) | `shared_jsonl_page_with_cancellation` | `sessions.observation.jsonl_page_lookup` |
| `runtime/observation/jsonl_observation_admission.rs` (add-missing) | `advance_coverage` | `sessions.observation.jsonl_coverage_advance` |
| `runtime/observation/jsonl_observation_admission.rs` (add-missing) | `capture` | `sessions.observation.jsonl_capture` |
| `runtime/observation/jsonl_observation_admission.rs` (add-missing) | `capture_window` | `sessions.observation.jsonl_capture_window` |

## Conventions followed

- Labels use the crate's established prefixes (`sessions.transcript.*`, `sessions.hosts.hermes.*`, `sessions.hosts.cursor.*`, `sessions.git_correlation.*`, `sessions.workflow_index.*`, `sessions.ingest.*`, `sessions.source.*`, `sessions.observation.*`); no duplicate labels crate-wide.
- Async fns use `future = true`; sync FS-walk/scan fns use plain `#[hotpath::measure]`.
- Skipped getters, `Display` impls, row decoders, thin wrappers, `#[cfg(test)]` code, and planning-only pure functions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28380b24-6ee4-47cd-af89-d7e6a286f2b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28380b24-6ee4-47cd-af89-d7e6a286f2b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

