### PR TITLE
test(hotpath): coverage for global-db and rusqlite-runtime measures

### DIFF
--- a/.github/workflows/hotpath-coverage.yml
+++ b/.github/workflows/hotpath-coverage.yml
@@ -1,0 +1,70 @@
+# Coverage lanes for the hotpath instrumentation already present in the
+# storage slice (tracedecay-rusqlite-runtime, tracedecay-global-db).
+#
+# Two lanes, same test set:
+#   1. feature off  — every `#[hotpath::measure]` macro must stay a no-op;
+#   2. `--features hotpath` — the `hotpath_coverage` tests wrap a real
+#      workload in a HotpathGuard and assert the JSON report carries the
+#      crates' existing measure labels, so the lane fails if the measures
+#      stop firing.
+#
+# hotpath stays opt-in: nothing here touches `default` or `production`
+# feature sets, and the metrics HTTP server is disabled at the job boundary
+# (see .github/workflows/hotpath-profile.yml, which owns the separate
+# index-bench profiling lane and is unaffected by this workflow).
+name: hotpath-coverage
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: hotpath-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Hotpath binds a localhost metrics server by default; tests disable it
+  # themselves before building a guard, and this makes that explicit at the
+  # job boundary too.
+  HOTPATH_METRICS_SERVER_OFF: "1"
+
+jobs:
+  slice-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: kache compiler cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/kache
+            ~/.cache/kache
+          key: kache-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: kache-${{ runner.os }}-
+      - name: Enable kache
+        shell: bash
+        run: |
+          command -v kache >/dev/null 2>&1 || cargo install kache --locked
+          kache init --no-service
+          echo "RUSTC_WRAPPER=kache" >> "$GITHUB_ENV"
+
+      # `test-helpers` only unlocks the registered-store harness the
+      # coverage test drives; it gates no production code.
+      - name: Slice tests (hotpath off)
+        run: |
+          cargo test -p tracedecay-rusqlite-runtime -p tracedecay-global-db \
+            --locked --features tracedecay-global-db/test-helpers
+
+      - name: Slice tests (hotpath on)
+        run: |
+          cargo test -p tracedecay-rusqlite-runtime -p tracedecay-global-db \
+            --locked --features \
+            tracedecay-rusqlite-runtime/hotpath,tracedecay-global-db/hotpath,tracedecay-global-db/test-helpers

--- a/crates/tracedecay-global-db/Cargo.toml
+++ b/crates/tracedecay-global-db/Cargo.toml
@@ -125,5 +125,11 @@ name = "lcm_expansion"
 harness = false
 required-features = ["test-helpers"]
 
+# Exercises this crate's existing `#[hotpath::measure]` labels in both
+# feature modes; needs the registered-store harness, never `default`.
+[[test]]
+name = "hotpath_coverage"
+required-features = ["test-helpers"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tracedecay_observation_fault_harness)"] }

--- a/crates/tracedecay-global-db/tests/hotpath_coverage.rs
+++ b/crates/tracedecay-global-db/tests/hotpath_coverage.rs
@@ -1,0 +1,147 @@
+//! Coverage for this crate's existing `#[hotpath::measure]` hot paths in
+//! both feature modes.
+//!
+//! With `--features hotpath` the test wraps one registered-store workload in
+//! a `HotpathGuard` that writes a JSON report to a temp file, then asserts
+//! the report carries the measure labels the workload crossed — proving the
+//! instrumentation fires rather than compiling to an empty report. Because
+//! this crate's `hotpath` feature forwards to its storage dependencies, the
+//! same report must also carry a `tracedecay-rusqlite-runtime` label,
+//! pinning the cross-crate feature wiring. With the feature off the
+//! identical workload runs with every macro expanded to a no-op.
+//!
+//! Exactly one `#[test]` lives in this binary on purpose: hotpath permits
+//! one live guard per process, and `cargo test` runs a binary's tests
+//! concurrently on shared process state.
+
+use tracedecay_global_db::tests::harness::RegisteredGlobalDbTestRuntime;
+use tracedecay_store::SessionRecord;
+
+const PROVIDER: &str = "claude";
+const SESSION: &str = "hotpath-coverage";
+
+fn session_record() -> SessionRecord {
+    SessionRecord {
+        provider: PROVIDER.to_owned(),
+        session_id: SESSION.to_owned(),
+        project_key: "/project".to_owned(),
+        project_path: "/project".to_owned(),
+        title: None,
+        started_at: None,
+        ended_at: None,
+        transcript_path: Some(format!("/tmp/{SESSION}.jsonl")),
+        metadata_json: None,
+        parent_session_id: None,
+        is_subagent: false,
+        agent_id: None,
+        parent_tool_use_id: None,
+    }
+}
+
+/// Drives the measured registered-store hot paths once: profile open
+/// (admission and schema convergence), a committed write transaction, and a
+/// session-activity read, mirroring the `session_activity_reads` bench.
+fn exercise_measured_hot_paths() {
+    let tokio = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build coverage runtime");
+    let profile = tempfile::tempdir().expect("temporary coverage profile");
+    tokio.block_on(async {
+        let runtime = RegisteredGlobalDbTestRuntime::profile(profile.path())
+            .await
+            .expect("open registered-store coverage fixture");
+        let database = runtime.profile_database();
+        assert!(database.upsert_session(&session_record()).await);
+        let transaction = database
+            .begin_write_transaction()
+            .await
+            .expect("begin coverage transaction");
+        transaction
+            .execute_batch(&format!(
+                "INSERT INTO session_messages(
+                     provider, message_id, session_id, role, timestamp, ordinal, text,
+                     kind, model, tool_names, source_path, source_offset, metadata_json
+                 )
+                 VALUES
+                     ('{PROVIDER}', 'message-000000', '{SESSION}', 'assistant', 1, 1,
+                      'payload', 'activity', NULL, 'tool', NULL, NULL, NULL),
+                     ('{PROVIDER}', 'message-000001', '{SESSION}', 'assistant', 2, 2,
+                      'payload', 'activity', NULL, 'tool', NULL, NULL, NULL);"
+            ))
+            .await
+            .expect("seed coverage session activity");
+        transaction.commit().await.expect("commit coverage rows");
+        let rows = database
+            .session_messages_after(PROVIDER, SESSION, 0, 16)
+            .await
+            .expect("read coverage session activity");
+        assert_eq!(rows.len(), 2);
+    });
+}
+
+/// Measure labels the workload above must have crossed. Each label already
+/// exists in `src/` (or, for the `rusqlite_runtime.` entry, in the storage
+/// dependency this crate's `hotpath` feature forwards to); this test adds no
+/// instrumentation of its own.
+#[cfg(feature = "hotpath")]
+const EXPECTED_MEASURE_LABELS: &[&str] = &[
+    "global_db.registered.admit",
+    "global_db.schema.persist.install",
+    "global_db.registered.txn.begin",
+    "global_db.registered.txn.commit",
+    "global_db.registered_sessions.after",
+    "rusqlite_runtime.exact_sql.execute_query",
+];
+
+#[cfg(feature = "hotpath")]
+#[test]
+fn measured_hot_paths_emit_a_hotpath_report() {
+    // Guard construction binds a localhost metrics server unless disabled.
+    // Tests must not open sockets, and parallel test processes would race on
+    // the port. SAFETY: this binary holds exactly one test, so nothing else
+    // reads or writes the environment concurrently — the same ordering the
+    // `tracedecay-index-bench` entrypoint relies on.
+    if std::env::var_os("HOTPATH_METRICS_SERVER_OFF").is_none() {
+        unsafe {
+            std::env::set_var("HOTPATH_METRICS_SERVER_OFF", "1");
+        }
+    }
+    let report_dir = tempfile::tempdir().expect("create hotpath report directory");
+    let report_path = report_dir.path().join("hotpath-coverage.json");
+    // The default report keeps only the top functions by share of runtime;
+    // cheap-but-covered measures must not fall off the end of the table.
+    let guard = hotpath::HotpathGuardBuilder::new("global-db-hotpath-coverage")
+        .format(hotpath::Format::Json)
+        .output_path(&report_path)
+        .functions_limit(512)
+        .build();
+
+    exercise_measured_hot_paths();
+
+    // The report is written when the guard drops; it must observe the whole
+    // workload above.
+    drop(guard);
+
+    let report = std::fs::read_to_string(&report_path).expect("read hotpath JSON report");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&report).expect("hotpath report is valid JSON");
+    assert!(
+        parsed.is_object(),
+        "hotpath report should be a JSON object, got: {parsed}"
+    );
+    for label in EXPECTED_MEASURE_LABELS {
+        assert!(
+            report.contains(label),
+            "hotpath report is missing measure label {label:?}; report: {report}"
+        );
+    }
+}
+
+#[cfg(not(feature = "hotpath"))]
+#[test]
+fn measured_hot_paths_run_with_the_feature_off() {
+    // Every `#[hotpath::measure]` in the crate expands to a no-op here; the
+    // workload succeeding is the proof the instrumentation stays inert.
+    exercise_measured_hot_paths();
+}

--- a/crates/tracedecay-rusqlite-runtime/tests/hotpath_coverage.rs
+++ b/crates/tracedecay-rusqlite-runtime/tests/hotpath_coverage.rs
@@ -1,0 +1,151 @@
+//! Coverage for this crate's existing `#[hotpath::measure]` hot paths in
+//! both feature modes.
+//!
+//! With `--features hotpath` the test wraps one writer/ledger/reader
+//! workload in a `HotpathGuard` that writes a JSON report to a temp file,
+//! then asserts the report carries the measure labels the workload crossed —
+//! proving the instrumentation fires rather than compiling to an empty
+//! report. With the feature off the identical workload runs with every
+//! macro expanded to a no-op.
+//!
+//! Exactly one `#[test]` lives in this binary on purpose: hotpath permits
+//! one live guard per process, and `cargo test` runs a binary's tests
+//! concurrently on shared process state.
+
+#[path = "../../../tests/storage_runtime_rusqlite_suite/runtime_test_support.rs"]
+mod runtime_test_support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracedecay_rusqlite_runtime::reader::ReaderPool;
+use tracedecay_store::{AdmissionConfigV1, RuntimeSubmitOutcomeV1};
+
+use runtime_test_support::{
+    CountExecutor, Probe, TestDatabase, outbox_request, read_request, reader_locator,
+    reader_runtime_fixture, run, writer, writer_runtime_fixture,
+};
+
+/// Drives the measured writer, ledger, and reader hot paths once.
+///
+/// The workload mirrors the acceptance suites: an authorized submit lands in
+/// the transactional outbox and commits (`rusqlite_runtime.writer.*`,
+/// `rusqlite.ledger.*`), then a reader pool lane pins a snapshot and serves
+/// a read (`rusqlite_runtime.reader.acquire_lane`).
+fn exercise_measured_hot_paths() {
+    let fixture = writer_runtime_fixture();
+    let database = TestDatabase::new("hotpath-coverage-writer.sqlite3");
+    let request = outbox_request(
+        &fixture.origin_binding,
+        &fixture.target_binding,
+        "operation.hotpath.coverage",
+        fixture.effect_id,
+        fixture.ordering_key,
+    );
+    let writer = Arc::new(writer(&database, &fixture.origin_binding));
+    let outcome = run({
+        let writer = Arc::clone(&writer);
+        let probe = Probe::for_submit(&request);
+        async move { writer.submit(request, probe).await }
+    })
+    .expect("execute coverage submit");
+    assert!(
+        matches!(outcome, RuntimeSubmitOutcomeV1::Committed { .. }),
+        "expected committed coverage submit, got {outcome:?}"
+    );
+    Arc::try_unwrap(writer)
+        .unwrap_or_else(|_| panic!("coverage submit retained the writer"))
+        .shutdown_and_join()
+        .expect("close coverage writer");
+
+    let reader_fixture = reader_runtime_fixture();
+    let reader_database = TestDatabase::new("hotpath-coverage-reader.sqlite3");
+    reader_database
+        .connect()
+        .execute_batch(
+            "PRAGMA journal_mode=WAL;
+             CREATE TABLE acceptance_rows(value INTEGER NOT NULL);
+             INSERT INTO acceptance_rows(value) VALUES (1);",
+        )
+        .expect("seed coverage reader authority");
+    let pool = ReaderPool::start(
+        reader_locator(&reader_fixture.binding, &reader_database.path),
+        AdmissionConfigV1::default().readers,
+        CountExecutor,
+    )
+    .expect("start coverage reader pool");
+    let request = read_request(&reader_fixture.binding, "foreground");
+    let probe = Probe::for_read(&request);
+    let mut reader = pool
+        .acquire(&request, &probe, Duration::ZERO)
+        .expect("acquire coverage reader lane");
+    let mut snapshot = reader.begin_snapshot().expect("begin coverage snapshot");
+    snapshot
+        .execute(request, &probe)
+        .expect("execute coverage snapshot read");
+}
+
+/// Measure labels the workload above must have crossed. Each label already
+/// exists in `src/`; this test adds no instrumentation of its own.
+#[cfg(feature = "hotpath")]
+const EXPECTED_MEASURE_LABELS: &[&str] = &[
+    "rusqlite_runtime.writer.submit_authorized",
+    "rusqlite_runtime.writer.transaction_batch",
+    "rusqlite_runtime.writer.execution_batch",
+    "rusqlite.ledger.outbox_insert",
+    "rusqlite.ledger.record_commit",
+    "rusqlite.ledger.idempotency_lookup",
+    "rusqlite_runtime.reader.acquire_lane",
+];
+
+#[cfg(feature = "hotpath")]
+#[test]
+fn measured_hot_paths_emit_a_hotpath_report() {
+    // Guard construction binds a localhost metrics server unless disabled.
+    // Tests must not open sockets, and parallel test processes would race on
+    // the port. SAFETY: this binary holds exactly one test, so nothing else
+    // reads or writes the environment concurrently — the same ordering the
+    // `tracedecay-index-bench` entrypoint relies on.
+    if std::env::var_os("HOTPATH_METRICS_SERVER_OFF").is_none() {
+        unsafe {
+            std::env::set_var("HOTPATH_METRICS_SERVER_OFF", "1");
+        }
+    }
+    let report_dir = tempfile::tempdir().expect("create hotpath report directory");
+    let report_path = report_dir.path().join("hotpath-coverage.json");
+    // The default report keeps only the top functions by share of runtime;
+    // cheap-but-covered measures must not fall off the end of the table.
+    let guard = hotpath::HotpathGuardBuilder::new("rusqlite-runtime-hotpath-coverage")
+        .format(hotpath::Format::Json)
+        .output_path(&report_path)
+        .functions_limit(512)
+        .build();
+
+    exercise_measured_hot_paths();
+
+    // The report is written when the guard drops; it must observe the whole
+    // workload above.
+    drop(guard);
+
+    let report = std::fs::read_to_string(&report_path).expect("read hotpath JSON report");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&report).expect("hotpath report is valid JSON");
+    assert!(
+        parsed.is_object(),
+        "hotpath report should be a JSON object, got: {parsed}"
+    );
+    for label in EXPECTED_MEASURE_LABELS {
+        assert!(
+            report.contains(label),
+            "hotpath report is missing measure label {label:?}; report: {report}"
+        );
+    }
+}
+
+#[cfg(not(feature = "hotpath"))]
+#[test]
+fn measured_hot_paths_run_with_the_feature_off() {
+    // Every `#[hotpath::measure]` in the crate expands to a no-op here; the
+    // workload succeeding is the proof the instrumentation stays inert.
+    exercise_measured_hot_paths();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

Coverage-only PR for the hotpath instrumentation that already exists in two crates. **No `#[hotpath::measure]` attributes were added, renamed, restamped, or edited anywhere**, and no other crate is touched.

- `crates/tracedecay-rusqlite-runtime/tests/hotpath_coverage.rs` — drives one writer/ledger/reader workload (authorized outbox submit + commit, reader-pool lane acquisition + pinned snapshot read) through the crate's existing measures. With `--features hotpath` it wraps the workload in a `HotpathGuard` writing a JSON report to a temp file and asserts the report carries the crossed labels (`rusqlite_runtime.writer.submit_authorized`, `rusqlite_runtime.writer.transaction_batch`, `rusqlite_runtime.writer.execution_batch`, `rusqlite.ledger.outbox_insert`, `rusqlite.ledger.record_commit`, `rusqlite.ledger.idempotency_lookup`, `rusqlite_runtime.reader.acquire_lane`) — proving the measures fire, not just that an empty report exists. With the feature off, the identical workload runs with every macro expanded to a no-op.
- `crates/tracedecay-global-db/tests/hotpath_coverage.rs` — same shape over the registered store: profile open (admission + schema install), a committed write transaction, and a session-activity read, mirroring the `session_activity_reads` bench workload. Asserts `global_db.registered.admit`, `global_db.schema.persist.install`, `global_db.registered.txn.begin`, `global_db.registered.txn.commit`, `global_db.registered_sessions.after`, and — pinning the cross-crate feature forwarding — `rusqlite_runtime.exact_sql.execute_query`.
- `crates/tracedecay-global-db/Cargo.toml` — one additive `[[test]]` entry (`required-features = ["test-helpers"]`, the harness gate; never `default`).
- `.github/workflows/hotpath-coverage.yml` — one small job with two lanes over the same two crates: tests with the feature off and with `--features hotpath`. `HOTPATH_METRICS_SERVER_OFF=1` at the job boundary (the tests also disable the server themselves before building a guard), kache kept as `RUSTC_WRAPPER`. `.github/workflows/hotpath-profile.yml` (index-bench / tracedecay-query) is untouched.

Each coverage test binary holds exactly one `#[test]` because hotpath permits one live guard per process and `cargo test` runs a binary's tests concurrently.

## hotpath stays opt-in

- Nothing moves `hotpath` into `default` or `production`; the workspace pin (`hotpath` 0.24, `default-features = false`, `features = ["threads"]`) is unchanged.
- The report-asserting halves of the tests are `#[cfg(feature = "hotpath")]`; the feature-off halves prove the macros stay no-ops.
- The metrics HTTP server is off in tests and CI.

## Verification

- `cargo test -p tracedecay-rusqlite-runtime -p tracedecay-global-db --locked --features tracedecay-global-db/test-helpers` — passes (feature off).
- `cargo test -p tracedecay-rusqlite-runtime -p tracedecay-global-db --locked --features tracedecay-rusqlite-runtime/hotpath,tracedecay-global-db/hotpath,tracedecay-global-db/test-helpers` — passes; the coverage tests verified non-empty JSON reports containing the labels above.

## Stacking

Stacked on #707 (`codex/tracedecay-total-redesign-plan-reopened`), which is this PR's base. **Do not merge this into master until #707 is merged**, and do not merge #707 on account of this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4ebc38a-74cc-47bd-aa44-45ddff51105a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4ebc38a-74cc-47bd-aa44-45ddff51105a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

