### PR TITLE
fix: green the release drift guard and install the PR autotrack port

### DIFF
--- a/crates/tracedecay/src/config.rs
+++ b/crates/tracedecay/src/config.rs
@@ -993,6 +993,27 @@ impl tracedecay_configuration::config::RuntimeConfigurationAuthorityPort
     }
 }
 
+/// Dashboard read port over the daemon's PR-autotrack state sidecar.
+struct DaemonPrAutoTrackReadPort;
+
+impl tracedecay_dashboard_api::DashboardPrAutoTrackReadPort for DaemonPrAutoTrackReadPort {
+    fn managed_summary(
+        &self,
+        store_root: &Path,
+    ) -> Vec<tracedecay_dashboard_api::DashboardPrAutoTrackEntryV1> {
+        crate::daemon::pr_autotrack::managed_summary(store_root)
+            .into_iter()
+            .map(
+                |entry| tracedecay_dashboard_api::DashboardPrAutoTrackEntryV1 {
+                    branch: entry.branch,
+                    pr: entry.pr,
+                    head_branch: entry.head_branch,
+                },
+            )
+            .collect()
+    }
+}
+
 pub(crate) fn install_usecase_runtime_configuration_authority() -> Result<()> {
     static INSTALLATION: LazyLock<std::result::Result<(), String>> = LazyLock::new(|| {
         tracedecay_configuration::config::install_runtime_configuration_authority(Arc::new(
@@ -1003,7 +1024,11 @@ pub(crate) fn install_usecase_runtime_configuration_authority() -> Result<()> {
             RootPinnedRuntimeConfigurationCache,
         ))
         .map_err(|error| error.to_string())?;
-        install_dashboard_configuration_read_port().map_err(|error| error.to_string())
+        install_dashboard_configuration_read_port().map_err(|error| error.to_string())?;
+        tracedecay_dashboard_api::install_dashboard_pr_autotrack_read_port(Arc::new(
+            DaemonPrAutoTrackReadPort,
+        ))
+        .map_err(|_| "dashboard PR autotrack read port was already installed".to_string())
     });
     INSTALLATION
         .as_ref()

--- a/tests/release_safety_test.sh
+++ b/tests/release_safety_test.sh
@@ -158,7 +158,8 @@ for path, text in ((stable_path, stable), (beta_path, beta)):
     release_test = re.search(
         r"- name: Test release distribution\n"
         r"\s+if: matrix\.name == 'x86_64-linux'\n"
-        r"\s+run: cargo test --workspace --release --target",
+        r"\s+run: (?:(?!- name:)[\s\S])*?"
+        r"cargo test --workspace --release --target",
         text,
     )
     if release_test is None:


### PR DESCRIPTION
Two fixes surfaced by the ponytail audit (#906).

## Release Version Drift CI job (red on every 707 run)

`tests/release_safety_test.sh` required `Test release distribution` to start with `run: cargo test --workspace --release --target`. The release workflows now run the hotpath helper build and the search-eval controlled workload first in the same multi-line step, with the workspace release test last. The guard now matches the cargo test command anywhere inside that step and still fails if the line is removed (checked).

## Dashboard PR-autotrack payload always empty

`settings_api::pr_autotrack_payload` reads `PR_AUTOTRACK_READ_PORT`, but nothing ever installed it, so the dashboard reported zero tracked PR branches regardless of daemon state. The daemon now installs an adapter over `pr_autotrack::managed_summary` next to the other root-owned dashboard ports.

## Verified

- `bash tests/release_safety_test.sh`, `release_drift_check_test.sh`, `install_script_test.sh`: pass locally
- `cargo check -p tracedecay --tests`: clean
- `cargo test -p tracedecay --features test-helpers --test daemon_suite pr_autotrack` and clippy on the root crate: see CI / PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
