### PR TITLE
fix(ci): ship Windows evaluator bins to nextest shards

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,10 @@ slow-timeout = { period = "10s", terminate-after = 36 }
 final-status-level = "slow"
 archive.include = [
     { path = "controlled-workload-hotpath", relative-to = "target", depth = 1, on-missing = "warn" },
+    # Windows archive only. `--extract-to` restores these beside the test
+    # profile so `search_eval_bin` finds them without env overrides.
+    { path = "debug/tracedecay-search-eval.exe", relative-to = "target", on-missing = "warn" },
+    { path = "debug/tracedecay-search-eval-direct.exe", relative-to = "target", on-missing = "warn" },
 ]
 
 [profile.ci.junit]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,16 @@ jobs:
       # second, feature-on resolution of the search-eval dependency graph
       # inside this job's bound (18 of its 62 minutes before it was cancelled),
       # and the parity property does not depend on the platform.
+      #
+      # Search-eval ships two binaries and has no test target, so
+      # `cargo nextest archive` never links them. Build with the same locked
+      # workspace/feature resolution as the archive; nextest `archive.include`
+      # then ships the `.exe` files to every shard via `--extract-to`.
+      # A `-p tracedecay-search-eval` build drops code-index language tiers.
+      - name: Build workspace binaries for the Windows test archive
+        shell: pwsh
+        run: cargo build --workspace --bins --locked --features tracedecay/test-helpers
+
       - name: Build nextest archive
         shell: pwsh
         run: cargo nextest archive --workspace --profile ci --locked --features tracedecay/test-helpers --timings --archive-file "$env:RUNNER_TEMP/nextest-archive.tar.zst"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes [#924](https://github.com/ScriptedAlchemy/tracedecay/issues/924): Windows nextest shards could not find `tracedecay-search-eval.exe` / `tracedecay-search-eval-direct.exe`.
- One distribution path: nextest `archive.include`. `--extract-to` restores the binaries into `target/debug/`, which is where `search_eval_bin` already looks.
- Archive host still runs `cargo build --workspace --bins --locked --features tracedecay/test-helpers` so those `.exe` files exist to include. A `-p tracedecay-search-eval` build is not equivalent (drops bundled Rust grammars).

## Motivation

Baseline [run 34039753429](https://github.com/ScriptedAlchemy/tracedecay/actions/runs/34039753429) failed the same five product tests on shards 2–5 because a nextest archive is not proof that subprocess executables are present.

This is CI/packaging only. Targets `codex/tracedecay-total-redesign-plan-reopened` (PR #707). Does not undraft or merge #707.

## Changes

- `.config/nextest.toml` — include the two Windows evaluator executables (`on-missing = "warn"`, same as the existing extra-file entry).
- `.github/workflows/ci.yml` — build workspace bins with the archive's locked features before `cargo nextest archive`.

Shrunk after review: removed the separate support artifact, env overrides, preflight, and Python packager/contract scripts.

## Test plan

- [x] Net diff is 14 lines in 2 files against current #707 tip
- [ ] Windows archive includes both `.exe` files
- [ ] Shards restore them under `target/debug/` via `--extract-to`
- [ ] Packaged validation and search-eval CLI tests no longer fail as missing-helper panics

## Checklist

- [x] No secrets, credentials, or `.env` files included
- [x] CI/workflow + packaging only
- [x] References #924
- [x] Does not undraft/merge #707

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2229c614-54ec-4835-8958-b6ebe0c824b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2229c614-54ec-4835-8958-b6ebe0c824b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

