### PR TITLE
fix(code-index): preserve text freshness and refuse graph pressure (#917)

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler.rs
@@ -5260,6 +5260,23 @@ impl CodeIndexSchedulerErrorV1 {
         }
     }
 
+    /// The typed interruption a reconcile pass stopped on, when it did.
+    ///
+    /// An interrupted pass is not a failed pass: the epoch that cancelled it
+    /// was advanced by an observed source change (or shutdown) whose caller
+    /// also posted the wake that re-runs the pass, so the worker attributes
+    /// it as superseded instead of reporting the served generation stale.
+    pub fn reconcile_interruption(
+        &self,
+    ) -> Option<crate::code_index::production::CodeIndexInterruptionV1> {
+        match self {
+            Self::Production(CodeIndexProductionErrorV1::Interrupted(interruption)) => {
+                Some(*interruption)
+            }
+            _ => None,
+        }
+    }
+
     pub fn is_graph_activation_refusal(&self) -> bool {
         matches!(self, Self::GraphActivationRefused(_))
             || matches!(

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler.rs
@@ -5387,7 +5387,7 @@ impl CodeIndexSchedulerErrorV1 {
             || matches!(
                 self,
                 Self::GraphProjection(CodeGraphProjectionError::BudgetExhausted { budget, .. })
-                    if budget == "resident_memory"
+                    if budget == tracedecay_graph_db::GraphBudgetKind::ResidentMemory.as_str()
             )
     }
 

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/graph_activation.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/graph_activation.rs
@@ -248,6 +248,22 @@ fn take_injected_activation_gate(
         .remove(worktree_id.as_str())
 }
 
+/// The typed reason a generation reports while its native graph is refused by
+/// the measured-RSS admission watermark. Shared by the persistent publication
+/// path and the injected test refusal so status and tests name one verdict.
+pub(crate) const RESIDENT_MEMORY_GRAPH_REFUSAL_REASON: &str =
+    "code graph activation was refused by the resident-memory policy";
+
+/// Whether a projection error is the resident-memory budget refusal that
+/// [`CodeIndexSchedulerErrorV1::is_graph_activation_refusal`] recognizes.
+pub(crate) fn is_resident_memory_refusal(error: &CodeGraphProjectionError) -> bool {
+    matches!(
+        error,
+        CodeGraphProjectionError::BudgetExhausted { budget, .. }
+            if budget == tracedecay_graph_db::GraphBudgetKind::ResidentMemory.as_str()
+    )
+}
+
 #[derive(Clone)]
 pub enum CodeGraphActivationAuthorityV1 {
     Persistent {
@@ -451,12 +467,12 @@ impl CodeGraphActivationAuthorityV1 {
                     ));
                 }
                 if has_injected_resident_memory_refusal(worktree_id) {
-                    latest.refuse_graph_activation(
-                        "code graph activation was refused by the resident-memory policy",
-                    );
+                    latest.refuse_graph_activation(RESIDENT_MEMORY_GRAPH_REFUSAL_REASON);
                     return Err(CodeIndexSchedulerErrorV1::GraphProjection(
                         CodeGraphProjectionError::BudgetExhausted {
-                            budget: "resident_memory".to_owned(),
+                            budget: tracedecay_graph_db::GraphBudgetKind::ResidentMemory
+                                .as_str()
+                                .to_owned(),
                             limit:
                                 tracedecay_runtime_core::resident_memory::detected_process_resident_memory_limit_v1()
                                     .get(),
@@ -671,6 +687,17 @@ impl LatestCompleteCodeIndexV1 {
             retained
                 .publish_verified_snapshot(&self.generation, Arc::clone(&cancellation))
                 .map_err(CodeGraphProjectionError::from)
+                .map_err(|error| {
+                    // The publication stopped at the measured-RSS watermark.
+                    // Record the typed refusal before the error reaches the
+                    // scheduler so status reports `refused` with its reason
+                    // instead of a `pending` graph that will never seat;
+                    // exact and lexical serving stay installed.
+                    if is_resident_memory_refusal(&error) {
+                        self.refuse_graph_activation(RESIDENT_MEMORY_GRAPH_REFUSAL_REASON);
+                    }
+                    error
+                })
         )?;
         let store = Arc::new(CodeGraphProjectionStore::from_verified_snapshot(
             snapshot,

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/graph_activation.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/graph_activation.rs
@@ -687,16 +687,15 @@ impl LatestCompleteCodeIndexV1 {
             retained
                 .publish_verified_snapshot(&self.generation, Arc::clone(&cancellation))
                 .map_err(CodeGraphProjectionError::from)
-                .map_err(|error| {
+                .inspect_err(|error| {
                     // The publication stopped at the measured-RSS watermark.
                     // Record the typed refusal before the error reaches the
                     // scheduler so status reports `refused` with its reason
                     // instead of a `pending` graph that will never seat;
                     // exact and lexical serving stay installed.
-                    if is_resident_memory_refusal(&error) {
+                    if is_resident_memory_refusal(error) {
                         self.refuse_graph_activation(RESIDENT_MEMORY_GRAPH_REFUSAL_REASON);
                     }
-                    error
                 })
         )?;
         let store = Arc::new(CodeGraphProjectionStore::from_verified_snapshot(

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/ignored_dependencies.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/ignored_dependencies.rs
@@ -77,7 +77,24 @@ pub struct CodeIndexIgnoredDependencyBuildV1 {
 }
 
 impl CodeIndexWorktreeSchedulerV1 {
+    /// Admit one verified ignored dependency entrypoint.
+    ///
+    /// This is the admission boundary: every interruption observed inside it —
+    /// including the shared source-read and snapshot-capture helpers, which
+    /// report interruptions as reconcile interruptions because the ordinary
+    /// reconcile path owns them too — surfaces to the caller as the typed
+    /// ignored-dependency refusal.
     pub fn index_verified_ignored_dependency(
+        &mut self,
+        serving: &LatestCompleteCodeIndexV1,
+        request: CodeIndexIgnoredDependencyRequestV1,
+        control: &dyn CodeIndexExecutionControlV1,
+    ) -> Result<CodeIndexIgnoredDependencyBuildV1, CodeIndexSchedulerErrorV1> {
+        self.index_verified_ignored_dependency_admission(serving, request, control)
+            .map_err(map_reconcile_interruption)
+    }
+
+    fn index_verified_ignored_dependency_admission(
         &mut self,
         serving: &LatestCompleteCodeIndexV1,
         request: CodeIndexIgnoredDependencyRequestV1,
@@ -257,7 +274,7 @@ impl CodeIndexWorktreeSchedulerV1 {
             Ok(generation) => generation,
             Err(error) => {
                 self.ignored_source_admissions = previous_roster;
-                return Err(map_production_interruption(error));
+                return Err(error.into());
             }
         };
         let generation_id = generation.manifest().generation_id.clone();
@@ -791,35 +808,59 @@ fn prove_gix_ignored(root: &Path, logical_path: &str) -> Result<(), CodeIndexSch
     }
 }
 
+/// Admission-owned checkpoint: the caller is the ignored-dependency admission
+/// itself, so an interruption is that admission's typed refusal.
 fn checkpoint(control: &dyn CodeIndexExecutionControlV1) -> Result<(), CodeIndexSchedulerErrorV1> {
+    map_reconcile_interruption_result(checkpoint_if_present(Some(control)))
+}
+
+/// Shared checkpoint for the source-read and snapshot-capture helpers.
+///
+/// These helpers run under the ordinary background reconcile as well as under
+/// an ignored-dependency admission, so an observed interruption is reported as
+/// the reconcile interruption the production pipeline itself raises. Reporting
+/// it as an ignored-dependency refusal attributed every superseded or shutdown
+/// reconcile to a dependency admission that never ran, and bypassed the
+/// superseded-reconcile retry that only recognizes the production
+/// interruption. The admission boundary maps the interruption back to its own
+/// refusal (see [`map_reconcile_interruption`]).
+pub fn checkpoint_if_present(
+    control: Option<&dyn CodeIndexExecutionControlV1>,
+) -> Result<(), CodeIndexSchedulerErrorV1> {
+    let Some(control) = control else {
+        return Ok(());
+    };
     if control.is_cancelled() {
-        Err(CodeIndexIgnoredDependencyRefusalV1::Cancelled.into())
+        Err(CodeIndexProductionErrorV1::Interrupted(CodeIndexInterruptionV1::Cancelled).into())
     } else if control.is_deadline_exceeded() {
-        Err(CodeIndexIgnoredDependencyRefusalV1::DeadlineExceeded.into())
+        Err(
+            CodeIndexProductionErrorV1::Interrupted(CodeIndexInterruptionV1::DeadlineExceeded)
+                .into(),
+        )
     } else {
         Ok(())
     }
 }
 
-pub fn checkpoint_if_present(
-    control: Option<&dyn CodeIndexExecutionControlV1>,
-) -> Result<(), CodeIndexSchedulerErrorV1> {
-    match control {
-        Some(control) => checkpoint(control),
-        None => Ok(()),
+/// Re-attribute a reconcile interruption observed under an ignored-dependency
+/// admission to that admission's typed refusal. Every other error passes
+/// through unchanged.
+fn map_reconcile_interruption(error: CodeIndexSchedulerErrorV1) -> CodeIndexSchedulerErrorV1 {
+    match error {
+        CodeIndexSchedulerErrorV1::Production(CodeIndexProductionErrorV1::Interrupted(
+            CodeIndexInterruptionV1::Cancelled,
+        )) => CodeIndexIgnoredDependencyRefusalV1::Cancelled.into(),
+        CodeIndexSchedulerErrorV1::Production(CodeIndexProductionErrorV1::Interrupted(
+            CodeIndexInterruptionV1::DeadlineExceeded,
+        )) => CodeIndexIgnoredDependencyRefusalV1::DeadlineExceeded.into(),
+        other => other,
     }
 }
 
-fn map_production_interruption(error: CodeIndexProductionErrorV1) -> CodeIndexSchedulerErrorV1 {
-    match error {
-        CodeIndexProductionErrorV1::Interrupted(CodeIndexInterruptionV1::Cancelled) => {
-            CodeIndexIgnoredDependencyRefusalV1::Cancelled.into()
-        }
-        CodeIndexProductionErrorV1::Interrupted(CodeIndexInterruptionV1::DeadlineExceeded) => {
-            CodeIndexIgnoredDependencyRefusalV1::DeadlineExceeded.into()
-        }
-        other => other.into(),
-    }
+fn map_reconcile_interruption_result<T>(
+    result: Result<T, CodeIndexSchedulerErrorV1>,
+) -> Result<T, CodeIndexSchedulerErrorV1> {
+    result.map_err(map_reconcile_interruption)
 }
 
 fn publication_evidence(

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/ignored_dependencies_tests/cancellation_tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/ignored_dependencies_tests/cancellation_tests.rs
@@ -1,8 +1,25 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use tracedecay_code_index::production::CodeIndexExecutionControlV1;
+use tracedecay_code_index::production::{
+    CodeIndexExecutionControlV1, CodeIndexInterruptionV1, CodeIndexProductionErrorV1,
+};
 
-use super::{CodeIndexIgnoredDependencyRefusalV1, GitFixture, assert_refusal};
+use super::{CodeIndexSchedulerErrorV1, GitFixture};
+
+/// The shared source readers run under the ordinary reconcile as well as under
+/// an ignored-dependency admission, so they report the reconcile interruption;
+/// only the admission boundary re-attributes it to the dependency refusal.
+fn assert_interrupted(error: CodeIndexSchedulerErrorV1, expected: CodeIndexInterruptionV1) {
+    assert!(
+        matches!(
+            &error,
+            CodeIndexSchedulerErrorV1::Production(CodeIndexProductionErrorV1::Interrupted(
+                interruption
+            )) if interruption == &expected
+        ),
+        "unexpected reconcile interruption: {error:?}"
+    );
+}
 
 struct CancelAfterChecks {
     checks: AtomicUsize,
@@ -49,7 +66,7 @@ fn admitted_source_read_observes_live_cancellation_between_chunks() {
     )
     .expect_err("live cancellation must interrupt a multi-chunk admitted-source read");
 
-    assert_refusal(error, CodeIndexIgnoredDependencyRefusalV1::Cancelled);
+    assert_interrupted(error, CodeIndexInterruptionV1::Cancelled);
     assert_eq!(control.checks.load(Ordering::Acquire), 5);
 }
 
@@ -71,6 +88,6 @@ fn ordinary_snapshot_read_observes_live_cancellation_between_chunks() {
     )
     .expect_err("live cancellation must interrupt a multi-chunk ordinary-source read");
 
-    assert_refusal(error, CodeIndexIgnoredDependencyRefusalV1::Cancelled);
+    assert_interrupted(error, CodeIndexInterruptionV1::Cancelled);
     assert_eq!(control.checks.load(Ordering::Acquire), 2);
 }

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/reconcile_panic_guard.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/reconcile_panic_guard.rs
@@ -361,6 +361,10 @@ pub enum ReconcileFaultKindV1 {
     /// is shaped like a capacity refusal and is not one: no release by any
     /// other holder can ever admit it.
     OversizedCapacity,
+    /// A source observation superseded the active reconcile.
+    Cancelled,
+    /// The active reconcile exhausted its own deadline.
+    DeadlineExceeded,
     /// A refusal the same input reproduces forever.
     Permanent,
 }
@@ -422,6 +426,18 @@ impl ReconcileFaultInjectionV1 {
                     },
                 ))
             }
+            ReconcileFaultKindV1::Cancelled => Err(
+                crate::code_index::production::CodeIndexProductionErrorV1::Interrupted(
+                    crate::code_index::production::CodeIndexInterruptionV1::Cancelled,
+                )
+                .into(),
+            ),
+            ReconcileFaultKindV1::DeadlineExceeded => Err(
+                crate::code_index::production::CodeIndexProductionErrorV1::Interrupted(
+                    crate::code_index::production::CodeIndexInterruptionV1::DeadlineExceeded,
+                )
+                .into(),
+            ),
             ReconcileFaultKindV1::Permanent => Err(super::CodeIndexSchedulerErrorV1::Identity(
                 "injected permanent reconcile refusal".to_owned(),
             )),

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -20,7 +20,7 @@ use std::{
 #[cfg(test)]
 use std::sync::Condvar;
 
-use tracedecay_code_index::production::CodeIndexPublishedGenerationV1;
+use tracedecay_code_index::production::{CodeIndexInterruptionV1, CodeIndexPublishedGenerationV1};
 use tracedecay_dashboard_api::code_index_freshness_api::{
     CodeGraphServingReadinessV1, CodeIndexConvergenceParkedV1,
 };
@@ -3101,6 +3101,11 @@ impl CodeIndexSchedulerRegistryV1 {
                 if worker_shutting_down.load(Ordering::Acquire) {
                     return;
                 }
+                // Writer wait starts when the wake is observed and ends when
+                // this pass holds every gate it needs to run; a pass that
+                // spends its budget here is blocked on a sibling holder, not
+                // on its own source work.
+                let pass_wake_observed_at = Instant::now();
                 // A quarantined or backing-off panic unit must not consume the
                 // pending arrival: the wake stays outstanding so a later
                 // eligible pass still measures its full queue wait.
@@ -3141,6 +3146,8 @@ impl CodeIndexSchedulerRegistryV1 {
                         }
                     }
                 };
+                let writer_wait_micros =
+                    u64::try_from(pass_wake_observed_at.elapsed().as_micros()).unwrap_or(u64::MAX);
                 let scheduler = Arc::clone(&worker_scheduler);
                 let graph_activation_enabled = worker_graph_activation.policy().is_enabled();
                 // A coalesced text-slice wake can outlive the graph-off pass
@@ -3382,6 +3389,28 @@ impl CodeIndexSchedulerRegistryV1 {
                     });
                 let retained_text_metadata =
                     retained_text.as_ref().map(|text| text.metadata().clone());
+                // Phase boundary: source reconciliation begins. Together with
+                // `code_index_generation_published` / `_interrupted` and
+                // `code_index_serving_generation_seated` this lets a status
+                // reader attribute a `progress: null` warming window to the
+                // uninstrumented capture+seal instead of to text or graph work.
+                tracing::info!(
+                    event = "code_index_reconcile_pass_started",
+                    path = "background_worker",
+                    trigger = trigger.label(),
+                    arrival = arrival.label(),
+                    queue_delay_micros = ?arrival
+                        .wake_micros()
+                        .map(|wake_micros| started_micros.saturating_sub(wake_micros).max(0)),
+                    writer_wait_micros,
+                    retained_text = retained_text_metadata
+                        .as_ref()
+                        .map(|metadata| metadata.manifest().generation_id.as_str()),
+                    text_serving_ready,
+                    serving_empty,
+                    graph_activation_deferred,
+                    "code-index background reconcile pass started"
+                );
                 let shutting_down = Arc::clone(&worker_shutting_down);
                 let source_result = hotpath::future!(
                     tokio::task::spawn_blocking(move || {
@@ -3600,6 +3629,19 @@ impl CodeIndexSchedulerRegistryV1 {
                                              contract violation before graph seating; status \
                                              reports it typed and every wake re-checks"
                                         );
+                                    } else if matches!(
+                                        &error,
+                                        tracedecay_query::retrieval::RetrievalPortError::Cancelled
+                                    ) && worker_shutting_down.load(Ordering::Acquire)
+                                    {
+                                        // Shutdown retired the text control mid-slice.
+                                        // The slice stops typed; nothing failed.
+                                        tracing::info!(
+                                            event = "code_index_text_projection_interrupted",
+                                            origin = "shutdown",
+                                            "published text projection stopped before graph seating"
+                                        );
+                                        return;
                                     } else {
                                         tracing::warn!(
                                             event = "code_index_text_projection_failed",
@@ -4239,7 +4281,13 @@ impl CodeIndexSchedulerRegistryV1 {
                                 .as_str()
                                 .to_owned();
                             match outcome {
-                                ServingSwapOutcomeV1::Seated => tracing::debug!(
+                                // Graph seating is the last strict-readiness
+                                // boundary after text publication, so it is
+                                // `info` like `code_index_generation_published`:
+                                // a dogfood or operator log must be able to
+                                // tell "text current, graph pending" from
+                                // "graph seated" without a debug filter.
+                                ServingSwapOutcomeV1::Seated => tracing::info!(
                                     event = "code_index_serving_generation_seated",
                                     generation_id,
                                     "the sealed generation now serves"
@@ -4303,6 +4351,33 @@ impl CodeIndexSchedulerRegistryV1 {
                 } else {
                     // Surface bounded non-terminal failure without new project-path data.
                     match &result {
+                        Ok((Err(error), _, _)) if error.reconcile_interruption().is_some() => {
+                            // An interrupted pass ran to a typed stop, not a
+                            // failure: shutdown, or a newer source observation
+                            // advanced the cancellation epoch. Every epoch
+                            // advance is paired with a wake, so the restored
+                            // arrival below is picked up by the pass that
+                            // observation already scheduled. Attribute the
+                            // origin instead of reporting the served
+                            // generation stale.
+                            panic_guard.record_progress();
+                            capacity_retry.record_progress();
+                            let origin = if worker_shutting_down.load(Ordering::Acquire) {
+                                "shutdown"
+                            } else {
+                                match error.reconcile_interruption() {
+                                    Some(CodeIndexInterruptionV1::DeadlineExceeded) => "deadline",
+                                    _ => "superseded_by_source_observation",
+                                }
+                            };
+                            tracing::info!(
+                                event = "code_index_reconcile_interrupted",
+                                path = "background_worker",
+                                origin,
+                                trigger = trigger.label(),
+                                "code-index background reconcile was interrupted; the pending wake re-runs it"
+                            );
+                        }
                         Ok((Err(error), _, _)) => {
                             // The pass completed; whatever refused it was not an
                             // unwind, so panic accounting restarts.
@@ -4312,6 +4387,7 @@ impl CodeIndexSchedulerRegistryV1 {
                                 event = "code_index_reconcile_failed",
                                 path = "background_worker",
                                 transient_capacity,
+                                trigger = trigger.label(),
                                 error = %error,
                                 "code-index background reconcile failed; the served generation stays stale"
                             );

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -1449,6 +1449,24 @@ impl CodeIndexSchedulerRegistryV1 {
             .is_some_and(|reconcile_in_progress| reconcile_in_progress.load(Ordering::Acquire) != 0)
     }
 
+    /// Test-only: hold an exact mounted worktree's owner-pass authority, as
+    /// the worker does from claiming a wake through text projection and graph
+    /// seating, without holding the scheduler mutex.
+    #[cfg(test)]
+    pub async fn hold_reconcile_pass_for_test(
+        &self,
+        project_root: &Path,
+    ) -> Option<super::ReconcilePassGuard> {
+        let project_root = project_root.canonicalize().ok()?;
+        let reconcile_in_progress = self
+            .mounted
+            .lock()
+            .await
+            .get(&project_root)
+            .map(|worktree| Arc::clone(&worktree.reconcile_in_progress))?;
+        Some(super::ReconcilePassGuard::enter(&reconcile_in_progress))
+    }
+
     /// Serving slot only — no Git open, no freshness ladder, no wake.
     #[cfg(test)]
     pub async fn latest_complete_serving_for_test(
@@ -6141,11 +6159,26 @@ impl CodeIndexSchedulerRegistryV1 {
                 .filter(|latest| {
                     latest.text_serving_is_ready() && text_matches_scope_identity(latest, &scope)
                 })?;
-            if pending_wake.has_pending_arrival()
-                || reconcile_in_progress.load(Ordering::Acquire) != 0
-            {
-                // The existing worker owns the freshness remedy. Re-requesting
-                // here would enqueue a redundant pass behind it.
+            if pending_wake.has_pending_arrival() {
+                // A pass is already queued behind the current owner work; it
+                // re-observes the source when it starts, so it also supplies
+                // this query's remedy.
+                return Some((latest, false));
+            }
+            if reconcile_in_progress.load(Ordering::Acquire) != 0 {
+                // In-flight owner work observed the source when *it* started,
+                // which may predate the change this query is asking about:
+                // after publication the same pass still owns the text
+                // projection and optional graph seating of the previous
+                // source state. Returning stale without a wake stranded that
+                // remedy until an unrelated hint arrived (issue #917). Post the
+                // coalesced follow-up the busy-lock arm below posts, so the
+                // worker re-runs the freshness ladder once this pass ends.
+                Self::note_wake(
+                    &pending_wake,
+                    &wake,
+                    CodeIndexCadenceTriggerV1::BusyFollowUp,
+                );
                 return Some((latest, false));
             }
             let mut scheduler = match scheduler.try_lock() {

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -3127,10 +3127,10 @@ impl CodeIndexSchedulerRegistryV1 {
                 if worker_shutting_down.load(Ordering::Acquire) {
                     return;
                 }
-                // Writer wait starts when the wake is observed and ends when
-                // this pass holds every gate it needs to run; a pass that
-                // spends its budget here is blocked on a sibling holder, not
-                // on its own source work.
+                // This aggregate starts when the wake is observed and ends
+                // when the pass holds every admission/publication gate it
+                // needs. It deliberately does not attribute the span to the
+                // SQL writer alone.
                 let pass_wake_observed_at = Instant::now();
                 // A quarantined or backing-off panic unit must not consume the
                 // pending arrival: the wake stays outstanding so a later
@@ -3172,7 +3172,7 @@ impl CodeIndexSchedulerRegistryV1 {
                         }
                     }
                 };
-                let writer_wait_micros =
+                let wake_to_gates_held_micros =
                     u64::try_from(pass_wake_observed_at.elapsed().as_micros()).unwrap_or(u64::MAX);
                 let scheduler = Arc::clone(&worker_scheduler);
                 let graph_activation_enabled = worker_graph_activation.policy().is_enabled();
@@ -3428,7 +3428,7 @@ impl CodeIndexSchedulerRegistryV1 {
                     queue_delay_micros = ?arrival
                         .wake_micros()
                         .map(|wake_micros| started_micros.saturating_sub(wake_micros).max(0)),
-                    writer_wait_micros,
+                    wake_to_gates_held_micros,
                     retained_text = retained_text_metadata
                         .as_ref()
                         .map(|metadata| metadata.manifest().generation_id.as_str()),

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry/reconcile_failure_isolation_tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry/reconcile_failure_isolation_tests.rs
@@ -14,9 +14,12 @@ use std::time::Duration;
 
 use tempfile::TempDir;
 
-use super::super::reconcile_panic_guard::{
-    MAX_CONSECUTIVE_CAPACITY_RETRIES_V1, MAX_CONSECUTIVE_RECONCILE_PANICS_V1,
-    ReconcileFaultInjectionV1, ReconcileFaultKindV1,
+use super::super::{
+    CodeIndexCadenceTriggerV1,
+    reconcile_panic_guard::{
+        MAX_CONSECUTIVE_CAPACITY_RETRIES_V1, MAX_CONSECUTIVE_RECONCILE_PANICS_V1,
+        ReconcileFaultInjectionV1, ReconcileFaultKindV1,
+    },
 };
 use super::CodeIndexSchedulerRegistryV1;
 
@@ -133,6 +136,30 @@ impl Fixture {
         worktree.wake.notify_one();
     }
 
+    /// One attributable wake with no epoch advance.
+    async fn wake_with_pending_arrival(&self) {
+        let canonical = self.project.canonicalize().expect("canonical project");
+        let mounted = self.registry.mounted.lock().await;
+        let worktree = mounted.get(&canonical).expect("mounted worktree");
+        CodeIndexSchedulerRegistryV1::note_wake(
+            &worktree.pending_wake,
+            &worktree.wake,
+            CodeIndexCadenceTriggerV1::QueryAdmission,
+        );
+    }
+
+    async fn pending_wake_micros(&self) -> u64 {
+        let canonical = self.project.canonicalize().expect("canonical project");
+        let mounted = self.registry.mounted.lock().await;
+        let worktree = mounted.get(&canonical).expect("mounted worktree");
+        let pending = worktree
+            .pending_wake
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        pending.micros
+    }
+
     /// Drive `EXTERNAL_WAKE_ROUNDS` spaced wakes over unchanged input.
     async fn drive_external_wakes(&self) {
         for _ in 0..EXTERNAL_WAKE_ROUNDS {
@@ -234,6 +261,62 @@ async fn changed_input_lifts_a_quarantined_reconcile() {
     assert!(
         after_hint > quarantined_at,
         "changed input must earn another attempt; stayed at {quarantined_at}"
+    );
+
+    fixture.registry.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn superseded_reconcile_retains_its_arrival_until_a_later_wake() {
+    let fixture = Fixture::mount("project.reconcile-superseded-arrival").await;
+    let fault = fixture
+        .install_fault(ReconcileFaultKindV1::Cancelled, usize::MAX)
+        .await;
+
+    fixture.wake_with_pending_arrival().await;
+    wait_for_attempts(&fault, 1).await;
+    fixture.settle_for(TERMINATION_QUIET_WINDOW).await;
+
+    assert_eq!(
+        fault.attempts(),
+        1,
+        "an interrupted pass relies on the source observation's wake instead of self-retrying"
+    );
+    assert_ne!(
+        fixture.pending_wake_micros().await,
+        0,
+        "the interrupted pass must restore the arrival a later source wake will consume"
+    );
+
+    let attempts_before_shutdown = fault.attempts();
+    fixture.registry.shutdown().await;
+    assert_eq!(
+        fault.attempts(),
+        attempts_before_shutdown,
+        "terminal shutdown must not retry the interrupted pass"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn deadline_interruption_retains_arrival_without_retrying_expired_work() {
+    let fixture = Fixture::mount("project.reconcile-deadline-arrival").await;
+    let fault = fixture
+        .install_fault(ReconcileFaultKindV1::DeadlineExceeded, usize::MAX)
+        .await;
+
+    fixture.wake_with_pending_arrival().await;
+    wait_for_attempts(&fault, 1).await;
+    fixture.settle_for(TERMINATION_QUIET_WINDOW).await;
+
+    assert_eq!(
+        fault.attempts(),
+        1,
+        "an expired reconcile must not retry the same deadline"
+    );
+    assert_ne!(
+        fixture.pending_wake_micros().await,
+        0,
+        "deadline attribution must not erase the accepted arrival"
     );
 
     fixture.registry.shutdown().await;

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -8009,7 +8009,28 @@ async fn a_different_content_successor_pointer_refuses_the_stale_seat() {
 async fn search_fails_fast_when_no_complete_generation_exists() {
     let fixture = GitFixture::new(&[("src/main.rs", "fn main() {}\n")]);
     let store = TempDir::new().expect("store root");
-    let (registry, scope) = mounted_core_query_worktree(&fixture, &store).await;
+    // The mounted registry only lends this test a real scope; the queries
+    // below run against an empty registry, so a text-current seat is all the
+    // scope derivation needs and graph seating is not awaited.
+    let registry = CodeIndexSchedulerRegistryV1::new(1);
+    registry
+        .mount_worktree(
+            test_project_id(),
+            fixture.path(),
+            store.path().to_path_buf(),
+            None,
+        )
+        .await
+        .expect("mount daemon-owned scheduler");
+    let text = wait_for_queryable_text_generation(&registry, fixture.path()).await;
+    let snapshot = text.metadata().snapshot();
+    let scope = ResolvedScope::new(
+        test_project_id(),
+        snapshot.repository.clone(),
+        snapshot.worktree.clone().expect("worktree id"),
+        snapshot.reference.clone(),
+    )
+    .expect("resolved scope");
 
     let empty = CodeIndexSchedulerRegistryV1::new(1);
     assert!(
@@ -9725,7 +9746,10 @@ async fn daemon_owned_per_worktree_scheduler_reconciles_saved_edits() {
             .await
             .expect("mount daemon-owned scheduler")
     );
-    let first = wait_for_initial_generation(&registry, fixture.path()).await;
+    // A saved edit is reconciled when its generation is text-current; graph
+    // seating of the successor is a separate, optional phase this test does
+    // not assert on.
+    let first = wait_for_queryable_text_generation_id(&registry, fixture.path()).await;
 
     fixture.edit("src/lib.rs", "pub fn alpha() -> u32 { 2 }\n");
     assert!(
@@ -9733,7 +9757,12 @@ async fn daemon_owned_per_worktree_scheduler_reconciles_saved_edits() {
             .notify_path(fixture.path(), fixture.path().join("src/lib.rs"))
             .await
     );
-    let second = wait_for_generation_change(&registry, fixture.path(), &first).await;
+    let second = wait_for_queryable_text_generation_change(&registry, fixture.path(), &first)
+        .await
+        .metadata()
+        .manifest()
+        .generation_id
+        .clone();
 
     assert_ne!(first, second);
     registry.shutdown().await;
@@ -10759,7 +10788,7 @@ async fn poisoned_scheduler_lock_does_not_retire_the_background_worker() {
         )
         .await
         .expect("mount worktree");
-    let initial = wait_for_initial_generation(&registry, fixture.path()).await;
+    let initial = wait_for_queryable_text_generation_id(&registry, fixture.path()).await;
     let scheduler = registry
         .scheduler_handle(fixture.path())
         .await
@@ -10779,7 +10808,8 @@ async fn poisoned_scheduler_lock_does_not_retire_the_background_worker() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .notify_path(fixture.path().join("src/lib.rs"));
-    let _ = wait_for_generation_change(&registry, fixture.path(), &initial).await;
+    // The worker survived the poison when the edit becomes text-current.
+    let _ = wait_for_queryable_text_generation_change(&registry, fixture.path(), &initial).await;
     registry.shutdown().await;
 }
 
@@ -12357,6 +12387,27 @@ async fn wait_for_queryable_text_generation(
     .expect("queryable text generation seated")
 }
 
+/// The generation id of the text-current seat.
+///
+/// Tests whose assertions only need exact/lexical text serving (a saved edit
+/// was reconciled, a newer generation is current, a scope resolves) must wait
+/// on this rather than on [`CodeIndexSchedulerRegistryV1::latest_generation_id`]:
+/// that resolver prefers the graph-bearing serving slot and keeps answering
+/// the previous generation until optional graph activation of the successor
+/// finishes, so a text-only test waiting on it was really waiting on graph
+/// seating (issue #917).
+async fn wait_for_queryable_text_generation_id(
+    registry: &CodeIndexSchedulerRegistryV1,
+    path: &Path,
+) -> tracedecay_domain::CodeGenerationId {
+    wait_for_queryable_text_generation(registry, path)
+        .await
+        .metadata()
+        .manifest()
+        .generation_id
+        .clone()
+}
+
 /// Wait until the text owner seats a generation distinct from `previous`.
 async fn wait_for_queryable_text_generation_change(
     registry: &CodeIndexSchedulerRegistryV1,
@@ -12646,12 +12697,14 @@ async fn unpinned_query_resolves_exact_admitted_worktree_scope() {
         )
         .await
         .expect("mount target worktree");
-    wait_for_initial_generation(&registry, first.path()).await;
-    let target_latest = wait_for_live_complete_generation(&registry, target.path()).await;
-    let target_generation = target_latest.generation.manifest().generation_id.clone();
-    let repository = target_latest.generation.snapshot().repository.clone();
+    // Unpinned exact queries resolve through the text owner, so the target
+    // must be text-current; neither worktree's graph seat is exercised here.
+    wait_for_queryable_text_generation(&registry, first.path()).await;
+    let target_latest = wait_for_queryable_text_generation(&registry, target.path()).await;
+    let target_generation = target_latest.metadata().manifest().generation_id.clone();
+    let repository = target_latest.metadata().snapshot().repository.clone();
     let worktree = target_latest
-        .generation
+        .metadata()
         .snapshot()
         .worktree
         .clone()
@@ -12663,7 +12716,7 @@ async fn unpinned_query_resolves_exact_admitted_worktree_scope() {
         &registry,
         target.path(),
         &context,
-        target_latest.generation.manifest().privacy_domain.clone(),
+        target_latest.metadata().manifest().privacy_domain.clone(),
     )
     .await;
     let scope =
@@ -12815,8 +12868,17 @@ async fn unpinned_cursor_continues_on_its_immutable_generation() {
         .latest_complete_fresh(fixture.path())
         .await
         .expect("retained generation stays servable while the rebuild runs");
+    // The cursor's immutability is tested against a *text-current* successor:
+    // an unpinned exact query now resolves the new generation while the
+    // continuation must stay on the one the cursor was minted for. Graph
+    // seating of that successor is irrelevant to exact serving.
     let refreshed =
-        wait_for_generation_change(&registry, fixture.path(), &original_generation).await;
+        wait_for_queryable_text_generation_change(&registry, fixture.path(), &original_generation)
+            .await
+            .metadata()
+            .manifest()
+            .generation_id
+            .clone();
     assert_ne!(refreshed, original_generation);
 
     let continuation_request = ExactOccurrenceRequest::new(
@@ -13717,8 +13779,17 @@ async fn mount_with_retained_generation_verifies_cadence_promptly() {
         .expect("mount with retained generation");
 
     // The retained generation is not queryable until its freshness frontier is
-    // proved. The mount wake must verify against gix and publish the new content.
-    let refreshed = wait_for_generation_change(&registry, fixture.path(), &first_generation).await;
+    // proved. The mount wake must verify against gix and publish the new
+    // content. "Published and queryable" is the text seat: the retained stale
+    // generation may take the graph-bearing serving slot first, and the
+    // successor's graph seating is not what this cadence test measures.
+    let refreshed =
+        wait_for_queryable_text_generation_change(&registry, fixture.path(), &first_generation)
+            .await
+            .metadata()
+            .manifest()
+            .generation_id
+            .clone();
     assert_ne!(refreshed, first_generation);
 
     // Early publish records the Published receipt on the source pass; a

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -13138,6 +13138,96 @@ async fn unpinned_query_serves_freshness_resolved_latest_generation() {
     registry.shutdown().await;
 }
 
+/// A text freshness query that arrives while the worker still owns a pass
+/// cannot run the ladder itself, and the in-flight pass observed the source
+/// when *it* started — after publication it is still projecting text or
+/// seating the graph of the previous source state. Answering stale without
+/// leaving a wake stranded the remedy until an unrelated hint arrived; the
+/// out-of-band commit stayed unserved (issue #917, the flaky tail of
+/// `unpinned_query_serves_freshness_resolved_latest_generation`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn text_freshness_query_during_owner_work_schedules_a_follow_up_pass() {
+    let fixture = GitFixture::new(&[("src/lib.rs", "pub fn alpha() -> u32 { 1 }\n")]);
+    let store = TempDir::new().expect("store root");
+    let registry = CodeIndexSchedulerRegistryV1::with_background_reconcile_permits(1, 1);
+    registry
+        .mount_worktree_with_graph_policy(
+            test_project_id(),
+            fixture.path(),
+            store.path().to_path_buf(),
+            None,
+            super::CodeGraphActivationPolicyV1::RefusedByConfiguration,
+        )
+        .await
+        .expect("mount graph-off worktree");
+    let initial_text = wait_for_queryable_text_generation(&registry, fixture.path()).await;
+    let initial = initial_text.metadata().manifest().generation_id.clone();
+    let snapshot = initial_text.metadata().snapshot();
+    let scope = ResolvedScope::new(
+        test_project_id(),
+        snapshot.repository.clone(),
+        snapshot.worktree.clone().expect("worktree identity"),
+        snapshot.reference.clone(),
+    )
+    .expect("resolved scope");
+
+    // Let the mount pass finish, then keep the worker from starting another
+    // one so the wake this query leaves behind stays observable.
+    let settled_deadline = Instant::now() + Duration::from_secs(10);
+    while registry
+        .reconcile_in_progress_for_test(fixture.path())
+        .await
+    {
+        assert!(
+            Instant::now() <= settled_deadline,
+            "initial graph-off mount never released its owner pass"
+        );
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+    let admission = registry
+        .background_reconcile_admission()
+        .acquire_owned()
+        .await
+        .expect("hold background reconcile admission");
+    registry.clear_pending_wake_for_scope(&scope).await;
+    // Stand in for the worker's own pass: in-progress, scheduler mutex free.
+    let owner_pass = registry
+        .hold_reconcile_pass_for_test(fixture.path())
+        .await
+        .expect("mounted worktree");
+
+    fixture.edit("src/lib.rs", "pub fn alpha() -> u32 { 2 }\n");
+    git(fixture.path(), &["commit", "-qam", "external"]);
+
+    let (latest, current) = registry
+        .latest_text_serving_freshness_for_scope(&scope)
+        .await
+        .expect("the seated text owner keeps serving during owner work");
+    assert_eq!(
+        latest.metadata().manifest().generation_id,
+        initial,
+        "the query is answered from the retained text generation"
+    );
+    assert!(
+        !current,
+        "a source the query could not verify is reported stale, never current"
+    );
+    assert!(
+        registry
+            .pending_wake_micros_for_scope(&scope)
+            .await
+            .is_some_and(|pending| pending != 0),
+        "the query must leave a follow-up wake for the worker to re-run the freshness ladder"
+    );
+
+    // Release the worker: the follow-up pass alone must reconcile the commit.
+    drop(owner_pass);
+    drop(admission);
+    let next = wait_for_queryable_text_generation_change(&registry, fixture.path(), &initial).await;
+    assert_ne!(next.metadata().manifest().generation_id, initial);
+    registry.shutdown().await;
+}
+
 /// An explicit caller-pinned generation is served generation-bound and
 /// read-only: the freshness ladder is bypassed, so an out-of-band commit after
 /// indexing never mutates the served generation and never triggers a reconcile.

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -3901,10 +3901,11 @@ fn cross_worktree_byte_reuse_without_identity_alias() {
         first_generation.manifest().snapshot_digest,
         second_generation.manifest().snapshot_digest
     );
-    assert_ne!(
+    assert_eq!(
         first_generation.capability().manifest_digest,
         second_generation.capability().manifest_digest,
-        "authorization identity remains generation-local"
+        "byte-identical capability evidence is generation-free; generation, occurrence, \
+         snapshot, and publication identities remain worktree-local above and below"
     );
     assert_ne!(
         first_generation.projection().publication_digest(),
@@ -10234,7 +10235,7 @@ async fn shutdown_signals_code_index_worker_without_taking_busy_scheduler_lock()
     // is *already* blocked acquiring that lock is a different wait than the one
     // under test — this test is about shutdown never taking the lock on its own
     // behalf.
-    wait_for_initial_generation(&registry, fixture.path()).await;
+    wait_for_live_complete_generation(&registry, fixture.path()).await;
     let scheduler = registry
         .scheduler_handle(fixture.path())
         .await
@@ -15492,6 +15493,25 @@ async fn graph_off_changed_source_advances_text_authority_without_full_decode() 
             }
         }
     };
+    // The successful query can land while the owner is finishing generation
+    // A and legitimately leave one coalesced BusyFollowUp. Let that pass
+    // settle before this test injects generation B's publication failure, so
+    // the assertion below observes only the failed pass's restored hint.
+    let settled_deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let in_progress = registry
+            .reconcile_in_progress_for_test(fixture.path())
+            .await;
+        let pending_wake = registry.pending_wake_micros_for_scope(&scope).await;
+        if !in_progress && pending_wake == Some(0) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() <= settled_deadline,
+            "generation A follow-up wake did not settle"
+        );
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
     let owner_epoch_a = {
         let scheduler = scheduler
             .lock()

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -13525,36 +13525,124 @@ async fn text_freshness_query_during_owner_work_schedules_a_follow_up_pass() {
         .hold_reconcile_pass_for_test(fixture.path())
         .await
         .expect("mounted worktree");
+    let scheduler = registry
+        .scheduler_handle(fixture.path())
+        .await
+        .expect("mounted scheduler");
+    let reconcile_control = {
+        let scheduler = scheduler
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        tracedecay_usecases::code_index::DaemonCodeIndexControlV1::new(
+            Arc::clone(&scheduler.epoch),
+            Arc::clone(&scheduler.shutting_down),
+        )
+    };
 
     fixture.edit("src/lib.rs", "pub fn alpha() -> u32 { 2 }\n");
     git(fixture.path(), &["commit", "-qam", "external"]);
 
-    let (latest, current) = registry
-        .latest_text_serving_freshness_for_scope(&scope)
+    let callers = 32;
+    let start = Arc::new(tokio::sync::Barrier::new(callers + 1));
+    let requests = (0..callers)
+        .map(|_| {
+            let registry = registry.clone();
+            let scope = scope.clone();
+            let start = Arc::clone(&start);
+            tokio::spawn(async move {
+                start.wait().await;
+                registry
+                    .latest_text_serving_freshness_for_scope(&scope)
+                    .await
+            })
+        })
+        .collect::<Vec<_>>();
+    start.wait().await;
+    for request in requests {
+        let (latest, current) = request
+            .await
+            .expect("freshness query joins")
+            .expect("the seated text owner keeps serving during owner work");
+        assert_eq!(
+            latest.metadata().manifest().generation_id,
+            initial,
+            "every query is answered from the retained text generation"
+        );
+        assert!(
+            !current,
+            "a source the queries could not verify is reported stale, never current"
+        );
+    }
+    let first_follow_up = registry
+        .pending_wake_micros_for_scope(&scope)
         .await
-        .expect("the seated text owner keeps serving during owner work");
+        .filter(|pending| *pending != 0)
+        .expect("the concurrent queries leave one coalesced follow-up");
+    let _ = registry
+        .latest_text_serving_freshness_for_scope(&scope)
+        .await;
     assert_eq!(
-        latest.metadata().manifest().generation_id,
-        initial,
-        "the query is answered from the retained text generation"
+        registry.pending_wake_micros_for_scope(&scope).await,
+        Some(first_follow_up),
+        "repeated reads preserve the one pending follow-up instead of restamping it"
     );
     assert!(
-        !current,
-        "a source the query could not verify is reported stale, never current"
+        !reconcile_control.is_cancelled(),
+        "freshness reads do not cancel or restart the owner pass"
     );
+
+    // Model the next worker pass claiming that wake while its owner authority
+    // remains held. A source edit observed during this pass must leave another
+    // coalesced follow-up, not disappear with the claimed arrival.
+    drop(owner_pass);
+    let next_owner_pass = registry
+        .hold_reconcile_pass_for_test(fixture.path())
+        .await
+        .expect("mounted worktree");
+    registry.clear_pending_wake_for_scope(&scope).await;
+    fixture.edit("src/lib.rs", "pub fn alpha() -> u32 { 3 }\n");
+    git(
+        fixture.path(),
+        &["commit", "-qam", "external during follow-up"],
+    );
+    let (_, current) = registry
+        .latest_text_serving_freshness_for_scope(&scope)
+        .await
+        .expect("retained text remains available during the follow-up pass");
+    assert!(!current);
     assert!(
         registry
             .pending_wake_micros_for_scope(&scope)
             .await
             .is_some_and(|pending| pending != 0),
-        "the query must leave a follow-up wake for the worker to re-run the freshness ladder"
+        "the source edit during the follow-up pass leaves the next necessary wake"
     );
 
-    // Release the worker: the follow-up pass alone must reconcile the commit.
-    drop(owner_pass);
+    // Release the worker: one BusyFollowUp pass must reconcile the latest
+    // source directly, without publishing or retrying the superseded edit.
+    drop(next_owner_pass);
     drop(admission);
     let next = wait_for_queryable_text_generation_change(&registry, fixture.path(), &initial).await;
     assert_ne!(next.metadata().manifest().generation_id, initial);
+    let current = scheduler
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .capture_authoritative_snapshot_without_active_generation_reuse(None)
+        .expect("capture current source");
+    assert_eq!(
+        next.metadata().snapshot().content_identity,
+        current.snapshot.content_identity,
+        "the pass serves the edit that arrived during its predecessor"
+    );
+    let busy_follow_ups = registry
+        .event_to_ready_receipts()
+        .into_iter()
+        .filter(|receipt| receipt.trigger == CodeIndexCadenceTriggerV1::BusyFollowUp)
+        .count();
+    assert_eq!(
+        busy_follow_ups, 1,
+        "coalesced reads and superseding edits produce one completed follow-up pass"
+    );
     registry.shutdown().await;
 }
 
@@ -14576,6 +14664,24 @@ async fn resident_memory_graph_refusal_seats_text_serving_without_graph() {
         latest.interactive_graph_store().is_err(),
         "a budget-refused native graph must not gain a substitute store"
     );
+    let freshness = registry
+        .dashboard_freshness(fixture.path())
+        .await
+        .expect("mounted worktree freshness");
+    match freshness.code_graph_serving {
+        Some(
+            tracedecay_dashboard_api::code_index_freshness_api::CodeGraphServingReadinessV1::Refused {
+                reason,
+            },
+        ) => assert_eq!(
+            reason,
+            super::graph_activation::RESIDENT_MEMORY_GRAPH_REFUSAL_REASON,
+            "the graph refusal keeps the canonical resident-memory reason"
+        ),
+        other => panic!(
+            "text serving must not turn the refused graph into strict graph readiness: {other:?}"
+        ),
+    }
 
     super::graph_activation::set_injected_resident_memory_refusal(&worktree_id, false);
     registry.shutdown().await;

--- a/crates/tracedecay-graph-db/src/error.rs
+++ b/crates/tracedecay-graph-db/src/error.rs
@@ -13,6 +13,12 @@ pub enum GraphBudgetKind {
     Write,
     Capacity,
     Mutation,
+    /// The process-wide measured-RSS admission watermark. A corpus-sized
+    /// publication that trips it is refused with the daemon still alive and
+    /// its text serving intact, instead of growing until the kernel kills the
+    /// whole process. The scheduler treats this name as a typed graph
+    /// refusal, never a retryable fault.
+    ResidentMemory,
 }
 
 impl GraphBudgetKind {
@@ -24,6 +30,7 @@ impl GraphBudgetKind {
             Self::Write => "write",
             Self::Capacity => "capacity",
             Self::Mutation => "mutation",
+            Self::ResidentMemory => "resident_memory",
         }
     }
 
@@ -36,6 +43,7 @@ impl GraphBudgetKind {
             "write" => Some(Self::Write),
             "capacity" => Some(Self::Capacity),
             "mutation" => Some(Self::Mutation),
+            "resident_memory" => Some(Self::ResidentMemory),
             _ => None,
         }
     }

--- a/crates/tracedecay-store-runtime/src/session_registry/code_graph.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/code_graph.rs
@@ -200,6 +200,75 @@ impl GraphCancellation for AtomicGraphCancellationV1 {
     }
 }
 
+/// Request cancellation for a corpus-sized sealed publication that also
+/// answers to the daemon's measured-RSS admission authority.
+///
+/// The publication is the largest single grower in the process and the only
+/// one that ran outside that authority: the maintenance sampler logged
+/// `daemon_resident_memory_over_budget` at the high watermark while the
+/// projection kept allocating until the kernel OOM-killed the daemon — taking
+/// the already-complete text serving down with the graph. Tripping the
+/// existing cancellation checkpoints at the watermark reuses the one abort
+/// path the publication already handles (staging discard, journal untouched);
+/// [`RetainedCodeGraphRuntimeV1::publish_verified_snapshot`] then reports the
+/// abort as a typed [`GraphBudgetKind::ResidentMemory`] refusal rather than a
+/// generic cancellation, so the scheduler seats text without graph instead of
+/// scheduling a retry into the same wall.
+struct ResidentMemoryGuardedGraphCancellationV1 {
+    request: Arc<AtomicBool>,
+    pressure: Arc<tracedecay_runtime_core::resident_memory::ResidentMemoryPressureV1>,
+    tripped: AtomicBool,
+}
+
+impl ResidentMemoryGuardedGraphCancellationV1 {
+    fn new(
+        request: Arc<AtomicBool>,
+        pressure: Arc<tracedecay_runtime_core::resident_memory::ResidentMemoryPressureV1>,
+    ) -> Self {
+        Self {
+            request,
+            pressure,
+            tripped: AtomicBool::new(false),
+        }
+    }
+
+    /// Whether the resident-memory watermark, not the request, ended the
+    /// publication. A request cancellation observed at any point keeps its
+    /// own identity even if the watermark also tripped.
+    fn refused_by_resident_memory(&self) -> bool {
+        self.tripped.load(Ordering::Acquire) && !self.request.load(Ordering::Acquire)
+    }
+}
+
+impl GraphCancellation for ResidentMemoryGuardedGraphCancellationV1 {
+    fn is_cancelled(&self) -> bool {
+        if self.request.load(Ordering::Acquire) {
+            return true;
+        }
+        if let tracedecay_runtime_core::resident_memory::ResidentMemoryPressureStateV1::OverBudget {
+            observed_bytes,
+            limit_bytes,
+            high_watermark_bytes,
+            ..
+        } = self.pressure.state()
+        {
+            if !self.tripped.swap(true, Ordering::AcqRel) {
+                tracing::warn!(
+                    event = "code_graph_publication_refused_resident_memory",
+                    observed_bytes,
+                    high_watermark_bytes,
+                    limit_bytes,
+                    "measured process RSS is over the admission watermark; the sealed graph \
+                     publication stops at its next checkpoint and the generation keeps serving \
+                     exact and lexical without a native graph"
+                );
+            }
+            return true;
+        }
+        false
+    }
+}
+
 struct MaintenanceGraphCancellationV1(tracedecay_session_memory::context::CancellationToken);
 
 impl GraphCancellation for MaintenanceGraphCancellationV1 {
@@ -534,6 +603,11 @@ pub(crate) struct RetainedCodeGraphRuntimeV1 {
     /// Registry-owned per-project-publication-shard locks; see
     /// `DaemonSessionRuntimeRegistryV1::code_graph_publication_gates`.
     publication_locks: Arc<CodeGraphShardPublicationLocksV1>,
+    /// The measured-RSS admission cell sealed publication answers to. Bound
+    /// from the manifest provider so the decoded offers and the corpus-sized
+    /// build obey one authority; tests substitute an isolated cell.
+    resident_memory_pressure:
+        Arc<tracedecay_runtime_core::resident_memory::ResidentMemoryPressureV1>,
 }
 
 /// Retirement releases the decoded-generation offer this runtime commissioned.
@@ -1068,6 +1142,17 @@ impl RetainedCodeGraphRuntimeV1 {
         Arc::clone(&self.authority)
     }
 
+    /// Bind sealed publication to an isolated measured-RSS cell so a fake RSS
+    /// series drives the refusal without touching `/proc` or other cases.
+    #[cfg(test)]
+    pub(super) fn with_resident_memory_pressure(
+        mut self,
+        pressure: &Arc<tracedecay_runtime_core::resident_memory::ResidentMemoryPressureV1>,
+    ) -> Self {
+        self.resident_memory_pressure = Arc::clone(pressure);
+        self
+    }
+
     /// Drops aborted catalog/manifest staging files for this sealed digest.
     /// A retry must not inherit another attempt's `.read-bundle-*.tmp` scratch.
     #[hotpath::measure(label = "daemon.session_registry.sweep_read_bundle_temporaries")]
@@ -1165,10 +1250,12 @@ impl RetainedCodeGraphRuntimeV1 {
             ))
             .map_err(|error| GraphDbError::invalid(error.to_string()))?,
         };
+        let resident_memory_guard = Arc::new(ResidentMemoryGuardedGraphCancellationV1::new(
+            Arc::clone(&request_cancelled),
+            Arc::clone(&self.resident_memory_pressure),
+        ));
         let probe = GraphPublicationProbeV1 {
-            request_cancellation: Arc::new(AtomicGraphCancellationV1::new(Arc::clone(
-                &request_cancelled,
-            ))),
+            request_cancellation: Arc::clone(&resident_memory_guard) as Arc<dyn GraphCancellation>,
             lifecycle_cancellation: graph_lifecycle_cancellation(&self.lifecycle_cancelled, None),
             deadline_at,
             cancellation: cancellation_identity.clone(),
@@ -1188,7 +1275,23 @@ impl RetainedCodeGraphRuntimeV1 {
             Some(RuntimeInterruptionV1::DeadlineExceeded) => Err(GraphDbError::DeadlineExceeded),
             None => Ok(()),
         };
-        let _build = self.publication_locks.claim_build(&interruption)?;
+        // A cancellation the watermark caused is reported as the typed budget
+        // it exhausted: the scheduler classifies that name as a graph refusal
+        // that leaves text serving seated, whereas a bare `Cancelled` would
+        // arm a retry into the same memory wall.
+        let refuse_if_resident_memory = |error: GraphDbError| match error {
+            GraphDbError::Cancelled if resident_memory_guard.refused_by_resident_memory() => {
+                GraphDbError::budget_exhausted(
+                    GraphBudgetKind::ResidentMemory,
+                    resident_memory_guard.pressure.limit_bytes(),
+                )
+            }
+            other => other,
+        };
+        let _build = self
+            .publication_locks
+            .claim_build(&interruption)
+            .map_err(refuse_if_resident_memory)?;
         let projection = tracedecay_code_index::graph_projection::code_graph_projection_identity(
             self.authority.namespace().clone(),
         )
@@ -1216,7 +1319,9 @@ impl RetainedCodeGraphRuntimeV1 {
             );
         #[cfg(any(test, feature = "test-helpers"))]
         PUBLICATION_PROJECTION_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
-        let manifest = manifest.map_err(map_code_graph_error)?;
+        let manifest = manifest
+            .map_err(map_code_graph_error)
+            .map_err(refuse_if_resident_memory)?;
         let relational_projection = GraphProjectionIdentityV1 {
             shard_id: self.authority.binding().shard_id.clone(),
             namespace: tracedecay_store::GraphNamespaceV1::new(self.authority.namespace().as_str())
@@ -1255,12 +1360,9 @@ impl RetainedCodeGraphRuntimeV1 {
             request_cancelled,
         };
         let mut staging_release = None;
-        let published = self.publish_prepared_sealed_generation(
-            &prepared,
-            &probe,
-            &context,
-            &mut staging_release,
-        );
+        let published = self
+            .publish_prepared_sealed_generation(&prepared, &probe, &context, &mut staging_release)
+            .map_err(refuse_if_resident_memory);
         // Everything corpus-sized this publication built — the projection
         // manifest, the staged relational rows, the sealed copy buffers — is
         // dead by here. Free it, release the duplicate staging rows the seal
@@ -2620,6 +2722,9 @@ impl DaemonSessionRuntimeRegistryV1 {
         let publication_locks = self.retain_project_publication_locks(&project_shard);
         Ok(RetainedCodeGraphRuntimeV1 {
             graph_registry: self.graph_registry.clone(),
+            resident_memory_pressure: Arc::clone(
+                self.graph_manifest_provider.resident_memory_pressure(),
+            ),
             graph_manifest_provider: Arc::clone(&self.graph_manifest_provider),
             _manifest_route: manifest_route,
             authority,

--- a/crates/tracedecay-store-runtime/src/session_registry/code_graph.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/code_graph.rs
@@ -245,6 +245,9 @@ impl GraphCancellation for ResidentMemoryGuardedGraphCancellationV1 {
         if self.request.load(Ordering::Acquire) {
             return true;
         }
+        if self.tripped.load(Ordering::Acquire) {
+            return true;
+        }
         if let tracedecay_runtime_core::resident_memory::ResidentMemoryPressureStateV1::OverBudget {
             observed_bytes,
             limit_bytes,

--- a/crates/tracedecay-store-runtime/src/session_registry/code_graph/sealed_publication_tests.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/code_graph/sealed_publication_tests.rs
@@ -1232,6 +1232,203 @@ async fn concurrent_sealed_publishers_share_one_gate_and_converge_on_one_head() 
     });
 }
 
+/// Sealed publication answers to the daemon's measured-RSS admission authority
+/// (issue #917). On the 4925-file dogfood checkout the projection grew from a
+/// 6.5 GiB text-serving baseline past the 11.3 GiB high watermark to a 15.4 GiB
+/// OOM kill while the maintenance sampler had already logged over-budget: the
+/// publication never consulted the cell. Over the watermark it must stop at
+/// its next checkpoint with the typed `resident_memory` budget (which the
+/// scheduler classifies as a graph refusal that keeps text seated, not a
+/// retryable fault), leave the publication journal untouched, and publish
+/// normally once measured RSS falls back under the low watermark.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sealed_publication_refuses_over_the_resident_memory_watermark() {
+    let temporary = tempfile::tempdir().expect("temporary fixture parent");
+    let root = temporary
+        .path()
+        .canonicalize()
+        .expect("canonical fixture root");
+    let profile_root = root.join("profile");
+    let project_root = root.join("project");
+    std::fs::create_dir_all(project_root.join("src")).expect("project source directory");
+    git(&project_root, &["init", "-q", "-b", "main"]);
+    git(&project_root, &["config", "user.name", "TraceDecay Test"]);
+    git(
+        &project_root,
+        &["config", "user.email", "tracedecay@example.invalid"],
+    );
+    std::fs::write(
+        project_root.join("src/lib.rs"),
+        "pub fn resident_memory_refusal_value() -> usize { 917 }\n",
+    )
+    .expect("project source");
+    git(&project_root, &["add", "."]);
+    git(
+        &project_root,
+        &["commit", "-qm", "resident memory refusal fixture"],
+    );
+    let project_id =
+        ProjectId::new("project.resident-memory-code-publication").expect("project id");
+    tracedecay_runtime_core::storage::pin_fixture_repository_identity(
+        &project_root,
+        project_id.as_str(),
+    )
+    .expect("project enrollment");
+    let canonical_project = project_root.canonicalize().expect("canonical project root");
+
+    let store_root = root.join("code-index-store");
+    let scoped_store = scoped_code_index_store_root(&store_root, &canonical_project);
+    let mut scheduler = CodeIndexWorktreeSchedulerV1::open(
+        project_id.clone(),
+        &canonical_project,
+        scoped_store.clone(),
+        Arc::new(SharedCodeIndexBytePoolV1::default()),
+    )
+    .expect("open worktree scheduler");
+    scheduler.reconcile_now().expect("seal the generation");
+    let latest = scheduler.latest_complete().expect("complete generation");
+    let repository_id = latest.generation().snapshot().repository.clone();
+    let reference = latest.generation().snapshot().reference.clone();
+    let worktree_id = scheduler.identity().worktree_id().clone();
+    let generation_id = latest.generation().manifest().generation_id.clone();
+    drop(scheduler);
+    let pointer: DurablePublicationPointerV1 = serde_json::from_slice(
+        &std::fs::read(scoped_store.join("active-code-generation-v1.json"))
+            .expect("active generation pointer"),
+    )
+    .expect("decode active generation pointer");
+    let replay_binding = CodeGraphReplayBindingV1 {
+        generations_root: scoped_store.join("code-generations-v1"),
+        sealed_state_digest: tracedecay_graph_db::SealedGraphStateDigest::try_from(
+            pointer.state_digest.clone(),
+        )
+        .expect("sealed state digest"),
+    };
+
+    let identity = profile_identity::load_or_create(&profile_root).expect("profile identity");
+    let _database_scope = tracedecay_runtime_core::db::enter_daemon_database_scope(
+        &profile_root,
+        61,
+        "resident memory code publication",
+    )
+    .expect("daemon database scope");
+    let registry = DaemonSessionRuntimeRegistryV1::open(identity)
+        .await
+        .expect("session runtime registry");
+    let project_database = registry
+        .project_memory(project_id.clone(), [canonical_project.clone()])
+        .await
+        .expect("project graph database");
+    let replay_root = project_database
+        .database_path()
+        .with_extension("graph-replay");
+    tracedecay_runtime_core::storage::PrivateStoreIo::create_private_directory(&replay_root)
+        .expect("private graph replay root");
+
+    // An isolated cell driven by a fake RSS series: no `/proc` read, and no
+    // interference with the process cell other cases observe.
+    let pressure = Arc::new(
+        tracedecay_runtime_core::resident_memory::ResidentMemoryPressureV1::new(
+            std::num::NonZeroU64::new(1024 * 1024 * 1024).expect("nonzero pressure limit"),
+        ),
+    );
+    let runtime = registry
+        .retain_code_graph_runtime(
+            project_id,
+            repository_id,
+            worktree_id,
+            reference,
+            generation_id,
+            project_database,
+            replay_binding,
+            None,
+        )
+        .await
+        .expect("retain the code graph runtime")
+        .with_resident_memory_pressure(&pressure);
+
+    pressure.publish_observed_resident_bytes(pressure.high_watermark_bytes() + 1);
+    let not_cancelled = Arc::new(AtomicBool::new(false));
+    let refused =
+        runtime.publish_verified_snapshot(latest.generation(), Arc::clone(&not_cancelled));
+    match refused {
+        Err(GraphDbError::BudgetExhausted { kind, limit }) => {
+            assert_eq!(kind, tracedecay_graph_db::GraphBudgetKind::ResidentMemory);
+            assert_eq!(limit, pressure.limit_bytes());
+        }
+        other => {
+            panic!("over-budget publication must report the resident-memory budget: {other:?}")
+        }
+    }
+    assert!(
+        !not_cancelled.load(Ordering::Acquire),
+        "the refusal must not be mistaken for a request cancellation"
+    );
+    // The refusal is the same abort path a request cancellation takes: no
+    // journal append, no verified head, nothing a retry has to repair.
+    assert_unverified_publication_state(&runtime, latest.generation(), false);
+
+    // The scheduler-facing classification names this budget as a graph
+    // refusal that keeps text serving, never a retryable activation fault.
+    let projection_error = tracedecay_code_index::graph_projection::CodeGraphProjectionError::from(
+        GraphDbError::budget_exhausted(
+            tracedecay_graph_db::GraphBudgetKind::ResidentMemory,
+            pressure.limit_bytes(),
+        ),
+    );
+    assert!(
+        tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerErrorV1::GraphProjection(
+            projection_error
+        )
+        .is_graph_activation_refusal()
+    );
+
+    // A request cancellation observed while the watermark is also tripped
+    // keeps its own identity: the caller cancelled, so it is told so.
+    let cancelled = Arc::new(AtomicBool::new(true));
+    assert!(matches!(
+        runtime.publish_verified_snapshot(latest.generation(), cancelled),
+        Err(GraphDbError::Cancelled)
+    ));
+
+    // Back under the low watermark the same runtime publishes the generation
+    // it just refused; the refusal poisoned nothing.
+    pressure.publish_observed_resident_bytes(pressure.low_watermark_bytes());
+    let published = runtime
+        .publish_verified_snapshot(latest.generation(), Arc::new(AtomicBool::new(false)))
+        .expect("nominal measured RSS publishes the sealed generation");
+    let projector_revision = GraphProjectorRevision::try_from(
+        tracedecay_code_index::graph_projection::CODE_GRAPH_PROJECTOR_REVISION.to_owned(),
+    )
+    .expect("projector revision");
+    let expected_generation = tracedecay_code_index::graph_projection::code_graph_generation_id(
+        &latest.generation().manifest().generation_id,
+        &projector_revision,
+    )
+    .expect("graph generation id");
+    assert_eq!(
+        published.generation().as_str(),
+        expected_generation.as_str(),
+        "the refused generation publishes unchanged once memory is nominal"
+    );
+    let (projection, key, _) = publication_replay(&runtime, latest.generation());
+    with_publication_context("inspect-refused-then-published", |context| {
+        let mut storage = runtime
+            .project_database
+            .graph_publication_storage()
+            .expect("graph publication storage");
+        let head = storage
+            .verified_head(&projection, context)
+            .expect("verified graph head")
+            .expect("the nominal publication advanced the verified head");
+        assert_eq!(&head, published.verified_head());
+        assert!(matches!(
+            storage.replay(&key, context).expect("publication replay"),
+            GraphPublicationReplayLookupV1::Active(_)
+        ));
+    });
+}
+
 fn pinned_publication_lock_cells(registry: &DaemonSessionRuntimeRegistryV1) -> usize {
     registry
         .code_graph_publication_gates

--- a/crates/tracedecay-store-runtime/src/session_registry/code_graph/sealed_publication_tests.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/code_graph/sealed_publication_tests.rs
@@ -1406,16 +1406,7 @@ async fn sealed_publication_refuses_over_the_resident_memory_watermark() {
         });
         let projection_deadline = Instant::now() + Duration::from_secs(10);
         loop {
-            let build_claimed = match runtime.publication_locks.build.try_lock() {
-                Ok(build) => {
-                    drop(build);
-                    false
-                }
-                Err(std::sync::TryLockError::WouldBlock) => true,
-                Err(std::sync::TryLockError::Poisoned(_)) => {
-                    panic!("publication build permit was poisoned")
-                }
-            };
+            let build_claimed = runtime.publication_locks.build.try_lock().is_err();
             if build_claimed
                 && (PUBLICATION_PROJECTION_IN_FLIGHT.load(Ordering::Acquire) != 0
                     || take_publication_projection_overlap_peak() != 0)

--- a/crates/tracedecay-store-runtime/src/session_registry/code_graph/sealed_publication_tests.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/code_graph/sealed_publication_tests.rs
@@ -34,7 +34,8 @@ use tracedecay_store::{
 
 use super::super::DaemonSessionRuntimeRegistryV1;
 use super::{
-    AtomicGraphCancellationV1, GraphPublicationProbeV1, RetainedCodeGraphRuntimeV1,
+    AtomicGraphCancellationV1, GraphPublicationProbeV1, PUBLICATION_PROJECTION_IN_FLIGHT,
+    ResidentMemoryGuardedGraphCancellationV1, RetainedCodeGraphRuntimeV1,
     take_publication_projection_overlap_peak,
 };
 use tracedecay_code_index_runtime::CodeGraphReplayBindingV1;
@@ -194,6 +195,46 @@ fn assert_unverified_publication_state(
                 .is_none()
         );
     });
+}
+
+#[test]
+fn resident_memory_trip_is_permanent_for_one_publication_attempt() {
+    let pressure = Arc::new(
+        tracedecay_runtime_core::resident_memory::ResidentMemoryPressureV1::new(
+            std::num::NonZeroU64::new(1024 * 1024 * 1024).expect("nonzero pressure limit"),
+        ),
+    );
+    let request_cancelled = Arc::new(AtomicBool::new(false));
+    let attempt = ResidentMemoryGuardedGraphCancellationV1::new(
+        Arc::clone(&request_cancelled),
+        Arc::clone(&pressure),
+    );
+
+    assert!(!attempt.is_cancelled());
+    pressure.publish_observed_resident_bytes(pressure.high_watermark_bytes() + 1);
+    assert!(attempt.is_cancelled());
+    assert!(attempt.refused_by_resident_memory());
+
+    pressure.publish_observed_resident_bytes(pressure.low_watermark_bytes());
+    assert!(
+        attempt.is_cancelled(),
+        "pressure recovery must not revive the publication attempt that tripped"
+    );
+    assert!(attempt.refused_by_resident_memory());
+
+    request_cancelled.store(true, Ordering::Release);
+    assert!(attempt.is_cancelled());
+    assert!(
+        !attempt.refused_by_resident_memory(),
+        "explicit request cancellation keeps its identity after a pressure trip"
+    );
+
+    let next_attempt =
+        ResidentMemoryGuardedGraphCancellationV1::new(Arc::new(AtomicBool::new(false)), pressure);
+    assert!(
+        !next_attempt.is_cancelled(),
+        "recovered pressure admits a distinct publication attempt"
+    );
 }
 
 fn journal_publication_without_head(
@@ -1347,10 +1388,51 @@ async fn sealed_publication_refuses_over_the_resident_memory_watermark() {
         .expect("retain the code graph runtime")
         .with_resident_memory_pressure(&pressure);
 
-    pressure.publish_observed_resident_bytes(pressure.high_watermark_bytes() + 1);
+    // Start under nominal pressure, let the real publication claim the corpus
+    // build permit and enter manifest projection, then trip the watermark.
+    // Holding the short publication gate keeps the attempt alive after that
+    // phase so this cannot collapse into an over-budget admission test.
+    pressure.publish_observed_resident_bytes(pressure.low_watermark_bytes());
+    let publication_gate = runtime
+        .publication_locks
+        .gate
+        .lock()
+        .expect("hold publication gate after manifest projection");
+    let _ = take_publication_projection_overlap_peak();
     let not_cancelled = Arc::new(AtomicBool::new(false));
-    let refused =
-        runtime.publish_verified_snapshot(latest.generation(), Arc::clone(&not_cancelled));
+    let refused = std::thread::scope(|scope| {
+        let publisher = scope.spawn(|| {
+            runtime.publish_verified_snapshot(latest.generation(), Arc::clone(&not_cancelled))
+        });
+        let projection_deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let build_claimed = match runtime.publication_locks.build.try_lock() {
+                Ok(build) => {
+                    drop(build);
+                    false
+                }
+                Err(std::sync::TryLockError::WouldBlock) => true,
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    panic!("publication build permit was poisoned")
+                }
+            };
+            if build_claimed
+                && (PUBLICATION_PROJECTION_IN_FLIGHT.load(Ordering::Acquire) != 0
+                    || take_publication_projection_overlap_peak() != 0)
+            {
+                break;
+            }
+            assert!(
+                Instant::now() <= projection_deadline,
+                "publication never entered manifest projection"
+            );
+            std::thread::yield_now();
+        }
+        pressure.publish_observed_resident_bytes(pressure.high_watermark_bytes() + 1);
+        drop(publication_gate);
+        publisher.join().expect("join pressured publisher")
+    });
+    let _ = take_publication_projection_overlap_peak();
     match refused {
         Err(GraphDbError::BudgetExhausted { kind, limit }) => {
             assert_eq!(kind, tracedecay_graph_db::GraphBudgetKind::ResidentMemory);

--- a/crates/tracedecay-store-runtime/src/session_registry/code_graph_manifest.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/code_graph_manifest.rs
@@ -1189,6 +1189,10 @@ pub(super) struct DaemonCodeGraphManifestProviderV1 {
     /// `Arc` so the pressure reclaimer can reach exactly this state through a
     /// `Weak` without keeping the provider alive.
     decoded: Arc<DecodedCodeGenerationOffersV1>,
+    /// The measured-RSS cell this provider's offers answer to. Sealed
+    /// publication consults the same cell so the one admission authority
+    /// governs both the retained accelerators and the corpus-sized build.
+    pressure: Arc<ResidentMemoryPressureV1>,
     /// Keeps the pressure reclaimer registered for this provider's lifetime.
     _pressure_registration: Option<ResidentMemoryPressureRegistrationV1>,
 }
@@ -1223,8 +1227,14 @@ impl DaemonCodeGraphManifestProviderV1 {
         Self {
             sources: RwLock::new(BTreeMap::new()),
             decoded,
+            pressure: Arc::clone(pressure),
             _pressure_registration: registration,
         }
+    }
+
+    /// The measured-RSS pressure cell this provider was bound to.
+    pub(super) fn resident_memory_pressure(&self) -> &Arc<ResidentMemoryPressureV1> {
+        &self.pressure
     }
 }
 

--- a/scripts/ci-pr-dogfood-smoke.sh
+++ b/scripts/ci-pr-dogfood-smoke.sh
@@ -43,13 +43,25 @@ print_compact_file() {
 # One line of code-index progress from a status payload, for the attempts
 # log: which phase the index is in and how far along, so a timeout report
 # shows where the journey stalled without rerunning it.
+#
+# The line names every identity strict readiness turns on, because they move
+# independently: `generation` is the sealed generation the worktree reports,
+# `progress_generation`/`sealed_source` identify the source the text projection
+# is committing against, and `serving` is graph seating. A `phase=None` row
+# with `rebuild=true` and no generation is the pre-seal source capture, which
+# publishes no progress record; it is not text or graph work.
+#
+# `rss_kb`/`peak_rss_kb` sample the daemon process the harness exported
+# (Linux `/proc` only; `n/a` elsewhere) so a timeout report carries memory
+# evidence, not only PASS/FAIL.
 summarize_status_progress() {
   local path="$1"
+  local progress
   [[ -s "$path" ]] || {
-    echo "progress=unavailable"
+    echo "progress=unavailable $(summarize_daemon_memory)"
     return 0
   }
-  python3 -S - "$path" <<'PY' 2>/dev/null || echo "progress=unparsed"
+  progress="$(python3 -S - "$path" <<'PY' 2>/dev/null || echo "progress=unparsed"
 import json, sys
 
 try:
@@ -58,12 +70,30 @@ try:
 except (OSError, ValueError):
     print("progress=unparsed")
     raise SystemExit(0)
+
+
+def short(identity):
+    if not isinstance(identity, str):
+        return identity
+    # generation.v1.<repo>.<ordinal>.<digest> -> keep the distinguishing tail.
+    parts = identity.rsplit(".", 2)
+    if len(parts) == 3 and len(parts[2]) > 12:
+        return "%s.%s" % (parts[1], parts[2][:12])
+    # sha256:<hex> -> the algorithm and a prefix of the digest.
+    algorithm, separator, digest = identity.partition(":")
+    if separator and len(digest) > 12:
+        return "%s:%s" % (algorithm, digest[:12])
+    return identity
+
+
 freshness = payload.get("code_index_freshness") or {}
 worktree = freshness.get("worktree") or {}
 progress = worktree.get("progress") or {}
 serving = worktree.get("code_graph_serving") or {}
 print(
-    "status=%s serving=%s phase=%s files=%s/%s pages=%s blocked=%s"
+    "status=%s serving=%s phase=%s files=%s/%s pages=%s blocked=%s "
+    "rebuild=%s staleness=%s generation=%s progress_generation=%s sealed_source=%s "
+    "eta_s=%s"
     % (
         freshness.get("status"),
         serving.get("state"),
@@ -72,7 +102,86 @@ print(
         progress.get("total_files"),
         progress.get("committed_pages"),
         progress.get("blocked_reason"),
+        worktree.get("rebuild_in_flight"),
+        worktree.get("staleness_state"),
+        short(worktree.get("latest_generation_id")),
+        short(progress.get("generation_id")),
+        short(progress.get("sealed_source_digest")),
+        progress.get("estimated_remaining_seconds"),
     )
+)
+PY
+)"
+  echo "$progress $(summarize_daemon_memory)"
+}
+
+# Current and peak resident memory of the harness daemon, when the harness
+# exported its pid and the platform exposes `/proc`.
+summarize_daemon_memory() {
+  local pid="${TRACEDECAY_DAEMON_HARNESS_PID:-}"
+  if [[ -n "$pid" && -r "/proc/$pid/status" ]]; then
+    awk '
+      /^VmRSS:/ { rss = $2 }
+      /^VmHWM:/ { peak = $2 }
+      END { printf "rss_kb=%s peak_rss_kb=%s\n", (rss == "" ? "n/a" : rss), (peak == "" ? "n/a" : peak) }
+    ' "/proc/$pid/status" 2>/dev/null || echo "rss_kb=n/a peak_rss_kb=n/a"
+  else
+    echo "rss_kb=n/a peak_rss_kb=n/a"
+  fi
+}
+
+# Compact phase timeline from the attempts log: the first elapsed time each
+# distinct (status, serving, phase) row was observed plus the peak daemon RSS,
+# so a report shows when the journey crossed each readiness boundary (or where
+# it stopped) without reading every attempt.
+summarize_phase_timeline() {
+  local attempts_log="$1"
+  [[ -s "$attempts_log" ]] || return 0
+  python3 -S - "$attempts_log" <<'PY' 2>/dev/null || true
+import sys
+
+first_seen = []
+seen = set()
+peak_rss = None
+last_elapsed = None
+with open(sys.argv[1], encoding="utf-8") as handle:
+    for line in handle:
+        fields = dict(
+            token.split("=", 1) for token in line.split() if "=" in token
+        )
+        elapsed = fields.get("elapsed_ms")
+        if elapsed is None:
+            continue
+        last_elapsed = elapsed
+        key = (
+            fields.get("status"),
+            fields.get("serving"),
+            fields.get("phase"),
+        )
+        if key not in seen:
+            seen.add(key)
+            first_seen.append(
+                (
+                    elapsed,
+                    key,
+                    fields.get("files"),
+                    fields.get("generation"),
+                )
+            )
+        peak = fields.get("peak_rss_kb")
+        if peak not in (None, "n/a"):
+            try:
+                peak_rss = max(peak_rss or 0, int(peak))
+            except ValueError:
+                pass
+for elapsed, (status, serving, phase), files, generation in first_seen:
+    print(
+        "tracedecay_ci_phase first_seen_elapsed_ms=%s status=%s serving=%s phase=%s files=%s generation=%s"
+        % (elapsed, status, serving, phase, files, generation)
+    )
+print(
+    "tracedecay_ci_phase_summary last_elapsed_ms=%s distinct_rows=%s daemon_peak_rss_kb=%s"
+    % (last_elapsed, len(first_seen), "n/a" if peak_rss is None else peak_rss)
 )
 PY
 }
@@ -209,6 +318,7 @@ raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)
       cat "$output_dir/status.validation.stdout"
       echo "tracedecay_ci_timing phase=status elapsed_ms=$duration_ms status=0"
       echo "tracedecay_ci_readiness attempts=$attempts elapsed_ms=$duration_ms"
+      summarize_phase_timeline "$output_dir/status.attempts.log"
       return 0
     fi
 
@@ -222,6 +332,8 @@ raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)
   duration_ms="$(elapsed_ms "$started_ms")"
   echo "tracedecay_ci_timing phase=status elapsed_ms=$duration_ms status=1"
   echo "error: TraceDecay PR dogfood did not reach strict index readiness within ${timeout_seconds}s" >&2
+  echo "----- phase timeline (first observation of each status/serving/phase row) -----" >&2
+  summarize_phase_timeline "$output_dir/status.attempts.log" >&2
   print_compact_file "status readiness attempts" "$output_dir/status.attempts.log"
   print_compact_file "last complete status output" "$output_dir/status.json"
   print_compact_file "last complete status stderr" "$output_dir/status.stderr"
@@ -317,7 +429,13 @@ main() {
 
   started_ms="$(python3 -S "$PROCESS_HELPER" monotonic-ms)"
   status=0
-  HOME="$WORK_DIR/home" \
+  # The daemon's stderr defaults to WARN, which hides every phase boundary the
+  # scheduler reports at INFO (reconcile pass started / interrupted, generation
+  # published, serving generation seated). A timeout report needs those
+  # timestamps to attribute the warming window, so enable exactly that target
+  # unless the operator already chose a filter.
+  RUST_LOG="${RUST_LOG:-warn,tracedecay_code_index_runtime::code_index_scheduler=info}" \
+    HOME="$WORK_DIR/home" \
     XDG_DATA_HOME="$WORK_DIR/home/.local/share" \
     XDG_CONFIG_HOME="$WORK_DIR/home/.config" \
     TRACEDECAY_BIN="$binary" \

--- a/scripts/ci-pr-dogfood-smoke.sh
+++ b/scripts/ci-pr-dogfood-smoke.sh
@@ -40,25 +40,22 @@ print_compact_file() {
   fi
 }
 
-# One line of code-index progress from a status payload, for the attempts
-# log: which phase the index is in and how far along, so a timeout report
-# shows where the journey stalled without rerunning it.
-#
-# The line names every identity strict readiness turns on, because they move
-# independently: `generation` is the sealed generation the worktree reports,
-# `progress_generation`/`sealed_source` identify the source the text projection
-# is committing against, and `serving` is graph seating. A `phase=None` row
-# with `rebuild=true` and no generation is the pre-seal source capture, which
-# publishes no progress record; it is not text or graph work.
-#
-# `rss_kb`/`peak_rss_kb` sample the daemon process the harness exported
-# (Linux `/proc` only; `n/a` elsewhere) so a timeout report carries memory
-# evidence, not only PASS/FAIL.
+# One line of code-index attribution from a status payload, for the attempts
+# log. Strict readiness is several distinct phases -- source capture and seal
+# (no progress phase yet), the bounded text projection, its finalization, then
+# the optional native graph seat -- and a timeout must name the one it died
+# in. So besides the phase and its counters this records the identities that
+# tell them apart: the sealed source digest and generation the text projection
+# is building, the coverage/staleness pair that gates `status=current`, the
+# graph seat state with its typed reason, and the graph-statistics state the
+# strict validator requires. Text readiness and graph seating stay separate
+# columns on purpose: a complete text projection waiting on the graph must
+# never read as a stalled text build (issue #917).
 summarize_status_progress() {
   local path="$1"
   local progress
   [[ -s "$path" ]] || {
-    echo "progress=unavailable $(summarize_daemon_memory)"
+    echo "progress=unavailable"
     return 0
   }
   progress="$(python3 -S - "$path" <<'PY' 2>/dev/null || echo "progress=unparsed"
@@ -72,116 +69,154 @@ except (OSError, ValueError):
     raise SystemExit(0)
 
 
-def short(identity):
-    if not isinstance(identity, str):
-        return identity
-    # generation.v1.<repo>.<ordinal>.<digest> -> keep the distinguishing tail.
-    parts = identity.rsplit(".", 2)
-    if len(parts) == 3 and len(parts[2]) > 12:
-        return "%s.%s" % (parts[1], parts[2][:12])
-    # sha256:<hex> -> the algorithm and a prefix of the digest.
-    algorithm, separator, digest = identity.partition(":")
-    if separator and len(digest) > 12:
-        return "%s:%s" % (algorithm, digest[:12])
-    return identity
+def tail(value, width=12):
+    if not isinstance(value, str) or not value:
+        return None
+    return value[-width:]
 
 
 freshness = payload.get("code_index_freshness") or {}
 worktree = freshness.get("worktree") or {}
 progress = worktree.get("progress") or {}
 serving = worktree.get("code_graph_serving") or {}
+statistics = payload.get("graph_statistics") or {}
+graph = serving.get("state")
+if serving.get("reason"):
+    graph = "%s:%s" % (graph, str(serving["reason"]).replace(" ", "_")[:48])
+elapsed_micros = progress.get("elapsed_micros")
+commit_micros = progress.get("last_commit_latency_micros")
 print(
-    "status=%s serving=%s phase=%s files=%s/%s pages=%s blocked=%s "
-    "rebuild=%s staleness=%s generation=%s progress_generation=%s sealed_source=%s "
-    "eta_s=%s"
+    "status=%s coverage=%s staleness=%s rebuild=%s gen=%s digest=%s graph=%s "
+    "gstats=%s phase=%s files=%s/%s pages=%s payload_mb=%s elapsed_s=%s "
+    "commit_ms=%s blocked=%s"
     % (
         freshness.get("status"),
-        serving.get("state"),
+        worktree.get("coverage"),
+        worktree.get("staleness_state"),
+        worktree.get("rebuild_in_flight"),
+        tail(worktree.get("latest_generation_id")),
+        tail(progress.get("sealed_source_digest")),
+        graph,
+        statistics.get("state"),
         progress.get("phase"),
         progress.get("completed_files"),
         progress.get("total_files"),
         progress.get("committed_pages"),
+        None
+        if progress.get("committed_payload_bytes") is None
+        else int(progress["committed_payload_bytes"]) // 1_000_000,
+        None if elapsed_micros is None else int(elapsed_micros) // 1_000_000,
+        None if commit_micros is None else int(commit_micros) // 1_000,
         progress.get("blocked_reason"),
-        worktree.get("rebuild_in_flight"),
-        worktree.get("staleness_state"),
-        short(worktree.get("latest_generation_id")),
-        short(progress.get("generation_id")),
-        short(progress.get("sealed_source_digest")),
-        progress.get("estimated_remaining_seconds"),
     )
 )
 PY
 )"
-  echo "$progress $(summarize_daemon_memory)"
+  echo "$progress"
 }
 
-# Current and peak resident memory of the harness daemon, when the harness
-# exported its pid and the platform exposes `/proc`.
+# The daemon's resident memory at this probe, in MiB, plus the peak the kernel
+# reports where it has one. The harness exports TRACEDECAY_DAEMON_PID; without
+# it (or once the daemon is gone) the sample says so instead of failing the
+# probe. Memory is part of the readiness evidence: on a 16 GiB runner the
+# native graph seat, not the text projection, is what can exhaust the host.
 summarize_daemon_memory() {
-  local pid="${TRACEDECAY_DAEMON_HARNESS_PID:-}"
-  if [[ -n "$pid" && -r "/proc/$pid/status" ]]; then
-    awk '
-      /^VmRSS:/ { rss = $2 }
-      /^VmHWM:/ { peak = $2 }
-      END { printf "rss_kb=%s peak_rss_kb=%s\n", (rss == "" ? "n/a" : rss), (peak == "" ? "n/a" : peak) }
-    ' "/proc/$pid/status" 2>/dev/null || echo "rss_kb=n/a peak_rss_kb=n/a"
-  else
-    echo "rss_kb=n/a peak_rss_kb=n/a"
-  fi
+  local pid="${TRACEDECAY_DAEMON_PID:-}"
+  [[ -n "$pid" ]] || {
+    echo "daemon_rss_mb=unavailable daemon_peak_rss_mb=unavailable"
+    return 0
+  }
+  python3 -S - "$PROCESS_HELPER" "$pid" <<'PY' 2>/dev/null || echo "daemon_rss_mb=unavailable daemon_peak_rss_mb=unavailable"
+import subprocess, sys
+
+completed = subprocess.run(
+    [sys.executable, "-S", sys.argv[1], "resident-memory", "--pid", sys.argv[2]],
+    check=False,
+    capture_output=True,
+    text=True,
+    timeout=10,
+)
+values = dict(
+    field.split("=", 1) for field in completed.stdout.split() if "=" in field
+)
+
+
+def mib(key):
+    raw = values.get(key)
+    return str(int(raw) // 1024) if raw and raw.isdigit() else "unavailable"
+
+
+print("daemon_rss_mb=%s daemon_peak_rss_mb=%s" % (mib("rss_kib"), mib("peak_rss_kib")))
+PY
 }
 
-# Compact phase timeline from the attempts log: the first elapsed time each
-# distinct (status, serving, phase) row was observed plus the peak daemon RSS,
-# so a report shows when the journey crossed each readiness boundary (or where
-# it stopped) without reading every attempt.
-summarize_phase_timeline() {
-  local attempts_log="$1"
-  [[ -s "$attempts_log" ]] || return 0
-  python3 -S - "$attempts_log" <<'PY' 2>/dev/null || true
+# Attribute the readiness journey from the attempts log: when progress first
+# became visible, when the text projection reached its complete state, when
+# the graph seat became ready, the peak daemon memory observed, and the last
+# phase/graph state. Printed on success and on timeout alike, so a PASS
+# carries its phase timings and peak memory rather than only a verdict, and a
+# timeout says whether it died sealing, projecting text, or seating the graph.
+report_readiness_phases() {
+  local attempts_path="$1"
+  local outcome="$2"
+  [[ -s "$attempts_path" ]] || {
+    echo "tracedecay_ci_readiness_phases outcome=$outcome attempts=0"
+    return 0
+  }
+  python3 -S - "$attempts_path" "$outcome" <<'PY' 2>/dev/null || echo "tracedecay_ci_readiness_phases outcome=$outcome parse=failed"
 import sys
 
-first_seen = []
-seen = set()
+first = {}
 peak_rss = None
-last_elapsed = None
+last = {}
+attempts = 0
 with open(sys.argv[1], encoding="utf-8") as handle:
     for line in handle:
         fields = dict(
-            token.split("=", 1) for token in line.split() if "=" in token
+            field.split("=", 1) for field in line.split() if "=" in field
         )
-        elapsed = fields.get("elapsed_ms")
-        if elapsed is None:
+        if "attempt" not in fields:
             continue
-        last_elapsed = elapsed
-        key = (
-            fields.get("status"),
-            fields.get("serving"),
-            fields.get("phase"),
-        )
-        if key not in seen:
-            seen.add(key)
-            first_seen.append(
-                (
-                    elapsed,
-                    key,
-                    fields.get("files"),
-                    fields.get("generation"),
-                )
-            )
-        peak = fields.get("peak_rss_kb")
-        if peak not in (None, "n/a"):
-            try:
-                peak_rss = max(peak_rss or 0, int(peak))
-            except ValueError:
-                pass
-for elapsed, (status, serving, phase), files, generation in first_seen:
-    print(
-        "tracedecay_ci_phase first_seen_elapsed_ms=%s status=%s serving=%s phase=%s files=%s generation=%s"
-        % (elapsed, status, serving, phase, files, generation)
-    )
+        attempts += 1
+        elapsed = fields.get("elapsed_ms")
+        last = fields
+        phase = fields.get("phase")
+        graph = fields.get("graph", "")
+        if phase not in (None, "None") and "first_progress_ms" not in first:
+            first["first_progress_ms"] = elapsed
+        if fields.get("gen") not in (None, "None") and "first_generation_ms" not in first:
+            first["first_generation_ms"] = elapsed
+        if (
+            phase == "ready" or fields.get("coverage") == "complete"
+        ) and "text_complete_ms" not in first:
+            first["text_complete_ms"] = elapsed
+        if graph.startswith("ready") and "graph_ready_ms" not in first:
+            first["graph_ready_ms"] = elapsed
+        if fields.get("status") == "current" and "status_current_ms" not in first:
+            first["status_current_ms"] = elapsed
+        for key in ("daemon_peak_rss_mb", "daemon_rss_mb"):
+            raw = fields.get(key)
+            if raw and raw.isdigit():
+                peak_rss = max(peak_rss or 0, int(raw))
+                break
 print(
-    "tracedecay_ci_phase_summary last_elapsed_ms=%s distinct_rows=%s daemon_peak_rss_kb=%s"
-    % (last_elapsed, len(first_seen), "n/a" if peak_rss is None else peak_rss)
+    "tracedecay_ci_readiness_phases outcome=%s attempts=%d first_progress_ms=%s "
+    "first_generation_ms=%s text_complete_ms=%s graph_ready_ms=%s status_current_ms=%s "
+    "peak_daemon_rss_mb=%s last_phase=%s last_files=%s last_graph=%s last_coverage=%s"
+    % (
+        sys.argv[2],
+        attempts,
+        first.get("first_progress_ms"),
+        first.get("first_generation_ms"),
+        first.get("text_complete_ms"),
+        first.get("graph_ready_ms"),
+        first.get("status_current_ms"),
+        "unavailable" if peak_rss is None else peak_rss,
+        last.get("phase"),
+        last.get("files"),
+        last.get("graph"),
+        last.get("coverage"),
+    )
 )
 PY
 }
@@ -307,9 +342,10 @@ raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)
           2>"$output_dir/status.validation.stderr" || validation_status=$?
       fi
     fi
-    printf 'attempt=%s elapsed_ms=%s probe_ms=%s status_rc=%s validation_rc=%s %s\n' \
+    printf 'attempt=%s elapsed_ms=%s probe_ms=%s status_rc=%s validation_rc=%s %s %s\n' \
       "$attempts" "$(elapsed_ms "$started_ms")" "$probe_ms" "$command_status" \
       "$validation_status" "$(summarize_status_progress "$output_dir/status.json")" \
+      "$(summarize_daemon_memory)" \
       >>"$output_dir/status.attempts.log"
     if ((command_status == 0 && validation_status == 0)); then
       duration_ms="$(elapsed_ms "$started_ms")"
@@ -318,7 +354,7 @@ raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)
       cat "$output_dir/status.validation.stdout"
       echo "tracedecay_ci_timing phase=status elapsed_ms=$duration_ms status=0"
       echo "tracedecay_ci_readiness attempts=$attempts elapsed_ms=$duration_ms"
-      summarize_phase_timeline "$output_dir/status.attempts.log"
+      report_readiness_phases "$output_dir/status.attempts.log" ready
       return 0
     fi
 
@@ -331,9 +367,8 @@ raise SystemExit(0 if math.isfinite(value) and value > 0 else 1)
 
   duration_ms="$(elapsed_ms "$started_ms")"
   echo "tracedecay_ci_timing phase=status elapsed_ms=$duration_ms status=1"
+  report_readiness_phases "$output_dir/status.attempts.log" timeout
   echo "error: TraceDecay PR dogfood did not reach strict index readiness within ${timeout_seconds}s" >&2
-  echo "----- phase timeline (first observation of each status/serving/phase row) -----" >&2
-  summarize_phase_timeline "$output_dir/status.attempts.log" >&2
   print_compact_file "status readiness attempts" "$output_dir/status.attempts.log"
   print_compact_file "last complete status output" "$output_dir/status.json"
   print_compact_file "last complete status stderr" "$output_dir/status.stderr"

--- a/scripts/lib/portable_process.py
+++ b/scripts/lib/portable_process.py
@@ -247,6 +247,58 @@ def command_realpath(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resident_memory_kib(pid: int) -> tuple[int | None, int | None]:
+    """Current and peak resident set size of `pid` in KiB, when measurable.
+
+    Linux exposes both through `/proc/<pid>/status` (`VmRSS`, `VmHWM`). Other
+    Unix kernels report the current size through `ps`; they have no portable
+    peak, so the caller keeps its own high-water mark across samples. A
+    process that has already exited yields no measurement rather than an
+    error: the sample is evidence, never a liveness check.
+    """
+    status_path = Path(f"/proc/{pid}/status")
+    try:
+        status = status_path.read_text(encoding="utf-8")
+    except OSError:
+        status = None
+    if status is not None:
+        current = peak = None
+        for line in status.splitlines():
+            key, _, rest = line.partition(":")
+            fields = rest.split()
+            if not fields or not fields[0].isdigit():
+                continue
+            if key == "VmRSS":
+                current = int(fields[0])
+            elif key == "VmHWM":
+                peak = int(fields[0])
+        return current, peak
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None, None
+    value = completed.stdout.strip()
+    if completed.returncode != 0 or not value.isdigit():
+        return None, None
+    return int(value), None
+
+
+def _render_kib(value: int | None) -> str:
+    return "unavailable" if value is None else str(value)
+
+
+def command_resident_memory(args: argparse.Namespace) -> int:
+    current, peak = _resident_memory_kib(args.pid)
+    print(f"rss_kib={_render_kib(current)} peak_rss_kib={_render_kib(peak)}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="action", required=True)
@@ -282,6 +334,10 @@ def build_parser() -> argparse.ArgumentParser:
     realpath = subparsers.add_parser("realpath")
     realpath.add_argument("path")
     realpath.set_defaults(func=command_realpath)
+
+    resident_memory = subparsers.add_parser("resident-memory")
+    resident_memory.add_argument("--pid", required=True, type=_positive_pid)
+    resident_memory.set_defaults(func=command_resident_memory)
     return parser
 
 

--- a/scripts/test-pr-dogfood-portability.py
+++ b/scripts/test-pr-dogfood-portability.py
@@ -171,6 +171,31 @@ class PortableProcessTests(unittest.TestCase):
         self.assertEqual(resolved.returncode, 0)
         self.assertEqual(Path(resolved.stdout.strip()), HELPER.resolve())
 
+    def test_resident_memory_sample_is_portable_and_never_fails_the_probe(self) -> None:
+        sampled = helper("resident-memory", "--pid", str(os.getpid()))
+        self.assertEqual(sampled.returncode, 0, sampled.stderr)
+        fields = dict(
+            field.split("=", 1) for field in sampled.stdout.split() if "=" in field
+        )
+        self.assertEqual(set(fields), {"rss_kib", "peak_rss_kib"})
+        # This interpreter is alive and resident on every supported kernel;
+        # the peak is Linux-only and reads `unavailable` elsewhere.
+        self.assertTrue(fields["rss_kib"].isdigit(), sampled.stdout)
+        self.assertGreater(int(fields["rss_kib"]), 0)
+        self.assertTrue(
+            fields["peak_rss_kib"].isdigit() or fields["peak_rss_kib"] == "unavailable",
+            sampled.stdout,
+        )
+
+        with subprocess.Popen([sys.executable, "-c", "pass"]) as exited:
+            exited.wait(timeout=10)
+            gone = helper("resident-memory", "--pid", str(exited.pid))
+        # A process that is already gone is a missing measurement, not an
+        # error: the sample is evidence for the attempts log, never a probe
+        # that may fail the readiness loop.
+        self.assertEqual(gone.returncode, 0, gone.stderr)
+        self.assertIn("rss_kib=unavailable", gone.stdout)
+
     def test_group_probes_ignore_an_unreaped_zombie_leader(self) -> None:
         holder_source = textwrap.dedent(
             """
@@ -491,7 +516,7 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
                       fi
                       count="$((count + 1))"
                       echo "$count" >"$FAKE_STATUS_COUNTER"
-                      if [[ "${FAKE_NEVER_READY:-0}" == "1" || "$count" -lt 3 ]]; then
+                      if [[ "${FAKE_NEVER_READY:-0}" == "1" || "$count" -lt 2 ]]; then
                         echo '{"code_index_freshness":{"status":"current","worktree":{"coverage":"complete","staleness_state":"fresh","latest_generation_id":"generation.text-only"}},"graph_statistics":{"state":"unavailable","reason":"exact_scope_generation_not_ready"}}'
                       else
                         echo '{"code_index_freshness":{"status":"current","worktree":{"coverage":"complete","staleness_state":"fresh","latest_generation_id":"generation.ready","code_graph_serving":{"state":"ready"}}},"graph_statistics":{"state":"observed","generation_id":"generation.ready","symbol_count":2,"edge_count":1}}'
@@ -556,8 +581,19 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
             self.assertIn(
                 "TraceDecay PR dogfood pr_context output is valid", completed.stdout
             )
-            self.assertIn("tracedecay_ci_readiness attempts=3", completed.stdout)
-            self.assertEqual(status_counter.read_text(encoding="utf-8").strip(), "4")
+            self.assertIn("tracedecay_ci_readiness attempts=2", completed.stdout)
+            # A PASS carries its phase attribution, not only the verdict: the
+            # readiness journey names when text completed and the graph seated,
+            # and reports the daemon memory it observed (unavailable here, the
+            # fake binary runs without the daemon harness).
+            self.assertRegex(
+                completed.stdout,
+                r"tracedecay_ci_readiness_phases outcome=ready attempts=2 "
+                r"first_progress_ms=\S+ first_generation_ms=\d+ text_complete_ms=\d+ "
+                r"graph_ready_ms=\d+ status_current_ms=\d+ peak_daemon_rss_mb=unavailable "
+                r"last_phase=\S+ last_files=\S+ last_graph=ready last_coverage=complete",
+            )
+            self.assertEqual(status_counter.read_text(encoding="utf-8").strip(), "3")
             self.assertIn("tracedecay_ci_dogfood outcome=complete", completed.stdout)
 
     def test_run_mode_bounds_never_ready_graph_and_surfaces_last_reason(self) -> None:
@@ -626,6 +662,23 @@ class DogfoodJourneyOutputTests(unittest.TestCase):
             self.assertIn("exact_scope_generation_not_ready", completed.stderr)
             self.assertNotIn("Traceback", completed.stderr)
             self.assertNotIn("tracedecay_ci_dogfood outcome=complete", completed.stdout)
+            # The timeout attributes the journey: text was complete and
+            # current the whole time, the graph never reported ready, and
+            # every probe row carries the graph column separately from the
+            # text phase so a waiting graph is never read as a text stall.
+            self.assertRegex(
+                completed.stdout,
+                r"tracedecay_ci_readiness_phases outcome=timeout attempts=\d+ "
+                r"first_progress_ms=None first_generation_ms=\d+ text_complete_ms=\d+ "
+                r"graph_ready_ms=None status_current_ms=\d+ peak_daemon_rss_mb=unavailable "
+                r"last_phase=None last_files=None/None last_graph=None last_coverage=complete",
+            )
+            self.assertRegex(
+                completed.stderr,
+                r"attempt=1 elapsed_ms=\d+ probe_ms=\d+ status_rc=0 validation_rc=1 "
+                r"status=current coverage=complete staleness=fresh rebuild=None "
+                r"gen=on\.text-only digest=None graph=None gstats=unavailable phase=None",
+            )
 
     def test_run_mode_retains_valid_status_when_next_probe_is_malformed(self) -> None:
         with tempfile.TemporaryDirectory(prefix="dogfood-malformed-status-") as tmp:

--- a/scripts/with-isolated-tracedecay-daemon.sh
+++ b/scripts/with-isolated-tracedecay-daemon.sh
@@ -17,7 +17,8 @@ Options:
   --lifecycle-label LABEL  Print start/stop messages using LABEL
 
 The harness creates an isolated TraceDecay profile and Unix socket, exports
-TRACEDECAY_DATA_DIR and TRACEDECAY_DAEMON_SOCKET to COMMAND, and removes the
+TRACEDECAY_DATA_DIR, TRACEDECAY_DAEMON_SOCKET and TRACEDECAY_DAEMON_HARNESS_PID
+(the daemon process id, for memory sampling) to COMMAND, and removes the
 profile after the command and daemon have stopped.
 EOF
   exit 2
@@ -166,6 +167,7 @@ else
   ) >"$daemon_log" 2>&1 &
 fi
 daemon_pid=$!
+export TRACEDECAY_DAEMON_HARNESS_PID="$daemon_pid"
 
 if ! python3 -S "$PROCESS_HELPER" wait-unix-socket \
   --path "$TRACEDECAY_DAEMON_SOCKET" \

--- a/scripts/with-isolated-tracedecay-daemon.sh
+++ b/scripts/with-isolated-tracedecay-daemon.sh
@@ -17,9 +17,9 @@ Options:
   --lifecycle-label LABEL  Print start/stop messages using LABEL
 
 The harness creates an isolated TraceDecay profile and Unix socket, exports
-TRACEDECAY_DATA_DIR, TRACEDECAY_DAEMON_SOCKET and TRACEDECAY_DAEMON_HARNESS_PID
-(the daemon process id, for memory sampling) to COMMAND, and removes the
-profile after the command and daemon have stopped.
+TRACEDECAY_DATA_DIR, TRACEDECAY_DAEMON_SOCKET and TRACEDECAY_DAEMON_PID (the
+daemon process id, for memory sampling) to COMMAND, and removes the profile
+after the command and daemon have stopped.
 EOF
   exit 2
 }
@@ -167,7 +167,10 @@ else
   ) >"$daemon_log" 2>&1 &
 fi
 daemon_pid=$!
-export TRACEDECAY_DAEMON_HARNESS_PID="$daemon_pid"
+# `exec-session` execs into the daemon, so this is the daemon's own PID. The
+# smoke command samples its resident memory per readiness probe; a timeout or
+# an OOM-killed daemon is then attributable to a phase and a peak, not a guess.
+export TRACEDECAY_DAEMON_PID="$daemon_pid"
 
 if ! python3 -S "$PROCESS_HELPER" wait-unix-socket \
   --path "$TRACEDECAY_DAEMON_SOCKET" \


### PR DESCRIPTION
## Summary

- Preserve text freshness when an out-of-band edit arrives while a reconcile still owns its pass: one coalesced `BusyFollowUp` remains pending under concurrent reads, later edits are not lost, and shutdown/deadline interruptions retain their typed ownership without retry storms.
- Refuse optional native-graph publication at the daemon's measured resident-memory watermark. A pressure trip is permanent for that publication attempt; a later request cancellation keeps cancellation identity precedence; a recovered cell admits a new attempt.
- Keep text and graph truth independent. Resident-memory refusal preserves exact/lexical text serving and records a typed graph refusal, but it does **not** satisfy strict graph readiness.
- Consolidate #962 and #963 dogfood evidence into one authority: `TRACEDECAY_DAEMON_PID`, the portable `resident-memory` reader, and one `tracedecay_ci_readiness_phases` schema. The strict validator and 600-second bound are unchanged.

This PR supersedes #962 and contains its unique memory-refusal work. It targets #707 (`codex/tracedecay-total-redesign-plan-reopened`) and includes base `850b7a8c089ade73573d58fa4711876eb2ef7199`. Keep #917 open: pressure containment prevents OOM loss of text service, but the remaining graph/text scale work still has to reach the unchanged strict contract.

Do not merge yet; the parent integration lane will sequence this with #800 work.

## Review fixes

- Monotonic per-attempt pressure cancellation, with explicit request cancellation kept distinct from `GraphBudgetKind::ResidentMemory`.
- Real publication enters manifest projection before pressure trips; no journal/head is exposed, and a new recovered attempt publishes normally.
- 32 simultaneous freshness reads retain one follow-up; a source edit during the next owner pass is served by the successor.
- Text-only waits use the text-current seat; graph/pinned-cursor paths retain complete-seat assertions.
- Reconcile timing is named `wake_to_gates_held_micros`, not SQL-writer wait.
- Latest #707 integration fixes the former #962 hotpath slice compile failure and preserves the generation-free capability digest contract.

## Final evidence (`10ed30e137a1307a7b5801981fabf5f0775ec30a`)

- `cargo test -p tracedecay-code-index-runtime --lib code_index_scheduler:: -- --test-threads=1` — 318 passed, 0 failed, 1 ignored.
- `cargo test -p tracedecay-store-runtime --lib sealed_publication_tests -- --test-threads=1` — 7 passed, 0 failed, 1 ignored.
- `cargo test -p tracedecay-rusqlite-runtime -p tracedecay-global-db --locked --features tracedecay-rusqlite-runtime/hotpath,tracedecay-global-db/hotpath,tracedecay-global-db/test-helpers` — passed (the previously failing slice).
- `cargo clippy -p tracedecay-graph-db -p tracedecay-code-index-runtime -p tracedecay-store-runtime --all-targets -- -D warnings` — 0 errors, 0 warnings.
- `python3 scripts/test-pr-dogfood-portability.py` — 15 passed; `python3 scripts/test-check-pr-dogfood-output.py` — 14 passed.
- Bounded publication scale: 2 scopes × 96 files, one overlapping projection, 147.8 MiB retained growth, 168.2 MiB sampled peak growth, 5.406 s wall; all configured RSS ceilings passed.
- Commitlint and scoped rustfmt checks passed.