### PR TITLE
fix(runtime-core): admit shipped alias trigger migration

### DIFF
--- a/crates/tracedecay-runtime-core/src/db/migrations.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations.rs
@@ -312,16 +312,16 @@ pub async fn ensure_schema_current(database: &crate::db::Database) -> Result<()>
     ensure_schema_current_engine_connection(&connection).await
 }
 
-/// Steps a store that is exactly one sanctioned step behind the final shape
-/// (v34 -> v35) and reports whether a step ran. Any other stamp is left for
-/// [`verify_final_schema_connection`] to judge. This is the writer-side
-/// remedy the read-only verifier names for a pending step.
-pub(crate) async fn step_schema_if_pending<C: Executor>(conn: &C) -> Result<bool> {
-    if get_version(conn).await? != PAYLOAD_DIGEST_STEP_SOURCE_VERSION {
-        return Ok(false);
+/// Applies either sanctioned writer-side repair before read-only admission:
+/// the v34 -> v35 payload-digest step, or the exact shipped-v35 alias-trigger
+/// replacement. Every other stamp or shape remains for
+/// [`verify_final_schema_connection`] to refuse.
+pub(crate) async fn step_schema_if_pending(conn: &Connection) -> Result<bool> {
+    if get_version(conn).await? == PAYLOAD_DIGEST_STEP_SOURCE_VERSION {
+        step_payload_digests(conn).await?;
+        return Ok(true);
     }
-    step_payload_digests(conn).await?;
-    Ok(true)
+    repair_shipped_v35_alias_trigger_connection(conn).await
 }
 
 async fn ensure_schema_current_engine_connection(
@@ -334,7 +334,123 @@ async fn ensure_schema_current_engine_connection(
     if current == PAYLOAD_DIGEST_STEP_SOURCE_VERSION {
         step_payload_digests(conn).await?;
     }
+    repair_shipped_v35_alias_trigger_engine_connection(conn).await?;
     verify_final_schema_connection(conn).await
+}
+
+async fn repair_shipped_v35_alias_trigger(conn: &(impl Executor + Sync)) -> Result<bool> {
+    if !final_shape::require_exact_final_shape_or_shipped_v35_alias_trigger(conn).await? {
+        return Ok(false);
+    }
+    crate::db::retrieval_anchor_schema::install_retrieval_anchor_schema(
+        conn,
+        "repair shipped v35 retrieval-anchor alias trigger",
+    )
+    .await?;
+    final_shape::require_exact_final_shape(conn).await?;
+    Ok(true)
+}
+
+async fn repair_shipped_v35_alias_trigger_engine_connection(
+    conn: &DatabaseEngineWriteConnection,
+) -> Result<()> {
+    if get_version(conn).await? != SCHEMA_VERSION
+        || !final_shape::require_exact_final_shape_or_shipped_v35_alias_trigger(conn).await?
+    {
+        return Ok(());
+    }
+    let transaction = conn
+        .authorized_long_lease_transaction()
+        .await
+        .map_err(|error| TraceDecayError::Database {
+            message: format!("failed to acquire shipped-v35 trigger repair lock: {error}"),
+            operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+        })?;
+    let result = repair_shipped_v35_alias_trigger(&transaction).await;
+    match result {
+        Ok(true) => transaction
+            .commit()
+            .await
+            .map_err(|error| TraceDecayError::Database {
+                message: format!("failed to commit shipped-v35 trigger repair: {error}"),
+                operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+            }),
+        Ok(false) => transaction
+            .rollback()
+            .await
+            .map_err(|error| TraceDecayError::Database {
+                message: format!(
+                    "failed to roll back redundant shipped-v35 trigger repair: {error}"
+                ),
+                operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+            }),
+        Err(error) => match transaction.rollback().await {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(trigger_repair_rollback_failure(error, rollback_error)),
+        },
+    }
+}
+
+async fn repair_shipped_v35_alias_trigger_connection(conn: &Connection) -> Result<bool> {
+    if get_version(conn).await? != SCHEMA_VERSION
+        || !final_shape::require_exact_final_shape_or_shipped_v35_alias_trigger(conn).await?
+    {
+        return Ok(false);
+    }
+    let transaction = conn
+        .authorized_long_lease_transaction()
+        .await
+        .map_err(|error| TraceDecayError::Database {
+            message: format!("failed to acquire shipped-v35 trigger repair lock: {error}"),
+            operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+        })?;
+    let result = repair_shipped_v35_alias_trigger(&transaction).await;
+    match result {
+        Ok(true) => {
+            transaction
+                .commit()
+                .await
+                .map(|()| true)
+                .map_err(|error| TraceDecayError::Database {
+                    message: format!("failed to commit shipped-v35 trigger repair: {error}"),
+                    operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+                })
+        }
+        Ok(false) => transaction
+            .rollback()
+            .await
+            .map(|()| false)
+            .map_err(|error| TraceDecayError::Database {
+                message: format!(
+                    "failed to roll back redundant shipped-v35 trigger repair: {error}"
+                ),
+                operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+            }),
+        Err(error) => match transaction.rollback().await {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(trigger_repair_rollback_failure(error, rollback_error)),
+        },
+    }
+}
+
+fn trigger_repair_rollback_failure(
+    error: TraceDecayError,
+    rollback_error: impl std::fmt::Display,
+) -> TraceDecayError {
+    match error {
+        TraceDecayError::ResetRequired { authority, reason } => TraceDecayError::ResetRequired {
+            authority,
+            reason: format!("{reason}; trigger-repair rollback also failed: {rollback_error}"),
+        },
+        TraceDecayError::Database { message, operation } => TraceDecayError::Database {
+            message: format!("{message}; trigger-repair rollback also failed: {rollback_error}"),
+            operation,
+        },
+        error => TraceDecayError::Database {
+            message: format!("{error}; trigger-repair rollback also failed: {rollback_error}"),
+            operation: "repair shipped v35 retrieval-anchor alias trigger".to_owned(),
+        },
+    }
 }
 
 /// Steps a v34 store to v35: creates the payload-digest objects (idempotent)
@@ -516,6 +632,7 @@ pub(crate) async fn ensure_schema_current_connection(conn: &Connection) -> Resul
     if current == PAYLOAD_DIGEST_STEP_SOURCE_VERSION {
         step_payload_digests(conn).await?;
     }
+    repair_shipped_v35_alias_trigger_connection(conn).await?;
     verify_final_schema_connection(conn).await
 }
 

--- a/crates/tracedecay-runtime-core/src/db/migrations/final_shape.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations/final_shape.rs
@@ -18,6 +18,30 @@ type SchemaInventory = BTreeMap<String, SchemaObject>;
 static EXPECTED_FINAL_SHAPE: LazyLock<std::result::Result<SchemaInventory, String>> =
     LazyLock::new(build_expected_final_shape);
 
+pub(super) const SHIPPED_V35_ALIAS_UPDATE_TRIGGER: &str = "
+    CREATE TRIGGER retrieval_anchor_aliases_immutable_update
+    BEFORE UPDATE ON retrieval_anchor_aliases BEGIN
+        SELECT RAISE(ABORT, 'retrieval anchor aliases are immutable');
+    END;
+";
+
+static SHIPPED_V35_ALIAS_UPDATE_OBJECT: LazyLock<std::result::Result<SchemaObject, String>> =
+    LazyLock::new(build_shipped_v35_alias_update_object);
+
+fn build_shipped_v35_alias_update_object() -> std::result::Result<SchemaObject, String> {
+    let connection = rusqlite::Connection::open_in_memory()
+        .map_err(|error| format!("failed to open shipped-v35 trigger fixture: {error}"))?;
+    connection
+        .execute_batch("CREATE TABLE retrieval_anchor_aliases(anchor_id TEXT);")
+        .map_err(|error| format!("failed to create shipped-v35 trigger table: {error}"))?;
+    connection
+        .execute_batch(SHIPPED_V35_ALIAS_UPDATE_TRIGGER)
+        .map_err(|error| format!("failed to create shipped-v35 trigger: {error}"))?;
+    read_rusqlite_inventory(&connection)?
+        .remove("retrieval_anchor_aliases_immutable_update")
+        .ok_or_else(|| "shipped-v35 trigger fixture did not create its trigger".to_owned())
+}
+
 fn build_expected_final_shape() -> std::result::Result<SchemaInventory, String> {
     let connection = rusqlite::Connection::open_in_memory()
         .map_err(|error| format!("failed to open canonical in-memory schema: {error}"))?;
@@ -215,9 +239,36 @@ pub(super) async fn require_final_shape_except_payload_digests(
 
 pub(super) async fn require_exact_final_shape(conn: &impl QueryExecutor) -> Result<()> {
     let actual = read_inventory(conn).await?;
+    require_final_shape_inventory(&actual, None)?;
+    Ok(())
+}
+
+/// Admits only the exact current shape or the exact shape emitted by the
+/// shipped v35 binary before alias-target correction was supported.
+///
+/// The returned flag identifies the one known trigger replacement the writer
+/// may perform. Every other missing, additional, or byte-different schema
+/// object remains reset-required.
+pub(super) async fn require_exact_final_shape_or_shipped_v35_alias_trigger(
+    conn: &impl QueryExecutor,
+) -> Result<bool> {
+    let actual = read_inventory(conn).await?;
+    let shipped = SHIPPED_V35_ALIAS_UPDATE_OBJECT
+        .as_ref()
+        .map_err(|error| database_error(error.clone()))?;
+    require_final_shape_inventory(&actual, Some(shipped))
+}
+
+fn require_final_shape_inventory(
+    actual: &SchemaInventory,
+    shipped_v35_alias_trigger: Option<&SchemaObject>,
+) -> Result<bool> {
+    const TRIGGER: &str = "retrieval_anchor_aliases_immutable_update";
+
     let expected = EXPECTED_FINAL_SHAPE
         .as_ref()
         .map_err(|error| database_error(error.clone()))?;
+    let mut shipped_trigger_found = false;
 
     for (name, expected_object) in expected {
         let Some(actual_object) = actual.get(name) else {
@@ -227,10 +278,14 @@ pub(super) async fn require_exact_final_shape(conn: &impl QueryExecutor) -> Resu
             )));
         };
         if actual_object != expected_object {
-            return Err(reset_required(format!(
-                "database schema has incompatible {} '{name}'",
-                expected_object.object_type
-            )));
+            if name == TRIGGER && shipped_v35_alias_trigger == Some(actual_object) {
+                shipped_trigger_found = true;
+            } else {
+                return Err(reset_required(format!(
+                    "database schema has incompatible {} '{name}'",
+                    expected_object.object_type
+                )));
+            }
         }
     }
     if let Some((name, object)) = actual
@@ -242,5 +297,5 @@ pub(super) async fn require_exact_final_shape(conn: &impl QueryExecutor) -> Resu
             object.object_type
         )));
     }
-    Ok(())
+    Ok(shipped_trigger_found)
 }

--- a/crates/tracedecay-runtime-core/src/db/migrations/tests.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations/tests.rs
@@ -5,6 +5,7 @@ use tracedecay_rusqlite_runtime::exact_sql::{
 };
 
 use crate::db::engine::{Connection, TestConnection};
+use crate::db::{Database, DatabaseAuthority, TestDatabaseRuntimeMode};
 
 use super::{
     PAYLOAD_DIGEST_BACKFILL_RECEIPT_KEY, PAYLOAD_DIGEST_STEP_SOURCE_VERSION, SCHEMA_VERSION,
@@ -117,6 +118,16 @@ async fn string_column(conn: &Connection, sql: &str) -> Vec<String> {
     values
 }
 
+async fn scalar_string(conn: &Connection, sql: &str) -> String {
+    let mut rows = conn.query(sql, ()).await.expect("failed to query string");
+    rows.next()
+        .await
+        .expect("failed to read string row")
+        .expect("string query should return a row")
+        .get(0)
+        .expect("failed to read string value")
+}
+
 async fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
     let mut rows = conn
         .query(&format!("PRAGMA table_info({table})"), ())
@@ -149,6 +160,239 @@ async fn an_empty_database_is_created_at_the_supported_schema_version() {
         .await
         .expect("reopening a current store is an identity check");
     assert_eq!(get_user_version(&conn).await, SCHEMA_VERSION);
+}
+
+#[tokio::test]
+async fn a_shipped_v35_alias_trigger_is_repaired_without_losing_rows() {
+    let (conn, dir) = create_schema_db().await;
+    let path = dir.path().join("test.db");
+    conn.execute(
+        "INSERT INTO retrieval_anchors(
+             anchor_id, anchor_json, owner_json, projection_generation
+         ) VALUES ('anchor.fixture', '{}', '{}', 'generation.fixture')",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO retrieval_anchor_aliases(
+             owner_json, alias_kind, locator_digest, anchor_id
+         ) VALUES ('{}', 'native', 'digest.fixture', 'anchor.fixture')",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute_batch("DROP TRIGGER retrieval_anchor_aliases_immutable_update;")
+        .await
+        .unwrap();
+    conn.execute_batch(super::final_shape::SHIPPED_V35_ALIAS_UPDATE_TRIGGER)
+        .await
+        .unwrap();
+    drop(conn);
+
+    let authority = DatabaseAuthority::acquire_test(&path, "shipped-v35 trigger repair fixture")
+        .expect("acquire production-open authority");
+    let (database, _initialized) =
+        Database::publish_test_runtime(&path, &authority, TestDatabaseRuntimeMode::Existing)
+            .await
+            .expect("the production writer should repair the exact shipped-v35 trigger");
+    drop(database);
+    drop(authority);
+
+    let conn = TestConnection::open(&path);
+
+    assert_eq!(
+        scalar_string(
+            &conn,
+            "SELECT anchor_id FROM retrieval_anchor_aliases WHERE locator_digest = 'digest.fixture'"
+        )
+        .await,
+        "anchor.fixture"
+    );
+    let trigger = scalar_string(
+        &conn,
+        "SELECT sql FROM sqlite_master
+         WHERE type = 'trigger' AND name = 'retrieval_anchor_aliases_immutable_update'",
+    )
+    .await;
+    assert!(trigger.contains("retrieval anchor alias requires exact supersession"));
+    verify_final_schema_connection(&conn)
+        .await
+        .expect("the repaired store must carry the exact final shape");
+    let preserved_alias = scalar_string(
+        &conn,
+        "SELECT anchor_id FROM retrieval_anchor_aliases WHERE locator_digest = 'digest.fixture'",
+    )
+    .await;
+    let canonical_trigger = trigger;
+    drop(conn);
+
+    let authority = DatabaseAuthority::acquire_test(&path, "canonical v35 reopen fixture")
+        .expect("reacquire production-open authority");
+    let (database, _initialized) =
+        Database::publish_test_runtime(&path, &authority, TestDatabaseRuntimeMode::Existing)
+            .await
+            .expect("a canonical store should reopen without mutation");
+    drop(database);
+    drop(authority);
+    let conn = TestConnection::open(&path);
+    assert_eq!(
+        scalar_string(
+            &conn,
+            "SELECT anchor_id FROM retrieval_anchor_aliases WHERE locator_digest = 'digest.fixture'",
+        )
+        .await,
+        preserved_alias
+    );
+    assert_eq!(
+        scalar_string(
+            &conn,
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'trigger' AND name = 'retrieval_anchor_aliases_immutable_update'",
+        )
+        .await,
+        canonical_trigger
+    );
+    conn.execute(
+        "INSERT INTO retrieval_anchors(
+             anchor_id, anchor_json, owner_json, projection_generation
+         ) VALUES ('anchor.corrected', '{}', '{}', 'generation.fixture')",
+        (),
+    )
+    .await
+    .unwrap();
+    assert!(
+        conn.execute(
+            "UPDATE retrieval_anchor_aliases
+             SET anchor_id = 'anchor.corrected'
+             WHERE locator_digest = 'digest.fixture'",
+            (),
+        )
+        .await
+        .is_err()
+    );
+    conn.execute(
+        "INSERT INTO retrieval_anchor_dispositions(
+             disposition_id, anchor_id, owner_json, state, superseded_by,
+             reason_class, effective_at, record_json
+         ) VALUES (
+             'dis.fixture', 'anchor.fixture', '{}', 'superseded',
+             'anchor.corrected', 'correction', 1, '{}'
+         )",
+        (),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        conn.execute(
+            "UPDATE retrieval_anchor_aliases
+             SET anchor_id = 'anchor.corrected'
+             WHERE locator_digest = 'digest.fixture'",
+            (),
+        )
+        .await
+        .unwrap(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn a_shipped_v35_alias_trigger_with_another_incompatibility_is_refused_unchanged() {
+    let (conn, dir) = create_schema_db().await;
+    let path = dir.path().join("test.db");
+    conn.execute_batch("DROP TRIGGER retrieval_anchor_aliases_immutable_update;")
+        .await
+        .unwrap();
+    conn.execute_batch(super::final_shape::SHIPPED_V35_ALIAS_UPDATE_TRIGGER)
+        .await
+        .unwrap();
+    conn.execute_batch("CREATE TABLE unexpected_v35_object(id INTEGER PRIMARY KEY);")
+        .await
+        .unwrap();
+    let shipped_trigger = scalar_string(
+        &conn,
+        "SELECT sql FROM sqlite_master
+         WHERE type = 'trigger' AND name = 'retrieval_anchor_aliases_immutable_update'",
+    )
+    .await;
+    drop(conn);
+
+    let authority = DatabaseAuthority::acquire_test(&path, "incompatible v35 fixture")
+        .expect("acquire production-open authority");
+    let error =
+        match Database::publish_test_runtime(&path, &authority, TestDatabaseRuntimeMode::Existing)
+            .await
+        {
+            Ok(_) => panic!("a second incompatibility must prevent the known trigger repair"),
+            Err(error) => error,
+        };
+
+    assert_eq!(
+        error
+            .reset_required_context()
+            .map(|(authority, _reason)| authority),
+        Some("SQLite store")
+    );
+    drop(authority);
+    let conn = TestConnection::open(&path);
+    assert_eq!(
+        scalar_string(
+            &conn,
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'trigger' AND name = 'retrieval_anchor_aliases_immutable_update'",
+        )
+        .await,
+        shipped_trigger
+    );
+    assert!(table_exists(&conn, "unexpected_v35_object").await);
+    drop(conn);
+    drop(dir);
+
+    let (conn, dir) = create_schema_db().await;
+    let path = dir.path().join("test.db");
+    conn.execute_batch(
+        "DROP TRIGGER retrieval_anchor_aliases_immutable_update;
+         CREATE TRIGGER retrieval_anchor_aliases_immutable_update
+         BEFORE UPDATE ON retrieval_anchor_aliases BEGIN
+             SELECT RAISE(ABORT, 'unrecognized alias trigger');
+         END;",
+    )
+    .await
+    .unwrap();
+    let unknown_trigger = scalar_string(
+        &conn,
+        "SELECT sql FROM sqlite_master
+         WHERE type = 'trigger' AND name = 'retrieval_anchor_aliases_immutable_update'",
+    )
+    .await;
+    drop(conn);
+
+    let authority = DatabaseAuthority::acquire_test(&path, "unknown v35 trigger fixture")
+        .expect("acquire production-open authority");
+    let error =
+        match Database::publish_test_runtime(&path, &authority, TestDatabaseRuntimeMode::Existing)
+            .await
+        {
+            Ok(_) => panic!("an unknown trigger body must remain reset-required"),
+            Err(error) => error,
+        };
+    assert_eq!(
+        error
+            .reset_required_context()
+            .map(|(authority, _reason)| authority),
+        Some("SQLite store")
+    );
+    drop(authority);
+    let conn = TestConnection::open(&path);
+    assert_eq!(
+        scalar_string(
+            &conn,
+            "SELECT sql FROM sqlite_master
+             WHERE type = 'trigger' AND name = 'retrieval_anchor_aliases_immutable_update'",
+        )
+        .await,
+        unknown_trigger
+    );
 }
 
 /// A store stamped with any other version was written by an incompatible


### PR DESCRIPTION
## Summary
- recognize and transactionally repair the exact shipped v35 `retrieval_anchor_aliases_immutable_update` trigger shape
- preserve every alias row while replacing only that incompatible trigger
- roll back and retain `ResetRequired` for any additional or different incompatibility

## Tests
- shipped v35 trigger repairs without losing rows
- shipped trigger plus another incompatibility is refused unchanged
- 2/2 exact migration tests passed
- runtime-core all-target check and clippy `-D warnings` passed
- rustfmt, diff checks, and commitlint passed

This is a store-open blocker discovered while exercising #707.
