### PR TITLE
fix(clippy): drop LSP large futures and hotpath needless return

### DIFF
--- a/crates/tracedecay-lsp/src/analyzer/client.rs
+++ b/crates/tracedecay-lsp/src/analyzer/client.rs
@@ -757,7 +757,11 @@ impl StdioLspClient {
     where
         R: LspRequest,
     {
-        let response = self.request::<R>(params, cancellation, timeouts).await?;
+        // Boxed: with profiling enabled `request` is the widest I/O future in
+        // this client. Awaiting it by value inflates every semantic wrapper
+        // and the dispatch match (a match future is as large as its widest
+        // arm).
+        let response = Box::pin(self.request::<R>(params, cancellation, timeouts)).await?;
         serde_json::to_value(response).map_err(|error| LspSemanticRequestError::InvalidResponse {
             class: error.to_string(),
         })

--- a/crates/tracedecay/src/daemon/shutdown_watchdog.rs
+++ b/crates/tracedecay/src/daemon/shutdown_watchdog.rs
@@ -108,7 +108,7 @@ fn finalize_hotpath_report_within(bound: Duration) {
 fn watchdog_fire_after() -> Duration {
     #[cfg(feature = "hotpath")]
     {
-        return shutdown_exit_bound().saturating_sub(HOTPATH_FINALIZE_BOUND);
+        shutdown_exit_bound().saturating_sub(HOTPATH_FINALIZE_BOUND)
     }
     #[cfg(not(feature = "hotpath"))]
     shutdown_exit_bound()


### PR DESCRIPTION
## Summary
- box the measured LSP analyzer `request` future at the `request_json` boundary so hotpath unification no longer inflates 24 semantic wrappers past `large_futures`
- drop the needless `return` in the hotpath arm of `watchdog_fire_after`
- no lint allows, no threshold changes, no behavior change

Unblocks dependency-inclusive clippy for sibling #1073 lanes.

## Verification
- `clippy -p tracedecay-lsp --all-targets --all-features`: 0/0
- `clippy -p tracedecay --all-targets --features hotpath`: 0/0 (was 24 `large_futures` + 1 `needless_return`)
- `clippy -p tracedecay-maintenance -p tracedecay-mcp --all-targets --all-features`: 0/0
- `tracedecay-lsp` tests: 216 lib + 49 integration
- fmt, diff check, commitlint
