### PR TITLE
fix(daemon): emit post-reaper shutdown phase receipts

### DIFF
--- a/crates/tracedecay/src/daemon/core_logging.rs
+++ b/crates/tracedecay/src/daemon/core_logging.rs
@@ -69,7 +69,26 @@ fn quote_log_value(value: &str) -> String {
 }
 
 pub(crate) fn log_daemon_event(event: &str, fields: &[(&str, String)]) {
-    eprintln!("{}", format_daemon_log_line(event, fields));
+    let line = format_daemon_log_line(event, fields);
+    #[cfg(test)]
+    capture_daemon_event_line(&line);
+    eprintln!("{line}");
+}
+
+#[cfg(test)]
+thread_local! {
+    static CAPTURED_DAEMON_EVENT_LINES: std::cell::RefCell<Vec<String>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+fn capture_daemon_event_line(line: &str) {
+    CAPTURED_DAEMON_EVENT_LINES.with(|captured| captured.borrow_mut().push(line.to_owned()));
+}
+
+#[cfg(test)]
+pub(crate) fn take_captured_daemon_event_lines() -> Vec<String> {
+    CAPTURED_DAEMON_EVENT_LINES.with(std::cell::RefCell::take)
 }
 
 /// The stderr tracing filter derived from a `RUST_LOG` value.

--- a/crates/tracedecay/src/daemon/core_logging.rs
+++ b/crates/tracedecay/src/daemon/core_logging.rs
@@ -70,25 +70,7 @@ fn quote_log_value(value: &str) -> String {
 
 pub(crate) fn log_daemon_event(event: &str, fields: &[(&str, String)]) {
     let line = format_daemon_log_line(event, fields);
-    #[cfg(test)]
-    capture_daemon_event_line(&line);
     eprintln!("{line}");
-}
-
-#[cfg(test)]
-thread_local! {
-    static CAPTURED_DAEMON_EVENT_LINES: std::cell::RefCell<Vec<String>> =
-        const { std::cell::RefCell::new(Vec::new()) };
-}
-
-#[cfg(test)]
-fn capture_daemon_event_line(line: &str) {
-    CAPTURED_DAEMON_EVENT_LINES.with(|captured| captured.borrow_mut().push(line.to_owned()));
-}
-
-#[cfg(test)]
-pub(crate) fn take_captured_daemon_event_lines() -> Vec<String> {
-    CAPTURED_DAEMON_EVENT_LINES.with(std::cell::RefCell::take)
 }
 
 /// The stderr tracing filter derived from a `RUST_LOG` value.

--- a/crates/tracedecay/src/daemon/shutdown_orchestration.rs
+++ b/crates/tracedecay/src/daemon/shutdown_orchestration.rs
@@ -492,28 +492,35 @@ async fn run_daemon_shutdown(
     // and graph_db.registry.close_retained measure the work underneath it.
     let store_close_deadline = budget.store_close();
     let store_close_started = tokio::time::Instant::now();
-    log_shutdown_phase(
-        "store_close",
-        "start",
-        store_close_started,
-        store_close_deadline,
-    );
-    let terminal = hotpath::measure_block!("daemon.shutdown.store_close", {
-        let _draining = DrainingGauge::arm("daemon.shutdown.draining.store_close");
-        if project_servers.timed_out_count() == 0 {
+    let terminal = if project_servers.timed_out_count() == 0 {
+        log_shutdown_phase(
+            "store_close",
+            "start",
+            store_close_started,
+            store_close_deadline,
+        );
+        let receipt = hotpath::measure_block!("daemon.shutdown.store_close", {
+            let _draining = DrainingGauge::arm("daemon.shutdown.draining.store_close");
             prepare_shutdown_owner_phases(plan.terminal_owner_phases)
                 .join(store_close_deadline)
                 .await
-        } else {
-            ShutdownReceipt::timed_out(store_close_deadline, "memory_graph_reconciliation")
-        }
-    });
-    log_shutdown_phase(
-        "store_close",
-        "complete",
-        store_close_started,
-        store_close_deadline,
-    );
+        });
+        log_shutdown_phase(
+            "store_close",
+            "complete",
+            store_close_started,
+            store_close_deadline,
+        );
+        receipt
+    } else {
+        log_shutdown_phase(
+            "store_close",
+            "skipped",
+            store_close_started,
+            store_close_deadline,
+        );
+        ShutdownReceipt::timed_out(store_close_deadline, "memory_graph_reconciliation")
+    };
     background.extend(terminal);
     let receipt = DaemonShutdownReceipt {
         in_flight,
@@ -670,69 +677,81 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_reaper_phases_emit_start_and_complete_receipts() {
-        let _ = super::super::take_captured_daemon_event_lines();
-        let lifecycle = DaemonLifecycle::default();
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
-        let _receipt = coordinate_daemon_shutdown(&lifecycle, deadline, async move {
-            DaemonShutdownPlan::new(JoinSet::new(), Vec::new(), |_| async {
-                ShutdownTaskReceipt::default()
-            })
-            .with_terminal_owner_phases(vec![vec![ShutdownOwner::new(
-                "memory_graph_reconciliation",
-                || {},
-                async {},
-            )]])
-        })
-        .await;
-
-        let lines = super::super::take_captured_daemon_event_lines();
-        assert_eq!(
-            shutdown_phase_outcomes(&lines),
-            [
-                "project_servers_start",
-                "project_servers_complete",
-                "store_close_start",
-                "store_close_complete",
-            ],
-            "{lines:?}"
-        );
-        for line in &lines {
-            if !line.contains("outcome=project_servers_") && !line.contains("outcome=store_close_")
-            {
-                continue;
-            }
-            assert!(
-                line.contains("elapsed_ms="),
-                "phase receipt must carry elapsed_ms: {line}"
-            );
-            assert!(
-                line.contains("deadline_remaining_ms="),
-                "phase receipt must carry deadline_remaining_ms: {line}"
-            );
-        }
-    }
-
-    fn shutdown_phase_outcomes(lines: &[String]) -> Vec<&str> {
-        lines
-            .iter()
-            .filter_map(|line| {
-                if !line.contains("event=daemon_shutdown") {
-                    return None;
-                }
-                line.split_whitespace().find_map(|field| {
-                    field.strip_prefix("outcome=").filter(|outcome| {
-                        matches!(
-                            *outcome,
-                            "project_servers_start"
-                                | "project_servers_complete"
-                                | "store_close_start"
-                                | "store_close_complete"
-                        )
+    async fn post_reaper_phase_receipts_reach_stderr() {
+        const CHILD_MODE: &str = "TRACEDECAY_SHUTDOWN_RECEIPT_TEST";
+        if let Ok(mode) = std::env::var(CHILD_MODE) {
+            let timed_out = mode == "timed_out";
+            let closed = Arc::new(AtomicBool::new(false));
+            let terminal_closed = Arc::clone(&closed);
+            let lifecycle = DaemonLifecycle::default();
+            let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+            let receipt =
+                coordinate_daemon_shutdown(&lifecycle, deadline, async move {
+                    DaemonShutdownPlan::new(JoinSet::new(), Vec::new(), move |_| async move {
+                        if timed_out {
+                            ShutdownTaskReceipt::timed_out("project_server")
+                        } else {
+                            ShutdownTaskReceipt::default()
+                        }
                     })
+                    .with_terminal_owner_phases(vec![vec![
+                        ShutdownOwner::new("memory_graph_reconciliation", || {}, async move {
+                            terminal_closed.store(true, Ordering::Release);
+                        }),
+                    ]])
                 })
-            })
-            .collect()
+                .await;
+            assert_eq!(closed.load(Ordering::Acquire), !timed_out);
+            assert_eq!(receipt.background.unfinished().is_empty(), !timed_out);
+            return;
+        }
+
+        for (mode, expected) in [
+            (
+                "complete",
+                vec![
+                    "project_servers_start",
+                    "project_servers_complete",
+                    "store_close_start",
+                    "store_close_complete",
+                ],
+            ),
+            (
+                "timed_out",
+                vec![
+                    "project_servers_start",
+                    "project_servers_complete",
+                    "store_close_skipped",
+                ],
+            ),
+        ] {
+            // A child process exercises the production stderr sink, including formatting.
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "daemon::shutdown_orchestration::tests::post_reaper_phase_receipts_reach_stderr", "--nocapture"])
+                .env(CHILD_MODE, mode)
+                .output().unwrap();
+            assert!(output.status.success(), "{output:?}");
+            let stderr = String::from_utf8(output.stderr).unwrap();
+            let phases: Vec<_> = stderr
+                .lines()
+                .filter(|line| {
+                    line.starts_with("[tracedecay] event=daemon_shutdown ")
+                        && (line.contains("outcome=project_servers_")
+                            || line.contains("outcome=store_close_"))
+                })
+                .collect();
+            let outcomes: Vec<_> = phases
+                .iter()
+                .map(|line| {
+                    assert!(line.contains("elapsed_ms="), "{line}");
+                    assert!(line.contains("deadline_remaining_ms="), "{line}");
+                    line.split_whitespace()
+                        .find_map(|field| field.strip_prefix("outcome="))
+                        .unwrap()
+                })
+                .collect();
+            assert_eq!(outcomes, expected, "{stderr}");
+        }
     }
 
     #[tokio::test]

--- a/crates/tracedecay/src/daemon/shutdown_orchestration.rs
+++ b/crates/tracedecay/src/daemon/shutdown_orchestration.rs
@@ -14,7 +14,7 @@ use super::store_shutdown::{ShutdownTaskOutcome, ShutdownTaskReceipt};
 use super::{
     DAEMON_BACKGROUND_DRAIN_DEADLINE, DAEMON_CLIENT_DRAIN_DEADLINE,
     DAEMON_PROJECT_SERVER_DRAIN_DEADLINE, DAEMON_STORE_CLOSE_RESERVE, DAEMON_TASK_ABORT_DEADLINE,
-    DaemonLifecycle, core_lifecycle::DaemonShutdownClaim,
+    DaemonLifecycle, core_lifecycle::DaemonShutdownClaim, log_daemon_event,
 };
 use tracedecay_domain::errors::Result;
 
@@ -91,6 +91,37 @@ impl DaemonShutdownBudget {
     fn store_close(self) -> tokio::time::Instant {
         self.phase(DAEMON_STORE_CLOSE_RESERVE, tokio::time::Duration::ZERO)
     }
+}
+
+/// Operator receipts for one serial shutdown phase. Hotpath already measures
+/// these windows (`daemon.shutdown.project_servers` / `store_close`; inner
+/// work includes `mcp.server.shutdown` and `graph_db.runtime.close.engine`).
+fn log_shutdown_phase(
+    phase: &str,
+    boundary: &str,
+    started: tokio::time::Instant,
+    deadline: tokio::time::Instant,
+) {
+    let now = tokio::time::Instant::now();
+    log_daemon_event(
+        "daemon_shutdown",
+        &[
+            ("outcome", format!("{phase}_{boundary}")),
+            (
+                "elapsed_ms",
+                now.saturating_duration_since(started)
+                    .as_millis()
+                    .to_string(),
+            ),
+            (
+                "deadline_remaining_ms",
+                deadline
+                    .saturating_duration_since(now)
+                    .as_millis()
+                    .to_string(),
+            ),
+        ],
+    );
 }
 
 pub(super) struct DaemonShutdownPlan {
@@ -427,6 +458,13 @@ async fn run_daemon_shutdown(
     // closes those graph runtimes, so it must run only after every server has
     // dropped its leases.
     let project_server_deadline = budget.project_servers();
+    let project_servers_started = tokio::time::Instant::now();
+    log_shutdown_phase(
+        "project_servers",
+        "start",
+        project_servers_started,
+        project_server_deadline,
+    );
     let project_servers = hotpath::measure_block!("daemon.shutdown.project_servers", {
         let _draining = DrainingGauge::arm("daemon.shutdown.draining.project_servers");
         // The drain gets its phase deadline, so it reaches its own bounded
@@ -442,11 +480,24 @@ async fn run_daemon_shutdown(
             ) => ShutdownTaskReceipt::timed_out("project_server_shutdown"),
         }
     });
+    log_shutdown_phase(
+        "project_servers",
+        "complete",
+        project_servers_started,
+        project_server_deadline,
+    );
     // Store close: the terminal owner phase (memory_graph_reconciliation)
     // drains retained graph owners and closes their Grafeo runtimes. This is
     // the outer view of the close; daemon.branch_admin.close_graph_runtimes
     // and graph_db.registry.close_retained measure the work underneath it.
     let store_close_deadline = budget.store_close();
+    let store_close_started = tokio::time::Instant::now();
+    log_shutdown_phase(
+        "store_close",
+        "start",
+        store_close_started,
+        store_close_deadline,
+    );
     let terminal = hotpath::measure_block!("daemon.shutdown.store_close", {
         let _draining = DrainingGauge::arm("daemon.shutdown.draining.store_close");
         if project_servers.timed_out_count() == 0 {
@@ -457,6 +508,12 @@ async fn run_daemon_shutdown(
             ShutdownReceipt::timed_out(store_close_deadline, "memory_graph_reconciliation")
         }
     });
+    log_shutdown_phase(
+        "store_close",
+        "complete",
+        store_close_started,
+        store_close_deadline,
+    );
     background.extend(terminal);
     let receipt = DaemonShutdownReceipt {
         in_flight,
@@ -610,6 +667,72 @@ mod tests {
         tokio::time::advance(tokio::time::Duration::from_secs(15)).await;
         assert_eq!(budget.project_servers(), tokio::time::Instant::now());
         assert_eq!(budget.store_close(), overall);
+    }
+
+    #[tokio::test]
+    async fn post_reaper_phases_emit_start_and_complete_receipts() {
+        let _ = super::super::take_captured_daemon_event_lines();
+        let lifecycle = DaemonLifecycle::default();
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+        let _receipt = coordinate_daemon_shutdown(&lifecycle, deadline, async move {
+            DaemonShutdownPlan::new(JoinSet::new(), Vec::new(), |_| async {
+                ShutdownTaskReceipt::default()
+            })
+            .with_terminal_owner_phases(vec![vec![ShutdownOwner::new(
+                "memory_graph_reconciliation",
+                || {},
+                async {},
+            )]])
+        })
+        .await;
+
+        let lines = super::super::take_captured_daemon_event_lines();
+        assert_eq!(
+            shutdown_phase_outcomes(&lines),
+            [
+                "project_servers_start",
+                "project_servers_complete",
+                "store_close_start",
+                "store_close_complete",
+            ],
+            "{lines:?}"
+        );
+        for line in &lines {
+            if !line.contains("outcome=project_servers_") && !line.contains("outcome=store_close_")
+            {
+                continue;
+            }
+            assert!(
+                line.contains("elapsed_ms="),
+                "phase receipt must carry elapsed_ms: {line}"
+            );
+            assert!(
+                line.contains("deadline_remaining_ms="),
+                "phase receipt must carry deadline_remaining_ms: {line}"
+            );
+        }
+    }
+
+    fn shutdown_phase_outcomes(lines: &[String]) -> Vec<&str> {
+        lines
+            .iter()
+            .filter_map(|line| {
+                if !line.contains("event=daemon_shutdown") {
+                    return None;
+                }
+                line.split_whitespace().find_map(|field| {
+                    field.strip_prefix("outcome=").filter(|outcome| {
+                        matches!(
+                            *outcome,
+                            "project_servers_start"
+                                | "project_servers_complete"
+                                | "store_close_start"
+                                | "store_close_complete"
+                        )
+                    })
+                })
+            })
+            .collect()
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- emit `daemon_shutdown` start/complete receipts for project-server drain and terminal store close after retirement reapers join
- include `elapsed_ms` and `deadline_remaining_ms` so a 5-second dogfood force-kill can name the stalled phase
- no timeout, deadline, or harness `--stop-timeout` changes

Needed to diagnose PR checkout dogfood force-kills (e.g. #1131 job 102359845662), which previously went silent after `retirement_reapers_joined`.

## Verification
- `post_reaper_phases_emit_start_and_complete_receipts` plus 13 sibling orchestration tests
- check/clippy `--no-deps -D warnings`, fmt, diff check, commitlint
