### PR TITLE
refactor(application): move work evidence retrieval out of root

### DIFF
--- a/crates/tracedecay-application/src/work/mod.rs
+++ b/crates/tracedecay-application/src/work/mod.rs
@@ -6,6 +6,7 @@
 //! composition lives here — above global-db — rather than inside it.
 
 mod registered;
+pub mod work_evidence_retrieval;
 pub mod work_topology;
 pub mod workflow_topology;
 
@@ -13,4 +14,11 @@ pub use registered::{
     RegisteredWorkApplicationServicesV1, RegisteredWorkProductServicesV1, RegisteredWorkTopologyV1,
     RegisteredWorkflowApplicationServicesV1, RegisteredWorkflowTopologyV1,
     work_intelligence_service,
+};
+#[cfg(any(test, feature = "test-helpers"))]
+pub use work_evidence_retrieval::tests::{StaticFederatedAuthority, federated_authority};
+pub use work_evidence_retrieval::{
+    WorkFederatedQueryAuthorityFutureV1, WorkFederatedQueryAuthorityPortV1,
+    WorkTaskSessionAdmittedRetrievalFutureV1, WorkTaskSessionAdmittedRetrievalPortV1,
+    WorkTaskSessionEvidenceRetrievalV1,
 };

--- a/crates/tracedecay-application/src/work/work_evidence_retrieval.rs
+++ b/crates/tracedecay-application/src/work/work_evidence_retrieval.rs
@@ -1,4 +1,4 @@
-//! Work evidence adapters over the daemon's mounted retrieval authorities.
+//! Work evidence adapters over mounted retrieval authorities.
 //!
 //! Work admits the exact task/version/accepted-attempt root. The `TaskSession`
 //! path then borrows one canonical session-temporal snapshot, ranks its compact
@@ -23,7 +23,8 @@ use tracedecay_contracts::{
 use tracedecay_domain::{
     AuthorizationRevision, ComponentRevision, EphemeralSanitizedQueryViewV1, FreshnessVectorDigest,
     HydrationStateV1, PrincipalId, QueryNormalizationRevision, RetrievalCursor, RetrievalGrainV1,
-    RetrievalRequest, RetrievalScope, SanitizerRevision, SingleRootScopeV1, VectorWatermark,
+    RetrievalRequest, RetrievalScope, SanitizerRevision, ScoreDomainId, SingleRootScopeV1,
+    VectorWatermark,
 };
 use tracedecay_query::retrieval::QueryAuthorityV1;
 use tracedecay_query::retrieval::evidence_lanes::{
@@ -41,41 +42,98 @@ use tracedecay_temporal_query::context::ContextBudget;
 use tracedecay_temporal_query::ports::ExecutionLimits;
 use tracedecay_temporal_query::ranking::DiversityLimits;
 
-use tracedecay_session_runtime::session_retrieval::SessionApplicationRetrievalPortV1;
-
 const WORK_EVIDENCE_CONTEXT_BYTES: u64 = 64 * 1024;
 const WORK_TASK_SESSION_SANITIZER_REVISION: &str = "sanitizer.work-task-session.v1";
 const WORK_TASK_SESSION_NORMALIZATION_REVISION: &str = "normalization.work-task-session.v1";
 
-pub(crate) type WorkFederatedQueryAuthorityFutureV1<'a> =
+pub type WorkFederatedQueryAuthorityFutureV1<'a> =
     Pin<Box<dyn Future<Output = Option<Arc<QueryAuthorityV1>>> + Send + 'a>>;
+
+pub type WorkTaskSessionAdmittedRetrievalFutureV1<'a> =
+    Pin<Box<dyn Future<Output = TaskSessionRetrievalOutcomeV1> + Send + 'a>>;
 
 /// Resolves the currently activated evaluated authority for an exact scope.
 /// Resolution occurs per request so an accepted-profile activation does not
 /// leave a long-lived Work runtime bound to a superseded profile.
-pub(crate) trait WorkFederatedQueryAuthorityPortV1: Send + Sync {
+pub trait WorkFederatedQueryAuthorityPortV1: Send + Sync {
     fn authority_for<'a>(
         &'a self,
         scope: &'a ResolvedScope,
     ) -> WorkFederatedQueryAuthorityFutureV1<'a>;
 }
 
+/// Already-admitted TaskSession retrieval used by Work evidence.
+///
+/// This is the `retrieve_task_session_admitted` method of the mounted session
+/// retrieval authority, inverted here so this crate does not depend on
+/// session-runtime.
+pub trait WorkTaskSessionAdmittedRetrievalPortV1: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
+    fn retrieve_task_session_admitted<'a>(
+        &'a self,
+        _context: &'a RequestContext,
+        _temporal_query: SessionTemporalQuery,
+        _task_binding: TaskSessionBindingV1,
+        _retrieval_request: RetrievalRequest,
+        _query: EphemeralSanitizedQueryViewV1,
+        _retriever_revision: ComponentRevision,
+        _score_domain: ScoreDomainId,
+        _policy_revision: ComponentRevision,
+        _selector: &'a dyn TaskSessionRankSelectorV1,
+    ) -> WorkTaskSessionAdmittedRetrievalFutureV1<'a> {
+        Box::pin(async { TaskSessionRetrievalOutcomeV1::Unavailable })
+    }
+}
+
+impl<T> WorkTaskSessionAdmittedRetrievalPortV1 for Arc<T>
+where
+    T: WorkTaskSessionAdmittedRetrievalPortV1 + ?Sized,
+{
+    fn retrieve_task_session_admitted<'a>(
+        &'a self,
+        context: &'a RequestContext,
+        temporal_query: SessionTemporalQuery,
+        task_binding: TaskSessionBindingV1,
+        retrieval_request: RetrievalRequest,
+        query: EphemeralSanitizedQueryViewV1,
+        retriever_revision: ComponentRevision,
+        score_domain: ScoreDomainId,
+        policy_revision: ComponentRevision,
+        selector: &'a dyn TaskSessionRankSelectorV1,
+    ) -> WorkTaskSessionAdmittedRetrievalFutureV1<'a> {
+        (**self).retrieve_task_session_admitted(
+            context,
+            temporal_query,
+            task_binding,
+            retrieval_request,
+            query,
+            retriever_revision,
+            score_domain,
+            policy_revision,
+            selector,
+        )
+    }
+}
+
 /// Adapter for the canonical project session retrieval authority.
+///
+/// `WorkEvidenceRetrievalV1` is the contracts DTO; this type is the application
+/// adapter that implements [`WorkEvidenceRetrievalPortV1`].
 #[derive(Clone)]
-pub(crate) struct DaemonWorkEvidenceRetrievalV1 {
-    retrieval: Arc<dyn SessionApplicationRetrievalPortV1>,
+pub struct WorkTaskSessionEvidenceRetrievalV1 {
+    retrieval: Arc<dyn WorkTaskSessionAdmittedRetrievalPortV1>,
     federated_authority: Option<Arc<dyn WorkFederatedQueryAuthorityPortV1>>,
 }
 
-impl DaemonWorkEvidenceRetrievalV1 {
-    pub(crate) fn new(retrieval: Arc<dyn SessionApplicationRetrievalPortV1>) -> Self {
+impl WorkTaskSessionEvidenceRetrievalV1 {
+    pub fn new(retrieval: impl WorkTaskSessionAdmittedRetrievalPortV1 + 'static) -> Self {
         Self {
-            retrieval,
+            retrieval: Arc::new(retrieval),
             federated_authority: None,
         }
     }
 
-    pub(crate) fn with_federated_authority(
+    pub fn with_federated_authority(
         mut self,
         authority: Arc<dyn WorkFederatedQueryAuthorityPortV1>,
     ) -> Self {
@@ -131,13 +189,13 @@ impl DaemonWorkEvidenceRetrievalV1 {
     }
 }
 
-impl WorkEvidenceRetrievalPortV1 for DaemonWorkEvidenceRetrievalV1 {
+impl WorkEvidenceRetrievalPortV1 for WorkTaskSessionEvidenceRetrievalV1 {
     fn clone_arc(&self) -> Arc<dyn WorkEvidenceRetrievalPortV1> {
         Arc::new(self.clone())
     }
 }
 
-impl WorkTaskSessionPortV1 for DaemonWorkEvidenceRetrievalV1 {
+impl WorkTaskSessionPortV1 for WorkTaskSessionEvidenceRetrievalV1 {
     fn retrieve_task_session<'a>(
         &'a self,
         context: &'a RequestContext,
@@ -222,7 +280,7 @@ impl WorkTaskSessionPortV1 for DaemonWorkEvidenceRetrievalV1 {
     }
 }
 
-impl WorkAnchorHydrationPortV1 for DaemonWorkEvidenceRetrievalV1 {
+impl WorkAnchorHydrationPortV1 for WorkTaskSessionEvidenceRetrievalV1 {
     fn hydrate_anchor<'a>(
         &'a self,
         _context: &'a RequestContext,
@@ -611,59 +669,30 @@ const fn work_freshness(freshness: SessionDataFreshness) -> WorkEvidenceFreshnes
     }
 }
 
-#[cfg(test)]
-pub(crate) mod tests {
+#[cfg(any(test, feature = "test-helpers"))]
+pub mod tests {
     use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use tracedecay_contracts::{
-        CancellationContext, CapabilityGrantSnapshot, Deadline, DisclosureClass, RequestId,
-        WorkProductSelectionScopeV1,
+        CancellationContext, CapabilityGrantSnapshot, Deadline, DisclosureClass, RequestContext,
+        RequestId, ResolvedScope, WorkTaskSessionReauthorizationErrorV1,
+        WorkTaskSessionReauthorizationPortV1, WorkTaskSessionRequestV1,
     };
     use tracedecay_domain::{
-        ActorId, AttemptId, CalibrationProfileId, DiversityPolicy, FusionProfile, ManifestDigest,
-        ObservationSourceIdentityV1, PrivacyDomainId, ProjectId, ProviderId, RepositoryId,
-        RetrievalAnchorId, RetrievalBudget, RetrievalCursorKeyId, RetrieverKind, RunId,
-        ScoreDomainCalibrationV1, ScoreDomainId, SessionId, SourceStoreId, TaskId, TemporalModeV1,
-        UtcMicros, WorkAttemptIdentityV1, WorkGraphVersionV1, WorkProductEventSequenceV1,
-        WorkProductSourceWatermarkV1, WorktreeId,
+        ActorId, CalibrationProfileId, DiversityPolicy, FusionProfile, ManifestDigest,
+        PrivacyDomainId, RetrievalAnchorId, RetrievalBudget, RetrievalCursorKeyId, RetrieverKind,
+        ScoreDomainCalibrationV1, ScoreDomainId, SourceStoreId, UtcMicros, WorkGraphVersionV1,
+        WorkProductEventSequenceV1, WorkProductSourceWatermarkV1,
     };
+    use tracedecay_query::retrieval::QueryAuthorityV1;
     use tracedecay_query::retrieval::fusion::RetrievalCursorKeyringV1;
-    use tracedecay_session_memory::context::{BranchId, ProfileId, SessionRootId, SessionStoreId};
     use tracedecay_tool_catalog::{CapabilityId, UseCaseId};
 
-    use super::*;
+    use super::{WorkFederatedQueryAuthorityFutureV1, WorkFederatedQueryAuthorityPortV1};
 
-    #[test]
-    fn task_session_structural_refusals_retain_exact_hydration_causes() {
-        assert_eq!(
-            cursor_manifest_hydration_refusal(
-                tracedecay_domain::CursorManifestLimitKindV1::Participants,
-                257,
-                256,
-            ),
-            WorkEvidenceHydrationErrorV1::StructuralRefusal(
-                SessionRetrievalStructuralRefusalV1::CursorManifestLimitExceeded {
-                    kind: tracedecay_domain::CursorManifestLimitKindV1::Participants,
-                    observed: 257,
-                    maximum: 256,
-                }
-            )
-        );
-        assert_eq!(
-            budget_hydration_refusal(
-                tracedecay_session_memory::session::SessionRetrievalBudgetStageV1::ContextTokens
-            ),
-            WorkEvidenceHydrationErrorV1::StructuralRefusal(
-                SessionRetrievalStructuralRefusalV1::BudgetExhausted {
-                    stage:
-                        tracedecay_session_memory::session::SessionRetrievalBudgetStageV1::ContextTokens,
-                }
-            )
-        );
-    }
-
-    pub(super) fn id<T>(value: &str) -> T
+    pub fn id<T>(value: &str) -> T
     where
         T: TryFrom<String>,
         T::Error: std::fmt::Debug,
@@ -676,7 +705,7 @@ pub(crate) mod tests {
             .expect("TaskSession fixture digest")
     }
 
-    pub(super) fn context(scope: ResolvedScope) -> RequestContext {
+    pub fn context(scope: ResolvedScope) -> RequestContext {
         let grant = CapabilityGrantSnapshot::new(
             id("grant.work-task-session"),
             1,
@@ -703,7 +732,7 @@ pub(crate) mod tests {
         .expect("TaskSession fixture context")
     }
 
-    pub(super) fn verified_version() -> tracedecay_contracts::VerifiedWorkGraphVersionV1 {
+    pub fn verified_version() -> tracedecay_contracts::VerifiedWorkGraphVersionV1 {
         tracedecay_contracts::VerifiedWorkGraphVersionV1::new(
             WorkGraphVersionV1::new(5).expect("graph version"),
             WorkProductEventSequenceV1::new(5).expect("event sequence"),
@@ -714,7 +743,7 @@ pub(crate) mod tests {
         .expect("verified Work version")
     }
 
-    pub(crate) fn federated_authority(privacy_domain: PrivacyDomainId) -> QueryAuthorityV1 {
+    pub fn federated_authority(privacy_domain: PrivacyDomainId) -> QueryAuthorityV1 {
         let budget = RetrievalBudget {
             max_candidates_per_lane: 32,
             max_fused_candidates: 16,
@@ -796,7 +825,7 @@ pub(crate) mod tests {
         .expect("federated TaskSession authority")
     }
 
-    pub(crate) struct StaticFederatedAuthority(pub(crate) Arc<QueryAuthorityV1>);
+    pub struct StaticFederatedAuthority(pub Arc<QueryAuthorityV1>);
 
     impl WorkFederatedQueryAuthorityPortV1 for StaticFederatedAuthority {
         fn authority_for<'a>(
@@ -809,7 +838,7 @@ pub(crate) mod tests {
     }
 
     #[derive(Default)]
-    pub(super) struct CountingReauthorization(pub(super) AtomicUsize);
+    pub struct CountingReauthorization(pub AtomicUsize);
 
     impl WorkTaskSessionReauthorizationPortV1 for CountingReauthorization {
         fn reauthorize_task_session(
@@ -822,14 +851,14 @@ pub(crate) mod tests {
         }
     }
 
-    struct FailingReauthorization {
-        calls: AtomicUsize,
+    pub struct FailingReauthorization {
+        pub calls: AtomicUsize,
         fail_at: usize,
         error: WorkTaskSessionReauthorizationErrorV1,
     }
 
     impl FailingReauthorization {
-        fn new(fail_at: usize, error: WorkTaskSessionReauthorizationErrorV1) -> Self {
+        pub fn new(fail_at: usize, error: WorkTaskSessionReauthorizationErrorV1) -> Self {
             Self {
                 calls: AtomicUsize::new(0),
                 fail_at,
@@ -852,174 +881,41 @@ pub(crate) mod tests {
             }
         }
     }
-
-    #[tokio::test]
-    async fn registered_project_session_hydrates_provider_qualified_task_evidence() {
-        let profile = tempfile::tempdir().expect("profile root");
-        let project = profile.path().join("project");
-        std::fs::create_dir_all(&project).expect("project root");
-        let project_id = id::<ProjectId>("project.work-task-session");
-        let repository_id = id::<RepositoryId>("repository.work-task-session");
-        let worktree_id = id::<WorktreeId>("worktree.work-task-session");
-        let runtime = crate::host_admission::HostAdmissionTestRuntimeV1::project(
-            profile.path(),
-            &project,
-            project_id.clone(),
-        )
-        .await
-        .expect("registered project session runtime");
-        let database = runtime
-            .registered_database_arc(tracedecay_sessions::admission::HostAdmissionScope::Project)
-            .expect("registered project session database");
-        let session_id = id::<SessionId>("session.work-task-session");
-        let task_id = id::<TaskId>("task.work-task-session");
-        let attempt = WorkAttemptIdentityV1::new(
-            task_id.clone(),
-            id::<RunId>("run.work-task-session"),
-            id::<AttemptId>("attempt.work-task-session"),
-        )
-        .expect("accepted Work attempt");
-        let query_text = format!(
-            "{} {}:{} codex {}",
-            task_id.as_str(),
-            attempt.run_id().as_str(),
-            attempt.attempt_id().as_str(),
-            session_id.as_str(),
-        );
-        crate::dashboard::observation_seed::seed_session_message_observation_for_test(
-            database.as_ref(),
-            crate::dashboard::observation_seed::DashboardSessionMessageSeedV1 {
-                project_id: project_id.as_str(),
-                provider: "codex",
-                session_id: session_id.as_str(),
-                message_id: "message.work-task-session.1",
-                role: "assistant",
-                content: &format!("{query_text} completed with durable provider evidence"),
-                model: Some("gpt-5.6"),
-                timestamp: 101,
-                ordinal: 1,
-            },
-        )
-        .await
-        .expect("seed canonical provider observation");
-        crate::dashboard::observation_seed::materialize_session_temporal_refresh_for_test(
-            database.as_ref(),
-            session_id.as_str(),
-        )
-        .await
-        .expect("materialize provider session temporal projection");
-
-        let root =
-            tracedecay_session_runtime::session_retrieval::DaemonSessionRetrievalRoot::project_identity_for_test(
-                ProfileId::new(database.binding().shard_id.profile_id.as_str().to_owned())
-                    .expect("profile identity"),
-                SessionStoreId::new("store.project.work-task-session")
-                    .expect("session store identity"),
-                SessionRootId::new("root.project.work-task-session")
-                    .expect("session root identity"),
-                database.binding().shard_id.clone(),
-                project_id,
-                tracedecay_session_memory::context::ResolvedGitRoute::new(
-                    repository_id,
-                    worktree_id,
-                    BranchId::new("branch.work-task-session").expect("branch identity"),
-                ),
-                project.display().to_string(),
-            );
-        let scope = root
-            .identity()
-            .session_request_scope()
-            .expect("resolved Work scope");
-        let retrieval =
-            tracedecay_session_runtime::session_retrieval::DaemonSessionRetrievalService::new(
-                database, root, None,
-            )
-            .expect("mounted project retrieval service");
-        let privacy_domain = id::<PrivacyDomainId>("privacy.work-task-session");
-        let adapter = DaemonWorkEvidenceRetrievalV1::new(Arc::new(retrieval))
-            .with_federated_authority(Arc::new(StaticFederatedAuthority(Arc::new(
-                federated_authority(privacy_domain),
-            ))));
-        let source =
-            ObservationSourceIdentityV1::for_provider(id::<ProviderId>("codex"), session_id)
-                .expect("provider-qualified session");
-        let request = WorkTaskSessionRequestV1 {
-            selection: WorkProductSelectionScopeV1::ProfileOwnedNoGit,
-            task_id,
-            verified_version: verified_version(),
-            accepted_attempts: BTreeSet::from([attempt.clone()]),
-            attempt,
-            source,
-            temporal: TemporalModeV1::Forensic,
-            page_size: 8,
-            continuation: None,
-            observed_at: UtcMicros(500),
-        };
-        let reauthorization = CountingReauthorization::default();
-
-        let request_context = context(scope);
-        for temporal in [
-            TemporalModeV1::Current,
-            TemporalModeV1::AsOf {
-                cutoff: UtcMicros(200_000_000),
-            },
-            TemporalModeV1::Evolution,
-            TemporalModeV1::Forensic,
-        ] {
-            let mut mode_request = request.clone();
-            mode_request.temporal = temporal;
-            let evidence = adapter
-                .retrieve_task_session(&request_context, mode_request, &reauthorization)
-                .await
-                .expect("real TaskSession evidence");
-
-            assert_eq!(evidence.task_id, request.task_id);
-            assert_eq!(evidence.source, request.source);
-            assert_eq!(evidence.attempt, request.attempt);
-            assert!(
-                evidence
-                    .hydrated
-                    .iter()
-                    .filter_map(|hydrated| hydrated.content.as_deref())
-                    .any(|content| content
-                        .windows(b"durable provider evidence".len())
-                        .any(|window| window == b"durable provider evidence")),
-                "the mounted adapter must hydrate the owning provider message in {temporal:?}: {evidence:?}",
-            );
-        }
-        assert!(
-            reauthorization.0.load(Ordering::SeqCst) >= 16,
-            "every temporal mode must reopen Work authority at all four stages",
-        );
-
-        for (fail_at, error, expected) in [
-            (
-                2,
-                WorkTaskSessionReauthorizationErrorV1::Denied,
-                WorkEvidenceHydrationErrorV1::NotFoundOrNotAuthorized,
-            ),
-            (
-                1,
-                WorkTaskSessionReauthorizationErrorV1::Stale,
-                WorkEvidenceHydrationErrorV1::Stale,
-            ),
-            (
-                3,
-                WorkTaskSessionReauthorizationErrorV1::Unavailable,
-                WorkEvidenceHydrationErrorV1::Unavailable,
-            ),
-        ] {
-            let reauthorization = FailingReauthorization::new(fail_at, error);
-            let actual = adapter
-                .retrieve_task_session(&request_context, request.clone(), &reauthorization)
-                .await
-                .expect_err("reauthorization failure must remain typed");
-            assert_eq!(actual, expected);
-            assert_eq!(reauthorization.calls.load(Ordering::SeqCst), fail_at);
-        }
-    }
 }
 
 #[cfg(test)]
-#[path = "work_evidence_retrieval/continuation_tests.rs"]
-mod continuation_tests;
+mod unit_tests {
+    use tracedecay_contracts::WorkEvidenceHydrationErrorV1;
+    use tracedecay_contracts::retrieval::SessionRetrievalStructuralRefusalV1;
+
+    use super::{budget_hydration_refusal, cursor_manifest_hydration_refusal};
+
+    #[test]
+    fn task_session_structural_refusals_retain_exact_hydration_causes() {
+        assert_eq!(
+            cursor_manifest_hydration_refusal(
+                tracedecay_domain::CursorManifestLimitKindV1::Participants,
+                257,
+                256,
+            ),
+            WorkEvidenceHydrationErrorV1::StructuralRefusal(
+                SessionRetrievalStructuralRefusalV1::CursorManifestLimitExceeded {
+                    kind: tracedecay_domain::CursorManifestLimitKindV1::Participants,
+                    observed: 257,
+                    maximum: 256,
+                }
+            )
+        );
+        assert_eq!(
+            budget_hydration_refusal(
+                tracedecay_session_memory::session::SessionRetrievalBudgetStageV1::ContextTokens
+            ),
+            WorkEvidenceHydrationErrorV1::StructuralRefusal(
+                SessionRetrievalStructuralRefusalV1::BudgetExhausted {
+                    stage:
+                        tracedecay_session_memory::session::SessionRetrievalBudgetStageV1::ContextTokens,
+                }
+            )
+        );
+    }
+}

--- a/crates/tracedecay-session-runtime/src/session_retrieval/admitted.rs
+++ b/crates/tracedecay-session-runtime/src/session_retrieval/admitted.rs
@@ -4,6 +4,9 @@ use std::future::Future;
 use std::pin::Pin;
 
 use sha2::{Digest, Sha256};
+use tracedecay_application::work::{
+    WorkTaskSessionAdmittedRetrievalFutureV1, WorkTaskSessionAdmittedRetrievalPortV1,
+};
 use tracedecay_contracts::{CancellationSignal, RequestContext, ResolvedScope};
 use tracedecay_domain::{
     ComponentRevision, EphemeralSanitizedQueryViewV1, RetrievalRequest, ScoreDomainId,
@@ -599,6 +602,62 @@ const fn temporal_store_unavailable_value() -> SessionRetrievalUnavailable {
     SessionRetrievalUnavailable::without_worker(
         SessionRetrievalUnavailableReason::TemporalStoreUnavailable,
     )
+}
+
+impl WorkTaskSessionAdmittedRetrievalPortV1 for DaemonSessionRetrievalService {
+    fn retrieve_task_session_admitted<'a>(
+        &'a self,
+        context: &'a RequestContext,
+        temporal_query: SessionTemporalQuery,
+        task_binding: TaskSessionBindingV1,
+        retrieval_request: RetrievalRequest,
+        query: EphemeralSanitizedQueryViewV1,
+        retriever_revision: ComponentRevision,
+        score_domain: ScoreDomainId,
+        policy_revision: ComponentRevision,
+        selector: &'a dyn TaskSessionRankSelectorV1,
+    ) -> WorkTaskSessionAdmittedRetrievalFutureV1<'a> {
+        SessionApplicationRetrievalPortV1::retrieve_task_session_admitted(
+            self,
+            context,
+            temporal_query,
+            task_binding,
+            retrieval_request,
+            query,
+            retriever_revision,
+            score_domain,
+            policy_revision,
+            selector,
+        )
+    }
+}
+
+impl WorkTaskSessionAdmittedRetrievalPortV1 for dyn SessionApplicationRetrievalPortV1 {
+    fn retrieve_task_session_admitted<'a>(
+        &'a self,
+        context: &'a RequestContext,
+        temporal_query: SessionTemporalQuery,
+        task_binding: TaskSessionBindingV1,
+        retrieval_request: RetrievalRequest,
+        query: EphemeralSanitizedQueryViewV1,
+        retriever_revision: ComponentRevision,
+        score_domain: ScoreDomainId,
+        policy_revision: ComponentRevision,
+        selector: &'a dyn TaskSessionRankSelectorV1,
+    ) -> WorkTaskSessionAdmittedRetrievalFutureV1<'a> {
+        SessionApplicationRetrievalPortV1::retrieve_task_session_admitted(
+            self,
+            context,
+            temporal_query,
+            task_binding,
+            retrieval_request,
+            query,
+            retriever_revision,
+            score_domain,
+            policy_revision,
+            selector,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/crates/tracedecay/src/daemon.rs
+++ b/crates/tracedecay/src/daemon.rs
@@ -405,7 +405,8 @@ pub(crate) mod store_runtime_tests;
 
 mod store_writer_gate;
 mod wire_io;
-pub(crate) mod work_evidence_retrieval;
+#[cfg(test)]
+mod work_evidence_retrieval_tests;
 use wire_io::{
     read_line_handling_wire_oversized, write_daemon_invocation_response, write_json_rpc_response,
 };

--- a/crates/tracedecay/src/daemon/invocation_state.rs
+++ b/crates/tracedecay/src/daemon/invocation_state.rs
@@ -17,6 +17,9 @@ use tracedecay_runtime_core::resident_memory::{
 use tracedecay_semantic_contracts::SemanticResourceCeilings;
 use tracedecay_tool_catalog::ApplicationSurfaceOperation;
 
+use tracedecay_application::work::{
+    WorkFederatedQueryAuthorityFutureV1, WorkFederatedQueryAuthorityPortV1,
+};
 use tracedecay_daemon_service::{
     DaemonAdvisoryRuntimeRegistrar, DaemonConfigurationRuntimeRegistrar,
     DaemonContextScoutRuntimeRegistrar, DaemonFeedbackRuntimeRegistrar, DaemonInvocationOutcome,
@@ -45,8 +48,7 @@ pub(crate) struct DaemonInvocationState {
         github_credential_lifecycle::DaemonGitHubReadOnlyCredentialLifecycleV1,
     pub(super) code_index_schedulers: code_index_scheduler::CodeIndexSchedulerRegistryV1,
     query_authority_provider: query_authority_provider::DaemonQueryAuthorityProviderV1,
-    work_federated_query_authority:
-        Arc<dyn crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityPortV1>,
+    work_federated_query_authority: Arc<dyn WorkFederatedQueryAuthorityPortV1>,
     semantic_projection_scheduler:
         tracedecay_application::semantic_runtime::DaemonGlobalSemanticProjectionSchedulerV1,
 }
@@ -432,7 +434,7 @@ impl DaemonInvocationState {
 
     pub(super) fn work_federated_query_authority(
         &self,
-    ) -> Arc<dyn crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityPortV1> {
+    ) -> Arc<dyn WorkFederatedQueryAuthorityPortV1> {
         Arc::clone(&self.work_federated_query_authority)
     }
 
@@ -1140,13 +1142,11 @@ struct DaemonWorkFederatedQueryAuthorityV1 {
     provider: query_authority_provider::DaemonQueryAuthorityProviderV1,
 }
 
-impl crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityPortV1
-    for DaemonWorkFederatedQueryAuthorityV1
-{
+impl WorkFederatedQueryAuthorityPortV1 for DaemonWorkFederatedQueryAuthorityV1 {
     fn authority_for<'a>(
         &'a self,
         scope: &'a tracedecay_contracts::ResolvedScope,
-    ) -> crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityFutureV1<'a> {
+    ) -> WorkFederatedQueryAuthorityFutureV1<'a> {
         Box::pin(async move {
             let mounted = self.schedulers.query_authority_for_scope(scope).await?;
             self.provider

--- a/crates/tracedecay/src/daemon/invocation_tests/mod.rs
+++ b/crates/tracedecay/src/daemon/invocation_tests/mod.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 use tracedecay_agent_hosts::agents::context_scout_ports::ContextScoutLifecycleAddressV1;
 use tracedecay_application::feedback::observations::FeedbackObservationEmitterV1;
 use tracedecay_application::lsp_runtime::DaemonLspSessionFactory;
+use tracedecay_application::work::{
+    WorkTaskSessionAdmittedRetrievalPortV1, WorkTaskSessionEvidenceRetrievalV1,
+};
 use tracedecay_contracts::ResolvedScope;
 use tracedecay_contracts::feedback::observations::FeedbackSourceEventV1;
 use tracedecay_daemon_service::{
@@ -26,26 +29,10 @@ use tracedecay_lsp::{
 
 struct DeniedWorkEvidenceRetrieval;
 
-impl tracedecay_session_runtime::session_retrieval::SessionApplicationRetrievalPortV1
-    for DeniedWorkEvidenceRetrieval
-{
-    fn retrieve_admitted<'a>(
-        &'a self,
-        _context: &'a tracedecay_contracts::RequestContext,
-        _query: tracedecay_session_memory::session::SessionTemporalQuery,
-    ) -> tracedecay_session_runtime::session_retrieval::SessionApplicationRetrievalFutureV1<'a>
-    {
-        Box::pin(async {
-            tracedecay_session_runtime::session_retrieval::SessionRetrievalServiceOutcome::Denied
-        })
-    }
-}
+impl WorkTaskSessionAdmittedRetrievalPortV1 for DeniedWorkEvidenceRetrieval {}
 
-pub(super) fn denied_work_evidence_retrieval()
--> crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1 {
-    crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1::new(Arc::new(
-        DeniedWorkEvidenceRetrieval,
-    ))
+pub(super) fn denied_work_evidence_retrieval() -> WorkTaskSessionEvidenceRetrievalV1 {
+    WorkTaskSessionEvidenceRetrievalV1::new(Arc::new(DeniedWorkEvidenceRetrieval))
 }
 
 pub(super) fn empty_work_proposal_routing(

--- a/crates/tracedecay/src/daemon/invocation_tests/work_evidence_journey_tests.rs
+++ b/crates/tracedecay/src/daemon/invocation_tests/work_evidence_journey_tests.rs
@@ -333,18 +333,14 @@ async fn registered_work_evidence_hydrates_the_provider_qualified_task_session()
         )
         .expect("mounted session retrieval");
     let evidence_retrieval =
-        crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1::new(Arc::new(
-            retrieval,
-        ))
-        .with_federated_authority(Arc::new(
-            crate::daemon::work_evidence_retrieval::tests::StaticFederatedAuthority(Arc::new(
-                crate::daemon::work_evidence_retrieval::tests::federated_authority(id::<
-                    PrivacyDomainId,
-                >(
-                    "privacy.work.evidence-journey",
+        tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1::new(Arc::new(retrieval))
+            .with_federated_authority(Arc::new(
+                tracedecay_application::work::StaticFederatedAuthority(Arc::new(
+                    tracedecay_application::work::federated_authority(id::<PrivacyDomainId>(
+                        "privacy.work.evidence-journey",
+                    )),
                 )),
-            )),
-        ));
+            ));
 
     let actor = id::<ActorId>("actor.work.evidence-journey");
     let grant_digest = digest('d');

--- a/crates/tracedecay/src/daemon/work_evidence_retrieval_tests.rs
+++ b/crates/tracedecay/src/daemon/work_evidence_retrieval_tests.rs
@@ -1,0 +1,189 @@
+//! Host-admission Work evidence journeys that stay at the composition root
+//! because they mount `HostAdmissionTestRuntimeV1` and dashboard observation
+//! seeds.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1;
+use tracedecay_application::work::work_evidence_retrieval::tests::{
+    CountingReauthorization, FailingReauthorization, StaticFederatedAuthority, context,
+    federated_authority, id, verified_version,
+};
+use tracedecay_contracts::{
+    WorkEvidenceHydrationErrorV1, WorkProductSelectionScopeV1, WorkTaskSessionPortV1,
+    WorkTaskSessionReauthorizationErrorV1, WorkTaskSessionRequestV1,
+};
+use tracedecay_domain::{
+    AttemptId, ObservationSourceIdentityV1, PrivacyDomainId, ProjectId, ProviderId, RepositoryId,
+    RunId, SessionId, TaskId, TemporalModeV1, UtcMicros, WorkAttemptIdentityV1, WorktreeId,
+};
+use tracedecay_session_memory::context::{BranchId, ProfileId, SessionRootId, SessionStoreId};
+
+mod continuation;
+
+#[tokio::test]
+async fn registered_project_session_hydrates_provider_qualified_task_evidence() {
+    let profile = tempfile::tempdir().expect("profile root");
+    let project = profile.path().join("project");
+    std::fs::create_dir_all(&project).expect("project root");
+    let project_id = id::<ProjectId>("project.work-task-session");
+    let repository_id = id::<RepositoryId>("repository.work-task-session");
+    let worktree_id = id::<WorktreeId>("worktree.work-task-session");
+    let runtime = crate::host_admission::HostAdmissionTestRuntimeV1::project(
+        profile.path(),
+        &project,
+        project_id.clone(),
+    )
+    .await
+    .expect("registered project session runtime");
+    let database = runtime
+        .registered_database_arc(tracedecay_sessions::admission::HostAdmissionScope::Project)
+        .expect("registered project session database");
+    let session_id = id::<SessionId>("session.work-task-session");
+    let task_id = id::<TaskId>("task.work-task-session");
+    let attempt = WorkAttemptIdentityV1::new(
+        task_id.clone(),
+        id::<RunId>("run.work-task-session"),
+        id::<AttemptId>("attempt.work-task-session"),
+    )
+    .expect("accepted Work attempt");
+    let query_text = format!(
+        "{} {}:{} codex {}",
+        task_id.as_str(),
+        attempt.run_id().as_str(),
+        attempt.attempt_id().as_str(),
+        session_id.as_str(),
+    );
+    crate::dashboard::observation_seed::seed_session_message_observation_for_test(
+        database.as_ref(),
+        crate::dashboard::observation_seed::DashboardSessionMessageSeedV1 {
+            project_id: project_id.as_str(),
+            provider: "codex",
+            session_id: session_id.as_str(),
+            message_id: "message.work-task-session.1",
+            role: "assistant",
+            content: &format!("{query_text} completed with durable provider evidence"),
+            model: Some("gpt-5.6"),
+            timestamp: 101,
+            ordinal: 1,
+        },
+    )
+    .await
+    .expect("seed canonical provider observation");
+    crate::dashboard::observation_seed::materialize_session_temporal_refresh_for_test(
+        database.as_ref(),
+        session_id.as_str(),
+    )
+    .await
+    .expect("materialize provider session temporal projection");
+
+    let root =
+        tracedecay_session_runtime::session_retrieval::DaemonSessionRetrievalRoot::project_identity_for_test(
+            ProfileId::new(database.binding().shard_id.profile_id.as_str().to_owned())
+                .expect("profile identity"),
+            SessionStoreId::new("store.project.work-task-session")
+                .expect("session store identity"),
+            SessionRootId::new("root.project.work-task-session")
+                .expect("session root identity"),
+            database.binding().shard_id.clone(),
+            project_id,
+            tracedecay_session_memory::context::ResolvedGitRoute::new(
+                repository_id,
+                worktree_id,
+                BranchId::new("branch.work-task-session").expect("branch identity"),
+            ),
+            project.display().to_string(),
+        );
+    let scope = root
+        .identity()
+        .session_request_scope()
+        .expect("resolved Work scope");
+    let retrieval =
+        tracedecay_session_runtime::session_retrieval::DaemonSessionRetrievalService::new(
+            database, root, None,
+        )
+        .expect("mounted project retrieval service");
+    let privacy_domain = id::<PrivacyDomainId>("privacy.work-task-session");
+    let adapter = WorkTaskSessionEvidenceRetrievalV1::new(Arc::new(retrieval))
+        .with_federated_authority(Arc::new(StaticFederatedAuthority(Arc::new(
+            federated_authority(privacy_domain),
+        ))));
+    let source = ObservationSourceIdentityV1::for_provider(id::<ProviderId>("codex"), session_id)
+        .expect("provider-qualified session");
+    let request = WorkTaskSessionRequestV1 {
+        selection: WorkProductSelectionScopeV1::ProfileOwnedNoGit,
+        task_id,
+        verified_version: verified_version(),
+        accepted_attempts: BTreeSet::from([attempt.clone()]),
+        attempt,
+        source,
+        temporal: TemporalModeV1::Forensic,
+        page_size: 8,
+        continuation: None,
+        observed_at: UtcMicros(500),
+    };
+    let reauthorization = CountingReauthorization::default();
+
+    let request_context = context(scope);
+    for temporal in [
+        TemporalModeV1::Current,
+        TemporalModeV1::AsOf {
+            cutoff: UtcMicros(200_000_000),
+        },
+        TemporalModeV1::Evolution,
+        TemporalModeV1::Forensic,
+    ] {
+        let mut mode_request = request.clone();
+        mode_request.temporal = temporal;
+        let evidence = adapter
+            .retrieve_task_session(&request_context, mode_request, &reauthorization)
+            .await
+            .expect("real TaskSession evidence");
+
+        assert_eq!(evidence.task_id, request.task_id);
+        assert_eq!(evidence.source, request.source);
+        assert_eq!(evidence.attempt, request.attempt);
+        assert!(
+            evidence
+                .hydrated
+                .iter()
+                .filter_map(|hydrated| hydrated.content.as_deref())
+                .any(|content| content
+                    .windows(b"durable provider evidence".len())
+                    .any(|window| window == b"durable provider evidence")),
+            "the mounted adapter must hydrate the owning provider message in {temporal:?}: {evidence:?}",
+        );
+    }
+    assert!(
+        reauthorization.0.load(Ordering::SeqCst) >= 16,
+        "every temporal mode must reopen Work authority at all four stages",
+    );
+
+    for (fail_at, error, expected) in [
+        (
+            2,
+            WorkTaskSessionReauthorizationErrorV1::Denied,
+            WorkEvidenceHydrationErrorV1::NotFoundOrNotAuthorized,
+        ),
+        (
+            1,
+            WorkTaskSessionReauthorizationErrorV1::Stale,
+            WorkEvidenceHydrationErrorV1::Stale,
+        ),
+        (
+            3,
+            WorkTaskSessionReauthorizationErrorV1::Unavailable,
+            WorkEvidenceHydrationErrorV1::Unavailable,
+        ),
+    ] {
+        let reauthorization = FailingReauthorization::new(fail_at, error);
+        let actual = adapter
+            .retrieve_task_session(&request_context, request.clone(), &reauthorization)
+            .await
+            .expect_err("reauthorization failure must remain typed");
+        assert_eq!(actual, expected);
+        assert_eq!(reauthorization.calls.load(Ordering::SeqCst), fail_at);
+    }
+}

--- a/crates/tracedecay/src/daemon/work_evidence_retrieval_tests/continuation.rs
+++ b/crates/tracedecay/src/daemon/work_evidence_retrieval_tests/continuation.rs
@@ -2,18 +2,20 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use tracedecay_contracts::{WorkProductSelectionScopeV1, WorkTaskSessionRequestV1};
+use tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1;
+use tracedecay_application::work::work_evidence_retrieval::tests::{
+    CountingReauthorization, StaticFederatedAuthority, context, federated_authority, id,
+    verified_version,
+};
+use tracedecay_contracts::{
+    WorkEvidenceHydrationErrorV1, WorkProductSelectionScopeV1, WorkTaskSessionPortV1,
+    WorkTaskSessionRequestV1,
+};
 use tracedecay_domain::{
     AttemptId, ObservationSourceIdentityV1, PrivacyDomainId, ProjectId, ProviderId, RepositoryId,
     RunId, SessionId, TaskId, TemporalModeV1, UtcMicros, WorkAttemptIdentityV1, WorktreeId,
 };
 use tracedecay_session_memory::context::{BranchId, ProfileId, SessionRootId, SessionStoreId};
-
-use super::tests::{
-    CountingReauthorization, StaticFederatedAuthority, context, federated_authority, id,
-    verified_version,
-};
-use super::*;
 
 #[tokio::test]
 async fn continuation_resumes_the_same_provider_session_without_repeating_evidence() {
@@ -102,11 +104,12 @@ async fn continuation_resumes_the_same_provider_session_without_repeating_eviden
             database, root, None,
         )
         .expect("mounted project retrieval service");
-    let adapter = DaemonWorkEvidenceRetrievalV1::new(Arc::new(retrieval)).with_federated_authority(
-        Arc::new(StaticFederatedAuthority(Arc::new(federated_authority(
-            id::<PrivacyDomainId>("privacy.work-task-session-continuation"),
-        )))),
-    );
+    let adapter = WorkTaskSessionEvidenceRetrievalV1::new(Arc::new(retrieval))
+        .with_federated_authority(Arc::new(StaticFederatedAuthority(Arc::new(
+            federated_authority(id::<PrivacyDomainId>(
+                "privacy.work-task-session-continuation",
+            )),
+        ))));
     let source = ObservationSourceIdentityV1::for_provider(id::<ProviderId>("codex"), session_id)
         .expect("provider-qualified session");
     let mut request = WorkTaskSessionRequestV1 {

--- a/crates/tracedecay/src/mcp/server.rs
+++ b/crates/tracedecay/src/mcp/server.rs
@@ -536,11 +536,11 @@ impl MountedProjectApplicationRetrievalV1 {
         &self,
         expected_scope: &tracedecay_contracts::ResolvedScope,
         federated_authority: Arc<
-            dyn crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityPortV1,
+            dyn tracedecay_application::work::WorkFederatedQueryAuthorityPortV1,
         >,
-    ) -> Result<crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1> {
+    ) -> Result<tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1> {
         Ok(
-            crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1::new(
+            tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1::new(
                 self.retrieval_for_scope(expected_scope)?,
             )
             .with_federated_authority(federated_authority),
@@ -1311,13 +1311,13 @@ impl McpServer {
         &self,
         expected_scope: &tracedecay_contracts::ResolvedScope,
         federated_authority: Arc<
-            dyn crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityPortV1,
+            dyn tracedecay_application::work::WorkFederatedQueryAuthorityPortV1,
         >,
-    ) -> Result<crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1> {
+    ) -> Result<tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1> {
         match self.project_application_retrieval.as_ref() {
             Some(mounted) => mounted.work_evidence_retrieval(expected_scope, federated_authority),
             None => Ok(
-                crate::daemon::work_evidence_retrieval::DaemonWorkEvidenceRetrievalV1::new(
+                tracedecay_application::work::WorkTaskSessionEvidenceRetrievalV1::new(
                     self.project_session_retrieval_for_scope(expected_scope)?,
                 )
                 .with_federated_authority(federated_authority),

--- a/crates/tracedecay/src/mcp/server/work_evidence_mount_tests.rs
+++ b/crates/tracedecay/src/mcp/server/work_evidence_mount_tests.rs
@@ -1,5 +1,8 @@
 use std::sync::Arc;
 
+use tracedecay_application::work::{
+    WorkFederatedQueryAuthorityFutureV1, WorkFederatedQueryAuthorityPortV1,
+};
 use tracedecay_contracts::{RequestContext, ResolvedScope};
 use tracedecay_domain::{ProjectId, RepositoryId, WorktreeId};
 use tracedecay_session_memory::context::{
@@ -28,13 +31,11 @@ impl tracedecay_session_runtime::session_retrieval::SessionApplicationRetrievalP
 
 struct MissingFederatedAuthority;
 
-impl crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityPortV1
-    for MissingFederatedAuthority
-{
+impl WorkFederatedQueryAuthorityPortV1 for MissingFederatedAuthority {
     fn authority_for<'a>(
         &'a self,
         _scope: &'a ResolvedScope,
-    ) -> crate::daemon::work_evidence_retrieval::WorkFederatedQueryAuthorityFutureV1<'a> {
+    ) -> WorkFederatedQueryAuthorityFutureV1<'a> {
         Box::pin(async { None })
     }
 }


### PR DESCRIPTION
Child of #707 for #1073 (composition root).

`crates/tracedecay/src/daemon/work_evidence_retrieval.rs` (1,025 lines) moves to `crates/tracedecay-application/src/work/work_evidence_retrieval.rs` as `WorkTaskSessionEvidenceRetrievalV1` (renamed; `WorkEvidenceRetrievalV1` is already the contracts DTO). Root `pub(crate) mod` deleted, no `pub use` shim. Test helpers `StaticFederatedAuthority` / `federated_authority` ride the existing `test-helpers` feature.

Reviewer attention — one dependency inversion: `tracedecay-session-runtime` already depends on `tracedecay-application`, so application cannot call `SessionApplicationRetrievalPortV1` directly without a cycle. The single admitted-retrieval method is inverted as `WorkTaskSessionAdmittedRetrievalPortV1`, implemented in session-runtime for `DaemonSessionRetrievalService` and `dyn SessionApplicationRetrievalPortV1`. It exists for a real crate-cycle boundary and has two implementations, not a one-impl pass-through; if a reviewer would rather keep the file in root than carry that port, say so and this PR closes.

Host-admission journeys stay in root (`daemon/work_evidence_retrieval_tests*`) because they mount `HostAdmissionTestRuntimeV1`. Root references are callers only: `mcp/server.rs` (import lines; also in #1135), `mcp/server/work_evidence_mount_tests.rs`, `daemon/invocation_state.rs`, `daemon/invocation_tests/**`.

Verification: `work::work_evidence_retrieval` unit test; `daemon::invocation_tests::work_evidence_journey_tests`; clippy `-D warnings` on application + root before and after merging #707 `3473b1f92`; fmt; commitlint.