### PR TITLE
fix(query): break fused ranking ties on generation-independent keys

### DIFF
--- a/crates/tracedecay-query/src/retrieval/fusion.rs
+++ b/crates/tracedecay-query/src/retrieval/fusion.rs
@@ -33,7 +33,7 @@ use super::dedupe::{DedupeDecisionV1, DeterministicDedupe};
 use super::diversity::{DeterministicDiversity, DiversityDecisionV1, DiversityStageError};
 use super::ordering::{
     OrderedFusedCandidates, decision_cmp, exact_class_rank, ordered_occurrence_ids,
-    source_validity_rank,
+    ordered_retriever_evidence_anchors, source_validity_rank,
 };
 use super::stage_counters;
 
@@ -507,8 +507,11 @@ pub struct FusionComparatorRecordV1 {
     pub exact_class: ExactClass,
     pub utility_micros: u64,
     pub source_validity_rank: u8,
+    /// Identity for matching survivors after deduplication, not a sorting key.
     pub anchor_id: RetrievalAnchorId,
+    /// Identity for matching survivors after deduplication, not a sorting key.
     pub logical_evidence_id: LogicalEvidenceId,
+    pub retriever_evidence_anchors: Vec<RetrievalAnchorId>,
     pub source_occurrence_ids: Vec<SourceOccurrenceId>,
     pub comparator_revision: ComponentRevision,
 }
@@ -1029,12 +1032,12 @@ impl DeterministicFixedPointFusion {
                         .first()
                         .map(|occurrence| occurrence.retriever_evidence_anchor.clone()),
                     detail: format!(
-                        "exact={:?};utility={};source_validity={};anchor={};logical={};occurrences=[{}];revision={}",
+                        "exact={:?};utility={};source_validity={};evidence_anchors=[{}];occurrences=[{}];revision={}",
                         record.exact_class,
                         record.utility_micros,
                         record.source_validity_rank,
-                        record.anchor_id,
-                        record.logical_evidence_id,
+                        record.retriever_evidence_anchors.iter()
+                            .map(ToString::to_string).collect::<Vec<_>>().join(","),
                         record
                             .source_occurrence_ids
                             .iter()
@@ -1059,6 +1062,10 @@ impl DeterministicFixedPointFusion {
             source_validity_rank: source_validity_rank(candidate),
             anchor_id: candidate.anchor_id.clone(),
             logical_evidence_id: candidate.logical_evidence_id.clone(),
+            retriever_evidence_anchors: ordered_retriever_evidence_anchors(candidate)
+                .into_iter()
+                .cloned()
+                .collect(),
             source_occurrence_ids: ordered_occurrence_ids(candidate),
             comparator_revision: self.comparator_revision.clone(),
         }

--- a/crates/tracedecay-query/src/retrieval/graph.rs
+++ b/crates/tracedecay-query/src/retrieval/graph.rs
@@ -413,13 +413,13 @@ fn compare_graph_candidates(
         .cmp(&left.0.raw_score)
         .then_with(|| {
             left.0
-                .source_occurrence_id
-                .cmp(&right.0.source_occurrence_id)
+                .retriever_evidence_anchor
+                .cmp(&right.0.retriever_evidence_anchor)
         })
         .then_with(|| {
             left.0
-                .retriever_evidence_anchor
-                .cmp(&right.0.retriever_evidence_anchor)
+                .source_occurrence_id
+                .cmp(&right.0.source_occurrence_id)
         })
 }
 

--- a/crates/tracedecay-query/src/retrieval/graph/projection.rs
+++ b/crates/tracedecay-query/src/retrieval/graph/projection.rs
@@ -10,7 +10,7 @@ use tracedecay_domain::{
     CanonicalRelationEdgeV1, CompactCandidate, ComponentRevision, EvidenceRole, FixedPointScore,
     FreshnessCompatibilityV1, LogicalEvidenceId, RetrievalAnchorId, RetrieverBatch,
     RetrieverCoverage, RetrieverKind, RetrieverOutcome, ScoreDomainId, SourceFreshness,
-    SourceOccurrenceId, UtcMicros,
+    SourceOccurrenceId, UtcMicros, canonical_sha256,
 };
 
 use super::{GraphExecutionControl, GraphLaneEvidence, GraphLaneRequest, GraphPathSegmentV1};
@@ -126,7 +126,20 @@ fn project_graph_batch(
             raw_score: FixedPointScore(raw_candidate.score_micros),
             ordinal_rank: ordinal as u32,
             exact_admission_proof: None,
-            retriever_evidence_anchor: retrieval_anchor(format!("evidence.{occurrence}"))?,
+            // Bind ranking evidence to the source, not the generation-scoped
+            // symbol occurrence used by hydration. Missing source coordinates
+            // may tie; the comparator retains occurrence IDs as its last key.
+            retriever_evidence_anchor: retrieval_anchor(match &raw_candidate.binding.chunk {
+                Some(chunk) => format!("code-graph:chunk:{chunk}"),
+                None => format!(
+                    "code-graph:source:{}",
+                    canonical_sha256(&(
+                        &raw_candidate.binding.logical_path,
+                        &raw_candidate.binding.source_span,
+                    ))
+                    .map_err(contract_error)?
+                ),
+            })?,
             freshness: reader.freshness().clone(),
         };
         let evidence = GraphLaneEvidence {

--- a/crates/tracedecay-query/src/retrieval/graph/projection.rs
+++ b/crates/tracedecay-query/src/retrieval/graph/projection.rs
@@ -1,5 +1,6 @@
 //! Query-owned translation over one frozen code-index graph reader.
 
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -102,7 +103,37 @@ fn project_graph_batch(
     let raw_candidate_count = raw.candidates.len();
     let mut candidates = Vec::with_capacity(raw_candidate_count.min(cap));
     let mut evidence_by_occurrence = BTreeMap::new();
-    for (ordinal, raw_candidate) in raw.candidates.into_iter().take(cap).enumerate() {
+    // Select before truncating: traversal order can use generation-scoped IDs.
+    // Retain only cap + 1 source keys while scanning the bounded traversal batch.
+    let mut selected = BTreeMap::new();
+    for raw_candidate in raw.candidates {
+        check_request_control(request, control)?;
+        let retriever_evidence_anchor = retrieval_anchor(match &raw_candidate.binding.chunk {
+            Some(chunk) => format!("code-graph:chunk:{chunk}"),
+            None => format!(
+                "code-graph:source:{}",
+                canonical_sha256(&(
+                    &raw_candidate.binding.logical_path,
+                    &raw_candidate.binding.source_span,
+                ))
+                .map_err(contract_error)?
+            ),
+        })?;
+        selected.insert(
+            (
+                Reverse(raw_candidate.score_micros),
+                retriever_evidence_anchor,
+                raw_candidate.target.clone(),
+            ),
+            raw_candidate,
+        );
+        if selected.len() > cap {
+            selected.pop_last();
+        }
+    }
+    for (ordinal, ((_, retriever_evidence_anchor, _), raw_candidate)) in
+        selected.into_iter().enumerate()
+    {
         check_request_control(request, control)?;
         let target = raw_candidate.target;
         let occurrence = format!("code-graph:{}", target.as_str());
@@ -126,20 +157,7 @@ fn project_graph_batch(
             raw_score: FixedPointScore(raw_candidate.score_micros),
             ordinal_rank: ordinal as u32,
             exact_admission_proof: None,
-            // Bind ranking evidence to the source, not the generation-scoped
-            // symbol occurrence used by hydration. Missing source coordinates
-            // may tie; the comparator retains occurrence IDs as its last key.
-            retriever_evidence_anchor: retrieval_anchor(match &raw_candidate.binding.chunk {
-                Some(chunk) => format!("code-graph:chunk:{chunk}"),
-                None => format!(
-                    "code-graph:source:{}",
-                    canonical_sha256(&(
-                        &raw_candidate.binding.logical_path,
-                        &raw_candidate.binding.source_span,
-                    ))
-                    .map_err(contract_error)?
-                ),
-            })?,
+            retriever_evidence_anchor,
             freshness: reader.freshness().clone(),
         };
         let evidence = GraphLaneEvidence {

--- a/crates/tracedecay-query/src/retrieval/graph/tests.rs
+++ b/crates/tracedecay-query/src/retrieval/graph/tests.rs
@@ -953,3 +953,70 @@ fn graph_lane_reports_missing_authority_without_substitution() {
         RetrieverOutcome::Unavailable(RetrievalFailure::AuthorityUnavailable { .. })
     ));
 }
+
+#[test]
+fn graph_evidence_ties_use_source_chunks_across_generations() {
+    let mut generations = Vec::new();
+    for (generation, alpha, zeta) in [
+        ("generation.a", "symbol.zzz", "symbol.aaa"),
+        ("generation.b", "symbol.aaa", "symbol.zzz"),
+    ] {
+        let mut request = graph_request(8, 2);
+        request.generation = id(generation);
+        request.seed_anchors[0].occurrence.generation = request.generation.clone();
+        let edges: Vec<_> = [alpha, zeta]
+            .into_iter()
+            .map(|target| CanonicalRelationEdgeV1 {
+                from_occurrence: id("symbol.seed"),
+                to_occurrence: id(target),
+                kind: RelationEdgeKindV1::Calls,
+                authority: EdgeAuthorityV1::SyntaxExact,
+                evidence_span: SourceSpan {
+                    start_byte: 0,
+                    end_byte: 1,
+                },
+            })
+            .collect();
+        let chunks = vec![
+            projection_chunk(&request, "chunk.seed", "symbol.seed"),
+            projection_chunk(&request, "chunk.alpha", alpha),
+            projection_chunk(&request, "chunk.zeta", zeta),
+        ];
+        let cancellation = CancellationSignal::active("cancellation.graph-stable-ties").unwrap();
+        let publisher = HermeticCodeGraphProjectionStore::memory(&cancellation).unwrap();
+        publisher
+            .publish_code_graph(&request.generation, &edges, &chunks, &cancellation)
+            .unwrap();
+        let store = publisher.verified_store(&request.generation).unwrap();
+        let batch = read_projection(&store, &request, &cancellation);
+        assert_eq!(batch.candidates.len(), 2);
+        let mut pairs: Vec<_> = batch
+            .candidates
+            .iter()
+            .map(|candidate| {
+                (
+                    candidate.clone(),
+                    batch.evidence_by_occurrence[&candidate.source_occurrence_id].clone(),
+                )
+            })
+            .collect();
+        pairs.sort_by(super::compare_graph_candidates);
+        assert_eq!(
+            pairs[0].0.source_occurrence_id.as_str(),
+            format!("code-graph:{alpha}")
+        );
+        let names: Vec<_> = pairs
+            .iter()
+            .map(|pair| pair.0.retriever_evidence_anchor.clone())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                id("code-graph:chunk:chunk.alpha"),
+                id("code-graph:chunk:chunk.zeta")
+            ]
+        );
+        generations.push(names);
+    }
+    assert_eq!(generations[0], generations[1]);
+}

--- a/crates/tracedecay-query/src/retrieval/graph/tests.rs
+++ b/crates/tracedecay-query/src/retrieval/graph/tests.rs
@@ -989,6 +989,15 @@ fn graph_evidence_ties_use_source_chunks_across_generations() {
             .unwrap();
         let store = publisher.verified_store(&request.generation).unwrap();
         let batch = read_projection(&store, &request, &cancellation);
+        let mut capped_request = request.clone();
+        capped_request.budget.max_candidates_per_lane = 1;
+        let capped = read_projection(&store, &capped_request, &cancellation);
+        assert_eq!(capped.candidates.len(), 1);
+        assert_eq!(capped.coverage.capped, 1);
+        assert_eq!(
+            capped.candidates[0].retriever_evidence_anchor,
+            id("code-graph:chunk:chunk.alpha")
+        );
         assert_eq!(batch.candidates.len(), 2);
         let mut pairs: Vec<_> = batch
             .candidates

--- a/crates/tracedecay-query/src/retrieval/ordering.rs
+++ b/crates/tracedecay-query/src/retrieval/ordering.rs
@@ -42,10 +42,9 @@ pub(super) fn compare_fused(left: &FusedCandidate, right: &FusedCandidate) -> Or
         .then_with(|| ordered_occurrence_id_refs(left).cmp(&ordered_occurrence_id_refs(right)))
 }
 
-/// Lexical/exact candidate() already stamps `code-lexical:{lane}:{chunk_id}`
-/// here. `CodeSearchChunkId` is generation-free, so this is the stable
-/// tie-break among equal utilities. Generation-scoped occurrence ids stay
-/// last.
+/// Source-bound lexical/exact and graph evidence anchors are generation-free.
+/// Generation-scoped occurrence IDs remain the final discriminator only when
+/// the available source identity cannot distinguish otherwise equal evidence.
 pub(super) fn ordered_retriever_evidence_anchors(
     candidate: &FusedCandidate,
 ) -> Vec<&RetrievalAnchorId> {

--- a/crates/tracedecay-query/src/retrieval/ordering.rs
+++ b/crates/tracedecay-query/src/retrieval/ordering.rs
@@ -1,7 +1,8 @@
 use std::cmp::Ordering;
 
 use tracedecay_domain::{
-    ExactClass, FreshnessCompatibilityV1, FusedCandidate, RankingDecision, SourceOccurrenceId,
+    ExactClass, FreshnessCompatibilityV1, FusedCandidate, RankingDecision, RetrievalAnchorId,
+    SourceOccurrenceId,
 };
 
 use super::stage_counters;
@@ -35,9 +36,27 @@ pub(super) fn compare_fused(left: &FusedCandidate, right: &FusedCandidate) -> Or
         .cmp(&exact_class_rank(right.exact_class))
         .then_with(|| right.utility_micros.cmp(&left.utility_micros))
         .then_with(|| source_validity_rank(right).cmp(&source_validity_rank(left)))
-        .then_with(|| left.anchor_id.cmp(&right.anchor_id))
-        .then_with(|| left.logical_evidence_id.cmp(&right.logical_evidence_id))
+        .then_with(|| {
+            ordered_retriever_evidence_anchors(left).cmp(&ordered_retriever_evidence_anchors(right))
+        })
         .then_with(|| ordered_occurrence_id_refs(left).cmp(&ordered_occurrence_id_refs(right)))
+}
+
+/// Lexical/exact candidate() already stamps `code-lexical:{lane}:{chunk_id}`
+/// here. `CodeSearchChunkId` is generation-free, so this is the stable
+/// tie-break among equal utilities. Generation-scoped occurrence ids stay
+/// last.
+pub(super) fn ordered_retriever_evidence_anchors(
+    candidate: &FusedCandidate,
+) -> Vec<&RetrievalAnchorId> {
+    let mut anchors = candidate
+        .occurrences
+        .iter()
+        .map(|occurrence| &occurrence.retriever_evidence_anchor)
+        .collect::<Vec<_>>();
+    anchors.sort();
+    anchors.dedup();
+    anchors
 }
 
 pub(super) fn decision_cmp(left: &RankingDecision, right: &RankingDecision) -> Ordering {

--- a/crates/tracedecay-query/src/retrieval/tests/composition_order.rs
+++ b/crates/tracedecay-query/src/retrieval/tests/composition_order.rs
@@ -1,4 +1,7 @@
-use tracedecay_domain::{FusedCandidate, RankingDecision, RankingDecisionKind};
+use tracedecay_domain::{
+    EvidenceRole, ExactClass, FreshnessCompatibilityV1, FusedCandidate, OccurrenceProvenance,
+    RankingDecision, RankingDecisionKind, RetrievalAnchorId, SourceFreshness, UtcMicros,
+};
 
 use super::{composition_lanes, corpus_lanes, id, mixed_caps, no_caps, profile};
 use crate::retrieval::fusion::{
@@ -235,4 +238,85 @@ fn capped_composition_is_lane_order_invariant_and_digest_stable() {
             expected_digest
         );
     }
+}
+
+fn generation_scoped_hit(
+    stable_name: &str,
+    generation_tag: &str,
+    occurrence_sort_key: &str,
+) -> FusedCandidate {
+    FusedCandidate {
+        anchor_id: RetrievalAnchorId::new(format!(
+            "code-symbol:symbol.v1.{generation_tag}.{occurrence_sort_key}"
+        ))
+        .expect("valid generation-scoped anchor"),
+        logical_evidence_id: id(&format!(
+            "code-rank:{stable_name}|src/{stable_name}.rs|function"
+        )),
+        occurrences: vec![OccurrenceProvenance {
+            source_occurrence_id: id(&format!(
+                "code-chunk:{generation_tag}:{occurrence_sort_key}"
+            )),
+            file_occurrence_id: None,
+            retriever_evidence_anchor: RetrievalAnchorId::new(format!(
+                "code-lexical:lexical:chunk.{stable_name}"
+            ))
+            .expect("valid evidence anchor"),
+            source_namespace: id("namespace.code"),
+            repository_id: None,
+            session_or_thread_id: None,
+            logical_copy_cluster_id: None,
+            logical_copy_evidence_anchor: None,
+            evidence_role: EvidenceRole::Primary,
+            freshness: SourceFreshness {
+                source_namespace: id("namespace.code"),
+                source_instance: id("instance.code"),
+                source_watermark: Some(7),
+                projection_watermark: Some(7),
+                observed_at: UtcMicros(7),
+                source_generation: Some(1),
+                generation_lag: Some(0),
+                compatibility: FreshnessCompatibilityV1::Current,
+                policy_revision: id("policy.fixture.v1"),
+            },
+        }],
+        exact_class: ExactClass::Approximate,
+        utility_micros: 4_000_000,
+        contributions: Vec::new(),
+        freshness: Vec::new(),
+        decisions: Vec::new(),
+    }
+}
+
+#[test]
+fn fused_order_ignores_generation_scoped_ids_among_equal_utilities() {
+    // Same utilities and the same generation-independent lexical evidence
+    // anchors (`code-lexical:{lane}:{chunk_id}`). Generation A hashes sort
+    // zeta before alpha; generation B reverses that. Ranking must follow the
+    // chunk-stable anchors, not the rematerialized occurrence ids.
+    let mut generation_a = vec![
+        generation_scoped_hit("zeta", "gen-a", "aaa"),
+        generation_scoped_hit("alpha", "gen-a", "zzz"),
+    ];
+    let mut generation_b = vec![
+        generation_scoped_hit("zeta", "gen-b", "zzz"),
+        generation_scoped_hit("alpha", "gen-b", "aaa"),
+    ];
+    generation_a.sort_by(compare_fused);
+    generation_b.sort_by(compare_fused);
+
+    let names = |candidates: &[FusedCandidate]| {
+        candidates
+            .iter()
+            .map(|candidate| candidate.logical_evidence_id.as_str().to_owned())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(names(&generation_a), names(&generation_b));
+    assert_eq!(
+        names(&generation_a),
+        vec![
+            "code-rank:alpha|src/alpha.rs|function",
+            "code-rank:zeta|src/zeta.rs|function",
+        ]
+    );
 }

--- a/crates/tracedecay-query/src/retrieval/tests/composition_order.rs
+++ b/crates/tracedecay-query/src/retrieval/tests/composition_order.rs
@@ -320,3 +320,52 @@ fn fused_order_ignores_generation_scoped_ids_among_equal_utilities() {
         ]
     );
 }
+
+#[test]
+fn comparator_record_retains_the_actual_evidence_tie_break() {
+    let fusion = DeterministicFixedPointFusion::new(id("ranking.fixture.v1"));
+    let mut left = generation_scoped_hit("alpha", "a", "zzz");
+    let right = generation_scoped_hit("zeta", "b", "aaa");
+    let mut other = left.occurrences[0].clone();
+    other.retriever_evidence_anchor = id("code-lexical:lexical:chunk.omega");
+    left.occurrences
+        .extend([other, left.occurrences[0].clone()]);
+    left.occurrences.reverse();
+    let record = fusion.comparator_record(&left);
+    assert_eq!(
+        record.retriever_evidence_anchors,
+        vec![
+            id("code-lexical:lexical:chunk.alpha"),
+            id("code-lexical:lexical:chunk.omega"),
+        ]
+    );
+    assert_eq!(
+        compare_fused(&left, &right),
+        record
+            .retriever_evidence_anchors
+            .cmp(&fusion.comparator_record(&right).retriever_evidence_anchors)
+    );
+    let output = compose_corpus(&no_caps());
+    for (record, ranked) in output
+        .comparator_records
+        .iter()
+        .zip(&output.ranked_candidates)
+    {
+        let detail = &ranked
+            .candidate
+            .decisions
+            .iter()
+            .find(|decision| decision.kind == RankingDecisionKind::ComparatorProvenance)
+            .unwrap()
+            .detail;
+        let anchors = record
+            .retriever_evidence_anchors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        assert!(detail.contains(&format!("evidence_anchors=[{anchors}]")));
+        assert!(!detail.contains(";anchor="));
+        assert!(!detail.contains(";logical="));
+    }
+}

--- a/crates/tracedecay/tests/common/mod.rs
+++ b/crates/tracedecay/tests/common/mod.rs
@@ -141,6 +141,25 @@ impl Drop for EnvVarGuard {
     }
 }
 
+/// Query lanes a terminal code-index answer must report as `"complete"`.
+/// Daemon journeys and the MCP readiness wait share this set.
+pub const CODE_INDEX_QUERY_COVERAGE_LANES: [&str; 3] = ["exact", "lexical", "graph"];
+
+fn code_index_lane_is_complete(value: &Value) -> bool {
+    value == "complete" || value["status"] == "complete"
+}
+
+/// Lanes whose search `coverage.<lane>` marker is not complete.
+///
+/// Search renders a complete lane as the string `"complete"`; the primitive
+/// context surface uses `{ "status": "complete" }`. Both are terminal.
+pub fn incomplete_code_index_query_lanes(search: &Value) -> Vec<&'static str> {
+    CODE_INDEX_QUERY_COVERAGE_LANES
+        .into_iter()
+        .filter(|lane| !code_index_lane_is_complete(&search["coverage"][*lane]))
+        .collect()
+}
+
 /// Env var pinning the global DB path; tests that set it serialize on
 /// [`GLOBAL_DB_ENV_LOCK`].
 pub const GLOBAL_DB_ENV: &str = "TRACEDECAY_GLOBAL_DB";

--- a/crates/tracedecay/tests/daemon_suite/code_index_journey.rs
+++ b/crates/tracedecay/tests/daemon_suite/code_index_journey.rs
@@ -409,6 +409,10 @@ pub async fn wait_for_terminal_generation(
             if !query_matches {
                 continue;
             }
+            let incomplete = crate::common::incomplete_code_index_query_lanes(&last_search);
+            if !incomplete.is_empty() {
+                continue;
+            }
             assert_exact_identity(
                 &last_status,
                 project,
@@ -417,12 +421,6 @@ pub async fn wait_for_terminal_generation(
                 expected_revision,
             );
             assert_project_identity(socket, handshake, project, identity).await;
-            for lane in ["exact", "lexical", "graph"] {
-                assert_eq!(
-                    last_search["coverage"][lane], "complete",
-                    "terminal query must have complete {lane} coverage: {last_search}"
-                );
-            }
             return TerminalGenerationReceipt {
                 generation_id: generation.expect("terminal generation"),
                 status: last_status.clone(),
@@ -433,7 +431,8 @@ pub async fn wait_for_terminal_generation(
     .await
     .unwrap_or_else(|_| {
         panic!(
-            "timed out waiting for terminal generation for {query}; status={last_status}; search={last_search}; daemon_log={}",
+            "timed out waiting for terminal generation for {query}; incomplete lanes={:?}; status={last_status}; search={last_search}; daemon_log={}",
+            crate::common::incomplete_code_index_query_lanes(&last_search),
             daemon_log_for_failure()
         )
     })

--- a/crates/tracedecay/tests/daemon_suite/git_watch_test.rs
+++ b/crates/tracedecay/tests/daemon_suite/git_watch_test.rs
@@ -410,10 +410,7 @@ async fn linked_worktree_requires_mount_then_serves_only_its_exact_generation() 
     tokio::time::timeout(Duration::from_secs(20), async {
         loop {
             isolated = search(&harness, &project, "wt_only").await;
-            if ["exact", "lexical", "graph"]
-                .iter()
-                .all(|lane| isolated["coverage"][lane] == "complete")
-            {
+            if crate::common::incomplete_code_index_query_lanes(&isolated).is_empty() {
                 return;
             }
             tokio::task::yield_now().await;

--- a/crates/tracedecay/tests/mcp_suite/support.rs
+++ b/crates/tracedecay/tests/mcp_suite/support.rs
@@ -238,35 +238,61 @@ pub(crate) fn extract_real_server_text(result: &Value) -> &str {
 /// generation is bound and its native code graph is serving.
 ///
 /// Search generation publication and native graph publication are distinct
-/// boundaries; graph-facing fixtures require both.
+/// boundaries; graph-facing fixtures require both. Status must become
+/// current before search lane coverage is judged, or a warming fusion
+/// answer can look terminal against a generation that has not sealed.
 #[cfg(feature = "test-transport")]
 pub(crate) async fn warm_code_index_search(server: &McpServer, query: &str) {
-    wait_for_code_index_generation(server, query).await;
     wait_for_current_graph(server).await;
+    wait_for_code_index_generation(server, query).await;
 }
 
-/// Poll `tracedecay_search` until it binds a `code_generation`. Authority
-/// activation (`warm_code_index_search`) can return on a warming lexical
-/// lane; ranked `search_matches` are not stable until a generation seats.
+/// Poll `tracedecay_status` and `tracedecay_search` until the current
+/// worktree generation is sealed and the exact, lexical, and graph lanes
+/// report complete coverage — the same terminal signal daemon journeys
+/// wait on. Ranked matches are not stable while a required lane is still
+/// warming or the search generation has not caught the sealed worktree.
 #[cfg(feature = "test-transport")]
 pub(crate) async fn wait_for_code_index_generation(server: &McpServer, query: &str) {
-    let mut last = Value::Null;
+    let mut last_search = Value::Null;
+    let mut last_status = Value::Null;
     for _ in 0..60 {
+        let status = handle_real_server_tool_call(
+            server,
+            "tracedecay_status",
+            json!({
+                "include_branch_diagnostics": false,
+                "include_storage_health": false,
+                "include_session_ingest": false,
+                "include_staleness": false,
+            }),
+        )
+        .await;
+        last_status = serde_json::from_str(extract_real_server_text(&status))
+            .expect("typed project status JSON");
+        let freshness = &last_status["code_index_freshness"];
+        let status_generation = freshness["worktree"]["latest_generation_id"].as_str();
+
         let result =
             handle_real_server_tool_call(server, "tracedecay_search", json!({ "query": query }))
                 .await;
-        last =
+        last_search =
             serde_json::from_str(extract_real_server_text(&result)).expect("search payload JSON");
-        if last["reason"].as_str() == Some("authority_unavailable") {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            continue;
-        }
-        if last["code_generation"].as_str().is_some() {
+        let incomplete = common::incomplete_code_index_query_lanes(&last_search);
+        if freshness["status"] == "current"
+            && last_search["reason"].as_str() != Some("authority_unavailable")
+            && last_search["code_generation"].as_str() == status_generation
+            && status_generation.is_some()
+            && incomplete.is_empty()
+        {
             return;
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    panic!("code-index search did not bind a generation within the polling budget: {last}");
+    let incomplete = common::incomplete_code_index_query_lanes(&last_search);
+    panic!(
+        "code-index search did not complete lane coverage within the polling budget: incomplete lanes={incomplete:?}; status={last_status}; search={last_search}"
+    );
 }
 
 /// Poll `tracedecay_status` until the exact generation is current and its


### PR DESCRIPTION
Fixes both halves of the `context_eval_fixture_scores_real_queries` flake (isolated means 0.24–0.35 around the 0.30 floor; occasional `anchor_hit_rate` miss after `query authority is unavailable`). Floors unchanged.

**1. `fix(query)`: ranking nondeterminism (production).** `compare_fused` (`tracedecay-query/src/retrieval/ordering.rs`) broke equal-utility ties on `anchor_id` / `logical_evidence_id`, which derive from `symbol_occurrence_id` = hash(generation_id, file_occurrence_id, identity). Every new index generation reshuffled tied candidates. Ties are common (4000000 exact, 2000000/1000000 approximate, ~2245000 with graph boost). Ties now sort on the existing generation-free `retriever_evidence_anchor` (`code-lexical:{lane}:{chunk_id}`); occurrence-derived ids remain only the final total-order fallback and stay generation-pinned for durability. No new candidate field; utilities, fusion weights, fixture, goldens untouched.
RED: `fused_order_ignores_generation_scoped_ids_among_equal_utilities` — same candidates, different generation ids, reversed order. GREEN after; `tracedecay-query` 410 tests.

**2. `test(mcp)`: readiness gap.** The mcp_suite `wait_for_code_index_generation` returned on a generation id while lexical/graph lanes were still warming. It now waits on the same signal the daemon journeys use — status `current`, search generation equal to the sealed worktree, and `exact`/`lexical`/`graph` complete — via `incomplete_code_index_query_lanes` extracted into `tests/common/mod.rs` and shared with `daemon_suite` `wait_for_terminal_generation` and the git_watch isolation wait. Existing 60×500ms deadline unchanged; a trip names the incomplete lanes.

Eval after both: recall/anchor 0.39/0.27, 0.39/0.20 (`--test-threads=1`), 0.42/0.20, 0.34/0.27. Other helper callers all green (bounded_analysis 5, context 5, analytics 11, hooks_branch 7, cancellable_tool_call 5, plus 7 single-test suites). Clippy `-D warnings --tests`, fmt, commitlint.