### PR TITLE
fix(automation): resolve lock dir prefix before cap-std open

### DIFF
--- a/crates/tracedecay-automation-runtime/src/automation/scheduler.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/scheduler.rs
@@ -819,13 +819,27 @@ fn new_automation_task_lock_token() -> Result<String> {
     Ok(hex::encode(random))
 }
 
+fn resolve_task_lock_parent(path: &Path) -> std::io::Result<PathBuf> {
+    let (parent, name) = path.parent().zip(path.file_name()).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "automation task-lock path requires a parent and file name",
+        )
+    })?;
+    // Resolve OS directory aliases without hiding a final symlink from no-follow checks.
+    Ok(
+        tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(parent)
+            .join(name),
+    )
+}
+
 fn try_acquire_task_lock_blocking(
     path: &Path,
     ownership_token: &str,
     stale_after_secs: Option<u64>,
     now_secs: i64,
 ) -> std::io::Result<Option<AutomationTaskLock>> {
-    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    let path = resolve_task_lock_parent(path)?;
     if let Some(parent) = path.parent() {
         tracedecay_runtime_core::storage::PrivateStoreIo::create_dir_all_durable(parent)?;
     }
@@ -979,7 +993,7 @@ fn prepare_task_lock_publication(
     ownership_token: &str,
     now_secs: i64,
 ) -> std::result::Result<PreparedTaskLockPublication, TaskLockStagingCreationError> {
-    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    let path = resolve_task_lock_parent(path)?;
     tracedecay_runtime_core::storage::reject_symlink_components(&path, "automation task lock")?;
     let parent_path = path.parent().ok_or_else(|| {
         std::io::Error::new(
@@ -1176,7 +1190,7 @@ fn remove_owned_task_lock_blocking(path: &Path, ownership_token: &str) -> std::i
 }
 
 fn acquire_task_lock_coordination(path: &Path) -> std::io::Result<std::fs::File> {
-    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    let path = resolve_task_lock_parent(path)?;
     let coordination_path = tracedecay_runtime_core::storage::append_lock_path(&path);
     tracedecay_runtime_core::storage::reject_symlink_components(
         &coordination_path,
@@ -1233,7 +1247,7 @@ struct AutomationTaskLockSnapshot {
 }
 
 fn read_task_lock_snapshot(path: &Path) -> std::io::Result<Option<AutomationTaskLockSnapshot>> {
-    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    let path = resolve_task_lock_parent(path)?;
     tracedecay_runtime_core::storage::reject_symlink_components(&path, "automation task lock")?;
     let parent_path = path.parent().ok_or_else(|| {
         std::io::Error::new(
@@ -2431,6 +2445,30 @@ evidence about it",
         assert_eq!(std::fs::read(&outside).unwrap(), b"unchanged");
         assert!(coordination_path.is_symlink());
         assert_ne!(error.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn task_lock_rejects_final_symlink_without_touching_target() {
+        let temp = tempdir().unwrap();
+        let real = temp.path().join("real");
+        let alias = temp.path().join("alias");
+        std::fs::create_dir(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let lock_path = alias.join("task.lock");
+        let outside = temp.path().join("outside");
+        let token = "1".repeat(AUTOMATION_TASK_LOCK_TOKEN_BYTES * 2);
+        let contents = format!("pid=invalid\ncreated_at=1\ntoken={token}\n");
+        std::fs::write(&outside, &contents).unwrap();
+        std::os::unix::fs::symlink(&outside, &lock_path).unwrap();
+
+        assert!(read_task_lock_snapshot(&lock_path).is_err());
+        assert!(prepare_task_lock_publication(&lock_path, &token, 200).is_err());
+        assert!(remove_owned_task_lock_blocking(&lock_path, &token).is_err());
+        assert!(try_acquire_task_lock_blocking(&lock_path, &token, Some(0), 200).is_err());
+        assert!(lock_path.is_symlink());
+        assert_eq!(std::fs::read_to_string(&outside).unwrap(), contents);
+        assert!(!tracedecay_runtime_core::storage::append_lock_path(&outside).exists());
     }
 
     #[test]

--- a/crates/tracedecay-automation-runtime/src/automation/scheduler.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/scheduler.rs
@@ -221,7 +221,12 @@ impl AutomationTaskLock {
         stale_after_secs: Option<u64>,
         now_secs: i64,
     ) -> Result<Option<Self>> {
-        let lock_dir = dashboard_root.join("automation_locks");
+        // cap-std ambient opens walk each component. On macOS `/var` is a
+        // firmlink to `/private/var`; opening the unresolved tempfile spelling
+        // can ENOENT under concurrent create. Resolve the existing prefix first.
+        let lock_dir = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(
+            &dashboard_root.join("automation_locks"),
+        );
         let path = lock_dir.join(format!("{key}.lock"));
         let ownership_token = new_automation_task_lock_token()?;
         let error_path = path.clone();
@@ -820,21 +825,22 @@ fn try_acquire_task_lock_blocking(
     stale_after_secs: Option<u64>,
     now_secs: i64,
 ) -> std::io::Result<Option<AutomationTaskLock>> {
+    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
     if let Some(parent) = path.parent() {
         tracedecay_runtime_core::storage::PrivateStoreIo::create_dir_all_durable(parent)?;
     }
-    let coordination = acquire_task_lock_coordination(path)?;
+    let coordination = acquire_task_lock_coordination(&path)?;
     for attempt in 0..2 {
-        match create_task_lock_file(path, ownership_token, now_secs) {
+        match create_task_lock_file(&path, ownership_token, now_secs) {
             Ok(task_lock) => return Ok(Some(task_lock)),
             Err(TaskLockPublicationError::Definite(error))
                 if error.kind() == std::io::ErrorKind::AlreadyExists =>
             {
-                let Some(snapshot) = read_task_lock_snapshot(path)? else {
+                let Some(snapshot) = read_task_lock_snapshot(&path)? else {
                     continue;
                 };
                 if attempt == 0 && task_lock_is_reclaimable(&snapshot, stale_after_secs, now_secs) {
-                    tracedecay_runtime_core::storage::PrivateStoreIo::remove_file_durable(path)?;
+                    tracedecay_runtime_core::storage::PrivateStoreIo::remove_file_durable(&path)?;
                     continue;
                 }
                 return Ok(None);
@@ -973,7 +979,8 @@ fn prepare_task_lock_publication(
     ownership_token: &str,
     now_secs: i64,
 ) -> std::result::Result<PreparedTaskLockPublication, TaskLockStagingCreationError> {
-    tracedecay_runtime_core::storage::reject_symlink_components(path, "automation task lock")?;
+    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    tracedecay_runtime_core::storage::reject_symlink_components(&path, "automation task lock")?;
     let parent_path = path.parent().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -990,7 +997,7 @@ fn prepare_task_lock_publication(
             )
         })?;
     let parent = Dir::open_ambient_dir(parent_path, ambient_authority())?;
-    let staging_path = task_lock_staging_path(path, ownership_token)?;
+    let staging_path = task_lock_staging_path(&path, ownership_token)?;
     let staging_name = staging_path
         .file_name()
         .map(std::ffi::OsStr::to_os_string)
@@ -1169,7 +1176,8 @@ fn remove_owned_task_lock_blocking(path: &Path, ownership_token: &str) -> std::i
 }
 
 fn acquire_task_lock_coordination(path: &Path) -> std::io::Result<std::fs::File> {
-    let coordination_path = tracedecay_runtime_core::storage::append_lock_path(path);
+    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    let coordination_path = tracedecay_runtime_core::storage::append_lock_path(&path);
     tracedecay_runtime_core::storage::reject_symlink_components(
         &coordination_path,
         "automation task-lock coordination",
@@ -1225,7 +1233,8 @@ struct AutomationTaskLockSnapshot {
 }
 
 fn read_task_lock_snapshot(path: &Path) -> std::io::Result<Option<AutomationTaskLockSnapshot>> {
-    tracedecay_runtime_core::storage::reject_symlink_components(path, "automation task lock")?;
+    let path = tracedecay_runtime_core::path_safety::canonicalize_path_or_existing_parent(path);
+    tracedecay_runtime_core::storage::reject_symlink_components(&path, "automation task lock")?;
     let parent_path = path.parent().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -2670,5 +2679,40 @@ evidence about it",
         .expect("dropping the guard inside spawn_blocking must not panic");
 
         assert_lock_released(&lock_path);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_task_locks_acquire_through_symlinked_dashboard_prefix() {
+        // cap-std ambient opens walk each component. A prefix symlink
+        // (`tmp/link` → `tmp/real`, or macOS `/var` → `/private/var`) must
+        // resolve before Dir::open_ambient_dir or concurrent acquires ENOENT.
+        let temp = tempdir().unwrap();
+        let real = temp.path().join("real");
+        let link = temp.path().join("link");
+        std::fs::create_dir_all(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let dashboard_root = link.join("dashboard");
+
+        let first_root = dashboard_root.clone();
+        let second_root = dashboard_root;
+        let first = tokio::spawn(async move {
+            AutomationTaskLock::try_acquire_keyed(&first_root, "concurrent-a", Some(10), 100).await
+        });
+        let second = tokio::spawn(async move {
+            AutomationTaskLock::try_acquire_keyed(&second_root, "concurrent-b", Some(10), 100).await
+        });
+        let first = first
+            .await
+            .expect("join first lock")
+            .expect("first lock acquire through prefix symlink");
+        let second = second
+            .await
+            .expect("join second lock")
+            .expect("second lock acquire through prefix symlink");
+        assert!(
+            first.is_some() && second.is_some(),
+            "distinct keys under a shared lock dir must both acquire"
+        );
     }
 }

--- a/crates/tracedecay/tests/runtime_acceptance_suite/tool_client_transport.rs
+++ b/crates/tracedecay/tests/runtime_acceptance_suite/tool_client_transport.rs
@@ -134,6 +134,11 @@ where
         while workers.len() < connections {
             match listener.accept() {
                 Ok((stream, _)) => {
+                    // macOS `accept` inherits `O_NONBLOCK` from a non-blocking
+                    // listener, so the first `read` returns `WouldBlock`.
+                    stream
+                        .set_nonblocking(false)
+                        .expect("accepted fake daemon stream must be blocking");
                     stream
                         .set_read_timeout(Some(LOCAL_TIMEOUT))
                         .expect("set read timeout");


### PR DESCRIPTION
Two base-red items from the macOS `Test macOS root-suites` lane (run 34321975876).

**`fix(automation)`** — `jobs::concurrent_manual_job_triggers_do_not_double_execute` failed with `failed to acquire automation lock '/var/folders/.../dashboard/automation_locks/...': No such file or directory`. Same class as `1fef6df27` (run ledger): `reject_symlink_components` exempts the first absolute component, so macOS `/var` → `/private/var` passes, then `Dir::open_ambient_dir` walks the firmlink and `ENOENT`s under concurrent create. The lock-dir prefix is now resolved with the existing `canonicalize_path_or_existing_parent` before `create_dir_all_durable` and each `Dir::open_ambient_dir`. RED: new `concurrent_task_locks_acquire_through_symlinked_dashboard_prefix` fails on the symlinked prefix; GREEN: scheduler module 36/36, the CI test 1/1.

**`test(runtime-acceptance)`** — `tool_client_transport::generic_tool_accepts_split_json_rpc_frame` hit `WouldBlock (os 35)` on the handshake read. Fixture only: `spawn_scripted_daemon` accepts from a nonblocking listener and macOS inherits `O_NONBLOCK` on the accepted stream (Linux does not). Same fix as `b0c40ee75`: `set_nonblocking(false)` on the accepted stream. `tool_client_transport` 9/9 on Linux (cannot reproduce the macOS behavior locally; CI covers it).

Clippy `-D warnings --tests` on automation-runtime and root; fmt; commitlint.