### PR TITLE
fix(semantic): separate scope CAS from project authorization

### DIFF
--- a/crates/tracedecay-application/src/config/retrieval.rs
+++ b/crates/tracedecay-application/src/config/retrieval.rs
@@ -565,6 +565,7 @@ impl RetrievalProfileMutationCapabilityV1 {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RetrievalProfileCasV1 {
+    /// Last semantic commit in this scope, independent of the current project revision.
     pub expected_configuration_revision: ConfigurationRevisionId,
     pub expected_active_digest: ManifestDigest,
     pub expected_rollback_digest: Option<ManifestDigest>,
@@ -597,6 +598,7 @@ pub struct RetrievalProfileAuditEventV1 {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RetrievalProfileCommitMetadataV1 {
     freshness_vector_digest: ManifestDigest,
+    base_configuration_revision: ConfigurationRevisionId,
     result_revision: ConfigurationRevisionId,
     now: UtcMicros,
 }
@@ -605,11 +607,13 @@ impl RetrievalProfileCommitMetadataV1 {
     #[must_use]
     pub fn new(
         freshness_vector_digest: ManifestDigest,
+        base_configuration_revision: ConfigurationRevisionId,
         result_revision: ConfigurationRevisionId,
         now: UtcMicros,
     ) -> Self {
         Self {
             freshness_vector_digest,
+            base_configuration_revision,
             result_revision,
             now,
         }
@@ -729,7 +733,7 @@ impl RetrievalProfileStateV1 {
     ) -> Result<&RetrievalProfileAuditEventV1, RetrievalProfileActivationErrorV1> {
         self.validate_cas(expected)?;
         let actor = capability
-            .validate(&expected.expected_configuration_revision, commit.now)?
+            .validate(&commit.base_configuration_revision, commit.now)?
             .clone();
         self.active.executable_under(current_runtime)?;
         candidate.executable_under(candidate_runtime)?;
@@ -766,7 +770,7 @@ impl RetrievalProfileStateV1 {
             return Err(RetrievalProfileActivationErrorV1::InvalidRollbackTrigger);
         }
         let actor = capability
-            .validate(&expected.expected_configuration_revision, commit.now)?
+            .validate(&commit.base_configuration_revision, commit.now)?
             .clone();
         let restored = self
             .rollback
@@ -918,7 +922,9 @@ fn audit_event(
     base_revision: ConfigurationRevisionId,
     commit: RetrievalProfileCommitMetadataV1,
 ) -> Result<RetrievalProfileAuditEventV1, RetrievalProfileActivationErrorV1> {
-    if commit.result_revision == base_revision {
+    if commit.result_revision == base_revision
+        || commit.result_revision == commit.base_configuration_revision
+    {
         return Err(RetrievalProfileActivationErrorV1::StaleRevision);
     }
     commit

--- a/crates/tracedecay-application/src/semantic_runtime/config_inventory_tests.rs
+++ b/crates/tracedecay-application/src/semantic_runtime/config_inventory_tests.rs
@@ -393,3 +393,167 @@ async fn absent_project_inventory_is_authoritative_until_profile_bootstrap() {
     assert!(published.revision().is_some());
     assert_eq!(published.scope_count(), 1);
 }
+
+#[test]
+fn sibling_configuration_commits_preserve_scope_cas_and_reject_stale_same_scope() {
+    use crate::config::retrieval::{
+        RetrievalProfileActivationErrorV1, RetrievalProfileCasV1, RetrievalProfileCommitMetadataV1,
+        RetrievalProfileMutationCapabilityV1,
+    };
+    use tracedecay_configuration::{
+        ConfigurationMutationAuthority, CurrentConfigurationMutationAuthorizationV1,
+    };
+    use tracedecay_domain::UtcMicros;
+    use tracedecay_domain::configuration::{
+        ConfigurationMutationEffectV1, ConfigurationMutationGrantReceiptV1,
+        ConfigurationMutationOperationV1, ConfigurationMutationSinkV1,
+    };
+
+    let capability = |revision: ConfigurationRevisionId| {
+        let scope_digest = ManifestDigest::new(format!("sha256:{}", "a".repeat(64))).unwrap();
+        let policy_digest: tracedecay_domain::AccessPolicyDigest =
+            typed(&format!("sha256:{}", "b".repeat(64)));
+        RetrievalProfileMutationCapabilityV1::from_current_authorization(
+            ConfigurationMutationAuthority {
+                receipt: ConfigurationMutationGrantReceiptV1::issue(
+                    typed("configuration.grant-receipt.scope"),
+                    typed("configuration.grant.scope"),
+                    typed("actor.scope"),
+                    ConfigurationMutationOperationV1::DirectMutation,
+                    scope_digest.clone(),
+                    revision,
+                    1,
+                    policy_digest.clone(),
+                    ConfigurationMutationSinkV1::ConfigurationStore,
+                    ConfigurationMutationEffectV1::CommitConfigurationRevision,
+                    Some(typed("configuration.idempotency.scope")),
+                    UtcMicros(1),
+                    UtcMicros(100),
+                )
+                .unwrap(),
+            },
+            CurrentConfigurationMutationAuthorizationV1 {
+                grant_revision: 1,
+                grant_digest: scope_digest.clone(),
+                scope_digest,
+                policy_epoch: 1,
+                policy_digest,
+            },
+        )
+        .unwrap()
+    };
+    let cas = |state: &RetrievalProfileStateV1| RetrievalProfileCasV1 {
+        expected_configuration_revision: state.configuration_revision().clone(),
+        expected_active_digest: state.active().profile_digest().clone(),
+        expected_rollback_digest: state.rollback_profile().map(|p| p.profile_digest().clone()),
+    };
+    let (_, mut primary) = initial_state("a");
+    let mut sibling = primary.clone();
+    let (_, candidate) = initial_state("b");
+    let runtime = RetrievalRuntimeCompatibilityV1 {
+        retrieval_ceiling: primary.active().profile().retrieval_budget,
+        semantic: None,
+        semantic_ceiling: None,
+        rerank: None,
+        rerank_ceiling: None,
+    };
+    let first_revision = primary.configuration_revision().clone();
+    let sibling_revision = typed::<ConfigurationRevisionId>("configuration.sibling");
+    let next_revision = typed::<ConfigurationRevisionId>("configuration.next");
+    let metadata = |base, result| {
+        RetrievalProfileCommitMetadataV1::new(
+            ManifestDigest::new(format!("sha256:{}", "c".repeat(64))).unwrap(),
+            base,
+            result,
+            UtcMicros(2),
+        )
+    };
+    let initial = cas(&primary);
+    primary
+        .activate(
+            &capability(first_revision.clone()),
+            &initial,
+            candidate.active().clone(),
+            &runtime,
+            &runtime,
+            metadata(first_revision.clone(), sibling_revision.clone()),
+        )
+        .unwrap();
+    // A project commit must not change the sibling's scope token. Its new grant
+    // authorizes the current project revision, while CAS checks its own state.
+    sibling
+        .activate(
+            &capability(sibling_revision.clone()),
+            &initial,
+            candidate.active().clone(),
+            &runtime,
+            &runtime,
+            metadata(sibling_revision.clone(), next_revision.clone()),
+        )
+        .unwrap();
+    sibling.snapshot().unwrap().into_state().unwrap();
+    let committed = sibling.clone();
+    assert_eq!(
+        sibling.activate(
+            &capability(next_revision.clone()),
+            &initial,
+            candidate.active().clone(),
+            &runtime,
+            &runtime,
+            metadata(next_revision.clone(), typed("configuration.stale")),
+        ),
+        Err(RetrievalProfileActivationErrorV1::CasConflict),
+    );
+    assert_eq!(sibling, committed);
+    let expected = cas(&sibling);
+    assert_eq!(
+        sibling.rollback(
+            &capability(sibling_revision.clone()),
+            &expected,
+            &runtime,
+            "restore".into(),
+            metadata(next_revision.clone(), typed("configuration.denied")),
+        ),
+        Err(RetrievalProfileActivationErrorV1::Unauthorized),
+    );
+    assert_eq!(sibling, committed);
+    // Unrelated project changes also leave rollback available.
+    let settings_revision = typed::<ConfigurationRevisionId>("configuration.settings");
+    sibling
+        .rollback(
+            &capability(settings_revision.clone()),
+            &expected,
+            &runtime,
+            "restore".into(),
+            metadata(settings_revision, typed("configuration.restored")),
+        )
+        .unwrap();
+    assert_eq!(sibling.active(), committed.rollback_profile().unwrap());
+    sibling.snapshot().unwrap().into_state().unwrap();
+    let restored_cas = cas(&sibling);
+    let restored_revision = sibling.configuration_revision().clone();
+    sibling
+        .activate(
+            &capability(restored_revision.clone()),
+            &restored_cas,
+            candidate.active().clone(),
+            &runtime,
+            &runtime,
+            metadata(restored_revision, typed("configuration.reactivated")),
+        )
+        .unwrap();
+    assert_eq!(sibling.active(), committed.active());
+    assert_eq!(sibling.rollback_profile(), committed.rollback_profile());
+    // Matching digests after activate/rollback/activate must not admit an old CAS.
+    let revision = sibling.configuration_revision().clone();
+    assert_eq!(
+        sibling.rollback(
+            &capability(revision.clone()),
+            &expected,
+            &runtime,
+            "stale restore".into(),
+            metadata(revision, typed("configuration.stale-aba")),
+        ),
+        Err(RetrievalProfileActivationErrorV1::CasConflict),
+    );
+}

--- a/crates/tracedecay-application/src/semantic_runtime/config_store.rs
+++ b/crates/tracedecay-application/src/semantic_runtime/config_store.rs
@@ -256,9 +256,7 @@ impl ProductionSemanticRetrievalConfigurationStoreV1 {
         now: UtcMicros,
     ) -> Result<SemanticConfigurationTransitionV1, SemanticConfigurationBackendErrorV1> {
         let stored = self.current_record().await?;
-        if stored.state.configuration_revision() != &base_configuration.revision_id
-            || result_configuration.revision_id == base_configuration.revision_id
-        {
+        if result_configuration.revision_id == base_configuration.revision_id {
             return Err(SemanticConfigurationBackendErrorV1::Conflict);
         }
         let prior_active = stored.state.active().clone();
@@ -277,6 +275,7 @@ impl ProductionSemanticRetrievalConfigurationStoreV1 {
                 candidate_runtime,
                 RetrievalProfileCommitMetadataV1::new(
                     freshness_vector_digest,
+                    base_configuration.revision_id.clone(),
                     result_configuration.revision_id.clone(),
                     now,
                 ),
@@ -338,6 +337,7 @@ impl ProductionSemanticRetrievalConfigurationStoreV1 {
                 trigger.clone(),
                 RetrievalProfileCommitMetadataV1::new(
                     freshness_vector_digest,
+                    base_configuration.revision_id.clone(),
                     result_configuration.revision_id.clone(),
                     now,
                 ),
@@ -405,7 +405,8 @@ impl ProductionSemanticRetrievalConfigurationStoreV1 {
             .await?
             .ok_or(SemanticConfigurationBackendErrorV1::Unavailable)?;
         if current.epoch != base_epoch
-            || current.state.configuration_revision() != &transition.base_configuration.revision_id
+            || current.state.configuration_revision()
+                != &transition.expected_cas.expected_configuration_revision
         {
             return Err(SemanticConfigurationBackendErrorV1::Conflict);
         }
@@ -555,7 +556,7 @@ impl SemanticRetrievalConfigurationPortV1 for ProductionSemanticRetrievalConfigu
                 load_pending(&transaction, &self.scope, &transition.transition_digest).await?;
             if current.epoch != pending.base_epoch
                 || current.state.configuration_revision()
-                    != &transition.base_configuration.revision_id
+                    != &transition.expected_cas.expected_configuration_revision
                 || pending.transition != *transition
             {
                 return Err(SemanticConfigurationBackendErrorV1::Conflict);

--- a/crates/tracedecay-application/src/semantic_runtime/configuration_operation.rs
+++ b/crates/tracedecay-application/src/semantic_runtime/configuration_operation.rs
@@ -476,10 +476,11 @@ impl ProductionSemanticConfigurationOperationV1 {
                 .rollback_profile()
                 .map(|profile| profile.profile_digest().clone()),
         };
+        let base_configuration = current_configuration_state(&self.configuration).await?;
         self.configuration
             .authorize_semantic_configuration_mutation(
                 request.authority.clone(),
-                &expected.expected_configuration_revision,
+                &base_configuration.revision_id,
                 request.now,
             )
             .await
@@ -531,7 +532,7 @@ impl ProductionSemanticConfigurationOperationV1 {
                 .mutate_direct(
                     request.authority,
                     request.central_mutation,
-                    expected.expected_configuration_revision,
+                    base_configuration.revision_id,
                 )
                 .await
                 .map_err(|_| SemanticActivationCoordinationErrorV1::Rejected)?;
@@ -545,9 +546,6 @@ impl ProductionSemanticConfigurationOperationV1 {
             .await
             .map_err(map_authority_error)
             .map_err(|error| log_semantic_activation_failure("resolve_current", error))?;
-        let base_configuration = current_configuration_state(&self.configuration)
-            .await
-            .map_err(|error| log_semantic_activation_failure("current_configuration", error))?;
         let base_pin = super::SemanticConfigurationPinV1::from_current(&base_configuration)
             .map_err(|_| {
                 log_semantic_activation_failure(
@@ -559,7 +557,7 @@ impl ProductionSemanticConfigurationOperationV1 {
             .preview_central_mutation(
                 &request.authority,
                 &request.central_mutation,
-                &expected.expected_configuration_revision,
+                &base_configuration.revision_id,
             )
             .await
             .map_err(|error| log_semantic_activation_failure("preview_configuration", error))?;
@@ -608,10 +606,11 @@ impl ProductionSemanticConfigurationOperationV1 {
                 .rollback_profile()
                 .map(|profile| profile.profile_digest().clone()),
         };
+        let base_configuration = current_configuration_state(&self.configuration).await?;
         self.configuration
             .authorize_semantic_configuration_mutation(
                 request.authority.clone(),
-                &expected.expected_configuration_revision,
+                &base_configuration.revision_id,
                 request.now,
             )
             .await?;
@@ -622,7 +621,7 @@ impl ProductionSemanticConfigurationOperationV1 {
                 .mutate_direct(
                     request.authority,
                     request.central_mutation,
-                    expected.expected_configuration_revision,
+                    base_configuration.revision_id,
                 )
                 .await
                 .map_err(|_| {
@@ -646,7 +645,6 @@ impl ProductionSemanticConfigurationOperationV1 {
             .resolve(restored_digest)
             .await
             .map_err(map_authority_error)?;
-        let base_configuration = current_configuration_state(&self.configuration).await?;
         let base_pin = super::SemanticConfigurationPinV1::from_current(&base_configuration)
             .map_err(|_| {
                 SemanticActivationCoordinationErrorV1::RejectedDetail(
@@ -657,7 +655,7 @@ impl ProductionSemanticConfigurationOperationV1 {
             .preview_central_mutation(
                 &request.authority,
                 &request.central_mutation,
-                &expected.expected_configuration_revision,
+                &base_configuration.revision_id,
             )
             .await?;
         self.configuration

--- a/crates/tracedecay-application/src/semantic_runtime/configuration_runtime.rs
+++ b/crates/tracedecay-application/src/semantic_runtime/configuration_runtime.rs
@@ -208,7 +208,7 @@ impl ProjectSemanticActivationExt for ProjectConfigurationRuntime {
         let capability = retrieval_profile_mutation_capability(
             self,
             authority,
-            &expected.expected_configuration_revision,
+            &base_configuration.revision_id,
             now,
         )
         .await?;
@@ -245,7 +245,7 @@ impl ProjectSemanticActivationExt for ProjectConfigurationRuntime {
         let capability = retrieval_profile_mutation_capability(
             self,
             authority,
-            &expected.expected_configuration_revision,
+            &base_configuration.revision_id,
             now,
         )
         .await?;

--- a/crates/tracedecay-application/src/semantic_runtime/ports.rs
+++ b/crates/tracedecay-application/src/semantic_runtime/ports.rs
@@ -978,6 +978,10 @@ impl SemanticConfigurationTransitionV1 {
     fn validate_fields(&self) -> Result<(), SemanticRuntimeContractErrorV1> {
         self.base_configuration.validate()?;
         self.result_configuration.validate()?;
+        self.expected_cas
+            .expected_configuration_revision
+            .validate()
+            .map_err(|_| SemanticRuntimeContractErrorV1::InvalidTransition)?;
         self.prior_active_profile_id
             .validate()
             .map_err(|_| SemanticRuntimeContractErrorV1::InvalidTransition)?;
@@ -998,8 +1002,6 @@ impl SemanticConfigurationTransitionV1 {
         validate_optional_semantic_pins(self.prior_rollback_semantic.as_ref())?;
         validate_optional_semantic_pins(self.result_rollback_semantic.as_ref())?;
         if self.base_configuration.revision_id == self.result_configuration.revision_id
-            || self.base_configuration.revision_id
-                != self.expected_cas.expected_configuration_revision
             || self.prior_active_profile_digest != self.expected_cas.expected_active_digest
             || self.result_rollback_semantic != self.prior_active_semantic
         {
@@ -1544,7 +1546,8 @@ fn validate_audit_link(
         || audit.prior_active_digest != transition.prior_active_profile_digest
         || audit.resulting_active_digest != transition.result_active_profile_digest
         || audit.evaluation_anchor != transition.evaluation_anchor
-        || audit.base_revision != transition.base_configuration.revision_id
+        // Audit chains follow this scope; configuration commits may occur between them.
+        || audit.base_revision != transition.expected_cas.expected_configuration_revision
         || audit.result_revision != transition.result_configuration.revision_id
         || audit.occurred_at != transition.transition_at
         || audit.event_id != expected_event_id


### PR DESCRIPTION
Semantic activation and rollback now authorize against the current project configuration while comparing the persisted scope token independently. A sibling scope or unrelated setting change no longer permanently rejects the untouched scope. Same-scope stale updates, unauthorized grants and ABA transitions remain rejected. Refs #1107. Validation: 113 application semantic tests passed, plus the final sibling-scope, rollback and ABA regression. The full linked-worktree production journey remains to be run on the integrated branch.