### PR TITLE
docs(ui): reconcile final concept authorities and pack links

### DIFF
--- a/mockups/ui-concept-v2/01-brain/final/05-admitted-activity-synapse.md
+++ b/mockups/ui-concept-v2/01-brain/final/05-admitted-activity-synapse.md
@@ -15,10 +15,10 @@ relates to the stable registry.
 
 - A synapse begins only when the dashboard receives an admitted activity event
   with a stable event identity, timestamp, family, and touched identity.
-- The exact touched project blooms; energy may traverse one or more relations
-  only when each hop has evidence from the repository, worktree, session,
-  agent, task, code, or Delivery projection. Decorative inter-project firing
-  is forbidden.
+- The exact touched project blooms; energy may traverse at most one evidenced,
+  drawn relation from the repository, worktree, session, agent, task, code, or
+  Delivery projection. This one-hop limit does not authorize onward propagation
+  or lighting sibling checkouts. Decorative inter-project firing is forbidden.
 - Heat is temporary and decays independently of the persistent project body.
   Siblings stay dark unless the event actually touched them. Hover, focus,
   loading, connectivity, and selection never masquerade as activity.

--- a/mockups/ui-concept-v2/INTERACTION-STATES.md
+++ b/mockups/ui-concept-v2/INTERACTION-STATES.md
@@ -34,29 +34,48 @@ under reduced motion, and reflow or provide focus modes at 200% browser zoom.
    that project—code graph plus graph, memory, analytics, identity, and checkout
    authorities.
 5. Return to all projects: explicit scope clear.
-6. Real activity: bloom exact `project_id`; conduct only across a drawn real
-   relation. A shared-repository hop does not light sibling checkouts.
+6. Real activity: bloom exact `project_id`; conduct across at most one
+   evidenced, drawn relation. A shared-repository hop does not light sibling checkouts.
 7. Honest states: registry loading, empty, partial, unavailable, inconsistent,
    or truncated; stream connecting/offline; graph empty/renderer unavailable.
 
-### Loom
+### Loom — accepted final target
 
-1. Weave overview: measured time down, hosts across, strand width by message
-   count, recorded/open/unknown ends distinguished.
-2. Zoom/pan/fit: printed time window changes; marks outside it are culled.
-3. Thread selected: selected thread stays full strength and others dim. The
-   keyboard-accessible table row is the focus target.
-4. Thread chain: canonical transcript/summary plus provider-qualified commits,
-   edited files, and branch/worktree spans with separate source coverage.
-5. Replay: loaded LCM page only; paused initially; previous/next, range seek,
-   0.5-4x presentation speed, `FOLLOW LOADED TAIL`, and
-   `RETURN TO LOADED TAIL`. `NOW` labels the newest event in the loaded page;
-   it does not promise streaming or complete history.
-6. Honest states: loading, served empty, undated partial, stale, offline, store
-   unavailable, source partial/unavailable, chain unavailable, linked-boundary
-   partial.
+The [final manifest](03-loom/final/README.md) and its seven same-stem briefs
+own this horizontal target. The older vertical layout below is an implementation
+inventory, not permission to substitute legacy geometry for the final plates.
 
-## Production evidence
+1. Follow loaded tail: time runs left to right; the cursor follows the end of
+   the currently loaded LCM page. Pan or select pauses follow; return-to-tail
+   resumes it. `NOW` means the loaded page end, never a global stream.
+2. Temporal replay: seek/play a cursor within the loaded page. Future events
+   remain withheld, not merely dimmed. Playback and follow are distinct state
+   dimensions: paused playback may still follow newly admitted loaded events.
+3. Branching execution: parent → evidenced spawn → parallel agent/subagent
+   branches → evidenced handoff/rejoin. Collapse preserves counts and grades.
+4. Dense overview: deterministic workstream bundles; semantic zoom reveals
+   groups → agents → events. Unique agents and participations remain distinct.
+5. Selected event: a roomy evidence workspace with exact transcript, task,
+   diff, source identity, and graded causal neighborhood, plus exact fallbacks.
+6. Feedback continuation: local feedback and evidenced later acknowledgement,
+   action, or contradiction; no inferred acknowledgement rendered as fact.
+7. Evidence gaps: loading, empty, partial, stale, offline, denied, ambiguous,
+   unavailable sources and linked boundaries remain separate typed states.
+
+Pan, fit, minimap, keyboard seek and semantic zoom retain temporal context.
+These are accepted target interactions; a shipping route must expose their
+actual availability rather than claiming integration from the concept alone.
+
+### Loom — legacy implementation baseline
+
+The earlier weave maps measured time down and hosts across, with strand width
+by message count and recorded/open/unknown ends. Its zoom/pan/fit, selected
+thread table, canonical thread chain and loaded-page replay remain useful
+behavioral evidence. Their presence does not establish the final horizontal
+hierarchical execution layout. Preserve loaded-page bounds, separate source
+coverage, initial paused playback and 0.5–4x presentation speed during migration.
+
+## Production inventory and behavioral evidence
 
 - Brain project-body/registry-row scoping, repository-hub exclusion, and exact
   activity identity/one-hop propagation:

--- a/mockups/ui-concept-v2/README.md
+++ b/mockups/ui-concept-v2/README.md
@@ -86,3 +86,26 @@ represents a distinct semantic or interaction state.
    health, controls, or success that no named production authority supplies.
 6. Every final state includes keyboard, reduced-motion, 200%-zoom/reflow,
    dense-real-data, and exact text/table/transcript fallback gates.
+
+## Validate a handoff
+
+Run the documentation-only check from the repository root:
+
+```sh
+python3 scripts/check-concept-pack.py
+python3 scripts/test-check-concept-pack.py
+# Also validate a split export and confirm the accepted PNGs are identical:
+python3 scripts/check-concept-pack.py --mirror /path/to/td-brain-demo/lookbook
+```
+
+The check enumerates missing/orphaned briefs, duplicate manifest mappings,
+broken local Markdown links, and rail names/order from `NAVIGATION.md`. It
+prints each pack's checkout commit and each PNG's Git blob identity; retain
+that output with the export review to distinguish mirrored assets from later
+revisions. The reported commit identifies the checkout; working-tree PNG blobs
+are printed independently so uncommitted image changes cannot impersonate it.
+No image-processing dependency or Rust build hook is involved.
+
+A split export may rewrite relative links for `pngs/` and `briefs/`, and link
+to its separately labelled application screenshots. PNG bytes must match;
+brief semantics and shared authorities still require review after path changes.

--- a/scripts/check-concept-pack.py
+++ b/scripts/check-concept-pack.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate final design handoffs; optionally compare a split export's plates."""
+import argparse
+from collections import Counter
+from pathlib import Path
+import re
+import subprocess
+from urllib.parse import unquote, urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CANONICAL = ROOT / 'mockups/ui-concept-v2'
+
+
+def links(path):
+    # The pack uses inline Markdown links, including images and table cells.
+    text = re.sub(r'```.*?```', '', path.read_text(), flags=re.S)
+    return re.findall(r'\]\(([^\s)]+)\)', text)
+
+
+def validate(pack):
+    errors = []
+    image_root = pack / 'pngs' if (pack / 'pngs').is_dir() else pack
+    brief_root = pack / 'briefs' if (pack / 'briefs').is_dir() else pack
+    rail = re.findall(r'^\| (\d{2}) \| (\w+) \|', (CANONICAL / 'NAVIGATION.md').read_text(), re.M)
+    surfaces = [f'{number}-{name.lower()}' for number, name in rail]
+    for root in {image_root, brief_root}:
+        actual = sorted(p.name for p in root.iterdir() if p.is_dir() and re.match(r'\d{2}-', p.name))
+        if actual != surfaces:
+            errors.append(f'{root}: surface order/names differ from canonical navigation')
+    if re.findall(r'^\| (\d{2}) \| (\w+) \|', (pack / 'NAVIGATION.md').read_text(), re.M) != rail:
+        errors.append(f'{pack}: navigation differs from canonical rail')
+    plates = {}
+    for surface in surfaces:
+        images = image_root / surface / 'final'
+        briefs = brief_root / surface / 'final'
+        manifest = briefs / 'README.md'
+        if not manifest.is_file():
+            errors.append(f'{manifest}: missing final manifest')
+            continue
+        counts = Counter(unquote(urlsplit(link).path) for link in links(manifest))
+        pngs = {p.stem: p for p in images.glob('*.png')}
+        mds = {p.stem: p for p in briefs.glob('*.md') if p.name != 'README.md'}
+        if not pngs:
+            errors.append(f'{images}: no final plates')
+        for stem in pngs.keys() - mds.keys():
+            errors.append(f'{pngs[stem]}: missing same-stem brief')
+        for stem in mds.keys() - pngs.keys():
+            errors.append(f'{mds[stem]}: orphaned brief')
+        for stem, png in pngs.items():
+            plates[f'{surface}/final/{png.name}'] = png
+            for target in (png, briefs / f'{stem}.md'):
+                count = sum(n for link, n in counts.items() if (manifest.parent / link).resolve() == target.resolve())
+                if count != 1:
+                    errors.append(f'{manifest}: {target.name} has {count} mappings; expected one')
+    link_roots = [pack.resolve()]
+    if image_root != pack:
+        # The split export links its separately labelled application screenshots.
+        link_roots.append((pack.parent / 'screenshots').resolve())
+    for doc in pack.rglob('*.md'):
+        for link in links(doc):
+            parsed = urlsplit(link)
+            if parsed.scheme or parsed.netloc or not parsed.path:
+                continue
+            target = (doc.parent / unquote(parsed.path)).resolve()
+            if not any(target.is_relative_to(root) for root in link_roots) or not target.exists():
+                errors.append(f'{doc}: broken or escaping local link {link}')
+    return plates, errors
+
+
+def provenance(pack, plates):
+    revision = subprocess.check_output(['git', '-C', str(pack), 'rev-parse', 'HEAD'], text=True).strip()
+    print(f'{pack}: source commit {revision}; {len(plates)} final plates')
+    for name, path in sorted(plates.items()):
+        blob = subprocess.check_output(['git', 'hash-object', str(path)], text=True).strip()
+        print(f'{blob} {name}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('pack', nargs='?', type=Path, default=CANONICAL)
+    parser.add_argument('--mirror', type=Path, help='Validate a second pack and compare its final PNG bytes')
+    args = parser.parse_args()
+    plates, errors = validate(args.pack)
+    provenance(args.pack, plates)
+    if args.mirror:
+        mirrored, mirror_errors = validate(args.mirror)
+        errors.extend(mirror_errors)
+        provenance(args.mirror, mirrored)
+        if plates.keys() != mirrored.keys():
+            errors.append('mirror: final plate names differ')
+        for name in plates.keys() & mirrored.keys():
+            if plates[name].read_bytes() != mirrored[name].read_bytes():
+                errors.append(f'mirror: plate bytes differ: {name}')
+    for error in errors:
+        print(error)
+    return bool(errors)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/test-check-concept-pack.py
+++ b/scripts/test-check-concept-pack.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Mutation checks against the actual final handoff, without editing its assets."""
+import importlib.util
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location('pack_check', Path(__file__).with_name('check-concept-pack.py'))
+pack_check = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pack_check)
+
+
+class PackTests(unittest.TestCase):
+    def test_final_pack_and_rejected_mutations(self):
+        _, errors = pack_check.validate(pack_check.CANONICAL)
+        self.assertEqual(errors, [])
+        with tempfile.TemporaryDirectory() as temp:
+            pack = Path(temp) / 'pack'
+            shutil.copytree(pack_check.CANONICAL, pack)
+            brief = next(pack.glob('*/final/[0-9]*.md'))
+            original = brief.read_text()
+            brief.unlink()
+            self.assertTrue(any('missing same-stem brief' in e for e in pack_check.validate(pack)[1]))
+            brief.write_text(original + '\n[Broken](missing-authority.md)\n')
+            self.assertTrue(any('broken or escaping local link' in e for e in pack_check.validate(pack)[1]))
+            brief.write_text(original)
+            manifest = brief.parent / 'README.md'
+            manifest.write_text(manifest.read_text() + f'\n[Duplicate]({brief.name})\n')
+            self.assertTrue(any('has 2 mappings' in e for e in pack_check.validate(pack)[1]))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make the final Loom interaction contract horizontal while clearly labeling the legacy vertical baseline, and constrain Brain activity to one evidenced drawn hop. Validate both co-located and split concept packs at the documentation boundary, including plate/brief mapping, local links and original image identity. Refs #1101. Both 35-plate packs validate, and missing-brief, broken-link and duplicate-mapping mutations are rejected. No concept PNG or runtime behavior changes.