### PR TITLE
build(extraction): track complete WGSL import inputs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,8 +21,8 @@ crates/tracedecay-agent-hosts/src/agents/hermes/templates/** text eol=lf
 crates/tracedecay/src/sessions/claude_observation_benchmark.rs text eol=lf
 crates/tracedecay/src/sessions/claude_observation_benchmark/** text eol=lf
 benchmark_data/claude-observation/** text eol=lf
-# Vendored, patched tree-sitter grammars: generated parser sources are
-# reviewed upstream-of-generation (grammar.js + patches), not line-by-line.
+# Vendored tree-sitter grammar sources retain their upstream bytes;
+# provenance and the import revision are documented beside the sources.
 # Collapse them out of PR diffs and language stats.
 crates/tracedecay-code-extraction/vendor/** linguist-generated=true
 # Vendored serde_json closure for source-provenance integration tests: Cargo

--- a/crates/tracedecay-code-extraction/Cargo.toml
+++ b/crates/tracedecay-code-extraction/Cargo.toml
@@ -12,6 +12,8 @@ include = [
     "/fixtures/**",
     "/tests/**",
     "/vendor/tree-sitter-wgsl/src/**",
+    "/vendor/tree-sitter-wgsl/LICENSE",
+    "/vendor/tree-sitter-wgsl/PROVENANCE.md",
     "/build.rs",
 ]
 

--- a/crates/tracedecay-code-extraction/build.rs
+++ b/crates/tracedecay-code-extraction/build.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
     if std::env::var("CARGO_FEATURE_LANG_WGSL").is_ok() {
         compile_wgsl_grammar();
     }
@@ -14,6 +15,5 @@ fn compile_wgsl_grammar() {
         .file(wgsl_dir.join("scanner.c"))
         .warnings(false)
         .compile("tree_sitter_wgsl");
-    println!("cargo::rerun-if-changed=vendor/tree-sitter-wgsl/src/parser.c");
-    println!("cargo::rerun-if-changed=vendor/tree-sitter-wgsl/src/scanner.c");
+    println!("cargo::rerun-if-changed=vendor/tree-sitter-wgsl/src");
 }


### PR DESCRIPTION
Watch the WGSL source directory so header-only changes rebuild the native parser, retain a build-script-only watch when the feature is disabled, and include the existing license and provenance in packaged sources. Correct the attribution comment; vendor bytes remain unchanged. Refs #1054. Verified Cargo package contents, existing WGSL extraction regression, unchanged-build freshness, actual native rebuild after a temporary header edit, and feature-disabled build behavior.