### PR TITLE
fix(dashboard): keep selection separate from admitted activity

### DIFF
--- a/dashboard/src/viz/graph/GraphCanvas.propagation.dom.test.tsx
+++ b/dashboard/src/viz/graph/GraphCanvas.propagation.dom.test.tsx
@@ -22,6 +22,7 @@ const sigmaState = vi.hoisted(() => ({
   graph: undefined as Graph | undefined,
   edgeReducer: undefined as Reducer | undefined,
   refreshes: 0,
+  handlers: new Map<string, (event: { node: string }) => void>(),
 }));
 
 vi.mock('graphology-layout-forceatlas2', () => ({
@@ -50,7 +51,9 @@ vi.mock('sigma', () => ({
     }
 
     resize() {}
-    on() {}
+    on(name: string, handler: (event: { node: string }) => void) {
+      sigmaState.handlers.set(name, handler);
+    }
     refresh() {
       sigmaState.refreshes += 1;
     }
@@ -94,6 +97,7 @@ describe('GraphCanvas travelling activation', () => {
     sigmaState.graph = undefined;
     sigmaState.edgeReducer = undefined;
     sigmaState.refreshes = 0;
+    sigmaState.handlers.clear();
     frames.length = 0;
     nextFrameId = 1;
     Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
@@ -124,8 +128,42 @@ describe('GraphCanvas travelling activation', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     localStorage.removeItem('td.motion-preference');
+  });
+
+  it('selects and hovers measured projects and repository hubs without creating activity', async () => {
+    const field = new ActivationField({ halfLifeMs: 4200 });
+    const onSelect = vi.fn();
+    const nodes = [
+      ...NODES,
+      { id: 'p2', label: 'sibling checkout', kind: 'checkout', degree: 1 },
+    ].map((node, index) => ({ ...node, x: index * 100, y: index * 20 }));
+    const edges = [...EDGES, { source: 'repo:r', target: 'p2', kind: 'checkout' }];
+    render(<GraphCanvas nodes={nodes} edges={edges} activation={field} onSelect={onSelect} />);
+    await waitFor(() => expect(sigmaState.graph).toBeDefined());
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    const graph = sigmaState.graph!;
+    const click = sigmaState.handlers.get('clickNode')!;
+    const hover = sigmaState.handlers.get('enterNode')!;
+    expect(click).toBeTypeOf('function');
+    expect(hover).toBeTypeOf('function');
+
+    let now = 0;
+    for (const node of ['p1', 'repo:r']) {
+      const refreshes = sigmaState.refreshes;
+      hover({ node });
+      pump(now += 200);
+      expect(sigmaState.refreshes).toBeGreaterThan(refreshes);
+      click({ node });
+      expect(onSelect).toHaveBeenLastCalledWith(node);
+      vi.advanceTimersByTime(200);
+      pump(now += 200);
+      expect(field.warm).toBe(false);
+      expect(nodes.map(({ id }) => field.heatOf(id))).toEqual([0, 0, 0]);
+      expect(pulseNodes(graph)).toEqual([]);
+    }
   });
 
   it('carries an externally delivered strike along the real edge and then sleeps', async () => {

--- a/dashboard/src/viz/graph/activationOverlay.ts
+++ b/dashboard/src/viz/graph/activationOverlay.ts
@@ -30,7 +30,6 @@ export interface ActivationOverlayOptions {
   realNodes: readonly string[];
   strands: readonly Strand[];
   field: ActivationField;
-  neighborsOf: ReadonlyMap<string, string[]>;
   theme: ThemeBox;
   focus: FocusState;
   /** Repaint the renderer. A no-op once the scene is gone. */
@@ -48,9 +47,6 @@ export interface ActivationOverlay {
   settle(): void;
   /** One static composition of the resting field. */
   repaintResting(): void;
-  /** A node was struck by the pointer: it fires now, its neighbourhood one
-   * synaptic delay later, along real caller/reference edges only. */
-  fireNeighborhood(node: string): void;
   stop(): void;
 }
 
@@ -59,7 +55,6 @@ export function createActivationOverlay({
   realNodes,
   strands,
   field,
-  neighborsOf,
   theme,
   focus,
   paint,
@@ -236,18 +231,6 @@ export function createActivationOverlay({
     repaintResting: () => {
       syncGlow();
       paint();
-    },
-    fireNeighborhood: (node: string) => {
-      // Traveling activation: the struck node fires now; its neighborhood
-      // fires one synaptic delay later (real caller/reference edges only).
-      field.strike([node], 1);
-      const neighbors = neighborsOf.get(node) ?? [];
-      // Under reduced motion the synaptic delay collapses: the neighbourhood is
-      // lit in the same paint as the struck node, so the propagation is still
-      // fully legible as a state without anything travelling across the screen.
-      if (isReduced()) field.strike(neighbors, 0.55);
-      else setTimeout(() => { field.strike(neighbors, 0.55); wake(); }, 140);
-      wake();
     },
     stop: () => {
       stopped = true;

--- a/dashboard/src/viz/graph/scene.ts
+++ b/dashboard/src/viz/graph/scene.ts
@@ -117,7 +117,6 @@ function compose(
     realNodes,
     strands,
     field,
-    neighborsOf,
     theme,
     focus,
     paint,
@@ -136,10 +135,8 @@ function compose(
     roominess,
     frame,
     selectedId,
-    onNodeClick: (node) => {
-      onSelect(node);
-      overlay.fireNeighborhood(node);
-    },
+    // Selection is reader intent, never an admitted activity event.
+    onNodeClick: onSelect,
     onStageClick: () => onSelect(null),
     onFocusChange: () => overlay.wake(),
   });


### PR DESCRIPTION
Graph selection no longer creates activity heat or delayed neighbor pulses. Selection and hover repaint remain functional; admitted events retain the existing propagation path. Addresses part of #1099; full renderer qualification remains open.

Validation: regression failed before the fix; 19 GraphCanvas DOM tests and dashboard typecheck passed.