### PR TITLE
fix(extraction): resume parsing without load-dependent omissions

### DIFF
--- a/crates/tracedecay-code-extraction/src/incremental.rs
+++ b/crates/tracedecay-code-extraction/src/incremental.rs
@@ -25,7 +25,8 @@ mod extraction;
 pub const DEFAULT_MAX_SOURCE_BYTES: usize = 2 * 1024 * 1024;
 /// A malformed edit stream cannot make range reporting itself unbounded.
 pub const DEFAULT_MAX_CHANGED_RANGES: usize = 256;
-/// Parsing is synchronous, but every invocation has a cooperative deadline.
+/// Default synchronous parse quantum. An admitted enclosing operation may resume
+/// an expired quantum; standalone parsing stops at its cooperative deadline.
 /// Cooperative means tree-sitter polls it between parse actions; a grammar
 /// scanner that never returns from one call is outside its reach (#1104).
 pub const DEFAULT_MAX_PARSE_TIME: Duration = Duration::from_millis(250);
@@ -306,7 +307,15 @@ impl RetainedParseDocument {
         let language_id = language_id.into();
         let source = source.into();
         let grammar_key = grammar_key(&language_id, identity.logical_path()).to_owned();
-        Self::open_normalized(identity, language_id, grammar_key, source, None, limits)
+        Self::open_normalized(
+            identity,
+            language_id,
+            grammar_key,
+            source,
+            None,
+            limits,
+            None,
+        )
     }
 
     pub fn open_prepared(
@@ -317,6 +326,28 @@ impl RetainedParseDocument {
         parsed_source: impl Into<String>,
         limits: ParseLimits,
     ) -> Result<(Self, ParseReport), ParseError> {
+        Self::open_prepared_with_control(
+            identity,
+            language_id,
+            grammar_key,
+            source,
+            parsed_source,
+            limits,
+            None,
+        )
+    }
+
+    /// Resume expired parse quanta while the enclosing operation remains admitted.
+    /// The control is checked by Tree-sitter between parse actions and is never retained.
+    pub fn open_prepared_with_control(
+        identity: ParseDocumentIdentity,
+        language_id: impl Into<String>,
+        grammar_key: impl Into<String>,
+        source: impl Into<String>,
+        parsed_source: impl Into<String>,
+        limits: ParseLimits,
+        control: Option<&dyn Fn() -> bool>,
+    ) -> Result<(Self, ParseReport), ParseError> {
         let source = source.into();
         let parsed_source = normalize_parsed_source(&source, parsed_source.into());
         Self::open_normalized(
@@ -326,6 +357,7 @@ impl RetainedParseDocument {
             source,
             parsed_source,
             limits,
+            control,
         )
     }
 
@@ -336,6 +368,7 @@ impl RetainedParseDocument {
         source: String,
         parsed_source: Option<String>,
         limits: ParseLimits,
+        control: Option<&dyn Fn() -> bool>,
     ) -> Result<(Self, ParseReport), ParseError> {
         ensure_source_bound(&source, limits)?;
         if let Some(parsed) = parsed_source.as_deref() {
@@ -360,7 +393,7 @@ impl RetainedParseDocument {
         })?;
         let parse_text = parsed_source.as_deref().unwrap_or(&source);
         let (tree, elapsed) =
-            parse_with_deadline(&language_id, &mut parser, parse_text, None, limits)?;
+            parse_with_deadline(&language_id, &mut parser, parse_text, None, limits, control)?;
         let changed_ranges = if source.is_empty() {
             Vec::new()
         } else {
@@ -427,7 +460,7 @@ impl RetainedParseDocument {
         edits: &[ParseInputEdit],
         new_source: impl Into<String>,
     ) -> Result<ParseReport, ParseError> {
-        self.apply_edits_normalized(next_identity, edits, new_source.into(), None, None)
+        self.apply_edits_normalized(next_identity, edits, new_source.into(), None, None, None)
     }
 
     pub fn apply_edits_prepared(
@@ -439,7 +472,14 @@ impl RetainedParseDocument {
     ) -> Result<ParseReport, ParseError> {
         let new_source = new_source.into();
         let new_parsed_source = normalize_parsed_source(&new_source, new_parsed_source.into());
-        self.apply_edits_normalized(next_identity, edits, new_source, new_parsed_source, None)
+        self.apply_edits_normalized(
+            next_identity,
+            edits,
+            new_source,
+            new_parsed_source,
+            None,
+            None,
+        )
     }
 
     fn apply_edits_normalized(
@@ -449,6 +489,7 @@ impl RetainedParseDocument {
         new_source: String,
         new_parsed_source: Option<String>,
         source_edit: Option<ParseInputEdit>,
+        control: Option<&dyn Fn() -> bool>,
     ) -> Result<ParseReport, ParseError> {
         if !self.identity.identifies_same_document(&next_identity) {
             crate::hotpath_observe::record_retained_parse_abstention(
@@ -510,6 +551,7 @@ impl RetainedParseDocument {
             parse_text,
             Some(&edited_tree),
             self.limits,
+            control,
         )?;
         let (changed_ranges, extraction_ranges) =
             crate::hotpath_observe::measure_change_ranges(|| {
@@ -554,7 +596,7 @@ impl RetainedParseDocument {
         next_identity: ParseDocumentIdentity,
         new_source: impl Into<String>,
     ) -> Result<ParseReport, ParseError> {
-        self.reparse_normalized(next_identity, new_source.into(), None)
+        self.reparse_normalized(next_identity, new_source.into(), None, None)
     }
 
     pub fn reparse_prepared(
@@ -563,9 +605,19 @@ impl RetainedParseDocument {
         new_source: impl Into<String>,
         new_parsed_source: impl Into<String>,
     ) -> Result<ParseReport, ParseError> {
+        self.reparse_prepared_with_control(next_identity, new_source, new_parsed_source, None)
+    }
+
+    pub fn reparse_prepared_with_control(
+        &mut self,
+        next_identity: ParseDocumentIdentity,
+        new_source: impl Into<String>,
+        new_parsed_source: impl Into<String>,
+        control: Option<&dyn Fn() -> bool>,
+    ) -> Result<ParseReport, ParseError> {
         let new_source = new_source.into();
         let new_parsed_source = normalize_parsed_source(&new_source, new_parsed_source.into());
-        self.reparse_normalized(next_identity, new_source, new_parsed_source)
+        self.reparse_normalized(next_identity, new_source, new_parsed_source, control)
     }
 
     fn reparse_normalized(
@@ -573,10 +625,16 @@ impl RetainedParseDocument {
         next_identity: ParseDocumentIdentity,
         new_source: String,
         new_parsed_source: Option<String>,
+        control: Option<&dyn Fn() -> bool>,
     ) -> Result<ParseReport, ParseError> {
         if self.source == new_source {
             if self.parsed_source != new_parsed_source {
-                return self.replace_normalized(next_identity, new_source, new_parsed_source);
+                return self.replace_normalized(
+                    next_identity,
+                    new_source,
+                    new_parsed_source,
+                    control,
+                );
             }
             return self.apply_edits_normalized(
                 next_identity,
@@ -584,6 +642,7 @@ impl RetainedParseDocument {
                 new_source,
                 new_parsed_source,
                 None,
+                control,
             );
         }
         let edit = minimal_edit(&self.source, &new_source);
@@ -593,6 +652,7 @@ impl RetainedParseDocument {
             new_source,
             new_parsed_source,
             Some(edit),
+            control,
         )
     }
 
@@ -602,7 +662,7 @@ impl RetainedParseDocument {
         next_identity: ParseDocumentIdentity,
         new_source: impl Into<String>,
     ) -> Result<ParseReport, ParseError> {
-        self.replace_normalized(next_identity, new_source.into(), None)
+        self.replace_normalized(next_identity, new_source.into(), None, None)
     }
 
     pub fn replace_prepared(
@@ -613,7 +673,7 @@ impl RetainedParseDocument {
     ) -> Result<ParseReport, ParseError> {
         let new_source = new_source.into();
         let new_parsed_source = normalize_parsed_source(&new_source, new_parsed_source.into());
-        self.replace_normalized(next_identity, new_source, new_parsed_source)
+        self.replace_normalized(next_identity, new_source, new_parsed_source, None)
     }
 
     fn replace_normalized(
@@ -621,6 +681,7 @@ impl RetainedParseDocument {
         next_identity: ParseDocumentIdentity,
         new_source: String,
         new_parsed_source: Option<String>,
+        control: Option<&dyn Fn() -> bool>,
     ) -> Result<ParseReport, ParseError> {
         if !self.identity.identifies_same_document(&next_identity) {
             crate::hotpath_observe::record_retained_parse_abstention(
@@ -639,6 +700,7 @@ impl RetainedParseDocument {
             parse_text,
             None,
             self.limits,
+            control,
         )?;
         let ranges = if new_source.is_empty() {
             Vec::new()
@@ -708,11 +770,12 @@ fn parse_with_deadline(
     source: &str,
     old_tree: Option<&Tree>,
     limits: ParseLimits,
+    control: Option<&dyn Fn() -> bool>,
 ) -> Result<(Tree, Duration), ParseError> {
     crate::hotpath_observe::measure_parse_file(
         language_id,
         source.len(),
-        || parse_with_deadline_unmeasured(parser, source, old_tree, limits),
+        || parse_with_deadline_unmeasured(parser, source, old_tree, limits, control),
         |result| match result {
             Ok((tree, _)) => {
                 crate::hotpath_observe::ParseFileOutcome::from_parsed_root(tree.root_node())
@@ -728,6 +791,7 @@ fn parse_with_deadline_unmeasured(
     source: &str,
     old_tree: Option<&Tree>,
     limits: ParseLimits,
+    control: Option<&dyn Fn() -> bool>,
 ) -> Result<(Tree, Duration), ParseError> {
     if limits.max_parse_time.is_zero() {
         return Err(ParseError::TimedOut {
@@ -735,38 +799,49 @@ fn parse_with_deadline_unmeasured(
         });
     }
     let started = Instant::now();
-    let mut timed_out = false;
-    let mut progress = |_: &tree_sitter::ParseState| {
-        if started.elapsed() >= limits.max_parse_time {
-            timed_out = true;
-            ControlFlow::Break(())
-        } else {
-            ControlFlow::Continue(())
-        }
-    };
-    let options = ParseOptions::new().progress_callback(&mut progress);
     let bytes = source.as_bytes();
-    let tree = parser.parse_with_options(
-        &mut |offset, _| match bytes.get(offset..) {
-            Some(remaining) => remaining,
-            None => &[],
-        },
-        old_tree,
-        Some(options),
-    );
-    let elapsed = started.elapsed();
-    match tree {
-        Some(tree) => Ok((tree, elapsed)),
-        None if timed_out || elapsed >= limits.max_parse_time => {
+    loop {
+        if control.is_some_and(|admitted| !admitted()) {
             parser.reset();
+            return Err(ParseError::TimedOut {
+                limit: limits.max_parse_time,
+            });
+        }
+        let quantum_started = Instant::now();
+        let mut timed_out = false;
+        let mut interrupted = false;
+        let mut progress = |_: &tree_sitter::ParseState| {
+            interrupted = control.is_some_and(|admitted| !admitted());
+            timed_out = quantum_started.elapsed() >= limits.max_parse_time;
+            if interrupted || timed_out {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        };
+        let options = ParseOptions::new().progress_callback(&mut progress);
+        let tree = parser.parse_with_options(
+            &mut |offset, _| bytes.get(offset..).unwrap_or(&[]),
+            old_tree,
+            Some(options),
+        );
+        if let Some(tree) = tree {
+            return Ok((tree, started.elapsed()));
+        }
+        if timed_out && !interrupted && control.is_some_and(|admitted| admitted()) {
+            // Tree-sitter resumes its suspended parse with the same input and old
+            // tree. Reset only on terminal failure, not between admitted quanta.
+            std::thread::yield_now();
+            continue;
+        }
+        parser.reset();
+        return if timed_out || interrupted {
             Err(ParseError::TimedOut {
                 limit: limits.max_parse_time,
             })
-        }
-        None => {
-            parser.reset();
+        } else {
             Err(ParseError::ParseFailed)
-        }
+        };
     }
 }
 

--- a/crates/tracedecay-code-extraction/tests/main/incremental_parse.rs
+++ b/crates/tracedecay-code-extraction/tests/main/incremental_parse.rs
@@ -944,3 +944,52 @@ fn incremental_import_artifact_does_not_keep_stale_rows_after_add_change_and_del
         deleted.artifact.imports
     );
 }
+
+#[test]
+fn admitted_parse_continuation_preserves_incremental_rows_and_prior_state_on_abort() {
+    let source = (0..2_000)
+        .map(|n| format!("fn item_{n}() -> u64 {{ {n} }}\n"))
+        .collect::<String>();
+    let identity = identity("commit.parse", "tree.parse", RepositoryDirtyStateV1::Clean);
+    let limits = ParseLimits {
+        max_parse_time: Duration::from_nanos(1),
+        ..ParseLimits::default()
+    };
+    let checks = std::cell::Cell::new(0);
+    let admitted = || {
+        checks.set(checks.get() + 1);
+        true
+    };
+    let (mut document, _) = RetainedParseDocument::open_prepared_with_control(
+        identity.clone(),
+        "rust",
+        "rust",
+        &source,
+        &source,
+        limits,
+        Some(&admitted),
+    )
+    .unwrap();
+    assert!(checks.get() > 10, "many quanta must have resumed");
+    let changed = source.replace("{ 100 }", "{ 101 }");
+    let report = document
+        .reparse_prepared_with_control(identity.clone(), &changed, &changed, Some(&admitted))
+        .unwrap();
+    assert_eq!(report.reuse, ParseReuse::Incremental);
+    let artifact = document
+        .extract_canonical_artifact(&RustExtractor, &report, None)
+        .unwrap()
+        .artifact;
+    let fresh = RustExtractor.extract_artifact("src/lib.rs", &changed);
+    assert_artifact_rows_match_fresh_parse(&artifact, &fresh);
+    let abort = || false;
+    assert!(matches!(
+        document.reparse_prepared_with_control(identity.clone(), &source, &source, Some(&abort)),
+        Err(ParseError::TimedOut { .. })
+    ));
+    assert_eq!(document.source(), changed);
+    document
+        .reparse_prepared_with_control(identity, &source, &source, Some(&admitted))
+        .unwrap();
+    assert_eq!(document.source(), source);
+}

--- a/crates/tracedecay-code-index/src/extract.rs
+++ b/crates/tracedecay-code-index/src/extract.rs
@@ -14,10 +14,10 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tracedecay_code_extraction::{ExtractedImportEvidenceV1, ExtractionArtifactV1};
 use tracedecay_domain::{
-    CodeGenerationId, ComplexityAnalysisV1, ContentDigest, Edge, ExtractionResult,
-    ExtractorRevision, FileOccurrenceId, GrammarRevision, LanguageDescriptorRevision,
-    LanguageDescriptorV1, LanguageId, ManifestDigest, Node, SourceSpan, UnresolvedRef,
-    ValidatedCodeFileV1, Visibility, canonical_sha256,
+    CodeGenerationId, ComplexityAnalysisV1, ContentDigest, Edge, ExtractorRevision,
+    FileOccurrenceId, GrammarRevision, LanguageDescriptorRevision, LanguageDescriptorV1,
+    LanguageId, ManifestDigest, Node, SourceSpan, UnresolvedRef, ValidatedCodeFileV1, Visibility,
+    canonical_sha256,
 };
 
 use super::{
@@ -295,73 +295,6 @@ impl TreeSitterExtractor {
                 parsed_len < file.sanitized_bytes.len(),
                 cancellation,
             )
-        })
-    }
-
-    /// Typed evidence for one file whose bounded retained parse exceeded its
-    /// per-file budget.
-    ///
-    /// The batch truthfully reports [`ParseOutcomeV1::TimedOut`] with zero
-    /// parsed bytes, every byte unsupported, and no parser rows, so the
-    /// chunker records the file as an unsupported document with a reason and
-    /// the rest of the generation still builds and publishes. Nothing here
-    /// invents structure: the digests cover the (empty) rows this parse
-    /// actually produced.
-    pub(crate) fn extract_parse_timed_out(
-        &self,
-        file: &ReceiptBoundCodeFileV1,
-        descriptor: &LanguageDescriptorV1,
-    ) -> Result<ExtractedCodeFileV1, ExtractionFailureV1> {
-        let authority = file.authority().clone();
-        let file = file.validated_file();
-        validate_descriptor(file, descriptor)?;
-        let artifact = ExtractionArtifactV1 {
-            result: ExtractionResult {
-                nodes: Vec::new(),
-                edges: Vec::new(),
-                unresolved_refs: Vec::new(),
-                errors: Vec::new(),
-                duration_ms: 0,
-            },
-            imports: Vec::new(),
-        };
-        let file_len = file.sanitized_bytes.len() as u64;
-        let unsupported_ranges = if file_len > 0 {
-            vec![SourceSpan {
-                start_byte: 0,
-                end_byte: file_len,
-            }]
-        } else {
-            Vec::new()
-        };
-        let rows_digest = rows_digest(file, descriptor, &artifact)?;
-        let parser_import_rows_digest = parser_import_rows_digest(&artifact.imports)?;
-        Ok(ExtractedCodeFileV1 {
-            authority,
-            batch: ExtractionBatchV1 {
-                generation_id: file.generation_id.clone(),
-                file_occurrence_id: file.file.file_occurrence_id.clone(),
-                language: descriptor.language.clone(),
-                descriptor_revision: descriptor.descriptor_revision.clone(),
-                grammar_revision: descriptor.grammar_revision.clone(),
-                extractor_revision: descriptor.extractor_revision.clone(),
-                content_digest: file.file.content_digest.clone(),
-                parse_outcome: ParseOutcomeV1::TimedOut,
-                parsed_ranges: Vec::new(),
-                error_ranges: Vec::new(),
-                unsupported_ranges,
-                coverage: ExtractionCoverageV1 {
-                    parsed_bytes: 0,
-                    error_bytes: 0,
-                    unsupported_bytes: file_len,
-                    symbols_extracted: 0,
-                    relations_extracted: 0,
-                    ambiguity_count: 0,
-                },
-                parser_import_rows_digest,
-                rows_digest,
-            },
-            parse_artifact: artifact,
         })
     }
 }

--- a/crates/tracedecay-code-index/src/production/mod.rs
+++ b/crates/tracedecay-code-index/src/production/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracedecay_code_extraction::incremental::ParseError;
+use tracedecay_code_extraction::incremental::{ParseDocumentIdentity, ParseError};
 use tracedecay_domain::{
     CanonicalRelationEdgeV1, CodeGenerationId, CodeGenerationManifestV1,
     CodeGenerationSourceCommitmentsV1, CodeIndexCapabilityManifestV1, ComponentVersion,
@@ -1857,12 +1857,20 @@ where
             let cancellation = ExtractionControlBridge { control };
             let extraction = match parse_for_indexing(
                 retained_parses,
-                config,
-                snapshot,
-                repository_parse_identity,
+                ParseDocumentIdentity::Repository {
+                    project_id: config.project_id.clone(),
+                    repository_id: snapshot.repository.clone(),
+                    worktree_id: snapshot.worktree.clone(),
+                    reference: snapshot.reference.clone(),
+                    commit: snapshot.source_revision.clone(),
+                    tree: repository_parse_identity.tree.clone(),
+                    dirty: repository_parse_identity.dirty,
+                    logical_path: file.logical_path.clone(),
+                },
                 file,
                 captured,
                 parser,
+                control,
             ) {
                 Ok((parse_artifacts, parsed_len)) => {
                     Self::checkpoint(control)?;
@@ -1881,16 +1889,16 @@ where
                             error => CodeIndexProductionErrorV1::Extraction(error),
                         })?
                 }
-                // One file exceeding the bounded parse budget is evidence about
-                // that file, never about the generation: record it as a typed
-                // unsupported document with a reason and keep building, instead
-                // of failing the whole reconcile cycle and leaving the served
-                // generation permanently stale.
-                Err(CodeIndexProductionErrorV1::RetainedParse(ParseError::TimedOut { .. })) => {
+                // A parse quantum is scheduling state, never evidence that the
+                // source is unsupported. Only the enclosing operation can stop
+                // admitted continuation, and it must not publish partial identity.
+                Err(
+                    error @ CodeIndexProductionErrorV1::RetainedParse(ParseError::TimedOut {
+                        ..
+                    }),
+                ) => {
                     Self::checkpoint(control)?;
-                    extractor
-                        .extract_parse_timed_out(&receipt_bound, descriptor)
-                        .map_err(CodeIndexProductionErrorV1::Extraction)?
+                    return Err(error);
                 }
                 Err(error) => return Err(error),
             };

--- a/crates/tracedecay-code-index/src/production/parser_artifacts.rs
+++ b/crates/tracedecay-code-index/src/production/parser_artifacts.rs
@@ -2,24 +2,20 @@ use tracedecay_code_extraction::incremental::{ParseCompleteness, ParseDocumentId
 use tracedecay_code_extraction::{
     ExtractionArtifactV1, LanguageExtractor as ParserLanguageExtractor,
 };
-use tracedecay_domain::{SanitizedCodeFileV1, SanitizedCodeSnapshotV1};
+use tracedecay_domain::SanitizedCodeFileV1;
 
 use crate::retained_parse::SharedRetainedParsePool;
 
-use super::{
-    CodeIndexCapturedFileV1, CodeIndexProductionConfigV1, CodeIndexProductionErrorV1,
-    CodeIndexRepositoryParseIdentityV1,
-};
+use super::{CodeIndexCapturedFileV1, CodeIndexExecutionControlV1, CodeIndexProductionErrorV1};
 
 #[hotpath::measure(label = "code_index.extract.parser_artifact")]
 pub(super) fn parse_for_indexing(
     retained_parses: &SharedRetainedParsePool,
-    config: &CodeIndexProductionConfigV1,
-    snapshot: &SanitizedCodeSnapshotV1,
-    repository_parse_identity: &CodeIndexRepositoryParseIdentityV1,
+    identity: ParseDocumentIdentity,
     file: &SanitizedCodeFileV1,
     captured: &CodeIndexCapturedFileV1,
     parser: &dyn ParserLanguageExtractor,
+    control: &dyn CodeIndexExecutionControlV1,
 ) -> Result<(ExtractionArtifactV1, usize), CodeIndexProductionErrorV1> {
     let language = file.language.as_ref().ok_or_else(|| {
         CodeIndexProductionErrorV1::Contract(
@@ -37,20 +33,13 @@ pub(super) fn parse_for_indexing(
             .len()
             .min(crate::extract::MAX_EXTRACTION_SOURCE_BYTES),
     );
-    let (report, mut extraction) = retained_parses.parse_and_extract_artifact(
-        ParseDocumentIdentity::Repository {
-            project_id: config.project_id.clone(),
-            repository_id: snapshot.repository.clone(),
-            worktree_id: snapshot.worktree.clone(),
-            reference: snapshot.reference.clone(),
-            commit: snapshot.source_revision.clone(),
-            tree: repository_parse_identity.tree.clone(),
-            dirty: repository_parse_identity.dirty,
-            logical_path: file.logical_path.clone(),
-        },
+    let admitted = || !control.is_cancelled() && !control.is_deadline_exceeded();
+    let (report, mut extraction) = retained_parses.parse_and_extract_artifact_with_control(
+        identity,
         language.as_str(),
         &source[..parsed_len],
         parser,
+        Some(&admitted),
     )?;
     if let ParseCompleteness::Partial { reasons } = report.completeness {
         extraction

--- a/crates/tracedecay-code-index/src/retained_parse.rs
+++ b/crates/tracedecay-code-index/src/retained_parse.rs
@@ -203,16 +203,26 @@ impl SharedRetainedParsePool {
         source: &str,
         extractor: &dyn LanguageExtractor,
     ) -> Result<(ParseReport, ParsedExtractionArtifactV1), ParseError> {
+        self.parse_and_extract_artifact_with_control(identity, language_id, source, extractor, None)
+    }
+
+    pub fn parse_and_extract_artifact_with_control(
+        &self,
+        identity: ParseDocumentIdentity,
+        language_id: &str,
+        source: &str,
+        extractor: &dyn LanguageExtractor,
+        control: Option<&dyn Fn() -> bool>,
+    ) -> Result<(ParseReport, ParsedExtractionArtifactV1), ParseError> {
         crate::hotpath_observe::measure_hot_loop!("code_index.collect.retained_artifact", {
-            let grammar_key = extractor.retained_grammar_key(identity.logical_path());
             let prepared_source = extractor.prepare_parse_source(source);
             let (report, extraction) = self.parse_internal(
                 identity,
                 language_id,
                 source,
                 prepared_source.as_ref(),
-                Some(&grammar_key),
                 Some(extractor),
+                control,
             )?;
             match extraction {
                 Some(extraction) => Ok((report, extraction)),
@@ -227,9 +237,12 @@ impl SharedRetainedParsePool {
         language_id: &str,
         source: &str,
         prepared_source: &str,
-        grammar_key: Option<&str>,
         extractor: Option<&dyn LanguageExtractor>,
+        control: Option<&dyn Fn() -> bool>,
     ) -> Result<(ParseReport, Option<ParsedExtractionArtifactV1>), ParseError> {
+        let grammar_key =
+            extractor.map(|extractor| extractor.retained_grammar_key(identity.logical_path()));
+        let grammar_key = grammar_key.as_deref();
         crate::hotpath_observe::measure_hot_loop!("code_index.collect.parse", {
             if source.len() > self.limits.max_total_source_bytes {
                 self.record_failure();
@@ -258,6 +271,7 @@ impl SharedRetainedParsePool {
                     prepared_source,
                     grammar_key,
                     extractor,
+                    control,
                 ),
                 None => {
                     // Serialize first admission per document. Unrelated documents
@@ -283,17 +297,19 @@ impl SharedRetainedParsePool {
                             prepared_source,
                             grammar_key,
                             extractor,
+                            control,
                         );
                     }
                     drop(state);
                     let opened = match grammar_key {
-                        Some(grammar_key) => RetainedParseDocument::open_prepared(
+                        Some(grammar_key) => RetainedParseDocument::open_prepared_with_control(
                             identity,
                             language_id,
                             grammar_key,
                             source,
                             prepared_source,
                             self.limits.document,
+                            control,
                         ),
                         None => RetainedParseDocument::open(
                             identity,
@@ -359,6 +375,7 @@ impl SharedRetainedParsePool {
         prepared_source: &str,
         grammar_key: Option<&str>,
         extractor: Option<&dyn LanguageExtractor>,
+        control: Option<&dyn Fn() -> bool>,
     ) -> Result<(ParseReport, Option<ParsedExtractionArtifactV1>), ParseError> {
         let mut retained = entry
             .lock()
@@ -366,20 +383,24 @@ impl SharedRetainedParsePool {
         let language_changed = retained.document.language_id() != language_id;
         let report = if !language_changed {
             match grammar_key {
-                Some(_) => retained
-                    .document
-                    .reparse_prepared(identity, source, prepared_source),
+                Some(_) => retained.document.reparse_prepared_with_control(
+                    identity,
+                    source,
+                    prepared_source,
+                    control,
+                ),
                 None => retained.document.reparse(identity, source),
             }
         } else {
             let opened = match grammar_key {
-                Some(grammar_key) => RetainedParseDocument::open_prepared(
+                Some(grammar_key) => RetainedParseDocument::open_prepared_with_control(
                     identity,
                     language_id,
                     grammar_key,
                     source,
                     prepared_source,
                     self.limits.document,
+                    control,
                 ),
                 None => {
                     RetainedParseDocument::open(identity, language_id, source, self.limits.document)

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -2,7 +2,7 @@ use std::{
     cell::Cell,
     collections::{BTreeMap, BTreeSet},
     io::Cursor,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -660,16 +660,11 @@ fn physical_artifact_reuse_preserves_byte_exact_sealed_generation() {
     drop(source);
 }
 
-/// One file exceeding the bounded per-file parse budget must never fail the
-/// whole build: the generation still completes, publishes, and serves, with
-/// the slow file recorded as a typed unsupported document (with a reason) and
-/// truthful coverage accounting.
+/// Expired parse quanta resume while the operation remains admitted; scheduling
+/// does not turn a valid source file into a durable unsupported document.
 #[test]
-fn slow_parse_file_publishes_a_completed_generation_with_a_typed_omission() {
-    // The retained parser's deadline is only observed every ~100 Tree-sitter
-    // parse operations, so the tiny file completes before the first progress
-    // check while the generated file reliably crosses many of them. A 1ns
-    // budget therefore deterministically times out exactly the large file.
+fn resumed_parse_quanta_publish_the_same_complete_generation() {
+    // One nanosecond forces every Tree-sitter progress checkpoint to suspend.
     let pool = SharedRetainedParsePool::new(RetainedParsePoolLimits {
         document: ParseLimits {
             max_parse_time: Duration::from_nanos(1),
@@ -736,45 +731,111 @@ fn slow_parse_file_publishes_a_completed_generation_with_a_typed_omission() {
         target_projection_key: projection_key(),
     };
 
+    let cold_request = request.clone();
     let generation = owner
         .build_and_publish(request, &ActiveControl)
-        .expect("a slow-parse file must not fail the whole generation");
-
-    // Truthful coverage: both files eligible, exactly the slow one omitted.
+        .expect("admitted parsing resumes to completion");
     assert_eq!(generation.coverage().files_eligible, 2);
-    assert_eq!(generation.coverage().files_unsupported, 1);
-
-    // The generation serves: the fast file's chunks are admitted, and no
-    // chunk was invented for the timed-out file.
-    let admitted = generation
-        .admitted_chunks()
-        .expect("published generation admits exact chunks");
-    assert!(!admitted.is_empty());
+    assert_eq!(generation.coverage().files_unsupported, 0);
+    let admitted = generation.admitted_chunks().expect("published chunks");
     assert!(
         admitted
             .iter()
-            .all(|chunk| chunk.chunk().anchor.file_occurrence_id.as_str() == "file.fast")
+            .any(|chunk| chunk.chunk().anchor.file_occurrence_id.as_str() == "file.slow")
     );
+    let mut cold_owner = CodeIndexProductionOwnerV1::new(
+        config(),
+        SharedPublicationStore::default(),
+        ApplyingProjectionSink,
+    )
+    .expect("cold production owner");
+    let cold = cold_owner
+        .build_and_publish(cold_request, &ActiveControl)
+        .expect("cold generation");
+    assert_eq!(
+        generation.encode_sealed().expect("resumed seal"),
+        cold.encode_sealed().expect("cold seal")
+    );
+}
 
-    // The omission is a typed per-file document state with a reason, durable
-    // through sealing.
-    let sealed = generation.encode_sealed().expect("generation seals");
-    let value: serde_json::Value = serde_json::from_slice(&sealed).expect("sealed JSON");
-    let slow_document = value["generation"]["files"]
-        .as_array()
-        .expect("sealed files")
-        .iter()
-        .map(|file| &file["artifacts"]["chunks"]["document"])
-        .find(|document| document["file_occurrence_id"] == "file.slow")
-        .expect("slow file document is retained in the generation");
-    assert_eq!(slow_document["eligibility"]["eligibility"], "unsupported");
-    let reason = slow_document["eligibility"]["reason"]["reason"]
-        .as_str()
-        .expect("typed omission carries a reason");
-    assert!(
-        reason.contains("parse budget"),
-        "unexpected omission reason: {reason}"
-    );
+#[test]
+fn resumed_parse_aborts_without_publication_when_operation_control_expires() {
+    struct DuringParseControl {
+        checks: AtomicUsize,
+        deadline: bool,
+    }
+    impl CodeIndexExecutionControlV1 for DuringParseControl {
+        fn is_cancelled(&self) -> bool {
+            !self.deadline && self.checks.fetch_add(1, Ordering::Relaxed) >= 100
+        }
+        fn is_deadline_exceeded(&self) -> bool {
+            self.deadline && self.checks.fetch_add(1, Ordering::Relaxed) >= 100
+        }
+    }
+    let source = (0..2_000)
+        .map(|n| format!("fn item_{n}() -> u64 {{ {n} }}\n"))
+        .collect::<String>();
+    for deadline in [false, true] {
+        let pool = SharedRetainedParsePool::new(RetainedParsePoolLimits {
+            document: ParseLimits {
+                max_parse_time: Duration::from_nanos(1),
+                ..ParseLimits::default()
+            },
+            ..RetainedParsePoolLimits::default()
+        })
+        .expect("parse pool");
+        let store = SharedPublicationStore::default();
+        let mut owner =
+            CodeIndexProductionOwnerV1::new(config(), store.clone(), ApplyingProjectionSink)
+                .expect("owner")
+                .with_retained_parse_pool(pool.clone());
+        let request = request_with_source(
+            "file.interrupted-parse",
+            1_100_000,
+            "commit.parse",
+            "tree.parse",
+            &source,
+        );
+        let scope = CodeIndexGenerationScopeV1::for_snapshot(&request.snapshot);
+        let error = owner
+            .build_and_publish(
+                request.clone(),
+                &DuringParseControl {
+                    checks: AtomicUsize::new(0),
+                    deadline,
+                },
+            )
+            .expect_err("interrupted parse cannot publish");
+        let expected = if deadline {
+            CodeIndexInterruptionV1::DeadlineExceeded
+        } else {
+            CodeIndexInterruptionV1::Cancelled
+        };
+        assert!(
+            matches!(error, CodeIndexProductionErrorV1::Interrupted(reason) if reason == expected)
+        );
+        assert_eq!(
+            pool.stats().failed_parses,
+            1,
+            "control expires inside the retained parser"
+        );
+        assert!(
+            store
+                .load_active(&scope)
+                .expect("publication state")
+                .is_none()
+        );
+        let recovered = owner
+            .build_and_publish(request, &ActiveControl)
+            .expect("retry after cancellation resets parser");
+        assert_eq!(recovered.coverage().files_unsupported, 0);
+        assert!(
+            !recovered
+                .admitted_chunks()
+                .expect("admitted chunks")
+                .is_empty()
+        );
+    }
 }
 
 #[test]
@@ -1521,24 +1582,9 @@ fn verified_lexical_source_pages_a_large_file_and_resumes_after_cancellation() {
             "pub fn bounded_item_{ordinal}() -> u32 {{ {ordinal} }}\n"
         ));
     }
-    // This test is about paging and cancellation resume, not about the parse
-    // budget, so the fixture must parse completely every time. A 1.5 MB file
-    // sits close enough to the 250ms default budget that a busy machine can
-    // time it out, publish a typed unsupported document, and fail this test
-    // for a reason it does not test. Pin a generous budget the same way the
-    // sibling budget test pins a 1ns one — deterministic in both directions.
-    let pool = SharedRetainedParsePool::new(RetainedParsePoolLimits {
-        document: ParseLimits {
-            max_parse_time: Duration::from_secs(60),
-            ..ParseLimits::default()
-        },
-        ..RetainedParsePoolLimits::default()
-    })
-    .expect("retained parse pool");
     let store = SharedPublicationStore::default();
     let mut owner = CodeIndexProductionOwnerV1::new(config(), store, ApplyingProjectionSink)
-        .expect("production owner")
-        .with_retained_parse_pool(pool);
+        .expect("production owner");
     let generation = owner
         .build_and_publish(
             request_with_source(


### PR DESCRIPTION
Resume Tree-sitter parse slices within the admitted indexing operation while retaining the 250ms quantum and global cancellation/deadline. Interrupted work cannot publish an unsupported-file placeholder. Standalone and LSP parsing retain their deadlines.

Fixes #1021. Validation: 1,158 extraction/index tests passed; strict Clippy and formatting passed. The 1.3MB SDK file produced identical 3,783 chunks and sealed digest idle and under eight competing CPU workers.