### PR TITLE
fix(query): own and report lexical candidate pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6817,6 +6817,7 @@ dependencies = [
  "tracedecay-graph-db",
  "tracedecay-private-fs",
  "tracedecay-temporal-query",
+ "tracing",
  "zeroize",
 ]
 

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/queries.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/queries.rs
@@ -1877,6 +1877,7 @@ fn retrieval_failure_omission(reason: &RetrievalFailure) -> OmissionReason {
         RetrievalFailure::AuthorityUnavailable { .. } => OmissionReason::Unavailable,
         RetrievalFailure::IncompatibleProjection { .. } => OmissionReason::Unsupported,
         RetrievalFailure::StaleSource => OmissionReason::Stale,
+        RetrievalFailure::CandidateSourcesPruned { .. } => OmissionReason::Budget,
         RetrievalFailure::InvalidRequest { .. } | RetrievalFailure::Internal { .. } => {
             OmissionReason::Failed
         }
@@ -2012,7 +2013,9 @@ where
             let evidence =
                 terminal_lane_evidence(finished_at, prepared.generation().clone(), omission);
             match reason {
-                RetrievalFailure::InvalidRequest { .. } | RetrievalFailure::Internal { .. } => {
+                RetrievalFailure::InvalidRequest { .. }
+                | RetrievalFailure::Internal { .. }
+                | RetrievalFailure::CandidateSourcesPruned { .. } => {
                     RetrievalPortOutcome::Failed(evidence)
                 }
                 RetrievalFailure::AuthorityUnavailable { .. }

--- a/crates/tracedecay-domain/src/retrieval.rs
+++ b/crates/tracedecay-domain/src/retrieval.rs
@@ -491,11 +491,24 @@ pub struct SanitizedBudgetUsage {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "failure", content = "detail", rename_all = "snake_case")]
 pub enum RetrievalFailure {
-    AuthorityUnavailable { detail: String },
-    IncompatibleProjection { detail: String },
+    /// Ranked results omit documents matching only these lexical term sources.
+    CandidateSourcesPruned {
+        term_sources: Vec<(String, u64)>,
+        document_frequency_budget: u64,
+    },
+    AuthorityUnavailable {
+        detail: String,
+    },
+    IncompatibleProjection {
+        detail: String,
+    },
     StaleSource,
-    InvalidRequest { detail: String },
-    Internal { detail: String },
+    InvalidRequest {
+        detail: String,
+    },
+    Internal {
+        detail: String,
+    },
 }
 
 /// Fatal request-level error (distinct from per-lane typed outcomes).

--- a/crates/tracedecay-query/Cargo.toml
+++ b/crates/tracedecay-query/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
 thiserror = "2"
+tracing = "0.1"
 tracedecay-contracts = { path = "../tracedecay-contracts", version = "0.1.0" }
 tracedecay-code-index = { path = "../tracedecay-code-index", version = "0.1.0", default-features = false }
 tracedecay-domain = { path = "../tracedecay-domain", version = "0.1.0" }

--- a/crates/tracedecay-query/src/retrieval/lexical.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical.rs
@@ -85,7 +85,10 @@ pub const MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1: usize = 16_384;
 /// nonempty source is always admitted. Ties keep request order so admission
 /// is deterministic. Sources past the bound still weigh admitted candidates
 /// through scoring; a document matching only those sources is never hydrated.
-pub(crate) fn admit_candidate_sources<S>(mut sources: Vec<(usize, S)>) -> Vec<S> {
+pub(crate) fn admit_candidate_sources<S>(
+    mut sources: Vec<(usize, S)>,
+    mut on_pruned: impl FnMut(usize, &S),
+) -> Vec<S> {
     sources.retain(|(frequency, _)| *frequency > 0);
     sources.sort_by_key(|(frequency, _)| *frequency);
     let total = sources.len();
@@ -94,7 +97,8 @@ pub(crate) fn admit_candidate_sources<S>(mut sources: Vec<(usize, S)>) -> Vec<S>
     for (ordinal, (frequency, source)) in sources.into_iter().enumerate() {
         let next = admitted_documents.saturating_add(frequency);
         if ordinal > 0 && next > MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1 {
-            break;
+            on_pruned(frequency, &source);
+            continue;
         }
         admitted_documents = next;
         admitted.push(source);
@@ -105,6 +109,28 @@ pub(crate) fn admit_candidate_sources<S>(mut sources: Vec<(usize, S)>) -> Vec<S>
     hotpath::gauge!("query.lane.lexical.candidate_documents_admitted")
         .set(admitted_documents as u64);
     admitted
+}
+
+fn candidate_admission_outcome<E>(
+    batch: RetrieverBatch<E>,
+    term_sources: Vec<(String, u64)>,
+) -> RetrieverOutcome<RetrieverBatch<E>> {
+    if term_sources.is_empty() {
+        RetrieverOutcome::Complete(batch)
+    } else {
+        tracing::debug!(
+            ?term_sources,
+            document_frequency_budget = MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1,
+            "lexical candidate term sources pruned by retrieval policy"
+        );
+        RetrieverOutcome::Partial {
+            value: batch,
+            reason: RetrievalFailure::CandidateSourcesPruned {
+                term_sources,
+                document_frequency_budget: MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1 as u64,
+            },
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/tracedecay-query/src/retrieval/lexical.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical.rs
@@ -119,7 +119,8 @@ fn candidate_admission_outcome<E>(
         RetrieverOutcome::Complete(batch)
     } else {
         tracing::debug!(
-            ?term_sources,
+            pruned_source_count = term_sources.len(),
+            source_document_frequencies = ?term_sources.iter().map(|(_, frequency)| *frequency).collect::<Vec<_>>(),
             document_frequency_budget = MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1,
             "lexical candidate term sources pruned by retrieval policy"
         );

--- a/crates/tracedecay-query/src/retrieval/lexical.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical.rs
@@ -65,7 +65,7 @@ pub const MAX_FUZZY_TERM_EXPANSIONS_V1: u32 = 64;
 /// Maximum UTF-8 bytes in one lexical whole term, subtoken, or phrase.
 pub const MAX_LEXICAL_QUERY_TERM_BYTES_V1: usize = 512;
 
-/// Candidate documents one lexical request hydrates before ranking. Every
+/// Summed document-frequency budget for lexical term-source admission. Every
 /// candidate is decoded from its row and scored, so the union of the request's
 /// term sources — not the winner cap — decides the lane's transient allocation
 /// and wall time: unbounded, a natural-language task whose terms include
@@ -73,11 +73,12 @@ pub const MAX_LEXICAL_QUERY_TERM_BYTES_V1: usize = 512;
 /// decoded, 5.7 s) and missed the context deadline. Term sources are admitted
 /// in ascending document-frequency order until their summed frequencies would
 /// exceed this bound; the most selective source is always admitted so a
-/// single common-term query still answers. Sized as the reader cache over a
-/// conservative 16 KiB per hydrated row (measured mean ~6.6 KiB), so one
-/// request's decode churn stays near 100 MiB.
-pub const MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1: usize =
-    CODE_LEXICAL_ARTIFACT_QUERY_CACHE_BUDGET_BYTES_V1 / (16 * 1024);
+/// single common-term query still answers. Phrase sources are admitted separately.
+/// This is a recall/latency policy, not a hard document or allocation ceiling:
+/// documents matching only pruned terms cannot rank. The initial 16,384 value
+/// retains the measured policy (~100 MiB decode churn at ~6.6 KiB per row);
+/// changing the reader cache must not change candidate eligibility.
+pub const MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1: usize = 16_384;
 
 /// Admit `(document_frequency, source)` pairs rarest-first while the summed
 /// frequency stays within [`MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1`]; the rarest

--- a/crates/tracedecay-query/src/retrieval/lexical/projection.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection.rs
@@ -17,7 +17,7 @@ use tracedecay_domain::{
 
 use super::{
     LexicalFieldV1, LexicalLaneEvidence, LexicalLaneRequest, MAX_FUZZY_TERM_EXPANSIONS_V1,
-    admit_candidate_sources, lexical_checkpoint,
+    admit_candidate_sources, candidate_admission_outcome, lexical_checkpoint,
 };
 use crate::retrieval::exact::{ExactAdmissionAuthority, ExactLaneEvidence, ExactLaneRequest};
 use crate::retrieval::ports::{
@@ -810,25 +810,33 @@ impl LexicalGenerationPostingsV1 {
         request: &LexicalLaneRequest<'_>,
         fuzzy: &FuzzyExpansionsV1,
         phrase_candidates: &BTreeMap<String, RoaringBitmap>,
+        pruned: &mut Vec<(String, u64)>,
     ) -> RoaringBitmap {
         let mut sources = Vec::new();
         for term in &request.whole_terms {
-            sources.push(self.whole_term_documents(&normalize_lexical(term)));
+            let (frequency, documents) = self.whole_term_documents(&normalize_lexical(term));
+            sources.push((frequency, (term.clone(), documents)));
             if let Some(expansions) = fuzzy.by_query.get(term) {
                 for expansion in expansions {
-                    sources.push(self.whole_term_documents(expansion));
+                    let (frequency, documents) = self.whole_term_documents(expansion);
+                    sources.push((frequency, (expansion.clone(), documents)));
                 }
             }
         }
         if let Some(postings) = self.term_documents.get(&LexicalFieldV1::Subtoken) {
             for subtoken in &request.subtokens {
                 if let Some(posting) = postings.get(&normalize_lexical(subtoken)) {
-                    sources.push((posting.documents.len() as usize, posting.documents.clone()));
+                    sources.push((
+                        posting.documents.len() as usize,
+                        (subtoken.clone(), posting.documents.clone()),
+                    ));
                 }
             }
         }
         let mut documents = RoaringBitmap::new();
-        for source in admit_candidate_sources(sources) {
+        for (_, source) in admit_candidate_sources(sources, |frequency, (term, _)| {
+            pruned.push((term.clone(), frequency as u64));
+        }) {
             documents |= source;
         }
         // Reuse the per-phrase n-gram candidate sets computed once by the
@@ -1067,7 +1075,7 @@ impl CodeLexicalProjectionAdapterV1 {
     fn lexical_batch(
         &self,
         request: &LexicalLaneRequest<'_>,
-    ) -> Result<RetrieverBatch<LexicalLaneEvidence>, RetrievalPortError> {
+    ) -> Result<RetrieverOutcome<RetrieverBatch<LexicalLaneEvidence>>, RetrievalPortError> {
         let fuzzy = self.fuzzy_expansions(request)?;
         let prepared = PreparedLexicalQueryV1::new(request);
         // Intersect the n-gram postings for each normalized phrase exactly once,
@@ -1091,9 +1099,10 @@ impl CodeLexicalProjectionAdapterV1 {
                 (phrase.clone(), frequency)
             })
             .collect::<BTreeMap<_, _>>();
-        let documents = self
-            .postings
-            .lexical_documents(request, &fuzzy, &phrase_candidates);
+        let mut pruned = Vec::new();
+        let documents =
+            self.postings
+                .lexical_documents(request, &fuzzy, &phrase_candidates, &mut pruned);
         let mut pairs = Vec::new();
         let mut excluded = self.rows.len() as u64 - documents.len();
         for document in documents {
@@ -1142,18 +1151,21 @@ impl CodeLexicalProjectionAdapterV1 {
         }
         hotpath::gauge!("query.lane.lexical.candidates").set(candidates.len());
         hotpath::gauge!("query.lane.lexical.examined").set(self.rows.len());
-        Ok(RetrieverBatch {
-            coverage: RetrieverCoverage {
-                examined: self.rows.len() as u64,
-                eligible: candidates.len() as u64,
-                excluded,
-                capped: 0,
-                unknown: 0,
+        Ok(candidate_admission_outcome(
+            RetrieverBatch {
+                coverage: RetrieverCoverage {
+                    examined: self.rows.len() as u64,
+                    eligible: candidates.len() as u64,
+                    excluded,
+                    capped: 0,
+                    unknown: 0,
+                },
+                candidates,
+                evidence_by_occurrence,
+                continuation: None,
             },
-            candidates,
-            evidence_by_occurrence,
-            continuation: None,
-        })
+            pruned,
+        ))
     }
 
     #[hotpath::measure(label = "query.lane.fuzzy.expand")]
@@ -1452,7 +1464,7 @@ impl LexicalPostingReadPort for CodeLexicalProjectionAdapterV1 {
         if let Some(outcome) = self.stale_outcome() {
             return Ok(outcome);
         }
-        Ok(RetrieverOutcome::Complete(self.lexical_batch(request)?))
+        self.lexical_batch(request)
     }
 }
 

--- a/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/reader.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/projection/artifact/reader.rs
@@ -57,7 +57,7 @@ use super::super::{
 use crate::retrieval::lexical::{
     LexicalFieldFilterV1, LexicalFieldV1, LexicalLaneEvidence, LexicalLaneRequest,
     MAX_FUZZY_TERM_EXPANSIONS_V1, MAX_LEXICAL_QUERY_TERM_BYTES_V1, admit_candidate_sources,
-    field_admitted, lexical_checkpoint,
+    candidate_admission_outcome, field_admitted, lexical_checkpoint,
 };
 
 #[derive(Clone)]
@@ -573,7 +573,7 @@ impl LexicalPostingReadPort for CodeLexicalArtifactReaderV1 {
             return Ok(RetrieverOutcome::Stale(self.receipt.freshness().clone()));
         }
         let connection = self.lock_connection().map_err(map_query_artifact_error)?;
-        let batch = ArtifactQueryV1::new(
+        let outcome = ArtifactQueryV1::new(
             &connection,
             &self.metadata,
             &self.receipt,
@@ -581,7 +581,6 @@ impl LexicalPostingReadPort for CodeLexicalArtifactReaderV1 {
             &self.fuzzy_vocabulary,
         )?
         .lexical_batch(request)?;
-        let outcome = RetrieverOutcome::Complete(batch);
         crate::hotpath_metrics::record_lane(
             "query.lane.lexical.candidates",
             "query.lane.lexical.examined",
@@ -1507,7 +1506,7 @@ impl<'a> ArtifactQueryV1<'a> {
     fn lexical_batch(
         &self,
         request: &LexicalLaneRequest<'_>,
-    ) -> Result<RetrieverBatch<LexicalLaneEvidence>, RetrievalPortError> {
+    ) -> Result<RetrieverOutcome<RetrieverBatch<LexicalLaneEvidence>>, RetrievalPortError> {
         let control = request.control;
         let fuzzy = self.fuzzy_expansions(request)?;
         let prepared = PreparedLexicalQueryV1::new(request);
@@ -1550,7 +1549,9 @@ impl<'a> ArtifactQueryV1<'a> {
                 Ok(())
             },
         )?;
-        let documents = self.lexical_documents(request, &fuzzy, &stats, &phrase_queries)?;
+        let mut pruned = Vec::new();
+        let documents =
+            self.lexical_documents(request, &fuzzy, &stats, &phrase_queries, &mut pruned)?;
         // The scan holds one transient row and retains complete rows only for
         // the cap-bounded winners. That avoids a second winner hydration pass
         // while preserving the same strict materialization ceiling.
@@ -1625,13 +1626,16 @@ impl<'a> ArtifactQueryV1<'a> {
             evidence_by_occurrence.insert(candidate.source_occurrence_id.clone(), evidence);
             candidates.push(candidate);
         }
-        Ok(capped_batch(
-            self.document_count,
-            eligible,
-            excluded,
-            truncated,
-            candidates,
-            evidence_by_occurrence,
+        Ok(candidate_admission_outcome(
+            capped_batch(
+                self.document_count,
+                eligible,
+                excluded,
+                truncated,
+                candidates,
+                evidence_by_occurrence,
+            ),
+            pruned,
         ))
     }
 
@@ -1764,6 +1768,7 @@ impl<'a> ArtifactQueryV1<'a> {
         fuzzy: &FuzzyExpansionsV1,
         stats: &LexicalStatsCacheV1,
         phrase_queries: &BTreeMap<String, DocumentQueryV1>,
+        pruned: &mut Vec<(String, u64)>,
     ) -> Result<DocumentQueryV1, RetrievalPortError> {
         let mut whole_terms = Vec::new();
         for term in &request.whole_terms {
@@ -1786,14 +1791,20 @@ impl<'a> ArtifactQueryV1<'a> {
                     let frequency = stats.whole_term_documents(&term);
                     sources.push((
                         frequency,
-                        DocumentQueryV1::term_except(term, subtoken_field.clone()),
+                        (
+                            term.clone(),
+                            DocumentQueryV1::term_except(term, subtoken_field.clone()),
+                        ),
                     ));
                 }
                 for subtoken in subtokens {
                     let frequency = stats.document_frequency(LexicalFieldV1::Subtoken, &subtoken);
                     sources.push((
                         frequency,
-                        DocumentQueryV1::term(subtoken_field.clone(), subtoken),
+                        (
+                            subtoken.clone(),
+                            DocumentQueryV1::term(subtoken_field.clone(), subtoken),
+                        ),
                     ));
                 }
             }
@@ -1808,7 +1819,10 @@ impl<'a> ArtifactQueryV1<'a> {
                     {
                         sources.push((
                             stats.whole_term_documents(&term),
-                            DocumentQueryV1::term_except_id(term_id, subtoken_field),
+                            (
+                                term,
+                                DocumentQueryV1::term_except_id(term_id, subtoken_field),
+                            ),
                         ));
                     }
                 }
@@ -1818,14 +1832,20 @@ impl<'a> ArtifactQueryV1<'a> {
                     {
                         sources.push((
                             stats.document_frequency(LexicalFieldV1::Subtoken, &subtoken),
-                            DocumentQueryV1::term_id(subtoken_field, term_id),
+                            (subtoken, DocumentQueryV1::term_id(subtoken_field, term_id)),
                         ));
                     }
                 }
             }
         }
         let mut admitted = phrase_queries.values().cloned().collect::<Vec<_>>();
-        admitted.extend(admit_candidate_sources(sources));
+        admitted.extend(
+            admit_candidate_sources(sources, |frequency, (term, _)| {
+                pruned.push((term.clone(), frequency as u64));
+            })
+            .into_iter()
+            .map(|(_, source)| source),
+        );
         union_document_queries(admitted)
     }
 

--- a/crates/tracedecay-query/src/retrieval/lexical/tests.rs
+++ b/crates/tracedecay-query/src/retrieval/lexical/tests.rs
@@ -12,9 +12,9 @@ use tracedecay_domain::{
     CompactCandidate, EphemeralSanitizedQueryViewV1, EvidenceRole, ExactAdmissionProof,
     ExactAdmissionRuleRevision, ExactFieldV1, FixedPointScore, FreshnessCompatibilityV1,
     PrincipalId, QueryNormalizationRevision, RetrievalBudget, RetrievalRequest, RetrievalScope,
-    RetrievalSnapshot, RetrieverBatch, RetrieverKind, RetrieverOutcome, SanitizerRevision,
-    SingleRootScopeV1, SourceFreshness, TemporalModeV1, UtcMicros, VectorWatermark,
-    split_subtokens, technical_tokens,
+    RetrievalSnapshot, RetrieverBatch, RetrieverCoverage, RetrieverKind, RetrieverOutcome,
+    SanitizerRevision, SingleRootScopeV1, SourceFreshness, TemporalModeV1, UtcMicros,
+    VectorWatermark, split_subtokens, technical_tokens,
 };
 
 use super::{
@@ -76,18 +76,42 @@ where
 #[test]
 fn candidate_sources_admit_rarest_first_within_the_document_budget() {
     let budget = MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1;
-    let admitted = admit_candidate_sources(vec![
-        (budget * 3, "the"),
-        (10, "pendingtoolkind"),
-        (budget - 100, "pending"),
-        (budget * 2, "tool"),
-        (200, "kind"),
-    ]);
+    let mut pruned = Vec::new();
+    let admitted = admit_candidate_sources(
+        vec![
+            (budget * 3, "the"),
+            (10, "pendingtoolkind"),
+            (budget - 100, "pending"),
+            (budget * 2, "tool"),
+            (200, "kind"),
+        ],
+        |frequency, term| pruned.push((term.to_string(), frequency as u64)),
+    );
     assert_eq!(
         admitted,
         ["pendingtoolkind", "kind"],
         "`pending` would push the admitted total past the budget, and every later \
          (more common) source is pruned with it"
+    );
+    assert_eq!(
+        pruned,
+        [
+            ("pending".to_owned(), (budget - 100) as u64),
+            ("tool".to_owned(), (budget * 2) as u64),
+            ("the".to_owned(), (budget * 3) as u64)
+        ]
+    );
+    let outcome = super::candidate_admission_outcome(
+        RetrieverBatch::<()> {
+            candidates: Vec::new(),
+            evidence_by_occurrence: BTreeMap::new(),
+            coverage: RetrieverCoverage::default(),
+            continuation: None,
+        },
+        pruned.clone(),
+    );
+    assert!(
+        matches!(outcome, RetrieverOutcome::Partial { value, reason: tracedecay_domain::RetrievalFailure::CandidateSourcesPruned { term_sources, document_frequency_budget } } if value.candidates.is_empty() && term_sources == pruned && document_frequency_budget == budget as u64)
     );
 }
 
@@ -95,28 +119,34 @@ fn candidate_sources_admit_rarest_first_within_the_document_budget() {
 fn candidate_sources_always_admit_the_most_selective_term() {
     let budget = MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1;
     assert_eq!(
-        admit_candidate_sources(vec![(budget * 20, "tracedecay"), (budget * 30, "the")]),
+        admit_candidate_sources(
+            vec![(budget * 20, "tracedecay"), (budget * 30, "the")],
+            |_, _| {}
+        ),
         ["tracedecay"]
     );
-    assert!(admit_candidate_sources(Vec::<(usize, &str)>::new()).is_empty());
+    assert!(admit_candidate_sources(Vec::<(usize, &str)>::new(), |_, _| {}).is_empty());
 }
 
 #[test]
 fn candidate_sources_ignore_empty_sources_before_admitting_a_common_term() {
     let budget = MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1;
     assert_eq!(
-        admit_candidate_sources(vec![(0, "missing"), (budget + 1, "common"), (0, "absent")]),
+        admit_candidate_sources(
+            vec![(0, "missing"), (budget + 1, "common"), (0, "absent")],
+            |_, _| {}
+        ),
         ["common"],
         "empty sources must not consume the first nonempty source exception"
     );
-    assert!(admit_candidate_sources(vec![(0, "missing"), (0, "absent")]).is_empty());
+    assert!(admit_candidate_sources(vec![(0, "missing"), (0, "absent")], |_, _| {}).is_empty());
 }
 
 #[test]
 fn candidate_sources_keep_request_order_across_equal_frequencies() {
     let half = MAX_LEXICAL_CANDIDATE_DOCUMENTS_V1 / 2;
     assert_eq!(
-        admit_candidate_sources(vec![(half, "b"), (half, "a"), (half, "c")]),
+        admit_candidate_sources(vec![(half, "b"), (half, "a"), (half, "c")], |_, _| {}),
         ["b", "a"]
     );
 }

--- a/crates/tracedecay-query/src/search_quality/semantic_native.rs
+++ b/crates/tracedecay-query/src/search_quality/semantic_native.rs
@@ -555,7 +555,9 @@ fn evaluate_semantic(
             },
         )),
         RetrieverOutcome::Unavailable(
-            RetrievalFailure::InvalidRequest { .. } | RetrievalFailure::Internal { .. },
+            RetrievalFailure::InvalidRequest { .. }
+            | RetrievalFailure::Internal { .. }
+            | RetrievalFailure::CandidateSourcesPruned { .. },
         ) => Err(SemanticNativeEvaluationErrorV1::Contract(
             "production exact-flat semantic execution failed".to_owned(),
         )),


### PR DESCRIPTION
Keep the existing 16,384 candidate-source policy independent of reader cache sizing. Return typed partial results when term sources are pruned, including empty results; operator logs retain counts and frequencies without query text.

Addresses #1052. Validation: 101 lexical tests and runtime typecheck passed. Bounded versus unbounded evaluation produced identical ranked results for all 28 checked-in queries; this small corpus does not establish production recall safety.