### PR TITLE
fix(sessions): preserve canonical repository evidence on replay

### DIFF
--- a/crates/tracedecay-cli/tests/core_cli_suite/observation_reset_recovery_test.rs
+++ b/crates/tracedecay-cli/tests/core_cli_suite/observation_reset_recovery_test.rs
@@ -13,7 +13,7 @@ use tracedecay_global_db::observation::OBSERVATION_NATIVE_SOURCE_SCHEME_MIGRATIO
 
 use crate::common::{
     canonical_existing_path, git_program, initialize_tracedecay_cli_project,
-    spawn_tracedecay_daemon, stop_managed_daemon, tracedecay_command_with_home,
+    spawn_tracedecay_daemon_with, stop_managed_daemon, tracedecay_command_with_home,
 };
 
 /// How long the daemon may take to re-derive the reset store from the
@@ -352,8 +352,19 @@ fn observation_authority_reset_recovers_the_retained_temporal_authority() {
         "a converged store records the swept Codex corpus and provider coverage"
     );
 
-    // Recovery runs offline: the daemon cannot open a refused store.
+    // Reopening unchanged history must settle without a spurious conflict.
+    assert_search_hits(&home, &project, true, "baseline catch_up");
     stop_managed_daemon(&home);
+    let reopen_log = home.join("ordinary-reopen.log");
+    let daemon = spawn_tracedecay_daemon_with(&home, |command| {
+        command.stderr(std::fs::File::create(&reopen_log).unwrap());
+    });
+    wait_for_described_session(&home, &project, "ordinary reopen");
+    assert_search_hits(&home, &project, true, "ordinary reopen catch_up");
+    drop(daemon);
+    assert_no_replay_conflicts(&reopen_log);
+
+    // Recovery runs offline: the daemon cannot open a refused store.
     make_observation_authority_refused(&sessions_db);
     replace_codex_rollout_identity(&home);
 
@@ -404,7 +415,10 @@ fn observation_authority_reset_recovers_the_retained_temporal_authority() {
     // store that has already converged is complete and current — and only
     // once its generations are rebuilt. Neither reading may be an unavailable
     // projection or the reset store read as converged.
-    let _daemon = spawn_tracedecay_daemon(&home);
+    let reset_log = home.join("reset-reopen.log");
+    let daemon = spawn_tracedecay_daemon_with(&home, |command| {
+        command.stderr(std::fs::File::create(&reset_log).unwrap());
+    });
     let reopened = doctor(&home, &project);
     assert!(
         is_evidence(&reopened),
@@ -486,4 +500,21 @@ fn observation_authority_reset_recovers_the_retained_temporal_authority() {
         scheduling_cursor_count(&sessions_db) > 0,
         "the rebuilt authority must record the swept Codex corpus and provider coverage again"
     );
+    drop(daemon);
+    assert_no_replay_conflicts(&reset_log);
+}
+
+fn assert_no_replay_conflicts(log: &Path) {
+    let output = std::fs::read_to_string(log).unwrap();
+    for reason in [
+        "authority_write_failed",
+        "external_source_commit_failed",
+        "observation repository provenance collision",
+        "external source idempotency key conflicts",
+    ] {
+        assert!(
+            !output.contains(reason),
+            "reopen must settle on its first pass: {output}"
+        );
+    }
 }

--- a/crates/tracedecay-rusqlite-runtime/src/repository/observation/authority.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/observation/authority.rs
@@ -6,8 +6,10 @@
 
 use rusqlite::{OptionalExtension, params};
 use tracedecay_domain::{
-    DurableObservationV1, FactOwnerV1, ObservationSourceCursorV1, RetrievalAnchorRecordV2,
-    RetrievalAnchorTargetV2, prove_cline_native_source_transition,
+    AnchorSourceGenerationV2, DurableObservationV1, EvidenceAvailabilityV1, FactOwnerV1,
+    GenerationBoundRepositoryProvenanceV1, ObservationSourceCursorV1, RepositoryProvenanceV1,
+    RetrievalAnchorRecordV2, RetrievalAnchorRecordV2Parts, RetrievalAnchorTargetV2,
+    prove_cline_native_source_transition,
 };
 use tracedecay_store::{
     AnchorDispositionReasonClassV1, AnchorDispositionStateV1, AnchoredObservationWrite,
@@ -357,12 +359,103 @@ pub(super) fn verify_observation_authority(
             .transpose()?,
     );
     if stored.as_ref() != Some(&expected) {
-        return Err(invalid("observation repository provenance collision"));
+        let Some((availability, capture, anchor_id, owner)) = stored else {
+            return Err(invalid("observation repository provenance collision"));
+        };
+        let replay = repository_replay_anchor(attachment, &availability)?;
+        let Some(replay) = replay else {
+            return Err(invalid("observation repository provenance collision"));
+        };
+        let retained: EvidenceAvailabilityV1<GenerationBoundRepositoryProvenanceV1> =
+            decode(availability)?;
+        if capture != retained.value().map(encode).transpose()?
+            || anchor_id.as_deref() != Some(replay.anchor_id().as_str())
+            || owner.as_deref() != Some(encode(replay.owner())?.as_str())
+        {
+            return Err(invalid("observation repository provenance collision"));
+        }
+        return verify_retrieval_anchor(connection, &replay);
     }
     if let Some(anchor) = attachment.anchor() {
         verify_retrieval_anchor(connection, anchor)?;
     }
     Ok(())
+}
+
+/// A concurrent first writer can recapture the same Git evidence at a later
+/// local clock. Normalize only that clock and its derived capture identities;
+/// the caller still verifies every retained provenance and anchor field and
+/// returns the original immutable receipt. Different Git evidence is a conflict.
+fn repository_replay_anchor(
+    attachment: &RepositoryProvenanceAttachmentV1,
+    retained_json: &str,
+) -> rusqlite::Result<Option<RetrievalAnchorRecordV2>> {
+    let retained: EvidenceAvailabilityV1<GenerationBoundRepositoryProvenanceV1> =
+        decode(retained_json.to_owned())?;
+    let (Some(old), Some(new), Some(anchor)) = (
+        retained.value(),
+        attachment.provenance(),
+        attachment.anchor(),
+    ) else {
+        return Ok(None);
+    };
+    let capture = new.capture();
+    let normalized = GenerationBoundRepositoryProvenanceV1::new(
+        new.generation_id().clone(),
+        RepositoryProvenanceV1::new(
+            capture.repository_id().clone(),
+            capture.project_id().cloned(),
+            capture.worktree_id().cloned(),
+            capture.canonical_root_digest().clone(),
+            capture.evidence().clone(),
+            old.capture().captured_at(),
+        )
+        .map_err(invalid)?,
+        new.source_observation().cloned(),
+    )
+    .map_err(invalid)?;
+    let normalized = match attachment.availability() {
+        EvidenceAvailabilityV1::Known(_) => EvidenceAvailabilityV1::Known(normalized),
+        EvidenceAvailabilityV1::PartiallyReadable(_) => {
+            EvidenceAvailabilityV1::PartiallyReadable(normalized)
+        }
+        _ => return Ok(None),
+    };
+    if encode(&normalized)? != retained_json {
+        return Ok(None);
+    }
+    let RetrievalAnchorTargetV2::RepositoryCapture {
+        repository_id,
+        receipt,
+        ..
+    } = anchor.target()
+    else {
+        return Ok(None);
+    };
+    RetrievalAnchorRecordV2::new(RetrievalAnchorRecordV2Parts {
+        target: RetrievalAnchorTargetV2::RepositoryCapture {
+            repository_id: repository_id.clone(),
+            capture_id: old.capture_id().clone(),
+            receipt: receipt.clone(),
+        },
+        owner: anchor.owner().clone(),
+        aliases: anchor.aliases().to_vec(),
+        occurred_at: anchor.occurred_at(),
+        ingested_at: anchor.ingested_at(),
+        evidence_class: anchor.evidence_class(),
+        source_generation: AnchorSourceGenerationV2::RepositoryCapture(old.capture_id().clone()),
+        projection_generation: anchor.projection_generation().clone(),
+        projection_watermark: anchor.projection_watermark().clone(),
+        coverage: anchor.coverage().clone(),
+        source_observations: anchor.source_observations().to_vec(),
+        source_anchors: anchor.source_anchors().to_vec(),
+        authorization: anchor.authorization().clone(),
+        payload_access: anchor.payload_access(),
+        retention_class: anchor.retention_class().clone(),
+        durability: anchor.durability().clone(),
+    })
+    .map(Some)
+    .map_err(invalid)
 }
 
 pub(super) fn read_cursor(

--- a/crates/tracedecay-rusqlite-runtime/src/repository/observation/tests.rs
+++ b/crates/tracedecay-rusqlite-runtime/src/repository/observation/tests.rs
@@ -1,14 +1,18 @@
 use rusqlite::Connection;
 use serde_json::json;
 use tracedecay_domain::{
-    CanonicalObservationEnvelopeV1, CanonicalObservationEvidenceV1, CanonicalObservationFactV1,
-    CanonicalObservationRelationsV1, ComponentVersion, FactOwnerV1, ObservationId,
-    ObservationIdentityMaterialV1, ObservationOrderingDomainV1, ObservationScopeV1,
-    ObservationSourceCursorV1, ObservationSourceGenerationV1, ObservationSourceIdentityV1,
-    ObservationSourceRangeV1, PayloadReferenceV1, ProjectId, ProjectionGenerationId, ProviderId,
-    ProviderUsageContractDimensionV1, RetentionClass, SanitizationReceiptId,
-    SanitizationReceiptRefV1, SanitizationReceiptV1, SanitizerDispositionV1, SensitivityV1,
-    SessionId, UtcMicros,
+    AnchorDurabilityClass, AnchorSourceGenerationV2, CanonicalObservationEnvelopeV1,
+    CanonicalObservationEvidenceV1, CanonicalObservationFactV1, CanonicalObservationRelationsV1,
+    ComponentVersion, CoverageReportV1, EvidenceAvailabilityV1, EvidenceClass, FactOwnerV1,
+    GenerationBoundRepositoryProvenanceV1, ObservationId, ObservationIdentityMaterialV1,
+    ObservationOrderingDomainV1, ObservationScopeV1, ObservationSourceCursorV1,
+    ObservationSourceGenerationV1, ObservationSourceIdentityV1, ObservationSourceRangeV1,
+    PayloadAccessState, PayloadReferenceV1, PrivacyDomainBoundLocatorDigest, ProjectId,
+    ProjectionGenerationId, ProviderId, ProviderUsageContractDimensionV1, RefId,
+    RepositoryEvidenceV1, RepositoryId, RepositoryProvenanceV1, RepositoryRemoteIdentityV1,
+    RetentionClass, RetrievalAnchorRecordV2, RetrievalAnchorRecordV2Parts, RetrievalAnchorTargetV2,
+    SanitizationReceiptId, SanitizationReceiptRefV1, SanitizationReceiptV1, SanitizerDispositionV1,
+    SensitivityV1, SessionId, UtcMicros, VectorWatermark,
 };
 use tracedecay_store::{
     AnchorDispositionReasonClassV1, AnchorDispositionStateV1, AnchoredObservationWrite,
@@ -143,6 +147,102 @@ fn semantic_anchor_replay_ignores_local_ingest_clock() {
             .unwrap(),
         1
     );
+}
+
+fn repository_write(
+    clock: i64,
+    branch: &str,
+    evidence_class: EvidenceClass,
+) -> AnchoredObservationWrite {
+    let write = anchored_at(
+        observation_write("repository replay", "receipt.repository-replay"),
+        UtcMicros(clock),
+    );
+    let capture = RepositoryProvenanceV1::new(
+        RepositoryId::new("repository.fixture").unwrap(),
+        Some(ProjectId::new("project.fixture").unwrap()),
+        None,
+        PrivacyDomainBoundLocatorDigest::new(
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .unwrap(),
+        RepositoryEvidenceV1::new(
+            EvidenceAvailabilityV1::Known(RefId::new(branch).unwrap()),
+            EvidenceAvailabilityV1::Unborn,
+            EvidenceAvailabilityV1::Unavailable,
+            EvidenceAvailabilityV1::Unknown,
+            RepositoryRemoteIdentityV1::Unknown,
+            EvidenceAvailabilityV1::Unknown,
+        )
+        .unwrap(),
+        UtcMicros(clock),
+    )
+    .unwrap();
+    let binding = GenerationBoundRepositoryProvenanceV1::new(
+        write.projection_generation().clone(),
+        capture,
+        Some(write.observation().observation_id().clone()),
+    )
+    .unwrap();
+    let anchor = RetrievalAnchorRecordV2::new(RetrievalAnchorRecordV2Parts {
+        target: RetrievalAnchorTargetV2::RepositoryCapture {
+            repository_id: binding.capture().repository_id().clone(),
+            capture_id: binding.capture_id().clone(),
+            receipt: write.observation().receipt().receipt().clone(),
+        },
+        owner: write.observation().scope().clone(),
+        aliases: vec![],
+        occurred_at: None,
+        ingested_at: UtcMicros(clock),
+        evidence_class,
+        source_generation: AnchorSourceGenerationV2::RepositoryCapture(
+            binding.capture_id().clone(),
+        ),
+        projection_generation: write.projection_generation().clone(),
+        projection_watermark: VectorWatermark::default(),
+        coverage: CoverageReportV1::default(),
+        source_observations: vec![write.observation().observation_id().clone()],
+        source_anchors: vec![],
+        authorization: write.retrieval_anchor().authorization().clone(),
+        payload_access: PayloadAccessState::Eligible,
+        retention_class: write.observation().retention_class().clone(),
+        durability: AnchorDurabilityClass::DurableEvidence,
+    })
+    .unwrap();
+    write
+        .with_repository_provenance_attachment(EvidenceAvailabilityV1::Known(binding), Some(anchor))
+        .unwrap()
+}
+
+#[test]
+fn repository_capture_replay_preserves_first_receipt_and_refuses_changed_evidence() {
+    let mut connection = connection();
+    let first = repository_write(1, "refs/heads/main", EvidenceClass::Observed);
+    let replay = repository_write(2, "refs/heads/main", EvidenceClass::Observed);
+    assert_eq!(first.observation(), replay.observation());
+    assert_ne!(
+        first.repository_provenance_attachment(),
+        replay.repository_provenance_attachment()
+    );
+    execute(&mut connection, &first).unwrap();
+    let request = ObservationReadOperationV1::Observation {
+        observation_id: first.observation().observation_id().clone(),
+    };
+    let retained = read(&mut connection, &request).unwrap();
+    execute(&mut connection, &replay).expect("same evidence with a new capture clock must replay");
+    assert_eq!(read(&mut connection, &request).unwrap(), retained);
+    let changed = repository_write(3, "refs/heads/other", EvidenceClass::Observed);
+    assert!(
+        execute(&mut connection, &changed).is_err(),
+        "different repository evidence must remain a conflict"
+    );
+    assert_eq!(read(&mut connection, &request).unwrap(), retained);
+    let changed_authority = repository_write(4, "refs/heads/main", EvidenceClass::Inferred);
+    assert!(
+        execute(&mut connection, &changed_authority).is_err(),
+        "same repository evidence with changed anchor authority must remain a conflict"
+    );
+    assert_eq!(read(&mut connection, &request).unwrap(), retained);
 }
 
 fn connection() -> Connection {


### PR DESCRIPTION
Reopened observation batches can recapture the same repository evidence with a later capture clock. Normalize only that clock and its derived identities against the retained capture before exact provenance and authority comparison; return the original immutable receipt. Changed repository evidence or anchor authority still refuses.

Fixes #1022. Validation: real daemon ordinary and post-reset reopen regression failed before the fix and passed after; all 18 writer tests passed, including changed-ref and changed-anchor refusal. Independent identity review found no blocker.