### PR TITLE
refactor(semantic): retain the Tokio dispatch handle directly

### DIFF
--- a/crates/tracedecay-application/src/semantic_runtime/production.rs
+++ b/crates/tracedecay-application/src/semantic_runtime/production.rs
@@ -4350,33 +4350,6 @@ pub fn project_lifecycle_status(project_path: &Path) -> Option<SemanticModelLife
 pub type SavedCodeGenerationScheduleHookV1 =
     Arc<dyn Fn(Arc<CodeIndexPublishedGenerationV1>) -> bool + Send + Sync>;
 
-/// Daemon runtime retained when the saved-generation hook is constructed.
-///
-/// Serving publication deliberately invokes the hook from `spawn_blocking`
-/// while it owns the synchronous scheduler. Looking up a current Tokio runtime
-/// from that worker always fails, so the hook must carry the daemon runtime
-/// across the blocking handoff instead.
-#[derive(Clone)]
-struct SemanticProjectionDispatchRuntimeV1 {
-    handle: tokio::runtime::Handle,
-}
-
-impl SemanticProjectionDispatchRuntimeV1 {
-    fn capture() -> Option<Self> {
-        tokio::runtime::Handle::try_current()
-            .ok()
-            .map(|handle| Self { handle })
-    }
-
-    fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        self.handle.spawn(future)
-    }
-}
-
 /// Owned authorities and identities captured by a saved-generation hook.
 pub struct SavedGenerationScheduleHookParametersV1 {
     pub project_root: PathBuf,
@@ -4423,7 +4396,8 @@ pub fn production_saved_generation_schedule_hook(
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .insert(project_root.clone(), runtime.as_ref().clone());
-    let dispatch_runtime = SemanticProjectionDispatchRuntimeV1::capture();
+    // Capture before the synchronous publication hook crosses into spawn_blocking.
+    let dispatch_runtime = tokio::runtime::Handle::try_current().ok();
     Arc::new(move |generation| {
         if generation.snapshot().worktree.as_ref() != Some(&worktree_id) {
             return false;
@@ -4627,7 +4601,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn saved_generation_dispatch_retains_daemon_runtime_across_blocking_handoff() {
-        let runtime = SemanticProjectionDispatchRuntimeV1::capture()
+        let runtime = tokio::runtime::Handle::try_current()
             .expect("daemon runtime is available while the hook is constructed");
         let (observed_tx, observed_rx) = oneshot::channel();
 


### PR DESCRIPTION
Remove the private wrapper that only forwarded runtime capture and spawn. The saved-generation hook still captures the daemon handle before crossing into a blocking worker.

Part of #1088. Validation: the existing blocking-handoff regression passed.