### PR TITLE
style(integration): restore query and graph check cleanliness

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/query_runtime.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/query_runtime.rs
@@ -202,7 +202,9 @@ pub fn canonical_query_policy(
     let mut candidate_profile = profile.clone();
     let mut candidate_diversity = diversity.clone();
     candidate_profile.evaluation_result_anchor = core_profile.evaluation_result_anchor.clone();
-    candidate_diversity.evaluation_result_anchor = core_diversity.evaluation_result_anchor.clone();
+    candidate_diversity
+        .evaluation_result_anchor
+        .clone_from(&core_diversity.evaluation_result_anchor);
     if diversity.evaluation_result_anchor.as_ref() == Some(&profile.evaluation_result_anchor)
         && candidate_profile == core_profile
         && candidate_diversity == core_diversity

--- a/crates/tracedecay/tests/graph_suite/graph_test.rs
+++ b/crates/tracedecay/tests/graph_suite/graph_test.rs
@@ -2,11 +2,11 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 
 use tempfile::TempDir;
-use tracedecay_runtime_core::git::churn::file_churn;
 use tracedecay_graph_query::health::{
     HealthDimensions, acyclicity_score, compute_composite_health, dependency_depth,
     gini_coefficient, gini_label, modularity_score,
 };
+use tracedecay_runtime_core::git::churn::file_churn;
 
 // These tests cover the store-independent health algorithms. Code-graph read
 // behavior is covered through the verified Grafeo reader and production MCP


### PR DESCRIPTION
Use clone_from for an existing optional policy anchor and restore graph-test import order after owner moves. No behavior changes.

Validation: integrated Clippy progressed past the corrected dependency; formatting identified only the corrected import ordering before the separate structural-lint work.