### PR TITLE
refactor(primitives): drop unused graph dependencies

### DIFF
--- a/crates/tracedecay-application/src/primitives/grep_analysis.rs
+++ b/crates/tracedecay-application/src/primitives/grep_analysis.rs
@@ -197,15 +197,7 @@ impl AstGrepAuthorityV1 for TraceDecayAstGrepAuthorityV1 {
     }
 }
 
-pub struct TraceDecayComplexityAuthorityV1 {
-    code_graph: Arc<dyn tracedecay_graph_query::CodeGraphProjectionReadPort>,
-}
-
-impl TraceDecayComplexityAuthorityV1 {
-    pub fn new(code_graph: Arc<dyn tracedecay_graph_query::CodeGraphProjectionReadPort>) -> Self {
-        Self { code_graph }
-    }
-}
+pub struct TraceDecayComplexityAuthorityV1;
 
 impl ComplexityAuthorityV1 for TraceDecayComplexityAuthorityV1 {
     fn complexity<'a>(
@@ -218,12 +210,11 @@ impl ComplexityAuthorityV1 for TraceDecayComplexityAuthorityV1 {
                 if request.window.cursor.is_some() {
                     return unsupported_compatibility_cursor();
                 }
-                let path =
+                let _path =
                     match effective_scoped_path(request.path.as_deref(), context.scope_prefix) {
                         Ok(path) => path,
                         Err(problem) => return PrimitiveOutcomeV1::Failed(problem),
                     };
-                let _ = (&self.code_graph, path);
                 PrimitiveOutcomeV1::Failed(GrepAnalysisProblemV1::AuthorityFailed(
                 "the verified graph generation does not publish the full complexity metric contract"
                     .to_owned(),

--- a/crates/tracedecay-application/src/primitives/production.rs
+++ b/crates/tracedecay-application/src/primitives/production.rs
@@ -746,20 +746,12 @@ impl LexicalGrepAuthorityV1 for TraceDecayLexicalGrepAuthorityV1 {
     }
 }
 
-pub struct TraceDecayRedundancyAuthorityV1 {
-    code_graph: Arc<dyn CodeGraphProjectionReadPort>,
-}
-
-impl TraceDecayRedundancyAuthorityV1 {
-    pub fn new(code_graph: Arc<dyn CodeGraphProjectionReadPort>) -> Self {
-        Self { code_graph }
-    }
-}
+pub struct TraceDecayRedundancyAuthorityV1;
 
 impl RedundancyAuthorityV1 for TraceDecayRedundancyAuthorityV1 {
     fn redundancy<'a>(
         &'a self,
-        context: &'a PrimitivePortContextV1<'a>,
+        _context: &'a PrimitivePortContextV1<'a>,
         request: &'a RedundancyRequestV1,
     ) -> PrimitiveFutureV1<'a, RedundancyResultV1> {
         Box::pin(hotpath::future!(
@@ -769,7 +761,6 @@ impl RedundancyAuthorityV1 for TraceDecayRedundancyAuthorityV1 {
                         "compatibility cursor unsupported".to_owned(),
                     ));
                 }
-                let _ = (&self.code_graph, request, context.scope_prefix);
                 PrimitiveOutcomeV1::Failed(GrepAnalysisProblemV1::AuthorityFailed(
                     "the verified graph generation does not publish redundancy fingerprints"
                         .to_owned(),
@@ -2819,9 +2810,7 @@ pub async fn open_production_primitive_runtime(
             Arc::clone(&source_runtime),
             Arc::clone(&code_graph),
         )),
-        Arc::new(TraceDecayRedundancyAuthorityV1::new(Arc::clone(
-            &code_graph,
-        ))),
+        Arc::new(TraceDecayRedundancyAuthorityV1),
         temporal,
         Arc::new(TraceDecaySourceLinesPortV1::new(Arc::clone(
             &source_runtime,

--- a/crates/tracedecay-application/src/primitives/runtime.rs
+++ b/crates/tracedecay-application/src/primitives/runtime.rs
@@ -559,9 +559,7 @@ pub fn open_primitive_project_runtime(
             Arc::clone(&source_runtime),
             Arc::clone(&code_graph),
         )),
-        Arc::new(TraceDecayComplexityAuthorityV1::new(Arc::clone(
-            &code_graph,
-        ))),
+        Arc::new(TraceDecayComplexityAuthorityV1),
         redundancy,
         Arc::new(TraceDecayDependencyDepthAuthorityV1::new(Arc::clone(
             &code_graph,


### PR DESCRIPTION
Remove retained graph handles from complexity and redundancy providers that currently return typed unsupported outcomes. Scope validation and unavailable behavior are unchanged; this does not claim those metrics are implemented.

Part of #1088. Validation: 50 primitive tests passed.