### PR TITLE
test(semantic): retain installed material during background progress

### DIFF
--- a/crates/tracedecay/src/daemon/production_harness/semantic_activation_journey_test.rs
+++ b/crates/tracedecay/src/daemon/production_harness/semantic_activation_journey_test.rs
@@ -141,6 +141,16 @@ pub(super) fn installed_selection_material(
             install_path,
             ..
         }
+        | SemanticModelLifecycleStateV1::Loading {
+            artifact_digest,
+            install_path,
+            ..
+        }
+        | SemanticModelLifecycleStateV1::Indexing {
+            artifact_digest,
+            install_path,
+            ..
+        }
         | SemanticModelLifecycleStateV1::Ready {
             artifact_digest,
             install_path,
@@ -148,6 +158,32 @@ pub(super) fn installed_selection_material(
         } => (artifact_digest, install_path),
         state => panic!("expected installed production model, got {state:?}"),
     }
+}
+
+#[test]
+#[ignore = "requires the verified TRACEDECAY_DISTRIBUTION_FASTEMBED_FIXTURE"]
+fn installed_selection_survives_background_projection_progress() {
+    let fixture = std::env::var_os("TRACEDECAY_DISTRIBUTION_FASTEMBED_FIXTURE")
+        .map(PathBuf::from)
+        .expect("verified distribution fixture");
+    let root = tempfile::tempdir().expect("isolated lifecycle");
+    let owner = tracedecay_semantic::SemanticModelLifecycleOwnerV1::open_default(root.path())
+        .expect("lifecycle owner");
+    seed_distribution_fixture(root.path(), &fixture, &owner);
+    owner
+        .select_model(Some(DEFAULT_FASTEMBED_MODEL_ID), true)
+        .expect("select model");
+    owner
+        .acquire_blocking_for_tests()
+        .expect("verified installation");
+    let installed = installed_selection_material(&owner);
+    owner.mark_loading().expect("background load");
+    assert_eq!(installed_selection_material(&owner), installed);
+    owner.mark_indexing(0, 3).expect("background projection");
+    assert_eq!(installed_selection_material(&owner), installed);
+    owner.mark_indexing(3, 3).expect("projection complete");
+    owner.mark_ready().expect("published projection");
+    assert_eq!(installed_selection_material(&owner), installed);
 }
 
 pub(super) async fn wait_for_semantic_generation(


### PR DESCRIPTION
The native lifecycle journey can observe Loading or Indexing after verified installation because background projection progresses independently. Read the same verified installation identity in those states without asserting readiness; unavailable and uninstalled states still fail.

Validation: real fixture regression passed across Installed, Loading, Indexing and Ready. Fixes a test-harness race exposed by the integrated native journey; does not alter production lifecycle semantics.