### PR TITLE
refactor(runtime): simplify composition and verify ownership boundaries

### DIFF
--- a/crates/tracedecay-api/src/remote.rs
+++ b/crates/tracedecay-api/src/remote.rs
@@ -296,13 +296,13 @@ pub fn remote_protocol_router(
     .layer(DefaultBodyLimit::max(MAX_REMOTE_HTTP_BODY_BYTES))
 }
 
-async fn protocol_route<Port: ?Sized, Request>(
+async fn protocol_route<Port, Request>(
     State(state): State<RemoteProtocolRouterStateV1<Port>>,
     admission: RemotePreBodyAdmissionV1<Request>,
     payload: Result<Json<RemoteHttpRequestV1<Request>>, JsonRejection>,
 ) -> Result<Response, RemoteHttpRejection>
 where
-    Port: RemoteProtocolPortV1<Request> + Send + Sync + 'static,
+    Port: RemoteProtocolPortV1<Request> + Send + Sync + 'static + ?Sized,
     Request: DeserializeOwned + RemoteSessionBoundProtocolBodyV1 + Send + 'static,
     Port::Output: Serialize + Send + 'static,
 {
@@ -390,13 +390,13 @@ where
     }
 }
 
-async fn enrollment_route<Port: ?Sized>(
+async fn enrollment_route<Port>(
     State(state): State<RemoteProtocolRouterStateV1<Port>>,
     admission: RemoteEnrollmentPreBodyAdmissionV1,
     payload: Result<Json<RemoteHttpRequestV1<EnrollmentRequestV1>>, JsonRejection>,
 ) -> Result<Response, RemoteHttpRejection>
 where
-    Port: RemoteEnrollmentProtocolPortV1 + Send + Sync + 'static,
+    Port: RemoteEnrollmentProtocolPortV1 + Send + Sync + 'static + ?Sized,
 {
     let request = hotpath::measure_block!("api.http.admission", {
         let Json(request) = match payload {

--- a/crates/tracedecay-api/src/remote.rs
+++ b/crates/tracedecay-api/src/remote.rs
@@ -21,7 +21,6 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracedecay_contracts::remote::auth::OpaqueRemoteCredential;
-use tracedecay_contracts::remote::capture::RemoteCaptureReceiptV1;
 use tracedecay_contracts::remote::capture_protocol::RemoteCaptureRequestV1;
 use tracedecay_contracts::remote::credential_admission::{
     RemoteAuthenticatedSessionV1, RemoteCredentialAdmissionPortV1, RemoteSessionBoundProtocolBodyV1,
@@ -31,15 +30,13 @@ use tracedecay_contracts::remote::protocol::{
     RemoteProtocolFailureV1, RemoteProtocolPortV1, RemoteProtocolRequestV1,
     RemoteProtocolResponseV1, RemoteProtocolServiceV1, remote_protocol_problem,
 };
-use tracedecay_contracts::remote::query::{RemoteQueryRequestV1, RemoteQueryResultV1};
+use tracedecay_contracts::remote::protocol_owner::RemoteOperationProtocolPortsV1;
+use tracedecay_contracts::remote::query::RemoteQueryRequestV1;
 use tracedecay_contracts::remote::recovery::{
-    BackupOperationStateV1, BackupRequestV1, PromotionCasReceiptV1, PromotionConfirmationV1,
-    StagedRestoreConfirmationV1, StagedRestoreProgressV1,
+    BackupRequestV1, PromotionConfirmationV1, StagedRestoreConfirmationV1,
 };
-use tracedecay_contracts::remote::replay::{RemoteReplayOutcomeV1, RemoteReplayRequestV1};
-use tracedecay_contracts::remote::transfer::{
-    RemoteFrameTransferReceiptV1, RemoteFrameTransferRequestV1,
-};
+use tracedecay_contracts::remote::replay::RemoteReplayRequestV1;
+use tracedecay_contracts::remote::transfer::RemoteFrameTransferRequestV1;
 use tracedecay_contracts::{
     ApplicationContractError, ApplicationProblemKind, CancellationSignal, RequestId,
     ResultContractRef,
@@ -136,13 +133,13 @@ impl<T> From<RemoteProtocolResponseV1<T>> for RemoteHttpResponseV1<T> {
     }
 }
 
-struct RemoteProtocolRouterStateV1<Port> {
+struct RemoteProtocolRouterStateV1<Port: ?Sized> {
     service: Arc<RemoteProtocolServiceV1<Port>>,
     credential_admission: Arc<dyn RemoteCredentialAdmissionPortV1>,
     clock: fn() -> UtcMicros,
 }
 
-impl<Port> Clone for RemoteProtocolRouterStateV1<Port> {
+impl<Port: ?Sized> Clone for RemoteProtocolRouterStateV1<Port> {
     fn clone(&self) -> Self {
         Self {
             service: Arc::clone(&self.service),
@@ -161,7 +158,7 @@ struct RemotePreBodyAdmissionV1<Request> {
     request: PhantomData<fn() -> Request>,
 }
 
-impl<Port, Request> FromRequestParts<RemoteProtocolRouterStateV1<Port>>
+impl<Port: ?Sized, Request> FromRequestParts<RemoteProtocolRouterStateV1<Port>>
     for RemotePreBodyAdmissionV1<Request>
 where
     Port: Send + Sync,
@@ -216,7 +213,7 @@ impl Drop for CancelRemoteRequestOnDropV1 {
     }
 }
 
-impl<Port> FromRequestParts<RemoteProtocolRouterStateV1<Port>>
+impl<Port: ?Sized> FromRequestParts<RemoteProtocolRouterStateV1<Port>>
     for RemoteEnrollmentPreBodyAdmissionV1
 where
     Port: Send + Sync,
@@ -252,63 +249,54 @@ where
 
 /// Build the sole Remote Brain HTTP router.
 ///
-/// The central composition root supplies the production protocol port, the
+/// The central composition root supplies the typed production operation ports, the
 /// fingerprint-indexed final credential authority, and the canonical runtime
 /// clock. Authentication occurs in a parts-only extractor before Axum polls or
 /// deserializes the JSON body. The typed body is then bound to that exact
 /// request-scoped session before delegation.
-pub fn remote_protocol_router<Port>(
-    port: Port,
+pub fn remote_protocol_router(
+    enrollment: Arc<dyn RemoteEnrollmentProtocolPortV1>,
+    operations: RemoteOperationProtocolPortsV1,
     credential_admission: Arc<dyn RemoteCredentialAdmissionPortV1>,
     clock: fn() -> UtcMicros,
-) -> Router
-where
-    Port: RemoteEnrollmentProtocolPortV1
-        + RemoteProtocolPortV1<RemoteCaptureRequestV1, Output = RemoteCaptureReceiptV1>
-        + RemoteProtocolPortV1<RemoteReplayRequestV1, Output = RemoteReplayOutcomeV1>
-        + RemoteProtocolPortV1<RemoteFrameTransferRequestV1, Output = RemoteFrameTransferReceiptV1>
-        + RemoteProtocolPortV1<RemoteQueryRequestV1, Output = RemoteQueryResultV1>
-        + RemoteProtocolPortV1<BackupRequestV1, Output = BackupOperationStateV1>
-        + RemoteProtocolPortV1<StagedRestoreConfirmationV1, Output = StagedRestoreProgressV1>
-        + RemoteProtocolPortV1<PromotionConfirmationV1, Output = PromotionCasReceiptV1>
-        + Send
-        + Sync
-        + 'static,
-{
-    let state = RemoteProtocolRouterStateV1 {
-        service: Arc::new(RemoteProtocolServiceV1::new(port)),
-        credential_admission,
-        clock,
-    };
-    Router::new()
-        .route("/enrollment", post(enrollment_route::<Port>))
-        .route(
-            "/capture",
-            post(protocol_route::<Port, RemoteCaptureRequestV1>),
-        )
-        .route(
-            "/replay",
-            post(protocol_route::<Port, RemoteReplayRequestV1>),
-        )
-        .route(
-            "/frames/transfer",
-            post(protocol_route::<Port, RemoteFrameTransferRequestV1>),
-        )
-        .route("/query", post(protocol_route::<Port, RemoteQueryRequestV1>))
-        .route("/backup", post(protocol_route::<Port, BackupRequestV1>))
-        .route(
-            "/restore",
-            post(protocol_route::<Port, StagedRestoreConfirmationV1>),
-        )
-        .route(
-            "/failover",
-            post(protocol_route::<Port, PromotionConfirmationV1>),
-        )
-        .layer(DefaultBodyLimit::max(MAX_REMOTE_HTTP_BODY_BYTES))
-        .with_state(state)
+) -> Router {
+    let router = Router::new().route(
+        "/enrollment",
+        post(enrollment_route::<dyn RemoteEnrollmentProtocolPortV1>).with_state(
+            RemoteProtocolRouterStateV1 {
+                service: Arc::new(RemoteProtocolServiceV1::new(enrollment)),
+                credential_admission: Arc::clone(&credential_admission),
+                clock,
+            },
+        ),
+    );
+    // Each route retains its own typed operation authority; no dispatcher sits
+    // between the validated request and the selected operation.
+    macro_rules! mount_operations {
+        ($($path:literal => $request:ty, $port:expr);+ $(;)?) => {
+            router$(.route(
+                $path,
+                post(protocol_route::<_, $request>).with_state(RemoteProtocolRouterStateV1 {
+                    service: Arc::new(RemoteProtocolServiceV1::new($port)),
+                    credential_admission: Arc::clone(&credential_admission),
+                    clock,
+                }),
+            ))+
+        };
+    }
+    mount_operations! {
+        "/capture" => RemoteCaptureRequestV1, operations.capture;
+        "/replay" => RemoteReplayRequestV1, operations.replay;
+        "/frames/transfer" => RemoteFrameTransferRequestV1, operations.frame_transfer;
+        "/query" => RemoteQueryRequestV1, operations.query;
+        "/backup" => BackupRequestV1, operations.backup;
+        "/restore" => StagedRestoreConfirmationV1, operations.restore;
+        "/failover" => PromotionConfirmationV1, operations.promotion;
+    }
+    .layer(DefaultBodyLimit::max(MAX_REMOTE_HTTP_BODY_BYTES))
 }
 
-async fn protocol_route<Port, Request>(
+async fn protocol_route<Port: ?Sized, Request>(
     State(state): State<RemoteProtocolRouterStateV1<Port>>,
     admission: RemotePreBodyAdmissionV1<Request>,
     payload: Result<Json<RemoteHttpRequestV1<Request>>, JsonRejection>,
@@ -402,7 +390,7 @@ where
     }
 }
 
-async fn enrollment_route<Port>(
+async fn enrollment_route<Port: ?Sized>(
     State(state): State<RemoteProtocolRouterStateV1<Port>>,
     admission: RemoteEnrollmentPreBodyAdmissionV1,
     payload: Result<Json<RemoteHttpRequestV1<EnrollmentRequestV1>>, JsonRejection>,

--- a/crates/tracedecay-api/src/remote_tests.rs
+++ b/crates/tracedecay-api/src/remote_tests.rs
@@ -331,8 +331,30 @@ fn query_request(scope: RemoteRepositoryScopeV1) -> RemoteHttpRequestV1<RemoteQu
     }
 }
 
-fn authenticated_router(port_calls: Arc<AtomicUsize>) -> Router {
+fn test_protocol_router(
+    port: UnreachedProtocolPort,
+    admission: Arc<dyn RemoteCredentialAdmissionPortV1>,
+    clock: fn() -> UtcMicros,
+) -> Router {
+    let port = Arc::new(port);
     remote_protocol_router(
+        port.clone(),
+        RemoteOperationProtocolPortsV1 {
+            capture: port.clone(),
+            replay: port.clone(),
+            frame_transfer: port.clone(),
+            query: port.clone(),
+            backup: port.clone(),
+            restore: port.clone(),
+            promotion: port,
+        },
+        admission,
+        clock,
+    )
+}
+
+fn authenticated_router(port_calls: Arc<AtomicUsize>) -> Router {
+    test_protocol_router(
         UnreachedProtocolPort {
             calls: port_calls,
             controlled_deadline: None,
@@ -347,7 +369,7 @@ fn rejecting_router(
     admission_calls: Arc<AtomicUsize>,
     port_calls: Arc<AtomicUsize>,
 ) -> Router {
-    remote_protocol_router(
+    test_protocol_router(
         UnreachedProtocolPort {
             calls: port_calls,
             controlled_deadline: None,
@@ -364,7 +386,7 @@ fn deadline_capturing_router(
     port_calls: Arc<AtomicUsize>,
     controlled_deadline: Arc<AtomicI64>,
 ) -> Router {
-    remote_protocol_router(
+    test_protocol_router(
         UnreachedProtocolPort {
             calls: port_calls,
             controlled_deadline: Some(controlled_deadline),

--- a/crates/tracedecay-application/src/store/vector_generations/graph_adapter/evaluation_runtime.rs
+++ b/crates/tracedecay-application/src/store/vector_generations/graph_adapter/evaluation_runtime.rs
@@ -1178,3 +1178,65 @@ mod settlement_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::transitions::tests::{admitted_embedding, prepared_generation};
+    use super::*;
+    use crate::store::vector_generations::{
+        GraphVectorGenerationStoreV1, VectorGenerationBeginOutcomeV1,
+    };
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn held_sql_transaction_does_not_starve_semantic_bootstrap_or_shutdown() {
+        let source = CodeGenerationId::new("code-generation.real-contention").unwrap();
+        let graph = Arc::new(
+            IsolatedSemanticEvaluationGraphV1::open_source_generations(
+                std::slice::from_ref(&source),
+                Arc::new(NeverCancelled),
+            )
+            .unwrap(),
+        );
+        let retained = graph.retained(&source).unwrap();
+        let store = GraphVectorGenerationStoreV1::open(&retained).await.unwrap();
+        let (plan, _, descriptor) =
+            prepared_generation(&source, "chunk.real-contention", 'f', &admitted_embedding());
+        store.configure_stage(descriptor).unwrap();
+        let handle = ExactSqlHandle::attach(&graph._writer.lock().unwrap(), &graph._readers)
+            .unwrap()
+            .with_write_authority(graph.write_authority.clone())
+            .unwrap();
+        let held = handle.begin_immediate().unwrap();
+        // Poll the contender first on the sole runtime worker. An inline SQL
+        // acquisition would block this worker until the 30-second idle lease,
+        // preventing the actual transaction holder below from committing.
+        let started = Instant::now();
+        let (outcome, (), bootstrap) = tokio::join!(biased;
+            store.begin_generation(plan, Arc::new(NeverCancelled)),
+            async {
+                held.commit_async().await.expect("the transaction holder can commit");
+            },
+            GraphVectorGenerationStoreV1::read_only(&retained),
+        );
+        assert!(
+            matches!(
+                outcome,
+                Ok(VectorGenerationBeginOutcomeV1::ReplayFromStart { .. })
+            ),
+            "{outcome:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "progress must not wait for the idle lease"
+        );
+        bootstrap.expect("concurrent bootstrap still responds");
+        retained.operation_task_owner().begin_shutdown();
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            retained.operation_task_owner().shutdown(),
+        )
+        .await
+        .expect("shutdown stays bounded")
+        .expect("owned operations settled");
+    }
+}

--- a/crates/tracedecay-application/src/store/vector_generations/graph_adapter/transitions.rs
+++ b/crates/tracedecay-application/src/store/vector_generations/graph_adapter/transitions.rs
@@ -1147,4 +1147,4 @@ impl GraphVectorGenerationStoreStateV1 {
 
 #[cfg(test)]
 #[path = "transitions/tests.rs"]
-mod tests;
+pub(super) mod tests;

--- a/crates/tracedecay-application/src/store/vector_generations/graph_adapter/transitions/tests.rs
+++ b/crates/tracedecay-application/src/store/vector_generations/graph_adapter/transitions/tests.rs
@@ -1001,7 +1001,8 @@ impl VerifiedSemanticVectorGraphRuntimeV1 for PublicationAuthorityProbeRuntime {
     }
 }
 
-fn admitted_embedding() -> tracedecay_domain::AdmittedEmbeddingProjectionKeyV1 {
+pub(in crate::store::vector_generations::graph_adapter) fn admitted_embedding()
+-> tracedecay_domain::AdmittedEmbeddingProjectionKeyV1 {
     EmbeddingProjectionKeyV1 {
         model_artifact_digest: digest('1'),
         tokenizer_digest: digest('2'),
@@ -1030,7 +1031,7 @@ fn admitted_embedding() -> tracedecay_domain::AdmittedEmbeddingProjectionKeyV1 {
     .unwrap()
 }
 
-fn prepared_generation(
+pub(in crate::store::vector_generations::graph_adapter) fn prepared_generation(
     source: &tracedecay_domain::CodeGenerationId,
     chunk: &str,
     digest_byte: char,

--- a/crates/tracedecay-automation-runtime/src/automation/effect_runtime/settlement.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/effect_runtime/settlement.rs
@@ -58,6 +58,7 @@ impl BoundSettlement {
     }
 
     #[cfg(any(test, feature = "test-helpers"))]
+    #[must_use]
     pub fn with_test_hooks(
         mut self,
         phase_hook: Option<SettlementPhaseHook>,

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/query_runtime.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/query_runtime.rs
@@ -1006,7 +1006,7 @@ mod tests {
                     .expect("changed budget"),
                 (evaluated_profile.clone(), evaluated_diversity.clone()),
             );
-            evaluated_profile.retrieval_budget = profile.retrieval_budget.clone();
+            evaluated_profile.retrieval_budget = profile.retrieval_budget;
             evaluated_diversity.per_file = Some(1);
             assert_eq!(
                 super::canonical_query_policy(&evaluated_profile, &evaluated_diversity)

--- a/crates/tracedecay-contracts/src/remote/protocol.rs
+++ b/crates/tracedecay-contracts/src/remote/protocol.rs
@@ -4,6 +4,7 @@
 //! deliberately absent from these serializable payloads.
 
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tracedecay_domain::{
@@ -102,13 +103,12 @@ pub trait RemoteEnrollmentProtocolPortV1: Send + Sync {
 
 /// Validates canonical protocol metadata before delegating exactly once to the
 /// authenticated transport-neutral remote port.
-pub struct RemoteProtocolServiceV1<Port> {
-    port: Port,
+pub struct RemoteProtocolServiceV1<Port: ?Sized> {
+    port: Arc<Port>,
 }
 
-impl<Port> RemoteProtocolServiceV1<Port> {
-    #[hotpath::skip]
-    pub const fn new(port: Port) -> Self {
+impl<Port: ?Sized> RemoteProtocolServiceV1<Port> {
+    pub fn new(port: Arc<Port>) -> Self {
         Self { port }
     }
 
@@ -659,9 +659,9 @@ mod tests {
     #[test]
     fn generic_protocol_service_delegates_once_to_application_port() {
         let calls = Arc::new(AtomicUsize::new(0));
-        let service = RemoteProtocolServiceV1::new(FakeProtocolPort {
+        let service = RemoteProtocolServiceV1::new(Arc::new(FakeProtocolPort {
             calls: Arc::clone(&calls),
-        });
+        }));
         let request = RemoteProtocolRequestV1::new(
             RequestId::new("request.remote").unwrap(),
             BrainId::new("brain.remote").unwrap(),

--- a/crates/tracedecay-contracts/src/remote/protocol_owner.rs
+++ b/crates/tracedecay-contracts/src/remote/protocol_owner.rs
@@ -1,23 +1,11 @@
-//! One canonical owner for the complete authenticated Remote Brain protocol.
-//!
-//! The owner composes operation authorities without flattening them into a
-//! store-aware service or a generic untyped dispatcher. Each operation keeps
-//! its existing application port and exact output contract.
+//! Typed operation capabilities supplied to the Remote Brain HTTP router.
 
 use std::sync::Arc;
 
-use tracedecay_domain::EnrollmentCredentialRecordV1;
-
-use crate::ApplicationContractError;
-
 use super::{
-    auth::OpaqueRemoteCredential,
     capture::RemoteCaptureReceiptV1,
     capture_protocol::RemoteCaptureRequestV1,
-    protocol::{
-        EnrollmentRequestV1, RemoteEnrollmentProtocolPortV1, RemoteProtocolPortV1,
-        RemoteProtocolRequestV1, RemoteProtocolResponseV1,
-    },
+    protocol::RemoteProtocolPortV1,
     query::{RemoteQueryRequestV1, RemoteQueryResultV1},
     recovery::{
         BackupOperationStateV1, BackupRequestV1, PromotionCasReceiptV1, PromotionConfirmationV1,
@@ -53,76 +41,3 @@ pub struct RemoteOperationProtocolPortsV1 {
     pub restore: Arc<RemoteRestoreProtocolOwnerPortV1>,
     pub promotion: Arc<RemotePromotionProtocolOwnerPortV1>,
 }
-
-pub struct RemoteProtocolOwnerV1 {
-    enrollment: Arc<dyn RemoteEnrollmentProtocolPortV1>,
-    operations: RemoteOperationProtocolPortsV1,
-}
-
-impl RemoteProtocolOwnerV1 {
-    pub fn new(
-        enrollment: Arc<dyn RemoteEnrollmentProtocolPortV1>,
-        operations: RemoteOperationProtocolPortsV1,
-    ) -> Self {
-        Self {
-            enrollment,
-            operations,
-        }
-    }
-}
-
-impl RemoteEnrollmentProtocolPortV1 for RemoteProtocolOwnerV1 {
-    fn execute_enrollment(
-        &self,
-        request: RemoteProtocolRequestV1<EnrollmentRequestV1>,
-        grant_credential: OpaqueRemoteCredential,
-        enrollment_credential: OpaqueRemoteCredential,
-    ) -> Result<RemoteProtocolResponseV1<EnrollmentCredentialRecordV1>, ApplicationContractError>
-    {
-        self.enrollment
-            .execute_enrollment(request, grant_credential, enrollment_credential)
-    }
-}
-
-macro_rules! delegate_remote_operation {
-    ($request:ty, $output:ty, $field:ident) => {
-        impl RemoteProtocolPortV1<$request> for RemoteProtocolOwnerV1 {
-            type Output = $output;
-
-            fn execute(
-                &self,
-                request: RemoteProtocolRequestV1<$request>,
-                credential: OpaqueRemoteCredential,
-            ) -> Result<RemoteProtocolResponseV1<Self::Output>, ApplicationContractError> {
-                self.operations.$field.execute(request, credential)
-            }
-
-            fn execute_controlled(
-                &self,
-                request: RemoteProtocolRequestV1<$request>,
-                credential: OpaqueRemoteCredential,
-                control: crate::remote::protocol::RemoteProtocolExecutionControlV1,
-            ) -> Result<RemoteProtocolResponseV1<Self::Output>, ApplicationContractError> {
-                self.operations
-                    .$field
-                    .execute_controlled(request, credential, control)
-            }
-        }
-    };
-}
-
-delegate_remote_operation!(RemoteCaptureRequestV1, RemoteCaptureReceiptV1, capture);
-delegate_remote_operation!(RemoteReplayRequestV1, RemoteReplayOutcomeV1, replay);
-delegate_remote_operation!(
-    RemoteFrameTransferRequestV1,
-    RemoteFrameTransferReceiptV1,
-    frame_transfer
-);
-delegate_remote_operation!(RemoteQueryRequestV1, RemoteQueryResultV1, query);
-delegate_remote_operation!(BackupRequestV1, BackupOperationStateV1, backup);
-delegate_remote_operation!(
-    StagedRestoreConfirmationV1,
-    StagedRestoreProgressV1,
-    restore
-);
-delegate_remote_operation!(PromotionConfirmationV1, PromotionCasReceiptV1, promotion);

--- a/crates/tracedecay-daemon-service/src/remote_http_transport.rs
+++ b/crates/tracedecay-daemon-service/src/remote_http_transport.rs
@@ -124,7 +124,9 @@ impl RemoteBrainTlsListener {
         router: Router,
         mut shutdown_requested: oneshot::Receiver<()>,
     ) -> Result<()> {
-        let router = router.layer(middleware::from_fn(force_remote_connection_close));
+        let router = crate::application_surface::with_hotpath_server_layer(
+            router.layer(middleware::from_fn(force_remote_connection_close)),
+        );
         let graceful = CancellationToken::new();
         let mut connections = JoinSet::new();
         loop {

--- a/crates/tracedecay/src/daemon/http_application.rs
+++ b/crates/tracedecay/src/daemon/http_application.rs
@@ -737,10 +737,7 @@ impl DaemonHttpApplicationService {
                 Some(RemoteBrainTlsServer {
                     listener,
                     endpoint,
-                    router:
-                        tracedecay_daemon_service::application_surface::with_hotpath_server_layer(
-                            Router::new().nest("/remote", router),
-                        ),
+                    router: Router::new().nest("/remote", router),
                     #[cfg(test)]
                     admission,
                     credentials,

--- a/crates/tracedecay/src/daemon/invocation_dispatch.rs
+++ b/crates/tracedecay/src/daemon/invocation_dispatch.rs
@@ -231,6 +231,10 @@ pub(super) fn invalid_multi_root_invocation_response(
 }
 
 #[cfg(any(not(unix), test))]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Portable transport composes separately owned lifecycle, route admission and HTTP owners; the extra argument is a test probe."
+)]
 pub(super) async fn execute_portable_daemon_invocation(
     lifecycle: DaemonLifecycle,
     store_administration: StoreAdministration,

--- a/crates/tracedecay/src/daemon/invocation_state.rs
+++ b/crates/tracedecay/src/daemon/invocation_state.rs
@@ -480,6 +480,10 @@ impl DaemonInvocationState {
     }
 
     #[hotpath::measure(label = "daemon.invocation_state.code_index_mount", future = true)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Mount composition binds project identity, store, semantic lifetime and graph publication owners explicitly."
+    )]
     pub(super) async fn mount_code_index(
         &self,
         project_id: tracedecay_domain::ProjectId,

--- a/crates/tracedecay/src/daemon/invocation_tests/project_lifecycle_tests.rs
+++ b/crates/tracedecay/src/daemon/invocation_tests/project_lifecycle_tests.rs
@@ -33,6 +33,10 @@ fn recovery_deadline() -> Deadline {
     Deadline::new(UtcMicros(i64::MAX)).expect("LSP deadline")
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The fixture varies profile, project, request identity and disconnect independently to test lifecycle isolation."
+)]
 async fn open_detached_session(
     service: &DaemonInvocationService,
     registry: &Arc<Mutex<LspSessionRegistry>>,

--- a/crates/tracedecay/src/daemon/maintenance.rs
+++ b/crates/tracedecay/src/daemon/maintenance.rs
@@ -1720,6 +1720,10 @@ impl MaintenanceCoordinator {
     }
 
     #[hotpath::skip]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "The task retains independently owned profile, stores, schedulers and cadence for its full cancellation lifetime."
+    )]
     async fn run(
         &self,
         profile_root: PathBuf,
@@ -1745,6 +1749,10 @@ impl MaintenanceCoordinator {
     }
 
     #[hotpath::measure(label = "daemon.maintenance.tick", future = true)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "A tick borrows independently owned stores and policy while retaining the continuation cursor."
+    )]
     async fn run_tick(
         &self,
         profile_root: &Path,

--- a/crates/tracedecay/src/daemon/project_composition.rs
+++ b/crates/tracedecay/src/daemon/project_composition.rs
@@ -258,6 +258,10 @@ struct ProjectOpenInputs<'a> {
 /// wrapper (and every instrumented caller) a few words wide instead of
 /// inlining the whole open.
 #[hotpath::measure(label = "daemon.project.compose.server", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "This composition entry binds route admission, store lifetime, invocation and HTTP owners before publishing a server."
+)]
 pub(super) async fn production_project_server(
     store_administration: &StoreAdministration,
     project_open_gates: &tokio::sync::Mutex<ProjectOpenGates>,

--- a/crates/tracedecay/src/daemon/project_open_orchestration.rs
+++ b/crates/tracedecay/src/daemon/project_open_orchestration.rs
@@ -379,6 +379,10 @@ async fn begin_portable_project_open(
 
 #[cfg(any(not(unix), test))]
 #[hotpath::measure(label = "daemon.project.orchestrate.warmup", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Warmup retains the independent daemon owners across the background handoff; the extra argument is a test probe."
+)]
 pub(super) async fn schedule_portable_project_server_warmup(
     lifecycle: DaemonLifecycle,
     store_administration: StoreAdministration,
@@ -424,6 +428,10 @@ pub(super) async fn schedule_portable_project_server_warmup(
 
 #[cfg(any(not(unix), test))]
 #[hotpath::measure(label = "daemon.project.orchestrate.request", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Foreground admission borrows the handshake while retaining independent daemon owners; the extra argument is a test probe."
+)]
 pub(super) async fn portable_project_server_for_request(
     lifecycle: DaemonLifecycle,
     store_administration: StoreAdministration,

--- a/crates/tracedecay/src/daemon/project_open_owners.rs
+++ b/crates/tracedecay/src/daemon/project_open_owners.rs
@@ -1232,6 +1232,10 @@ pub(super) async fn install_semantic_activation_runtime_owner(
 }
 
 #[hotpath::measure(label = "daemon.project.activate.lsp", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Composition supplies distinct capability, database, analyzer and diagnostic owners without merging their authority."
+)]
 async fn register_production_lsp_owner(
     invocation: &DaemonInvocationState,
     project_root: &Path,

--- a/crates/tracedecay/src/daemon/query_authority_provider_activation_tests.rs
+++ b/crates/tracedecay/src/daemon/query_authority_provider_activation_tests.rs
@@ -1196,6 +1196,10 @@ async fn project_cursor_authority_resumes_prepared_and_fusion_after_reopen() {
 /// Install one committed semantic route through the exact production path:
 /// reserve the epoch fence, prepare the query authority, bind the semantic
 /// authority to the committed activation, and install both as one pair.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The fixture independently varies scope, privacy, cursor keys and committed state to exercise authority rejection."
+)]
 async fn install_committed_semantic_route(
     registry: &tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerRegistryV1,
     provider: &DaemonQueryAuthorityProviderV1,

--- a/crates/tracedecay/src/daemon/remote_protocol.rs
+++ b/crates/tracedecay/src/daemon/remote_protocol.rs
@@ -27,9 +27,7 @@ use tracedecay_contracts::remote::protocol::{
     remote_enrollment_result_contract_v1, remote_protocol_problem,
     remote_replay_result_contract_v1,
 };
-use tracedecay_contracts::remote::protocol_owner::{
-    RemoteOperationProtocolPortsV1, RemoteProtocolOwnerV1,
-};
+use tracedecay_contracts::remote::protocol_owner::RemoteOperationProtocolPortsV1;
 use tracedecay_contracts::remote::recovery::{
     BackupOperationStateV1, BackupRequestV1, PromotionCasReceiptV1, PromotionConfirmationV1,
     RemoteRecoveryControlPortV1, RemoteRecoveryInterruptionV1, RemoteRecoveryProtocolOwnerV1,
@@ -668,36 +666,35 @@ pub(crate) fn build_daemon_remote_protocol_router(
         restore_contract: remote_result_contract("remote.restore.result")?,
         promotion_contract: remote_result_contract("remote.promotion.result")?,
     });
-    let owner = RemoteProtocolOwnerV1::new(
-        Arc::new(DaemonRemoteEnrollmentProtocolPortV1 {
+    let enrollment = Arc::new(DaemonRemoteEnrollmentProtocolPortV1 {
+        credentials: Arc::clone(&credentials),
+    });
+    let operations = RemoteOperationProtocolPortsV1 {
+        capture: Arc::new(DaemonRemoteCaptureProtocolPortV1 {
             credentials: Arc::clone(&credentials),
         }),
-        RemoteOperationProtocolPortsV1 {
-            capture: Arc::new(DaemonRemoteCaptureProtocolPortV1 {
-                credentials: Arc::clone(&credentials),
-            }),
-            replay: Arc::new(DaemonRemoteReplayProtocolPortV1 {
-                credentials: Arc::clone(&credentials),
-                transaction: Arc::clone(&transaction),
-            }),
-            frame_transfer: Arc::new(DaemonRemoteFrameTransferProtocolPortV1 {
-                credentials: Arc::clone(&credentials),
-            }),
-            query: Arc::new(observability::DaemonRemoteQueryProtocolPortV1::new(
-                Arc::clone(&credentials),
-                transaction,
-                invocation,
-            )),
-            backup: recovery.clone(),
-            restore: recovery.clone(),
-            promotion: recovery,
-        },
-    );
+        replay: Arc::new(DaemonRemoteReplayProtocolPortV1 {
+            credentials: Arc::clone(&credentials),
+            transaction: Arc::clone(&transaction),
+        }),
+        frame_transfer: Arc::new(DaemonRemoteFrameTransferProtocolPortV1 {
+            credentials: Arc::clone(&credentials),
+        }),
+        query: Arc::new(observability::DaemonRemoteQueryProtocolPortV1::new(
+            Arc::clone(&credentials),
+            transaction,
+            invocation,
+        )),
+        backup: recovery.clone(),
+        restore: recovery.clone(),
+        promotion: recovery,
+    };
     let admission = Arc::new(RemoteCredentialAdmissionServiceV1::new(
         DaemonRemoteCredentialLookupV1::new(credentials),
     ));
     Ok(tracedecay_api::remote::remote_protocol_router(
-        owner,
+        enrollment,
+        operations,
         admission,
         tracedecay_contracts::clock::now_micros,
     ))

--- a/crates/tracedecay/src/daemon/retained_owner/lcm/retrieval.rs
+++ b/crates/tracedecay/src/daemon/retained_owner/lcm/retrieval.rs
@@ -557,6 +557,10 @@ fn clamped_text(
     Ok((clamped, truncated))
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Maps independent retained request filters into the canonical temporal query; no additional request authority is introduced."
+)]
 fn retrieval_query(
     session_id: &SessionId,
     provider: Option<&str>,

--- a/crates/tracedecay/src/daemon/scheduler.rs
+++ b/crates/tracedecay/src/daemon/scheduler.rs
@@ -153,6 +153,10 @@ fn scheduler_run_observer(
 }
 
 #[hotpath::measure(label = "daemon.scheduler.settle_retained_automation", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Settlement composes the retained run, effect guard, cancellation and project observer without transferring their authorities."
+)]
 async fn settle_scheduler_retained_automation<T, P>(
     engine: &DaemonEngine,
     project_id: &tracedecay_domain::ProjectId,
@@ -1106,6 +1110,10 @@ fn boxed_host_receipt_review<'a>(
     ))
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The task owns its wake, generation and completion tokens until scheduler exit is committed."
+)]
 async fn run_automation_scheduler_loop(
     project_path: PathBuf,
     handshake: DaemonHandshake,
@@ -1996,6 +2004,10 @@ async fn automation_scheduler_has_work(
 /// Ticks every schedulable user-defined job with the same lock/cooldown
 /// discipline as the fixed tasks (enforced inside the job runner).
 #[hotpath::measure(label = "daemon.scheduler.user_jobs_pass", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Job dispatch binds retained project memory and pinned configuration to the admitted backend and shared error result."
+)]
 async fn run_user_jobs_scheduler_pass(
     engine: &DaemonEngine,
     run_control: &AutomationRunControl,

--- a/crates/tracedecay/src/daemon/scheduler/effect_admission.rs
+++ b/crates/tracedecay/src/daemon/scheduler/effect_admission.rs
@@ -100,6 +100,10 @@ async fn fixed_task_schedule_decision(
 }
 
 #[hotpath::measure(label = "daemon.scheduler.automation_effect", future = true)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Admission binds the engine, retained memory, cancellation and pinned configuration before creating an effect."
+)]
 pub(super) async fn scheduler_automation_effect(
     engine: &DaemonEngine,
     memory: &crate::tracedecay::TraceDecay,
@@ -246,6 +250,10 @@ pub(super) fn synchronize_scheduler_effect_control(run_control: &AutomationRunCo
     run_control.read_control().interrupted();
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Settlement keeps the effect and runner guard alive together while recording the exact project and task outcome."
+)]
 pub(super) async fn abandon_reused_scheduler_skip(
     engine: &DaemonEngine,
     project_id: &tracedecay_domain::ProjectId,

--- a/crates/tracedecay/src/host_admission/session_test_support.rs
+++ b/crates/tracedecay/src/host_admission/session_test_support.rs
@@ -279,6 +279,10 @@ impl HostAdmissionTestRuntimeV1 {
     }
 
     #[doc(hidden)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "The test boundary varies provider, project, Git and message filters independently to verify isolation."
+    )]
     pub async fn search_session_messages_git_scoped_for_test(
         &self,
         scope: HostAdmissionScope,

--- a/crates/tracedecay/src/lib.rs
+++ b/crates/tracedecay/src/lib.rs
@@ -20,7 +20,6 @@
 #![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![allow(clippy::unused_self)]
-#![allow(clippy::too_many_arguments)]
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::struct_field_names)]
 #![allow(clippy::match_same_arms)]

--- a/crates/tracedecay/src/mcp/server/requests.rs
+++ b/crates/tracedecay/src/mcp/server/requests.rs
@@ -1313,10 +1313,12 @@ impl McpServer {
         analytics_arguments: Value,
         analytics_session_id: Option<String>,
         dispatch: DispatchedToolCall,
-        connection_client_name: Option<&str>,
-        connection_instance_id: Option<&str>,
-        connection_notifications: &std::sync::Mutex<Vec<Value>>,
+        connection_server: &Self,
     ) -> JsonRpcResponse {
+        let client_name = connection_server.client_name();
+        let connection_client_name = client_name.as_deref();
+        let connection_instance_id = connection_server.connection_identity.instance_id();
+        let connection_notifications = &connection_server.pending_notifications;
         let DispatchedToolCall {
             cg,
             selected_owner,
@@ -1712,8 +1714,6 @@ impl McpServer {
         if fast_unavailable {
             return Self::finish_unavailable_tool_call(id, &tool_name, dispatch);
         }
-        let connection_client_name = self.client_name();
-        let connection_instance_id = self.connection_identity.instance_id();
         let response = dispatch_server
             .complete_tool_call(
                 id.clone(),
@@ -1721,9 +1721,7 @@ impl McpServer {
                 analytics_arguments,
                 analytics_session_id,
                 dispatch,
-                connection_client_name.as_deref(),
-                connection_instance_id,
-                &self.pending_notifications,
+                self,
             )
             .await;
         if let Some(response) = dispatch_server.project_server_revoked_response(&id, &tool_name) {

--- a/crates/tracedecay/src/mcp/tools/handlers/admin_cli.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/admin_cli.rs
@@ -97,6 +97,10 @@ struct AdminCliContext<'a> {
 }
 
 impl<'a> AdminCliContext<'a> {
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Binds independently admitted project, profile, session, and request authorities at the CLI composition boundary"
+    )]
     fn with_project(
         cg: &'a TraceDecay,
         global_db: &'a RegisteredGlobalDbLeaseV1,
@@ -219,6 +223,10 @@ impl<'a> AdminCliContext<'a> {
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "CLI dispatch carries independently admitted store and sync authorities plus protocol request identity and controls"
+)]
 pub(super) async fn handle_admin_cli(
     cg: &TraceDecay,
     args: Value,

--- a/crates/tracedecay/src/mcp/tools/handlers/application_surface.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/application_surface.rs
@@ -106,8 +106,7 @@ pub(super) async fn handle_application_surface(
     executor: Option<&dyn DaemonInvocationExecutor>,
     target: InvocationTarget,
     protocol_request_id: Option<RequestId>,
-    protocol_deadline: Option<Deadline>,
-    protocol_cancellation: Option<CancellationSignal>,
+    request_controls: tracedecay_mcp::RequestControls<'_>,
 ) -> Result<tracedecay_mcp::ToolResult> {
     let ApplicationToolRequest {
         request: request_args,
@@ -135,8 +134,8 @@ pub(super) async fn handle_application_surface(
     let controls = complete_protocol_controls(
         operation,
         &request_id,
-        protocol_deadline,
-        protocol_cancellation,
+        request_controls.deadline.cloned(),
+        request_controls.cancellation.cloned(),
     )?;
     let result = match controls {
         Some((deadline, cancellation)) => {

--- a/crates/tracedecay/src/mcp/tools/handlers/dashboard.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/dashboard.rs
@@ -649,6 +649,10 @@ fn dashboard_tool_result(cg: &TraceDecay, args: &Value, payload: &Value) -> Tool
 }
 
 #[hotpath::measure(label = "mcp.dashboard.open.total")]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Dashboard mounting composes independently optional provider authorities; their absence must remain explicit"
+)]
 pub(super) async fn handle_dashboard(
     cg: &TraceDecay,
     args: Value,

--- a/crates/tracedecay/src/mcp/tools/handlers/dispatch_groups.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/dispatch_groups.rs
@@ -505,8 +505,6 @@ fn dispatch_graph_tools_inner<'a>(
                     admitted_graph_query(cg, &options, "code_symbol_search"),
                     args,
                     selected_scope_prefix,
-                    options.code_index_search_executor.as_ref(),
-                    options.code_index_search_authority.as_ref(),
                     options.code_index_ignored_dependency_admission.as_deref(),
                     options.code_index_freshness_reader.as_ref(),
                     &admitted_tool_context(cg, &options)?,
@@ -542,8 +540,6 @@ fn dispatch_graph_tools_inner<'a>(
                     admitted_graph_query(cg, &options, "context"),
                     args,
                     selected_scope_prefix,
-                    options.code_index_search_executor.as_ref(),
-                    options.code_index_search_authority.as_ref(),
                     options.code_index_freshness_reader.as_ref(),
                     &admitted_tool_context(cg, &options)?,
                 )
@@ -882,8 +878,10 @@ fn dispatch_application_surface_tools_inner<'a>(
             options.application_invocation_executor,
             options.application_invocation_target,
             options.application_request_id.clone(),
-            options.application_deadline.clone(),
-            options.application_cancellation.clone(),
+            RequestControls {
+                deadline: options.application_deadline.as_ref(),
+                cancellation: options.application_cancellation.as_ref(),
+            },
         )
         .await
     })

--- a/crates/tracedecay/src/mcp/tools/handlers/graph.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/graph.rs
@@ -229,8 +229,6 @@ pub(super) async fn handle_search<F>(
     graph: F,
     args: Value,
     scope_prefix: Option<&str>,
-    search_executor: Option<&crate::mcp::server::CodeIndexSearchExecutor>,
-    search_authority: Option<&crate::mcp::server::CodeIndexSearchAuthorityV1>,
     ignored_dependency_admission: Option<
         &dyn tracedecay_application::code_index::CodeIndexIgnoredDependencyAdmissionPortV1,
     >,
@@ -240,6 +238,8 @@ pub(super) async fn handle_search<F>(
 where
     F: Future<Output = Result<tracedecay_graph_query::VerifiedGraphQuery>>,
 {
+    let search_executor = ctx.code_index_search_executor();
+    let search_authority = ctx.code_index_search_authority();
     let deadline = ctx.deadline().cloned();
     let cancellation = ctx.cancellation().cloned();
     let query =
@@ -789,14 +789,14 @@ pub(super) async fn handle_context<F>(
     graph: F,
     args: Value,
     scope_prefix: Option<&str>,
-    search_executor: Option<&crate::mcp::server::CodeIndexSearchExecutor>,
-    search_authority: Option<&crate::mcp::server::CodeIndexSearchAuthorityV1>,
     freshness_reader: Option<&CodeIndexFreshnessReader>,
     ctx: &McpToolContext<'_>,
 ) -> Result<ToolResult>
 where
     F: Future<Output = Result<tracedecay_graph_query::VerifiedGraphQuery>>,
 {
+    let search_executor = ctx.code_index_search_executor();
+    let search_authority = ctx.code_index_search_authority();
     let deadline = ctx.deadline().cloned();
     let cancellation = ctx.cancellation().cloned();
     let request: ContextSurfaceRequestV1 = decode_primitive_request(&args, "tracedecay_context")?;

--- a/crates/tracedecay/src/mcp/tools/handlers/info/status.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/info/status.rs
@@ -214,6 +214,10 @@ pub(crate) async fn graph_statistics_value(
 }
 
 #[hotpath::measure(label = "mcp.info.status.total")]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Status combines independent index, session, generation, and daemon readers without making any one reader authoritative for another"
+)]
 pub(crate) async fn handle_status(
     cg: &TraceDecay,
     args: Value,

--- a/crates/tracedecay/src/mcp/tools/handlers/redundancy.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/redundancy.rs
@@ -157,6 +157,10 @@ mod tests {
     use super::{RedundancyOptions, RedundancyScanV1, redundancy_md};
     use tracedecay_graph_query::redundancy_scan::{RedundancyNodeViewV1, RedundancyPairViewV1};
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Fixture varies both node identities, locations, body sizes, and ranking independently"
+    )]
     fn test_pair(
         id_a: &str,
         name_a: &str,

--- a/crates/tracedecay/src/mcp/tools/handlers/workflow.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/workflow.rs
@@ -714,13 +714,11 @@ where
     let body = hotpath::measure_block!(
         "mcp.workflow.affected_tests.assemble",
         run_affected_tests_body(
-            output.exit_code,
+            &output,
             &results,
             &test_names,
             truncated,
             &selected_targets,
-            &output.stderr,
-            &output.stdout,
             managed_test_terminal(&emitter, &receipt)
         )
     );
@@ -1184,20 +1182,18 @@ fn missing_requested_test<'a>(
 }
 
 fn run_affected_tests_body(
-    exit_code: Option<i32>,
+    output: &tracedecay_mcp::TestRunOutput,
     results: &[(String, bool)],
     test_names: &[String],
     truncated: bool,
     selected_targets: &[TestTarget],
-    stderr: &str,
-    stdout: &str,
     terminal: Value,
 ) -> Value {
     let passed = results.iter().filter(|(_, ok)| *ok).count();
     let failed = results.iter().filter(|(_, ok)| !*ok).count();
 
     json!({
-        "exit_code": exit_code,
+        "exit_code": output.exit_code,
         "passed": passed,
         "failed": failed,
         "total_observed": results.len(),
@@ -1213,8 +1209,8 @@ fn run_affected_tests_body(
                 })
             })
             .collect::<Vec<_>>(),
-        "stderr_tail": tail(stderr, 2000),
-        "stdout_tail": tail(stdout, 2000),
+        "stderr_tail": tail(&output.stderr, 2000),
+        "stdout_tail": tail(&output.stdout, 2000),
         "terminal": terminal,
     })
 }

--- a/crates/tracedecay/src/mcp/tools/handlers/workflow/affected_test_failure.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/workflow/affected_test_failure.rs
@@ -14,6 +14,10 @@ use super::{
 use tracedecay_mcp::{TestRunFailure, TestRunOutput, ToolResult};
 
 #[hotpath::measure(future = true, label = "mcp.workflow.affected_tests.failure")]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Failure settlement retains the admitted emitter and deadline alongside the exact dispatched target set and observed failure"
+)]
 pub(super) async fn terminal_failure(
     emitter: &OperationEmitter,
     args: &Value,
@@ -126,13 +130,11 @@ pub(super) async fn terminal_failure(
     });
     let body = hotpath::measure_block!("mcp.workflow.affected_tests.assemble", {
         let mut body = run_affected_tests_body(
-            partial.exit_code.or(failure_exit_code),
+            &partial,
             &results,
             test_names,
             truncated,
             selected_targets,
-            &partial.stderr,
-            &partial.stdout,
             managed_test_terminal(emitter, &receipt),
         );
         body["error"] = json!({

--- a/crates/tracedecay/src/tracedecay/lifecycle/branches.rs
+++ b/crates/tracedecay/src/tracedecay/lifecycle/branches.rs
@@ -196,6 +196,10 @@ impl TraceDecay {
     }
 
     #[hotpath::skip]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "Branch opening keeps configuration and profile leases distinct from graph access mode and read-only policy."
+    )]
     async fn open_branch_with_registered_configuration_access(
         project_root: &Path,
         branch_name: &str,


### PR DESCRIPTION
The composition root now reuses admitted MCP owners instead of passing their fields separately, and enables `too_many_arguments` with reasoned item-level exceptions at actual composition boundaries. Remote HTTP routes mount canonical operation ports directly, removing the forwarding owner while retaining transport admission and cancellation behavior.

This follow-up also preserves the original HTTPS measurement middleware order and adds a regression using a real contended SQLite writer during semantic bootstrap and shutdown. Integration Clippy findings are fixed at their declarations.

Validation: 52 MCP tests, 9 API tests plus 1 contract test, 33 mounted HTTP/TLS tests, and real writer-contention tests passed (including a 25% CPU quota run). Both Hotpath root test-compilation gates and workspace Hotpath Clippy passed on the transport candidate. Final combined root all-target Clippy with `test-helpers` passed with zero errors and warnings (`cc-12740`, commit `dce72a7a1`).

Partial progress on #1086, #1088, #1073 and #913; these remain open for their remaining acceptance criteria. Targets the head branch of draft #707, not master.
