### PR TITLE
style(code-index-runtime): drop format_collect in teardown fixture

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -10963,9 +10963,10 @@ async fn shutdown_releases_indexed_generation_and_scheduler_owners() {
     let _measurement = hotpath::HotpathGuardBuilder::new("indexed-registry-shutdown").build();
     let sources = (0..128)
         .map(|file| {
-            let source = (0..16)
-                .map(|symbol| format!("pub fn item_{file}_{symbol}() -> u32 {{ {symbol} }}\n"))
-                .collect::<String>();
+            let source = (0..16).fold(String::new(), |mut source, symbol| {
+                let _ = writeln!(source, "pub fn item_{file}_{symbol}() -> u32 {{ {symbol} }}");
+                source
+            });
             (format!("src/module_{file}.rs"), source)
         })
         .collect::<Vec<_>>();

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -10964,7 +10964,10 @@ async fn shutdown_releases_indexed_generation_and_scheduler_owners() {
     let sources = (0..128)
         .map(|file| {
             let source = (0..16).fold(String::new(), |mut source, symbol| {
-                let _ = writeln!(source, "pub fn item_{file}_{symbol}() -> u32 {{ {symbol} }}");
+                let _ = writeln!(
+                    source,
+                    "pub fn item_{file}_{symbol}() -> u32 {{ {symbol} }}"
+                );
                 source
             });
             (format!("src/module_{file}.rs"), source)


### PR DESCRIPTION
The #707 tip (`cc243d6e9`) fails the CI Clippy job (`cargo clippy --workspace --all-targets --locked -- -D warnings`): `clippy::format_collect` at `crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs:10966`, introduced by `ce84a4da8 perf(code-index): measure scheduler teardown ownership costs`. The tip's own CI has been cancelled by back-to-back merges all day, so this never surfaced on the branch.

Fix: build the fixture source with `fold` + `writeln!` (the `std::fmt::Write` import already exists). Test-only; no behavior change.

Local `cargo clippy --workspace --all-targets --no-deps -- -D warnings` on the tip: red before, green after (4m41s, no other errors behind it).