### PR TITLE
fix(tracedecay): ship the bench harness unconditionally

### DIFF
--- a/crates/tracedecay-cli/Cargo.toml
+++ b/crates/tracedecay-cli/Cargo.toml
@@ -71,7 +71,7 @@ hotpath-cpu = [
     "hotpath/hotpath-cpu",
 ]
 hotpath-mcp = ["hotpath", "hotpath/hotpath-mcp"]
-production = ["tracedecay/production", "tracedecay/bench"]
+production = ["tracedecay/production"]
 # Opt-in tiered graph storage; not part of `production`.
 graph-disk-tier = ["tracedecay/graph-disk-tier"]
 graph-tiered-storage = ["tracedecay/graph-tiered-storage"]

--- a/crates/tracedecay/Cargo.toml
+++ b/crates/tracedecay/Cargo.toml
@@ -198,11 +198,6 @@ lang-fsharp = ["tracedecay-code-index/lang-fsharp"]
 lang-quint = ["tracedecay-code-index/lang-quint"]
 lang-toml = ["tracedecay-code-index/lang-toml"]
 lang-lean = ["tracedecay-code-index/lang-lean"]
-# Shipped `tracedecay bench` / MCP `admin_project` action `bench`. Off the
-# default library graph; `tracedecay-cli`'s `production` feature selects it
-# so the command stays in the binary without compiling this module into
-# `cargo check -p tracedecay --lib`.
-bench = []
 
 # Integration fixture surface. `HostAdmissionTestRuntimeV1` and the registered
 # database scaffolding it owns are assembled by the composition root, so they

--- a/crates/tracedecay/src/bench.rs
+++ b/crates/tracedecay/src/bench.rs
@@ -59,8 +59,7 @@ impl Default for BenchOptions {
 
 /// The embedded default query set. Compiled into the binary so `tracedecay bench`
 /// works without any external file dependency.
-pub const DEFAULT_QUERIES_TOML: &str =
-    include_str!("../../../../benchmark_data/queries/default.toml");
+pub const DEFAULT_QUERIES_TOML: &str = include_str!("../../../benchmark_data/queries/default.toml");
 
 /// Run the bench from a TOML query file on disk.
 pub fn run_bench(cg: &TraceDecay, queries_path: &Path, opts: BenchOptions) -> Result<BenchReport> {

--- a/crates/tracedecay/src/lib.rs
+++ b/crates/tracedecay/src/lib.rs
@@ -33,11 +33,6 @@
 #![allow(clippy::missing_fields_in_debug)]
 #![allow(clippy::single_match_else)]
 
-// Query-bench implementation for `tracedecay bench` / MCP `admin_project`
-// action `bench`. Kept off the default library graph; the CLI production
-// feature selects `bench` so the shipped command still compiles.
-#[cfg(any(test, feature = "bench", feature = "test-helpers"))]
-#[path = "../benches/query_bench/harness.rs"]
 pub mod bench;
 // Fixture surface for integration tests, assembled by the composition root.
 // Gated so a default or `production` build carries none of it.

--- a/crates/tracedecay/src/mcp/tools/handlers/admin_project.rs
+++ b/crates/tracedecay/src/mcp/tools/handlers/admin_project.rs
@@ -218,35 +218,22 @@ pub(super) async fn handle_admin_project(
             json,
             max_nodes,
         } => {
-            #[cfg(any(test, feature = "bench", feature = "test-helpers"))]
-            {
-                let report = crate::bench::run_bench_with_toml(
-                    cg,
-                    queries_toml
-                        .as_deref()
-                        .unwrap_or(crate::bench::DEFAULT_QUERIES_TOML),
-                    crate::bench::BenchOptions {
-                        format: crate::bench::OutputFormat::Json,
-                        max_nodes,
-                    },
-                )?;
-                let output = if json {
-                    crate::bench::format_report_json(&report)
-                } else {
-                    crate::bench::format_report_console(&report)
-                };
-                json!({ "output": output })
-            }
-            #[cfg(not(any(test, feature = "bench", feature = "test-helpers")))]
-            {
-                let _ = (queries_toml, json, max_nodes);
-                return Err(TraceDecayError::ProjectRoute {
-                    reason_code: "verified-code-context-benchmark-unavailable".to_owned(),
-                    retryable: false,
-                    detail: "the benchmark is not yet mounted on an admitted code-graph authority"
-                        .to_owned(),
-                });
-            }
+            let report = crate::bench::run_bench_with_toml(
+                cg,
+                queries_toml
+                    .as_deref()
+                    .unwrap_or(crate::bench::DEFAULT_QUERIES_TOML),
+                crate::bench::BenchOptions {
+                    format: crate::bench::OutputFormat::Json,
+                    max_nodes,
+                },
+            )?;
+            let output = if json {
+                crate::bench::format_report_json(&report)
+            } else {
+                crate::bench::format_report_console(&report)
+            };
+            json!({ "output": output })
         }
         AdminProjectAction::AutomaticFactReceiptList { state, limit } => {
             let db = cg.open_project_store_db()?;


### PR DESCRIPTION
Fixes a defect introduced by #1176 (`keep bench and test runtimes off lib`), found in independent review.

`tracedecay bench` (CLI subcommand and MCP `admin_project` `bench` action) is shipped product behavior, so its harness returns to `crates/tracedecay/src/bench.rs` unconditionally. The `bench` feature is deleted from `tracedecay` and from `tracedecay-cli`'s `production` list; the criterion benches under `benches/` depend on `tracedecay::bench` instead of the library `#[path]`-including a file from `benches/`.

Why: the feature only achieved that `cargo check -p tracedecay --lib` skipped the module (the CLI's default `production` compiled it anyway), while `cargo build -p tracedecay-cli --no-default-features` shipped a daemon whose feature-off arm returned reason code `verified-code-context-benchmark-unavailable` with the detail "the benchmark is not yet mounted on an admitted code-graph authority" — the same code the harness uses for the genuine unmounted-graph refusal (`tests/graph_suite/bench_test.rs:46`), with a false cause. That arm is deleted; the code now has exactly one production site.

Harness body is byte-identical to the moved copy apart from the `include_str!` depth. No `feature = "bench"` remains anywhere; the `test-helpers`-gated `session_temporal_benchmark` `#[path]` and the `rmcp-benchmark` gate are untouched (they gate non-shipped surfaces truthfully).

Verification: `cargo check -p tracedecay --lib` (bench compiled, no cfg); `cargo build -p tracedecay-cli --no-default-features` exposes `tracedecay bench --help`; `graph_suite bench_test` 1/1; daemon_suite admin_project 2/2; `cargo bench -p tracedecay --no-run`; clippy `-D warnings` before and after merging #707; fmt; commitlint. Reviewed READY by an independent Opus pass.