### PR TITLE
fix(automation): recheck cancellation before journal reservation

### DIFF
--- a/crates/tracedecay-automation-runtime/src/automation/effect_runtime.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/effect_runtime.rs
@@ -32,6 +32,7 @@ pub use settlement::{
     DeferredSettledOutcome, DeferredSettlementOutcome, DeferredSettlementPairSubmission,
     DeferredSettlementRequest, RetainedAutomationSettlementOutcome,
     RetainedAutomationSettlementProjection, RetainedSettlementPairWaiter, RetainedSettlementWaiter,
-    ReusedSchedulerSkipStartError, pinned_automation_configuration_digest,
+    ReusedSchedulerSkipStartError, observe_admission_decision,
+    pinned_automation_configuration_digest,
 };
 pub use terminal::{AutomationSettledProblem, AutomationSettledTerminal};

--- a/crates/tracedecay-automation-runtime/src/automation/effect_runtime/settlement.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/effect_runtime/settlement.rs
@@ -19,10 +19,10 @@ use tracedecay_contracts::retained_surfaces::{
 };
 use tracedecay_contracts::{
     ApplicationProblem, ApplicationProblemEnvelope, CancellationSignal, ProblemOwningLayer,
-    RequestContext, RetainedSurfaceExecutionContextV1, RetainedSurfaceExecutionErrorV1,
-    RetainedSurfaceOperation, retained_surface_application_operation,
-    retained_surface_execution_problem, retained_surface_outcome_matches_terminal,
-    retained_surface_problem_matches_terminal,
+    RequestAdmission, RequestContext, RetainedSurfaceExecutionContextV1,
+    RetainedSurfaceExecutionErrorV1, RetainedSurfaceOperation,
+    retained_surface_application_operation, retained_surface_execution_problem,
+    retained_surface_outcome_matches_terminal, retained_surface_problem_matches_terminal,
 };
 use tracedecay_domain::configuration::ConfigurationRevisionId;
 use tracedecay_domain::{FactOwnerV1, ManifestDigest, RunId, UtcMicros};
@@ -498,10 +498,11 @@ pub enum AutomationEffectAdmission {
     PreAdmissionProblem(ApplicationProblemEnvelope),
 }
 
-/// Bounded admission-decision census: every prepared automation effect
-/// settles into exactly one of these outcomes, so a run that never executed
-/// is diagnosable from counters instead of log archaeology.
-fn observe_admission_decision(admission: &AutomationEffectAdmission) {
+/// Bounded admission-decision census: every automation-effect admission,
+/// including a root refusal before prepare, settles into exactly one of
+/// these outcomes, so a run that never executed is diagnosable from
+/// counters instead of log archaeology.
+pub fn observe_admission_decision(admission: &AutomationEffectAdmission) {
     match admission {
         AutomationEffectAdmission::Execute(_) => {
             hotpath::gauge!("daemon.effect_admission.admitted_total").inc(1_u64);
@@ -1210,6 +1211,33 @@ impl AutomationEffectAuthority {
             process_run_id: tracedecay_runtime_core::runtime_identity::process_run_id().to_owned(),
             recovery,
         };
+        // Classification I/O can outlive the admitted snapshot. Recheck the
+        // live cancellation and the usecase clock immediately before the
+        // journal write. `observed_at` stays the pinned admission instant.
+        let live_at = tracedecay_contracts::try_now_micros().map_err(|error| {
+            contract_error(format!(
+                "automation reservation clock is unavailable: {error}"
+            ))
+        })?;
+        let live_admission = context
+            .clone()
+            .with_cancellation(cancellation.context())
+            .admission_at(live_at);
+        if let Some(problem) = match live_admission {
+            RequestAdmission::Admitted => None,
+            RequestAdmission::Cancelled => Some(ApplicationProblem::cancelled_before_admission()),
+            RequestAdmission::TimedOut => Some(ApplicationProblem::timed_out_before_admission()),
+        } {
+            let envelope = ApplicationProblemEnvelope::new(
+                operation.result_contract().clone(),
+                context.request_id().clone(),
+                problem,
+            )
+            .map_err(contract_error)?;
+            let admission = AutomationEffectAdmission::PreAdmissionProblem(envelope);
+            observe_admission_decision(&admission);
+            return Ok(admission);
+        }
         let reserve_path = journal_path.clone();
         let requested = admission.clone();
         let index_root = dashboard_root.clone();

--- a/crates/tracedecay-automation-runtime/src/automation/effect_runtime/settlement/tests.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/effect_runtime/settlement/tests.rs
@@ -3260,3 +3260,141 @@ async fn external_admission_does_not_resolve_memory_owner_but_memory_admission_d
         }
     }
 }
+
+#[tokio::test]
+async fn cancelled_after_admission_does_not_reserve_journal() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (authority, _, _) = retained_external_authority(
+        temp.path(),
+        external_admission("run.fixture-cancel", "request.fixture-cancel"),
+    );
+    let context = authority.context.clone();
+    let cancellation = authority.cancellation.clone();
+    let configuration_digest = authority.admission.configuration_digest.clone();
+    authority
+        .abandon_uncommitted()
+        .await
+        .expect("abandon fixture reservation");
+
+    let request =
+        session_reflector_admission("run.pre-admission-cancel", "request.pre-admission-cancel")
+            .request;
+    let journal_path = canonical_journal_path(temp.path(), &request.run_id);
+    assert!(
+        cancellation.cancel(UtcMicros(3)),
+        "post-admission cancel must win the live signal"
+    );
+
+    let result = Box::pin(AutomationEffectAuthority::prepare(
+        AdmittedAutomationEffectRequest {
+            context: context.clone(),
+            cancellation,
+            observed_at: UtcMicros(2),
+            configuration_digest,
+            request,
+            dashboard_root: temp.path().to_path_buf(),
+        },
+        || {
+            Ok(FactOwnerV1::Project {
+                project_id: context.scope().project_id.clone(),
+            })
+        },
+        |_, _| async { Err(contract_error("cancelled admission must not read receipts")) },
+    ))
+    .await
+    .expect("typed pre-admission outcome");
+
+    let AutomationEffectAdmission::PreAdmissionProblem(envelope) = result else {
+        panic!("cancelled run must stay a typed pre-admission problem, not reserve durable state");
+    };
+    assert_eq!(
+        envelope.problem.source(),
+        &tracedecay_contracts::ApplicationProblem::cancelled_before_admission()
+    );
+    assert!(
+        envelope.problem.is_pre_admission(),
+        "cancellation after admission and before reservation is still pre-admission"
+    );
+    assert!(
+        !journal_path.exists(),
+        "cancelled run must not reserve journal state"
+    );
+    assert!(
+        recovery_index::indexed_journals_blocking(temp.path(), context.scope())
+            .expect("pending index")
+            .is_empty(),
+        "cancelled run must not enter the pending journal index"
+    );
+}
+
+#[tokio::test]
+async fn timed_out_after_admission_does_not_reserve_journal() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let (authority, _, _) = retained_external_authority(
+        temp.path(),
+        external_admission("run.fixture-timeout", "request.fixture-timeout"),
+    );
+    // Snapshot admission stays valid: observed_at (2) is before expires_at (100).
+    // The live usecase clock is far past that deadline, so the reservation
+    // recheck must refuse without writing journal state.
+    let context = authority
+        .context
+        .clone()
+        .with_deadline(Deadline::new(UtcMicros(100)).expect("elapsed deadline"));
+    let cancellation = authority.cancellation.clone();
+    let configuration_digest = authority.admission.configuration_digest.clone();
+    authority
+        .abandon_uncommitted()
+        .await
+        .expect("abandon fixture reservation");
+
+    let request =
+        session_reflector_admission("run.pre-admission-timeout", "request.pre-admission-timeout")
+            .request;
+    let journal_path = canonical_journal_path(temp.path(), &request.run_id);
+    assert!(
+        tracedecay_contracts::now_micros() >= UtcMicros(100),
+        "fresh clock must be past the admitted deadline"
+    );
+
+    let result = Box::pin(AutomationEffectAuthority::prepare(
+        AdmittedAutomationEffectRequest {
+            context: context.clone(),
+            cancellation,
+            observed_at: UtcMicros(2),
+            configuration_digest,
+            request,
+            dashboard_root: temp.path().to_path_buf(),
+        },
+        || {
+            Ok(FactOwnerV1::Project {
+                project_id: context.scope().project_id.clone(),
+            })
+        },
+        |_, _| async { Err(contract_error("timed-out admission must not read receipts")) },
+    ))
+    .await
+    .expect("typed pre-admission outcome");
+
+    let AutomationEffectAdmission::PreAdmissionProblem(envelope) = result else {
+        panic!("timed-out run must stay a typed pre-admission problem, not reserve durable state");
+    };
+    assert_eq!(
+        envelope.problem.source(),
+        &tracedecay_contracts::ApplicationProblem::timed_out_before_admission()
+    );
+    assert!(
+        envelope.problem.is_pre_admission(),
+        "timeout after admission and before reservation is still pre-admission"
+    );
+    assert!(
+        !journal_path.exists(),
+        "timed-out run must not reserve journal state"
+    );
+    assert!(
+        recovery_index::indexed_journals_blocking(temp.path(), context.scope())
+            .expect("pending index")
+            .is_empty(),
+        "timed-out run must not enter the pending journal index"
+    );
+}

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/query_runtime.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/query_runtime.rs
@@ -189,22 +189,11 @@ pub enum DeferredMountAttemptV1 {
 pub async fn retry_deferred_query_authority_until_serving<F, Fut>(
     registry: &CodeIndexSchedulerRegistryV1,
     project_root: PathBuf,
-    scope: ResolvedScope,
     mut attempt: F,
 ) where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = DeferredMountAttemptV1>,
 {
-    if crate::project_reads::code_index_disabled_for_scope(registry, &scope) {
-        tracing::info!(
-            event = "query_authority_mount",
-            outcome = "code_index_disabled",
-            project_id = %scope.project_id,
-            deferred = true,
-            "route indexes no code by contract; deferred query authority is terminal"
-        );
-        return;
-    }
     let mut publications = registry.subscribe_generation_publications();
     let mut ready_poll = tokio::time::interval(Duration::from_secs(1));
     ready_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -222,6 +211,8 @@ pub async fn retry_deferred_query_authority_until_serving<F, Fut>(
             publication = publications.recv() => match publication {
                 Ok(publication) if publication.project_root == project_root => {}
                 Ok(_) => {}
+                // A lagged receiver dropped publications; one of them may have
+                // been this project's, so attempt the mount anyway.
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
             }

--- a/crates/tracedecay-daemon-service/src/profile_host_admission_replay.rs
+++ b/crates/tracedecay-daemon-service/src/profile_host_admission_replay.rs
@@ -603,7 +603,7 @@ impl ProfileHostAdmissionBootstrapWorker {
             match result {
                 Ok(()) => {
                     if consecutive_retryable > 0 {
-                        tracing::info!(
+                        tracing::warn!(
                             event = "profile_host_admission_bootstrap_recovered",
                             attempts = consecutive_retryable + 1,
                         );
@@ -625,7 +625,7 @@ impl ProfileHostAdmissionBootstrapWorker {
                     consecutive_retryable = consecutive_retryable.saturating_add(1);
                     self.backoff_count.fetch_add(1, Ordering::AcqRel);
                     if consecutive_retryable == 1 {
-                        tracing::info!(
+                        tracing::warn!(
                             event = "profile_host_admission_bootstrap_retry",
                             reason_code,
                         );

--- a/crates/tracedecay/src/daemon/automation_effect.rs
+++ b/crates/tracedecay/src/daemon/automation_effect.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use tracedecay_automation_runtime::automation::effect_runtime::contract_error;
 use tracedecay_automation_runtime::automation::effect_runtime::settlement::{
     AdmittedAutomationEffectRequest, AutomationEffectAdmission, AutomationEffectAuthority,
+    observe_admission_decision,
 };
 use tracedecay_contracts::retained_surfaces::{
     AutomationRunRequestV1, RetainedSurfaceOperation, retained_surface_application_operation,
@@ -68,8 +69,9 @@ pub(crate) async fn prepare(
                 problem,
             )
             .map_err(contract_error)?;
-            hotpath::gauge!("daemon.effect_admission.refused.pre_admission_total").inc(1_u64);
-            return Ok(AutomationEffectAdmission::PreAdmissionProblem(envelope));
+            let admission = AutomationEffectAdmission::PreAdmissionProblem(envelope);
+            observe_admission_decision(&admission);
+            return Ok(admission);
         }
         Err(RegisteredRetainedRequestContextError::Runtime(error)) => return Err(error),
     };

--- a/crates/tracedecay/src/daemon/project_open_owners/query_authority_upgrade.rs
+++ b/crates/tracedecay/src/daemon/project_open_owners/query_authority_upgrade.rs
@@ -16,8 +16,8 @@ pub(super) use tracedecay_code_index_runtime::code_index_scheduler::query_runtim
 
 /// Spawns the deferred query-authority waiter on the project owner.
 ///
-/// A route whose code index is disabled never seats a text generation, so the
-/// runtime helper exits immediately and this returns `false`.
+/// A route whose code index is disabled never seats a text generation, so this
+/// returns `false` and never parks a waiter.
 pub(super) fn spawn_deferred_query_authority_mount(
     owner: &crate::mcp::McpServer,
     invocation: DaemonInvocationState,
@@ -25,6 +25,10 @@ pub(super) fn spawn_deferred_query_authority_mount(
     scope: ResolvedScope,
     mount: DeferredQueryAuthorityMountV1,
 ) -> bool {
+    // Same contract as the deferred advisory owner: a route whose code index
+    // is disabled never seats a text generation, so this retry has nothing to
+    // wait for. Parking it would poll the shared store once a second for the
+    // daemon's life and re-mount on every other route's publication.
     if tracedecay_code_index_runtime::project_reads::code_index_disabled_for_scope(
         &invocation.code_index_schedulers,
         &scope,
@@ -41,20 +45,13 @@ pub(super) fn spawn_deferred_query_authority_mount(
     owner.spawn_background_task(hotpath::future!(
         async move {
             let schedulers = invocation.code_index_schedulers.clone();
-            retry_deferred_query_authority_until_serving(
-                &schedulers,
-                project_root.clone(),
-                scope.clone(),
-                || {
-                    let invocation = invocation.clone();
-                    let project_root = project_root.clone();
-                    let scope = scope.clone();
-                    let mount = mount.clone();
-                    async move {
-                        try_deferred_mount(&invocation, &project_root, &scope, &mount).await
-                    }
-                },
-            )
+            retry_deferred_query_authority_until_serving(&schedulers, project_root.clone(), || {
+                let invocation = invocation.clone();
+                let project_root = project_root.clone();
+                let scope = scope.clone();
+                let mount = mount.clone();
+                async move { try_deferred_mount(&invocation, &project_root, &scope, &mount).await }
+            })
             .await;
         },
         label = "daemon.project.query_authority_deferred"


### PR DESCRIPTION
Fixes defects introduced by #1181 and #1180, found in independent review.

- `test(automation)` + `fix(automation): recheck cancellation before journal reservation` — #1181 hoisted admission out of the settlement kernel so it ran before retirement classification (a `spawn_blocking` file read); a run cancelled during classification then proceeded to reserve durable journal state. The kernel now re-evaluates the live cancellation signal (`CancellationSignal::context()` re-reads the atomic) and the deadline against a fresh `tracedecay_contracts::try_now_micros()` immediately before `reserve_or_replay_indexed_blocking` — the durable boundary, with nothing durable between — mapping `Cancelled`/`TimedOut` to the typed `PreAdmissionProblem`. `observed_at` stays the pinned admission instant on the durable record. RED→GREEN: `cancelled_after_admission_does_not_reserve_journal` and the timeout twin both assert the journal file and recovery index are empty.
- `refactor(automation): keep one pre-admission gauge authority` — `observe_admission_decision` in `settlement.rs` is the single owner of `daemon.effect_admission.refused.pre_admission_total`; root's own early pre-admission refusal calls it, so the census has no hole and the "every effect settles into exactly one outcome" doc holds.
- `fix(daemon-service): surface host admission recovery at warn` — #1180 moved the replay worker from the unconditional daemon log to `tracing::info!`, so `profile_host_admission_bootstrap_recovered`/`_retry` vanished under the default WARN filter; raised to WARN (the `stopped`/`exhausted` events `branch_admin.rs` asserts were already WARN and are untouched).
- `refactor(code-index-runtime): single disable check for deferred mounts` — `code_index_disabled_for_scope` was checked in both the root spawn wrapper and the runtime helper; the unreachable runtime copy and the dead `_scope` parameter are gone, and the two invariant comments #1180 dropped (lagged receiver; once-a-second polling cost) are restored.

Verification: settlement 59; root `daemon::automation_effect` 9; deferred-mount 3; clippy `-D warnings --tests` on automation-runtime, daemon-service, code-index-runtime (lib) and root; fmt; commitlint. Two independent Opus passes; second pass's items (stale-clock deadline recheck, gauge hole, dead parameter) fixed and folded. The only clippy noise left in this area is the pre-existing `format_collect` in `code_index_scheduler/tests.rs`, fixed separately in #1184.