### PR TITLE
fix(maintenance): restore compaction coverage and one operator log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6744,8 +6744,6 @@ dependencies = [
  "tracedecay-store",
  "tracedecay-store-runtime",
  "tracedecay-tool-catalog",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/tracedecay-maintenance/Cargo.toml
+++ b/crates/tracedecay-maintenance/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = "1"
 sha2 = "0.11"
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "time", "sync"] }
-tracing = "0.1"
 tracedecay-application = { path = "../tracedecay-application", version = "0.1.0" }
 tracedecay-contracts = { path = "../tracedecay-contracts", version = "0.1.0" }
 tracedecay-automation = { path = "../tracedecay-automation", version = "0.1.0" }
@@ -49,7 +48,6 @@ tracedecay-tool-catalog = { path = "../tracedecay-tool-catalog", version = "0.1.
 libc = "0.2"
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 filetime = "0.2"
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/tracedecay-maintenance/src/compaction_receipt.rs
+++ b/crates/tracedecay-maintenance/src/compaction_receipt.rs
@@ -1,7 +1,7 @@
 //! Live-compaction outcome → operator receipt.
 
-use crate::log_maintenance_event;
 use crate::retention::live_compaction::LiveStoreCompactionOutcomeV1;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Record one live-compaction outcome and return whether the store is healthy.
 #[must_use]
@@ -15,7 +15,7 @@ pub fn record_live_compaction_outcome(
             freelist_before,
             freelist_after,
         } => {
-            log_maintenance_event(
+            log_daemon_event(
                 "retention_compaction",
                 &[
                     ("store", store_name.to_owned()),
@@ -28,7 +28,7 @@ pub fn record_live_compaction_outcome(
             true
         }
         LiveStoreCompactionOutcomeV1::Failed(failure) => {
-            log_maintenance_event(
+            log_daemon_event(
                 "retention_degraded",
                 &[
                     ("pass", "compaction".to_owned()),

--- a/crates/tracedecay-maintenance/src/generation.rs
+++ b/crates/tracedecay-maintenance/src/generation.rs
@@ -36,6 +36,9 @@ pub async fn run_project_generation_maintenance(
     compaction: Option<&CompactionThresholdConfig>,
     continuation: Option<MaintenanceContinuation>,
 ) -> MaintenanceTickOutcome {
+    // Each ordered phase gets its own wall span: the outer generation span is
+    // inclusive, so a slow tick is attributed to vector retention, code
+    // generation retention, scope reconciliation, or compaction — not guessed.
     let mut outcome = hotpath::measure_block!(
         "daemon.maintenance.vector_retention",
         run_semantic_vector_generation_retention(
@@ -124,6 +127,8 @@ pub async fn run_project_generation_maintenance(
     finalize_generation_outcome(outcome, cancellation)
 }
 
+/// Cancelled and degraded ticks are recorded too: a maintenance lane that
+/// silently retries forever is exactly the waste being diagnosed.
 fn finalize_generation_outcome(
     outcome: MaintenanceTickOutcome,
     cancellation: &tracedecay_session_memory::context::CancellationToken,

--- a/crates/tracedecay-maintenance/src/lib.rs
+++ b/crates/tracedecay-maintenance/src/lib.rs
@@ -56,67 +56,31 @@ pub mod store_maintenance;
 pub mod telemetry;
 pub mod tick;
 
-/// Operator-log line for a maintenance kernel. Callers supply structured fields.
-pub fn log_maintenance_event(event: &str, fields: &[(&str, String)]) {
-    if event == "retention_degraded" {
-        tracing::warn!(target: "tracedecay_maintenance", event, ?fields, "maintenance event");
-    } else {
-        tracing::info!(target: "tracedecay_maintenance", event, ?fields, "maintenance event");
-    }
-}
-
 #[cfg(test)]
 mod logging_tests {
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex};
+    use tracedecay_runtime_core::logging::format_daemon_log_line;
 
-    #[derive(Clone)]
-    struct Capture(Arc<Mutex<Vec<u8>>>);
-
-    impl Write for Capture {
-        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            self.0.lock().unwrap().write(bytes)
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
+    #[test]
+    fn retention_degraded_formats_the_daemon_operator_line() {
+        let fields = [
+            ("pass", "code_generations".to_owned()),
+            (
+                "failure",
+                "registered_enrollment_inventory_unavailable".to_owned(),
+            ),
+        ];
+        assert_eq!(
+            format_daemon_log_line("retention_degraded", &fields),
+            "[tracedecay] event=retention_degraded pass=code_generations failure=registered_enrollment_inventory_unavailable"
+        );
     }
 
     #[test]
-    fn degraded_retention_is_visible_at_warn_while_success_remains_informational() {
-        for level in [tracing::Level::WARN, tracing::Level::INFO] {
-            let buffer = Arc::new(Mutex::new(Vec::new()));
-            let writer = Capture(Arc::clone(&buffer));
-            let subscriber = tracing_subscriber::fmt()
-                .without_time()
-                .with_max_level(level)
-                .with_writer(move || writer.clone())
-                .finish();
-            tracing::subscriber::with_default(subscriber, || {
-                super::log_maintenance_event(
-                    "retention_degraded",
-                    &[
-                        ("pass", "code_generations".to_owned()),
-                        (
-                            "failure",
-                            "registered_enrollment_inventory_unavailable".to_owned(),
-                        ),
-                    ],
-                );
-                super::log_maintenance_event(
-                    "retention_compaction",
-                    &[("freed_pages", "12".to_owned())],
-                );
-            });
-            let output = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
-            assert!(output.contains("WARN"));
-            assert!(output.contains("retention_degraded"));
-            assert!(output.contains("code_generations"));
-            assert!(output.contains("registered_enrollment_inventory_unavailable"));
-            assert_eq!(
-                output.contains("retention_compaction"),
-                level == tracing::Level::INFO
-            );
-        }
+    fn retention_compaction_formats_freed_pages() {
+        let fields = [("freed_pages", "12".to_owned())];
+        assert_eq!(
+            format_daemon_log_line("retention_compaction", &fields),
+            "[tracedecay] event=retention_compaction freed_pages=12"
+        );
     }
 }

--- a/crates/tracedecay-maintenance/src/lib.rs
+++ b/crates/tracedecay-maintenance/src/lib.rs
@@ -10,40 +10,30 @@
 #![warn(clippy::pedantic)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 #![cfg_attr(not(test), deny(clippy::expect_used))]
-#![allow(clippy::module_name_repetitions)]
+// Pedantic docs: Results already carry typed errors; this crate is not a
+// rustdoc surface.
 #![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_panics_doc)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::too_many_lines)]
+// Pedantic `#[must_use]` on every bool/query helper across the kernel.
 #![allow(clippy::must_use_candidate)]
-#![allow(clippy::struct_excessive_bools)]
-#![allow(clippy::similar_names)]
-#![allow(clippy::wildcard_imports)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
-#![allow(clippy::unused_self)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::items_after_statements)]
-#![allow(clippy::struct_field_names)]
-#![allow(clippy::match_same_arms)]
-#![allow(clippy::option_option)]
+// Extracted retention/orphan/backup passes are still long, ordered journeys.
+#![allow(clippy::too_many_lines)]
+// Existing if-let / match style in those journeys.
 #![allow(clippy::manual_let_else)]
-#![allow(clippy::ref_option)]
-#![allow(clippy::zero_sized_map_values)]
-#![allow(clippy::used_underscore_binding)]
-#![allow(clippy::manual_async_fn)]
-#![allow(clippy::unused_async)]
-#![allow(clippy::unnecessary_wraps)]
-#![allow(clippy::if_not_else)]
-#![allow(clippy::fn_params_excessive_bools)]
-#![allow(clippy::case_sensitive_file_extension_comparisons)]
-#![allow(clippy::missing_fields_in_debug)]
 #![allow(clippy::single_match_else)]
-#![allow(clippy::large_futures)]
-#![allow(unreachable_pub)]
+#![allow(clippy::match_same_arms)]
+// Helpers sit next to the pass they serve.
+#![allow(clippy::items_after_statements)]
+// Owned error values and explicit port arguments at crate boundaries.
+#![allow(clippy::needless_pass_by_value)]
+#![allow(clippy::too_many_arguments)]
+// Telemetry record methods keep `&self` so the registry stays the owner.
+#![allow(clippy::unused_self)]
+// Store-file suffix checks and sqlite page/clock conversions.
+#![allow(clippy::case_sensitive_file_extension_comparisons)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+// Uniform fallible surfaces that currently always return Ok.
+#![allow(clippy::unnecessary_wraps)]
 
 pub mod clock;
 pub mod compaction_receipt;

--- a/crates/tracedecay-maintenance/src/store_maintenance/graph_replay.rs
+++ b/crates/tracedecay-maintenance/src/store_maintenance/graph_replay.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
 use crate::lease::ProjectStoreMaintenanceLeaseV1;
-use crate::log_maintenance_event;
 use tracedecay_code_index_retention::code_index_generations::{
     code_generation_graph_replay_release_page, complete_code_generation_graph_replay_release,
     try_acquire_code_generation_store_lock,
 };
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 pub enum ReconcileOutcome {
     /// Every queued release event has been consumed.
@@ -68,7 +68,7 @@ fn log_code_generation_retention_degraded_with_error(
     error: &dyn std::fmt::Debug,
 ) {
     observations.mark_loud_retention_log();
-    log_maintenance_event(
+    log_daemon_event(
         "retention_degraded",
         &[
             ("pass", "code_generations".to_string()),
@@ -224,7 +224,7 @@ pub async fn reconcile_graph_replay_releases(
                     retire_generation_read_bundle(store_root, &release.generation.generation_file)
                 {
                     observations.mark_loud_retention_log();
-                    log_maintenance_event(
+                    log_daemon_event(
                         "retention_degraded",
                         &[
                             ("pass", "code_generations".to_string()),

--- a/crates/tracedecay-maintenance/src/store_maintenance/mod.rs
+++ b/crates/tracedecay-maintenance/src/store_maintenance/mod.rs
@@ -11,12 +11,12 @@ use std::path::{Path, PathBuf};
 
 use crate::clock::now_secs_i64;
 use crate::lease::ProjectStoreMaintenanceLeaseV1;
-use crate::log_maintenance_event;
 use crate::telemetry::StoreTelemetrySamplingRegistry;
 use crate::tick::MaintenanceTickOutcome;
 use tracedecay_application::semantic_runtime::ProjectSemanticActivationExt;
 use tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerRegistryV1;
 use tracedecay_contracts::storage::compaction::CompactionThresholdConfig;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_semantic_contracts::SemanticConfig;
 
 mod graph_replay;
@@ -172,7 +172,7 @@ pub async fn run_semantic_vector_generation_retention(
                 census.action,
                 tracedecay_graph_db::SemanticVectorRetentionAction::None
             ) {
-                log_maintenance_event(
+                log_daemon_event(
                     "retention_semantic_vector_generations",
                     &[
                         ("project", root.display().to_string()),
@@ -634,7 +634,7 @@ pub async fn apply_code_generation_retention(
             // the typed error, a pointer CAS loss under rebuild churn is
             // indistinguishable from unrecognized-file or storage failures.
             observations.mark_loud_retention_log();
-            log_maintenance_event(
+            log_daemon_event(
                 "retention_degraded",
                 &[
                     ("pass", "code_generations".to_string()),
@@ -897,7 +897,7 @@ pub async fn apply_code_generation_retention(
             );
             let reclaimed = generation_reclaimed.saturating_add(text_artifact_reclaimed);
             if reclaimed > 0 {
-                log_maintenance_event(
+                log_daemon_event(
                     "retention_code_generations",
                     &[
                         ("store", "code-index-v1".to_string()),
@@ -970,7 +970,7 @@ pub async fn apply_code_generation_retention(
             // apply step's typed error names the exact refusal (CAS loss,
             // unsafe state, storage) instead of a bare retry label.
             observations.mark_loud_retention_log();
-            log_maintenance_event(
+            log_daemon_event(
                 "retention_degraded",
                 &[
                     ("pass", "code_generations".to_string()),
@@ -1655,7 +1655,7 @@ pub async fn run_code_index_scope_reconciliation(
                 .as_ref()
                 .map_or(0, |receipt| receipt.reclaimed_bytes);
             if reclaimed > 0 || report.plan.stranded_scope_count() > 0 {
-                log_maintenance_event(
+                log_daemon_event(
                     "retention_code_index_scopes",
                     &[
                         ("store", "code-index-v1".to_string()),
@@ -1703,7 +1703,7 @@ pub async fn run_code_index_scope_reconciliation(
 /// Durable failure visibility for scope reconciliation. Every refusal names why
 /// so a fail-closed pass is never mistaken for "nothing was stranded".
 fn log_code_index_scope_reconciliation_degraded(failure: &str) {
-    log_maintenance_event(
+    log_daemon_event(
         "retention_degraded",
         &[
             ("pass", "code_index_scopes".to_string()),
@@ -1741,7 +1741,7 @@ pub fn run_branch_compaction(
     if report.policy_invalid {
         // Never silent: an out-of-range threshold disables the pass entirely
         // and would otherwise be indistinguishable from "nothing to compact".
-        log_maintenance_event(
+        log_daemon_event(
             "retention_degraded",
             &[
                 ("pass", "branch_compaction".to_string()),
@@ -1770,7 +1770,7 @@ pub fn run_branch_compaction(
                 == crate::retention::branch_compaction::BranchCompactionSkipReason::IncrementalVacuumUnavailable
         })
         .count();
-    log_maintenance_event(
+    log_daemon_event(
         "retention_branch_compaction",
         &[
             ("project", lease.project_root().display().to_string()),

--- a/crates/tracedecay-maintenance/src/telemetry.rs
+++ b/crates/tracedecay-maintenance/src/telemetry.rs
@@ -23,8 +23,8 @@ use tracedecay_domain::{ManifestDigest, UtcMicros};
 use tracedecay_runtime_core::db::DatabaseStorageTelemetryHandle;
 use tracedecay_tool_catalog::{CapabilityId, UseCaseId};
 
-use crate::log_maintenance_event;
 use crate::tick::MaintenanceTickOutcome;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 const STORAGE_TELEMETRY_CONTEXT_HORIZON_MICROS: i64 = 30_000_000;
 const STORAGE_TELEMETRY_CAPABILITY: &str = "capability.application.storage.telemetry";
@@ -720,7 +720,7 @@ impl StoreTelemetrySamplingRegistry {
             "code_generations" => RetentionOperatorLogLaneV1::CodeGeneration,
             _ => {
                 self.mark_loud_retention_log();
-                log_maintenance_event(
+                log_daemon_event(
                     "retention_degraded",
                     &[("pass", pass.to_owned()), ("failure", failure.to_owned())],
                 );
@@ -735,7 +735,7 @@ impl StoreTelemetrySamplingRegistry {
             self.mark_loud_retention_log();
             self.clear_by_design_retention_log(lane, project_root);
         }
-        log_maintenance_event(
+        log_daemon_event(
             "retention_degraded",
             &[("pass", pass.to_owned()), ("failure", failure.to_owned())],
         );

--- a/crates/tracedecay-runtime-core/src/lib.rs
+++ b/crates/tracedecay-runtime-core/src/lib.rs
@@ -104,6 +104,7 @@ pub mod git;
 pub mod git_discovery;
 pub mod git_repository;
 pub mod lifecycle_lease;
+pub mod logging;
 pub mod operation_task_owner;
 pub mod os_str_bytes;
 pub mod path_safety;

--- a/crates/tracedecay-runtime-core/src/logging.rs
+++ b/crates/tracedecay-runtime-core/src/logging.rs
@@ -1,0 +1,142 @@
+//! Always-visible daemon operator-log lines.
+//!
+//! The operator contract is a single stderr logfmt line
+//! `[tracedecay] event=<name> k=v …`. Unix writes it to fd 2 so it
+//! appears when `RUST_LOG` is unset; the stderr tracing subscriber (default
+//! WARN) does not filter it.
+
+use std::fmt::Write;
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::io::Write as _;
+#[cfg(unix)]
+use std::os::fd::{FromRawFd, RawFd};
+
+/// Opening marker of every bespoke daemon log line. Watcher recovery anchors
+/// on it, so `tracing` output — which never carries the marker — cannot forge
+/// a `git_watch_*` event through a structured field that happens to be named
+/// `event`.
+pub const DAEMON_LOG_MARKER: &str = "[tracedecay] event=";
+
+/// Format one operator-log line. Values that are not a safe token are quoted.
+#[must_use]
+pub fn format_daemon_log_line(event: &str, fields: &[(&str, String)]) -> String {
+    let mut line = format!("{DAEMON_LOG_MARKER}{}", quote_log_value(event));
+    for (key, value) in fields {
+        line.push(' ');
+        line.push_str(key);
+        line.push('=');
+        line.push_str(&quote_log_value(value));
+    }
+    line
+}
+
+fn quote_log_value(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/' | b':'))
+    {
+        return value.to_string();
+    }
+
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => {
+                let _ = write!(escaped, "\\u{{{:x}}}", ch as u32);
+            }
+            ch => escaped.push(ch),
+        }
+    }
+    format!("\"{escaped}\"")
+}
+
+/// Emit one operator-log line to stderr. Returns `()` so match-arm call
+/// sites stay type-compatible. Unix writes fd 2 directly so a test harness
+/// that captures `eprintln` cannot hide the operator line; the unix test
+/// below `dup2`s fd 2 and asserts the exact [`format_daemon_log_line`] bytes.
+pub fn log_daemon_event(event: &str, fields: &[(&str, String)]) {
+    let line = format_daemon_log_line(event, fields);
+    write_operator_line(&line);
+}
+
+#[cfg(unix)]
+fn write_operator_line(line: &str) {
+    const STDERR_FD: RawFd = 2;
+    // SAFETY: fd 2 is process stderr for the life of the process. The
+    // `File` must not close it, so it is wrapped in `ManuallyDrop`.
+    let mut stderr = std::mem::ManuallyDrop::new(unsafe { File::from_raw_fd(STDERR_FD) });
+    let _ = writeln!(&mut *stderr, "{line}");
+}
+
+#[cfg(not(unix))]
+fn write_operator_line(line: &str) {
+    eprintln!("{line}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_daemon_log_line;
+    #[cfg(unix)]
+    use std::io::{Read, Seek, SeekFrom, Write};
+    #[cfg(unix)]
+    use std::os::fd::AsRawFd;
+
+    #[cfg(unix)]
+    fn capture_stderr(emit: impl FnOnce()) -> String {
+        let mut tmp = tempfile::tempfile().expect("stderr capture file");
+        // SAFETY: `saved` is a new fd onto the current stderr; `dup2` onto
+        // fd 2 is restored before this function returns, so the process
+        // stderr identity is unchanged for later tests.
+        unsafe {
+            let saved = libc::dup(libc::STDERR_FILENO);
+            assert!(saved >= 0, "dup stderr");
+            assert_eq!(
+                libc::dup2(tmp.as_raw_fd(), libc::STDERR_FILENO),
+                libc::STDERR_FILENO
+            );
+            emit();
+            let _ = std::io::stderr().flush();
+            assert_eq!(libc::dup2(saved, libc::STDERR_FILENO), libc::STDERR_FILENO);
+            libc::close(saved);
+        }
+        tmp.seek(SeekFrom::Start(0)).expect("rewind capture");
+        let mut buf = String::new();
+        tmp.read_to_string(&mut buf).expect("read capture");
+        buf
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn log_daemon_event_writes_the_logfmt_line_to_stderr_when_rust_log_is_unset() {
+        assert!(
+            std::env::var_os("RUST_LOG").is_none(),
+            "visibility is the unset-RUST_LOG path; the emitter is eprintln, not tracing"
+        );
+        let fields = [
+            ("pass", "code_generations".to_string()),
+            (
+                "failure",
+                "registered_enrollment_inventory_unavailable".to_string(),
+            ),
+        ];
+        let expected = format_daemon_log_line("retention_degraded", &fields);
+        let captured = capture_stderr(|| super::log_daemon_event("retention_degraded", &fields));
+        assert_eq!(
+            captured.lines().find(|line| *line == expected.as_str()),
+            Some(expected.as_str()),
+            "stderr capture: {captured:?}"
+        );
+        assert_eq!(
+            expected,
+            "[tracedecay] event=retention_degraded pass=code_generations failure=registered_enrollment_inventory_unavailable"
+        );
+    }
+}

--- a/crates/tracedecay-runtime-core/src/storage/identity_tests.rs
+++ b/crates/tracedecay-runtime-core/src/storage/identity_tests.rs
@@ -180,17 +180,4 @@ mod enrolled_project_roots_tests {
         let roots = enrolled_project_roots(Vec::<PathBuf>::new(), &project_id).expect("filter");
         assert!(roots.is_empty());
     }
-
-    #[test]
-    fn keeps_only_roots_whose_path_derived_id_matches() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let enrolled = temp.path().join("enrolled");
-        let other = temp.path().join("other");
-        fs::create_dir_all(&enrolled).expect("enrolled");
-        fs::create_dir_all(&other).expect("other");
-        let project_id = ProjectId::new(default_profile_project_id(&enrolled)).expect("project id");
-        let roots =
-            enrolled_project_roots(vec![enrolled.clone(), other], &project_id).expect("filter");
-        assert_eq!(roots, vec![enrolled.canonicalize().expect("canonical")]);
-    }
 }

--- a/crates/tracedecay/src/daemon/adoption_observation.rs
+++ b/crates/tracedecay/src/daemon/adoption_observation.rs
@@ -19,8 +19,8 @@ use tracedecay_contracts::{
 use tracedecay_domain::{AdoptionEligibilityObservedV1, CoverageStateV1};
 use tracedecay_tool_catalog::{CatalogContributionV1, ProfileId};
 
-use super::log_daemon_event;
 use tracedecay_global_db::RegisteredGlobalDb;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Composed capability namespaces mapped onto the closed adoption capability
 /// families (`AdoptionEligibilityObservedV1::validate`). Prefix, not equality:

--- a/crates/tracedecay/src/daemon/automation_observation.rs
+++ b/crates/tracedecay/src/daemon/automation_observation.rs
@@ -7,8 +7,8 @@ use tracedecay_application::observability::{
 use tracedecay_automation_runtime::automation::observation::automation_funnel_observation_from_record;
 use tracedecay_automation_runtime::automation::run_ledger::AutomationRunLedgerRecord;
 
-use super::log_daemon_event;
 use tracedecay_daemon_service::DaemonInvocationService;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 pub(crate) async fn project_run_observation_producer(
     service: &DaemonInvocationService,

--- a/crates/tracedecay/src/daemon/bootstrap.rs
+++ b/crates/tracedecay/src/daemon/bootstrap.rs
@@ -16,6 +16,7 @@ use tracedecay_runtime_core::DAEMON_SHUTDOWN_DEADLINE;
 use tracedecay_store_runtime::spawn_semantic_artifact_gc_maintenance;
 
 use super::*;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Slice of the shutdown budget reserved for writing the terminal shutdown
 /// receipts to the daemon log after the coordinator returns.

--- a/crates/tracedecay/src/daemon/branch_admin.rs
+++ b/crates/tracedecay/src/daemon/branch_admin.rs
@@ -34,6 +34,7 @@ use tracedecay_daemon_service::{
     ProfileHostAdmissionBootstrapOperation, ProfileHostAdmissionBootstrapStatus,
     ProfileHostAdmissionReplayRegistry,
 };
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_session_runtime::session_temporal_refresh_scheduler::SessionTemporalRefreshSchedulerRegistry;
 use tracedecay_store_runtime::StoreWriterGates;
 pub(super) use tracedecay_store_runtime::{StoreWriterClass, WriterScope};
@@ -645,7 +646,7 @@ impl StoreAdministration {
                     self.manual_branch_publications
                         .join_failed
                         .store(true, Ordering::Release);
-                    super::log_daemon_event(
+                    log_daemon_event(
                         "manual_branch_publication",
                         &[
                             ("action", "reap".to_owned()),
@@ -691,7 +692,7 @@ impl StoreAdministration {
                 self.manual_branch_publications
                     .join_failed
                     .store(true, Ordering::Release);
-                super::log_daemon_event(
+                log_daemon_event(
                     "manual_branch_publication",
                     &[
                         ("action", "shutdown".to_owned()),

--- a/crates/tracedecay/src/daemon/connection_serving.rs
+++ b/crates/tracedecay/src/daemon/connection_serving.rs
@@ -9,6 +9,7 @@ use tracedecay_daemon_protocol::DaemonInvocationPayload;
 use tracedecay_daemon_service::ProfileHostAdmissionBootstrapStatus;
 use tracedecay_daemon_service::{DaemonInvocationService, Lease};
 use tracedecay_mcp::BrokerSelectedResponseLease;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_session_memory::context::CancellationToken;
 
 /// Hermetic production-route benchmark support for the typed RMCP transport.

--- a/crates/tracedecay/src/daemon/core_admission.rs
+++ b/crates/tracedecay/src/daemon/core_admission.rs
@@ -12,12 +12,13 @@ use tokio::time::{Duration, Instant, timeout, timeout_at};
 use super::{
     AuthenticatedFirstRequest, BrokerStream, BrokerStreamTransport, DaemonAuthPreface,
     DaemonHandshake, JsonRpcResponse, McpMethod, Result, StoreAdministration, TraceDecayError,
-    classify_mcp_method, log_daemon_event, parse_daemon_invocation_request,
-    read_line_handling_wire_oversized, write_json_rpc_response,
+    classify_mcp_method, parse_daemon_invocation_request, read_line_handling_wire_oversized,
+    write_json_rpc_response,
 };
 use tracedecay_contracts::{ApplicationProblem, LegalAction, RetryDirective, SafeDiagnostic};
 use tracedecay_daemon_protocol::DAEMON_SHUTDOWN_METHOD;
 use tracedecay_mcp::ErrorCode;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_runtime_core::weak_registry::WeakRegistry;
 
 pub(crate) const MAX_CONCURRENT_DAEMON_CLIENTS: usize = 64;

--- a/crates/tracedecay/src/daemon/core_logging.rs
+++ b/crates/tracedecay/src/daemon/core_logging.rs
@@ -2,7 +2,6 @@
 
 #[cfg(unix)]
 use std::collections::HashMap;
-use std::fmt::Write;
 
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::Layer as _;
@@ -12,6 +11,10 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 use super::{Path, TraceDecayError};
 #[cfg(unix)]
 use tracedecay_daemon_control::SERVICE_NAME;
+#[cfg(unix)]
+use tracedecay_runtime_core::logging::DAEMON_LOG_MARKER;
+use tracedecay_runtime_core::logging::format_daemon_log_line;
+
 /// A single git-watcher lifecycle event recovered from the daemon log, for the
 /// `tracedecay doctor` watcher-health section.
 #[cfg(unix)]
@@ -23,54 +26,6 @@ pub struct WatcherEvent {
     pub project: Option<String>,
     /// The `action=`/`reason=` field, when present (context for the event).
     pub detail: Option<String>,
-}
-
-/// Opening marker of every bespoke daemon log line. Watcher recovery anchors
-/// on it, so `tracing` output — which never carries the marker — cannot forge
-/// a `git_watch_*` event through a structured field that happens to be named
-/// `event`.
-const DAEMON_LOG_MARKER: &str = "[tracedecay] event=";
-
-pub(crate) fn format_daemon_log_line(event: &str, fields: &[(&str, String)]) -> String {
-    let mut line = format!("{DAEMON_LOG_MARKER}{}", quote_log_value(event));
-    for (key, value) in fields {
-        line.push(' ');
-        line.push_str(key);
-        line.push('=');
-        line.push_str(&quote_log_value(value));
-    }
-    line
-}
-
-fn quote_log_value(value: &str) -> String {
-    if !value.is_empty()
-        && value
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.' | b'/' | b':'))
-    {
-        return value.to_string();
-    }
-
-    let mut escaped = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '\\' => escaped.push_str("\\\\"),
-            '"' => escaped.push_str("\\\""),
-            '\n' => escaped.push_str("\\n"),
-            '\r' => escaped.push_str("\\r"),
-            '\t' => escaped.push_str("\\t"),
-            ch if ch.is_control() => {
-                let _ = write!(escaped, "\\u{{{:x}}}", ch as u32);
-            }
-            ch => escaped.push(ch),
-        }
-    }
-    format!("\"{escaped}\"")
-}
-
-pub(crate) fn log_daemon_event(event: &str, fields: &[(&str, String)]) {
-    let line = format_daemon_log_line(event, fields);
-    eprintln!("{line}");
 }
 
 /// The stderr tracing filter derived from a `RUST_LOG` value.
@@ -415,6 +370,18 @@ mod stderr_tracing_tests {
             assert_eq!(filter.level_for_target("tracedecay"), LevelFilter::WARN);
             assert_eq!(filter.max_level(), LevelFilter::WARN);
             assert!(filter.unparsed().is_empty());
+        }
+    }
+
+    #[test]
+    fn unset_rust_log_defaults_maintenance_to_warn() {
+        for value in [None, Some(""), Some("  ")] {
+            let filter = parse(value);
+            assert_eq!(filter.level_for_target("tracedecay"), LevelFilter::WARN);
+            assert_eq!(
+                filter.level_for_target("tracedecay_maintenance"),
+                LevelFilter::WARN
+            );
         }
     }
 

--- a/crates/tracedecay/src/daemon/core_proxy.rs
+++ b/crates/tracedecay/src/daemon/core_proxy.rs
@@ -18,7 +18,7 @@ use super::{
     next_daemon_response_line, write_daemon_preamble,
 };
 #[cfg(unix)]
-use super::{binary_version, connect_with_restart_grace, log_daemon_event};
+use super::{binary_version, connect_with_restart_grace};
 #[cfg(unix)]
 use tracedecay_daemon_identity::connection_for_socket_path;
 #[cfg(unix)]
@@ -32,6 +32,8 @@ use tracedecay_mcp::transport::StdioTransport;
 use tracedecay_mcp::transport::{McpDuplexTransport, McpTransportReader, McpTransportWriter};
 #[cfg(unix)]
 use tracedecay_mcp::{ErrorCode, JsonRpcResponse};
+#[cfg(unix)]
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Decides at `tracedecay serve` startup whether to proxy to the daemon.
 ///

--- a/crates/tracedecay/src/daemon/engine.rs
+++ b/crates/tracedecay/src/daemon/engine.rs
@@ -15,6 +15,9 @@ use tracedecay_daemon_protocol::{client_version_skew, version_skew_action};
 use tracedecay_hooks::core_events::HOOK_EVENT_METHOD;
 
 #[cfg(unix)]
+use tracedecay_runtime_core::logging::log_daemon_event;
+
+#[cfg(unix)]
 fn git_watch_sync_config(config: &tracedecay_configuration::SyncConfig) -> GitWatchSyncConfigV1 {
     GitWatchSyncConfigV1 {
         auto_watch: config.auto_watch,

--- a/crates/tracedecay/src/daemon/engine/shutdown.rs
+++ b/crates/tracedecay/src/daemon/engine/shutdown.rs
@@ -23,9 +23,10 @@ use crate::daemon::shutdown_coordination::{ShutdownOwner, ShutdownStatus};
 use crate::daemon::shutdown_orchestration::{
     DaemonShutdownPlan, DaemonShutdownReceipt, coordinate_daemon_shutdown,
 };
-use crate::daemon::{log_daemon_event, project_open_tasks, shutdown_project_servers};
+use crate::daemon::{project_open_tasks, shutdown_project_servers};
 #[cfg(test)]
 use tracedecay_runtime_core::DAEMON_SHUTDOWN_DEADLINE;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_store_runtime::ShutdownTaskReceipt;
 
 impl DaemonEngine {

--- a/crates/tracedecay/src/daemon/invocation_dispatch.rs
+++ b/crates/tracedecay/src/daemon/invocation_dispatch.rs
@@ -18,6 +18,7 @@ use tracedecay_daemon_service::{
     DaemonInvocationService, Lease, SemanticInvocationControlV1,
 };
 use tracedecay_runtime_core::cancellation::CancellationToken;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_store::StoreShardScopeV1;
 
 fn semantic_invocation_interruption_response(

--- a/crates/tracedecay/src/daemon/invocation_state.rs
+++ b/crates/tracedecay/src/daemon/invocation_state.rs
@@ -32,6 +32,7 @@ use tracedecay_daemon_service::{
 use tracedecay_domain::errors::{Result, TraceDecayError};
 
 use super::*;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 mod project_invocation;
 

--- a/crates/tracedecay/src/daemon/maintenance.rs
+++ b/crates/tracedecay/src/daemon/maintenance.rs
@@ -16,6 +16,7 @@ use tracedecay_maintenance::tick::{
 };
 
 use super::branch_admin::StoreAdministration;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 const MAINTENANCE_STORE_PAGE_LIMIT: usize = 8;
 
@@ -27,7 +28,7 @@ async fn join_abandoned_maintenance_task(task: Option<JoinHandle<()>>, owner: &'
     match tokio::time::timeout(super::DAEMON_TASK_ABORT_DEADLINE, task).await {
         Ok(Ok(()) | Err(_)) => {}
         Err(_) => {
-            super::log_daemon_event(
+            log_daemon_event(
                 "daemon_shutdown",
                 &[
                     ("outcome", "maintenance_task_abandoned".to_string()),
@@ -46,7 +47,7 @@ async fn run_registered_store_retention(
     let now = match now_secs_i64() {
         Ok(now) => now,
         Err(failure) => {
-            super::log_daemon_event(
+            log_daemon_event(
                 "retention_degraded",
                 &[
                     ("pass", "session_retention".to_owned()),
@@ -68,7 +69,7 @@ async fn run_registered_store_retention(
         Some(Ok(session_lcm)) => {
             let reclaimed = session_lcm.bytes_reclaimed();
             if reclaimed > 0 || !session_lcm.errors.is_empty() {
-                super::log_daemon_event(
+                log_daemon_event(
                     "retention_session_lcm",
                     &[
                         ("store", "mounted_sessions".to_owned()),
@@ -78,7 +79,7 @@ async fn run_registered_store_retention(
                 );
             }
         }
-        Some(Err(_)) => super::log_daemon_event(
+        Some(Err(_)) => log_daemon_event(
             "retention_degraded",
             &[
                 ("pass", "session_lcm".to_owned()),
@@ -91,7 +92,7 @@ async fn run_registered_store_retention(
         Some(Ok(observations)) => {
             let reclaimed = observations.bytes_reclaimed();
             if reclaimed > 0 || !observations.errors.is_empty() {
-                super::log_daemon_event(
+                log_daemon_event(
                     "retention_observation",
                     &[
                         ("store", "mounted_sessions".to_owned()),
@@ -101,7 +102,7 @@ async fn run_registered_store_retention(
                 );
             }
         }
-        Some(Err(_)) => super::log_daemon_event(
+        Some(Err(_)) => log_daemon_event(
             "retention_degraded",
             &[
                 ("pass", "observation".to_owned()),
@@ -112,7 +113,7 @@ async fn run_registered_store_retention(
     }
     match &report.observability {
         Ok(receipt) if receipt.expired_detail > 0 || receipt.expired_rollup > 0 => {
-            super::log_daemon_event(
+            log_daemon_event(
                 "retention_observability_analytics",
                 &[
                     ("store", "mounted_sessions".to_owned()),
@@ -121,7 +122,7 @@ async fn run_registered_store_retention(
                 ],
             );
         }
-        Err(error) => super::log_daemon_event(
+        Err(error) => log_daemon_event(
             "retention_degraded",
             &[
                 ("pass", "observability_analytics".to_owned()),
@@ -147,7 +148,7 @@ async fn run_profile_observability_retention(
     let now = match now_secs_i64() {
         Ok(now) => now,
         Err(failure) => {
-            super::log_daemon_event(
+            log_daemon_event(
                 "retention_degraded",
                 &[
                     ("pass", "observability_analytics".to_owned()),
@@ -160,7 +161,7 @@ async fn run_profile_observability_retention(
     match database.prune_observability_events(now).await {
         Ok(receipt) => {
             if receipt.expired_detail > 0 || receipt.expired_rollup > 0 {
-                super::log_daemon_event(
+                log_daemon_event(
                     "retention_observability_analytics",
                     &[
                         ("store", "global.db".to_owned()),
@@ -172,7 +173,7 @@ async fn run_profile_observability_retention(
             true
         }
         Err(_) => {
-            super::log_daemon_event(
+            log_daemon_event(
                 "retention_degraded",
                 &[
                     ("pass", "observability_analytics".to_owned()),
@@ -712,7 +713,7 @@ impl MaintenanceCoordinator {
             .store_telemetry_sampling()
             .admit_retention_tick_log(outcome)
         {
-            super::log_daemon_event("retention_maintenance_tick", &tick_fields);
+            log_daemon_event("retention_maintenance_tick", &tick_fields);
         }
         outcome
     }

--- a/crates/tracedecay/src/daemon/pr_autotrack.rs
+++ b/crates/tracedecay/src/daemon/pr_autotrack.rs
@@ -49,6 +49,7 @@ use tracedecay_domain::ProjectId;
 use tracedecay_domain::errors::TraceDecayError;
 
 use tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerRegistryV1;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 const CODE_INDEX_SCHEDULER_UNAVAILABLE: &str = "code_index_scheduler_unavailable";
 
@@ -68,7 +69,6 @@ async fn git_authority_available(repo_root: &Path) -> bool {
 
 #[cfg(test)]
 use super::branch_admin::StoreAdministration;
-use super::log_daemon_event;
 
 mod runtime;
 pub(crate) use runtime::PrAutotrackTask;

--- a/crates/tracedecay/src/daemon/pr_autotrack/runtime.rs
+++ b/crates/tracedecay/src/daemon/pr_autotrack/runtime.rs
@@ -8,13 +8,13 @@ use tracedecay_domain::errors::TraceDecayError;
 use tracedecay_runtime_core::cancellation::CancellationToken;
 
 use crate::daemon::branch_admin::StoreAdministration;
-use crate::daemon::log_daemon_event;
 use tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerRegistryV1;
 
 use super::{
     MAX_NEW_TRACKS_PER_CYCLE, PrCommandControl, PrDiscovery, PrStoreAdministration,
     discover_open_prs_with_control, load_state, reconcile_project_with_administration,
 };
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Base cadence of the poll loop; per-project intervals are honored on top of
 /// this floor via a last-run map.

--- a/crates/tracedecay/src/daemon/production_harness.rs
+++ b/crates/tracedecay/src/daemon/production_harness.rs
@@ -31,6 +31,9 @@ use tracedecay_code_index_runtime::git_transactions;
 #[cfg(any(test, feature = "test-transport"))]
 use tracedecay_daemon_identity::profile_identity;
 
+#[cfg(all(unix, any(test, feature = "test-transport")))]
+use tracedecay_runtime_core::logging::log_daemon_event;
+
 /// Captures the daemon's exact native Git transaction precondition for
 /// transport-parity tests. This is not compiled into production builds.
 #[cfg(all(unix, feature = "test-transport"))]
@@ -1127,7 +1130,7 @@ async fn shutdown_production_project_harness(mut resources: ProductionProjectHar
         .shutdown_manual_branch_publications()
         .await
     {
-        super::log_daemon_event(
+        log_daemon_event(
             "manual_branch_publication",
             &[
                 ("outcome", "harness_shutdown_failed".to_owned()),

--- a/crates/tracedecay/src/daemon/production_harness/generation_retention_test.rs
+++ b/crates/tracedecay/src/daemon/production_harness/generation_retention_test.rs
@@ -9,6 +9,7 @@ use tracedecay_contracts::doctor::{
     DoctorEvidenceStateV1, DoctorStorageFamilyReadV1, DoctorStorageFindingKindV1,
     DoctorStorageIncompleteReasonV1,
 };
+use tracedecay_contracts::storage::compaction::CompactionThresholdConfig;
 use tracedecay_domain::{
     AdmittedEmbeddingProjectionKeyV1, ChangedCodeChunkSetV1, ChangedCodeChunkV1, ChunkerRevision,
     CodeGenerationId, CodeSearchChunkId, ContentDigest, EmbeddingDeviceClassV1,
@@ -782,6 +783,7 @@ async fn semantic_writer_contention_preserves_bootstrap_and_route_shutdown_progr
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mounted_daemon_maintenance_retains_activation_lease_and_converges_after_restart() {
+    let compaction = CompactionThresholdConfig::default();
     let isolation = TempDir::new().expect("isolated production composition");
     let project_root = isolation.path().join("project");
     std::fs::create_dir_all(&project_root).expect("project root");
@@ -901,7 +903,7 @@ async fn mounted_daemon_maintenance_retains_activation_lease_and_converges_after
             schedulers,
             &observations,
             &cancellation,
-            None,
+            Some(&compaction),
             None,
         )
         .await
@@ -918,7 +920,7 @@ async fn mounted_daemon_maintenance_retains_activation_lease_and_converges_after
             schedulers,
             &observations,
             &cancellation,
-            None,
+            Some(&compaction),
             None,
         )
         .await
@@ -1014,7 +1016,7 @@ async fn mounted_daemon_maintenance_retains_activation_lease_and_converges_after
             schedulers,
             &observations,
             &cancellation,
-            None,
+            Some(&compaction),
             None,
         )
         .await
@@ -1060,7 +1062,7 @@ async fn mounted_daemon_maintenance_retains_activation_lease_and_converges_after
             restarted_schedulers,
             &restarted_observations,
             &restarted_cancellation,
-            None,
+            Some(&compaction),
             None,
         )
         .await
@@ -1257,6 +1259,7 @@ async fn run_generation_cadence(
     harness: &ProductionProjectCompositionHarnessV1,
     project_root: &Path,
 ) -> bool {
+    let compaction = CompactionThresholdConfig::default();
     let resources = harness.resources.as_ref().expect("live harness resources");
     let graph = harness
         .server(project_root)
@@ -1268,7 +1271,7 @@ async fn run_generation_cadence(
         &resources.invocation.code_index_schedulers,
         &resources.store_administration.store_telemetry_sampling(),
         &tracedecay_session_memory::context::CancellationToken::new(),
-        None,
+        Some(&compaction),
         None,
     )
     .await

--- a/crates/tracedecay/src/daemon/project_composition.rs
+++ b/crates/tracedecay/src/daemon/project_composition.rs
@@ -8,6 +8,7 @@ use super::*;
 use tracedecay_code_index_runtime::code_index_scheduler;
 use tracedecay_daemon_identity::profile_identity;
 use tracedecay_daemon_service::DaemonSemanticRuntimeRegistrationError;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_semantic_contracts::SemanticResourceCeilings;
 use tracedecay_session_runtime::session_sync::DaemonSessionSyncConfig;
 use tracedecay_session_runtime::session_temporal_refresh_scheduler::{

--- a/crates/tracedecay/src/daemon/project_composition/code_index_activation.rs
+++ b/crates/tracedecay/src/daemon/project_composition/code_index_activation.rs
@@ -7,6 +7,7 @@
 use super::*;
 use tracedecay_code_index_runtime::code_index_scheduler::query_runtime::QueryRuntimeMountErrorV1;
 use tracedecay_domain::EmbeddingDocumentCompositionV1;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_semantic_contracts::SemanticResourceCeilings;
 
 /// Inputs the deferred mount closure re-clones on every activation attempt.

--- a/crates/tracedecay/src/daemon/project_composition/session_database_admission.rs
+++ b/crates/tracedecay/src/daemon/project_composition/session_database_admission.rs
@@ -3,8 +3,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use tracedecay_domain::errors::Result;
-
-use super::log_daemon_event;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 #[hotpath::measure(label = "daemon.project.compose.join_sessions", future = true)]
 pub(super) async fn join_independent_session_opens<Project, Profile, ProjectOpen, ProfileOpen>(

--- a/crates/tracedecay/src/daemon/project_open_orchestration.rs
+++ b/crates/tracedecay/src/daemon/project_open_orchestration.rs
@@ -5,6 +5,7 @@
 //! and a draining daemon never starts a new one.
 
 use super::*;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Bounds how long a foreground request waits for a route's background open.
 /// The open task itself is deliberately left running after the deadline.

--- a/crates/tracedecay/src/daemon/project_open_owners/advisory_runtime/deferred.rs
+++ b/crates/tracedecay/src/daemon/project_open_owners/advisory_runtime/deferred.rs
@@ -13,7 +13,6 @@ use super::{
     DaemonInvocationState, ProjectOpenDependentOwnerState, register_production_advisory_owner,
     register_production_feedback_and_advisory, register_production_feedback_cycle,
 };
-use crate::daemon::log_daemon_event;
 use tracedecay_contracts::doctor::{
     SemanticOwnerDegradedReasonV1, SemanticOwnerPrerequisiteV1, SemanticOwnerStateV1,
 };
@@ -21,6 +20,7 @@ use tracedecay_contracts::now_micros;
 use tracedecay_daemon_service::ProjectRuntimePublicationAttemptV1;
 use tracedecay_domain::errors::{Result, TraceDecayError};
 use tracedecay_runtime_core::cancellation::CancellationToken;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// The deferred advisory owner is a detached background task: when it gives up
 /// (or never sees a publication) nothing in the request path reports it, and a

--- a/crates/tracedecay/src/daemon/project_open_owners/automation_effect_recovery.rs
+++ b/crates/tracedecay/src/daemon/project_open_owners/automation_effect_recovery.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use tracedecay_automation_runtime::automation::effect_recovery::recovery_report_fields;
 use tracedecay_contracts::CancellationSignal;
 
-use crate::daemon::log_daemon_event;
 use crate::tracedecay::TraceDecay;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 #[hotpath::measure(label = "daemon.project.automation_recovery", future = true)]
 pub(crate) async fn reconcile_project_open_automation_effects(project: Arc<TraceDecay>) {

--- a/crates/tracedecay/src/daemon/project_server_lifecycle.rs
+++ b/crates/tracedecay/src/daemon/project_server_lifecycle.rs
@@ -9,6 +9,7 @@ use super::*;
 use std::collections::HashSet;
 use tracedecay_daemon_identity::authority;
 use tracedecay_daemon_service::ProfileHostAdmissionBootstrapStatus;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_store_runtime::{
     ShutdownTaskOutcome, ShutdownTaskReceipt, join_shutdown_tasks_until,
 };

--- a/crates/tracedecay/src/daemon/scheduler.rs
+++ b/crates/tracedecay/src/daemon/scheduler.rs
@@ -16,9 +16,10 @@ use tracedecay_automation_runtime::automation::effect_runtime::settlement::{
 use tracedecay_domain::errors::{Result, TraceDecayError};
 
 use super::branch_admin::MaintenanceReaperKind;
-use super::{
-    DAEMON_TASK_ABORT_DEADLINE, DaemonEngine, DaemonHandshake, ProjectServerKey, log_daemon_event,
-};
+use super::{DAEMON_TASK_ABORT_DEADLINE, DaemonEngine, DaemonHandshake, ProjectServerKey};
+#[cfg(test)]
+use tracedecay_runtime_core::logging::format_daemon_log_line;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 mod combined_effect;
 pub(crate) mod effect_admission;
@@ -243,7 +244,7 @@ pub(super) fn daemon_scheduler_record_log_line(
     project_path: &Path,
     record: &tracedecay_automation_runtime::automation::run_ledger::AutomationRunLedgerRecord,
 ) -> String {
-    super::format_daemon_log_line(
+    format_daemon_log_line(
         "scheduler_task",
         &scheduler_record_log_fields(project_path, record),
     )

--- a/crates/tracedecay/src/daemon/scheduler/combined_effect.rs
+++ b/crates/tracedecay/src/daemon/scheduler/combined_effect.rs
@@ -27,6 +27,7 @@ use tracedecay_automation_runtime::automation::effect_runtime::settlement::{
     DeferredRunSettlementRequest, DeferredSettlementOutcome, DeferredSettlementRequest,
 };
 use tracedecay_domain::errors::Result;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 pub(super) enum CombinedEffectAdmission {
     Execute {
@@ -107,7 +108,7 @@ fn collect_settlement_result(
             if let DeferredSettlementOutcome::Settled(settled) = &outcome
                 && let Some(problem) = settled.terminal.problem()
             {
-                super::log_daemon_event(
+                log_daemon_event(
                     "scheduler_task_application_problem",
                     &super::scheduler_application_problem_log_fields(project_path, task, problem),
                 );
@@ -229,7 +230,7 @@ where
                 }
                 Ok(terminal) => {
                     if let Some(problem) = terminal.problem() {
-                        super::log_daemon_event(
+                        log_daemon_event(
                             "scheduler_task_application_problem",
                             &super::scheduler_application_problem_log_fields(
                                 project_path,

--- a/crates/tracedecay/src/daemon/scheduler/effect_admission.rs
+++ b/crates/tracedecay/src/daemon/scheduler/effect_admission.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use tracedecay_automation_runtime::automation::AutomationRunControl;
 use tracedecay_automation_runtime::automation::backend::AgentTaskKind;
 
-use super::super::{DaemonEngine, DaemonHandshake, log_daemon_event};
+use super::super::{DaemonEngine, DaemonHandshake};
 use super::{
     automation_scheduler_has_work, effective_automation_config_for_project,
     log_scheduler_automation_replay, log_scheduler_task_error, log_scheduler_task_start,
@@ -18,6 +18,7 @@ use tracedecay_automation_runtime::automation::effect_runtime::settlement::{
     AutomationEffectAdmission, AutomationEffectAuthority,
 };
 use tracedecay_domain::errors::{Result, TraceDecayError};
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 pub(super) fn log_scheduler_pre_admission_problem(
     project_path: &Path,

--- a/crates/tracedecay/src/daemon/scheduler/host_receipt_review.rs
+++ b/crates/tracedecay/src/daemon/scheduler/host_receipt_review.rs
@@ -7,9 +7,8 @@ use tracedecay_automation_runtime::automation::AutomationRunControl;
 use crate::tracedecay::TraceDecay;
 use tracedecay_domain::errors::{Result, TraceDecayError};
 
-use super::{
-    DaemonEngine, DaemonHandshake, effective_automation_config_for_project, log_daemon_event,
-};
+use super::{DaemonEngine, DaemonHandshake, effective_automation_config_for_project};
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 const HOST_RECEIPT_REVIEW_BATCH_LIMIT: usize = 8;
 

--- a/crates/tracedecay/src/daemon/shutdown_coordination.rs
+++ b/crates/tracedecay/src/daemon/shutdown_coordination.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use tokio::time::Instant;
+use tracedecay_runtime_core::logging::log_daemon_event;
 pub(crate) use tracedecay_store_runtime::ShutdownStatus;
 
 type ShutdownJoin = Pin<Box<dyn Future<Output = ShutdownStatus> + Send + 'static>>;
@@ -283,7 +284,7 @@ async fn join_shutdown_phase(
                 ShutdownStatus::Failed(_) => "failed",
                 ShutdownStatus::TimedOut => "timed_out",
             };
-            super::log_daemon_event(
+            log_daemon_event(
                 "daemon_shutdown",
                 &[
                     ("outcome", "owner_joined".to_string()),

--- a/crates/tracedecay/src/daemon/shutdown_orchestration.rs
+++ b/crates/tracedecay/src/daemon/shutdown_orchestration.rs
@@ -13,9 +13,10 @@ use super::shutdown_coordination::{
 use super::{
     DAEMON_BACKGROUND_DRAIN_DEADLINE, DAEMON_CLIENT_DRAIN_DEADLINE,
     DAEMON_PROJECT_SERVER_DRAIN_DEADLINE, DAEMON_STORE_CLOSE_RESERVE, DAEMON_TASK_ABORT_DEADLINE,
-    DaemonLifecycle, core_lifecycle::DaemonShutdownClaim, log_daemon_event,
+    DaemonLifecycle, core_lifecycle::DaemonShutdownClaim,
 };
 use tracedecay_domain::errors::Result;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_store_runtime::{ShutdownTaskOutcome, ShutdownTaskReceipt};
 
 type ProjectServerShutdownFuture =

--- a/crates/tracedecay/src/daemon/shutdown_watchdog.rs
+++ b/crates/tracedecay/src/daemon/shutdown_watchdog.rs
@@ -32,8 +32,8 @@ use std::time::Duration;
 #[cfg(feature = "hotpath")]
 use std::sync::{Mutex, mpsc};
 
-use super::log_daemon_event;
 use tracedecay_runtime_core::DAEMON_SHUTDOWN_DEADLINE;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 /// Wall clock past the graceful drain deadline reserved for receipt logging,
 /// endpoint cleanup, profiling finalization, and bounded CLI runtime teardown.

--- a/crates/tracedecay/src/daemon/store_maintenance/mod.rs
+++ b/crates/tracedecay/src/daemon/store_maintenance/mod.rs
@@ -8,8 +8,8 @@ use tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerRegis
 use tracedecay_runtime_core::branch::BranchAdminAction;
 
 use super::branch_admin::StoreAdministration;
-use super::log_daemon_event;
 use crate::tracedecay::TraceDecay;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 #[cfg(test)]
 mod vector_retention_tests;

--- a/crates/tracedecay/src/daemon/store_maintenance/vector_retention_tests.rs
+++ b/crates/tracedecay/src/daemon/store_maintenance/vector_retention_tests.rs
@@ -21,6 +21,7 @@ use tracedecay_code_index_retention::code_index_generations::{
 };
 use tracedecay_code_index_runtime::code_index_scheduler::CodeIndexSchedulerRegistryV1;
 use tracedecay_code_index_runtime::code_index_scheduler::semantic_vector_graph::ProjectVectorReadableSources;
+use tracedecay_contracts::storage::compaction::CompactionThresholdConfig;
 use tracedecay_domain::UtcMicros;
 use tracedecay_maintenance::store_maintenance::{
     CodeGenerationRetentionOutcomeV1, VectorRetentionInventoryV1, apply_code_generation_retention,
@@ -273,6 +274,7 @@ fn committed_retrieval_profiles_keep_the_unseated_state_retryable() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unseated_semantic_runtime_sweeps_quietly_without_a_degraded_loop() {
+    let compaction = CompactionThresholdConfig::default();
     let fixture = open_unseated_graph_fixture().await;
     let root = fixture.graph.project_root();
 
@@ -355,7 +357,7 @@ async fn unseated_semantic_runtime_sweeps_quietly_without_a_degraded_loop() {
             &fixture.schedulers,
             &fixture.observations,
             &fixture.cancellation,
-            None,
+            Some(&compaction),
             continuation,
         )
         .await;
@@ -385,6 +387,7 @@ async fn unseated_semantic_runtime_sweeps_quietly_without_a_degraded_loop() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn semantic_vector_continuation_skips_code_generation_retention() {
+    let compaction = CompactionThresholdConfig::default();
     let fixture = open_unseated_graph_fixture().await;
     let before = sealed_generation_files(&fixture.store_root);
 
@@ -393,7 +396,7 @@ async fn semantic_vector_continuation_skips_code_generation_retention() {
         &fixture.schedulers,
         &fixture.observations,
         &fixture.cancellation,
-        None,
+        Some(&compaction),
         Some(tracedecay_maintenance::tick::MaintenanceContinuation::SemanticVectorRetention),
     )
     .await;

--- a/crates/tracedecay/src/daemon/tests/logging.rs
+++ b/crates/tracedecay/src/daemon/tests/logging.rs
@@ -1,6 +1,7 @@
+use tracedecay_runtime_core::logging::format_daemon_log_line;
 #[test]
 fn daemon_log_line_formats_stable_key_value_fields() {
-    let line = super::super::format_daemon_log_line(
+    let line = format_daemon_log_line(
         "scheduler_task",
         &[
             ("task", "memory_curator".to_string()),
@@ -65,7 +66,7 @@ fn scheduler_application_problem_log_excludes_hostile_payload() {
         tracedecay_automation_runtime::automation::backend::AgentTaskKind::MemoryCurator,
         &problem,
     );
-    let line = super::super::format_daemon_log_line("scheduler_task_application_problem", &fields);
+    let line = format_daemon_log_line("scheduler_task_application_problem", &fields);
 
     assert!(!line.contains(SECRET));
     assert!(!line.contains("hostile automatic fact content"));
@@ -77,7 +78,7 @@ fn scheduler_application_problem_log_excludes_hostile_payload() {
 }
 #[test]
 fn daemon_log_line_escapes_quotes_and_backslashes() {
-    let line = super::super::format_daemon_log_line(
+    let line = format_daemon_log_line(
         "client_error",
         &[("error", r#"failed at "step" \ retry"#.to_string())],
     );
@@ -90,7 +91,7 @@ fn daemon_log_line_escapes_quotes_and_backslashes() {
 
 #[test]
 fn daemon_log_line_escapes_control_characters() {
-    let line = super::super::format_daemon_log_line(
+    let line = format_daemon_log_line(
         "client_error",
         &[("error", "first\nsecond\rthird\tfourth".to_string())],
     );
@@ -104,7 +105,7 @@ fn daemon_log_line_escapes_control_characters() {
 #[cfg(unix)]
 #[test]
 fn scheduler_task_start_log_uses_task_key_and_project() {
-    let line = super::super::format_daemon_log_line(
+    let line = format_daemon_log_line(
         "scheduler_task",
         &super::super::scheduler_task_log_fields(
             std::path::Path::new("/tmp/project with spaces"),
@@ -174,7 +175,7 @@ fn scheduler_record_log_preserves_skipped_status_and_reason() {
 
 #[test]
 fn query_authority_awaiting_generation_log_is_typed_not_degraded() {
-    let line = super::super::format_daemon_log_line(
+    let line = format_daemon_log_line(
         "project_open_phase",
         &[
             ("project", "/tmp/project".to_string()),
@@ -194,27 +195,23 @@ fn query_authority_awaiting_generation_log_is_typed_not_degraded() {
 }
 
 #[test]
-fn retention_degraded_log_names_the_pass_and_failure() {
-    let line = super::super::format_daemon_log_line(
-        "retention_degraded",
-        &[
-            ("pass", "semantic_vector_generations".to_string()),
-            (
-                "failure",
-                "unavailable:semantic retrieval is not calibrated".to_string(),
-            ),
-        ],
-    );
-
+fn retention_degraded_log_formats_the_pass_and_failure() {
+    let fields = [
+        ("pass", "semantic_vector_generations".to_string()),
+        (
+            "failure",
+            "unavailable:semantic retrieval is not calibrated".to_string(),
+        ),
+    ];
     assert_eq!(
-        line,
+        format_daemon_log_line("retention_degraded", &fields),
         "[tracedecay] event=retention_degraded pass=semantic_vector_generations failure=\"unavailable:semantic retrieval is not calibrated\""
     );
 }
 
 #[test]
 fn retention_maintenance_tick_retry_log_keeps_outcome_fields() {
-    let line = super::super::format_daemon_log_line(
+    let line = format_daemon_log_line(
         "retention_maintenance_tick",
         &[
             ("succeeded", "false".to_string()),


### PR DESCRIPTION
Fixes defects introduced by #1177 (`extract store kernels and tick policy from root`), found in independent review.

- `test(maintenance): restore compaction coverage in retention journeys` — #1177 changed seven test call sites from `&RetentionConfig::default()` to `None`; since `RetentionConfig::default().compaction` is `Some(CompactionThresholdConfig::default())` and the new signature skips the compaction block on `None`, those tests silently stopped exercising `compact_project_store`, `run_branch_compaction` and both failure→`Retry` arms. All seven now pass `Some(&CompactionThresholdConfig::default())` (a local, so the default is single-sourced). Coverage proven: a panic probe inside the compaction block fails `unseated_semantic_runtime_sweeps_quietly_without_a_degraded_loop` with the restored args.
- `fix(maintenance): emit retention events through the daemon log authority` — #1177 replaced `log_daemon_event` (unconditional `[tracedecay] event=… k=v` stderr, the parsed operator contract that `parse_watcher_log_line` and doctor watcher health read) with a `tracing::info!/warn!` wrapper, so `retention_branch_gc`/`retention_compaction`/`retention_maintenance_tick` vanished under the default WARN filter and `retention_degraded` was emitted in two shapes. The emitter (`format_daemon_log_line`/`log_daemon_event`, byte-identical) now lives in `tracedecay-runtime-core::logging`; `log_maintenance_event` is deleted; 37 root and maintenance files import it directly (no re-exports). One unix test captures fd 2 and asserts the exact emitted line with `RUST_LOG` unset; the other logging tests are named for the formatter contract they verify.
- `docs(maintenance): restore moved invariant comments` — the per-phase wall-span rationale and the `finalize_generation_outcome` silently-retrying-lanes note, byte-exact.
- `test(runtime-core): drop duplicate enrolled-roots test` — strict subset of an existing test.
- `refactor(maintenance): drop unneeded crate-level lint allows` — 36 → 14, each kept one justified in a comment; `unreachable_pub` removed (0 hits).

Verification: root `generation_retention` 7 / `vector_retention` 8 / `maintenance::tests` 28 / `tests::logging` 9; `daemon::core_logging` 13; runtime-core `logging` + `storage` 43; `tracedecay-maintenance` 156; clippy `-D warnings --tests` on maintenance/runtime-core/root; `cargo check --workspace --all-targets`; fmt; commitlint. Two independent Opus passes. Workspace `--all-targets` clippy stops at the pre-existing `format_collect` in `code_index_scheduler/tests.rs` (fixed in #1184); none of the dropped allows fire.

Noted for a follow-up, not touched here: `tracedecay-code-index-runtime/src/logging.rs` is a third, divergent emitter — its lines omit the `[tracedecay] event=` marker (so doctor's watcher-health parser never sees `git_watch_*` events) and skip control-character escaping.