### PR TITLE
fix(memory): keep fact store cancellation typed through outcomes

### DIFF
--- a/crates/tracedecay-automation-runtime/src/automation/outcomes.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/outcomes.rs
@@ -34,7 +34,9 @@ use super::config_error;
 use super::managed_skills::{ManagedSkillState, list_managed_skills};
 use super::skill_usage::{SkillUsageSummary, summarize_skill_usage};
 use tracedecay_domain::errors::{Result, TraceDecayError};
-use tracedecay_session_memory::memory::MemoryApplication;
+use tracedecay_session_memory::memory::{
+    MemoryApplication, MemoryApplicationError, memory_application_error,
+};
 
 const AUTOMATION_OUTCOMES_FILENAME: &str = "automation_outcomes.json";
 /// Outcome refreshes update independent halves of one snapshot. This lock
@@ -404,6 +406,13 @@ pub fn compute_skill_outcomes(
         .collect()
 }
 
+fn map_fact_outcome_memory_error(context: &str, error: MemoryApplicationError) -> TraceDecayError {
+    if error.is_cancellation() {
+        return memory_application_error(error);
+    }
+    config_error(format!("{context}: {error}"))
+}
+
 pub async fn compute_fact_outcomes<A: ProjectMemoryFactStore>(
     application: &MemoryApplication<A>,
     now_unix: i64,
@@ -421,7 +430,9 @@ pub async fn compute_fact_outcomes<A: ProjectMemoryFactStore>(
                 read_control,
             )
             .await
-            .map_err(|error| config_error(format!("list automatic fact receipts: {error}")))?;
+            .map_err(|error| {
+                map_fact_outcome_memory_error("list automatic fact receipts", error)
+            })?;
         let next_after_apply_id = page.next_after_apply_id().cloned();
 
         for receipt in page.receipts() {
@@ -446,10 +457,13 @@ pub async fn compute_fact_outcomes<A: ProjectMemoryFactStore>(
                     .get_project_memory_fact(fact_id, read_control)
                     .await
                     .map_err(|error| {
-                        config_error(format!(
-                            "read applied automatic fact receipt '{}': {error}",
-                            receipt.apply_id().as_str()
-                        ))
+                        map_fact_outcome_memory_error(
+                            &format!(
+                                "read applied automatic fact receipt '{}'",
+                                receipt.apply_id().as_str()
+                            ),
+                            error,
+                        )
                     })?
             } else {
                 None

--- a/crates/tracedecay-automation-runtime/src/automation/runner.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/runner.rs
@@ -34,7 +34,7 @@ use tracedecay_global_db::{RegisteredGlobalDb, RegisteredGlobalDbLeaseV1};
 use tracedecay_policy::CurationApplyAuthorityV1;
 use tracedecay_runtime_core::tracedecay::current_timestamp;
 use tracedecay_session_memory::fact_store::DatabaseFactStore;
-use tracedecay_session_memory::memory::MemoryApplication;
+use tracedecay_session_memory::memory::{MemoryApplication, is_memory_application_cancellation};
 
 mod curation;
 mod evidence;
@@ -699,6 +699,9 @@ fn run_combined_review_for_retrieval_inner<'a>(
         )
         .await
         {
+            if is_memory_application_cancellation(&err) {
+                return Err(err);
+            }
             tracing::warn!(error = %err, "failed to refresh fact outcomes");
         }
 

--- a/crates/tracedecay-automation-runtime/src/automation/session_reflector.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/session_reflector.rs
@@ -2,7 +2,9 @@ use std::collections::BTreeSet;
 
 use serde_json::{Value, json};
 use tracedecay_domain::{Confidence, FactCategoryV1, PayloadAccessState};
-use tracedecay_session_memory::memory::ProjectMemoryFactAddRequest;
+use tracedecay_session_memory::memory::{
+    MemoryApplicationError, ProjectMemoryFactAddRequest, memory_application_error,
+};
 use tracedecay_store::{
     ProjectMemoryFactProjectionV1, ProjectMemoryFactSearchFilterV1, ProjectMemoryFactSearchKindV1,
     ProjectMemoryFactSearchQuery, ProjectMemoryFactStore,
@@ -14,6 +16,16 @@ use tracedecay_session_memory::memory::MemoryApplication;
 use tracedecay_session_memory::memory::trust::{
     DEFAULT_TRUST, HIGH_TRUST_REPRESENTATIVE, LOW_TRUST_REPRESENTATIVE,
 };
+
+fn map_session_reflector_memory_error(
+    operation: &'static str,
+    error: MemoryApplicationError,
+) -> TraceDecayError {
+    if error.is_cancellation() {
+        return memory_application_error(error);
+    }
+    TraceDecayError::database_operation(operation, error)
+}
 
 pub(crate) async fn validate_fact_candidates<A: ProjectMemoryFactStore>(
     memory: &MemoryApplication<A>,
@@ -283,7 +295,7 @@ async fn validate_fact_candidate<A: ProjectMemoryFactStore>(
         .find_exact_fact_by_content(&content, run_control.read_control())
         .await
         .map_err(|error| {
-            TraceDecayError::database_operation(
+            map_session_reflector_memory_error(
                 "validate session reflector exact duplicate through memory authority",
                 error,
             )
@@ -339,7 +351,7 @@ async fn validate_fact_candidate<A: ProjectMemoryFactStore>(
         .search_project_memory_facts(query, run_control.read_control())
         .await
         .map_err(|error| {
-            TraceDecayError::database_operation(
+            map_session_reflector_memory_error(
                 "validate session reflector near duplicate through memory authority",
                 error,
             )

--- a/crates/tracedecay-dashboard-api/src/memory_service/graph.rs
+++ b/crates/tracedecay-dashboard-api/src/memory_service/graph.rs
@@ -135,7 +135,7 @@ fn graph_authority_error(
 ) -> DashboardGraphReadError {
     let message = error.to_string();
     match error {
-        MemoryApplicationError::Store(FactStoreError::GraphDeadlineExceeded) => {
+        MemoryApplicationError::Cancelled(FactStoreError::GraphDeadlineExceeded) => {
             DashboardGraphReadError::TimedOut(message)
         }
         MemoryApplicationError::Store(FactStoreError::GraphResetRequired { reason, .. }) => {
@@ -143,14 +143,12 @@ fn graph_authority_error(
         }
         _ if request_timed_out => DashboardGraphReadError::TimedOut(message),
         _ if request_cancelled => DashboardGraphReadError::Cancelled(message),
+        MemoryApplicationError::Cancelled(_) => DashboardGraphReadError::Cancelled(message),
         MemoryApplicationError::Store(FactStoreError::GraphConflict) => {
             DashboardGraphReadError::Conflicting(message)
         }
         MemoryApplicationError::Store(FactStoreError::GraphUnavailable) => {
             DashboardGraphReadError::Unavailable(message)
-        }
-        MemoryApplicationError::Store(FactStoreError::GraphCancelled) => {
-            DashboardGraphReadError::Cancelled(message)
         }
         MemoryApplicationError::Store(FactStoreError::GraphBudgetExhausted) => {
             DashboardGraphReadError::BudgetExhausted(message)
@@ -578,12 +576,22 @@ mod tests {
     #[test]
     fn typed_graph_deadline_and_request_terminal_state_have_precedence() {
         let error = graph_authority_error(
-            MemoryApplicationError::Store(FactStoreError::GraphDeadlineExceeded),
+            MemoryApplicationError::Cancelled(FactStoreError::GraphDeadlineExceeded),
             true,
             true,
         );
 
         assert!(matches!(error, DashboardGraphReadError::TimedOut(_)));
+
+        let error = graph_authority_error(
+            MemoryApplicationError::Cancelled(FactStoreError::GraphCancelled),
+            true,
+            false,
+        );
+        assert!(
+            matches!(error, DashboardGraphReadError::TimedOut(_)),
+            "request timeout still precedes a coincident graph cancellation"
+        );
 
         let error = graph_authority_error(
             MemoryApplicationError::Store(FactStoreError::GraphConflict),

--- a/crates/tracedecay-session-memory/src/memory/canonical.rs
+++ b/crates/tracedecay-session-memory/src/memory/canonical.rs
@@ -338,7 +338,7 @@ fn commit_proof(
 fn store_error(error: MemoryUseCaseError<FactStoreError>) -> MemoryApplicationError {
     match error {
         MemoryUseCaseError::Invariant(error) => invariant_error(error),
-        MemoryUseCaseError::Authority(error) => MemoryApplicationError::Store(error),
+        MemoryUseCaseError::Authority(error) => MemoryApplicationError::from(error),
     }
 }
 

--- a/crates/tracedecay-session-memory/src/memory/error.rs
+++ b/crates/tracedecay-session-memory/src/memory/error.rs
@@ -21,7 +21,9 @@ pub enum MemoryApplicationError {
         request_owner: FactOwnerV1,
     },
     #[error("fact store operation failed")]
-    Store(#[from] FactStoreError),
+    Store(#[source] FactStoreError),
+    #[error("fact store operation was cancelled")]
+    Cancelled(#[source] FactStoreError),
     #[error("memory input is invalid: {invariant}")]
     InvalidInput { invariant: &'static str },
     #[error("memory authority returned a result violating {invariant}")]
@@ -73,6 +75,25 @@ impl<T: Debug> From<MemoryMutationError<T>> for MemoryApplicationError {
             MemoryMutationError::Application(error) => error,
             MemoryMutationError::InvalidAuthorityResult { error, .. } => error,
         }
+    }
+}
+
+impl From<FactStoreError> for MemoryApplicationError {
+    fn from(error: FactStoreError) -> Self {
+        match error {
+            FactStoreError::ReadCancelled
+            | FactStoreError::GraphCancelled
+            | FactStoreError::GraphDeadlineExceeded => Self::Cancelled(error),
+            // FactStoreError is #[non_exhaustive]; a future cancellation variant would land in Store.
+            error => Self::Store(error),
+        }
+    }
+}
+
+impl MemoryApplicationError {
+    /// True for store cancellation and deadline failures, not ordinary store errors.
+    pub fn is_cancellation(&self) -> bool {
+        matches!(self, Self::Cancelled(_))
     }
 }
 

--- a/crates/tracedecay-session-memory/src/memory/mod.rs
+++ b/crates/tracedecay-session-memory/src/memory/mod.rs
@@ -75,12 +75,20 @@ use tracedecay_store::{
     StoredFactV1,
 };
 
+/// Operation label for a typed memory-application cancellation. Callers that
+/// must distinguish cancellation from a generic database failure match this
+/// exact [`TraceDecayError::Database::operation`] instead of scanning Display.
+pub const MEMORY_APPLICATION_INTERRUPTED_OPERATION: &str = "memory application interrupted";
+
 /// Maps a [`MemoryApplicationError`] onto the root/dashboard-facing
 /// [`TraceDecayError`]. The single conversion site for every project-memory
 /// route across the root crate and the dashboard API, so both stay in sync
 /// instead of maintaining independent copies.
 pub fn memory_application_error(error: MemoryApplicationError) -> TraceDecayError {
     match error {
+        MemoryApplicationError::Cancelled(error) => {
+            TraceDecayError::database_operation(MEMORY_APPLICATION_INTERRUPTED_OPERATION, error)
+        }
         MemoryApplicationError::Store(tracedecay_store::FactStoreError::GraphResetRequired {
             owner,
             reason,
@@ -93,6 +101,16 @@ pub fn memory_application_error(error: MemoryApplicationError) -> TraceDecayErro
         }
         error => TraceDecayError::database_operation("memory application", error),
     }
+}
+
+/// True when [`memory_application_error`] mapped a store cancellation or
+/// deadline into the typed interrupted-operation database error.
+pub fn is_memory_application_cancellation(error: &TraceDecayError) -> bool {
+    matches!(
+        error,
+        TraceDecayError::Database { operation, .. }
+            if operation == MEMORY_APPLICATION_INTERRUPTED_OPERATION
+    )
 }
 
 /// Builds a [`MemoryApplication`] directly over a database handle's

--- a/crates/tracedecay-session-memory/src/memory/project_memory/add.rs
+++ b/crates/tracedecay-session-memory/src/memory/project_memory/add.rs
@@ -166,7 +166,7 @@ pub fn automatic_fact_add_command(
         Some(run_id.to_owned()),
     )?
     .into_command(context.operation_id().clone())
-    .map_err(MemoryApplicationError::Store)
+    .map_err(MemoryApplicationError::from)
 }
 
 fn fact_add_material(
@@ -196,7 +196,7 @@ fn fact_add_material(
         trust,
         actor,
     )
-    .map_err(MemoryApplicationError::Store)
+    .map_err(MemoryApplicationError::from)
 }
 
 fn rejected_add_effect_material(
@@ -245,7 +245,7 @@ impl<A: ProjectMemoryFactStore> MemoryApplication<A> {
         )?;
         let command = material
             .into_command(context.operation_id().clone())
-            .map_err(MemoryApplicationError::Store)?;
+            .map_err(MemoryApplicationError::from)?;
         Ok(ProjectMemoryFactAddPreflight::Ready {
             effect_material,
             command: Box::new(command),

--- a/crates/tracedecay-session-memory/src/memory/tests.rs
+++ b/crates/tracedecay-session-memory/src/memory/tests.rs
@@ -981,6 +981,71 @@ async fn automation_receipt_recovery_rejects_foreign_authority_identity() {
 }
 
 #[test]
+fn read_cancelled_maps_to_cancellation_variant_not_store() {
+    let error = MemoryApplicationError::from(FactStoreError::ReadCancelled);
+    assert!(
+        matches!(
+            error,
+            MemoryApplicationError::Cancelled(FactStoreError::ReadCancelled)
+        ),
+        "ReadCancelled must stay typed as cancellation, not Store: {error:?}"
+    );
+    assert!(!matches!(error, MemoryApplicationError::Store(_)));
+
+    let mapped = memory_application_error(error);
+    assert!(
+        is_memory_application_cancellation(&mapped),
+        "ReadCancelled must map to typed cancellation, not a generic store/database wrap: {mapped}"
+    );
+    assert!(
+        mapped.to_string().contains("cancelled"),
+        "typed cancellation must keep the store cancellation Display: {mapped}"
+    );
+    assert!(
+        !mapped.to_string().contains("config error"),
+        "cancellation must not be wrapped as a config error: {mapped}"
+    );
+}
+
+#[test]
+fn store_storage_error_cause_survives_into_trace_decay_message() {
+    let error = MemoryApplicationError::from(FactStoreError::Storage {
+        operation: "open project memory",
+        source: Box::new(std::io::Error::other("disk full")),
+    });
+    assert!(
+        matches!(error, MemoryApplicationError::Store(_)),
+        "ordinary Storage failures stay Store, not Cancelled: {error:?}"
+    );
+    let mapped = memory_application_error(error);
+    let message = mapped.to_string();
+    assert!(
+        message.contains("fact store operation failed"),
+        "Store Display must remain in the TraceDecayError chain: {message}"
+    );
+    assert!(
+        message.contains("fact storage operation open project memory failed"),
+        "Storage Display must survive flatten_error_chain: {message}"
+    );
+    assert!(
+        message.contains("disk full"),
+        "Storage source must survive flatten_error_chain: {message}"
+    );
+}
+
+#[test]
+fn graph_deadline_exceeded_maps_to_cancellation_variant_not_store() {
+    let error = MemoryApplicationError::from(FactStoreError::GraphDeadlineExceeded);
+    assert!(matches!(
+        error,
+        MemoryApplicationError::Cancelled(FactStoreError::GraphDeadlineExceeded)
+    ));
+    assert!(is_memory_application_cancellation(
+        &memory_application_error(error)
+    ));
+}
+
+#[test]
 fn graph_reset_required_keeps_profile_and_project_authority_in_root_errors() {
     let profile = memory_application_error(MemoryApplicationError::Store(
         FactStoreError::GraphResetRequired {

--- a/crates/tracedecay-session-memory/src/memory_mapping.rs
+++ b/crates/tracedecay-session-memory/src/memory_mapping.rs
@@ -1099,7 +1099,9 @@ pub fn map_memory_error(error: MemoryApplicationError) -> RetainedSurfaceExecuti
         MemoryApplicationError::OwnerMismatch { .. } => {
             RetainedSurfaceExecutionErrorV1::NotFoundOrNotAuthorized
         }
-        MemoryApplicationError::Store(error) => map_store_error(error),
+        MemoryApplicationError::Store(error) | MemoryApplicationError::Cancelled(error) => {
+            map_store_error(error)
+        }
         error @ (MemoryApplicationError::InvalidAuthorityResult { .. }
         | MemoryApplicationError::InvalidEvidenceAnchor(_)
         | MemoryApplicationError::EvidenceAnchor(_)) => {

--- a/crates/tracedecay-store-runtime/src/session_registry/project_memory_relation_graph_contract_tests.rs
+++ b/crates/tracedecay-store-runtime/src/session_registry/project_memory_relation_graph_contract_tests.rs
@@ -586,7 +586,7 @@ async fn registered_memory_relation_graph_survives_restart_and_isolates_topologi
             CORE_RELATIONS_AFTER_CHORD,
         )
         .await,
-        Err(MemoryApplicationError::Store(
+        Err(MemoryApplicationError::Cancelled(
             FactStoreError::GraphCancelled
         ))
     ));
@@ -599,7 +599,7 @@ async fn registered_memory_relation_graph_survives_restart_and_isolates_topologi
             3,
         )
         .await,
-        Err(MemoryApplicationError::Store(
+        Err(MemoryApplicationError::Cancelled(
             FactStoreError::GraphCancelled
         ))
     ));

--- a/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
+++ b/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
@@ -1,5 +1,7 @@
 use crate::support::*;
+use sha2::{Digest, Sha256};
 use tracedecay_domain::SessionId;
+use tracedecay_domain::canonical_text::encode_tagged_lowercase_hex;
 
 #[path = "session_reflector/automatic_fact_receipts.rs"]
 mod automatic_fact_receipts;
@@ -1723,7 +1725,19 @@ async fn session_reflector_runner_ledgers_missing_facts_array() {
     assert_eq!(records[0].model.as_deref(), Some("fixture-model"));
     assert!(records[0].evidence_hash.is_some());
     assert!(records[0].input_hash.is_some());
-    assert_eq!(records[0].proposed_ops.as_ref(), Some(&output));
+    let expected_sha256 = encode_tagged_lowercase_hex(
+        "sha256:",
+        &Sha256::digest(serde_json::to_vec(&output).unwrap()),
+    );
+    assert_eq!(
+        records[0].proposed_ops.as_ref(),
+        Some(&json!({
+            "schema_version": 1,
+            "expected_field": "facts",
+            "output_sha256": expected_sha256,
+            "output_kind": "object",
+        }))
+    );
     assert!(records[0].error.as_deref().is_some_and(|error| {
         error.contains("session reflector output must include a facts array")
     }));

--- a/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
+++ b/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
@@ -1,6 +1,8 @@
 use crate::support::*;
+#[cfg(feature = "test-transport")]
 use sha2::{Digest, Sha256};
 use tracedecay_domain::SessionId;
+#[cfg(feature = "test-transport")]
 use tracedecay_domain::canonical_text::encode_tagged_lowercase_hex;
 
 #[path = "session_reflector/automatic_fact_receipts.rs"]

--- a/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
+++ b/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
@@ -1249,14 +1249,28 @@ async fn session_reflector_rejects_unsupported_source_role_and_time_filters_with
     let _global_db = isolate_global_db(&cg);
 
     let backend = InspectSessionEvidenceBackend;
-    for (host_mode, query) in [
-        (AutomationHostMode::Standalone, "active project banana"),
-        (AutomationHostMode::DelegatedHost, "project banana evidence"),
-    ] {
-        let config = AutomationConfig {
+    let unsupported_filter_options = SessionReflectorAutomationOptions {
+        trigger: AutomationTrigger::ManualCli,
+        provider: "cursor".to_string(),
+        query: "active project banana".to_string(),
+        scope: LcmScope::Session,
+        session_id: Some("project-reflect-1".to_string()),
+        include_summaries: false,
+        evidence_limit: 5,
+        sort: LcmGrepSort::Relevance,
+        source: Some("project_lcm".to_string()),
+        role: Some("assistant".to_string()),
+        start_time: Some(1_715_100_000),
+        end_time: Some(1_715_100_010),
+        run_id: None,
+        ..SessionReflectorAutomationOptions::default()
+    };
+    let standalone = run_session_reflector_with_backend(
+        &cg,
+        &AutomationConfig {
             enabled: true,
             backend: AutomationBackend::CodexAppServer,
-            host_mode,
+            host_mode: AutomationHostMode::Standalone,
             tasks: AutomationTaskSet {
                 session_reflector: AutomationTaskConfig {
                     enabled: true,
@@ -1266,44 +1280,79 @@ async fn session_reflector_rejects_unsupported_source_role_and_time_filters_with
                 ..AutomationTaskSet::default()
             },
             ..AutomationConfig::default()
-        };
+        },
+        &test_automation_run_control(Arc::new(AtomicBool::new(false))),
+        &backend,
+        unsupported_filter_options.clone(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        standalone.ledger_record.status,
+        AutomationRunStatus::Skipped
+    );
+    assert_eq!(
+        standalone.ledger_record.error.as_deref(),
+        Some("session_evidence_filter_unavailable")
+    );
 
-        let run = run_session_reflector_with_backend(
-            &cg,
-            &config,
-            &test_automation_run_control(Arc::new(AtomicBool::new(false))),
-            &backend,
-            SessionReflectorAutomationOptions {
-                trigger: AutomationTrigger::ManualCli,
-                provider: "cursor".to_string(),
-                query: query.to_string(),
-                scope: LcmScope::Session,
-                session_id: Some("project-reflect-1".to_string()),
-                include_summaries: false,
-                evidence_limit: 5,
-                sort: LcmGrepSort::Relevance,
-                source: Some("project_lcm".to_string()),
-                role: Some("assistant".to_string()),
-                start_time: Some(1_715_100_000),
-                end_time: Some(1_715_100_010),
-                run_id: None,
-                ..SessionReflectorAutomationOptions::default()
+    let delegated = run_session_reflector_with_backend(
+        &cg,
+        &AutomationConfig {
+            enabled: true,
+            backend: AutomationBackend::CodexAppServer,
+            host_mode: AutomationHostMode::DelegatedHost,
+            tasks: AutomationTaskSet {
+                session_reflector: AutomationTaskConfig {
+                    enabled: true,
+                    schedule: Some("manual".to_string()),
+                    ..AutomationTaskConfig::default()
+                },
+                ..AutomationTaskSet::default()
             },
-        )
-        .await
-        .unwrap();
+            ..AutomationConfig::default()
+        },
+        &test_automation_run_control(Arc::new(AtomicBool::new(false))),
+        &backend,
+        SessionReflectorAutomationOptions {
+            query: "project banana evidence".to_string(),
+            ..unsupported_filter_options
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(delegated.ledger_record.status, AutomationRunStatus::Skipped);
+    assert_eq!(
+        delegated.ledger_record.error.as_deref(),
+        Some("delegated_host_mode")
+    );
 
-        assert_eq!(run.ledger_record.status, AutomationRunStatus::Skipped);
-        assert_eq!(
-            run.ledger_record.error.as_deref(),
-            Some("session_evidence_filter_unavailable")
-        );
-    }
+    let memory = tracedecay_session_memory::memory::MemoryApplication::new(
+        project_memory_owner(&cg),
+        tracedecay_session_memory::fact_store::DatabaseFactStore::new(cg.db()),
+    )
+    .unwrap();
+    let run_control = test_automation_run_control(Arc::new(AtomicBool::new(false)));
     assert!(
-        load_run_records(&cg.store_layout().dashboard_root, 10)
+        list_automatic_fact_receipts(&memory, None, 10, run_control.read_control())
             .await
             .unwrap()
-            .is_empty()
+            .is_empty(),
+        "filter and host-mode refusals must not write automatic facts"
+    );
+    let records = load_run_records(&cg.store_layout().dashboard_root, 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        records.len(),
+        1,
+        "only the delegated host gate persists a skip record: {records:?}"
+    );
+    assert!(
+        records.iter().all(|record| {
+            record.status == AutomationRunStatus::Skipped && record.proposed_ops.is_none()
+        }),
+        "refusals must not persist an applied run: {records:?}"
     );
 }
 

--- a/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
+++ b/crates/tracedecay/tests/automation_runner_test/session_reflector.rs
@@ -547,7 +547,7 @@ async fn session_reflector_runner_applies_valid_automatic_facts_by_default() {
             },
             {
                 "content": "Use the fact-store workflow only when the user explicitly asks to memorize or remember a subject",
-                "category": "tool_guidance",
+                "category": "tool",
                 "tags": ["memory", "workflow"],
                 "entities": ["TraceDecay"],
                 "trust": 0.74,
@@ -714,7 +714,7 @@ async fn session_reflector_runner_applies_valid_automatic_facts_by_default() {
     ));
     assert!(has_quarantine_reason("reason is required"));
     assert!(has_quarantine_reason(
-        "confidence is not supported; use trust"
+        "fact proposal contains an unsupported field"
     ));
     assert_eq!(
         run.report["accepted_facts"][2]["add_fact_request"]["trust"],
@@ -803,7 +803,11 @@ async fn session_reflector_runner_applies_valid_automatic_facts_by_default() {
     );
     let eval_payload = read_artifact(&cg, &run.run_id, &run.ledger_record, "generated_evals").await;
     assert_eq!(eval_payload["task"], json!("session_reflector"));
-    assert_eq!(eval_payload["summary"]["eval_count"], json!(11));
+    assert_eq!(
+        eval_payload["summary"]["eval_count"],
+        json!(4),
+        "evals come from applied receipt ids plus the sanitized rejection summary"
+    );
     assert!(
         eval_payload["eval_definitions"]
             .as_array()


### PR DESCRIPTION
Fixes five `automation_runner_test` failures that were red on the #707 tip (193/198) and owned by no lane. A GPT diagnosis classified two as a production regression and three as stale tests; an Opus review confirmed each classification against the production contract before merge.

**Production regression.** `FactStoreError::ReadCancelled` (and `GraphCancelled`/`GraphDeadlineExceeded`) were wrapped into `MemoryApplicationError::Store` and then into a generic config error at the outcome-refresh boundary (`outcomes.rs`), so an interrupted reflector or combined-review run reported `config error: … fact store operation failed` instead of its typed cancellation (introduced by `01e1a49a4`). The three cancellation-shaped variants now map to `MemoryApplicationError::Cancelled`; genuine store failures stay `Store`, which keeps `#[source]` so causes (`Storage`, `Contract`, `GraphConflict`, `CommitConflict`) still surface through `flatten_error_chain`. The two previously-failing interrupt tests pass with zero assertion changes; boundary tests `read_cancelled_maps_to_cancellation_variant_not_store`, `graph_deadline_exceeded_maps_to_cancellation_variant_not_store` and a Storage-cause-survives test are falsifiable. Dashboard `memory_service/graph.rs` drops the now-unreachable `Store(GraphCancelled|GraphDeadlineExceeded)` arms and keeps the request-timeout guard ahead of `Cancelled` (precedence unchanged; covered by `typed_graph_deadline_and_request_terminal_state_have_precedence`); the two `store-runtime` graph-contract assertions migrate to `Cancelled(...)`.

**Stale tests, each corrected to the cited production contract (no assertion weakened):**
- `session_reflector_runner_applies_valid_automatic_facts_by_default` — fixture emitted category `"tool_guidance"`, which never existed in production (`git log -S` empty); production accepts `"tool"` (`session_reflector.rs` category acceptor). No alias added.
- `session_reflector_runner_ledgers_missing_facts_array` — expected raw `{"summary":"no facts"}`; production intentionally retains only the safe projection `{expected_field, output_kind, output_sha256, schema_version}` (`lifecycle.rs` `failed_output_projection`, privacy behavior `79211a2df`). The test recomputes the digest from the raw output and asserts the exact projection, which is what proves raw output is not retained.
- `session_reflector_rejects_unsupported_source_role_and_time_filters_without_writes` — expected `session_evidence_filter_unavailable` in delegated mode, but delegated mode refuses at the host gate (`lifecycle.rs` `task_skip_reason` → `delegated_host_mode`) before evidence filtering. Split into standalone (filter refusal) and delegated (host-gate refusal); both prove no writes and the delegated case asserts exactly one skip record.

Verification: `automation_runner_test` (test-transport) 198/198; `tracedecay-session-memory memory` 86; `tracedecay-store-runtime session_registry` 95; `tracedecay-dashboard-api memory_service` 33; clippy `-D warnings --tests` on session-memory/store-runtime/dashboard-api/automation-runtime/root; fmt; commitlint. Two independent Opus passes.