### PR TITLE
test(daemon): bound rmcp fixture drain without leaking the runtime

### DIFF
--- a/crates/tracedecay-daemon-control/src/service/tests.rs
+++ b/crates/tracedecay-daemon-control/src/service/tests.rs
@@ -656,12 +656,17 @@ fn serve_counted_authenticated_probe(
 /// `listener`, answering `versions[n]` on the n-th completed identity
 /// exchange (the last entry repeats once the list is exhausted). Every
 /// readiness connection must carry its authenticated initialize request.
-/// Returns the count of identity responses served, which lets tests prove the
-/// readiness wait actually consulted the daemon.
+/// Returns the served count plus a channel that fires after each successful
+/// write-and-increment so tests can wait on that acknowledgement instead of
+/// racing the increment that follows the identity response (f92ced4acc).
 #[cfg(target_os = "linux")]
-fn serve_identity_probes(listener: UnixListener, versions: Vec<&'static str>) -> Arc<AtomicUsize> {
+fn serve_identity_probes(
+    listener: UnixListener,
+    versions: Vec<&'static str>,
+) -> (Arc<AtomicUsize>, std::sync::mpsc::Receiver<usize>) {
     let served = Arc::new(AtomicUsize::new(0));
     let count = Arc::clone(&served);
+    let (acknowledged, acknowledgements) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else {
@@ -699,11 +704,12 @@ fn serve_identity_probes(listener: UnixListener, versions: Vec<&'static str>) ->
                 }
             });
             if writeln!(stream, "{response}").is_ok() {
-                count.fetch_add(1, Ordering::SeqCst);
+                let served_count = count.fetch_add(1, Ordering::SeqCst) + 1;
+                let _ = acknowledged.send(served_count);
             }
         }
     });
-    served
+    (served, acknowledgements)
 }
 
 #[cfg(unix)]
@@ -1893,7 +1899,7 @@ fn refresh_installed_service_preserves_existing_socket_path() {
     )
     .expect("refresh service");
     let listener = UnixListener::bind(&custom_socket).expect("bind managed daemon socket");
-    let _served = serve_identity_probes(listener, vec![TEST_BUILD_VERSION]);
+    let (_served, _) = serve_identity_probes(listener, vec![TEST_BUILD_VERSION]);
     super::restore_installed_service_after_update_with_runner(
         &runner,
         previous_state,
@@ -2025,7 +2031,7 @@ fn restore_quiesced_service_starts_existing_unit_without_rewriting_it() {
     );
     std::fs::write(&service_path, &original_unit).expect("existing service unit");
     let listener = UnixListener::bind(&custom_socket).expect("bind managed daemon socket");
-    let served = serve_identity_probes(listener, vec![TEST_BUILD_VERSION]);
+    let (served, acknowledged) = serve_identity_probes(listener, vec![TEST_BUILD_VERSION]);
 
     super::restore_installed_service_after_update_with_runner(
         &runner,
@@ -2034,6 +2040,9 @@ fn restore_quiesced_service_starts_existing_unit_without_rewriting_it() {
     )
     .expect("restore service");
 
+    acknowledged
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("identity probe ack");
     assert_eq!(
         std::fs::read_to_string(service_path).expect("service unit"),
         original_unit
@@ -2213,7 +2222,8 @@ fn restore_after_update_waits_for_authenticated_daemon_identity() {
     // The first identity answer is a stale daemon; restore must keep polling
     // until the expected version answers instead of trusting the systemctl
     // exit status.
-    let served = serve_identity_probes(listener, vec!["0.0.0-stale", TEST_BUILD_VERSION]);
+    let (served, acknowledged) =
+        serve_identity_probes(listener, vec!["0.0.0-stale", TEST_BUILD_VERSION]);
 
     super::restore_installed_service_after_update(
         DaemonServiceState::RunningEnabled,
@@ -2221,6 +2231,12 @@ fn restore_after_update_waits_for_authenticated_daemon_identity() {
     )
     .expect("restore must succeed once the daemon answers the expected identity");
 
+    acknowledged
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("identity probe ack");
+    acknowledged
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("identity probe ack");
     assert_eq!(
         served.load(Ordering::SeqCst),
         2,
@@ -2269,10 +2285,13 @@ fn start_service_reloads_units_and_requires_authenticated_identity() {
     )
     .expect("existing service unit");
     let listener = UnixListener::bind(&socket_path).expect("bind managed daemon socket");
-    let served = serve_identity_probes(listener, vec![TEST_BUILD_VERSION]);
+    let (served, acknowledged) = serve_identity_probes(listener, vec![TEST_BUILD_VERSION]);
 
     super::start_service(TEST_BUILD_VERSION).expect("start service");
 
+    acknowledged
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("identity probe ack");
     let commands = std::fs::read_to_string(log).expect("systemctl log");
     assert!(
         systemctl_log_contains_sequence(
@@ -2321,7 +2340,7 @@ fn wait_for_installed_service_state_rejects_identity_mismatch_at_the_deadline() 
     )
     .expect("existing service unit");
     let listener = UnixListener::bind(&socket_path).expect("bind managed daemon socket");
-    let _served = serve_identity_probes(listener, vec!["0.0.0-stale"]);
+    let (_served, _) = serve_identity_probes(listener, vec!["0.0.0-stale"]);
 
     let error = super::wait_for_installed_service_state_with(
         &runner,

--- a/crates/tracedecay/src/daemon/tests/rmcp_route.rs
+++ b/crates/tracedecay/src/daemon/tests/rmcp_route.rs
@@ -15,7 +15,7 @@ const PHASE_TIMEOUT: Duration = Duration::from_secs(20);
 /// a join timeout well under the 360s harness kill turns that wedge into
 /// a typed red instead of a SIGKILL.
 #[cfg(unix)]
-const FIXTURE_DRAIN_BOUND: Duration = Duration::from_secs(120);
+const FIXTURE_DRAIN_BOUND: Duration = Duration::from_mins(2);
 const AUTH_TOKEN: &str = "0123456789abcdef0123456789abcdef";
 
 struct RmcpRouteFixture {

--- a/crates/tracedecay/src/daemon/tests/rmcp_route.rs
+++ b/crates/tracedecay/src/daemon/tests/rmcp_route.rs
@@ -10,6 +10,12 @@ use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 use super::*;
 
 const PHASE_TIMEOUT: Duration = Duration::from_secs(20);
+/// Wall-clock bound for the dedicated-runtime drain. Isolation `--exact`
+/// hangs sat in `Runtime::drop` after the two servers were already down;
+/// a join timeout well under the 360s harness kill turns that wedge into
+/// a typed red instead of a SIGKILL.
+#[cfg(unix)]
+const FIXTURE_DRAIN_BOUND: Duration = Duration::from_secs(120);
 const AUTH_TOKEN: &str = "0123456789abcdef0123456789abcdef";
 
 struct RmcpRouteFixture {
@@ -935,8 +941,43 @@ async fn selected_target_rmcp_flushes_response_and_disconnect_cancels_selector_o
 }
 
 #[cfg(unix)]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn production_rmcp_cancels_concurrent_requests_before_or_after_registration() {
+#[test]
+fn production_rmcp_cancels_concurrent_requests_before_or_after_registration() {
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name("rmcp-cancel-route".into())
+        .spawn(move || {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                    .expect("cancellation test runtime");
+                runtime.block_on(
+                    production_rmcp_cancels_concurrent_requests_before_or_after_registration_inner(
+                    ),
+                );
+                // Production non-foreground shape (`main.rs`): bound leftover
+                // blocking work. `shutdown_background()` is timeout 0.
+                runtime.shutdown_timeout(Duration::from_secs(2));
+            }));
+            let _ = done_tx.send(outcome);
+        })
+        .expect("spawn cancellation test thread");
+    match done_rx.recv_timeout(FIXTURE_DRAIN_BOUND) {
+        Ok(Ok(())) => {}
+        Ok(Err(payload)) => std::panic::resume_unwind(payload),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("rmcp cancellation fixture: dedicated-runtime drain exceeded the test bound");
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("rmcp cancellation fixture: dedicated-runtime thread disconnected");
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn production_rmcp_cancels_concurrent_requests_before_or_after_registration_inner() {
     let fixture = rmcp_route_fixture("rmcp-live-cancellation").await;
     let executor = Arc::new(ControlledCancellationExecutor::new());
     let project_path = fixture
@@ -965,7 +1006,7 @@ async fn production_rmcp_cancels_concurrent_requests_before_or_after_registratio
             .project_servers()
             .lock()
             .await;
-        owners.insert_route(route, key.clone(), controlled_server);
+        owners.insert_route(route, key.clone(), Arc::clone(&controlled_server));
         assert!(owners.mark_ready(&key));
     }
 
@@ -1050,8 +1091,20 @@ async fn production_rmcp_cancels_concurrent_requests_before_or_after_registratio
     assert_eq!(cancellation_observed, started);
     assert_eq!(completed, started);
 
-    // The replacement route leaves the original server owned by the fixture.
-    // Drain both owners before Tokio drops its runtime and the profile is removed.
+    // The replacement route leaves the original fixture server and the
+    // controlled replacement both live. Shut those two servers down
+    // first so ownership is explicit, then drain the remaining engine
+    // owners (`shutdown_all` is the production-bounded canceller).
+    {
+        let mut owners = fixture
+            .engine
+            .store_administration
+            .project_servers()
+            .lock()
+            .await;
+        owners.remove(&key);
+    }
+    controlled_server.shutdown().await;
     fixture.server.shutdown().await;
     let shutdown = fixture.engine.shutdown_all().await;
     assert!(


### PR DESCRIPTION
Two load-sensitive test defects that appeared on unrelated PRs into #707 (diagnosed independently; neither PR could have caused them).

**`daemon::tests::rmcp_route::production_rmcp_cancels_concurrent_requests_before_or_after_registration`** — hung to nextest's 360s kill, including in `--exact` single-test runs. Root cause (from the hang logs): the hang happens *after* both fixture servers retire, in `#[tokio::test]`'s implicit `Runtime::drop`, which joins leftover engine blocking work indefinitely — the code-index scheduler's `spawn_blocking` try-lock loop (exits only on `shutting_down`), text-serving passes, and the automation scheduler's file-lock thread. Production never joins those unbounded: owners drain under `DAEMON_SHUTDOWN_DEADLINE` with typed per-owner `TimedOut`, and the CLI bounds runtime teardown with `runtime.shutdown_timeout(2s)` (`tracedecay-cli/src/main.rs:741`). The test now mirrors that exactly: keeps `engine.shutdown_all()` (the only thing that cancels the owners) and the `project_servers.is_clean()` assertion, explicitly shuts down the two servers it created ahead of it, runs on a dedicated runtime ended with `shutdown_timeout(2s)` and a normal fixture drop, and joins the test thread at a bound well under 360s so a wedge is a typed red naming the phase instead of a harness kill. An intermediate version that used `shutdown_background()` + `mem::forget(fixture)` was rejected in review as hiding the hang; it is not in this branch. 5/5 exact runs green with `owner_joined status=clean` for every owner and no straggler receipt.

**`tracedecay-daemon-control` `service::tests::restore_quiesced_service_starts_existing_unit_without_rewriting_it`** — the fixture server wrote the identity response (unblocking the client) and only then incremented `served`, so the test could read the pre-increment value. The fixture now acks over a channel strictly after write + increment; all three `served` readers await the ack with a bounded `recv_timeout` (the sender lives in an infinite accept loop, so an unbounded `recv` could never observe `Disconnected` and a missing probe would hang instead of failing).

Verification: rmcp exact ×5 + module (4 passed, 1 ignored); daemon-control `service::tests --test-threads=16` ×2 (70 passed); fmt; commitlint. Clippy `-D warnings --tests` on the branch's merge base hit the pre-existing `large_enum_variant` on `NodeResultV1`, fixed on the tip by `4a0ef8b18`; these two test files are untouched by that. Two independent Opus review rounds.