### PR TITLE
fix(automation): survive Darwin create race; canonical alias-scope test

### DIFF
--- a/crates/tracedecay-automation-runtime/src/automation/effect_runtime/journal.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/effect_runtime/journal.rs
@@ -1231,7 +1231,10 @@ fn open_lock_nofollow(path: &Path) -> std::io::Result<std::fs::File> {
         .write(true)
         .create(true)
         .follow(FollowSymlinks::No);
-    let file = directory.open_with(name, &options)?;
+    // Concurrent settlements race the first creation of this lock; the shared
+    // helper absorbs the spurious Darwin `ENOENT` the losers are handed.
+    let file =
+        tracedecay_private_fs::capability_dir::open_or_create_with(&directory, name, &options)?;
     if !file.metadata()?.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/crates/tracedecay-automation-runtime/src/automation/effect_runtime/recovery_index.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/effect_runtime/recovery_index.rs
@@ -1333,23 +1333,26 @@ fn with_index_lock<T>(path: &Path, operation: impl FnOnce() -> Result<T>) -> Res
         .write(true)
         .create(true)
         .follow(FollowSymlinks::No);
-    let lock = lock_directory
-        .open_with(lock_name, &options)
-        .map(cap_std::fs::File::into_std)
-        .and_then(|file| {
-            let metadata = file.metadata()?;
-            if !metadata.is_file() {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "automation pending index lock is not a regular file",
-                ));
-            }
-            fs2::FileExt::lock_exclusive(&file)?;
-            Ok(file)
-        })
-        .map_err(|error| {
-            contract_error(format!("automation pending index lock failed: {error}"))
-        })?;
+    // Concurrent index writers race the first creation of this lock; the
+    // shared helper absorbs the spurious Darwin `ENOENT` the losers are handed.
+    let lock = tracedecay_private_fs::capability_dir::open_or_create_with(
+        &lock_directory,
+        lock_name,
+        &options,
+    )
+    .map(cap_std::fs::File::into_std)
+    .and_then(|file| {
+        let metadata = file.metadata()?;
+        if !metadata.is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "automation pending index lock is not a regular file",
+            ));
+        }
+        fs2::FileExt::lock_exclusive(&file)?;
+        Ok(file)
+    })
+    .map_err(|error| contract_error(format!("automation pending index lock failed: {error}")))?;
     let result = operation();
     let unlock = fs2::FileExt::unlock(&lock).map_err(|error| {
         contract_error(format!("automation pending index unlock failed: {error}"))

--- a/crates/tracedecay-automation-runtime/src/automation/run_ledger/exact_publication.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/run_ledger/exact_publication.rs
@@ -80,7 +80,10 @@ fn acquire_nofollow_lock(lock_path: &Path) -> std::io::Result<std::fs::File> {
         .write(true)
         .create(true)
         .follow(FollowSymlinks::No);
-    let file = directory.open_with(name, &options)?;
+    // Concurrent writers race the first creation of this lock; the shared
+    // helper absorbs the spurious Darwin `ENOENT` the losers are handed.
+    let file =
+        tracedecay_private_fs::capability_dir::open_or_create_with(&directory, name, &options)?;
     if !file.metadata()?.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
@@ -133,7 +136,12 @@ pub(super) fn open_run_ledger_nofollow(
         .append(append)
         .create(create)
         .follow(FollowSymlinks::No);
-    match directory.open_with(name, &options) {
+    let opened = if create {
+        tracedecay_private_fs::capability_dir::open_or_create_with(&directory, name, &options)
+    } else {
+        directory.open_with(name, &options)
+    };
+    match opened {
         Ok(file) => {
             let metadata = file.metadata()?;
             if !metadata.is_file() {

--- a/crates/tracedecay-automation-runtime/src/automation/scheduler.rs
+++ b/crates/tracedecay-automation-runtime/src/automation/scheduler.rs
@@ -1240,7 +1240,12 @@ fn acquire_task_lock_coordination(path: &Path) -> std::io::Result<std::fs::File>
             .follow(FollowSymlinks::No);
         #[cfg(unix)]
         options.mode(0o600);
-        let file = parent.open_with(file_name, &options)?.into_std();
+        // Concurrent acquirers race the first creation of this coordination
+        // file; the shared helper absorbs the spurious Darwin `ENOENT`.
+        let file = tracedecay_private_fs::capability_dir::open_or_create_with(
+            &parent, file_name, &options,
+        )?
+        .into_std();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/tracedecay-private-fs/src/capability_dir.rs
+++ b/crates/tracedecay-private-fs/src/capability_dir.rs
@@ -1,8 +1,9 @@
 //! Capability-relative durable directory primitives shared by the quarantine
 //! and retirement authorities: atomic no-replace rename between already-open
-//! parent capabilities, directory metadata sync, and recursive no-follow
-//! removal. Every mutation is relative to an open `Dir` handle so a parent
-//! path swapped for a symlink cannot redirect the operation.
+//! parent capabilities, directory metadata sync, recursive no-follow removal,
+//! and create-or-open of one entry that survives the Darwin create race.
+//! Every mutation is relative to an open `Dir` handle so a parent path
+//! swapped for a symlink cannot redirect the operation.
 
 use std::ffi::OsStr;
 use std::io;
@@ -10,9 +11,53 @@ use std::io;
 use cap_fs_ext::DirExt;
 #[cfg(not(windows))]
 use cap_fs_ext::OpenOptionsMaybeDirExt;
-use cap_std::fs::Dir;
-#[cfg(not(windows))]
-use cap_std::fs::OpenOptions;
+use cap_std::fs::{Dir, File, OpenOptions};
+
+/// How many times a create-or-open that reports the entry missing is asked
+/// again before the answer is believed. xnu bounds its own retry of the same
+/// condition at ten; downstream measurements found one extra look always
+/// sufficed, so this is generous without letting a genuinely missing parent
+/// spin.
+const CREATE_RACE_LOOKS: usize = 8;
+
+/// Creates or opens `name` beneath an already-open directory capability.
+///
+/// `options` must request `create(true)` without `create_new`: this is the
+/// create-or-open form, whose two correct answers are "the entry was created"
+/// and "the existing entry was opened". On macOS that form has a defect the
+/// others do not. `openat(dirfd, name, O_CREAT)` without `O_EXCL` hands most
+/// callers that lose the first-creation race of one name a spurious `ENOENT`
+/// (xnu's `vn_open_auth` retries a create that failed with `EEXIST` as an
+/// open, and the fallback is not atomic), even though the entry is present
+/// the moment the error arrives. `O_CREAT|O_EXCL`, opens of an existing entry,
+/// and absolute-path `open` are all correct, which is why the std-based
+/// sidecar locks never see it and only the capability-relative lock and
+/// ledger opens do — and those are exactly the files many writers create at
+/// once.
+///
+/// A `NotFound` answer is therefore looked at again a bounded number of
+/// times. A parent that is genuinely gone still reports `NotFound` after the
+/// bound, so the caller's error mapping keeps working.
+pub fn open_or_create_with(
+    directory: &Dir,
+    name: &OsStr,
+    options: &OpenOptions,
+) -> io::Result<File> {
+    look_again_on_not_found(|| directory.open_with(name, options))
+}
+
+fn look_again_on_not_found<T>(mut attempt: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+    let mut looks = 0;
+    loop {
+        match attempt() {
+            Err(error) if error.kind() == io::ErrorKind::NotFound && looks < CREATE_RACE_LOOKS => {
+                looks += 1;
+                std::thread::yield_now();
+            }
+            result => return result,
+        }
+    }
+}
 
 /// Atomically renames one directory entry between already-open parent
 /// capabilities without allowing an occupied destination to be replaced.
@@ -301,5 +346,85 @@ mod tests {
     fn sync_directory_flushes_an_open_capability() {
         let root = tempfile::tempdir().expect("create sync fixture");
         sync_directory(&open(root.path())).expect("sync an open directory capability");
+    }
+
+    #[test]
+    fn a_transient_missing_answer_is_looked_at_again() {
+        let mut attempts = 0;
+        let value = look_again_on_not_found(|| {
+            attempts += 1;
+            if attempts <= 2 {
+                Err(io::Error::from(io::ErrorKind::NotFound))
+            } else {
+                Ok(attempts)
+            }
+        })
+        .expect("the entry that appears within the bound is returned");
+        assert_eq!(value, 3);
+    }
+
+    #[test]
+    fn a_persistent_missing_answer_is_still_reported_after_the_bound() {
+        let mut attempts = 0;
+        let error = look_again_on_not_found(|| -> io::Result<()> {
+            attempts += 1;
+            Err(io::Error::from(io::ErrorKind::NotFound))
+        })
+        .expect_err("a parent that is genuinely gone must not spin");
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert_eq!(attempts, CREATE_RACE_LOOKS + 1);
+    }
+
+    #[test]
+    fn other_errors_are_not_looked_at_again() {
+        let mut attempts = 0;
+        let error = look_again_on_not_found(|| -> io::Result<()> {
+            attempts += 1;
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        })
+        .expect_err("only the create race is retried");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(attempts, 1);
+    }
+
+    /// Many threads racing the first creation of one name must all come back
+    /// holding the same entry. On macOS this is the `openat(O_CREAT)` race
+    /// the helper exists for; elsewhere it is a plain concurrency smoke test.
+    #[test]
+    fn concurrent_creators_of_one_entry_all_open_it() {
+        use std::os::unix::fs::MetadataExt;
+
+        let root = tempfile::tempdir().expect("create race fixture");
+        for round in 0..16 {
+            let name = format!("racy-{round}.lock");
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+            let handles = (0..8)
+                .map(|_| {
+                    let path = root.path().to_path_buf();
+                    let name = name.clone();
+                    let barrier = std::sync::Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        let directory = open(&path);
+                        let mut options = OpenOptions::new();
+                        options.read(true).write(true).create(true);
+                        barrier.wait();
+                        open_or_create_with(&directory, OsStr::new(&name), &options)
+                            .expect("a create-or-open loser must still be handed the entry")
+                            .into_std()
+                            .metadata()
+                            .expect("metadata of the opened entry")
+                            .ino()
+                    })
+                })
+                .collect::<Vec<_>>();
+            let inodes = handles
+                .into_iter()
+                .map(|handle| handle.join().expect("creator thread"))
+                .collect::<Vec<_>>();
+            assert!(
+                inodes.iter().all(|inode| *inode == inodes[0]),
+                "every racer must open the one created entry"
+            );
+        }
     }
 }

--- a/crates/tracedecay-runtime-core/src/db/access/tests.rs
+++ b/crates/tracedecay-runtime-core/src/db/access/tests.rs
@@ -326,10 +326,18 @@ fn a_scope_entered_before_its_profile_root_exists_still_matches_the_opened_datab
     let scope = crate::db::enter_daemon_database_scope(&profile_root, 1, "alias scope").unwrap();
 
     // Only now does the profile root exist, which is what lets the opened
-    // database resolve it to the `resolved` spelling.
+    // database resolve it to the `resolved` spelling. The identity is fully
+    // canonical, so the expectation must be too: on macOS `tempdir()` itself
+    // is spelled through the `/var` -> `/private/var` alias, and comparing
+    // against `resolved.join("profile")` would fail on spelling alone even
+    // though both name the same directory.
     std::fs::create_dir(&profile_root).unwrap();
     let identity = DatabaseIdentity::for_path(&profile_root.join("global.db")).unwrap();
-    assert_eq!(identity.profile_root, resolved.join("profile"));
+    assert_eq!(
+        identity.profile_root,
+        resolved.canonicalize().unwrap().join("profile"),
+        "the opened database must resolve the alias to the target directory"
+    );
     assert_eq!(
         exact_scoped_runtime_role(&identity.profile_root, "match alias scope").unwrap(),
         Some(DatabaseAuthorityRole::Daemon),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **A — profile scope path identity**: `db::access::tests::a_scope_entered_before_its_profile_root_exists_still_matches_the_opened_database` compared the opened database's fully canonical `profile_root` against `resolved.join("profile")`, which on macOS is itself spelled through the `/var -> /private/var` alias. The production key path is already correct (`canonical_profile_root` resolves through the deepest existing ancestor, `DatabaseIdentity::for_path` fully canonicalizes, and the second assertion — the actual scope match — never failed). The expectation now compares in canonical spelling, like its sibling tests.
- **B — concurrent ledger / lock `ENOENT`**: root cause is a Darwin kernel defect, not a missing parent directory. `openat(dirfd, name, O_CREAT)` *without* `O_EXCL` hands most callers that lose the first-creation race of one name a spurious `ENOENT` (xnu `vn_open_auth` retries a create that failed `EEXIST` as an open, non-atomically), even though the entry exists the moment the error arrives. Only the capability-relative create-or-open form is affected; absolute-path `open`, `O_CREAT|O_EXCL`, and opens of an existing entry are correct — which is why the std-based sidecar locks never hit it and why the earlier `/var` prefix canonicalization couldn't fix it (the parent was never the missing entry). References: [golang/go#81246](https://github.com/golang/go/issues/81246), [spiceai/spiceai#13231](https://github.com/spiceai/spiceai/pull/13231).

## Motivation

macOS-only failures on PR #707 tip (`b90dbb415`), reproduced in the latest macOS CI run of that branch (`Test macOS runtime-storage` / `root-suites`) and locally on a Mac Studio.

## Changes

- `crates/tracedecay-private-fs/src/capability_dir.rs`: new shared `open_or_create_with(dir, name, options)` — bounded (8) "look again" when a cap-std create-or-open reports `NotFound`, mirroring xnu's own bounded retry of the same condition; a genuinely missing parent still reports `NotFound`. Unit tests cover transient/persistent/other-error retry semantics plus an 8-thread × 16-round concurrent-creation test (this is the real proof on a macOS host, where the module's tests compile).
- `run_ledger/exact_publication.rs`: ledger lock (`automation_runs.jsonl.lock`) and the ledger itself when `create` is requested now go through the helper.
- `scheduler.rs`: task-lock coordination file (`<key>.lock.lock`) goes through the helper.
- `effect_runtime/journal.rs`, `effect_runtime/recovery_index.rs`: the two sibling automation lock files with the identical create-or-open shape (separate commit; drop it if you want the PR narrower).
- `runtime-core/src/db/access/tests.rs`: canonical expectation for the alias-scope test.

Not touched: cargo-conductor / hauler; `tracedecay-semantic` `io_primitives::open_member` and `agent-hosts` `text_file_transaction` have the same cap-std create-or-open shape and would be follow-up candidates.

## Test plan

Linux host, with `TMPDIR` routed through a top-level symlink (`/mactmp -> /workspace/target/mactmp-real`) to mimic the `/var -> /private/var` shape:

- [x] Old assertion in A reproduces the exact macOS panic (`left: /workspace/target/mactmp-real/.../resolved/profile`, `right: /mactmp/.../resolved/profile`); new assertion passes.
- [x] `cargo nextest run -p tracedecay-private-fs -p tracedecay-runtime-core -E 'test(capability_dir) | test(a_scope_entered_before_its_profile_root_exists) | test(a_root_reached_through_a_symlink)'` — 10/10 pass
- [x] `cargo nextest run -p tracedecay -p tracedecay-automation-runtime -E '... run_ledger:: | scheduler_diagnostic | concurrent_repeats_append_one_terminal | concurrent_task_locks_acquire_through_symlinked_dashboard_prefix'` — 154/154 pass
- [x] `cargo nextest run -p tracedecay --features tracedecay/test-helpers -E 'binary(automation_runner_test) & (test(run_ledger::) | test(jobs::concurrent_manual_job_triggers_do_not_double_execute) | test(scheduler::))'` — 54/54 pass, including `run_ledger_keeps_concurrent_jsonl_writes_intact` and `concurrent_manual_job_triggers_do_not_double_execute`
- [x] `cargo clippy -p tracedecay-private-fs -p tracedecay-automation-runtime -p tracedecay-runtime-core --all-targets --locked -- -D warnings` clean; `cargo fmt --all --check` clean
- [ ] macOS CI on this branch (the Darwin race cannot be exercised on Linux; the bounded retry is a no-op there)

## Checklist

- [ ] `CHANGELOG.md` updated — not done; this fixes unreleased test/product behaviour on a feature branch
- [x] No secrets, credentials, or `.env` files included
- [x] Breaking changes documented (none)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4949801-fc42-4a07-9598-9310581765c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4949801-fc42-4a07-9598-9310581765c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

