### PR TITLE
test(daemon): anchor lsp lease expiry before disconnect returns

### DIFF
--- a/crates/tracedecay-daemon-service/src/invocation/lsp.rs
+++ b/crates/tracedecay-daemon-service/src/invocation/lsp.rs
@@ -911,15 +911,13 @@ impl DaemonInvocationService {
         let session_id = access.session_id().clone();
         let sessions = Arc::clone(&self.lsp_sessions);
         let registry = Arc::clone(lsp_registry);
-        let (activate_expiry, expiry_activated) = tokio::sync::oneshot::channel::<u64>();
+        let (activate_expiry, expiry_activated) =
+            tokio::sync::oneshot::channel::<(u64, tokio::time::Sleep)>();
         let expiry = async move {
-            let Ok(expires_at_ms) = expiry_activated.await else {
+            let Ok((expires_at_ms, expiry_sleep)) = expiry_activated.await else {
                 return;
             };
-            tokio::time::sleep(std::time::Duration::from_millis(
-                expires_at_ms.saturating_sub(now_millis()),
-            ))
-            .await;
+            expiry_sleep.await;
             registry.lock().await.expire_at(expires_at_ms);
             sessions
                 .lock()
@@ -988,7 +986,14 @@ impl DaemonInvocationService {
                 return;
             }
         };
-        if activate_expiry.send(expires_at_ms).is_err()
+        // The Sleep's Instant deadline must be captured before the caller can
+        // advance virtual time. Tokio registers the timer on first poll, not
+        // construction; remaining TTL is read here so disconnect work does not
+        // stretch the lease.
+        let expiry_sleep = tokio::time::sleep(std::time::Duration::from_millis(
+            expires_at_ms.saturating_sub(now_millis()),
+        ));
+        if activate_expiry.send((expires_at_ms, expiry_sleep)).is_err()
             && let Err(problem) = self.lsp_lease_tasks.cancel(access.session_id()).await
         {
             tracing::error!(

--- a/crates/tracedecay-daemon-service/src/invocation/types.rs
+++ b/crates/tracedecay-daemon-service/src/invocation/types.rs
@@ -874,6 +874,8 @@ struct LspLeaseTask {
     generation: u64,
     cancellation: tracedecay_runtime_core::cancellation::CancellationToken,
     handle: tokio::task::JoinHandle<()>,
+    #[cfg(any(test, feature = "test-helpers"))]
+    finished: Option<tokio::sync::oneshot::Receiver<()>>,
 }
 
 impl LspLeaseTask {
@@ -949,6 +951,8 @@ impl LspLeaseTaskRegistry {
             let task_registry = Arc::downgrade(self);
             let task_session_id = session_id.clone();
             let (start, started) = tokio::sync::oneshot::channel();
+            #[cfg(any(test, feature = "test-helpers"))]
+            let (finished_tx, finished_rx) = tokio::sync::oneshot::channel();
             let handle = tokio::spawn(async move {
                 let admitted = tokio::select! {
                     result = started => result.is_ok(),
@@ -963,6 +967,10 @@ impl LspLeaseTaskRegistry {
                 if let Some(task_registry) = task_registry.upgrade() {
                     task_registry.finish(&task_session_id, generation);
                 }
+                #[cfg(any(test, feature = "test-helpers"))]
+                {
+                    let _ = finished_tx.send(());
+                }
             });
             let previous = state.tasks.insert(
                 session_id,
@@ -970,6 +978,8 @@ impl LspLeaseTaskRegistry {
                     generation,
                     cancellation,
                     handle,
+                    #[cfg(any(test, feature = "test-helpers"))]
+                    finished: Some(finished_rx),
                 },
             );
             (previous, start, generation)
@@ -1052,6 +1062,28 @@ impl LspLeaseTaskRegistry {
         match self.state.lock() {
             Ok(state) => state.tasks.len(),
             Err(poisoned) => poisoned.into_inner().tasks.len(),
+        }
+    }
+
+    /// Await every registered lease task's completion signal.
+    ///
+    /// The sender fires after `finish` removes the task, so this does not
+    /// hold `lsp_sessions`. A missing receiver means the lease already ended.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub async fn wait_until_idle(&self) {
+        let receivers = {
+            let mut state = match self.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            state
+                .tasks
+                .values_mut()
+                .filter_map(|task| task.finished.take())
+                .collect::<Vec<_>>()
+        };
+        for finished in receivers {
+            let _ = finished.await;
         }
     }
 }

--- a/crates/tracedecay/src/daemon/invocation_tests/lsp_tests.rs
+++ b/crates/tracedecay/src/daemon/invocation_tests/lsp_tests.rs
@@ -658,13 +658,13 @@ async fn lsp_disconnect_expiry_settles_unacknowledged_outbound_as_dropped() {
     // drain below awaits the SQLite writer thread's acknowledgement, which a
     // paused clock does not see as pending work: the runtime would auto-advance
     // straight through the recorder's shutdown deadline while the write is
-    // still in flight.
+    // still in flight. Disconnect captures the Sleep's Instant deadline
+    // before returning; tokio registers that timer on first poll.
     service.disconnect_lsp_session(&registry, session).await;
-    tokio::task::yield_now().await;
     tokio::time::pause();
     tokio::time::advance(std::time::Duration::from_millis(LSP_SESSION_TTL_MS)).await;
     tokio::time::resume();
-    tokio::task::yield_now().await;
+    service.lsp_lease_tasks.wait_until_idle().await;
 
     assert!(service.lsp_sessions.lock().await.is_empty());
     assert_eq!(registry.lock().await.active_sessions(), 0);


### PR DESCRIPTION
Closes the last load-only failure tracked under #863's cross-test isolation umbrella: `daemon::invocation_tests::lsp_tests` (the `lsp_sessions` not-yet-empty assertion at ~line 669) failed under `--test-threads=16` (RED ticket `cc-15164`).

Root cause: the lease-expiry task computed its `sleep` from `now_millis()` — a `SystemTime` clock that `tokio::time::advance` cannot move — *after* the test's virtual-TTL advance, so the remaining TTL was still ~full and the test passed only when the spawned task happened to be polled before `pause()`. Fix: `disconnect_lsp_session` constructs the expiry `Sleep` before returning (reading `now_millis()` at the sleep site, so the lease does not fire late by the disconnect body's elapsed time), anchoring the absolute deadline ahead of any caller's advance. Production ordering is unchanged (`expire_at` still precedes `retain`, both inside the lease task); `disconnect_lsp_session` still returns `()`.

The test observes settlement through the existing production surface — `assert_one_lsp_delivery_drop` (`settled == 1`, exactly-once via `settle_in_flight_delivery`'s `take()`) — plus a `#[cfg(any(test, feature = "test-helpers"))]` `LspLeaseTaskRegistry::wait_until_idle()` that fires after `finish()`, outside the `lsp_sessions` lock. No public type added (an intermediate version exposed a `pub` settlement handle no production caller could await; review rejected it and it is not in this branch). No deadline lengthened, no sleep added; two `yield_now()`s replaced by the real signal and an `Enqueued` assertion added.

Verification: GREEN under 16-way load ×3 (`cc-15262`, `cc-15283`, `cc-15308`), exact 1/1; `tracedecay-daemon-service` 282 (covers the `dispatch_tests.rs` call sites); fmt; commitlint. Two independent Opus review rounds.