### PR TITLE
fix(logging): route remaining raw operator events via log authority

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/git_transactions/native.rs
+++ b/crates/tracedecay-code-index-runtime/src/git_transactions/native.rs
@@ -23,6 +23,7 @@ use tracedecay_domain::{
     RepositoryIndexStateV1, RepositoryStateSnapshotV1, RepositoryWorkingTreeSnapshotV1,
     RepositoryWorkingTreeStateV1, UtcMicros, WorktreeId, canonical_sha256, parse_hunk_header,
 };
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_store::GitIndexTransactionRecordV1;
 
 use crate::git_index_transactions::{
@@ -365,12 +366,12 @@ impl GitIndexPreviewAssembler for DaemonProjectGitIndexPreviewAssembler {
     ) -> Result<MaterializedGitIndexPreview, GitIndexTransactionPortError> {
         let scope = request.context.scope();
         if scope.project_id != self.project_id {
-            // The daemon has no tracing subscriber; its diagnostic channel is
-            // this event line, so anything emitted through tracing here is
-            // unreadable in the process that runs it.
-            eprintln!(
-                "[tracedecay] event=git_index_preview_project_mismatch requested={} mounted={}",
-                scope.project_id, self.project_id
+            log_daemon_event(
+                "git_index_preview_project_mismatch",
+                &[
+                    ("requested", scope.project_id.to_string()),
+                    ("mounted", self.project_id.to_string()),
+                ],
             );
             return Err(GitIndexTransactionPortError::StalePreview);
         }
@@ -459,9 +460,18 @@ impl GitIndexPreviewAssembler for NativeGitIndexPreviewAssembler {
             ) {
                 for (field, recaptured_value) in &recaptured {
                     if requested.get(field) != Some(recaptured_value) {
-                        eprintln!(
-                            "[tracedecay] event=git_index_preview_snapshot_field_changed field={field} recaptured={recaptured_value} requested={:?}",
-                            requested.get(field)
+                        log_daemon_event(
+                            "git_index_preview_snapshot_field_changed",
+                            &[
+                                ("field", field.clone()),
+                                ("recaptured", recaptured_value.to_string()),
+                                (
+                                    "requested",
+                                    requested
+                                        .get(field)
+                                        .map_or_else(|| "absent".to_owned(), ToString::to_string),
+                                ),
+                            ],
                         );
                     }
                 }


### PR DESCRIPTION
Finishes the operator-log authority cutover begun in #1190: every remaining raw `eprintln!("[tracedecay] …")` in production code now goes through `tracedecay_runtime_core::logging::log_daemon_event`, so all operator lines share one `[tracedecay] event=<name> k=v` shape with the authority's value quoting and control-character escaping.

Sites (event names): `code-index-runtime` `git_transactions/native.rs` — `git_index_preview_project_mismatch`, `git_index_preview_snapshot_field_changed` (an absent requested field now reads `requested=absent` rather than `None`); `lsp` — `analyzer_start_failed`, `analyzer_semantic_request_failed`, `lsp_feedback_cycle_failed`; `global-db` — `registered_database_wal_checkpoint_failed` (was a free-text line); root `daemon/core_proxy.rs` — `core_proxy_warning` (was a free-text `warning:` line). Return values and control flow are unchanged everywhere. `rg 'eprintln!\("\[tracedecay\]' crates --glob '!**/tests/**' --glob '!**/tests.rs'` is now empty. No consumer in the repo parsed any of the old exact lines.

Verification: `cargo test -p tracedecay-code-index-runtime --lib -- git_transactions` 46 passed; `cargo clippy --no-deps --all-targets -D warnings` clean for `tracedecay-code-index-runtime` (own lints), `tracedecay-lsp`, `tracedecay-global-db`, `tracedecay` lib (the tip's pre-existing `verified_profile_backup.rs` unused-import reds are fixed on the in-flight clippy branch); fmt; commitlint. Opus review of the first commit: READY; the second commit is the same mechanical shape at the three LSP sites it flagged plus the two free-text lines found by the same grep.