### PR TITLE
fix(logging): route lsp, global-db, proxy events via log authority

### DIFF
--- a/crates/tracedecay-global-db/src/registered_maintenance.rs
+++ b/crates/tracedecay-global-db/src/registered_maintenance.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use tracedecay_domain::errors::TraceDecayError;
 use tracedecay_runtime_core::db::DatabaseAuthorityRole;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 use crate::RegisteredGlobalDb;
 
@@ -94,7 +95,10 @@ impl RegisteredGlobalDb {
     #[hotpath::skip]
     pub async fn checkpoint(&self) {
         if let Err(error) = self.checkpoint_result().await {
-            eprintln!("[tracedecay] registered database WAL checkpoint failed: {error}");
+            log_daemon_event(
+                "registered_database_wal_checkpoint_failed",
+                &[("error", error.to_string())],
+            );
         }
     }
 

--- a/crates/tracedecay-lsp/src/analyzer/broker/semantic_authority.rs
+++ b/crates/tracedecay-lsp/src/analyzer/broker/semantic_authority.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
+use tracedecay_runtime_core::logging::log_daemon_event;
 
 use super::super::client::{
     LspRefreshTimeouts, LspSemanticRequestError, StdioLspClient, decode_semantic_request,
@@ -377,7 +378,7 @@ fn analyzer_event_outcome(event: AnalyzerEvent) -> LspSemanticOperationOutcome {
 }
 
 pub(crate) fn analyzer_start_failure(error: &TraceDecayError) -> LspSemanticOperationOutcome {
-    eprintln!("[tracedecay] event=analyzer_start_failed error={error}");
+    log_daemon_event("analyzer_start_failed", &[("error", error.to_string())]);
     analyzer_event_outcome(AnalyzerEvent::StartupFailed)
 }
 
@@ -390,7 +391,10 @@ pub(crate) fn semantic_operation_outcome(
             code: Some(-32601), ..
         }) => LspSemanticOperationOutcome::Unavailable,
         Err(error) => {
-            eprintln!("[tracedecay] event=analyzer_semantic_request_failed error={error}");
+            log_daemon_event(
+                "analyzer_semantic_request_failed",
+                &[("error", error.to_string())],
+            );
             analyzer_event_outcome(error.analyzer_event())
         }
     }

--- a/crates/tracedecay-lsp/src/gateway.rs
+++ b/crates/tracedecay-lsp/src/gateway.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use serde_json::{Value, json};
 use tracedecay_domain::ManifestDigest;
+use tracedecay_runtime_core::logging::log_daemon_event;
 use tracedecay_runtime_core::path_safety::{canonicalize_existing_prefix, same_canonical_path};
 use url::Url;
 
@@ -814,9 +815,9 @@ impl FeedbackCyclePort for FeedbackCycleAdapter {
         let _task = self.runtime.spawn(Box::pin(async move {
             let _permit = permit;
             if let Err(error) = authority.execute(request).await {
-                eprintln!(
-                    "[tracedecay] event=lsp_feedback_cycle_failed failure_class={}",
-                    error.class()
+                log_daemon_event(
+                    "lsp_feedback_cycle_failed",
+                    &[("failure_class", error.class().to_owned())],
                 );
             }
         }));

--- a/crates/tracedecay/src/daemon/core_proxy.rs
+++ b/crates/tracedecay/src/daemon/core_proxy.rs
@@ -580,7 +580,7 @@ async fn write_proxy_request_result(
                 &responses,
                 binary_version()?,
             ) {
-                eprintln!("[tracedecay] warning: {warning}");
+                log_daemon_event("core_proxy_warning", &[("warning", warning)]);
             }
             for response in responses {
                 writer.write_line(&response).await?;


### PR DESCRIPTION
Completes what #1212 described but only partially shipped: its second commit was rejected by the local `commit-msg` hook (76-char subject) and the retry only renamed the first commit, so #1212 merged the `git_transactions/native.rs` change alone under a subject that over-claims. This PR carries the remaining four sites, so the cutover to `tracedecay_runtime_core::logging::log_daemon_event` is now actually complete.

Sites (event names): `lsp` — `analyzer_start_failed`, `analyzer_semantic_request_failed`, `lsp_feedback_cycle_failed`; `global-db` — `registered_database_wal_checkpoint_failed` (was a free-text `[tracedecay] …` line); root `daemon/core_proxy.rs` — `core_proxy_warning` (was a free-text `[tracedecay] warning:` line). Control flow and return values unchanged. After this, `rg 'eprintln!\("\[tracedecay\]' crates --glob '!**/tests/**' --glob '!**/tests.rs'` is empty. No consumer in the repo parsed the old lines.

Verification (same tree as reviewed): `cargo clippy --no-deps --all-targets -D warnings` clean for `tracedecay-lsp`, `tracedecay-global-db`, and the `tracedecay` lib (the only reds were the tip's pre-existing `verified_profile_backup.rs` unused imports, fixed on the in-flight clippy branch); fmt; commitlint. The Opus review of #1212 named the three LSP sites as the remaining gap; the two free-text lines came from the same grep.