### PR TITLE
style: make workspace clippy green on the integration tip

### DIFF
--- a/crates/tracedecay-agent-hosts/src/agents/context_scout_owner.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/context_scout_owner.rs
@@ -907,33 +907,25 @@ impl ProjectContextScoutOwnerV1 {
         expires_at: UtcMicros,
     ) -> Option<ContextScoutPublicMutationV1> {
         let configuration = self.configuration.read().await;
-        let Some(control) = configuration
+        let control = configuration
             .as_ref()
-            .map(ContextScoutConfigurationPinV1::control)
-        else {
-            return None;
-        };
+            .map(ContextScoutConfigurationPinV1::control)?;
         let window = match request.window {
             ContextScoutClaimWindowV1::IdleWindow => ContextScoutDeliveryWindowV1::IdleWindow,
             ContextScoutClaimWindowV1::OnRequest => ContextScoutDeliveryWindowV1::OnRequest,
         };
-        let Some(digest) = canonical_sha256(&(
+        let digest = canonical_sha256(&(
             "tracedecay.context-scout.delivery-lease.v1",
             &request.idempotency_key,
             request.address,
             request.window,
             control.configuration_revision,
         ))
-        .ok() else {
-            return None;
-        };
-        let Some(encoded) = digest
+        .ok()?;
+        let encoded = digest
             .as_str()
             .strip_prefix("sha256:")
-            .and_then(|encoded| encoded.get(..32))
-        else {
-            return None;
-        };
+            .and_then(|encoded| encoded.get(..32))?;
         let mut lease_id = [0; 16];
         if hex::decode_to_slice(encoded, &mut lease_id).is_err() {
             return None;

--- a/crates/tracedecay-agent-hosts/src/agents/context_scout_v2.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/context_scout_v2.rs
@@ -293,7 +293,7 @@ pub struct ContextScoutMutationBindingV1 {
 #[serde(rename_all = "snake_case", tag = "operation", content = "result")]
 pub enum ContextScoutMutationResultV1 {
     Cancel(ContextScoutDurableStoreOutcomeV1),
-    Claim(ContextScoutDurableClaimOutcomeV1),
+    Claim(Box<ContextScoutDurableClaimOutcomeV1>),
     Delivery {
         outcome: ContextScoutDurableStoreOutcomeV1,
         receipt: ContextScoutDeliveryReceiptV1,
@@ -311,7 +311,7 @@ pub struct ContextScoutMutationSettlementV1 {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ContextScoutMutationSettlementOutcomeV1 {
-    Reconciled(ContextScoutMutationSettlementV1),
+    Reconciled(Box<ContextScoutMutationSettlementV1>),
     IdempotencyConflict,
     Unavailable,
 }

--- a/crates/tracedecay-agent-hosts/src/agents/context_scout_v2/store.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/context_scout_v2/store.rs
@@ -230,13 +230,13 @@ impl ContextScoutPublicMutationV1 {
                 configuration_revision,
                 now,
                 lease,
-            } => Some(ContextScoutMutationResultV1::Claim(state.claim(
+            } => Some(ContextScoutMutationResultV1::Claim(Box::new(state.claim(
                 address,
                 Some(window),
                 Some(configuration_revision),
                 now,
                 lease,
-            ))),
+            )))),
             Self::Delivery {
                 work,
                 envelope_id,
@@ -1143,7 +1143,7 @@ impl ProjectContextScoutDurableStoreV1 {
         if observed.as_ref() != Some(&settlement) {
             return ContextScoutMutationSettlementOutcomeV1::Unavailable;
         }
-        ContextScoutMutationSettlementOutcomeV1::Reconciled(settlement)
+        ContextScoutMutationSettlementOutcomeV1::Reconciled(Box::new(settlement))
     }
 
     #[hotpath::measure(

--- a/crates/tracedecay-agent-hosts/src/agents/context_scout_v2/store_tests.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/context_scout_v2/store_tests.rs
@@ -122,7 +122,7 @@ async fn public_claim_retains_empty_and_changed_settlements_for_exact_replay() {
     };
     assert!(matches!(
         first.result,
-        ContextScoutMutationResultV1::Claim(ContextScoutDurableClaimOutcomeV1::Empty)
+        ContextScoutMutationResultV1::Claim(Box::new(ContextScoutDurableClaimOutcomeV1::Empty))
     ));
     assert_eq!(
         store
@@ -188,7 +188,8 @@ async fn public_claim_retains_empty_and_changed_settlements_for_exact_replay() {
     };
     assert!(matches!(
         claimed.result,
-        ContextScoutMutationResultV1::Claim(ContextScoutDurableClaimOutcomeV1::Claimed(_))
+        ContextScoutMutationResultV1::Claim(ref outcome)
+            if matches!(**outcome, ContextScoutDurableClaimOutcomeV1::Claimed(_))
     ));
     assert_eq!(
         store

--- a/crates/tracedecay-agent-hosts/src/agents/context_scout_v2/store_tests.rs
+++ b/crates/tracedecay-agent-hosts/src/agents/context_scout_v2/store_tests.rs
@@ -120,10 +120,10 @@ async fn public_claim_retains_empty_and_changed_settlements_for_exact_replay() {
     let ContextScoutMutationSettlementOutcomeV1::Reconciled(first) = first else {
         panic!("empty claim must retain a reconciled settlement");
     };
-    assert!(matches!(
+    assert_eq!(
         first.result,
         ContextScoutMutationResultV1::Claim(Box::new(ContextScoutDurableClaimOutcomeV1::Empty))
-    ));
+    );
     assert_eq!(
         store
             .commit_public_mutation(empty_binding.clone(), empty)

--- a/crates/tracedecay-application/src/tracedecay/mod.rs
+++ b/crates/tracedecay-application/src/tracedecay/mod.rs
@@ -143,22 +143,21 @@ pub fn build_branch_diagnostics(
     serving_source: Option<(&str, &str)>,
 ) -> BranchDiagnostics {
     let meta = branch_meta::load_branch_meta(data_root);
-    let observed_serving_branch = serving_source
-        .and_then(|(reference, revision)| {
-            meta.as_ref().and_then(|meta| {
-                meta.branches.iter().find_map(|(name, entry)| {
-                    entry
-                        .graph_source
-                        .as_ref()
-                        .filter(|source| {
-                            source.reference == reference
-                                && source.source_oid == revision
-                                && meta.is_query_eligible(name)
-                        })
-                        .map(|_| name.clone())
-                })
+    let observed_serving_branch = serving_source.and_then(|(reference, revision)| {
+        meta.as_ref().and_then(|meta| {
+            meta.branches.iter().find_map(|(name, entry)| {
+                entry
+                    .graph_source
+                    .as_ref()
+                    .filter(|source| {
+                        source.reference == reference
+                            && source.source_oid == revision
+                            && meta.is_query_eligible(name)
+                    })
+                    .map(|_| name.clone())
             })
-        });
+        })
+    });
     let (open_active_branch, serving_branch, fallback_warning) =
         if let Some(branch) = observed_serving_branch {
             (Some(branch.clone()), Some(branch), None)

--- a/crates/tracedecay-application/src/tracedecay/mod.rs
+++ b/crates/tracedecay-application/src/tracedecay/mod.rs
@@ -140,12 +140,10 @@ pub fn build_branch_diagnostics(
     serving_branch: Option<String>,
     fallback_warning: Option<String>,
     serving_db_path: PathBuf,
-    serving_source_reference: Option<&str>,
-    serving_source_revision: Option<&str>,
+    serving_source: Option<(&str, &str)>,
 ) -> BranchDiagnostics {
     let meta = branch_meta::load_branch_meta(data_root);
-    let observed_serving_branch = serving_source_reference
-        .zip(serving_source_revision)
+    let observed_serving_branch = serving_source
         .and_then(|(reference, revision)| {
             meta.as_ref().and_then(|meta| {
                 meta.branches.iter().find_map(|(name, entry)| {

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/branch_publication.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/branch_publication.rs
@@ -645,7 +645,7 @@ fn branch_generation_observation(
             .parked
             .as_ref()
             .map(|parked| parked.reason.as_str())
-            .or_else(|| match freshness.code_graph_serving.as_ref() {
+            .or(match freshness.code_graph_serving.as_ref() {
                 Some(CodeGraphServingReadinessV1::Refused { reason }) => Some(reason.as_str()),
                 Some(CodeGraphServingReadinessV1::Unavailable { reason })
                     if !freshness.rebuild_in_flight =>

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/queries.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/queries.rs
@@ -1418,10 +1418,8 @@ fn augment_callee_dispatch_page(
     scope: &tracedecay_contracts::CodeQueryScope,
     budget: RetrievalBudget,
     control: &dyn GraphExecutionControl,
-) -> Result<
-    NativeLanePageV1<SymbolRelationRecord>,
-    Box<NativeLaneOutcomeV1<SymbolRelationRecord>>,
-> {
+) -> Result<NativeLanePageV1<SymbolRelationRecord>, Box<NativeLaneOutcomeV1<SymbolRelationRecord>>>
+{
     let candidate_cap = usize::try_from(budget.max_candidates_per_lane).unwrap_or(usize::MAX);
     let mut page = NativeLanePageV1 {
         generation: page.generation,

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/queries.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/queries.rs
@@ -1418,7 +1418,10 @@ fn augment_callee_dispatch_page(
     scope: &tracedecay_contracts::CodeQueryScope,
     budget: RetrievalBudget,
     control: &dyn GraphExecutionControl,
-) -> Result<NativeLanePageV1<SymbolRelationRecord>, NativeLaneOutcomeV1<SymbolRelationRecord>> {
+) -> Result<
+    NativeLanePageV1<SymbolRelationRecord>,
+    Box<NativeLaneOutcomeV1<SymbolRelationRecord>>,
+> {
     let candidate_cap = usize::try_from(budget.max_candidates_per_lane).unwrap_or(usize::MAX);
     let mut page = NativeLanePageV1 {
         generation: page.generation,
@@ -1442,11 +1445,11 @@ fn augment_callee_dispatch_page(
         match check_dispatch_control(control, budget) {
             Ok(()) => {}
             Err(DispatchExpansionStop::Cancelled) => {
-                return Err(NativeLaneOutcomeV1::Cancelled);
+                return Err(Box::new(NativeLaneOutcomeV1::Cancelled));
             }
             Err(DispatchExpansionStop::TimedOut) => {
-                return Err(NativeLaneOutcomeV1::TimedOut(callee_dispatch_usage(
-                    &page, examined, control,
+                return Err(Box::new(NativeLaneOutcomeV1::TimedOut(
+                    callee_dispatch_usage(&page, examined, control),
                 )));
             }
         }
@@ -1489,11 +1492,11 @@ fn augment_callee_dispatch_page(
                 break 'callees;
             }
             Err(DispatchExpansionStop::Cancelled) => {
-                return Err(NativeLaneOutcomeV1::Cancelled);
+                return Err(Box::new(NativeLaneOutcomeV1::Cancelled));
             }
             Err(DispatchExpansionStop::TimedOut) => {
-                return Err(NativeLaneOutcomeV1::TimedOut(callee_dispatch_usage(
-                    &page, examined, control,
+                return Err(Box::new(NativeLaneOutcomeV1::TimedOut(
+                    callee_dispatch_usage(&page, examined, control),
                 )));
             }
         }
@@ -1515,13 +1518,13 @@ fn augment_callee_dispatch(
         NativeLaneOutcomeV1::Complete(page) => {
             match augment_callee_dispatch_page(latest, page, scope, budget, control) {
                 Ok(page) => NativeLaneOutcomeV1::Complete(page),
-                Err(terminal) => terminal,
+                Err(terminal) => *terminal,
             }
         }
         NativeLaneOutcomeV1::Partial { page, reason } => {
             match augment_callee_dispatch_page(latest, page, scope, budget, control) {
                 Ok(page) => NativeLaneOutcomeV1::Partial { page, reason },
-                Err(terminal) => terminal,
+                Err(terminal) => *terminal,
             }
         }
         NativeLaneOutcomeV1::Unavailable(reason) => NativeLaneOutcomeV1::Unavailable(reason),

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -4622,7 +4622,7 @@ impl CodeIndexSchedulerRegistryV1 {
                         })
                         .await;
                         match handoff {
-                            Ok(Ok(Some(_)) | Ok(None)) => {}
+                            Ok(Ok(Some(_) | None)) => {}
                             Ok(Err(error)) => tracing::warn!(
                                 event = "code_index_semantic_retained_handoff_failed",
                                 error = %error,

--- a/crates/tracedecay-contracts/src/diagnostics/provider.rs
+++ b/crates/tracedecay-contracts/src/diagnostics/provider.rs
@@ -440,8 +440,8 @@ impl AnalyzerAdmittedDiagnosticProviderV1 {
 /// runtime budget merely to enter the read path.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FeedbackDiagnosticProviderAdmissionV1 {
-    Analyzer(AnalyzerAdmittedDiagnosticProviderV1),
-    StoredPublication(DiagnosticProviderIdentity),
+    Analyzer(Box<AnalyzerAdmittedDiagnosticProviderV1>),
+    StoredPublication(Box<DiagnosticProviderIdentity>),
 }
 
 impl FeedbackDiagnosticProviderAdmissionV1 {
@@ -454,7 +454,7 @@ impl FeedbackDiagnosticProviderAdmissionV1 {
                 field: "stored diagnostic publication admission",
             });
         }
-        Ok(Self::StoredPublication(identity))
+        Ok(Self::StoredPublication(Box::new(identity)))
     }
 
     pub fn identity(&self) -> &DiagnosticProviderIdentity {
@@ -491,7 +491,7 @@ impl FeedbackDiagnosticProviderAdmissionV1 {
 
 impl From<AnalyzerAdmittedDiagnosticProviderV1> for FeedbackDiagnosticProviderAdmissionV1 {
     fn from(value: AnalyzerAdmittedDiagnosticProviderV1) -> Self {
-        Self::Analyzer(value)
+        Self::Analyzer(Box::new(value))
     }
 }
 

--- a/crates/tracedecay-contracts/src/git/native_integration_surface.rs
+++ b/crates/tracedecay-contracts/src/git/native_integration_surface.rs
@@ -433,7 +433,7 @@ pub enum NativeIntegrationCancellationProjectionV1 {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum NativeIntegrationSurfaceResultV1 {
-    StackSnapshot(NativeIntegrationSealedStackSnapshotProjectionV1),
+    StackSnapshot(Box<NativeIntegrationSealedStackSnapshotProjectionV1>),
     Preview(NativeIntegrationPreviewProjectionV1),
     Approval(NativeIntegrationApprovalProjectionV1),
     Receipt(NativeIntegrationReceiptProjectionV1),
@@ -470,10 +470,10 @@ impl NativeIntegrationSurfaceResultV1 {
     ) -> Result<Self, ApplicationContractError> {
         Ok(match outcome {
             NativeIntegrationStackResolutionOutcomeV1::Complete(selection) => {
-                Self::StackSnapshot(NativeIntegrationSealedStackSnapshotProjectionV1 {
+                Self::StackSnapshot(Box::new(NativeIntegrationSealedStackSnapshotProjectionV1 {
                     selection: NativeIntegrationSnapshotProjectionV1::project(selection)?,
                     sealed_snapshot,
-                })
+                }))
             }
             NativeIntegrationStackResolutionOutcomeV1::Partial => {
                 Self::unavailable(NativeIntegrationSurfaceUnavailableV1::Partial)

--- a/crates/tracedecay-daemon-service/src/invocation/dispatch.rs
+++ b/crates/tracedecay-daemon-service/src/invocation/dispatch.rs
@@ -1079,6 +1079,16 @@ impl DaemonInvocationService {
     }
 }
 
+fn missing_work_runtime_problem(
+    publication: Option<crate::project_runtime::ProjectRuntimePublicationStateV1>,
+    request_id: String,
+) -> DaemonInvocationResponse {
+    if publication == Some(crate::project_runtime::ProjectRuntimePublicationStateV1::Ready) {
+        return super::work::concealed_application_problem(request_id);
+    }
+    super::work::missing_registered_owner_problem(publication, request_id)
+}
+
 #[cfg(test)]
 mod future_size_guard {
     use super::*;
@@ -1113,14 +1123,4 @@ mod future_size_guard {
              any large payload arm in the dispatch match",
         );
     }
-}
-
-fn missing_work_runtime_problem(
-    publication: Option<crate::project_runtime::ProjectRuntimePublicationStateV1>,
-    request_id: String,
-) -> DaemonInvocationResponse {
-    if publication == Some(crate::project_runtime::ProjectRuntimePublicationStateV1::Ready) {
-        return super::work::concealed_application_problem(request_id);
-    }
-    super::work::missing_registered_owner_problem(publication, request_id)
 }

--- a/crates/tracedecay-daemon-service/src/invocation/primitive.rs
+++ b/crates/tracedecay-daemon-service/src/invocation/primitive.rs
@@ -810,12 +810,17 @@ async fn execute_context_scout_mutation(
                 tracedecay_contracts::context_scout::ContextScoutMutationResultV1 { outcome },
             )
         }
-        ContextScoutMutationResultV1::Claim(ContextScoutDurableClaimOutcomeV1::Claimed(claim)) => {
-            serde_json::to_value(public_context_scout_claim(claim))
-        }
-        ContextScoutMutationResultV1::Claim(ContextScoutDurableClaimOutcomeV1::Empty) => {
-            serde_json::to_value(ContextScoutClaimResultV1::Empty)
-        }
+        ContextScoutMutationResultV1::Claim(outcome) => match outcome.as_ref() {
+            ContextScoutDurableClaimOutcomeV1::Claimed(claim) => {
+                serde_json::to_value(public_context_scout_claim(claim))
+            }
+            ContextScoutDurableClaimOutcomeV1::Empty => {
+                serde_json::to_value(ContextScoutClaimResultV1::Empty)
+            }
+            ContextScoutDurableClaimOutcomeV1::Unavailable => {
+                return context_scout_mutation_unavailable(wire_request_id);
+            }
+        },
         ContextScoutMutationResultV1::Delivery { outcome, receipt } => {
             let Some(outcome) = context_scout_store_outcome(*outcome) else {
                 return context_scout_mutation_unavailable(wire_request_id);
@@ -824,9 +829,6 @@ async fn execute_context_scout_mutation(
                 outcome,
                 receipt: receipt.clone(),
             })
-        }
-        ContextScoutMutationResultV1::Claim(ContextScoutDurableClaimOutcomeV1::Unavailable) => {
-            return context_scout_mutation_unavailable(wire_request_id);
         }
     };
     let Ok(payload) = payload else {

--- a/crates/tracedecay-daemon-service/src/invocation/work/workflow_fan_out.rs
+++ b/crates/tracedecay-daemon-service/src/invocation/work/workflow_fan_out.rs
@@ -166,8 +166,8 @@ pub(super) fn reconcile_workflow_fan_out(
         }
         let newly_settled = terminal_planned
             .iter()
+            .filter(|&identity| !projection.settled_fan_out_attempts().contains(identity))
             .cloned()
-            .filter(|identity| !projection.settled_fan_out_attempts().contains(identity))
             .collect::<Vec<_>>();
         if !newly_settled.is_empty() {
             projection = apply_scheduler_command(

--- a/crates/tracedecay-daemon-service/src/invocation/work_routing.rs
+++ b/crates/tracedecay-daemon-service/src/invocation/work_routing.rs
@@ -137,7 +137,7 @@ impl WorkRoutingSnapshotPortV1 for DaemonWorkProposalRoutingAuthorityV1 {
     ) -> Result<WorkRoutingSnapshotV1, WorkRoutingSnapshotErrorV1> {
         if context.validate().is_err()
             || context.scope() != &self.scope
-            || &context.grant().digest != &self.grant_digest
+            || context.grant().digest != self.grant_digest
             || !context.allows(
                 &self.generate_proposal_capability,
                 &self.generate_proposal_use_case,

--- a/crates/tracedecay-graph-query/src/redundancy_scan.rs
+++ b/crates/tracedecay-graph-query/src/redundancy_scan.rs
@@ -477,7 +477,7 @@ pub async fn redundancy_for_symbols(
                 pairs.push(pair);
             }
             compared += 1;
-            if compared % REDUNDANCY_PAIR_SLICE == 0 {
+            if compared.is_multiple_of(REDUNDANCY_PAIR_SLICE) {
                 tokio::task::yield_now().await;
             }
         }

--- a/crates/tracedecay-mcp/src/handlers/info/status.rs
+++ b/crates/tracedecay-mcp/src/handlers/info/status.rs
@@ -115,7 +115,7 @@ fn attach_compact_branch_summary(
 }
 
 fn attach_full_branch_status(
-    branch_diagnostics: BranchDiagnostics,
+    branch_diagnostics: &BranchDiagnostics,
     output: &mut Value,
     retrieval_serving: &CodeIndexRetrievalServingV1,
 ) {
@@ -324,7 +324,7 @@ pub async fn handle_status(
     }
 
     if include_branch_diagnostics {
-        attach_full_branch_status(branch_diagnostics, &mut output, &retrieval_serving);
+        attach_full_branch_status(&branch_diagnostics, &mut output, &retrieval_serving);
     } else {
         attach_compact_branch_summary(&branch_diagnostics, &mut output, &retrieval_serving);
     }

--- a/crates/tracedecay-mcp/src/tool_context.rs
+++ b/crates/tracedecay-mcp/src/tool_context.rs
@@ -267,8 +267,7 @@ impl McpAdmittedProjectV1 {
             self.identity.serving_branch.clone(),
             self.identity.fallback_warning.clone(),
             self.graph_db_path.clone(),
-            serving_source_reference,
-            serving_source_revision,
+            serving_source_reference.zip(serving_source_revision),
         )
     }
 

--- a/crates/tracedecay-session-memory/src/external_source_store.rs
+++ b/crates/tracedecay-session-memory/src/external_source_store.rs
@@ -45,7 +45,7 @@ pub enum RuntimeExternalSourceErrorV1 {
         "external source runtime rejected {admission_bytes}-byte commit for {commit_count} source observations: {outcome:?}"
     )]
     SubmitRejected {
-        outcome: RuntimeSubmitOutcomeV1,
+        outcome: Box<RuntimeSubmitOutcomeV1>,
         admission_bytes: u64,
         commit_count: usize,
     },
@@ -57,7 +57,7 @@ pub enum RuntimeExternalSourceErrorV1 {
     #[error("external source runtime {phase} read was unavailable: {coverage:?}")]
     ReadUnavailable {
         phase: &'static str,
-        coverage: RuntimeReadCoverageV1,
+        coverage: Box<RuntimeReadCoverageV1>,
     },
     #[error("external source idempotency key conflicts with a prior command")]
     IdempotencyConflict,
@@ -477,7 +477,7 @@ impl RuntimeExternalSourceStore {
                 }
                 outcome => {
                     return Err(RuntimeExternalSourceErrorV1::SubmitRejected {
-                        outcome,
+                        outcome: Box::new(outcome),
                         admission_bytes,
                         commit_count,
                     });
@@ -836,7 +836,7 @@ impl RuntimeExternalSourceStore {
                 Err(RuntimeExternalSourceErrorV1::IdempotencyConflict)
             }
             outcome => Err(RuntimeExternalSourceErrorV1::SubmitRejected {
-                outcome,
+                outcome: Box::new(outcome),
                 admission_bytes: serialized_len(&projection)?,
                 commit_count: 1,
             }),
@@ -1189,7 +1189,7 @@ fn read_unavailable(
 ) -> RuntimeExternalSourceErrorV1 {
     RuntimeExternalSourceErrorV1::ReadUnavailable {
         phase,
-        coverage: coverage.clone(),
+        coverage: Box::new(coverage.clone()),
     }
 }
 

--- a/crates/tracedecay-session-runtime/src/session_temporal_refresh_scheduler/wake.rs
+++ b/crates/tracedecay-session-runtime/src/session_temporal_refresh_scheduler/wake.rs
@@ -918,9 +918,7 @@ impl SessionTemporalRefreshWake {
         &self,
         timeout: std::time::Duration,
     ) -> Option<SessionHistoricalRefreshReceipt> {
-        let Some(state) = self.target() else {
-            return None;
-        };
+        let state = self.target()?;
         if state.cancelled.load(Ordering::Acquire) {
             return None;
         }

--- a/crates/tracedecay/src/tracedecay/diagnostics.rs
+++ b/crates/tracedecay/src/tracedecay/diagnostics.rs
@@ -160,7 +160,6 @@ impl TraceDecay {
             self.fallback_warning.clone(),
             self.db_path(),
             None,
-            None,
         )
     }
 

--- a/crates/tracedecay/tests/product_surface_suite/verified_profile_backup.rs
+++ b/crates/tracedecay/tests/product_surface_suite/verified_profile_backup.rs
@@ -22,10 +22,9 @@ use tracedecay_graph_db::{
 use tracedecay_maintenance::profile_backup::{
     ProfileBackupError, create_complete_profile_backup, rehearse_complete_profile_backup,
 };
-use tracedecay_runtime_core::db::DatabaseAuthority;
 use tracedecay_runtime_core::storage::{
-    PROFILE_IDENTITY_RECORD_NAME, STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION,
-    StorageMode, StoreKind, StoreManifest, write_store_manifest_to_path,
+    STORE_MANIFEST_FILENAME, STORE_MANIFEST_SCHEMA_VERSION, StorageMode, StoreKind, StoreManifest,
+    write_store_manifest_to_path,
 };
 use tracedecay_store::{
     BrainId, ProjectId, RetainedGraphStoreLeaseV1, RetainedGraphStoreOwnerAttachmentV1,


### PR DESCRIPTION
Restores the CI gate `cargo clippy --workspace --all-targets --no-deps --locked -- -D warnings` on the #707 tip. Fourteen behavior-preserving commits, one lint family each; no `#[allow]`/`#[expect]` added, no `clippy.toml`, no lint threshold changed.

- `large_enum_variant`: boxed `NativeIntegrationSurfaceResultV1::StackSnapshot`, `FeedbackDiagnosticProviderAdmissionV1::{Analyzer, StoredPublication}`, `ContextScoutMutationResultV1::{Claim, Reconciled}`. `Box` is transparent to serde (internally/adjacently tagged, no `flatten`/`untagged`) and schemars; neither type appears in `dashboard/src/contracts/generated.ts`, so no regeneration.
- `result_large_err`: boxed the `SubmitRejected.outcome` / `ReadUnavailable.coverage` payloads of `RuntimeExternalSourceErrorV1` (clears 18 Result sites; `Display` text byte-identical since `Debug for Box<T>` forwards) and the `Err` type of `NativeLaneOutcomeV1` in code-index-runtime queries.
- `too_many_arguments`: `build_branch_diagnostics` takes `serving_source: Option<(&str, &str)>` — the body already `.zip()`ed the two args, and the only real caller splits an already-zipped pair, so the pairing makes an impossible state unrepresentable rather than dropping a case.
- Semantics-preserving rewrites: `is_multiple_of` (divisor is a non-zero const), nested or-pattern, `.or(match …)` on a side-effect-free `&str` discriminant read, `?` for let-else on owned `Option`s, `&BranchDiagnostics` by reference, filter-then-clone, value comparison instead of `&a != &b`, a private fn relocated intact above its test module, two genuinely unused test imports removed.

Verification: gate run above on the rebased tip (`Finished`, 0 errors); `cargo fmt --all -- --check`; module tests for every touched module non-zero (external_source_store 5, redundancy_scan 17, application tracedecay 1, wake 3, mcp status 11, context_scout 47, future_size_guard 1, registry+queries 1+7, verified_backup 1). Opus review READY: every commit verified semantically equivalent by inspection, both prior tip merges recomputed as pure auto-merges (since linearized away), no wire shape changed.