### PR TITLE
fix(code-index): attribute whitespace-only windows to neighboring grains

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler.rs
@@ -5903,10 +5903,9 @@ impl CodeIndexWorktreeSchedulerV1 {
             repository: repository_id.clone(),
             sanitizer_revision,
             policy_revision: id::<PolicyRevisionId>("policy.daemon.v1")?,
-            // V3 retains unresolved per-file references and derives
-            // conservative cross-file edges at generation sealing. V2
-            // artifacts remain decodable, but cannot be reused as a current
-            // graph because they never recorded that evidence.
+            // A persisted generation whose chunker revision does not match
+            // is a typed rebuild, not a silent reuse. V2 artifacts remain
+            // decodable but never recorded unresolved per-file references.
             chunker_revision: id::<ChunkerRevision>(DAEMON_CODE_INDEX_CHUNKER_REVISION)?,
             privacy_domain: id::<PrivacyDomainId>("privacy.local-code-index")?,
             privacy_key_epoch: 1,

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -64,7 +64,8 @@ use super::{
 use crate::code_index::production::{
     CodeIndexAtomicPublicationPort, CodeIndexExecutionControlV1, CodeIndexInterruptionV1,
     CodeIndexProductionErrorV1, CodeIndexPublicationStoreErrorV1,
-    UninterruptibleCodeIndexControlV1, VerifiedSealedLexicalPageReadV1,
+    DAEMON_CODE_INDEX_CHUNKER_REVISION, UninterruptibleCodeIndexControlV1,
+    VerifiedSealedLexicalPageReadV1,
 };
 use crate::semantic_code::rerank_adapter::{
     GenerationBoundCodeRerankViewsV1, ProductionCodeRerankAuthorityV1,
@@ -3850,7 +3851,8 @@ fn chunker_transition_preserves_safe_serving_until_replacement() {
     drop(config_a);
 
     let mut config_b = scheduler(&fixture, store.path().to_path_buf(), bytes);
-    replace_scheduler_chunker_revision(&mut config_b, "chunker.daemon.v5");
+    let foreign_revision = format!("{DAEMON_CODE_INDEX_CHUNKER_REVISION}-foreign");
+    replace_scheduler_chunker_revision(&mut config_b, &foreign_revision);
     assert_eq!(
         config_b
             .latest_complete()
@@ -3886,7 +3888,7 @@ fn chunker_transition_preserves_safe_serving_until_replacement() {
             .manifest()
             .chunker_revision
             .as_str(),
-        "chunker.daemon.v5"
+        foreign_revision.as_str()
     );
 }
 

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -3850,7 +3850,7 @@ fn chunker_transition_preserves_safe_serving_until_replacement() {
     drop(config_a);
 
     let mut config_b = scheduler(&fixture, store.path().to_path_buf(), bytes);
-    replace_scheduler_chunker_revision(&mut config_b, "chunker.daemon.v4");
+    replace_scheduler_chunker_revision(&mut config_b, "chunker.daemon.v5");
     assert_eq!(
         config_b
             .latest_complete()
@@ -3886,7 +3886,7 @@ fn chunker_transition_preserves_safe_serving_until_replacement() {
             .manifest()
             .chunker_revision
             .as_str(),
-        "chunker.daemon.v4"
+        "chunker.daemon.v5"
     );
 }
 

--- a/crates/tracedecay-code-index/src/chunks.rs
+++ b/crates/tracedecay-code-index/src/chunks.rs
@@ -3171,6 +3171,70 @@ mod tests {
     }
 
     #[test]
+    fn all_whitespace_source_retains_whitespace_only_windows() {
+        let source = "   \n\n\t  \n";
+        let result = chunk_source(source);
+        result.validate().expect("valid all-whitespace chunk set");
+        assert_byte_exact_coverage(source, &result);
+        assert!(
+            !result.chunks.is_empty(),
+            "an all-whitespace file must keep its FileWindow grains"
+        );
+        assert!(
+            result.chunks.iter().all(|chunk| {
+                chunk.anchor.grain == CodeSearchChunkGrainV1::FileWindow
+                    && span_is_whitespace_only(source, chunk.anchor.source_span)
+            }),
+            "all-whitespace FileWindows must be retained when no retrievable neighbor exists"
+        );
+    }
+
+    #[test]
+    fn fold_that_exceeds_max_chunk_text_bytes_retains_the_window() {
+        let mut source = "x".repeat(MAX_CHUNK_TEXT_BYTES);
+        source.push_str("  ");
+        let max = MAX_CHUNK_TEXT_BYTES as u64;
+        let mut pending = vec![
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::SymbolBody,
+                symbol: Some(0),
+                split_path: vec![],
+                span: SourceSpan {
+                    start_byte: 0,
+                    end_byte: max,
+                },
+                parent: None,
+            },
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::FileWindow,
+                symbol: None,
+                split_path: vec![0],
+                span: SourceSpan {
+                    start_byte: max,
+                    end_byte: max + 2,
+                },
+                parent: None,
+            },
+        ];
+        attribute_whitespace_only_windows(&source, &mut pending);
+        assert_eq!(
+            pending.len(),
+            2,
+            "a fold that would exceed MAX_CHUNK_TEXT_BYTES must keep the window"
+        );
+        assert_eq!(
+            pending[0].span,
+            SourceSpan {
+                start_byte: 0,
+                end_byte: max,
+            },
+            "the retrievable target span must stay unchanged"
+        );
+        assert_eq!(pending[1].grain, CodeSearchChunkGrainV1::FileWindow);
+        assert!(span_is_whitespace_only(&source, pending[1].span));
+    }
+
+    #[test]
     fn symbol_member_chunks_include_leading_attributes() {
         let result = chunk_source(
             "pub enum DomainError {\n    #[error(\"time interval start must not be after its end\")]\n    InvalidTimeInterval,\n}\n",

--- a/crates/tracedecay-code-index/src/chunks.rs
+++ b/crates/tracedecay-code-index/src/chunks.rs
@@ -1694,6 +1694,7 @@ impl DeterministicCodeChunker {
             if cursor < len {
                 emit_windows(source, cursor, len, gap_ordinal, &mut pending);
             }
+            attribute_whitespace_only_windows(source, &mut pending);
             Ok::<_, ChunkingFailureV1>((pending, emissions))
         })?;
 
@@ -2353,6 +2354,112 @@ fn emit_windows(
     }
 }
 
+fn span_is_whitespace_only(source: &str, span: SourceSpan) -> bool {
+    if span.is_empty() {
+        return false;
+    }
+    let text = &source[span.start_byte as usize..span.end_byte as usize];
+    !text.is_empty() && text.chars().all(char::is_whitespace)
+}
+
+/// Fold whitespace-only `FileWindow` pieces into an adjacent retrievable
+/// grain so those bytes stay covered without minting an unreachable row.
+///
+/// Prefer the preceding retrievable piece; a leading window folds forward.
+/// Overlapping fallback windows in one whitespace gap are attributed as
+/// one contiguous range. A window is left in place only when no retrievable
+/// neighbor exists or folding it would exceed [`MAX_CHUNK_TEXT_BYTES`].
+fn attribute_whitespace_only_windows(source: &str, pending: &mut Vec<PendingChunk>) {
+    let whitespace_windows: Vec<usize> = pending
+        .iter()
+        .enumerate()
+        .filter(|(_, piece)| {
+            piece.grain == CodeSearchChunkGrainV1::FileWindow
+                && span_is_whitespace_only(source, piece.span)
+        })
+        .map(|(index, _)| index)
+        .collect();
+    if whitespace_windows.is_empty() {
+        return;
+    }
+
+    let mut ordered = whitespace_windows;
+    ordered.sort_by_key(|&index| (pending[index].span.start_byte, pending[index].span.end_byte));
+
+    let mut runs: Vec<Vec<usize>> = Vec::new();
+    for index in ordered {
+        if let Some(run) = runs.last_mut() {
+            let run_end = run
+                .iter()
+                .map(|&member| pending[member].span.end_byte)
+                .max()
+                .unwrap_or(0);
+            if pending[index].span.start_byte <= run_end {
+                run.push(index);
+                continue;
+            }
+        }
+        runs.push(vec![index]);
+    }
+
+    let mut drop = vec![false; pending.len()];
+    for run in runs {
+        let start = run
+            .iter()
+            .map(|&index| pending[index].span.start_byte)
+            .min()
+            .unwrap_or(0);
+        let end = run
+            .iter()
+            .map(|&index| pending[index].span.end_byte)
+            .max()
+            .unwrap_or(0);
+        let in_run = |index: usize| run.contains(&index);
+        let retrievable = |index: usize, piece: &PendingChunk| {
+            !in_run(index)
+                && !drop[index]
+                && !piece.span.is_empty()
+                && !span_is_whitespace_only(source, piece.span)
+        };
+        // Adjacent or overlapping: oversized fallback windows share an
+        // overlap band, so a retrievable window may start inside a
+        // whitespace-only run rather than exactly at its end.
+        let preceding = pending.iter().enumerate().find_map(|(index, piece)| {
+            (retrievable(index, piece)
+                && (piece.span.end_byte == start
+                    || (piece.span.end_byte > start && piece.span.start_byte < start)))
+                .then_some(index)
+        });
+        let following = pending.iter().enumerate().find_map(|(index, piece)| {
+            (retrievable(index, piece)
+                && (piece.span.start_byte == end
+                    || (piece.span.start_byte < end && piece.span.end_byte > end)))
+                .then_some(index)
+        });
+        let Some(target) = preceding.or(following) else {
+            continue;
+        };
+        let new_start = pending[target].span.start_byte.min(start);
+        let new_end = pending[target].span.end_byte.max(end);
+        if new_end.saturating_sub(new_start) > MAX_CHUNK_TEXT_BYTES as u64 {
+            continue;
+        }
+        pending[target].span.start_byte = new_start;
+        pending[target].span.end_byte = new_end;
+        for index in run {
+            drop[index] = true;
+        }
+    }
+
+    let mut kept = Vec::with_capacity(pending.len());
+    for (index, piece) in std::mem::take(pending).into_iter().enumerate() {
+        if !drop[index] {
+            kept.push(piece);
+        }
+    }
+    *pending = kept;
+}
+
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
@@ -2669,9 +2776,12 @@ mod tests {
 
     fn chunk_source(source: &str) -> CodeFileChunksV1 {
         let file = validated_file("src/lib.rs", source.as_bytes());
-        let batch = batch_for(&file, ParseOutcomeV1::Complete);
+        let descriptor = rust_descriptor();
+        let extracted = TreeSitterExtractor::new()
+            .extract(&file, &descriptor, &NeverCancelled)
+            .expect("extract source");
         chunker()
-            .chunk_file(&file, &batch, &rust_descriptor(), &NeverCancelled)
+            .chunk_file(&file, extracted.batch(), &descriptor, &NeverCancelled)
             .expect("chunking succeeds")
     }
 
@@ -2937,6 +3047,127 @@ mod tests {
             chunk.anchor.grain == CodeSearchChunkGrainV1::SymbolSignature
                 && chunk.sanitized_text.as_str().contains("fn ")
         }));
+    }
+
+    fn whitespace_heavy_functions(count: usize) -> String {
+        (0..count)
+            .map(|index| format!("pub fn symbol_{index}() {{}}\n\n"))
+            .collect()
+    }
+
+    fn assert_byte_exact_coverage(source: &str, chunks: &CodeFileChunksV1) {
+        let mut covered = vec![false; source.len()];
+        for chunk in &chunks.chunks {
+            for covered_byte in &mut covered[chunk.anchor.source_span.start_byte as usize
+                ..chunk.anchor.source_span.end_byte as usize]
+            {
+                *covered_byte = true;
+            }
+        }
+        assert!(covered.iter().all(|covered| *covered), "full byte coverage");
+    }
+
+    #[test]
+    fn whitespace_only_windows_are_attributed_to_neighboring_grains() {
+        let source = whitespace_heavy_functions(8);
+        let result = chunk_source(&source);
+        result.validate().expect("valid chunk set");
+        assert_byte_exact_coverage(&source, &result);
+
+        assert!(
+            result.chunks.iter().all(|chunk| {
+                chunk.anchor.grain != CodeSearchChunkGrainV1::FileWindow
+                    || !span_is_whitespace_only(source.as_str(), chunk.anchor.source_span)
+            }),
+            "whitespace-only FileWindow chunks must not be emitted"
+        );
+
+        let alpha_source = "pub fn alpha() {}\n\npub fn beta() {}\n";
+        let alpha = chunk_source(alpha_source);
+        alpha.validate().expect("valid adjacent-literal fixture");
+        assert_byte_exact_coverage(alpha_source, &alpha);
+        assert!(alpha.chunks.iter().all(|chunk| {
+            chunk.anchor.grain != CodeSearchChunkGrainV1::FileWindow
+                || !span_is_whitespace_only(alpha_source, chunk.anchor.source_span)
+        }));
+
+        let literal = b"alpha";
+        let literal_start = alpha_source.find("alpha").expect("alpha literal") as u64;
+        let literal_end = literal_start + literal.len() as u64;
+        let folded_start = alpha_source.find("\n\n").expect("folded gap") as u64;
+        let folded_end = folded_start + 2;
+        let term = alpha
+            .chunks
+            .iter()
+            .flat_map(|chunk| chunk.exact_terms.iter())
+            .find(|term| term.original_bytes() == literal)
+            .expect("exact term for alpha");
+        assert_eq!(
+            term.span(),
+            SourceSpan {
+                start_byte: literal_start,
+                end_byte: literal_end,
+            }
+        );
+        assert!(
+            term.span().end_byte <= folded_start || term.span().start_byte >= folded_end,
+            "exact occurrence must not cross the folded whitespace range"
+        );
+        for term in alpha
+            .chunks
+            .iter()
+            .flat_map(|chunk| chunk.exact_terms.iter())
+        {
+            let start = term.span().start_byte as usize;
+            let end = term.span().end_byte as usize;
+            assert_eq!(
+                &alpha_source.as_bytes()[start..end],
+                term.original_bytes(),
+                "exact term bytes stay on the literal"
+            );
+            assert!(
+                !alpha_source[start..end].chars().all(char::is_whitespace),
+                "exact occurrence must not land in a folded whitespace region"
+            );
+        }
+    }
+
+    #[test]
+    fn leading_whitespace_window_folds_forward_into_the_next_retrievable_grain() {
+        let source = "   hello";
+        let mut pending = vec![
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::FileWindow,
+                symbol: None,
+                split_path: vec![0],
+                span: SourceSpan {
+                    start_byte: 0,
+                    end_byte: 3,
+                },
+                parent: None,
+            },
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::FileWindow,
+                symbol: None,
+                split_path: vec![1],
+                span: SourceSpan {
+                    start_byte: 3,
+                    end_byte: 8,
+                },
+                parent: None,
+            },
+        ];
+        attribute_whitespace_only_windows(source, &mut pending);
+        assert_eq!(pending.len(), 1, "the leading whitespace window folds away");
+        assert_eq!(
+            pending[0].span,
+            SourceSpan {
+                start_byte: 0,
+                end_byte: 8,
+            }
+        );
+        assert_eq!(&source[0..8], "   hello");
+        assert_eq!(pending[0].split_path, vec![1]);
     }
 
     #[test]

--- a/crates/tracedecay-code-index/src/chunks.rs
+++ b/crates/tracedecay-code-index/src/chunks.rs
@@ -2365,9 +2365,14 @@ fn span_is_whitespace_only(source: &str, span: SourceSpan) -> bool {
 /// Fold whitespace-only `FileWindow` pieces into an adjacent retrievable
 /// grain so those bytes stay covered without minting an unreachable row.
 ///
-/// Prefer the preceding retrievable piece; a leading window folds forward.
-/// Overlapping fallback windows in one whitespace gap are attributed as
-/// one contiguous range. A window is left in place only when no retrievable
+/// The target is the nearest piece by span: the preceding retrievable
+/// piece whose `end_byte` equals the window start, otherwise the
+/// following retrievable piece whose `start_byte` equals the window end.
+/// Any retrievable grain, including [`CodeSearchChunkGrainV1::SymbolBody`],
+/// may be the target. Overlapping fallback windows in one whitespace gap
+/// are attributed as one contiguous range; a piece that merely overlaps the
+/// run without abutting it (possible only inside an oversized unowned
+/// region) is not a target. A window is left in place only when no such
 /// neighbor exists or folding it would exceed [`MAX_CHUNK_TEXT_BYTES`].
 fn attribute_whitespace_only_windows(source: &str, pending: &mut Vec<PendingChunk>) {
     let whitespace_windows: Vec<usize> = pending
@@ -2421,21 +2426,20 @@ fn attribute_whitespace_only_windows(source: &str, pending: &mut Vec<PendingChun
                 && !piece.span.is_empty()
                 && !span_is_whitespace_only(source, piece.span)
         };
-        // Adjacent or overlapping: oversized fallback windows share an
-        // overlap band, so a retrievable window may start inside a
-        // whitespace-only run rather than exactly at its end.
-        let preceding = pending.iter().enumerate().find_map(|(index, piece)| {
-            (retrievable(index, piece)
-                && (piece.span.end_byte == start
-                    || (piece.span.end_byte > start && piece.span.start_byte < start)))
-                .then_some(index)
-        });
-        let following = pending.iter().enumerate().find_map(|(index, piece)| {
-            (retrievable(index, piece)
-                && (piece.span.start_byte == end
-                    || (piece.span.start_byte < end && piece.span.end_byte > end)))
-                .then_some(index)
-        });
+        // Nearest by span, not pending-vector order: an enclosing parent
+        // can appear first and is not the abutting neighbor.
+        let preceding = pending
+            .iter()
+            .enumerate()
+            .filter(|(index, piece)| retrievable(*index, piece) && piece.span.end_byte == start)
+            .max_by_key(|(_, piece)| piece.span.start_byte)
+            .map(|(index, _)| index);
+        let following = pending
+            .iter()
+            .enumerate()
+            .filter(|(index, piece)| retrievable(*index, piece) && piece.span.start_byte == end)
+            .min_by_key(|(_, piece)| piece.span.end_byte)
+            .map(|(index, _)| index);
         let Some(target) = preceding.or(following) else {
             continue;
         };
@@ -3232,6 +3236,82 @@ mod tests {
         );
         assert_eq!(pending[1].grain, CodeSearchChunkGrainV1::FileWindow);
         assert!(span_is_whitespace_only(&source, pending[1].span));
+    }
+
+    #[test]
+    fn whitespace_window_folds_into_the_abutting_body_not_the_enclosing_parent() {
+        let source = "aaaa  bbbb";
+        let mut pending = vec![
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::SymbolSignature,
+                symbol: Some(0),
+                split_path: vec![],
+                span: SourceSpan {
+                    start_byte: 0,
+                    end_byte: 10,
+                },
+                parent: None,
+            },
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::SymbolBody,
+                symbol: Some(1),
+                split_path: vec![],
+                span: SourceSpan {
+                    start_byte: 0,
+                    end_byte: 4,
+                },
+                parent: Some((0, vec![])),
+            },
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::FileWindow,
+                symbol: None,
+                split_path: vec![0],
+                span: SourceSpan {
+                    start_byte: 4,
+                    end_byte: 6,
+                },
+                parent: None,
+            },
+            PendingChunk {
+                grain: CodeSearchChunkGrainV1::SymbolBody,
+                symbol: Some(2),
+                split_path: vec![],
+                span: SourceSpan {
+                    start_byte: 6,
+                    end_byte: 10,
+                },
+                parent: Some((0, vec![])),
+            },
+        ];
+        attribute_whitespace_only_windows(source, &mut pending);
+        let body = pending
+            .iter()
+            .find(|piece| {
+                piece.grain == CodeSearchChunkGrainV1::SymbolBody && piece.symbol == Some(1)
+            })
+            .expect("abutting body remains");
+        assert_eq!(
+            body.span,
+            SourceSpan {
+                start_byte: 0,
+                end_byte: 6,
+            },
+            "the window must fold into the abutting SymbolBody, not the enclosing parent"
+        );
+        assert_eq!(
+            pending
+                .iter()
+                .find(|piece| piece.grain == CodeSearchChunkGrainV1::SymbolSignature)
+                .expect("parent remains")
+                .span
+                .end_byte,
+            10,
+            "the enclosing parent span must stay unchanged"
+        );
+        assert!(pending.iter().all(|piece| {
+            piece.grain != CodeSearchChunkGrainV1::FileWindow
+                || !span_is_whitespace_only(source, piece.span)
+        }));
     }
 
     #[test]

--- a/crates/tracedecay-code-index/src/production/mod.rs
+++ b/crates/tracedecay-code-index/src/production/mod.rs
@@ -103,7 +103,10 @@ pub use sealed_codec::{
 /// Current daemon chunker identity shared by production indexing and native
 /// semantic evaluation fixtures. Historical revisions remain decodable but
 /// must never be emitted as current activation evidence.
-pub const DAEMON_CODE_INDEX_CHUNKER_REVISION: &str = "chunker.daemon.v3";
+///
+/// `v4` attributes whitespace-only FileWindow ranges to a neighboring
+/// retrievable grain instead of minting unreachable rows.
+pub const DAEMON_CODE_INDEX_CHUNKER_REVISION: &str = "chunker.daemon.v4";
 
 /// Immutable configuration retained by one production index owner.
 #[derive(Clone, Debug)]

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -34,13 +34,13 @@ use tracedecay_code_index::{
     retained_parse::{RetainedParsePoolLimits, SharedRetainedParsePool},
 };
 use tracedecay_domain::{
-    BranchStackNodeV1, ChunkerRevision, CodeGenerationId, CommitId, EdgeAuthorityV1,
-    FileOccurrenceId, LanguageId, ManifestDigest, PolicyRevisionId, PrivacyDomainId, ProjectId,
-    ProjectionBatchRequestV1, ProjectionKeyV1, ProjectionKindV1, ProjectionOperationV1,
-    ProjectionOutcomeV1, ProviderEvaluationStateV1, RefId, RelationEdgeKindV1,
-    RepositoryDirtyStateV1, RepositoryId, SanitizationReceiptId, SanitizedCodeFileV1,
-    SanitizedCodeSnapshotV1, SanitizerRevision, SnapshotFileDispositionV1, StackNodeId,
-    SymbolOccurrenceId, TestAttributionEvidenceClassV1, TreeId, UtcMicros, WorktreeId,
+    BranchStackNodeV1, ChunkerRevision, CodeGenerationId, CodeSearchChunkGrainV1, CommitId,
+    EdgeAuthorityV1, FileOccurrenceId, LanguageId, ManifestDigest, PolicyRevisionId,
+    PrivacyDomainId, ProjectId, ProjectionBatchRequestV1, ProjectionKeyV1, ProjectionKindV1,
+    ProjectionOperationV1, ProjectionOutcomeV1, ProviderEvaluationStateV1, RefId,
+    RelationEdgeKindV1, RepositoryDirtyStateV1, RepositoryId, SanitizationReceiptId,
+    SanitizedCodeFileV1, SanitizedCodeSnapshotV1, SanitizerRevision, SnapshotFileDispositionV1,
+    StackNodeId, SymbolOccurrenceId, TestAttributionEvidenceClassV1, TreeId, UtcMicros, WorktreeId,
 };
 use tracedecay_graph_db::{GraphDbError, GraphNamespace, GraphProjectorRevision};
 
@@ -1204,6 +1204,53 @@ fn active_generation_loads_share_the_published_allocation() {
         second.chunks().chunks().as_ptr(),
         "active reads must share the immutable generation instead of cloning its complete indices"
     );
+}
+
+#[test]
+fn sealed_store_drops_whitespace_only_window_chunks() {
+    const FUNCTIONS: usize = 32;
+    let source: String = (0..FUNCTIONS)
+        .map(|index| format!("pub fn symbol_{index}() {{}}\n\n"))
+        .collect();
+    let mut owner = CodeIndexProductionOwnerV1::new(
+        config(),
+        SharedPublicationStore::default(),
+        ApplyingProjectionSink,
+    )
+    .expect("production owner");
+    let generation = owner
+        .build_and_publish(
+            request_with_source(
+                "file.whitespace-window-attribution",
+                1_260_000,
+                "commit.whitespace-window-attribution",
+                "tree.whitespace-window-attribution",
+                &source,
+            ),
+            &ActiveControl,
+        )
+        .expect("whitespace-heavy fixture publishes");
+    let chunks = generation.chunks().chunks();
+    assert!(
+        chunks.iter().all(|chunk| {
+            chunk.anchor.grain != CodeSearchChunkGrainV1::FileWindow
+                || !chunk
+                    .sanitized_text
+                    .as_str()
+                    .chars()
+                    .all(char::is_whitespace)
+        }),
+        "sealed rows must not include whitespace-only FileWindow chunks"
+    );
+    // One-line functions previously minted signature + body + whitespace window
+    // (3N). Attribution keeps signature + body only.
+    assert_eq!(chunks.len(), FUNCTIONS * 2);
+    assert!(
+        chunks.len() < FUNCTIONS * 3,
+        "sealed chunk count must drop below the three-per-function baseline"
+    );
+    let sealed = generation.encode_sealed().expect("generation seals");
+    assert!(!sealed.is_empty(), "sealed store must carry bytes");
 }
 
 #[test]

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -3146,23 +3146,23 @@ fn partitioned_codec_fixture() -> (
 }
 
 const PARTITIONED_FORMAT_STATE_DIGEST: &str =
-    "sha256:f1741f8ee5b4fec3dfc723e6de9ab9794de3a016f837ef7d1186306e09526abf";
+    "sha256:55a8f6b59193787ebeba77f4ae3614d519a4c394a8632ce7d55f029527b2863d";
 const PARTITIONED_FORMAT_SEGMENTS: &[(&str, u64)] = &[
     (
-        "sha256:0ae42f3ae5844c46e7fea6cfb07f91e09d6634e8f9c2f1df053d62cc7d7c1f24",
-        8_584,
+        "sha256:b7e78bc9522624146b3ac2abae80dafa3f9c3d1804de4f20a3c7757b0e311c41",
+        7_958,
     ),
     (
-        "sha256:21d54dff99989ad1b91b8254ad1a7c1310fe866755e0c3157153c2ab18951b19",
-        3_856,
+        "sha256:1234ca6694f475b5310910489523d2b98b3c9324d5965d59f62c3b81fd29e947",
+        3_543,
     ),
     (
-        "sha256:4f03e051764f885e2eb5f3537a2f7d26741f72f936fd6e4dc5ec1fd53a0751da",
-        3_964,
+        "sha256:baf5484b24df712b9f750f915e7aceb1da1544f2b9c08d0041763b66d2b1308c",
+        3_651,
     ),
     (
-        "sha256:1bfa6399cd1a9f5d06ec697add39064ac1cc4f51dcfc866ba903c62ac3cad476",
-        11_830,
+        "sha256:8350d333af33c7a63db799d9b0177a35d028bfe5f4e779a51a1de4d2a58589d6",
+        10_133,
     ),
 ];
 

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -3246,6 +3246,7 @@ fn partitioned_codec_has_stable_bytes_and_round_trips() {
                     evidence_buffer_address.set(Some(address));
                 }
                 largest_evidence_page.set(largest_evidence_page.get().max(end - start));
+                evidence_buffer_capacity.set(buffer.capacity());
             }
             segment_reads.set(segment_reads.get() + 1);
             Ok(())

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -3146,22 +3146,22 @@ fn partitioned_codec_fixture() -> (
 }
 
 const PARTITIONED_FORMAT_STATE_DIGEST: &str =
-    "sha256:55a8f6b59193787ebeba77f4ae3614d519a4c394a8632ce7d55f029527b2863d";
+    "sha256:e96ece6001108c2449cf1792edb0597b6f2c4e1ce7e7ad6a93bd4048b3eac0e9";
 const PARTITIONED_FORMAT_SEGMENTS: &[(&str, u64)] = &[
     (
-        "sha256:b7e78bc9522624146b3ac2abae80dafa3f9c3d1804de4f20a3c7757b0e311c41",
+        "sha256:e60fb9cbbc20e653116ea726d6967baba2ef5bf49b05ac9f567986d8abc21007",
         7_958,
     ),
     (
-        "sha256:1234ca6694f475b5310910489523d2b98b3c9324d5965d59f62c3b81fd29e947",
+        "sha256:cc1e8d56b83abef4f90373329ee58c3c84e8b175f8fe83ce4ff1893988ee5324",
         3_543,
     ),
     (
-        "sha256:baf5484b24df712b9f750f915e7aceb1da1544f2b9c08d0041763b66d2b1308c",
+        "sha256:07ff7248bb7c7f9674d5ae87d44355dffc5801c2bcb60d44475356cb3c125a9c",
         3_651,
     ),
     (
-        "sha256:8350d333af33c7a63db799d9b0177a35d028bfe5f4e779a51a1de4d2a58589d6",
+        "sha256:d17aab52161832b3e2a6fd395b590edd26e1dab45f5df179d06c4868ca666c7a",
         10_133,
     ),
 ];


### PR DESCRIPTION
Closes #1204, per the product-owner decision: whitespace-only `FileWindow` chunks are folded into the nearest abutting retrievable grain instead of being minted as unreachable rows. Byte coverage stays exact (the target's `source_span` widens over the run; nothing is dropped); exact-literal term spans are unchanged because they derive from `piece.span.start_byte` plus the in-text offset, so widening the base shifts slice and base together. A window is left in place only when no abutting neighbor exists or the fold would exceed `MAX_CHUNK_TEXT_BYTES` — both `continue` branches have tests that fail if either becomes a drop.

Target selection is nearest-by-span: the preceding retrievable piece with `end_byte == window.start`, else the following with `start_byte == window.end`; preceding wins when both abut (covered by `whitespace_window_folds_into_the_abutting_body_not_the_enclosing_parent`, which also kills the earlier first-in-`pending` behavior where an enclosing signature absorbed a child's whitespace). Any retrievable grain including `SymbolBody` may be the target.

Chunker identity bumps to `chunker.daemon.v4`; a persisted v3 store takes the typed `incompatibilities == ["chunker_revision"]` / `Preserved` serving / replacement-generation path asserted by `chunker_transition_preserves_safe_serving_until_replacement` (foreign revision now derived from the current constant so the next bump cannot collide). The partitioned codec pins are regenerated from the live encoder; only digests moved, all four segment byte lengths are unchanged, confirming the same windows fold. Also restores the evidence-page capacity probe that had left "the evidence allocation must be bounded by the largest evidence page" reading a never-written cell since `4d4fff1f4` (its own commit).

Measured delta on the 260-file real corpus (baseline fold removed vs treatment, same method both runs): 10,285 → 9,615 chunks (−6.5% rows), 37,684,821 → 36,318,371 sealed bytes (−3.6%), 214 → 212 pages. The issue's "a third" was measured on the synthetic one-line-function fixture, where it holds by construction (`sealed_store_drops_whitespace_only_window_chunks` asserts 3N → 2N).

Verification on the rebased tip: `chunks::tests` 36 passed / 2 failed / 1 ignored — the two reds are the pre-existing import-evidence failures tracked in #1213, independent of this branch; `code_index_suite` `partitioned_codec_has_stable_bytes_and_round_trips` + `sealed_store_drops_whitespace_only_window_chunks` 2 passed; `chunker_transition_preserves_safe_serving_until_replacement` 1 passed; crate clippy clean; fmt; every commit commitlinted. Two Opus review rounds (round 2 READY; the overlap-not-abutting doc sentence and the capacity-commit attribution it noted are applied).