### PR TITLE
fix(code-index): read census-less sealed manifests; repin stale extraction ids

### DIFF
--- a/crates/tracedecay-code-extraction/tests/extract_alloc.rs
+++ b/crates/tracedecay-code-extraction/tests/extract_alloc.rs
@@ -540,7 +540,7 @@ fn representative_language_walks_allocate_by_changed_region() {
             grammar_key: "bash",
             source: regional_fixture("tiny() { :; }\n"),
             needle: "tiny()",
-            expected_digest: "0b6dc46dcc1aa39ee5e93ab7b7380922ca2299c3090679be0d9f8084d5dbbb3f",
+            expected_digest: "d1b8003a5b51fbeaa81bc03dc58ff38ad4f8ebd7af74533882cbabe8c47a2eb1",
         },
         Case {
             tier: "full",

--- a/crates/tracedecay-code-index/src/chunks.rs
+++ b/crates/tracedecay-code-index/src/chunks.rs
@@ -2746,6 +2746,23 @@ mod tests {
 
     fn batch_for(file: &ReceiptBoundCodeFileV1, outcome: ParseOutcomeV1) -> ExtractionBatchV1 {
         let descriptor = rust_descriptor();
+        // The parser import digest is the extractor's to state, never the
+        // fixture's: chunking re-derives the rows and refuses a batch that
+        // declares different ones. An outcome that attests no structure
+        // carries no rows at all, which is what the unsupported-document path
+        // builds its artifacts from.
+        let parser_import_rows_digest = match &outcome {
+            ParseOutcomeV1::Complete | ParseOutcomeV1::Partial { .. } => TreeSitterExtractor::new()
+                .extract(file, &descriptor, &NeverCancelled)
+                .expect("fixture extraction")
+                .batch()
+                .parser_import_rows_digest
+                .clone(),
+            ParseOutcomeV1::Failed { .. }
+            | ParseOutcomeV1::TimedOut
+            | ParseOutcomeV1::Cancelled => crate::extract::parser_import_rows_digest(&[])
+                .expect("empty parser import rows digest"),
+        };
         ExtractionBatchV1 {
             generation_id: file.generation_id.clone(),
             file_occurrence_id: file.file.file_occurrence_id.clone(),
@@ -2765,8 +2782,7 @@ mod tests {
                 parsed_bytes: file.sanitized_bytes.len() as u64,
                 ..ExtractionCoverageV1::default()
             },
-            parser_import_rows_digest: crate::extract::parser_import_rows_digest(&[])
-                .expect("empty parser import rows digest"),
+            parser_import_rows_digest,
             rows_digest: id::<ManifestDigest>(&digest('d')),
         }
     }
@@ -3377,6 +3393,19 @@ mod tests {
         fn extract(&self, file_path: &str, source: &str) -> tracedecay_domain::ExtractionResult {
             self.calls.fetch_add(1, Ordering::Relaxed);
             tracedecay_code_extraction::RustExtractor.extract(file_path, source)
+        }
+
+        // Delegating to the real artifact walk, not to the trait default over
+        // `extract`, is what keeps the counting double honest: the default
+        // carries no import evidence, so a batch minted through it would
+        // declare rows the live extractor does not agree with.
+        fn extract_artifact(&self, file_path: &str, source: &str) -> ExtractionArtifactV1 {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            tracedecay_code_extraction::LanguageExtractor::extract_artifact(
+                &tracedecay_code_extraction::RustExtractor,
+                file_path,
+                source,
+            )
         }
 
         fn extract_parsed(

--- a/crates/tracedecay-code-index/src/extract.rs
+++ b/crates/tracedecay-code-index/src/extract.rs
@@ -793,7 +793,7 @@ mod tests {
 
         assert_eq!(
             extraction.batch().rows_digest.as_str(),
-            "sha256:62eaaf3e43a4f9773e43c7f2385213ca6aa59bb5a0ee6c07ff44fa7e37beede3"
+            "sha256:6431a84c4dec7f12db966cf75f5ef825c1f9bd4d32843622199fa244425d803e"
         );
     }
 

--- a/crates/tracedecay-code-index/src/production/partitioned_codec.rs
+++ b/crates/tracedecay-code-index/src/production/partitioned_codec.rs
@@ -215,7 +215,15 @@ struct PartitionedPublishedGenerationV1 {
     format_revision: u32,
     manifest: CodeGenerationManifestV1,
     snapshot: SanitizedCodeSnapshotV1,
-    statistics: CodeIndexGenerationStatisticsV1,
+    /// The sealed census, absent in manifests written before this revision
+    /// carried one. Readers surface that gap as an unavailable census rather
+    /// than a zeroed one: a census is an aggregate *of* the generation, so
+    /// reporting absence costs nothing a caller could mistake for evidence,
+    /// while a default would claim a repository of no bytes and no symbols.
+    /// Row evidence takes the opposite route — see the segment decoder, which
+    /// refuses historical rows instead of defaulting their fields.
+    #[serde(default)]
+    statistics: Option<CodeIndexGenerationStatisticsV1>,
     repository_parse_identity: CodeIndexRepositoryParseIdentityV1,
     ignored_source_admissions: Vec<CodeIndexIgnoredSourceAdmissionV1>,
     ignored_source_admissions_digest: ManifestDigest,
@@ -2621,7 +2629,7 @@ impl<R: Read + Seek> VerifiedSealedLexicalPageSourceV1<R> {
             reader,
             generation.manifest,
             generation.snapshot,
-            Some(generation.statistics),
+            generation.statistics,
             source,
             source_state_digest,
             maximum_page_chunks,
@@ -2922,7 +2930,7 @@ impl CodeIndexPublishedGenerationV1 {
         VerifiedSealedTextGenerationMetadataV1::from_partitioned_manifest(
             generation.manifest,
             generation.snapshot,
-            Some(generation.statistics),
+            generation.statistics,
         )
         .map(Some)
     }

--- a/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
+++ b/crates/tracedecay-code-index/tests/code_index_suite/production_orchestration.rs
@@ -3186,6 +3186,40 @@ fn partitioned_codec_has_stable_bytes_and_round_trips() {
         PARTITIONED_FORMAT_SEGMENTS,
         "a file or evidence segment changed bytes"
     );
+    assert_eq!(
+        CodeIndexPublishedGenerationV1::partitioned_text_metadata(&manifest)
+            .expect("partitioned text metadata parses")
+            .expect("revision seven partitioned manifest")
+            .generation_statistics(),
+        expected.generation_statistics().ok().as_ref(),
+        "a freshly sealed manifest carries the generation's own census"
+    );
+
+    // The same revision as a writer produced it before the census existed:
+    // these bytes minus that one field. Text owners still bind against it,
+    // and the census reads as unavailable rather than as a measured zero.
+    let mut pre_census: serde_json::Value =
+        serde_json::from_slice(&manifest).expect("partitioned manifest JSON");
+    pre_census["generation"]
+        .as_object_mut()
+        .expect("generation payload")
+        .remove("statistics")
+        .expect("a fresh manifest carries a census to remove");
+    pre_census["state_digest"] = serde_json::json!(format!(
+        "sha256:{}",
+        hex::encode(Sha256::digest(
+            serde_json::to_vec(&pre_census["generation"]).expect("pre-census payload bytes")
+        ))
+    ));
+    let pre_census = serde_json::to_vec(&pre_census).expect("pre-census manifest bytes");
+    assert_eq!(
+        CodeIndexPublishedGenerationV1::partitioned_text_metadata(&pre_census)
+            .expect("a manifest written without a census still authenticates")
+            .expect("revision seven partitioned manifest")
+            .generation_statistics(),
+        None,
+        "an absent census must read as unavailable, not as a measured zero"
+    );
 
     // Decode at width two with three file segments: the third file read must
     // reuse a slot from the first window, so the bound below covers cross-window


### PR DESCRIPTION
Closes #1213. Also resolves the "extraction output differs on CI" scare from the #1210 census: there is no nondeterminism — the failing digests reproduce byte-for-byte on x86_64 at the tip (ARM Linux, ARM macOS, x86_64 Linux, two profiles, two feature sets, one answer). Two extractor changes shipped without moving their pins, and the `statistics` field added by `febe69e83` had no legacy read path.

- `test(code-extraction): repin region.sh rows after shell call binding` — `1c1266048` reshaped Bash extraction (script `Module` node with a `Contains` edge from the file root, `<file>::<name>` qualified names, `parent_id` on functions, top-level call sites; verified sane against the bash fixtures and the shell dead-code journey). The `extract_alloc` pin is now the value the live extractor produces.
- `test(code-index): realign Rust fixtures with retained import evidence` — `76d93bd80` made every Rust `use` emit import evidence; the `canonical_rows_digest` pin moves accordingly, and the chunks fixture `batch_for` now derives `parser_import_rows_digest` from the same live `TreeSitterExtractor` extraction the chunker re-derives, instead of hard-coding an empty digest (the cause of #1213's eleven `chunks::tests` reds). `CountingRustExtractor` overrides `extract_artifact` so the parse-count test mints batches the real extractor agrees with.
- `fix(code-index): read sealed manifests written without a census` — the metadata-only readers decode `statistics` as `#[serde(default)] Option<…>`; a legacy manifest without it reads as typed `None`, which `project_reads.rs` maps to `GenerationCensusSnapshot::Unavailable { SealedGenerationCensusInvalid }` and every consumer (status text, CLI table, MCP `graph_statistics`) renders as unavailable. `CodeIndexGenerationStatisticsV1` has no `Default`, so a zeroed census is not constructible on this path; the writer's field is a non-optional reference, so no new manifest can omit it; the full decode path recomputes the census from restored rows and never reads the persisted field. New test strips `statistics` from live encoder bytes and asserts `generation_statistics() == None` ("an absent census must read as unavailable, not as a measured zero"). Historical fixtures untouched.

Verification (Opus READY): `extract_alloc` 1 passed; `chunks::tests extract::tests` 46 passed / 1 ignored (all previously-red tests green); `production::partitioned_codec::tests` 12 passed incl. both historical-revision tests; `code_index_suite production_orchestration` 44 passed incl. `historical_writer_bytes_read_through_both_partitioned_readers`; codec pins untouched and `partitioned_codec_has_stable_bytes_and_round_trips` passes; clippy `-D warnings` for both crates; fmt.

Advisory carried to a follow-up issue: the bash case in `representative_language_walks_allocate_by_changed_region` is vacuous since `1c1266048` resets Bash changed-region walks to a full-document walk.