### PR TITLE
fix(code-index-runtime): correct scheduler wake and witness accounting

### DIFF
--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -4516,6 +4516,18 @@ impl CodeIndexSchedulerRegistryV1 {
                             // converged on the durable head.
                             let publication_matches =
                                 scheduler.active_publication_matches(&latest)?;
+                            // The freshness fence is the single source-currency
+                            // authority; the witness only binds one of its
+                            // proofs to the seat. Asking the fence whether it
+                            // has verified *this* sealed snapshot is what makes
+                            // the binding truthful for a seat this pass did not
+                            // publish.
+                            let pass_proves_latest = source_freshness
+                                .serves_recently_verified_source(
+                                    &latest.generation().snapshot().content_identity,
+                                    &project_root,
+                                    &shutting_down,
+                                );
                             let mut serving = serving_generation
                                 .write()
                                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -4541,26 +4553,39 @@ impl CodeIndexSchedulerRegistryV1 {
                                     .write()
                                     .unwrap_or_else(std::sync::PoisonError::into_inner) =
                                     Some(latest.text_generation_handle());
-                                // Only a generation extracted from the live
-                                // checkout this pass and seated as the active
-                                // publication carries its pass's freshness
-                                // proof into the witness. A stale seat and a
-                                // retained/restored seat stay unproven until
-                                // the quiet exact-source probe passes, so busy
-                                // verified reads never serve bytes no proof
-                                // has vouched for.
-                                *serving_source_witness
-                                    .write()
-                                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                                    if published_pass
-                                        && matches!(outcome, ServingSwapOutcomeV1::Seated)
-                                    {
-                                        scheduler.source_currency_witness_for(
-                                            &latest.generation().manifest().generation_id,
-                                        )
-                                    } else {
-                                        None
-                                    };
+                            }
+                            // A pass is the only thing that verifies source
+                            // against the sealed digests, so it is also the
+                            // only thing that can re-prove a seat. `Offered`
+                            // is that case: the active publication already
+                            // serves and this pass re-observed the checkout it
+                            // was sealed from. Arming only on a publication
+                            // left a restored, retired, or withdrawn seat
+                            // permanently unproven — busy verified reads then
+                            // refused a generation whose source was current.
+                            match outcome {
+                                ServingSwapOutcomeV1::Seated | ServingSwapOutcomeV1::Offered => {
+                                    *serving_source_witness
+                                        .write()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                                        pass_proves_latest.then(|| super::ServingSourceWitnessV1 {
+                                            generation_id: latest
+                                                .generation()
+                                                .manifest()
+                                                .generation_id
+                                                .clone(),
+                                        });
+                                }
+                                // The durable pointer names a successor, so no
+                                // proof of this seat's currency exists to bind.
+                                ServingSwapOutcomeV1::SeatedStale => {
+                                    *serving_source_witness
+                                        .write()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+                                }
+                                // The slot kept a foreign incumbent; its
+                                // witness belongs to that generation.
+                                ServingSwapOutcomeV1::Superseded => {}
                             }
                             drop(serving);
                             // The serving slot is now fully published, including

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -2199,6 +2199,20 @@ impl CodeIndexSchedulerRegistryV1 {
             .map(|worktree| Arc::clone(&worktree.serving_source_witness))
     }
 
+    /// The shared source-freshness fence for one mounted root, so tests can
+    /// age its bounded proof instead of waiting the bound out in wall clock.
+    #[cfg(test)]
+    pub(crate) async fn source_freshness_for_root(
+        &self,
+        project_root: &Path,
+    ) -> Option<super::SourceFreshnessFenceV1> {
+        let project_root = project_root.canonicalize().ok()?;
+        let mounted = self.mounted.lock().await;
+        mounted
+            .get(&project_root)
+            .map(|worktree| worktree.source_freshness.clone())
+    }
+
     /// Drop the retained serving generation, reproducing a mount whose restore
     /// produced nothing servable.
     #[cfg(test)]

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -6683,12 +6683,21 @@ impl CodeIndexSchedulerRegistryV1 {
     /// sealed source. Once that proof expires, the immutable owner remains
     /// available as stale while one coalesced wake asks the retained worker to
     /// run the exact stat/content proof. The read never performs that work or
-    /// waits for the scheduler mutex.
+    /// waits for the scheduler mutex — the pass counter is read only to
+    /// attribute the wake, never to decide currency.
     pub async fn latest_text_serving_freshness_for_scope(
         &self,
         scope: &tracedecay_contracts::ResolvedScope,
     ) -> Option<(LatestCodeTextGenerationV1, bool)> {
-        let (root, source_freshness, text_generation, wake, pending_wake, shutting_down) = {
+        let (
+            root,
+            source_freshness,
+            text_generation,
+            wake,
+            pending_wake,
+            reconcile_in_progress,
+            shutting_down,
+        ) = {
             let mounted = self.mounted.lock().await;
             let (root, worktree) = unique_mounted_for_scope(&mounted, scope).unique()?;
             (
@@ -6697,6 +6706,7 @@ impl CodeIndexSchedulerRegistryV1 {
                 Arc::clone(&worktree.text_generation),
                 Arc::clone(&worktree.wake),
                 Arc::clone(&worktree.pending_wake),
+                Arc::clone(&worktree.reconcile_in_progress),
                 Arc::clone(&worktree.shutting_down),
             )
         };
@@ -6714,11 +6724,18 @@ impl CodeIndexSchedulerRegistryV1 {
             &shutting_down,
         );
         if !current {
-            Self::note_wake_if_idle(
-                &pending_wake,
-                &wake,
-                CodeIndexCadenceTriggerV1::QueryAdmission,
-            );
+            // Attribution, not admission. A read that cannot verify the owner
+            // while a pass already owns the worktree is a follow-up to that
+            // pass: its wake is served after the in-flight pass ends, so its
+            // event-to-ready latency measures the busy window, not the query
+            // ladder's. Reporting both as `QueryAdmission` buried an unrelated
+            // pass inside the query-admission cadence sample.
+            let trigger = if reconcile_in_progress.load(Ordering::Acquire) == 0 {
+                CodeIndexCadenceTriggerV1::QueryAdmission
+            } else {
+                CodeIndexCadenceTriggerV1::BusyFollowUp
+            };
+            Self::note_wake_if_idle(&pending_wake, &wake, trigger);
         }
         Some((latest, current))
     }

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry.rs
@@ -6857,6 +6857,12 @@ impl CodeIndexSchedulerRegistryV1 {
     /// ready, the shared source fence suppresses a wake while its proof is
     /// current. Authenticated metadata without those owners is still warming
     /// and always needs the worker's next bounded slice.
+    ///
+    /// An in-flight pass is deliberately *not* a third suppression. That pass
+    /// observed the checkout when it started, which may predate the state this
+    /// admission found unservable, so declining here strands the remedy until
+    /// an unrelated hint arrives. The claim above already coalesces the only
+    /// duplicate worth suppressing — a wake nobody has dequeued yet.
     pub async fn request_query_background_reconcile(
         &self,
         scope: &tracedecay_contracts::ResolvedScope,
@@ -6878,7 +6884,6 @@ impl CodeIndexSchedulerRegistryV1 {
             hints,
             wake,
             pending_wake,
-            reconcile_in_progress,
         ) = {
             let mounted = self.mounted.lock().await;
             let Some((root, worktree)) = unique_mounted_for_scope(&mounted, scope).unique() else {
@@ -6893,7 +6898,6 @@ impl CodeIndexSchedulerRegistryV1 {
                 Arc::clone(&worktree.hints),
                 Arc::clone(&worktree.wake),
                 Arc::clone(&worktree.pending_wake),
-                Arc::clone(&worktree.reconcile_in_progress),
             )
         };
         #[cfg(test)]
@@ -6908,13 +6912,6 @@ impl CodeIndexSchedulerRegistryV1 {
         let Some(wake_claim) = PendingWakeClaimV1::claim(Arc::clone(&pending_wake)) else {
             return false;
         };
-        // The pending marker covers admission until the worker dequeues it;
-        // the pass counter covers the interval after dequeue. A query arriving
-        // in that second interval is already covered by the running source
-        // proof and must not queue an identical follow-up pass.
-        if reconcile_in_progress.load(Ordering::Acquire) != 0 {
-            return false;
-        }
         #[cfg(test)]
         if let Some(test_control) = test_control.as_ref()
             && test_control.pauses_after_claim.load(Ordering::Acquire)

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry/serving_readiness_tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/registry/serving_readiness_tests.rs
@@ -1,8 +1,9 @@
 //! Serving notifications cover installation and renewed source admission.
 
+use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 use tracedecay_contracts::ResolvedScope;
@@ -10,6 +11,38 @@ use tracedecay_domain::ProjectId;
 
 use super::super::graph_activation::install_injected_activation_gate;
 use super::{CodeIndexCadenceOutcomeV1, CodeIndexSchedulerRegistryV1};
+
+/// Failure bound on an owner pass finishing once the worker is parked. Nothing
+/// here passes because time elapsed; a pass that never ends fails loudly.
+const OWNER_PASS_QUIESCENCE_CEILING: Duration = Duration::from_mins(2);
+
+/// Park the background worker and wait out whatever pass is already in flight.
+///
+/// The worker releases its admission permit after source reconciliation but
+/// keeps its owner-pass guard through text seating, so winning the permit only
+/// proves that no *new* pass can start. A pass still running past that point
+/// installs a serving generation and signals `serving_generation_changed`,
+/// which a test sampling that watch would then attribute to its own next step.
+async fn quiesced_background_reconcile_admission(
+    registry: &CodeIndexSchedulerRegistryV1,
+    project_root: &Path,
+) -> tokio::sync::OwnedSemaphorePermit {
+    let admission = registry
+        .background_reconcile_admission()
+        .acquire_owned()
+        .await
+        .expect("hold the background worker at its dequeue point");
+    let deadline = Instant::now() + OWNER_PASS_QUIESCENCE_CEILING;
+    while registry.reconcile_in_progress_for_test(project_root).await {
+        assert!(
+            Instant::now() <= deadline,
+            "the owner pass for {} never finished",
+            project_root.display()
+        );
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+    admission
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn serving_waiter_tracks_installation_freshness_and_retirement() {
@@ -136,11 +169,7 @@ async fn serving_waiter_tracks_installation_freshness_and_retirement() {
             .checked_sub(state.staleness_threshold + Duration::from_secs(1))
             .expect("age the readiness proof");
     }
-    let admission = registry
-        .background_reconcile_admission()
-        .acquire_owned()
-        .await
-        .expect("hold expired-proof verification in the background");
+    let admission = quiesced_background_reconcile_admission(&registry, &project).await;
     changes.borrow_and_update();
     assert!(
         tokio::time::timeout(
@@ -186,11 +215,7 @@ async fn serving_waiter_tracks_installation_freshness_and_retirement() {
         published.generation_id
     );
 
-    let admission = registry
-        .background_reconcile_admission()
-        .acquire_owned()
-        .await
-        .expect("hold unchanged-source revalidation");
+    let admission = quiesced_background_reconcile_admission(&registry, &project).await;
     changes.borrow_and_update();
     let seat_epoch = {
         let mounted = registry.mounted.lock().await;

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -8745,14 +8745,19 @@ async fn ignored_dependency_waits_for_global_admission_before_publication_gate()
     registry.shutdown().await;
 }
 
-/// Busy-read stat proof reuse is explicitly bounded: an out-of-band write with
-/// no Git or scheduler hint may reuse the prior proof inside the memo window,
-/// but the first probe after that window must sweep and withdraw the witness.
+/// Busy-read proof reuse is explicitly bounded, but the bound belongs to the
+/// freshness fence, not to a per-read worktree sweep: an ordinary read never
+/// walks the checkout. An out-of-band write that moves no Git metadata and
+/// reaches no hint authority is therefore served from the live proof until
+/// that proof expires. The first read after it does declines the seat and
+/// hands the exact stat-plus-sealed-digest comparison to the retained worker,
+/// whose pass is the only authority that may withdraw the witness from the
+/// disproved generation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn a_disproving_exact_source_probe_withdraws_the_busy_read_witness() {
     let fixture = GitFixture::new(&[("src/main.rs", "fn main() {}\n")]);
     let store = TempDir::new().expect("store root");
-    let (registry, scope) = mounted_core_query_worktree(&fixture, &store).await;
+    let (registry, scope) = mounted_core_query_worktree_with_one_permit(&fixture, &store).await;
 
     let ready = tokio::time::timeout(Duration::from_secs(10), async {
         loop {
@@ -8773,8 +8778,14 @@ async fn a_disproving_exact_source_probe_withdraws_the_busy_read_witness() {
         .serving_source_witness_for_root(fixture.path())
         .await
         .expect("mounted worktree witness");
+    let source_freshness = registry
+        .source_freshness_for_root(fixture.path())
+        .await
+        .expect("mounted worktree source fence");
+    // Hold the worker at its dequeue point so every observation below is the
+    // read path's own answer and never a pass that raced it.
+    let admission = quiesced_background_reconcile_admission(&registry, fixture.path()).await;
 
-    // Drift the worktree; the stat-signature fence disproves the seat.
     std::fs::write(
         fixture.path().join("src/main.rs"),
         "fn main() { drifted(); }\n",
@@ -8786,28 +8797,61 @@ async fn a_disproving_exact_source_probe_withdraws_the_busy_read_witness() {
             .latest_complete_ready_decoded_for_root_scope(fixture.path(), &scope)
             .await
             .is_some(),
-        "a raw unhinted write may reuse the proof only inside the explicit bounded interval"
+        "an unhinted raw write reuses the live proof; a read never walks the checkout"
     );
-    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    // Expire that proof exactly as its own bound does, without waiting it out.
+    {
+        let mut state = source_freshness
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.last_reconciled_at = Instant::now()
+            .checked_sub(state.staleness_threshold + Duration::from_secs(1))
+            .expect("age the source proof past its own bound");
+    }
+    registry.clear_pending_wake_for_scope(&scope).await;
     assert!(
         registry
             .latest_complete_ready_decoded_for_root_scope(fixture.path(), &scope)
             .await
             .is_none(),
-        "a drifted worktree disproves the seated generation's currency"
+        "an expired proof disproves the seated generation's currency"
     );
-    // The probe posts a reconcile wake, so the worker may already be sealing a
-    // successor; what must hold is that the witness never keeps naming the
-    // disproved generation.
-    assert_ne!(
+    assert!(
+        registry
+            .pending_wake_micros_for_scope(&scope)
+            .await
+            .is_some_and(|pending| pending != 0),
+        "the declining read hands the exact source proof to the retained worker"
+    );
+    assert_eq!(
         witness
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .as_ref()
             .map(|witness| witness.generation_id.clone()),
-        Some(disproved_generation_id),
-        "the disproving probe withdraws the busy-read witness"
+        Some(disproved_generation_id.clone()),
+        "a read that cannot verify source may not fabricate the disproof itself"
     );
+
+    // Release the worker: its pass re-derives the sealed digests, observes the
+    // drift, and the witness stops naming the disproved generation.
+    drop(admission);
+    let deadline = Instant::now() + SERVING_SEAT_FAILURE_CEILING;
+    while witness
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .map(|witness| witness.generation_id.clone())
+        == Some(disproved_generation_id.clone())
+    {
+        assert!(
+            Instant::now() <= deadline,
+            "the disproving reconcile pass never withdrew the busy-read witness"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
 
     registry.shutdown().await;
 }

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -17952,18 +17952,30 @@ async fn pinned_configuration_refuses_native_graph_before_text_serving_swap() {
         .await
         .expect("mount scheduler under configured graph policy");
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
-    let latest = loop {
-        if let Some((latest, _)) = registry
+    // The identity port answers only for a text owner the fence still proves
+    // current, so it must be resolved in the same wait that admits the owner:
+    // the fence's bounded proof expires on its own clock, and a pass renewing
+    // it republishes the owner. Sampling the owner once and resolving its
+    // identity afterwards turned either boundary into a red.
+    let deadline = Instant::now() + SERVING_SEAT_FAILURE_CEILING;
+    let (latest, identity) = loop {
+        if let Some((latest, current)) = registry
             .latest_text_serving_freshness_for_scope(&scope)
             .await
             && latest.query_owners_are_warm()
+            && current
+            && let Some(identity) = <CodeIndexSchedulerRegistryV1 as tracedecay_application::diagnostics_publication::CodeIndexPublicationIdentityPortV1>::resolve_current_for_scope(
+                &registry,
+                fixture.path().to_path_buf(),
+                scope.clone(),
+            )
+            .await
         {
-            break latest;
+            break (latest, identity);
         }
         assert!(
-            std::time::Instant::now() <= deadline,
-            "configured graph refusal withheld the text-serving generation"
+            Instant::now() <= deadline,
+            "configured graph refusal withheld the ready text owner's publication identity"
         );
         tokio::time::sleep(Duration::from_millis(10)).await;
     };
@@ -17980,13 +17992,6 @@ async fn pinned_configuration_refuses_native_graph_before_text_serving_swap() {
         .files
         .first()
         .expect("indexed file");
-    let identity = <CodeIndexSchedulerRegistryV1 as tracedecay_application::diagnostics_publication::CodeIndexPublicationIdentityPortV1>::resolve_current_for_scope(
-        &registry,
-        fixture.path().to_path_buf(),
-        scope.clone(),
-    )
-    .await
-    .expect("ready text owner retains file identity without a graph seat");
     assert_eq!(
         identity.generation_id(),
         &latest.metadata().manifest().generation_id

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -11887,12 +11887,11 @@ async fn wait_for_quiescent_owner_pass(
 ///
 /// Winning the permit only proves no *new* pass can start. The worker releases
 /// it after source reconciliation but keeps its `reconcile_in_progress` guard
-/// through text seating, so the permit is routinely free while a pass runs. A
-/// query that claims the pending wake in that window is suppressed as already
-/// covered by the running source proof and returns before it reaches the claim
-/// gate — so a test that then waits for the claim would wait on a rendezvous
-/// nothing will ever reach. With the permit held the counter is monotone to
-/// zero, so this settles once and stays settled for the rest of the test.
+/// through text seating, so the permit is routinely free while a pass runs and
+/// that pass still moves the serving seat, its witness, and the pending wake
+/// under a test that already believes the worker is parked. With the permit
+/// held the pass counter is monotone to zero, so this settles once and stays
+/// settled for the rest of the test.
 async fn quiesced_background_reconcile_admission(
     registry: &CodeIndexSchedulerRegistryV1,
     project_root: &Path,

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -14388,20 +14388,16 @@ async fn wait_for_dashboard_ready(registry: &CodeIndexSchedulerRegistryV1, path:
 /// Publication broadcast and [`CodeIndexSchedulerRegistryV1::latest_generation_id`]
 /// stay behind optional graph seating. Unpinned exact/lexical queries resolve
 /// through the text owner, so that slot is the typed receipt this wait joins.
+/// The text lane publishes the per-worktree serving-generation watch, so
+/// [`wait_until_serving_seat`] blocks on that signal rather than sampling.
 async fn wait_for_queryable_text_generation(
     registry: &CodeIndexSchedulerRegistryV1,
     path: &Path,
 ) -> super::LatestCodeTextGenerationV1 {
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if let Some(text) = registry.latest_text_serving_for_root(path).await {
-                break text;
-            }
-            tokio::time::sleep(Duration::from_millis(2)).await;
-        }
+    wait_until_serving_seat(registry, path, SERVING_SEAT_FAILURE_CEILING, || async {
+        registry.latest_text_serving_for_root(path).await
     })
     .await
-    .expect("queryable text generation seated")
 }
 
 /// The generation id of the text-current seat.
@@ -14426,24 +14422,22 @@ async fn wait_for_queryable_text_generation_id(
 }
 
 /// Wait until the text owner seats a generation distinct from `previous`.
+///
+/// Same signal as [`wait_for_queryable_text_generation`], narrowed to a
+/// successor: the seat that replaces `previous` is itself a per-worktree
+/// serving-generation change.
 async fn wait_for_queryable_text_generation_change(
     registry: &CodeIndexSchedulerRegistryV1,
     path: &Path,
     previous: &tracedecay_domain::CodeGenerationId,
 ) -> super::LatestCodeTextGenerationV1 {
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            if let Some(text) = registry.latest_text_serving_for_root(path).await {
-                let generation_id = text.metadata().manifest().generation_id.clone();
-                if &generation_id != previous {
-                    break text;
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(2)).await;
-        }
+    wait_until_serving_seat(registry, path, SERVING_SEAT_FAILURE_CEILING, || async {
+        registry
+            .latest_text_serving_for_root(path)
+            .await
+            .filter(|text| &text.metadata().manifest().generation_id != previous)
     })
     .await
-    .expect("changed queryable text generation seated")
 }
 
 /// Wait until the mounted worktree seats a generation distinct from `previous`.

--- a/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
+++ b/crates/tracedecay-code-index-runtime/src/code_index_scheduler/tests.rs
@@ -8439,8 +8439,10 @@ async fn selected_generation_mints_feedback_identity_after_registry_lookup_close
 /// Fail-closed half of the busy-read witness: a seated generation whose
 /// currency was never proven (a boot-restored seat, a stale seat, or a
 /// withdrawn proof) must stay a typed abstention while the scheduler mutex is
-/// busy, exactly as before. Only the exact-source probe's own verdict may arm
-/// busy serving.
+/// busy, exactly as before. Only a reconcile pass may arm busy serving: it is
+/// the only thing that compares the checkout against the sealed digests, so it
+/// is the only thing whose verdict can bind a seat to proven source. Reads no
+/// longer walk the tree and so can never arm the witness themselves.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn busy_scheduler_still_refuses_a_seated_generation_without_a_currency_witness() {
     let fixture = GitFixture::new(&[("src/main.rs", "fn main() {}\n")]);
@@ -10200,8 +10202,13 @@ async fn dashboard_freshness_reports_pending_rebuild_liveness() {
     registry.shutdown().await;
 }
 
+/// A running source-verification pass is not itself a reason to decline query
+/// admission. What declines here is the freshness gate: the seat is servable
+/// and its proof is unexpired, so the query already has its answer and there is
+/// no remedy to schedule. The pass is held only to put the worktree in the
+/// verifying state whose dashboard projection this also pins.
 #[tokio::test]
-async fn active_source_verification_does_not_queue_a_second_query_pass() {
+async fn a_fresh_seat_declines_query_admission_during_source_verification() {
     let fixture = GitFixture::new(&[("src/main.rs", "fn main() {}\n")]);
     let store = TempDir::new().expect("store root");
     let (registry, scope) = mounted_core_query_worktree(&fixture, &store).await;
@@ -10214,12 +10221,12 @@ async fn active_source_verification_does_not_queue_a_second_query_pass() {
         .expect("mounted reconcile owner");
     assert!(
         !registry.request_query_background_reconcile(&scope).await,
-        "the active source proof already supplies the query's remedy"
+        "a servable seat under an unexpired proof is already the query's answer"
     );
     assert_eq!(
         registry.pending_wake_micros_for_scope(&scope).await,
         Some(0),
-        "query admission must not queue a duplicate pass after worker dequeue"
+        "a declined admission must leave the pending wake unclaimed"
     );
 
     let projected = registry


### PR DESCRIPTION
Fixes the deterministic and load reds left in `code_index_scheduler` after #1221 and #1225 (issue #1222). Bisection reassigned three of the four deterministic ones to `3bc9dedfe` (verify stale reads in background), which moved reads off the witness-arming path; `669438a31` owns only one.

**Production (three, `registry.rs`):**
- A query during an in-flight pass still records a follow-up wake — the pass observed the checkout when it *started*, which can predate the state the read found unverifiable — but it is now labelled `BusyFollowUp` (an existing trigger, matching the convention already used for busy `WouldBlock`) instead of `QueryAdmission`, so busy-window wakes stay out of the cadence sample operators use to size query admission. The read does no work and never takes the scheduler mutex.
- Removed the `reconcile_in_progress != 0 → return false` suppression `669438a31` added to `request_query_background_reconcile`: a pass counter is not a currency authority, and it contradicted the older unchanged contract in `cold_read_wake_tests.rs` (a mid-pass cold query records one wake and does not supersede the in-flight snapshot). Duplicates are bounded by `PendingWakeClaimV1::claim` — 100 concurrent queries during one pass produce exactly one wake, before and after. The #1103 livelock guard is the freshness gate, which is untouched.
- A pass that re-verifies an already-seated generation returns `Offered`, which never re-armed `serving_source_witness`, so a restored/retired/withdrawn seat had no path back to proven and busy verified reads refused a generation the scheduler had just confirmed current. The worker now asks the freshness fence whether it verified *this* sealed snapshot (exact content-digest binding — strictly tighter than the mint it replaces) and arms on `Offered` as well as `Seated`; `SeatedStale` clears, `Superseded` leaves the incumbent's witness alone. A witness never authorizes serving alone — reads still require a live fence proof — so a stale witness cannot re-prove a drifted seat. One additional tightening: on `Offered` without a proving pass the witness is cleared rather than left dangling.

**Tests:** the busy-read witness test is rewritten against the bound that exists (the probe-side withdrawal it asserted was deleted by `3bc9dedfe`); two load-racy tests now wait on #1225's pass-quiescence barrier / fold resolution into the readiness wait; the last two 5 s wall-clock pollers of the #1206 class (`wait_for_queryable_text_generation[_change]`, 17 call sites) migrate onto `wait_until_serving_seat` — they were the source of 8 of 9 module reds under load; two stale test names/docs corrected. No assertion weakened (net +3), no test-only production API (`source_freshness_for_root` is `#[cfg(test)]`, mirroring an existing accessor).

**Verification (two independent Opus reviews, READY):** A.1–A.4 20/20 each single-threaded; B tests 20/20 at 32 threads; full module at `--test-threads=32` completes at **356 passed / 1 failed** — the one red is `verified_empty_source_remains_observable_while_scheduler_is_busy`, deterministic on the untouched tip (3/3) and tracked in #1230. `git merge-tree` clean against the in-flight #1103 branch (both touch the freshness fence read-only). Crate clippy `-D warnings`, fmt, commitlint on all eight messages.