### PR TITLE
style(contracts): box the large native preview result variant

### DIFF
--- a/crates/tracedecay-application/src/observability/execution_emit.rs
+++ b/crates/tracedecay-application/src/observability/execution_emit.rs
@@ -547,7 +547,7 @@ mod tests {
     }
 
     fn preview() -> NativeIntegrationSurfaceResultV1 {
-        NativeIntegrationSurfaceResultV1::Preview(NativeIntegrationPreviewProjectionV1 {
+        NativeIntegrationSurfaceResultV1::Preview(Box::new(NativeIntegrationPreviewProjectionV1 {
             preview_id: NativeIntegrationPreviewId::new("preview.native.fixture").unwrap(),
             preview_digest: digest('a'),
             selection: tracedecay_contracts::NativeIntegrationSnapshotProjectionV1 {
@@ -566,7 +566,7 @@ mod tests {
             ordered_commit_count: 2,
             created_at: UtcMicros(20),
             expires_at: UtcMicros(30),
-        })
+        }))
     }
 
     fn committed_receipt() -> NativeIntegrationSurfaceResultV1 {

--- a/crates/tracedecay-application/src/observability/work_conflict_emit.rs
+++ b/crates/tracedecay-application/src/observability/work_conflict_emit.rs
@@ -519,15 +519,15 @@ mod tests {
     }
 
     fn preview_result(preview: &NativeIntegrationPreviewV1) -> NativeIntegrationSurfaceResultV1 {
-        NativeIntegrationSurfaceResultV1::Preview(
+        NativeIntegrationSurfaceResultV1::Preview(Box::new(
             NativeIntegrationPreviewProjectionV1::project(preview).unwrap(),
-        )
+        ))
     }
 
     fn projection_result(
         disposition: NativeIntegrationPreviewDispositionV1,
     ) -> NativeIntegrationSurfaceResultV1 {
-        NativeIntegrationSurfaceResultV1::Preview(NativeIntegrationPreviewProjectionV1 {
+        NativeIntegrationSurfaceResultV1::Preview(Box::new(NativeIntegrationPreviewProjectionV1 {
             preview_id: NativeIntegrationPreviewId::new("preview.work-conflict.projection")
                 .unwrap(),
             preview_digest: digest('a'),
@@ -545,7 +545,7 @@ mod tests {
             ordered_commit_count: 1,
             created_at: UtcMicros(12),
             expires_at: UtcMicros(1_000),
-        })
+        }))
     }
 
     fn receipt_result(

--- a/crates/tracedecay-contracts/src/git/native_integration_surface.rs
+++ b/crates/tracedecay-contracts/src/git/native_integration_surface.rs
@@ -410,7 +410,7 @@ pub enum NativeIntegrationCancellationProjectionV1 {
 #[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum NativeIntegrationSurfaceResultV1 {
     StackSnapshot(Box<NativeIntegrationSealedStackSnapshotProjectionV1>),
-    Preview(NativeIntegrationPreviewProjectionV1),
+    Preview(Box<NativeIntegrationPreviewProjectionV1>),
     Approval(NativeIntegrationApprovalProjectionV1),
     Receipt(NativeIntegrationReceiptProjectionV1),
     Status(NativeIntegrationStatusProjectionV1),
@@ -476,9 +476,9 @@ impl NativeIntegrationSurfaceResultV1 {
         outcome: &NativeIntegrationPreflightOutcomeV1,
     ) -> Result<Self, ApplicationContractError> {
         Ok(match outcome {
-            NativeIntegrationPreflightOutcomeV1::Preview(preview) => {
-                Self::Preview(NativeIntegrationPreviewProjectionV1::project(preview)?)
-            }
+            NativeIntegrationPreflightOutcomeV1::Preview(preview) => Self::Preview(Box::new(
+                NativeIntegrationPreviewProjectionV1::project(preview)?,
+            )),
             NativeIntegrationPreflightOutcomeV1::Partial => {
                 Self::unavailable(NativeIntegrationSurfaceUnavailableV1::Partial)
             }


### PR DESCRIPTION
Restores part of the workspace clippy gate on the tip. `4e9eb1fe6` (feat(native): bind semantic evidence to apply) grew `NativeIntegrationPreviewProjectionV1` past the `large_enum_variant` threshold (≥1400 B vs 232 B for the next variant) on `NativeIntegrationSurfaceResultV1`. Same fix shape as #1215's `StackSnapshot`: `Preview(Box<…>)`. `Box` is transparent to serde (internally tagged, no flatten/untagged) and schemars, so no wire or generated-contract change; match sites bind by reference and deref-coerce, so only the four constructors changed (one production in `from_stack_resolution`, three test fixtures).

The gate is still red after this on `too_many_arguments` (8/7) in `tracedecay-agent-hosts/src/native_integration/registry.rs:365/:392` and the daemon-service wrapper from the same merge; that is being fixed as an identity-struct cutover in a separate PR because it spans three crates the owning lane is actively editing.

Verification: `cargo clippy -p tracedecay-contracts --no-deps --all-targets -- -D warnings` clean; workspace clippy now stops only at the agent-hosts lint; fmt.