### PR TITLE
fix(tests): key the mcp-suite store template on the schema fingerprint

### DIFF
--- a/crates/tracedecay-runtime-core/src/db/migrations.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations.rs
@@ -14,6 +14,8 @@ use tracedecay_domain::errors::{Result, TraceDecayError};
 
 mod final_shape;
 
+pub use final_shape::{expected_final_schema_fingerprint, fingerprint_schema_objects};
+
 const ROOT_SCHEMA: &str = "CREATE TABLE IF NOT EXISTS metadata (
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL

--- a/crates/tracedecay-runtime-core/src/db/migrations/final_shape.rs
+++ b/crates/tracedecay-runtime-core/src/db/migrations/final_shape.rs
@@ -4,7 +4,12 @@ use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use crate::db::engine::QueryExecutor;
+use tracedecay_domain::canonical_text::canonical_framed_sha256;
 use tracedecay_domain::errors::{Result, TraceDecayError};
+
+/// Domain tag for [`fingerprint_schema_objects`]. Changing it would rename
+/// every cache keyed on the digest; keep it stable.
+const SCHEMA_SHAPE_FINGERPRINT_DOMAIN: &[u8] = b"tracedecay.final-schema-shape.v1";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SchemaObject {
@@ -123,6 +128,36 @@ fn read_rusqlite_inventory(
         }
     }
     Ok(inventory)
+}
+
+/// Deterministic fingerprint of a schema-object set (`name` + `sql`, sorted).
+///
+/// Two inventories that differ in any object's name or DDL produce different
+/// keys; permutation of the same pairs does not. This is the cache identity
+/// for fixtures that must not reuse a store template after the final shape
+/// changes without a `SCHEMA_VERSION` bump.
+pub fn fingerprint_schema_objects<'a, I>(objects: I) -> String
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    let mut rows: Vec<(&str, &str)> = objects.into_iter().collect();
+    rows.sort_unstable_by(|left, right| left.0.cmp(right.0).then(left.1.cmp(right.1)));
+    let mut parts = Vec::with_capacity(rows.len().saturating_mul(2));
+    for (name, sql) in &rows {
+        parts.push(name.as_bytes());
+        parts.push(sql.as_bytes());
+    }
+    canonical_framed_sha256(SCHEMA_SHAPE_FINGERPRINT_DOMAIN, &parts)
+}
+
+/// Fingerprint of the exact final shape this binary creates and admits.
+pub fn expected_final_schema_fingerprint() -> Result<String> {
+    let inventory = EXPECTED_FINAL_SHAPE
+        .as_ref()
+        .map_err(|error| database_error(error.clone()))?;
+    Ok(fingerprint_schema_objects(inventory.iter().map(
+        |(name, object)| (name.as_str(), object.sql.as_str()),
+    )))
 }
 
 pub(super) fn require_admissible_final_shape_rusqlite(
@@ -311,4 +346,39 @@ fn require_final_shape_inventory(
         )));
     }
     Ok(shipped_trigger_found)
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    use super::fingerprint_schema_objects;
+
+    #[test]
+    fn schema_object_fingerprint_differs_for_different_ddl_and_matches_for_the_same_set() {
+        let baseline = [
+            ("alpha", "CREATE TABLE alpha(id INTEGER PRIMARY KEY)"),
+            ("beta", "CREATE INDEX beta ON alpha(id)"),
+        ];
+        let same_set_permuted = [
+            ("beta", "CREATE INDEX beta ON alpha(id)"),
+            ("alpha", "CREATE TABLE alpha(id INTEGER PRIMARY KEY)"),
+        ];
+        let different_ddl = [
+            (
+                "alpha",
+                "CREATE TABLE alpha(id INTEGER PRIMARY KEY, extra TEXT)",
+            ),
+            ("beta", "CREATE INDEX beta ON alpha(id)"),
+        ];
+        let same_key = fingerprint_schema_objects(baseline);
+        assert_eq!(
+            same_key,
+            fingerprint_schema_objects(same_set_permuted),
+            "identical name+sql pairs must produce the same cache key regardless of input order"
+        );
+        assert_ne!(
+            same_key,
+            fingerprint_schema_objects(different_ddl),
+            "a DDL change must produce a different cache key"
+        );
+    }
 }

--- a/crates/tracedecay/tests/mcp_suite/fixture.rs
+++ b/crates/tracedecay/tests/mcp_suite/fixture.rs
@@ -33,18 +33,18 @@ use tracedecay_runtime_core::storage::{
 
 use crate::common::GLOBAL_DB_ENV;
 
-/// Bump when the template layout or fixture sources change, so stale
-/// templates from previous revisions in a cached target dir are ignored.
-const TEMPLATE_DIR_REVISION: &str = "mcp-suite-store-template-v6";
-
-/// The template directory is also keyed on the runtime-core schema version:
-/// a template seeded by a binary one schema step behind would otherwise be
-/// copied into every fixture and refused (or stepped) on admission.
-fn template_dir_name() -> String {
-    format!(
-        "{TEMPLATE_DIR_REVISION}-schema{}",
-        tracedecay_runtime_core::db::migrations::SCHEMA_VERSION
-    )
+/// Shared on-disk template identity. Keyed on the admitted final-shape
+/// fingerprint, not `SCHEMA_VERSION` or a hand-maintained revision: a required
+/// table can land in the final shape without a version bump, and a warm
+/// target must not reuse the previous template.
+fn template_dir_name() -> Option<String> {
+    match tracedecay_runtime_core::db::migrations::expected_final_schema_fingerprint() {
+        Ok(fingerprint) => Some(format!("mcp-suite-store-template-{fingerprint}")),
+        Err(error) => {
+            eprintln!("[mcp_suite::fixture] schema fingerprint unavailable: {error}");
+            None
+        }
+    }
 }
 
 const EMPTY_FLAVOR: &str = "empty";
@@ -216,7 +216,7 @@ async fn template_root() -> Option<&'static Path> {
 /// every concurrent process blocks briefly and then finds READY.
 async fn ensure_template() -> Option<PathBuf> {
     let tmp_root = Path::new(env!("CARGO_TARGET_TMPDIR"));
-    let template_dir_name = template_dir_name();
+    let template_dir_name = template_dir_name()?;
     let shared = tmp_root.join(&template_dir_name);
     if shared.join("READY").is_file() {
         return Some(shared);
@@ -291,11 +291,21 @@ async fn build_template(dest: &Path) -> io::Result<()> {
         .await
         .map_err(io_other)?;
     let sessions_db_path = cg.store_layout().sessions_db_path.clone();
+    let graph_db_path = cg.store_layout().graph_db_path.clone();
     cg.checkpoint().await.map_err(io_other)?;
     cg.close();
 
     purge_configuration(&sessions_db_path)?;
     purge_global_registry(&global_db_path).await?;
+    let built_fingerprint = sqlite_master_shape_fingerprint(&graph_db_path)?;
+    let expected_fingerprint =
+        tracedecay_runtime_core::db::migrations::expected_final_schema_fingerprint()
+            .map_err(io_other)?;
+    if built_fingerprint != expected_fingerprint {
+        return Err(io::Error::other(format!(
+            "built template schema fingerprint {built_fingerprint} does not match expected {expected_fingerprint}"
+        )));
+    }
     copy_tree(&root, &dest.join(EMPTY_FLAVOR))?;
 
     fs::write(dest.join("READY"), b"ok")?;
@@ -450,4 +460,34 @@ fn rewrite_json(path: &Path, edit: impl FnOnce(&mut Value)) -> io::Result<()> {
 
 fn io_other(err: impl std::fmt::Display) -> io::Error {
     io::Error::other(err.to_string())
+}
+
+/// Reads `sqlite_master` (`name` + `sql`, sorted) from a freshly built
+/// template graph database and returns the same fingerprint the cache key
+/// uses. A stale template whose objects drifted without a version bump
+/// cannot match.
+fn sqlite_master_shape_fingerprint(database_path: &Path) -> io::Result<String> {
+    let conn = Connection::open(database_path).map_err(io_other)?;
+    let mut statement = conn
+        .prepare(
+            "SELECT name, COALESCE(sql, '') FROM sqlite_master
+             WHERE type IN ('table', 'index', 'trigger', 'view')
+               AND name NOT LIKE 'sqlite_%'",
+        )
+        .map_err(io_other)?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(io_other)?;
+    let objects = rows
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(io_other)?;
+    Ok(
+        tracedecay_runtime_core::db::migrations::fingerprint_schema_objects(
+            objects
+                .iter()
+                .map(|(name, sql)| (name.as_str(), sql.as_str())),
+        ),
+    )
 }


### PR DESCRIPTION
## Summary

- **Defect:** `mcp_suite` cached a pre-built store template as `mcp-suite-store-template-v<TEMPLATE_DIR_REVISION>-schema<SCHEMA_VERSION>` under `CARGO_TARGET_TMPDIR`. Tip commit `7f7cd14dd0` ("include runtime ledger in final shape") made `td_runtime_writer_checkpoint_v1` a required table without bumping `SCHEMA_VERSION` (still 35). Warm target dirs reused the stale template; 14 tests failed with `ResetRequired` until the cache dir was deleted. Fresh CI checkouts did not hit this.
- **Fix:** Key the template on the admitted final-shape fingerprint (sorted `name` + `sql` via `canonical_framed_sha256`), not a hand-maintained revision or `SCHEMA_VERSION`. `SCHEMA_VERSION` stays a migration authority. After each template build, the fixture re-reads `sqlite_master` from the graph DB and refuses to publish if that digest disagrees with the authority. A stale `v6-schema35` dir can never be reused.
- **Do not merge** — this is a small fix lane against the integration tip.

## Test plan

- [x] `cargo test -p tracedecay-runtime-core --lib db::migrations::final_shape::fingerprint_tests::schema_object_fingerprint_differs_for_different_ddl_and_matches_for_the_same_set -- --exact` — **1 passed** (cc-18639)
- [x] Planted stale `mcp-suite-store-template-v6-schema35` under `CARGO_TARGET_TMPDIR`, then `cargo test -p tracedecay --features test-transport --test mcp_suite -- --exact mcp_handler_test::status_runtime_test::test_status mcp_handler_test::status_runtime_test::status_can_omit_verbose_branch_diagnostics mcp_server_test::protocol_test::test_initialize` — **3 passed** (cc-18656). New dir `mcp-suite-store-template-5104eeb2…` was built; stale READY left unused.
- [x] Same three tests again against the warm fingerprint template — **3 passed** in 4.74s (cc-18673)
- [x] `cargo clippy -p tracedecay-runtime-core --lib --no-deps -- -D warnings` — clean (cc-18683)
- [x] `cargo clippy -p tracedecay --test mcp_suite --features test-transport --no-deps -- -D warnings` — **tip-side only** (cc-18674), not this diff:
  - `clippy::unnested_or_patterns` in `crates/tracedecay/src/daemon/invocation_state.rs:936`
  - `clippy::too_many_lines` in `crates/tracedecay/src/mcp/server.rs:651` (`new_with_registered_test_context`)

## Tickets

| Ticket | What |
| --- | --- |
| cc-18639 | fingerprint unit test (1 passed) |
| cc-18644 | first mcp_suite compile; failed on tip `serving_scope` (fixed by `1c10f19525`, then merged) |
| cc-18656 | mcp_suite ×3 with planted stale template (3 passed) |
| cc-18673 | mcp_suite ×3 warm rerun (3 passed) |
| cc-18674 | mcp_suite clippy `--no-deps -D warnings` (2 tip-side lib hits) |
| cc-18683 | runtime-core clippy `--no-deps -D warnings` (clean) |