### PR TITLE
test(mcp): align lcm expand and grep contracts with canonical occurrence

### DIFF
--- a/crates/tracedecay/tests/mcp_suite/mcp_handler_test/lcm_test.rs
+++ b/crates/tracedecay/tests/mcp_suite/mcp_handler_test/lcm_test.rs
@@ -15,7 +15,10 @@ use tracedecay_domain::sha256_hex_suffix;
 #[cfg(feature = "test-transport")]
 use tracedecay_lcm::types::LcmImmutableSummaryPublication;
 #[cfg(feature = "test-transport")]
-use tracedecay_lcm::{LcmLifecycleUpdate, LcmMaintenanceDebt, LcmSourceRef, LcmSummaryNodeDraft};
+use tracedecay_lcm::{
+    LCM_EXPAND_QUERY_SYNTHESIS_SYSTEM_PROMPT, LcmLifecycleUpdate, LcmMaintenanceDebt, LcmSourceRef,
+    LcmSummaryNodeDraft,
+};
 #[cfg(feature = "test-transport")]
 use tracedecay_sessions::admission::HostAdmissionScope;
 #[cfg(feature = "test-transport")]
@@ -872,7 +875,11 @@ async fn lcm_grep_and_load_session_honor_native_filters_and_content_clamp() {
     let grep_payload: Value = serde_json::from_str(extract_text(&grep.value)).unwrap();
     assert_eq!(grep_payload["status"], "partial");
     assert_eq!(grep_payload["count"], 1);
-    assert_eq!(grep_payload["omitted"], 3);
+    // Coverage counts the query-relevant result-eligible population, not a
+    // census of every seeded message: the single filtered hit is the only
+    // eligible anchor, and its unresolved provenance is the one omission.
+    assert_eq!(grep_payload["omitted"], 1, "payload: {grep_payload}");
+    assert_eq!(grep_payload["temporal"]["coverage"]["unknown"], 1);
     assert_eq!(
         grep_payload["hits"][0]["message_id"],
         "lcm-native-old-cli-assistant"
@@ -977,7 +984,7 @@ async fn lcm_grep_accepts_string_timestamp_filters() {
     let payload: Value = serde_json::from_str(extract_text(&grep.value)).unwrap();
     assert_eq!(payload["status"], "partial", "payload: {payload}");
     assert_eq!(payload["count"], 1);
-    assert_eq!(payload["omitted"], 3);
+    assert_eq!(payload["omitted"], 1, "payload: {payload}");
     assert_eq!(
         payload["hits"][0]["message_id"],
         "lcm-string-timestamps-target"
@@ -1035,7 +1042,7 @@ async fn lcm_grep_accepts_relative_time_filters() {
     let payload: Value = serde_json::from_str(extract_text(&grep.value)).unwrap();
     assert_eq!(payload["status"], "partial", "payload: {payload}");
     assert_eq!(payload["count"], 1);
-    assert_eq!(payload["omitted"], 2);
+    assert_eq!(payload["omitted"], 1, "payload: {payload}");
     assert_eq!(
         payload["hits"][0]["message_id"],
         "lcm-relative-timestamps-new"
@@ -1171,11 +1178,9 @@ async fn lcm_expand_query_large_response_preserves_synthesis_contract() {
         payload["prompt"],
         "Summarize oversized expand-query evidence"
     );
-    assert!(
-        payload["synthesis_prompt"]["system"]
-            .as_str()
-            .unwrap()
-            .contains("expanded LCM retrieval context")
+    assert_eq!(
+        payload["synthesis_prompt"]["system"],
+        LCM_EXPAND_QUERY_SYNTHESIS_SYSTEM_PROMPT
     );
     assert!(
         payload["synthesis_prompt"]["user"]

--- a/crates/tracedecay/tests/mcp_suite/mcp_handler_test/schema_test.rs
+++ b/crates/tracedecay/tests/mcp_suite/mcp_handler_test/schema_test.rs
@@ -178,11 +178,19 @@ async fn schema_required_arguments_match_representative_handler_parsers() {
     let target_branches = expand["properties"]["target"]["oneOf"]
         .as_array()
         .expect("closed target branches");
-    assert_eq!(target_branches.len(), 3);
-    assert_eq!(target_branches[0]["required"], json!(["kind", "store_id"]));
-    assert_eq!(target_branches[1]["required"], json!(["kind", "node_id"]));
+    assert_eq!(target_branches.len(), 4);
     assert_eq!(
-        target_branches[2]["required"],
+        target_branches[0]["properties"]["kind"]["const"],
+        "canonical_occurrence"
+    );
+    assert_eq!(
+        target_branches[0]["required"],
+        json!(["kind", "message_id"])
+    );
+    assert_eq!(target_branches[1]["required"], json!(["kind", "store_id"]));
+    assert_eq!(target_branches[2]["required"], json!(["kind", "node_id"]));
+    assert_eq!(
+        target_branches[3]["required"],
         json!(["kind", "payload_ref"])
     );
     expect_missing_argument_error(


### PR DESCRIPTION
Aligns the root `mcp_suite` LCM expectations with contracts the tip introduced intentionally:

- `d67aa5d3d6 fix(lcm): expand canonical session occurrences` — `LcmExpandTarget` gained `canonical_occurrence`, so `schema_test` now asserts four `oneOf` branches with the new one first.
- `c14b2ae981 fix(retrieval): read a derived group's bounds, not its membership` — coverage counts the query-relevant result-eligible population (see `docs/ROOT-DERIVED-RECORD-READ-DECISION.md`), so the filtered grep fixtures report `omitted: 1` (the single eligible hit with unresolved provenance) instead of a census of every seeded message.
- `6cebb171c0 refactor(prompts): focus host and session guidance` — the expand-query synthesis prompt was reworded; `lcm_test` asserts the exported `LCM_EXPAND_QUERY_SYNTHESIS_SYSTEM_PROMPT` constant.

No production code changed; the new counts were confirmed intentional from the commit bodies and the decision memo before any expected value moved.

Verification (lane `td-target-wave2-collapse`):
- 5 target tests: 5/5 (cc-19717).
- full `mcp_suite` (`--features test-transport,test-helpers`): 344 passed / 3 failed (cc-19722). Remaining reds: `work_test::work_attempt_consumers_read_the_public_start_attempt_effect` (Work-graph-authority, owned by the `fix(sweep)` lane) and two `session_search_test` deadline flakes under a 640 s loaded run that pass 2/2 single-threaded.
- `cargo check -p tracedecay --tests --features test-transport,test-helpers` green (cc-19721).